### PR TITLE
Use root working directory in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,8 @@ RUN --mount=type=cache,target=/app/target \
 FROM gcr.io/distroless/cc-debian12 AS runner 
 
 ARG TARGETARCH
-WORKDIR /app
+
+WORKDIR /
 
 COPY --from=builder /out/agentgateway /app/agentgateway
 


### PR DESCRIPTION
Some of the filepaths we read are relative so this fixes that