### PR TITLE
Fixes around usage of HTTP2

### DIFF
--- a/crates/agentgateway/src/mcp/relay/pool.rs
+++ b/crates/agentgateway/src/mcp/relay/pool.rs
@@ -174,7 +174,6 @@ impl ConnectionPool {
 				let url = format!("http://{}:{}{}", mcp.host, mcp.port, path);
 				let client =
 					ClientWrapper::new_with_client(self.client.clone(), target.backend_policies.clone());
-				let client = reqwest::Client::new();
 				let mut transport = StreamableHttpClientTransport::with_client(
 					client,
 					StreamableHttpClientTransportConfig {

--- a/crates/agentgateway/src/mcp/sse.rs
+++ b/crates/agentgateway/src/mcp/sse.rs
@@ -110,7 +110,7 @@ impl App {
 				.targets
 				.iter()
 				.map(|t| {
-					let backend_policies = binds.backend_policies(PolicyTarget::Backend(t.name.clone()));
+					let backend_policies = binds.backend_policies(PolicyTarget::Backend(name.clone()));
 					Arc::new(McpTarget {
 						name: t.name.clone(),
 						spec: t.spec.clone(),


### PR DESCRIPTION
When we use HTTP2, we add the port to the authority which breaks some servers.

Also, a small fix to SSE code to use the proper client and add better logging.