### PR TITLE
Add a2a target to ads client

### DIFF
--- a/crates/agentgateway/src/main.rs
+++ b/crates/agentgateway/src/main.rs
@@ -10,9 +10,9 @@ use tracing_subscriber::{self, EnvFilter};
 
 use agentgateway::admin;
 use agentgateway::mtrcs;
+use agentgateway::proto::agentgateway::dev::a2a::target::Target as XdsA2ATarget;
 use agentgateway::proto::agentgateway::dev::listener::Listener as XdsListener;
 use agentgateway::proto::agentgateway::dev::mcp::target::Target as XdsMCPTarget;
-use agentgateway::proto::agentgateway::dev::a2a::target::Target as XdsA2ATarget;
 use agentgateway::relay;
 use agentgateway::signal;
 use agentgateway::trcng;

--- a/crates/agentgateway/src/main.rs
+++ b/crates/agentgateway/src/main.rs
@@ -11,7 +11,8 @@ use tracing_subscriber::{self, EnvFilter};
 use agentgateway::admin;
 use agentgateway::mtrcs;
 use agentgateway::proto::agentgateway::dev::listener::Listener as XdsListener;
-use agentgateway::proto::agentgateway::dev::mcp::target::Target as XdsTarget;
+use agentgateway::proto::agentgateway::dev::mcp::target::Target as XdsMCPTarget;
+use agentgateway::proto::agentgateway::dev::a2a::target::Target as XdsA2ATarget;
 use agentgateway::relay;
 use agentgateway::signal;
 use agentgateway::trcng;
@@ -272,7 +273,8 @@ async fn main() -> Result<()> {
 			let cfg_clone = dynamic.clone();
 			let xds_config = xds::client::Config::new(Arc::new(cfg_clone));
 			let ads_client = xds_config
-				.with_watched_handler::<XdsTarget>(xds::MCP_TARGET_TYPE, updater.clone())
+				.with_watched_handler::<XdsMCPTarget>(xds::MCP_TARGET_TYPE, updater.clone())
+				.with_watched_handler::<XdsA2ATarget>(xds::A2A_TARGET_TYPE, updater.clone())
 				.with_watched_handler::<XdsListener>(xds::LISTENER_TYPE, updater)
 				.build(metrics, awaiting_ready);
 


### PR DESCRIPTION
Need as part of adding Agent Gateway integration to kgateway: https://github.com/kgateway-dev/kgateway/pull/11151 

Tested with kgateway xds and now the a2a targets show up:
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/2f9c5deb-c6d4-452e-afdd-a90bad5c3b91" />
