### PR TITLE
adds features to implement MCP server responsibilities in agentgateway

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,6 +136,7 @@ dependencies = [
  "futures-util",
  "google-cloud-auth",
  "headers",
+ "heck 0.4.1",
  "hex",
  "hickory-resolver",
  "http 1.3.1",
@@ -1286,7 +1287,7 @@ version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -1803,7 +1804,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -2317,6 +2318,12 @@ checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
  "http 1.3.1",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -4090,7 +4097,7 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -5174,7 +5181,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "rustversion",

--- a/MCP-Authentication.md
+++ b/MCP-Authentication.md
@@ -1,0 +1,117 @@
+## **MCP Authentication API in agentgateway**
+
+### **Scenario 1: agentgateway adapts traffic for Authorization Servers**
+
+Most Authorization Servers don’t implement the standards as is, and the traffic from MCP Clients has to be adapted before it is forwarded to them.
+A quick example is Keycloak, which doesn’t expose the certs at the well-known endpoint, and that needs to be redirected to */protocol/openid-connect/certs*
+
+In this scenario agentgateway:
+
+1. Exposes protected resource metadata (on behalf of the mcp server)
+2. Proxies to the Authorization Server Metadata endpoint
+3. Proxies and adapts traffic to the Authorization Server for client registration
+4. Validates token against the AS jwks
+5. Reject traffic without an access token and set the WWW-Authentication header to the resource metadata endpoint.
+
+Config for this scenario:
+
+```yaml
+mcpAuthentication:
+ issuer: [http://localhost:7080/realms/mcp](http://localhost:7080/realms/mcp)
+ jwksUrl: http://localhost:7080/protocol/openid-connect/certs
+ provider:
+   # this is an indicator to adapt traffic for keycloak
+   # It sets the jwksUrl to the keycloak certs endpoint (and uses it for validation) an
+   # sets the issuer to the agentgateway URL, for it to adapt traffic to this provider
+   keycloak: {}
+ resourceMetadata:
+   resource: http://localhost:3000/mcp
+   scopesSupported:
+   - read:all
+   bearerMethodsSupported:
+   - header
+   - body
+   - query
+   # these two fields are optional
+   resourceDocumentation: http://localhost:3000/stdio/docs
+   resourcePolicyUri: http://localhost:3000/stdio/policies
+```
+
+### **Scenario 2: agentgateway acts solely as a resource server on behalf of MCP Servers**
+
+In this scenario agentgateway:
+
+1. Exposes protected resource metadata (on behalf of the mcp server)
+2. Validates token against the AS jwks
+3. Reject traffic without access token and set the WWW-Authentication header to the resource metadata endpoint.
+
+NOTE: The route for oauth-authorization-server is not configured.
+
+Config for this scenario:
+
+```
+mcpAuthentication:
+ # points to the external Authorization Server
+ # which handles the oauth server metadata, and everything else up to the point of using the token
+ issuer: http://localhost:9000
+ jwksUrl: http://localhost:9000/.well-known/jwks.json
+ resourceMetadata:
+   resource: http://localhost:3000/mcp
+   scopesSupported:
+   - read:all
+   bearerMethodsSupported:
+   - header
+   - body
+   - query
+   resourceDocumentation: http://localhost:3000/stdio/docs
+   resourcePolicyUri: http://localhost:3000/stdio/policies
+```
+
+## Key information:
+
+Audience and resource can be used interchangeably.
+The resource returned by the .well-known/oauth-protected-resource has to be the same as the domain the result is returned from. Meaning:
+
+If we query:
+
+```
+curl -s http://localhost:3003/.well-known/oauth-protected-resource/mcp | jq .resource
+```
+
+The value below should be returned which shows that [http://localhost:3003/mcp](http://localhost:3003/mcp) matches:
+```
+"http://localhost:3003/mcp"
+```
+
+The well known resource metadata endpoint is formed like this:
+
+If the server is accessible at [http://www.example.com](http://www.example.com), then the endpoint is:
+
+```
+[http://www.example.com](http://www.example.com)/.well-known/oauth-protected-resource
+```
+
+If the endpoint has some path e.g.
+
+```
+[http://www.example.com](http://www.example.com)/path
+```
+
+Then it is postfixed:
+
+```
+[http://www.example.com](http://www.example.com)/.well-known/oauth-protected-resource/path
+```
+
+The key audience is equal to the key resource, and it has to match the endpoint receiving traffic. Which is the location of the proxy.
+
+WWW-Authentication has to return the following information:
+```
+WWW-Authenticate: Bearer resource\_metadata="[http://localhost:3003/.well-known/oauth-protected-resource/mcp](http://localhost:3003/.well-known/oauth-protected-resource//mcp)"
+```
+
+This has the same approach of being configured postfixed with the path of the request.
+
+### **Scenario 3: agentgateway passes traffic as is to an MCP Server that already implements MCP Authorization**
+
+On this scenario, we don't need the mcpAuthentication property in those cases.

--- a/Makefile
+++ b/Makefile
@@ -77,18 +77,18 @@ generate-apis: install-go-tools
 		--go_opt=paths=source_relative \
 		./crates/agentgateway/proto/workload.proto
 
-.PHONY: run-validate-deps
-run-validate-deps:
+.PHONY: run-validation-deps
+run-validation-deps:
 	@common/scripts/manage-validation-deps.sh start
 
-.PHONY: stop-validate-deps
-stop-validate-deps:
+.PHONY: stop-validation-deps
+stop-validation-deps:
 	@common/scripts/manage-validation-deps.sh stop
 
 CONFIG_FILES := $(wildcard examples/*/config.yaml)
 
 .PHONY: validate
-validate: run-validate-deps $(CONFIG_FILES) stop-validate-deps
+validate: run-validation-deps $(CONFIG_FILES) stop-validation-deps
 
 .PHONY: $(CONFIG_FILES)
 $(CONFIG_FILES):

--- a/Makefile
+++ b/Makefile
@@ -77,11 +77,18 @@ generate-apis: install-go-tools
 		--go_opt=paths=source_relative \
 		./crates/agentgateway/proto/workload.proto
 
+.PHONY: run-validate-deps
+run-validate-deps:
+	@common/scripts/manage-validation-deps.sh start
+
+.PHONY: stop-validate-deps
+stop-validate-deps:
+	@common/scripts/manage-validation-deps.sh stop
 
 CONFIG_FILES := $(wildcard examples/*/config.yaml)
 
 .PHONY: validate
-validate: $(CONFIG_FILES)
+validate: run-validate-deps $(CONFIG_FILES) stop-validate-deps
 
 .PHONY: $(CONFIG_FILES)
 $(CONFIG_FILES):

--- a/common/scripts/manage-validation-deps.sh
+++ b/common/scripts/manage-validation-deps.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+set -euo pipefail
+
+KEYCLOAK_BASE_URL="http://localhost:7080"
+# Wait for JWKS to ensure realm import completed
+KEYCLOAK_REALM_JWKS_ENDPOINT="$KEYCLOAK_BASE_URL/realms/mcp/protocol/openid-connect/certs"
+
+wait_for_http_ok() {
+  local url="$1"
+  local timeout_seconds="${2:-120}"
+  local sleep_seconds="${3:-2}"
+
+  echo -n "Waiting for $url"
+  local start_ts
+  start_ts=$(date +%s)
+  while true; do
+    if curl -fsS "$url" >/dev/null 2>&1; then
+      echo " - OK"
+      return 0
+    fi
+
+    local now
+    now=$(date +%s)
+    if (( now - start_ts >= timeout_seconds )); then
+      echo " - TIMEOUT after ${timeout_seconds}s"
+      return 1
+    fi
+
+    echo -n "."
+    sleep "$sleep_seconds"
+  done
+}
+
+case "${1:-}" in
+  start)
+    echo "Starting MCP authentication server..."
+    python3 examples/mcp-authentication/auth_server.py &
+
+    echo "Starting Keycloak..."
+    pushd examples/mcp-authentication/keycloak >/dev/null
+    docker compose up -d
+    popd >/dev/null
+
+    # Realm import may complete after container is up; wait for JWKS specifically
+    if ! wait_for_http_ok "$KEYCLOAK_REALM_JWKS_ENDPOINT" 180 3; then
+      echo "Keycloak realm JWKS endpoint did not become available in time" >&2
+      exit 1
+    fi
+    ;;
+  stop)
+    pkill -f "examples/mcp-authentication/auth_server.py" 2>/dev/null || true
+    pushd examples/mcp-authentication/keycloak >/dev/null
+    docker compose down
+    popd >/dev/null
+    ;;
+  *)
+    echo "Usage: $0 {start|stop}"
+    exit 1
+    ;;
+esac

--- a/crates/agentgateway/Cargo.toml
+++ b/crates/agentgateway/Cargo.toml
@@ -122,6 +122,7 @@ value-bag.workspace = true
 net2 = "0.2.39"
 core_affinity = "0.8.3"
 macro_rules_attribute = "0.2.2"
+heck = "0.4"
 [build-dependencies]
 anyhow.workspace = true
 prost-build.workspace = true

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 use std::{cmp, net};
 
 use anyhow::anyhow;
+use heck::ToSnakeCase;
 use indexmap::IndexMap;
 use itertools::Itertools;
 use macro_rules_attribute::apply;
@@ -23,6 +24,8 @@ use rustls_pemfile::Item;
 use secrecy::SecretString;
 use serde::ser::SerializeMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_json::Value;
+use std::collections::BTreeMap;
 use thiserror::Error;
 
 use crate::http::auth::BackendAuth;
@@ -1072,10 +1075,45 @@ pub struct McpAuthorization(RuleSet);
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 pub struct ResourceMetadata {
 	pub resource: String,
-	pub scopes_supported: Vec<String>,
-	pub bearer_methods_supported: Vec<String>,
-	pub resource_documentation: Option<String>,
-	pub resource_policy_uri: Option<String>,
+	#[serde(flatten)]
+	pub extra: BTreeMap<String, Value>,
+}
+
+impl ResourceMetadata {
+	/// Build RFC-compliant JSON for the protected resource metadata.
+	///
+	/// - Enforces computed `resource` and `authorization_servers`.
+	/// - Converts any additional config keys from camelCase to snake_case.
+	/// - Adds MCP-specific fields used by the gateway.
+	pub fn to_rfc_json(&self, resource_uri: String, issuer: String) -> Value {
+		let mut map = serde_json::Map::new();
+
+		// Copy user-provided extra keys, converting to snake_case, while preventing overrides
+		// of fields we compute.
+		for (key, value) in &self.extra {
+			let snake = key.to_snake_case();
+			if snake == "resource" || snake == "authorization_servers" {
+				continue;
+			}
+			map.insert(snake, value.clone());
+		}
+
+		// Computed fields
+		map.insert("resource".into(), Value::String(resource_uri));
+		map.insert(
+			"authorization_servers".into(),
+			Value::Array(vec![Value::String(issuer)]),
+		);
+
+		// MCP-specific additions
+		map.insert(
+			"mcp_protocol_version".into(),
+			Value::String("2025-06-18".into()),
+		);
+		map.insert("resource_type".into(), Value::String("mcp-server".into()));
+
+		Value::Object(map)
+	}
 }
 
 #[apply(schema!)]

--- a/examples/mcp-authentication/README.md
+++ b/examples/mcp-authentication/README.md
@@ -16,10 +16,10 @@ Let's look at the config to understand what's going on.
 For the demo, start Keycloak and the mock authorization server on `http://localhost:9000`:
 
 ```bash
-make run-validate-deps
+make run-validation-deps
 ```
 
-> You can stop the dependencies with the command `make stop-validate-deps`
+> You can stop the dependencies with the command `make stop-validation-deps`
 
 ---
 
@@ -174,6 +174,8 @@ Notes:
   npx @modelcontextprotocol/inspector
   ```
   Set transport to "Streamable" and URL to `http://localhost:3000/stdio/mcp` (`/remote/mcp` or `/keycloak/mcp`). 
+
+  The MCP Authorization flow starts after the initial unauthorized request. The mock server redirects back to the MCP client automatically, meanwhile for Keycloak use the credentials `testuser` and `testpass` to authenticate.
 
 ---
 

--- a/examples/mcp-authentication/README.md
+++ b/examples/mcp-authentication/README.md
@@ -1,0 +1,183 @@
+## MCP Authentication Example
+
+This example shows how to protect MCP servers with agentgateway using the MCP Authorization spec.
+
+> Note: The current MCP Authorization spec focuses on authentication; m
+
+### Running the example
+
+```bash
+cargo run -- -f examples/mcp-authentication/config.yaml
+```
+
+Let's look at the config to understand what's going on.
+
+### Demo dependencies
+For the demo, start Keycloak and the mock authorization server on `http://localhost:9000`:
+
+```bash
+make run-validate-deps
+```
+
+> You can stop the dependencies with the command `make stop-validate-deps`
+
+---
+
+### Scenario A: External Authorization Server (spec-compliant)
+
+Agentgateway acts as the resource server. Point to your Authorization Server’s issuer and JWKS, set the expected audience, and expose resource metadata. No provider adaptation is required.
+
+Taken from `examples/mcp-authentication/config.yaml`:
+
+```yaml
+- backends:
+  - mcp:
+      targets:
+      - name: everything
+        stdio:
+          cmd: npx
+          args:
+          - '@modelcontextprotocol/server-everything'
+  matches:
+  - path:
+      exact: /stdio/mcp
+  - path:
+      exact: /.well-known/oauth-protected-resource/stdio/mcp
+  policies:
+    cors:
+      allowHeaders:
+      - mcp-protocol-version
+      - content-type
+      allowOrigins:
+      - '*'
+    mcpAuthentication:
+      issuer: http://localhost:9000
+      jwksUrl: http://localhost:9000/.well-known/jwks.json
+      audience: http://localhost:3000/stdio/mcp
+      resourceMetadata:
+        resource: http://localhost:3000/stdio/mcp
+        scopesSupported:
+        - read:all
+        bearerMethodsSupported:
+        - header
+        - body
+        - query
+        resourceDocumentation: http://localhost:3000/stdio/docs
+        resourcePolicyUri: http://localhost:3000/stdio/policies
+```
+
+- Resource metadata: `GET http://localhost:3000/.well-known/oauth-protected-resource/stdio/mcp`
+- MCP server entry point: `POST/GET http://localhost:3000/stdio/mcp`
+
+Unauthenticated requests receive `401 Unauthorized` with `WWW-Authenticate` and a link to the resource metadata.
+
+---
+
+### Scenario B: Remote MCP + External Authorization Server
+
+Also in `examples/mcp-authentication/config.yaml`:
+
+```yaml
+- backends:
+  - mcp:
+      targets:
+      - name: mcpbin
+        mcp:
+          host: mcpbin.is.solo.io
+          port: 443
+          path: /remote/mcp
+  matches:
+  - path:
+      exact: /remote/mcp
+  - path:
+      exact: /.well-known/oauth-protected-resource/remote/mcp
+  policies:
+    backendTLS: {}
+    cors:
+      allowHeaders:
+      - mcp-protocol-version
+      - content-type
+      allowOrigins:
+      - '*'
+    mcpAuthentication:
+      issuer: http://localhost:9000
+      jwksUrl: http://localhost:9000/.well-known/jwks.json
+      audience: http://localhost:3000/remote/mcp
+      resourceMetadata:
+        resource: http://localhost:3000/remote/mcp
+        scopesSupported:
+        - offline_access
+        bearerMethodsSupported:
+        - header
+        - body
+        - query
+        resourceDocumentation: http://localhost:3000/remote/docs
+        resourcePolicyUri: http://localhost:3000/remote/policies
+```
+
+---
+
+### Scenario C: Adapting a vendor Authorization Server (e.g., Keycloak)
+
+When your Authorization Server doesn’t implement the spec as-is, agentgateway can adapt the required endpoints while still validating JWTs.
+
+Excerpt from `examples/mcp-authentication/config.yaml`:
+
+```yaml
+- backends:
+  - mcp:
+      targets:
+      - name: everything
+        stdio:
+          cmd: npx
+          args:
+          - '@modelcontextprotocol/server-everything'
+  matches:
+  - path: { exact: /keycloak/mcp }
+  - path: { exact: /.well-known/oauth-protected-resource/keycloak/mcp }
+  - path: { exact: /.well-known/oauth-authorization-server/keycloak/mcp }
+  - path: { exact: /.well-known/oauth-authorization-server/keycloak/mcp/client-registration }
+  - path: { exact: /realms/mcp/protocol/openid-connect/certs }
+  policies:
+    cors:
+      allowHeaders: [mcp-protocol-version, content-type]
+      allowOrigins: ['*']
+    mcpAuthentication:
+      issuer: http://localhost:7080/realms/mcp
+      jwksUrl: http://localhost:7080/realms/mcp/protocol/openid-connect/certs
+      audience: mcp_proxy
+      provider:
+        keycloak: {}
+      resourceMetadata:
+        resource: http://localhost:3000/keycloak/mcp
+        scopesSupported: [profile, offline_access, openid]
+        bearerMethodsSupported: [header, body, query]
+        resourceDocumentation: http://localhost:3000/keycloak/docs
+        resourcePolicyUri: http://localhost:3000/keycloak/policies
+```
+
+Notes:
+- Omit the `provider` block for spec-compliant servers. Use it only when adaptation is needed.
+
+---
+
+### Quick test
+
+- Without a token:
+  ```bash
+  curl -i http://localhost:3000/stdio/mcp
+  ```
+  Expect `401 Unauthorized` and a `WWW-Authenticate` header referencing the well-known resource metadata.
+
+- With MCP Inspector:
+  ```bash
+  npx @modelcontextprotocol/inspector
+  ```
+  Set transport to "Streamable" and URL to `http://localhost:3000/stdio/mcp` (`/remote/mcp` or `/keycloak/mcp`). 
+
+---
+
+### Troubleshooting
+- Ensure `issuer` and `jwksUrl` match your Authorization Server.
+- Ensure `audience` equals the resource URL clients will request.
+- Verify resource metadata is reachable at `/.well-known/oauth-protected-resource/...` and reflects the same `resource` value used in `audience`.

--- a/examples/mcp-authentication/auth_server.py
+++ b/examples/mcp-authentication/auth_server.py
@@ -1,0 +1,563 @@
+#!/usr/bin/env python3
+import json
+import base64
+import hashlib
+import hmac
+import time
+import secrets
+import urllib.parse
+import subprocess
+import os
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from urllib.parse import urlparse, parse_qs
+
+# RSA key components (generated with openssl)
+PRIVATE_KEY_PEM = """-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC8V4ETh0yKdPbJ
+dvxKfqTByeTL3b+VxUePnuYzwWFuvMFZL7oLsCyBZ/IUO9tsTtBA5XZt3Q5mVPg2
+Ljke0BrPmcoL7CFtjelfjpiRp5/HkPXabHkXa7Z7F+5ybDmjrtjG+dm7Ygy4Di2+
+rH1l9W0LcspzvJL7IZU6EaWJ9flIV3Kzom30ai7SxMDOUJiymzbPDCkIT142eXfN
+bHgjCmNf4H5O6wi3+mWzCiSHVYWgnmJDVvmxtf9WNPy3ReNZln5eFPPib2b5ylne
+BxDppTQ/p+qtQ4MCb4/9kExchDINnUxGxB05V2lC9u5tu89qCxlfnlHcdQtuZB1E
+eKMqRB5tAgMBAAECggEAFiBUlGn+eryjeocdPBY1PmP82lt2hL6cudlx0246R1Nr
+BpKGEZX0oI5I4QooLMj0i885Us5XwPtl/p1/DejmYXHAjBaFVdTIcDa1I1V1PrF/
+xJWeQztfAIaO94fR3LIvmu6i3vH1qxDVXHNwtu/2i9QER0UF4nVvTddhYnwQeWhC
+5QmL3IQFwhQ5xVI0i+KI+NCsKV10drDUoZGcu/zFia5SmdsjCQ7+Xen85yumNSmP
+ATD7WMfEL0XM21/rbhF3cFOGGDPR9dWbO5Bgfa4ol0uzUE8Q8F+y7QK1tkM8gb4/
+astNNUlQas2TE6XeMD47+LjfhrQOYxfeUtmukctp0QKBgQDrOSWLo+29eyUdm4ZF
+lyFnrBlKB+5cxUCec1cLi68eDsVI3aS/UGmJC6qhj2Irwo+VJT4iKp9uZMIM9KCI
+8veuIc82VCpKDZ2NzwW1+nc9swth85qAFqRXcRoW2Zg87T8ZmkRxjOKQILETgIzY
+lmkmtTg/YUtCR6wq/NiR8/VkPQKBgQDM+kcfRrTGl4W1Hlvn48VkIFvVcvze5AQl
+OTD8ldfslR2PZPbSp24I+IZHYzreFX5KjZwR7k8Zw/0JPZp+xLil/4rlDrnQpnbT
+c3mNVuGcsVOOFiQHNDlvRW1Mh5Y0hKqZ4WJE64GI2y9GLN4KBD0Ey+++bC5t7uiC
+wqZpjuLV8QKBgQCht5NRku2DROO6nE9PDt1/ijmExTkifNa1WTTyEiHeN2d5djCq
++1zjRKsWEh77WPMgJg+2q7kay5kCETlBjlGsXUA56Nl+Oigk87zIZR+PwsXDnRiO
+kYKBP5ghN45L7QxhzMbbjnHBh0hW0R2EVryKSTMXmAuG0QHUOCupBKGkPQKBgFbs
+i9ynj2HoP7te9HqSDNM5JbiO2s1qxJdEeZGjub2KPs7gcgtDFVaYjdkYK46ibrwO
+8XBpLwIuKtAQX8QCiItcovogFIx3C00AWzuk7GgWiuhmW0Dy1KhrOL6LgRcka3R2
+L8YqWPRAfvuzazW0NmwiT7jhB493EQLiqM962JcBAoGAN3UzRXyHCP4ViiQmpNFA
+JfQI3oIkOH7Vx67/xtRCUhBDYCKfnPs2lnXv5Pj6AugBdgF5nv1Ss0VD82iiX9+g
+4GOk+gaCXB9gSlNuBe5Z3WRjsRZAOHlKcoJyCP+hif90cs55h1AuqUuLczPCBtcI
+eInnfGNXAr7Q3p5QaAWOmJk=
+-----END PRIVATE KEY-----"""
+
+# RSA public key components for JWK
+RSA_N = "vFeBE4dMinT2yXb8Sn6kwcnky92_lcVHj57mM8FhbrzBWS-6C7AsgWfyFDvbbE7QQOV2bd0OZlT4Ni45HtAaz5nKC-whbY3pX46Ykaefx5D12mx5F2u2exfucmw5o67YxvnZu2IMuA4tvqx9ZfVtC3LKc7yS-yGVOhGlifX5SFdys6Jt9Gou0sTAzlCYsps2zwwpCE9eNnl3zWx4IwpjX-B-TusIt_plswokh1WFoJ5iQ1b5sbX_VjT8t0XjWZZ-XhTz4m9m-cpZ3gcQ6aU0P6fqrUODAm-P_ZBMXIQyDZ1MRsQdOVdpQvbubbvPagsZX55R3HULbmQdRHijKkQebQ"
+RSA_E = "AQAB"
+
+# JWK for RSA RS256
+PUBLIC_KEY_JWK = {
+    "kty": "RSA",
+    "kid": "key-1",
+    "use": "sig",
+    "alg": "RS256",
+    "n": RSA_N,
+    "e": RSA_E
+}
+
+# In-memory storage
+registered_clients = {}
+authorization_codes = {}
+tokens = {}
+
+def generate_id(prefix="", length=32):
+    """Generate a random ID with optional prefix"""
+    chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-"
+    return prefix + ''.join(secrets.choice(chars) for _ in range(length))
+
+def base64url_encode(data):
+    """Base64url encode data"""
+    if isinstance(data, str):
+        data = data.encode('utf-8')
+    return base64.urlsafe_b64encode(data).rstrip(b'=').decode('ascii')
+
+def create_jwt_with_openssl(payload):
+    """Create a JWT using openssl command for RS256 signing"""
+    # Header
+    header = {
+        "typ": "JWT",
+        "alg": "RS256",
+        "kid": "key-1"
+    }
+
+    # Encode header and payload
+    encoded_header = base64url_encode(json.dumps(header, separators=(',', ':')))
+    encoded_payload = base64url_encode(json.dumps(payload, separators=(',', ':')))
+
+    # Create the signing input
+    signing_input = f"{encoded_header}.{encoded_payload}"
+
+    # Write private key to temp file
+    with open('/tmp/jwt_private_key.pem', 'w') as f:
+        f.write(PRIVATE_KEY_PEM)
+
+    try:
+        # Use openssl to sign
+        process = subprocess.run([
+            'openssl', 'dgst', '-sha256', '-sign', '/tmp/jwt_private_key.pem'
+        ], input=signing_input.encode(), capture_output=True)
+
+        if process.returncode != 0:
+            raise Exception(f"OpenSSL signing failed: {process.stderr.decode()}")
+
+        signature = base64url_encode(process.stdout)
+        return f"{signing_input}.{signature}"
+
+    finally:
+        # Clean up temp file
+        if os.path.exists('/tmp/jwt_private_key.pem'):
+            os.remove('/tmp/jwt_private_key.pem')
+
+class AuthServerHandler(BaseHTTPRequestHandler):
+    def do_OPTIONS(self):
+        """Handle CORS preflight requests"""
+        self.send_response(200)
+        self.send_header('Access-Control-Allow-Origin', '*')
+        self.send_header('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
+        self.send_header('Access-Control-Allow-Headers', 'Content-Type, Authorization')
+        self.end_headers()
+
+    def send_json_response(self, data, status_code=200):
+        """Send a JSON response with CORS headers"""
+        self.send_response(status_code)
+        self.send_header('Content-Type', 'application/json')
+        self.send_header('Access-Control-Allow-Origin', '*')
+        self.end_headers()
+        self.wfile.write(json.dumps(data, indent=2).encode('utf-8'))
+
+    def send_redirect(self, location):
+        """Send a redirect response"""
+        self.send_response(302)
+        self.send_header('Location', location)
+        self.send_header('Access-Control-Allow-Origin', '*')
+        self.end_headers()
+
+    def send_html_response(self, html_content, status_code=200):
+        """Send an HTML response"""
+        self.send_response(status_code)
+        self.send_header('Content-Type', 'text/html; charset=utf-8')
+        self.send_header('Access-Control-Allow-Origin', '*')
+        self.end_headers()
+        self.wfile.write(html_content.encode('utf-8'))
+
+    def get_request_body(self):
+        """Get and parse request body"""
+        content_length = int(self.headers.get('Content-Length', 0))
+        if content_length > 0:
+            body = self.rfile.read(content_length).decode('utf-8')
+            if self.headers.get('Content-Type', '').startswith('application/x-www-form-urlencoded'):
+                return dict(urllib.parse.parse_qsl(body))
+            else:
+                try:
+                    return json.loads(body)
+                except:
+                    return dict(urllib.parse.parse_qsl(body))
+        return {}
+
+    def do_POST(self):
+        """Handle POST requests"""
+        path = urlparse(self.path).path
+
+        if path == '/register':
+            self.handle_register()
+        elif path == '/token':
+            self.handle_token()
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def do_GET(self):
+        """Handle GET requests"""
+        parsed_url = urlparse(self.path)
+        path = parsed_url.path
+        query_params = parse_qs(parsed_url.query)
+
+        if path == '/authorize':
+            self.handle_authorize(query_params)
+        elif path == '/.well-known/jwks.json':
+            self.handle_jwks()
+        elif path == '/.well-known/oauth-authorization-server':
+            self.handle_discovery()
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def handle_register(self):
+        """Handle client registration"""
+        try:
+            body = self.get_request_body()
+            client_id = generate_id('mcp_')
+            client_secret = generate_id('secret_')
+
+            registration = {
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "client_name": body.get("client_name", "MCP Test Client"),
+                "client_description": body.get("client_description", "A test MCP client"),
+                "client_logo_url": body.get("client_logo_url"),
+                "client_uri": body.get("client_uri"),
+                "developer_name": body.get("developer_name", "Test Developer"),
+                "developer_email": body.get("developer_email", "test@example.com"),
+                "redirect_uris": body.get("redirect_uris", ["http://localhost:6274/oauth/callback/debug"]),
+                "grant_types": ["authorization_code", "refresh_token"],
+                "response_types": ["code"],
+                "token_endpoint_auth_method": "client_secret_basic",
+                "created_at": time.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                "updated_at": time.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+            }
+
+            registered_clients[client_id] = registration
+            self.send_json_response(registration)
+
+        except Exception as e:
+            self.send_json_response({"error": "invalid_request", "error_description": str(e)}, 400)
+
+    def handle_authorize(self, query_params):
+        """Handle authorization request"""
+        try:
+            # Extract parameters (query_params values are lists)
+            response_type = query_params.get('response_type', [''])[0]
+            client_id = query_params.get('client_id', [''])[0]
+            code_challenge = query_params.get('code_challenge', [''])[0]
+            code_challenge_method = query_params.get('code_challenge_method', [''])[0]
+            redirect_uri = query_params.get('redirect_uri', [''])[0]
+            resource = query_params.get('resource', [''])[0]
+            scope = query_params.get('scope', [''])[0]
+
+            if response_type != 'code':
+                self.send_json_response({"error": "unsupported_response_type"}, 400)
+                return
+
+            # Allow the hardcoded client_id from the example
+            if client_id not in registered_clients and client_id == 'mcp_6950e6b7db0e6115a5af3a790340ad87':
+                registered_clients[client_id] = {
+                    "client_id": client_id,
+                    "redirect_uris": ["http://localhost:6274/oauth/callback/debug"]
+                }
+
+            if client_id not in registered_clients:
+                self.send_json_response({"error": "invalid_client"}, 400)
+                return
+
+            # Generate authorization code
+            code = generate_id('', 43)  # Match example length
+            code_data = {
+                "client_id": client_id,
+                "redirect_uri": redirect_uri,
+                "resource": resource,
+                "scope": scope,
+                "code_challenge": code_challenge,
+                "code_challenge_method": code_challenge_method,
+                "expires_at": time.time() + 600  # 10 minutes
+            }
+
+            authorization_codes[code] = code_data
+
+            # Build callback URL
+            callback_url = f"{redirect_uri}?code={code}"
+
+            # Show authorization consent page with countdown
+            self.show_authorization_page(client_id, callback_url)
+
+        except Exception as e:
+            self.send_json_response({"error": "server_error", "error_description": str(e)}, 500)
+
+    def show_authorization_page(self, client_id, callback_url):
+        """Show authorization consent page with countdown"""
+        html_content = f"""
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>MCP Authorization</title>
+    <style>
+        body {{
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            margin: 0;
+            padding: 0;
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }}
+        .container {{
+            background: white;
+            padding: 2rem;
+            border-radius: 12px;
+            box-shadow: 0 20px 40px rgba(0,0,0,0.1);
+            text-align: center;
+            max-width: 400px;
+            width: 90%;
+        }}
+        .logo {{
+            font-size: 2.5rem;
+            margin-bottom: 1rem;
+        }}
+        h1 {{
+            color: #333;
+            margin-bottom: 0.5rem;
+            font-size: 1.5rem;
+        }}
+        .subtitle {{
+            color: #666;
+            margin-bottom: 2rem;
+            font-size: 1rem;
+        }}
+        .client-info {{
+            background: #f8f9fa;
+            padding: 1rem;
+            border-radius: 8px;
+            margin: 1rem 0;
+            border-left: 4px solid #667eea;
+        }}
+        .countdown {{
+            font-size: 3rem;
+            font-weight: bold;
+            color: #667eea;
+            margin: 1.5rem 0;
+            font-family: 'Courier New', monospace;
+        }}
+        .status {{
+            color: #28a745;
+            font-weight: 500;
+            margin-top: 1rem;
+        }}
+        .spinner {{
+            display: inline-block;
+            width: 20px;
+            height: 20px;
+            border: 2px solid #f3f3f3;
+            border-top: 2px solid #667eea;
+            border-radius: 50%;
+            animation: spin 1s linear infinite;
+            margin-right: 8px;
+        }}
+        @keyframes spin {{
+            0% {{ transform: rotate(0deg); }}
+            100% {{ transform: rotate(360deg); }}
+        }}
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="logo">🔐</div>
+        <h1>Authorization Successful</h1>
+        <p class="subtitle">MCP Authentication Server</p>
+
+        <div class="client-info">
+            <strong>Client ID:</strong><br>
+            <code>{client_id}</code>
+        </div>
+
+        <div class="status">
+            <div class="spinner"></div>
+            Authorization granted! Redirecting in...
+        </div>
+
+        <div class="countdown" id="countdown">3</div>
+
+        <p style="color: #666; font-size: 0.9rem;">
+            You will be redirected automatically to complete the authentication flow.
+        </p>
+    </div>
+
+    <script>
+        let countdown = 3;
+        const countdownElement = document.getElementById('countdown');
+
+        const timer = setInterval(() => {{
+            countdown--;
+            countdownElement.textContent = countdown;
+
+            if (countdown <= 0) {{
+                clearInterval(timer);
+                countdownElement.textContent = '0';
+                window.location.href = '{callback_url}';
+            }}
+        }}, 1000);
+
+        // Also allow manual redirect by clicking
+        document.addEventListener('click', () => {{
+            clearInterval(timer);
+            window.location.href = '{callback_url}';
+        }});
+    </script>
+</body>
+</html>
+        """
+        self.send_html_response(html_content)
+
+    def handle_token(self):
+        """Handle token request"""
+        try:
+            body = self.get_request_body()
+            grant_type = body.get('grant_type')
+
+            if grant_type == 'authorization_code':
+                code = body.get('code')
+                redirect_uri = body.get('redirect_uri')
+                client_id = body.get('client_id')
+
+                # Check for client credentials in Authorization header (Basic auth)
+                auth_header = self.headers.get('Authorization', '')
+                if not client_id and auth_header.startswith('Basic '):
+                    try:
+                        # Decode Basic auth
+                        encoded = auth_header.split(' ', 1)[1]
+                        decoded = base64.b64decode(encoded).decode('utf-8')
+                        client_id, _ = decoded.split(':', 1)
+                    except Exception:
+                        pass
+
+                if code not in authorization_codes:
+                    self.send_json_response({"error": "invalid_grant"}, 400)
+                    return
+
+                code_data = authorization_codes[code]
+
+                if (time.time() > code_data['expires_at'] or
+                    code_data['client_id'] != client_id or
+                    code_data['redirect_uri'] != redirect_uri):
+                    self.send_json_response({"error": "invalid_grant"}, 400)
+                    return
+
+                # Clean up authorization code
+                del authorization_codes[code]
+
+                # Create tokens
+                now = int(time.time())
+                access_token_id = generate_id('access_')
+                refresh_token_id = generate_id('refresh_')
+
+                access_token_payload = {
+                    "aud": code_data.get('resource', 'http://localhost:3000/mcp'),
+                    "client_id": client_id,
+                    "exp": now + 3600,  # 1 hour
+                    "iat": now,
+                    "iss": "http://localhost:9000",
+                    "jti": access_token_id,
+                    "resource": code_data.get('resource', 'http://localhost:3000/mcp'),
+                    "scope": code_data.get('scope', ''),
+                    "sub": "9026451",
+                    "type": "access"
+                }
+
+                refresh_token_payload = {
+                    "aud": code_data.get('resource', 'http://localhost:3000/mcp'),
+                    "client_id": client_id,
+                    "exp": now + (30 * 24 * 3600),  # 30 days
+                    "iat": now,
+                    "iss": "http://localhost:9000",
+                    "jti": refresh_token_id,
+                    "resource": code_data.get('resource', 'http://localhost:3000/mcp'),
+                    "scope": code_data.get('scope', ''),
+                    "sub": "9026451",
+                    "type": "refresh"
+                }
+
+                access_token = create_jwt_with_openssl(access_token_payload)
+                refresh_token = create_jwt_with_openssl(refresh_token_payload)
+
+                # Store tokens
+                tokens[access_token_id] = {"token": access_token, "payload": access_token_payload}
+                tokens[refresh_token_id] = {"token": refresh_token, "payload": refresh_token_payload}
+
+                response = {
+                    "access_token": access_token,
+                    "refresh_token": refresh_token,
+                    "token_type": "bearer",
+                    "expires_in": 3600
+                }
+
+                self.send_json_response(response)
+
+            elif grant_type == 'refresh_token':
+                # Handle refresh token (simplified for demo)
+                refresh_token = body.get('refresh_token')
+
+                # In a real implementation, you'd verify the refresh token
+                # For simplicity, we'll just issue a new access token
+                now = int(time.time())
+                new_access_token_id = generate_id('access_')
+
+                new_access_token_payload = {
+                    "aud": "http://localhost:3000/mcp",
+                    "client_id": body.get('client_id', 'mcp_6950e6b7db0e6115a5af3a790340ad87'),
+                    "exp": now + 3600,
+                    "iat": now,
+                    "iss": "http://localhost:9000",
+                    "jti": new_access_token_id,
+                    "resource": "http://localhost:3000/mcp",
+                    "scope": "",
+                    "sub": "9026451",
+                    "type": "access"
+                }
+
+                new_access_token = create_jwt_with_openssl(new_access_token_payload)
+                tokens[new_access_token_id] = {"token": new_access_token, "payload": new_access_token_payload}
+
+                response = {
+                    "access_token": new_access_token,
+                    "refresh_token": refresh_token,
+                    "token_type": "bearer",
+                    "expires_in": 3600
+                }
+
+                self.send_json_response(response)
+
+            else:
+                self.send_json_response({"error": "unsupported_grant_type"}, 400)
+
+        except Exception as e:
+            self.send_json_response({"error": "server_error", "error_description": str(e)}, 500)
+
+    def handle_jwks(self):
+        """Handle JWKS request"""
+        jwks = {
+            "keys": [PUBLIC_KEY_JWK]
+        }
+        self.send_json_response(jwks)
+
+    def handle_discovery(self):
+        """Handle OAuth discovery endpoint"""
+        discovery = {
+            "issuer": "http://localhost:9000",
+            "authorization_endpoint": "http://localhost:9000/authorize",
+            "token_endpoint": "http://localhost:9000/token",
+            "jwks_uri": "http://localhost:9000/.well-known/jwks.json",
+            "registration_endpoint": "http://localhost:9000/register",
+            "response_types_supported": ["code"],
+            "grant_types_supported": ["authorization_code", "refresh_token"],
+            "token_endpoint_auth_methods_supported": ["client_secret_basic", "client_secret_post"],
+            "code_challenge_methods_supported": ["S256"]
+        }
+        self.send_json_response(discovery)
+
+    def log_message(self, format, *args):
+        """Override to provide cleaner logging"""
+        print(f"[{self.address_string()}] {format % args}")
+
+def main():
+    port = 9000
+    server = HTTPServer(('localhost', port), AuthServerHandler)
+
+    print(f"MCP Authorization Server running on http://localhost:{port}")
+    print("Using RSA RS256 for JWT signing with OpenSSL")
+    print("Endpoints:")
+    print("  POST /register - Client registration")
+    print("  GET  /authorize - Authorization endpoint")
+    print("  POST /token - Token endpoint")
+    print("  GET  /.well-known/jwks.json - JWKS endpoint")
+    print("  GET  /.well-known/oauth-authorization-server - Discovery endpoint")
+    print("\nPress Ctrl+C to stop the server")
+
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nShutting down server...")
+        server.shutdown()
+
+if __name__ == '__main__':
+    main()

--- a/examples/mcp-authentication/config.yaml
+++ b/examples/mcp-authentication/config.yaml
@@ -1,0 +1,174 @@
+# yaml-language-server: $schema=../../schema/local.json
+binds:
+- listeners:
+  - routes:
+
+    # --- Scenario A: Local stdio MCP + Spec-compliant External Authorization Server
+    # Exposes:
+    #   - MCP server (streamable HTTP) at /stdio/mcp
+    #   - Well-known OAuth Resource Metadata at /.well-known/oauth-protected-resource/stdio/mcp
+    # Validates incoming Bearer tokens against the configured Authorization Server (issuer + JWKS).
+    - backends:
+      - mcp:
+          targets:
+          - name: everything
+            stdio:
+              args:
+              - '@modelcontextprotocol/server-everything'
+              cmd: npx
+      matches:
+      - path:
+          exact: /stdio/mcp
+      - path:
+          exact: /.well-known/oauth-protected-resource/stdio/mcp
+      policies:
+        cors:
+          allowHeaders:
+          - mcp-protocol-version
+          - content-type
+          allowOrigins:
+          - '*'
+        mcpAuthentication:
+          issuer: http://localhost:9000
+          jwksUrl: http://localhost:9000/.well-known/jwks.json
+          audience: http://localhost:3000/stdio/mcp
+          resourceMetadata:
+            resource: http://localhost:3000/stdio/mcp
+            scopesSupported:
+            - read:all
+            bearerMethodsSupported:
+            - header
+            - body
+            - query
+            resourceDocumentation: http://localhost:3000/stdio/docs
+            resourcePolicyUri: http://localhost:3000/stdio/policies
+
+    # --- Scenario B: Remote MCP over HTTPS + Spec-compliant Authorization Server
+    # Proxies to a remote MCP server and serves the same resource metadata locally.
+    - backends:
+      - mcp:
+          targets:
+          - mcp:
+              host: mcpbin.is.solo.io
+              path: /remote/mcp
+              port: 443
+            name: mcpbin
+      matches:
+      - path:
+          exact: /remote/mcp
+      - path:
+          exact: /.well-known/oauth-protected-resource/remote/mcp
+      policies:
+        backendTLS: {}
+        cors:
+          allowHeaders:
+          - mcp-protocol-version
+          - content-type
+          allowOrigins:
+          - '*'
+        mcpAuthentication:
+          issuer: http://localhost:9000
+          jwksUrl: http://localhost:9000/.well-known/jwks.json
+          audience: http://localhost:3000/remote/mcp
+          resourceMetadata:
+            resource: http://localhost:3000/remote/mcp
+            scopesSupported:
+            - offline_access
+            bearerMethodsSupported:
+            - header
+            - body
+            - query
+            resourceDocumentation: http://localhost:3000/remote/docs
+            resourcePolicyUri: http://localhost:3000/remote/policies
+
+
+    # --- Scenario C: Local stdio MCP + Keycloak adaptation (non-spec provider)
+    # When the provider isn't spec-compliant, enable an adapter that exposes modified
+    # oauth-authorization-server endpoints while still validating JWTs.
+    - backends:
+      - mcp:
+          targets:
+          - name: everything
+            stdio:
+              args:
+              - '@modelcontextprotocol/server-everything'
+              cmd: npx
+      matches:
+      - path:
+          exact: /keycloak/mcp
+      - path:
+          exact: /.well-known/oauth-protected-resource/keycloak/mcp
+      - path:
+          exact: /.well-known/oauth-authorization-server/keycloak/mcp
+      - path:
+          exact: /.well-known/oauth-authorization-server/keycloak/mcp/client-registration
+      policies:
+        cors:
+          allowHeaders:
+          - mcp-protocol-version
+          - content-type
+          allowOrigins:
+          - '*'
+        mcpAuthentication:
+          issuer: http://localhost:7080/realms/mcp
+          jwksUrl: http://localhost:7080/realms/mcp/protocol/openid-connect/certs
+          audience: mcp_proxy
+          provider:
+            keycloak: {}
+          resourceMetadata:
+            resource: http://localhost:3000/keycloak/mcp
+            scopesSupported:
+            - profile
+            - offline_access
+            - openid
+            bearerMethodsSupported:
+            - header
+            - body
+            - query
+            resourceDocumentation: http://localhost:3000/keycloak/docs
+            resourcePolicyUri: http://localhost:3000/keycloak/policies
+
+    # Example configuration for Auth0:
+    # - backends:
+    #   - mcp:
+    #       targets:
+    #       - name: everything
+    #         stdio:
+    #           args:
+    #           - '@modelcontextprotocol/server-everything'
+    #           cmd: npx
+    #   matches:
+    #   - path:
+    #       exact: /auth0/mcp
+    #   - path:
+    #       exact: /.well-known/oauth-protected-resource/auth0/mcp
+    #   - path:
+    #       exact: /.well-known/oauth-authorization-server/auth0/mcp
+    #   policies:
+    #     cors:
+    #       allowHeaders:
+    #       - mcp-protocol-version
+    #       - content-type
+    #       allowOrigins:
+    #       - '*'
+    #     mcpAuthentication:
+    #       issuer: https://dev-y6sikgx3n3shy7ci.eu.auth0.com
+    #       jwksUrl: https://dev-y6sikgx3n3shy7ci.eu.auth0.com/.well-known/jwks.json
+    #       audience: urn:agent-gateway
+    #       provider:
+    #         auth0: {}
+    #       resourceMetadata:
+    #         resource: http://localhost:3000/auth0/mcp
+    #         scopesSupported:  
+    #         - profile
+    #         - offline_access
+    #         - openid
+    #         bearerMethodsSupported:
+    #         - header
+    #         - body
+    #         - query
+    #         resourceDocumentation: http://localhost:3000/keycloak/docs
+    #         resourcePolicyUri: http://localhost:3000/keycloak/policies
+
+  # Public port to listen on
+  port: 3000

--- a/examples/mcp-authentication/keycloak/docker-compose.yml
+++ b/examples/mcp-authentication/keycloak/docker-compose.yml
@@ -1,0 +1,18 @@
+services:
+  keycloak:
+    container_name: keycloak
+    image: quay.io/keycloak/keycloak:26.3
+    environment:
+      KC_HOSTNAME: localhost
+      KC_HOSTNAME_PORT: 7080
+      KC_HOSTNAME_STRICT_BACKCHANNEL: "true"
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin
+      KC_HEALTH_ENABLED: "true"
+      KC_LOG_LEVEL: info
+    command: ["start-dev", "--import-realm", "--http-port", "7080", "--https-port", "7443"]
+    volumes:
+    - ./mcp-realm.json:/opt/keycloak/data/import/mcp-realm.json
+    ports:
+    - "7080:7080"
+    - "7443:7443"

--- a/examples/mcp-authentication/keycloak/mcp-realm.json
+++ b/examples/mcp-authentication/keycloak/mcp-realm.json
@@ -1,0 +1,269 @@
+{
+  "realm": "mcp",
+  "enabled": true,
+  "displayName": "MCP Realm",
+  "displayNameHtml": "<div class=\"kc-logo-text\"><span>MCP</span></div>",
+  "loginTheme": "keycloak",
+  "adminTheme": "keycloak",
+  "accountTheme": "keycloak",
+  "emailTheme": "keycloak",
+  "internationalizationEnabled": false,
+  "registrationAllowed": false,
+  "registrationEmailAsUsername": false,
+  "rememberMe": false,
+  "verifyEmail": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": false,
+  "editUsernameAllowed": false,
+  "bruteForceProtected": false,
+  "permanentLockout": false,
+  "maxFailureWaitSeconds": 900,
+  "minimumQuickLoginWaitSeconds": 60,
+  "waitIncrementSeconds": 60,
+  "quickLoginCheckMilliSeconds": 1000,
+  "maxDeltaTimeSeconds": 43200,
+  "failureFactor": 30,
+  "defaultRoles": [
+    "offline_access",
+    "uma_authorization"
+  ],
+  "requiredCredentials": [
+    "password"
+  ],
+  "otpPolicyType": "totp",
+  "otpPolicyAlgorithm": "HmacSHA1",
+  "otpPolicyInitialCounter": 0,
+  "otpPolicyDigits": 6,
+  "otpPolicyLookAheadWindow": 1,
+  "otpPolicyPeriod": 30,
+  "otpSupportedApplications": [
+    "FreeOTP",
+    "Google Authenticator"
+  ],
+  "webAuthnPolicyRpEntityName": "keycloak",
+  "webAuthnPolicySignatureAlgorithms": [
+    "ES256"
+  ],
+  "webAuthnPolicyRpId": "",
+  "webAuthnPolicyAttestationConveyancePreference": "not specified",
+  "webAuthnPolicyAuthenticatorAttachment": "not specified",
+  "webAuthnPolicyRequireResidentKey": "not specified",
+  "webAuthnPolicyUserVerificationRequirement": "not specified",
+  "webAuthnPolicyCreateTimeout": 0,
+  "webAuthnPolicyAvoidSameAuthenticatorRegister": false,
+  "scopeMappings": [],
+  "clientScopeMappings": {},
+  "clients": [],
+  "clientScopes": [
+    {
+      "name": "profile",
+      "description": "OpenID Connect built-in scope: profile",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${profileScopeConsentText}"
+      },
+      "protocolMappers": [
+        {
+          "name": "profile",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "profile",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "profile",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "name": "email",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "email",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "name": "mcp_proxy",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "lightweight.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "included.custom.audience": "mcp_proxy",
+            "userinfo.token.claim": "false"
+          }
+        },
+        {
+          "name": "sub",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-sub-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "access.token.claim": "true"
+          }
+        }
+      ]
+    }
+  ],
+  "defaultDefaultClientScopes": [
+    "profile",
+    "email",
+    "offline_access"
+  ],
+  "defaultOptionalClientScopes": [
+    "offline_access"
+  ],
+  "browserSecurityHeaders": {
+    "contentSecurityPolicyReportOnly": "",
+    "xContentTypeOptions": "nosniff",
+    "xRobotsTag": "none",
+    "xFrameOptions": "SAMEORIGIN",
+    "contentSecurityPolicy": "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "xXSSProtection": "1; mode=block",
+    "strictTransportSecurity": "max-age=31536000; includeSubDomains"
+  },
+  "smtpServer": {},
+  "eventsEnabled": false,
+  "eventsListeners": [
+    "jboss-logging"
+  ],
+  "enabledEventTypes": [],
+  "adminEventsEnabled": false,
+  "adminEventsDetailsEnabled": false,
+  "identityProviders": [],
+  "identityProviderMappers": [],
+  "components": {
+    "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy": [
+      {
+        "name": "Consent Required",
+        "providerId": "consent-required",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {}
+      },
+      {
+        "name": "Full Scope Disabled",
+        "providerId": "scope",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {}
+      },
+      {
+        "name": "Max Clients Limit",
+        "providerId": "max-clients",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "max-clients": [
+            "200"
+          ]
+        }
+      },
+      {
+        "name": "Allowed Protocol Mapper Types",
+        "providerId": "allowed-protocol-mappers",
+        "subType": "authenticated",
+        "subComponents": {},
+        "config": {
+          "allowed-protocol-mapper-types": [
+            "saml-role-list-mapper",
+            "oidc-usermodel-attribute-mapper",
+            "oidc-usermodel-property-mapper",
+            "oidc-address-mapper",
+            "saml-user-attribute-mapper",
+            "oidc-full-name-mapper",
+            "saml-user-property-mapper",
+            "oidc-sha256-pairwise-sub-mapper"
+          ]
+        }
+      },
+      {
+        "name": "Allowed Client Scopes",
+        "providerId": "allowed-client-templates",
+        "subType": "authenticated",
+        "subComponents": {},
+        "config": {
+          "allow-default-scopes": [
+            "true"
+          ]
+        }
+      },
+      {
+        "name": "Allowed Protocol Mapper Types",
+        "providerId": "allowed-protocol-mappers",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "allowed-protocol-mapper-types": [
+            "oidc-usermodel-property-mapper",
+            "oidc-sha256-pairwise-sub-mapper",
+            "oidc-usermodel-attribute-mapper",
+            "saml-user-property-mapper",
+            "oidc-full-name-mapper",
+            "oidc-address-mapper",
+            "saml-role-list-mapper",
+            "saml-user-attribute-mapper"
+          ]
+        }
+      }
+    ]
+  },
+  "users": [
+    {
+      "username": "testuser",
+      "enabled": true,
+      "email": "test@example.com",
+      "emailVerified": true,
+      "firstName": "Test",
+      "lastName": "User",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "testpass"
+        }
+      ],
+      "realmRoles": [
+        "offline_access",
+        "uma_authorization"
+      ],
+      "clientRoles": {}
+    }
+  ],
+  "roles": {
+    "realm": [
+      {
+        "name": "offline_access",
+        "description": "Offline access",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "mcp"
+      },
+      {
+        "name": "uma_authorization",
+        "description": "User-Managed Access",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "mcp"
+      }
+    ]
+  },
+  "groups": [],
+  "userManagedAccessAllowed": false
+}

--- a/schema/README.md
+++ b/schema/README.md
@@ -129,16 +129,13 @@ This defaults to 'true'.|
 |`binds[].listeners[].routes[].policies.mcpAuthorization.rules`||
 |`binds[].listeners[].routes[].policies.mcpAuthentication`|Authentication for MCP clients.|
 |`binds[].listeners[].routes[].policies.mcpAuthentication.issuer`||
+|`binds[].listeners[].routes[].policies.mcpAuthentication.audience`||
 |`binds[].listeners[].routes[].policies.mcpAuthentication.jwksUrl`||
 |`binds[].listeners[].routes[].policies.mcpAuthentication.provider`||
 |`binds[].listeners[].routes[].policies.mcpAuthentication.provider.(any)(1)auth0`||
 |`binds[].listeners[].routes[].policies.mcpAuthentication.provider.(any)(1)keycloak`||
 |`binds[].listeners[].routes[].policies.mcpAuthentication.resourceMetadata`||
 |`binds[].listeners[].routes[].policies.mcpAuthentication.resourceMetadata.resource`||
-|`binds[].listeners[].routes[].policies.mcpAuthentication.resourceMetadata.scopesSupported`||
-|`binds[].listeners[].routes[].policies.mcpAuthentication.resourceMetadata.bearerMethodsSupported`||
-|`binds[].listeners[].routes[].policies.mcpAuthentication.resourceMetadata.resourceDocumentation`||
-|`binds[].listeners[].routes[].policies.mcpAuthentication.resourceMetadata.resourcePolicyUri`||
 |`binds[].listeners[].routes[].policies.a2a`|Mark this traffic as A2A to enable A2A processing and telemetry.|
 |`binds[].listeners[].routes[].policies.ai`|Mark this as LLM traffic to enable LLM processing.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard`||

--- a/schema/README.md
+++ b/schema/README.md
@@ -128,13 +128,17 @@ This defaults to 'true'.|
 |`binds[].listeners[].routes[].policies.mcpAuthorization`|Authorization policies for MCP access.|
 |`binds[].listeners[].routes[].policies.mcpAuthorization.rules`||
 |`binds[].listeners[].routes[].policies.mcpAuthentication`|Authentication for MCP clients.|
-|`binds[].listeners[].routes[].policies.mcpAuthentication.mode`||
 |`binds[].listeners[].routes[].policies.mcpAuthentication.issuer`||
-|`binds[].listeners[].routes[].policies.mcpAuthentication.scopes`||
-|`binds[].listeners[].routes[].policies.mcpAuthentication.audience`||
+|`binds[].listeners[].routes[].policies.mcpAuthentication.jwksUrl`||
 |`binds[].listeners[].routes[].policies.mcpAuthentication.provider`||
 |`binds[].listeners[].routes[].policies.mcpAuthentication.provider.(any)(1)auth0`||
 |`binds[].listeners[].routes[].policies.mcpAuthentication.provider.(any)(1)keycloak`||
+|`binds[].listeners[].routes[].policies.mcpAuthentication.resourceMetadata`||
+|`binds[].listeners[].routes[].policies.mcpAuthentication.resourceMetadata.resource`||
+|`binds[].listeners[].routes[].policies.mcpAuthentication.resourceMetadata.scopesSupported`||
+|`binds[].listeners[].routes[].policies.mcpAuthentication.resourceMetadata.bearerMethodsSupported`||
+|`binds[].listeners[].routes[].policies.mcpAuthentication.resourceMetadata.resourceDocumentation`||
+|`binds[].listeners[].routes[].policies.mcpAuthentication.resourceMetadata.resourcePolicyUri`||
 |`binds[].listeners[].routes[].policies.a2a`|Mark this traffic as A2A to enable A2A processing and telemetry.|
 |`binds[].listeners[].routes[].policies.ai`|Mark this as LLM traffic to enable LLM processing.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard`||

--- a/schema/local.json
+++ b/schema/local.json
@@ -984,6 +984,9 @@
                               "issuer": {
                                 "type": "string"
                               },
+                              "audience": {
+                                "type": "string"
+                              },
                               "jwksUrl": {
                                 "type": "string"
                               },
@@ -1029,42 +1032,18 @@
                                 "properties": {
                                   "resource": {
                                     "type": "string"
-                                  },
-                                  "scopesSupported": {
-                                    "type": "array",
-                                    "items": {
-                                      "type": "string"
-                                    }
-                                  },
-                                  "bearerMethodsSupported": {
-                                    "type": "array",
-                                    "items": {
-                                      "type": "string"
-                                    }
-                                  },
-                                  "resourceDocumentation": {
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ]
-                                  },
-                                  "resourcePolicyUri": {
-                                    "type": [
-                                      "string",
-                                      "null"
-                                    ]
                                   }
                                 },
                                 "required": [
-                                  "resource",
-                                  "scopesSupported",
-                                  "bearerMethodsSupported"
-                                ]
+                                  "resource"
+                                ],
+                                "additionalProperties": true
                               }
                             },
                             "additionalProperties": false,
                             "required": [
                               "issuer",
+                              "audience",
                               "jwksUrl",
                               "resourceMetadata"
                             ],

--- a/schema/local.json
+++ b/schema/local.json
@@ -981,35 +981,10 @@
                               "null"
                             ],
                             "properties": {
-                              "mode": {
-                                "oneOf": [
-                                  {
-                                    "description": "A valid token, issued by a configured issuer, must be present.",
-                                    "type": "string",
-                                    "const": "strict"
-                                  },
-                                  {
-                                    "description": "If a token exists, validate it.\nThis is the default option.\nWarning: this allows requests without a JWT token!",
-                                    "type": "string",
-                                    "const": "optional"
-                                  },
-                                  {
-                                    "description": "Requests are never rejected. This is useful for usage of claims in later steps (authorization, logging, etc).\nWarning: this allows requests without a JWT token!",
-                                    "type": "string",
-                                    "const": "permissive"
-                                  }
-                                ]
-                              },
                               "issuer": {
                                 "type": "string"
                               },
-                              "scopes": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                }
-                              },
-                              "audience": {
+                              "jwksUrl": {
                                 "type": "string"
                               },
                               "provider": {
@@ -1048,14 +1023,50 @@
                                     "type": "null"
                                   }
                                 ]
+                              },
+                              "resourceMetadata": {
+                                "type": "object",
+                                "properties": {
+                                  "resource": {
+                                    "type": "string"
+                                  },
+                                  "scopesSupported": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "bearerMethodsSupported": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "resourceDocumentation": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "resourcePolicyUri": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "resource",
+                                  "scopesSupported",
+                                  "bearerMethodsSupported"
+                                ]
                               }
                             },
                             "additionalProperties": false,
                             "required": [
-                              "mode",
                               "issuer",
-                              "scopes",
-                              "audience"
+                              "jwksUrl",
+                              "resourceMetadata"
                             ],
                             "default": null
                           },


### PR DESCRIPTION
This PR adds the options to configure MCP Server responsibilities in the agentgateway.

- Returning 401 and WWW-Authentication header when the requests are unauthenticated
- Custom authorization server with jwks location
- Adds more metadata to the resource metadata endpoint.

Additionally, it adds a test authorization server to try out the flows

See the example under `examples/mcp-authentication/README.md` for quickly testing out the changes.
