### PR TITLE
Small docs and UI fixes

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -30,5 +30,5 @@ Run the agentgateway binary:
 ```bash
 ./target/release/agentgateway
 ```
-Open your browser and navigate to `http://localhost:19000/ui` to see the agentgateway UI.
+Open your browser and navigate to `http://localhost:15000/ui` to see the agentgateway UI.
 

--- a/ui/src/components/backend-config.tsx
+++ b/ui/src/components/backend-config.tsx
@@ -60,12 +60,12 @@ export function BackendConfig() {
     });
   };
 
-  const handleEditBackend = (backendContext: typeof backends[0]) => {
+  const handleEditBackend = (backendContext: (typeof backends)[0]) => {
     populateFormFromBackendContext(backendContext);
     openEditDialog(backendContext);
   };
 
-  const handleDeleteBackend = async (backendContext: typeof backends[0]) => {
+  const handleDeleteBackend = async (backendContext: (typeof backends)[0]) => {
     await deleteBackend(backendContext, () => {
       loadBackends();
     });

--- a/ui/src/components/backend/backend-components.tsx
+++ b/ui/src/components/backend/backend-components.tsx
@@ -43,7 +43,7 @@ import {
 } from "lucide-react";
 import { Bind } from "@/lib/types";
 import { BackendWithContext } from "@/lib/backend-hooks";
-import { 
+import {
   DEFAULT_BACKEND_FORM,
   BACKEND_TYPES,
   BACKEND_TABLE_HEADERS,
@@ -159,7 +159,10 @@ export const BackendTable: React.FC<BackendTableProps> = ({
                     <TableHeader>
                       <TableRow>
                         {BACKEND_TABLE_HEADERS.map((header) => (
-                          <TableHead key={header} className={header === "Actions" ? "text-right" : ""}>
+                          <TableHead
+                            key={header}
+                            className={header === "Actions" ? "text-right" : ""}
+                          >
                             {header}
                           </TableHead>
                         ))}
@@ -309,7 +312,7 @@ export const AddBackendDialog: React.FC<AddBackendDialogProps> = ({
                   Server,
                   Globe,
                 }[icon];
-                
+
                 return (
                   <Button
                     key={value}
@@ -416,7 +419,7 @@ export const AddBackendDialog: React.FC<AddBackendDialogProps> = ({
 
           {/* MCP Backend Configuration */}
           {selectedBackendType === "mcp" && (
-            <McpBackendForm 
+            <McpBackendForm
               backendForm={backendForm}
               addMcpTarget={addMcpTarget}
               removeMcpTarget={removeMcpTarget}
@@ -484,9 +487,7 @@ const ServiceBackendForm: React.FC<ServiceBackendFormProps> = ({ backendForm, se
         <Input
           id="service-hostname"
           value={backendForm.serviceHostname}
-          onChange={(e) =>
-            setBackendForm((prev) => ({ ...prev, serviceHostname: e.target.value }))
-          }
+          onChange={(e) => setBackendForm((prev) => ({ ...prev, serviceHostname: e.target.value }))}
           placeholder="my-service"
         />
       </div>
@@ -499,9 +500,7 @@ const ServiceBackendForm: React.FC<ServiceBackendFormProps> = ({ backendForm, se
         min="0"
         max="65535"
         value={backendForm.servicePort}
-        onChange={(e) =>
-          setBackendForm((prev) => ({ ...prev, servicePort: e.target.value }))
-        }
+        onChange={(e) => setBackendForm((prev) => ({ ...prev, servicePort: e.target.value }))}
         placeholder="80"
       />
     </div>
@@ -538,9 +537,7 @@ const HostBackendForm: React.FC<HostBackendFormProps> = ({ backendForm, setBacke
         <Input
           id="host-address"
           value={backendForm.hostAddress}
-          onChange={(e) =>
-            setBackendForm((prev) => ({ ...prev, hostAddress: e.target.value }))
-          }
+          onChange={(e) => setBackendForm((prev) => ({ ...prev, hostAddress: e.target.value }))}
           placeholder="192.168.1.100:8080"
         />
       </div>
@@ -551,9 +548,7 @@ const HostBackendForm: React.FC<HostBackendFormProps> = ({ backendForm, setBacke
           <Input
             id="host-hostname"
             value={backendForm.hostHostname}
-            onChange={(e) =>
-              setBackendForm((prev) => ({ ...prev, hostHostname: e.target.value }))
-            }
+            onChange={(e) => setBackendForm((prev) => ({ ...prev, hostHostname: e.target.value }))}
             placeholder="example.com"
           />
         </div>
@@ -565,9 +560,7 @@ const HostBackendForm: React.FC<HostBackendFormProps> = ({ backendForm, setBacke
             min="0"
             max="65535"
             value={backendForm.hostPort}
-            onChange={(e) =>
-              setBackendForm((prev) => ({ ...prev, hostPort: e.target.value }))
-            }
+            onChange={(e) => setBackendForm((prev) => ({ ...prev, hostPort: e.target.value }))}
             placeholder="8080"
           />
         </div>
@@ -749,9 +742,7 @@ const AiBackendForm: React.FC<AiBackendFormProps> = ({ backendForm, setBackendFo
             key={value}
             type="button"
             variant={backendForm.aiProvider === value ? "default" : "outline"}
-            onClick={() =>
-              setBackendForm((prev) => ({ ...prev, aiProvider: value as any }))
-            }
+            onClick={() => setBackendForm((prev) => ({ ...prev, aiProvider: value as any }))}
             className="text-sm"
           >
             {label}
@@ -768,9 +759,7 @@ const AiBackendForm: React.FC<AiBackendFormProps> = ({ backendForm, setBackendFo
         <Input
           id="ai-model"
           value={backendForm.aiModel}
-          onChange={(e) =>
-            setBackendForm((prev) => ({ ...prev, aiModel: e.target.value }))
-          }
+          onChange={(e) => setBackendForm((prev) => ({ ...prev, aiModel: e.target.value }))}
           placeholder={AI_MODEL_PLACEHOLDERS[backendForm.aiProvider]}
         />
       </div>
@@ -783,9 +772,7 @@ const AiBackendForm: React.FC<AiBackendFormProps> = ({ backendForm, setBackendFo
           <Input
             id="ai-region"
             value={backendForm.aiRegion}
-            onChange={(e) =>
-              setBackendForm((prev) => ({ ...prev, aiRegion: e.target.value }))
-            }
+            onChange={(e) => setBackendForm((prev) => ({ ...prev, aiRegion: e.target.value }))}
             placeholder={AI_REGION_PLACEHOLDERS[backendForm.aiProvider]}
           />
         </div>
@@ -798,9 +785,7 @@ const AiBackendForm: React.FC<AiBackendFormProps> = ({ backendForm, setBackendFo
         <Input
           id="ai-project-id"
           value={backendForm.aiProjectId}
-          onChange={(e) =>
-            setBackendForm((prev) => ({ ...prev, aiProjectId: e.target.value }))
-          }
+          onChange={(e) => setBackendForm((prev) => ({ ...prev, aiProjectId: e.target.value }))}
           placeholder="my-gcp-project"
         />
       </div>
@@ -833,9 +818,7 @@ const AiBackendForm: React.FC<AiBackendFormProps> = ({ backendForm, setBackendFo
           <Input
             id="ai-host-address"
             value={backendForm.aiHostAddress}
-            onChange={(e) =>
-              setBackendForm((prev) => ({ ...prev, aiHostAddress: e.target.value }))
-            }
+            onChange={(e) => setBackendForm((prev) => ({ ...prev, aiHostAddress: e.target.value }))}
             placeholder="api.custom-ai-provider.com:443"
           />
         </div>
@@ -862,9 +845,7 @@ const AiBackendForm: React.FC<AiBackendFormProps> = ({ backendForm, setBackendFo
               min="1"
               max="65535"
               value={backendForm.aiHostPort}
-              onChange={(e) =>
-                setBackendForm((prev) => ({ ...prev, aiHostPort: e.target.value }))
-              }
+              onChange={(e) => setBackendForm((prev) => ({ ...prev, aiHostPort: e.target.value }))}
               placeholder="443"
             />
           </div>
@@ -872,4 +853,4 @@ const AiBackendForm: React.FC<AiBackendFormProps> = ({ backendForm, setBackendFo
       )}
     </div>
   </div>
-); 
+);

--- a/ui/src/components/policy-config.tsx
+++ b/ui/src/components/policy-config.tsx
@@ -77,8 +77,6 @@ interface PolicyDialogState {
   data: any;
 }
 
-
-
 export function PolicyConfig() {
   const { refreshListeners } = useServer();
   const [binds, setBinds] = useState<Bind[]>([]);
@@ -282,8 +280,6 @@ export function PolicyConfig() {
       setIsSubmitting(false);
     }
   };
-
-
 
   const getRoutesByBind = () => {
     const routesByBind = new Map<number, RouteWithContext[]>();

--- a/ui/src/components/policy/form-renderers.tsx
+++ b/ui/src/components/policy/form-renderers.tsx
@@ -49,7 +49,7 @@ export function renderJwtAuthForm({ data, onChange }: FormRendererProps) {
         <Label htmlFor="jwks">JWKS URL or File Path *</Label>
         <Input
           id="jwks"
-          value={data.jwks || ""}
+          value={typeof data.jwks === "object" ? data.jwks.file : data.jwks || ""}
           onChange={(e) => onChange({ ...data, jwks: e.target.value })}
           placeholder="https://example.auth0.com/.well-known/jwks.json"
         />

--- a/ui/src/components/route-config.tsx
+++ b/ui/src/components/route-config.tsx
@@ -3,18 +3,18 @@
 import { useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { Plus, Route } from "lucide-react";
-import { 
-  useRouteData, 
-  useRouteFormState, 
-  useRouteDialogs, 
-  useRouteOperations 
+import {
+  useRouteData,
+  useRouteFormState,
+  useRouteDialogs,
+  useRouteOperations,
 } from "@/lib/route-hooks";
 import { populateEditForm, populateTcpEditForm } from "@/lib/route-utils";
-import { 
-  RouteTable, 
-  AddRouteDialog, 
-  EditRouteDialog, 
-  EditTcpRouteDialog 
+import {
+  RouteTable,
+  AddRouteDialog,
+  EditRouteDialog,
+  EditTcpRouteDialog,
 } from "@/components/route/route-components";
 
 export function RouteConfig() {
@@ -53,14 +53,8 @@ export function RouteConfig() {
     closeAllDialogs,
   } = useRouteDialogs();
 
-  const {
-    isSubmitting,
-    addRoute,
-    editRoute,
-    editTcpRoute,
-    deleteRoute,
-    deleteTcpRoute,
-  } = useRouteOperations();
+  const { isSubmitting, addRoute, editRoute, editTcpRoute, deleteRoute, deleteTcpRoute } =
+    useRouteOperations();
 
   // Load routes on component mount
   useEffect(() => {
@@ -70,69 +64,56 @@ export function RouteConfig() {
   // Event handlers
   const handleAddRoute = async () => {
     if (!selectedListener) return;
-    
-    await addRoute(
-      selectedListener,
-      routeForm,
-      tcpRouteForm,
-      () => {
-        loadRoutes();
-        resetRouteForm();
-        setIsAddRouteDialogOpen(false);
-      }
-    );
+
+    await addRoute(selectedListener, routeForm, tcpRouteForm, () => {
+      loadRoutes();
+      resetRouteForm();
+      setIsAddRouteDialogOpen(false);
+    });
   };
 
   const handleEditRoute = async () => {
     if (!editingRoute) return;
-    
-    await editRoute(
-      editingRoute,
-      routeForm,
-      () => {
-        loadRoutes();
-        resetRouteForm();
-        setEditingRoute(null);
-        setIsEditRouteDialogOpen(false);
-      }
-    );
+
+    await editRoute(editingRoute, routeForm, () => {
+      loadRoutes();
+      resetRouteForm();
+      setEditingRoute(null);
+      setIsEditRouteDialogOpen(false);
+    });
   };
 
   const handleEditTcpRoute = async () => {
     if (!editingTcpRoute) return;
-    
-    await editTcpRoute(
-      editingTcpRoute,
-      tcpRouteForm,
-      () => {
-        loadRoutes();
-        resetRouteForm();
-        setEditingTcpRoute(null);
-        setIsEditTcpRouteDialogOpen(false);
-      }
-    );
+
+    await editTcpRoute(editingTcpRoute, tcpRouteForm, () => {
+      loadRoutes();
+      resetRouteForm();
+      setEditingTcpRoute(null);
+      setIsEditTcpRouteDialogOpen(false);
+    });
   };
 
-  const handleDeleteRoute = async (routeContext: typeof routes[0]) => {
+  const handleDeleteRoute = async (routeContext: (typeof routes)[0]) => {
     await deleteRoute(routeContext, () => {
       loadRoutes();
     });
   };
 
-  const handleDeleteTcpRoute = async (tcpRouteContext: typeof tcpRoutes[0]) => {
+  const handleDeleteTcpRoute = async (tcpRouteContext: (typeof tcpRoutes)[0]) => {
     await deleteTcpRoute(tcpRouteContext, () => {
       loadRoutes();
     });
   };
 
-  const handleEditRouteClick = (routeContext: typeof routes[0]) => {
+  const handleEditRouteClick = (routeContext: (typeof routes)[0]) => {
     setEditingRoute(routeContext);
     const formData = populateEditForm(routeContext.route);
     setRouteForm(formData);
     setIsEditRouteDialogOpen(true);
   };
 
-  const handleEditTcpRouteClick = (tcpRouteContext: typeof tcpRoutes[0]) => {
+  const handleEditTcpRouteClick = (tcpRouteContext: (typeof tcpRoutes)[0]) => {
     setEditingTcpRoute(tcpRouteContext);
     const formData = populateTcpEditForm(tcpRouteContext.route);
     setTcpRouteForm(formData);

--- a/ui/src/components/route/route-components.tsx
+++ b/ui/src/components/route/route-components.tsx
@@ -39,23 +39,19 @@ import {
   Network,
 } from "lucide-react";
 import { Route as RouteType, TcpRoute, Listener, Bind } from "@/lib/types";
-import { 
-  CombinedRouteWithContext, 
-  RouteWithContext, 
-  TcpRouteWithContext 
-} from "@/lib/route-hooks";
-import { 
-  DEFAULT_HTTP_ROUTE_FORM, 
-  DEFAULT_TCP_ROUTE_FORM, 
+import { CombinedRouteWithContext, RouteWithContext, TcpRouteWithContext } from "@/lib/route-hooks";
+import {
+  DEFAULT_HTTP_ROUTE_FORM,
+  DEFAULT_TCP_ROUTE_FORM,
   PATH_MATCH_TYPES,
   ROUTE_TABLE_HEADERS,
-  ROUTE_TYPE_CONFIGS 
+  ROUTE_TYPE_CONFIGS,
 } from "@/lib/route-constants";
-import { 
-  isTcpListener, 
-  getPathDisplayString, 
-  populateEditForm, 
-  populateTcpEditForm 
+import {
+  isTcpListener,
+  getPathDisplayString,
+  populateEditForm,
+  populateTcpEditForm,
 } from "@/lib/route-utils";
 
 interface RouteTableProps {
@@ -139,7 +135,10 @@ export const RouteTable: React.FC<RouteTableProps> = ({
                     <TableHeader>
                       <TableRow>
                         {ROUTE_TABLE_HEADERS.map((header) => (
-                          <TableHead key={header} className={header === "Actions" ? "text-right" : ""}>
+                          <TableHead
+                            key={header}
+                            className={header === "Actions" ? "text-right" : ""}
+                          >
                             {header}
                           </TableHead>
                         ))}
@@ -287,7 +286,9 @@ interface AddRouteDialogProps {
   tcpRouteForm: typeof DEFAULT_TCP_ROUTE_FORM;
   setTcpRouteForm: React.Dispatch<React.SetStateAction<typeof DEFAULT_TCP_ROUTE_FORM>>;
   selectedListener: { listener: Listener; bind: Bind } | null;
-  setSelectedListener: React.Dispatch<React.SetStateAction<{ listener: Listener; bind: Bind } | null>>;
+  setSelectedListener: React.Dispatch<
+    React.SetStateAction<{ listener: Listener; bind: Bind } | null>
+  >;
   availableListeners: { listener: Listener; bind: Bind }[];
   onAddRoute: () => void;
   onCancel: () => void;
@@ -439,7 +440,10 @@ export const AddRouteDialog: React.FC<AddRouteDialogProps> = ({
                   <Select
                     value={routeForm.pathType}
                     onValueChange={(value) =>
-                      setRouteForm((prev) => ({ ...prev, pathType: value as keyof typeof PATH_MATCH_TYPES }))
+                      setRouteForm((prev) => ({
+                        ...prev,
+                        pathType: value as keyof typeof PATH_MATCH_TYPES,
+                      }))
                     }
                   >
                     <SelectTrigger>
@@ -455,9 +459,7 @@ export const AddRouteDialog: React.FC<AddRouteDialogProps> = ({
                   </Select>
                 </div>
                 <div className="space-y-2">
-                  <Label htmlFor="path-value">
-                    {PATH_MATCH_TYPES[routeForm.pathType]}
-                  </Label>
+                  <Label htmlFor="path-value">{PATH_MATCH_TYPES[routeForm.pathType]}</Label>
                   <Input
                     id="path-value"
                     value={routeForm.pathPrefix}
@@ -486,9 +488,7 @@ export const AddRouteDialog: React.FC<AddRouteDialogProps> = ({
                   <Input
                     id="methods"
                     value={routeForm.methods}
-                    onChange={(e) =>
-                      setRouteForm((prev) => ({ ...prev, methods: e.target.value }))
-                    }
+                    onChange={(e) => setRouteForm((prev) => ({ ...prev, methods: e.target.value }))}
                     placeholder="GET, POST, PUT"
                   />
                 </div>
@@ -627,7 +627,10 @@ export const EditRouteDialog: React.FC<EditRouteDialogProps> = ({
               <Select
                 value={routeForm.pathType}
                 onValueChange={(value) =>
-                  setRouteForm((prev) => ({ ...prev, pathType: value as keyof typeof PATH_MATCH_TYPES }))
+                  setRouteForm((prev) => ({
+                    ...prev,
+                    pathType: value as keyof typeof PATH_MATCH_TYPES,
+                  }))
                 }
               >
                 <SelectTrigger>
@@ -643,15 +646,11 @@ export const EditRouteDialog: React.FC<EditRouteDialogProps> = ({
               </Select>
             </div>
             <div className="space-y-2">
-              <Label htmlFor="edit-path-value">
-                {PATH_MATCH_TYPES[routeForm.pathType]}
-              </Label>
+              <Label htmlFor="edit-path-value">{PATH_MATCH_TYPES[routeForm.pathType]}</Label>
               <Input
                 id="edit-path-value"
                 value={routeForm.pathPrefix}
-                onChange={(e) =>
-                  setRouteForm((prev) => ({ ...prev, pathPrefix: e.target.value }))
-                }
+                onChange={(e) => setRouteForm((prev) => ({ ...prev, pathPrefix: e.target.value }))}
                 placeholder={routeForm.pathType === "regex" ? "^/api/.*" : "/"}
               />
             </div>
@@ -683,9 +682,7 @@ export const EditRouteDialog: React.FC<EditRouteDialogProps> = ({
               <Input
                 id="edit-query-params"
                 value={routeForm.queryParams}
-                onChange={(e) =>
-                  setRouteForm((prev) => ({ ...prev, queryParams: e.target.value }))
-                }
+                onChange={(e) => setRouteForm((prev) => ({ ...prev, queryParams: e.target.value }))}
                 placeholder="version=v1, type=json"
               />
             </div>
@@ -751,9 +748,7 @@ export const EditTcpRouteDialog: React.FC<EditTcpRouteDialogProps> = ({
               <Input
                 id="edit-tcp-rule-name"
                 value={tcpRouteForm.ruleName}
-                onChange={(e) =>
-                  setTcpRouteForm((prev) => ({ ...prev, ruleName: e.target.value }))
-                }
+                onChange={(e) => setTcpRouteForm((prev) => ({ ...prev, ruleName: e.target.value }))}
                 placeholder="tcp-rule-1"
               />
             </div>
@@ -779,9 +774,7 @@ export const EditTcpRouteDialog: React.FC<EditTcpRouteDialogProps> = ({
             <Input
               id="edit-tcp-hostnames"
               value={tcpRouteForm.hostnames}
-              onChange={(e) =>
-                setTcpRouteForm((prev) => ({ ...prev, hostnames: e.target.value }))
-              }
+              onChange={(e) => setTcpRouteForm((prev) => ({ ...prev, hostnames: e.target.value }))}
               placeholder="example.com, *.example.com"
             />
             <p className="text-xs text-muted-foreground">Leave empty to match all hostnames</p>
@@ -793,8 +786,8 @@ export const EditTcpRouteDialog: React.FC<EditTcpRouteDialogProps> = ({
               <span className="text-sm font-medium">TCP Route Configuration</span>
             </div>
             <p className="text-sm text-muted-foreground">
-              TCP routes are simpler than HTTP routes. They only support hostname-based routing
-              and don&apos;t have path matching, headers, or query parameters.
+              TCP routes are simpler than HTTP routes. They only support hostname-based routing and
+              don&apos;t have path matching, headers, or query parameters.
             </p>
           </div>
         </div>
@@ -811,4 +804,4 @@ export const EditTcpRouteDialog: React.FC<EditTcpRouteDialogProps> = ({
       </DialogContent>
     </Dialog>
   );
-}; 
+};

--- a/ui/src/lib/backend-constants.ts
+++ b/ui/src/lib/backend-constants.ts
@@ -104,4 +104,4 @@ export const AI_MODEL_PLACEHOLDERS = {
 export const AI_REGION_PLACEHOLDERS = {
   vertex: "us-central1",
   bedrock: "us-east-1",
-} as const; 
+} as const;

--- a/ui/src/lib/backend-hooks.ts
+++ b/ui/src/lib/backend-hooks.ts
@@ -3,10 +3,7 @@ import { Backend, Route, Listener, Bind } from "@/lib/types";
 import { fetchConfig, updateConfig } from "@/lib/api";
 import { useServer } from "@/lib/server-context";
 import { toast } from "sonner";
-import { 
-  DEFAULT_BACKEND_FORM, 
-  DEFAULT_MCP_TARGET 
-} from "./backend-constants";
+import { DEFAULT_BACKEND_FORM, DEFAULT_MCP_TARGET } from "./backend-constants";
 import {
   getBackendType,
   populateFormFromBackend,
@@ -106,7 +103,7 @@ export const useBackendFormState = () => {
     const { backend, bind, listener, routeIndex } = backendContext;
     const backendType = getBackendType(backend);
     const formData = populateFormFromBackend(backend, bind, listener, routeIndex);
-    
+
     setSelectedBackendType(backendType);
     setBackendForm(formData);
   };
@@ -137,7 +134,7 @@ export const useBackendFormState = () => {
 
   const parseAndUpdateUrl = (index: number, url: string) => {
     const { host, port, path } = parseUrl(url);
-    
+
     setBackendForm((prev) => ({
       ...prev,
       mcpTargets: prev.mcpTargets.map((target, i) =>
@@ -225,9 +222,7 @@ export const useBackendOperations = () => {
       const config = await fetchConfig();
 
       // Use editing backend's route info or form values
-      const bindPort = editingBackend
-        ? editingBackend.bind.port
-        : parseInt(form.selectedBindPort);
+      const bindPort = editingBackend ? editingBackend.bind.port : parseInt(form.selectedBindPort);
       const routeIndex = editingBackend
         ? editingBackend.routeIndex
         : parseInt(form.selectedRouteIndex);
@@ -262,9 +257,7 @@ export const useBackendOperations = () => {
           route.backends[editingBackend.backendIndex] = newBackend;
         }
 
-        toast.success(
-          `${backendType.toUpperCase()} backend "${form.name}" updated successfully`
-        );
+        toast.success(`${backendType.toUpperCase()} backend "${form.name}" updated successfully`);
       } else {
         // Add new backend
         if (!config.binds[bindIndex].listeners[listenerIndex].routes![routeIndex].backends) {
@@ -274,9 +267,7 @@ export const useBackendOperations = () => {
           newBackend
         );
 
-        toast.success(
-          `${backendType.toUpperCase()} backend "${form.name}" added successfully`
-        );
+        toast.success(`${backendType.toUpperCase()} backend "${form.name}" added successfully`);
       }
 
       // Update the configuration
@@ -291,10 +282,7 @@ export const useBackendOperations = () => {
     }
   };
 
-  const deleteBackend = async (
-    backendContext: BackendWithContext,
-    onSuccess: () => void
-  ) => {
+  const deleteBackend = async (backendContext: BackendWithContext, onSuccess: () => void) => {
     setIsSubmitting(true);
     try {
       const config = await fetchConfig();
@@ -326,4 +314,4 @@ export const useBackendOperations = () => {
     addBackend,
     deleteBackend,
   };
-}; 
+};

--- a/ui/src/lib/backend-utils.ts
+++ b/ui/src/lib/backend-utils.ts
@@ -82,7 +82,9 @@ export const getBackendName = (backend: Backend): string => {
 
 // Get backend type color
 export const getBackendTypeColor = (type: string): string => {
-  return BACKEND_TYPE_COLORS[type as keyof typeof BACKEND_TYPE_COLORS] || BACKEND_TYPE_COLORS.default;
+  return (
+    BACKEND_TYPE_COLORS[type as keyof typeof BACKEND_TYPE_COLORS] || BACKEND_TYPE_COLORS.default
+  );
 };
 
 // Get backend details for table display
@@ -159,11 +161,14 @@ export const getBackendDetails = (backend: Backend): { primary: string; secondar
     return { primary: "Dynamic routing" };
   }
 
-  return { primary: ""   };
+  return { primary: "" };
 };
 
 // Form validation functions
-export const validateCommonFields = (form: typeof DEFAULT_BACKEND_FORM, editingBackend?: boolean): boolean => {
+export const validateCommonFields = (
+  form: typeof DEFAULT_BACKEND_FORM,
+  editingBackend?: boolean
+): boolean => {
   if (!form.name.trim()) return false;
   // Only validate route selection when adding (not editing)
   if (!editingBackend && (!form.selectedBindPort || !form.selectedRouteIndex)) return false;
@@ -176,11 +181,7 @@ export const validateCommonFields = (form: typeof DEFAULT_BACKEND_FORM, editingB
 };
 
 export const validateServiceBackend = (form: typeof DEFAULT_BACKEND_FORM): boolean => {
-  return !!(
-    form.serviceNamespace.trim() &&
-    form.serviceHostname.trim() &&
-    form.servicePort.trim()
-  );
+  return !!(form.serviceNamespace.trim() && form.serviceHostname.trim() && form.servicePort.trim());
 };
 
 export const validateHostBackend = (form: typeof DEFAULT_BACKEND_FORM): boolean => {
@@ -206,10 +207,8 @@ export const validateMcpBackend = (form: typeof DEFAULT_BACKEND_FORM): boolean =
 
 export const validateAiBackend = (form: typeof DEFAULT_BACKEND_FORM): boolean => {
   if (form.aiProvider === "vertex" && !form.aiProjectId.trim()) return false;
-  if (
-    form.aiProvider === "bedrock" &&
-    (!form.aiModel.trim() || !form.aiRegion.trim())
-  ) return false;
+  if (form.aiProvider === "bedrock" && (!form.aiModel.trim() || !form.aiRegion.trim()))
+    return false;
   return true;
 };
 
@@ -242,7 +241,10 @@ export const addWeightIfNeeded = (backend: any, weight: number): any => {
   return backend;
 };
 
-export const createServiceBackend = (form: typeof DEFAULT_BACKEND_FORM, weight: number): Backend => {
+export const createServiceBackend = (
+  form: typeof DEFAULT_BACKEND_FORM,
+  weight: number
+): Backend => {
   return addWeightIfNeeded(
     {
       service: {
@@ -559,9 +561,7 @@ export const populateFormFromBackend = (
     aiProvider: backend.ai?.provider ? (Object.keys(backend.ai.provider)[0] as any) : "openAI",
     aiModel: backend.ai?.provider ? Object.values(backend.ai.provider)[0]?.model || "" : "",
     aiRegion: backend.ai?.provider ? Object.values(backend.ai.provider)[0]?.region || "" : "",
-    aiProjectId: backend.ai?.provider
-      ? Object.values(backend.ai.provider)[0]?.projectId || ""
-      : "",
+    aiProjectId: backend.ai?.provider ? Object.values(backend.ai.provider)[0]?.projectId || "" : "",
     aiHostOverrideType: backend.ai?.hostOverride?.Address
       ? "address"
       : backend.ai?.hostOverride?.Hostname

--- a/ui/src/lib/policy-constants.ts
+++ b/ui/src/lib/policy-constants.ts
@@ -140,4 +140,4 @@ export const POLICY_TYPES: Record<PolicyType, PolicyTypeInfo> = {
     description: "AI/LLM policy configuration",
     httpOnly: true,
   },
-}; 
+};

--- a/ui/src/lib/policy-defaults.ts
+++ b/ui/src/lib/policy-defaults.ts
@@ -96,4 +96,4 @@ export function getDefaultPolicyData(type: PolicyType) {
     default:
       return {};
   }
-} 
+}

--- a/ui/src/lib/route-constants.ts
+++ b/ui/src/lib/route-constants.ts
@@ -25,12 +25,12 @@ export const PATH_MATCH_TYPES = {
 
 export const ROUTE_TABLE_HEADERS = [
   "Name",
-  "Type", 
+  "Type",
   "Listener",
   "Hostnames",
   "Path",
   "Backends",
-  "Actions"
+  "Actions",
 ] as const;
 
 export const ROUTE_TYPE_CONFIGS = {
@@ -40,8 +40,8 @@ export const ROUTE_TYPE_CONFIGS = {
     icon: "Globe",
   },
   tcp: {
-    label: "TCP", 
+    label: "TCP",
     color: "bg-blue-500 hover:bg-blue-600 text-white",
     icon: "Server",
   },
-} as const; 
+} as const;

--- a/ui/src/lib/route-hooks.ts
+++ b/ui/src/lib/route-hooks.ts
@@ -3,10 +3,7 @@ import { Route as RouteType, TcpRoute, Listener, Bind } from "@/lib/types";
 import { fetchBinds, updateConfig, fetchConfig } from "@/lib/api";
 import { useServer } from "@/lib/server-context";
 import { toast } from "sonner";
-import { 
-  DEFAULT_HTTP_ROUTE_FORM, 
-  DEFAULT_TCP_ROUTE_FORM 
-} from "./route-constants";
+import { DEFAULT_HTTP_ROUTE_FORM, DEFAULT_TCP_ROUTE_FORM } from "./route-constants";
 import {
   isTcpListener,
   buildMatch,
@@ -331,10 +328,7 @@ export const useRouteOperations = () => {
     }
   };
 
-  const deleteRoute = async (
-    routeContext: RouteWithContext,
-    onSuccess: () => void
-  ) => {
+  const deleteRoute = async (routeContext: RouteWithContext, onSuccess: () => void) => {
     setIsSubmitting(true);
     try {
       const config = await fetchConfig();
@@ -360,10 +354,7 @@ export const useRouteOperations = () => {
     }
   };
 
-  const deleteTcpRoute = async (
-    tcpRouteContext: TcpRouteWithContext,
-    onSuccess: () => void
-  ) => {
+  const deleteTcpRoute = async (tcpRouteContext: TcpRouteWithContext, onSuccess: () => void) => {
     setIsSubmitting(true);
     try {
       const config = await fetchConfig();
@@ -397,4 +388,4 @@ export const useRouteOperations = () => {
     deleteRoute,
     deleteTcpRoute,
   };
-}; 
+};

--- a/ui/src/lib/route-utils.ts
+++ b/ui/src/lib/route-utils.ts
@@ -75,8 +75,7 @@ export const populateEditForm = (route: RouteType): typeof DEFAULT_HTTP_ROUTE_FO
           : "pathPrefix",
     headers: firstMatch?.headers?.map((h) => `${h.name}:${h.value.exact || ""}`).join(", ") || "",
     methods: firstMatch?.method?.method || "",
-    queryParams:
-      firstMatch?.query?.map((q) => `${q.name}=${q.value.exact || ""}`).join(", ") || "",
+    queryParams: firstMatch?.query?.map((q) => `${q.name}=${q.value.exact || ""}`).join(", ") || "",
   };
 };
 
@@ -99,7 +98,7 @@ export const getPathDisplayString = (match: Match): string => {
 
 // Get route type label
 export const getRouteTypeLabel = (route: RouteType | TcpRoute): string => {
-  return 'matches' in route ? 'HTTP' : 'TCP';
+  return "matches" in route ? "HTTP" : "TCP";
 };
 
 // Create new HTTP route object
@@ -120,9 +119,7 @@ export const createHttpRoute = (
 };
 
 // Create new TCP route object
-export const createTcpRoute = (
-  tcpRouteForm: typeof DEFAULT_TCP_ROUTE_FORM
-): TcpRoute => {
+export const createTcpRoute = (tcpRouteForm: typeof DEFAULT_TCP_ROUTE_FORM): TcpRoute => {
   const newTcpRoute: TcpRoute = {
     hostnames: parseStringArray(tcpRouteForm.hostnames),
     backends: [],
@@ -166,4 +163,4 @@ export const updateTcpRoute = (
   if (tcpRouteForm.ruleName) updatedTcpRoute.ruleName = tcpRouteForm.ruleName;
 
   return updatedTcpRoute;
-}; 
+};


### PR DESCRIPTION
- Pull in the latest lint fixes from running `npm run build`
- Correct the port that the UI runs on by default in the docs 
- Fix a bug where a jwks filepath was previously rendered as [object Object] in the UI