### PR TITLE
Remote rate limit: support multiple sets of descriptors

### DIFF
--- a/crates/agentgateway/src/cel/mod.rs
+++ b/crates/agentgateway/src/cel/mod.rs
@@ -3,6 +3,7 @@
 
 use std::collections::HashSet;
 use std::fmt::{Debug, Display, Formatter};
+use std::net::IpAddr;
 use std::sync::Arc;
 
 use agent_core::strng::Strng;
@@ -23,6 +24,7 @@ use crate::llm::{LLMRequest, LLMResponse};
 use crate::serdes::*;
 use crate::telemetry::log::CelLogging;
 use crate::{json, llm};
+use crate::transport::stream::{TCPConnectionInfo, TLSConnectionInfo};
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -40,6 +42,7 @@ impl From<Box<dyn std::error::Error>> for Error {
 	}
 }
 
+pub const SOURCE_ATTRIBUTE: &str = "source";
 pub const REQUEST_ATTRIBUTE: &str = "request";
 pub const REQUEST_BODY_ATTRIBUTE: &str = "request.body";
 pub const LLM_ATTRIBUTE: &str = "llm";
@@ -122,6 +125,7 @@ impl ContextBuilder {
 			// TODO: split headers and the rest?
 			headers: req.headers().clone(),
 			uri: req.uri().clone(),
+			path: req.uri().path().to_string(),
 			body: None,
 		});
 		self.attributes.contains(REQUEST_BODY_ATTRIBUTE)
@@ -140,6 +144,16 @@ impl ContextBuilder {
 			return;
 		}
 		self.context.jwt = Some(info.clone())
+	}
+
+	pub fn with_source(&mut self, tcp: &TCPConnectionInfo, tls: Option<&TLSConnectionInfo>) {
+		if !self.attributes.contains(JWT_ATTRIBUTE) {
+			return;
+		}
+		self.context.source = Some(SourceContext {
+			address: tcp.peer_addr.ip(),
+			port: tcp.peer_addr.port(),
+		})
 	}
 
 	pub fn with_llm_request(&mut self, info: &LLMRequest) -> bool {
@@ -201,6 +215,7 @@ impl ContextBuilder {
 			response,
 			jwt,
 			llm,
+			source,
 		} = &self.context;
 
 		ctx.add_variable_from_value(REQUEST_ATTRIBUTE, opt_to_value(request)?);
@@ -208,6 +223,7 @@ impl ContextBuilder {
 		ctx.add_variable_from_value(JWT_ATTRIBUTE, opt_to_value(jwt)?);
 		ctx.add_variable_from_value(MCP_ATTRIBUTE, opt_to_value(&mcp)?);
 		ctx.add_variable_from_value(LLM_ATTRIBUTE, opt_to_value(llm)?);
+		ctx.add_variable_from_value(SOURCE_ATTRIBUTE, opt_to_value(source)?);
 
 		Ok(Executor { ctx })
 	}
@@ -267,6 +283,7 @@ pub struct ExpressionContext {
 	pub response: Option<ResponseContext>,
 	pub jwt: Option<Claims>,
 	pub llm: Option<LLMContext>,
+	pub source: Option<SourceContext>
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -279,6 +296,8 @@ pub struct RequestContext {
 	#[serde(with = "http_serde::uri")]
 	#[cfg_attr(feature = "schema", schemars(with = "String"))]
 	pub uri: ::http::Uri,
+
+	pub path: String,
 
 	#[serde(with = "http_serde::header_map")]
 	#[cfg_attr(
@@ -296,6 +315,14 @@ pub struct ResponseContext {
 	#[serde(with = "http_serde::status_code")]
 	#[cfg_attr(feature = "schema", schemars(with = "u16"))]
 	pub code: ::http::StatusCode,
+}
+
+
+#[derive(Clone, Debug, Serialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+pub struct SourceContext {
+	address: IpAddr,
+	port: u16,
 }
 
 #[derive(Clone, Debug, Serialize)]

--- a/crates/agentgateway/src/cel/mod.rs
+++ b/crates/agentgateway/src/cel/mod.rs
@@ -23,8 +23,8 @@ use crate::http::jwt::Claims;
 use crate::llm::{LLMRequest, LLMResponse};
 use crate::serdes::*;
 use crate::telemetry::log::CelLogging;
-use crate::{json, llm};
 use crate::transport::stream::{TCPConnectionInfo, TLSConnectionInfo};
+use crate::{json, llm};
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -147,7 +147,7 @@ impl ContextBuilder {
 	}
 
 	pub fn with_source(&mut self, tcp: &TCPConnectionInfo, tls: Option<&TLSConnectionInfo>) {
-		if !self.attributes.contains(JWT_ATTRIBUTE) {
+		if !self.attributes.contains(SOURCE_ATTRIBUTE) {
 			return;
 		}
 		self.context.source = Some(SourceContext {
@@ -283,7 +283,7 @@ pub struct ExpressionContext {
 	pub response: Option<ResponseContext>,
 	pub jwt: Option<Claims>,
 	pub llm: Option<LLMContext>,
-	pub source: Option<SourceContext>
+	pub source: Option<SourceContext>,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -316,7 +316,6 @@ pub struct ResponseContext {
 	#[cfg_attr(feature = "schema", schemars(with = "u16"))]
 	pub code: ::http::StatusCode,
 }
-
 
 #[derive(Clone, Debug, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]

--- a/crates/agentgateway/src/http/transformation_cel_tests.rs
+++ b/crates/agentgateway/src/http/transformation_cel_tests.rs
@@ -31,6 +31,6 @@ fn test_transformation() {
 		ctx.register_expression(e)
 	}
 	ctx.with_request(&req);
-	xfm.apply_request(&mut req, &ctx);
+	xfm.apply_request(&mut req, &ctx.build().unwrap());
 	assert_eq!(req.headers().get("x-insert").unwrap(), "hello Bar");
 }

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -292,7 +292,10 @@ impl HTTPProxy {
 		log: &mut RequestLog,
 	) -> Result<Response, ProxyError> {
 		log.tls_info = connection.get::<TLSConnectionInfo>().cloned();
-		log.cel.ctx().with_source(&log.tcp_info, log.tls_info.as_ref());
+		log
+			.cel
+			.ctx()
+			.with_source(&log.tcp_info, log.tls_info.as_ref());
 		let selected_listener = self.selected_listener.clone();
 		let upstream = self.inputs.upstream.clone();
 		let inputs = self.inputs.clone();

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -96,16 +96,20 @@ async fn apply_request_policies(
 			return Err(ProxyError::RateLimitExceeded);
 		}
 	}
-
+	let exec = log
+		.cel
+		.ctx()
+		.build()
+		.map_err(|_| ProxyError::ProcessingString("failed to build cel context".to_string()))?;
 	let lrl = if let Some(rrl) = &policies.remote_rate_limit {
-		rrl.check(client, req).await?
+		rrl.check(client, req, &exec).await?
 	} else {
 		http::PolicyResponse::default()
 	};
 	let policy_resp = ext_auth.merge(lrl);
 
 	if let Some(j) = &policies.transformation {
-		j.apply_request(req, log.cel.ctx())
+		j.apply_request(req, &exec)
 			.map_err(|_| ProxyError::TransformationFailure)?;
 	}
 
@@ -288,6 +292,7 @@ impl HTTPProxy {
 		log: &mut RequestLog,
 	) -> Result<Response, ProxyError> {
 		log.tls_info = connection.get::<TLSConnectionInfo>().cloned();
+		log.cel.ctx().with_source(&log.tcp_info, log.tls_info.as_ref());
 		let selected_listener = self.selected_listener.clone();
 		let upstream = self.inputs.upstream.clone();
 		let inputs = self.inputs.clone();

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -92,12 +92,16 @@ pub struct RoutePolicies {
 
 impl RoutePolicies {
 	pub fn register_cel_expressions(&self, req: &http::Request, ctx: &mut ContextBuilder) {
-		let Some(xfm) = &self.transformation else {
-			return;
+		if let Some(xfm) = &self.transformation {
+			for expr in xfm.expressions() {
+				ctx.register_expression(expr)
+			}
 		};
-		for expr in xfm.expressions() {
-			ctx.register_expression(expr)
-		}
+		if let Some(rrl) = &self.remote_rate_limit {
+			for expr in rrl.expressions() {
+				ctx.register_expression(expr)
+			}
+		};
 	}
 }
 

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -20,7 +20,6 @@ use serde_with::{TryFromInto, serde_as};
 use crate::http::auth::BackendAuth;
 use crate::http::backendtls::{BackendTLS, LocalBackendTLS};
 use crate::http::jwt::{JwkError, Jwt};
-use crate::http::remoteratelimit::Descriptor;
 use crate::http::{filters, retry, timeout};
 use crate::llm::AIProvider;
 use crate::store::LocalWorkload;
@@ -731,8 +730,9 @@ async fn convert_route(
 			let (bref, backend) =
 				to_simple_backend_and_ref(strng::format!("{}/ratelimit", key), &p.target);
 			let pol = http::remoteratelimit::RemoteRateLimit {
+				domain: p.domain,
 				target: Arc::new(bref),
-				descriptors: p.descriptors,
+				descriptors: Arc::new(p.descriptors),
 			};
 			backend
 				.into_iter()
@@ -887,7 +887,8 @@ pub struct LocalExtAuthz {
 
 #[apply(schema!)]
 pub struct LocalRemoteRateLimit {
+	pub domain: String,
 	#[serde(flatten)]
 	pub target: SimpleLocalBackend,
-	pub descriptors: HashMap<String, Descriptor>,
+	pub descriptors: crate::http::remoteratelimit::DescriptorSet,
 }


### PR DESCRIPTION
Also add `domain` support, and pull values from CEL

example
```yaml
remoteRateLimit:
  host: lo:8081
  domain: api-gateway
  descriptors:
  - - key: remote_address
      value: 'source.address'
  - - key: path
      value: 'request.path'
```