### PR TITLE
feat: responsively show added or deleted policies

### DIFF
--- a/ui/src/components/policy-config.tsx
+++ b/ui/src/components/policy-config.tsx
@@ -144,6 +144,19 @@ export function PolicyConfig() {
 
       setRoutes(allRoutes);
 
+      if (selectedRoute) {
+        const updatedSelectedRoute = allRoutes.find(
+          (r) =>
+            r.bind.port === selectedRoute.bind.port &&
+            r.listener.name === selectedRoute.listener.name &&
+            r.routeIndex === selectedRoute.routeIndex &&
+            r.routeType === selectedRoute.routeType
+        );
+        if (updatedSelectedRoute) {
+          setSelectedRoute(updatedSelectedRoute);
+        }
+      }
+
       // Auto-expand binds with routes
       const bindsWithRoutes = new Set<number>();
       allRoutes.forEach(({ bind }) => bindsWithRoutes.add(bind.port));


### PR DESCRIPTION
## Summary

Updates the selected route with the latest configured policies after addition or removal of a policy so the status and buttons responsively update without requiring a full refresh. Prior to this, a page reload would be required to see the latest status.

## Before

Policy status and buttons do not update after adding or removing a policy. Policy configuration page needs to be reloaded to see the updated status and `Edit` button.

------------

![4GIiM5BW6a](https://github.com/user-attachments/assets/f8b3aaee-0208-4f6b-a94f-3803c916bcbc)

## After

Configured policies update immediately after addition or removal.

------------

![firefox_760BT5dC3U](https://github.com/user-attachments/assets/e5bcdb72-7d83-4345-96c7-b93538f00553)
