### PR TITLE
mcp auth: allow user to override

### DIFF
--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -1046,9 +1046,6 @@ impl ResourceMetadata {
 		// Copy user-provided extra keys, converting to snake_case
 		for (key, value) in &self.extra {
 			let snake = key.to_snake_case();
-			if snake == "resource" || snake == "authorization_servers" {
-				continue;
-			}
 			map.insert(snake, value.clone());
 		}
 

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -1017,7 +1017,6 @@ pub struct Authorization(pub RuleSet);
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 pub struct ResourceMetadata {
-	pub resource: String,
 	#[serde(flatten)]
 	pub extra: BTreeMap<String, Value>,
 }
@@ -1025,14 +1024,26 @@ pub struct ResourceMetadata {
 impl ResourceMetadata {
 	/// Build RFC-compliant JSON for the protected resource metadata.
 	///
-	/// - Enforces computed `resource` and `authorization_servers`.
+	/// - Defaults computed `resource` and `authorization_servers`.
 	/// - Converts any additional config keys from camelCase to snake_case.
 	/// - Adds MCP-specific fields used by the gateway.
 	pub fn to_rfc_json(&self, resource_uri: String, issuer: String) -> Value {
 		let mut map = serde_json::Map::new();
 
-		// Copy user-provided extra keys, converting to snake_case, while preventing overrides
-		// of fields we compute.
+		// Computed fields. User can override them if they explicitly configure them.
+		map.insert("resource".into(), Value::String(resource_uri));
+		map.insert(
+			"authorization_servers".into(),
+			Value::Array(vec![Value::String(issuer)]),
+		);
+		// MCP-specific additions
+		map.insert(
+			"mcp_protocol_version".into(),
+			Value::String("2025-06-18".into()),
+		);
+		map.insert("resource_type".into(), Value::String("mcp-server".into()));
+
+		// Copy user-provided extra keys, converting to snake_case
 		for (key, value) in &self.extra {
 			let snake = key.to_snake_case();
 			if snake == "resource" || snake == "authorization_servers" {
@@ -1040,20 +1051,6 @@ impl ResourceMetadata {
 			}
 			map.insert(snake, value.clone());
 		}
-
-		// Computed fields
-		map.insert("resource".into(), Value::String(resource_uri));
-		map.insert(
-			"authorization_servers".into(),
-			Value::Array(vec![Value::String(issuer)]),
-		);
-
-		// MCP-specific additions
-		map.insert(
-			"mcp_protocol_version".into(),
-			Value::String("2025-06-18".into()),
-		);
-		map.insert("resource_type".into(), Value::String("mcp-server".into()));
 
 		Value::Object(map)
 	}

--- a/schema/README.md
+++ b/schema/README.md
@@ -134,7 +134,6 @@ This folder contains JSON schemas for various parts of the project
 |`binds[].listeners[].routes[].policies.mcpAuthentication.provider.(any)(1)auth0`||
 |`binds[].listeners[].routes[].policies.mcpAuthentication.provider.(any)(1)keycloak`||
 |`binds[].listeners[].routes[].policies.mcpAuthentication.resourceMetadata`||
-|`binds[].listeners[].routes[].policies.mcpAuthentication.resourceMetadata.resource`||
 |`binds[].listeners[].routes[].policies.a2a`|Mark this traffic as A2A to enable A2A processing and telemetry.|
 |`binds[].listeners[].routes[].policies.ai`|Mark this as LLM traffic to enable LLM processing.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard`||
@@ -506,7 +505,6 @@ This folder contains JSON schemas for various parts of the project
 |`policies[].policy.mcpAuthentication.provider.(any)(1)auth0`||
 |`policies[].policy.mcpAuthentication.provider.(any)(1)keycloak`||
 |`policies[].policy.mcpAuthentication.resourceMetadata`||
-|`policies[].policy.mcpAuthentication.resourceMetadata.resource`||
 |`policies[].policy.a2a`|Mark this traffic as A2A to enable A2A processing and telemetry.|
 |`policies[].policy.ai`|Mark this as LLM traffic to enable LLM processing.|
 |`policies[].policy.ai.promptGuard`||

--- a/schema/local.json
+++ b/schema/local.json
@@ -1094,14 +1094,6 @@
                               },
                               "resourceMetadata": {
                                 "type": "object",
-                                "properties": {
-                                  "resource": {
-                                    "type": "string"
-                                  }
-                                },
-                                "required": [
-                                  "resource"
-                                ],
                                 "additionalProperties": true
                               }
                             },
@@ -4551,14 +4543,6 @@
                   },
                   "resourceMetadata": {
                     "type": "object",
-                    "properties": {
-                      "resource": {
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "resource"
-                    ],
                     "additionalProperties": true
                   }
                 },


### PR DESCRIPTION
For fields we have defaults for, make user config take precedence.

Fixes https://github.com/agentgateway/agentgateway/issues/449