### PR TITLE
Return error on MCP post for all non-success status codes

### DIFF
--- a/crates/agentgateway/src/mcp/relay/pool.rs
+++ b/crates/agentgateway/src/mcp/relay/pool.rs
@@ -563,7 +563,7 @@ impl StreamableHttpClient for ClientWrapper {
 			return Ok(StreamableHttpPostResponse::Accepted);
 		}
 
-		if resp.status().is_client_error() || resp.status().is_server_error() {
+		if !resp.status().is_success() {
 			return Err(StreamableHttpError::Client(HttpError::new(anyhow!(
 				"received status code {}",
 				resp.status()


### PR DESCRIPTION
Ran into an issue when trying to proxy MCP servers using older versions of the [FastMCP](https://github.com/jlowin/fastmcp/) framework, which had a bug where requests to `/mcp` incorrectly resulted in a redirect (`307`) to `/mcp/`. However, since redirects are not explicitly handled, the error manifested within the `agentgateway` logs as follows, leading me on a bit of a wild-goose chase to try to understand what was going on. 

```
2025-09-09T09:21:12.435495Z     error   rmcp::transport::worker worker quit with fatal: Unexpected content type: None, when send initialize request
2025-09-09T09:21:12.435575Z     error   mcp::relay::pool        Failed to connect target mcp: connection closed: initialize response
2025-09-09T09:21:12.435838Z     error   rmcp::transport::streamable_http_server::tower  Failed to create service: initialize failed: -32603: Failed to list connections: connection closed: initialize response
```

This code change proposes that any unexpected (non-success) response (including redirects and informational responses) be handled in the same fashion as client/server errors, which at least surfaces the underlying issue in the logs, making debugging this a little easier. E.g.:

```
2025-09-09T09:17:12.212540Z     error   rmcp::transport::worker worker quit with fatal: Client error: received status code 307 Temporary Redirect, when send initialize request
2025-09-09T09:17:12.212844Z     error   mcp::relay::pool        Failed to connect target mcp: connection closed: initialize response
2025-09-09T09:17:12.213751Z     error   rmcp::transport::streamable_http_server::tower  Failed to create service: initialize failed: -32603: Failed to list connections: connection closed: initialize response
```