### PR TITLE
feat: Allow loading OpenAPI schemas from remote URLs [TESTING GOOGLE JULES AGENT]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,6 +243,7 @@ dependencies = [
  "tower-serve-static",
  "tracing",
  "tracing-subscriber",
+ "url",
  "wiremock",
 ]
 

--- a/crates/agentgateway/Cargo.toml
+++ b/crates/agentgateway/Cargo.toml
@@ -70,6 +70,7 @@ tower-http.workspace = true
 tower-serve-static = { workspace = true, optional = true }
 tracing.workspace = true
 tracing-subscriber.workspace = true
+url = "2.5.0"
 
 [build-dependencies]
 tonic-build.workspace = true

--- a/crates/agentgateway/Cargo.toml
+++ b/crates/agentgateway/Cargo.toml
@@ -70,7 +70,7 @@ tower-http.workspace = true
 tower-serve-static = { workspace = true, optional = true }
 tracing.workspace = true
 tracing-subscriber.workspace = true
-url = "2.5.0"
+url.workspace = true
 
 [build-dependencies]
 tonic-build.workspace = true

--- a/crates/agentgateway/proto/common.proto
+++ b/crates/agentgateway/proto/common.proto
@@ -14,7 +14,7 @@ message LocalDataSource {
 }
 
 message RemoteDataSource {
-  string url = 1;
+  string host = 1;
   uint32 port = 2;
   string path = 3;
   repeated Header headers = 4;

--- a/crates/agentgateway/proto/mcp/target.proto
+++ b/crates/agentgateway/proto/mcp/target.proto
@@ -77,8 +77,13 @@ message Target {
     string host = 1;
     // The port of the target.
     uint32 port = 2;
-    // The schema of the target.
-    agentgateway.dev.common.LocalDataSource schema = 3;
+
+    oneof schema_source {
+      // The local schema of the target.
+      agentgateway.dev.common.LocalDataSource local_schema = 3;
+      // The remote schema of the target.
+      agentgateway.dev.common.RemoteDataSource remote_schema = 7;
+    }
 
     agentgateway.dev.common.BackendAuth auth = 4;
 

--- a/crates/agentgateway/proto/mcp/target.proto
+++ b/crates/agentgateway/proto/mcp/target.proto
@@ -80,7 +80,7 @@ message Target {
 
     oneof schema_source {
       // The local schema of the target.
-      agentgateway.dev.common.LocalDataSource local_schema = 3;
+      agentgateway.dev.common.LocalDataSource schema = 3;
       // The remote schema of the target.
       agentgateway.dev.common.RemoteDataSource remote_schema = 7;
     }

--- a/crates/agentgateway/src/authn.rs
+++ b/crates/agentgateway/src/authn.rs
@@ -66,7 +66,12 @@ fn duration_from_pb(duration: Option<pbjson_types::Duration>, default: Duration)
 
 impl JwksRemoteSource {
 	fn from_xds(remote: &common::RemoteDataSource) -> Result<Self, JwkError> {
-		let url = format!("{}:{}/{}", remote.url, remote.port, remote.path);
+		let scheme = match remote.port {
+			443 => "https",
+			80 => "http",
+			_ => return Err(JwkError::InvalidConfig("invalid port".to_string())),
+		};
+		let url = format!("{}://{}/{}", scheme, remote.host, remote.path);
 		let client = reqwest::ClientBuilder::new()
 			.timeout(duration_from_pb(
 				remote.initial_timeout,

--- a/crates/agentgateway/src/outbound.rs
+++ b/crates/agentgateway/src/outbound.rs
@@ -8,9 +8,11 @@ use crate::proto::agentgateway::dev::mcp::target::{
 	target::filter::Matcher as XdsFitlerMatcher,
 };
 use crate::relay::{Filter, FilterMatcher};
-use openapiv3::OpenAPI;
-use rmcp::model::Tool;
+use crate::proto::agentgateway::dev::mcp::target::openapi_target::SchemaSource as ProtoSchemaSource;
+use rmcp::model::Tool; // This was present in the original, but not explicitly in the new struct. Keeping if other parts of the file use it.
 use serde::Serialize;
+// openapiv3::OpenAPI is no longer needed in this file directly by OpenAPITarget struct or its TryFrom.
+// It will be used by the load_openapi_schema function in openapi.rs
 use std::collections::HashMap;
 pub mod backend;
 pub mod openapi;
@@ -200,10 +202,9 @@ impl TryFrom<XdsSseTarget> for SseTargetSpec {
 #[derive(Clone, Serialize, Debug)]
 pub struct OpenAPITarget {
 	pub host: String,
-	pub prefix: String,
 	pub port: u32,
-	#[serde(skip_serializing_if = "Vec::is_empty")]
-	pub tools: Vec<(Tool, openapi::UpstreamOpenAPICall)>,
+	#[serde(skip_serializing)] 
+	pub schema_source: Option<ProtoSchemaSource>,
 	#[serde(skip_serializing_if = "HashMap::is_empty")]
 	pub headers: HashMap<String, String>,
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -216,32 +217,33 @@ impl TryFrom<XdsOpenAPITarget> for OpenAPITarget {
 	type Error = openapi::ParseError;
 
 	fn try_from(value: XdsOpenAPITarget) -> Result<Self, Self::Error> {
-		let schema = value.schema.ok_or(openapi::ParseError::MissingSchema)?;
-		let schema_bytes =
-			proto::resolve_local_data_source(&schema.source.ok_or(openapi::ParseError::MissingFields)?)?;
-		let schema: OpenAPI =
-			serde_json::from_slice(&schema_bytes).map_err(openapi::ParseError::SerdeError)?;
-		let tools = openapi::parse_openapi_schema(&schema)?;
-		let prefix = openapi::get_server_prefix(&schema)?;
-		let headers = proto::resolve_header_map(&value.headers)?;
+		// Schema loading and parsing logic is removed.
+		// Tools and prefix are no longer derived here.
+
+		let resolved_headers = proto::resolve_header_map(&value.headers)
+            .map_err(|e| openapi::ParseError::InformationRequired(format!("Header resolution error: {}", e)) )?; // Added error mapping
+
+		let backend_auth_converted = match value.auth {
+			Some(auth) => auth.try_into().map_err(|e: anyhow::Error| {
+				openapi::ParseError::InformationRequired(format!("Auth conversion error: {}", e))
+			})?,
+			None => None,
+		};
+
+		let tls_converted = match value.tls {
+			Some(tls) => Some(TlsConfig::try_from(tls).map_err(|e: anyhow::Error| {
+				openapi::ParseError::InformationRequired(format!("TLS conversion error: {}", e))
+			})?),
+			None => None,
+		};
+
 		Ok(OpenAPITarget {
 			host: value.host.clone(),
-			prefix,
 			port: value.port,
-			tools,
-			headers,
-			backend_auth: match value.auth {
-				Some(auth) => auth
-					.try_into()
-					.map_err(|_| openapi::ParseError::MissingSchema)?,
-				None => None,
-			},
-			tls: match value.tls {
-				Some(tls) => {
-					Some(TlsConfig::try_from(tls).map_err(|_| openapi::ParseError::MissingSchema)?)
-				},
-				None => None,
-			},
+			schema_source: value.schema_source.clone(), // Store the oneof directly
+			headers: resolved_headers,
+			backend_auth: backend_auth_converted,
+			tls: tls_converted,
 		})
 	}
 }

--- a/crates/agentgateway/src/outbound/openapi.rs
+++ b/crates/agentgateway/src/outbound/openapi.rs
@@ -10,6 +10,16 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tracing::instrument;
+// use url::Url; // Already imported by the new block
+
+// Corrected and new imports based on instructions
+use crate::proto::common::{Header, LocalDataSource, RemoteDataSource};
+use crate::proto::mcp::target::{target::openapi_target::SchemaSource as OpenapiTargetSchemaSource, Target_OpenAPITarget};
+use openapiv3::OpenAPI;
+use reqwest::header::{HeaderMap as ReqwestHeaderMap, HeaderName as ReqwestHeaderName, HeaderValue as ReqwestHeaderValue};
+use url::Url; // Ensure this is present if the previous line was commented out due to merge
+use std::fs::read_to_string as std_fs_read_to_string;
+
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct UpstreamOpenAPICall {
@@ -20,24 +30,157 @@ pub struct UpstreamOpenAPICall {
 
 #[derive(Debug, thiserror::Error)]
 pub enum ParseError {
-	#[error("missing fields")]
-	MissingFields,
-	#[error("missing schema")]
-	MissingSchema,
-	#[error("missing components")]
-	MissingComponents,
-	#[error("invalid reference: {0}")]
-	InvalidReference(String),
-	#[error("missing reference")]
-	MissingReference(String),
-	#[error("unsupported reference")]
-	UnsupportedReference(String),
-	#[error("information requireds")]
-	InformationRequired(String),
-	#[error("serde error: {0}")]
-	SerdeError(#[from] serde_json::Error),
-	#[error("io error: {0}")]
-	IoError(#[from] std::io::Error),
+    #[error("missing fields")]
+    MissingFields,
+    #[error("missing schema")]
+    MissingSchema,
+    #[error("missing components")]
+    MissingComponents,
+    #[error("invalid reference: {0}")]
+    InvalidReference(String),
+    #[error("missing reference")]
+    MissingReference(String),
+    #[error("unsupported reference")]
+    UnsupportedReference(String),
+    #[error("information required: {0}")] // Corrected typo from "requireds"
+    InformationRequired(String),
+    #[error("serde error: {0}")]
+    SerdeError(#[from] serde_json::Error),
+    #[error("io error: {0}")]
+    IoError(#[from] std::io::Error),
+    #[error("HTTP request failed: {0}")]
+    HttpError(#[from] reqwest::Error),
+    #[error("Invalid URL: {0}")]
+    InvalidUrl(#[from] url::ParseError),
+    #[error("Schema source not specified in OpenAPI target")]
+    SchemaSourceMissing,
+    #[error("Unsupported schema format or content type from URL {0}. Only JSON and YAML are supported.")]
+    UnsupportedSchemaFormat(String), // Added URL to message
+    #[error("Local schema file path not specified")]
+    LocalPathMissing,
+    #[error("Local schema inline content not specified or empty")]
+    LocalInlineMissing, // Added for inline content
+    #[error("Invalid header name or value")]
+    InvalidHeader,
+    #[error("Header value source not supported (e.g. env_value)")]
+    HeaderValueSourceNotSupported(String),
+}
+
+pub async fn load_openapi_schema(target_config: &Target_OpenAPITarget) -> Result<OpenAPI, ParseError> {
+    match &target_config.schema_source {
+        Some(OpenapiTargetSchemaSource::RemoteSchema(remote_source)) => {
+            let url_string = &remote_source.url;
+            if url_string.is_empty() {
+                // Using a more specific error if possible, or a generic InvalidUrl
+                return Err(ParseError::InvalidUrl(url::ParseError::RelativeUrlWithoutBase));
+            }
+            let url = Url::parse(url_string).map_err(ParseError::InvalidUrl)?;
+            tracing::info!("Loading OpenAPI schema from remote URL: {}", url);
+
+            let client = reqwest::Client::new(); // Create a new client for each call or reuse one if available
+            let mut request_builder = client.get(url.clone()); // Clone URL for error message and use here
+
+            // Add headers from RemoteDataSource if any
+            // common.proto defines `repeated Header headers = 4;`
+            // and `message Header { string key = 1; oneof value { string string_value = 2; string env_value = 3; } }`
+            if !remote_source.headers.is_empty() {
+                let mut req_headers = ReqwestHeaderMap::new();
+                for header_proto in &remote_source.headers {
+                    let header_key = &header_proto.key;
+                    match &header_proto.value {
+                        Some(crate::proto::common::header::Value::StringValue(val_str)) => {
+                            match (
+                                ReqwestHeaderName::from_bytes(header_key.as_bytes()),
+                                ReqwestHeaderValue::from_str(val_str)
+                            ) {
+                                (Ok(name), Ok(value)) => {
+                                    req_headers.insert(name, value);
+                                }
+                                _ => {
+                                    tracing::warn!("Invalid header (key or value): {}={}", header_key, val_str);
+                                    return Err(ParseError::InvalidHeader);
+                                }
+                            }
+                        }
+                        Some(crate::proto::common::header::Value::EnvValue(env_key)) => {
+                            // As per instructions, env_value is not supported yet.
+                            tracing::warn!("Header value from environment variable is not supported yet: key={}, env_key={}", header_key, env_key);
+                            return Err(ParseError::HeaderValueSourceNotSupported(header_key.clone()));
+                        }
+                        None => {
+                            // This case should ideally not happen if protobuf is well-defined (oneof implies one must be set)
+                            tracing::warn!("Header value not set for key: {}", header_key);
+                            return Err(ParseError::InvalidHeader);
+                        }
+                    }
+                }
+                if !req_headers.is_empty() {
+                    request_builder = request_builder.headers(req_headers);
+                }
+            }
+            // No static_headers in common.proto's RemoteDataSource
+
+            let response = request_builder.send().await.map_err(ParseError::HttpError)?;
+
+            if !response.status().is_success() {
+                return Err(ParseError::HttpError(response.error_for_status().unwrap_err()));
+            }
+            let schema_text = response.text().await.map_err(ParseError::HttpError)?;
+
+            let openapi_doc: OpenAPI = serde_json::from_str(&schema_text)
+                .or_else(|_json_err| {
+                    serde_yaml::from_str(&schema_text).map_err(|_yaml_err| {
+                        ParseError::UnsupportedSchemaFormat(url_string.clone())
+                    })
+                })?;
+            Ok(openapi_doc)
+        }
+        Some(OpenapiTargetSchemaSource::LocalSchema(local_source)) => {
+            // common.proto: message LocalDataSource { oneof source { string file_path = 1; bytes inline = 2; } }
+            match &local_source.source {
+                Some(crate::proto::common::local_data_source::Source::FilePath(path)) => {
+                    if path.is_empty() {
+                        return Err(ParseError::LocalPathMissing);
+                    }
+                    tracing::info!("Loading OpenAPI schema from local file: {}", path);
+                    let schema_content = std_fs_read_to_string(path).map_err(ParseError::IoError)?;
+                    serde_json::from_str(&schema_content)
+                        .or_else(|_json_err| {
+                            serde_yaml::from_str(&schema_content).map_err(|_yaml_err| {
+                                ParseError::UnsupportedSchemaFormat(path.clone())
+                            })
+                        })
+                }
+                Some(crate::proto::common::local_data_source::Source::Inline(inline_bytes)) => {
+                    if inline_bytes.is_empty() {
+                        return Err(ParseError::LocalInlineMissing);
+                    }
+                    tracing::info!("Loading OpenAPI schema from inline bytes");
+                    // Attempt to parse directly from bytes, assuming UTF-8.
+                    // serde_yaml can parse from &str or &[u8]. serde_json from &str or &[u8] or Read.
+                    // Using from_slice for both if possible, or from_utf8_lossy if text is guaranteed.
+                    // For simplicity, convert to &str first.
+                    let schema_content = std::str::from_utf8(inline_bytes)
+                        .map_err(|_| ParseError::UnsupportedSchemaFormat("inline bytes (not valid UTF-8)".to_string()))?;
+
+                    serde_json::from_str(schema_content)
+                        .or_else(|_json_err| {
+                             serde_yaml::from_str(schema_content).map_err(|_yaml_err| {
+                                ParseError::UnsupportedSchemaFormat("inline bytes".to_string())
+                            })
+                        })
+                }
+                None => {
+                    tracing::error!("No source specified in LocalSchema");
+                    Err(ParseError::LocalPathMissing) // Or a more generic error like SchemaSourceMissing
+                }
+            }
+        }
+        None => {
+            tracing::error!("No schema source specified for OpenAPI target");
+            Err(ParseError::SchemaSourceMissing)
+        }
+    }
 }
 
 pub(crate) fn get_server_prefix(server: &OpenAPI) -> Result<String, ParseError> {
@@ -49,6 +192,259 @@ pub(crate) fn get_server_prefix(server: &OpenAPI) -> Result<String, ParseError> 
 			server.servers
 		))),
 	}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*; // Imports load_openapi_schema, ParseError etc.
+    use crate::proto::agentgateway::dev::mcp::target::{
+        Target_OpenAPITarget as ProtoXdsOpenApiTarget,
+        openapi_target::SchemaSource as ProtoSchemaSource,
+    };
+    // Adjusted import path for HeaderValueProto to match common.proto structure if necessary
+    use crate::proto::common::{
+        LocalDataSource, RemoteDataSource, Header, 
+        header::Value as HeaderValueProto, // Assuming this is the correct path for the oneof enum
+        local_data_source::Source as LocalSourceProto // Assuming this is the correct path for the oneof enum
+    };
+    use wiremock::matchers::{method, path, header as wm_header};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+    use std::fs::File;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    // Helper to create ProtoXdsOpenApiTarget for testing
+    fn create_test_proto_target(schema_source: Option<ProtoSchemaSource>) -> ProtoXdsOpenApiTarget {
+        ProtoXdsOpenApiTarget {
+            host: "localhost".to_string(),
+            port: 8080,
+            schema_source,
+            auth: None,
+            tls: None,
+            headers: vec![], // For the OpenAPITarget message itself, not RemoteDataSource
+        }
+    }
+
+    #[tokio::test]
+    async fn test_load_remote_schema_json_success() {
+        let server = MockServer::start().await;
+        let schema_content = r#"{ "openapi": "3.0.0", "info": { "title": "Remote JSON", "version": "1.0.0" }, "paths": {} }"#;
+        Mock::given(method("GET"))
+            .and(path("/schema.json"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(schema_content))
+            .mount(&server)
+            .await;
+
+        let remote_source = RemoteDataSource {
+            url: format!("{}/schema.json", server.uri()),
+            headers: vec![], // Corrected: Vec<Header>, not Option
+            // static_headers: Default::default(), // Field does not exist
+            // Other fields of RemoteDataSource like port, initial_timeout, refresh_interval are defaulted or not used by load_openapi_schema
+            port: 0, 
+            initial_timeout: None,
+            refresh_interval: None,
+            path: "".to_string(), // path field for RemoteDataSource
+        };
+        let proto_target = create_test_proto_target(Some(ProtoSchemaSource::RemoteSchema(remote_source)));
+
+        let result = load_openapi_schema(&proto_target).await;
+        assert!(result.is_ok(), "Expected OK, got {:?}", result.err());
+        let openapi_doc = result.unwrap();
+        assert_eq!(openapi_doc.info.title, "Remote JSON");
+    }
+
+    #[tokio::test]
+    async fn test_load_remote_schema_yaml_success() {
+        let server = MockServer::start().await;
+        let schema_content = "openapi: 3.0.0
+info:
+  title: Remote YAML
+  version: 1.0.0
+paths: {}";
+        Mock::given(method("GET"))
+            .and(path("/schema.yaml"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(schema_content))
+            .mount(&server)
+            .await;
+
+        let remote_source = RemoteDataSource {
+            url: format!("{}/schema.yaml", server.uri()),
+            headers: vec![], // Corrected
+            port: 0,
+            initial_timeout: None,
+            refresh_interval: None,
+            path: "".to_string(),
+        };
+        let proto_target = create_test_proto_target(Some(ProtoSchemaSource::RemoteSchema(remote_source)));
+
+        let result = load_openapi_schema(&proto_target).await;
+        assert!(result.is_ok(), "Expected OK, got {:?}", result.err());
+        let openapi_doc = result.unwrap();
+        assert_eq!(openapi_doc.info.title, "Remote YAML");
+    }
+
+    #[tokio::test]
+    async fn test_load_remote_schema_with_headers() {
+        let server = MockServer::start().await;
+        let schema_content = r#"{ "openapi": "3.0.0", "info": { "title": "With Headers", "version": "1.0.0" }, "paths": {} }"#;
+        Mock::given(method("GET"))
+            .and(path("/schema_secret.json"))
+            .and(wm_header("X-Auth-Token", "secret_token"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(schema_content))
+            .mount(&server)
+            .await;
+        
+        let headers_proto = vec![Header {
+            key: "X-Auth-Token".to_string(),
+            value: Some(HeaderValueProto::StringValue("secret_token".to_string())),
+        }];
+        let remote_source = RemoteDataSource {
+            url: format!("{}/schema_secret.json", server.uri()),
+            headers: headers_proto, // Corrected: Pass the vec directly
+            port: 0,
+            initial_timeout: None,
+            refresh_interval: None,
+            path: "".to_string(),
+        };
+        let proto_target = create_test_proto_target(Some(ProtoSchemaSource::RemoteSchema(remote_source)));
+
+        let result = load_openapi_schema(&proto_target).await;
+        assert!(result.is_ok(), "Expected OK, got {:?}", result.err());
+        let openapi_doc = result.unwrap();
+        assert_eq!(openapi_doc.info.title, "With Headers");
+    }
+    
+    // test_load_remote_schema_with_static_headers is OMITTED because static_headers does not exist on RemoteDataSource
+
+    #[tokio::test]
+    async fn test_load_remote_schema_not_found_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/nonexistent.json"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let remote_source = RemoteDataSource { 
+            url: format!("{}/nonexistent.json", server.uri()), 
+            headers: vec![], 
+            port: 0,
+            initial_timeout: None,
+            refresh_interval: None,
+            path: "".to_string(),
+        };
+        let proto_target = create_test_proto_target(Some(ProtoSchemaSource::RemoteSchema(remote_source)));
+
+        let result = load_openapi_schema(&proto_target).await;
+        assert!(result.is_err());
+        match result.err().unwrap() {
+            ParseError::HttpError(_) => {} // Expected error
+            e => panic!("Unexpected error type: {:?}", e),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_load_remote_schema_malformed_content() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/malformed.json"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("{ malformed json "))
+            .mount(&server)
+            .await;
+
+        let remote_source = RemoteDataSource { 
+            url: format!("{}/malformed.json", server.uri()), 
+            headers: vec![], 
+            port: 0,
+            initial_timeout: None,
+            refresh_interval: None,
+            path: "".to_string(),
+        };
+        let proto_target = create_test_proto_target(Some(ProtoSchemaSource::RemoteSchema(remote_source)));
+
+        let result = load_openapi_schema(&proto_target).await;
+        assert!(result.is_err());
+        match result.err().unwrap() {
+            ParseError::UnsupportedSchemaFormat(_) => {} // Expected error
+            e => panic!("Unexpected error type: {:?}", e),
+        }
+    }
+   
+    #[tokio::test]
+    async fn test_load_remote_schema_invalid_url() {
+        let remote_source = RemoteDataSource { 
+            url: "this is not a valid url".to_string(), 
+            headers: vec![], 
+            port: 0,
+            initial_timeout: None,
+            refresh_interval: None,
+            path: "".to_string(),
+        };
+        let proto_target = create_test_proto_target(Some(ProtoSchemaSource::RemoteSchema(remote_source)));
+        let result = load_openapi_schema(&proto_target).await;
+        assert!(result.is_err());
+        match result.err().unwrap() {
+            ParseError::InvalidUrl(_) => {} // Expected
+            e => panic!("Unexpected error: {:?}", e),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_load_local_schema_json_success() {
+        let mut temp_file = NamedTempFile::new().unwrap();
+        let schema_content = r#"{ "openapi": "3.0.0", "info": { "title": "Local JSON", "version": "1.0.0" }, "paths": {} }"#;
+        writeln!(temp_file, "{}", schema_content).unwrap();
+
+        let local_data_source = LocalDataSource {
+            source: Some(LocalSourceProto::FilePath(temp_file.path().to_str().unwrap().to_string())),
+        };
+        let proto_target = create_test_proto_target(Some(ProtoSchemaSource::LocalSchema(local_data_source)));
+
+        let result = load_openapi_schema(&proto_target).await;
+        assert!(result.is_ok(), "Expected OK, got {:?}", result.err());
+        let openapi_doc = result.unwrap();
+        assert_eq!(openapi_doc.info.title, "Local JSON");
+    }
+   
+    #[tokio::test]
+    async fn test_load_local_schema_inline_success() {
+        let schema_content = r#"{ "openapi": "3.0.0", "info": { "title": "Local Inline JSON", "version": "1.0.0" }, "paths": {} }"#;
+        let local_data_source = LocalDataSource {
+            source: Some(LocalSourceProto::Inline(schema_content.as_bytes().to_vec())), // Corrected to ::Inline from ::InlineBytes
+        };
+        let proto_target = create_test_proto_target(Some(ProtoSchemaSource::LocalSchema(local_data_source)));
+
+        let result = load_openapi_schema(&proto_target).await;
+        assert!(result.is_ok(), "Expected OK, got {:?}", result.err());
+        let openapi_doc = result.unwrap();
+        assert_eq!(openapi_doc.info.title, "Local Inline JSON");
+    }
+
+    #[tokio::test]
+    async fn test_load_local_schema_file_not_found() {
+        let local_data_source = LocalDataSource {
+            source: Some(LocalSourceProto::FilePath("/path/to/nonexistent/schema.json".to_string())),
+        };
+        let proto_target = create_test_proto_target(Some(ProtoSchemaSource::LocalSchema(local_data_source)));
+
+        let result = load_openapi_schema(&proto_target).await;
+        assert!(result.is_err());
+        match result.err().unwrap() {
+            ParseError::IoError(_) => {} // Expected error
+            e => panic!("Unexpected error type: {:?}", e),
+        }
+    }
+   
+    #[tokio::test]
+    async fn test_load_schema_no_source_specified() {
+        let proto_target = create_test_proto_target(None); // No schema_source
+        let result = load_openapi_schema(&proto_target).await;
+        assert!(result.is_err());
+        match result.err().unwrap() {
+            ParseError::SchemaSourceMissing => {} // Expected
+            e => panic!("Unexpected error: {:?}", e),
+        }
+    }
 }
 
 fn resolve_schema<'a>(

--- a/crates/agentgateway/src/outbound/openapi.rs
+++ b/crates/agentgateway/src/outbound/openapi.rs
@@ -73,11 +73,11 @@ pub async fn load_openapi_schema(target_config: &OpenApiTarget) -> Result<OpenAP
 	match &target_config.schema_source {
 		Some(schema_source) => match schema_source {
 			SchemaSource::RemoteSchema(remote_source) => {
-        let scheme = match remote_source.port {
-          443 => "https",
-          80 => "http",
-          _ => return Err(ParseError::InvalidUrl(url::ParseError::InvalidPort)),
-        };
+				let scheme = match remote_source.port {
+					443 => "https",
+					80 => "http",
+					_ => return Err(ParseError::InvalidUrl(url::ParseError::InvalidPort)),
+				};
 				let url_string = format!("{}://{}/{}", scheme, remote_source.host, remote_source.path);
 				let url = Url::parse(&url_string).map_err(ParseError::InvalidUrl)?;
 				tracing::info!("Loading OpenAPI schema from remote URL: {}", url);

--- a/crates/agentgateway/src/relay/pool.rs
+++ b/crates/agentgateway/src/relay/pool.rs
@@ -1,4 +1,6 @@
 use crate::outbound;
+// Import for the protobuf type Target_OpenAPITarget
+use crate::proto::agentgateway::dev::mcp::target::Target_OpenAPITarget as ProtoXdsOpenApiTarget;
 
 use super::*;
 use futures::{FutureExt, StreamExt, future::BoxFuture, stream::BoxStream};
@@ -198,30 +200,59 @@ impl ConnectionPool {
 					),
 				}
 			},
-			McpTargetSpec::OpenAPI(open_api) => {
+			McpTargetSpec::OpenAPI(openapi_target_spec_from_outbound) => { // Renamed for clarity
 				tracing::debug!("starting OpenAPI transport for target: {}", target.name);
 
-				let builder = reqwest::Client::builder();
-				let (scheme, builder) = tls_cfg(builder, &open_api.tls, open_api.port).await?;
+				// 1. Retrieve schema_source
+				let current_schema_source_proto = openapi_target_spec_from_outbound.schema_source.clone()
+					.ok_or_else(|| anyhow::anyhow!("OpenAPI target {} is missing schema_source definition", target.name))?;
 
-				let mut headers = get_default_headers(&open_api.backend_auth, rq_ctx).await?;
-				for (key, value) in open_api.headers.iter() {
-					headers.insert(
+				// 2. Prepare for load_openapi_schema
+				let proto_target_for_loading = ProtoXdsOpenApiTarget {
+					host: openapi_target_spec_from_outbound.host.clone(),
+					port: openapi_target_spec_from_outbound.port,
+					schema_source: Some(current_schema_source_proto),
+					auth: None, // Not needed for schema loading
+					tls: None,  // Not needed for schema loading
+					headers: vec![], // Not needed for schema loading
+				};
+
+				// 3. Call load_openapi_schema
+				let loaded_openapi_doc = crate::outbound::openapi::load_openapi_schema(&proto_target_for_loading)
+					.await
+					.map_err(|e| anyhow::anyhow!("Failed to load OpenAPI schema for target {}: {}", target.name, e))?;
+
+				// 4. Parse Tools and Prefix
+				let tools = crate::outbound::openapi::parse_openapi_schema(&loaded_openapi_doc)
+					.map_err(|e| anyhow::anyhow!("Failed to parse tools from OpenAPI schema for target {}: {}", target.name, e))?;
+				let prefix = crate::outbound::openapi::get_server_prefix(&loaded_openapi_doc)
+					.map_err(|e| anyhow::anyhow!("Failed to get server prefix from OpenAPI schema for target {}: {}", target.name, e))?;
+
+				// 5. Construct openapi::Handler (client setup)
+				let builder = reqwest::Client::builder();
+				let (scheme, builder) = tls_cfg(builder, &openapi_target_spec_from_outbound.tls, openapi_target_spec_from_outbound.port).await?;
+
+				let mut api_headers = get_default_headers(&openapi_target_spec_from_outbound.backend_auth, rq_ctx).await?;
+				for (key, value) in &openapi_target_spec_from_outbound.headers {
+					api_headers.insert(
 						HeaderName::from_bytes(key.as_bytes())?,
 						HeaderValue::from_str(value)?,
 					);
 				}
-				let client = builder.default_headers(headers).build()?;
+				let final_client = builder.default_headers(api_headers).build()?;
+
 				upstream::UpstreamTarget {
-					filters: target.filters.clone(),
-					spec: upstream::UpstreamTargetSpec::OpenAPI(openapi::Handler {
-						host: open_api.host.clone(),
-						client,
-						tools: open_api.tools.clone(),
-						scheme: scheme.to_string(),
-						prefix: open_api.prefix.clone(),
-						port: open_api.port,
-					}),
+					filters: target.filters.clone(), // From the outer 'target' variable
+					spec: upstream::UpstreamTargetSpec::OpenAPI(
+						crate::outbound::openapi::Handler {
+							host: openapi_target_spec_from_outbound.host.clone(),
+							client: final_client,
+							tools, // From parse_openapi_schema
+							scheme: scheme.to_string(),
+							prefix, // From get_server_prefix
+							port: openapi_target_spec_from_outbound.port,
+						}
+					),
 				}
 			},
 		};

--- a/crates/agentgateway/src/relay/pool.rs
+++ b/crates/agentgateway/src/relay/pool.rs
@@ -1,6 +1,6 @@
 use crate::outbound;
 // Import for the protobuf type Target_OpenAPITarget
-use crate::proto::agentgateway::dev::mcp::target::Target_OpenAPITarget as ProtoXdsOpenApiTarget;
+use crate::proto::agentgateway::dev::mcp::target::target::OpenApiTarget as ProtoXdsOpenApiTarget;
 
 use super::*;
 use futures::{FutureExt, StreamExt, future::BoxFuture, stream::BoxStream};
@@ -200,39 +200,72 @@ impl ConnectionPool {
 					),
 				}
 			},
-			McpTargetSpec::OpenAPI(openapi_target_spec_from_outbound) => { // Renamed for clarity
+			McpTargetSpec::OpenAPI(openapi_target_spec_from_outbound) => {
+				// Renamed for clarity
 				tracing::debug!("starting OpenAPI transport for target: {}", target.name);
 
 				// 1. Retrieve schema_source
-				let current_schema_source_proto = openapi_target_spec_from_outbound.schema_source.clone()
-					.ok_or_else(|| anyhow::anyhow!("OpenAPI target {} is missing schema_source definition", target.name))?;
+				let current_schema_source_proto = openapi_target_spec_from_outbound
+					.schema_source
+					.clone()
+					.ok_or_else(|| {
+					anyhow::anyhow!(
+						"OpenAPI target {} is missing schema_source definition",
+						target.name
+					)
+				})?;
 
 				// 2. Prepare for load_openapi_schema
 				let proto_target_for_loading = ProtoXdsOpenApiTarget {
 					host: openapi_target_spec_from_outbound.host.clone(),
 					port: openapi_target_spec_from_outbound.port,
 					schema_source: Some(current_schema_source_proto),
-					auth: None, // Not needed for schema loading
-					tls: None,  // Not needed for schema loading
+					auth: None,      // Not needed for schema loading
+					tls: None,       // Not needed for schema loading
 					headers: vec![], // Not needed for schema loading
 				};
 
 				// 3. Call load_openapi_schema
-				let loaded_openapi_doc = crate::outbound::openapi::load_openapi_schema(&proto_target_for_loading)
-					.await
-					.map_err(|e| anyhow::anyhow!("Failed to load OpenAPI schema for target {}: {}", target.name, e))?;
+				let loaded_openapi_doc =
+					crate::outbound::openapi::load_openapi_schema(&proto_target_for_loading)
+						.await
+						.map_err(|e| {
+							anyhow::anyhow!(
+								"Failed to load OpenAPI schema for target {}: {}",
+								target.name,
+								e
+							)
+						})?;
 
 				// 4. Parse Tools and Prefix
-				let tools = crate::outbound::openapi::parse_openapi_schema(&loaded_openapi_doc)
-					.map_err(|e| anyhow::anyhow!("Failed to parse tools from OpenAPI schema for target {}: {}", target.name, e))?;
-				let prefix = crate::outbound::openapi::get_server_prefix(&loaded_openapi_doc)
-					.map_err(|e| anyhow::anyhow!("Failed to get server prefix from OpenAPI schema for target {}: {}", target.name, e))?;
+				let tools =
+					crate::outbound::openapi::parse_openapi_schema(&loaded_openapi_doc).map_err(|e| {
+						anyhow::anyhow!(
+							"Failed to parse tools from OpenAPI schema for target {}: {}",
+							target.name,
+							e
+						)
+					})?;
+				let prefix =
+					crate::outbound::openapi::get_server_prefix(&loaded_openapi_doc).map_err(|e| {
+						anyhow::anyhow!(
+							"Failed to get server prefix from OpenAPI schema for target {}: {}",
+							target.name,
+							e
+						)
+					})?;
 
 				// 5. Construct openapi::Handler (client setup)
 				let builder = reqwest::Client::builder();
-				let (scheme, builder) = tls_cfg(builder, &openapi_target_spec_from_outbound.tls, openapi_target_spec_from_outbound.port).await?;
+				let (scheme, builder) = tls_cfg(
+					builder,
+					&openapi_target_spec_from_outbound.tls,
+					openapi_target_spec_from_outbound.port,
+				)
+				.await?;
 
-				let mut api_headers = get_default_headers(&openapi_target_spec_from_outbound.backend_auth, rq_ctx).await?;
+				let mut api_headers =
+					get_default_headers(&openapi_target_spec_from_outbound.backend_auth, rq_ctx).await?;
 				for (key, value) in &openapi_target_spec_from_outbound.headers {
 					api_headers.insert(
 						HeaderName::from_bytes(key.as_bytes())?,
@@ -243,16 +276,14 @@ impl ConnectionPool {
 
 				upstream::UpstreamTarget {
 					filters: target.filters.clone(), // From the outer 'target' variable
-					spec: upstream::UpstreamTargetSpec::OpenAPI(
-						crate::outbound::openapi::Handler {
-							host: openapi_target_spec_from_outbound.host.clone(),
-							client: final_client,
-							tools, // From parse_openapi_schema
-							scheme: scheme.to_string(),
-							prefix, // From get_server_prefix
-							port: openapi_target_spec_from_outbound.port,
-						}
-					),
+					spec: upstream::UpstreamTargetSpec::OpenAPI(crate::outbound::openapi::Handler {
+						host: openapi_target_spec_from_outbound.host.clone(),
+						client: final_client,
+						tools, // From parse_openapi_schema
+						scheme: scheme.to_string(),
+						prefix, // From get_server_prefix
+						port: openapi_target_spec_from_outbound.port,
+					}),
 				}
 			},
 		};

--- a/examples/openapi/config.json
+++ b/examples/openapi/config.json
@@ -17,8 +17,10 @@
         "openapi": {
           "host": "petstore3.swagger.io",
           "port": 443,
-          "schema": {
-            "file_path": "examples/openapi/openapi.json"
+          "remote_schema": {
+            "host": "petstore3.swagger.io",
+            "port": 443,
+            "path": "api/v3/openapi.json"
           }
         }
       }


### PR DESCRIPTION
This change introduces the ability to specify OpenAPI schemas via remote URLs in addition to local file paths for MCP OpenAPI targets.

Key changes:

- Updated `crates/agentgateway/proto/mcp/target.proto`:
    - Modified `OpenAPITarget` to use a `oneof schema_source` which can be either `local_schema` (using `common.LocalDataSource`) or `remote_schema` (using `common.RemoteDataSource`).

- Updated `crates/agentgateway/src/outbound/openapi.rs`:
    - Added an async function `load_openapi_schema` that takes an `OpenAPITarget` protobuf and loads the schema.
    - If `remote_schema` is specified, it fetches the schema from the URL (supporting headers from `RemoteDataSource`).
    - If `local_schema` is specified, it loads from the local path or inline bytes.
    - Handles JSON and YAML formats, and includes error handling for network issues, invalid URLs, and malformed content.
    - Updated `ParseError` enum for more specific error reporting.
    - Added comprehensive unit tests for `load_openapi_schema` covering remote and local loading scenarios with `wiremock` and `tempfile`.

- Updated `crates/agentgateway/src/outbound.rs`:
    - Modified the `outbound::OpenAPITarget` struct to store the raw protobuf `schema_source` instead of pre-parsed tools and prefix.
    - Its `TryFrom<XdsOpenAPITarget>` implementation now stores this `schema_source` without immediate processing.

- Updated `crates/agentgateway/src/relay/pool.rs`:
    - In `ConnectionPool::connect`, for `McpTargetSpec::OpenAPI`: - It now calls the new `openapi::load_openapi_schema` with the stored protobuf `schema_source`. - After successfully loading, it calls `openapi::parse_openapi_schema` and `openapi::get_server_prefix` to derive tools and the prefix. - The `openapi::Handler` is then instantiated with these dynamically derived values.

This enhancement provides greater flexibility in configuring OpenAPI targets by allowing schemas to be hosted and fetched from remote locations.

resolves #130