### PR TITLE
Add request headers for global ratelimiting

### DIFF
--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -60,7 +60,11 @@ async fn apply_request_policies(
 
 	// Extract dynamic metadata for CEL context
 	log.cel.ctx().with_extauthz(req);
-
+	log.cel.ctx().with_request(req);
+	log
+		.cel
+		.ctx()
+		.with_source(&log.tcp_info, log.tls_info.as_ref());
 	let exec = log
 		.cel
 		.ctx()
@@ -105,6 +109,11 @@ async fn apply_llm_request_policies(
 	let (rl_resp, response) = if let Some(rrl) = &policies.remote_rate_limit
 		&& let Some(log) = log
 	{
+		log.cel.ctx().with_request(req);
+		log
+			.cel
+			.ctx()
+			.with_source(&log.tcp_info, log.tls_info.as_ref());
 		let exec = log
 			.cel
 			.ctx()

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -60,7 +60,6 @@ async fn apply_request_policies(
 
 	// Extract dynamic metadata for CEL context
 	log.cel.ctx().with_extauthz(req);
-	log.cel.ctx().with_request(req);
 	log
 		.cel
 		.ctx()
@@ -109,7 +108,6 @@ async fn apply_llm_request_policies(
 	let (rl_resp, response) = if let Some(rrl) = &policies.remote_rate_limit
 		&& let Some(log) = log
 	{
-		log.cel.ctx().with_request(req);
 		log
 			.cel
 			.ctx()

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -359,7 +359,10 @@ impl HTTPProxy {
 		);
 		// Register all expressions
 		route_policies.register_cel_expressions(log.cel.ctx());
-		log.cel.ctx().with_source(&log.tcp_info, log.tls_info.as_ref());
+		log
+			.cel
+			.ctx()
+			.with_source(&log.tcp_info, log.tls_info.as_ref());
 		// This is unfortunate but we record the request twice possibly; we want to record it as early as possible
 		// so we can do logging, etc when we find no routes.
 		// But we may find new expressions that now need the request.

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -60,10 +60,7 @@ async fn apply_request_policies(
 
 	// Extract dynamic metadata for CEL context
 	log.cel.ctx().with_extauthz(req);
-	log
-		.cel
-		.ctx()
-		.with_source(&log.tcp_info, log.tls_info.as_ref());
+
 	let exec = log
 		.cel
 		.ctx()
@@ -108,10 +105,6 @@ async fn apply_llm_request_policies(
 	let (rl_resp, response) = if let Some(rrl) = &policies.remote_rate_limit
 		&& let Some(log) = log
 	{
-		log
-			.cel
-			.ctx()
-			.with_source(&log.tcp_info, log.tls_info.as_ref());
 		let exec = log
 			.cel
 			.ctx()
@@ -265,10 +258,6 @@ impl HTTPProxy {
 		log: &mut RequestLog,
 	) -> Result<Response, ProxyResponse> {
 		log.tls_info = connection.get::<TLSConnectionInfo>().cloned();
-		log
-			.cel
-			.ctx()
-			.with_source(&log.tcp_info, log.tls_info.as_ref());
 		let selected_listener = self.selected_listener.clone();
 		let inputs = self.inputs.clone();
 		let bind_name = self.bind_name.clone();
@@ -370,6 +359,7 @@ impl HTTPProxy {
 		);
 		// Register all expressions
 		route_policies.register_cel_expressions(log.cel.ctx());
+		log.cel.ctx().with_source(&log.tcp_info, log.tls_info.as_ref());
 		// This is unfortunate but we record the request twice possibly; we want to record it as early as possible
 		// so we can do logging, etc when we find no routes.
 		// But we may find new expressions that now need the request.


### PR DESCRIPTION
This change is needed to properly process `IP source` and `Headers` based global ratelimiting rules.