### PR TITLE
Add metrics around token usage

### DIFF
--- a/crates/agentgateway/src/telemetry/metrics.rs
+++ b/crates/agentgateway/src/telemetry/metrics.rs
@@ -1,10 +1,12 @@
 use std::fmt::Debug;
+use std::sync::Arc;
 
-use agent_core::metrics::{DefaultedUnknown, EncodeDisplay};
+use agent_core::metrics::{DefaultedUnknown, EncodeArc, EncodeDisplay};
 use agent_core::strng::RichStrng;
 use agent_core::version;
 use prometheus_client::encoding::{EncodeLabelSet, EncodeMetric};
 use prometheus_client::metrics::family::Family;
+use prometheus_client::metrics::histogram::Histogram as PromHistogram;
 use prometheus_client::metrics::info::Info;
 use prometheus_client::registry;
 use prometheus_client::registry::Registry;
@@ -26,17 +28,17 @@ pub struct HTTPLabels {
 
 #[derive(Clone, Hash, Default, Debug, PartialEq, Eq, EncodeLabelSet)]
 pub struct GenAILabels {
-	gen_ai_operation_name: DefaultedUnknown<RichStrng>,
-	gen_ai_system: DefaultedUnknown<RichStrng>,
-	gen_ai_request_model: DefaultedUnknown<RichStrng>,
-	gen_ai_response_model: DefaultedUnknown<RichStrng>,
+	pub gen_ai_operation_name: DefaultedUnknown<RichStrng>,
+	pub gen_ai_system: DefaultedUnknown<RichStrng>,
+	pub gen_ai_request_model: DefaultedUnknown<RichStrng>,
+	pub gen_ai_response_model: DefaultedUnknown<RichStrng>,
 }
 
 #[derive(Clone, Hash, Default, Debug, PartialEq, Eq, EncodeLabelSet)]
 pub struct GenAILabelsTokenUsage {
-	#[flatten]
-	common: GenAILabels,
-	gen_ai_token_type: DefaultedUnknown<RichStrng>,
+	pub gen_ai_token_type: DefaultedUnknown<RichStrng>,
+	#[prometheus(flatten)]
+	pub common: EncodeArc<GenAILabels>,
 }
 
 #[derive(Clone, Hash, Debug, PartialEq, Eq, EncodeLabelSet)]
@@ -61,7 +63,10 @@ pub struct Metrics {
 	pub requests: Counter,
 	pub downstream_connection: TCPCounter,
 
-	pub token_usage: Histogram<GenAILabelsTokenUsage>,
+	pub gen_ai_token_usage: Histogram<GenAILabelsTokenUsage>,
+	pub gen_ai_request_duration: Histogram<GenAILabels>,
+	pub gen_ai_time_per_output_token: Histogram<GenAILabels>,
+	pub gen_ai_time_to_first_token: Histogram<GenAILabels>,
 }
 
 impl Metrics {
@@ -73,6 +78,44 @@ impl Metrics {
 				tag: version::BuildInfo::new().version,
 			}),
 		);
+
+		let gen_ai_token_usage = Family::<GenAILabelsTokenUsage, _>::new_with_constructor(move || {
+			PromHistogram::new(TOKEN_USAGE_BUCKET)
+		});
+		registry.register(
+			"gen_ai_client_token_usage",
+			"Number of tokens used per request",
+			gen_ai_token_usage.clone(),
+		);
+
+		// TODO: add error attribute if it ends with an error
+		let gen_ai_request_duration = Family::<GenAILabels, _>::new_with_constructor(move || {
+			PromHistogram::new(REQUEST_DURATION_BUCKET)
+		});
+		registry.register(
+			"gen_ai_server_request_duration",
+			"Duration of generative AI request",
+			gen_ai_request_duration.clone(),
+		);
+
+		let gen_ai_time_per_output_token = Family::<GenAILabels, _>::new_with_constructor(move || {
+			PromHistogram::new(OUTPUT_TOKEN_BUCKET)
+		});
+		registry.register(
+			"gen_ai_server_time_per_output_token",
+			"Time to generate each output token for a given request",
+			gen_ai_time_per_output_token.clone(),
+		);
+
+		let gen_ai_time_to_first_token = Family::<GenAILabels, _>::new_with_constructor(move || {
+			PromHistogram::new(FIRST_TOKEN_BUCKET)
+		});
+		registry.register(
+			"gen_ai_server_time_to_first_token",
+			"Time to generate the first token for a given request",
+			gen_ai_time_to_first_token.clone(),
+		);
+
 		Metrics {
 			requests: build(
 				registry,
@@ -84,21 +127,38 @@ impl Metrics {
 				"downstream_connections",
 				"The total number of downstream connections established",
 			),
-			token_usage: build(
-				registry,
-				"gen_ai.client.token.usage",
-				"Number of tokens used per request",
-			),
+			gen_ai_token_usage,
+			gen_ai_request_duration,
+			gen_ai_time_per_output_token,
+			gen_ai_time_to_first_token,
 		}
 	}
 }
 
-fn build<T, C>(registry: &mut Registry, name: &str, help: &str) -> Family<T, C>
-where
-	T: Clone + std::hash::Hash + Eq + Send + Sync + Debug + EncodeLabelSet + 'static,
-	C: Default + Sync + Send + EncodeMetric + prometheus_client::metrics::TypedMetric + Debug+ 'static,
-{
-	let m = Family::<T, C>::default();
+fn build<T: Clone + std::hash::Hash + Eq + Send + Sync + Debug + EncodeLabelSet + 'static>(
+	registry: &mut Registry,
+	name: &str,
+	help: &str,
+) -> Family<T, prometheus_client::metrics::counter::Counter> {
+	let m = Family::<T, _>::default();
 	registry.register(name, help, m.clone());
 	m
 }
+
+// https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-metrics/#metric-gen_aiclienttokenusage
+const TOKEN_USAGE_BUCKET: [f64; 14] = [
+	1., 4., 16., 64., 256., 1024., 4096., 16384., 65536., 262144., 1048576., 4194304., 16777216.,
+	67108864.,
+];
+// https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-metrics/#metric-gen_aiserverrequestduration
+const REQUEST_DURATION_BUCKET: [f64; 14] = [
+	0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.64, 1.28, 2.56, 5.12, 10.24, 20.48, 40.96, 81.92,
+];
+// https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-metrics/#metric-gen_aiservertime_per_output_token
+const OUTPUT_TOKEN_BUCKET: [f64; 13] = [
+	0.01, 0.025, 0.05, 0.075, 0.1, 0.15, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.5,
+];
+// https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-metrics/#metric-gen_aiservertime_to_first_token
+const FIRST_TOKEN_BUCKET: [f64; 16] = [
+	0.001, 0.005, 0.01, 0.02, 0.04, 0.06, 0.08, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0,
+];

--- a/crates/core/src/metrics.rs
+++ b/crates/core/src/metrics.rs
@@ -1,7 +1,10 @@
-use std::fmt::{Display, Write};
+use std::fmt::{Display, Error, Write};
 use std::mem;
+use std::sync::Arc;
 
-use prometheus_client::encoding::{EncodeLabelValue, LabelValueEncoder};
+use prometheus_client::encoding::{
+	EncodeLabelSet, EncodeLabelValue, LabelSetEncoder, LabelValueEncoder,
+};
 use prometheus_client::registry::Registry;
 use tracing::error;
 use tracing::field::{DisplayValue, display};
@@ -209,5 +212,21 @@ impl<T: Display> From<T> for EncodeDisplay<T> {
 impl<T: Display> From<Option<T>> for DefaultedUnknown<EncodeDisplay<T>> {
 	fn from(t: Option<T>) -> Self {
 		DefaultedUnknown(t.map(EncodeDisplay::from))
+	}
+}
+
+#[derive(Default, Hash, PartialEq, Eq, Clone, Debug)]
+// EncodeArc is a wrapper around a type to make Arc<T> encodable if T is
+pub struct EncodeArc<T>(pub Arc<T>);
+
+impl<T: EncodeLabelSet> EncodeLabelSet for EncodeArc<T> {
+	fn encode(&self, encoder: LabelSetEncoder) -> Result<(), Error> {
+		self.0.encode(encoder)
+	}
+}
+
+impl<T: EncodeLabelSet> From<Arc<T>> for EncodeArc<T> {
+	fn from(value: Arc<T>) -> Self {
+		EncodeArc(value)
 	}
 }


### PR DESCRIPTION
Example (hiding the buckets since they are noisy)

Following https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-metrics

```
# HELP agentgateway_gen_ai_client_token_usage Number of tokens used per request.
# TYPE agentgateway_gen_ai_client_token_usage histogram
agentgateway_gen_ai_client_token_usage_sum{gen_ai_token_type="input",gen_ai_operation_name="chat",gen_ai_system="openai",gen_ai_request_model="gpt-3.5-turbo",gen_ai_response_model="gpt-4o-mini-2024-07-18"} 44.0
agentgateway_gen_ai_client_token_usage_count{gen_ai_token_type="input",gen_ai_operation_name="chat",gen_ai_system="openai",gen_ai_request_model="gpt-3.5-turbo",gen_ai_response_model="gpt-4o-mini-2024-07-18"} 2
agentgateway_gen_ai_client_token_usage_sum{gen_ai_token_type="output",gen_ai_operation_name="chat",gen_ai_system="openai",gen_ai_request_model="gpt-3.5-turbo",gen_ai_response_model="gpt-4o-mini-2024-07-18"} 388.0
agentgateway_gen_ai_client_token_usage_count{gen_ai_token_type="output",gen_ai_operation_name="chat",gen_ai_system="openai",gen_ai_request_model="gpt-3.5-turbo",gen_ai_response_model="gpt-4o-mini-2024-07-18"} 2
# HELP agentgateway_gen_ai_server_request_duration Duration of generative AI request.
# TYPE agentgateway_gen_ai_server_request_duration histogram
agentgateway_gen_ai_server_request_duration_sum{gen_ai_operation_name="chat",gen_ai_system="openai",gen_ai_request_model="gpt-3.5-turbo",gen_ai_response_model="gpt-4o-mini-2024-07-18"} 3.521742502
agentgateway_gen_ai_server_request_duration_count{gen_ai_operation_name="chat",gen_ai_system="openai",gen_ai_request_model="gpt-3.5-turbo",gen_ai_response_model="gpt-4o-mini-2024-07-18"} 2
agentgateway_gen_ai_server_request_duration_sum{gen_ai_operation_name="chat",gen_ai_system="openai",gen_ai_request_model="gpt-3.5-turbo",gen_ai_response_model="unknown"} 0.004818768
agentgateway_gen_ai_server_request_duration_count{gen_ai_operation_name="chat",gen_ai_system="openai",gen_ai_request_model="gpt-3.5-turbo",gen_ai_response_model="unknown"} 1
# HELP agentgateway_gen_ai_server_time_per_output_token Time to generate each output token for a given request.
# TYPE agentgateway_gen_ai_server_time_per_output_token histogram
agentgateway_gen_ai_server_time_per_output_token_sum{gen_ai_operation_name="chat",gen_ai_system="openai",gen_ai_request_model="gpt-3.5-turbo",gen_ai_response_model="gpt-4o-mini-2024-07-18"} 0.018072102201030929
agentgateway_gen_ai_server_time_per_output_token_count{gen_ai_operation_name="chat",gen_ai_system="openai",gen_ai_request_model="gpt-3.5-turbo",gen_ai_response_model="gpt-4o-mini-2024-07-18"} 2
# HELP agentgateway_gen_ai_server_time_to_first_token Time to generate the first token for a given request.
# TYPE agentgateway_gen_ai_server_time_to_first_token histogram
agentgateway_gen_ai_server_time_to_first_token_sum{gen_ai_operation_name="chat",gen_ai_system="openai",gen_ai_request_model="gpt-3.5-turbo",gen_ai_response_model="gpt-4o-mini-2024-07-18"} 0.015754675
agentgateway_gen_ai_server_time_to_first_token_count{gen_ai_operation_name="chat",gen_ai_system="openai",gen_ai_request_model="gpt-3.5-turbo",gen_ai_response_model="gpt-4o-mini-2024-07-18"} 2
```