### PR TITLE
Consistently use rustls instead of openssl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ ppp = "2.3.0"
 bytes = "1.10.1"
 jsonwebtoken = "9.3"
 openapiv3 = "2.0.0"
-reqwest = "0.12.14"
+reqwest =  { version = "0.12.14" , default-features = false, features = ["http2", "charset", "macos-system-configuration", "rustls-tls"]}
 itertools = "0.14"
 async-trait = "0.1"
 lazy_static = "1.4"


### PR DESCRIPTION
```
$ ldd ./target/debug/agentproxy
        linux-vdso.so.1 (0x00007db47c287000)
        libgcc_s.so.1 => /usr/lib/libgcc_s.so.1 (0x00007db47c233000)
        libm.so.6 => /usr/lib/libm.so.6 (0x00007db479908000)
        libc.so.6 => /usr/lib/libc.so.6 (0x00007db479716000)
        /lib64/ld-linux-x86-64.so.2 => /usr/lib64/ld-linux-x86-64.so.2 (0x00007db47c289000)
```

Fixes https://github.com/agentproxy-dev/agentproxy/issues/51

Note: we still do depend on the glibc based on which version we compiled, so if we want to be really portable we need to build with musl.