### PR TITLE
 Add HTTP authorization policies

### DIFF
--- a/crates/agentgateway/src/http/authorization.rs
+++ b/crates/agentgateway/src/http/authorization.rs
@@ -1,0 +1,221 @@
+use std::collections::{HashMap, HashSet};
+use std::fmt::Display;
+use std::str::FromStr;
+
+use crate::cel::{ContextBuilder, Executor};
+use crate::http::jwt::Claims;
+use crate::mcp::rbac::ResourceType;
+use crate::*;
+use agent_core::bow::OwnedOrBorrowed;
+use anyhow::{Context as _, Error};
+use lazy_static::lazy_static;
+use secrecy::SecretString;
+use serde::ser::{SerializeMap, SerializeSeq};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_json::Value;
+use serde_json::map::Map;
+use tracing::log;
+
+#[derive(Clone, Debug)]
+pub struct HTTPAuthorizationSet(RuleSets);
+
+impl HTTPAuthorizationSet {
+	pub fn new(rs: RuleSets) -> Self {
+		Self(rs)
+	}
+	pub fn apply(
+		&self,
+		req: &mut crate::http::Request,
+		exec: &cel::Executor<'_>,
+	) -> anyhow::Result<()> {
+		tracing::debug!("Checking HTTP request");
+		let allowed = self
+			.0
+			.validate(|| Ok(agent_core::bow::OwnedOrBorrowed::Borrowed(exec)));
+		if !allowed {
+			anyhow::bail!("HTTP authorization denied");
+		}
+		Ok(())
+	}
+
+	pub fn register(&self, cel: &mut ContextBuilder) {
+		self.0.register(cel);
+	}
+}
+
+#[apply(schema!)]
+pub struct RuleSet {
+	#[serde(serialize_with = "se_policies", deserialize_with = "de_policies")]
+	#[cfg_attr(feature = "schema", schemars(with = "Vec<String>"))]
+	pub rules: PolicySet,
+}
+
+impl RuleSet {
+	pub fn register(&self, cel: &mut ContextBuilder) {
+		for rule in &self.rules.allow {
+			cel.register_expression(rule.as_ref());
+		}
+		for rule in &self.rules.deny {
+			cel.register_expression(rule.as_ref());
+		}
+	}
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct PolicySet {
+	allow: Vec<Arc<cel::Expression>>,
+	deny: Vec<Arc<cel::Expression>>,
+}
+
+#[derive(Clone, Debug)]
+pub enum Policy {
+	Allow(Arc<cel::Expression>),
+	Deny(Arc<cel::Expression>),
+}
+
+#[apply(schema!)]
+#[serde(untagged)]
+enum RuleSerde {
+	Object {
+		#[serde(flatten)]
+		rule: RuleTypeSerde,
+	},
+	PlainString(String),
+}
+
+#[apply(schema!)]
+enum RuleTypeSerde {
+	Allow(String),
+	Deny(String),
+}
+
+impl PolicySet {
+	pub fn add(&mut self, p: impl Into<String>) -> Result<(), cel::Error> {
+		self.allow.push(Arc::new(cel::Expression::new(p)?));
+		Ok(())
+	}
+}
+
+pub fn se_policies<S: Serializer>(t: &PolicySet, serializer: S) -> Result<S::Ok, S::Error> {
+	let mut m = serializer.serialize_map(Some(2))?;
+	m.serialize_entry("allow", &t.allow)?;
+	m.serialize_entry("deny", &t.deny)?;
+	m.end()
+}
+
+pub fn de_policies<'de: 'a, 'a, D>(deserializer: D) -> Result<PolicySet, D::Error>
+where
+	D: Deserializer<'de>,
+{
+	let raw = Vec::<RuleSerde>::deserialize(deserializer)?;
+	let mut res = PolicySet {
+		allow: vec![],
+		deny: vec![],
+	};
+	for r in raw {
+		match r {
+			RuleSerde::Object {
+				rule: RuleTypeSerde::Allow(allow),
+			}
+			| RuleSerde::PlainString(allow) => res.allow.push(
+				cel::Expression::new(&allow)
+					.map(Arc::new)
+					.map_err(|e| serde::de::Error::custom(e.to_string()))?,
+			),
+			RuleSerde::Object {
+				rule: RuleTypeSerde::Deny(deny),
+			} => res.deny.push(
+				cel::Expression::new(deny)
+					.map(Arc::new)
+					.map_err(|e| serde::de::Error::custom(e.to_string()))?,
+			),
+		};
+	}
+	Ok(res)
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+pub struct RuleSets(Vec<RuleSet>);
+
+impl From<Vec<RuleSet>> for RuleSets {
+	fn from(value: Vec<RuleSet>) -> Self {
+		Self(value)
+	}
+}
+
+impl RuleSets {
+	pub fn register(&self, ctx: &mut ContextBuilder) {
+		for rule_set in &self.0 {
+			rule_set.register(ctx);
+		}
+	}
+	pub fn validate<'a>(
+		&self,
+		exec: impl FnOnce() -> anyhow::Result<OwnedOrBorrowed<'a, Executor<'a>>>,
+	) -> bool {
+		let rule_sets = &self.0;
+		let has_rules = rule_sets.iter().any(|r| r.has_rules());
+		// If there are no rule sets, everyone has access
+		if !has_rules {
+			return true;
+		}
+		// Build executor only when we have rules
+		let Ok(exec) = exec() else {
+			return false;
+		};
+		let exec = exec.as_ref();
+		// If there are any DENY, deny
+		if rule_sets.iter().any(|r| r.denies(exec)) {
+			return false;
+		}
+		// If there are any ALLOW, allow
+		if rule_sets.iter().any(|r| r.allows(exec)) {
+			return true;
+		}
+		// Else deny
+		false
+	}
+
+	pub fn is_empty(&self) -> bool {
+		self.0.is_empty()
+	}
+}
+
+impl RuleSet {
+	pub fn new(rules: PolicySet) -> Self {
+		Self { rules }
+	}
+
+	pub fn has_rules(&self) -> bool {
+		!self.rules.allow.is_empty() || !self.rules.deny.is_empty()
+	}
+	pub fn denies(&self, exec: &cel::Executor) -> bool {
+		if self.rules.deny.is_empty() {
+			false
+		} else {
+			self
+				.rules
+				.deny
+				.iter()
+				.any(|rule| exec.eval_bool(rule.as_ref()))
+		}
+	}
+
+	pub fn allows(&self, exec: &cel::Executor) -> bool {
+		if self.rules.allow.is_empty() {
+			false
+		} else {
+			self
+				.rules
+				.allow
+				.iter()
+				.any(|rule| exec.eval_bool(rule.as_ref()))
+		}
+	}
+}
+
+#[cfg(any(test, feature = "internal_benches"))]
+#[path = "authorization_tests.rs"]
+mod tests;

--- a/crates/agentgateway/src/http/authorization_tests.rs
+++ b/crates/agentgateway/src/http/authorization_tests.rs
@@ -1,10 +1,12 @@
+use super::*;
+use crate::http::authorization::PolicySet;
+use crate::mcp::rbac::ResourceId;
+use agent_core::bow::OwnedOrBorrowed;
 #[cfg(test)]
 use assert_matches::assert_matches;
 use divan::Bencher;
 use secrecy::SecretString;
 use serde_json::{Map, Value};
-
-use super::*;
 
 fn create_policy_set(policies: Vec<&str>) -> PolicySet {
 	let mut policy_set = PolicySet::default();
@@ -19,7 +21,8 @@ fn test_rbac_reject_exact_match() {
 	let policies = vec![r#"mcp.tool.name == "increment" && jwt.user == "admin""#];
 	let rbac = RuleSet::new(create_policy_set(policies));
 	let mut ctx = ContextBuilder::new();
-	RuleSets::from(vec![rbac.clone()]).register(&mut ctx);
+	let rs = RuleSets::from(vec![rbac.clone()]);
+	rs.register(&mut ctx);
 	ctx.with_jwt(&Claims {
 		inner: Map::from_iter([("sub".to_string(), "1234567890".to_string().into())]),
 		jwt: SecretString::new("".into()),
@@ -31,7 +34,7 @@ fn test_rbac_reject_exact_match() {
 		))))
 		.unwrap();
 
-	assert_matches!(rbac.validate_internal(&exec), Ok(false));
+	assert_matches!(rs.validate(|| Ok(OwnedOrBorrowed::Borrowed(&exec))), false);
 }
 
 #[test]
@@ -39,7 +42,8 @@ fn test_rbac_check_exact_match() {
 	let policies = vec![r#"mcp.tool.name == "increment" && jwt.sub == "1234567890""#];
 	let rbac = RuleSet::new(create_policy_set(policies));
 	let mut ctx = ContextBuilder::new();
-	RuleSets::from(vec![rbac.clone()]).register(&mut ctx);
+	let rs = RuleSets::from(vec![rbac.clone()]);
+	rs.register(&mut ctx);
 	ctx.with_jwt(&Claims {
 		inner: Map::from_iter([("sub".to_string(), "1234567890".to_string().into())]),
 		jwt: SecretString::new("".into()),
@@ -51,7 +55,7 @@ fn test_rbac_check_exact_match() {
 		))))
 		.unwrap();
 
-	assert_matches!(rbac.validate_internal(&exec), Ok(true));
+	assert_matches!(rs.validate(|| Ok(OwnedOrBorrowed::Borrowed(&exec))), true);
 }
 
 #[test]
@@ -59,7 +63,8 @@ fn test_rbac_target() {
 	let policies = vec![r#"mcp.tool.name == "increment" && mcp.tool.target == "server""#];
 	let rbac = RuleSet::new(create_policy_set(policies));
 	let mut ctx = ContextBuilder::new();
-	RuleSets::from(vec![rbac.clone()]).register(&mut ctx);
+	let rs = RuleSets::from(vec![rbac.clone()]);
+	rs.register(&mut ctx);
 	ctx.with_jwt(&Claims {
 		inner: Map::from_iter([("sub".to_string(), "1234567890".to_string().into())]),
 		jwt: SecretString::new("".into()),
@@ -71,7 +76,7 @@ fn test_rbac_target() {
 		))))
 		.unwrap();
 
-	assert_matches!(rbac.validate_internal(&exec), Ok(true));
+	assert_matches!(rs.validate(|| Ok(OwnedOrBorrowed::Borrowed(&exec))), true);
 
 	let exec_different_target = ctx
 		.build_with_mcp(Some(&ResourceType::Tool(ResourceId::new(
@@ -80,7 +85,10 @@ fn test_rbac_target() {
 		))))
 		.unwrap();
 
-	assert_matches!(rbac.validate_internal(&exec_different_target), Ok(false));
+	assert_matches!(
+		rs.validate(|| Ok(OwnedOrBorrowed::Borrowed(&exec_different_target))),
+		false
+	);
 }
 
 #[test]
@@ -88,7 +96,8 @@ fn test_rbac_check_contains_match() {
 	let policies = vec![r#"mcp.tool.name == "increment" && jwt.groups == "admin""#];
 	let rbac = RuleSet::new(create_policy_set(policies));
 	let mut ctx = ContextBuilder::new();
-	RuleSets::from(vec![rbac.clone()]).register(&mut ctx);
+	let rs = RuleSets::from(vec![rbac.clone()]);
+	rs.register(&mut ctx);
 	ctx.with_jwt(&Claims {
 		inner: Map::from_iter([("groups".to_string(), "admin".to_string().into())]),
 		jwt: SecretString::new("".into()),
@@ -100,7 +109,7 @@ fn test_rbac_check_contains_match() {
 		))))
 		.unwrap();
 
-	assert_matches!(rbac.validate_internal(&exec), Ok(true));
+	assert_matches!(rs.validate(|| Ok(OwnedOrBorrowed::Borrowed(&exec))), true);
 }
 
 #[test]
@@ -108,7 +117,8 @@ fn test_rbac_check_nested_key_match() {
 	let policies = vec![r#"mcp.tool.name == "increment" && jwt.user.role == "admin""#];
 	let rbac = RuleSet::new(create_policy_set(policies));
 	let mut ctx = ContextBuilder::new();
-	RuleSets::from(vec![rbac.clone()]).register(&mut ctx);
+	let rs = RuleSets::from(vec![rbac.clone()]);
+	rs.register(&mut ctx);
 	let mut user_obj = Map::new();
 	user_obj.insert("role".to_string(), "admin".into());
 	ctx.with_jwt(&Claims {
@@ -122,7 +132,7 @@ fn test_rbac_check_nested_key_match() {
 		))))
 		.unwrap();
 
-	assert_matches!(rbac.validate_internal(&exec), Ok(true));
+	assert_matches!(rs.validate(|| Ok(OwnedOrBorrowed::Borrowed(&exec))), true);
 }
 
 #[test]
@@ -130,7 +140,8 @@ fn test_rbac_check_array_contains_match() {
 	let policies = vec![r#"mcp.tool.name == "increment" && jwt.roles.contains("admin")"#];
 	let rbac = RuleSet::new(create_policy_set(policies));
 	let mut ctx = ContextBuilder::new();
-	RuleSets::from(vec![rbac.clone()]).register(&mut ctx);
+	let rs = RuleSets::from(vec![rbac.clone()]);
+	rs.register(&mut ctx);
 	let roles: Vec<Value> = vec!["user".into(), "admin".into(), "developer".into()];
 	ctx.with_jwt(&Claims {
 		inner: Map::from_iter([("roles".to_string(), roles.into())]),
@@ -143,7 +154,7 @@ fn test_rbac_check_array_contains_match() {
 		))))
 		.unwrap();
 
-	assert_matches!(rbac.validate_internal(&exec), Ok(true));
+	assert_matches!(rs.validate(|| Ok(OwnedOrBorrowed::Borrowed(&exec))), true);
 }
 
 #[divan::bench]
@@ -151,7 +162,8 @@ fn bench(b: Bencher) {
 	let policies = vec![r#"mcp.tool.name == "increment" && jwt.user.role == "admin""#];
 	let rbac = RuleSet::new(create_policy_set(policies));
 	let mut ctx = ContextBuilder::new();
-	RuleSets::from(vec![rbac.clone()]).register(&mut ctx);
+	let rs = RuleSets::from(vec![rbac.clone()]);
+	rs.register(&mut ctx);
 	let mut user_obj = Map::new();
 	user_obj.insert("role".to_string(), "admin".into());
 	ctx.with_jwt(&Claims {
@@ -165,6 +177,6 @@ fn bench(b: Bencher) {
 		))))
 		.unwrap();
 	b.bench(|| {
-		rbac.validate_internal(&exec);
+		rs.validate(|| Ok(OwnedOrBorrowed::Borrowed(&exec)));
 	});
 }

--- a/crates/agentgateway/src/http/mod.rs
+++ b/crates/agentgateway/src/http/mod.rs
@@ -14,6 +14,7 @@ mod tests_common;
 #[allow(dead_code)]
 mod transformation;
 // Do not warn is it is WIP
+pub mod authorization;
 pub mod backendtls;
 pub mod ext_authz;
 pub mod ext_proc;

--- a/crates/agentgateway/src/http/remoteratelimit.rs
+++ b/crates/agentgateway/src/http/remoteratelimit.rs
@@ -27,7 +27,6 @@ use crate::http::remoteratelimit::proto::{RateLimitDescriptor, RateLimitRequest}
 use crate::http::transformation_cel::Transformation;
 use crate::http::{HeaderName, HeaderValue, PolicyResponse, Request, Response};
 use crate::llm::LLMRequest;
-use crate::mcp::rbac::PolicySet;
 use crate::proxy::ProxyError;
 use crate::proxy::httpproxy::PolicyClient;
 use crate::transport::stream::{TCPConnectionInfo, TLSConnectionInfo};

--- a/crates/agentgateway/src/mcp/rbac_tests.rs
+++ b/crates/agentgateway/src/mcp/rbac_tests.rs
@@ -7,7 +7,7 @@ use serde_json::{Map, Value};
 use super::*;
 
 fn create_policy_set(policies: Vec<&str>) -> PolicySet {
-	let mut policy_set = PolicySet::new();
+	let mut policy_set = PolicySet::default();
 	for p in policies.into_iter() {
 		policy_set.add(p).expect("Failed to parse policy");
 	}

--- a/crates/agentgateway/src/mcp/relay/mod.rs
+++ b/crates/agentgateway/src/mcp/relay/mod.rs
@@ -29,9 +29,10 @@ use tokio_util::sync::CancellationToken;
 use tracing::instrument;
 
 use crate::cel::ContextBuilder;
+use crate::http::authorization::RuleSets;
 use crate::http::jwt::Claims;
 use crate::mcp::rbac;
-use crate::mcp::rbac::{Identity, RuleSets};
+use crate::mcp::rbac::{Identity, McpAuthorizationSet};
 use crate::mcp::relay::pool::ConnectionPool;
 use crate::mcp::relay::upstream::UpstreamTarget;
 use crate::mcp::sse::{MCPInfo, McpBackendGroup};
@@ -40,7 +41,7 @@ use crate::store::Stores;
 use crate::telemetry::log::AsyncLog;
 use crate::telemetry::trc::TraceParent;
 use crate::transport::stream::{TCPConnectionInfo, TLSConnectionInfo};
-use crate::types::agent::{McpAuthorization, McpBackend};
+use crate::types::agent::McpBackend;
 use crate::{ProxyInputs, client};
 
 type McpError = ErrorData;
@@ -89,7 +90,7 @@ impl RqCtx {
 pub struct Relay {
 	pool: Arc<RwLock<pool::ConnectionPool>>,
 	metrics: Arc<metrics::Metrics>,
-	policies: RuleSets,
+	policies: McpAuthorizationSet,
 	// If we have 1 target only, we don't prefix everything with 'target_'.
 	// Else this is empty
 	default_target_name: Option<String>,
@@ -101,7 +102,7 @@ impl Relay {
 		pi: Arc<ProxyInputs>,
 		backend: McpBackendGroup,
 		metrics: Arc<metrics::Metrics>,
-		policies: RuleSets,
+		policies: McpAuthorizationSet,
 		client: PolicyClient,
 		stateful: bool,
 	) -> Self {

--- a/crates/agentgateway/src/mcp/sse.rs
+++ b/crates/agentgateway/src/mcp/sse.rs
@@ -47,11 +47,11 @@ use tracing::warn;
 use url::form_urlencoded;
 
 use crate::cel::ContextBuilder;
+use crate::http::authorization::RuleSets;
 use crate::http::jwt::Claims;
 use crate::http::*;
 use crate::json::{from_body, to_body};
 use crate::llm::LLMRequest;
-use crate::mcp::rbac::RuleSets;
 use crate::mcp::relay::Relay;
 use crate::mcp::{rbac, relay};
 use crate::proxy::httpproxy::PolicyClient;

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -28,13 +28,14 @@ use serde_json::Value;
 use thiserror::Error;
 
 use crate::http::auth::BackendAuth;
+use crate::http::authorization::RuleSet;
 use crate::http::jwt::Jwt;
 use crate::http::localratelimit::RateLimit;
 use crate::http::{
 	HeaderName, HeaderValue, StatusCode, ext_authz, ext_proc, filters, remoteratelimit, retry,
 	status, timeout, uri,
 };
-use crate::mcp::rbac::RuleSet;
+use crate::mcp::rbac::McpAuthorization;
 use crate::proxy::ProxyError;
 use crate::transport::tls;
 use crate::types::discovery::{NamespacedHostname, Service};
@@ -1046,6 +1047,8 @@ pub enum Policy {
 	InferenceRouting(ext_proc::InferenceRouting),
 
 	// Supported targets: Gateway < Route < RouteRule; single policy allowed
+	Authorization(Authorization),
+	// Supported targets: Gateway < Route < RouteRule; single policy allowed
 	// Transformation(),
 	// Supported targets: Gateway < Route < RouteRule; single policy allowed
 	LocalRateLimit(Vec<crate::http::localratelimit::RateLimit>),
@@ -1067,7 +1070,7 @@ pub enum Policy {
 pub struct A2aPolicy {}
 
 #[apply(schema!)]
-pub struct McpAuthorization(RuleSet);
+pub struct Authorization(pub RuleSet);
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -1155,11 +1158,6 @@ pub enum McpIDP {
 	Keycloak {},
 }
 
-impl McpAuthorization {
-	pub fn into_inner(self) -> RuleSet {
-		self.0
-	}
-}
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[cfg_attr(feature = "schema", schemars(with = "String"))]

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -27,6 +27,7 @@ use thiserror::Error;
 
 use super::agent::*;
 use crate::http::auth::{AwsAuth, BackendAuth};
+use crate::http::authorization::RuleSet;
 use crate::http::jwt::Jwt;
 use crate::http::localratelimit::RateLimit;
 use crate::http::{
@@ -34,7 +35,6 @@ use crate::http::{
 	status, timeout, uri,
 };
 use crate::llm::{AIBackend, AIProvider};
-use crate::mcp::rbac::RuleSet;
 use crate::transport::tls;
 use crate::types::agent::Backend::Opaque;
 use crate::types::discovery::NamespacedHostname;

--- a/schema/README.md
+++ b/schema/README.md
@@ -130,6 +130,8 @@ This defaults to 'true'.|
 |`binds[].listeners[].routes[].policies.cors.maxAge`||
 |`binds[].listeners[].routes[].policies.mcpAuthorization`|Authorization policies for MCP access.|
 |`binds[].listeners[].routes[].policies.mcpAuthorization.rules`||
+|`binds[].listeners[].routes[].policies.authorization`|Authorization policies for HTTP access.|
+|`binds[].listeners[].routes[].policies.authorization.rules`||
 |`binds[].listeners[].routes[].policies.mcpAuthentication`|Authentication for MCP clients.|
 |`binds[].listeners[].routes[].policies.mcpAuthentication.issuer`||
 |`binds[].listeners[].routes[].policies.mcpAuthentication.audience`||

--- a/schema/local.json
+++ b/schema/local.json
@@ -1004,6 +1004,26 @@
                             ],
                             "default": null
                           },
+                          "authorization": {
+                            "description": "Authorization policies for HTTP access.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "rules": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                              "rules"
+                            ],
+                            "default": null
+                          },
                           "mcpAuthentication": {
                             "description": "Authentication for MCP clients.",
                             "type": [

--- a/schema/local.json
+++ b/schema/local.json
@@ -998,6 +998,7 @@
                                 }
                               }
                             },
+                            "additionalProperties": false,
                             "required": [
                               "rules"
                             ],


### PR DESCRIPTION
This mirrors the MCP authz, but is done earlier in the processing and
for all traffic, not just HTTP.

```yaml
policies:
  authorization:
    rules:
    - allow: 'request.path == "/authz/public"'
    - deny: 'request.path == "/authz/deny"'
    - 'request.headers["x-allow"] == "true"'
```

Additonally, add an `allow` and `deny` concept. The old behavior is supported (as `allow`)