### PR TITLE
llm: make tokenization optional, disabled by default

### DIFF
--- a/crates/agentgateway/src/cel/mod.rs
+++ b/crates/agentgateway/src/cel/mod.rs
@@ -212,7 +212,7 @@ impl ContextBuilder {
 			o.total_tokens = info.total_tokens;
 			if let Some(pt) = info.input_tokens_from_response {
 				// Better info, override
-				o.input_tokens = pt;
+				o.input_tokens = Some(pt);
 			}
 			o.response_model = info.provider_model.clone();
 			// Not always set
@@ -362,7 +362,8 @@ pub struct LLMContext {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	response_model: Option<Strng>,
 	provider: Strng,
-	input_tokens: u64,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	input_tokens: Option<u64>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	output_tokens: Option<u64>,
 	#[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/agentgateway/src/http/localratelimit.rs
+++ b/crates/agentgateway/src/http/localratelimit.rs
@@ -3,6 +3,7 @@ use serde::ser::SerializeMap;
 
 use crate::http::Request;
 use crate::llm::LLMRequest;
+use crate::proxy::ProxyError;
 use crate::types::agent::{HostRedirect, PathRedirect};
 use crate::*;
 
@@ -76,25 +77,50 @@ impl TryFrom<RateLimitSerde> for RateLimit {
 }
 
 impl RateLimit {
-	pub fn check_request(&self, req: &Request) -> bool {
+	pub fn check_request(&self, req: &Request) -> Result<(), ProxyError> {
 		if self.limit_type != RateLimitType::Requests {
-			return true;
+			return Ok(());
 		}
-		self.ratelimit.try_wait().is_ok()
+		// TODO: return headers on success, not just failure
+		self
+			.ratelimit
+			.try_wait()
+			.map_err(|(limit, remaining, reset)| ProxyError::RateLimitExceeded {
+				limit,
+				remaining,
+				reset_seconds: reset.as_secs(),
+			})
 	}
 
-	pub fn check_llm_request(&self, req: &LLMRequest) -> bool {
+	pub fn check_llm_request(&self, req: &LLMRequest) -> Result<(), ProxyError> {
 		if self.limit_type != RateLimitType::Tokens {
-			return true;
+			return Ok(());
 		}
 		if let Some(it) = req.input_tokens {
 			// If we tokenized the request, check to make sure we permit that many tokens
 			// We will add the response tokens in `amend_tokens`
-			self.ratelimit.try_wait_n(it).is_ok()
+			self
+				.ratelimit
+				.try_wait_n(it)
+				.map_err(|(limit, remaining, reset)| ProxyError::RateLimitExceeded {
+					limit,
+					remaining,
+					reset_seconds: reset.as_secs(),
+				})
 		} else {
 			// Otherwise, make sure at least 1 token is allowed.
 			// Note this may lead to large over-allowance, especially with fast fill_intervals.
-			self.ratelimit.available_refill() > 0
+			let avail = self.ratelimit.available_refill();
+			if avail > 0 {
+				Ok(())
+			} else {
+				Err(ProxyError::RateLimitExceeded {
+					limit: self.ratelimit.max_tokens(),
+					remaining: avail,
+					reset_seconds: (self.ratelimit.next_refill() - clocksource::precise::Instant::now())
+						.as_secs(),
+				})
+			}
 		}
 	}
 
@@ -283,16 +309,20 @@ mod ratelimit {
 		/// Non-blocking function to "wait" for a single token. On success, a single
 		/// token has been acquired. On failure, a `Duration` hinting at when the
 		/// next refill would occur is returned.
-		pub fn try_wait(&self) -> Result<(), core::time::Duration> {
+		pub fn try_wait(&self) -> Result<(), (u64, u64, core::time::Duration)> {
 			self.try_wait_n(1)
 		}
 
 		/// Non-blocking function to "wait" for multiple tokens. On success, all requested
 		/// tokens have been acquired. On failure, a `Duration` hinting at when the
 		/// next refill would occur is returned. Either all tokens are acquired or none.
-		pub fn try_wait_n(&self, n: u64) -> Result<(), core::time::Duration> {
+		pub fn try_wait_n(&self, n: u64) -> Result<(), (u64, u64, core::time::Duration)> {
 			if n == 0 || n > self.parameters.capacity {
-				return Err(core::time::Duration::from_nanos(0));
+				return Err((
+					self.parameters.capacity,
+					self.available.load(Ordering::Acquire),
+					core::time::Duration::from_nanos(0),
+				));
 			}
 
 			// We have an outer loop that drives the refilling of the token bucket.
@@ -327,7 +357,7 @@ mod ratelimit {
 								// Refill failed and there weren't enough tokens already
 								// available. We return the error which contains a
 								// duration until the next refill.
-								return Err(e);
+								return Err((self.parameters.capacity, available, e));
 							},
 						}
 					}

--- a/crates/agentgateway/src/http/mod.rs
+++ b/crates/agentgateway/src/http/mod.rs
@@ -35,6 +35,14 @@ use tower_serve_static::private::mime;
 
 use crate::proxy::ProxyError;
 
+pub mod x_headers {
+	use http::HeaderName;
+
+	pub const X_RATELIMIT_LIMIT: HeaderName = HeaderName::from_static("x-ratelimit-limit");
+	pub const X_RATELIMIT_REMAINING: HeaderName = HeaderName::from_static("x-ratelimit-remaining");
+	pub const X_RATELIMIT_RESET: HeaderName = HeaderName::from_static("x-ratelimit-reset");
+}
+
 pub fn modify_req(
 	req: &mut Request,
 	f: impl FnOnce(&mut ::http::request::Parts) -> anyhow::Result<()>,

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -42,6 +42,11 @@ pub mod vertex;
 pub struct AIBackend {
 	pub provider: AIProvider,
 	pub host_override: Option<Target>,
+	/// Whether to tokenize on the request flow. This enables us to do more accurate rate limits,
+	/// since we know (part of) the cost of the request upfront.
+	/// This comes with the cost of an expensive operation.
+	#[serde(default)]
+	pub tokenize: bool,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -61,7 +66,8 @@ trait Provider {
 
 #[derive(Debug, Clone)]
 pub struct LLMRequest {
-	pub input_tokens: u64,
+	/// Input tokens derived by tokenizing the request. Not always enabled
+	pub input_tokens: Option<u64>,
 	pub request_model: Strng,
 	pub provider: Strng,
 	pub streaming: bool,
@@ -120,7 +126,7 @@ impl AIProvider {
 			a2a: None,
 			llm: None,
 			inference_routing: None,
-			llm_provider: Some((self.clone(), true)),
+			llm_provider: None,
 		};
 		match self {
 			AIProvider::OpenAI(_) => (Target::Hostname(openai::DEFAULT_HOST, 443), btls),
@@ -132,7 +138,7 @@ impl AIProvider {
 					a2a: None,
 					llm: None,
 					inference_routing: None,
-					llm_provider: Some((self.clone(), true)),
+					llm_provider: None,
 				};
 				(Target::Hostname(p.get_host(), 443), bp)
 			},
@@ -144,7 +150,7 @@ impl AIProvider {
 					a2a: None,
 					llm: None,
 					inference_routing: None,
-					llm_provider: Some((self.clone(), true)),
+					llm_provider: None,
 				};
 				(Target::Hostname(p.get_host(), 443), bp)
 			},
@@ -220,6 +226,7 @@ impl AIProvider {
 		client: client::Client,
 		policies: Option<&Policy>,
 		req: Request,
+		tokenize: bool,
 		mut log: &mut Option<&mut RequestLog>,
 	) -> (Result<RequestResult, AIError>) {
 		// Buffer the body, max 2mb
@@ -245,7 +252,7 @@ impl AIProvider {
 				return Ok(RequestResult::Rejected(dr));
 			}
 		}
-		let llm_info = self.to_llm_request(&req).await?;
+		let llm_info = self.to_llm_request(&req, tokenize).await?;
 		if let Some(log) = log {
 			let needs_prompt = log.cel.cel_context.with_llm_request(&llm_info);
 			if needs_prompt {
@@ -468,16 +475,24 @@ impl AIProvider {
 	pub async fn to_llm_request(
 		&self,
 		req: &universal::ChatCompletionRequest,
+		tokenize: bool,
 	) -> Result<LLMRequest, AIError> {
-		let req2 = req.clone(); // TODO: avoid clone, we need it for spawn_blocking though
-		let tokens = tokio::task::spawn_blocking(move || {
-			let res = num_tokens_from_messages(&req2.model, &req2.messages)?;
-			Ok::<_, AIError>(res)
-		})
-		.await??;
+		let input_tokens = if tokenize {
+			// TODO: avoid clone, we need it for spawn_blocking though
+			let msg = req.clone().messages.clone();
+			let model = req.clone().model.clone();
+			let tokens = tokio::task::spawn_blocking(move || {
+				let res = num_tokens_from_messages(&model, &msg)?;
+				Ok::<_, AIError>(res)
+			})
+			.await??;
+			Some(tokens)
+		} else {
+			None
+		};
 		// Pass the original body through
 		let llm = LLMRequest {
-			input_tokens: tokens,
+			input_tokens,
 			request_model: req.model.as_str().into(),
 			provider: self.provider(),
 			streaming: req.stream.unwrap_or_default(),
@@ -587,10 +602,17 @@ pub enum AIError {
 fn amend_tokens(rate_limit: &[RateLimit], llm_resp: &LLMResponse) {
 	for lrl in rate_limit {
 		let base = llm_resp.request.input_tokens;
-		let input_mismatch = llm_resp
-			.input_tokens_from_response
-			.map(|real| (real as i64) - (base as i64))
-			.unwrap_or_default();
+		let input_mismatch = match (
+			llm_resp.request.input_tokens,
+			llm_resp.input_tokens_from_response,
+		) {
+			// Already counted 'req'
+			(Some(req), Some(resp)) => (resp as i64) - (req as i64),
+			// No request or response count... this is probably an issue.
+			(_, None) => 0,
+			// No request counted, so count the full response
+			(_, Some(resp)) => resp as i64,
+		};
 		let response = llm_resp.output_tokens.unwrap_or_default();
 		let tokens_to_remove = input_mismatch + (response as i64);
 		lrl.amend_tokens(tokens_to_remove)

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -601,7 +601,6 @@ pub enum AIError {
 
 fn amend_tokens(rate_limit: &[RateLimit], llm_resp: &LLMResponse) {
 	for lrl in rate_limit {
-		let base = llm_resp.request.input_tokens;
 		let input_mismatch = match (
 			llm_resp.request.input_tokens,
 			llm_resp.input_tokens_from_response,

--- a/crates/agentgateway/src/proxy/mod.rs
+++ b/crates/agentgateway/src/proxy/mod.rs
@@ -55,7 +55,11 @@ pub enum ProxyError {
 	#[error("processing failed: {0}")]
 	ProcessingString(String),
 	#[error("rate limit exceeded")]
-	RateLimitExceeded,
+	RateLimitExceeded {
+		limit: u64,
+		remaining: u64,
+		reset_seconds: u64,
+	},
 	#[error("rate limit failed")]
 	RateLimitFailed,
 	#[error("invalid request")]
@@ -103,15 +107,32 @@ impl ProxyError {
 			ProxyError::RequestTimeout => StatusCode::GATEWAY_TIMEOUT,
 			ProxyError::Processing(_) => StatusCode::SERVICE_UNAVAILABLE,
 			ProxyError::ProcessingString(_) => StatusCode::SERVICE_UNAVAILABLE,
-			ProxyError::RateLimitExceeded => StatusCode::TOO_MANY_REQUESTS,
+			ProxyError::RateLimitExceeded { .. } => StatusCode::TOO_MANY_REQUESTS,
 			ProxyError::RateLimitFailed => StatusCode::TOO_MANY_REQUESTS,
 		};
 		let msg = self.to_string();
-		::http::Response::builder()
+		let mut rb = ::http::Response::builder()
 			.status(code)
-			.header(hyper::header::CONTENT_TYPE, "text/plain")
-			.body(http::Body::from(msg))
-			.unwrap()
+			.header(hyper::header::CONTENT_TYPE, "text/plain");
+
+		// Apply per-error headers
+		if let ProxyError::RateLimitExceeded {
+			limit,
+			remaining,
+			reset_seconds,
+		} = self
+		{
+			if let Ok(hv) = HeaderValue::try_from(limit.to_string()) {
+				rb = rb.header(http::x_headers::X_RATELIMIT_LIMIT, hv)
+			}
+			if let Ok(hv) = HeaderValue::try_from(remaining.to_string()) {
+				rb = rb.header(http::x_headers::X_RATELIMIT_REMAINING, hv)
+			}
+			if let Ok(hv) = HeaderValue::try_from(reset_seconds.to_string()) {
+				rb = rb.header(http::x_headers::X_RATELIMIT_RESET, hv)
+			}
+		}
+		rb.body(http::Body::from(msg)).unwrap()
 	}
 }
 

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -55,7 +55,8 @@ pub struct BackendPolicies {
 	pub backend_auth: Option<BackendAuth>,
 	pub a2a: Option<A2aPolicy>,
 	// bool represents "should use default settings for provider"
-	pub llm_provider: Option<(llm::AIProvider, bool)>,
+	// second bool represents "tokenize"
+	pub llm_provider: Option<(llm::AIProvider, bool, bool)>,
 	pub llm: Option<llm::Policy>,
 	pub inference_routing: Option<InferenceRouting>,
 }

--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -506,16 +506,10 @@ impl Drop for DropOnLog {
 		let dur = format!("{}ms", log.start.elapsed().as_millis());
 		let grpc = log.grpc_status.load();
 
-		if let (Some(req), Some(resp)) = (log.llm_request.as_ref(), llm_response.as_ref()) {
-			if Some(req.input_tokens) != resp.input_tokens_from_response {
-				// TODO: remove this, just for dev
-				tracing::warn!("maybe bug: mismatch in tokens {req:?}, {resp:?}");
-			}
-		}
 		let input_tokens = llm_response
 			.as_ref()
 			.and_then(|t| t.input_tokens_from_response)
-			.or_else(|| log.llm_request.as_ref().map(|req| req.input_tokens));
+			.or_else(|| log.llm_request.as_ref().and_then(|req| req.input_tokens));
 
 		let mcp = log.mcp_status.take();
 

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -278,6 +278,7 @@ impl TryFrom<&proto::agent::Backend> for Backend {
 			Some(proto::agent::backend::Kind::Ai(a)) => Backend::AI(
 				name.clone(),
 				AIBackend {
+					tokenize: false,
 					host_override: a
 						.r#override
 						.as_ref()

--- a/schema/README.md
+++ b/schema/README.md
@@ -233,6 +233,9 @@ This defaults to 'true'.|
 |`binds[].listeners[].routes[].backends[].(1)ai.provider.(1)bedrock.model`||
 |`binds[].listeners[].routes[].backends[].(1)ai.provider.(1)bedrock.region`||
 |`binds[].listeners[].routes[].backends[].(1)ai.hostOverride`||
+|`binds[].listeners[].routes[].backends[].(1)ai.tokenize`|Whether to tokenize on the request flow. This enables us to do more accurate rate limits,
+since we know (part of) the cost of the request upfront.
+This comes with the cost of an expensive operation.|
 |`binds[].listeners[].tcpRoutes`||
 |`binds[].listeners[].tcpRoutes[].name`||
 |`binds[].listeners[].tcpRoutes[].ruleName`||

--- a/schema/cel.json
+++ b/schema/cel.json
@@ -99,7 +99,10 @@
           "type": "string"
         },
         "input_tokens": {
-          "type": "integer",
+          "type": [
+            "integer",
+            "null"
+          ],
           "format": "uint64",
           "minimum": 0
         },
@@ -201,7 +204,6 @@
         "streaming",
         "request_model",
         "provider",
-        "input_tokens",
         "params"
       ]
     },

--- a/schema/local.json
+++ b/schema/local.json
@@ -1978,6 +1978,11 @@
                                         "string",
                                         "null"
                                       ]
+                                    },
+                                    "tokenize": {
+                                      "description": "Whether to tokenize on the request flow. This enables us to do more accurate rate limits,\nsince we know (part of) the cost of the request upfront.\nThis comes with the cost of an expensive operation.",
+                                      "type": "boolean",
+                                      "default": false
                                     }
                                   },
                                   "required": [


### PR DESCRIPTION
This makes rate limits slightly more accurate, at the cost of dramatic performance hit