### PR TITLE
feat(pat): implement PAT functionality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,7 +167,7 @@ tonic-prost = { version = "0.14" }
 tonic-prost-build = { version = "0.14", features = ["transport"] }
 tonic-build = { version = "0.14", features = ["transport"] }
 tower = { version = "0.5" }
-tower-http = { version = "0.6", features = ["cors"] }
+tower-http = { version = "0.6", features = ["cors", "trace"] }
 tower-serve-static = "0.1"
 tower-service = "0.3"
 tracing = "0.1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ RUN --mount=type=cache,id=cargo,target=/usr/local/cargo/registry \
     cargo fetch --locked
 RUN --mount=type=cache,target=/app/target \
     --mount=type=cache,id=cargo,target=/usr/local/cargo/registry \
-    cargo build --features ui  --target "$(cat /build/target)"  --profile ${PROFILE} && \
+    cargo build --features ui,pat  --target "$(cat /build/target)"  --profile ${PROFILE} && \
     mkdir /out && \
     mv /app/target/$(cat /build/target)/${PROFILE}/agentgateway /out
 

--- a/crates/agentgateway/Cargo.toml
+++ b/crates/agentgateway/Cargo.toml
@@ -15,6 +15,7 @@ ui = []
 schema = ["schemars"]
 tls-ring = ["rustls/ring", "tokio-rustls/ring"]
 internal_benches = ["divan"]
+pat = ["dep:sqlx", "dep:argon2", "dep:moka", "dep:dashmap"]
 
 [dependencies]
 a2a-sdk.workspace = true
@@ -126,6 +127,10 @@ macro_rules_attribute.workspace = true
 heck.workspace = true
 async-compression.workspace = true
 bpe-openai = "0.3.0"
+argon2 = { version = "0.5", optional = true }
+moka = { version = "0.12", features = ["future"], optional = true }
+sqlx = { version = "0.8.6", default-features = false, features = ["runtime-tokio", "postgres", "chrono", "uuid", "derive", "tls-rustls"], optional = true }
+dashmap = { version = "5", optional = true }
 
 [build-dependencies]
 anyhow.workspace = true

--- a/crates/agentgateway/proto/resource.proto
+++ b/crates/agentgateway/proto/resource.proto
@@ -36,7 +36,6 @@ message Listener {
   Protocol protocol = 6;
   TLSConfig tls = 7;
 }
-
 message TLSConfig {
   bytes cert = 1;
   bytes private_key = 2;
@@ -384,6 +383,10 @@ message PolicySpec {
     repeated string allow = 1;
     repeated string deny = 2;
   }
+  // Personal Access Token (PAT) policy configuration.
+  message Pat {
+    bool enabled = 1; // When true, PAT authentication is required for this route
+  }
   oneof kind {
     LocalRateLimit local_rate_limit = 1;
     ExternalAuth ext_authz = 2;
@@ -394,6 +397,7 @@ message PolicySpec {
     RBAC authorization = 7;
     RBAC mcp_authorization = 8;
     Ai ai = 9;
+    Pat pat = 10;
   }
 }
 

--- a/crates/agentgateway/src/http/mod.rs
+++ b/crates/agentgateway/src/http/mod.rs
@@ -5,6 +5,8 @@ mod buflist;
 pub mod cors;
 pub mod jwt;
 pub mod localratelimit;
+#[cfg(feature = "pat")]
+pub mod pat;
 pub mod retry;
 pub mod route;
 

--- a/crates/agentgateway/src/http/pat.rs
+++ b/crates/agentgateway/src/http/pat.rs
@@ -1,0 +1,545 @@
+#![cfg(feature = "pat")]
+use std::net::IpAddr;
+use std::sync::OnceLock;
+use std::time::{Duration, Instant};
+
+use anyhow::Result;
+use argon2::{
+	Algorithm, Argon2, Params, PasswordHash, PasswordVerifier, Version,
+	password_hash::{PasswordHasher, SaltString, rand_core::OsRng},
+};
+use chrono::{DateTime, Utc};
+use moka::future::Cache;
+use secrecy::{ExposeSecret, SecretString};
+use sqlx::postgres::PgListener;
+// (De)serialization derives are intentionally minimized here; TokenRow is mapped into a public
+// representation elsewhere so we don't need serde derives on it.
+use rand::Rng as _;
+use rand::distr::Alphanumeric;
+use sqlx::{PgPool, types::Uuid};
+use tracing::debug;
+
+use crate::http::jwt::Claims;
+use serde_json::{Map, Value};
+
+const PREFIX_LEN: usize = 24;
+
+// Explicit Argon2id parameters (default replaced) for consistent, auditable hashing.
+const ARGON2_M_COST: u32 = 64 * 1024; // 64 MiB
+const ARGON2_T_COST: u32 = 3; // iterations
+const ARGON2_P_COST: u32 = 1; // parallelism (lanes)
+
+fn argon2_instance() -> Argon2<'static> {
+	let params =
+		Params::new(ARGON2_M_COST, ARGON2_T_COST, ARGON2_P_COST, None).expect("valid argon2 params");
+	Argon2::new(Algorithm::Argon2id, Version::V0x13, params)
+}
+
+// Revocation + cache tuning constants (parity with source branch expectations)
+const POS_CACHE_TTL_SECS: u64 = 300;
+const NEG_CACHE_TTL_SECS: u64 = 15;
+const NEG_CACHE_CAP: u64 = 50_000;
+const POS_CACHE_CAP: u64 = 100_000;
+const REVOCATION_CACHE_CAP: u64 = 50_000;
+const REVOCATION_TTL_SECS: u64 = 86_400; // 24h, conservatively > max token expiry scan interval
+
+static REVOKED_PREFIXES: OnceLock<moka::future::Cache<String, ()>> = OnceLock::new();
+fn revoked_cache() -> &'static moka::future::Cache<String, ()> {
+	REVOKED_PREFIXES.get_or_init(|| {
+		moka::future::Cache::builder()
+			.time_to_live(Duration::from_secs(REVOCATION_TTL_SECS))
+			.max_capacity(REVOCATION_CACHE_CAP)
+			.build()
+	})
+}
+pub fn mark_pat_revoked(prefix: &str) {
+	// Insert asynchronously; we don't need to await this for correctness and
+	// want to avoid unused Future warnings at call sites.
+	let fut = revoked_cache().insert(prefix.to_string(), ());
+	tokio::spawn(async move {
+		let _ = fut.await;
+	});
+}
+
+// Optional dedicated DB URL for revocation LISTEN to isolate from main pool saturation.
+static PAT_DB_URL: OnceLock<String> = OnceLock::new();
+#[cfg(feature = "pat")]
+pub fn set_pat_db_url(url: &str) {
+	let _ = PAT_DB_URL.set(url.to_string());
+}
+fn pat_db_url() -> Option<&'static str> {
+	PAT_DB_URL.get().map(|s| s.as_str())
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum PatError {
+	#[error("missing bearer token")]
+	Missing,
+	#[error("not a PAT")]
+	NotPat,
+	#[error("not found")]
+	NotFound,
+	#[error("revoked/expired")]
+	Disabled,
+	#[error("invalid token")]
+	Invalid,
+	#[error("internal: {0}")]
+	Internal(String),
+}
+
+#[derive(Clone, Debug)]
+pub struct PatAuth {
+	repo: TokenRepo,
+	pos: Cache<String, Claims>,
+	neg: Cache<String, ()>,
+}
+
+// Resolve the configured base prefix (default "agpk"). This is the static discriminator preceding
+// any environment tag, allowing operators to change branding or namespace without touching code.
+pub fn token_base_prefix() -> &'static str {
+	static BASE: OnceLock<String> = OnceLock::new();
+	BASE.get_or_init(|| {
+		let raw = std::env::var("PAT_TOKEN_PREFIX").unwrap_or_else(|_| "agpk".to_string());
+		// Basic sanitation: trim and fallback if empty
+		let trimmed = raw.trim();
+		if trimmed.is_empty() {
+			"agpk".to_string()
+		} else {
+			trimmed.to_string()
+		}
+	})
+}
+
+impl PatAuth {
+	pub fn new(pool: PgPool) -> Self {
+		let me = Self {
+			repo: TokenRepo::new(pool),
+			pos: Cache::builder()
+				.time_to_live(Duration::from_secs(POS_CACHE_TTL_SECS))
+				.max_capacity(POS_CACHE_CAP)
+				.build(),
+			neg: Cache::builder()
+				.time_to_live(Duration::from_secs(NEG_CACHE_TTL_SECS))
+				.max_capacity(NEG_CACHE_CAP)
+				.build(),
+		};
+		me.spawn_revocation_listener();
+		me.spawn_index_check();
+		me
+	}
+
+	fn spawn_revocation_listener(&self) {
+		let pool = self.repo.pool.clone();
+		let pos_cache = self.pos.clone();
+		tokio::spawn(async move {
+			let mut backoff = Duration::from_secs(1);
+			loop {
+				// Use dedicated connection if PAT_DB_URL set, else borrow from pool
+				let dedicated = pat_db_url();
+				let listener_res = if let Some(url) = dedicated {
+					PgListener::connect(url).await
+				} else {
+					PgListener::connect_with(&pool).await
+				};
+				match listener_res {
+					Ok(mut listener) => {
+						if dedicated.is_some() {
+							tracing::info!(
+								target = "audit",
+								action = "pat.revoke.listener",
+								mode = "dedicated_conn",
+								"revocation listener using dedicated connection"
+							);
+						}
+						match listener.listen("pat_revoked").await {
+							Ok(_) => {
+								tracing::info!(
+									target = "audit",
+									action = "pat.revoke.listener",
+									status = "started",
+									"revocation listener active"
+								);
+								backoff = Duration::from_secs(1);
+								while let Ok(notification) = listener.recv().await {
+									let payload = notification.payload().to_string();
+									mark_pat_revoked(&payload);
+									// Invalidate the singleton's positive cache
+									pos_cache.invalidate(&payload).await;
+									tracing::debug!(target="audit", action="pat.revoke.propagate", token_prefix=%payload, "propagated token revocation");
+								}
+								tracing::warn!(
+									target = "audit",
+									action = "pat.revoke.listener",
+									status = "disconnected",
+									"revocation listener disconnected; will retry"
+								);
+							},
+							Err(e) => {
+								tracing::warn!(target="audit", action="pat.revoke.listener", status="listen_failed", error=%e, "failed to LISTEN; will retry");
+							},
+						}
+					},
+					Err(e) => {
+						tracing::warn!(target="audit", action="pat.revoke.listener", status="connect_failed", error=%e, "failed to connect PgListener; will retry");
+					},
+				}
+				// Add jitter to prevent thundering herd
+				let jitter = Duration::from_millis(rand::rng().random_range(0..1000));
+				tokio::time::sleep(backoff + jitter).await;
+				backoff = (backoff * 2).min(Duration::from_secs(60));
+			}
+		});
+	}
+
+	pub async fn authenticate(
+		&self,
+		authz_value: &str,
+		peer_ip: Option<IpAddr>,
+	) -> Result<(Claims, ZeroToken), PatError> {
+		let token = authz_value
+			.strip_prefix("Bearer ")
+			.ok_or(PatError::Missing)?;
+		if !token.starts_with(&format!("{}_", token_base_prefix())) {
+			tracing::warn!(target = "audit", action = "pat.auth", outcome = "not_pat");
+			return Err(PatError::NotPat);
+		}
+		if token.len() < PREFIX_LEN {
+			tracing::info!(target = "audit", action = "pat.auth", outcome = "too_short");
+			return Err(PatError::Invalid);
+		}
+		let prefix: String = token.get(..PREFIX_LEN).unwrap_or(token).to_string();
+		if self.neg.get(&prefix).await.is_some() {
+			tracing::info!(
+				target = "audit",
+				action = "pat.auth",
+				outcome = "cached_negative"
+			);
+			return Err(PatError::NotFound);
+		}
+		if let Some(p) = self.pos.get(&prefix).await {
+			if revoked_cache().get(&prefix).await.is_some() {
+				self.pos.invalidate(&prefix).await;
+			} else {
+				return Ok((p, ZeroToken::new(token)));
+			}
+		}
+		let t0 = Instant::now();
+		let rec_opt = self
+			.repo
+			.find_active_by_prefix(&prefix)
+			.await
+			.map_err(|e| PatError::Internal(e.to_string()))?;
+		let rec = match rec_opt {
+			Some(r) => r,
+			None => {
+				tracing::info!(target="audit", action="pat.auth", prefix=%prefix, outcome="not_found");
+				return Err(PatError::NotFound);
+			},
+		};
+		let parsed = PasswordHash::new(&rec.key_hash).map_err(|_| PatError::Invalid)?;
+		if argon2_instance()
+			.verify_password(token.as_bytes(), &parsed)
+			.is_err()
+		{
+			self.neg.insert(prefix.clone(), ()).await;
+			tracing::info!(target="audit", action="pat.auth", prefix=%prefix, outcome="invalid_hash");
+			return Err(PatError::Invalid);
+		}
+		let mut claims_map = Map::with_capacity(6);
+		claims_map.insert("sub".to_string(), Value::String(rec.user_id.clone()));
+		claims_map.insert(
+			"tenant_id".to_string(),
+			Value::String(rec.tenant_id.clone()),
+		);
+		claims_map.insert("token_type".to_string(), Value::String("pat".to_string()));
+		if !rec.scopes.is_empty() {
+			claims_map.insert("scope".to_string(), Value::String(rec.scopes.join(" ")));
+		}
+		if let Some(email) = &rec.creator_email {
+			claims_map.insert("email".to_string(), Value::String(email.clone()));
+		}
+		if !rec.creator_groups.is_empty() {
+			claims_map.insert(
+				"groups".to_string(),
+				Value::Array(
+					rec
+						.creator_groups
+						.iter()
+						.map(|g| Value::String(g.clone()))
+						.collect(),
+				),
+			);
+		}
+		let claims = Claims {
+			inner: claims_map.clone(),
+			jwt: SecretString::new(format!("pat:{}", rec.token_prefix).into()),
+		};
+		self
+			.pos
+			.insert(rec.token_prefix.clone(), claims.clone())
+			.await;
+		let repo = self.repo.clone();
+		tokio::spawn(async move {
+			let _ = repo.touch_last_used(rec.id, peer_ip).await;
+		});
+		debug!(took_ms=%t0.elapsed().as_millis(), prefix=%prefix, "pat validated");
+		Ok((claims, ZeroToken::new(token)))
+	}
+	pub fn repo(&self) -> &TokenRepo {
+		&self.repo
+	}
+}
+
+impl PatAuth {
+	fn spawn_index_check(&self) {
+		let pool = self.repo.pool.clone();
+		tokio::spawn(async move {
+			if let Ok(rows) = sqlx::query_scalar::<_, String>("SELECT indexrelid::regclass::text FROM pg_index i JOIN pg_class c ON c.oid=i.indrelid JOIN pg_class ic ON ic.oid=i.indexrelid WHERE c.relname='proxy_keys'").fetch_all(&pool).await {
+				let have: std::collections::HashSet<_> = rows.iter().map(|s| s.as_str()).collect();
+				if !have.iter().any(|n| n.contains("token_prefix")) {
+					tracing::warn!(target="audit", action="pat.index.check", missing="token_prefix", suggestion = "CREATE UNIQUE INDEX IF NOT EXISTS proxy_keys_token_prefix_idx ON proxy_keys(token_prefix)");
+				}
+				if !have.iter().any(|n| n.contains("tenant_user_created_at")) {
+					tracing::warn!(target="audit", action="pat.index.check", missing="tenant_user_created_at", suggestion = "CREATE INDEX IF NOT EXISTS proxy_keys_tenant_user_created_at_idx ON proxy_keys(tenant_id, user_id, created_at DESC)");
+				}
+			}
+		});
+	}
+}
+
+#[derive(Clone)]
+pub struct ZeroToken(SecretString);
+impl ZeroToken {
+	pub fn new(raw: &str) -> Self {
+		Self(SecretString::new(raw.to_string().into_boxed_str()))
+	}
+	pub fn expose(&self) -> &str {
+		self.0.expose_secret()
+	}
+}
+impl std::fmt::Debug for ZeroToken {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		write!(f, "<redacted>")
+	}
+}
+
+#[derive(sqlx::FromRow, Clone)]
+pub struct TokenRow {
+	pub id: Uuid,
+	pub tenant_id: String,
+	pub user_id: String,
+	pub name: Option<String>,
+	pub token_prefix: String,
+	pub hash_algo: String,
+	pub hash_params: serde_json::Value,
+	pub key_hash: String,
+	pub scopes: Vec<String>,
+	pub created_by: Option<String>,
+	pub creator_email: Option<String>,
+	pub creator_groups: Vec<String>,
+	pub created_at: DateTime<Utc>,
+	pub last_used_at: Option<DateTime<Utc>>,
+	pub last_used_ip: Option<String>,
+	pub expires_at: Option<DateTime<Utc>>,
+	pub revoked_at: Option<DateTime<Utc>>,
+}
+
+// Minimal projection for listing tokens (excludes hash fields)
+#[derive(sqlx::FromRow, Clone, Debug)]
+pub struct PublicTokenRow {
+	pub id: Uuid,
+	pub token_prefix: String,
+	pub scopes: Vec<String>,
+	pub creator_email: Option<String>,
+	pub creator_groups: Vec<String>,
+	pub created_at: DateTime<Utc>,
+	pub last_used_at: Option<DateTime<Utc>>,
+	pub expires_at: Option<DateTime<Utc>>,
+	pub revoked_at: Option<DateTime<Utc>>,
+}
+
+impl std::fmt::Debug for TokenRow {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("TokenRow")
+			.field("id", &self.id)
+			.field("tenant_id", &self.tenant_id)
+			.field("user_id", &self.user_id)
+			.field("name", &self.name)
+			.field("token_prefix", &self.token_prefix)
+			// intentionally omit hash_algo, hash_params, key_hash
+			.field("scopes", &self.scopes)
+			.field("created_by", &self.created_by)
+			.field("creator_email", &self.creator_email)
+			.field("creator_groups", &self.creator_groups)
+			.field("created_at", &self.created_at)
+			.field("last_used_at", &self.last_used_at)
+			.field("last_used_ip", &self.last_used_ip)
+			.field("expires_at", &self.expires_at)
+			.field("revoked_at", &self.revoked_at)
+			.finish()
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	#[test]
+	fn tokenrow_debug_redacts_hash() {
+		let row = TokenRow {
+			id: Uuid::nil(),
+			tenant_id: "t".into(),
+			user_id: "u".into(),
+			name: Some("n".into()),
+			token_prefix: "agpk_live_exampleprefixxx"
+				.chars()
+				.take(PREFIX_LEN)
+				.collect(),
+			hash_algo: "argon2id".into(),
+			hash_params: serde_json::json!({"m": 65536, "t":3}),
+			key_hash: "$argon2id$v=19$m=65536,t=3,p=1$SALT$HASH".into(),
+			scopes: vec!["read".into()],
+			created_by: Some("creator".into()),
+			creator_email: Some("c@example.com".into()),
+			creator_groups: vec!["g1".into()],
+			created_at: Utc::now(),
+			last_used_at: None,
+			last_used_ip: None,
+			expires_at: None,
+			revoked_at: None,
+		};
+		let dbg = format!("{:?}", row);
+		assert!(
+			!dbg.contains("key_hash"),
+			"debug output should not contain key_hash field name"
+		);
+		assert!(
+			!dbg.contains("argon2id"),
+			"debug output should not leak hash algorithm"
+		);
+		assert!(
+			!dbg.contains("$argon2id$"),
+			"debug output should not leak hash value"
+		);
+		assert!(dbg.contains("TokenRow"));
+		assert!(dbg.contains("token_prefix")); // safe
+	}
+}
+
+/// Parameters for creating a new token
+pub struct CreateTokenParams<'a> {
+	pub creator: &'a str,
+	pub creator_email: Option<&'a str>,
+	pub creator_groups: &'a [String],
+	pub tenant_id: &'a str,
+	pub user_id: &'a str,
+	pub name: Option<&'a str>,
+	pub scopes: &'a [String],
+	pub expires_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Clone, Debug)]
+pub struct TokenRepo {
+	pool: PgPool,
+}
+impl TokenRepo {
+	pub fn new(pool: PgPool) -> Self {
+		Self { pool }
+	}
+}
+
+impl TokenRepo {
+	pub async fn create(&self, params: CreateTokenParams<'_>) -> Result<(ZeroToken, TokenRow)> {
+		let CreateTokenParams {
+			creator,
+			creator_email,
+			creator_groups,
+			tenant_id,
+			user_id,
+			name,
+			scopes,
+			expires_at,
+		} = params;
+		// Scope allow-list validation removed (was unused)
+		// Generate random suffix (40 chars) using thread-local RNG (scoped so non-Send RNG is dropped before any await)
+		let rand: String = {
+			let mut rng = rand::rng();
+			(0..40).map(|_| rng.sample(Alphanumeric) as char).collect()
+		}; // rng dropped here
+		// Optional environment tag (PAT_TOKEN_ENV). If unset or empty, no environment segment is inserted.
+		// Resulting formats:
+		//   Without env: <base>_<rand>
+		//   With env:    <base>_<env>_<rand>
+		fn token_env() -> Option<&'static str> {
+			static ENV: OnceLock<Option<String>> = OnceLock::new();
+			ENV
+				.get_or_init(|| match std::env::var("PAT_TOKEN_ENV") {
+					Ok(v) if !v.trim().is_empty() => Some(v.trim().to_string()),
+					_ => None,
+				})
+				.as_ref()
+				.map(|s| s.as_str())
+		}
+		let token = if let Some(env) = token_env() {
+			format!("{}_{}_{rand}", token_base_prefix(), env)
+		} else {
+			format!("{}_{}", token_base_prefix(), rand)
+		};
+		let prefix: String = token.chars().take(PREFIX_LEN).collect();
+		// Use OsRng (from password-hash's rand_core) to avoid version mismatch with rand 0.9
+		let salt = SaltString::generate(&mut OsRng);
+		let hash = argon2_instance()
+			.hash_password(token.as_bytes(), &salt)
+			.map_err(|e| anyhow::anyhow!("argon2 hash error: {e}"))?
+			.to_string();
+		let row: TokenRow = sqlx::query_as(r#"INSERT INTO proxy_keys (tenant_id, user_id, name, token_prefix, hash_algo, hash_params, key_hash, scopes, expires_at, created_by, creator_email, creator_groups)
+            VALUES ($1,$2,$3,$4,'argon2id','{}',$5,$6,$7,$8,$9,$10)
+            RETURNING id, tenant_id, user_id, name, token_prefix, hash_algo, hash_params, key_hash, scopes, created_by, creator_email, creator_groups, created_at, last_used_at, last_used_ip, expires_at, revoked_at"#)
+            .bind(tenant_id).bind(user_id).bind(name).bind(&prefix).bind(&hash).bind(scopes).bind(expires_at).bind(creator).bind(creator_email.map(|s| s.to_string())).bind(creator_groups)
+            .fetch_one(&self.pool).await?;
+		Ok((ZeroToken::new(&token), row))
+	}
+	pub async fn list_public(
+		&self,
+		tenant_id: &str,
+		user_id: &str,
+		limit: i64,
+		offset: i64,
+		search: Option<&str>,
+	) -> Result<Vec<PublicTokenRow>> {
+		let lim = limit.clamp(1, 200);
+		let off = offset.max(0);
+		if let Some(s) = search {
+			let like = format!("%{}%", s.replace('%', "\\%"));
+			Ok(sqlx::query_as::<_, PublicTokenRow>("SELECT id, token_prefix, scopes, creator_email, creator_groups, created_at, last_used_at, expires_at, revoked_at FROM proxy_keys WHERE tenant_id=$1 AND user_id=$2 AND (token_prefix ILIKE $3 OR $3 = '%%') ORDER BY created_at DESC LIMIT $4 OFFSET $5")
+                .bind(tenant_id).bind(user_id).bind(&like).bind(lim).bind(off).fetch_all(&self.pool).await?)
+		} else {
+			Ok(sqlx::query_as::<_, PublicTokenRow>("SELECT id, token_prefix, scopes, creator_email, creator_groups, created_at, last_used_at, expires_at, revoked_at FROM proxy_keys WHERE tenant_id=$1 AND user_id=$2 ORDER BY created_at DESC LIMIT $3 OFFSET $4")
+                .bind(tenant_id).bind(user_id).bind(lim).bind(off).fetch_all(&self.pool).await?)
+		}
+	}
+	pub async fn revoke(&self, tenant_id: &str, id: Uuid) -> Result<Option<String>> {
+		let rec = sqlx::query_as::<_, (String,)>("UPDATE proxy_keys SET revoked_at=now() WHERE id=$1 AND tenant_id=$2 AND revoked_at IS NULL RETURNING token_prefix")
+            .bind(id).bind(tenant_id).fetch_optional(&self.pool).await?;
+		if let Some((prefix,)) = rec.clone() {
+			// send cluster notification
+			let _ = sqlx::query("NOTIFY pat_revoked, $1")
+				.bind(&prefix)
+				.execute(&self.pool)
+				.await; // best-effort
+		}
+		Ok(rec.map(|t| t.0))
+	}
+	pub async fn find_active_by_prefix(&self, prefix: &str) -> Result<Option<TokenRow>> {
+		Ok(sqlx::query_as::<_, TokenRow>("SELECT id, tenant_id, user_id, name, token_prefix, hash_algo, hash_params, key_hash, scopes, created_by, creator_email, creator_groups, created_at, last_used_at, last_used_ip, expires_at, revoked_at FROM proxy_keys WHERE token_prefix=$1 AND revoked_at IS NULL AND (expires_at IS NULL OR expires_at>now()) LIMIT 1").bind(prefix).fetch_optional(&self.pool).await?)
+	}
+	pub async fn touch_last_used(&self, id: Uuid, ip: Option<IpAddr>) -> Result<()> {
+		// Bind IP as text and cast to inet to avoid needing IpAddr Encode impl
+		let ip_txt: Option<String> = ip.map(|i| i.to_string());
+		sqlx::query("UPDATE proxy_keys SET last_used_at=now(), last_used_ip=COALESCE($2::inet,last_used_ip) WHERE id=$1")
+            .bind(id)
+            .bind(ip_txt)
+            .execute(&self.pool)
+            .await?;
+		Ok(())
+	}
+}

--- a/crates/agentgateway/src/pat_global.rs
+++ b/crates/agentgateway/src/pat_global.rs
@@ -1,0 +1,30 @@
+#![cfg(feature = "pat")]
+//! Global PAT authentication singleton for cache sharing across all routes
+
+use crate::http::pat::PatAuth;
+use sqlx::PgPool;
+use std::sync::{Arc, OnceLock};
+
+/// Global PAT authenticator instance shared across all routes
+static GLOBAL_PAT_AUTH: OnceLock<Arc<PatAuth>> = OnceLock::new();
+
+/// Initialize the global PAT authenticator.
+/// This should be called once during application startup when PAT is enabled.
+/// Returns the Arc to the global instance.
+pub fn init_global_pat_auth(pool: PgPool) -> Arc<PatAuth> {
+	GLOBAL_PAT_AUTH
+		.get_or_init(|| {
+			tracing::info!(
+				target = "audit",
+				action = "pat.global.init",
+				"Initializing global PAT authenticator"
+			);
+			Arc::new(PatAuth::new(pool))
+		})
+		.clone()
+}
+
+/// Get the global PAT authenticator if it has been initialized
+pub fn get_global_pat_auth() -> Option<Arc<PatAuth>> {
+	GLOBAL_PAT_AUTH.get().cloned()
+}

--- a/crates/agentgateway/src/proxy/mod.rs
+++ b/crates/agentgateway/src/proxy/mod.rs
@@ -50,6 +50,12 @@ pub enum ProxyError {
 	BackendUnsupportedMirror,
 	#[error("authentication failure: {0}")]
 	JwtAuthenticationFailure(http::jwt::TokenError),
+	#[cfg(feature = "pat")]
+	#[error("PAT authentication client failure")]
+	PatAuthClient,
+	#[cfg(feature = "pat")]
+	#[error("PAT authentication server failure: {0}")]
+	PatAuthServer(String),
 	#[error("transformation failed")]
 	TransformationFailure,
 	#[error("service not found")]
@@ -114,6 +120,10 @@ impl ProxyError {
 			ProxyError::InvalidRequest => StatusCode::BAD_REQUEST,
 
 			ProxyError::JwtAuthenticationFailure(_) => StatusCode::FORBIDDEN,
+			#[cfg(feature = "pat")]
+			ProxyError::PatAuthClient => StatusCode::UNAUTHORIZED,
+			#[cfg(feature = "pat")]
+			ProxyError::PatAuthServer(_) => StatusCode::INTERNAL_SERVER_ERROR,
 			ProxyError::AuthorizationFailed => StatusCode::FORBIDDEN,
 
 			ProxyError::DnsResolution => StatusCode::SERVICE_UNAVAILABLE,

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -1016,6 +1016,9 @@ pub enum Policy {
 	// Supported targets: Gateway < Route < RouteRule; single policy allowed
 	JwtAuth(crate::http::jwt::Jwt),
 	// Supported targets: Gateway < Route < RouteRule; single policy allowed
+	#[cfg(feature = "pat")]
+	Pat(bool), // PAT enabled on this route
+	// Supported targets: Gateway < Route < RouteRule; single policy allowed
 	// ExtProc(),
 	// Supported targets: Gateway < Route < RouteRule; single policy allowed
 	Transformation(crate::http::transformation_cel::Transformation),

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -608,6 +608,9 @@ impl TryFrom<&proto::agent::Policy> for TargetedPolicy {
 			_ => return Err(ProtoError::EnumParse("unknown target kind".to_string())),
 		};
 		let policy = match &spec.kind {
+			// PAT policy translation (feature gated)
+			#[cfg(feature = "pat")]
+			Some(proto::agent::policy_spec::Kind::Pat(p)) => Policy::Pat(p.enabled),
 			Some(proto::agent::policy_spec::Kind::LocalRateLimit(lrl)) => {
 				let t = proto::agent::policy_spec::local_rate_limit::Type::try_from(lrl.r#type)?;
 				Policy::LocalRateLimit(vec![

--- a/examples/pat/README.md
+++ b/examples/pat/README.md
@@ -1,0 +1,50 @@
+# PAT Authentication Examples
+
+This directory contains examples of different ways to configure Personal Access Token (PAT) authentication for routes.
+
+## Available Approaches
+
+1. **pat-ai-routes.yaml** - Automatically require PAT for AI/LLM endpoints
+   - Uses `PAT_REQUIRE_FOR_AI_ROUTES=true`
+   - Auto-detects AI routes by pattern matching
+
+2. **pat-route-patterns.yaml** - Pattern-based PAT requirements
+   - Uses `PAT_REQUIRED_ROUTE_PATTERNS` with wildcards
+   - Flexible pattern matching for route names
+
+3. **pat-explicit-routes.yaml** - Traditional per-route configuration
+   - Explicitly set `pat: true` in route policies
+   - Most control but requires config changes
+
+## Environment Variables
+
+```bash
+# Enable PAT globally (required for all approaches)
+export PAT_ENABLED=true
+
+# Auto-require PAT for AI routes
+export PAT_REQUIRE_FOR_AI_ROUTES=true
+
+# Require PAT for specific route patterns
+export PAT_REQUIRED_ROUTE_PATTERNS="admin*,internal/*,v2/api/*"
+
+# PAT token configuration
+export PAT_TOKEN_PREFIX=agpk  # Default prefix for tokens
+export PAT_MAX_EXPIRY_DAYS=365  # Maximum token validity
+```
+
+## Testing
+
+```bash
+# Test without PAT (should fail for protected routes)
+curl http://gateway/protected/endpoint
+# Returns: 401 Unauthorized
+
+# Test with PAT token
+curl -H "Authorization: Bearer agpk_YOUR_TOKEN" http://gateway/protected/endpoint
+# Returns: Success
+
+# Test public endpoint (no PAT needed)
+curl http://gateway/public/endpoint
+# Returns: Success
+```

--- a/examples/pat/pat-ai-routes.yaml
+++ b/examples/pat/pat-ai-routes.yaml
@@ -1,0 +1,52 @@
+# Example: Automatically require PAT for AI/LLM routes
+# 
+# Set environment variables:
+#   PAT_ENABLED=true
+#   PAT_REQUIRE_FOR_AI_ROUTES=true
+#
+# This configuration will automatically require PAT authentication
+# for routes that appear to be AI endpoints (openai, anthropic, etc.)
+
+binds:
+  - name: "main"
+    port: 8080
+    listeners:
+      - name: "api"
+        hostnames: ["*"]
+        routes:
+          # These routes will automatically require PAT when
+          # PAT_REQUIRE_FOR_AI_ROUTES=true is set
+          - name: "openai-chat"
+            hostnames: ["*"]
+            matches:
+              - path:
+                  prefix: "/openai/v1/chat/completions"
+            backends:
+              - backend:
+                  ai:
+                    provider: "openai"
+                    
+          - name: "anthropic-messages"
+            hostnames: ["*"]
+            matches:
+              - path:
+                  prefix: "/anthropic/v1/messages"
+            backends:
+              - backend:
+                  ai:
+                    provider: "anthropic"
+                    
+          # This non-AI route won't require PAT
+          - name: "health"
+            hostnames: ["*"]
+            matches:
+              - path:
+                  exact: "/health"
+            backends:
+              - backend:
+                  upstream:
+                    host: "health-service"
+                    port: 8080
+
+# Note: No need to explicitly set `pat: true` on each route.
+# The PAT_REQUIRE_FOR_AI_ROUTES environment variable handles it dynamically.

--- a/examples/pat/pat-route-patterns.yaml
+++ b/examples/pat/pat-route-patterns.yaml
@@ -1,0 +1,58 @@
+# Example: Require PAT for specific route patterns
+#
+# Set environment variables:
+#   PAT_ENABLED=true
+#   PAT_REQUIRED_ROUTE_PATTERNS="admin*,internal/*,v2/api/*"
+#
+# This will require PAT authentication for:
+# - Any route starting with "admin"
+# - Any route starting with "internal/"
+# - Any route starting with "v2/api/"
+
+binds:
+  - name: "main"
+    port: 8080
+    listeners:
+      - name: "api"
+        hostnames: ["*"]
+        routes:
+          # Will require PAT (matches "admin*" pattern)
+          - name: "admin-users"
+            hostnames: ["*"]
+            matches:
+              - path:
+                  prefix: "/admin/users"
+            backends:
+              - backend:
+                  upstream:
+                    host: "admin-service"
+                    port: 8080
+                    
+          # Will require PAT (matches "admin*" pattern)
+          - name: "admin-config"
+            hostnames: ["*"]
+            matches:
+              - path:
+                  prefix: "/admin/config"
+            backends:
+              - backend:
+                  upstream:
+                    host: "admin-service"
+                    port: 8080
+                    
+          # Will NOT require PAT (doesn't match any pattern)
+          - name: "public-api"
+            hostnames: ["*"]
+            matches:
+              - path:
+                  prefix: "/api/v1/public"
+            backends:
+              - backend:
+                  upstream:
+                    host: "public-service"
+                    port: 8080
+
+# Testing:
+# curl -H "Authorization: Bearer agpk_YOUR_TOKEN" http://gateway/admin/users  # Works
+# curl http://gateway/admin/users  # Returns 401
+# curl http://gateway/api/v1/public  # Works without PAT

--- a/schema/001_create_proxy_keys.sql
+++ b/schema/001_create_proxy_keys.sql
@@ -1,0 +1,37 @@
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS proxy_keys (
+  id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id        TEXT NOT NULL DEFAULT 'default',
+  user_id          TEXT NOT NULL,
+  name             TEXT,
+  token_prefix     TEXT NOT NULL,
+  hash_algo        TEXT NOT NULL DEFAULT 'argon2id',
+  hash_params      JSONB NOT NULL DEFAULT '{}'::jsonb,
+  key_hash         TEXT NOT NULL,
+  scopes           TEXT[] NOT NULL DEFAULT '{}',
+  created_by       TEXT,
+  creator_email    TEXT,
+  creator_groups   TEXT[] NOT NULL DEFAULT '{}',
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+  last_used_at     TIMESTAMPTZ,
+  last_used_ip     INET,
+  expires_at       TIMESTAMPTZ,
+  revoked_at       TIMESTAMPTZ,
+  CONSTRAINT ux_proxy_keys_tenant_prefix UNIQUE (tenant_id, token_prefix),
+  CONSTRAINT ck_time_exp CHECK (expires_at IS NULL OR expires_at > created_at),
+  CONSTRAINT ck_time_rev CHECK (revoked_at IS NULL OR revoked_at > created_at),
+  CONSTRAINT ck_prefix_len CHECK (length(token_prefix)=24)
+);
+
+-- Ensure quick lookup by prefix (used for auth) and uniqueness to prevent duplicates.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_proxy_keys_token_prefix ON proxy_keys (token_prefix);
+CREATE INDEX IF NOT EXISTS idx_proxy_keys_tenant_user_created ON proxy_keys (tenant_id, user_id, created_at DESC);
+
+-- Argon2id parameters currently: m=65536 (64MiB), t=3, p=1 (see pat.rs argon2_instance())
+
+CREATE INDEX IF NOT EXISTS ix_proxy_keys_user ON proxy_keys(tenant_id, user_id);
+CREATE INDEX IF NOT EXISTS ix_proxy_keys_active ON proxy_keys(tenant_id) WHERE revoked_at IS NULL;
+CREATE INDEX IF NOT EXISTS ix_proxy_keys_last_used ON proxy_keys(last_used_at);
+CREATE INDEX IF NOT EXISTS idx_proxy_keys_creator_email_active ON proxy_keys(creator_email) WHERE revoked_at IS NULL;
+CREATE INDEX IF NOT EXISTS ix_proxy_keys_revoked_at ON proxy_keys(revoked_at) WHERE revoked_at IS NOT NULL;

--- a/ui/middleware.ts
+++ b/ui/middleware.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+// Redirect convenience: hitting the bare origin (/) goes to the UI basePath (/ui/)
+export function middleware(req: NextRequest) {
+  if (req.nextUrl.pathname === '/') {
+    const url = req.nextUrl.clone();
+    url.pathname = '/ui/';
+    return NextResponse.redirect(url);
+  }
+  return NextResponse.next();
+}
+
+// Apply only at root
+export const config = {
+  matcher: ['/'],
+};

--- a/ui/src/app/tokens/page.tsx
+++ b/ui/src/app/tokens/page.tsx
@@ -1,0 +1,276 @@
+"use client";
+import React, { useEffect, useState } from "react";
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { toast } from "sonner";
+import { formatDistanceToNow } from "date-fns";
+import { Loader2, Trash2, Copy, Shield } from "lucide-react";
+
+interface TokenRecord {
+  id: string; // internal only (not displayed directly)
+  token_prefix: string;
+  // scopes removed (currently unused); backend may omit field
+  created_at: string;
+  expires_at: string | null;
+  revoked_at: string | null;
+  last_used_at: string | null;
+}
+
+interface CreateResponse {
+  token: string;
+  token_record: TokenRecord;
+}
+
+export default function TokensPage() {
+  const [tokens, setTokens] = useState<TokenRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [creating, setCreating] = useState(false);
+  const [newExpiry, setNewExpiry] = useState("");
+  const [showToken, setShowToken] = useState<CreateResponse | null>(null);
+
+  const load = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/tokens", { credentials: "include" });
+      if (res.ok) {
+        const data = await res.json();
+        setTokens(data);
+      } else if (res.status === 401) {
+        toast.error("Authenticate to view tokens");
+      } else if (res.status === 503) {
+        toast.error("Token management unavailable (DB not configured)");
+      } else {
+        toast.error("Failed to load tokens");
+      }
+    } catch (e) {
+      console.error(e);
+      toast.error("Network error loading tokens");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const handleCreate = async () => {
+    setCreating(true);
+    try {
+      const body = {
+        expires_at: newExpiry ? new Date(newExpiry).toISOString() : null,
+      };
+      const res = await fetch("/api/tokens", {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (res.ok) {
+        const data: CreateResponse = await res.json();
+        setTokens((prev) => [data.token_record, ...prev]);
+        setShowToken(data);
+        setNewExpiry("");
+        toast.success("Token created");
+      } else if (res.status === 401) {
+        toast.error("Authenticate to create tokens");
+      } else if (res.status === 403) {
+        toast.error("Forbidden");
+      } else {
+        const err = await safeError(res);
+        toast.error(err || "Create failed");
+      }
+    } catch (e) {
+      console.error(e);
+      toast.error("Create failed");
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    try {
+      const res = await fetch(`/api/tokens/${id}`, { method: "DELETE", credentials: "include" });
+      if (res.status === 204) {
+        setTokens((prev) => prev.filter((t) => t.id !== id));
+        toast.success("Token revoked");
+      } else if (res.status === 401) {
+        toast.error("Authenticate to revoke token");
+      } else if (res.status === 403) {
+        toast.error("Forbidden");
+      } else {
+        toast.error("Revoke failed");
+      }
+    } catch (e) {
+      console.error(e);
+      toast.error("Revoke failed");
+    }
+  };
+
+  const copy = (value: string) => {
+    navigator.clipboard.writeText(value);
+    toast.success("Copied");
+  };
+
+  return (
+    <div className="container mx-auto py-8 px-4 space-y-8">
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Shield className="h-5 w-5" /> Personal Access Tokens
+          </CardTitle>
+          <CardDescription>
+            Manage scoped access tokens. Prefixes only; full secret shown once at creation.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="flex flex-col md:flex-row gap-4 items-end">
+            <div>
+              <label className="block text-sm font-medium mb-1">Expires At (optional)</label>
+              <Input
+                type="datetime-local"
+                value={newExpiry}
+                onChange={(e) => setNewExpiry(e.target.value)}
+              />
+            </div>
+            <Button onClick={handleCreate} disabled={creating}>
+              {creating && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}Create
+            </Button>
+          </div>
+
+          {loading ? (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" /> Loading tokens...
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Prefix</TableHead>
+                    <TableHead>Created</TableHead>
+                    <TableHead>Last Used</TableHead>
+                    <TableHead>Expires</TableHead>
+                    <TableHead>Status</TableHead>
+                    <TableHead className="w-24">Actions</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {tokens.map((t) => (
+                    <TableRow key={t.id} className={t.revoked_at ? "opacity-60" : ""}>
+                      <TableCell className="font-mono text-xs">{t.token_prefix}</TableCell>
+                      <TableCell className="text-xs">
+                        {formatDistanceToNow(new Date(t.created_at), { addSuffix: true })}
+                      </TableCell>
+                      <TableCell className="text-xs">
+                        {t.last_used_at
+                          ? formatDistanceToNow(new Date(t.last_used_at), { addSuffix: true })
+                          : "—"}
+                      </TableCell>
+                      <TableCell className="text-xs">
+                        {t.expires_at
+                          ? formatDistanceToNow(new Date(t.expires_at), { addSuffix: true })
+                          : "—"}
+                      </TableCell>
+                      <TableCell className="text-xs">
+                        {t.revoked_at
+                          ? "Revoked"
+                          : t.expires_at && new Date(t.expires_at) < new Date()
+                            ? "Expired"
+                            : "Active"}
+                      </TableCell>
+                      <TableCell className="flex gap-2">
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => copy(t.token_prefix)}
+                          title="Copy prefix"
+                        >
+                          <Copy className="h-3 w-3" />
+                        </Button>
+                        {!t.revoked_at && (
+                          <Button
+                            variant="destructive"
+                            size="sm"
+                            onClick={() => handleDelete(t.id)}
+                            title="Revoke"
+                          >
+                            <Trash2 className="h-3 w-3" />
+                          </Button>
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                  {tokens.length === 0 && !loading && (
+                    <TableRow>
+                      <TableCell colSpan={7} className="text-center text-sm text-muted-foreground">
+                        No tokens
+                      </TableCell>
+                    </TableRow>
+                  )}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Dialog open={!!showToken} onOpenChange={(o) => !o && setShowToken(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Copy your token now</DialogTitle>
+            <DialogDescription>
+              This is the only time the full token will be shown. Store it securely.
+            </DialogDescription>
+          </DialogHeader>
+          {showToken && (
+            <div className="space-y-3">
+              <div>
+                <label className="text-xs font-medium">Full Token</label>
+                <div className="mt-1 p-2 bg-muted rounded font-mono text-xs break-all">
+                  {showToken.token}
+                </div>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="mt-2"
+                  onClick={() => copy(showToken.token)}
+                >
+                  Copy Token
+                </Button>
+              </div>
+              <div className="text-xs text-muted-foreground">
+                Prefix: {showToken.token_record.token_prefix}
+              </div>
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+async function safeError(res: Response): Promise<string | null> {
+  try {
+    const data = await res.json();
+    return data.error || null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
This implements PAT functionality (commonly referred to as virtual keys in the AI gateway space) 

I've been using this for several weeks now in an enterprise-y environment. I'm sure there's improvements to be made, but it gets the job done. FWIW, I'm not a fan of long-lived static credentials, but it's a valuable convenience factor for the LLM side of the project.

Some random thoughts: 

- This introduces some heavy dependencies (postgres), so it's feature flagged. I made it a default in the `Dockerfile` but I can update that if needed. Argon is heavy and might be overkill here
- XDS + CEL could make this significantly better. I've exposed environment variables, but ideally... this gets ported into Kgateway
- Maintainers of the project should probably decide on how the UI should/can be used (I personally feel like people expect it to be more than a "troubleshooting UI" at this point)