### PR TITLE
[DOCS] add missing cache-control header in example config to fix playground errors

### DIFF
--- a/examples/basic/config.yaml
+++ b/examples/basic/config.yaml
@@ -10,6 +10,7 @@ binds:
           allowHeaders:
             - mcp-protocol-version
             - content-type
+            - cache-control
       backends:
       - mcp:
           name: default


### PR DESCRIPTION
- needed to add cache-control for allowHeaders in order to fix errors in playground

Access to fetch at 'http://localhost:3000/sse' from origin 'http://localhost:15000/' has been blocked by CORS policy: Request header field cache-control is not allowed by Access-Control-Allow-Headers in preflight response.