### PR TITLE
Integrate rules with mesh identity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1030,9 +1030,11 @@ dependencies = [
  "async-stream",
  "axum",
  "base64 0.22.1",
+ "bytes",
  "clap",
  "futures",
  "http 1.3.1",
+ "ppp",
  "prost",
  "prost-build",
  "prost-types",
@@ -1041,8 +1043,9 @@ dependencies = [
  "rustc_version",
  "serde",
  "serde_json",
+ "serde_yaml",
  "split-iter",
- "thiserror",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -1214,6 +1217,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "ppp"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a7a2049cd2570bd67bf0228e86bf850f8ceb5190a345c471d03a909da6049e0"
+dependencies = [
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1307,7 +1319,7 @@ dependencies = [
  "rustc-hash",
  "rustls 0.23.25",
  "socket2",
- "thiserror",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
  "web-time",
@@ -1327,7 +1339,7 @@ dependencies = [
  "rustls 0.23.25",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.12",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1551,7 +1563,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-util",
  "tracing",
@@ -1844,6 +1856,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1962,11 +1987,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.12",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2234,6 +2279,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,9 @@ prost-types = "0.13"
 tonic = { version = "0.12", default-features = false, features = ["prost", "codegen"] }
 split-iter = "0.1"
 thiserror = "2.0"
+serde_yaml = "0.9.34"
+ppp = "2.3.0"
+bytes = "1.10.1"
 
 [build-dependencies]
 tonic-build = { version = "0.12", default-features = false, features = ["prost"] }

--- a/manifests/example-everything.yaml
+++ b/manifests/example-everything.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mcp-everything
+spec:
+  selector:
+    matchLabels:
+      app: mcp-everything
+  template:
+    metadata:
+      labels:
+        app: mcp-everything
+    spec:
+      containers:
+        - name: mcp-everything
+          image: localhost:5000/mcp-everything
+          command: ["node", "dist/sse.js"]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mcp-everything
+spec:
+  selector:
+    app: mcp-everything
+  type: ClusterIP
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 3001

--- a/manifests/gateway.yaml
+++ b/manifests/gateway.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mcp-gateway
+spec:
+  selector:
+    matchLabels:
+      app: mcp-gateway
+  template:
+    metadata:
+      labels:
+        app: mcp-gateway
+    spec:
+      containers:
+        - name: mcp-gateway
+          image: localhost:5000/mcp-gateway:latest
+          command:
+            - mcp-gateway
+            - --config=/config/config.yaml
+          volumeMounts:
+            - name: config-volume
+              mountPath: /config
+      volumes:
+        - name: config-volume
+          configMap:
+            name: mcp-gateway-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mcp-gateway
+spec:
+  selector:
+    app: mcp-gateway
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8001
+  type: ClusterIP
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mcp-gateway-config
+data:
+  config.yaml: |
+    listener:
+      sse:
+        host: 0.0.0.0
+        port: 8001
+    rules: []
+    targets:
+      local:
+        stdio:
+          args:
+          - '@modelcontextprotocol/server-everything'
+          cmd: npx
+
+#      remote:
+#        sse:
+#          host: mcp-everything
+#          port: 80

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,4 +2,5 @@ pub mod rbac;
 pub mod relay;
 // pub mod ads;
 pub mod proto;
+pub mod proxyprotocol;
 pub mod sse;

--- a/src/proxyprotocol.rs
+++ b/src/proxyprotocol.rs
@@ -1,0 +1,135 @@
+use axum::extract::connect_info::Connected;
+use axum::serve::IncomingStream;
+use std::net::SocketAddr;
+use tokio::net::TcpListener;
+
+impl Connected<IncomingStream<'_, Listener>> for Address {
+	fn connect_info(target: IncomingStream<'_, Listener>) -> Self {
+		target.remote_addr().clone()
+	}
+}
+
+pub struct Listener(TcpListener, bool);
+
+impl Listener {
+	pub fn new(s: TcpListener, enabled: bool) -> Self {
+		Self(s, enabled)
+	}
+}
+
+#[derive(Clone, Debug)]
+pub struct Address {
+	pub addr: SocketAddr,
+	pub identity: Option<String>,
+}
+
+impl axum::serve::Listener for Listener {
+	type Io = <TcpListener as axum::serve::Listener>::Io;
+	type Addr = Address;
+
+	async fn accept(&mut self) -> (Self::Io, Self::Addr) {
+		let (mut io, addr) = axum::serve::Listener::accept(&mut self.0).await;
+
+		let addr = if !self.1 {
+			Address {
+				addr,
+				identity: None,
+			}
+		} else {
+			let header = protocol::parse(&mut io).await.expect("TODO");
+			Address {
+				addr,
+				identity: header.identity,
+			}
+		};
+		(io, addr)
+	}
+
+	fn local_addr(&self) -> std::io::Result<Self::Addr> {
+		axum::serve::Listener::local_addr(&self.0).map(|addr| Address {
+			addr,
+			identity: None,
+		})
+	}
+}
+
+mod protocol {
+	use ppp::v2;
+	use std::io;
+	use std::task::Context;
+	use tokio::io::{AsyncRead, AsyncReadExt, ReadBuf};
+
+	const PROXY_PROTOCOL_AUTHORITY_TLV: u8 = 0xD0;
+
+	#[derive(PartialEq, Debug)]
+	pub struct Header {
+		pub identity: Option<String>,
+	}
+
+	#[derive(thiserror::Error, Debug)]
+	pub enum Error {
+		#[error("io error: {0}")]
+		Io(#[from] io::Error),
+		#[error("protocol error")]
+		InvalidProtocol,
+		#[error("parse error: {0}")]
+		Parse(v2::ParseError),
+		#[error("imcomplete header (read {0})")]
+		Incomplete(usize),
+	}
+
+	pub struct PeekReader<'a>(pub &'a mut tokio::net::TcpStream);
+
+	impl AsyncRead for PeekReader<'_> {
+		fn poll_read(
+			self: std::pin::Pin<&mut Self>,
+			cx: &mut Context<'_>,
+			buf: &mut ReadBuf<'_>,
+		) -> std::task::Poll<std::io::Result<()>> {
+			std::pin::Pin::new(&*self.0)
+				.poll_peek(cx, buf)
+				.map_ok(|_| ())
+		}
+	}
+
+	pub async fn parse<IO: AsyncRead + Unpin>(source_stream: &mut IO) -> Result<Header, Error> {
+		use ppp::PartialResult;
+		// Typical header is roughly 50 bytes, but identity could be longer, or they
+		// could have more TLVs (why? not sure), so give an ample buffer
+		const PEEK_CAPACITY: usize = 512;
+		let mut buf = bytes::BytesMut::with_capacity(PEEK_CAPACITY);
+		let mut total_read = 0;
+		let header = loop {
+			let read = source_stream.read_buf(&mut buf).await?;
+			if read == 0 {
+				return Err(Error::Incomplete(total_read));
+			}
+			total_read += read;
+			// Note: intentionally do not use HeaderResult::parse. Not only is it wasteful to attempt
+			// to parse v1, which we will never use, it also has a bug (https://github.com/misalcedo/ppp/issues/28).
+			match v2::Header::try_from(buf.as_ref()) {
+				Ok(header) => {
+					break header;
+				},
+				Err(e) if !e.is_incomplete() => return Err(Error::Parse(e)),
+				_ => {},
+			}
+			if total_read >= buf.capacity() {
+				return Err(Error::Incomplete(total_read));
+			}
+		};
+		let mut identity: Option<String> = None;
+		for tlv in header.tlvs() {
+			let tlv = tlv.map_err(|_| Error::InvalidProtocol)?;
+			tracing::trace!(?tlv, "saw tlv");
+			match tlv.kind {
+				PROXY_PROTOCOL_AUTHORITY_TLV => {
+					let s = std::str::from_utf8(&tlv.value).map_err(|_| Error::InvalidProtocol)?;
+					identity = Some(s.to_string());
+				},
+				_other => {},
+			}
+		}
+		Ok(Header { identity })
+	}
+}

--- a/src/relay.rs
+++ b/src/relay.rs
@@ -124,7 +124,7 @@ impl ServerHandler for Relay {
 		if !self.rbac.check(rbac::ResourceType::Tool {
 			id: request.name.to_string(),
 		}) {
-			return Err(McpError::method_not_found::<CallToolRequestMethod>());
+			return Err(McpError::invalid_request("not allowed", None));
 		}
 		let tool_name = request.name.to_string();
 		let (service_name, tool) = tool_name.split_once(':').unwrap();


### PR DESCRIPTION
This adds support for terminating PROXY protocol to read mesh mTLS identity (from ztunnel). This is done by a new field, `mode`, under `listener.sse`. Additionally, a new `rules.key` is added; this is probably not the right long term API. Example full config:

```
{
  "listener": {
    "sse": {
      "host": "0.0.0.0",
      "port": 15088,
      "mode": "proxy"
    }
  },
  "rules": [
    {
      "key": "sub",
      "value": "1234567890",
      "resource": { "type": "tool", "id": "*" },
      "matcher": { "type": "equals" }
    },
    {
      "key": "connection:identity",
      "value": "spiffe://cluster.local/ns/default/sa/default",
      "resource": { "type": "tool", "id": "everything:add" },
      "matcher": { "type": "equals" }
    }
  ],
  "targets": {
    "git": {
      "stdio": {
        "cmd": "uvx",
        "args": ["mcp-server-git"]
      }
    },
    "everything": {
      "stdio": {
        "cmd": "npx",
        "args": ["@modelcontextprotocol/server-everything"]
      }
    }
  }
}
```

Also added but not really required/needed for this:
* Support reading from YAML
* Add a few example k8s manifests