### PR TITLE
fix: add serialization to rate limit config

### DIFF
--- a/crates/agentgateway/src/http/localratelimit.rs
+++ b/crates/agentgateway/src/http/localratelimit.rs
@@ -22,6 +22,10 @@ impl serde::Serialize for RateLimit {
 	where
 		S: serde::Serializer,
 	{
+		let mut map = serializer.serialize_map(Some(4))?;
+		map.serialize_entry("type", &self.limit_type)?;
+		map.serialize_entry("maxTokens", &self.max_tokens)?;
+		map.serialize_entry("tokensPerFill", &self.tokens_per_fill)?;
 		map.serialize_entry("fillInterval", &(self.fill_interval.as_secs().to_string() + "s"))?;
 		map.end()
 	}

--- a/crates/agentgateway/src/http/localratelimit.rs
+++ b/crates/agentgateway/src/http/localratelimit.rs
@@ -22,11 +22,7 @@ impl serde::Serialize for RateLimit {
 	where
 		S: serde::Serializer,
 	{
-		let mut map = serializer.serialize_map(Some(4))?;
-		map.serialize_entry("type", &self.limit_type)?;
-		map.serialize_entry("maxTokens", &self.max_tokens)?;
-		map.serialize_entry("tokensPerFill", &self.tokens_per_fill)?;
-		map.serialize_entry("fillInterval", &format!("{}s", self.fill_interval.as_secs()))?;
+		map.serialize_entry("fillInterval", &(self.fill_interval.as_secs().to_string() + "s"))?;
 		map.end()
 	}
 }

--- a/crates/agentgateway/src/proxy/gateway_test.rs
+++ b/crates/agentgateway/src/proxy/gateway_test.rs
@@ -70,7 +70,7 @@ async fn local_ratelimit() {
 		name: strng::new("rl"),
 		target: PolicyTarget::Route("route".into()),
 		policy: Policy::LocalRateLimit(vec![
-			http::localratelimit::RateLimitSerde {
+			http::localratelimit::RateLimitSpec {
 				max_tokens: 1,
 				tokens_per_fill: 1,
 				fill_interval: Duration::from_secs(1),

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -114,7 +114,7 @@ impl From<RoutePolicies> for LLMRequestPolicies {
 			local_rate_limit: value
 				.local_rate_limit
 				.iter()
-				.filter(|r| r.limit_type == http::localratelimit::RateLimitType::Tokens)
+				.filter(|r| r.spec.limit_type == http::localratelimit::RateLimitType::Tokens)
 				.cloned()
 				.collect(),
 			llm: value.llm.clone(),

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -604,7 +604,7 @@ impl TryFrom<&proto::agent::PolicySpec> for Policy {
 			Some(proto::agent::policy_spec::Kind::LocalRateLimit(lrl)) => {
 				let t = proto::agent::policy_spec::local_rate_limit::Type::try_from(lrl.r#type)?;
 				Policy::LocalRateLimit(vec![
-					localratelimit::RateLimitSerde {
+					localratelimit::RateLimitSpec {
 						max_tokens: lrl.max_tokens,
 						tokens_per_fill: lrl.tokens_per_fill,
 						fill_interval: lrl


### PR DESCRIPTION
Local rate limit needs to be included in `<IP>:15000/config_dump`

before the change:
```
 {
                  "localRateLimit": [
                    {}
                  ]
                }
```
after the change:
```
  {
                  "localRateLimit": [
                    {
                      "type": "requests",
                      "maxTokens": 10,
                      "tokensPerFill": 1,
                      "fillInterval": "60s"
                    }
                  ]
                }
```