### PR TITLE
Fix xds for prompt response guards

### DIFF
--- a/crates/agentgateway/src/llm/pii/credit_card_recognizer.rs
+++ b/crates/agentgateway/src/llm/pii/credit_card_recognizer.rs
@@ -8,7 +8,7 @@ pub struct CreditCardRecognizer {
 impl CreditCardRecognizer {
 	pub fn new() -> Self {
 		let mut recognizer = PatternRecognizer::new(
-			"URL",
+			"CREDIT_CARD",
 			vec![
 				"credit".to_string(),
 				"card".to_string(),


### PR DESCRIPTION
When we implemented regexes / webhooks for response guards we didn't update the agent_xds logic to handle a potential config where only a response guard is provided. 

This addresses that and fixes a typo in the credit card recognizer.

Smoke tested with kgateway main.