### PR TITLE
feat: support ADMIN_ADDR env var

### DIFF
--- a/crates/agentgateway/src/lib.rs
+++ b/crates/agentgateway/src/lib.rs
@@ -73,6 +73,9 @@ pub struct RawConfig {
 	cluster_id: Option<String>,
 	network: Option<String>,
 
+	// Admin UI address in the format "ip:port"
+	admin_addr: Option<String>,
+
 	auth_token: Option<String>,
 
 	connection_termination_deadline: Option<Duration>,


### PR DESCRIPTION
This allows containers to bind to `0.0.0.0` to access admin dashboard.