### PR TITLE
fix: change directResponse status default from string to number

### DIFF
--- a/ui/src/lib/policy-defaults.ts
+++ b/ui/src/lib/policy-defaults.ts
@@ -80,7 +80,7 @@ export function getDefaultPolicyData(type: PolicyType) {
     case "directResponse":
       return {
         body: "",
-        status: "200",
+        status: 200,
       };
     case "extAuthz":
       return {


### PR DESCRIPTION
Change the default status value for directResponse policy from string '200' to number 200 to match the expected type in the DirectResponse interface.
