### PR TITLE
llm: implement different modes based on route

### DIFF
--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::str::FromStr;
 
 use ::http::uri::{Authority, PathAndQuery};
@@ -75,6 +76,39 @@ pub struct NamedAIProvider {
 	/// This comes with the cost of an expensive operation.
 	#[serde(default)]
 	pub tokenize: bool,
+	pub routes: BTreeMap<Strng, RouteType>,
+}
+
+const DEFAULT_ROUTE: &str = "*";
+impl NamedAIProvider {
+	pub fn use_default_policies(&self) -> bool {
+		self.host_override.is_none()
+	}
+	pub fn resolve_route(&self, path: &str) -> RouteType {
+		for (path_suffix, rt) in &self.routes {
+			if path_suffix == DEFAULT_ROUTE {
+				return *rt;
+			}
+			if path.ends_with(path_suffix.as_str()) {
+				return *rt;
+			}
+		}
+		// If there is no match, there is an implicit default to Completions
+		RouteType::Completions
+	}
+}
+
+#[apply(schema!)]
+#[derive(Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum RouteType {
+	/// OpenAI /v1/chat/completions
+	Completions,
+	/// Anthropic /v1/messages
+	Messages,
+	/// OpenAI /v1/models
+	Models,
+	/// Send the request to the upstream LLM provider as-is
+	Passthrough,
 }
 
 #[apply(schema!)]
@@ -189,11 +223,19 @@ impl AIProvider {
 			},
 		}
 	}
-	pub fn setup_request(&self, req: &mut Request, llm_request: &LLMRequest) -> anyhow::Result<()> {
+	pub fn setup_request(
+		&self,
+		req: &mut Request,
+		route_type: RouteType,
+		llm_request: Option<&LLMRequest>,
+	) -> anyhow::Result<()> {
+		let override_path = route_type != RouteType::Passthrough;
 		match self {
 			AIProvider::OpenAI(_) => http::modify_req(req, |req| {
 				http::modify_uri(req, |uri| {
-					uri.path_and_query = Some(PathAndQuery::from_static(openai::DEFAULT_PATH));
+					if override_path {
+						uri.path_and_query = Some(PathAndQuery::from_static(openai::DEFAULT_PATH));
+					}
 					uri.authority = Some(Authority::from_static(openai::DEFAULT_HOST_STR));
 					Ok(())
 				})?;
@@ -202,7 +244,9 @@ impl AIProvider {
 			AIProvider::Anthropic(_) => {
 				http::modify_req(req, |req| {
 					http::modify_uri(req, |uri| {
-						uri.path_and_query = Some(PathAndQuery::from_static(anthropic::DEFAULT_PATH));
+						if override_path {
+							uri.path_and_query = Some(PathAndQuery::from_static(anthropic::DEFAULT_PATH));
+						}
 						uri.authority = Some(Authority::from_static(anthropic::DEFAULT_HOST_STR));
 						Ok(())
 					})?;
@@ -222,7 +266,9 @@ impl AIProvider {
 			},
 			AIProvider::Gemini(_) => http::modify_req(req, |req| {
 				http::modify_uri(req, |uri| {
-					uri.path_and_query = Some(PathAndQuery::from_static(gemini::DEFAULT_PATH));
+					if override_path {
+						uri.path_and_query = Some(PathAndQuery::from_static(gemini::DEFAULT_PATH));
+					}
 					uri.authority = Some(Authority::from_static(gemini::DEFAULT_HOST_STR));
 					Ok(())
 				})?;
@@ -240,12 +286,12 @@ impl AIProvider {
 				})
 			},
 			AIProvider::Bedrock(provider) => {
-				// For Bedrock, use a default model path - the actual model will be specified in the request body
-				let path =
-					provider.get_path_for_model(llm_request.streaming, llm_request.request_model.as_str());
 				http::modify_req(req, |req| {
 					http::modify_uri(req, |uri| {
-						uri.path_and_query = Some(PathAndQuery::from_str(&path)?);
+						if override_path && let Some(l) = llm_request {
+							let path = provider.get_path_for_model(l.streaming, l.request_model.as_str());
+							uri.path_and_query = Some(PathAndQuery::from_str(&path)?);
+						}
 						uri.authority = Some(Authority::from_str(&provider.get_host())?);
 						Ok(())
 					})?;

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeMap;
 use std::str::FromStr;
 
 use ::http::uri::{Authority, PathAndQuery};
@@ -76,6 +75,10 @@ pub struct NamedAIProvider {
 	/// This comes with the cost of an expensive operation.
 	#[serde(default)]
 	pub tokenize: bool,
+	#[cfg_attr(
+		feature = "schema",
+		schemars(with = "std::collections::HashMap<String, String>")
+	)]
 	pub routes: IndexMap<Strng, RouteType>,
 }
 

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -76,7 +76,7 @@ pub struct NamedAIProvider {
 	/// This comes with the cost of an expensive operation.
 	#[serde(default)]
 	pub tokenize: bool,
-	pub routes: BTreeMap<Strng, RouteType>,
+	pub routes: IndexMap<Strng, RouteType>,
 }
 
 const DEFAULT_ROUTE: &str = "*";

--- a/crates/agentgateway/src/llm/policy.rs
+++ b/crates/agentgateway/src/llm/policy.rs
@@ -518,13 +518,13 @@ fn default_body() -> Bytes {
 mod webhook {
 	use ::http::header::CONTENT_TYPE;
 	use ::http::{HeaderMap, HeaderValue, header};
+	use async_openai::types::CreateChatCompletionResponse;
 	use serde::{Deserialize, Serialize};
 
 	use crate::client::Client;
 	use crate::llm::universal::Request;
 	use crate::types::agent::Target;
 	use crate::*;
-	use async_openai::types::CreateChatCompletionResponse;
 
 	#[derive(Debug, Clone, Serialize, Deserialize)]
 	#[serde(rename_all = "snake_case")]

--- a/crates/agentgateway/src/llm/universal.rs
+++ b/crates/agentgateway/src/llm/universal.rs
@@ -1,6 +1,8 @@
 #![allow(deprecated)]
 #![allow(deprecated_in_future)]
 
+use std::collections::HashMap;
+
 #[allow(deprecated)]
 #[allow(deprecated_in_future)]
 pub use async_openai::types::ChatCompletionFunctions;
@@ -30,7 +32,6 @@ pub use async_openai::types::{
 	ServiceTier, WebSearchOptions,
 };
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Request {

--- a/crates/agentgateway/src/proxy/gateway_test.rs
+++ b/crates/agentgateway/src/proxy/gateway_test.rs
@@ -247,6 +247,7 @@ fn setup_llm_mock(
 		tokenize,
 		backend_tls: None,
 		backend_auth: None,
+		routes: Default::default(),
 	})
 	.translate(strng::format!("{}", mock.address()))
 	.unwrap();

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -23,7 +23,7 @@ use crate::http::{
 	Authority, HeaderName, HeaderValue, PolicyResponse, Request, Response, Scheme, StatusCode, Uri,
 	auth, filters, get_host, merge_in_headers, retry,
 };
-use crate::llm::{LLMRequest, RequestResult};
+use crate::llm::{LLMRequest, RequestResult, RouteType};
 use crate::proxy::{ProxyError, ProxyResponse, resolve_simple_backend};
 use crate::store::{BackendPolicies, LLMRequestPolicies, LLMResponsePolicies};
 use crate::telemetry::log;
@@ -720,12 +720,12 @@ async fn make_backend_call(
 						a2a: None,
 						inference_routing: None,
 						// Attach LLM provider, but don't use default setup
-						llm_provider: Some((provider.provider.clone(), false, provider.tokenize)),
+						llm_provider: Some(provider.clone()),
 					}),
 				),
 				None => {
 					let (tgt, mut pol) = provider.provider.default_connector();
-					pol.llm_provider = Some((provider.provider.clone(), true, provider.tokenize));
+					pol.llm_provider = Some(provider.clone());
 					(tgt, Some(pol))
 				},
 			};
@@ -842,41 +842,69 @@ async fn make_backend_call(
 		log.add(|l| l.a2a_method = Some(method));
 	}
 
-	let (mut req, response_policies, llm_request) =
-		if let Some((llm, use_default_policies, tokenize)) = &policies.llm_provider {
-			let r = llm
-				.process_request(
-					&client,
-					route_policies.llm.as_deref(),
-					req,
-					*tokenize,
+	let (mut req, response_policies, llm_request) = if let Some(llm) = &policies.llm_provider {
+		let route_type = llm.resolve_route(req.uri().path());
+		trace!("llm: route {} to {route_type:?}", req.uri().path());
+		// First, we process the incoming request. This entails translating to the relevant provider,
+		// and parsing the request to build the LLMRequest for logging/etc, and applying LLM policies like
+		// prompt enrichment, prompt guard, etc.
+		match route_type {
+			RouteType::Completions => {
+				let r = llm
+					.provider
+					.process_request(
+						&client,
+						route_policies.llm.as_deref(),
+						req,
+						llm.tokenize,
+						&mut log,
+					)
+					.await
+					.map_err(|e| ProxyError::Processing(e.into()))?;
+				let (mut req, llm_request) = match r {
+					RequestResult::Success(r, lr) => (r, lr),
+					RequestResult::Rejected(dr) => return Ok(Box::pin(async move { Ok(dr) })),
+				};
+				// If a user doesn't configure explicit overrides for connecting to a provider, setup default
+				// paths, TLS, etc.
+				if llm.use_default_policies() {
+					llm
+						.provider
+						.setup_request(&mut req, route_type, Some(&llm_request))
+						.map_err(ProxyError::Processing)?;
+				}
+				// Apply all policies (rate limits)
+				let response_policies = apply_llm_request_policies(
+					&route_policies,
+					policy_client,
 					&mut log,
+					&mut req,
+					&llm_request,
+					response_headers,
 				)
-				.await
-				.map_err(|e| ProxyError::Processing(e.into()))?;
-			let (mut req, llm_request) = match r {
-				RequestResult::Success(r, lr) => (r, lr),
-				RequestResult::Rejected(dr) => return Ok(Box::pin(async move { Ok(dr) })),
-			};
-			if *use_default_policies {
+				.await?;
+				log.add(|l| l.llm_request = Some(llm_request.clone()));
+				(req, response_policies, Some(llm_request))
+			},
+			RouteType::Messages => {
+				todo!()
+			},
+			RouteType::Models => {
+				todo!()
+			},
+			RouteType::Passthrough => {
+				// For passthrough, we only need to setup the response so we get default TLS, hostname, etc set.
+				// We do not need LLM policies nor token-based rate limits, etc.
 				llm
-					.setup_request(&mut req, &llm_request)
+					.provider
+					.setup_request(&mut req, route_type, None)
 					.map_err(ProxyError::Processing)?;
-			}
-			let response_policies = apply_llm_request_policies(
-				&route_policies,
-				policy_client,
-				&mut log,
-				&mut req,
-				&llm_request,
-				response_headers,
-			)
-			.await?;
-			log.add(|l| l.llm_request = Some(llm_request.clone()));
-			(req, response_policies, Some(llm_request))
-		} else {
-			(req, LLMResponsePolicies::default(), None)
-		};
+				(req, LLMResponsePolicies::default(), None)
+			},
+		}
+	} else {
+		(req, LLMResponsePolicies::default(), None)
+	};
 	// Some auth types (AWS) need to be applied after all request processing
 	auth::apply_late_backend_auth(policies.backend_auth.as_ref(), &mut req).await?;
 	let transport = build_transport(&inputs, &backend_call, policies.backend_tls.clone()).await?;
@@ -896,22 +924,22 @@ async fn make_backend_call(
 		a2a::apply_to_response(policies.a2a.as_ref(), a2a_type, &mut resp)
 			.await
 			.map_err(ProxyError::Processing)?;
-		let mut resp =
-			if let (Some((llm, _, _)), Some(llm_request)) = (policies.llm_provider, llm_request) {
-				llm
-					.process_response(
-						&client,
-						llm_request,
-						response_policies,
-						llm_response_log.expect("must be set"),
-						include_completion_in_log,
-						resp,
-					)
-					.await
-					.map_err(|e| ProxyError::Processing(e.into()))?
-			} else {
-				resp
-			};
+		let mut resp = if let (Some(llm), Some(llm_request)) = (policies.llm_provider, llm_request) {
+			llm
+				.provider
+				.process_response(
+					&client,
+					llm_request,
+					response_policies,
+					llm_response_log.expect("must be set"),
+					include_completion_in_log,
+					resp,
+				)
+				.await
+				.map_err(|e| ProxyError::Processing(e.into()))?
+		} else {
+			resp
+		};
 		maybe_inference.mutate_response(&mut resp).await?;
 		Ok(resp)
 	}))

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -886,11 +886,18 @@ async fn make_backend_call(
 				log.add(|l| l.llm_request = Some(llm_request.clone()));
 				(req, response_policies, Some(llm_request))
 			},
-			RouteType::Messages => {
-				todo!()
-			},
-			RouteType::Models => {
-				todo!()
+			RouteType::Messages | RouteType::Models => {
+				return Ok(Box::pin(async move {
+					Ok(
+						::http::Response::builder()
+							.status(::http::StatusCode::NOT_IMPLEMENTED)
+							.header(::http::header::CONTENT_TYPE, "application/json")
+							.body(http::Body::from(format!(
+								"{{\"error\":\"Route '{route_type:?}' not implemented\"}}"
+							)))
+							.expect("Failed to build response"),
+					)
+				}));
 			},
 			RouteType::Passthrough => {
 				// For passthrough, we only need to setup the response so we get default TLS, hostname, etc set.

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -52,9 +52,7 @@ pub struct BackendPolicies {
 	pub backend_tls: Option<BackendTLS>,
 	pub backend_auth: Option<BackendAuth>,
 	pub a2a: Option<A2aPolicy>,
-	// bool represents "should use default settings for provider"
-	// second bool represents "tokenize"
-	pub llm_provider: Option<(llm::AIProvider, bool, bool)>,
+	pub llm_provider: Option<Arc<llm::NamedAIProvider>>,
 	pub inference_routing: Option<InferenceRouting>,
 }
 

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeMap;
 use std::net::{IpAddr, SocketAddr};
 use std::num::NonZeroU16;
 use std::sync::Arc;

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -335,7 +335,7 @@ impl TryFrom<&proto::agent::Backend> for Backend {
 										.map_err(|e| ProtoError::Generic(e.to_string()))
 								})
 								.transpose()?,
-							routes: BTreeMap::default(),
+							routes: IndexMap::default(),
 						};
 						local_provider_group.push((provider_name, np));
 					}

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::net::{IpAddr, SocketAddr};
 use std::num::NonZeroU16;
 use std::sync::Arc;
@@ -334,6 +335,7 @@ impl TryFrom<&proto::agent::Backend> for Backend {
 										.map_err(|e| ProtoError::Generic(e.to_string()))
 								})
 								.transpose()?,
+							routes: BTreeMap::default(),
 						};
 						local_provider_group.push((provider_name, np));
 					}

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 
@@ -194,6 +194,10 @@ pub struct LocalNamedAIProvider {
 	/// Routes defines how to identify the type of traffic we should handle
 	/// The keys are URL suffix matches, like `/v1/models`. The special `*` can be used to match anything.
 	#[serde(default)]
+	#[cfg_attr(
+		feature = "schema",
+		schemars(with = "std::collections::HashMap<String, String>")
+	)]
 	pub routes: IndexMap<Strng, RouteType>,
 	#[serde(rename = "backendTLS", default)]
 	pub backend_tls: Option<LocalBackendTLS>,

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::net::SocketAddr;
 use std::path::PathBuf;
 
@@ -15,7 +15,7 @@ use crate::client::Client;
 use crate::http::auth::BackendAuth;
 use crate::http::backendtls::LocalBackendTLS;
 use crate::http::{filters, retry, timeout};
-use crate::llm::{AIBackend, AIProvider, NamedAIProvider};
+use crate::llm::{AIBackend, AIProvider, NamedAIProvider, RouteType};
 use crate::mcp::rbac::McpAuthorization;
 use crate::store::LocalWorkload;
 use crate::types::agent::PolicyTarget::RouteRule;
@@ -191,7 +191,10 @@ pub struct LocalNamedAIProvider {
 	/// This comes with the cost of an expensive operation.
 	#[serde(default)]
 	pub tokenize: bool,
-
+	/// Routes defines how to identify the type of traffic we should handle
+	/// The keys are URL suffix matches, like `/v1/models`. The special `*` can be used to match anything.
+	#[serde(default)]
+	pub routes: BTreeMap<Strng, RouteType>,
 	#[serde(rename = "backendTLS", default)]
 	pub backend_tls: Option<LocalBackendTLS>,
 	#[serde(default)]
@@ -236,6 +239,7 @@ impl LocalAIBackend {
 						host_override: p.host_override,
 						path_override: p.path_override,
 						tokenize: p.tokenize,
+						routes: p.routes,
 					},
 				));
 			}

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -194,7 +194,7 @@ pub struct LocalNamedAIProvider {
 	/// Routes defines how to identify the type of traffic we should handle
 	/// The keys are URL suffix matches, like `/v1/models`. The special `*` can be used to match anything.
 	#[serde(default)]
-	pub routes: BTreeMap<Strng, RouteType>,
+	pub routes: IndexMap<Strng, RouteType>,
 	#[serde(rename = "backendTLS", default)]
 	pub backend_tls: Option<LocalBackendTLS>,
 	#[serde(default)]

--- a/schema/README.md
+++ b/schema/README.md
@@ -319,6 +319,7 @@ This folder contains JSON schemas for various parts of the project
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)hostOverride`||
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)pathOverride`||
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)tokenize`|Whether to tokenize on the request flow. This enables us to do more accurate rate limits,<br>since we know (part of) the cost of the request upfront.<br>This comes with the cost of an expensive operation.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)routes`|Routes defines how to identify the type of traffic we should handle<br>The keys are URL suffix matches, like `/v1/models`. The special `*` can be used to match anything.|
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)backendTLS`||
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)backendTLS.cert`||
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)backendTLS.key`||
@@ -358,6 +359,7 @@ This folder contains JSON schemas for various parts of the project
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].hostOverride`||
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].pathOverride`||
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].tokenize`|Whether to tokenize on the request flow. This enables us to do more accurate rate limits,<br>since we know (part of) the cost of the request upfront.<br>This comes with the cost of an expensive operation.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].routes`|Routes defines how to identify the type of traffic we should handle<br>The keys are URL suffix matches, like `/v1/models`. The special `*` can be used to match anything.|
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].backendTLS`||
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].backendTLS.cert`||
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].backendTLS.key`||

--- a/schema/local.json
+++ b/schema/local.json
@@ -2783,6 +2783,35 @@
                                           "type": "boolean",
                                           "default": false
                                         },
+                                        "routes": {
+                                          "description": "Routes defines how to identify the type of traffic we should handle\nThe keys are URL suffix matches, like `/v1/models`. The special `*` can be used to match anything.",
+                                          "type": "object",
+                                          "additionalProperties": {
+                                            "oneOf": [
+                                              {
+                                                "description": "OpenAI /v1/chat/completions",
+                                                "type": "string",
+                                                "const": "completions"
+                                              },
+                                              {
+                                                "description": "Anthropic /v1/messages",
+                                                "type": "string",
+                                                "const": "messages"
+                                              },
+                                              {
+                                                "description": "OpenAI /v1/models",
+                                                "type": "string",
+                                                "const": "models"
+                                              },
+                                              {
+                                                "description": "Send the request to the upstream LLM provider as-is",
+                                                "type": "string",
+                                                "const": "passthrough"
+                                              }
+                                            ]
+                                          },
+                                          "default": {}
+                                        },
                                         "backendTLS": {
                                           "type": [
                                             "object",
@@ -3108,6 +3137,35 @@
                                                       "description": "Whether to tokenize on the request flow. This enables us to do more accurate rate limits,\nsince we know (part of) the cost of the request upfront.\nThis comes with the cost of an expensive operation.",
                                                       "type": "boolean",
                                                       "default": false
+                                                    },
+                                                    "routes": {
+                                                      "description": "Routes defines how to identify the type of traffic we should handle\nThe keys are URL suffix matches, like `/v1/models`. The special `*` can be used to match anything.",
+                                                      "type": "object",
+                                                      "additionalProperties": {
+                                                        "oneOf": [
+                                                          {
+                                                            "description": "OpenAI /v1/chat/completions",
+                                                            "type": "string",
+                                                            "const": "completions"
+                                                          },
+                                                          {
+                                                            "description": "Anthropic /v1/messages",
+                                                            "type": "string",
+                                                            "const": "messages"
+                                                          },
+                                                          {
+                                                            "description": "OpenAI /v1/models",
+                                                            "type": "string",
+                                                            "const": "models"
+                                                          },
+                                                          {
+                                                            "description": "Send the request to the upstream LLM provider as-is",
+                                                            "type": "string",
+                                                            "const": "passthrough"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "default": {}
                                                     },
                                                     "backendTLS": {
                                                       "type": [

--- a/schema/local.json
+++ b/schema/local.json
@@ -2787,28 +2787,7 @@
                                           "description": "Routes defines how to identify the type of traffic we should handle\nThe keys are URL suffix matches, like `/v1/models`. The special `*` can be used to match anything.",
                                           "type": "object",
                                           "additionalProperties": {
-                                            "oneOf": [
-                                              {
-                                                "description": "OpenAI /v1/chat/completions",
-                                                "type": "string",
-                                                "const": "completions"
-                                              },
-                                              {
-                                                "description": "Anthropic /v1/messages",
-                                                "type": "string",
-                                                "const": "messages"
-                                              },
-                                              {
-                                                "description": "OpenAI /v1/models",
-                                                "type": "string",
-                                                "const": "models"
-                                              },
-                                              {
-                                                "description": "Send the request to the upstream LLM provider as-is",
-                                                "type": "string",
-                                                "const": "passthrough"
-                                              }
-                                            ]
+                                            "type": "string"
                                           },
                                           "default": {}
                                         },
@@ -3142,28 +3121,7 @@
                                                       "description": "Routes defines how to identify the type of traffic we should handle\nThe keys are URL suffix matches, like `/v1/models`. The special `*` can be used to match anything.",
                                                       "type": "object",
                                                       "additionalProperties": {
-                                                        "oneOf": [
-                                                          {
-                                                            "description": "OpenAI /v1/chat/completions",
-                                                            "type": "string",
-                                                            "const": "completions"
-                                                          },
-                                                          {
-                                                            "description": "Anthropic /v1/messages",
-                                                            "type": "string",
-                                                            "const": "messages"
-                                                          },
-                                                          {
-                                                            "description": "OpenAI /v1/models",
-                                                            "type": "string",
-                                                            "const": "models"
-                                                          },
-                                                          {
-                                                            "description": "Send the request to the upstream LLM provider as-is",
-                                                            "type": "string",
-                                                            "const": "passthrough"
-                                                          }
-                                                        ]
+                                                        "type": "string"
                                                       },
                                                       "default": {}
                                                     },


### PR DESCRIPTION
This will be needed to support OpenAI responses, v1/models, anthropic, etc

Usage
```
- matches:
  - path:
      pathPrefix: /openaisimple
  policies:
    urlRewrite:
      path:
        prefix: /
    backendAuth:
      key:
        file: $HOME/.secrets/openai
  backends:
  - ai:
      name: openai
      routes:
        /v1/chat/completions: completions
        /v1/models: passthrough
        "*": passthrough
      provider:
        openAI:
          model: gpt-3.5-turbo
```