### PR TITLE
docs(DEVELOPMENT.md): fix `CARGO_NET_GIT_FETCH_WITH_CLI` env var

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -20,7 +20,7 @@ Build the agentgateway binary:
 
 ```bash
 cd ..
-CARGO_NET_GIT_FETCH_WITH_CLI=true
+export CARGO_NET_GIT_FETCH_WITH_CLI=true
 make build
 ```
 


### PR DESCRIPTION
Minor miss in #342.

To address [this comment](https://github.com/agentgateway/agentgateway/pull/342/files#r2288580495) without this env var, build fails with the following error:

```
error: failed to load source for dependency `async-openai`

Caused by:
  Unable to update https://github.com/howardjohn/async-openai?rev=c95098beac2c65132c8a7b7c7bf39a9ad6479acb#c95098be

Caused by:
  failed to clone into: /home/foo/.asdf/installs/rust/stable/git/db/async-openai-7596ea9b828427ed

Caused by:
  revision c95098beac2c65132c8a7b7c7bf39a9ad6479acb not found

Caused by:
  failed to authenticate when downloading repository: ssh://git@github.com/howardjohn/async-openai

  * attempted ssh-agent authentication, but no usernames succeeded: `git`

  if the git CLI succeeds then `net.git-fetch-with-cli` may help here
  https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli

Caused by:
  no authentication methods succeeded
```