### PR TITLE
Support AI policies via XDS, change AI policy from a backend policy to a route policy.

### DIFF
--- a/crates/agentgateway/proto/resource.proto
+++ b/crates/agentgateway/proto/resource.proto
@@ -4,6 +4,7 @@ package agentgateway.dev.resource;
 
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
+import "google/protobuf/struct.proto";
 
 option go_package = "github.com/agentgateway/agentgateway/go/api;api";
 
@@ -263,7 +264,17 @@ message PolicySpec {
     google.protobuf.Duration fill_interval = 3;
     Type type = 4;
   }
-  message Ai {
+    message Ai {
+      message Message {
+        string role = 1;
+        string content = 2;
+      }
+
+      message PromptEnrichment {
+        repeated Message append = 1;
+        repeated Message prepend = 2;
+      }
+
     enum BuiltinRegexRule {
       BUILTIN_UNSPECIFIED = 0;
       SSN = 1;
@@ -293,7 +304,7 @@ message PolicySpec {
     message Action {
       ActionKind kind = 1;
       // Only used when kind == REJECT
-      PromptGuardResponse reject_response = 2;
+      RequestRejection reject_response = 2;
     }
 
     message RegexRules {
@@ -312,23 +323,38 @@ message PolicySpec {
       BackendAuthPolicy auth = 2;
     }
 
-    message PromptGuardResponse {
+    // Response sent when rejecting a request
+    message RequestRejection {
       bytes body = 1;
       uint32 status = 2;
     }
 
-    message PromptGuardRequest {
-      PromptGuardResponse response = 1;
+    // Configuration for guarding/processing LLM responses
+    message ResponseGuard {
+      RegexRules regex = 1;
+      Webhook webhook = 2;
+    }
+
+    // Configuration for guarding/processing prompts
+    message RequestGuard {
+      // Response to send when request is rejected
+      RequestRejection rejection = 1;
       RegexRules regex = 2;
       Webhook webhook = 3;
       Moderation openai_moderation = 4;
     }
 
     message PromptGuard {
-      PromptGuardRequest request = 1;
+      // Guards applied to client requests before they reach the LLM
+      RequestGuard request = 1;
+      // Guards applied to LLM responses before they reach the client
+      ResponseGuard response = 2;
     }
 
     PromptGuard prompt_guard = 1;
+    map<string, string> defaults = 2;
+    map<string, string> overrides = 3;
+    PromptEnrichment prompts = 4;
   }
   message ExternalAuth {
     BackendReference target = 1;

--- a/crates/agentgateway/proto/resource.proto
+++ b/crates/agentgateway/proto/resource.proto
@@ -264,11 +264,6 @@ message PolicySpec {
     Type type = 4;
   }
   message Ai {
-    message PromptGuardResponse {
-      bytes body = 1;
-      uint32 status = 2;
-    }
-
     enum BuiltinRegexRule {
       BUILTIN_UNSPECIFIED = 0;
       SSN = 1;
@@ -315,6 +310,11 @@ message PolicySpec {
       // Model to use. Defaults to `omni-moderation-latest`
       google.protobuf.StringValue model = 1;
       BackendAuthPolicy auth = 2;
+    }
+
+    message PromptGuardResponse {
+      bytes body = 1;
+      uint32 status = 2;
     }
 
     message PromptGuardRequest {

--- a/crates/agentgateway/proto/resource.proto
+++ b/crates/agentgateway/proto/resource.proto
@@ -263,6 +263,73 @@ message PolicySpec {
     google.protobuf.Duration fill_interval = 3;
     Type type = 4;
   }
+  message Ai {
+    message PromptGuardResponse {
+      bytes body = 1;
+      uint32 status = 2;
+    }
+
+    enum BuiltinRegexRule {
+      BUILTIN_UNSPECIFIED = 0;
+      SSN = 1;
+      CREDIT_CARD = 2;
+      PHONE_NUMBER = 3;
+      EMAIL = 4;
+    }
+
+    message NamedRegex {
+      string pattern = 1;
+      string name = 2;
+    }
+
+    message RegexRule {
+      oneof kind {
+        BuiltinRegexRule builtin = 1;
+        NamedRegex regex = 2;
+      }
+    }
+
+    enum ActionKind {
+      ACTION_UNSPECIFIED = 0;
+      MASK = 1;
+      REJECT = 2;
+    }
+
+    message Action {
+      ActionKind kind = 1;
+      // Only used when kind == REJECT
+      PromptGuardResponse reject_response = 2;
+    }
+
+    message RegexRules {
+      Action action = 1;
+      repeated RegexRule rules = 2;
+    }
+
+    message Webhook {
+      string host = 1;
+      uint32 port = 2;
+    }
+
+    message Moderation {
+      // Model to use. Defaults to `omni-moderation-latest`
+      google.protobuf.StringValue model = 1;
+      BackendAuthPolicy auth = 2;
+    }
+
+    message PromptGuardRequest {
+      PromptGuardResponse response = 1;
+      RegexRules regex = 2;
+      Webhook webhook = 3;
+      Moderation openai_moderation = 4;
+    }
+
+    message PromptGuard {
+      PromptGuardRequest request = 1;
+    }
+
+    PromptGuard prompt_guard = 1;
+  }
   message ExternalAuth {
     BackendReference target = 1;
     map<string, string> context = 2;
@@ -300,6 +367,7 @@ message PolicySpec {
     BackendAuthPolicy auth = 6;
     RBAC authorization = 7;
     RBAC mcp_authorization = 8;
+    Ai ai = 9;
   }
 }
 

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -129,7 +129,6 @@ impl AIProvider {
 			// We will use original request for now
 			backend_auth: None,
 			a2a: None,
-			llm: None,
 			inference_routing: None,
 			llm_provider: None,
 		};
@@ -141,7 +140,6 @@ impl AIProvider {
 					backend_tls: Some(http::backendtls::SYSTEM_TRUST.clone()),
 					backend_auth: Some(BackendAuth::Gcp {}),
 					a2a: None,
-					llm: None,
 					inference_routing: None,
 					llm_provider: None,
 				};
@@ -153,7 +151,6 @@ impl AIProvider {
 					backend_tls: Some(http::backendtls::SYSTEM_TRUST.clone()),
 					backend_auth: Some(BackendAuth::Aws(AwsAuth::Implicit {})),
 					a2a: None,
-					llm: None,
 					inference_routing: None,
 					llm_provider: None,
 				};

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -28,7 +28,7 @@ mod pii;
 pub mod policy;
 #[cfg(test)]
 mod tests;
-mod universal;
+pub mod universal;
 pub mod vertex;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -25,7 +25,7 @@ pub mod bedrock;
 pub mod gemini;
 pub mod openai;
 mod pii;
-mod policy;
+pub mod policy;
 #[cfg(test)]
 mod tests;
 mod universal;

--- a/crates/agentgateway/src/llm/policy.rs
+++ b/crates/agentgateway/src/llm/policy.rs
@@ -292,6 +292,7 @@ pub struct Moderation {
 	/// Model to use. Defaults to `omni-moderation-latest`
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub model: Option<Strng>,
+	#[serde(serialize_with = "ser_redact")]
 	pub auth: SimpleBackendAuth,
 }
 

--- a/crates/agentgateway/src/llm/policy.rs
+++ b/crates/agentgateway/src/llm/policy.rs
@@ -15,13 +15,13 @@ use crate::{client, *};
 #[apply(schema!)]
 pub struct Policy {
 	#[serde(default, skip_serializing_if = "Option::is_none")]
-	prompt_guard: Option<PromptGuard>,
+	pub prompt_guard: Option<PromptGuard>,
 	#[serde(default, skip_serializing_if = "Option::is_none")]
-	defaults: Option<HashMap<String, serde_json::Value>>,
+	pub defaults: Option<HashMap<String, serde_json::Value>>,
 	#[serde(default, skip_serializing_if = "Option::is_none")]
-	overrides: Option<HashMap<String, serde_json::Value>>,
+	pub overrides: Option<HashMap<String, serde_json::Value>>,
 	#[serde(default, skip_serializing_if = "Option::is_none")]
-	prompts: Option<PromptEnrichment>,
+	pub prompts: Option<PromptEnrichment>,
 }
 
 #[apply(schema!)]
@@ -42,7 +42,7 @@ pub struct PromptEnrichment {
 
 #[apply(schema!)]
 pub struct PromptGuard {
-	request: Option<PromptGuardRequest>,
+	pub request: Option<PromptGuardRequest>,
 }
 impl Policy {
 	pub fn apply_prompt_enrichment(
@@ -219,20 +219,20 @@ impl Policy {
 #[apply(schema!)]
 pub struct PromptGuardRequest {
 	#[serde(default)]
-	response: PromptGuardResponse,
+	pub response: PromptGuardResponse,
 	#[serde(default, skip_serializing_if = "Option::is_none")]
-	regex: Option<RegexRules>,
+	pub regex: Option<RegexRules>,
 	#[serde(default, skip_serializing_if = "Option::is_none")]
-	webhook: Option<Webhook>,
+	pub webhook: Option<Webhook>,
 	#[serde(default, skip_serializing_if = "Option::is_none")]
-	openai_moderation: Option<Moderation>,
+	pub openai_moderation: Option<Moderation>,
 }
 
 #[apply(schema!)]
 pub struct RegexRules {
 	#[serde(default)]
-	action: Action,
-	rules: Vec<RegexRule>,
+	pub action: Action,
+	pub rules: Vec<RegexRule>,
 }
 
 #[apply(schema!)]
@@ -283,7 +283,7 @@ pub struct NamedRegex {
 
 #[apply(schema!)]
 pub struct Webhook {
-	target: Target,
+	pub target: Target,
 	// TODO: headers
 }
 
@@ -291,8 +291,8 @@ pub struct Webhook {
 pub struct Moderation {
 	/// Model to use. Defaults to `omni-moderation-latest`
 	#[serde(default, skip_serializing_if = "Option::is_none")]
-	model: Option<Strng>,
-	auth: SimpleBackendAuth,
+	pub model: Option<Strng>,
+	pub auth: SimpleBackendAuth,
 }
 
 #[apply(schema!)]
@@ -309,10 +309,10 @@ pub enum Action {
 #[apply(schema!)]
 pub struct PromptGuardResponse {
 	#[serde(default = "default_body", serialize_with = "ser_string_or_bytes")]
-	body: Bytes,
+	pub body: Bytes,
 	#[serde(default = "default_code", with = "http_serde::status_code")]
 	#[cfg_attr(feature = "schema", schemars(with = "std::num::NonZeroU16"))]
-	status: StatusCode,
+	pub status: StatusCode,
 }
 
 impl Default for PromptGuardResponse {

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -853,7 +853,13 @@ async fn make_backend_call(
 	let (mut req, response_policies, llm_request) =
 		if let Some((llm, use_default_policies, tokenize)) = &policies.llm_provider {
 			let r = llm
-				.process_request(client, route_policies.llm.as_deref(), req, *tokenize, &mut log)
+				.process_request(
+					client,
+					route_policies.llm.as_deref(),
+					req,
+					*tokenize,
+					&mut log,
+				)
 				.await
 				.map_err(|e| ProxyError::Processing(e.into()))?;
 			let (mut req, llm_request) = match r {

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -738,7 +738,6 @@ async fn make_backend_call(
 						backend_tls: None,
 						backend_auth: None,
 						a2a: None,
-						llm: None,
 						inference_routing: None,
 						// Attach LLM provider, but don't use default setup
 						llm_provider: Some((ai.provider.clone(), false, ai.tokenize)),
@@ -854,7 +853,7 @@ async fn make_backend_call(
 	let (mut req, response_policies, llm_request) =
 		if let Some((llm, use_default_policies, tokenize)) = &policies.llm_provider {
 			let r = llm
-				.process_request(client, policies.llm.as_ref(), req, *tokenize, &mut log)
+				.process_request(client, route_policies.llm.as_deref(), req, *tokenize, &mut log)
 				.await
 				.map_err(|e| ProxyError::Processing(e.into()))?;
 			let (mut req, llm_request) = match r {

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -86,7 +86,7 @@ pub struct RoutePolicies {
 	pub jwt: Option<http::jwt::Jwt>,
 	pub ext_authz: Option<ext_authz::ExtAuthz>,
 	pub transformation: Option<http::transformation_cel::Transformation>,
-	pub llm: Option<Box<llm::Policy>>,
+	pub llm: Option<Arc<llm::Policy>>,
 }
 
 impl RoutePolicies {
@@ -126,7 +126,7 @@ impl From<RoutePolicies> for LLMRequestPolicies {
 pub struct LLMRequestPolicies {
 	pub local_rate_limit: Vec<http::localratelimit::RateLimit>,
 	pub remote_rate_limit: Option<http::remoteratelimit::RemoteRateLimit>,
-	pub llm: Option<Box<llm::Policy>>,
+	pub llm: Option<Arc<llm::Policy>>,
 }
 
 #[derive(Debug, Default)]
@@ -224,7 +224,7 @@ impl Store {
 					authz.push(p.clone().0);
 				},
 				Policy::AI(p) => {
-					pol.llm.get_or_insert_with(|| Box::new(*p.clone()));
+					pol.llm.get_or_insert_with(|| p.clone());
 				},
 				_ => {}, // others are not route policies
 			}

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -260,7 +260,7 @@ impl Store {
 					pol.backend_auth.get_or_insert_with(|| p.clone());
 				},
 				Policy::AI(p) => {
-					pol.llm.get_or_insert_with(|| p.clone());
+					pol.llm.get_or_insert_with(|| *p.clone());
 				},
 				Policy::InferenceRouting(p) => {
 					pol.inference_routing.get_or_insert_with(|| p.clone());

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -997,7 +997,7 @@ pub enum Policy {
 	BackendAuth(BackendAuth),
 	// Supported targets: Backend; single policy allowed
 	#[serde(rename = "ai")]
-	AI(llm::Policy),
+	AI(Box<llm::Policy>),
 	// Supported targets: Backend; single policy allowed
 	InferenceRouting(ext_proc::InferenceRouting),
 

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -1000,8 +1000,7 @@ pub enum Policy {
 
 	// Supported targets: Gateway < Route < RouteRule; single policy allowed
 	#[serde(rename = "ai")]
-	AI(Box<llm::Policy>),
-
+	AI(Arc<llm::Policy>),
 	// Supported targets: Gateway < Route < RouteRule; single policy allowed
 	Authorization(Authorization),
 	// Supported targets: Gateway < Route < RouteRule; single policy allowed

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -996,10 +996,11 @@ pub enum Policy {
 	// Supported targets: Backend; single policy allowed
 	BackendAuth(BackendAuth),
 	// Supported targets: Backend; single policy allowed
+	InferenceRouting(ext_proc::InferenceRouting),
+
+	// Supported targets: Gateway < Route < RouteRule; single policy allowed
 	#[serde(rename = "ai")]
 	AI(Box<llm::Policy>),
-	// Supported targets: Backend; single policy allowed
-	InferenceRouting(ext_proc::InferenceRouting),
 
 	// Supported targets: Gateway < Route < RouteRule; single policy allowed
 	Authorization(Authorization),

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -726,7 +726,7 @@ impl TryFrom<&proto::agent::Policy> for TargetedPolicy {
 					})
 				});
 
-				Policy::AI(Box::new(llm::Policy {
+				Policy::AI(Arc::new(llm::Policy {
 					prompt_guard,
 					defaults: Some(
 						ai.defaults

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 use rustls::ServerConfig;
 
 use super::agent::*;
-use crate::http::auth::{AwsAuth, BackendAuth};
-use crate::http::{StatusCode, authorization, backendtls, ext_proc, filters, localratelimit, uri};
+use crate::http::auth::{AwsAuth, BackendAuth, };
+use crate::http::{StatusCode, backendtls, ext_proc, filters, localratelimit, uri};
 use crate::llm::{AIBackend, AIProvider};
 use crate::mcp::rbac::McpAuthorization;
 use crate::types::discovery::NamespacedHostname;
@@ -666,6 +666,102 @@ impl TryFrom<&proto::agent::Policy> for TargetedPolicy {
 			},
 			Some(proto::agent::policy_spec::Kind::McpAuthorization(rbac)) => {
 				Policy::McpAuthorization(McpAuthorization::try_from(rbac)?)
+			},
+			Some(proto::agent::policy_spec::Kind::Ai(ai)) => {
+				let prompt_guard = ai.prompt_guard.as_ref().and_then(|pg| {
+					let reqp = pg.request.as_ref()?;
+
+					let response = if let Some(resp) = &reqp.response {
+						let status = u16::try_from(resp.status)
+							.ok()
+							.and_then(|c| StatusCode::from_u16(c).ok())
+							.unwrap_or(StatusCode::FORBIDDEN);
+						crate::llm::policy::PromptGuardResponse {
+							body: Bytes::from(resp.body.clone()),
+							status,
+						}
+					} else {
+						//  use default response, since the response field is not optional on PromptGuardResponse
+						crate::llm::policy::PromptGuardResponse::default()
+					};
+
+					let regex = reqp.regex.as_ref().map(|rr| {
+						let action = match rr.action.as_ref().and_then(|a| proto::agent::policy_spec::ai::ActionKind::try_from(a.kind).ok()) {
+							Some(proto::agent::policy_spec::ai::ActionKind::Reject) => crate::llm::policy::Action::Reject { response: response.clone() },
+							_ => crate::llm::policy::Action::Mask,
+						};
+						let rules = rr
+							.rules
+							.iter()
+							.filter_map(|r| match &r.kind {
+								Some(proto::agent::policy_spec::ai::regex_rule::Kind::Builtin(b)) => {
+									match proto::agent::policy_spec::ai::BuiltinRegexRule::try_from(*b) {
+										Ok(builtin) => {
+											let builtin = match builtin {
+																							proto::agent::policy_spec::ai::BuiltinRegexRule::Ssn => crate::llm::policy::Builtin::Ssn,
+											proto::agent::policy_spec::ai::BuiltinRegexRule::CreditCard => crate::llm::policy::Builtin::CreditCard,
+											proto::agent::policy_spec::ai::BuiltinRegexRule::PhoneNumber => crate::llm::policy::Builtin::PhoneNumber,
+											proto::agent::policy_spec::ai::BuiltinRegexRule::Email => crate::llm::policy::Builtin::Email,
+												_ => {
+													warn!(value = *b, "Unknown builtin regex rule, skipping");
+													return None;
+												}
+											};
+											Some(crate::llm::policy::RegexRule::Builtin { builtin })
+										},
+										Err(_) => {
+											warn!(value = *b, "Invalid builtin regex rule value, skipping");
+											None
+										}
+									}
+								},
+								Some(proto::agent::policy_spec::ai::regex_rule::Kind::Regex(n)) => {
+									match regex::Regex::new(&n.pattern) {
+										Ok(pattern) => Some(crate::llm::policy::RegexRule::Regex { pattern, name: n.name.clone() }),
+										Err(err) => {
+											warn!(error = %err, name = %n.name, pattern = %n.pattern, "Invalid regex pattern");
+											None
+										}
+									}
+								},
+								None => None,
+							})
+							.collect();
+						crate::llm::policy::RegexRules { action, rules }
+					});
+
+					let webhook = reqp.webhook.as_ref().and_then(|w| {
+						match u16::try_from(w.port) {
+							Ok(port) => Some(crate::llm::policy::Webhook {
+								target: Target::Hostname(w.host.clone().into(), port),
+							}),
+							Err(_) => {
+								warn!(port = w.port, host = %w.host, "Webhook port out of range, ignoring webhook");
+								None
+							}
+						}
+					});
+
+					let openai_moderation = reqp.openai_moderation.as_ref().map(|m| crate::llm::policy::Moderation {
+						model: m.model.as_deref().map(strng::new),
+						auth: match m.auth.as_ref().and_then(|a| a.kind.clone()) {
+							Some(crate::types::proto::agent::backend_auth_policy::Kind::Passthrough(_)) => SimpleBackendAuth::Passthrough {},
+							Some(crate::types::proto::agent::backend_auth_policy::Kind::Key(k)) => SimpleBackendAuth::Key(k.secret.into()),
+							_ => SimpleBackendAuth::Passthrough {},
+						},
+					});
+
+					Some(crate::llm::policy::PromptGuard {
+						request: Some(crate::llm::policy::PromptGuardRequest {
+							response,
+							regex,
+							webhook,
+							openai_moderation,
+						}),
+					})
+				});
+
+				Policy::AI(llm::Policy { prompt_guard, defaults: None, overrides: None, prompts: None })
 			},
 			_ => return Err(ProtoError::EnumParse("unknown spec kind".to_string())),
 		};

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 use rustls::ServerConfig;
 
 use super::agent::*;
-use crate::http::auth::{AwsAuth, BackendAuth, };
-use crate::http::{StatusCode, backendtls, ext_proc, filters, localratelimit, uri};
+use crate::http::auth::{AwsAuth, BackendAuth, SimpleBackendAuth};
+use crate::http::{StatusCode, authorization, backendtls, ext_proc, filters, localratelimit, uri};
 use crate::llm::{AIBackend, AIProvider};
 use crate::mcp::rbac::McpAuthorization;
 use crate::types::discovery::NamespacedHostname;

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -726,7 +726,7 @@ impl TryFrom<&proto::agent::Policy> for TargetedPolicy {
 					})
 				});
 
-				Policy::AI(llm::Policy {
+				Policy::AI(Box::new(llm::Policy {
 					prompt_guard,
 					defaults: Some(
 						ai.defaults
@@ -741,7 +741,7 @@ impl TryFrom<&proto::agent::Policy> for TargetedPolicy {
 							.collect(),
 					),
 					prompts: ai.prompts.as_ref().map(convert_prompt_enrichment),
-				})
+				}))
 			},
 			_ => return Err(ProtoError::EnumParse("unknown spec kind".to_string())),
 		};

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -744,7 +744,7 @@ async fn convert_route(
 			external_policies.push(backend_tgt(Policy::A2a(p))?)
 		}
 		if let Some(p) = ai {
-			external_policies.push(backend_tgt(Policy::AI(p))?)
+			external_policies.push(backend_tgt(Policy::AI(Box::new(p)))?)
 		}
 		if let Some(p) = backend_tls {
 			external_policies.push(backend_tgt(Policy::BackendTLS(p.try_into()?))?)

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -744,7 +744,7 @@ async fn convert_route(
 			external_policies.push(backend_tgt(Policy::A2a(p))?)
 		}
 		if let Some(p) = ai {
-			external_policies.push(backend_tgt(Policy::AI(Box::new(p)))?)
+			external_policies.push(backend_tgt(Policy::AI(Arc::new(p)))?)
 		}
 		if let Some(p) = backend_tls {
 			external_policies.push(backend_tgt(Policy::BackendTLS(p.try_into()?))?)

--- a/go/api/resource.pb.go
+++ b/go/api/resource.pb.go
@@ -11,6 +11,7 @@ import (
 	wrappers "github.com/golang/protobuf/ptypes/wrappers"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	_ "google.golang.org/protobuf/types/known/structpb"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
@@ -3558,8 +3559,11 @@ func (x *PolicySpec_LocalRateLimit) GetType() PolicySpec_LocalRateLimit_Type {
 }
 
 type PolicySpec_Ai struct {
-	state         protoimpl.MessageState     `protogen:"open.v1"`
-	PromptGuard   *PolicySpec_Ai_PromptGuard `protobuf:"bytes,1,opt,name=prompt_guard,json=promptGuard,proto3" json:"prompt_guard,omitempty"`
+	state         protoimpl.MessageState          `protogen:"open.v1"`
+	PromptGuard   *PolicySpec_Ai_PromptGuard      `protobuf:"bytes,1,opt,name=prompt_guard,json=promptGuard,proto3" json:"prompt_guard,omitempty"`
+	Defaults      map[string]string               `protobuf:"bytes,2,rep,name=defaults,proto3" json:"defaults,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Overrides     map[string]string               `protobuf:"bytes,3,rep,name=overrides,proto3" json:"overrides,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Prompts       *PolicySpec_Ai_PromptEnrichment `protobuf:"bytes,4,opt,name=prompts,proto3" json:"prompts,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -3597,6 +3601,27 @@ func (*PolicySpec_Ai) Descriptor() ([]byte, []int) {
 func (x *PolicySpec_Ai) GetPromptGuard() *PolicySpec_Ai_PromptGuard {
 	if x != nil {
 		return x.PromptGuard
+	}
+	return nil
+}
+
+func (x *PolicySpec_Ai) GetDefaults() map[string]string {
+	if x != nil {
+		return x.Defaults
+	}
+	return nil
+}
+
+func (x *PolicySpec_Ai) GetOverrides() map[string]string {
+	if x != nil {
+		return x.Overrides
+	}
+	return nil
+}
+
+func (x *PolicySpec_Ai) GetPrompts() *PolicySpec_Ai_PromptEnrichment {
+	if x != nil {
+		return x.Prompts
 	}
 	return nil
 }
@@ -3864,6 +3889,110 @@ func (x *PolicySpec_RBAC) GetDeny() []string {
 	return nil
 }
 
+type PolicySpec_Ai_Message struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Role          string                 `protobuf:"bytes,1,opt,name=role,proto3" json:"role,omitempty"`
+	Content       string                 `protobuf:"bytes,2,opt,name=content,proto3" json:"content,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PolicySpec_Ai_Message) Reset() {
+	*x = PolicySpec_Ai_Message{}
+	mi := &file_resource_proto_msgTypes[45]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PolicySpec_Ai_Message) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PolicySpec_Ai_Message) ProtoMessage() {}
+
+func (x *PolicySpec_Ai_Message) ProtoReflect() protoreflect.Message {
+	mi := &file_resource_proto_msgTypes[45]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PolicySpec_Ai_Message.ProtoReflect.Descriptor instead.
+func (*PolicySpec_Ai_Message) Descriptor() ([]byte, []int) {
+	return file_resource_proto_rawDescGZIP(), []int{30, 1, 0}
+}
+
+func (x *PolicySpec_Ai_Message) GetRole() string {
+	if x != nil {
+		return x.Role
+	}
+	return ""
+}
+
+func (x *PolicySpec_Ai_Message) GetContent() string {
+	if x != nil {
+		return x.Content
+	}
+	return ""
+}
+
+type PolicySpec_Ai_PromptEnrichment struct {
+	state         protoimpl.MessageState   `protogen:"open.v1"`
+	Append        []*PolicySpec_Ai_Message `protobuf:"bytes,1,rep,name=append,proto3" json:"append,omitempty"`
+	Prepend       []*PolicySpec_Ai_Message `protobuf:"bytes,2,rep,name=prepend,proto3" json:"prepend,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PolicySpec_Ai_PromptEnrichment) Reset() {
+	*x = PolicySpec_Ai_PromptEnrichment{}
+	mi := &file_resource_proto_msgTypes[46]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PolicySpec_Ai_PromptEnrichment) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PolicySpec_Ai_PromptEnrichment) ProtoMessage() {}
+
+func (x *PolicySpec_Ai_PromptEnrichment) ProtoReflect() protoreflect.Message {
+	mi := &file_resource_proto_msgTypes[46]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PolicySpec_Ai_PromptEnrichment.ProtoReflect.Descriptor instead.
+func (*PolicySpec_Ai_PromptEnrichment) Descriptor() ([]byte, []int) {
+	return file_resource_proto_rawDescGZIP(), []int{30, 1, 1}
+}
+
+func (x *PolicySpec_Ai_PromptEnrichment) GetAppend() []*PolicySpec_Ai_Message {
+	if x != nil {
+		return x.Append
+	}
+	return nil
+}
+
+func (x *PolicySpec_Ai_PromptEnrichment) GetPrepend() []*PolicySpec_Ai_Message {
+	if x != nil {
+		return x.Prepend
+	}
+	return nil
+}
+
 type PolicySpec_Ai_NamedRegex struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Pattern       string                 `protobuf:"bytes,1,opt,name=pattern,proto3" json:"pattern,omitempty"`
@@ -3874,7 +4003,7 @@ type PolicySpec_Ai_NamedRegex struct {
 
 func (x *PolicySpec_Ai_NamedRegex) Reset() {
 	*x = PolicySpec_Ai_NamedRegex{}
-	mi := &file_resource_proto_msgTypes[45]
+	mi := &file_resource_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3886,7 +4015,7 @@ func (x *PolicySpec_Ai_NamedRegex) String() string {
 func (*PolicySpec_Ai_NamedRegex) ProtoMessage() {}
 
 func (x *PolicySpec_Ai_NamedRegex) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[45]
+	mi := &file_resource_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3899,7 +4028,7 @@ func (x *PolicySpec_Ai_NamedRegex) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicySpec_Ai_NamedRegex.ProtoReflect.Descriptor instead.
 func (*PolicySpec_Ai_NamedRegex) Descriptor() ([]byte, []int) {
-	return file_resource_proto_rawDescGZIP(), []int{30, 1, 0}
+	return file_resource_proto_rawDescGZIP(), []int{30, 1, 2}
 }
 
 func (x *PolicySpec_Ai_NamedRegex) GetPattern() string {
@@ -3929,7 +4058,7 @@ type PolicySpec_Ai_RegexRule struct {
 
 func (x *PolicySpec_Ai_RegexRule) Reset() {
 	*x = PolicySpec_Ai_RegexRule{}
-	mi := &file_resource_proto_msgTypes[46]
+	mi := &file_resource_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3941,7 +4070,7 @@ func (x *PolicySpec_Ai_RegexRule) String() string {
 func (*PolicySpec_Ai_RegexRule) ProtoMessage() {}
 
 func (x *PolicySpec_Ai_RegexRule) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[46]
+	mi := &file_resource_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3954,7 +4083,7 @@ func (x *PolicySpec_Ai_RegexRule) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicySpec_Ai_RegexRule.ProtoReflect.Descriptor instead.
 func (*PolicySpec_Ai_RegexRule) Descriptor() ([]byte, []int) {
-	return file_resource_proto_rawDescGZIP(), []int{30, 1, 1}
+	return file_resource_proto_rawDescGZIP(), []int{30, 1, 3}
 }
 
 func (x *PolicySpec_Ai_RegexRule) GetKind() isPolicySpec_Ai_RegexRule_Kind {
@@ -4002,14 +4131,14 @@ type PolicySpec_Ai_Action struct {
 	state protoimpl.MessageState   `protogen:"open.v1"`
 	Kind  PolicySpec_Ai_ActionKind `protobuf:"varint,1,opt,name=kind,proto3,enum=agentgateway.dev.resource.PolicySpec_Ai_ActionKind" json:"kind,omitempty"`
 	// Only used when kind == REJECT
-	RejectResponse *PolicySpec_Ai_PromptGuardResponse `protobuf:"bytes,2,opt,name=reject_response,json=rejectResponse,proto3" json:"reject_response,omitempty"`
+	RejectResponse *PolicySpec_Ai_RequestRejection `protobuf:"bytes,2,opt,name=reject_response,json=rejectResponse,proto3" json:"reject_response,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
 
 func (x *PolicySpec_Ai_Action) Reset() {
 	*x = PolicySpec_Ai_Action{}
-	mi := &file_resource_proto_msgTypes[47]
+	mi := &file_resource_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4021,7 +4150,7 @@ func (x *PolicySpec_Ai_Action) String() string {
 func (*PolicySpec_Ai_Action) ProtoMessage() {}
 
 func (x *PolicySpec_Ai_Action) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[47]
+	mi := &file_resource_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4034,7 +4163,7 @@ func (x *PolicySpec_Ai_Action) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicySpec_Ai_Action.ProtoReflect.Descriptor instead.
 func (*PolicySpec_Ai_Action) Descriptor() ([]byte, []int) {
-	return file_resource_proto_rawDescGZIP(), []int{30, 1, 2}
+	return file_resource_proto_rawDescGZIP(), []int{30, 1, 4}
 }
 
 func (x *PolicySpec_Ai_Action) GetKind() PolicySpec_Ai_ActionKind {
@@ -4044,7 +4173,7 @@ func (x *PolicySpec_Ai_Action) GetKind() PolicySpec_Ai_ActionKind {
 	return PolicySpec_Ai_ACTION_UNSPECIFIED
 }
 
-func (x *PolicySpec_Ai_Action) GetRejectResponse() *PolicySpec_Ai_PromptGuardResponse {
+func (x *PolicySpec_Ai_Action) GetRejectResponse() *PolicySpec_Ai_RequestRejection {
 	if x != nil {
 		return x.RejectResponse
 	}
@@ -4061,7 +4190,7 @@ type PolicySpec_Ai_RegexRules struct {
 
 func (x *PolicySpec_Ai_RegexRules) Reset() {
 	*x = PolicySpec_Ai_RegexRules{}
-	mi := &file_resource_proto_msgTypes[48]
+	mi := &file_resource_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4073,7 +4202,7 @@ func (x *PolicySpec_Ai_RegexRules) String() string {
 func (*PolicySpec_Ai_RegexRules) ProtoMessage() {}
 
 func (x *PolicySpec_Ai_RegexRules) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[48]
+	mi := &file_resource_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4086,7 +4215,7 @@ func (x *PolicySpec_Ai_RegexRules) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicySpec_Ai_RegexRules.ProtoReflect.Descriptor instead.
 func (*PolicySpec_Ai_RegexRules) Descriptor() ([]byte, []int) {
-	return file_resource_proto_rawDescGZIP(), []int{30, 1, 3}
+	return file_resource_proto_rawDescGZIP(), []int{30, 1, 5}
 }
 
 func (x *PolicySpec_Ai_RegexRules) GetAction() *PolicySpec_Ai_Action {
@@ -4113,7 +4242,7 @@ type PolicySpec_Ai_Webhook struct {
 
 func (x *PolicySpec_Ai_Webhook) Reset() {
 	*x = PolicySpec_Ai_Webhook{}
-	mi := &file_resource_proto_msgTypes[49]
+	mi := &file_resource_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4125,7 +4254,7 @@ func (x *PolicySpec_Ai_Webhook) String() string {
 func (*PolicySpec_Ai_Webhook) ProtoMessage() {}
 
 func (x *PolicySpec_Ai_Webhook) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[49]
+	mi := &file_resource_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4138,7 +4267,7 @@ func (x *PolicySpec_Ai_Webhook) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicySpec_Ai_Webhook.ProtoReflect.Descriptor instead.
 func (*PolicySpec_Ai_Webhook) Descriptor() ([]byte, []int) {
-	return file_resource_proto_rawDescGZIP(), []int{30, 1, 4}
+	return file_resource_proto_rawDescGZIP(), []int{30, 1, 6}
 }
 
 func (x *PolicySpec_Ai_Webhook) GetHost() string {
@@ -4166,7 +4295,7 @@ type PolicySpec_Ai_Moderation struct {
 
 func (x *PolicySpec_Ai_Moderation) Reset() {
 	*x = PolicySpec_Ai_Moderation{}
-	mi := &file_resource_proto_msgTypes[50]
+	mi := &file_resource_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4178,7 +4307,7 @@ func (x *PolicySpec_Ai_Moderation) String() string {
 func (*PolicySpec_Ai_Moderation) ProtoMessage() {}
 
 func (x *PolicySpec_Ai_Moderation) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[50]
+	mi := &file_resource_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4191,7 +4320,7 @@ func (x *PolicySpec_Ai_Moderation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicySpec_Ai_Moderation.ProtoReflect.Descriptor instead.
 func (*PolicySpec_Ai_Moderation) Descriptor() ([]byte, []int) {
-	return file_resource_proto_rawDescGZIP(), []int{30, 1, 5}
+	return file_resource_proto_rawDescGZIP(), []int{30, 1, 7}
 }
 
 func (x *PolicySpec_Ai_Moderation) GetModel() *wrappers.StringValue {
@@ -4208,7 +4337,8 @@ func (x *PolicySpec_Ai_Moderation) GetAuth() *BackendAuthPolicy {
 	return nil
 }
 
-type PolicySpec_Ai_PromptGuardResponse struct {
+// Response sent when rejecting a request
+type PolicySpec_Ai_RequestRejection struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Body          []byte                 `protobuf:"bytes,1,opt,name=body,proto3" json:"body,omitempty"`
 	Status        uint32                 `protobuf:"varint,2,opt,name=status,proto3" json:"status,omitempty"`
@@ -4216,21 +4346,21 @@ type PolicySpec_Ai_PromptGuardResponse struct {
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *PolicySpec_Ai_PromptGuardResponse) Reset() {
-	*x = PolicySpec_Ai_PromptGuardResponse{}
-	mi := &file_resource_proto_msgTypes[51]
+func (x *PolicySpec_Ai_RequestRejection) Reset() {
+	*x = PolicySpec_Ai_RequestRejection{}
+	mi := &file_resource_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *PolicySpec_Ai_PromptGuardResponse) String() string {
+func (x *PolicySpec_Ai_RequestRejection) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*PolicySpec_Ai_PromptGuardResponse) ProtoMessage() {}
+func (*PolicySpec_Ai_RequestRejection) ProtoMessage() {}
 
-func (x *PolicySpec_Ai_PromptGuardResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[51]
+func (x *PolicySpec_Ai_RequestRejection) ProtoReflect() protoreflect.Message {
+	mi := &file_resource_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4241,50 +4371,49 @@ func (x *PolicySpec_Ai_PromptGuardResponse) ProtoReflect() protoreflect.Message 
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use PolicySpec_Ai_PromptGuardResponse.ProtoReflect.Descriptor instead.
-func (*PolicySpec_Ai_PromptGuardResponse) Descriptor() ([]byte, []int) {
-	return file_resource_proto_rawDescGZIP(), []int{30, 1, 6}
+// Deprecated: Use PolicySpec_Ai_RequestRejection.ProtoReflect.Descriptor instead.
+func (*PolicySpec_Ai_RequestRejection) Descriptor() ([]byte, []int) {
+	return file_resource_proto_rawDescGZIP(), []int{30, 1, 8}
 }
 
-func (x *PolicySpec_Ai_PromptGuardResponse) GetBody() []byte {
+func (x *PolicySpec_Ai_RequestRejection) GetBody() []byte {
 	if x != nil {
 		return x.Body
 	}
 	return nil
 }
 
-func (x *PolicySpec_Ai_PromptGuardResponse) GetStatus() uint32 {
+func (x *PolicySpec_Ai_RequestRejection) GetStatus() uint32 {
 	if x != nil {
 		return x.Status
 	}
 	return 0
 }
 
-type PolicySpec_Ai_PromptGuardRequest struct {
-	state            protoimpl.MessageState             `protogen:"open.v1"`
-	Response         *PolicySpec_Ai_PromptGuardResponse `protobuf:"bytes,1,opt,name=response,proto3" json:"response,omitempty"`
-	Regex            *PolicySpec_Ai_RegexRules          `protobuf:"bytes,2,opt,name=regex,proto3" json:"regex,omitempty"`
-	Webhook          *PolicySpec_Ai_Webhook             `protobuf:"bytes,3,opt,name=webhook,proto3" json:"webhook,omitempty"`
-	OpenaiModeration *PolicySpec_Ai_Moderation          `protobuf:"bytes,4,opt,name=openai_moderation,json=openaiModeration,proto3" json:"openai_moderation,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+// Configuration for guarding/processing LLM responses
+type PolicySpec_Ai_ResponseGuard struct {
+	state         protoimpl.MessageState    `protogen:"open.v1"`
+	Regex         *PolicySpec_Ai_RegexRules `protobuf:"bytes,1,opt,name=regex,proto3" json:"regex,omitempty"`
+	Webhook       *PolicySpec_Ai_Webhook    `protobuf:"bytes,2,opt,name=webhook,proto3" json:"webhook,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
-func (x *PolicySpec_Ai_PromptGuardRequest) Reset() {
-	*x = PolicySpec_Ai_PromptGuardRequest{}
-	mi := &file_resource_proto_msgTypes[52]
+func (x *PolicySpec_Ai_ResponseGuard) Reset() {
+	*x = PolicySpec_Ai_ResponseGuard{}
+	mi := &file_resource_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *PolicySpec_Ai_PromptGuardRequest) String() string {
+func (x *PolicySpec_Ai_ResponseGuard) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*PolicySpec_Ai_PromptGuardRequest) ProtoMessage() {}
+func (*PolicySpec_Ai_ResponseGuard) ProtoMessage() {}
 
-func (x *PolicySpec_Ai_PromptGuardRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[52]
+func (x *PolicySpec_Ai_ResponseGuard) ProtoReflect() protoreflect.Message {
+	mi := &file_resource_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4295,33 +4424,89 @@ func (x *PolicySpec_Ai_PromptGuardRequest) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use PolicySpec_Ai_PromptGuardRequest.ProtoReflect.Descriptor instead.
-func (*PolicySpec_Ai_PromptGuardRequest) Descriptor() ([]byte, []int) {
-	return file_resource_proto_rawDescGZIP(), []int{30, 1, 7}
+// Deprecated: Use PolicySpec_Ai_ResponseGuard.ProtoReflect.Descriptor instead.
+func (*PolicySpec_Ai_ResponseGuard) Descriptor() ([]byte, []int) {
+	return file_resource_proto_rawDescGZIP(), []int{30, 1, 9}
 }
 
-func (x *PolicySpec_Ai_PromptGuardRequest) GetResponse() *PolicySpec_Ai_PromptGuardResponse {
-	if x != nil {
-		return x.Response
-	}
-	return nil
-}
-
-func (x *PolicySpec_Ai_PromptGuardRequest) GetRegex() *PolicySpec_Ai_RegexRules {
+func (x *PolicySpec_Ai_ResponseGuard) GetRegex() *PolicySpec_Ai_RegexRules {
 	if x != nil {
 		return x.Regex
 	}
 	return nil
 }
 
-func (x *PolicySpec_Ai_PromptGuardRequest) GetWebhook() *PolicySpec_Ai_Webhook {
+func (x *PolicySpec_Ai_ResponseGuard) GetWebhook() *PolicySpec_Ai_Webhook {
 	if x != nil {
 		return x.Webhook
 	}
 	return nil
 }
 
-func (x *PolicySpec_Ai_PromptGuardRequest) GetOpenaiModeration() *PolicySpec_Ai_Moderation {
+// Configuration for guarding/processing prompts
+type PolicySpec_Ai_RequestGuard struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Response to send when request is rejected
+	Rejection        *PolicySpec_Ai_RequestRejection `protobuf:"bytes,1,opt,name=rejection,proto3" json:"rejection,omitempty"`
+	Regex            *PolicySpec_Ai_RegexRules       `protobuf:"bytes,2,opt,name=regex,proto3" json:"regex,omitempty"`
+	Webhook          *PolicySpec_Ai_Webhook          `protobuf:"bytes,3,opt,name=webhook,proto3" json:"webhook,omitempty"`
+	OpenaiModeration *PolicySpec_Ai_Moderation       `protobuf:"bytes,4,opt,name=openai_moderation,json=openaiModeration,proto3" json:"openai_moderation,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *PolicySpec_Ai_RequestGuard) Reset() {
+	*x = PolicySpec_Ai_RequestGuard{}
+	mi := &file_resource_proto_msgTypes[55]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PolicySpec_Ai_RequestGuard) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PolicySpec_Ai_RequestGuard) ProtoMessage() {}
+
+func (x *PolicySpec_Ai_RequestGuard) ProtoReflect() protoreflect.Message {
+	mi := &file_resource_proto_msgTypes[55]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PolicySpec_Ai_RequestGuard.ProtoReflect.Descriptor instead.
+func (*PolicySpec_Ai_RequestGuard) Descriptor() ([]byte, []int) {
+	return file_resource_proto_rawDescGZIP(), []int{30, 1, 10}
+}
+
+func (x *PolicySpec_Ai_RequestGuard) GetRejection() *PolicySpec_Ai_RequestRejection {
+	if x != nil {
+		return x.Rejection
+	}
+	return nil
+}
+
+func (x *PolicySpec_Ai_RequestGuard) GetRegex() *PolicySpec_Ai_RegexRules {
+	if x != nil {
+		return x.Regex
+	}
+	return nil
+}
+
+func (x *PolicySpec_Ai_RequestGuard) GetWebhook() *PolicySpec_Ai_Webhook {
+	if x != nil {
+		return x.Webhook
+	}
+	return nil
+}
+
+func (x *PolicySpec_Ai_RequestGuard) GetOpenaiModeration() *PolicySpec_Ai_Moderation {
 	if x != nil {
 		return x.OpenaiModeration
 	}
@@ -4329,15 +4514,18 @@ func (x *PolicySpec_Ai_PromptGuardRequest) GetOpenaiModeration() *PolicySpec_Ai_
 }
 
 type PolicySpec_Ai_PromptGuard struct {
-	state         protoimpl.MessageState            `protogen:"open.v1"`
-	Request       *PolicySpec_Ai_PromptGuardRequest `protobuf:"bytes,1,opt,name=request,proto3" json:"request,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Guards applied to client requests before they reach the LLM
+	Request *PolicySpec_Ai_RequestGuard `protobuf:"bytes,1,opt,name=request,proto3" json:"request,omitempty"`
+	// Guards applied to LLM responses before they reach the client
+	Response      *PolicySpec_Ai_ResponseGuard `protobuf:"bytes,2,opt,name=response,proto3" json:"response,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *PolicySpec_Ai_PromptGuard) Reset() {
 	*x = PolicySpec_Ai_PromptGuard{}
-	mi := &file_resource_proto_msgTypes[53]
+	mi := &file_resource_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4349,7 +4537,7 @@ func (x *PolicySpec_Ai_PromptGuard) String() string {
 func (*PolicySpec_Ai_PromptGuard) ProtoMessage() {}
 
 func (x *PolicySpec_Ai_PromptGuard) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[53]
+	mi := &file_resource_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4362,12 +4550,19 @@ func (x *PolicySpec_Ai_PromptGuard) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicySpec_Ai_PromptGuard.ProtoReflect.Descriptor instead.
 func (*PolicySpec_Ai_PromptGuard) Descriptor() ([]byte, []int) {
-	return file_resource_proto_rawDescGZIP(), []int{30, 1, 8}
+	return file_resource_proto_rawDescGZIP(), []int{30, 1, 11}
 }
 
-func (x *PolicySpec_Ai_PromptGuard) GetRequest() *PolicySpec_Ai_PromptGuardRequest {
+func (x *PolicySpec_Ai_PromptGuard) GetRequest() *PolicySpec_Ai_RequestGuard {
 	if x != nil {
 		return x.Request
+	}
+	return nil
+}
+
+func (x *PolicySpec_Ai_PromptGuard) GetResponse() *PolicySpec_Ai_ResponseGuard {
+	if x != nil {
+		return x.Response
 	}
 	return nil
 }
@@ -4382,7 +4577,7 @@ type AIBackend_Override struct {
 
 func (x *AIBackend_Override) Reset() {
 	*x = AIBackend_Override{}
-	mi := &file_resource_proto_msgTypes[55]
+	mi := &file_resource_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4394,7 +4589,7 @@ func (x *AIBackend_Override) String() string {
 func (*AIBackend_Override) ProtoMessage() {}
 
 func (x *AIBackend_Override) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[55]
+	mi := &file_resource_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4433,7 +4628,7 @@ type AIBackend_OpenAI struct {
 
 func (x *AIBackend_OpenAI) Reset() {
 	*x = AIBackend_OpenAI{}
-	mi := &file_resource_proto_msgTypes[56]
+	mi := &file_resource_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4445,7 +4640,7 @@ func (x *AIBackend_OpenAI) String() string {
 func (*AIBackend_OpenAI) ProtoMessage() {}
 
 func (x *AIBackend_OpenAI) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[56]
+	mi := &file_resource_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4477,7 +4672,7 @@ type AIBackend_Gemini struct {
 
 func (x *AIBackend_Gemini) Reset() {
 	*x = AIBackend_Gemini{}
-	mi := &file_resource_proto_msgTypes[57]
+	mi := &file_resource_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4489,7 +4684,7 @@ func (x *AIBackend_Gemini) String() string {
 func (*AIBackend_Gemini) ProtoMessage() {}
 
 func (x *AIBackend_Gemini) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[57]
+	mi := &file_resource_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4523,7 +4718,7 @@ type AIBackend_Vertex struct {
 
 func (x *AIBackend_Vertex) Reset() {
 	*x = AIBackend_Vertex{}
-	mi := &file_resource_proto_msgTypes[58]
+	mi := &file_resource_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4535,7 +4730,7 @@ func (x *AIBackend_Vertex) String() string {
 func (*AIBackend_Vertex) ProtoMessage() {}
 
 func (x *AIBackend_Vertex) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[58]
+	mi := &file_resource_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4581,7 +4776,7 @@ type AIBackend_Anthropic struct {
 
 func (x *AIBackend_Anthropic) Reset() {
 	*x = AIBackend_Anthropic{}
-	mi := &file_resource_proto_msgTypes[59]
+	mi := &file_resource_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4593,7 +4788,7 @@ func (x *AIBackend_Anthropic) String() string {
 func (*AIBackend_Anthropic) ProtoMessage() {}
 
 func (x *AIBackend_Anthropic) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[59]
+	mi := &file_resource_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4628,7 +4823,7 @@ type AIBackend_Bedrock struct {
 
 func (x *AIBackend_Bedrock) Reset() {
 	*x = AIBackend_Bedrock{}
-	mi := &file_resource_proto_msgTypes[60]
+	mi := &file_resource_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4640,7 +4835,7 @@ func (x *AIBackend_Bedrock) String() string {
 func (*AIBackend_Bedrock) ProtoMessage() {}
 
 func (x *AIBackend_Bedrock) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[60]
+	mi := &file_resource_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4688,7 +4883,7 @@ var File_resource_proto protoreflect.FileDescriptor
 
 const file_resource_proto_rawDesc = "" +
 	"\n" +
-	"\x0eresource.proto\x12\x19agentgateway.dev.resource\x1a\x1egoogle/protobuf/duration.proto\x1a\x1egoogle/protobuf/wrappers.proto\"\x87\x03\n" +
+	"\x0eresource.proto\x12\x19agentgateway.dev.resource\x1a\x1egoogle/protobuf/duration.proto\x1a\x1egoogle/protobuf/wrappers.proto\x1a\x1cgoogle/protobuf/struct.proto\"\x87\x03\n" +
 	"\bResource\x125\n" +
 	"\x04bind\x18\x01 \x01(\v2\x1f.agentgateway.dev.resource.BindH\x00R\x04bind\x12A\n" +
 	"\blistener\x18\x02 \x01(\v2#.agentgateway.dev.resource.ListenerH\x00R\blistener\x128\n" +
@@ -4842,7 +5037,7 @@ const file_resource_proto_rawDesc = "" +
 	"\n" +
 	"route_rule\x18\x04 \x01(\tH\x00R\trouteRule\x12\x1a\n" +
 	"\abackend\x18\x05 \x01(\tH\x00R\abackendB\x06\n" +
-	"\x04kind\"\xa6\x1a\n" +
+	"\x04kind\"\xf0 \n" +
 	"\n" +
 	"PolicySpec\x12`\n" +
 	"\x10local_rate_limit\x18\x01 \x01(\v24.agentgateway.dev.resource.PolicySpec.LocalRateLimitH\x00R\x0elocalRateLimit\x12Q\n" +
@@ -4863,9 +5058,18 @@ const file_resource_proto_rawDesc = "" +
 	"\x04type\x18\x04 \x01(\x0e29.agentgateway.dev.resource.PolicySpec.LocalRateLimit.TypeR\x04type\"\x1e\n" +
 	"\x04Type\x12\v\n" +
 	"\aREQUEST\x10\x00\x12\t\n" +
-	"\x05TOKEN\x10\x01\x1a\x9b\f\n" +
+	"\x05TOKEN\x10\x01\x1a\xe5\x12\n" +
 	"\x02Ai\x12W\n" +
-	"\fprompt_guard\x18\x01 \x01(\v24.agentgateway.dev.resource.PolicySpec.Ai.PromptGuardR\vpromptGuard\x1a:\n" +
+	"\fprompt_guard\x18\x01 \x01(\v24.agentgateway.dev.resource.PolicySpec.Ai.PromptGuardR\vpromptGuard\x12R\n" +
+	"\bdefaults\x18\x02 \x03(\v26.agentgateway.dev.resource.PolicySpec.Ai.DefaultsEntryR\bdefaults\x12U\n" +
+	"\toverrides\x18\x03 \x03(\v27.agentgateway.dev.resource.PolicySpec.Ai.OverridesEntryR\toverrides\x12S\n" +
+	"\aprompts\x18\x04 \x01(\v29.agentgateway.dev.resource.PolicySpec.Ai.PromptEnrichmentR\aprompts\x1a7\n" +
+	"\aMessage\x12\x12\n" +
+	"\x04role\x18\x01 \x01(\tR\x04role\x12\x18\n" +
+	"\acontent\x18\x02 \x01(\tR\acontent\x1a\xa8\x01\n" +
+	"\x10PromptEnrichment\x12H\n" +
+	"\x06append\x18\x01 \x03(\v20.agentgateway.dev.resource.PolicySpec.Ai.MessageR\x06append\x12J\n" +
+	"\aprepend\x18\x02 \x03(\v20.agentgateway.dev.resource.PolicySpec.Ai.MessageR\aprepend\x1a:\n" +
 	"\n" +
 	"NamedRegex\x12\x18\n" +
 	"\apattern\x18\x01 \x01(\tR\apattern\x12\x12\n" +
@@ -4873,10 +5077,10 @@ const file_resource_proto_rawDesc = "" +
 	"\tRegexRule\x12U\n" +
 	"\abuiltin\x18\x01 \x01(\x0e29.agentgateway.dev.resource.PolicySpec.Ai.BuiltinRegexRuleH\x00R\abuiltin\x12K\n" +
 	"\x05regex\x18\x02 \x01(\v23.agentgateway.dev.resource.PolicySpec.Ai.NamedRegexH\x00R\x05regexB\x06\n" +
-	"\x04kind\x1a\xb8\x01\n" +
+	"\x04kind\x1a\xb5\x01\n" +
 	"\x06Action\x12G\n" +
-	"\x04kind\x18\x01 \x01(\x0e23.agentgateway.dev.resource.PolicySpec.Ai.ActionKindR\x04kind\x12e\n" +
-	"\x0freject_response\x18\x02 \x01(\v2<.agentgateway.dev.resource.PolicySpec.Ai.PromptGuardResponseR\x0erejectResponse\x1a\x9f\x01\n" +
+	"\x04kind\x18\x01 \x01(\x0e23.agentgateway.dev.resource.PolicySpec.Ai.ActionKindR\x04kind\x12b\n" +
+	"\x0freject_response\x18\x02 \x01(\v29.agentgateway.dev.resource.PolicySpec.Ai.RequestRejectionR\x0erejectResponse\x1a\x9f\x01\n" +
 	"\n" +
 	"RegexRules\x12G\n" +
 	"\x06action\x18\x01 \x01(\v2/.agentgateway.dev.resource.PolicySpec.Ai.ActionR\x06action\x12H\n" +
@@ -4887,17 +5091,27 @@ const file_resource_proto_rawDesc = "" +
 	"\n" +
 	"Moderation\x122\n" +
 	"\x05model\x18\x01 \x01(\v2\x1c.google.protobuf.StringValueR\x05model\x12@\n" +
-	"\x04auth\x18\x02 \x01(\v2,.agentgateway.dev.resource.BackendAuthPolicyR\x04auth\x1aA\n" +
-	"\x13PromptGuardResponse\x12\x12\n" +
+	"\x04auth\x18\x02 \x01(\v2,.agentgateway.dev.resource.BackendAuthPolicyR\x04auth\x1a>\n" +
+	"\x10RequestRejection\x12\x12\n" +
 	"\x04body\x18\x01 \x01(\fR\x04body\x12\x16\n" +
-	"\x06status\x18\x02 \x01(\rR\x06status\x1a\xe7\x02\n" +
-	"\x12PromptGuardRequest\x12X\n" +
-	"\bresponse\x18\x01 \x01(\v2<.agentgateway.dev.resource.PolicySpec.Ai.PromptGuardResponseR\bresponse\x12I\n" +
+	"\x06status\x18\x02 \x01(\rR\x06status\x1a\xa6\x01\n" +
+	"\rResponseGuard\x12I\n" +
+	"\x05regex\x18\x01 \x01(\v23.agentgateway.dev.resource.PolicySpec.Ai.RegexRulesR\x05regex\x12J\n" +
+	"\awebhook\x18\x02 \x01(\v20.agentgateway.dev.resource.PolicySpec.Ai.WebhookR\awebhook\x1a\xe0\x02\n" +
+	"\fRequestGuard\x12W\n" +
+	"\trejection\x18\x01 \x01(\v29.agentgateway.dev.resource.PolicySpec.Ai.RequestRejectionR\trejection\x12I\n" +
 	"\x05regex\x18\x02 \x01(\v23.agentgateway.dev.resource.PolicySpec.Ai.RegexRulesR\x05regex\x12J\n" +
 	"\awebhook\x18\x03 \x01(\v20.agentgateway.dev.resource.PolicySpec.Ai.WebhookR\awebhook\x12`\n" +
-	"\x11openai_moderation\x18\x04 \x01(\v23.agentgateway.dev.resource.PolicySpec.Ai.ModerationR\x10openaiModeration\x1ad\n" +
-	"\vPromptGuard\x12U\n" +
-	"\arequest\x18\x01 \x01(\v2;.agentgateway.dev.resource.PolicySpec.Ai.PromptGuardRequestR\arequest\"b\n" +
+	"\x11openai_moderation\x18\x04 \x01(\v23.agentgateway.dev.resource.PolicySpec.Ai.ModerationR\x10openaiModeration\x1a\xb2\x01\n" +
+	"\vPromptGuard\x12O\n" +
+	"\arequest\x18\x01 \x01(\v25.agentgateway.dev.resource.PolicySpec.Ai.RequestGuardR\arequest\x12R\n" +
+	"\bresponse\x18\x02 \x01(\v26.agentgateway.dev.resource.PolicySpec.Ai.ResponseGuardR\bresponse\x1a;\n" +
+	"\rDefaultsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a<\n" +
+	"\x0eOverridesEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"b\n" +
 	"\x10BuiltinRegexRule\x12\x17\n" +
 	"\x13BUILTIN_UNSPECIFIED\x10\x00\x12\a\n" +
 	"\x03SSN\x10\x01\x12\x0f\n" +
@@ -5017,7 +5231,7 @@ func file_resource_proto_rawDescGZIP() []byte {
 }
 
 var file_resource_proto_enumTypes = make([]protoimpl.EnumInfo, 7)
-var file_resource_proto_msgTypes = make([]protoimpl.MessageInfo, 61)
+var file_resource_proto_msgTypes = make([]protoimpl.MessageInfo, 66)
 var file_resource_proto_goTypes = []any{
 	(Protocol)(0),                                // 0: agentgateway.dev.resource.Protocol
 	(PolicySpec_LocalRateLimit_Type)(0),          // 1: agentgateway.dev.resource.PolicySpec.LocalRateLimit.Type
@@ -5071,128 +5285,141 @@ var file_resource_proto_goTypes = []any{
 	(*PolicySpec_InferenceRouting)(nil),          // 49: agentgateway.dev.resource.PolicySpec.InferenceRouting
 	(*PolicySpec_BackendTLS)(nil),                // 50: agentgateway.dev.resource.PolicySpec.BackendTLS
 	(*PolicySpec_RBAC)(nil),                      // 51: agentgateway.dev.resource.PolicySpec.RBAC
-	(*PolicySpec_Ai_NamedRegex)(nil),             // 52: agentgateway.dev.resource.PolicySpec.Ai.NamedRegex
-	(*PolicySpec_Ai_RegexRule)(nil),              // 53: agentgateway.dev.resource.PolicySpec.Ai.RegexRule
-	(*PolicySpec_Ai_Action)(nil),                 // 54: agentgateway.dev.resource.PolicySpec.Ai.Action
-	(*PolicySpec_Ai_RegexRules)(nil),             // 55: agentgateway.dev.resource.PolicySpec.Ai.RegexRules
-	(*PolicySpec_Ai_Webhook)(nil),                // 56: agentgateway.dev.resource.PolicySpec.Ai.Webhook
-	(*PolicySpec_Ai_Moderation)(nil),             // 57: agentgateway.dev.resource.PolicySpec.Ai.Moderation
-	(*PolicySpec_Ai_PromptGuardResponse)(nil),    // 58: agentgateway.dev.resource.PolicySpec.Ai.PromptGuardResponse
-	(*PolicySpec_Ai_PromptGuardRequest)(nil),     // 59: agentgateway.dev.resource.PolicySpec.Ai.PromptGuardRequest
-	(*PolicySpec_Ai_PromptGuard)(nil),            // 60: agentgateway.dev.resource.PolicySpec.Ai.PromptGuard
-	nil,                                          // 61: agentgateway.dev.resource.PolicySpec.ExternalAuth.ContextEntry
-	(*AIBackend_Override)(nil),                   // 62: agentgateway.dev.resource.AIBackend.Override
-	(*AIBackend_OpenAI)(nil),                     // 63: agentgateway.dev.resource.AIBackend.OpenAI
-	(*AIBackend_Gemini)(nil),                     // 64: agentgateway.dev.resource.AIBackend.Gemini
-	(*AIBackend_Vertex)(nil),                     // 65: agentgateway.dev.resource.AIBackend.Vertex
-	(*AIBackend_Anthropic)(nil),                  // 66: agentgateway.dev.resource.AIBackend.Anthropic
-	(*AIBackend_Bedrock)(nil),                    // 67: agentgateway.dev.resource.AIBackend.Bedrock
-	(*duration.Duration)(nil),                    // 68: google.protobuf.Duration
-	(*wrappers.BytesValue)(nil),                  // 69: google.protobuf.BytesValue
-	(*wrappers.BoolValue)(nil),                   // 70: google.protobuf.BoolValue
-	(*wrappers.StringValue)(nil),                 // 71: google.protobuf.StringValue
+	(*PolicySpec_Ai_Message)(nil),                // 52: agentgateway.dev.resource.PolicySpec.Ai.Message
+	(*PolicySpec_Ai_PromptEnrichment)(nil),       // 53: agentgateway.dev.resource.PolicySpec.Ai.PromptEnrichment
+	(*PolicySpec_Ai_NamedRegex)(nil),             // 54: agentgateway.dev.resource.PolicySpec.Ai.NamedRegex
+	(*PolicySpec_Ai_RegexRule)(nil),              // 55: agentgateway.dev.resource.PolicySpec.Ai.RegexRule
+	(*PolicySpec_Ai_Action)(nil),                 // 56: agentgateway.dev.resource.PolicySpec.Ai.Action
+	(*PolicySpec_Ai_RegexRules)(nil),             // 57: agentgateway.dev.resource.PolicySpec.Ai.RegexRules
+	(*PolicySpec_Ai_Webhook)(nil),                // 58: agentgateway.dev.resource.PolicySpec.Ai.Webhook
+	(*PolicySpec_Ai_Moderation)(nil),             // 59: agentgateway.dev.resource.PolicySpec.Ai.Moderation
+	(*PolicySpec_Ai_RequestRejection)(nil),       // 60: agentgateway.dev.resource.PolicySpec.Ai.RequestRejection
+	(*PolicySpec_Ai_ResponseGuard)(nil),          // 61: agentgateway.dev.resource.PolicySpec.Ai.ResponseGuard
+	(*PolicySpec_Ai_RequestGuard)(nil),           // 62: agentgateway.dev.resource.PolicySpec.Ai.RequestGuard
+	(*PolicySpec_Ai_PromptGuard)(nil),            // 63: agentgateway.dev.resource.PolicySpec.Ai.PromptGuard
+	nil,                                          // 64: agentgateway.dev.resource.PolicySpec.Ai.DefaultsEntry
+	nil,                                          // 65: agentgateway.dev.resource.PolicySpec.Ai.OverridesEntry
+	nil,                                          // 66: agentgateway.dev.resource.PolicySpec.ExternalAuth.ContextEntry
+	(*AIBackend_Override)(nil),                   // 67: agentgateway.dev.resource.AIBackend.Override
+	(*AIBackend_OpenAI)(nil),                     // 68: agentgateway.dev.resource.AIBackend.OpenAI
+	(*AIBackend_Gemini)(nil),                     // 69: agentgateway.dev.resource.AIBackend.Gemini
+	(*AIBackend_Vertex)(nil),                     // 70: agentgateway.dev.resource.AIBackend.Vertex
+	(*AIBackend_Anthropic)(nil),                  // 71: agentgateway.dev.resource.AIBackend.Anthropic
+	(*AIBackend_Bedrock)(nil),                    // 72: agentgateway.dev.resource.AIBackend.Bedrock
+	(*duration.Duration)(nil),                    // 73: google.protobuf.Duration
+	(*wrappers.BytesValue)(nil),                  // 74: google.protobuf.BytesValue
+	(*wrappers.BoolValue)(nil),                   // 75: google.protobuf.BoolValue
+	(*wrappers.StringValue)(nil),                 // 76: google.protobuf.StringValue
 }
 var file_resource_proto_depIdxs = []int32{
-	8,  // 0: agentgateway.dev.resource.Resource.bind:type_name -> agentgateway.dev.resource.Bind
-	9,  // 1: agentgateway.dev.resource.Resource.listener:type_name -> agentgateway.dev.resource.Listener
-	11, // 2: agentgateway.dev.resource.Resource.route:type_name -> agentgateway.dev.resource.Route
-	39, // 3: agentgateway.dev.resource.Resource.backend:type_name -> agentgateway.dev.resource.Backend
-	38, // 4: agentgateway.dev.resource.Resource.policy:type_name -> agentgateway.dev.resource.Policy
-	12, // 5: agentgateway.dev.resource.Resource.tcp_route:type_name -> agentgateway.dev.resource.TCPRoute
-	0,  // 6: agentgateway.dev.resource.Listener.protocol:type_name -> agentgateway.dev.resource.Protocol
-	10, // 7: agentgateway.dev.resource.Listener.tls:type_name -> agentgateway.dev.resource.TLSConfig
-	22, // 8: agentgateway.dev.resource.Route.matches:type_name -> agentgateway.dev.resource.RouteMatch
-	27, // 9: agentgateway.dev.resource.Route.filters:type_name -> agentgateway.dev.resource.RouteFilter
-	35, // 10: agentgateway.dev.resource.Route.backends:type_name -> agentgateway.dev.resource.RouteBackend
-	13, // 11: agentgateway.dev.resource.Route.traffic_policy:type_name -> agentgateway.dev.resource.TrafficPolicy
-	35, // 12: agentgateway.dev.resource.TCPRoute.backends:type_name -> agentgateway.dev.resource.RouteBackend
-	68, // 13: agentgateway.dev.resource.TrafficPolicy.backend_request_timeout:type_name -> google.protobuf.Duration
-	68, // 14: agentgateway.dev.resource.TrafficPolicy.request_timeout:type_name -> google.protobuf.Duration
-	14, // 15: agentgateway.dev.resource.TrafficPolicy.retry:type_name -> agentgateway.dev.resource.Retry
-	68, // 16: agentgateway.dev.resource.Retry.backoff:type_name -> google.protobuf.Duration
-	16, // 17: agentgateway.dev.resource.BackendAuthPolicy.passthrough:type_name -> agentgateway.dev.resource.Passthrough
-	17, // 18: agentgateway.dev.resource.BackendAuthPolicy.key:type_name -> agentgateway.dev.resource.Key
-	18, // 19: agentgateway.dev.resource.BackendAuthPolicy.gcp:type_name -> agentgateway.dev.resource.Gcp
-	19, // 20: agentgateway.dev.resource.BackendAuthPolicy.aws:type_name -> agentgateway.dev.resource.Aws
-	20, // 21: agentgateway.dev.resource.Aws.explicit_config:type_name -> agentgateway.dev.resource.AwsExplicitConfig
-	21, // 22: agentgateway.dev.resource.Aws.implicit:type_name -> agentgateway.dev.resource.AwsImplicit
-	23, // 23: agentgateway.dev.resource.RouteMatch.path:type_name -> agentgateway.dev.resource.PathMatch
-	26, // 24: agentgateway.dev.resource.RouteMatch.headers:type_name -> agentgateway.dev.resource.HeaderMatch
-	25, // 25: agentgateway.dev.resource.RouteMatch.method:type_name -> agentgateway.dev.resource.MethodMatch
-	24, // 26: agentgateway.dev.resource.RouteMatch.query_params:type_name -> agentgateway.dev.resource.QueryMatch
-	30, // 27: agentgateway.dev.resource.RouteFilter.request_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
-	30, // 28: agentgateway.dev.resource.RouteFilter.response_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
-	32, // 29: agentgateway.dev.resource.RouteFilter.request_redirect:type_name -> agentgateway.dev.resource.RequestRedirect
-	33, // 30: agentgateway.dev.resource.RouteFilter.url_rewrite:type_name -> agentgateway.dev.resource.UrlRewrite
-	31, // 31: agentgateway.dev.resource.RouteFilter.request_mirror:type_name -> agentgateway.dev.resource.RequestMirror
-	29, // 32: agentgateway.dev.resource.RouteFilter.direct_response:type_name -> agentgateway.dev.resource.DirectResponse
-	28, // 33: agentgateway.dev.resource.RouteFilter.cors:type_name -> agentgateway.dev.resource.CORS
-	68, // 34: agentgateway.dev.resource.CORS.max_age:type_name -> google.protobuf.Duration
-	34, // 35: agentgateway.dev.resource.HeaderModifier.add:type_name -> agentgateway.dev.resource.Header
-	34, // 36: agentgateway.dev.resource.HeaderModifier.set:type_name -> agentgateway.dev.resource.Header
-	44, // 37: agentgateway.dev.resource.RequestMirror.backend:type_name -> agentgateway.dev.resource.BackendReference
-	44, // 38: agentgateway.dev.resource.RouteBackend.backend:type_name -> agentgateway.dev.resource.BackendReference
-	27, // 39: agentgateway.dev.resource.RouteBackend.filters:type_name -> agentgateway.dev.resource.RouteFilter
-	45, // 40: agentgateway.dev.resource.PolicySpec.local_rate_limit:type_name -> agentgateway.dev.resource.PolicySpec.LocalRateLimit
-	47, // 41: agentgateway.dev.resource.PolicySpec.ext_authz:type_name -> agentgateway.dev.resource.PolicySpec.ExternalAuth
-	48, // 42: agentgateway.dev.resource.PolicySpec.a2a:type_name -> agentgateway.dev.resource.PolicySpec.A2a
-	49, // 43: agentgateway.dev.resource.PolicySpec.inference_routing:type_name -> agentgateway.dev.resource.PolicySpec.InferenceRouting
-	50, // 44: agentgateway.dev.resource.PolicySpec.backend_tls:type_name -> agentgateway.dev.resource.PolicySpec.BackendTLS
-	15, // 45: agentgateway.dev.resource.PolicySpec.auth:type_name -> agentgateway.dev.resource.BackendAuthPolicy
-	51, // 46: agentgateway.dev.resource.PolicySpec.authorization:type_name -> agentgateway.dev.resource.PolicySpec.RBAC
-	51, // 47: agentgateway.dev.resource.PolicySpec.mcp_authorization:type_name -> agentgateway.dev.resource.PolicySpec.RBAC
-	46, // 48: agentgateway.dev.resource.PolicySpec.ai:type_name -> agentgateway.dev.resource.PolicySpec.Ai
-	36, // 49: agentgateway.dev.resource.Policy.target:type_name -> agentgateway.dev.resource.PolicyTarget
-	37, // 50: agentgateway.dev.resource.Policy.spec:type_name -> agentgateway.dev.resource.PolicySpec
-	40, // 51: agentgateway.dev.resource.Backend.static:type_name -> agentgateway.dev.resource.StaticBackend
-	41, // 52: agentgateway.dev.resource.Backend.ai:type_name -> agentgateway.dev.resource.AIBackend
-	42, // 53: agentgateway.dev.resource.Backend.mcp:type_name -> agentgateway.dev.resource.MCPBackend
-	62, // 54: agentgateway.dev.resource.AIBackend.override:type_name -> agentgateway.dev.resource.AIBackend.Override
-	63, // 55: agentgateway.dev.resource.AIBackend.openai:type_name -> agentgateway.dev.resource.AIBackend.OpenAI
-	64, // 56: agentgateway.dev.resource.AIBackend.gemini:type_name -> agentgateway.dev.resource.AIBackend.Gemini
-	65, // 57: agentgateway.dev.resource.AIBackend.vertex:type_name -> agentgateway.dev.resource.AIBackend.Vertex
-	66, // 58: agentgateway.dev.resource.AIBackend.anthropic:type_name -> agentgateway.dev.resource.AIBackend.Anthropic
-	67, // 59: agentgateway.dev.resource.AIBackend.bedrock:type_name -> agentgateway.dev.resource.AIBackend.Bedrock
-	43, // 60: agentgateway.dev.resource.MCPBackend.targets:type_name -> agentgateway.dev.resource.MCPTarget
-	5,  // 61: agentgateway.dev.resource.MCPBackend.stateful_mode:type_name -> agentgateway.dev.resource.MCPBackend.StatefulMode
-	44, // 62: agentgateway.dev.resource.MCPTarget.backend:type_name -> agentgateway.dev.resource.BackendReference
-	6,  // 63: agentgateway.dev.resource.MCPTarget.protocol:type_name -> agentgateway.dev.resource.MCPTarget.Protocol
-	68, // 64: agentgateway.dev.resource.PolicySpec.LocalRateLimit.fill_interval:type_name -> google.protobuf.Duration
-	1,  // 65: agentgateway.dev.resource.PolicySpec.LocalRateLimit.type:type_name -> agentgateway.dev.resource.PolicySpec.LocalRateLimit.Type
-	60, // 66: agentgateway.dev.resource.PolicySpec.Ai.prompt_guard:type_name -> agentgateway.dev.resource.PolicySpec.Ai.PromptGuard
-	44, // 67: agentgateway.dev.resource.PolicySpec.ExternalAuth.target:type_name -> agentgateway.dev.resource.BackendReference
-	61, // 68: agentgateway.dev.resource.PolicySpec.ExternalAuth.context:type_name -> agentgateway.dev.resource.PolicySpec.ExternalAuth.ContextEntry
-	44, // 69: agentgateway.dev.resource.PolicySpec.InferenceRouting.endpoint_picker:type_name -> agentgateway.dev.resource.BackendReference
-	4,  // 70: agentgateway.dev.resource.PolicySpec.InferenceRouting.failure_mode:type_name -> agentgateway.dev.resource.PolicySpec.InferenceRouting.FailureMode
-	69, // 71: agentgateway.dev.resource.PolicySpec.BackendTLS.cert:type_name -> google.protobuf.BytesValue
-	69, // 72: agentgateway.dev.resource.PolicySpec.BackendTLS.key:type_name -> google.protobuf.BytesValue
-	69, // 73: agentgateway.dev.resource.PolicySpec.BackendTLS.root:type_name -> google.protobuf.BytesValue
-	70, // 74: agentgateway.dev.resource.PolicySpec.BackendTLS.insecure:type_name -> google.protobuf.BoolValue
-	2,  // 75: agentgateway.dev.resource.PolicySpec.Ai.RegexRule.builtin:type_name -> agentgateway.dev.resource.PolicySpec.Ai.BuiltinRegexRule
-	52, // 76: agentgateway.dev.resource.PolicySpec.Ai.RegexRule.regex:type_name -> agentgateway.dev.resource.PolicySpec.Ai.NamedRegex
-	3,  // 77: agentgateway.dev.resource.PolicySpec.Ai.Action.kind:type_name -> agentgateway.dev.resource.PolicySpec.Ai.ActionKind
-	58, // 78: agentgateway.dev.resource.PolicySpec.Ai.Action.reject_response:type_name -> agentgateway.dev.resource.PolicySpec.Ai.PromptGuardResponse
-	54, // 79: agentgateway.dev.resource.PolicySpec.Ai.RegexRules.action:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Action
-	53, // 80: agentgateway.dev.resource.PolicySpec.Ai.RegexRules.rules:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RegexRule
-	71, // 81: agentgateway.dev.resource.PolicySpec.Ai.Moderation.model:type_name -> google.protobuf.StringValue
-	15, // 82: agentgateway.dev.resource.PolicySpec.Ai.Moderation.auth:type_name -> agentgateway.dev.resource.BackendAuthPolicy
-	58, // 83: agentgateway.dev.resource.PolicySpec.Ai.PromptGuardRequest.response:type_name -> agentgateway.dev.resource.PolicySpec.Ai.PromptGuardResponse
-	55, // 84: agentgateway.dev.resource.PolicySpec.Ai.PromptGuardRequest.regex:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RegexRules
-	56, // 85: agentgateway.dev.resource.PolicySpec.Ai.PromptGuardRequest.webhook:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Webhook
-	57, // 86: agentgateway.dev.resource.PolicySpec.Ai.PromptGuardRequest.openai_moderation:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Moderation
-	59, // 87: agentgateway.dev.resource.PolicySpec.Ai.PromptGuard.request:type_name -> agentgateway.dev.resource.PolicySpec.Ai.PromptGuardRequest
-	71, // 88: agentgateway.dev.resource.AIBackend.OpenAI.model:type_name -> google.protobuf.StringValue
-	71, // 89: agentgateway.dev.resource.AIBackend.Gemini.model:type_name -> google.protobuf.StringValue
-	71, // 90: agentgateway.dev.resource.AIBackend.Vertex.model:type_name -> google.protobuf.StringValue
-	71, // 91: agentgateway.dev.resource.AIBackend.Anthropic.model:type_name -> google.protobuf.StringValue
-	71, // 92: agentgateway.dev.resource.AIBackend.Bedrock.model:type_name -> google.protobuf.StringValue
-	71, // 93: agentgateway.dev.resource.AIBackend.Bedrock.guardrail_identifier:type_name -> google.protobuf.StringValue
-	71, // 94: agentgateway.dev.resource.AIBackend.Bedrock.guardrail_version:type_name -> google.protobuf.StringValue
-	95, // [95:95] is the sub-list for method output_type
-	95, // [95:95] is the sub-list for method input_type
-	95, // [95:95] is the sub-list for extension type_name
-	95, // [95:95] is the sub-list for extension extendee
-	0,  // [0:95] is the sub-list for field type_name
+	8,   // 0: agentgateway.dev.resource.Resource.bind:type_name -> agentgateway.dev.resource.Bind
+	9,   // 1: agentgateway.dev.resource.Resource.listener:type_name -> agentgateway.dev.resource.Listener
+	11,  // 2: agentgateway.dev.resource.Resource.route:type_name -> agentgateway.dev.resource.Route
+	39,  // 3: agentgateway.dev.resource.Resource.backend:type_name -> agentgateway.dev.resource.Backend
+	38,  // 4: agentgateway.dev.resource.Resource.policy:type_name -> agentgateway.dev.resource.Policy
+	12,  // 5: agentgateway.dev.resource.Resource.tcp_route:type_name -> agentgateway.dev.resource.TCPRoute
+	0,   // 6: agentgateway.dev.resource.Listener.protocol:type_name -> agentgateway.dev.resource.Protocol
+	10,  // 7: agentgateway.dev.resource.Listener.tls:type_name -> agentgateway.dev.resource.TLSConfig
+	22,  // 8: agentgateway.dev.resource.Route.matches:type_name -> agentgateway.dev.resource.RouteMatch
+	27,  // 9: agentgateway.dev.resource.Route.filters:type_name -> agentgateway.dev.resource.RouteFilter
+	35,  // 10: agentgateway.dev.resource.Route.backends:type_name -> agentgateway.dev.resource.RouteBackend
+	13,  // 11: agentgateway.dev.resource.Route.traffic_policy:type_name -> agentgateway.dev.resource.TrafficPolicy
+	35,  // 12: agentgateway.dev.resource.TCPRoute.backends:type_name -> agentgateway.dev.resource.RouteBackend
+	73,  // 13: agentgateway.dev.resource.TrafficPolicy.backend_request_timeout:type_name -> google.protobuf.Duration
+	73,  // 14: agentgateway.dev.resource.TrafficPolicy.request_timeout:type_name -> google.protobuf.Duration
+	14,  // 15: agentgateway.dev.resource.TrafficPolicy.retry:type_name -> agentgateway.dev.resource.Retry
+	73,  // 16: agentgateway.dev.resource.Retry.backoff:type_name -> google.protobuf.Duration
+	16,  // 17: agentgateway.dev.resource.BackendAuthPolicy.passthrough:type_name -> agentgateway.dev.resource.Passthrough
+	17,  // 18: agentgateway.dev.resource.BackendAuthPolicy.key:type_name -> agentgateway.dev.resource.Key
+	18,  // 19: agentgateway.dev.resource.BackendAuthPolicy.gcp:type_name -> agentgateway.dev.resource.Gcp
+	19,  // 20: agentgateway.dev.resource.BackendAuthPolicy.aws:type_name -> agentgateway.dev.resource.Aws
+	20,  // 21: agentgateway.dev.resource.Aws.explicit_config:type_name -> agentgateway.dev.resource.AwsExplicitConfig
+	21,  // 22: agentgateway.dev.resource.Aws.implicit:type_name -> agentgateway.dev.resource.AwsImplicit
+	23,  // 23: agentgateway.dev.resource.RouteMatch.path:type_name -> agentgateway.dev.resource.PathMatch
+	26,  // 24: agentgateway.dev.resource.RouteMatch.headers:type_name -> agentgateway.dev.resource.HeaderMatch
+	25,  // 25: agentgateway.dev.resource.RouteMatch.method:type_name -> agentgateway.dev.resource.MethodMatch
+	24,  // 26: agentgateway.dev.resource.RouteMatch.query_params:type_name -> agentgateway.dev.resource.QueryMatch
+	30,  // 27: agentgateway.dev.resource.RouteFilter.request_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
+	30,  // 28: agentgateway.dev.resource.RouteFilter.response_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
+	32,  // 29: agentgateway.dev.resource.RouteFilter.request_redirect:type_name -> agentgateway.dev.resource.RequestRedirect
+	33,  // 30: agentgateway.dev.resource.RouteFilter.url_rewrite:type_name -> agentgateway.dev.resource.UrlRewrite
+	31,  // 31: agentgateway.dev.resource.RouteFilter.request_mirror:type_name -> agentgateway.dev.resource.RequestMirror
+	29,  // 32: agentgateway.dev.resource.RouteFilter.direct_response:type_name -> agentgateway.dev.resource.DirectResponse
+	28,  // 33: agentgateway.dev.resource.RouteFilter.cors:type_name -> agentgateway.dev.resource.CORS
+	73,  // 34: agentgateway.dev.resource.CORS.max_age:type_name -> google.protobuf.Duration
+	34,  // 35: agentgateway.dev.resource.HeaderModifier.add:type_name -> agentgateway.dev.resource.Header
+	34,  // 36: agentgateway.dev.resource.HeaderModifier.set:type_name -> agentgateway.dev.resource.Header
+	44,  // 37: agentgateway.dev.resource.RequestMirror.backend:type_name -> agentgateway.dev.resource.BackendReference
+	44,  // 38: agentgateway.dev.resource.RouteBackend.backend:type_name -> agentgateway.dev.resource.BackendReference
+	27,  // 39: agentgateway.dev.resource.RouteBackend.filters:type_name -> agentgateway.dev.resource.RouteFilter
+	45,  // 40: agentgateway.dev.resource.PolicySpec.local_rate_limit:type_name -> agentgateway.dev.resource.PolicySpec.LocalRateLimit
+	47,  // 41: agentgateway.dev.resource.PolicySpec.ext_authz:type_name -> agentgateway.dev.resource.PolicySpec.ExternalAuth
+	48,  // 42: agentgateway.dev.resource.PolicySpec.a2a:type_name -> agentgateway.dev.resource.PolicySpec.A2a
+	49,  // 43: agentgateway.dev.resource.PolicySpec.inference_routing:type_name -> agentgateway.dev.resource.PolicySpec.InferenceRouting
+	50,  // 44: agentgateway.dev.resource.PolicySpec.backend_tls:type_name -> agentgateway.dev.resource.PolicySpec.BackendTLS
+	15,  // 45: agentgateway.dev.resource.PolicySpec.auth:type_name -> agentgateway.dev.resource.BackendAuthPolicy
+	51,  // 46: agentgateway.dev.resource.PolicySpec.authorization:type_name -> agentgateway.dev.resource.PolicySpec.RBAC
+	51,  // 47: agentgateway.dev.resource.PolicySpec.mcp_authorization:type_name -> agentgateway.dev.resource.PolicySpec.RBAC
+	46,  // 48: agentgateway.dev.resource.PolicySpec.ai:type_name -> agentgateway.dev.resource.PolicySpec.Ai
+	36,  // 49: agentgateway.dev.resource.Policy.target:type_name -> agentgateway.dev.resource.PolicyTarget
+	37,  // 50: agentgateway.dev.resource.Policy.spec:type_name -> agentgateway.dev.resource.PolicySpec
+	40,  // 51: agentgateway.dev.resource.Backend.static:type_name -> agentgateway.dev.resource.StaticBackend
+	41,  // 52: agentgateway.dev.resource.Backend.ai:type_name -> agentgateway.dev.resource.AIBackend
+	42,  // 53: agentgateway.dev.resource.Backend.mcp:type_name -> agentgateway.dev.resource.MCPBackend
+	67,  // 54: agentgateway.dev.resource.AIBackend.override:type_name -> agentgateway.dev.resource.AIBackend.Override
+	68,  // 55: agentgateway.dev.resource.AIBackend.openai:type_name -> agentgateway.dev.resource.AIBackend.OpenAI
+	69,  // 56: agentgateway.dev.resource.AIBackend.gemini:type_name -> agentgateway.dev.resource.AIBackend.Gemini
+	70,  // 57: agentgateway.dev.resource.AIBackend.vertex:type_name -> agentgateway.dev.resource.AIBackend.Vertex
+	71,  // 58: agentgateway.dev.resource.AIBackend.anthropic:type_name -> agentgateway.dev.resource.AIBackend.Anthropic
+	72,  // 59: agentgateway.dev.resource.AIBackend.bedrock:type_name -> agentgateway.dev.resource.AIBackend.Bedrock
+	43,  // 60: agentgateway.dev.resource.MCPBackend.targets:type_name -> agentgateway.dev.resource.MCPTarget
+	5,   // 61: agentgateway.dev.resource.MCPBackend.stateful_mode:type_name -> agentgateway.dev.resource.MCPBackend.StatefulMode
+	44,  // 62: agentgateway.dev.resource.MCPTarget.backend:type_name -> agentgateway.dev.resource.BackendReference
+	6,   // 63: agentgateway.dev.resource.MCPTarget.protocol:type_name -> agentgateway.dev.resource.MCPTarget.Protocol
+	73,  // 64: agentgateway.dev.resource.PolicySpec.LocalRateLimit.fill_interval:type_name -> google.protobuf.Duration
+	1,   // 65: agentgateway.dev.resource.PolicySpec.LocalRateLimit.type:type_name -> agentgateway.dev.resource.PolicySpec.LocalRateLimit.Type
+	63,  // 66: agentgateway.dev.resource.PolicySpec.Ai.prompt_guard:type_name -> agentgateway.dev.resource.PolicySpec.Ai.PromptGuard
+	64,  // 67: agentgateway.dev.resource.PolicySpec.Ai.defaults:type_name -> agentgateway.dev.resource.PolicySpec.Ai.DefaultsEntry
+	65,  // 68: agentgateway.dev.resource.PolicySpec.Ai.overrides:type_name -> agentgateway.dev.resource.PolicySpec.Ai.OverridesEntry
+	53,  // 69: agentgateway.dev.resource.PolicySpec.Ai.prompts:type_name -> agentgateway.dev.resource.PolicySpec.Ai.PromptEnrichment
+	44,  // 70: agentgateway.dev.resource.PolicySpec.ExternalAuth.target:type_name -> agentgateway.dev.resource.BackendReference
+	66,  // 71: agentgateway.dev.resource.PolicySpec.ExternalAuth.context:type_name -> agentgateway.dev.resource.PolicySpec.ExternalAuth.ContextEntry
+	44,  // 72: agentgateway.dev.resource.PolicySpec.InferenceRouting.endpoint_picker:type_name -> agentgateway.dev.resource.BackendReference
+	4,   // 73: agentgateway.dev.resource.PolicySpec.InferenceRouting.failure_mode:type_name -> agentgateway.dev.resource.PolicySpec.InferenceRouting.FailureMode
+	74,  // 74: agentgateway.dev.resource.PolicySpec.BackendTLS.cert:type_name -> google.protobuf.BytesValue
+	74,  // 75: agentgateway.dev.resource.PolicySpec.BackendTLS.key:type_name -> google.protobuf.BytesValue
+	74,  // 76: agentgateway.dev.resource.PolicySpec.BackendTLS.root:type_name -> google.protobuf.BytesValue
+	75,  // 77: agentgateway.dev.resource.PolicySpec.BackendTLS.insecure:type_name -> google.protobuf.BoolValue
+	52,  // 78: agentgateway.dev.resource.PolicySpec.Ai.PromptEnrichment.append:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Message
+	52,  // 79: agentgateway.dev.resource.PolicySpec.Ai.PromptEnrichment.prepend:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Message
+	2,   // 80: agentgateway.dev.resource.PolicySpec.Ai.RegexRule.builtin:type_name -> agentgateway.dev.resource.PolicySpec.Ai.BuiltinRegexRule
+	54,  // 81: agentgateway.dev.resource.PolicySpec.Ai.RegexRule.regex:type_name -> agentgateway.dev.resource.PolicySpec.Ai.NamedRegex
+	3,   // 82: agentgateway.dev.resource.PolicySpec.Ai.Action.kind:type_name -> agentgateway.dev.resource.PolicySpec.Ai.ActionKind
+	60,  // 83: agentgateway.dev.resource.PolicySpec.Ai.Action.reject_response:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RequestRejection
+	56,  // 84: agentgateway.dev.resource.PolicySpec.Ai.RegexRules.action:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Action
+	55,  // 85: agentgateway.dev.resource.PolicySpec.Ai.RegexRules.rules:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RegexRule
+	76,  // 86: agentgateway.dev.resource.PolicySpec.Ai.Moderation.model:type_name -> google.protobuf.StringValue
+	15,  // 87: agentgateway.dev.resource.PolicySpec.Ai.Moderation.auth:type_name -> agentgateway.dev.resource.BackendAuthPolicy
+	57,  // 88: agentgateway.dev.resource.PolicySpec.Ai.ResponseGuard.regex:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RegexRules
+	58,  // 89: agentgateway.dev.resource.PolicySpec.Ai.ResponseGuard.webhook:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Webhook
+	60,  // 90: agentgateway.dev.resource.PolicySpec.Ai.RequestGuard.rejection:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RequestRejection
+	57,  // 91: agentgateway.dev.resource.PolicySpec.Ai.RequestGuard.regex:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RegexRules
+	58,  // 92: agentgateway.dev.resource.PolicySpec.Ai.RequestGuard.webhook:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Webhook
+	59,  // 93: agentgateway.dev.resource.PolicySpec.Ai.RequestGuard.openai_moderation:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Moderation
+	62,  // 94: agentgateway.dev.resource.PolicySpec.Ai.PromptGuard.request:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RequestGuard
+	61,  // 95: agentgateway.dev.resource.PolicySpec.Ai.PromptGuard.response:type_name -> agentgateway.dev.resource.PolicySpec.Ai.ResponseGuard
+	76,  // 96: agentgateway.dev.resource.AIBackend.OpenAI.model:type_name -> google.protobuf.StringValue
+	76,  // 97: agentgateway.dev.resource.AIBackend.Gemini.model:type_name -> google.protobuf.StringValue
+	76,  // 98: agentgateway.dev.resource.AIBackend.Vertex.model:type_name -> google.protobuf.StringValue
+	76,  // 99: agentgateway.dev.resource.AIBackend.Anthropic.model:type_name -> google.protobuf.StringValue
+	76,  // 100: agentgateway.dev.resource.AIBackend.Bedrock.model:type_name -> google.protobuf.StringValue
+	76,  // 101: agentgateway.dev.resource.AIBackend.Bedrock.guardrail_identifier:type_name -> google.protobuf.StringValue
+	76,  // 102: agentgateway.dev.resource.AIBackend.Bedrock.guardrail_version:type_name -> google.protobuf.StringValue
+	103, // [103:103] is the sub-list for method output_type
+	103, // [103:103] is the sub-list for method input_type
+	103, // [103:103] is the sub-list for extension type_name
+	103, // [103:103] is the sub-list for extension extendee
+	0,   // [0:103] is the sub-list for field type_name
 }
 
 func init() { file_resource_proto_init() }
@@ -5283,7 +5510,7 @@ func file_resource_proto_init() {
 		(*BackendReference_Service)(nil),
 		(*BackendReference_Backend)(nil),
 	}
-	file_resource_proto_msgTypes[46].OneofWrappers = []any{
+	file_resource_proto_msgTypes[48].OneofWrappers = []any{
 		(*PolicySpec_Ai_RegexRule_Builtin)(nil),
 		(*PolicySpec_Ai_RegexRule_Regex)(nil),
 	}
@@ -5293,7 +5520,7 @@ func file_resource_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_resource_proto_rawDesc), len(file_resource_proto_rawDesc)),
 			NumEnums:      7,
-			NumMessages:   61,
+			NumMessages:   66,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/go/api/resource.pb.go
+++ b/go/api/resource.pb.go
@@ -127,6 +127,110 @@ func (PolicySpec_LocalRateLimit_Type) EnumDescriptor() ([]byte, []int) {
 	return file_resource_proto_rawDescGZIP(), []int{30, 0, 0}
 }
 
+type PolicySpec_Ai_BuiltinRegexRule int32
+
+const (
+	PolicySpec_Ai_BUILTIN_UNSPECIFIED PolicySpec_Ai_BuiltinRegexRule = 0
+	PolicySpec_Ai_SSN                 PolicySpec_Ai_BuiltinRegexRule = 1
+	PolicySpec_Ai_CREDIT_CARD         PolicySpec_Ai_BuiltinRegexRule = 2
+	PolicySpec_Ai_PHONE_NUMBER        PolicySpec_Ai_BuiltinRegexRule = 3
+	PolicySpec_Ai_EMAIL               PolicySpec_Ai_BuiltinRegexRule = 4
+)
+
+// Enum value maps for PolicySpec_Ai_BuiltinRegexRule.
+var (
+	PolicySpec_Ai_BuiltinRegexRule_name = map[int32]string{
+		0: "BUILTIN_UNSPECIFIED",
+		1: "SSN",
+		2: "CREDIT_CARD",
+		3: "PHONE_NUMBER",
+		4: "EMAIL",
+	}
+	PolicySpec_Ai_BuiltinRegexRule_value = map[string]int32{
+		"BUILTIN_UNSPECIFIED": 0,
+		"SSN":                 1,
+		"CREDIT_CARD":         2,
+		"PHONE_NUMBER":        3,
+		"EMAIL":               4,
+	}
+)
+
+func (x PolicySpec_Ai_BuiltinRegexRule) Enum() *PolicySpec_Ai_BuiltinRegexRule {
+	p := new(PolicySpec_Ai_BuiltinRegexRule)
+	*p = x
+	return p
+}
+
+func (x PolicySpec_Ai_BuiltinRegexRule) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (PolicySpec_Ai_BuiltinRegexRule) Descriptor() protoreflect.EnumDescriptor {
+	return file_resource_proto_enumTypes[2].Descriptor()
+}
+
+func (PolicySpec_Ai_BuiltinRegexRule) Type() protoreflect.EnumType {
+	return &file_resource_proto_enumTypes[2]
+}
+
+func (x PolicySpec_Ai_BuiltinRegexRule) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use PolicySpec_Ai_BuiltinRegexRule.Descriptor instead.
+func (PolicySpec_Ai_BuiltinRegexRule) EnumDescriptor() ([]byte, []int) {
+	return file_resource_proto_rawDescGZIP(), []int{30, 1, 0}
+}
+
+type PolicySpec_Ai_ActionKind int32
+
+const (
+	PolicySpec_Ai_ACTION_UNSPECIFIED PolicySpec_Ai_ActionKind = 0
+	PolicySpec_Ai_MASK               PolicySpec_Ai_ActionKind = 1
+	PolicySpec_Ai_REJECT             PolicySpec_Ai_ActionKind = 2
+)
+
+// Enum value maps for PolicySpec_Ai_ActionKind.
+var (
+	PolicySpec_Ai_ActionKind_name = map[int32]string{
+		0: "ACTION_UNSPECIFIED",
+		1: "MASK",
+		2: "REJECT",
+	}
+	PolicySpec_Ai_ActionKind_value = map[string]int32{
+		"ACTION_UNSPECIFIED": 0,
+		"MASK":               1,
+		"REJECT":             2,
+	}
+)
+
+func (x PolicySpec_Ai_ActionKind) Enum() *PolicySpec_Ai_ActionKind {
+	p := new(PolicySpec_Ai_ActionKind)
+	*p = x
+	return p
+}
+
+func (x PolicySpec_Ai_ActionKind) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (PolicySpec_Ai_ActionKind) Descriptor() protoreflect.EnumDescriptor {
+	return file_resource_proto_enumTypes[3].Descriptor()
+}
+
+func (PolicySpec_Ai_ActionKind) Type() protoreflect.EnumType {
+	return &file_resource_proto_enumTypes[3]
+}
+
+func (x PolicySpec_Ai_ActionKind) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use PolicySpec_Ai_ActionKind.Descriptor instead.
+func (PolicySpec_Ai_ActionKind) EnumDescriptor() ([]byte, []int) {
+	return file_resource_proto_rawDescGZIP(), []int{30, 1, 1}
+}
+
 type PolicySpec_InferenceRouting_FailureMode int32
 
 const (
@@ -160,11 +264,11 @@ func (x PolicySpec_InferenceRouting_FailureMode) String() string {
 }
 
 func (PolicySpec_InferenceRouting_FailureMode) Descriptor() protoreflect.EnumDescriptor {
-	return file_resource_proto_enumTypes[2].Descriptor()
+	return file_resource_proto_enumTypes[4].Descriptor()
 }
 
 func (PolicySpec_InferenceRouting_FailureMode) Type() protoreflect.EnumType {
-	return &file_resource_proto_enumTypes[2]
+	return &file_resource_proto_enumTypes[4]
 }
 
 func (x PolicySpec_InferenceRouting_FailureMode) Number() protoreflect.EnumNumber {
@@ -173,7 +277,7 @@ func (x PolicySpec_InferenceRouting_FailureMode) Number() protoreflect.EnumNumbe
 
 // Deprecated: Use PolicySpec_InferenceRouting_FailureMode.Descriptor instead.
 func (PolicySpec_InferenceRouting_FailureMode) EnumDescriptor() ([]byte, []int) {
-	return file_resource_proto_rawDescGZIP(), []int{30, 3, 0}
+	return file_resource_proto_rawDescGZIP(), []int{30, 4, 0}
 }
 
 type MCPBackend_StatefulMode int32
@@ -206,11 +310,11 @@ func (x MCPBackend_StatefulMode) String() string {
 }
 
 func (MCPBackend_StatefulMode) Descriptor() protoreflect.EnumDescriptor {
-	return file_resource_proto_enumTypes[3].Descriptor()
+	return file_resource_proto_enumTypes[5].Descriptor()
 }
 
 func (MCPBackend_StatefulMode) Type() protoreflect.EnumType {
-	return &file_resource_proto_enumTypes[3]
+	return &file_resource_proto_enumTypes[5]
 }
 
 func (x MCPBackend_StatefulMode) Number() protoreflect.EnumNumber {
@@ -255,11 +359,11 @@ func (x MCPTarget_Protocol) String() string {
 }
 
 func (MCPTarget_Protocol) Descriptor() protoreflect.EnumDescriptor {
-	return file_resource_proto_enumTypes[4].Descriptor()
+	return file_resource_proto_enumTypes[6].Descriptor()
 }
 
 func (MCPTarget_Protocol) Type() protoreflect.EnumType {
-	return &file_resource_proto_enumTypes[4]
+	return &file_resource_proto_enumTypes[6]
 }
 
 func (x MCPTarget_Protocol) Number() protoreflect.EnumNumber {
@@ -2626,6 +2730,7 @@ type PolicySpec struct {
 	//	*PolicySpec_Auth
 	//	*PolicySpec_Authorization
 	//	*PolicySpec_McpAuthorization
+	//	*PolicySpec_Ai_
 	Kind          isPolicySpec_Kind `protobuf_oneof:"kind"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -2740,6 +2845,15 @@ func (x *PolicySpec) GetMcpAuthorization() *PolicySpec_RBAC {
 	return nil
 }
 
+func (x *PolicySpec) GetAi() *PolicySpec_Ai {
+	if x != nil {
+		if x, ok := x.Kind.(*PolicySpec_Ai_); ok {
+			return x.Ai
+		}
+	}
+	return nil
+}
+
 type isPolicySpec_Kind interface {
 	isPolicySpec_Kind()
 }
@@ -2776,6 +2890,10 @@ type PolicySpec_McpAuthorization struct {
 	McpAuthorization *PolicySpec_RBAC `protobuf:"bytes,8,opt,name=mcp_authorization,json=mcpAuthorization,proto3,oneof"`
 }
 
+type PolicySpec_Ai_ struct {
+	Ai *PolicySpec_Ai `protobuf:"bytes,9,opt,name=ai,proto3,oneof"`
+}
+
 func (*PolicySpec_LocalRateLimit_) isPolicySpec_Kind() {}
 
 func (*PolicySpec_ExtAuthz) isPolicySpec_Kind() {}
@@ -2791,6 +2909,8 @@ func (*PolicySpec_Auth) isPolicySpec_Kind() {}
 func (*PolicySpec_Authorization) isPolicySpec_Kind() {}
 
 func (*PolicySpec_McpAuthorization) isPolicySpec_Kind() {}
+
+func (*PolicySpec_Ai_) isPolicySpec_Kind() {}
 
 type Policy struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -3437,6 +3557,50 @@ func (x *PolicySpec_LocalRateLimit) GetType() PolicySpec_LocalRateLimit_Type {
 	return PolicySpec_LocalRateLimit_REQUEST
 }
 
+type PolicySpec_Ai struct {
+	state         protoimpl.MessageState     `protogen:"open.v1"`
+	PromptGuard   *PolicySpec_Ai_PromptGuard `protobuf:"bytes,1,opt,name=prompt_guard,json=promptGuard,proto3" json:"prompt_guard,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PolicySpec_Ai) Reset() {
+	*x = PolicySpec_Ai{}
+	mi := &file_resource_proto_msgTypes[39]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PolicySpec_Ai) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PolicySpec_Ai) ProtoMessage() {}
+
+func (x *PolicySpec_Ai) ProtoReflect() protoreflect.Message {
+	mi := &file_resource_proto_msgTypes[39]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PolicySpec_Ai.ProtoReflect.Descriptor instead.
+func (*PolicySpec_Ai) Descriptor() ([]byte, []int) {
+	return file_resource_proto_rawDescGZIP(), []int{30, 1}
+}
+
+func (x *PolicySpec_Ai) GetPromptGuard() *PolicySpec_Ai_PromptGuard {
+	if x != nil {
+		return x.PromptGuard
+	}
+	return nil
+}
+
 type PolicySpec_ExternalAuth struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Target        *BackendReference      `protobuf:"bytes,1,opt,name=target,proto3" json:"target,omitempty"`
@@ -3447,7 +3611,7 @@ type PolicySpec_ExternalAuth struct {
 
 func (x *PolicySpec_ExternalAuth) Reset() {
 	*x = PolicySpec_ExternalAuth{}
-	mi := &file_resource_proto_msgTypes[39]
+	mi := &file_resource_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3459,7 +3623,7 @@ func (x *PolicySpec_ExternalAuth) String() string {
 func (*PolicySpec_ExternalAuth) ProtoMessage() {}
 
 func (x *PolicySpec_ExternalAuth) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[39]
+	mi := &file_resource_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3472,7 +3636,7 @@ func (x *PolicySpec_ExternalAuth) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicySpec_ExternalAuth.ProtoReflect.Descriptor instead.
 func (*PolicySpec_ExternalAuth) Descriptor() ([]byte, []int) {
-	return file_resource_proto_rawDescGZIP(), []int{30, 1}
+	return file_resource_proto_rawDescGZIP(), []int{30, 2}
 }
 
 func (x *PolicySpec_ExternalAuth) GetTarget() *BackendReference {
@@ -3497,7 +3661,7 @@ type PolicySpec_A2A struct {
 
 func (x *PolicySpec_A2A) Reset() {
 	*x = PolicySpec_A2A{}
-	mi := &file_resource_proto_msgTypes[40]
+	mi := &file_resource_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3509,7 +3673,7 @@ func (x *PolicySpec_A2A) String() string {
 func (*PolicySpec_A2A) ProtoMessage() {}
 
 func (x *PolicySpec_A2A) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[40]
+	mi := &file_resource_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3522,7 +3686,7 @@ func (x *PolicySpec_A2A) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicySpec_A2A.ProtoReflect.Descriptor instead.
 func (*PolicySpec_A2A) Descriptor() ([]byte, []int) {
-	return file_resource_proto_rawDescGZIP(), []int{30, 2}
+	return file_resource_proto_rawDescGZIP(), []int{30, 3}
 }
 
 type PolicySpec_InferenceRouting struct {
@@ -3535,7 +3699,7 @@ type PolicySpec_InferenceRouting struct {
 
 func (x *PolicySpec_InferenceRouting) Reset() {
 	*x = PolicySpec_InferenceRouting{}
-	mi := &file_resource_proto_msgTypes[41]
+	mi := &file_resource_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3547,7 +3711,7 @@ func (x *PolicySpec_InferenceRouting) String() string {
 func (*PolicySpec_InferenceRouting) ProtoMessage() {}
 
 func (x *PolicySpec_InferenceRouting) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[41]
+	mi := &file_resource_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3560,7 +3724,7 @@ func (x *PolicySpec_InferenceRouting) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicySpec_InferenceRouting.ProtoReflect.Descriptor instead.
 func (*PolicySpec_InferenceRouting) Descriptor() ([]byte, []int) {
-	return file_resource_proto_rawDescGZIP(), []int{30, 3}
+	return file_resource_proto_rawDescGZIP(), []int{30, 4}
 }
 
 func (x *PolicySpec_InferenceRouting) GetEndpointPicker() *BackendReference {
@@ -3592,7 +3756,7 @@ type PolicySpec_BackendTLS struct {
 
 func (x *PolicySpec_BackendTLS) Reset() {
 	*x = PolicySpec_BackendTLS{}
-	mi := &file_resource_proto_msgTypes[42]
+	mi := &file_resource_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3604,7 +3768,7 @@ func (x *PolicySpec_BackendTLS) String() string {
 func (*PolicySpec_BackendTLS) ProtoMessage() {}
 
 func (x *PolicySpec_BackendTLS) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[42]
+	mi := &file_resource_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3617,7 +3781,7 @@ func (x *PolicySpec_BackendTLS) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicySpec_BackendTLS.ProtoReflect.Descriptor instead.
 func (*PolicySpec_BackendTLS) Descriptor() ([]byte, []int) {
-	return file_resource_proto_rawDescGZIP(), []int{30, 4}
+	return file_resource_proto_rawDescGZIP(), []int{30, 5}
 }
 
 func (x *PolicySpec_BackendTLS) GetCert() *wrappers.BytesValue {
@@ -3658,7 +3822,7 @@ type PolicySpec_RBAC struct {
 
 func (x *PolicySpec_RBAC) Reset() {
 	*x = PolicySpec_RBAC{}
-	mi := &file_resource_proto_msgTypes[43]
+	mi := &file_resource_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3670,7 +3834,7 @@ func (x *PolicySpec_RBAC) String() string {
 func (*PolicySpec_RBAC) ProtoMessage() {}
 
 func (x *PolicySpec_RBAC) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[43]
+	mi := &file_resource_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3683,7 +3847,7 @@ func (x *PolicySpec_RBAC) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicySpec_RBAC.ProtoReflect.Descriptor instead.
 func (*PolicySpec_RBAC) Descriptor() ([]byte, []int) {
-	return file_resource_proto_rawDescGZIP(), []int{30, 5}
+	return file_resource_proto_rawDescGZIP(), []int{30, 6}
 }
 
 func (x *PolicySpec_RBAC) GetAllow() []string {
@@ -3700,6 +3864,514 @@ func (x *PolicySpec_RBAC) GetDeny() []string {
 	return nil
 }
 
+type PolicySpec_Ai_PromptGuardResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Body          []byte                 `protobuf:"bytes,1,opt,name=body,proto3" json:"body,omitempty"`
+	Status        uint32                 `protobuf:"varint,2,opt,name=status,proto3" json:"status,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PolicySpec_Ai_PromptGuardResponse) Reset() {
+	*x = PolicySpec_Ai_PromptGuardResponse{}
+	mi := &file_resource_proto_msgTypes[45]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PolicySpec_Ai_PromptGuardResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PolicySpec_Ai_PromptGuardResponse) ProtoMessage() {}
+
+func (x *PolicySpec_Ai_PromptGuardResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_resource_proto_msgTypes[45]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PolicySpec_Ai_PromptGuardResponse.ProtoReflect.Descriptor instead.
+func (*PolicySpec_Ai_PromptGuardResponse) Descriptor() ([]byte, []int) {
+	return file_resource_proto_rawDescGZIP(), []int{30, 1, 0}
+}
+
+func (x *PolicySpec_Ai_PromptGuardResponse) GetBody() []byte {
+	if x != nil {
+		return x.Body
+	}
+	return nil
+}
+
+func (x *PolicySpec_Ai_PromptGuardResponse) GetStatus() uint32 {
+	if x != nil {
+		return x.Status
+	}
+	return 0
+}
+
+type PolicySpec_Ai_NamedRegex struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Pattern       string                 `protobuf:"bytes,1,opt,name=pattern,proto3" json:"pattern,omitempty"`
+	Name          string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PolicySpec_Ai_NamedRegex) Reset() {
+	*x = PolicySpec_Ai_NamedRegex{}
+	mi := &file_resource_proto_msgTypes[46]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PolicySpec_Ai_NamedRegex) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PolicySpec_Ai_NamedRegex) ProtoMessage() {}
+
+func (x *PolicySpec_Ai_NamedRegex) ProtoReflect() protoreflect.Message {
+	mi := &file_resource_proto_msgTypes[46]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PolicySpec_Ai_NamedRegex.ProtoReflect.Descriptor instead.
+func (*PolicySpec_Ai_NamedRegex) Descriptor() ([]byte, []int) {
+	return file_resource_proto_rawDescGZIP(), []int{30, 1, 1}
+}
+
+func (x *PolicySpec_Ai_NamedRegex) GetPattern() string {
+	if x != nil {
+		return x.Pattern
+	}
+	return ""
+}
+
+func (x *PolicySpec_Ai_NamedRegex) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+type PolicySpec_Ai_RegexRule struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to Kind:
+	//
+	//	*PolicySpec_Ai_RegexRule_Builtin
+	//	*PolicySpec_Ai_RegexRule_Regex
+	Kind          isPolicySpec_Ai_RegexRule_Kind `protobuf_oneof:"kind"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PolicySpec_Ai_RegexRule) Reset() {
+	*x = PolicySpec_Ai_RegexRule{}
+	mi := &file_resource_proto_msgTypes[47]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PolicySpec_Ai_RegexRule) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PolicySpec_Ai_RegexRule) ProtoMessage() {}
+
+func (x *PolicySpec_Ai_RegexRule) ProtoReflect() protoreflect.Message {
+	mi := &file_resource_proto_msgTypes[47]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PolicySpec_Ai_RegexRule.ProtoReflect.Descriptor instead.
+func (*PolicySpec_Ai_RegexRule) Descriptor() ([]byte, []int) {
+	return file_resource_proto_rawDescGZIP(), []int{30, 1, 2}
+}
+
+func (x *PolicySpec_Ai_RegexRule) GetKind() isPolicySpec_Ai_RegexRule_Kind {
+	if x != nil {
+		return x.Kind
+	}
+	return nil
+}
+
+func (x *PolicySpec_Ai_RegexRule) GetBuiltin() PolicySpec_Ai_BuiltinRegexRule {
+	if x != nil {
+		if x, ok := x.Kind.(*PolicySpec_Ai_RegexRule_Builtin); ok {
+			return x.Builtin
+		}
+	}
+	return PolicySpec_Ai_BUILTIN_UNSPECIFIED
+}
+
+func (x *PolicySpec_Ai_RegexRule) GetRegex() *PolicySpec_Ai_NamedRegex {
+	if x != nil {
+		if x, ok := x.Kind.(*PolicySpec_Ai_RegexRule_Regex); ok {
+			return x.Regex
+		}
+	}
+	return nil
+}
+
+type isPolicySpec_Ai_RegexRule_Kind interface {
+	isPolicySpec_Ai_RegexRule_Kind()
+}
+
+type PolicySpec_Ai_RegexRule_Builtin struct {
+	Builtin PolicySpec_Ai_BuiltinRegexRule `protobuf:"varint,1,opt,name=builtin,proto3,enum=agentgateway.dev.resource.PolicySpec_Ai_BuiltinRegexRule,oneof"`
+}
+
+type PolicySpec_Ai_RegexRule_Regex struct {
+	Regex *PolicySpec_Ai_NamedRegex `protobuf:"bytes,2,opt,name=regex,proto3,oneof"`
+}
+
+func (*PolicySpec_Ai_RegexRule_Builtin) isPolicySpec_Ai_RegexRule_Kind() {}
+
+func (*PolicySpec_Ai_RegexRule_Regex) isPolicySpec_Ai_RegexRule_Kind() {}
+
+type PolicySpec_Ai_Action struct {
+	state protoimpl.MessageState   `protogen:"open.v1"`
+	Kind  PolicySpec_Ai_ActionKind `protobuf:"varint,1,opt,name=kind,proto3,enum=agentgateway.dev.resource.PolicySpec_Ai_ActionKind" json:"kind,omitempty"`
+	// Only used when kind == REJECT
+	RejectResponse *PolicySpec_Ai_PromptGuardResponse `protobuf:"bytes,2,opt,name=reject_response,json=rejectResponse,proto3" json:"reject_response,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *PolicySpec_Ai_Action) Reset() {
+	*x = PolicySpec_Ai_Action{}
+	mi := &file_resource_proto_msgTypes[48]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PolicySpec_Ai_Action) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PolicySpec_Ai_Action) ProtoMessage() {}
+
+func (x *PolicySpec_Ai_Action) ProtoReflect() protoreflect.Message {
+	mi := &file_resource_proto_msgTypes[48]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PolicySpec_Ai_Action.ProtoReflect.Descriptor instead.
+func (*PolicySpec_Ai_Action) Descriptor() ([]byte, []int) {
+	return file_resource_proto_rawDescGZIP(), []int{30, 1, 3}
+}
+
+func (x *PolicySpec_Ai_Action) GetKind() PolicySpec_Ai_ActionKind {
+	if x != nil {
+		return x.Kind
+	}
+	return PolicySpec_Ai_ACTION_UNSPECIFIED
+}
+
+func (x *PolicySpec_Ai_Action) GetRejectResponse() *PolicySpec_Ai_PromptGuardResponse {
+	if x != nil {
+		return x.RejectResponse
+	}
+	return nil
+}
+
+type PolicySpec_Ai_RegexRules struct {
+	state         protoimpl.MessageState     `protogen:"open.v1"`
+	Action        *PolicySpec_Ai_Action      `protobuf:"bytes,1,opt,name=action,proto3" json:"action,omitempty"`
+	Rules         []*PolicySpec_Ai_RegexRule `protobuf:"bytes,2,rep,name=rules,proto3" json:"rules,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PolicySpec_Ai_RegexRules) Reset() {
+	*x = PolicySpec_Ai_RegexRules{}
+	mi := &file_resource_proto_msgTypes[49]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PolicySpec_Ai_RegexRules) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PolicySpec_Ai_RegexRules) ProtoMessage() {}
+
+func (x *PolicySpec_Ai_RegexRules) ProtoReflect() protoreflect.Message {
+	mi := &file_resource_proto_msgTypes[49]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PolicySpec_Ai_RegexRules.ProtoReflect.Descriptor instead.
+func (*PolicySpec_Ai_RegexRules) Descriptor() ([]byte, []int) {
+	return file_resource_proto_rawDescGZIP(), []int{30, 1, 4}
+}
+
+func (x *PolicySpec_Ai_RegexRules) GetAction() *PolicySpec_Ai_Action {
+	if x != nil {
+		return x.Action
+	}
+	return nil
+}
+
+func (x *PolicySpec_Ai_RegexRules) GetRules() []*PolicySpec_Ai_RegexRule {
+	if x != nil {
+		return x.Rules
+	}
+	return nil
+}
+
+type PolicySpec_Ai_Webhook struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Host          string                 `protobuf:"bytes,1,opt,name=host,proto3" json:"host,omitempty"`
+	Port          uint32                 `protobuf:"varint,2,opt,name=port,proto3" json:"port,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PolicySpec_Ai_Webhook) Reset() {
+	*x = PolicySpec_Ai_Webhook{}
+	mi := &file_resource_proto_msgTypes[50]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PolicySpec_Ai_Webhook) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PolicySpec_Ai_Webhook) ProtoMessage() {}
+
+func (x *PolicySpec_Ai_Webhook) ProtoReflect() protoreflect.Message {
+	mi := &file_resource_proto_msgTypes[50]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PolicySpec_Ai_Webhook.ProtoReflect.Descriptor instead.
+func (*PolicySpec_Ai_Webhook) Descriptor() ([]byte, []int) {
+	return file_resource_proto_rawDescGZIP(), []int{30, 1, 5}
+}
+
+func (x *PolicySpec_Ai_Webhook) GetHost() string {
+	if x != nil {
+		return x.Host
+	}
+	return ""
+}
+
+func (x *PolicySpec_Ai_Webhook) GetPort() uint32 {
+	if x != nil {
+		return x.Port
+	}
+	return 0
+}
+
+type PolicySpec_Ai_Moderation struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Model to use. Defaults to `omni-moderation-latest`
+	Model         *wrappers.StringValue `protobuf:"bytes,1,opt,name=model,proto3" json:"model,omitempty"`
+	Auth          *BackendAuthPolicy    `protobuf:"bytes,2,opt,name=auth,proto3" json:"auth,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PolicySpec_Ai_Moderation) Reset() {
+	*x = PolicySpec_Ai_Moderation{}
+	mi := &file_resource_proto_msgTypes[51]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PolicySpec_Ai_Moderation) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PolicySpec_Ai_Moderation) ProtoMessage() {}
+
+func (x *PolicySpec_Ai_Moderation) ProtoReflect() protoreflect.Message {
+	mi := &file_resource_proto_msgTypes[51]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PolicySpec_Ai_Moderation.ProtoReflect.Descriptor instead.
+func (*PolicySpec_Ai_Moderation) Descriptor() ([]byte, []int) {
+	return file_resource_proto_rawDescGZIP(), []int{30, 1, 6}
+}
+
+func (x *PolicySpec_Ai_Moderation) GetModel() *wrappers.StringValue {
+	if x != nil {
+		return x.Model
+	}
+	return nil
+}
+
+func (x *PolicySpec_Ai_Moderation) GetAuth() *BackendAuthPolicy {
+	if x != nil {
+		return x.Auth
+	}
+	return nil
+}
+
+type PolicySpec_Ai_PromptGuardRequest struct {
+	state            protoimpl.MessageState             `protogen:"open.v1"`
+	Response         *PolicySpec_Ai_PromptGuardResponse `protobuf:"bytes,1,opt,name=response,proto3" json:"response,omitempty"`
+	Regex            *PolicySpec_Ai_RegexRules          `protobuf:"bytes,2,opt,name=regex,proto3" json:"regex,omitempty"`
+	Webhook          *PolicySpec_Ai_Webhook             `protobuf:"bytes,3,opt,name=webhook,proto3" json:"webhook,omitempty"`
+	OpenaiModeration *PolicySpec_Ai_Moderation          `protobuf:"bytes,4,opt,name=openai_moderation,json=openaiModeration,proto3" json:"openai_moderation,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *PolicySpec_Ai_PromptGuardRequest) Reset() {
+	*x = PolicySpec_Ai_PromptGuardRequest{}
+	mi := &file_resource_proto_msgTypes[52]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PolicySpec_Ai_PromptGuardRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PolicySpec_Ai_PromptGuardRequest) ProtoMessage() {}
+
+func (x *PolicySpec_Ai_PromptGuardRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_resource_proto_msgTypes[52]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PolicySpec_Ai_PromptGuardRequest.ProtoReflect.Descriptor instead.
+func (*PolicySpec_Ai_PromptGuardRequest) Descriptor() ([]byte, []int) {
+	return file_resource_proto_rawDescGZIP(), []int{30, 1, 7}
+}
+
+func (x *PolicySpec_Ai_PromptGuardRequest) GetResponse() *PolicySpec_Ai_PromptGuardResponse {
+	if x != nil {
+		return x.Response
+	}
+	return nil
+}
+
+func (x *PolicySpec_Ai_PromptGuardRequest) GetRegex() *PolicySpec_Ai_RegexRules {
+	if x != nil {
+		return x.Regex
+	}
+	return nil
+}
+
+func (x *PolicySpec_Ai_PromptGuardRequest) GetWebhook() *PolicySpec_Ai_Webhook {
+	if x != nil {
+		return x.Webhook
+	}
+	return nil
+}
+
+func (x *PolicySpec_Ai_PromptGuardRequest) GetOpenaiModeration() *PolicySpec_Ai_Moderation {
+	if x != nil {
+		return x.OpenaiModeration
+	}
+	return nil
+}
+
+type PolicySpec_Ai_PromptGuard struct {
+	state         protoimpl.MessageState            `protogen:"open.v1"`
+	Request       *PolicySpec_Ai_PromptGuardRequest `protobuf:"bytes,1,opt,name=request,proto3" json:"request,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PolicySpec_Ai_PromptGuard) Reset() {
+	*x = PolicySpec_Ai_PromptGuard{}
+	mi := &file_resource_proto_msgTypes[53]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PolicySpec_Ai_PromptGuard) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PolicySpec_Ai_PromptGuard) ProtoMessage() {}
+
+func (x *PolicySpec_Ai_PromptGuard) ProtoReflect() protoreflect.Message {
+	mi := &file_resource_proto_msgTypes[53]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PolicySpec_Ai_PromptGuard.ProtoReflect.Descriptor instead.
+func (*PolicySpec_Ai_PromptGuard) Descriptor() ([]byte, []int) {
+	return file_resource_proto_rawDescGZIP(), []int{30, 1, 8}
+}
+
+func (x *PolicySpec_Ai_PromptGuard) GetRequest() *PolicySpec_Ai_PromptGuardRequest {
+	if x != nil {
+		return x.Request
+	}
+	return nil
+}
+
 type AIBackend_Override struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Host          string                 `protobuf:"bytes,1,opt,name=host,proto3" json:"host,omitempty"`
@@ -3710,7 +4382,7 @@ type AIBackend_Override struct {
 
 func (x *AIBackend_Override) Reset() {
 	*x = AIBackend_Override{}
-	mi := &file_resource_proto_msgTypes[45]
+	mi := &file_resource_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3722,7 +4394,7 @@ func (x *AIBackend_Override) String() string {
 func (*AIBackend_Override) ProtoMessage() {}
 
 func (x *AIBackend_Override) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[45]
+	mi := &file_resource_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3761,7 +4433,7 @@ type AIBackend_OpenAI struct {
 
 func (x *AIBackend_OpenAI) Reset() {
 	*x = AIBackend_OpenAI{}
-	mi := &file_resource_proto_msgTypes[46]
+	mi := &file_resource_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3773,7 +4445,7 @@ func (x *AIBackend_OpenAI) String() string {
 func (*AIBackend_OpenAI) ProtoMessage() {}
 
 func (x *AIBackend_OpenAI) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[46]
+	mi := &file_resource_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3805,7 +4477,7 @@ type AIBackend_Gemini struct {
 
 func (x *AIBackend_Gemini) Reset() {
 	*x = AIBackend_Gemini{}
-	mi := &file_resource_proto_msgTypes[47]
+	mi := &file_resource_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3817,7 +4489,7 @@ func (x *AIBackend_Gemini) String() string {
 func (*AIBackend_Gemini) ProtoMessage() {}
 
 func (x *AIBackend_Gemini) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[47]
+	mi := &file_resource_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3851,7 +4523,7 @@ type AIBackend_Vertex struct {
 
 func (x *AIBackend_Vertex) Reset() {
 	*x = AIBackend_Vertex{}
-	mi := &file_resource_proto_msgTypes[48]
+	mi := &file_resource_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3863,7 +4535,7 @@ func (x *AIBackend_Vertex) String() string {
 func (*AIBackend_Vertex) ProtoMessage() {}
 
 func (x *AIBackend_Vertex) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[48]
+	mi := &file_resource_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3909,7 +4581,7 @@ type AIBackend_Anthropic struct {
 
 func (x *AIBackend_Anthropic) Reset() {
 	*x = AIBackend_Anthropic{}
-	mi := &file_resource_proto_msgTypes[49]
+	mi := &file_resource_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3921,7 +4593,7 @@ func (x *AIBackend_Anthropic) String() string {
 func (*AIBackend_Anthropic) ProtoMessage() {}
 
 func (x *AIBackend_Anthropic) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[49]
+	mi := &file_resource_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3956,7 +4628,7 @@ type AIBackend_Bedrock struct {
 
 func (x *AIBackend_Bedrock) Reset() {
 	*x = AIBackend_Bedrock{}
-	mi := &file_resource_proto_msgTypes[50]
+	mi := &file_resource_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3968,7 +4640,7 @@ func (x *AIBackend_Bedrock) String() string {
 func (*AIBackend_Bedrock) ProtoMessage() {}
 
 func (x *AIBackend_Bedrock) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[50]
+	mi := &file_resource_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4170,7 +4842,7 @@ const file_resource_proto_rawDesc = "" +
 	"\n" +
 	"route_rule\x18\x04 \x01(\tH\x00R\trouteRule\x12\x1a\n" +
 	"\abackend\x18\x05 \x01(\tH\x00R\abackendB\x06\n" +
-	"\x04kind\"\xcc\r\n" +
+	"\x04kind\"\xa6\x1a\n" +
 	"\n" +
 	"PolicySpec\x12`\n" +
 	"\x10local_rate_limit\x18\x01 \x01(\v24.agentgateway.dev.resource.PolicySpec.LocalRateLimitH\x00R\x0elocalRateLimit\x12Q\n" +
@@ -4181,7 +4853,8 @@ const file_resource_proto_rawDesc = "" +
 	"backendTls\x12B\n" +
 	"\x04auth\x18\x06 \x01(\v2,.agentgateway.dev.resource.BackendAuthPolicyH\x00R\x04auth\x12R\n" +
 	"\rauthorization\x18\a \x01(\v2*.agentgateway.dev.resource.PolicySpec.RBACH\x00R\rauthorization\x12Y\n" +
-	"\x11mcp_authorization\x18\b \x01(\v2*.agentgateway.dev.resource.PolicySpec.RBACH\x00R\x10mcpAuthorization\x1a\x86\x02\n" +
+	"\x11mcp_authorization\x18\b \x01(\v2*.agentgateway.dev.resource.PolicySpec.RBACH\x00R\x10mcpAuthorization\x12:\n" +
+	"\x02ai\x18\t \x01(\v2(.agentgateway.dev.resource.PolicySpec.AiH\x00R\x02ai\x1a\x86\x02\n" +
 	"\x0eLocalRateLimit\x12\x1d\n" +
 	"\n" +
 	"max_tokens\x18\x01 \x01(\x04R\tmaxTokens\x12&\n" +
@@ -4190,7 +4863,53 @@ const file_resource_proto_rawDesc = "" +
 	"\x04type\x18\x04 \x01(\x0e29.agentgateway.dev.resource.PolicySpec.LocalRateLimit.TypeR\x04type\"\x1e\n" +
 	"\x04Type\x12\v\n" +
 	"\aREQUEST\x10\x00\x12\t\n" +
-	"\x05TOKEN\x10\x01\x1a\xea\x01\n" +
+	"\x05TOKEN\x10\x01\x1a\x9b\f\n" +
+	"\x02Ai\x12W\n" +
+	"\fprompt_guard\x18\x01 \x01(\v24.agentgateway.dev.resource.PolicySpec.Ai.PromptGuardR\vpromptGuard\x1aA\n" +
+	"\x13PromptGuardResponse\x12\x12\n" +
+	"\x04body\x18\x01 \x01(\fR\x04body\x12\x16\n" +
+	"\x06status\x18\x02 \x01(\rR\x06status\x1a:\n" +
+	"\n" +
+	"NamedRegex\x12\x18\n" +
+	"\apattern\x18\x01 \x01(\tR\apattern\x12\x12\n" +
+	"\x04name\x18\x02 \x01(\tR\x04name\x1a\xb7\x01\n" +
+	"\tRegexRule\x12U\n" +
+	"\abuiltin\x18\x01 \x01(\x0e29.agentgateway.dev.resource.PolicySpec.Ai.BuiltinRegexRuleH\x00R\abuiltin\x12K\n" +
+	"\x05regex\x18\x02 \x01(\v23.agentgateway.dev.resource.PolicySpec.Ai.NamedRegexH\x00R\x05regexB\x06\n" +
+	"\x04kind\x1a\xb8\x01\n" +
+	"\x06Action\x12G\n" +
+	"\x04kind\x18\x01 \x01(\x0e23.agentgateway.dev.resource.PolicySpec.Ai.ActionKindR\x04kind\x12e\n" +
+	"\x0freject_response\x18\x02 \x01(\v2<.agentgateway.dev.resource.PolicySpec.Ai.PromptGuardResponseR\x0erejectResponse\x1a\x9f\x01\n" +
+	"\n" +
+	"RegexRules\x12G\n" +
+	"\x06action\x18\x01 \x01(\v2/.agentgateway.dev.resource.PolicySpec.Ai.ActionR\x06action\x12H\n" +
+	"\x05rules\x18\x02 \x03(\v22.agentgateway.dev.resource.PolicySpec.Ai.RegexRuleR\x05rules\x1a1\n" +
+	"\aWebhook\x12\x12\n" +
+	"\x04host\x18\x01 \x01(\tR\x04host\x12\x12\n" +
+	"\x04port\x18\x02 \x01(\rR\x04port\x1a\x82\x01\n" +
+	"\n" +
+	"Moderation\x122\n" +
+	"\x05model\x18\x01 \x01(\v2\x1c.google.protobuf.StringValueR\x05model\x12@\n" +
+	"\x04auth\x18\x02 \x01(\v2,.agentgateway.dev.resource.BackendAuthPolicyR\x04auth\x1a\xe7\x02\n" +
+	"\x12PromptGuardRequest\x12X\n" +
+	"\bresponse\x18\x01 \x01(\v2<.agentgateway.dev.resource.PolicySpec.Ai.PromptGuardResponseR\bresponse\x12I\n" +
+	"\x05regex\x18\x02 \x01(\v23.agentgateway.dev.resource.PolicySpec.Ai.RegexRulesR\x05regex\x12J\n" +
+	"\awebhook\x18\x03 \x01(\v20.agentgateway.dev.resource.PolicySpec.Ai.WebhookR\awebhook\x12`\n" +
+	"\x11openai_moderation\x18\x04 \x01(\v23.agentgateway.dev.resource.PolicySpec.Ai.ModerationR\x10openaiModeration\x1ad\n" +
+	"\vPromptGuard\x12U\n" +
+	"\arequest\x18\x01 \x01(\v2;.agentgateway.dev.resource.PolicySpec.Ai.PromptGuardRequestR\arequest\"b\n" +
+	"\x10BuiltinRegexRule\x12\x17\n" +
+	"\x13BUILTIN_UNSPECIFIED\x10\x00\x12\a\n" +
+	"\x03SSN\x10\x01\x12\x0f\n" +
+	"\vCREDIT_CARD\x10\x02\x12\x10\n" +
+	"\fPHONE_NUMBER\x10\x03\x12\t\n" +
+	"\x05EMAIL\x10\x04\":\n" +
+	"\n" +
+	"ActionKind\x12\x16\n" +
+	"\x12ACTION_UNSPECIFIED\x10\x00\x12\b\n" +
+	"\x04MASK\x10\x01\x12\n" +
+	"\n" +
+	"\x06REJECT\x10\x02\x1a\xea\x01\n" +
 	"\fExternalAuth\x12C\n" +
 	"\x06target\x18\x01 \x01(\v2+.agentgateway.dev.resource.BackendReferenceR\x06target\x12Y\n" +
 	"\acontext\x18\x02 \x03(\v2?.agentgateway.dev.resource.PolicySpec.ExternalAuth.ContextEntryR\acontext\x1a:\n" +
@@ -4297,156 +5016,183 @@ func file_resource_proto_rawDescGZIP() []byte {
 	return file_resource_proto_rawDescData
 }
 
-var file_resource_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
-var file_resource_proto_msgTypes = make([]protoimpl.MessageInfo, 51)
+var file_resource_proto_enumTypes = make([]protoimpl.EnumInfo, 7)
+var file_resource_proto_msgTypes = make([]protoimpl.MessageInfo, 61)
 var file_resource_proto_goTypes = []any{
 	(Protocol)(0),                                // 0: agentgateway.dev.resource.Protocol
 	(PolicySpec_LocalRateLimit_Type)(0),          // 1: agentgateway.dev.resource.PolicySpec.LocalRateLimit.Type
-	(PolicySpec_InferenceRouting_FailureMode)(0), // 2: agentgateway.dev.resource.PolicySpec.InferenceRouting.FailureMode
-	(MCPBackend_StatefulMode)(0),                 // 3: agentgateway.dev.resource.MCPBackend.StatefulMode
-	(MCPTarget_Protocol)(0),                      // 4: agentgateway.dev.resource.MCPTarget.Protocol
-	(*Resource)(nil),                             // 5: agentgateway.dev.resource.Resource
-	(*Bind)(nil),                                 // 6: agentgateway.dev.resource.Bind
-	(*Listener)(nil),                             // 7: agentgateway.dev.resource.Listener
-	(*TLSConfig)(nil),                            // 8: agentgateway.dev.resource.TLSConfig
-	(*Route)(nil),                                // 9: agentgateway.dev.resource.Route
-	(*TCPRoute)(nil),                             // 10: agentgateway.dev.resource.TCPRoute
-	(*TrafficPolicy)(nil),                        // 11: agentgateway.dev.resource.TrafficPolicy
-	(*Retry)(nil),                                // 12: agentgateway.dev.resource.Retry
-	(*BackendAuthPolicy)(nil),                    // 13: agentgateway.dev.resource.BackendAuthPolicy
-	(*Passthrough)(nil),                          // 14: agentgateway.dev.resource.Passthrough
-	(*Key)(nil),                                  // 15: agentgateway.dev.resource.Key
-	(*Gcp)(nil),                                  // 16: agentgateway.dev.resource.Gcp
-	(*Aws)(nil),                                  // 17: agentgateway.dev.resource.Aws
-	(*AwsExplicitConfig)(nil),                    // 18: agentgateway.dev.resource.AwsExplicitConfig
-	(*AwsImplicit)(nil),                          // 19: agentgateway.dev.resource.AwsImplicit
-	(*RouteMatch)(nil),                           // 20: agentgateway.dev.resource.RouteMatch
-	(*PathMatch)(nil),                            // 21: agentgateway.dev.resource.PathMatch
-	(*QueryMatch)(nil),                           // 22: agentgateway.dev.resource.QueryMatch
-	(*MethodMatch)(nil),                          // 23: agentgateway.dev.resource.MethodMatch
-	(*HeaderMatch)(nil),                          // 24: agentgateway.dev.resource.HeaderMatch
-	(*RouteFilter)(nil),                          // 25: agentgateway.dev.resource.RouteFilter
-	(*CORS)(nil),                                 // 26: agentgateway.dev.resource.CORS
-	(*DirectResponse)(nil),                       // 27: agentgateway.dev.resource.DirectResponse
-	(*HeaderModifier)(nil),                       // 28: agentgateway.dev.resource.HeaderModifier
-	(*RequestMirror)(nil),                        // 29: agentgateway.dev.resource.RequestMirror
-	(*RequestRedirect)(nil),                      // 30: agentgateway.dev.resource.RequestRedirect
-	(*UrlRewrite)(nil),                           // 31: agentgateway.dev.resource.UrlRewrite
-	(*Header)(nil),                               // 32: agentgateway.dev.resource.Header
-	(*RouteBackend)(nil),                         // 33: agentgateway.dev.resource.RouteBackend
-	(*PolicyTarget)(nil),                         // 34: agentgateway.dev.resource.PolicyTarget
-	(*PolicySpec)(nil),                           // 35: agentgateway.dev.resource.PolicySpec
-	(*Policy)(nil),                               // 36: agentgateway.dev.resource.Policy
-	(*Backend)(nil),                              // 37: agentgateway.dev.resource.Backend
-	(*StaticBackend)(nil),                        // 38: agentgateway.dev.resource.StaticBackend
-	(*AIBackend)(nil),                            // 39: agentgateway.dev.resource.AIBackend
-	(*MCPBackend)(nil),                           // 40: agentgateway.dev.resource.MCPBackend
-	(*MCPTarget)(nil),                            // 41: agentgateway.dev.resource.MCPTarget
-	(*BackendReference)(nil),                     // 42: agentgateway.dev.resource.BackendReference
-	(*PolicySpec_LocalRateLimit)(nil),            // 43: agentgateway.dev.resource.PolicySpec.LocalRateLimit
-	(*PolicySpec_ExternalAuth)(nil),              // 44: agentgateway.dev.resource.PolicySpec.ExternalAuth
-	(*PolicySpec_A2A)(nil),                       // 45: agentgateway.dev.resource.PolicySpec.A2a
-	(*PolicySpec_InferenceRouting)(nil),          // 46: agentgateway.dev.resource.PolicySpec.InferenceRouting
-	(*PolicySpec_BackendTLS)(nil),                // 47: agentgateway.dev.resource.PolicySpec.BackendTLS
-	(*PolicySpec_RBAC)(nil),                      // 48: agentgateway.dev.resource.PolicySpec.RBAC
-	nil,                                          // 49: agentgateway.dev.resource.PolicySpec.ExternalAuth.ContextEntry
-	(*AIBackend_Override)(nil),                   // 50: agentgateway.dev.resource.AIBackend.Override
-	(*AIBackend_OpenAI)(nil),                     // 51: agentgateway.dev.resource.AIBackend.OpenAI
-	(*AIBackend_Gemini)(nil),                     // 52: agentgateway.dev.resource.AIBackend.Gemini
-	(*AIBackend_Vertex)(nil),                     // 53: agentgateway.dev.resource.AIBackend.Vertex
-	(*AIBackend_Anthropic)(nil),                  // 54: agentgateway.dev.resource.AIBackend.Anthropic
-	(*AIBackend_Bedrock)(nil),                    // 55: agentgateway.dev.resource.AIBackend.Bedrock
-	(*duration.Duration)(nil),                    // 56: google.protobuf.Duration
-	(*wrappers.BytesValue)(nil),                  // 57: google.protobuf.BytesValue
-	(*wrappers.BoolValue)(nil),                   // 58: google.protobuf.BoolValue
-	(*wrappers.StringValue)(nil),                 // 59: google.protobuf.StringValue
+	(PolicySpec_Ai_BuiltinRegexRule)(0),          // 2: agentgateway.dev.resource.PolicySpec.Ai.BuiltinRegexRule
+	(PolicySpec_Ai_ActionKind)(0),                // 3: agentgateway.dev.resource.PolicySpec.Ai.ActionKind
+	(PolicySpec_InferenceRouting_FailureMode)(0), // 4: agentgateway.dev.resource.PolicySpec.InferenceRouting.FailureMode
+	(MCPBackend_StatefulMode)(0),                 // 5: agentgateway.dev.resource.MCPBackend.StatefulMode
+	(MCPTarget_Protocol)(0),                      // 6: agentgateway.dev.resource.MCPTarget.Protocol
+	(*Resource)(nil),                             // 7: agentgateway.dev.resource.Resource
+	(*Bind)(nil),                                 // 8: agentgateway.dev.resource.Bind
+	(*Listener)(nil),                             // 9: agentgateway.dev.resource.Listener
+	(*TLSConfig)(nil),                            // 10: agentgateway.dev.resource.TLSConfig
+	(*Route)(nil),                                // 11: agentgateway.dev.resource.Route
+	(*TCPRoute)(nil),                             // 12: agentgateway.dev.resource.TCPRoute
+	(*TrafficPolicy)(nil),                        // 13: agentgateway.dev.resource.TrafficPolicy
+	(*Retry)(nil),                                // 14: agentgateway.dev.resource.Retry
+	(*BackendAuthPolicy)(nil),                    // 15: agentgateway.dev.resource.BackendAuthPolicy
+	(*Passthrough)(nil),                          // 16: agentgateway.dev.resource.Passthrough
+	(*Key)(nil),                                  // 17: agentgateway.dev.resource.Key
+	(*Gcp)(nil),                                  // 18: agentgateway.dev.resource.Gcp
+	(*Aws)(nil),                                  // 19: agentgateway.dev.resource.Aws
+	(*AwsExplicitConfig)(nil),                    // 20: agentgateway.dev.resource.AwsExplicitConfig
+	(*AwsImplicit)(nil),                          // 21: agentgateway.dev.resource.AwsImplicit
+	(*RouteMatch)(nil),                           // 22: agentgateway.dev.resource.RouteMatch
+	(*PathMatch)(nil),                            // 23: agentgateway.dev.resource.PathMatch
+	(*QueryMatch)(nil),                           // 24: agentgateway.dev.resource.QueryMatch
+	(*MethodMatch)(nil),                          // 25: agentgateway.dev.resource.MethodMatch
+	(*HeaderMatch)(nil),                          // 26: agentgateway.dev.resource.HeaderMatch
+	(*RouteFilter)(nil),                          // 27: agentgateway.dev.resource.RouteFilter
+	(*CORS)(nil),                                 // 28: agentgateway.dev.resource.CORS
+	(*DirectResponse)(nil),                       // 29: agentgateway.dev.resource.DirectResponse
+	(*HeaderModifier)(nil),                       // 30: agentgateway.dev.resource.HeaderModifier
+	(*RequestMirror)(nil),                        // 31: agentgateway.dev.resource.RequestMirror
+	(*RequestRedirect)(nil),                      // 32: agentgateway.dev.resource.RequestRedirect
+	(*UrlRewrite)(nil),                           // 33: agentgateway.dev.resource.UrlRewrite
+	(*Header)(nil),                               // 34: agentgateway.dev.resource.Header
+	(*RouteBackend)(nil),                         // 35: agentgateway.dev.resource.RouteBackend
+	(*PolicyTarget)(nil),                         // 36: agentgateway.dev.resource.PolicyTarget
+	(*PolicySpec)(nil),                           // 37: agentgateway.dev.resource.PolicySpec
+	(*Policy)(nil),                               // 38: agentgateway.dev.resource.Policy
+	(*Backend)(nil),                              // 39: agentgateway.dev.resource.Backend
+	(*StaticBackend)(nil),                        // 40: agentgateway.dev.resource.StaticBackend
+	(*AIBackend)(nil),                            // 41: agentgateway.dev.resource.AIBackend
+	(*MCPBackend)(nil),                           // 42: agentgateway.dev.resource.MCPBackend
+	(*MCPTarget)(nil),                            // 43: agentgateway.dev.resource.MCPTarget
+	(*BackendReference)(nil),                     // 44: agentgateway.dev.resource.BackendReference
+	(*PolicySpec_LocalRateLimit)(nil),            // 45: agentgateway.dev.resource.PolicySpec.LocalRateLimit
+	(*PolicySpec_Ai)(nil),                        // 46: agentgateway.dev.resource.PolicySpec.Ai
+	(*PolicySpec_ExternalAuth)(nil),              // 47: agentgateway.dev.resource.PolicySpec.ExternalAuth
+	(*PolicySpec_A2A)(nil),                       // 48: agentgateway.dev.resource.PolicySpec.A2a
+	(*PolicySpec_InferenceRouting)(nil),          // 49: agentgateway.dev.resource.PolicySpec.InferenceRouting
+	(*PolicySpec_BackendTLS)(nil),                // 50: agentgateway.dev.resource.PolicySpec.BackendTLS
+	(*PolicySpec_RBAC)(nil),                      // 51: agentgateway.dev.resource.PolicySpec.RBAC
+	(*PolicySpec_Ai_PromptGuardResponse)(nil),    // 52: agentgateway.dev.resource.PolicySpec.Ai.PromptGuardResponse
+	(*PolicySpec_Ai_NamedRegex)(nil),             // 53: agentgateway.dev.resource.PolicySpec.Ai.NamedRegex
+	(*PolicySpec_Ai_RegexRule)(nil),              // 54: agentgateway.dev.resource.PolicySpec.Ai.RegexRule
+	(*PolicySpec_Ai_Action)(nil),                 // 55: agentgateway.dev.resource.PolicySpec.Ai.Action
+	(*PolicySpec_Ai_RegexRules)(nil),             // 56: agentgateway.dev.resource.PolicySpec.Ai.RegexRules
+	(*PolicySpec_Ai_Webhook)(nil),                // 57: agentgateway.dev.resource.PolicySpec.Ai.Webhook
+	(*PolicySpec_Ai_Moderation)(nil),             // 58: agentgateway.dev.resource.PolicySpec.Ai.Moderation
+	(*PolicySpec_Ai_PromptGuardRequest)(nil),     // 59: agentgateway.dev.resource.PolicySpec.Ai.PromptGuardRequest
+	(*PolicySpec_Ai_PromptGuard)(nil),            // 60: agentgateway.dev.resource.PolicySpec.Ai.PromptGuard
+	nil,                                          // 61: agentgateway.dev.resource.PolicySpec.ExternalAuth.ContextEntry
+	(*AIBackend_Override)(nil),                   // 62: agentgateway.dev.resource.AIBackend.Override
+	(*AIBackend_OpenAI)(nil),                     // 63: agentgateway.dev.resource.AIBackend.OpenAI
+	(*AIBackend_Gemini)(nil),                     // 64: agentgateway.dev.resource.AIBackend.Gemini
+	(*AIBackend_Vertex)(nil),                     // 65: agentgateway.dev.resource.AIBackend.Vertex
+	(*AIBackend_Anthropic)(nil),                  // 66: agentgateway.dev.resource.AIBackend.Anthropic
+	(*AIBackend_Bedrock)(nil),                    // 67: agentgateway.dev.resource.AIBackend.Bedrock
+	(*duration.Duration)(nil),                    // 68: google.protobuf.Duration
+	(*wrappers.BytesValue)(nil),                  // 69: google.protobuf.BytesValue
+	(*wrappers.BoolValue)(nil),                   // 70: google.protobuf.BoolValue
+	(*wrappers.StringValue)(nil),                 // 71: google.protobuf.StringValue
 }
 var file_resource_proto_depIdxs = []int32{
-	6,  // 0: agentgateway.dev.resource.Resource.bind:type_name -> agentgateway.dev.resource.Bind
-	7,  // 1: agentgateway.dev.resource.Resource.listener:type_name -> agentgateway.dev.resource.Listener
-	9,  // 2: agentgateway.dev.resource.Resource.route:type_name -> agentgateway.dev.resource.Route
-	37, // 3: agentgateway.dev.resource.Resource.backend:type_name -> agentgateway.dev.resource.Backend
-	36, // 4: agentgateway.dev.resource.Resource.policy:type_name -> agentgateway.dev.resource.Policy
-	10, // 5: agentgateway.dev.resource.Resource.tcp_route:type_name -> agentgateway.dev.resource.TCPRoute
+	8,  // 0: agentgateway.dev.resource.Resource.bind:type_name -> agentgateway.dev.resource.Bind
+	9,  // 1: agentgateway.dev.resource.Resource.listener:type_name -> agentgateway.dev.resource.Listener
+	11, // 2: agentgateway.dev.resource.Resource.route:type_name -> agentgateway.dev.resource.Route
+	39, // 3: agentgateway.dev.resource.Resource.backend:type_name -> agentgateway.dev.resource.Backend
+	38, // 4: agentgateway.dev.resource.Resource.policy:type_name -> agentgateway.dev.resource.Policy
+	12, // 5: agentgateway.dev.resource.Resource.tcp_route:type_name -> agentgateway.dev.resource.TCPRoute
 	0,  // 6: agentgateway.dev.resource.Listener.protocol:type_name -> agentgateway.dev.resource.Protocol
-	8,  // 7: agentgateway.dev.resource.Listener.tls:type_name -> agentgateway.dev.resource.TLSConfig
-	20, // 8: agentgateway.dev.resource.Route.matches:type_name -> agentgateway.dev.resource.RouteMatch
-	25, // 9: agentgateway.dev.resource.Route.filters:type_name -> agentgateway.dev.resource.RouteFilter
-	33, // 10: agentgateway.dev.resource.Route.backends:type_name -> agentgateway.dev.resource.RouteBackend
-	11, // 11: agentgateway.dev.resource.Route.traffic_policy:type_name -> agentgateway.dev.resource.TrafficPolicy
-	33, // 12: agentgateway.dev.resource.TCPRoute.backends:type_name -> agentgateway.dev.resource.RouteBackend
-	56, // 13: agentgateway.dev.resource.TrafficPolicy.backend_request_timeout:type_name -> google.protobuf.Duration
-	56, // 14: agentgateway.dev.resource.TrafficPolicy.request_timeout:type_name -> google.protobuf.Duration
-	12, // 15: agentgateway.dev.resource.TrafficPolicy.retry:type_name -> agentgateway.dev.resource.Retry
-	56, // 16: agentgateway.dev.resource.Retry.backoff:type_name -> google.protobuf.Duration
-	14, // 17: agentgateway.dev.resource.BackendAuthPolicy.passthrough:type_name -> agentgateway.dev.resource.Passthrough
-	15, // 18: agentgateway.dev.resource.BackendAuthPolicy.key:type_name -> agentgateway.dev.resource.Key
-	16, // 19: agentgateway.dev.resource.BackendAuthPolicy.gcp:type_name -> agentgateway.dev.resource.Gcp
-	17, // 20: agentgateway.dev.resource.BackendAuthPolicy.aws:type_name -> agentgateway.dev.resource.Aws
-	18, // 21: agentgateway.dev.resource.Aws.explicit_config:type_name -> agentgateway.dev.resource.AwsExplicitConfig
-	19, // 22: agentgateway.dev.resource.Aws.implicit:type_name -> agentgateway.dev.resource.AwsImplicit
-	21, // 23: agentgateway.dev.resource.RouteMatch.path:type_name -> agentgateway.dev.resource.PathMatch
-	24, // 24: agentgateway.dev.resource.RouteMatch.headers:type_name -> agentgateway.dev.resource.HeaderMatch
-	23, // 25: agentgateway.dev.resource.RouteMatch.method:type_name -> agentgateway.dev.resource.MethodMatch
-	22, // 26: agentgateway.dev.resource.RouteMatch.query_params:type_name -> agentgateway.dev.resource.QueryMatch
-	28, // 27: agentgateway.dev.resource.RouteFilter.request_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
-	28, // 28: agentgateway.dev.resource.RouteFilter.response_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
-	30, // 29: agentgateway.dev.resource.RouteFilter.request_redirect:type_name -> agentgateway.dev.resource.RequestRedirect
-	31, // 30: agentgateway.dev.resource.RouteFilter.url_rewrite:type_name -> agentgateway.dev.resource.UrlRewrite
-	29, // 31: agentgateway.dev.resource.RouteFilter.request_mirror:type_name -> agentgateway.dev.resource.RequestMirror
-	27, // 32: agentgateway.dev.resource.RouteFilter.direct_response:type_name -> agentgateway.dev.resource.DirectResponse
-	26, // 33: agentgateway.dev.resource.RouteFilter.cors:type_name -> agentgateway.dev.resource.CORS
-	56, // 34: agentgateway.dev.resource.CORS.max_age:type_name -> google.protobuf.Duration
-	32, // 35: agentgateway.dev.resource.HeaderModifier.add:type_name -> agentgateway.dev.resource.Header
-	32, // 36: agentgateway.dev.resource.HeaderModifier.set:type_name -> agentgateway.dev.resource.Header
-	42, // 37: agentgateway.dev.resource.RequestMirror.backend:type_name -> agentgateway.dev.resource.BackendReference
-	42, // 38: agentgateway.dev.resource.RouteBackend.backend:type_name -> agentgateway.dev.resource.BackendReference
-	25, // 39: agentgateway.dev.resource.RouteBackend.filters:type_name -> agentgateway.dev.resource.RouteFilter
-	43, // 40: agentgateway.dev.resource.PolicySpec.local_rate_limit:type_name -> agentgateway.dev.resource.PolicySpec.LocalRateLimit
-	44, // 41: agentgateway.dev.resource.PolicySpec.ext_authz:type_name -> agentgateway.dev.resource.PolicySpec.ExternalAuth
-	45, // 42: agentgateway.dev.resource.PolicySpec.a2a:type_name -> agentgateway.dev.resource.PolicySpec.A2a
-	46, // 43: agentgateway.dev.resource.PolicySpec.inference_routing:type_name -> agentgateway.dev.resource.PolicySpec.InferenceRouting
-	47, // 44: agentgateway.dev.resource.PolicySpec.backend_tls:type_name -> agentgateway.dev.resource.PolicySpec.BackendTLS
-	13, // 45: agentgateway.dev.resource.PolicySpec.auth:type_name -> agentgateway.dev.resource.BackendAuthPolicy
-	48, // 46: agentgateway.dev.resource.PolicySpec.authorization:type_name -> agentgateway.dev.resource.PolicySpec.RBAC
-	48, // 47: agentgateway.dev.resource.PolicySpec.mcp_authorization:type_name -> agentgateway.dev.resource.PolicySpec.RBAC
-	34, // 48: agentgateway.dev.resource.Policy.target:type_name -> agentgateway.dev.resource.PolicyTarget
-	35, // 49: agentgateway.dev.resource.Policy.spec:type_name -> agentgateway.dev.resource.PolicySpec
-	38, // 50: agentgateway.dev.resource.Backend.static:type_name -> agentgateway.dev.resource.StaticBackend
-	39, // 51: agentgateway.dev.resource.Backend.ai:type_name -> agentgateway.dev.resource.AIBackend
-	40, // 52: agentgateway.dev.resource.Backend.mcp:type_name -> agentgateway.dev.resource.MCPBackend
-	50, // 53: agentgateway.dev.resource.AIBackend.override:type_name -> agentgateway.dev.resource.AIBackend.Override
-	51, // 54: agentgateway.dev.resource.AIBackend.openai:type_name -> agentgateway.dev.resource.AIBackend.OpenAI
-	52, // 55: agentgateway.dev.resource.AIBackend.gemini:type_name -> agentgateway.dev.resource.AIBackend.Gemini
-	53, // 56: agentgateway.dev.resource.AIBackend.vertex:type_name -> agentgateway.dev.resource.AIBackend.Vertex
-	54, // 57: agentgateway.dev.resource.AIBackend.anthropic:type_name -> agentgateway.dev.resource.AIBackend.Anthropic
-	55, // 58: agentgateway.dev.resource.AIBackend.bedrock:type_name -> agentgateway.dev.resource.AIBackend.Bedrock
-	41, // 59: agentgateway.dev.resource.MCPBackend.targets:type_name -> agentgateway.dev.resource.MCPTarget
-	3,  // 60: agentgateway.dev.resource.MCPBackend.stateful_mode:type_name -> agentgateway.dev.resource.MCPBackend.StatefulMode
-	42, // 61: agentgateway.dev.resource.MCPTarget.backend:type_name -> agentgateway.dev.resource.BackendReference
-	4,  // 62: agentgateway.dev.resource.MCPTarget.protocol:type_name -> agentgateway.dev.resource.MCPTarget.Protocol
-	56, // 63: agentgateway.dev.resource.PolicySpec.LocalRateLimit.fill_interval:type_name -> google.protobuf.Duration
-	1,  // 64: agentgateway.dev.resource.PolicySpec.LocalRateLimit.type:type_name -> agentgateway.dev.resource.PolicySpec.LocalRateLimit.Type
-	42, // 65: agentgateway.dev.resource.PolicySpec.ExternalAuth.target:type_name -> agentgateway.dev.resource.BackendReference
-	49, // 66: agentgateway.dev.resource.PolicySpec.ExternalAuth.context:type_name -> agentgateway.dev.resource.PolicySpec.ExternalAuth.ContextEntry
-	42, // 67: agentgateway.dev.resource.PolicySpec.InferenceRouting.endpoint_picker:type_name -> agentgateway.dev.resource.BackendReference
-	2,  // 68: agentgateway.dev.resource.PolicySpec.InferenceRouting.failure_mode:type_name -> agentgateway.dev.resource.PolicySpec.InferenceRouting.FailureMode
-	57, // 69: agentgateway.dev.resource.PolicySpec.BackendTLS.cert:type_name -> google.protobuf.BytesValue
-	57, // 70: agentgateway.dev.resource.PolicySpec.BackendTLS.key:type_name -> google.protobuf.BytesValue
-	57, // 71: agentgateway.dev.resource.PolicySpec.BackendTLS.root:type_name -> google.protobuf.BytesValue
-	58, // 72: agentgateway.dev.resource.PolicySpec.BackendTLS.insecure:type_name -> google.protobuf.BoolValue
-	59, // 73: agentgateway.dev.resource.AIBackend.OpenAI.model:type_name -> google.protobuf.StringValue
-	59, // 74: agentgateway.dev.resource.AIBackend.Gemini.model:type_name -> google.protobuf.StringValue
-	59, // 75: agentgateway.dev.resource.AIBackend.Vertex.model:type_name -> google.protobuf.StringValue
-	59, // 76: agentgateway.dev.resource.AIBackend.Anthropic.model:type_name -> google.protobuf.StringValue
-	59, // 77: agentgateway.dev.resource.AIBackend.Bedrock.model:type_name -> google.protobuf.StringValue
-	59, // 78: agentgateway.dev.resource.AIBackend.Bedrock.guardrail_identifier:type_name -> google.protobuf.StringValue
-	59, // 79: agentgateway.dev.resource.AIBackend.Bedrock.guardrail_version:type_name -> google.protobuf.StringValue
-	80, // [80:80] is the sub-list for method output_type
-	80, // [80:80] is the sub-list for method input_type
-	80, // [80:80] is the sub-list for extension type_name
-	80, // [80:80] is the sub-list for extension extendee
-	0,  // [0:80] is the sub-list for field type_name
+	10, // 7: agentgateway.dev.resource.Listener.tls:type_name -> agentgateway.dev.resource.TLSConfig
+	22, // 8: agentgateway.dev.resource.Route.matches:type_name -> agentgateway.dev.resource.RouteMatch
+	27, // 9: agentgateway.dev.resource.Route.filters:type_name -> agentgateway.dev.resource.RouteFilter
+	35, // 10: agentgateway.dev.resource.Route.backends:type_name -> agentgateway.dev.resource.RouteBackend
+	13, // 11: agentgateway.dev.resource.Route.traffic_policy:type_name -> agentgateway.dev.resource.TrafficPolicy
+	35, // 12: agentgateway.dev.resource.TCPRoute.backends:type_name -> agentgateway.dev.resource.RouteBackend
+	68, // 13: agentgateway.dev.resource.TrafficPolicy.backend_request_timeout:type_name -> google.protobuf.Duration
+	68, // 14: agentgateway.dev.resource.TrafficPolicy.request_timeout:type_name -> google.protobuf.Duration
+	14, // 15: agentgateway.dev.resource.TrafficPolicy.retry:type_name -> agentgateway.dev.resource.Retry
+	68, // 16: agentgateway.dev.resource.Retry.backoff:type_name -> google.protobuf.Duration
+	16, // 17: agentgateway.dev.resource.BackendAuthPolicy.passthrough:type_name -> agentgateway.dev.resource.Passthrough
+	17, // 18: agentgateway.dev.resource.BackendAuthPolicy.key:type_name -> agentgateway.dev.resource.Key
+	18, // 19: agentgateway.dev.resource.BackendAuthPolicy.gcp:type_name -> agentgateway.dev.resource.Gcp
+	19, // 20: agentgateway.dev.resource.BackendAuthPolicy.aws:type_name -> agentgateway.dev.resource.Aws
+	20, // 21: agentgateway.dev.resource.Aws.explicit_config:type_name -> agentgateway.dev.resource.AwsExplicitConfig
+	21, // 22: agentgateway.dev.resource.Aws.implicit:type_name -> agentgateway.dev.resource.AwsImplicit
+	23, // 23: agentgateway.dev.resource.RouteMatch.path:type_name -> agentgateway.dev.resource.PathMatch
+	26, // 24: agentgateway.dev.resource.RouteMatch.headers:type_name -> agentgateway.dev.resource.HeaderMatch
+	25, // 25: agentgateway.dev.resource.RouteMatch.method:type_name -> agentgateway.dev.resource.MethodMatch
+	24, // 26: agentgateway.dev.resource.RouteMatch.query_params:type_name -> agentgateway.dev.resource.QueryMatch
+	30, // 27: agentgateway.dev.resource.RouteFilter.request_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
+	30, // 28: agentgateway.dev.resource.RouteFilter.response_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
+	32, // 29: agentgateway.dev.resource.RouteFilter.request_redirect:type_name -> agentgateway.dev.resource.RequestRedirect
+	33, // 30: agentgateway.dev.resource.RouteFilter.url_rewrite:type_name -> agentgateway.dev.resource.UrlRewrite
+	31, // 31: agentgateway.dev.resource.RouteFilter.request_mirror:type_name -> agentgateway.dev.resource.RequestMirror
+	29, // 32: agentgateway.dev.resource.RouteFilter.direct_response:type_name -> agentgateway.dev.resource.DirectResponse
+	28, // 33: agentgateway.dev.resource.RouteFilter.cors:type_name -> agentgateway.dev.resource.CORS
+	68, // 34: agentgateway.dev.resource.CORS.max_age:type_name -> google.protobuf.Duration
+	34, // 35: agentgateway.dev.resource.HeaderModifier.add:type_name -> agentgateway.dev.resource.Header
+	34, // 36: agentgateway.dev.resource.HeaderModifier.set:type_name -> agentgateway.dev.resource.Header
+	44, // 37: agentgateway.dev.resource.RequestMirror.backend:type_name -> agentgateway.dev.resource.BackendReference
+	44, // 38: agentgateway.dev.resource.RouteBackend.backend:type_name -> agentgateway.dev.resource.BackendReference
+	27, // 39: agentgateway.dev.resource.RouteBackend.filters:type_name -> agentgateway.dev.resource.RouteFilter
+	45, // 40: agentgateway.dev.resource.PolicySpec.local_rate_limit:type_name -> agentgateway.dev.resource.PolicySpec.LocalRateLimit
+	47, // 41: agentgateway.dev.resource.PolicySpec.ext_authz:type_name -> agentgateway.dev.resource.PolicySpec.ExternalAuth
+	48, // 42: agentgateway.dev.resource.PolicySpec.a2a:type_name -> agentgateway.dev.resource.PolicySpec.A2a
+	49, // 43: agentgateway.dev.resource.PolicySpec.inference_routing:type_name -> agentgateway.dev.resource.PolicySpec.InferenceRouting
+	50, // 44: agentgateway.dev.resource.PolicySpec.backend_tls:type_name -> agentgateway.dev.resource.PolicySpec.BackendTLS
+	15, // 45: agentgateway.dev.resource.PolicySpec.auth:type_name -> agentgateway.dev.resource.BackendAuthPolicy
+	51, // 46: agentgateway.dev.resource.PolicySpec.authorization:type_name -> agentgateway.dev.resource.PolicySpec.RBAC
+	51, // 47: agentgateway.dev.resource.PolicySpec.mcp_authorization:type_name -> agentgateway.dev.resource.PolicySpec.RBAC
+	46, // 48: agentgateway.dev.resource.PolicySpec.ai:type_name -> agentgateway.dev.resource.PolicySpec.Ai
+	36, // 49: agentgateway.dev.resource.Policy.target:type_name -> agentgateway.dev.resource.PolicyTarget
+	37, // 50: agentgateway.dev.resource.Policy.spec:type_name -> agentgateway.dev.resource.PolicySpec
+	40, // 51: agentgateway.dev.resource.Backend.static:type_name -> agentgateway.dev.resource.StaticBackend
+	41, // 52: agentgateway.dev.resource.Backend.ai:type_name -> agentgateway.dev.resource.AIBackend
+	42, // 53: agentgateway.dev.resource.Backend.mcp:type_name -> agentgateway.dev.resource.MCPBackend
+	62, // 54: agentgateway.dev.resource.AIBackend.override:type_name -> agentgateway.dev.resource.AIBackend.Override
+	63, // 55: agentgateway.dev.resource.AIBackend.openai:type_name -> agentgateway.dev.resource.AIBackend.OpenAI
+	64, // 56: agentgateway.dev.resource.AIBackend.gemini:type_name -> agentgateway.dev.resource.AIBackend.Gemini
+	65, // 57: agentgateway.dev.resource.AIBackend.vertex:type_name -> agentgateway.dev.resource.AIBackend.Vertex
+	66, // 58: agentgateway.dev.resource.AIBackend.anthropic:type_name -> agentgateway.dev.resource.AIBackend.Anthropic
+	67, // 59: agentgateway.dev.resource.AIBackend.bedrock:type_name -> agentgateway.dev.resource.AIBackend.Bedrock
+	43, // 60: agentgateway.dev.resource.MCPBackend.targets:type_name -> agentgateway.dev.resource.MCPTarget
+	5,  // 61: agentgateway.dev.resource.MCPBackend.stateful_mode:type_name -> agentgateway.dev.resource.MCPBackend.StatefulMode
+	44, // 62: agentgateway.dev.resource.MCPTarget.backend:type_name -> agentgateway.dev.resource.BackendReference
+	6,  // 63: agentgateway.dev.resource.MCPTarget.protocol:type_name -> agentgateway.dev.resource.MCPTarget.Protocol
+	68, // 64: agentgateway.dev.resource.PolicySpec.LocalRateLimit.fill_interval:type_name -> google.protobuf.Duration
+	1,  // 65: agentgateway.dev.resource.PolicySpec.LocalRateLimit.type:type_name -> agentgateway.dev.resource.PolicySpec.LocalRateLimit.Type
+	60, // 66: agentgateway.dev.resource.PolicySpec.Ai.prompt_guard:type_name -> agentgateway.dev.resource.PolicySpec.Ai.PromptGuard
+	44, // 67: agentgateway.dev.resource.PolicySpec.ExternalAuth.target:type_name -> agentgateway.dev.resource.BackendReference
+	61, // 68: agentgateway.dev.resource.PolicySpec.ExternalAuth.context:type_name -> agentgateway.dev.resource.PolicySpec.ExternalAuth.ContextEntry
+	44, // 69: agentgateway.dev.resource.PolicySpec.InferenceRouting.endpoint_picker:type_name -> agentgateway.dev.resource.BackendReference
+	4,  // 70: agentgateway.dev.resource.PolicySpec.InferenceRouting.failure_mode:type_name -> agentgateway.dev.resource.PolicySpec.InferenceRouting.FailureMode
+	69, // 71: agentgateway.dev.resource.PolicySpec.BackendTLS.cert:type_name -> google.protobuf.BytesValue
+	69, // 72: agentgateway.dev.resource.PolicySpec.BackendTLS.key:type_name -> google.protobuf.BytesValue
+	69, // 73: agentgateway.dev.resource.PolicySpec.BackendTLS.root:type_name -> google.protobuf.BytesValue
+	70, // 74: agentgateway.dev.resource.PolicySpec.BackendTLS.insecure:type_name -> google.protobuf.BoolValue
+	2,  // 75: agentgateway.dev.resource.PolicySpec.Ai.RegexRule.builtin:type_name -> agentgateway.dev.resource.PolicySpec.Ai.BuiltinRegexRule
+	53, // 76: agentgateway.dev.resource.PolicySpec.Ai.RegexRule.regex:type_name -> agentgateway.dev.resource.PolicySpec.Ai.NamedRegex
+	3,  // 77: agentgateway.dev.resource.PolicySpec.Ai.Action.kind:type_name -> agentgateway.dev.resource.PolicySpec.Ai.ActionKind
+	52, // 78: agentgateway.dev.resource.PolicySpec.Ai.Action.reject_response:type_name -> agentgateway.dev.resource.PolicySpec.Ai.PromptGuardResponse
+	55, // 79: agentgateway.dev.resource.PolicySpec.Ai.RegexRules.action:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Action
+	54, // 80: agentgateway.dev.resource.PolicySpec.Ai.RegexRules.rules:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RegexRule
+	71, // 81: agentgateway.dev.resource.PolicySpec.Ai.Moderation.model:type_name -> google.protobuf.StringValue
+	15, // 82: agentgateway.dev.resource.PolicySpec.Ai.Moderation.auth:type_name -> agentgateway.dev.resource.BackendAuthPolicy
+	52, // 83: agentgateway.dev.resource.PolicySpec.Ai.PromptGuardRequest.response:type_name -> agentgateway.dev.resource.PolicySpec.Ai.PromptGuardResponse
+	56, // 84: agentgateway.dev.resource.PolicySpec.Ai.PromptGuardRequest.regex:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RegexRules
+	57, // 85: agentgateway.dev.resource.PolicySpec.Ai.PromptGuardRequest.webhook:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Webhook
+	58, // 86: agentgateway.dev.resource.PolicySpec.Ai.PromptGuardRequest.openai_moderation:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Moderation
+	59, // 87: agentgateway.dev.resource.PolicySpec.Ai.PromptGuard.request:type_name -> agentgateway.dev.resource.PolicySpec.Ai.PromptGuardRequest
+	71, // 88: agentgateway.dev.resource.AIBackend.OpenAI.model:type_name -> google.protobuf.StringValue
+	71, // 89: agentgateway.dev.resource.AIBackend.Gemini.model:type_name -> google.protobuf.StringValue
+	71, // 90: agentgateway.dev.resource.AIBackend.Vertex.model:type_name -> google.protobuf.StringValue
+	71, // 91: agentgateway.dev.resource.AIBackend.Anthropic.model:type_name -> google.protobuf.StringValue
+	71, // 92: agentgateway.dev.resource.AIBackend.Bedrock.model:type_name -> google.protobuf.StringValue
+	71, // 93: agentgateway.dev.resource.AIBackend.Bedrock.guardrail_identifier:type_name -> google.protobuf.StringValue
+	71, // 94: agentgateway.dev.resource.AIBackend.Bedrock.guardrail_version:type_name -> google.protobuf.StringValue
+	95, // [95:95] is the sub-list for method output_type
+	95, // [95:95] is the sub-list for method input_type
+	95, // [95:95] is the sub-list for extension type_name
+	95, // [95:95] is the sub-list for extension extendee
+	0,  // [0:95] is the sub-list for field type_name
 }
 
 func init() { file_resource_proto_init() }
@@ -4519,6 +5265,7 @@ func file_resource_proto_init() {
 		(*PolicySpec_Auth)(nil),
 		(*PolicySpec_Authorization)(nil),
 		(*PolicySpec_McpAuthorization)(nil),
+		(*PolicySpec_Ai_)(nil),
 	}
 	file_resource_proto_msgTypes[32].OneofWrappers = []any{
 		(*Backend_Static)(nil),
@@ -4536,13 +5283,17 @@ func file_resource_proto_init() {
 		(*BackendReference_Service)(nil),
 		(*BackendReference_Backend)(nil),
 	}
+	file_resource_proto_msgTypes[47].OneofWrappers = []any{
+		(*PolicySpec_Ai_RegexRule_Builtin)(nil),
+		(*PolicySpec_Ai_RegexRule_Regex)(nil),
+	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_resource_proto_rawDesc), len(file_resource_proto_rawDesc)),
-			NumEnums:      5,
-			NumMessages:   51,
+			NumEnums:      7,
+			NumMessages:   61,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/go/api/resource.pb.go
+++ b/go/api/resource.pb.go
@@ -3864,58 +3864,6 @@ func (x *PolicySpec_RBAC) GetDeny() []string {
 	return nil
 }
 
-type PolicySpec_Ai_PromptGuardResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Body          []byte                 `protobuf:"bytes,1,opt,name=body,proto3" json:"body,omitempty"`
-	Status        uint32                 `protobuf:"varint,2,opt,name=status,proto3" json:"status,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *PolicySpec_Ai_PromptGuardResponse) Reset() {
-	*x = PolicySpec_Ai_PromptGuardResponse{}
-	mi := &file_resource_proto_msgTypes[45]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *PolicySpec_Ai_PromptGuardResponse) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*PolicySpec_Ai_PromptGuardResponse) ProtoMessage() {}
-
-func (x *PolicySpec_Ai_PromptGuardResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[45]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use PolicySpec_Ai_PromptGuardResponse.ProtoReflect.Descriptor instead.
-func (*PolicySpec_Ai_PromptGuardResponse) Descriptor() ([]byte, []int) {
-	return file_resource_proto_rawDescGZIP(), []int{30, 1, 0}
-}
-
-func (x *PolicySpec_Ai_PromptGuardResponse) GetBody() []byte {
-	if x != nil {
-		return x.Body
-	}
-	return nil
-}
-
-func (x *PolicySpec_Ai_PromptGuardResponse) GetStatus() uint32 {
-	if x != nil {
-		return x.Status
-	}
-	return 0
-}
-
 type PolicySpec_Ai_NamedRegex struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Pattern       string                 `protobuf:"bytes,1,opt,name=pattern,proto3" json:"pattern,omitempty"`
@@ -3926,7 +3874,7 @@ type PolicySpec_Ai_NamedRegex struct {
 
 func (x *PolicySpec_Ai_NamedRegex) Reset() {
 	*x = PolicySpec_Ai_NamedRegex{}
-	mi := &file_resource_proto_msgTypes[46]
+	mi := &file_resource_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3938,7 +3886,7 @@ func (x *PolicySpec_Ai_NamedRegex) String() string {
 func (*PolicySpec_Ai_NamedRegex) ProtoMessage() {}
 
 func (x *PolicySpec_Ai_NamedRegex) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[46]
+	mi := &file_resource_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3951,7 +3899,7 @@ func (x *PolicySpec_Ai_NamedRegex) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicySpec_Ai_NamedRegex.ProtoReflect.Descriptor instead.
 func (*PolicySpec_Ai_NamedRegex) Descriptor() ([]byte, []int) {
-	return file_resource_proto_rawDescGZIP(), []int{30, 1, 1}
+	return file_resource_proto_rawDescGZIP(), []int{30, 1, 0}
 }
 
 func (x *PolicySpec_Ai_NamedRegex) GetPattern() string {
@@ -3981,7 +3929,7 @@ type PolicySpec_Ai_RegexRule struct {
 
 func (x *PolicySpec_Ai_RegexRule) Reset() {
 	*x = PolicySpec_Ai_RegexRule{}
-	mi := &file_resource_proto_msgTypes[47]
+	mi := &file_resource_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3993,7 +3941,7 @@ func (x *PolicySpec_Ai_RegexRule) String() string {
 func (*PolicySpec_Ai_RegexRule) ProtoMessage() {}
 
 func (x *PolicySpec_Ai_RegexRule) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[47]
+	mi := &file_resource_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4006,7 +3954,7 @@ func (x *PolicySpec_Ai_RegexRule) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicySpec_Ai_RegexRule.ProtoReflect.Descriptor instead.
 func (*PolicySpec_Ai_RegexRule) Descriptor() ([]byte, []int) {
-	return file_resource_proto_rawDescGZIP(), []int{30, 1, 2}
+	return file_resource_proto_rawDescGZIP(), []int{30, 1, 1}
 }
 
 func (x *PolicySpec_Ai_RegexRule) GetKind() isPolicySpec_Ai_RegexRule_Kind {
@@ -4061,7 +4009,7 @@ type PolicySpec_Ai_Action struct {
 
 func (x *PolicySpec_Ai_Action) Reset() {
 	*x = PolicySpec_Ai_Action{}
-	mi := &file_resource_proto_msgTypes[48]
+	mi := &file_resource_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4073,7 +4021,7 @@ func (x *PolicySpec_Ai_Action) String() string {
 func (*PolicySpec_Ai_Action) ProtoMessage() {}
 
 func (x *PolicySpec_Ai_Action) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[48]
+	mi := &file_resource_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4086,7 +4034,7 @@ func (x *PolicySpec_Ai_Action) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicySpec_Ai_Action.ProtoReflect.Descriptor instead.
 func (*PolicySpec_Ai_Action) Descriptor() ([]byte, []int) {
-	return file_resource_proto_rawDescGZIP(), []int{30, 1, 3}
+	return file_resource_proto_rawDescGZIP(), []int{30, 1, 2}
 }
 
 func (x *PolicySpec_Ai_Action) GetKind() PolicySpec_Ai_ActionKind {
@@ -4113,7 +4061,7 @@ type PolicySpec_Ai_RegexRules struct {
 
 func (x *PolicySpec_Ai_RegexRules) Reset() {
 	*x = PolicySpec_Ai_RegexRules{}
-	mi := &file_resource_proto_msgTypes[49]
+	mi := &file_resource_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4125,7 +4073,7 @@ func (x *PolicySpec_Ai_RegexRules) String() string {
 func (*PolicySpec_Ai_RegexRules) ProtoMessage() {}
 
 func (x *PolicySpec_Ai_RegexRules) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[49]
+	mi := &file_resource_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4138,7 +4086,7 @@ func (x *PolicySpec_Ai_RegexRules) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicySpec_Ai_RegexRules.ProtoReflect.Descriptor instead.
 func (*PolicySpec_Ai_RegexRules) Descriptor() ([]byte, []int) {
-	return file_resource_proto_rawDescGZIP(), []int{30, 1, 4}
+	return file_resource_proto_rawDescGZIP(), []int{30, 1, 3}
 }
 
 func (x *PolicySpec_Ai_RegexRules) GetAction() *PolicySpec_Ai_Action {
@@ -4165,7 +4113,7 @@ type PolicySpec_Ai_Webhook struct {
 
 func (x *PolicySpec_Ai_Webhook) Reset() {
 	*x = PolicySpec_Ai_Webhook{}
-	mi := &file_resource_proto_msgTypes[50]
+	mi := &file_resource_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4177,7 +4125,7 @@ func (x *PolicySpec_Ai_Webhook) String() string {
 func (*PolicySpec_Ai_Webhook) ProtoMessage() {}
 
 func (x *PolicySpec_Ai_Webhook) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[50]
+	mi := &file_resource_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4190,7 +4138,7 @@ func (x *PolicySpec_Ai_Webhook) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicySpec_Ai_Webhook.ProtoReflect.Descriptor instead.
 func (*PolicySpec_Ai_Webhook) Descriptor() ([]byte, []int) {
-	return file_resource_proto_rawDescGZIP(), []int{30, 1, 5}
+	return file_resource_proto_rawDescGZIP(), []int{30, 1, 4}
 }
 
 func (x *PolicySpec_Ai_Webhook) GetHost() string {
@@ -4218,7 +4166,7 @@ type PolicySpec_Ai_Moderation struct {
 
 func (x *PolicySpec_Ai_Moderation) Reset() {
 	*x = PolicySpec_Ai_Moderation{}
-	mi := &file_resource_proto_msgTypes[51]
+	mi := &file_resource_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4230,7 +4178,7 @@ func (x *PolicySpec_Ai_Moderation) String() string {
 func (*PolicySpec_Ai_Moderation) ProtoMessage() {}
 
 func (x *PolicySpec_Ai_Moderation) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[51]
+	mi := &file_resource_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4243,7 +4191,7 @@ func (x *PolicySpec_Ai_Moderation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicySpec_Ai_Moderation.ProtoReflect.Descriptor instead.
 func (*PolicySpec_Ai_Moderation) Descriptor() ([]byte, []int) {
-	return file_resource_proto_rawDescGZIP(), []int{30, 1, 6}
+	return file_resource_proto_rawDescGZIP(), []int{30, 1, 5}
 }
 
 func (x *PolicySpec_Ai_Moderation) GetModel() *wrappers.StringValue {
@@ -4258,6 +4206,58 @@ func (x *PolicySpec_Ai_Moderation) GetAuth() *BackendAuthPolicy {
 		return x.Auth
 	}
 	return nil
+}
+
+type PolicySpec_Ai_PromptGuardResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Body          []byte                 `protobuf:"bytes,1,opt,name=body,proto3" json:"body,omitempty"`
+	Status        uint32                 `protobuf:"varint,2,opt,name=status,proto3" json:"status,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PolicySpec_Ai_PromptGuardResponse) Reset() {
+	*x = PolicySpec_Ai_PromptGuardResponse{}
+	mi := &file_resource_proto_msgTypes[51]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PolicySpec_Ai_PromptGuardResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PolicySpec_Ai_PromptGuardResponse) ProtoMessage() {}
+
+func (x *PolicySpec_Ai_PromptGuardResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_resource_proto_msgTypes[51]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PolicySpec_Ai_PromptGuardResponse.ProtoReflect.Descriptor instead.
+func (*PolicySpec_Ai_PromptGuardResponse) Descriptor() ([]byte, []int) {
+	return file_resource_proto_rawDescGZIP(), []int{30, 1, 6}
+}
+
+func (x *PolicySpec_Ai_PromptGuardResponse) GetBody() []byte {
+	if x != nil {
+		return x.Body
+	}
+	return nil
+}
+
+func (x *PolicySpec_Ai_PromptGuardResponse) GetStatus() uint32 {
+	if x != nil {
+		return x.Status
+	}
+	return 0
 }
 
 type PolicySpec_Ai_PromptGuardRequest struct {
@@ -4865,10 +4865,7 @@ const file_resource_proto_rawDesc = "" +
 	"\aREQUEST\x10\x00\x12\t\n" +
 	"\x05TOKEN\x10\x01\x1a\x9b\f\n" +
 	"\x02Ai\x12W\n" +
-	"\fprompt_guard\x18\x01 \x01(\v24.agentgateway.dev.resource.PolicySpec.Ai.PromptGuardR\vpromptGuard\x1aA\n" +
-	"\x13PromptGuardResponse\x12\x12\n" +
-	"\x04body\x18\x01 \x01(\fR\x04body\x12\x16\n" +
-	"\x06status\x18\x02 \x01(\rR\x06status\x1a:\n" +
+	"\fprompt_guard\x18\x01 \x01(\v24.agentgateway.dev.resource.PolicySpec.Ai.PromptGuardR\vpromptGuard\x1a:\n" +
 	"\n" +
 	"NamedRegex\x12\x18\n" +
 	"\apattern\x18\x01 \x01(\tR\apattern\x12\x12\n" +
@@ -4890,7 +4887,10 @@ const file_resource_proto_rawDesc = "" +
 	"\n" +
 	"Moderation\x122\n" +
 	"\x05model\x18\x01 \x01(\v2\x1c.google.protobuf.StringValueR\x05model\x12@\n" +
-	"\x04auth\x18\x02 \x01(\v2,.agentgateway.dev.resource.BackendAuthPolicyR\x04auth\x1a\xe7\x02\n" +
+	"\x04auth\x18\x02 \x01(\v2,.agentgateway.dev.resource.BackendAuthPolicyR\x04auth\x1aA\n" +
+	"\x13PromptGuardResponse\x12\x12\n" +
+	"\x04body\x18\x01 \x01(\fR\x04body\x12\x16\n" +
+	"\x06status\x18\x02 \x01(\rR\x06status\x1a\xe7\x02\n" +
 	"\x12PromptGuardRequest\x12X\n" +
 	"\bresponse\x18\x01 \x01(\v2<.agentgateway.dev.resource.PolicySpec.Ai.PromptGuardResponseR\bresponse\x12I\n" +
 	"\x05regex\x18\x02 \x01(\v23.agentgateway.dev.resource.PolicySpec.Ai.RegexRulesR\x05regex\x12J\n" +
@@ -5071,13 +5071,13 @@ var file_resource_proto_goTypes = []any{
 	(*PolicySpec_InferenceRouting)(nil),          // 49: agentgateway.dev.resource.PolicySpec.InferenceRouting
 	(*PolicySpec_BackendTLS)(nil),                // 50: agentgateway.dev.resource.PolicySpec.BackendTLS
 	(*PolicySpec_RBAC)(nil),                      // 51: agentgateway.dev.resource.PolicySpec.RBAC
-	(*PolicySpec_Ai_PromptGuardResponse)(nil),    // 52: agentgateway.dev.resource.PolicySpec.Ai.PromptGuardResponse
-	(*PolicySpec_Ai_NamedRegex)(nil),             // 53: agentgateway.dev.resource.PolicySpec.Ai.NamedRegex
-	(*PolicySpec_Ai_RegexRule)(nil),              // 54: agentgateway.dev.resource.PolicySpec.Ai.RegexRule
-	(*PolicySpec_Ai_Action)(nil),                 // 55: agentgateway.dev.resource.PolicySpec.Ai.Action
-	(*PolicySpec_Ai_RegexRules)(nil),             // 56: agentgateway.dev.resource.PolicySpec.Ai.RegexRules
-	(*PolicySpec_Ai_Webhook)(nil),                // 57: agentgateway.dev.resource.PolicySpec.Ai.Webhook
-	(*PolicySpec_Ai_Moderation)(nil),             // 58: agentgateway.dev.resource.PolicySpec.Ai.Moderation
+	(*PolicySpec_Ai_NamedRegex)(nil),             // 52: agentgateway.dev.resource.PolicySpec.Ai.NamedRegex
+	(*PolicySpec_Ai_RegexRule)(nil),              // 53: agentgateway.dev.resource.PolicySpec.Ai.RegexRule
+	(*PolicySpec_Ai_Action)(nil),                 // 54: agentgateway.dev.resource.PolicySpec.Ai.Action
+	(*PolicySpec_Ai_RegexRules)(nil),             // 55: agentgateway.dev.resource.PolicySpec.Ai.RegexRules
+	(*PolicySpec_Ai_Webhook)(nil),                // 56: agentgateway.dev.resource.PolicySpec.Ai.Webhook
+	(*PolicySpec_Ai_Moderation)(nil),             // 57: agentgateway.dev.resource.PolicySpec.Ai.Moderation
+	(*PolicySpec_Ai_PromptGuardResponse)(nil),    // 58: agentgateway.dev.resource.PolicySpec.Ai.PromptGuardResponse
 	(*PolicySpec_Ai_PromptGuardRequest)(nil),     // 59: agentgateway.dev.resource.PolicySpec.Ai.PromptGuardRequest
 	(*PolicySpec_Ai_PromptGuard)(nil),            // 60: agentgateway.dev.resource.PolicySpec.Ai.PromptGuard
 	nil,                                          // 61: agentgateway.dev.resource.PolicySpec.ExternalAuth.ContextEntry
@@ -5169,17 +5169,17 @@ var file_resource_proto_depIdxs = []int32{
 	69, // 73: agentgateway.dev.resource.PolicySpec.BackendTLS.root:type_name -> google.protobuf.BytesValue
 	70, // 74: agentgateway.dev.resource.PolicySpec.BackendTLS.insecure:type_name -> google.protobuf.BoolValue
 	2,  // 75: agentgateway.dev.resource.PolicySpec.Ai.RegexRule.builtin:type_name -> agentgateway.dev.resource.PolicySpec.Ai.BuiltinRegexRule
-	53, // 76: agentgateway.dev.resource.PolicySpec.Ai.RegexRule.regex:type_name -> agentgateway.dev.resource.PolicySpec.Ai.NamedRegex
+	52, // 76: agentgateway.dev.resource.PolicySpec.Ai.RegexRule.regex:type_name -> agentgateway.dev.resource.PolicySpec.Ai.NamedRegex
 	3,  // 77: agentgateway.dev.resource.PolicySpec.Ai.Action.kind:type_name -> agentgateway.dev.resource.PolicySpec.Ai.ActionKind
-	52, // 78: agentgateway.dev.resource.PolicySpec.Ai.Action.reject_response:type_name -> agentgateway.dev.resource.PolicySpec.Ai.PromptGuardResponse
-	55, // 79: agentgateway.dev.resource.PolicySpec.Ai.RegexRules.action:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Action
-	54, // 80: agentgateway.dev.resource.PolicySpec.Ai.RegexRules.rules:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RegexRule
+	58, // 78: agentgateway.dev.resource.PolicySpec.Ai.Action.reject_response:type_name -> agentgateway.dev.resource.PolicySpec.Ai.PromptGuardResponse
+	54, // 79: agentgateway.dev.resource.PolicySpec.Ai.RegexRules.action:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Action
+	53, // 80: agentgateway.dev.resource.PolicySpec.Ai.RegexRules.rules:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RegexRule
 	71, // 81: agentgateway.dev.resource.PolicySpec.Ai.Moderation.model:type_name -> google.protobuf.StringValue
 	15, // 82: agentgateway.dev.resource.PolicySpec.Ai.Moderation.auth:type_name -> agentgateway.dev.resource.BackendAuthPolicy
-	52, // 83: agentgateway.dev.resource.PolicySpec.Ai.PromptGuardRequest.response:type_name -> agentgateway.dev.resource.PolicySpec.Ai.PromptGuardResponse
-	56, // 84: agentgateway.dev.resource.PolicySpec.Ai.PromptGuardRequest.regex:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RegexRules
-	57, // 85: agentgateway.dev.resource.PolicySpec.Ai.PromptGuardRequest.webhook:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Webhook
-	58, // 86: agentgateway.dev.resource.PolicySpec.Ai.PromptGuardRequest.openai_moderation:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Moderation
+	58, // 83: agentgateway.dev.resource.PolicySpec.Ai.PromptGuardRequest.response:type_name -> agentgateway.dev.resource.PolicySpec.Ai.PromptGuardResponse
+	55, // 84: agentgateway.dev.resource.PolicySpec.Ai.PromptGuardRequest.regex:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RegexRules
+	56, // 85: agentgateway.dev.resource.PolicySpec.Ai.PromptGuardRequest.webhook:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Webhook
+	57, // 86: agentgateway.dev.resource.PolicySpec.Ai.PromptGuardRequest.openai_moderation:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Moderation
 	59, // 87: agentgateway.dev.resource.PolicySpec.Ai.PromptGuard.request:type_name -> agentgateway.dev.resource.PolicySpec.Ai.PromptGuardRequest
 	71, // 88: agentgateway.dev.resource.AIBackend.OpenAI.model:type_name -> google.protobuf.StringValue
 	71, // 89: agentgateway.dev.resource.AIBackend.Gemini.model:type_name -> google.protobuf.StringValue
@@ -5283,7 +5283,7 @@ func file_resource_proto_init() {
 		(*BackendReference_Service)(nil),
 		(*BackendReference_Backend)(nil),
 	}
-	file_resource_proto_msgTypes[47].OneofWrappers = []any{
+	file_resource_proto_msgTypes[46].OneofWrappers = []any{
 		(*PolicySpec_Ai_RegexRule_Builtin)(nil),
 		(*PolicySpec_Ai_RegexRule_Regex)(nil),
 	}

--- a/schema/README.md
+++ b/schema/README.md
@@ -139,9 +139,9 @@ This folder contains JSON schemas for various parts of the project
 |`binds[].listeners[].routes[].policies.ai`|Mark this as LLM traffic to enable LLM processing.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard`||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request`||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request.response`||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request.response.body`||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request.response.status`||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request.rejection`||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request.rejection.body`||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request.rejection.status`||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request.regex`||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request.regex.action`||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request.regex.action.(1)reject`||
@@ -160,6 +160,19 @@ This folder contains JSON schemas for various parts of the project
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request.openaiModeration.auth.(1)passthrough`||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request.openaiModeration.auth.(1)key`||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request.openaiModeration.auth.(1)key.(any)file`||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response`||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response.regex`||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response.regex.action`||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response.regex.action.(1)reject`||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response.regex.action.(1)reject.response`||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response.regex.action.(1)reject.response.body`||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response.regex.action.(1)reject.response.status`||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response.regex.rules`||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response.regex.rules[].(any)builtin`||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response.regex.rules[].(any)pattern`||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response.regex.rules[].(any)name`||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response.webhook`||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response.webhook.target`||
 |`binds[].listeners[].routes[].policies.ai.defaults`||
 |`binds[].listeners[].routes[].policies.ai.overrides`||
 |`binds[].listeners[].routes[].policies.ai.prompts`||

--- a/schema/local.json
+++ b/schema/local.json
@@ -1127,7 +1127,7 @@
                                       "null"
                                     ],
                                     "properties": {
-                                      "response": {
+                                      "rejection": {
                                         "type": "object",
                                         "properties": {
                                           "body": {
@@ -1342,6 +1342,139 @@
                                         "additionalProperties": false,
                                         "required": [
                                           "auth"
+                                        ]
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  },
+                                  "response": {
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "properties": {
+                                      "regex": {
+                                        "type": [
+                                          "object",
+                                          "null"
+                                        ],
+                                        "properties": {
+                                          "action": {
+                                            "oneOf": [
+                                              {
+                                                "type": "string",
+                                                "enum": [
+                                                  "mask"
+                                                ]
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "reject": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "response": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                          "body": {
+                                                            "type": [
+                                                              "array",
+                                                              "string"
+                                                            ],
+                                                            "items": {
+                                                              "type": "integer",
+                                                              "format": "uint8",
+                                                              "minimum": 0,
+                                                              "maximum": 255
+                                                            },
+                                                            "default": "The request was rejected due to inappropriate content"
+                                                          },
+                                                          "status": {
+                                                            "type": "integer",
+                                                            "format": "uint16",
+                                                            "minimum": 1,
+                                                            "maximum": 65535,
+                                                            "default": 403
+                                                          }
+                                                        },
+                                                        "additionalProperties": false,
+                                                        "default": {
+                                                          "body": "The request was rejected due to inappropriate content",
+                                                          "status": 403
+                                                        }
+                                                      }
+                                                    },
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "required": [
+                                                  "reject"
+                                                ],
+                                                "additionalProperties": false
+                                              }
+                                            ],
+                                            "default": "mask"
+                                          },
+                                          "rules": {
+                                            "type": "array",
+                                            "items": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "builtin": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "ssn",
+                                                        "creditCard",
+                                                        "phoneNumber",
+                                                        "email"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "additionalProperties": false,
+                                                  "required": [
+                                                    "builtin"
+                                                  ]
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "pattern": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "additionalProperties": false,
+                                                  "required": [
+                                                    "pattern",
+                                                    "name"
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        },
+                                        "additionalProperties": false,
+                                        "required": [
+                                          "rules"
+                                        ]
+                                      },
+                                      "webhook": {
+                                        "type": [
+                                          "object",
+                                          "null"
+                                        ],
+                                        "properties": {
+                                          "target": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "additionalProperties": false,
+                                        "required": [
+                                          "target"
                                         ]
                                       }
                                     },


### PR DESCRIPTION
- adds protos for supporting AI policies via xds (enrichment, prompt guard)
- adds struct to eventually support applying prompt guards to llm responses as well
- reworks ai policy so it can target gateways/routes instead of backends
