### PR TITLE
fix: fix the workerThreads type to allow null

### DIFF
--- a/crates/agentgateway/src/lib.rs
+++ b/crates/agentgateway/src/lib.rs
@@ -93,7 +93,7 @@ pub struct RawConfig {
 	#[cfg_attr(feature = "schema", schemars(with = "Option<String>"))]
 	connection_min_termination_deadline: Option<Duration>,
 
-	#[cfg_attr(feature = "schema", schemars(with = "String"))]
+	#[cfg_attr(feature = "schema", schemars(with = "Option<String>"))]
 	worker_threads: Option<StringOrInt>,
 
 	tracing: Option<RawTracing>,

--- a/schema/local.json
+++ b/schema/local.json
@@ -109,7 +109,10 @@
           "default": null
         },
         "workerThreads": {
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "tracing": {
           "type": [
@@ -266,9 +269,6 @@
         }
       },
       "additionalProperties": false,
-      "required": [
-        "workerThreads"
-      ],
       "default": null
     },
     "binds": {


### PR DESCRIPTION
this PR switched $schema in all examples to an absolute URL and made config.workerThreads optional in the generate dschema. no more "my yaml needs the repo cloned down to work"