### PR TITLE
policy/ai: enable optional header forwarding for webhook

### DIFF
--- a/crates/agentgateway/proto/resource.proto
+++ b/crates/agentgateway/proto/resource.proto
@@ -4,7 +4,6 @@ package agentgateway.dev.resource;
 
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
-import "google/protobuf/struct.proto";
 
 option go_package = "github.com/agentgateway/agentgateway/go/api;api";
 
@@ -122,7 +121,7 @@ message Aws {
 message AwsExplicitConfig {
   // AWS Access Key ID for authentication
   string access_key_id = 1;
-  // AWS Secret Access Key for authentication  
+  // AWS Secret Access Key for authentication
   string secret_access_key = 2;
   // AWS Region (e.g., "us-west-2", "us-east-1")
   string region = 3;
@@ -318,6 +317,7 @@ message PolicySpec {
     message Webhook {
       string host = 1;
       uint32 port = 2;
+      repeated HeaderMatch forward_header_matches = 3;
     }
 
     message Moderation {
@@ -404,7 +404,7 @@ message PolicySpec {
     repeated string allow = 1;
     repeated string deny = 2;
   }
-  
+
   // JWT authentication configuration
   message JWT {
     // Validation mode for JWT authentication
@@ -416,16 +416,16 @@ message PolicySpec {
       // Requests are never rejected (useful for claims in later steps)
       PERMISSIVE = 2;
     }
-    
+
     // How the JWT validation should behave
     Mode mode = 1;
-    
+
     // JWT issuer that must match the 'iss' claim
     string issuer = 2;
-    
+
     // List of audiences - the 'aud' claim must be in this list
     repeated string audiences = 3;
-    
+
     // JWKS configuration - where to get the keys for validation
     oneof jwks_source {
       // Inline JWKS as a JSON string
@@ -452,7 +452,7 @@ message PolicySpec {
   message BodyTransformation {
     string expression = 1;
   }
-  
+
   oneof kind {
     LocalRateLimit local_rate_limit = 1;
     ExternalAuth ext_authz = 2;

--- a/examples/ai-prompt-guard/README.md
+++ b/examples/ai-prompt-guard/README.md
@@ -70,3 +70,27 @@ curl http://localhost:3000   -H "Content-Type: application/json"   -H "Authoriza
   }'
 Response rejected due to inappropriate content
 ```
+
+### Guardrails Webhook
+
+A webhook can be used to reject or mask content before it is sent to the LLM.
+
+Example policy to forward the request to a webhook for moderation:
+```yaml
+policies:
+  ai:
+    promptGuard:
+      request:
+        webhook:
+          target: 127.0.0.1:8000
+          # By default, request headers are not forwarded.
+          # forwardHeaderMatches specifies a list of header matchers to use
+          # to determine the request headers to forward to the webhook
+          forwardHeaderMatches:
+          - name: h1
+            value:
+              regex: v1
+          - name: h2
+            value:
+              regex: v2.*
+```

--- a/go/api/resource.pb.go
+++ b/go/api/resource.pb.go
@@ -11,7 +11,6 @@ import (
 	wrappers "github.com/golang/protobuf/ptypes/wrappers"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-	_ "google.golang.org/protobuf/types/known/structpb"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
@@ -4686,11 +4685,12 @@ func (x *PolicySpec_Ai_RegexRules) GetRules() []*PolicySpec_Ai_RegexRule {
 }
 
 type PolicySpec_Ai_Webhook struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Host          string                 `protobuf:"bytes,1,opt,name=host,proto3" json:"host,omitempty"`
-	Port          uint32                 `protobuf:"varint,2,opt,name=port,proto3" json:"port,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state                protoimpl.MessageState `protogen:"open.v1"`
+	Host                 string                 `protobuf:"bytes,1,opt,name=host,proto3" json:"host,omitempty"`
+	Port                 uint32                 `protobuf:"varint,2,opt,name=port,proto3" json:"port,omitempty"`
+	ForwardHeaderMatches []*HeaderMatch         `protobuf:"bytes,3,rep,name=forward_header_matches,json=forwardHeaderMatches,proto3" json:"forward_header_matches,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *PolicySpec_Ai_Webhook) Reset() {
@@ -4735,6 +4735,13 @@ func (x *PolicySpec_Ai_Webhook) GetPort() uint32 {
 		return x.Port
 	}
 	return 0
+}
+
+func (x *PolicySpec_Ai_Webhook) GetForwardHeaderMatches() []*HeaderMatch {
+	if x != nil {
+		return x.ForwardHeaderMatches
+	}
+	return nil
 }
 
 type PolicySpec_Ai_Moderation struct {
@@ -5464,7 +5471,7 @@ var File_resource_proto protoreflect.FileDescriptor
 
 const file_resource_proto_rawDesc = "" +
 	"\n" +
-	"\x0eresource.proto\x12\x19agentgateway.dev.resource\x1a\x1egoogle/protobuf/duration.proto\x1a\x1egoogle/protobuf/wrappers.proto\x1a\x1cgoogle/protobuf/struct.proto\"\x87\x03\n" +
+	"\x0eresource.proto\x12\x19agentgateway.dev.resource\x1a\x1egoogle/protobuf/duration.proto\x1a\x1egoogle/protobuf/wrappers.proto\"\x87\x03\n" +
 	"\bResource\x125\n" +
 	"\x04bind\x18\x01 \x01(\v2\x1f.agentgateway.dev.resource.BindH\x00R\x04bind\x12A\n" +
 	"\blistener\x18\x02 \x01(\v2#.agentgateway.dev.resource.ListenerH\x00R\blistener\x128\n" +
@@ -5621,7 +5628,7 @@ const file_resource_proto_rawDesc = "" +
 	"route_rule\x18\x04 \x01(\tH\x00R\trouteRule\x12\x1a\n" +
 	"\abackend\x18\x05 \x01(\tH\x00R\abackend\x12\x1a\n" +
 	"\aservice\x18\x06 \x01(\tH\x00R\aserviceB\x06\n" +
-	"\x04kind\"\xef-\n" +
+	"\x04kind\"\xce.\n" +
 	"\n" +
 	"PolicySpec\x12`\n" +
 	"\x10local_rate_limit\x18\x01 \x01(\v24.agentgateway.dev.resource.PolicySpec.LocalRateLimitH\x00R\x0elocalRateLimit\x12Q\n" +
@@ -5645,7 +5652,7 @@ const file_resource_proto_rawDesc = "" +
 	"\x04type\x18\x04 \x01(\x0e29.agentgateway.dev.resource.PolicySpec.LocalRateLimit.TypeR\x04type\"\x1e\n" +
 	"\x04Type\x12\v\n" +
 	"\aREQUEST\x10\x00\x12\t\n" +
-	"\x05TOKEN\x10\x01\x1a\xe5\x12\n" +
+	"\x05TOKEN\x10\x01\x1a\xc4\x13\n" +
 	"\x02Ai\x12W\n" +
 	"\fprompt_guard\x18\x01 \x01(\v24.agentgateway.dev.resource.PolicySpec.Ai.PromptGuardR\vpromptGuard\x12R\n" +
 	"\bdefaults\x18\x02 \x03(\v26.agentgateway.dev.resource.PolicySpec.Ai.DefaultsEntryR\bdefaults\x12U\n" +
@@ -5671,10 +5678,11 @@ const file_resource_proto_rawDesc = "" +
 	"\n" +
 	"RegexRules\x12G\n" +
 	"\x06action\x18\x01 \x01(\v2/.agentgateway.dev.resource.PolicySpec.Ai.ActionR\x06action\x12H\n" +
-	"\x05rules\x18\x02 \x03(\v22.agentgateway.dev.resource.PolicySpec.Ai.RegexRuleR\x05rules\x1a1\n" +
+	"\x05rules\x18\x02 \x03(\v22.agentgateway.dev.resource.PolicySpec.Ai.RegexRuleR\x05rules\x1a\x8f\x01\n" +
 	"\aWebhook\x12\x12\n" +
 	"\x04host\x18\x01 \x01(\tR\x04host\x12\x12\n" +
-	"\x04port\x18\x02 \x01(\rR\x04port\x1a\x82\x01\n" +
+	"\x04port\x18\x02 \x01(\rR\x04port\x12\\\n" +
+	"\x16forward_header_matches\x18\x03 \x03(\v2&.agentgateway.dev.resource.HeaderMatchR\x14forwardHeaderMatches\x1a\x82\x01\n" +
 	"\n" +
 	"Moderation\x122\n" +
 	"\x05model\x18\x01 \x01(\v2\x1c.google.protobuf.StringValueR\x05model\x12@\n" +
@@ -6048,31 +6056,32 @@ var file_resource_proto_depIdxs = []int32{
 	66,  // 94: agentgateway.dev.resource.PolicySpec.Ai.Action.reject_response:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RequestRejection
 	62,  // 95: agentgateway.dev.resource.PolicySpec.Ai.RegexRules.action:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Action
 	61,  // 96: agentgateway.dev.resource.PolicySpec.Ai.RegexRules.rules:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RegexRule
-	85,  // 97: agentgateway.dev.resource.PolicySpec.Ai.Moderation.model:type_name -> google.protobuf.StringValue
-	17,  // 98: agentgateway.dev.resource.PolicySpec.Ai.Moderation.auth:type_name -> agentgateway.dev.resource.BackendAuthPolicy
-	63,  // 99: agentgateway.dev.resource.PolicySpec.Ai.ResponseGuard.regex:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RegexRules
-	64,  // 100: agentgateway.dev.resource.PolicySpec.Ai.ResponseGuard.webhook:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Webhook
-	66,  // 101: agentgateway.dev.resource.PolicySpec.Ai.RequestGuard.rejection:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RequestRejection
-	63,  // 102: agentgateway.dev.resource.PolicySpec.Ai.RequestGuard.regex:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RegexRules
-	64,  // 103: agentgateway.dev.resource.PolicySpec.Ai.RequestGuard.webhook:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Webhook
-	65,  // 104: agentgateway.dev.resource.PolicySpec.Ai.RequestGuard.openai_moderation:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Moderation
-	68,  // 105: agentgateway.dev.resource.PolicySpec.Ai.PromptGuard.request:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RequestGuard
-	67,  // 106: agentgateway.dev.resource.PolicySpec.Ai.PromptGuard.response:type_name -> agentgateway.dev.resource.PolicySpec.Ai.ResponseGuard
-	56,  // 107: agentgateway.dev.resource.PolicySpec.TransformationPolicy.Transform.set:type_name -> agentgateway.dev.resource.PolicySpec.HeaderTransformation
-	56,  // 108: agentgateway.dev.resource.PolicySpec.TransformationPolicy.Transform.add:type_name -> agentgateway.dev.resource.PolicySpec.HeaderTransformation
-	57,  // 109: agentgateway.dev.resource.PolicySpec.TransformationPolicy.Transform.body:type_name -> agentgateway.dev.resource.PolicySpec.BodyTransformation
-	85,  // 110: agentgateway.dev.resource.AIBackend.OpenAI.model:type_name -> google.protobuf.StringValue
-	85,  // 111: agentgateway.dev.resource.AIBackend.Gemini.model:type_name -> google.protobuf.StringValue
-	85,  // 112: agentgateway.dev.resource.AIBackend.Vertex.model:type_name -> google.protobuf.StringValue
-	85,  // 113: agentgateway.dev.resource.AIBackend.Anthropic.model:type_name -> google.protobuf.StringValue
-	85,  // 114: agentgateway.dev.resource.AIBackend.Bedrock.model:type_name -> google.protobuf.StringValue
-	85,  // 115: agentgateway.dev.resource.AIBackend.Bedrock.guardrail_identifier:type_name -> google.protobuf.StringValue
-	85,  // 116: agentgateway.dev.resource.AIBackend.Bedrock.guardrail_version:type_name -> google.protobuf.StringValue
-	117, // [117:117] is the sub-list for method output_type
-	117, // [117:117] is the sub-list for method input_type
-	117, // [117:117] is the sub-list for extension type_name
-	117, // [117:117] is the sub-list for extension extendee
-	0,   // [0:117] is the sub-list for field type_name
+	28,  // 97: agentgateway.dev.resource.PolicySpec.Ai.Webhook.forward_header_matches:type_name -> agentgateway.dev.resource.HeaderMatch
+	85,  // 98: agentgateway.dev.resource.PolicySpec.Ai.Moderation.model:type_name -> google.protobuf.StringValue
+	17,  // 99: agentgateway.dev.resource.PolicySpec.Ai.Moderation.auth:type_name -> agentgateway.dev.resource.BackendAuthPolicy
+	63,  // 100: agentgateway.dev.resource.PolicySpec.Ai.ResponseGuard.regex:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RegexRules
+	64,  // 101: agentgateway.dev.resource.PolicySpec.Ai.ResponseGuard.webhook:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Webhook
+	66,  // 102: agentgateway.dev.resource.PolicySpec.Ai.RequestGuard.rejection:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RequestRejection
+	63,  // 103: agentgateway.dev.resource.PolicySpec.Ai.RequestGuard.regex:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RegexRules
+	64,  // 104: agentgateway.dev.resource.PolicySpec.Ai.RequestGuard.webhook:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Webhook
+	65,  // 105: agentgateway.dev.resource.PolicySpec.Ai.RequestGuard.openai_moderation:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Moderation
+	68,  // 106: agentgateway.dev.resource.PolicySpec.Ai.PromptGuard.request:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RequestGuard
+	67,  // 107: agentgateway.dev.resource.PolicySpec.Ai.PromptGuard.response:type_name -> agentgateway.dev.resource.PolicySpec.Ai.ResponseGuard
+	56,  // 108: agentgateway.dev.resource.PolicySpec.TransformationPolicy.Transform.set:type_name -> agentgateway.dev.resource.PolicySpec.HeaderTransformation
+	56,  // 109: agentgateway.dev.resource.PolicySpec.TransformationPolicy.Transform.add:type_name -> agentgateway.dev.resource.PolicySpec.HeaderTransformation
+	57,  // 110: agentgateway.dev.resource.PolicySpec.TransformationPolicy.Transform.body:type_name -> agentgateway.dev.resource.PolicySpec.BodyTransformation
+	85,  // 111: agentgateway.dev.resource.AIBackend.OpenAI.model:type_name -> google.protobuf.StringValue
+	85,  // 112: agentgateway.dev.resource.AIBackend.Gemini.model:type_name -> google.protobuf.StringValue
+	85,  // 113: agentgateway.dev.resource.AIBackend.Vertex.model:type_name -> google.protobuf.StringValue
+	85,  // 114: agentgateway.dev.resource.AIBackend.Anthropic.model:type_name -> google.protobuf.StringValue
+	85,  // 115: agentgateway.dev.resource.AIBackend.Bedrock.model:type_name -> google.protobuf.StringValue
+	85,  // 116: agentgateway.dev.resource.AIBackend.Bedrock.guardrail_identifier:type_name -> google.protobuf.StringValue
+	85,  // 117: agentgateway.dev.resource.AIBackend.Bedrock.guardrail_version:type_name -> google.protobuf.StringValue
+	118, // [118:118] is the sub-list for method output_type
+	118, // [118:118] is the sub-list for method input_type
+	118, // [118:118] is the sub-list for extension type_name
+	118, // [118:118] is the sub-list for extension extendee
+	0,   // [0:118] is the sub-list for field type_name
 }
 
 func init() { file_resource_proto_init() }

--- a/schema/README.md
+++ b/schema/README.md
@@ -154,6 +154,11 @@ This folder contains JSON schemas for various parts of the project
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request.regex.rules[].(any)name`||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request.webhook`||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request.webhook.target`||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request.webhook.forwardHeaderMatches`||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request.webhook.forwardHeaderMatches[].name`||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request.webhook.forwardHeaderMatches[].value`||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request.webhook.forwardHeaderMatches[].value.(1)exact`||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request.webhook.forwardHeaderMatches[].value.(1)regex`||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request.openaiModeration`||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request.openaiModeration.model`|Model to use. Defaults to `omni-moderation-latest`|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request.openaiModeration.auth`||
@@ -173,6 +178,11 @@ This folder contains JSON schemas for various parts of the project
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response.regex.rules[].(any)name`||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response.webhook`||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response.webhook.target`||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response.webhook.forwardHeaderMatches`||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response.webhook.forwardHeaderMatches[].name`||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response.webhook.forwardHeaderMatches[].value`||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response.webhook.forwardHeaderMatches[].value.(1)exact`||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response.webhook.forwardHeaderMatches[].value.(1)regex`||
 |`binds[].listeners[].routes[].policies.ai.defaults`||
 |`binds[].listeners[].routes[].policies.ai.overrides`||
 |`binds[].listeners[].routes[].policies.ai.prompts`||
@@ -405,6 +415,11 @@ This folder contains JSON schemas for various parts of the project
 |`policies[].policy.ai.promptGuard.request.regex.rules[].(any)name`||
 |`policies[].policy.ai.promptGuard.request.webhook`||
 |`policies[].policy.ai.promptGuard.request.webhook.target`||
+|`policies[].policy.ai.promptGuard.request.webhook.forwardHeaderMatches`||
+|`policies[].policy.ai.promptGuard.request.webhook.forwardHeaderMatches[].name`||
+|`policies[].policy.ai.promptGuard.request.webhook.forwardHeaderMatches[].value`||
+|`policies[].policy.ai.promptGuard.request.webhook.forwardHeaderMatches[].value.(1)exact`||
+|`policies[].policy.ai.promptGuard.request.webhook.forwardHeaderMatches[].value.(1)regex`||
 |`policies[].policy.ai.promptGuard.request.openaiModeration`||
 |`policies[].policy.ai.promptGuard.request.openaiModeration.model`|Model to use. Defaults to `omni-moderation-latest`|
 |`policies[].policy.ai.promptGuard.request.openaiModeration.auth`||
@@ -424,6 +439,11 @@ This folder contains JSON schemas for various parts of the project
 |`policies[].policy.ai.promptGuard.response.regex.rules[].(any)name`||
 |`policies[].policy.ai.promptGuard.response.webhook`||
 |`policies[].policy.ai.promptGuard.response.webhook.target`||
+|`policies[].policy.ai.promptGuard.response.webhook.forwardHeaderMatches`||
+|`policies[].policy.ai.promptGuard.response.webhook.forwardHeaderMatches[].name`||
+|`policies[].policy.ai.promptGuard.response.webhook.forwardHeaderMatches[].value`||
+|`policies[].policy.ai.promptGuard.response.webhook.forwardHeaderMatches[].value.(1)exact`||
+|`policies[].policy.ai.promptGuard.response.webhook.forwardHeaderMatches[].value.(1)regex`||
 |`policies[].policy.ai.defaults`||
 |`policies[].policy.ai.overrides`||
 |`policies[].policy.ai.prompts`||

--- a/schema/local.json
+++ b/schema/local.json
@@ -1289,6 +1289,50 @@
                                         "properties": {
                                           "target": {
                                             "type": "string"
+                                          },
+                                          "forwardHeaderMatches": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object",
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "oneOf": [
+                                                    {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "exact": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "exact"
+                                                      ],
+                                                      "additionalProperties": false
+                                                    },
+                                                    {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "regex": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "regex"
+                                                      ],
+                                                      "additionalProperties": false
+                                                    }
+                                                  ]
+                                                }
+                                              },
+                                              "additionalProperties": false,
+                                              "required": [
+                                                "name",
+                                                "value"
+                                              ]
+                                            }
                                           }
                                         },
                                         "additionalProperties": false,
@@ -1485,6 +1529,50 @@
                                         "properties": {
                                           "target": {
                                             "type": "string"
+                                          },
+                                          "forwardHeaderMatches": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object",
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "oneOf": [
+                                                    {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "exact": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "exact"
+                                                      ],
+                                                      "additionalProperties": false
+                                                    },
+                                                    {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "regex": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "regex"
+                                                      ],
+                                                      "additionalProperties": false
+                                                    }
+                                                  ]
+                                                }
+                                              },
+                                              "additionalProperties": false,
+                                              "required": [
+                                                "name",
+                                                "value"
+                                              ]
+                                            }
                                           }
                                         },
                                         "additionalProperties": false,
@@ -3692,6 +3780,50 @@
                             "properties": {
                               "target": {
                                 "type": "string"
+                              },
+                              "forwardHeaderMatches": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "oneOf": [
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "exact": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "exact"
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "regex": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "regex"
+                                          ],
+                                          "additionalProperties": false
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ]
+                                }
                               }
                             },
                             "additionalProperties": false,
@@ -3888,6 +4020,50 @@
                             "properties": {
                               "target": {
                                 "type": "string"
+                              },
+                              "forwardHeaderMatches": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "oneOf": [
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "exact": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "exact"
+                                          ],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "regex": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "regex"
+                                          ],
+                                          "additionalProperties": false
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ]
+                                }
                               }
                             },
                             "additionalProperties": false,


### PR DESCRIPTION
Optionally enables header forwarding based on header matchers when using a webhook for prompt guarding. This changes the current behavior by not forwarding any headers to the webhook by default.