### PR TITLE
Start invoking pii filters and improve regex masking

### DIFF
--- a/crates/agentgateway/src/llm/pii/mod.rs
+++ b/crates/agentgateway/src/llm/pii/mod.rs
@@ -28,7 +28,10 @@ pub static SSN: Lazy<Box<dyn Recognizer + Sync + Send + 'static>> =
 	Lazy::new(|| Box::new(us_ssn_recognizer::UsSsnRecognizer::new()));
 
 #[allow(clippy::borrowed_box)]
-pub fn recognizer(r: &Box<dyn Recognizer + Sync + Send + 'static>, text: &str) -> Vec<recognizer_result::RecognizerResult> {
+pub fn recognizer(
+	r: &Box<dyn Recognizer + Sync + Send + 'static>,
+	text: &str,
+) -> Vec<recognizer_result::RecognizerResult> {
 	r.recognize(text)
 }
 

--- a/crates/agentgateway/src/llm/pii/mod.rs
+++ b/crates/agentgateway/src/llm/pii/mod.rs
@@ -28,9 +28,8 @@ pub static SSN: Lazy<Box<dyn Recognizer + Sync + Send + 'static>> =
 	Lazy::new(|| Box::new(us_ssn_recognizer::UsSsnRecognizer::new()));
 
 #[allow(clippy::borrowed_box)]
-pub fn recognizer(r: &Box<dyn Recognizer + Sync + Send + 'static>, text: &str) {
-	let _results = r.recognize(text);
-	// TODO: actually return!
+pub fn recognizer(r: &Box<dyn Recognizer + Sync + Send + 'static>, text: &str) -> Vec<recognizer_result::RecognizerResult> {
+	r.recognize(text)
 }
 
 #[cfg(test)]

--- a/crates/agentgateway/src/llm/pii/phone_recognizer.rs
+++ b/crates/agentgateway/src/llm/pii/phone_recognizer.rs
@@ -61,7 +61,7 @@ impl Recognizer for PhoneRecognizer {
 			results.sort_by_key(|r| (r.start, r.end));
 			let mut merged = Vec::new();
 			let mut current = results[0].clone();
-			
+
 			for result in results.into_iter().skip(1) {
 				// Check if overlapping or adjacent (within 1 character)
 				if result.start <= current.end + 1 {

--- a/crates/agentgateway/src/llm/pii/phone_recognizer.rs
+++ b/crates/agentgateway/src/llm/pii/phone_recognizer.rs
@@ -1,3 +1,4 @@
+use once_cell::sync::Lazy;
 use phonenumber::{country, parse};
 use regex::Regex;
 
@@ -21,65 +22,76 @@ impl PhoneRecognizer {
 
 impl Recognizer for PhoneRecognizer {
 	fn recognize(&self, text: &str) -> Vec<RecognizerResult> {
-		let mut results = Vec::new();
-		// For each region, try to find phone numbers
-		for &region in &self.regions {
-			// phonenumber::parse requires a country code, so we use the region
-			let country = match region {
-				"US" => country::US,
-				"GB" => country::GB,
-				"DE" => country::DE,
-				"IL" => country::IL,
-				"IN" => country::IN,
-				"CA" => country::CA,
-				"BR" => country::BR,
-				_ => continue,
-			};
-			// Use a sliding window to try to parse phone numbers from all substrings
-			// (phonenumber crate does not provide a matcher, so we use a heuristic)
-			for start in 0..text.len() {
-				for end in (start + 7)..=std::cmp::min(text.len(), start + 20) {
-					// phone numbers are usually 7-20 chars
-					// TODO: we currently match this for every substring basically
-					let candidate = &text[start..end];
-					if let Ok(number) = parse(Some(country), candidate)
-						&& number.is_valid()
-					{
-						results.push(RecognizerResult {
-							entity_type: "PHONE_NUMBER".to_string(),
-							matched: candidate.to_string(),
-							start,
-							end,
-							score: 0.7, // Higher score for library-validated
-						});
-					}
-				}
-			}
-		}
-		// Merge overlapping and adjacent matches
-		if !results.is_empty() {
-			results.sort_by_key(|r| (r.start, r.end));
-			let mut merged = Vec::new();
-			let mut current = results[0].clone();
+		static CANDIDATE_RE: Lazy<Regex> =
+			Lazy::new(|| Regex::new(r"(?i)(^|[^0-9])([+()]?[0-9][0-9\s().\-]{6,30})").unwrap());
 
-			for result in results.into_iter().skip(1) {
-				// Check if overlapping or adjacent (within 1 character)
-				if result.start <= current.end + 1 {
-					current.end = current.end.max(result.end);
-					if current.start < text.len() && current.end <= text.len() {
-						current.matched = text[current.start..current.end].to_string();
+		// Map region strings once.
+		fn to_country(code: &str) -> Option<country::Id> {
+			match code {
+				"US" => Some(country::US),
+				"CA" => Some(country::CA),
+				"GB" => Some(country::GB),
+				"DE" => Some(country::DE),
+				"IL" => Some(country::IL),
+				"IN" => Some(country::IN),
+				"BR" => Some(country::BR),
+				_ => None,
+			}
+		}
+
+		let mut results = Vec::new();
+
+		for caps in CANDIDATE_RE.captures_iter(text) {
+			let m = caps.get(2).unwrap();
+			let mut best: Option<RecognizerResult> = None;
+
+			for &region in &self.regions {
+				let Some(country) = to_country(region) else {
+					continue;
+				};
+				let candidate = m.as_str();
+
+				if let Ok(num) = parse(Some(country), candidate) {
+					if !num.is_valid() {
+						continue;
 					}
-				} else {
-					merged.push(current);
-					current = result;
+
+					// prefer longer matches
+					let digit_count = candidate.chars().filter(|c| c.is_ascii_digit()).count();
+					let score = 0.6_f32 + (digit_count.min(15) as f32) / 100.0;
+
+					let res = RecognizerResult {
+						entity_type: "PHONE_NUMBER".to_string(),
+						matched: candidate.to_string(),
+						start: m.start(),
+						end: m.end(),
+						score,
+					};
+
+					best = match best {
+						Some(prev) => {
+							let prev_digits = prev.matched.chars().filter(|c| c.is_ascii_digit()).count();
+							if digit_count > prev_digits || (digit_count == prev_digits && score > prev.score) {
+								Some(res)
+							} else {
+								Some(prev)
+							}
+						},
+						None => Some(res),
+					};
 				}
 			}
-			merged.push(current);
-			merged
-		} else {
-			results
+
+			if let Some(r) = best {
+				results.push(r);
+			}
 		}
+
+		results.sort_by_key(|r| (r.start, r.end, r.matched.clone()));
+		results.dedup_by(|a, b| a.start == b.start && a.end == b.end && a.matched == b.matched);
+		results
 	}
+
 	fn name(&self) -> &str {
 		"PHONE_NUMBER"
 	}

--- a/crates/agentgateway/src/llm/policy.rs
+++ b/crates/agentgateway/src/llm/policy.rs
@@ -165,23 +165,23 @@ impl Policy {
 			let Some(original_content) = universal::message_text(msg) else {
 				continue;
 			};
-			
+
 			if let Some(rgx) = &g.regex {
 				let mut current_content = original_content.to_string();
 				let mut content_modified = false;
-				
+
 				// Process each rule sequentially, updating the content as we go
 				for r in &rgx.rules {
 					match r {
 						RegexRule::Builtin { builtin } => {
 							let rec = match builtin {
-								Builtin::Ssn         => &*pii::SSN,
-								Builtin::CreditCard  => &*pii::CC,
+								Builtin::Ssn => &*pii::SSN,
+								Builtin::CreditCard => &*pii::CC,
 								Builtin::PhoneNumber => &*pii::PHONE,
-								Builtin::Email       => &*pii::EMAIL,
+								Builtin::Email => &*pii::EMAIL,
 							};
 							let results = pii::recognizer(rec, &current_content);
-							
+
 							if !results.is_empty() {
 								match &rgx.action {
 									Action::Reject { response } => {
@@ -191,11 +191,11 @@ impl Policy {
 										// Sort in reverse to avoid index shifting during replacement
 										let mut sorted_results = results;
 										sorted_results.sort_by(|a, b| b.start.cmp(&a.start));
-										
+
 										for result in sorted_results {
 											current_content.replace_range(
-												result.start..result.end, 
-												&format!("<{}>", result.entity_type.to_uppercase())
+												result.start..result.end,
+												&format!("<{}>", result.entity_type.to_uppercase()),
 											);
 										}
 										content_modified = true;
@@ -204,11 +204,11 @@ impl Policy {
 							}
 						},
 						RegexRule::Regex { pattern, name } => {
-							let ranges: Vec<std::ops::Range<usize>> =
-							pattern.find_iter(&current_content)
-								   .map(|m| m.range())
-								   .collect();
-							
+							let ranges: Vec<std::ops::Range<usize>> = pattern
+								.find_iter(&current_content)
+								.map(|m| m.range())
+								.collect();
+
 							if !ranges.is_empty() {
 								match &rgx.action {
 									Action::Reject { response } => {
@@ -220,14 +220,13 @@ impl Policy {
 											current_content.replace_range(range, &format!("<{name}>"));
 										}
 										content_modified = true;
-						
 									},
 								}
 							}
 						},
 					}
 				}
-				
+
 				// Only update the message if content was actually modified
 				if content_modified {
 					*msg = Self::convert_message(Message {

--- a/crates/agentgateway/src/llm/policy.rs
+++ b/crates/agentgateway/src/llm/policy.rs
@@ -1,5 +1,3 @@
-use std::ops::Deref;
-
 use ::http::HeaderMap;
 use async_openai::types::{ChatCompletionRequestMessage, CreateChatCompletionRequest};
 use bytes::Bytes;
@@ -164,52 +162,78 @@ impl Policy {
 			}
 		}
 		for msg in &mut req.messages {
-			let content = {
-				let Some(content) = universal::message_text(msg) else {
-					continue;
-				};
-				content.to_string()
+			let Some(original_content) = universal::message_text(msg) else {
+				continue;
 			};
+			
 			if let Some(rgx) = &g.regex {
+				let mut current_content = original_content.to_string();
+				let mut content_modified = false;
+				
+				// Process each rule sequentially, updating the content as we go
 				for r in &rgx.rules {
 					match r {
 						RegexRule::Builtin { builtin } => {
-							let results = match builtin {
-								Builtin::Ssn => pii::recognizer(pii::SSN.deref(), &content),
-								Builtin::CreditCard => pii::recognizer(pii::CC.deref(), &content),
-								Builtin::PhoneNumber => pii::recognizer(pii::PHONE.deref(), &content),
-								Builtin::Email => pii::recognizer(pii::EMAIL.deref(), &content),
+							let rec = match builtin {
+								Builtin::Ssn         => &*pii::SSN,
+								Builtin::CreditCard  => &*pii::CC,
+								Builtin::PhoneNumber => &*pii::PHONE,
+								Builtin::Email       => &*pii::EMAIL,
 							};
+							let results = pii::recognizer(rec, &current_content);
 							
 							if !results.is_empty() {
-								if let Action::Reject { response } = &rgx.action {
-									return Ok(Some(response.as_response()));
+								match &rgx.action {
+									Action::Reject { response } => {
+										return Ok(Some(response.as_response()));
+									},
+									Action::Mask => {
+										// Sort in reverse to avoid index shifting during replacement
+										let mut sorted_results = results;
+										sorted_results.sort_by(|a, b| b.start.cmp(&a.start));
+										
+										for result in sorted_results {
+											current_content.replace_range(
+												result.start..result.end, 
+												&format!("<{}>", result.entity_type.to_uppercase())
+											);
+										}
+										content_modified = true;
+									},
 								}
-								
-								let mut new_content = content.clone();
-								for result in results.iter().rev() {
-									new_content.replace_range(result.start..result.end, &format!("<{}>", result.entity_type));
-								}
-								*msg = Self::convert_message(Message {
-									role: universal::message_role(msg).to_string(),
-									content: new_content,
-								});
 							}
 						},
 						RegexRule::Regex { pattern, name } => {
-							if let Some(m) = pattern.find(&content) {
-								if let Action::Reject { response } = &rgx.action {
-									return Ok(Some(response.as_response()));
+							let ranges: Vec<std::ops::Range<usize>> =
+							pattern.find_iter(&current_content)
+								   .map(|m| m.range())
+								   .collect();
+							
+							if !ranges.is_empty() {
+								match &rgx.action {
+									Action::Reject { response } => {
+										return Ok(Some(response.as_response()));
+									},
+									Action::Mask => {
+										// Process matches in reverse order to avoid index shifting
+										for range in ranges.into_iter().rev() {
+											current_content.replace_range(range, &format!("<{name}>"));
+										}
+										content_modified = true;
+						
+									},
 								}
-								let mut new_content = content.to_string();
-								new_content.replace_range(m.range(), &format!("<{name}>"));
-								*msg = Self::convert_message(Message {
-									role: universal::message_role(msg).to_string(),
-									content: new_content,
-								});
 							}
 						},
 					}
+				}
+				
+				// Only update the message if content was actually modified
+				if content_modified {
+					*msg = Self::convert_message(Message {
+						role: universal::message_role(msg).to_string(),
+						content: current_content,
+					});
 				}
 			}
 		}


### PR DESCRIPTION
Initially I set out to start invoking the builtin PII regex rules so that they could be used, since they are now configurable via XDS, but realized this required a number of changes.

This PR:

1. Uses the builtin PII recognizers
2. Explicitly checks for the mask action to be set before doing masking. Theoretically we don't really need to, but IMO it makes it way easier to follow.
3. Fixes a bug in custom regex pattern masking where only the first instance of a pattern was replaced
4. Updates the content string as it is being masked to avoid having to deal with potentially overlapping merges later. (I did consider calculating all the matches up front, then merging overlapping matches before applying all at once, but it didn't seem worth the overhead/complexity). Even if we decide the PII stuff is not ready ATM we should be doing some version of this since otherwise an llm policy w/ multiple custom regexes in a single policy is not going to mask correctly.
5. Improves the de-duplication we are doing with the phone recognizer builtin. It is still kind of janky and starts matches way too early sometimes from what i've been able to test, but IMO it's better than what we had before.

closes the PII/regex gaps in https://github.com/kgateway-dev/kgateway/issues/11847

