### PR TITLE
ui: bump @a2a-js/sdk to switch to the new well-known URI of agent card

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@a2a-js/sdk": "^0.3.2",
+        "@a2a-js/sdk": "^0.3.4",
         "@modelcontextprotocol/sdk": "^1.9.0",
         "@radix-ui/react-accordion": "^1.2.8",
         "@radix-ui/react-checkbox": "^1.1.5",
@@ -56,9 +56,9 @@
       }
     },
     "node_modules/@a2a-js/sdk": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@a2a-js/sdk/-/sdk-0.3.2.tgz",
-      "integrity": "sha512-maqxdZ/xeuSRywObfBTvwXbXvkDMmKVkiY8K9rCHDwm0QYUJuu512GnNrwuxkKTwXpNyByzEPg3RYfBveRl96w==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@a2a-js/sdk/-/sdk-0.3.4.tgz",
+      "integrity": "sha512-WXMk/UspvQFxesvb8hXyfPE8d3ibpiRie24Yw/5ruMqNJcdwxjfZ1G0gj6vYE/I9RAZD145CNzedpZA2cLV2JQ==",
       "dependencies": {
         "uuid": "^11.1.0"
       },
@@ -66,7 +66,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "express": "^4.21.2"
+        "express": "^4.21.2 || ^5.1.0"
       },
       "peerDependenciesMeta": {
         "express": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -12,7 +12,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@a2a-js/sdk": "^0.3.2",
+    "@a2a-js/sdk": "^0.3.4",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "@radix-ui/react-accordion": "^1.2.8",
     "@radix-ui/react-checkbox": "^1.1.5",


### PR DESCRIPTION
The `@a2a-js/sdk` changes the well-known path for agent card from `/.well-known/agent.json` to `/.well-known/agent-card.json` in `v0.3.3`.

This PR bumps the sdk to move to the new path.

Fixes #346