### PR TITLE
jwt: support multiple JWT providers in jwtAuth Policy

### DIFF
--- a/crates/agentgateway/src/http/jwt.rs
+++ b/crates/agentgateway/src/http/jwt.rs
@@ -57,6 +57,12 @@ pub enum JwkError {
 #[derive(Clone)]
 pub struct Jwt {
 	mode: Mode,
+	providers: Vec<Provider>,
+}
+
+#[derive(Clone)]
+struct Provider {
+	issuer: String,
 	keys: HashMap<String, Jwk>,
 }
 
@@ -69,10 +75,28 @@ impl serde::Serialize for Jwt {
 		#[derive(serde::Serialize)]
 		pub struct Serde<'a> {
 			mode: Mode,
-			keys: Vec<&'a str>,
+			providers: &'a Vec<Provider>,
 		}
 		Serde {
 			mode: self.mode,
+			providers: &self.providers,
+		}
+		.serialize(serializer)
+	}
+}
+
+impl serde::Serialize for Provider {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: serde::Serializer,
+	{
+		#[derive(serde::Serialize)]
+		pub struct Serde<'a> {
+			issuer: &'a str,
+			keys: Vec<&'a str>,
+		}
+		Serde {
+			issuer: &self.issuer,
 			keys: self.keys.keys().map(|x| x.as_str()).collect::<Vec<_>>(),
 		}
 		.serialize(serializer)
@@ -86,11 +110,27 @@ impl Debug for Jwt {
 }
 
 #[derive(Debug, Clone, serde::Deserialize)]
+#[serde(untagged, rename_all = "camelCase", deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+pub enum LocalJwtConfig {
+	Multi {
+		#[serde(default)]
+		mode: Mode,
+		providers: Vec<ProviderConfig>,
+	},
+	Single {
+		#[serde(default)]
+		mode: Mode,
+		issuer: String,
+		audiences: Vec<String>,
+		jwks: serdes::FileInlineOrRemote,
+	},
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
-pub struct LocalJwtConfig {
-	#[serde(default)]
-	pub mode: Mode,
+pub struct ProviderConfig {
 	pub issuer: String,
 	pub audiences: Vec<String>,
 	pub jwks: serdes::FileInlineOrRemote,
@@ -114,23 +154,43 @@ pub enum Mode {
 
 impl LocalJwtConfig {
 	pub async fn try_into(self, client: Client) -> Result<Jwt, JwkError> {
-		let jwks: JwkSet = self
-			.jwks
-			.load::<JwkSet>(client)
-			.await
-			.map_err(JwkError::JwkLoadError)?;
+		let (mode, providers_cfg) = match self {
+			LocalJwtConfig::Multi { mode, providers } => (mode, providers),
+			LocalJwtConfig::Single {
+				mode,
+				issuer,
+				audiences,
+				jwks,
+			} => (
+				mode,
+				vec![ProviderConfig {
+					issuer,
+					audiences,
+					jwks,
+				}],
+			),
+		};
 
-		Jwt::from_jwks(jwks, self.mode, self.issuer, self.audiences)
+		let mut providers = Vec::with_capacity(providers_cfg.len());
+		for pc in providers_cfg {
+			let jwks: JwkSet = pc
+				.jwks
+				.load::<JwkSet>(client.clone())
+				.await
+				.map_err(JwkError::JwkLoadError)?;
+			let provider = Provider::from_jwks(jwks, pc.issuer, pc.audiences)?;
+			providers.push(provider);
+		}
+		Ok(Jwt { mode, providers })
 	}
 }
 
-impl Jwt {
+impl Provider {
 	pub fn from_jwks(
 		jwks: JwkSet,
-		mode: Mode,
 		issuer: String,
 		audiences: Vec<String>,
-	) -> Result<Jwt, JwkError> {
+	) -> Result<Provider, JwkError> {
 		let mut keys = HashMap::new();
 		let to_supported_alg = |key_algorithm: Option<KeyAlgorithm>| match key_algorithm {
 			Some(key_alg) => jsonwebtoken::Algorithm::from_str(key_alg.to_string().as_str()).ok(),
@@ -179,7 +239,22 @@ impl Jwt {
 			}
 		}
 
-		Ok(Jwt { mode, keys })
+		Ok(Provider { issuer, keys })
+	}
+}
+
+impl Jwt {
+	pub fn from_jwks(
+		jwks: JwkSet,
+		mode: Mode,
+		issuer: String,
+		audiences: Vec<String>,
+	) -> Result<Jwt, JwkError> {
+		let provider = Provider::from_jwks(jwks, issuer, audiences)?;
+		Ok(Jwt {
+			mode,
+			providers: vec![provider],
+		})
 	}
 }
 
@@ -251,7 +326,16 @@ impl Jwt {
 			TokenError::MissingKeyId
 		})?;
 
-		let key = self.keys.get(kid).ok_or_else(|| {
+		// Search for the key across all providers
+		let mut key_found = None;
+		for provider in &self.providers {
+			if let Some(key) = provider.keys.get(kid) {
+				key_found = Some(key);
+				break;
+			}
+		}
+
+		let key = key_found.ok_or_else(|| {
 			debug!(%kid, "Token refers to an unknown key.");
 
 			TokenError::UnknownKeyId(kid.to_owned())

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -1068,7 +1068,7 @@ pub struct McpAuthentication {
 
 impl McpAuthentication {
 	pub fn as_jwt(&self) -> anyhow::Result<http::jwt::LocalJwtConfig> {
-		Ok(http::jwt::LocalJwtConfig {
+		Ok(http::jwt::LocalJwtConfig::Single {
 			mode: http::jwt::Mode::Optional,
 			issuer: self.issuer.clone(),
 			audiences: vec![self.audience.clone()],

--- a/schema/README.md
+++ b/schema/README.md
@@ -212,12 +212,19 @@ This folder contains JSON schemas for various parts of the project
 |`binds[].listeners[].routes[].policies.remoteRateLimit.(any)(1)service.port`||
 |`binds[].listeners[].routes[].policies.remoteRateLimit.(any)(1)host`||
 |`binds[].listeners[].routes[].policies.jwtAuth`|Authenticate incoming JWT requests.|
-|`binds[].listeners[].routes[].policies.jwtAuth.mode`||
-|`binds[].listeners[].routes[].policies.jwtAuth.issuer`||
-|`binds[].listeners[].routes[].policies.jwtAuth.audiences`||
-|`binds[].listeners[].routes[].policies.jwtAuth.jwks`||
-|`binds[].listeners[].routes[].policies.jwtAuth.jwks.(any)file`||
-|`binds[].listeners[].routes[].policies.jwtAuth.jwks.(any)url`||
+|`binds[].listeners[].routes[].policies.jwtAuth.(any)(any)mode`||
+|`binds[].listeners[].routes[].policies.jwtAuth.(any)(any)providers`||
+|`binds[].listeners[].routes[].policies.jwtAuth.(any)(any)providers[].issuer`||
+|`binds[].listeners[].routes[].policies.jwtAuth.(any)(any)providers[].audiences`||
+|`binds[].listeners[].routes[].policies.jwtAuth.(any)(any)providers[].jwks`||
+|`binds[].listeners[].routes[].policies.jwtAuth.(any)(any)providers[].jwks.(any)file`||
+|`binds[].listeners[].routes[].policies.jwtAuth.(any)(any)providers[].jwks.(any)url`||
+|`binds[].listeners[].routes[].policies.jwtAuth.(any)(any)mode`||
+|`binds[].listeners[].routes[].policies.jwtAuth.(any)(any)issuer`||
+|`binds[].listeners[].routes[].policies.jwtAuth.(any)(any)audiences`||
+|`binds[].listeners[].routes[].policies.jwtAuth.(any)(any)jwks`||
+|`binds[].listeners[].routes[].policies.jwtAuth.(any)(any)jwks.(any)file`||
+|`binds[].listeners[].routes[].policies.jwtAuth.(any)(any)jwks.(any)url`||
 |`binds[].listeners[].routes[].policies.extAuthz`|Authenticate incoming requests by calling an external authorization server.|
 |`binds[].listeners[].routes[].policies.extAuthz.(any)(1)service`||
 |`binds[].listeners[].routes[].policies.extAuthz.(any)(1)service.name`||
@@ -456,12 +463,19 @@ This folder contains JSON schemas for various parts of the project
 |`policies[].policy.remoteRateLimit.(any)(1)service.port`||
 |`policies[].policy.remoteRateLimit.(any)(1)host`||
 |`policies[].policy.jwtAuth`|Authenticate incoming JWT requests.|
-|`policies[].policy.jwtAuth.mode`||
-|`policies[].policy.jwtAuth.issuer`||
-|`policies[].policy.jwtAuth.audiences`||
-|`policies[].policy.jwtAuth.jwks`||
-|`policies[].policy.jwtAuth.jwks.(any)file`||
-|`policies[].policy.jwtAuth.jwks.(any)url`||
+|`policies[].policy.jwtAuth.(any)(any)mode`||
+|`policies[].policy.jwtAuth.(any)(any)providers`||
+|`policies[].policy.jwtAuth.(any)(any)providers[].issuer`||
+|`policies[].policy.jwtAuth.(any)(any)providers[].audiences`||
+|`policies[].policy.jwtAuth.(any)(any)providers[].jwks`||
+|`policies[].policy.jwtAuth.(any)(any)providers[].jwks.(any)file`||
+|`policies[].policy.jwtAuth.(any)(any)providers[].jwks.(any)url`||
+|`policies[].policy.jwtAuth.(any)(any)mode`||
+|`policies[].policy.jwtAuth.(any)(any)issuer`||
+|`policies[].policy.jwtAuth.(any)(any)audiences`||
+|`policies[].policy.jwtAuth.(any)(any)jwks`||
+|`policies[].policy.jwtAuth.(any)(any)jwks.(any)file`||
+|`policies[].policy.jwtAuth.(any)(any)jwks.(any)url`||
 |`policies[].policy.extAuthz`|Authenticate incoming requests by calling an external authorization server.|
 |`policies[].policy.extAuthz.(any)(1)service`||
 |`policies[].policy.extAuthz.(any)(1)service.name`||

--- a/schema/local.json
+++ b/schema/local.json
@@ -1866,75 +1866,164 @@
                           },
                           "jwtAuth": {
                             "description": "Authenticate incoming JWT requests.",
-                            "type": [
-                              "object",
-                              "null"
-                            ],
-                            "properties": {
-                              "mode": {
-                                "oneOf": [
-                                  {
-                                    "description": "A valid token, issued by a configured issuer, must be present.",
-                                    "type": "string",
-                                    "const": "strict"
-                                  },
-                                  {
-                                    "description": "If a token exists, validate it.\nThis is the default option.\nWarning: this allows requests without a JWT token!",
-                                    "type": "string",
-                                    "const": "optional"
-                                  },
-                                  {
-                                    "description": "Requests are never rejected. This is useful for usage of claims in later steps (authorization, logging, etc).\nWarning: this allows requests without a JWT token!",
-                                    "type": "string",
-                                    "const": "permissive"
-                                  }
-                                ],
-                                "default": "optional"
-                              },
-                              "issuer": {
-                                "type": "string"
-                              },
-                              "audiences": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                }
-                              },
-                              "jwks": {
+                            "anyOf": [
+                              {
                                 "anyOf": [
                                   {
                                     "type": "object",
                                     "properties": {
-                                      "file": {
-                                        "type": "string"
+                                      "mode": {
+                                        "oneOf": [
+                                          {
+                                            "description": "A valid token, issued by a configured issuer, must be present.",
+                                            "type": "string",
+                                            "const": "strict"
+                                          },
+                                          {
+                                            "description": "If a token exists, validate it.\nThis is the default option.\nWarning: this allows requests without a JWT token!",
+                                            "type": "string",
+                                            "const": "optional"
+                                          },
+                                          {
+                                            "description": "Requests are never rejected. This is useful for usage of claims in later steps (authorization, logging, etc).\nWarning: this allows requests without a JWT token!",
+                                            "type": "string",
+                                            "const": "permissive"
+                                          }
+                                        ],
+                                        "default": "optional"
+                                      },
+                                      "providers": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "issuer": {
+                                              "type": "string"
+                                            },
+                                            "audiences": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "jwks": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "file": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "file"
+                                                  ]
+                                                },
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "url": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "url"
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "additionalProperties": false,
+                                          "required": [
+                                            "issuer",
+                                            "audiences",
+                                            "jwks"
+                                          ]
+                                        }
                                       }
                                     },
+                                    "additionalProperties": false,
                                     "required": [
-                                      "file"
+                                      "providers"
                                     ]
-                                  },
-                                  {
-                                    "type": "string"
                                   },
                                   {
                                     "type": "object",
                                     "properties": {
-                                      "url": {
+                                      "mode": {
+                                        "oneOf": [
+                                          {
+                                            "description": "A valid token, issued by a configured issuer, must be present.",
+                                            "type": "string",
+                                            "const": "strict"
+                                          },
+                                          {
+                                            "description": "If a token exists, validate it.\nThis is the default option.\nWarning: this allows requests without a JWT token!",
+                                            "type": "string",
+                                            "const": "optional"
+                                          },
+                                          {
+                                            "description": "Requests are never rejected. This is useful for usage of claims in later steps (authorization, logging, etc).\nWarning: this allows requests without a JWT token!",
+                                            "type": "string",
+                                            "const": "permissive"
+                                          }
+                                        ],
+                                        "default": "optional"
+                                      },
+                                      "issuer": {
                                         "type": "string"
+                                      },
+                                      "audiences": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "jwks": {
+                                        "anyOf": [
+                                          {
+                                            "type": "object",
+                                            "properties": {
+                                              "file": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "file"
+                                            ]
+                                          },
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "object",
+                                            "properties": {
+                                              "url": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "url"
+                                            ]
+                                          }
+                                        ]
                                       }
                                     },
+                                    "additionalProperties": false,
                                     "required": [
-                                      "url"
+                                      "issuer",
+                                      "audiences",
+                                      "jwks"
                                     ]
                                   }
                                 ]
+                              },
+                              {
+                                "type": "null"
                               }
-                            },
-                            "additionalProperties": false,
-                            "required": [
-                              "issuer",
-                              "audiences",
-                              "jwks"
                             ]
                           },
                           "extAuthz": {
@@ -4180,75 +4269,164 @@
               },
               "jwtAuth": {
                 "description": "Authenticate incoming JWT requests.",
-                "type": [
-                  "object",
-                  "null"
-                ],
-                "properties": {
-                  "mode": {
-                    "oneOf": [
-                      {
-                        "description": "A valid token, issued by a configured issuer, must be present.",
-                        "type": "string",
-                        "const": "strict"
-                      },
-                      {
-                        "description": "If a token exists, validate it.\nThis is the default option.\nWarning: this allows requests without a JWT token!",
-                        "type": "string",
-                        "const": "optional"
-                      },
-                      {
-                        "description": "Requests are never rejected. This is useful for usage of claims in later steps (authorization, logging, etc).\nWarning: this allows requests without a JWT token!",
-                        "type": "string",
-                        "const": "permissive"
-                      }
-                    ],
-                    "default": "optional"
-                  },
-                  "issuer": {
-                    "type": "string"
-                  },
-                  "audiences": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "jwks": {
+                "anyOf": [
+                  {
                     "anyOf": [
                       {
                         "type": "object",
                         "properties": {
-                          "file": {
-                            "type": "string"
+                          "mode": {
+                            "oneOf": [
+                              {
+                                "description": "A valid token, issued by a configured issuer, must be present.",
+                                "type": "string",
+                                "const": "strict"
+                              },
+                              {
+                                "description": "If a token exists, validate it.\nThis is the default option.\nWarning: this allows requests without a JWT token!",
+                                "type": "string",
+                                "const": "optional"
+                              },
+                              {
+                                "description": "Requests are never rejected. This is useful for usage of claims in later steps (authorization, logging, etc).\nWarning: this allows requests without a JWT token!",
+                                "type": "string",
+                                "const": "permissive"
+                              }
+                            ],
+                            "default": "optional"
+                          },
+                          "providers": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "issuer": {
+                                  "type": "string"
+                                },
+                                "audiences": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "jwks": {
+                                  "anyOf": [
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "file": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "file"
+                                      ]
+                                    },
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "url": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "url"
+                                      ]
+                                    }
+                                  ]
+                                }
+                              },
+                              "additionalProperties": false,
+                              "required": [
+                                "issuer",
+                                "audiences",
+                                "jwks"
+                              ]
+                            }
                           }
                         },
+                        "additionalProperties": false,
                         "required": [
-                          "file"
+                          "providers"
                         ]
-                      },
-                      {
-                        "type": "string"
                       },
                       {
                         "type": "object",
                         "properties": {
-                          "url": {
+                          "mode": {
+                            "oneOf": [
+                              {
+                                "description": "A valid token, issued by a configured issuer, must be present.",
+                                "type": "string",
+                                "const": "strict"
+                              },
+                              {
+                                "description": "If a token exists, validate it.\nThis is the default option.\nWarning: this allows requests without a JWT token!",
+                                "type": "string",
+                                "const": "optional"
+                              },
+                              {
+                                "description": "Requests are never rejected. This is useful for usage of claims in later steps (authorization, logging, etc).\nWarning: this allows requests without a JWT token!",
+                                "type": "string",
+                                "const": "permissive"
+                              }
+                            ],
+                            "default": "optional"
+                          },
+                          "issuer": {
                             "type": "string"
+                          },
+                          "audiences": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "jwks": {
+                            "anyOf": [
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "file": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "file"
+                                ]
+                              },
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "url": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "url"
+                                ]
+                              }
+                            ]
                           }
                         },
+                        "additionalProperties": false,
                         "required": [
-                          "url"
+                          "issuer",
+                          "audiences",
+                          "jwks"
                         ]
                       }
                     ]
+                  },
+                  {
+                    "type": "null"
                   }
-                },
-                "additionalProperties": false,
-                "required": [
-                  "issuer",
-                  "audiences",
-                  "jwks"
                 ]
               },
               "extAuthz": {


### PR DESCRIPTION
Resolve #402

---

- In the original issue, I used the term `issuers`. But since the [reference](https://docs.solo.io/gloo-mesh-enterprise/main/security/jwt/jwt-multiple-providers/) also uses `provider`, and because it overlaps with the existing `issuer` field, I changed the name to `providers`. I think this name fits better, as it makes clear that each one is an independent authentication provider.
  - Still, I’d be happy to hear any suggestions for a better field name or other feedback.
- I’m not very familiar with Rust, so some parts may not be perfect. Thanks for your understanding.
- Additionally, I’m wondering if this feature also requires a UI change before it can be released.
  - Currently, if both a single provider and multiple providers are configured, the code treats it as an invalid config.
  - However, if `providers` is set in the file and jwtAuth is modified through the UI, the UI still returns the providers field as is, which causes it to fail.