### PR TITLE
initial MVP of OpenAPI support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,6 +506,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -555,6 +564,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -950,6 +974,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1148,6 +1188,7 @@ checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
+ "serde",
 ]
 
 [[package]]
@@ -1279,12 +1320,14 @@ dependencies = [
  "headers",
  "http 1.3.1",
  "jsonwebtoken",
+ "openapiv3",
  "ppp",
  "prometheus-client",
  "prost",
  "prost-build",
  "prost-types",
  "rand 0.8.5",
+ "reqwest",
  "rmcp",
  "rustc_version",
  "serde",
@@ -1338,6 +1381,23 @@ name = "multimap"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
+
+[[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -1399,10 +1459,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
 
 [[package]]
+name = "openapiv3"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc02deea53ffe807708244e5914f6b099ad7015a207ee24317c22112e17d9c5c"
+dependencies = [
+ "indexmap 2.8.0",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "openssl"
+version = "0.10.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "overload"
@@ -1496,6 +1605,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "powerfmt"
@@ -1805,18 +1920,22 @@ checksum = "989e327e510263980e231de548a33e63d34962d29ae61b467389a1a09627a254"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
  "futures-core",
  "futures-util",
+ "h2 0.4.8",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.6.0",
  "hyper-rustls 0.27.5",
+ "hyper-tls",
  "hyper-util",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -1828,7 +1947,9 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
+ "system-configuration",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls 0.26.2",
  "tokio-util",
  "tower 0.5.2",
@@ -2306,6 +2427,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2461,6 +2603,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -2725,6 +2877,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,8 @@ serde_yaml = "0.9.34"
 ppp = "2.3.0"
 bytes = "1.10.1"
 jsonwebtoken = "9.3"
+openapiv3 = "2.0.0"
+reqwest = "0.12.14"
 
 [build-dependencies]
 tonic-build = { version = "0.12", features = [

--- a/build.rs
+++ b/build.rs
@@ -70,7 +70,7 @@ fn main() -> Result<(), anyhow::Error> {
 	);
 	println!("cargo:rustc-env=MCPGW_BUILD_PROFILE_NAME={}", profile_name);
 
-  // This tells cargo to re-run this build script only when the proto files
+	// This tells cargo to re-run this build script only when the proto files
 	// we're interested in change or the any of the proto directories were updated.
 	for path in [proto_files, include_dirs].concat() {
 		println!("cargo:rerun-if-changed={}", path.to_str().unwrap());

--- a/src/main.rs
+++ b/src/main.rs
@@ -138,7 +138,7 @@ async fn main() -> Result<()> {
 					.map_err(|e| anyhow::anyhow!("error running xds client: {:?}", e))
 			});
 
-      // Add admin listener
+			// Add admin listener
 			let state_3 = state.clone();
 			let listener = tokio::net::TcpListener::bind("127.0.0.1:19000").await?;
 			let app = AdminApp::new(state_3);
@@ -164,8 +164,6 @@ async fn main() -> Result<()> {
 					.await
 					.map_err(|e| anyhow::anyhow!("error serving metrics: {:?}", e))
 			});
-
-
 
 			// Wait for all servers to finish? I think this does what I want :shrug:
 			while let Some(result) = run_set.join_next().await {

--- a/src/static.rs
+++ b/src/static.rs
@@ -11,7 +11,7 @@ use crate::xds::{Listener, ListenerMode, Target, XdsStore as ProxyState};
 use axum::http::HeaderMap;
 use tokio::sync::RwLock;
 
-#[derive(Default, Debug, Eq, PartialEq, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Default, Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct StaticConfig {
 	#[serde(default)]

--- a/src/version.rs
+++ b/src/version.rs
@@ -53,7 +53,12 @@ impl Display for BuildInfo {
 		write!(
 			f,
 			"version.BuildInfo{{RustVersion:\"{}\", BuildProfile:\"{}\", BuildStatus:\"{}\", GitTag:\"{}\", Version:\"{}\", GitRevision:\"{}\"}}",
-			self.rust_version, self.build_profile, self.build_status, self.git_tag, self.version, self.git_revision
+			self.rust_version,
+			self.build_profile,
+			self.build_status,
+			self.git_tag,
+			self.version,
+			self.git_revision
 		)
 	}
 }

--- a/src/xds.rs
+++ b/src/xds.rs
@@ -32,6 +32,7 @@ use self::envoy::service::discovery::v3::DeltaDiscoveryRequest;
 use crate::rbac;
 use crate::strng::Strng;
 use crate::xds;
+use openapiv3::Paths;
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
@@ -190,19 +191,30 @@ impl Handler<XdsRbac> for ProxyStateUpdater {
 	}
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq)]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct Target {
 	pub name: String,
 	pub spec: TargetSpec,
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq)]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 #[serde(tag = "type")]
 pub enum TargetSpec {
 	#[serde(rename = "sse")]
 	Sse { host: String, port: u32 },
 	#[serde(rename = "stdio")]
 	Stdio { cmd: String, args: Vec<String> },
+	#[serde(rename = "openapi")]
+	OpenAPI {
+		host: String,
+		port: u32,
+		schema: OpenAPISchema,
+	},
+}
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct OpenAPISchema {
+	// The crate OpenAPI type requires a lot more, we only need paths for now so use only a subset of it.
+	pub paths: Paths,
 }
 
 impl From<&XdsTarget> for Target {


### PR DESCRIPTION
Very basic support for adding some openapi spec in config, and having it exposed through the gateway.

Currentlt supported: list_tools and call_tools, with a very, very small portion of the specification translated. Remaining work will be isolated changes into the translation spec; hoping to merge this now to get the parts that touch the rest of the codebase merged in

Example config:

```yaml
type: static
listener:
  type: sse
  host: 0.0.0.0
  port: 8001
policies: []
targets:
- name: openapi
  spec:
    type: openapi
    host: localhost
    port: 8080
    schema:
      paths:
        /pets/{id}:
          get:
            summary: List all pets
            operationId: listPets
            tags:
              - pets
            parameters:
              - name: limit
                in: query
                description: How many items to return at one time (max 100)
                required: false
                schema:
                  type: integer
                  format: int32
            responses:
              200:
                description: An paged array of pets
                headers:
                  x-next:
                    description: A link to the next page of responses
                    schema:
                      type: string
```

![2025-03-24_14-25-56](https://github.com/user-attachments/assets/bbffd1b1-1af6-4354-b9d5-30a071e1661b)
