### PR TITLE
Enhancements to multiple AI providers

### DIFF
--- a/crates/agentgateway/proto/resource.proto
+++ b/crates/agentgateway/proto/resource.proto
@@ -541,6 +541,7 @@ message AIBackend {
     Anthropic anthropic = 5;
     Bedrock bedrock = 6;
   }
+  google.protobuf.StringValue path_override = 7;
 }
 
 message MCPBackend {

--- a/crates/agentgateway/proto/resource.proto
+++ b/crates/agentgateway/proto/resource.proto
@@ -254,6 +254,8 @@ message PolicyTarget {
     string backend = 5;
     // namespace}/{hostname}
     string service = 6;
+    // For Backend: `{ns}/{name}/{sub-backend}`
+    string sub_backend = 7;
   }
 }
 message PolicySpec {

--- a/crates/agentgateway/src/http/mod.rs
+++ b/crates/agentgateway/src/http/mod.rs
@@ -46,6 +46,8 @@ pub mod x_headers {
 	pub const X_RATELIMIT_RESET: HeaderName = HeaderName::from_static("x-ratelimit-reset");
 	pub const X_AMZN_REQUESTID: HeaderName = HeaderName::from_static("x-amzn-requestid");
 
+	pub const RETRY_AFTER_MS: HeaderName = HeaderName::from_static("retry-after-ms");
+
 	pub const X_RATELIMIT_RESET_REQUESTS: HeaderName =
 		HeaderName::from_static("x-ratelimit-reset-requests");
 	pub const X_RATELIMIT_RESET_TOKENS: HeaderName =

--- a/crates/agentgateway/src/http/outlierdetection.rs
+++ b/crates/agentgateway/src/http/outlierdetection.rs
@@ -41,6 +41,11 @@ fn process_rate_limit_headers(h: &HeaderMap, now: SystemTime) -> Option<std::tim
 			return Some(duration);
 		}
 	}
+	if let Some(retry_after) = get_header(h, &x_headers::RETRY_AFTER_MS)
+		&& let Ok(ms) = retry_after.parse::<u64>()
+	{
+		return Some(std::time::Duration::from_millis(ms));
+	}
 
 	// x-ratelimit-reset: commonly used.
 	// Typically this is a unix epoch timestamp OR number of seconds. Rarely it is number of milliseconds.

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -69,6 +69,7 @@ pub struct NamedAIProvider {
 	pub name: Strng,
 	pub provider: AIProvider,
 	pub host_override: Option<Target>,
+	pub path_override: Option<Strng>,
 	/// Whether to tokenize on the request flow. This enables us to do more accurate rate limits,
 	/// since we know (part of) the cost of the request upfront.
 	/// This comes with the cost of an expensive operation.

--- a/crates/agentgateway/src/mcp/sse.rs
+++ b/crates/agentgateway/src/mcp/sse.rs
@@ -85,7 +85,7 @@ impl App {
 				.targets
 				.iter()
 				.map(|t| {
-					let backend_policies = binds.backend_policies(name.clone(), None);
+					let backend_policies = binds.backend_policies(name.clone(), None, Some(t.name.clone()));
 					Arc::new(McpTarget {
 						name: t.name.clone(),
 						spec: t.spec.clone(),

--- a/crates/agentgateway/src/proxy/gateway_test.rs
+++ b/crates/agentgateway/src/proxy/gateway_test.rs
@@ -18,7 +18,7 @@ use tokio::io::DuplexStream;
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use crate::http::{Body, Response};
-use crate::llm::{AIProvider, NamedAIProvider, openai};
+use crate::llm::{AIProvider, openai};
 use crate::proxy::Gateway;
 use crate::proxy::request_builder::RequestBuilder;
 use crate::store::Stores;
@@ -27,6 +27,7 @@ use crate::types::agent::{
 	Backend, BackendReference, Bind, BindName, Listener, ListenerProtocol, ListenerSet, PathMatch,
 	Policy, PolicyTarget, Route, RouteBackendReference, RouteMatch, RouteSet, Target, TargetedPolicy,
 };
+use crate::types::local::LocalNamedAIProvider;
 use crate::{ProxyInputs, client, mcp, *};
 
 #[tokio::test]
@@ -238,17 +239,18 @@ fn setup_llm_mock(
 	config: &str,
 ) -> (MockServer, TestBind, Client<MemoryConnector, Body>) {
 	let t = setup(config).unwrap();
-	let b = Backend::AI(
-		strng::format!("{}", mock.address()),
-		crate::types::local::LocalAIBackend::Provider(NamedAIProvider {
-			name: "default".into(),
-			provider,
-			host_override: Some(Target::Address(*mock.address())),
-			path_override: None,
-			tokenize,
-		})
-		.into(),
-	);
+	let (be, _) = crate::types::local::LocalAIBackend::Provider(LocalNamedAIProvider {
+		name: "default".into(),
+		provider,
+		host_override: Some(Target::Address(*mock.address())),
+		path_override: None,
+		tokenize,
+		backend_tls: None,
+		backend_auth: None,
+	})
+	.translate(strng::format!("{}", mock.address()))
+	.unwrap();
+	let b = Backend::AI(strng::format!("{}", mock.address()), be);
 	t.pi.stores.binds.write().insert_backend(b);
 	let t = t.with_bind(simple_bind(basic_route(*mock.address())));
 	let io = t.serve_http(strng::new("bind"));

--- a/crates/agentgateway/src/proxy/gateway_test.rs
+++ b/crates/agentgateway/src/proxy/gateway_test.rs
@@ -244,6 +244,7 @@ fn setup_llm_mock(
 			name: "default".into(),
 			provider,
 			host_override: Some(Target::Address(*mock.address())),
+			path_override: None,
 			tokenize,
 		})
 		.into(),

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -1,6 +1,8 @@
 use std::net::SocketAddr;
+use std::str::FromStr;
 use std::sync::Arc;
 
+use ::http::uri::PathAndQuery;
 use ::http::{HeaderMap, header};
 use anyhow::anyhow;
 use futures_util::FutureExt;
@@ -707,7 +709,7 @@ async fn make_backend_call(
 	log.add(|l| l.inference_pool = override_dest);
 
 	let backend_call = match backend {
-		Backend::AI(_, _) => {
+		Backend::AI(_, _ai) => {
 			let provider = ai_provider.expect("must be set above");
 			let (target, default_policies) = match &provider.host_override {
 				Some(target) => (
@@ -727,6 +729,13 @@ async fn make_backend_call(
 					(tgt, Some(pol))
 				},
 			};
+			if let Some(po) = &provider.path_override {
+				http::modify_req_uri(&mut req, |p| {
+					p.path_and_query = Some(PathAndQuery::from_str(po)?);
+					Ok(())
+				})
+				.map_err(ProxyError::Processing)?;
+			}
 			BackendCall {
 				target,
 				default_policies,

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -17,11 +17,7 @@ use crate::llm::policy::ResponseGuard;
 use crate::mcp::rbac::McpAuthorizationSet;
 use crate::proxy::httpproxy::PolicyClient;
 use crate::store::Event;
-use crate::types::agent::{
-	A2aPolicy, Backend, BackendName, Bind, BindName, GatewayName, Listener, ListenerKey, ListenerSet,
-	McpAuthentication, Policy, PolicyName, PolicyTarget, Route, RouteKey, RouteName, RouteRuleName,
-	ServiceName, TCPRoute, TargetedPolicy,
-};
+use crate::types::agent::{A2aPolicy, Backend, BackendName, Bind, BindName, GatewayName, Listener, ListenerKey, ListenerSet, McpAuthentication, Policy, PolicyName, PolicyTarget, Route, RouteKey, RouteName, RouteRuleName, ServiceName, SubBackendName, TCPRoute, TargetedPolicy};
 use crate::types::proto::agent::resource::Kind as XdsKind;
 use crate::types::proto::agent::{
 	Backend as XdsBackend, Bind as XdsBind, Listener as XdsListener, Policy as XdsPolicy,
@@ -245,16 +241,20 @@ impl Store {
 		&self,
 		backend: BackendName,
 		service: Option<ServiceName>,
+		sub_backend: Option<SubBackendName>,
 	) -> BackendPolicies {
 		let backend_rules = self.policies_by_target.get(&PolicyTarget::Backend(backend));
 		let service_rules =
 			service.and_then(|t| self.policies_by_target.get(&PolicyTarget::Service(t)));
+		let sub_backend_rules =
+		sub_backend.and_then(|t| self.policies_by_target.get(&PolicyTarget::SubBackend(t)));
 
-		// Backend > Service
-		let rules = backend_rules
+		// Subbackend > Backend > Service
+		let rules = sub_backend_rules
 			.iter()
 			.copied()
 			.flatten()
+			.chain(backend_rules.iter().copied().flatten())
 			.chain(service_rules.iter().copied().flatten())
 			.filter_map(|n| self.policies_by_name.get(n));
 

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -17,7 +17,11 @@ use crate::llm::policy::ResponseGuard;
 use crate::mcp::rbac::McpAuthorizationSet;
 use crate::proxy::httpproxy::PolicyClient;
 use crate::store::Event;
-use crate::types::agent::{A2aPolicy, Backend, BackendName, Bind, BindName, GatewayName, Listener, ListenerKey, ListenerSet, McpAuthentication, Policy, PolicyName, PolicyTarget, Route, RouteKey, RouteName, RouteRuleName, ServiceName, SubBackendName, TCPRoute, TargetedPolicy};
+use crate::types::agent::{
+	A2aPolicy, Backend, BackendName, Bind, BindName, GatewayName, Listener, ListenerKey, ListenerSet,
+	McpAuthentication, Policy, PolicyName, PolicyTarget, Route, RouteKey, RouteName, RouteRuleName,
+	ServiceName, SubBackendName, TCPRoute, TargetedPolicy,
+};
 use crate::types::proto::agent::resource::Kind as XdsKind;
 use crate::types::proto::agent::{
 	Backend as XdsBackend, Bind as XdsBind, Listener as XdsListener, Policy as XdsPolicy,
@@ -247,7 +251,7 @@ impl Store {
 		let service_rules =
 			service.and_then(|t| self.policies_by_target.get(&PolicyTarget::Service(t)));
 		let sub_backend_rules =
-		sub_backend.and_then(|t| self.policies_by_target.get(&PolicyTarget::SubBackend(t)));
+			sub_backend.and_then(|t| self.policies_by_target.get(&PolicyTarget::SubBackend(t)));
 
 		// Subbackend > Backend > Service
 		let rules = sub_backend_rules

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -457,6 +457,7 @@ impl Backend {
 }
 
 pub type BackendName = Strng;
+pub type SubBackendName = Strng;
 pub type ServiceName = Strng;
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -965,6 +966,9 @@ pub enum PolicyTarget {
 	// Note: Backend includes Service:port, this is used when we are *only* attaching to service
 	Service(ServiceName),
 	Backend(BackendName),
+	// Some Backend types group multiple backends.
+	// Format: <backend>/<sub-backend>
+	SubBackend(SubBackendName),
 }
 
 #[derive(Debug, Clone, serde::Serialize)]

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -896,6 +896,7 @@ impl TryFrom<&proto::agent::Policy> for TargetedPolicy {
 			Some(proto::agent::policy_target::Kind::RouteRule(v)) => PolicyTarget::RouteRule(v.into()),
 			Some(proto::agent::policy_target::Kind::Service(v)) => PolicyTarget::Service(v.into()),
 			Some(proto::agent::policy_target::Kind::Backend(v)) => PolicyTarget::Backend(v.into()),
+			Some(proto::agent::policy_target::Kind::SubBackend(v)) => PolicyTarget::SubBackend(v.into()),
 			_ => return Err(ProtoError::EnumParse("unknown target kind".to_string())),
 		};
 		let policy = spec.try_into()?;

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -307,6 +307,7 @@ impl TryFrom<&proto::agent::Backend> for Backend {
 					name: name.clone(),
 					provider,
 					tokenize: false,
+					path_override: a.path_override.as_ref().map(strng::new),
 					host_override: a
 						.r#override
 						.as_ref()

--- a/crates/agentgateway/src/types/loadbalancer.rs
+++ b/crates/agentgateway/src/types/loadbalancer.rs
@@ -335,7 +335,10 @@ impl<T: Clone + Sync + Send + 'static> EndpointSet<T> {
 				let evict_at = uneviction_heap.peek().map(|x| x.0);
 				tokio::select! {
 					true = maybe_sleep_until(evict_at) => handle_eviction(&mut uneviction_heap),
-					item = eviction_events.recv() => handle_recv_evict(&mut uneviction_heap, item)
+					item = eviction_events.recv() => {
+						if item.is_none() { return };
+						handle_recv_evict(&mut uneviction_heap, item)
+					}
 				}
 			}
 		});

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -149,6 +149,7 @@ fn default_weight() -> usize {
 }
 
 #[apply(schema_de!)]
+#[allow(clippy::large_enum_variant)] // Size is not sensitive for local config
 pub enum LocalBackend {
 	// This one is a reference
 	Service {
@@ -168,6 +169,7 @@ pub enum LocalBackend {
 
 #[apply(schema_de!)]
 #[serde(untagged)]
+#[allow(clippy::large_enum_variant)] // Size is not sensitive for local config
 pub enum LocalAIBackend {
 	Provider(LocalNamedAIProvider),
 	Groups { groups: Vec<LocalAIProviders> },
@@ -197,7 +199,7 @@ pub struct LocalNamedAIProvider {
 }
 
 impl LocalAIBackend {
-	fn translate(
+	pub fn translate(
 		self,
 		backend_name: BackendName,
 	) -> anyhow::Result<(AIBackend, Vec<TargetedPolicy>)> {

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -15,7 +15,7 @@ use crate::client::Client;
 use crate::http::auth::BackendAuth;
 use crate::http::backendtls::LocalBackendTLS;
 use crate::http::{filters, retry, timeout};
-use crate::llm::{AIBackend, NamedAIProvider};
+use crate::llm::{AIBackend, AIProvider, NamedAIProvider};
 use crate::mcp::rbac::McpAuthorization;
 use crate::store::LocalWorkload;
 use crate::types::agent::PolicyTarget::RouteRule;
@@ -169,31 +169,78 @@ pub enum LocalBackend {
 #[apply(schema_de!)]
 #[serde(untagged)]
 pub enum LocalAIBackend {
-	Provider(NamedAIProvider),
-	Groups {
-		groups: Vec<LocalAIProviders>
-	},
+	Provider(LocalNamedAIProvider),
+	Groups { groups: Vec<LocalAIProviders> },
 }
 
 #[apply(schema_de!)]
 pub struct LocalAIProviders {
-	providers: Vec<NamedAIProvider>,
+	providers: Vec<LocalNamedAIProvider>,
 }
 
-impl From<LocalAIBackend> for AIBackend {
-	fn from(value: LocalAIBackend) -> Self {
-		let providers = match value {
+#[apply(schema_de!)]
+pub struct LocalNamedAIProvider {
+	pub name: Strng,
+	pub provider: AIProvider,
+	pub host_override: Option<Target>,
+	pub path_override: Option<Strng>,
+	/// Whether to tokenize on the request flow. This enables us to do more accurate rate limits,
+	/// since we know (part of) the cost of the request upfront.
+	/// This comes with the cost of an expensive operation.
+	#[serde(default)]
+	pub tokenize: bool,
+
+	#[serde(rename = "backendTLS", default)]
+	pub backend_tls: Option<LocalBackendTLS>,
+	#[serde(default)]
+	pub backend_auth: Option<BackendAuth>,
+}
+
+impl LocalAIBackend {
+	fn translate(
+		self,
+		backend_name: BackendName,
+	) -> anyhow::Result<(AIBackend, Vec<TargetedPolicy>)> {
+		let providers = match self {
 			LocalAIBackend::Provider(p) => {
 				vec![vec![p]]
 			},
 			LocalAIBackend::Groups { groups } => groups.into_iter().map(|g| g.providers).collect_vec(),
 		};
-		let eps = providers
-			.into_iter()
-			.map(|p| p.into_iter().map(|p| (p.name.clone(), p)).collect_vec())
-			.collect_vec();
-		let es = types::loadbalancer::EndpointSet::new(eps);
-		AIBackend { providers: es }
+		let mut ep_groups = vec![];
+		let mut policies = vec![];
+		for g in providers {
+			let mut group = vec![];
+			for p in g {
+				if let Some(btls) = p.backend_tls {
+					policies.push(TargetedPolicy {
+						name: strng::format!("{backend_name}/{}-tls", p.name),
+						target: PolicyTarget::SubBackend(strng::format!("{}/{}", backend_name, p.name.clone())),
+						policy: Policy::BackendTLS(btls.try_into()?),
+					});
+				}
+				if let Some(bauth) = p.backend_auth {
+					policies.push(TargetedPolicy {
+						name: strng::format!("{backend_name}/{}-auth", p.name),
+						target: PolicyTarget::SubBackend(strng::format!("{}/{}", backend_name, p.name.clone())),
+						policy: Policy::BackendAuth(bauth),
+					});
+				}
+				group.push((
+					p.name.clone(),
+					NamedAIProvider {
+						name: p.name,
+						provider: p.provider,
+						host_override: p.host_override,
+						path_override: p.path_override,
+						tokenize: p.tokenize,
+					},
+				));
+			}
+			ep_groups.push(group);
+		}
+		let es = types::loadbalancer::EndpointSet::new(ep_groups);
+		Ok((AIBackend { providers: es }, policies))
 	}
 }
 
@@ -274,7 +321,10 @@ impl LocalBackend {
 				backends.push(Backend::MCP(name, m));
 				(backends, policies)
 			},
-			LocalBackend::AI(tgt) => (vec![Backend::AI(name, tgt.clone().into())], vec![]),
+			LocalBackend::AI(tgt) => {
+				let (be, pols) = tgt.clone().translate(name.clone())?;
+				(vec![Backend::AI(name, be)], pols)
+			},
 			LocalBackend::Invalid => (vec![Backend::Invalid], vec![]),
 		})
 	}

--- a/go/api/resource.pb.go
+++ b/go/api/resource.pb.go
@@ -2749,6 +2749,7 @@ type PolicyTarget struct {
 	//	*PolicyTarget_RouteRule
 	//	*PolicyTarget_Backend
 	//	*PolicyTarget_Service
+	//	*PolicyTarget_SubBackend
 	Kind          isPolicyTarget_Kind `protobuf_oneof:"kind"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -2845,6 +2846,15 @@ func (x *PolicyTarget) GetService() string {
 	return ""
 }
 
+func (x *PolicyTarget) GetSubBackend() string {
+	if x != nil {
+		if x, ok := x.Kind.(*PolicyTarget_SubBackend); ok {
+			return x.SubBackend
+		}
+	}
+	return ""
+}
+
 type isPolicyTarget_Kind interface {
 	isPolicyTarget_Kind()
 }
@@ -2880,6 +2890,11 @@ type PolicyTarget_Service struct {
 	Service string `protobuf:"bytes,6,opt,name=service,proto3,oneof"`
 }
 
+type PolicyTarget_SubBackend struct {
+	// For Backend: `{ns}/{name}/{sub-backend}`
+	SubBackend string `protobuf:"bytes,7,opt,name=sub_backend,json=subBackend,proto3,oneof"`
+}
+
 func (*PolicyTarget_Gateway) isPolicyTarget_Kind() {}
 
 func (*PolicyTarget_Listener) isPolicyTarget_Kind() {}
@@ -2891,6 +2906,8 @@ func (*PolicyTarget_RouteRule) isPolicyTarget_Kind() {}
 func (*PolicyTarget_Backend) isPolicyTarget_Kind() {}
 
 func (*PolicyTarget_Service) isPolicyTarget_Kind() {}
+
+func (*PolicyTarget_SubBackend) isPolicyTarget_Kind() {}
 
 type PolicySpec struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -3364,7 +3381,8 @@ type AIBackend struct {
 	//	*AIBackend_Vertex_
 	//	*AIBackend_Anthropic_
 	//	*AIBackend_Bedrock_
-	Provider      isAIBackend_Provider `protobuf_oneof:"provider"`
+	Provider      isAIBackend_Provider  `protobuf_oneof:"provider"`
+	PathOverride  *wrappers.StringValue `protobuf:"bytes,7,opt,name=path_override,json=pathOverride,proto3" json:"path_override,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -3454,6 +3472,13 @@ func (x *AIBackend) GetBedrock() *AIBackend_Bedrock {
 		if x, ok := x.Provider.(*AIBackend_Bedrock_); ok {
 			return x.Bedrock
 		}
+	}
+	return nil
+}
+
+func (x *AIBackend) GetPathOverride() *wrappers.StringValue {
+	if x != nil {
+		return x.PathOverride
 	}
 	return nil
 }
@@ -5846,7 +5871,7 @@ const file_resource_proto_rawDesc = "" +
 	"\fRouteBackend\x12E\n" +
 	"\abackend\x18\x01 \x01(\v2+.agentgateway.dev.resource.BackendReferenceR\abackend\x12\x16\n" +
 	"\x06weight\x18\x02 \x01(\x05R\x06weight\x12@\n" +
-	"\afilters\x18\x04 \x03(\v2&.agentgateway.dev.resource.RouteFilterR\afilters\"\xc1\x01\n" +
+	"\afilters\x18\x04 \x03(\v2&.agentgateway.dev.resource.RouteFilterR\afilters\"\xe4\x01\n" +
 	"\fPolicyTarget\x12\x1a\n" +
 	"\agateway\x18\x01 \x01(\tH\x00R\agateway\x12\x1c\n" +
 	"\blistener\x18\x02 \x01(\tH\x00R\blistener\x12\x16\n" +
@@ -5854,7 +5879,9 @@ const file_resource_proto_rawDesc = "" +
 	"\n" +
 	"route_rule\x18\x04 \x01(\tH\x00R\trouteRule\x12\x1a\n" +
 	"\abackend\x18\x05 \x01(\tH\x00R\abackend\x12\x1a\n" +
-	"\aservice\x18\x06 \x01(\tH\x00R\aserviceB\x06\n" +
+	"\aservice\x18\x06 \x01(\tH\x00R\aservice\x12!\n" +
+	"\vsub_backend\x18\a \x01(\tH\x00R\n" +
+	"subBackendB\x06\n" +
 	"\x04kind\"\xc13\n" +
 	"\n" +
 	"PolicySpec\x12`\n" +
@@ -6041,14 +6068,15 @@ const file_resource_proto_rawDesc = "" +
 	"\x04kind\"7\n" +
 	"\rStaticBackend\x12\x12\n" +
 	"\x04host\x18\x01 \x01(\tR\x04host\x12\x12\n" +
-	"\x04port\x18\x02 \x01(\x05R\x04port\"\xab\b\n" +
+	"\x04port\x18\x02 \x01(\x05R\x04port\"\xee\b\n" +
 	"\tAIBackend\x12I\n" +
 	"\boverride\x18\x01 \x01(\v2-.agentgateway.dev.resource.AIBackend.OverrideR\boverride\x12E\n" +
 	"\x06openai\x18\x02 \x01(\v2+.agentgateway.dev.resource.AIBackend.OpenAIH\x00R\x06openai\x12E\n" +
 	"\x06gemini\x18\x03 \x01(\v2+.agentgateway.dev.resource.AIBackend.GeminiH\x00R\x06gemini\x12E\n" +
 	"\x06vertex\x18\x04 \x01(\v2+.agentgateway.dev.resource.AIBackend.VertexH\x00R\x06vertex\x12N\n" +
 	"\tanthropic\x18\x05 \x01(\v2..agentgateway.dev.resource.AIBackend.AnthropicH\x00R\tanthropic\x12H\n" +
-	"\abedrock\x18\x06 \x01(\v2,.agentgateway.dev.resource.AIBackend.BedrockH\x00R\abedrock\x1a2\n" +
+	"\abedrock\x18\x06 \x01(\v2,.agentgateway.dev.resource.AIBackend.BedrockH\x00R\abedrock\x12A\n" +
+	"\rpath_override\x18\a \x01(\v2\x1c.google.protobuf.StringValueR\fpathOverride\x1a2\n" +
 	"\bOverride\x12\x12\n" +
 	"\x04host\x18\x01 \x01(\tR\x04host\x12\x12\n" +
 	"\x04port\x18\x02 \x01(\x05R\x04port\x1a<\n" +
@@ -6200,10 +6228,10 @@ var file_resource_proto_goTypes = []any{
 	(*AIBackend_Anthropic)(nil),                       // 83: agentgateway.dev.resource.AIBackend.Anthropic
 	(*AIBackend_Bedrock)(nil),                         // 84: agentgateway.dev.resource.AIBackend.Bedrock
 	(*duration.Duration)(nil),                         // 85: google.protobuf.Duration
-	(*wrappers.UInt32Value)(nil),                      // 86: google.protobuf.UInt32Value
-	(*wrappers.BytesValue)(nil),                       // 87: google.protobuf.BytesValue
-	(*wrappers.BoolValue)(nil),                        // 88: google.protobuf.BoolValue
-	(*wrappers.StringValue)(nil),                      // 89: google.protobuf.StringValue
+	(*wrappers.StringValue)(nil),                      // 86: google.protobuf.StringValue
+	(*wrappers.UInt32Value)(nil),                      // 87: google.protobuf.UInt32Value
+	(*wrappers.BytesValue)(nil),                       // 88: google.protobuf.BytesValue
+	(*wrappers.BoolValue)(nil),                        // 89: google.protobuf.BoolValue
 	(*structpb.Value)(nil),                            // 90: google.protobuf.Value
 }
 var file_resource_proto_depIdxs = []int32{
@@ -6271,72 +6299,73 @@ var file_resource_proto_depIdxs = []int32{
 	82,  // 61: agentgateway.dev.resource.AIBackend.vertex:type_name -> agentgateway.dev.resource.AIBackend.Vertex
 	83,  // 62: agentgateway.dev.resource.AIBackend.anthropic:type_name -> agentgateway.dev.resource.AIBackend.Anthropic
 	84,  // 63: agentgateway.dev.resource.AIBackend.bedrock:type_name -> agentgateway.dev.resource.AIBackend.Bedrock
-	46,  // 64: agentgateway.dev.resource.MCPBackend.targets:type_name -> agentgateway.dev.resource.MCPTarget
-	8,   // 65: agentgateway.dev.resource.MCPBackend.stateful_mode:type_name -> agentgateway.dev.resource.MCPBackend.StatefulMode
-	47,  // 66: agentgateway.dev.resource.MCPTarget.backend:type_name -> agentgateway.dev.resource.BackendReference
-	9,   // 67: agentgateway.dev.resource.MCPTarget.protocol:type_name -> agentgateway.dev.resource.MCPTarget.Protocol
-	60,  // 68: agentgateway.dev.resource.PolicySpec.RemoteRateLimit.descriptors:type_name -> agentgateway.dev.resource.PolicySpec.RemoteRateLimit.Descriptor
-	47,  // 69: agentgateway.dev.resource.PolicySpec.RemoteRateLimit.target:type_name -> agentgateway.dev.resource.BackendReference
-	85,  // 70: agentgateway.dev.resource.PolicySpec.LocalRateLimit.fill_interval:type_name -> google.protobuf.Duration
-	2,   // 71: agentgateway.dev.resource.PolicySpec.LocalRateLimit.type:type_name -> agentgateway.dev.resource.PolicySpec.LocalRateLimit.Type
-	73,  // 72: agentgateway.dev.resource.PolicySpec.Ai.prompt_guard:type_name -> agentgateway.dev.resource.PolicySpec.Ai.PromptGuard
-	74,  // 73: agentgateway.dev.resource.PolicySpec.Ai.defaults:type_name -> agentgateway.dev.resource.PolicySpec.Ai.DefaultsEntry
-	75,  // 74: agentgateway.dev.resource.PolicySpec.Ai.overrides:type_name -> agentgateway.dev.resource.PolicySpec.Ai.OverridesEntry
-	63,  // 75: agentgateway.dev.resource.PolicySpec.Ai.prompts:type_name -> agentgateway.dev.resource.PolicySpec.Ai.PromptEnrichment
-	47,  // 76: agentgateway.dev.resource.PolicySpec.ExternalAuth.target:type_name -> agentgateway.dev.resource.BackendReference
-	77,  // 77: agentgateway.dev.resource.PolicySpec.ExternalAuth.context:type_name -> agentgateway.dev.resource.PolicySpec.ExternalAuth.ContextEntry
-	5,   // 78: agentgateway.dev.resource.PolicySpec.ExternalAuth.failure_mode:type_name -> agentgateway.dev.resource.PolicySpec.ExternalAuth.FailureMode
-	76,  // 79: agentgateway.dev.resource.PolicySpec.ExternalAuth.include_request_body:type_name -> agentgateway.dev.resource.PolicySpec.ExternalAuth.BodyOptions
-	85,  // 80: agentgateway.dev.resource.PolicySpec.ExternalAuth.timeout:type_name -> google.protobuf.Duration
-	86,  // 81: agentgateway.dev.resource.PolicySpec.ExternalAuth.status_on_error:type_name -> google.protobuf.UInt32Value
-	47,  // 82: agentgateway.dev.resource.PolicySpec.InferenceRouting.endpoint_picker:type_name -> agentgateway.dev.resource.BackendReference
-	6,   // 83: agentgateway.dev.resource.PolicySpec.InferenceRouting.failure_mode:type_name -> agentgateway.dev.resource.PolicySpec.InferenceRouting.FailureMode
-	87,  // 84: agentgateway.dev.resource.PolicySpec.BackendTLS.cert:type_name -> google.protobuf.BytesValue
-	87,  // 85: agentgateway.dev.resource.PolicySpec.BackendTLS.key:type_name -> google.protobuf.BytesValue
-	87,  // 86: agentgateway.dev.resource.PolicySpec.BackendTLS.root:type_name -> google.protobuf.BytesValue
-	88,  // 87: agentgateway.dev.resource.PolicySpec.BackendTLS.insecure:type_name -> google.protobuf.BoolValue
-	89,  // 88: agentgateway.dev.resource.PolicySpec.BackendTLS.hostname:type_name -> google.protobuf.StringValue
-	7,   // 89: agentgateway.dev.resource.PolicySpec.JWT.mode:type_name -> agentgateway.dev.resource.PolicySpec.JWT.Mode
-	78,  // 90: agentgateway.dev.resource.PolicySpec.TransformationPolicy.request:type_name -> agentgateway.dev.resource.PolicySpec.TransformationPolicy.Transform
-	78,  // 91: agentgateway.dev.resource.PolicySpec.TransformationPolicy.response:type_name -> agentgateway.dev.resource.PolicySpec.TransformationPolicy.Transform
-	61,  // 92: agentgateway.dev.resource.PolicySpec.RemoteRateLimit.Descriptor.entries:type_name -> agentgateway.dev.resource.PolicySpec.RemoteRateLimit.Entry
-	1,   // 93: agentgateway.dev.resource.PolicySpec.RemoteRateLimit.Descriptor.type:type_name -> agentgateway.dev.resource.PolicySpec.RemoteRateLimit.Type
-	62,  // 94: agentgateway.dev.resource.PolicySpec.Ai.PromptEnrichment.append:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Message
-	62,  // 95: agentgateway.dev.resource.PolicySpec.Ai.PromptEnrichment.prepend:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Message
-	3,   // 96: agentgateway.dev.resource.PolicySpec.Ai.RegexRule.builtin:type_name -> agentgateway.dev.resource.PolicySpec.Ai.BuiltinRegexRule
-	64,  // 97: agentgateway.dev.resource.PolicySpec.Ai.RegexRule.regex:type_name -> agentgateway.dev.resource.PolicySpec.Ai.NamedRegex
-	4,   // 98: agentgateway.dev.resource.PolicySpec.Ai.Action.kind:type_name -> agentgateway.dev.resource.PolicySpec.Ai.ActionKind
-	70,  // 99: agentgateway.dev.resource.PolicySpec.Ai.Action.reject_response:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RequestRejection
-	66,  // 100: agentgateway.dev.resource.PolicySpec.Ai.RegexRules.action:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Action
-	65,  // 101: agentgateway.dev.resource.PolicySpec.Ai.RegexRules.rules:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RegexRule
-	29,  // 102: agentgateway.dev.resource.PolicySpec.Ai.Webhook.forward_header_matches:type_name -> agentgateway.dev.resource.HeaderMatch
-	89,  // 103: agentgateway.dev.resource.PolicySpec.Ai.Moderation.model:type_name -> google.protobuf.StringValue
-	18,  // 104: agentgateway.dev.resource.PolicySpec.Ai.Moderation.auth:type_name -> agentgateway.dev.resource.BackendAuthPolicy
-	67,  // 105: agentgateway.dev.resource.PolicySpec.Ai.ResponseGuard.regex:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RegexRules
-	68,  // 106: agentgateway.dev.resource.PolicySpec.Ai.ResponseGuard.webhook:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Webhook
-	70,  // 107: agentgateway.dev.resource.PolicySpec.Ai.RequestGuard.rejection:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RequestRejection
-	67,  // 108: agentgateway.dev.resource.PolicySpec.Ai.RequestGuard.regex:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RegexRules
-	68,  // 109: agentgateway.dev.resource.PolicySpec.Ai.RequestGuard.webhook:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Webhook
-	69,  // 110: agentgateway.dev.resource.PolicySpec.Ai.RequestGuard.openai_moderation:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Moderation
-	72,  // 111: agentgateway.dev.resource.PolicySpec.Ai.PromptGuard.request:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RequestGuard
-	71,  // 112: agentgateway.dev.resource.PolicySpec.Ai.PromptGuard.response:type_name -> agentgateway.dev.resource.PolicySpec.Ai.ResponseGuard
-	90,  // 113: agentgateway.dev.resource.PolicySpec.Ai.DefaultsEntry.value:type_name -> google.protobuf.Value
-	90,  // 114: agentgateway.dev.resource.PolicySpec.Ai.OverridesEntry.value:type_name -> google.protobuf.Value
-	58,  // 115: agentgateway.dev.resource.PolicySpec.TransformationPolicy.Transform.set:type_name -> agentgateway.dev.resource.PolicySpec.HeaderTransformation
-	58,  // 116: agentgateway.dev.resource.PolicySpec.TransformationPolicy.Transform.add:type_name -> agentgateway.dev.resource.PolicySpec.HeaderTransformation
-	59,  // 117: agentgateway.dev.resource.PolicySpec.TransformationPolicy.Transform.body:type_name -> agentgateway.dev.resource.PolicySpec.BodyTransformation
-	89,  // 118: agentgateway.dev.resource.AIBackend.OpenAI.model:type_name -> google.protobuf.StringValue
-	89,  // 119: agentgateway.dev.resource.AIBackend.Gemini.model:type_name -> google.protobuf.StringValue
-	89,  // 120: agentgateway.dev.resource.AIBackend.Vertex.model:type_name -> google.protobuf.StringValue
-	89,  // 121: agentgateway.dev.resource.AIBackend.Anthropic.model:type_name -> google.protobuf.StringValue
-	89,  // 122: agentgateway.dev.resource.AIBackend.Bedrock.model:type_name -> google.protobuf.StringValue
-	89,  // 123: agentgateway.dev.resource.AIBackend.Bedrock.guardrail_identifier:type_name -> google.protobuf.StringValue
-	89,  // 124: agentgateway.dev.resource.AIBackend.Bedrock.guardrail_version:type_name -> google.protobuf.StringValue
-	125, // [125:125] is the sub-list for method output_type
-	125, // [125:125] is the sub-list for method input_type
-	125, // [125:125] is the sub-list for extension type_name
-	125, // [125:125] is the sub-list for extension extendee
-	0,   // [0:125] is the sub-list for field type_name
+	86,  // 64: agentgateway.dev.resource.AIBackend.path_override:type_name -> google.protobuf.StringValue
+	46,  // 65: agentgateway.dev.resource.MCPBackend.targets:type_name -> agentgateway.dev.resource.MCPTarget
+	8,   // 66: agentgateway.dev.resource.MCPBackend.stateful_mode:type_name -> agentgateway.dev.resource.MCPBackend.StatefulMode
+	47,  // 67: agentgateway.dev.resource.MCPTarget.backend:type_name -> agentgateway.dev.resource.BackendReference
+	9,   // 68: agentgateway.dev.resource.MCPTarget.protocol:type_name -> agentgateway.dev.resource.MCPTarget.Protocol
+	60,  // 69: agentgateway.dev.resource.PolicySpec.RemoteRateLimit.descriptors:type_name -> agentgateway.dev.resource.PolicySpec.RemoteRateLimit.Descriptor
+	47,  // 70: agentgateway.dev.resource.PolicySpec.RemoteRateLimit.target:type_name -> agentgateway.dev.resource.BackendReference
+	85,  // 71: agentgateway.dev.resource.PolicySpec.LocalRateLimit.fill_interval:type_name -> google.protobuf.Duration
+	2,   // 72: agentgateway.dev.resource.PolicySpec.LocalRateLimit.type:type_name -> agentgateway.dev.resource.PolicySpec.LocalRateLimit.Type
+	73,  // 73: agentgateway.dev.resource.PolicySpec.Ai.prompt_guard:type_name -> agentgateway.dev.resource.PolicySpec.Ai.PromptGuard
+	74,  // 74: agentgateway.dev.resource.PolicySpec.Ai.defaults:type_name -> agentgateway.dev.resource.PolicySpec.Ai.DefaultsEntry
+	75,  // 75: agentgateway.dev.resource.PolicySpec.Ai.overrides:type_name -> agentgateway.dev.resource.PolicySpec.Ai.OverridesEntry
+	63,  // 76: agentgateway.dev.resource.PolicySpec.Ai.prompts:type_name -> agentgateway.dev.resource.PolicySpec.Ai.PromptEnrichment
+	47,  // 77: agentgateway.dev.resource.PolicySpec.ExternalAuth.target:type_name -> agentgateway.dev.resource.BackendReference
+	77,  // 78: agentgateway.dev.resource.PolicySpec.ExternalAuth.context:type_name -> agentgateway.dev.resource.PolicySpec.ExternalAuth.ContextEntry
+	5,   // 79: agentgateway.dev.resource.PolicySpec.ExternalAuth.failure_mode:type_name -> agentgateway.dev.resource.PolicySpec.ExternalAuth.FailureMode
+	76,  // 80: agentgateway.dev.resource.PolicySpec.ExternalAuth.include_request_body:type_name -> agentgateway.dev.resource.PolicySpec.ExternalAuth.BodyOptions
+	85,  // 81: agentgateway.dev.resource.PolicySpec.ExternalAuth.timeout:type_name -> google.protobuf.Duration
+	87,  // 82: agentgateway.dev.resource.PolicySpec.ExternalAuth.status_on_error:type_name -> google.protobuf.UInt32Value
+	47,  // 83: agentgateway.dev.resource.PolicySpec.InferenceRouting.endpoint_picker:type_name -> agentgateway.dev.resource.BackendReference
+	6,   // 84: agentgateway.dev.resource.PolicySpec.InferenceRouting.failure_mode:type_name -> agentgateway.dev.resource.PolicySpec.InferenceRouting.FailureMode
+	88,  // 85: agentgateway.dev.resource.PolicySpec.BackendTLS.cert:type_name -> google.protobuf.BytesValue
+	88,  // 86: agentgateway.dev.resource.PolicySpec.BackendTLS.key:type_name -> google.protobuf.BytesValue
+	88,  // 87: agentgateway.dev.resource.PolicySpec.BackendTLS.root:type_name -> google.protobuf.BytesValue
+	89,  // 88: agentgateway.dev.resource.PolicySpec.BackendTLS.insecure:type_name -> google.protobuf.BoolValue
+	86,  // 89: agentgateway.dev.resource.PolicySpec.BackendTLS.hostname:type_name -> google.protobuf.StringValue
+	7,   // 90: agentgateway.dev.resource.PolicySpec.JWT.mode:type_name -> agentgateway.dev.resource.PolicySpec.JWT.Mode
+	78,  // 91: agentgateway.dev.resource.PolicySpec.TransformationPolicy.request:type_name -> agentgateway.dev.resource.PolicySpec.TransformationPolicy.Transform
+	78,  // 92: agentgateway.dev.resource.PolicySpec.TransformationPolicy.response:type_name -> agentgateway.dev.resource.PolicySpec.TransformationPolicy.Transform
+	61,  // 93: agentgateway.dev.resource.PolicySpec.RemoteRateLimit.Descriptor.entries:type_name -> agentgateway.dev.resource.PolicySpec.RemoteRateLimit.Entry
+	1,   // 94: agentgateway.dev.resource.PolicySpec.RemoteRateLimit.Descriptor.type:type_name -> agentgateway.dev.resource.PolicySpec.RemoteRateLimit.Type
+	62,  // 95: agentgateway.dev.resource.PolicySpec.Ai.PromptEnrichment.append:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Message
+	62,  // 96: agentgateway.dev.resource.PolicySpec.Ai.PromptEnrichment.prepend:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Message
+	3,   // 97: agentgateway.dev.resource.PolicySpec.Ai.RegexRule.builtin:type_name -> agentgateway.dev.resource.PolicySpec.Ai.BuiltinRegexRule
+	64,  // 98: agentgateway.dev.resource.PolicySpec.Ai.RegexRule.regex:type_name -> agentgateway.dev.resource.PolicySpec.Ai.NamedRegex
+	4,   // 99: agentgateway.dev.resource.PolicySpec.Ai.Action.kind:type_name -> agentgateway.dev.resource.PolicySpec.Ai.ActionKind
+	70,  // 100: agentgateway.dev.resource.PolicySpec.Ai.Action.reject_response:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RequestRejection
+	66,  // 101: agentgateway.dev.resource.PolicySpec.Ai.RegexRules.action:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Action
+	65,  // 102: agentgateway.dev.resource.PolicySpec.Ai.RegexRules.rules:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RegexRule
+	29,  // 103: agentgateway.dev.resource.PolicySpec.Ai.Webhook.forward_header_matches:type_name -> agentgateway.dev.resource.HeaderMatch
+	86,  // 104: agentgateway.dev.resource.PolicySpec.Ai.Moderation.model:type_name -> google.protobuf.StringValue
+	18,  // 105: agentgateway.dev.resource.PolicySpec.Ai.Moderation.auth:type_name -> agentgateway.dev.resource.BackendAuthPolicy
+	67,  // 106: agentgateway.dev.resource.PolicySpec.Ai.ResponseGuard.regex:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RegexRules
+	68,  // 107: agentgateway.dev.resource.PolicySpec.Ai.ResponseGuard.webhook:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Webhook
+	70,  // 108: agentgateway.dev.resource.PolicySpec.Ai.RequestGuard.rejection:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RequestRejection
+	67,  // 109: agentgateway.dev.resource.PolicySpec.Ai.RequestGuard.regex:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RegexRules
+	68,  // 110: agentgateway.dev.resource.PolicySpec.Ai.RequestGuard.webhook:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Webhook
+	69,  // 111: agentgateway.dev.resource.PolicySpec.Ai.RequestGuard.openai_moderation:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Moderation
+	72,  // 112: agentgateway.dev.resource.PolicySpec.Ai.PromptGuard.request:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RequestGuard
+	71,  // 113: agentgateway.dev.resource.PolicySpec.Ai.PromptGuard.response:type_name -> agentgateway.dev.resource.PolicySpec.Ai.ResponseGuard
+	90,  // 114: agentgateway.dev.resource.PolicySpec.Ai.DefaultsEntry.value:type_name -> google.protobuf.Value
+	90,  // 115: agentgateway.dev.resource.PolicySpec.Ai.OverridesEntry.value:type_name -> google.protobuf.Value
+	58,  // 116: agentgateway.dev.resource.PolicySpec.TransformationPolicy.Transform.set:type_name -> agentgateway.dev.resource.PolicySpec.HeaderTransformation
+	58,  // 117: agentgateway.dev.resource.PolicySpec.TransformationPolicy.Transform.add:type_name -> agentgateway.dev.resource.PolicySpec.HeaderTransformation
+	59,  // 118: agentgateway.dev.resource.PolicySpec.TransformationPolicy.Transform.body:type_name -> agentgateway.dev.resource.PolicySpec.BodyTransformation
+	86,  // 119: agentgateway.dev.resource.AIBackend.OpenAI.model:type_name -> google.protobuf.StringValue
+	86,  // 120: agentgateway.dev.resource.AIBackend.Gemini.model:type_name -> google.protobuf.StringValue
+	86,  // 121: agentgateway.dev.resource.AIBackend.Vertex.model:type_name -> google.protobuf.StringValue
+	86,  // 122: agentgateway.dev.resource.AIBackend.Anthropic.model:type_name -> google.protobuf.StringValue
+	86,  // 123: agentgateway.dev.resource.AIBackend.Bedrock.model:type_name -> google.protobuf.StringValue
+	86,  // 124: agentgateway.dev.resource.AIBackend.Bedrock.guardrail_identifier:type_name -> google.protobuf.StringValue
+	86,  // 125: agentgateway.dev.resource.AIBackend.Bedrock.guardrail_version:type_name -> google.protobuf.StringValue
+	126, // [126:126] is the sub-list for method output_type
+	126, // [126:126] is the sub-list for method input_type
+	126, // [126:126] is the sub-list for extension type_name
+	126, // [126:126] is the sub-list for extension extendee
+	0,   // [0:126] is the sub-list for field type_name
 }
 
 func init() { file_resource_proto_init() }
@@ -6400,6 +6429,7 @@ func file_resource_proto_init() {
 		(*PolicyTarget_RouteRule)(nil),
 		(*PolicyTarget_Backend)(nil),
 		(*PolicyTarget_Service)(nil),
+		(*PolicyTarget_SubBackend)(nil),
 	}
 	file_resource_proto_msgTypes[30].OneofWrappers = []any{
 		(*PolicySpec_LocalRateLimit_)(nil),

--- a/schema/README.md
+++ b/schema/README.md
@@ -318,26 +318,27 @@ This folder contains JSON schemas for various parts of the project
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)provider.(1)bedrock.guardrailVersion`||
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)hostOverride`||
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)tokenize`|Whether to tokenize on the request flow. This enables us to do more accurate rate limits,<br>since we know (part of) the cost of the request upfront.<br>This comes with the cost of an expensive operation.|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)providers`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)providers[].name`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)providers[].provider`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)providers[].provider.(1)openAI`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)providers[].provider.(1)openAI.model`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)providers[].provider.(1)gemini`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)providers[].provider.(1)gemini.model`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)providers[].provider.(1)vertex`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)providers[].provider.(1)vertex.model`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)providers[].provider.(1)vertex.region`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)providers[].provider.(1)vertex.projectId`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)providers[].provider.(1)anthropic`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)providers[].provider.(1)anthropic.model`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)providers[].provider.(1)bedrock`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)providers[].provider.(1)bedrock.model`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)providers[].provider.(1)bedrock.region`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)providers[].provider.(1)bedrock.guardrailIdentifier`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)providers[].provider.(1)bedrock.guardrailVersion`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)providers[].hostOverride`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)providers[].tokenize`|Whether to tokenize on the request flow. This enables us to do more accurate rate limits,<br>since we know (part of) the cost of the request upfront.<br>This comes with the cost of an expensive operation.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].name`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].provider`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].provider.(1)openAI`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].provider.(1)openAI.model`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].provider.(1)gemini`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].provider.(1)gemini.model`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].provider.(1)vertex`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].provider.(1)vertex.model`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].provider.(1)vertex.region`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].provider.(1)vertex.projectId`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].provider.(1)anthropic`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].provider.(1)anthropic.model`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].provider.(1)bedrock`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].provider.(1)bedrock.model`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].provider.(1)bedrock.region`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].provider.(1)bedrock.guardrailIdentifier`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].provider.(1)bedrock.guardrailVersion`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].hostOverride`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].tokenize`|Whether to tokenize on the request flow. This enables us to do more accurate rate limits,<br>since we know (part of) the cost of the request upfront.<br>This comes with the cost of an expensive operation.|
 |`binds[].listeners[].routes[].backends[].weight`||
 |`binds[].listeners[].tcpRoutes`||
 |`binds[].listeners[].tcpRoutes[].name`||

--- a/schema/README.md
+++ b/schema/README.md
@@ -317,7 +317,25 @@ This folder contains JSON schemas for various parts of the project
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)provider.(1)bedrock.guardrailIdentifier`||
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)provider.(1)bedrock.guardrailVersion`||
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)hostOverride`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)pathOverride`||
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)tokenize`|Whether to tokenize on the request flow. This enables us to do more accurate rate limits,<br>since we know (part of) the cost of the request upfront.<br>This comes with the cost of an expensive operation.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)backendTLS`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)backendTLS.cert`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)backendTLS.key`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)backendTLS.root`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)backendTLS.hostname`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)backendTLS.insecure`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)backendTLS.insecureHost`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)backendAuth`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)backendAuth.(any)(1)passthrough`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)backendAuth.(any)(1)key`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)backendAuth.(any)(1)key.(any)file`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)backendAuth.(any)(1)gcp`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)backendAuth.(any)(1)aws`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)backendAuth.(any)(1)aws.(any)accessKeyId`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)backendAuth.(any)(1)aws.(any)secretAccessKey`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)backendAuth.(any)(1)aws.(any)region`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)backendAuth.(any)(1)aws.(any)sessionToken`||
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)groups`||
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers`||
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].name`||
@@ -338,7 +356,25 @@ This folder contains JSON schemas for various parts of the project
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].provider.(1)bedrock.guardrailIdentifier`||
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].provider.(1)bedrock.guardrailVersion`||
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].hostOverride`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].pathOverride`||
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].tokenize`|Whether to tokenize on the request flow. This enables us to do more accurate rate limits,<br>since we know (part of) the cost of the request upfront.<br>This comes with the cost of an expensive operation.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].backendTLS`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].backendTLS.cert`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].backendTLS.key`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].backendTLS.root`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].backendTLS.hostname`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].backendTLS.insecure`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].backendTLS.insecureHost`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].backendAuth`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].backendAuth.(any)(1)passthrough`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].backendAuth.(any)(1)key`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].backendAuth.(any)(1)key.(any)file`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].backendAuth.(any)(1)gcp`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].backendAuth.(any)(1)aws`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].backendAuth.(any)(1)aws.(any)accessKeyId`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].backendAuth.(any)(1)aws.(any)secretAccessKey`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].backendAuth.(any)(1)aws.(any)region`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].backendAuth.(any)(1)aws.(any)sessionToken`||
 |`binds[].listeners[].routes[].backends[].weight`||
 |`binds[].listeners[].tcpRoutes`||
 |`binds[].listeners[].tcpRoutes[].name`||
@@ -370,6 +406,7 @@ This folder contains JSON schemas for various parts of the project
 |`policies[].target.(1)routeRule`||
 |`policies[].target.(1)service`||
 |`policies[].target.(1)backend`||
+|`policies[].target.(1)subBackend`||
 |`policies[].policy`||
 |`policies[].policy.requestHeaderModifier`|Headers to be modified in the request.|
 |`policies[].policy.requestHeaderModifier.add`||

--- a/schema/local.json
+++ b/schema/local.json
@@ -2772,10 +2772,167 @@
                                             "null"
                                           ]
                                         },
+                                        "pathOverride": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
                                         "tokenize": {
                                           "description": "Whether to tokenize on the request flow. This enables us to do more accurate rate limits,\nsince we know (part of) the cost of the request upfront.\nThis comes with the cost of an expensive operation.",
                                           "type": "boolean",
                                           "default": false
+                                        },
+                                        "backendTLS": {
+                                          "type": [
+                                            "object",
+                                            "null"
+                                          ],
+                                          "properties": {
+                                            "cert": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "key": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "root": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "hostname": {
+                                              "type": [
+                                                "string",
+                                                "null"
+                                              ]
+                                            },
+                                            "insecure": {
+                                              "type": "boolean",
+                                              "default": false
+                                            },
+                                            "insecureHost": {
+                                              "type": "boolean",
+                                              "default": false
+                                            }
+                                          },
+                                          "additionalProperties": false
+                                        },
+                                        "backendAuth": {
+                                          "anyOf": [
+                                            {
+                                              "oneOf": [
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "passthrough": {
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "passthrough"
+                                                  ],
+                                                  "additionalProperties": false
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "key": {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "file": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "file"
+                                                          ]
+                                                        },
+                                                        {
+                                                          "type": "string"
+                                                        }
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key"
+                                                  ],
+                                                  "additionalProperties": false
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "gcp": {
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "gcp"
+                                                  ],
+                                                  "additionalProperties": false
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "aws": {
+                                                      "anyOf": [
+                                                        {
+                                                          "description": "Use explicit AWS credentials",
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "accessKeyId": {
+                                                              "type": "string"
+                                                            },
+                                                            "secretAccessKey": {
+                                                              "type": "string"
+                                                            },
+                                                            "region": {
+                                                              "type": "string"
+                                                            },
+                                                            "sessionToken": {
+                                                              "type": [
+                                                                "string",
+                                                                "null"
+                                                              ]
+                                                            }
+                                                          },
+                                                          "additionalProperties": false,
+                                                          "required": [
+                                                            "accessKeyId",
+                                                            "secretAccessKey",
+                                                            "region"
+                                                          ]
+                                                        },
+                                                        {
+                                                          "description": "Use implicit AWS authentication (environment variables, IAM roles, etc.)",
+                                                          "type": "object",
+                                                          "additionalProperties": false
+                                                        }
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "aws"
+                                                  ],
+                                                  "additionalProperties": false
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "type": "null"
+                                            }
+                                          ],
+                                          "default": null
                                         }
                                       },
                                       "additionalProperties": false,
@@ -2941,10 +3098,167 @@
                                                         "null"
                                                       ]
                                                     },
+                                                    "pathOverride": {
+                                                      "type": [
+                                                        "string",
+                                                        "null"
+                                                      ]
+                                                    },
                                                     "tokenize": {
                                                       "description": "Whether to tokenize on the request flow. This enables us to do more accurate rate limits,\nsince we know (part of) the cost of the request upfront.\nThis comes with the cost of an expensive operation.",
                                                       "type": "boolean",
                                                       "default": false
+                                                    },
+                                                    "backendTLS": {
+                                                      "type": [
+                                                        "object",
+                                                        "null"
+                                                      ],
+                                                      "properties": {
+                                                        "cert": {
+                                                          "type": [
+                                                            "string",
+                                                            "null"
+                                                          ]
+                                                        },
+                                                        "key": {
+                                                          "type": [
+                                                            "string",
+                                                            "null"
+                                                          ]
+                                                        },
+                                                        "root": {
+                                                          "type": [
+                                                            "string",
+                                                            "null"
+                                                          ]
+                                                        },
+                                                        "hostname": {
+                                                          "type": [
+                                                            "string",
+                                                            "null"
+                                                          ]
+                                                        },
+                                                        "insecure": {
+                                                          "type": "boolean",
+                                                          "default": false
+                                                        },
+                                                        "insecureHost": {
+                                                          "type": "boolean",
+                                                          "default": false
+                                                        }
+                                                      },
+                                                      "additionalProperties": false
+                                                    },
+                                                    "backendAuth": {
+                                                      "anyOf": [
+                                                        {
+                                                          "oneOf": [
+                                                            {
+                                                              "type": "object",
+                                                              "properties": {
+                                                                "passthrough": {
+                                                                  "type": "object",
+                                                                  "additionalProperties": false
+                                                                }
+                                                              },
+                                                              "required": [
+                                                                "passthrough"
+                                                              ],
+                                                              "additionalProperties": false
+                                                            },
+                                                            {
+                                                              "type": "object",
+                                                              "properties": {
+                                                                "key": {
+                                                                  "anyOf": [
+                                                                    {
+                                                                      "type": "object",
+                                                                      "properties": {
+                                                                        "file": {
+                                                                          "type": "string"
+                                                                        }
+                                                                      },
+                                                                      "required": [
+                                                                        "file"
+                                                                      ]
+                                                                    },
+                                                                    {
+                                                                      "type": "string"
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "required": [
+                                                                "key"
+                                                              ],
+                                                              "additionalProperties": false
+                                                            },
+                                                            {
+                                                              "type": "object",
+                                                              "properties": {
+                                                                "gcp": {
+                                                                  "type": "object",
+                                                                  "additionalProperties": false
+                                                                }
+                                                              },
+                                                              "required": [
+                                                                "gcp"
+                                                              ],
+                                                              "additionalProperties": false
+                                                            },
+                                                            {
+                                                              "type": "object",
+                                                              "properties": {
+                                                                "aws": {
+                                                                  "anyOf": [
+                                                                    {
+                                                                      "description": "Use explicit AWS credentials",
+                                                                      "type": "object",
+                                                                      "properties": {
+                                                                        "accessKeyId": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "secretAccessKey": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "region": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "sessionToken": {
+                                                                          "type": [
+                                                                            "string",
+                                                                            "null"
+                                                                          ]
+                                                                        }
+                                                                      },
+                                                                      "additionalProperties": false,
+                                                                      "required": [
+                                                                        "accessKeyId",
+                                                                        "secretAccessKey",
+                                                                        "region"
+                                                                      ]
+                                                                    },
+                                                                    {
+                                                                      "description": "Use implicit AWS authentication (environment variables, IAM roles, etc.)",
+                                                                      "type": "object",
+                                                                      "additionalProperties": false
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "required": [
+                                                                "aws"
+                                                              ],
+                                                              "additionalProperties": false
+                                                            }
+                                                          ]
+                                                        },
+                                                        {
+                                                          "type": "null"
+                                                        }
+                                                      ],
+                                                      "default": null
                                                     }
                                                   },
                                                   "additionalProperties": false,
@@ -3234,6 +3548,18 @@
                 },
                 "required": [
                   "backend"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "subBackend": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "subBackend"
                 ],
                 "additionalProperties": false
               }

--- a/schema/local.json
+++ b/schema/local.json
@@ -2787,172 +2787,184 @@
                                     {
                                       "type": "object",
                                       "properties": {
-                                        "providers": {
+                                        "groups": {
                                           "type": "array",
                                           "items": {
                                             "type": "object",
                                             "properties": {
-                                              "name": {
-                                                "type": "string"
-                                              },
-                                              "provider": {
-                                                "oneOf": [
-                                                  {
-                                                    "type": "object",
-                                                    "properties": {
-                                                      "openAI": {
-                                                        "type": "object",
-                                                        "properties": {
-                                                          "model": {
-                                                            "type": [
-                                                              "string",
-                                                              "null"
-                                                            ]
-                                                          }
-                                                        },
-                                                        "additionalProperties": false
-                                                      }
+                                              "providers": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
                                                     },
-                                                    "required": [
-                                                      "openAI"
-                                                    ],
-                                                    "additionalProperties": false
-                                                  },
-                                                  {
-                                                    "type": "object",
-                                                    "properties": {
-                                                      "gemini": {
-                                                        "type": "object",
-                                                        "properties": {
-                                                          "model": {
-                                                            "type": [
-                                                              "string",
-                                                              "null"
-                                                            ]
-                                                          }
+                                                    "provider": {
+                                                      "oneOf": [
+                                                        {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "openAI": {
+                                                              "type": "object",
+                                                              "properties": {
+                                                                "model": {
+                                                                  "type": [
+                                                                    "string",
+                                                                    "null"
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "additionalProperties": false
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "openAI"
+                                                          ],
+                                                          "additionalProperties": false
+                                                        },
+                                                        {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "gemini": {
+                                                              "type": "object",
+                                                              "properties": {
+                                                                "model": {
+                                                                  "type": [
+                                                                    "string",
+                                                                    "null"
+                                                                  ]
+                                                                }
+                                                              }
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "gemini"
+                                                          ],
+                                                          "additionalProperties": false
+                                                        },
+                                                        {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "vertex": {
+                                                              "type": "object",
+                                                              "properties": {
+                                                                "model": {
+                                                                  "type": [
+                                                                    "string",
+                                                                    "null"
+                                                                  ]
+                                                                },
+                                                                "region": {
+                                                                  "type": [
+                                                                    "string",
+                                                                    "null"
+                                                                  ]
+                                                                },
+                                                                "projectId": {
+                                                                  "type": "string"
+                                                                }
+                                                              },
+                                                              "required": [
+                                                                "projectId"
+                                                              ]
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "vertex"
+                                                          ],
+                                                          "additionalProperties": false
+                                                        },
+                                                        {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "anthropic": {
+                                                              "type": "object",
+                                                              "properties": {
+                                                                "model": {
+                                                                  "type": [
+                                                                    "string",
+                                                                    "null"
+                                                                  ]
+                                                                }
+                                                              }
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "anthropic"
+                                                          ],
+                                                          "additionalProperties": false
+                                                        },
+                                                        {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "bedrock": {
+                                                              "type": "object",
+                                                              "properties": {
+                                                                "model": {
+                                                                  "type": [
+                                                                    "string",
+                                                                    "null"
+                                                                  ]
+                                                                },
+                                                                "region": {
+                                                                  "type": "string"
+                                                                },
+                                                                "guardrailIdentifier": {
+                                                                  "type": [
+                                                                    "string",
+                                                                    "null"
+                                                                  ]
+                                                                },
+                                                                "guardrailVersion": {
+                                                                  "type": [
+                                                                    "string",
+                                                                    "null"
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "required": [
+                                                                "region"
+                                                              ]
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "bedrock"
+                                                          ],
+                                                          "additionalProperties": false
                                                         }
-                                                      }
+                                                      ]
                                                     },
-                                                    "required": [
-                                                      "gemini"
-                                                    ],
-                                                    "additionalProperties": false
+                                                    "hostOverride": {
+                                                      "type": [
+                                                        "string",
+                                                        "null"
+                                                      ]
+                                                    },
+                                                    "tokenize": {
+                                                      "description": "Whether to tokenize on the request flow. This enables us to do more accurate rate limits,\nsince we know (part of) the cost of the request upfront.\nThis comes with the cost of an expensive operation.",
+                                                      "type": "boolean",
+                                                      "default": false
+                                                    }
                                                   },
-                                                  {
-                                                    "type": "object",
-                                                    "properties": {
-                                                      "vertex": {
-                                                        "type": "object",
-                                                        "properties": {
-                                                          "model": {
-                                                            "type": [
-                                                              "string",
-                                                              "null"
-                                                            ]
-                                                          },
-                                                          "region": {
-                                                            "type": [
-                                                              "string",
-                                                              "null"
-                                                            ]
-                                                          },
-                                                          "projectId": {
-                                                            "type": "string"
-                                                          }
-                                                        },
-                                                        "required": [
-                                                          "projectId"
-                                                        ]
-                                                      }
-                                                    },
-                                                    "required": [
-                                                      "vertex"
-                                                    ],
-                                                    "additionalProperties": false
-                                                  },
-                                                  {
-                                                    "type": "object",
-                                                    "properties": {
-                                                      "anthropic": {
-                                                        "type": "object",
-                                                        "properties": {
-                                                          "model": {
-                                                            "type": [
-                                                              "string",
-                                                              "null"
-                                                            ]
-                                                          }
-                                                        }
-                                                      }
-                                                    },
-                                                    "required": [
-                                                      "anthropic"
-                                                    ],
-                                                    "additionalProperties": false
-                                                  },
-                                                  {
-                                                    "type": "object",
-                                                    "properties": {
-                                                      "bedrock": {
-                                                        "type": "object",
-                                                        "properties": {
-                                                          "model": {
-                                                            "type": [
-                                                              "string",
-                                                              "null"
-                                                            ]
-                                                          },
-                                                          "region": {
-                                                            "type": "string"
-                                                          },
-                                                          "guardrailIdentifier": {
-                                                            "type": [
-                                                              "string",
-                                                              "null"
-                                                            ]
-                                                          },
-                                                          "guardrailVersion": {
-                                                            "type": [
-                                                              "string",
-                                                              "null"
-                                                            ]
-                                                          }
-                                                        },
-                                                        "required": [
-                                                          "region"
-                                                        ]
-                                                      }
-                                                    },
-                                                    "required": [
-                                                      "bedrock"
-                                                    ],
-                                                    "additionalProperties": false
-                                                  }
-                                                ]
-                                              },
-                                              "hostOverride": {
-                                                "type": [
-                                                  "string",
-                                                  "null"
-                                                ]
-                                              },
-                                              "tokenize": {
-                                                "description": "Whether to tokenize on the request flow. This enables us to do more accurate rate limits,\nsince we know (part of) the cost of the request upfront.\nThis comes with the cost of an expensive operation.",
-                                                "type": "boolean",
-                                                "default": false
+                                                  "additionalProperties": false,
+                                                  "required": [
+                                                    "name",
+                                                    "provider"
+                                                  ]
+                                                }
                                               }
                                             },
                                             "additionalProperties": false,
                                             "required": [
-                                              "name",
-                                              "provider"
+                                              "providers"
                                             ]
                                           }
                                         }
                                       },
                                       "additionalProperties": false,
                                       "required": [
-                                        "providers"
+                                        "groups"
                                       ]
                                     }
                                   ]


### PR DESCRIPTION
* Allow configuring the double nested nature
* Allow sub-backend policies
* Allow inline backend TLS and backend auth on the provider
* Fix a bug in the load balancer algorithm

Example:
```yaml
    routes:
    -
      policies:
        urlRewrite:
          authority: auto
      backends:
      - ai:
          groups:
          - providers:
            - name: cerebras
              hostOverride: "api.cerebras.ai:443"
              pathOverride: /v1/chat/completions
              provider:
                openAI:
                  model: "qwen-3-coder-480b"
              backendAuth:
                key:
                  file: $HOME/.secrets/cerebras
              backendTLS: {}
          - providers:
            - name: openrouter
              hostOverride: "openrouter.ai:443"
              pathOverride: /api/v1/chat/completions
              provider:
                openAI:
                  model: "@preset/free"
              backendAuth:
                key:
                  file: $HOME/.secrets/openrouter
              backendTLS: {}
```