### PR TITLE
policy/ai: enable webhook on LLM response

### DIFF
--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -230,7 +230,7 @@ impl AIProvider {
 
 	pub async fn process_request(
 		&self,
-		client: client::Client,
+		client: &client::Client,
 		policies: Option<&Policy>,
 		req: Request,
 		tokenize: bool,
@@ -299,6 +299,7 @@ impl AIProvider {
 
 	pub async fn process_response(
 		&self,
+		client: &client::Client,
 		req: LLMRequest,
 		rate_limit: LLMResponsePolicies,
 		log: AsyncLog<llm::LLMResponse>,
@@ -360,13 +361,17 @@ impl AIProvider {
 					first_token: Default::default(),
 				};
 				// Apply response prompt guard
-				if let Some(dr) =
-					Policy::apply_response_prompt_guard(&mut success, &rate_limit.prompt_guard)
-						.await
-						.map_err(|e| {
-							warn!("failed to apply response prompt guard: {e}");
-							AIError::PromptWebhookError
-						})? {
+				if let Some(dr) = Policy::apply_response_prompt_guard(
+					client,
+					&mut success,
+					&parts.headers,
+					&rate_limit.prompt_guard,
+				)
+				.await
+				.map_err(|e| {
+					warn!("failed to apply response prompt guard: {e}");
+					AIError::PromptWebhookError
+				})? {
 					return Ok(dr);
 				}
 

--- a/crates/agentgateway/src/llm/policy.rs
+++ b/crates/agentgateway/src/llm/policy.rs
@@ -86,7 +86,7 @@ impl Policy {
 	}
 	pub async fn apply_prompt_guard(
 		&self,
-		client: client::Client,
+		client: &client::Client,
 		req: &mut universal::Request,
 		http_headers: &HeaderMap,
 		claims: Option<Claims>,
@@ -127,11 +127,11 @@ impl Policy {
 		if let Some(webhook) = &g.webhook {
 			let headers =
 				Self::get_webhook_forward_headers(http_headers, &webhook.forward_header_matches);
-			let whr = webhook::send_request(client.clone(), &webhook.target, &headers, req).await?;
+			let whr = webhook::send_request(client, &webhook.target, &headers, req).await?;
 			match whr.action {
 				RequestAction::Mask(mask) => {
 					debug!(
-						"webhook masked: {}",
+						"webhook masked request: {}",
 						mask
 							.reason
 							.unwrap_or_else(|| "no reason specified".to_string())
@@ -144,7 +144,7 @@ impl Policy {
 				},
 				RequestAction::Reject(rej) => {
 					debug!(
-						"webhook rejected: {}",
+						"webhook rejected request: {}",
 						rej
 							.reason
 							.unwrap_or_else(|| "no reason specified".to_string())
@@ -157,7 +157,7 @@ impl Policy {
 				},
 				RequestAction::Pass(pass) => {
 					debug!(
-						"webhook passed: {}",
+						"webhook passed request: {}",
 						pass
 							.reason
 							.unwrap_or_else(|| "no reason specified".to_string())
@@ -311,12 +311,71 @@ impl Policy {
 	}
 
 	pub async fn apply_response_prompt_guard(
+		client: &client::Client,
 		resp: &mut CreateChatCompletionResponse,
+		http_headers: &HeaderMap,
 		g: &Option<ResponseGuard>,
 	) -> anyhow::Result<Option<Response>> {
 		let Some(guard) = g else {
 			return Ok(None);
 		};
+
+		if let Some(webhook) = &guard.webhook {
+			let headers =
+				Self::get_webhook_forward_headers(http_headers, &webhook.forward_header_matches);
+			let whr = webhook::send_response(client, &webhook.target, &headers, resp).await?;
+			match whr.action {
+				RequestAction::Mask(mask) => {
+					debug!(
+						"webhook masked response: {}",
+						mask
+							.reason
+							.unwrap_or_else(|| "no reason specified".to_string())
+					);
+					let MaskActionBody::PromptMessages(body) = mask.body else {
+						anyhow::bail!("invalid webhook response");
+					};
+					let msgs = body.messages;
+					if resp.choices.len() != msgs.len() {
+						anyhow::bail!("webhook response message count mismatch");
+					}
+					for (i, (resp_msg, wh_msg)) in resp.choices.iter_mut().zip(msgs).enumerate() {
+						if resp_msg.message.role.to_string() != wh_msg.role {
+							anyhow::bail!(
+								"webhook response message {} role mismatch; expected {}, got {}",
+								i,
+								resp_msg.message.role,
+								wh_msg.role
+							);
+						}
+						resp_msg.message.content = Some(wh_msg.content);
+					}
+				},
+				RequestAction::Reject(rej) => {
+					debug!(
+						"webhook rejected response: {}",
+						rej
+							.reason
+							.unwrap_or_else(|| "no reason specified".to_string())
+					);
+					return Ok(Some(
+						::http::response::Builder::new()
+							.status(rej.status_code)
+							.body(http::Body::from(rej.body))?,
+					));
+				},
+				RequestAction::Pass(pass) => {
+					debug!(
+						"webhook passed response: {}",
+						pass
+							.reason
+							.unwrap_or_else(|| "no reason specified".to_string())
+					);
+					// No action needed
+				},
+			}
+		}
+
 		for msg in resp.choices.iter_mut() {
 			let Some(original_content) = msg.message.content.as_deref() else {
 				continue;
@@ -471,6 +530,7 @@ mod webhook {
 	use crate::llm::universal::Request;
 	use crate::types::agent::Target;
 	use crate::*;
+	use async_openai::types::CreateChatCompletionResponse;
 
 	#[derive(Debug, Clone, Serialize, Deserialize)]
 	#[serde(rename_all = "snake_case")]
@@ -612,6 +672,35 @@ mod webhook {
 					.collect(),
 			},
 		};
+		build_request(&body, target, http_headers)
+	}
+
+	fn build_request_for_response(
+		target: &Target,
+		http_headers: &HeaderMap,
+		resp: &CreateChatCompletionResponse,
+	) -> anyhow::Result<crate::http::Request> {
+		let body = GuardrailsPromptRequest {
+			body: PromptMessages {
+				messages: resp
+					.choices
+					.iter()
+					.filter_map(|m| {
+						let role = m.message.role.to_string();
+						let content = m.message.content.clone();
+						content.map(|content| Message { role, content })
+					})
+					.collect(),
+			},
+		};
+		build_request(&body, target, http_headers)
+	}
+
+	fn build_request(
+		body: &GuardrailsPromptRequest,
+		target: &Target,
+		http_headers: &HeaderMap,
+	) -> anyhow::Result<crate::http::Request> {
 		let body_bytes = serde_json::to_vec(&body)?;
 		let mut rb = ::http::Request::builder()
 			.uri(format!("http://{target}/request"))
@@ -631,7 +720,7 @@ mod webhook {
 	}
 
 	pub async fn send_request(
-		client: Client,
+		client: &Client,
 		target: &Target,
 		http_headers: &HeaderMap,
 		req: &Request,
@@ -644,8 +733,25 @@ mod webhook {
 				transport: Default::default(), // TODO: use policies
 			})
 			.await?;
-		let bb = axum::body::to_bytes(res.into_body(), 2_097_152).await?;
-		let parsed = serde_json::from_slice::<GuardrailsPromptResponse>(&bb)?;
+		let parsed = json::from_body(res.into_body()).await?;
+		Ok(parsed)
+	}
+
+	pub async fn send_response(
+		client: &Client,
+		target: &Target,
+		http_headers: &HeaderMap,
+		resp: &CreateChatCompletionResponse,
+	) -> anyhow::Result<GuardrailsPromptResponse> {
+		let whr = build_request_for_response(target, http_headers, resp)?;
+		let res = client
+			.call(client::Call {
+				req: whr,
+				target: target.clone(),
+				transport: Default::default(), // TODO: use policies
+			})
+			.await?;
+		let parsed = json::from_body(res.into_body()).await?;
 		Ok(parsed)
 	}
 }

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -823,7 +823,7 @@ async fn make_backend_call(
 		if let Some((llm, use_default_policies, tokenize)) = &policies.llm_provider {
 			let r = llm
 				.process_request(
-					client,
+					&client,
 					route_policies.llm.as_deref(),
 					req,
 					*tokenize,
@@ -877,6 +877,7 @@ async fn make_backend_call(
 			if let (Some((llm, _, _)), Some(llm_request)) = (policies.llm_provider, llm_request) {
 				llm
 					.process_response(
+						&client,
 						llm_request,
 						response_policies,
 						llm_response_log.expect("must be set"),

--- a/examples/ai-prompt-guard/README.md
+++ b/examples/ai-prompt-guard/README.md
@@ -73,9 +73,9 @@ Response rejected due to inappropriate content
 
 ### Guardrails Webhook
 
-A webhook can be used to reject or mask content before it is sent to the LLM.
+A webhook can be used to reject or mask content sent to or received from the LLM.
 
-Example policy to forward the request to a webhook for moderation:
+Example policy to forward the request and response to a webhook for moderation:
 ```yaml
 policies:
   ai:
@@ -93,4 +93,7 @@ policies:
           - name: h2
             value:
               regex: v2.*
-```
+      response:
+        webhook:
+          target: 127.0.0.1:8000
+          # set forwardHeaderMatches for to forward response headers


### PR DESCRIPTION
Adds the ability to send LLM response to a webhook if a webhook policy exists for the response.