### PR TITLE
Minor fixup to types

### DIFF
--- a/crates/agentgateway/src/http/auth.rs
+++ b/crates/agentgateway/src/http/auth.rs
@@ -10,9 +10,8 @@ use crate::proxy::ProxyError;
 use crate::serdes::deser_key_from_file;
 use crate::*;
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[apply(schema!)]
+#[serde(untagged)]
 pub enum AwsAuth {
 	/// Use explicit AWS credentials
 	#[serde(rename_all = "camelCase")]
@@ -33,9 +32,7 @@ pub enum AwsAuth {
 	Implicit {},
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields, untagged)]
-#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[apply(schema!)]
 pub enum BackendAuth {
 	Passthrough {},
 	Key(

--- a/crates/agentgateway/src/llm/policy.rs
+++ b/crates/agentgateway/src/llm/policy.rs
@@ -128,8 +128,6 @@ pub struct PromptGuardRequest {
 #[apply(schema!)]
 pub struct RegexRules {
 	#[serde(default)]
-	response: PromptGuardResponse,
-	#[serde(default, flatten)]
 	action: Action,
 	rules: Vec<RegexRule>,
 }
@@ -188,7 +186,6 @@ pub struct Webhook {
 
 #[apply(schema!)]
 #[derive(Default)]
-#[serde(tag = "action")]
 pub enum Action {
 	#[default]
 	Mask,

--- a/schema/README.md
+++ b/schema/README.md
@@ -143,11 +143,15 @@ This defaults to 'true'.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request.response.body`||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request.response.status`||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request.regex`||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request.regex.(any)(1)action`||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request.regex.(any)(1)response`||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request.regex.(any)(1)response.body`||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request.regex.(any)(1)response.status`||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request.regex.(any)(1)action`||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request.regex.action`||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request.regex.action.(1)reject`||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request.regex.action.(1)reject.response`||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request.regex.action.(1)reject.response.body`||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request.regex.action.(1)reject.response.status`||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request.regex.rules`||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request.regex.rules[].(any)builtin`||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request.regex.rules[].(any)pattern`||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request.regex.rules[].(any)name`||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request.webhook`||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request.webhook.target`||
 |`binds[].listeners[].routes[].policies.backendTLS`|Send TLS to the backend.|
@@ -157,13 +161,15 @@ This defaults to 'true'.|
 |`binds[].listeners[].routes[].policies.backendTLS.insecure`||
 |`binds[].listeners[].routes[].policies.backendTLS.insecureHost`||
 |`binds[].listeners[].routes[].policies.backendAuth`|Authenticate to the backend.|
-|`binds[].listeners[].routes[].policies.backendAuth.(any)(any)(any)file`||
-|`binds[].listeners[].routes[].policies.backendAuth.(any)(any)(1)explicitConfig`||
-|`binds[].listeners[].routes[].policies.backendAuth.(any)(any)(1)explicitConfig.accessKeyId`||
-|`binds[].listeners[].routes[].policies.backendAuth.(any)(any)(1)explicitConfig.secretAccessKey`||
-|`binds[].listeners[].routes[].policies.backendAuth.(any)(any)(1)explicitConfig.region`||
-|`binds[].listeners[].routes[].policies.backendAuth.(any)(any)(1)explicitConfig.sessionToken`||
-|`binds[].listeners[].routes[].policies.backendAuth.(any)(any)(1)implicit`||
+|`binds[].listeners[].routes[].policies.backendAuth.(any)(1)passthrough`||
+|`binds[].listeners[].routes[].policies.backendAuth.(any)(1)key`||
+|`binds[].listeners[].routes[].policies.backendAuth.(any)(1)key.(any)file`||
+|`binds[].listeners[].routes[].policies.backendAuth.(any)(1)gcp`||
+|`binds[].listeners[].routes[].policies.backendAuth.(any)(1)aws`||
+|`binds[].listeners[].routes[].policies.backendAuth.(any)(1)aws.(any)accessKeyId`||
+|`binds[].listeners[].routes[].policies.backendAuth.(any)(1)aws.(any)secretAccessKey`||
+|`binds[].listeners[].routes[].policies.backendAuth.(any)(1)aws.(any)region`||
+|`binds[].listeners[].routes[].policies.backendAuth.(any)(1)aws.(any)sessionToken`||
 |`binds[].listeners[].routes[].policies.localRateLimit`|Rate limit incoming requests. State is kept local.|
 |`binds[].listeners[].routes[].policies.localRateLimit[].maxTokens`||
 |`binds[].listeners[].routes[].policies.localRateLimit[].tokensPerFill`||

--- a/schema/local.json
+++ b/schema/local.json
@@ -1118,146 +1118,112 @@
                                         }
                                       },
                                       "regex": {
-                                        "anyOf": [
-                                          {
-                                            "type": "object",
-                                            "properties": {
-                                              "response": {
-                                                "type": "object",
-                                                "properties": {
-                                                  "body": {
-                                                    "type": [
-                                                      "array",
-                                                      "string"
-                                                    ],
-                                                    "items": {
-                                                      "type": "integer",
-                                                      "format": "uint8",
-                                                      "minimum": 0,
-                                                      "maximum": 255
-                                                    },
-                                                    "default": "The request was rejected due to inappropriate content"
-                                                  },
-                                                  "status": {
-                                                    "type": "integer",
-                                                    "format": "uint16",
-                                                    "minimum": 1,
-                                                    "maximum": 65535,
-                                                    "default": 403
-                                                  }
-                                                },
-                                                "additionalProperties": false,
-                                                "default": {
-                                                  "body": "The request was rejected due to inappropriate content",
-                                                  "status": 403
-                                                }
-                                              },
-                                              "rules": {
-                                                "type": "array",
-                                                "items": {
-                                                  "anyOf": [
-                                                    {
-                                                      "type": "object",
-                                                      "properties": {
-                                                        "builtin": {
-                                                          "type": "string",
-                                                          "enum": [
-                                                            "ssn",
-                                                            "creditCard",
-                                                            "phoneNumber",
-                                                            "email"
-                                                          ]
-                                                        }
-                                                      },
-                                                      "additionalProperties": false,
-                                                      "required": [
-                                                        "builtin"
-                                                      ]
-                                                    },
-                                                    {
-                                                      "type": "object",
-                                                      "properties": {
-                                                        "pattern": {
-                                                          "type": "string"
-                                                        },
-                                                        "name": {
-                                                          "type": "string"
-                                                        }
-                                                      },
-                                                      "additionalProperties": false,
-                                                      "required": [
-                                                        "pattern",
-                                                        "name"
-                                                      ]
-                                                    }
-                                                  ]
-                                                }
-                                              }
-                                            },
-                                            "unevaluatedProperties": false,
+                                        "type": [
+                                          "object",
+                                          "null"
+                                        ],
+                                        "properties": {
+                                          "action": {
                                             "oneOf": [
                                               {
-                                                "type": "object",
-                                                "properties": {
-                                                  "action": {
-                                                    "type": "string",
-                                                    "const": "mask"
-                                                  }
-                                                },
-                                                "required": [
-                                                  "action"
+                                                "type": "string",
+                                                "enum": [
+                                                  "mask"
                                                 ]
                                               },
                                               {
                                                 "type": "object",
                                                 "properties": {
-                                                  "response": {
+                                                  "reject": {
                                                     "type": "object",
                                                     "properties": {
-                                                      "body": {
-                                                        "type": [
-                                                          "array",
-                                                          "string"
-                                                        ],
-                                                        "items": {
-                                                          "type": "integer",
-                                                          "format": "uint8",
-                                                          "minimum": 0,
-                                                          "maximum": 255
+                                                      "response": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "body": {
+                                                            "type": [
+                                                              "array",
+                                                              "string"
+                                                            ],
+                                                            "items": {
+                                                              "type": "integer",
+                                                              "format": "uint8",
+                                                              "minimum": 0,
+                                                              "maximum": 255
+                                                            },
+                                                            "default": "The request was rejected due to inappropriate content"
+                                                          },
+                                                          "status": {
+                                                            "type": "integer",
+                                                            "format": "uint16",
+                                                            "minimum": 1,
+                                                            "maximum": 65535,
+                                                            "default": 403
+                                                          }
                                                         },
-                                                        "default": "The request was rejected due to inappropriate content"
-                                                      },
-                                                      "status": {
-                                                        "type": "integer",
-                                                        "format": "uint16",
-                                                        "minimum": 1,
-                                                        "maximum": 65535,
-                                                        "default": 403
+                                                        "additionalProperties": false,
+                                                        "default": {
+                                                          "body": "The request was rejected due to inappropriate content",
+                                                          "status": 403
+                                                        }
                                                       }
                                                     },
-                                                    "additionalProperties": false,
-                                                    "default": {
-                                                      "body": "The request was rejected due to inappropriate content",
-                                                      "status": 403
-                                                    }
-                                                  },
-                                                  "action": {
-                                                    "type": "string",
-                                                    "const": "reject"
+                                                    "additionalProperties": false
                                                   }
                                                 },
                                                 "required": [
-                                                  "action"
-                                                ]
+                                                  "reject"
+                                                ],
+                                                "additionalProperties": false
                                               }
                                             ],
-                                            "required": [
-                                              "rules"
-                                            ]
+                                            "default": "mask"
                                           },
-                                          {
-                                            "type": "null"
+                                          "rules": {
+                                            "type": "array",
+                                            "items": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "builtin": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "ssn",
+                                                        "creditCard",
+                                                        "phoneNumber",
+                                                        "email"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "additionalProperties": false,
+                                                  "required": [
+                                                    "builtin"
+                                                  ]
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "pattern": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "additionalProperties": false,
+                                                  "required": [
+                                                    "pattern",
+                                                    "name"
+                                                  ]
+                                                }
+                                              ]
+                                            }
                                           }
+                                        },
+                                        "additionalProperties": false,
+                                        "required": [
+                                          "rules"
                                         ]
                                       },
                                       "webhook": {
@@ -1325,40 +1291,67 @@
                             "description": "Authenticate to the backend.",
                             "anyOf": [
                               {
-                                "anyOf": [
+                                "oneOf": [
                                   {
                                     "type": "object",
+                                    "properties": {
+                                      "passthrough": {
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "required": [
+                                      "passthrough"
+                                    ],
                                     "additionalProperties": false
                                   },
                                   {
-                                    "anyOf": [
-                                      {
-                                        "type": "object",
-                                        "properties": {
-                                          "file": {
+                                    "type": "object",
+                                    "properties": {
+                                      "key": {
+                                        "anyOf": [
+                                          {
+                                            "type": "object",
+                                            "properties": {
+                                              "file": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "file"
+                                            ]
+                                          },
+                                          {
                                             "type": "string"
                                           }
-                                        },
-                                        "required": [
-                                          "file"
                                         ]
-                                      },
-                                      {
-                                        "type": "string"
                                       }
-                                    ]
-                                  },
-                                  {
-                                    "type": "object",
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
                                     "additionalProperties": false
                                   },
                                   {
-                                    "oneOf": [
-                                      {
-                                        "description": "Use explicit AWS credentials",
+                                    "type": "object",
+                                    "properties": {
+                                      "gcp": {
                                         "type": "object",
-                                        "properties": {
-                                          "explicitConfig": {
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "required": [
+                                      "gcp"
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "aws": {
+                                        "anyOf": [
+                                          {
+                                            "description": "Use explicit AWS credentials",
                                             "type": "object",
                                             "properties": {
                                               "accessKeyId": {
@@ -1377,32 +1370,25 @@
                                                 ]
                                               }
                                             },
+                                            "additionalProperties": false,
                                             "required": [
                                               "accessKeyId",
                                               "secretAccessKey",
                                               "region"
                                             ]
+                                          },
+                                          {
+                                            "description": "Use implicit AWS authentication (environment variables, IAM roles, etc.)",
+                                            "type": "object",
+                                            "additionalProperties": false
                                           }
-                                        },
-                                        "required": [
-                                          "explicitConfig"
-                                        ],
-                                        "additionalProperties": false
-                                      },
-                                      {
-                                        "description": "Use implicit AWS authentication (environment variables, IAM roles, etc.)",
-                                        "type": "object",
-                                        "properties": {
-                                          "implicit": {
-                                            "type": "object"
-                                          }
-                                        },
-                                        "required": [
-                                          "implicit"
-                                        ],
-                                        "additionalProperties": false
+                                        ]
                                       }
-                                    ]
+                                    },
+                                    "required": [
+                                      "aws"
+                                    ],
+                                    "additionalProperties": false
                                   }
                                 ]
                               },


### PR DESCRIPTION
Recent PR made backendAuth unusable due to `untagged`  on BackendAuth instead of AwsAuth.

prompt guard suffers from some issues around type duplication