### PR TITLE
Add CSRF Policy support

### DIFF
--- a/crates/agentgateway/proto/resource.proto
+++ b/crates/agentgateway/proto/resource.proto
@@ -521,24 +521,12 @@ message PolicySpec {
     string expression = 1;
   }
 
-  // String matcher for CSRF additional origins
-  message StringMatcher {
-    bool ignore_case = 6;
-
-    oneof match_pattern {
-      string exact = 1;
-      string prefix = 2;
-      string suffix = 3;
-      string safe_regex = 4;
-      string contains = 7;
-    }
-  }
-
   // Cross-Site Request Forgery (CSRF) policy configuration.
   message CSRF {
     // Additional origins that are allowed for CSRF validation beyond the same-origin policy.
-    // If a request's origin header matches any of these matchers, the request will be allowed.
-    repeated StringMatcher additional_origins = 1;
+    // If a request's origin header matches any of these exact origins, the request will be allowed.
+    // Each origin should be in the format "scheme://host[:port]" (e.g., "https://www.example.com")
+    repeated string additional_origins = 1;
   }
 
   oneof kind {

--- a/crates/agentgateway/proto/resource.proto
+++ b/crates/agentgateway/proto/resource.proto
@@ -521,6 +521,26 @@ message PolicySpec {
     string expression = 1;
   }
 
+  // String matcher for CSRF additional origins
+  message StringMatcher {
+    bool ignore_case = 6;
+
+    oneof match_pattern {
+      string exact = 1;
+      string prefix = 2;
+      string suffix = 3;
+      string safe_regex = 4;
+      string contains = 7;
+    }
+  }
+
+  // Cross-Site Request Forgery (CSRF) policy configuration.
+  message CSRF {
+    // Additional origins that are allowed for CSRF validation beyond the same-origin policy.
+    // If a request's origin header matches any of these matchers, the request will be allowed.
+    repeated StringMatcher additional_origins = 1;
+  }
+
   oneof kind {
     LocalRateLimit local_rate_limit = 1;
     ExternalAuth ext_authz = 2;
@@ -534,6 +554,7 @@ message PolicySpec {
     JWT jwt = 10;
     TransformationPolicy transformation = 11;
     RemoteRateLimit remote_rate_limit = 12;
+    CSRF csrf = 13;
   }
 }
 

--- a/crates/agentgateway/src/http/csrf.rs
+++ b/crates/agentgateway/src/http/csrf.rs
@@ -1,267 +1,121 @@
 use ::http::{Method, StatusCode, header};
-use serde::de::Error;
+use std::collections::HashSet;
 
 use crate::http::{PolicyResponse, Request, filters};
 use crate::*;
 
-/// String matcher for CSRF additional origins
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub enum StringMatcher {
-	Exact(String),
-	Prefix(String),
-	Suffix(String),
-	Contains(String),
-	SafeRegex(String),
-}
-
-impl StringMatcher {
-	/// Check if the given value matches this matcher
-	pub fn matches(&self, value: &str) -> bool {
-		match self {
-			StringMatcher::Exact(exact) => value == exact,
-			StringMatcher::Prefix(prefix) => value.starts_with(prefix),
-			StringMatcher::Suffix(suffix) => value.ends_with(suffix),
-			StringMatcher::Contains(contains) => value.contains(contains),
-			StringMatcher::SafeRegex(regex) => regex::Regex::new(regex)
-				.map(|r| r.is_match(value))
-				.unwrap_or(false),
-		}
-	}
-}
-
-#[derive(Default, Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[cfg_attr(feature = "schema", derive(JsonSchema))]
-pub struct StringMatcherSerde {
-	pub exact: Option<String>,
-	pub prefix: Option<String>,
-	pub suffix: Option<String>,
-	pub contains: Option<String>,
-	pub safe_regex: Option<String>,
-	#[serde(default)]
-	pub ignore_case: bool,
-}
-
-impl TryFrom<StringMatcherSerde> for StringMatcher {
-	type Error = anyhow::Error;
-
-	fn try_from(value: StringMatcherSerde) -> Result<Self, Self::Error> {
-		let mut count = 0;
-		let mut result = None;
-
-		if let Some(exact) = value.exact {
-			count += 1;
-			result = Some(StringMatcher::Exact(exact));
-		}
-		if let Some(prefix) = value.prefix {
-			count += 1;
-			result = Some(StringMatcher::Prefix(prefix));
-		}
-		if let Some(suffix) = value.suffix {
-			count += 1;
-			result = Some(StringMatcher::Suffix(suffix));
-		}
-		if let Some(contains) = value.contains {
-			count += 1;
-			result = Some(StringMatcher::Contains(contains));
-		}
-		if let Some(safe_regex) = value.safe_regex {
-			count += 1;
-			result = Some(StringMatcher::SafeRegex(safe_regex));
-		}
-
-		if count != 1 {
-			anyhow::bail!("Exactly one of exact, prefix, suffix, contains, or safe_regex must be set");
-		}
-
-		result.ok_or_else(|| anyhow::anyhow!("No matcher type set"))
-	}
-}
-
-#[apply(schema_ser!)]
-#[cfg_attr(feature = "schema", schemars(with = "CsrfSerde"))]
+#[apply(schema)]
 pub struct Csrf {
-	/// Additional origins that are allowed for CSRF validation
 	#[serde(default)]
-	additional_origins: Vec<StringMatcher>,
-}
-
-impl<'de> serde::Deserialize<'de> for Csrf {
-	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-	where
-		D: serde::Deserializer<'de>,
-	{
-		Csrf::try_from(CsrfSerde::deserialize(deserializer)?).map_err(D::Error::custom)
-	}
-}
-
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-#[cfg_attr(feature = "schema", derive(JsonSchema))]
-pub struct CsrfSerde {
-	/// Additional origins that are allowed for CSRF validation
-	#[serde(default)]
-	pub additional_origins: Vec<StringMatcherSerde>,
-}
-
-impl TryFrom<CsrfSerde> for Csrf {
-	type Error = anyhow::Error;
-
-	fn try_from(value: CsrfSerde) -> Result<Self, Self::Error> {
-		let additional_origins = value
-			.additional_origins
-			.into_iter()
-			.map(StringMatcher::try_from)
-			.collect::<Result<Vec<_>, _>>()?;
-
-		Ok(Csrf { additional_origins })
-	}
+	additional_origins: HashSet<String>,
 }
 
 impl Csrf {
-	/// Apply CSRF validation to the request
-	/// Returns a PolicyResponse indicating whether the request should be allowed
 	pub fn apply(&self, req: &mut Request) -> Result<PolicyResponse, filters::Error> {
-		// Only apply CSRF protection to modifying methods
-		if !is_modify_method(req.method()) {
+		// 1. Allow all GET, HEAD, or OPTIONS requests
+		if is_safe_method(req.method()) {
 			return Ok(Default::default());
 		}
 
-		let source_origin = source_origin_value(req)?;
-		if source_origin.is_empty() {
-			// No source origin found, this is suspicious for modifying requests
-			// Return 403 Forbidden as per Envoy behavior
-			let response = ::http::Response::builder()
-				.status(StatusCode::FORBIDDEN)
-				.body(crate::http::Body::from("Invalid origin"))?;
-			return Ok(PolicyResponse {
-				direct_response: Some(response),
-				response_headers: None,
-			});
+		// 2. Check Sec-Fetch-Site header first
+		match get_sec_fetch_site_header(req)? {
+			Some(sec_fetch_site) => {
+				match sec_fetch_site.as_str() {
+					"same-origin" | "none" => return Ok(Default::default()),
+					_ => {
+						// Check if request is exempt (trusted origins)
+						if self.is_request_exempt(req)? {
+							return Ok(Default::default());
+						}
+						return self.create_forbidden_response(
+							"Cross-origin request detected from Sec-Fetch-Site header".to_string(),
+						);
+					},
+				}
+			},
+			None => {
+				// No Sec-Fetch-Site header - fallthrough to Origin check
+			},
 		}
 
-		if !self.is_valid(&source_origin, req)? {
-			// Origin validation failed
-			let response = ::http::Response::builder()
-				.status(StatusCode::FORBIDDEN)
-				.body(crate::http::Body::from("Invalid origin"))?;
-			return Ok(PolicyResponse {
-				direct_response: Some(response),
-				response_headers: None,
-			});
+		// 3. Get Origin header once
+		let Some(origin) = get_origin_header(req)? else {
+			// If no Origin header, allow
+			return Ok(Default::default());
+		};
+
+		// 5. Check if Origin matches Host header
+		let target_origin = get_target_origin(req)?;
+		if origin == target_origin {
+			return Ok(Default::default());
 		}
 
-		// Origin validation passed
-		Ok(Default::default())
+		// 6. Check trusted origins as last resort
+		if self.is_request_exempt(req)? {
+			return Ok(Default::default());
+		}
+
+		// Request failed all checks - reject
+		self.create_forbidden_response("Cross-origin request detected".to_string())
 	}
 
-	/// Check if the source origin is valid for this request
-	fn is_valid(&self, source_origin: &str, req: &Request) -> Result<bool, filters::Error> {
-		let target_origin = target_origin_value(req)?;
-
-		// First check if source and target origins match exactly
-		if source_origin == target_origin {
-			return Ok(true);
+	fn is_request_exempt(&self, req: &Request) -> Result<bool, filters::Error> {
+		if let Some(origin) = get_origin_header(req)? {
+			return Ok(self.additional_origins.contains(&origin));
 		}
-
-		// Check against additional origins
-		for matcher in self.additional_origins.iter() {
-			if matcher.matches(source_origin) {
-				return Ok(true);
-			}
-		}
-
 		Ok(false)
 	}
+
+	/// Create a 403 Forbidden response
+	fn create_forbidden_response(&self, message: String) -> Result<PolicyResponse, filters::Error> {
+		let response = ::http::Response::builder()
+			.status(StatusCode::FORBIDDEN)
+			.body(crate::http::Body::from(message))?;
+		Ok(PolicyResponse {
+			direct_response: Some(response),
+			response_headers: None,
+		})
+	}
 }
 
-/// Check if the HTTP method is a modifying method that requires CSRF protection
-fn is_modify_method(method: &Method) -> bool {
-	matches!(
-		method,
-		&Method::POST | &Method::PUT | &Method::DELETE | &Method::PATCH
-	)
+/// Check if the HTTP method is a safe method
+fn is_safe_method(method: &Method) -> bool {
+	matches!(method, &Method::GET | &Method::HEAD | &Method::OPTIONS)
 }
 
-/// Extract the source origin value from request headers
-fn source_origin_value(req: &Request) -> Result<String, filters::Error> {
-	// Try Origin header first
+/// Extract the Origin header value
+fn get_origin_header(req: &Request) -> Result<Option<String>, filters::Error> {
 	if let Some(origin_value) = req.headers().get(header::ORIGIN) {
 		let origin_str = origin_value.to_str().map_err(|_| {
 			filters::Error::InvalidFilterConfiguration("Invalid Origin header".to_string())
 		})?;
 
-		// Handle "null" origin
+		// Handle "null" origin as no origin
 		if origin_str == "null" {
-			return Ok(String::new());
+			return Ok(None);
 		}
 
-		return Ok(origin_str.to_string());
+		return Ok(Some(origin_str.to_string()));
 	}
+	Ok(None)
+}
 
-	// Fall back to Referer header
-	if let Some(referer_value) = req.headers().get(header::REFERER) {
-		let referer_str = referer_value.to_str().map_err(|_| {
-			filters::Error::InvalidFilterConfiguration("Invalid Referer header".to_string())
+/// Extract the Sec-Fetch-Site header value
+fn get_sec_fetch_site_header(req: &Request) -> Result<Option<String>, filters::Error> {
+	if let Some(sec_fetch_site_value) = req.headers().get("sec-fetch-site") {
+		let sec_fetch_site_str = sec_fetch_site_value.to_str().map_err(|_| {
+			filters::Error::InvalidFilterConfiguration("Invalid Sec-Fetch-Site header".to_string())
 		})?;
-		// For referer, extract the origin part (scheme + host + port)
-		let origin = extract_origin_from_url(referer_str);
-		return Ok(origin);
+		return Ok(Some(sec_fetch_site_str.to_string()));
 	}
-
-	Ok(String::new())
+	Ok(None)
 }
 
-/// Extract the target origin value from the request
-fn target_origin_value(req: &Request) -> Result<String, filters::Error> {
-	// After URI normalization, the Host header is removed and the host info
-	// is moved to req.uri().authority().
-	if let Some(authority) = req.uri().authority() {
-		let scheme = req.uri().scheme_str().unwrap_or("http");
-		let full_origin = format!("{}://{}", scheme, authority);
-		return Ok(full_origin);
-	}
-
-	let host_value = req.headers().get(header::HOST).ok_or_else(|| {
-		filters::Error::InvalidFilterConfiguration("Missing target origin information".to_string())
+/// Extract the target origin from the request
+fn get_target_origin(req: &Request) -> Result<String, filters::Error> {
+	let authority = req.uri().authority().ok_or_else(|| {
+		filters::Error::InvalidFilterConfiguration("Missing authority in URI".to_string())
 	})?;
-
-	let host_str = host_value
-		.to_str()
-		.map_err(|_| filters::Error::InvalidFilterConfiguration("Invalid Host header".to_string()))?;
-
-	if host_str.is_empty() {
-		return Ok(String::new());
-	}
-
-	// Construct the full origin from the request scheme and host
-	// Default to http if no scheme is present in the request URI
-	let scheme = if req.uri().scheme().is_some() {
-		req.uri().scheme_str().unwrap_or("http")
-	} else {
-		"http"
-	};
-
-	let full_origin = format!("{}://{}", scheme, host_str);
-	Ok(full_origin)
-}
-
-/// Extract origin (scheme + host + port) from a full URL
-fn extract_origin_from_url(url: &str) -> String {
-	if url.is_empty() {
-		return String::new();
-	}
-
-	// Parse the URL and extract origin
-	if let Ok(uri) = url.parse::<::http::Uri>()
-		&& let Some(authority) = uri.authority()
-		&& let Some(scheme) = uri.scheme_str()
-	{
-		let origin = format!("{}://{}", scheme, authority);
-		return origin;
-	}
-
-	// If parsing fails, return empty
-	String::new()
+	let scheme = req.uri().scheme_str().unwrap_or("http");
+	Ok(format!("{}://{}", scheme, authority))
 }

--- a/crates/agentgateway/src/http/csrf.rs
+++ b/crates/agentgateway/src/http/csrf.rs
@@ -1,0 +1,267 @@
+use ::http::{Method, StatusCode, header};
+use serde::de::Error;
+
+use crate::http::{PolicyResponse, Request, filters};
+use crate::*;
+
+/// String matcher for CSRF additional origins
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum StringMatcher {
+	Exact(String),
+	Prefix(String),
+	Suffix(String),
+	Contains(String),
+	SafeRegex(String),
+}
+
+impl StringMatcher {
+	/// Check if the given value matches this matcher
+	pub fn matches(&self, value: &str) -> bool {
+		match self {
+			StringMatcher::Exact(exact) => value == exact,
+			StringMatcher::Prefix(prefix) => value.starts_with(prefix),
+			StringMatcher::Suffix(suffix) => value.ends_with(suffix),
+			StringMatcher::Contains(contains) => value.contains(contains),
+			StringMatcher::SafeRegex(regex) => regex::Regex::new(regex)
+				.map(|r| r.is_match(value))
+				.unwrap_or(false),
+		}
+	}
+}
+
+#[derive(Default, Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+pub struct StringMatcherSerde {
+	pub exact: Option<String>,
+	pub prefix: Option<String>,
+	pub suffix: Option<String>,
+	pub contains: Option<String>,
+	pub safe_regex: Option<String>,
+	#[serde(default)]
+	pub ignore_case: bool,
+}
+
+impl TryFrom<StringMatcherSerde> for StringMatcher {
+	type Error = anyhow::Error;
+
+	fn try_from(value: StringMatcherSerde) -> Result<Self, Self::Error> {
+		let mut count = 0;
+		let mut result = None;
+
+		if let Some(exact) = value.exact {
+			count += 1;
+			result = Some(StringMatcher::Exact(exact));
+		}
+		if let Some(prefix) = value.prefix {
+			count += 1;
+			result = Some(StringMatcher::Prefix(prefix));
+		}
+		if let Some(suffix) = value.suffix {
+			count += 1;
+			result = Some(StringMatcher::Suffix(suffix));
+		}
+		if let Some(contains) = value.contains {
+			count += 1;
+			result = Some(StringMatcher::Contains(contains));
+		}
+		if let Some(safe_regex) = value.safe_regex {
+			count += 1;
+			result = Some(StringMatcher::SafeRegex(safe_regex));
+		}
+
+		if count != 1 {
+			anyhow::bail!("Exactly one of exact, prefix, suffix, contains, or safe_regex must be set");
+		}
+
+		result.ok_or_else(|| anyhow::anyhow!("No matcher type set"))
+	}
+}
+
+#[apply(schema_ser!)]
+#[cfg_attr(feature = "schema", schemars(with = "CsrfSerde"))]
+pub struct Csrf {
+	/// Additional origins that are allowed for CSRF validation
+	#[serde(default)]
+	additional_origins: Vec<StringMatcher>,
+}
+
+impl<'de> serde::Deserialize<'de> for Csrf {
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: serde::Deserializer<'de>,
+	{
+		Csrf::try_from(CsrfSerde::deserialize(deserializer)?).map_err(D::Error::custom)
+	}
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+pub struct CsrfSerde {
+	/// Additional origins that are allowed for CSRF validation
+	#[serde(default)]
+	pub additional_origins: Vec<StringMatcherSerde>,
+}
+
+impl TryFrom<CsrfSerde> for Csrf {
+	type Error = anyhow::Error;
+
+	fn try_from(value: CsrfSerde) -> Result<Self, Self::Error> {
+		let additional_origins = value
+			.additional_origins
+			.into_iter()
+			.map(StringMatcher::try_from)
+			.collect::<Result<Vec<_>, _>>()?;
+
+		Ok(Csrf { additional_origins })
+	}
+}
+
+impl Csrf {
+	/// Apply CSRF validation to the request
+	/// Returns a PolicyResponse indicating whether the request should be allowed
+	pub fn apply(&self, req: &mut Request) -> Result<PolicyResponse, filters::Error> {
+		// Only apply CSRF protection to modifying methods
+		if !is_modify_method(req.method()) {
+			return Ok(Default::default());
+		}
+
+		let source_origin = source_origin_value(req)?;
+		if source_origin.is_empty() {
+			// No source origin found, this is suspicious for modifying requests
+			// Return 403 Forbidden as per Envoy behavior
+			let response = ::http::Response::builder()
+				.status(StatusCode::FORBIDDEN)
+				.body(crate::http::Body::from("Invalid origin"))?;
+			return Ok(PolicyResponse {
+				direct_response: Some(response),
+				response_headers: None,
+			});
+		}
+
+		if !self.is_valid(&source_origin, req)? {
+			// Origin validation failed
+			let response = ::http::Response::builder()
+				.status(StatusCode::FORBIDDEN)
+				.body(crate::http::Body::from("Invalid origin"))?;
+			return Ok(PolicyResponse {
+				direct_response: Some(response),
+				response_headers: None,
+			});
+		}
+
+		// Origin validation passed
+		Ok(Default::default())
+	}
+
+	/// Check if the source origin is valid for this request
+	fn is_valid(&self, source_origin: &str, req: &Request) -> Result<bool, filters::Error> {
+		let target_origin = target_origin_value(req)?;
+
+		// First check if source and target origins match exactly
+		if source_origin == target_origin {
+			return Ok(true);
+		}
+
+		// Check against additional origins
+		for matcher in self.additional_origins.iter() {
+			if matcher.matches(source_origin) {
+				return Ok(true);
+			}
+		}
+
+		Ok(false)
+	}
+}
+
+/// Check if the HTTP method is a modifying method that requires CSRF protection
+fn is_modify_method(method: &Method) -> bool {
+	matches!(
+		method,
+		&Method::POST | &Method::PUT | &Method::DELETE | &Method::PATCH
+	)
+}
+
+/// Extract the source origin value from request headers
+fn source_origin_value(req: &Request) -> Result<String, filters::Error> {
+	// Try Origin header first
+	if let Some(origin_value) = req.headers().get(header::ORIGIN) {
+		let origin_str = origin_value.to_str().map_err(|_| {
+			filters::Error::InvalidFilterConfiguration("Invalid Origin header".to_string())
+		})?;
+
+		// Handle "null" origin
+		if origin_str == "null" {
+			return Ok(String::new());
+		}
+
+		return Ok(origin_str.to_string());
+	}
+
+	// Fall back to Referer header
+	if let Some(referer_value) = req.headers().get(header::REFERER) {
+		let referer_str = referer_value.to_str().map_err(|_| {
+			filters::Error::InvalidFilterConfiguration("Invalid Referer header".to_string())
+		})?;
+		// For referer, extract the origin part (scheme + host + port)
+		let origin = extract_origin_from_url(referer_str);
+		return Ok(origin);
+	}
+
+	Ok(String::new())
+}
+
+/// Extract the target origin value from the request
+fn target_origin_value(req: &Request) -> Result<String, filters::Error> {
+	// After URI normalization, the Host header is removed and the host info
+	// is moved to req.uri().authority().
+	if let Some(authority) = req.uri().authority() {
+		let scheme = req.uri().scheme_str().unwrap_or("http");
+		let full_origin = format!("{}://{}", scheme, authority);
+		return Ok(full_origin);
+	}
+
+	let host_value = req.headers().get(header::HOST).ok_or_else(|| {
+		filters::Error::InvalidFilterConfiguration("Missing target origin information".to_string())
+	})?;
+
+	let host_str = host_value
+		.to_str()
+		.map_err(|_| filters::Error::InvalidFilterConfiguration("Invalid Host header".to_string()))?;
+
+	if host_str.is_empty() {
+		return Ok(String::new());
+	}
+
+	// Construct the full origin from the request scheme and host
+	// Default to http if no scheme is present in the request URI
+	let scheme = if req.uri().scheme().is_some() {
+		req.uri().scheme_str().unwrap_or("http")
+	} else {
+		"http"
+	};
+
+	let full_origin = format!("{}://{}", scheme, host_str);
+	Ok(full_origin)
+}
+
+/// Extract origin (scheme + host + port) from a full URL
+fn extract_origin_from_url(url: &str) -> String {
+	if url.is_empty() {
+		return String::new();
+	}
+
+	// Parse the URL and extract origin
+	if let Ok(uri) = url.parse::<::http::Uri>()
+		&& let Some(authority) = uri.authority()
+		&& let Some(scheme) = uri.scheme_str()
+	{
+		let origin = format!("{}://{}", scheme, authority);
+		return origin;
+	}
+
+	// If parsing fails, return empty
+	String::new()
+}

--- a/crates/agentgateway/src/http/mod.rs
+++ b/crates/agentgateway/src/http/mod.rs
@@ -17,6 +17,7 @@ mod transformation;
 pub mod authorization;
 pub mod backendtls;
 pub mod compression;
+pub mod csrf;
 pub mod ext_authz;
 pub mod ext_proc;
 pub mod outlierdetection;

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -90,13 +90,10 @@ async fn apply_request_policies(
 	}
 
 	if let Some(csrf) = &policies.csrf {
-		let res = csrf
+		csrf
 			.apply(req)
-			.map_err(|_| ProxyError::CsrfValidationFailed)?;
-		if let Some(response) = res.direct_response {
-			return Err(ProxyResponse::DirectResponse(Box::new(response)));
-		}
-		res.apply(response_policies.headers())?;
+			.map_err(|_| ProxyError::CsrfValidationFailed)?
+			.apply(response_policies.headers())?;
 	}
 
 	Ok(())

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -89,6 +89,16 @@ async fn apply_request_policies(
 			.map_err(|_| ProxyError::TransformationFailure)?;
 	}
 
+	if let Some(csrf) = &policies.csrf {
+		let res = csrf
+			.apply(req)
+			.map_err(|_| ProxyError::CsrfValidationFailed)?;
+		if let Some(response) = res.direct_response {
+			return Err(ProxyResponse::DirectResponse(Box::new(response)));
+		}
+		res.apply(response_policies.headers())?;
+	}
+
 	Ok(())
 }
 

--- a/crates/agentgateway/src/proxy/mod.rs
+++ b/crates/agentgateway/src/proxy/mod.rs
@@ -52,6 +52,8 @@ pub enum ProxyError {
 	JwtAuthenticationFailure(http::jwt::TokenError),
 	#[error("transformation failed")]
 	TransformationFailure,
+	#[error("CSRF validation failed")]
+	CsrfValidationFailed,
 	#[error("service not found")]
 	ServiceNotFound,
 	#[error("invalid backend type")]
@@ -106,6 +108,7 @@ impl ProxyError {
 			ProxyError::BackendAuthenticationFailed(_) => StatusCode::INTERNAL_SERVER_ERROR,
 			ProxyError::InvalidBackendType => StatusCode::INTERNAL_SERVER_ERROR,
 			ProxyError::TransformationFailure => StatusCode::INTERNAL_SERVER_ERROR,
+			ProxyError::CsrfValidationFailed => StatusCode::FORBIDDEN,
 
 			ProxyError::UpgradeFailed(_, _) => StatusCode::BAD_GATEWAY,
 

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -88,6 +88,7 @@ pub struct RoutePolicies {
 	pub ext_authz: Option<ext_authz::ExtAuthz>,
 	pub transformation: Option<http::transformation_cel::Transformation>,
 	pub llm: Option<Arc<llm::Policy>>,
+	pub csrf: Option<http::csrf::Csrf>,
 }
 
 impl RoutePolicies {
@@ -231,6 +232,7 @@ impl Store {
 			transformation: None,
 			authorization: None,
 			llm: None,
+			csrf: None,
 		};
 		for rule in rules {
 			match &rule {
@@ -257,6 +259,9 @@ impl Store {
 				},
 				Policy::AI(p) => {
 					pol.llm.get_or_insert_with(|| p.clone());
+				},
+				Policy::Csrf(p) => {
+					pol.csrf.get_or_insert_with(|| p.clone());
 				},
 				_ => {}, // others are not route policies
 			}

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -1004,6 +1004,8 @@ pub enum Policy {
 	// Supported targets: Gateway < Route < RouteRule; single policy allowed
 	// Supported targets: Gateway < Route < RouteRule; single policy allowed
 	Transformation(crate::http::transformation_cel::Transformation),
+	// Supported targets: Gateway < Route < RouteRule; single policy allowed
+	Csrf(crate::http::csrf::Csrf),
 }
 
 #[apply(schema!)]

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -585,6 +585,10 @@ struct FilterOrPolicy {
 	)]
 	transformations: Option<crate::http::transformation_cel::Transformation>,
 
+	/// Handle CSRF protection by validating request origins against configured allowed origins.
+	#[serde(default)]
+	csrf: Option<http::csrf::Csrf>,
+
 	// TrafficPolicy
 	/// Timeout requests that exceed the configured duration.
 	#[serde(default)]
@@ -873,6 +877,7 @@ async fn split_policies(
 		remote_rate_limit,
 		jwt_auth,
 		transformations,
+		csrf,
 		ext_authz,
 		timeout,
 		retry,
@@ -937,6 +942,9 @@ async fn split_policies(
 	}
 	if let Some(p) = transformations {
 		route_policies.push(Policy::Transformation(p));
+	}
+	if let Some(p) = csrf {
+		route_policies.push(Policy::Csrf(p))
 	}
 	if let Some(p) = authorization {
 		route_policies.push(Policy::Authorization(p))

--- a/go/api/resource.pb.go
+++ b/go/api/resource.pb.go
@@ -4896,158 +4896,20 @@ func (x *PolicySpec_BodyTransformation) GetExpression() string {
 	return ""
 }
 
-// String matcher for CSRF additional origins
-type PolicySpec_StringMatcher struct {
-	state      protoimpl.MessageState `protogen:"open.v1"`
-	IgnoreCase bool                   `protobuf:"varint,6,opt,name=ignore_case,json=ignoreCase,proto3" json:"ignore_case,omitempty"`
-	// Types that are valid to be assigned to MatchPattern:
-	//
-	//	*PolicySpec_StringMatcher_Exact
-	//	*PolicySpec_StringMatcher_Prefix
-	//	*PolicySpec_StringMatcher_Suffix
-	//	*PolicySpec_StringMatcher_SafeRegex
-	//	*PolicySpec_StringMatcher_Contains
-	MatchPattern  isPolicySpec_StringMatcher_MatchPattern `protobuf_oneof:"match_pattern"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *PolicySpec_StringMatcher) Reset() {
-	*x = PolicySpec_StringMatcher{}
-	mi := &file_resource_proto_msgTypes[57]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *PolicySpec_StringMatcher) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*PolicySpec_StringMatcher) ProtoMessage() {}
-
-func (x *PolicySpec_StringMatcher) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[57]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use PolicySpec_StringMatcher.ProtoReflect.Descriptor instead.
-func (*PolicySpec_StringMatcher) Descriptor() ([]byte, []int) {
-	return file_resource_proto_rawDescGZIP(), []int{36, 12}
-}
-
-func (x *PolicySpec_StringMatcher) GetIgnoreCase() bool {
-	if x != nil {
-		return x.IgnoreCase
-	}
-	return false
-}
-
-func (x *PolicySpec_StringMatcher) GetMatchPattern() isPolicySpec_StringMatcher_MatchPattern {
-	if x != nil {
-		return x.MatchPattern
-	}
-	return nil
-}
-
-func (x *PolicySpec_StringMatcher) GetExact() string {
-	if x != nil {
-		if x, ok := x.MatchPattern.(*PolicySpec_StringMatcher_Exact); ok {
-			return x.Exact
-		}
-	}
-	return ""
-}
-
-func (x *PolicySpec_StringMatcher) GetPrefix() string {
-	if x != nil {
-		if x, ok := x.MatchPattern.(*PolicySpec_StringMatcher_Prefix); ok {
-			return x.Prefix
-		}
-	}
-	return ""
-}
-
-func (x *PolicySpec_StringMatcher) GetSuffix() string {
-	if x != nil {
-		if x, ok := x.MatchPattern.(*PolicySpec_StringMatcher_Suffix); ok {
-			return x.Suffix
-		}
-	}
-	return ""
-}
-
-func (x *PolicySpec_StringMatcher) GetSafeRegex() string {
-	if x != nil {
-		if x, ok := x.MatchPattern.(*PolicySpec_StringMatcher_SafeRegex); ok {
-			return x.SafeRegex
-		}
-	}
-	return ""
-}
-
-func (x *PolicySpec_StringMatcher) GetContains() string {
-	if x != nil {
-		if x, ok := x.MatchPattern.(*PolicySpec_StringMatcher_Contains); ok {
-			return x.Contains
-		}
-	}
-	return ""
-}
-
-type isPolicySpec_StringMatcher_MatchPattern interface {
-	isPolicySpec_StringMatcher_MatchPattern()
-}
-
-type PolicySpec_StringMatcher_Exact struct {
-	Exact string `protobuf:"bytes,1,opt,name=exact,proto3,oneof"`
-}
-
-type PolicySpec_StringMatcher_Prefix struct {
-	Prefix string `protobuf:"bytes,2,opt,name=prefix,proto3,oneof"`
-}
-
-type PolicySpec_StringMatcher_Suffix struct {
-	Suffix string `protobuf:"bytes,3,opt,name=suffix,proto3,oneof"`
-}
-
-type PolicySpec_StringMatcher_SafeRegex struct {
-	SafeRegex string `protobuf:"bytes,4,opt,name=safe_regex,json=safeRegex,proto3,oneof"`
-}
-
-type PolicySpec_StringMatcher_Contains struct {
-	Contains string `protobuf:"bytes,7,opt,name=contains,proto3,oneof"`
-}
-
-func (*PolicySpec_StringMatcher_Exact) isPolicySpec_StringMatcher_MatchPattern() {}
-
-func (*PolicySpec_StringMatcher_Prefix) isPolicySpec_StringMatcher_MatchPattern() {}
-
-func (*PolicySpec_StringMatcher_Suffix) isPolicySpec_StringMatcher_MatchPattern() {}
-
-func (*PolicySpec_StringMatcher_SafeRegex) isPolicySpec_StringMatcher_MatchPattern() {}
-
-func (*PolicySpec_StringMatcher_Contains) isPolicySpec_StringMatcher_MatchPattern() {}
-
 // Cross-Site Request Forgery (CSRF) policy configuration.
 type PolicySpec_CSRF struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Additional origins that are allowed for CSRF validation beyond the same-origin policy.
-	// If a request's origin header matches any of these matchers, the request will be allowed.
-	AdditionalOrigins []*PolicySpec_StringMatcher `protobuf:"bytes,1,rep,name=additional_origins,json=additionalOrigins,proto3" json:"additional_origins,omitempty"`
+	// If a request's origin header matches any of these exact origins, the request will be allowed.
+	// Each origin should be in the format "scheme://host[:port]" (e.g., "https://www.example.com")
+	AdditionalOrigins []string `protobuf:"bytes,1,rep,name=additional_origins,json=additionalOrigins,proto3" json:"additional_origins,omitempty"`
 	unknownFields     protoimpl.UnknownFields
 	sizeCache         protoimpl.SizeCache
 }
 
 func (x *PolicySpec_CSRF) Reset() {
 	*x = PolicySpec_CSRF{}
-	mi := &file_resource_proto_msgTypes[58]
+	mi := &file_resource_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5059,7 +4921,7 @@ func (x *PolicySpec_CSRF) String() string {
 func (*PolicySpec_CSRF) ProtoMessage() {}
 
 func (x *PolicySpec_CSRF) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[58]
+	mi := &file_resource_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5072,10 +4934,10 @@ func (x *PolicySpec_CSRF) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicySpec_CSRF.ProtoReflect.Descriptor instead.
 func (*PolicySpec_CSRF) Descriptor() ([]byte, []int) {
-	return file_resource_proto_rawDescGZIP(), []int{36, 13}
+	return file_resource_proto_rawDescGZIP(), []int{36, 12}
 }
 
-func (x *PolicySpec_CSRF) GetAdditionalOrigins() []*PolicySpec_StringMatcher {
+func (x *PolicySpec_CSRF) GetAdditionalOrigins() []string {
 	if x != nil {
 		return x.AdditionalOrigins
 	}
@@ -5092,7 +4954,7 @@ type PolicySpec_RemoteRateLimit_Descriptor struct {
 
 func (x *PolicySpec_RemoteRateLimit_Descriptor) Reset() {
 	*x = PolicySpec_RemoteRateLimit_Descriptor{}
-	mi := &file_resource_proto_msgTypes[59]
+	mi := &file_resource_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5104,7 +4966,7 @@ func (x *PolicySpec_RemoteRateLimit_Descriptor) String() string {
 func (*PolicySpec_RemoteRateLimit_Descriptor) ProtoMessage() {}
 
 func (x *PolicySpec_RemoteRateLimit_Descriptor) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[59]
+	mi := &file_resource_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5144,7 +5006,7 @@ type PolicySpec_RemoteRateLimit_Entry struct {
 
 func (x *PolicySpec_RemoteRateLimit_Entry) Reset() {
 	*x = PolicySpec_RemoteRateLimit_Entry{}
-	mi := &file_resource_proto_msgTypes[60]
+	mi := &file_resource_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5156,7 +5018,7 @@ func (x *PolicySpec_RemoteRateLimit_Entry) String() string {
 func (*PolicySpec_RemoteRateLimit_Entry) ProtoMessage() {}
 
 func (x *PolicySpec_RemoteRateLimit_Entry) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[60]
+	mi := &file_resource_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5196,7 +5058,7 @@ type PolicySpec_Ai_Message struct {
 
 func (x *PolicySpec_Ai_Message) Reset() {
 	*x = PolicySpec_Ai_Message{}
-	mi := &file_resource_proto_msgTypes[61]
+	mi := &file_resource_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5208,7 +5070,7 @@ func (x *PolicySpec_Ai_Message) String() string {
 func (*PolicySpec_Ai_Message) ProtoMessage() {}
 
 func (x *PolicySpec_Ai_Message) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[61]
+	mi := &file_resource_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5248,7 +5110,7 @@ type PolicySpec_Ai_PromptEnrichment struct {
 
 func (x *PolicySpec_Ai_PromptEnrichment) Reset() {
 	*x = PolicySpec_Ai_PromptEnrichment{}
-	mi := &file_resource_proto_msgTypes[62]
+	mi := &file_resource_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5260,7 +5122,7 @@ func (x *PolicySpec_Ai_PromptEnrichment) String() string {
 func (*PolicySpec_Ai_PromptEnrichment) ProtoMessage() {}
 
 func (x *PolicySpec_Ai_PromptEnrichment) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[62]
+	mi := &file_resource_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5300,7 +5162,7 @@ type PolicySpec_Ai_NamedRegex struct {
 
 func (x *PolicySpec_Ai_NamedRegex) Reset() {
 	*x = PolicySpec_Ai_NamedRegex{}
-	mi := &file_resource_proto_msgTypes[63]
+	mi := &file_resource_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5312,7 +5174,7 @@ func (x *PolicySpec_Ai_NamedRegex) String() string {
 func (*PolicySpec_Ai_NamedRegex) ProtoMessage() {}
 
 func (x *PolicySpec_Ai_NamedRegex) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[63]
+	mi := &file_resource_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5355,7 +5217,7 @@ type PolicySpec_Ai_RegexRule struct {
 
 func (x *PolicySpec_Ai_RegexRule) Reset() {
 	*x = PolicySpec_Ai_RegexRule{}
-	mi := &file_resource_proto_msgTypes[64]
+	mi := &file_resource_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5367,7 +5229,7 @@ func (x *PolicySpec_Ai_RegexRule) String() string {
 func (*PolicySpec_Ai_RegexRule) ProtoMessage() {}
 
 func (x *PolicySpec_Ai_RegexRule) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[64]
+	mi := &file_resource_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5435,7 +5297,7 @@ type PolicySpec_Ai_Action struct {
 
 func (x *PolicySpec_Ai_Action) Reset() {
 	*x = PolicySpec_Ai_Action{}
-	mi := &file_resource_proto_msgTypes[65]
+	mi := &file_resource_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5447,7 +5309,7 @@ func (x *PolicySpec_Ai_Action) String() string {
 func (*PolicySpec_Ai_Action) ProtoMessage() {}
 
 func (x *PolicySpec_Ai_Action) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[65]
+	mi := &file_resource_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5487,7 +5349,7 @@ type PolicySpec_Ai_RegexRules struct {
 
 func (x *PolicySpec_Ai_RegexRules) Reset() {
 	*x = PolicySpec_Ai_RegexRules{}
-	mi := &file_resource_proto_msgTypes[66]
+	mi := &file_resource_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5499,7 +5361,7 @@ func (x *PolicySpec_Ai_RegexRules) String() string {
 func (*PolicySpec_Ai_RegexRules) ProtoMessage() {}
 
 func (x *PolicySpec_Ai_RegexRules) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[66]
+	mi := &file_resource_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5540,7 +5402,7 @@ type PolicySpec_Ai_Webhook struct {
 
 func (x *PolicySpec_Ai_Webhook) Reset() {
 	*x = PolicySpec_Ai_Webhook{}
-	mi := &file_resource_proto_msgTypes[67]
+	mi := &file_resource_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5552,7 +5414,7 @@ func (x *PolicySpec_Ai_Webhook) String() string {
 func (*PolicySpec_Ai_Webhook) ProtoMessage() {}
 
 func (x *PolicySpec_Ai_Webhook) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[67]
+	mi := &file_resource_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5600,7 +5462,7 @@ type PolicySpec_Ai_Moderation struct {
 
 func (x *PolicySpec_Ai_Moderation) Reset() {
 	*x = PolicySpec_Ai_Moderation{}
-	mi := &file_resource_proto_msgTypes[68]
+	mi := &file_resource_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5612,7 +5474,7 @@ func (x *PolicySpec_Ai_Moderation) String() string {
 func (*PolicySpec_Ai_Moderation) ProtoMessage() {}
 
 func (x *PolicySpec_Ai_Moderation) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[68]
+	mi := &file_resource_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5653,7 +5515,7 @@ type PolicySpec_Ai_RequestRejection struct {
 
 func (x *PolicySpec_Ai_RequestRejection) Reset() {
 	*x = PolicySpec_Ai_RequestRejection{}
-	mi := &file_resource_proto_msgTypes[69]
+	mi := &file_resource_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5665,7 +5527,7 @@ func (x *PolicySpec_Ai_RequestRejection) String() string {
 func (*PolicySpec_Ai_RequestRejection) ProtoMessage() {}
 
 func (x *PolicySpec_Ai_RequestRejection) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[69]
+	mi := &file_resource_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5706,7 +5568,7 @@ type PolicySpec_Ai_ResponseGuard struct {
 
 func (x *PolicySpec_Ai_ResponseGuard) Reset() {
 	*x = PolicySpec_Ai_ResponseGuard{}
-	mi := &file_resource_proto_msgTypes[70]
+	mi := &file_resource_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5718,7 +5580,7 @@ func (x *PolicySpec_Ai_ResponseGuard) String() string {
 func (*PolicySpec_Ai_ResponseGuard) ProtoMessage() {}
 
 func (x *PolicySpec_Ai_ResponseGuard) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[70]
+	mi := &file_resource_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5762,7 +5624,7 @@ type PolicySpec_Ai_RequestGuard struct {
 
 func (x *PolicySpec_Ai_RequestGuard) Reset() {
 	*x = PolicySpec_Ai_RequestGuard{}
-	mi := &file_resource_proto_msgTypes[71]
+	mi := &file_resource_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5774,7 +5636,7 @@ func (x *PolicySpec_Ai_RequestGuard) String() string {
 func (*PolicySpec_Ai_RequestGuard) ProtoMessage() {}
 
 func (x *PolicySpec_Ai_RequestGuard) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[71]
+	mi := &file_resource_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5830,7 +5692,7 @@ type PolicySpec_Ai_PromptGuard struct {
 
 func (x *PolicySpec_Ai_PromptGuard) Reset() {
 	*x = PolicySpec_Ai_PromptGuard{}
-	mi := &file_resource_proto_msgTypes[72]
+	mi := &file_resource_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5842,7 +5704,7 @@ func (x *PolicySpec_Ai_PromptGuard) String() string {
 func (*PolicySpec_Ai_PromptGuard) ProtoMessage() {}
 
 func (x *PolicySpec_Ai_PromptGuard) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[72]
+	mi := &file_resource_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6698,7 +6560,7 @@ const file_resource_proto_rawDesc = "" +
 	"\aservice\x18\x06 \x01(\tH\x00R\aservice\x12!\n" +
 	"\vsub_backend\x18\a \x01(\tH\x00R\n" +
 	"subBackendB\x06\n" +
-	"\x04kind\"\x8e6\n" +
+	"\x04kind\"\xac5\n" +
 	"\n" +
 	"PolicySpec\x12`\n" +
 	"\x10local_rate_limit\x18\x01 \x01(\v24.agentgateway.dev.resource.PolicySpec.LocalRateLimitH\x00R\x0elocalRateLimit\x12Q\n" +
@@ -6875,19 +6737,9 @@ const file_resource_proto_rawDesc = "" +
 	"\x12BodyTransformation\x12\x1e\n" +
 	"\n" +
 	"expression\x18\x01 \x01(\tR\n" +
-	"expression\x1a\xcc\x01\n" +
-	"\rStringMatcher\x12\x1f\n" +
-	"\vignore_case\x18\x06 \x01(\bR\n" +
-	"ignoreCase\x12\x16\n" +
-	"\x05exact\x18\x01 \x01(\tH\x00R\x05exact\x12\x18\n" +
-	"\x06prefix\x18\x02 \x01(\tH\x00R\x06prefix\x12\x18\n" +
-	"\x06suffix\x18\x03 \x01(\tH\x00R\x06suffix\x12\x1f\n" +
-	"\n" +
-	"safe_regex\x18\x04 \x01(\tH\x00R\tsafeRegex\x12\x1c\n" +
-	"\bcontains\x18\a \x01(\tH\x00R\bcontainsB\x0f\n" +
-	"\rmatch_pattern\x1aj\n" +
-	"\x04CSRF\x12b\n" +
-	"\x12additional_origins\x18\x01 \x03(\v23.agentgateway.dev.resource.PolicySpec.StringMatcherR\x11additionalOriginsB\x06\n" +
+	"expression\x1a5\n" +
+	"\x04CSRF\x12-\n" +
+	"\x12additional_origins\x18\x01 \x03(\tR\x11additionalOriginsB\x06\n" +
 	"\x04kind\"\x98\x01\n" +
 	"\x06Policy\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12?\n" +
@@ -7048,24 +6900,24 @@ var file_resource_proto_goTypes = []any{
 	(*PolicySpec_TransformationPolicy)(nil),                     // 64: agentgateway.dev.resource.PolicySpec.TransformationPolicy
 	(*PolicySpec_HeaderTransformation)(nil),                     // 65: agentgateway.dev.resource.PolicySpec.HeaderTransformation
 	(*PolicySpec_BodyTransformation)(nil),                       // 66: agentgateway.dev.resource.PolicySpec.BodyTransformation
-	(*PolicySpec_StringMatcher)(nil),                            // 67: agentgateway.dev.resource.PolicySpec.StringMatcher
-	(*PolicySpec_CSRF)(nil),                                     // 68: agentgateway.dev.resource.PolicySpec.CSRF
-	(*PolicySpec_RemoteRateLimit_Descriptor)(nil),               // 69: agentgateway.dev.resource.PolicySpec.RemoteRateLimit.Descriptor
-	(*PolicySpec_RemoteRateLimit_Entry)(nil),                    // 70: agentgateway.dev.resource.PolicySpec.RemoteRateLimit.Entry
-	(*PolicySpec_Ai_Message)(nil),                               // 71: agentgateway.dev.resource.PolicySpec.Ai.Message
-	(*PolicySpec_Ai_PromptEnrichment)(nil),                      // 72: agentgateway.dev.resource.PolicySpec.Ai.PromptEnrichment
-	(*PolicySpec_Ai_NamedRegex)(nil),                            // 73: agentgateway.dev.resource.PolicySpec.Ai.NamedRegex
-	(*PolicySpec_Ai_RegexRule)(nil),                             // 74: agentgateway.dev.resource.PolicySpec.Ai.RegexRule
-	(*PolicySpec_Ai_Action)(nil),                                // 75: agentgateway.dev.resource.PolicySpec.Ai.Action
-	(*PolicySpec_Ai_RegexRules)(nil),                            // 76: agentgateway.dev.resource.PolicySpec.Ai.RegexRules
-	(*PolicySpec_Ai_Webhook)(nil),                               // 77: agentgateway.dev.resource.PolicySpec.Ai.Webhook
-	(*PolicySpec_Ai_Moderation)(nil),                            // 78: agentgateway.dev.resource.PolicySpec.Ai.Moderation
-	(*PolicySpec_Ai_RequestRejection)(nil),                      // 79: agentgateway.dev.resource.PolicySpec.Ai.RequestRejection
-	(*PolicySpec_Ai_ResponseGuard)(nil),                         // 80: agentgateway.dev.resource.PolicySpec.Ai.ResponseGuard
-	(*PolicySpec_Ai_RequestGuard)(nil),                          // 81: agentgateway.dev.resource.PolicySpec.Ai.RequestGuard
-	(*PolicySpec_Ai_PromptGuard)(nil),                           // 82: agentgateway.dev.resource.PolicySpec.Ai.PromptGuard
-	nil,                                                         // 83: agentgateway.dev.resource.PolicySpec.Ai.DefaultsEntry
-	nil,                                                         // 84: agentgateway.dev.resource.PolicySpec.Ai.OverridesEntry
+	(*PolicySpec_CSRF)(nil),                                     // 67: agentgateway.dev.resource.PolicySpec.CSRF
+	(*PolicySpec_RemoteRateLimit_Descriptor)(nil),               // 68: agentgateway.dev.resource.PolicySpec.RemoteRateLimit.Descriptor
+	(*PolicySpec_RemoteRateLimit_Entry)(nil),                    // 69: agentgateway.dev.resource.PolicySpec.RemoteRateLimit.Entry
+	(*PolicySpec_Ai_Message)(nil),                               // 70: agentgateway.dev.resource.PolicySpec.Ai.Message
+	(*PolicySpec_Ai_PromptEnrichment)(nil),                      // 71: agentgateway.dev.resource.PolicySpec.Ai.PromptEnrichment
+	(*PolicySpec_Ai_NamedRegex)(nil),                            // 72: agentgateway.dev.resource.PolicySpec.Ai.NamedRegex
+	(*PolicySpec_Ai_RegexRule)(nil),                             // 73: agentgateway.dev.resource.PolicySpec.Ai.RegexRule
+	(*PolicySpec_Ai_Action)(nil),                                // 74: agentgateway.dev.resource.PolicySpec.Ai.Action
+	(*PolicySpec_Ai_RegexRules)(nil),                            // 75: agentgateway.dev.resource.PolicySpec.Ai.RegexRules
+	(*PolicySpec_Ai_Webhook)(nil),                               // 76: agentgateway.dev.resource.PolicySpec.Ai.Webhook
+	(*PolicySpec_Ai_Moderation)(nil),                            // 77: agentgateway.dev.resource.PolicySpec.Ai.Moderation
+	(*PolicySpec_Ai_RequestRejection)(nil),                      // 78: agentgateway.dev.resource.PolicySpec.Ai.RequestRejection
+	(*PolicySpec_Ai_ResponseGuard)(nil),                         // 79: agentgateway.dev.resource.PolicySpec.Ai.ResponseGuard
+	(*PolicySpec_Ai_RequestGuard)(nil),                          // 80: agentgateway.dev.resource.PolicySpec.Ai.RequestGuard
+	(*PolicySpec_Ai_PromptGuard)(nil),                           // 81: agentgateway.dev.resource.PolicySpec.Ai.PromptGuard
+	nil,                                                         // 82: agentgateway.dev.resource.PolicySpec.Ai.DefaultsEntry
+	nil,                                                         // 83: agentgateway.dev.resource.PolicySpec.Ai.OverridesEntry
+	nil,                                                         // 84: agentgateway.dev.resource.PolicySpec.Ai.ModelAliasesEntry
 	(*PolicySpec_ExternalAuth_BodyOptions)(nil),                 // 85: agentgateway.dev.resource.PolicySpec.ExternalAuth.BodyOptions
 	nil, // 86: agentgateway.dev.resource.PolicySpec.ExternalAuth.ContextEntry
 	(*PolicySpec_TransformationPolicy_Transform)(nil), // 87: agentgateway.dev.resource.PolicySpec.TransformationPolicy.Transform
@@ -7144,7 +6996,7 @@ var file_resource_proto_depIdxs = []int32{
 	63,  // 57: agentgateway.dev.resource.PolicySpec.jwt:type_name -> agentgateway.dev.resource.PolicySpec.JWT
 	64,  // 58: agentgateway.dev.resource.PolicySpec.transformation:type_name -> agentgateway.dev.resource.PolicySpec.TransformationPolicy
 	55,  // 59: agentgateway.dev.resource.PolicySpec.remote_rate_limit:type_name -> agentgateway.dev.resource.PolicySpec.RemoteRateLimit
-	68,  // 60: agentgateway.dev.resource.PolicySpec.csrf:type_name -> agentgateway.dev.resource.PolicySpec.CSRF
+	67,  // 60: agentgateway.dev.resource.PolicySpec.csrf:type_name -> agentgateway.dev.resource.PolicySpec.CSRF
 	45,  // 61: agentgateway.dev.resource.Policy.target:type_name -> agentgateway.dev.resource.PolicyTarget
 	46,  // 62: agentgateway.dev.resource.Policy.spec:type_name -> agentgateway.dev.resource.PolicySpec
 	49,  // 63: agentgateway.dev.resource.Backend.static:type_name -> agentgateway.dev.resource.StaticBackend
@@ -7155,52 +7007,52 @@ var file_resource_proto_depIdxs = []int32{
 	8,   // 68: agentgateway.dev.resource.MCPBackend.stateful_mode:type_name -> agentgateway.dev.resource.MCPBackend.StatefulMode
 	53,  // 69: agentgateway.dev.resource.MCPTarget.backend:type_name -> agentgateway.dev.resource.BackendReference
 	9,   // 70: agentgateway.dev.resource.MCPTarget.protocol:type_name -> agentgateway.dev.resource.MCPTarget.Protocol
-	69,  // 71: agentgateway.dev.resource.PolicySpec.RemoteRateLimit.descriptors:type_name -> agentgateway.dev.resource.PolicySpec.RemoteRateLimit.Descriptor
+	68,  // 71: agentgateway.dev.resource.PolicySpec.RemoteRateLimit.descriptors:type_name -> agentgateway.dev.resource.PolicySpec.RemoteRateLimit.Descriptor
 	53,  // 72: agentgateway.dev.resource.PolicySpec.RemoteRateLimit.target:type_name -> agentgateway.dev.resource.BackendReference
 	96,  // 73: agentgateway.dev.resource.PolicySpec.LocalRateLimit.fill_interval:type_name -> google.protobuf.Duration
 	2,   // 74: agentgateway.dev.resource.PolicySpec.LocalRateLimit.type:type_name -> agentgateway.dev.resource.PolicySpec.LocalRateLimit.Type
-	82,  // 75: agentgateway.dev.resource.PolicySpec.Ai.prompt_guard:type_name -> agentgateway.dev.resource.PolicySpec.Ai.PromptGuard
-	83,  // 76: agentgateway.dev.resource.PolicySpec.Ai.defaults:type_name -> agentgateway.dev.resource.PolicySpec.Ai.DefaultsEntry
-	84,  // 77: agentgateway.dev.resource.PolicySpec.Ai.overrides:type_name -> agentgateway.dev.resource.PolicySpec.Ai.OverridesEntry
-	72,  // 78: agentgateway.dev.resource.PolicySpec.Ai.prompts:type_name -> agentgateway.dev.resource.PolicySpec.Ai.PromptEnrichment
-	53,  // 79: agentgateway.dev.resource.PolicySpec.ExternalAuth.target:type_name -> agentgateway.dev.resource.BackendReference
-	86,  // 80: agentgateway.dev.resource.PolicySpec.ExternalAuth.context:type_name -> agentgateway.dev.resource.PolicySpec.ExternalAuth.ContextEntry
-	5,   // 81: agentgateway.dev.resource.PolicySpec.ExternalAuth.failure_mode:type_name -> agentgateway.dev.resource.PolicySpec.ExternalAuth.FailureMode
-	85,  // 82: agentgateway.dev.resource.PolicySpec.ExternalAuth.include_request_body:type_name -> agentgateway.dev.resource.PolicySpec.ExternalAuth.BodyOptions
-	96,  // 83: agentgateway.dev.resource.PolicySpec.ExternalAuth.timeout:type_name -> google.protobuf.Duration
-	97,  // 84: agentgateway.dev.resource.PolicySpec.ExternalAuth.status_on_error:type_name -> google.protobuf.UInt32Value
-	53,  // 85: agentgateway.dev.resource.PolicySpec.InferenceRouting.endpoint_picker:type_name -> agentgateway.dev.resource.BackendReference
-	6,   // 86: agentgateway.dev.resource.PolicySpec.InferenceRouting.failure_mode:type_name -> agentgateway.dev.resource.PolicySpec.InferenceRouting.FailureMode
-	98,  // 87: agentgateway.dev.resource.PolicySpec.BackendTLS.cert:type_name -> google.protobuf.BytesValue
-	98,  // 88: agentgateway.dev.resource.PolicySpec.BackendTLS.key:type_name -> google.protobuf.BytesValue
-	98,  // 89: agentgateway.dev.resource.PolicySpec.BackendTLS.root:type_name -> google.protobuf.BytesValue
-	99,  // 90: agentgateway.dev.resource.PolicySpec.BackendTLS.insecure:type_name -> google.protobuf.BoolValue
-	100, // 91: agentgateway.dev.resource.PolicySpec.BackendTLS.hostname:type_name -> google.protobuf.StringValue
-	7,   // 92: agentgateway.dev.resource.PolicySpec.JWT.mode:type_name -> agentgateway.dev.resource.PolicySpec.JWT.Mode
-	87,  // 93: agentgateway.dev.resource.PolicySpec.TransformationPolicy.request:type_name -> agentgateway.dev.resource.PolicySpec.TransformationPolicy.Transform
-	87,  // 94: agentgateway.dev.resource.PolicySpec.TransformationPolicy.response:type_name -> agentgateway.dev.resource.PolicySpec.TransformationPolicy.Transform
-	67,  // 95: agentgateway.dev.resource.PolicySpec.CSRF.additional_origins:type_name -> agentgateway.dev.resource.PolicySpec.StringMatcher
-	70,  // 96: agentgateway.dev.resource.PolicySpec.RemoteRateLimit.Descriptor.entries:type_name -> agentgateway.dev.resource.PolicySpec.RemoteRateLimit.Entry
+	81,  // 75: agentgateway.dev.resource.PolicySpec.Ai.prompt_guard:type_name -> agentgateway.dev.resource.PolicySpec.Ai.PromptGuard
+	82,  // 76: agentgateway.dev.resource.PolicySpec.Ai.defaults:type_name -> agentgateway.dev.resource.PolicySpec.Ai.DefaultsEntry
+	83,  // 77: agentgateway.dev.resource.PolicySpec.Ai.overrides:type_name -> agentgateway.dev.resource.PolicySpec.Ai.OverridesEntry
+	71,  // 78: agentgateway.dev.resource.PolicySpec.Ai.prompts:type_name -> agentgateway.dev.resource.PolicySpec.Ai.PromptEnrichment
+	84,  // 79: agentgateway.dev.resource.PolicySpec.Ai.model_aliases:type_name -> agentgateway.dev.resource.PolicySpec.Ai.ModelAliasesEntry
+	53,  // 80: agentgateway.dev.resource.PolicySpec.ExternalAuth.target:type_name -> agentgateway.dev.resource.BackendReference
+	86,  // 81: agentgateway.dev.resource.PolicySpec.ExternalAuth.context:type_name -> agentgateway.dev.resource.PolicySpec.ExternalAuth.ContextEntry
+	5,   // 82: agentgateway.dev.resource.PolicySpec.ExternalAuth.failure_mode:type_name -> agentgateway.dev.resource.PolicySpec.ExternalAuth.FailureMode
+	85,  // 83: agentgateway.dev.resource.PolicySpec.ExternalAuth.include_request_body:type_name -> agentgateway.dev.resource.PolicySpec.ExternalAuth.BodyOptions
+	96,  // 84: agentgateway.dev.resource.PolicySpec.ExternalAuth.timeout:type_name -> google.protobuf.Duration
+	97,  // 85: agentgateway.dev.resource.PolicySpec.ExternalAuth.status_on_error:type_name -> google.protobuf.UInt32Value
+	53,  // 86: agentgateway.dev.resource.PolicySpec.InferenceRouting.endpoint_picker:type_name -> agentgateway.dev.resource.BackendReference
+	6,   // 87: agentgateway.dev.resource.PolicySpec.InferenceRouting.failure_mode:type_name -> agentgateway.dev.resource.PolicySpec.InferenceRouting.FailureMode
+	98,  // 88: agentgateway.dev.resource.PolicySpec.BackendTLS.cert:type_name -> google.protobuf.BytesValue
+	98,  // 89: agentgateway.dev.resource.PolicySpec.BackendTLS.key:type_name -> google.protobuf.BytesValue
+	98,  // 90: agentgateway.dev.resource.PolicySpec.BackendTLS.root:type_name -> google.protobuf.BytesValue
+	99,  // 91: agentgateway.dev.resource.PolicySpec.BackendTLS.insecure:type_name -> google.protobuf.BoolValue
+	100, // 92: agentgateway.dev.resource.PolicySpec.BackendTLS.hostname:type_name -> google.protobuf.StringValue
+	7,   // 93: agentgateway.dev.resource.PolicySpec.JWT.mode:type_name -> agentgateway.dev.resource.PolicySpec.JWT.Mode
+	87,  // 94: agentgateway.dev.resource.PolicySpec.TransformationPolicy.request:type_name -> agentgateway.dev.resource.PolicySpec.TransformationPolicy.Transform
+	87,  // 95: agentgateway.dev.resource.PolicySpec.TransformationPolicy.response:type_name -> agentgateway.dev.resource.PolicySpec.TransformationPolicy.Transform
+	69,  // 96: agentgateway.dev.resource.PolicySpec.RemoteRateLimit.Descriptor.entries:type_name -> agentgateway.dev.resource.PolicySpec.RemoteRateLimit.Entry
 	1,   // 97: agentgateway.dev.resource.PolicySpec.RemoteRateLimit.Descriptor.type:type_name -> agentgateway.dev.resource.PolicySpec.RemoteRateLimit.Type
-	71,  // 98: agentgateway.dev.resource.PolicySpec.Ai.PromptEnrichment.append:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Message
-	71,  // 99: agentgateway.dev.resource.PolicySpec.Ai.PromptEnrichment.prepend:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Message
+	70,  // 98: agentgateway.dev.resource.PolicySpec.Ai.PromptEnrichment.append:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Message
+	70,  // 99: agentgateway.dev.resource.PolicySpec.Ai.PromptEnrichment.prepend:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Message
 	3,   // 100: agentgateway.dev.resource.PolicySpec.Ai.RegexRule.builtin:type_name -> agentgateway.dev.resource.PolicySpec.Ai.BuiltinRegexRule
-	73,  // 101: agentgateway.dev.resource.PolicySpec.Ai.RegexRule.regex:type_name -> agentgateway.dev.resource.PolicySpec.Ai.NamedRegex
+	72,  // 101: agentgateway.dev.resource.PolicySpec.Ai.RegexRule.regex:type_name -> agentgateway.dev.resource.PolicySpec.Ai.NamedRegex
 	4,   // 102: agentgateway.dev.resource.PolicySpec.Ai.Action.kind:type_name -> agentgateway.dev.resource.PolicySpec.Ai.ActionKind
-	79,  // 103: agentgateway.dev.resource.PolicySpec.Ai.Action.reject_response:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RequestRejection
-	75,  // 104: agentgateway.dev.resource.PolicySpec.Ai.RegexRules.action:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Action
-	74,  // 105: agentgateway.dev.resource.PolicySpec.Ai.RegexRules.rules:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RegexRule
+	78,  // 103: agentgateway.dev.resource.PolicySpec.Ai.Action.reject_response:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RequestRejection
+	74,  // 104: agentgateway.dev.resource.PolicySpec.Ai.RegexRules.action:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Action
+	73,  // 105: agentgateway.dev.resource.PolicySpec.Ai.RegexRules.rules:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RegexRule
 	35,  // 106: agentgateway.dev.resource.PolicySpec.Ai.Webhook.forward_header_matches:type_name -> agentgateway.dev.resource.HeaderMatch
 	100, // 107: agentgateway.dev.resource.PolicySpec.Ai.Moderation.model:type_name -> google.protobuf.StringValue
 	18,  // 108: agentgateway.dev.resource.PolicySpec.Ai.Moderation.auth:type_name -> agentgateway.dev.resource.BackendAuthPolicy
-	76,  // 109: agentgateway.dev.resource.PolicySpec.Ai.ResponseGuard.regex:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RegexRules
-	77,  // 110: agentgateway.dev.resource.PolicySpec.Ai.ResponseGuard.webhook:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Webhook
-	79,  // 111: agentgateway.dev.resource.PolicySpec.Ai.RequestGuard.rejection:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RequestRejection
-	76,  // 112: agentgateway.dev.resource.PolicySpec.Ai.RequestGuard.regex:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RegexRules
-	77,  // 113: agentgateway.dev.resource.PolicySpec.Ai.RequestGuard.webhook:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Webhook
-	78,  // 114: agentgateway.dev.resource.PolicySpec.Ai.RequestGuard.openai_moderation:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Moderation
-	81,  // 115: agentgateway.dev.resource.PolicySpec.Ai.PromptGuard.request:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RequestGuard
-	80,  // 116: agentgateway.dev.resource.PolicySpec.Ai.PromptGuard.response:type_name -> agentgateway.dev.resource.PolicySpec.Ai.ResponseGuard
+	75,  // 109: agentgateway.dev.resource.PolicySpec.Ai.ResponseGuard.regex:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RegexRules
+	76,  // 110: agentgateway.dev.resource.PolicySpec.Ai.ResponseGuard.webhook:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Webhook
+	78,  // 111: agentgateway.dev.resource.PolicySpec.Ai.RequestGuard.rejection:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RequestRejection
+	75,  // 112: agentgateway.dev.resource.PolicySpec.Ai.RequestGuard.regex:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RegexRules
+	76,  // 113: agentgateway.dev.resource.PolicySpec.Ai.RequestGuard.webhook:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Webhook
+	77,  // 114: agentgateway.dev.resource.PolicySpec.Ai.RequestGuard.openai_moderation:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Moderation
+	80,  // 115: agentgateway.dev.resource.PolicySpec.Ai.PromptGuard.request:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RequestGuard
+	79,  // 116: agentgateway.dev.resource.PolicySpec.Ai.PromptGuard.response:type_name -> agentgateway.dev.resource.PolicySpec.Ai.ResponseGuard
 	65,  // 117: agentgateway.dev.resource.PolicySpec.TransformationPolicy.Transform.set:type_name -> agentgateway.dev.resource.PolicySpec.HeaderTransformation
 	65,  // 118: agentgateway.dev.resource.PolicySpec.TransformationPolicy.Transform.add:type_name -> agentgateway.dev.resource.PolicySpec.HeaderTransformation
 	66,  // 119: agentgateway.dev.resource.PolicySpec.TransformationPolicy.Transform.body:type_name -> agentgateway.dev.resource.PolicySpec.BodyTransformation
@@ -7332,14 +7184,7 @@ func file_resource_proto_init() {
 	file_resource_proto_msgTypes[53].OneofWrappers = []any{
 		(*PolicySpec_JWT_Inline)(nil),
 	}
-	file_resource_proto_msgTypes[57].OneofWrappers = []any{
-		(*PolicySpec_StringMatcher_Exact)(nil),
-		(*PolicySpec_StringMatcher_Prefix)(nil),
-		(*PolicySpec_StringMatcher_Suffix)(nil),
-		(*PolicySpec_StringMatcher_SafeRegex)(nil),
-		(*PolicySpec_StringMatcher_Contains)(nil),
-	}
-	file_resource_proto_msgTypes[64].OneofWrappers = []any{
+	file_resource_proto_msgTypes[63].OneofWrappers = []any{
 		(*PolicySpec_Ai_RegexRule_Builtin)(nil),
 		(*PolicySpec_Ai_RegexRule_Regex)(nil),
 	}

--- a/go/api/resource.pb.go
+++ b/go/api/resource.pb.go
@@ -3306,6 +3306,7 @@ type PolicySpec struct {
 	//	*PolicySpec_Jwt
 	//	*PolicySpec_Transformation
 	//	*PolicySpec_RemoteRateLimit_
+	//	*PolicySpec_Csrf
 	Kind          isPolicySpec_Kind `protobuf_oneof:"kind"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -3456,6 +3457,15 @@ func (x *PolicySpec) GetRemoteRateLimit() *PolicySpec_RemoteRateLimit {
 	return nil
 }
 
+func (x *PolicySpec) GetCsrf() *PolicySpec_CSRF {
+	if x != nil {
+		if x, ok := x.Kind.(*PolicySpec_Csrf); ok {
+			return x.Csrf
+		}
+	}
+	return nil
+}
+
 type isPolicySpec_Kind interface {
 	isPolicySpec_Kind()
 }
@@ -3508,6 +3518,10 @@ type PolicySpec_RemoteRateLimit_ struct {
 	RemoteRateLimit *PolicySpec_RemoteRateLimit `protobuf:"bytes,12,opt,name=remote_rate_limit,json=remoteRateLimit,proto3,oneof"`
 }
 
+type PolicySpec_Csrf struct {
+	Csrf *PolicySpec_CSRF `protobuf:"bytes,13,opt,name=csrf,proto3,oneof"`
+}
+
 func (*PolicySpec_LocalRateLimit_) isPolicySpec_Kind() {}
 
 func (*PolicySpec_ExtAuthz) isPolicySpec_Kind() {}
@@ -3531,6 +3545,8 @@ func (*PolicySpec_Jwt) isPolicySpec_Kind() {}
 func (*PolicySpec_Transformation) isPolicySpec_Kind() {}
 
 func (*PolicySpec_RemoteRateLimit_) isPolicySpec_Kind() {}
+
+func (*PolicySpec_Csrf) isPolicySpec_Kind() {}
 
 type Policy struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -4880,6 +4896,192 @@ func (x *PolicySpec_BodyTransformation) GetExpression() string {
 	return ""
 }
 
+// String matcher for CSRF additional origins
+type PolicySpec_StringMatcher struct {
+	state      protoimpl.MessageState `protogen:"open.v1"`
+	IgnoreCase bool                   `protobuf:"varint,6,opt,name=ignore_case,json=ignoreCase,proto3" json:"ignore_case,omitempty"`
+	// Types that are valid to be assigned to MatchPattern:
+	//
+	//	*PolicySpec_StringMatcher_Exact
+	//	*PolicySpec_StringMatcher_Prefix
+	//	*PolicySpec_StringMatcher_Suffix
+	//	*PolicySpec_StringMatcher_SafeRegex
+	//	*PolicySpec_StringMatcher_Contains
+	MatchPattern  isPolicySpec_StringMatcher_MatchPattern `protobuf_oneof:"match_pattern"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PolicySpec_StringMatcher) Reset() {
+	*x = PolicySpec_StringMatcher{}
+	mi := &file_resource_proto_msgTypes[57]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PolicySpec_StringMatcher) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PolicySpec_StringMatcher) ProtoMessage() {}
+
+func (x *PolicySpec_StringMatcher) ProtoReflect() protoreflect.Message {
+	mi := &file_resource_proto_msgTypes[57]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PolicySpec_StringMatcher.ProtoReflect.Descriptor instead.
+func (*PolicySpec_StringMatcher) Descriptor() ([]byte, []int) {
+	return file_resource_proto_rawDescGZIP(), []int{36, 12}
+}
+
+func (x *PolicySpec_StringMatcher) GetIgnoreCase() bool {
+	if x != nil {
+		return x.IgnoreCase
+	}
+	return false
+}
+
+func (x *PolicySpec_StringMatcher) GetMatchPattern() isPolicySpec_StringMatcher_MatchPattern {
+	if x != nil {
+		return x.MatchPattern
+	}
+	return nil
+}
+
+func (x *PolicySpec_StringMatcher) GetExact() string {
+	if x != nil {
+		if x, ok := x.MatchPattern.(*PolicySpec_StringMatcher_Exact); ok {
+			return x.Exact
+		}
+	}
+	return ""
+}
+
+func (x *PolicySpec_StringMatcher) GetPrefix() string {
+	if x != nil {
+		if x, ok := x.MatchPattern.(*PolicySpec_StringMatcher_Prefix); ok {
+			return x.Prefix
+		}
+	}
+	return ""
+}
+
+func (x *PolicySpec_StringMatcher) GetSuffix() string {
+	if x != nil {
+		if x, ok := x.MatchPattern.(*PolicySpec_StringMatcher_Suffix); ok {
+			return x.Suffix
+		}
+	}
+	return ""
+}
+
+func (x *PolicySpec_StringMatcher) GetSafeRegex() string {
+	if x != nil {
+		if x, ok := x.MatchPattern.(*PolicySpec_StringMatcher_SafeRegex); ok {
+			return x.SafeRegex
+		}
+	}
+	return ""
+}
+
+func (x *PolicySpec_StringMatcher) GetContains() string {
+	if x != nil {
+		if x, ok := x.MatchPattern.(*PolicySpec_StringMatcher_Contains); ok {
+			return x.Contains
+		}
+	}
+	return ""
+}
+
+type isPolicySpec_StringMatcher_MatchPattern interface {
+	isPolicySpec_StringMatcher_MatchPattern()
+}
+
+type PolicySpec_StringMatcher_Exact struct {
+	Exact string `protobuf:"bytes,1,opt,name=exact,proto3,oneof"`
+}
+
+type PolicySpec_StringMatcher_Prefix struct {
+	Prefix string `protobuf:"bytes,2,opt,name=prefix,proto3,oneof"`
+}
+
+type PolicySpec_StringMatcher_Suffix struct {
+	Suffix string `protobuf:"bytes,3,opt,name=suffix,proto3,oneof"`
+}
+
+type PolicySpec_StringMatcher_SafeRegex struct {
+	SafeRegex string `protobuf:"bytes,4,opt,name=safe_regex,json=safeRegex,proto3,oneof"`
+}
+
+type PolicySpec_StringMatcher_Contains struct {
+	Contains string `protobuf:"bytes,7,opt,name=contains,proto3,oneof"`
+}
+
+func (*PolicySpec_StringMatcher_Exact) isPolicySpec_StringMatcher_MatchPattern() {}
+
+func (*PolicySpec_StringMatcher_Prefix) isPolicySpec_StringMatcher_MatchPattern() {}
+
+func (*PolicySpec_StringMatcher_Suffix) isPolicySpec_StringMatcher_MatchPattern() {}
+
+func (*PolicySpec_StringMatcher_SafeRegex) isPolicySpec_StringMatcher_MatchPattern() {}
+
+func (*PolicySpec_StringMatcher_Contains) isPolicySpec_StringMatcher_MatchPattern() {}
+
+// Cross-Site Request Forgery (CSRF) policy configuration.
+type PolicySpec_CSRF struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Additional origins that are allowed for CSRF validation beyond the same-origin policy.
+	// If a request's origin header matches any of these matchers, the request will be allowed.
+	AdditionalOrigins []*PolicySpec_StringMatcher `protobuf:"bytes,1,rep,name=additional_origins,json=additionalOrigins,proto3" json:"additional_origins,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *PolicySpec_CSRF) Reset() {
+	*x = PolicySpec_CSRF{}
+	mi := &file_resource_proto_msgTypes[58]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PolicySpec_CSRF) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PolicySpec_CSRF) ProtoMessage() {}
+
+func (x *PolicySpec_CSRF) ProtoReflect() protoreflect.Message {
+	mi := &file_resource_proto_msgTypes[58]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PolicySpec_CSRF.ProtoReflect.Descriptor instead.
+func (*PolicySpec_CSRF) Descriptor() ([]byte, []int) {
+	return file_resource_proto_rawDescGZIP(), []int{36, 13}
+}
+
+func (x *PolicySpec_CSRF) GetAdditionalOrigins() []*PolicySpec_StringMatcher {
+	if x != nil {
+		return x.AdditionalOrigins
+	}
+	return nil
+}
+
 type PolicySpec_RemoteRateLimit_Descriptor struct {
 	state         protoimpl.MessageState              `protogen:"open.v1"`
 	Entries       []*PolicySpec_RemoteRateLimit_Entry `protobuf:"bytes,1,rep,name=entries,proto3" json:"entries,omitempty"`
@@ -4890,7 +5092,7 @@ type PolicySpec_RemoteRateLimit_Descriptor struct {
 
 func (x *PolicySpec_RemoteRateLimit_Descriptor) Reset() {
 	*x = PolicySpec_RemoteRateLimit_Descriptor{}
-	mi := &file_resource_proto_msgTypes[57]
+	mi := &file_resource_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4902,7 +5104,7 @@ func (x *PolicySpec_RemoteRateLimit_Descriptor) String() string {
 func (*PolicySpec_RemoteRateLimit_Descriptor) ProtoMessage() {}
 
 func (x *PolicySpec_RemoteRateLimit_Descriptor) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[57]
+	mi := &file_resource_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4942,7 +5144,7 @@ type PolicySpec_RemoteRateLimit_Entry struct {
 
 func (x *PolicySpec_RemoteRateLimit_Entry) Reset() {
 	*x = PolicySpec_RemoteRateLimit_Entry{}
-	mi := &file_resource_proto_msgTypes[58]
+	mi := &file_resource_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4954,7 +5156,7 @@ func (x *PolicySpec_RemoteRateLimit_Entry) String() string {
 func (*PolicySpec_RemoteRateLimit_Entry) ProtoMessage() {}
 
 func (x *PolicySpec_RemoteRateLimit_Entry) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[58]
+	mi := &file_resource_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4994,7 +5196,7 @@ type PolicySpec_Ai_Message struct {
 
 func (x *PolicySpec_Ai_Message) Reset() {
 	*x = PolicySpec_Ai_Message{}
-	mi := &file_resource_proto_msgTypes[59]
+	mi := &file_resource_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5006,7 +5208,7 @@ func (x *PolicySpec_Ai_Message) String() string {
 func (*PolicySpec_Ai_Message) ProtoMessage() {}
 
 func (x *PolicySpec_Ai_Message) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[59]
+	mi := &file_resource_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5046,7 +5248,7 @@ type PolicySpec_Ai_PromptEnrichment struct {
 
 func (x *PolicySpec_Ai_PromptEnrichment) Reset() {
 	*x = PolicySpec_Ai_PromptEnrichment{}
-	mi := &file_resource_proto_msgTypes[60]
+	mi := &file_resource_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5058,7 +5260,7 @@ func (x *PolicySpec_Ai_PromptEnrichment) String() string {
 func (*PolicySpec_Ai_PromptEnrichment) ProtoMessage() {}
 
 func (x *PolicySpec_Ai_PromptEnrichment) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[60]
+	mi := &file_resource_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5098,7 +5300,7 @@ type PolicySpec_Ai_NamedRegex struct {
 
 func (x *PolicySpec_Ai_NamedRegex) Reset() {
 	*x = PolicySpec_Ai_NamedRegex{}
-	mi := &file_resource_proto_msgTypes[61]
+	mi := &file_resource_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5110,7 +5312,7 @@ func (x *PolicySpec_Ai_NamedRegex) String() string {
 func (*PolicySpec_Ai_NamedRegex) ProtoMessage() {}
 
 func (x *PolicySpec_Ai_NamedRegex) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[61]
+	mi := &file_resource_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5153,7 +5355,7 @@ type PolicySpec_Ai_RegexRule struct {
 
 func (x *PolicySpec_Ai_RegexRule) Reset() {
 	*x = PolicySpec_Ai_RegexRule{}
-	mi := &file_resource_proto_msgTypes[62]
+	mi := &file_resource_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5165,7 +5367,7 @@ func (x *PolicySpec_Ai_RegexRule) String() string {
 func (*PolicySpec_Ai_RegexRule) ProtoMessage() {}
 
 func (x *PolicySpec_Ai_RegexRule) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[62]
+	mi := &file_resource_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5233,7 +5435,7 @@ type PolicySpec_Ai_Action struct {
 
 func (x *PolicySpec_Ai_Action) Reset() {
 	*x = PolicySpec_Ai_Action{}
-	mi := &file_resource_proto_msgTypes[63]
+	mi := &file_resource_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5245,7 +5447,7 @@ func (x *PolicySpec_Ai_Action) String() string {
 func (*PolicySpec_Ai_Action) ProtoMessage() {}
 
 func (x *PolicySpec_Ai_Action) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[63]
+	mi := &file_resource_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5285,7 +5487,7 @@ type PolicySpec_Ai_RegexRules struct {
 
 func (x *PolicySpec_Ai_RegexRules) Reset() {
 	*x = PolicySpec_Ai_RegexRules{}
-	mi := &file_resource_proto_msgTypes[64]
+	mi := &file_resource_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5297,7 +5499,7 @@ func (x *PolicySpec_Ai_RegexRules) String() string {
 func (*PolicySpec_Ai_RegexRules) ProtoMessage() {}
 
 func (x *PolicySpec_Ai_RegexRules) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[64]
+	mi := &file_resource_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5338,7 +5540,7 @@ type PolicySpec_Ai_Webhook struct {
 
 func (x *PolicySpec_Ai_Webhook) Reset() {
 	*x = PolicySpec_Ai_Webhook{}
-	mi := &file_resource_proto_msgTypes[65]
+	mi := &file_resource_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5350,7 +5552,7 @@ func (x *PolicySpec_Ai_Webhook) String() string {
 func (*PolicySpec_Ai_Webhook) ProtoMessage() {}
 
 func (x *PolicySpec_Ai_Webhook) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[65]
+	mi := &file_resource_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5398,7 +5600,7 @@ type PolicySpec_Ai_Moderation struct {
 
 func (x *PolicySpec_Ai_Moderation) Reset() {
 	*x = PolicySpec_Ai_Moderation{}
-	mi := &file_resource_proto_msgTypes[66]
+	mi := &file_resource_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5410,7 +5612,7 @@ func (x *PolicySpec_Ai_Moderation) String() string {
 func (*PolicySpec_Ai_Moderation) ProtoMessage() {}
 
 func (x *PolicySpec_Ai_Moderation) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[66]
+	mi := &file_resource_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5451,7 +5653,7 @@ type PolicySpec_Ai_RequestRejection struct {
 
 func (x *PolicySpec_Ai_RequestRejection) Reset() {
 	*x = PolicySpec_Ai_RequestRejection{}
-	mi := &file_resource_proto_msgTypes[67]
+	mi := &file_resource_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5463,7 +5665,7 @@ func (x *PolicySpec_Ai_RequestRejection) String() string {
 func (*PolicySpec_Ai_RequestRejection) ProtoMessage() {}
 
 func (x *PolicySpec_Ai_RequestRejection) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[67]
+	mi := &file_resource_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5504,7 +5706,7 @@ type PolicySpec_Ai_ResponseGuard struct {
 
 func (x *PolicySpec_Ai_ResponseGuard) Reset() {
 	*x = PolicySpec_Ai_ResponseGuard{}
-	mi := &file_resource_proto_msgTypes[68]
+	mi := &file_resource_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5516,7 +5718,7 @@ func (x *PolicySpec_Ai_ResponseGuard) String() string {
 func (*PolicySpec_Ai_ResponseGuard) ProtoMessage() {}
 
 func (x *PolicySpec_Ai_ResponseGuard) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[68]
+	mi := &file_resource_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5560,7 +5762,7 @@ type PolicySpec_Ai_RequestGuard struct {
 
 func (x *PolicySpec_Ai_RequestGuard) Reset() {
 	*x = PolicySpec_Ai_RequestGuard{}
-	mi := &file_resource_proto_msgTypes[69]
+	mi := &file_resource_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5572,7 +5774,7 @@ func (x *PolicySpec_Ai_RequestGuard) String() string {
 func (*PolicySpec_Ai_RequestGuard) ProtoMessage() {}
 
 func (x *PolicySpec_Ai_RequestGuard) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[69]
+	mi := &file_resource_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5628,7 +5830,7 @@ type PolicySpec_Ai_PromptGuard struct {
 
 func (x *PolicySpec_Ai_PromptGuard) Reset() {
 	*x = PolicySpec_Ai_PromptGuard{}
-	mi := &file_resource_proto_msgTypes[70]
+	mi := &file_resource_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5640,7 +5842,7 @@ func (x *PolicySpec_Ai_PromptGuard) String() string {
 func (*PolicySpec_Ai_PromptGuard) ProtoMessage() {}
 
 func (x *PolicySpec_Ai_PromptGuard) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[70]
+	mi := &file_resource_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5681,7 +5883,7 @@ type PolicySpec_ExternalAuth_BodyOptions struct {
 
 func (x *PolicySpec_ExternalAuth_BodyOptions) Reset() {
 	*x = PolicySpec_ExternalAuth_BodyOptions{}
-	mi := &file_resource_proto_msgTypes[74]
+	mi := &file_resource_proto_msgTypes[75]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5693,7 +5895,7 @@ func (x *PolicySpec_ExternalAuth_BodyOptions) String() string {
 func (*PolicySpec_ExternalAuth_BodyOptions) ProtoMessage() {}
 
 func (x *PolicySpec_ExternalAuth_BodyOptions) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[74]
+	mi := &file_resource_proto_msgTypes[75]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5742,7 +5944,7 @@ type PolicySpec_TransformationPolicy_Transform struct {
 
 func (x *PolicySpec_TransformationPolicy_Transform) Reset() {
 	*x = PolicySpec_TransformationPolicy_Transform{}
-	mi := &file_resource_proto_msgTypes[76]
+	mi := &file_resource_proto_msgTypes[77]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5754,7 +5956,7 @@ func (x *PolicySpec_TransformationPolicy_Transform) String() string {
 func (*PolicySpec_TransformationPolicy_Transform) ProtoMessage() {}
 
 func (x *PolicySpec_TransformationPolicy_Transform) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[76]
+	mi := &file_resource_proto_msgTypes[77]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5808,7 +6010,7 @@ type AIBackend_HostOverride struct {
 
 func (x *AIBackend_HostOverride) Reset() {
 	*x = AIBackend_HostOverride{}
-	mi := &file_resource_proto_msgTypes[77]
+	mi := &file_resource_proto_msgTypes[78]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5820,7 +6022,7 @@ func (x *AIBackend_HostOverride) String() string {
 func (*AIBackend_HostOverride) ProtoMessage() {}
 
 func (x *AIBackend_HostOverride) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[77]
+	mi := &file_resource_proto_msgTypes[78]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5859,7 +6061,7 @@ type AIBackend_OpenAI struct {
 
 func (x *AIBackend_OpenAI) Reset() {
 	*x = AIBackend_OpenAI{}
-	mi := &file_resource_proto_msgTypes[78]
+	mi := &file_resource_proto_msgTypes[79]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5871,7 +6073,7 @@ func (x *AIBackend_OpenAI) String() string {
 func (*AIBackend_OpenAI) ProtoMessage() {}
 
 func (x *AIBackend_OpenAI) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[78]
+	mi := &file_resource_proto_msgTypes[79]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5903,7 +6105,7 @@ type AIBackend_Gemini struct {
 
 func (x *AIBackend_Gemini) Reset() {
 	*x = AIBackend_Gemini{}
-	mi := &file_resource_proto_msgTypes[79]
+	mi := &file_resource_proto_msgTypes[80]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5915,7 +6117,7 @@ func (x *AIBackend_Gemini) String() string {
 func (*AIBackend_Gemini) ProtoMessage() {}
 
 func (x *AIBackend_Gemini) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[79]
+	mi := &file_resource_proto_msgTypes[80]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5949,7 +6151,7 @@ type AIBackend_Vertex struct {
 
 func (x *AIBackend_Vertex) Reset() {
 	*x = AIBackend_Vertex{}
-	mi := &file_resource_proto_msgTypes[80]
+	mi := &file_resource_proto_msgTypes[81]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5961,7 +6163,7 @@ func (x *AIBackend_Vertex) String() string {
 func (*AIBackend_Vertex) ProtoMessage() {}
 
 func (x *AIBackend_Vertex) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[80]
+	mi := &file_resource_proto_msgTypes[81]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6007,7 +6209,7 @@ type AIBackend_Anthropic struct {
 
 func (x *AIBackend_Anthropic) Reset() {
 	*x = AIBackend_Anthropic{}
-	mi := &file_resource_proto_msgTypes[81]
+	mi := &file_resource_proto_msgTypes[82]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6019,7 +6221,7 @@ func (x *AIBackend_Anthropic) String() string {
 func (*AIBackend_Anthropic) ProtoMessage() {}
 
 func (x *AIBackend_Anthropic) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[81]
+	mi := &file_resource_proto_msgTypes[82]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6054,7 +6256,7 @@ type AIBackend_Bedrock struct {
 
 func (x *AIBackend_Bedrock) Reset() {
 	*x = AIBackend_Bedrock{}
-	mi := &file_resource_proto_msgTypes[82]
+	mi := &file_resource_proto_msgTypes[83]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6066,7 +6268,7 @@ func (x *AIBackend_Bedrock) String() string {
 func (*AIBackend_Bedrock) ProtoMessage() {}
 
 func (x *AIBackend_Bedrock) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[82]
+	mi := &file_resource_proto_msgTypes[83]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6129,7 +6331,7 @@ type AIBackend_Provider struct {
 
 func (x *AIBackend_Provider) Reset() {
 	*x = AIBackend_Provider{}
-	mi := &file_resource_proto_msgTypes[83]
+	mi := &file_resource_proto_msgTypes[84]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6141,7 +6343,7 @@ func (x *AIBackend_Provider) String() string {
 func (*AIBackend_Provider) ProtoMessage() {}
 
 func (x *AIBackend_Provider) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[83]
+	mi := &file_resource_proto_msgTypes[84]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6273,7 +6475,7 @@ type AIBackend_ProviderGroup struct {
 
 func (x *AIBackend_ProviderGroup) Reset() {
 	*x = AIBackend_ProviderGroup{}
-	mi := &file_resource_proto_msgTypes[84]
+	mi := &file_resource_proto_msgTypes[85]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6285,7 +6487,7 @@ func (x *AIBackend_ProviderGroup) String() string {
 func (*AIBackend_ProviderGroup) ProtoMessage() {}
 
 func (x *AIBackend_ProviderGroup) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[84]
+	mi := &file_resource_proto_msgTypes[85]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6496,7 +6698,7 @@ const file_resource_proto_rawDesc = "" +
 	"\aservice\x18\x06 \x01(\tH\x00R\aservice\x12!\n" +
 	"\vsub_backend\x18\a \x01(\tH\x00R\n" +
 	"subBackendB\x06\n" +
-	"\x04kind\"\xb34\n" +
+	"\x04kind\"\x8e6\n" +
 	"\n" +
 	"PolicySpec\x12`\n" +
 	"\x10local_rate_limit\x18\x01 \x01(\v24.agentgateway.dev.resource.PolicySpec.LocalRateLimitH\x00R\x0elocalRateLimit\x12Q\n" +
@@ -6512,7 +6714,8 @@ const file_resource_proto_rawDesc = "" +
 	"\x03jwt\x18\n" +
 	" \x01(\v2).agentgateway.dev.resource.PolicySpec.JWTH\x00R\x03jwt\x12d\n" +
 	"\x0etransformation\x18\v \x01(\v2:.agentgateway.dev.resource.PolicySpec.TransformationPolicyH\x00R\x0etransformation\x12c\n" +
-	"\x11remote_rate_limit\x18\f \x01(\v25.agentgateway.dev.resource.PolicySpec.RemoteRateLimitH\x00R\x0fremoteRateLimit\x1a\xdb\x03\n" +
+	"\x11remote_rate_limit\x18\f \x01(\v25.agentgateway.dev.resource.PolicySpec.RemoteRateLimitH\x00R\x0fremoteRateLimit\x12@\n" +
+	"\x04csrf\x18\r \x01(\v2*.agentgateway.dev.resource.PolicySpec.CSRFH\x00R\x04csrf\x1a\xdb\x03\n" +
 	"\x0fRemoteRateLimit\x12\x16\n" +
 	"\x06domain\x18\x01 \x01(\tR\x06domain\x12b\n" +
 	"\vdescriptors\x18\x02 \x03(\v2@.agentgateway.dev.resource.PolicySpec.RemoteRateLimit.DescriptorR\vdescriptors\x12C\n" +
@@ -6672,7 +6875,19 @@ const file_resource_proto_rawDesc = "" +
 	"\x12BodyTransformation\x12\x1e\n" +
 	"\n" +
 	"expression\x18\x01 \x01(\tR\n" +
-	"expressionB\x06\n" +
+	"expression\x1a\xcc\x01\n" +
+	"\rStringMatcher\x12\x1f\n" +
+	"\vignore_case\x18\x06 \x01(\bR\n" +
+	"ignoreCase\x12\x16\n" +
+	"\x05exact\x18\x01 \x01(\tH\x00R\x05exact\x12\x18\n" +
+	"\x06prefix\x18\x02 \x01(\tH\x00R\x06prefix\x12\x18\n" +
+	"\x06suffix\x18\x03 \x01(\tH\x00R\x06suffix\x12\x1f\n" +
+	"\n" +
+	"safe_regex\x18\x04 \x01(\tH\x00R\tsafeRegex\x12\x1c\n" +
+	"\bcontains\x18\a \x01(\tH\x00R\bcontainsB\x0f\n" +
+	"\rmatch_pattern\x1aj\n" +
+	"\x04CSRF\x12b\n" +
+	"\x12additional_origins\x18\x01 \x03(\v23.agentgateway.dev.resource.PolicySpec.StringMatcherR\x11additionalOriginsB\x06\n" +
 	"\x04kind\"\x98\x01\n" +
 	"\x06Policy\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12?\n" +
@@ -6764,7 +6979,7 @@ func file_resource_proto_rawDescGZIP() []byte {
 }
 
 var file_resource_proto_enumTypes = make([]protoimpl.EnumInfo, 10)
-var file_resource_proto_msgTypes = make([]protoimpl.MessageInfo, 85)
+var file_resource_proto_msgTypes = make([]protoimpl.MessageInfo, 86)
 var file_resource_proto_goTypes = []any{
 	(Protocol)(0),                                // 0: agentgateway.dev.resource.Protocol
 	(PolicySpec_RemoteRateLimit_Type)(0),         // 1: agentgateway.dev.resource.PolicySpec.RemoteRateLimit.Type
@@ -6833,39 +7048,40 @@ var file_resource_proto_goTypes = []any{
 	(*PolicySpec_TransformationPolicy)(nil),                     // 64: agentgateway.dev.resource.PolicySpec.TransformationPolicy
 	(*PolicySpec_HeaderTransformation)(nil),                     // 65: agentgateway.dev.resource.PolicySpec.HeaderTransformation
 	(*PolicySpec_BodyTransformation)(nil),                       // 66: agentgateway.dev.resource.PolicySpec.BodyTransformation
-	(*PolicySpec_RemoteRateLimit_Descriptor)(nil),               // 67: agentgateway.dev.resource.PolicySpec.RemoteRateLimit.Descriptor
-	(*PolicySpec_RemoteRateLimit_Entry)(nil),                    // 68: agentgateway.dev.resource.PolicySpec.RemoteRateLimit.Entry
-	(*PolicySpec_Ai_Message)(nil),                               // 69: agentgateway.dev.resource.PolicySpec.Ai.Message
-	(*PolicySpec_Ai_PromptEnrichment)(nil),                      // 70: agentgateway.dev.resource.PolicySpec.Ai.PromptEnrichment
-	(*PolicySpec_Ai_NamedRegex)(nil),                            // 71: agentgateway.dev.resource.PolicySpec.Ai.NamedRegex
-	(*PolicySpec_Ai_RegexRule)(nil),                             // 72: agentgateway.dev.resource.PolicySpec.Ai.RegexRule
-	(*PolicySpec_Ai_Action)(nil),                                // 73: agentgateway.dev.resource.PolicySpec.Ai.Action
-	(*PolicySpec_Ai_RegexRules)(nil),                            // 74: agentgateway.dev.resource.PolicySpec.Ai.RegexRules
-	(*PolicySpec_Ai_Webhook)(nil),                               // 75: agentgateway.dev.resource.PolicySpec.Ai.Webhook
-	(*PolicySpec_Ai_Moderation)(nil),                            // 76: agentgateway.dev.resource.PolicySpec.Ai.Moderation
-	(*PolicySpec_Ai_RequestRejection)(nil),                      // 77: agentgateway.dev.resource.PolicySpec.Ai.RequestRejection
-	(*PolicySpec_Ai_ResponseGuard)(nil),                         // 78: agentgateway.dev.resource.PolicySpec.Ai.ResponseGuard
-	(*PolicySpec_Ai_RequestGuard)(nil),                          // 79: agentgateway.dev.resource.PolicySpec.Ai.RequestGuard
-	(*PolicySpec_Ai_PromptGuard)(nil),                           // 80: agentgateway.dev.resource.PolicySpec.Ai.PromptGuard
-	nil,                                                         // 81: agentgateway.dev.resource.PolicySpec.Ai.DefaultsEntry
-	nil,                                                         // 82: agentgateway.dev.resource.PolicySpec.Ai.OverridesEntry
-	nil,                                                         // 83: agentgateway.dev.resource.PolicySpec.Ai.ModelAliasesEntry
-	(*PolicySpec_ExternalAuth_BodyOptions)(nil),                 // 84: agentgateway.dev.resource.PolicySpec.ExternalAuth.BodyOptions
-	nil, // 85: agentgateway.dev.resource.PolicySpec.ExternalAuth.ContextEntry
-	(*PolicySpec_TransformationPolicy_Transform)(nil), // 86: agentgateway.dev.resource.PolicySpec.TransformationPolicy.Transform
-	(*AIBackend_HostOverride)(nil),                    // 87: agentgateway.dev.resource.AIBackend.HostOverride
-	(*AIBackend_OpenAI)(nil),                          // 88: agentgateway.dev.resource.AIBackend.OpenAI
-	(*AIBackend_Gemini)(nil),                          // 89: agentgateway.dev.resource.AIBackend.Gemini
-	(*AIBackend_Vertex)(nil),                          // 90: agentgateway.dev.resource.AIBackend.Vertex
-	(*AIBackend_Anthropic)(nil),                       // 91: agentgateway.dev.resource.AIBackend.Anthropic
-	(*AIBackend_Bedrock)(nil),                         // 92: agentgateway.dev.resource.AIBackend.Bedrock
-	(*AIBackend_Provider)(nil),                        // 93: agentgateway.dev.resource.AIBackend.Provider
-	(*AIBackend_ProviderGroup)(nil),                   // 94: agentgateway.dev.resource.AIBackend.ProviderGroup
-	(*duration.Duration)(nil),                         // 95: google.protobuf.Duration
-	(*wrappers.UInt32Value)(nil),                      // 96: google.protobuf.UInt32Value
-	(*wrappers.BytesValue)(nil),                       // 97: google.protobuf.BytesValue
-	(*wrappers.BoolValue)(nil),                        // 98: google.protobuf.BoolValue
-	(*wrappers.StringValue)(nil),                      // 99: google.protobuf.StringValue
+	(*PolicySpec_StringMatcher)(nil),                            // 67: agentgateway.dev.resource.PolicySpec.StringMatcher
+	(*PolicySpec_CSRF)(nil),                                     // 68: agentgateway.dev.resource.PolicySpec.CSRF
+	(*PolicySpec_RemoteRateLimit_Descriptor)(nil),               // 69: agentgateway.dev.resource.PolicySpec.RemoteRateLimit.Descriptor
+	(*PolicySpec_RemoteRateLimit_Entry)(nil),                    // 70: agentgateway.dev.resource.PolicySpec.RemoteRateLimit.Entry
+	(*PolicySpec_Ai_Message)(nil),                               // 71: agentgateway.dev.resource.PolicySpec.Ai.Message
+	(*PolicySpec_Ai_PromptEnrichment)(nil),                      // 72: agentgateway.dev.resource.PolicySpec.Ai.PromptEnrichment
+	(*PolicySpec_Ai_NamedRegex)(nil),                            // 73: agentgateway.dev.resource.PolicySpec.Ai.NamedRegex
+	(*PolicySpec_Ai_RegexRule)(nil),                             // 74: agentgateway.dev.resource.PolicySpec.Ai.RegexRule
+	(*PolicySpec_Ai_Action)(nil),                                // 75: agentgateway.dev.resource.PolicySpec.Ai.Action
+	(*PolicySpec_Ai_RegexRules)(nil),                            // 76: agentgateway.dev.resource.PolicySpec.Ai.RegexRules
+	(*PolicySpec_Ai_Webhook)(nil),                               // 77: agentgateway.dev.resource.PolicySpec.Ai.Webhook
+	(*PolicySpec_Ai_Moderation)(nil),                            // 78: agentgateway.dev.resource.PolicySpec.Ai.Moderation
+	(*PolicySpec_Ai_RequestRejection)(nil),                      // 79: agentgateway.dev.resource.PolicySpec.Ai.RequestRejection
+	(*PolicySpec_Ai_ResponseGuard)(nil),                         // 80: agentgateway.dev.resource.PolicySpec.Ai.ResponseGuard
+	(*PolicySpec_Ai_RequestGuard)(nil),                          // 81: agentgateway.dev.resource.PolicySpec.Ai.RequestGuard
+	(*PolicySpec_Ai_PromptGuard)(nil),                           // 82: agentgateway.dev.resource.PolicySpec.Ai.PromptGuard
+	nil,                                                         // 83: agentgateway.dev.resource.PolicySpec.Ai.DefaultsEntry
+	nil,                                                         // 84: agentgateway.dev.resource.PolicySpec.Ai.OverridesEntry
+	(*PolicySpec_ExternalAuth_BodyOptions)(nil),                 // 85: agentgateway.dev.resource.PolicySpec.ExternalAuth.BodyOptions
+	nil, // 86: agentgateway.dev.resource.PolicySpec.ExternalAuth.ContextEntry
+	(*PolicySpec_TransformationPolicy_Transform)(nil), // 87: agentgateway.dev.resource.PolicySpec.TransformationPolicy.Transform
+	(*AIBackend_HostOverride)(nil),                    // 88: agentgateway.dev.resource.AIBackend.HostOverride
+	(*AIBackend_OpenAI)(nil),                          // 89: agentgateway.dev.resource.AIBackend.OpenAI
+	(*AIBackend_Gemini)(nil),                          // 90: agentgateway.dev.resource.AIBackend.Gemini
+	(*AIBackend_Vertex)(nil),                          // 91: agentgateway.dev.resource.AIBackend.Vertex
+	(*AIBackend_Anthropic)(nil),                       // 92: agentgateway.dev.resource.AIBackend.Anthropic
+	(*AIBackend_Bedrock)(nil),                         // 93: agentgateway.dev.resource.AIBackend.Bedrock
+	(*AIBackend_Provider)(nil),                        // 94: agentgateway.dev.resource.AIBackend.Provider
+	(*AIBackend_ProviderGroup)(nil),                   // 95: agentgateway.dev.resource.AIBackend.ProviderGroup
+	(*duration.Duration)(nil),                         // 96: google.protobuf.Duration
+	(*wrappers.UInt32Value)(nil),                      // 97: google.protobuf.UInt32Value
+	(*wrappers.BytesValue)(nil),                       // 98: google.protobuf.BytesValue
+	(*wrappers.BoolValue)(nil),                        // 99: google.protobuf.BoolValue
+	(*wrappers.StringValue)(nil),                      // 100: google.protobuf.StringValue
 }
 var file_resource_proto_depIdxs = []int32{
 	11,  // 0: agentgateway.dev.resource.Resource.bind:type_name -> agentgateway.dev.resource.Bind
@@ -6882,10 +7098,10 @@ var file_resource_proto_depIdxs = []int32{
 	16,  // 11: agentgateway.dev.resource.Route.traffic_policy:type_name -> agentgateway.dev.resource.TrafficPolicy
 	46,  // 12: agentgateway.dev.resource.Route.inline_policies:type_name -> agentgateway.dev.resource.PolicySpec
 	44,  // 13: agentgateway.dev.resource.TCPRoute.backends:type_name -> agentgateway.dev.resource.RouteBackend
-	95,  // 14: agentgateway.dev.resource.TrafficPolicy.backend_request_timeout:type_name -> google.protobuf.Duration
-	95,  // 15: agentgateway.dev.resource.TrafficPolicy.request_timeout:type_name -> google.protobuf.Duration
+	96,  // 14: agentgateway.dev.resource.TrafficPolicy.backend_request_timeout:type_name -> google.protobuf.Duration
+	96,  // 15: agentgateway.dev.resource.TrafficPolicy.request_timeout:type_name -> google.protobuf.Duration
 	17,  // 16: agentgateway.dev.resource.TrafficPolicy.retry:type_name -> agentgateway.dev.resource.Retry
-	95,  // 17: agentgateway.dev.resource.Retry.backoff:type_name -> google.protobuf.Duration
+	96,  // 17: agentgateway.dev.resource.Retry.backoff:type_name -> google.protobuf.Duration
 	19,  // 18: agentgateway.dev.resource.BackendAuthPolicy.passthrough:type_name -> agentgateway.dev.resource.Passthrough
 	20,  // 19: agentgateway.dev.resource.BackendAuthPolicy.key:type_name -> agentgateway.dev.resource.Key
 	21,  // 20: agentgateway.dev.resource.BackendAuthPolicy.gcp:type_name -> agentgateway.dev.resource.Gcp
@@ -6910,7 +7126,7 @@ var file_resource_proto_depIdxs = []int32{
 	40,  // 39: agentgateway.dev.resource.RouteFilter.request_mirror:type_name -> agentgateway.dev.resource.RequestMirror
 	38,  // 40: agentgateway.dev.resource.RouteFilter.direct_response:type_name -> agentgateway.dev.resource.DirectResponse
 	37,  // 41: agentgateway.dev.resource.RouteFilter.cors:type_name -> agentgateway.dev.resource.CORS
-	95,  // 42: agentgateway.dev.resource.CORS.max_age:type_name -> google.protobuf.Duration
+	96,  // 42: agentgateway.dev.resource.CORS.max_age:type_name -> google.protobuf.Duration
 	43,  // 43: agentgateway.dev.resource.HeaderModifier.add:type_name -> agentgateway.dev.resource.Header
 	43,  // 44: agentgateway.dev.resource.HeaderModifier.set:type_name -> agentgateway.dev.resource.Header
 	53,  // 45: agentgateway.dev.resource.RequestMirror.backend:type_name -> agentgateway.dev.resource.BackendReference
@@ -6928,85 +7144,86 @@ var file_resource_proto_depIdxs = []int32{
 	63,  // 57: agentgateway.dev.resource.PolicySpec.jwt:type_name -> agentgateway.dev.resource.PolicySpec.JWT
 	64,  // 58: agentgateway.dev.resource.PolicySpec.transformation:type_name -> agentgateway.dev.resource.PolicySpec.TransformationPolicy
 	55,  // 59: agentgateway.dev.resource.PolicySpec.remote_rate_limit:type_name -> agentgateway.dev.resource.PolicySpec.RemoteRateLimit
-	45,  // 60: agentgateway.dev.resource.Policy.target:type_name -> agentgateway.dev.resource.PolicyTarget
-	46,  // 61: agentgateway.dev.resource.Policy.spec:type_name -> agentgateway.dev.resource.PolicySpec
-	49,  // 62: agentgateway.dev.resource.Backend.static:type_name -> agentgateway.dev.resource.StaticBackend
-	50,  // 63: agentgateway.dev.resource.Backend.ai:type_name -> agentgateway.dev.resource.AIBackend
-	51,  // 64: agentgateway.dev.resource.Backend.mcp:type_name -> agentgateway.dev.resource.MCPBackend
-	94,  // 65: agentgateway.dev.resource.AIBackend.provider_groups:type_name -> agentgateway.dev.resource.AIBackend.ProviderGroup
-	52,  // 66: agentgateway.dev.resource.MCPBackend.targets:type_name -> agentgateway.dev.resource.MCPTarget
-	8,   // 67: agentgateway.dev.resource.MCPBackend.stateful_mode:type_name -> agentgateway.dev.resource.MCPBackend.StatefulMode
-	53,  // 68: agentgateway.dev.resource.MCPTarget.backend:type_name -> agentgateway.dev.resource.BackendReference
-	9,   // 69: agentgateway.dev.resource.MCPTarget.protocol:type_name -> agentgateway.dev.resource.MCPTarget.Protocol
-	67,  // 70: agentgateway.dev.resource.PolicySpec.RemoteRateLimit.descriptors:type_name -> agentgateway.dev.resource.PolicySpec.RemoteRateLimit.Descriptor
-	53,  // 71: agentgateway.dev.resource.PolicySpec.RemoteRateLimit.target:type_name -> agentgateway.dev.resource.BackendReference
-	95,  // 72: agentgateway.dev.resource.PolicySpec.LocalRateLimit.fill_interval:type_name -> google.protobuf.Duration
-	2,   // 73: agentgateway.dev.resource.PolicySpec.LocalRateLimit.type:type_name -> agentgateway.dev.resource.PolicySpec.LocalRateLimit.Type
-	80,  // 74: agentgateway.dev.resource.PolicySpec.Ai.prompt_guard:type_name -> agentgateway.dev.resource.PolicySpec.Ai.PromptGuard
-	81,  // 75: agentgateway.dev.resource.PolicySpec.Ai.defaults:type_name -> agentgateway.dev.resource.PolicySpec.Ai.DefaultsEntry
-	82,  // 76: agentgateway.dev.resource.PolicySpec.Ai.overrides:type_name -> agentgateway.dev.resource.PolicySpec.Ai.OverridesEntry
-	70,  // 77: agentgateway.dev.resource.PolicySpec.Ai.prompts:type_name -> agentgateway.dev.resource.PolicySpec.Ai.PromptEnrichment
-	83,  // 78: agentgateway.dev.resource.PolicySpec.Ai.model_aliases:type_name -> agentgateway.dev.resource.PolicySpec.Ai.ModelAliasesEntry
+	68,  // 60: agentgateway.dev.resource.PolicySpec.csrf:type_name -> agentgateway.dev.resource.PolicySpec.CSRF
+	45,  // 61: agentgateway.dev.resource.Policy.target:type_name -> agentgateway.dev.resource.PolicyTarget
+	46,  // 62: agentgateway.dev.resource.Policy.spec:type_name -> agentgateway.dev.resource.PolicySpec
+	49,  // 63: agentgateway.dev.resource.Backend.static:type_name -> agentgateway.dev.resource.StaticBackend
+	50,  // 64: agentgateway.dev.resource.Backend.ai:type_name -> agentgateway.dev.resource.AIBackend
+	51,  // 65: agentgateway.dev.resource.Backend.mcp:type_name -> agentgateway.dev.resource.MCPBackend
+	95,  // 66: agentgateway.dev.resource.AIBackend.provider_groups:type_name -> agentgateway.dev.resource.AIBackend.ProviderGroup
+	52,  // 67: agentgateway.dev.resource.MCPBackend.targets:type_name -> agentgateway.dev.resource.MCPTarget
+	8,   // 68: agentgateway.dev.resource.MCPBackend.stateful_mode:type_name -> agentgateway.dev.resource.MCPBackend.StatefulMode
+	53,  // 69: agentgateway.dev.resource.MCPTarget.backend:type_name -> agentgateway.dev.resource.BackendReference
+	9,   // 70: agentgateway.dev.resource.MCPTarget.protocol:type_name -> agentgateway.dev.resource.MCPTarget.Protocol
+	69,  // 71: agentgateway.dev.resource.PolicySpec.RemoteRateLimit.descriptors:type_name -> agentgateway.dev.resource.PolicySpec.RemoteRateLimit.Descriptor
+	53,  // 72: agentgateway.dev.resource.PolicySpec.RemoteRateLimit.target:type_name -> agentgateway.dev.resource.BackendReference
+	96,  // 73: agentgateway.dev.resource.PolicySpec.LocalRateLimit.fill_interval:type_name -> google.protobuf.Duration
+	2,   // 74: agentgateway.dev.resource.PolicySpec.LocalRateLimit.type:type_name -> agentgateway.dev.resource.PolicySpec.LocalRateLimit.Type
+	82,  // 75: agentgateway.dev.resource.PolicySpec.Ai.prompt_guard:type_name -> agentgateway.dev.resource.PolicySpec.Ai.PromptGuard
+	83,  // 76: agentgateway.dev.resource.PolicySpec.Ai.defaults:type_name -> agentgateway.dev.resource.PolicySpec.Ai.DefaultsEntry
+	84,  // 77: agentgateway.dev.resource.PolicySpec.Ai.overrides:type_name -> agentgateway.dev.resource.PolicySpec.Ai.OverridesEntry
+	72,  // 78: agentgateway.dev.resource.PolicySpec.Ai.prompts:type_name -> agentgateway.dev.resource.PolicySpec.Ai.PromptEnrichment
 	53,  // 79: agentgateway.dev.resource.PolicySpec.ExternalAuth.target:type_name -> agentgateway.dev.resource.BackendReference
-	85,  // 80: agentgateway.dev.resource.PolicySpec.ExternalAuth.context:type_name -> agentgateway.dev.resource.PolicySpec.ExternalAuth.ContextEntry
+	86,  // 80: agentgateway.dev.resource.PolicySpec.ExternalAuth.context:type_name -> agentgateway.dev.resource.PolicySpec.ExternalAuth.ContextEntry
 	5,   // 81: agentgateway.dev.resource.PolicySpec.ExternalAuth.failure_mode:type_name -> agentgateway.dev.resource.PolicySpec.ExternalAuth.FailureMode
-	84,  // 82: agentgateway.dev.resource.PolicySpec.ExternalAuth.include_request_body:type_name -> agentgateway.dev.resource.PolicySpec.ExternalAuth.BodyOptions
-	95,  // 83: agentgateway.dev.resource.PolicySpec.ExternalAuth.timeout:type_name -> google.protobuf.Duration
-	96,  // 84: agentgateway.dev.resource.PolicySpec.ExternalAuth.status_on_error:type_name -> google.protobuf.UInt32Value
+	85,  // 82: agentgateway.dev.resource.PolicySpec.ExternalAuth.include_request_body:type_name -> agentgateway.dev.resource.PolicySpec.ExternalAuth.BodyOptions
+	96,  // 83: agentgateway.dev.resource.PolicySpec.ExternalAuth.timeout:type_name -> google.protobuf.Duration
+	97,  // 84: agentgateway.dev.resource.PolicySpec.ExternalAuth.status_on_error:type_name -> google.protobuf.UInt32Value
 	53,  // 85: agentgateway.dev.resource.PolicySpec.InferenceRouting.endpoint_picker:type_name -> agentgateway.dev.resource.BackendReference
 	6,   // 86: agentgateway.dev.resource.PolicySpec.InferenceRouting.failure_mode:type_name -> agentgateway.dev.resource.PolicySpec.InferenceRouting.FailureMode
-	97,  // 87: agentgateway.dev.resource.PolicySpec.BackendTLS.cert:type_name -> google.protobuf.BytesValue
-	97,  // 88: agentgateway.dev.resource.PolicySpec.BackendTLS.key:type_name -> google.protobuf.BytesValue
-	97,  // 89: agentgateway.dev.resource.PolicySpec.BackendTLS.root:type_name -> google.protobuf.BytesValue
-	98,  // 90: agentgateway.dev.resource.PolicySpec.BackendTLS.insecure:type_name -> google.protobuf.BoolValue
-	99,  // 91: agentgateway.dev.resource.PolicySpec.BackendTLS.hostname:type_name -> google.protobuf.StringValue
+	98,  // 87: agentgateway.dev.resource.PolicySpec.BackendTLS.cert:type_name -> google.protobuf.BytesValue
+	98,  // 88: agentgateway.dev.resource.PolicySpec.BackendTLS.key:type_name -> google.protobuf.BytesValue
+	98,  // 89: agentgateway.dev.resource.PolicySpec.BackendTLS.root:type_name -> google.protobuf.BytesValue
+	99,  // 90: agentgateway.dev.resource.PolicySpec.BackendTLS.insecure:type_name -> google.protobuf.BoolValue
+	100, // 91: agentgateway.dev.resource.PolicySpec.BackendTLS.hostname:type_name -> google.protobuf.StringValue
 	7,   // 92: agentgateway.dev.resource.PolicySpec.JWT.mode:type_name -> agentgateway.dev.resource.PolicySpec.JWT.Mode
-	86,  // 93: agentgateway.dev.resource.PolicySpec.TransformationPolicy.request:type_name -> agentgateway.dev.resource.PolicySpec.TransformationPolicy.Transform
-	86,  // 94: agentgateway.dev.resource.PolicySpec.TransformationPolicy.response:type_name -> agentgateway.dev.resource.PolicySpec.TransformationPolicy.Transform
-	68,  // 95: agentgateway.dev.resource.PolicySpec.RemoteRateLimit.Descriptor.entries:type_name -> agentgateway.dev.resource.PolicySpec.RemoteRateLimit.Entry
-	1,   // 96: agentgateway.dev.resource.PolicySpec.RemoteRateLimit.Descriptor.type:type_name -> agentgateway.dev.resource.PolicySpec.RemoteRateLimit.Type
-	69,  // 97: agentgateway.dev.resource.PolicySpec.Ai.PromptEnrichment.append:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Message
-	69,  // 98: agentgateway.dev.resource.PolicySpec.Ai.PromptEnrichment.prepend:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Message
-	3,   // 99: agentgateway.dev.resource.PolicySpec.Ai.RegexRule.builtin:type_name -> agentgateway.dev.resource.PolicySpec.Ai.BuiltinRegexRule
-	71,  // 100: agentgateway.dev.resource.PolicySpec.Ai.RegexRule.regex:type_name -> agentgateway.dev.resource.PolicySpec.Ai.NamedRegex
-	4,   // 101: agentgateway.dev.resource.PolicySpec.Ai.Action.kind:type_name -> agentgateway.dev.resource.PolicySpec.Ai.ActionKind
-	77,  // 102: agentgateway.dev.resource.PolicySpec.Ai.Action.reject_response:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RequestRejection
-	73,  // 103: agentgateway.dev.resource.PolicySpec.Ai.RegexRules.action:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Action
-	72,  // 104: agentgateway.dev.resource.PolicySpec.Ai.RegexRules.rules:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RegexRule
-	35,  // 105: agentgateway.dev.resource.PolicySpec.Ai.Webhook.forward_header_matches:type_name -> agentgateway.dev.resource.HeaderMatch
-	99,  // 106: agentgateway.dev.resource.PolicySpec.Ai.Moderation.model:type_name -> google.protobuf.StringValue
-	18,  // 107: agentgateway.dev.resource.PolicySpec.Ai.Moderation.auth:type_name -> agentgateway.dev.resource.BackendAuthPolicy
-	74,  // 108: agentgateway.dev.resource.PolicySpec.Ai.ResponseGuard.regex:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RegexRules
-	75,  // 109: agentgateway.dev.resource.PolicySpec.Ai.ResponseGuard.webhook:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Webhook
-	77,  // 110: agentgateway.dev.resource.PolicySpec.Ai.RequestGuard.rejection:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RequestRejection
-	74,  // 111: agentgateway.dev.resource.PolicySpec.Ai.RequestGuard.regex:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RegexRules
-	75,  // 112: agentgateway.dev.resource.PolicySpec.Ai.RequestGuard.webhook:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Webhook
-	76,  // 113: agentgateway.dev.resource.PolicySpec.Ai.RequestGuard.openai_moderation:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Moderation
-	79,  // 114: agentgateway.dev.resource.PolicySpec.Ai.PromptGuard.request:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RequestGuard
-	78,  // 115: agentgateway.dev.resource.PolicySpec.Ai.PromptGuard.response:type_name -> agentgateway.dev.resource.PolicySpec.Ai.ResponseGuard
-	65,  // 116: agentgateway.dev.resource.PolicySpec.TransformationPolicy.Transform.set:type_name -> agentgateway.dev.resource.PolicySpec.HeaderTransformation
-	65,  // 117: agentgateway.dev.resource.PolicySpec.TransformationPolicy.Transform.add:type_name -> agentgateway.dev.resource.PolicySpec.HeaderTransformation
-	66,  // 118: agentgateway.dev.resource.PolicySpec.TransformationPolicy.Transform.body:type_name -> agentgateway.dev.resource.PolicySpec.BodyTransformation
-	99,  // 119: agentgateway.dev.resource.AIBackend.OpenAI.model:type_name -> google.protobuf.StringValue
-	99,  // 120: agentgateway.dev.resource.AIBackend.Gemini.model:type_name -> google.protobuf.StringValue
-	99,  // 121: agentgateway.dev.resource.AIBackend.Vertex.model:type_name -> google.protobuf.StringValue
-	99,  // 122: agentgateway.dev.resource.AIBackend.Anthropic.model:type_name -> google.protobuf.StringValue
-	99,  // 123: agentgateway.dev.resource.AIBackend.Bedrock.model:type_name -> google.protobuf.StringValue
-	99,  // 124: agentgateway.dev.resource.AIBackend.Bedrock.guardrail_identifier:type_name -> google.protobuf.StringValue
-	99,  // 125: agentgateway.dev.resource.AIBackend.Bedrock.guardrail_version:type_name -> google.protobuf.StringValue
-	87,  // 126: agentgateway.dev.resource.AIBackend.Provider.host_override:type_name -> agentgateway.dev.resource.AIBackend.HostOverride
-	99,  // 127: agentgateway.dev.resource.AIBackend.Provider.path_override:type_name -> google.protobuf.StringValue
-	88,  // 128: agentgateway.dev.resource.AIBackend.Provider.openai:type_name -> agentgateway.dev.resource.AIBackend.OpenAI
-	89,  // 129: agentgateway.dev.resource.AIBackend.Provider.gemini:type_name -> agentgateway.dev.resource.AIBackend.Gemini
-	90,  // 130: agentgateway.dev.resource.AIBackend.Provider.vertex:type_name -> agentgateway.dev.resource.AIBackend.Vertex
-	91,  // 131: agentgateway.dev.resource.AIBackend.Provider.anthropic:type_name -> agentgateway.dev.resource.AIBackend.Anthropic
-	92,  // 132: agentgateway.dev.resource.AIBackend.Provider.bedrock:type_name -> agentgateway.dev.resource.AIBackend.Bedrock
-	93,  // 133: agentgateway.dev.resource.AIBackend.ProviderGroup.providers:type_name -> agentgateway.dev.resource.AIBackend.Provider
-	134, // [134:134] is the sub-list for method output_type
-	134, // [134:134] is the sub-list for method input_type
-	134, // [134:134] is the sub-list for extension type_name
-	134, // [134:134] is the sub-list for extension extendee
-	0,   // [0:134] is the sub-list for field type_name
+	87,  // 93: agentgateway.dev.resource.PolicySpec.TransformationPolicy.request:type_name -> agentgateway.dev.resource.PolicySpec.TransformationPolicy.Transform
+	87,  // 94: agentgateway.dev.resource.PolicySpec.TransformationPolicy.response:type_name -> agentgateway.dev.resource.PolicySpec.TransformationPolicy.Transform
+	67,  // 95: agentgateway.dev.resource.PolicySpec.CSRF.additional_origins:type_name -> agentgateway.dev.resource.PolicySpec.StringMatcher
+	70,  // 96: agentgateway.dev.resource.PolicySpec.RemoteRateLimit.Descriptor.entries:type_name -> agentgateway.dev.resource.PolicySpec.RemoteRateLimit.Entry
+	1,   // 97: agentgateway.dev.resource.PolicySpec.RemoteRateLimit.Descriptor.type:type_name -> agentgateway.dev.resource.PolicySpec.RemoteRateLimit.Type
+	71,  // 98: agentgateway.dev.resource.PolicySpec.Ai.PromptEnrichment.append:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Message
+	71,  // 99: agentgateway.dev.resource.PolicySpec.Ai.PromptEnrichment.prepend:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Message
+	3,   // 100: agentgateway.dev.resource.PolicySpec.Ai.RegexRule.builtin:type_name -> agentgateway.dev.resource.PolicySpec.Ai.BuiltinRegexRule
+	73,  // 101: agentgateway.dev.resource.PolicySpec.Ai.RegexRule.regex:type_name -> agentgateway.dev.resource.PolicySpec.Ai.NamedRegex
+	4,   // 102: agentgateway.dev.resource.PolicySpec.Ai.Action.kind:type_name -> agentgateway.dev.resource.PolicySpec.Ai.ActionKind
+	79,  // 103: agentgateway.dev.resource.PolicySpec.Ai.Action.reject_response:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RequestRejection
+	75,  // 104: agentgateway.dev.resource.PolicySpec.Ai.RegexRules.action:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Action
+	74,  // 105: agentgateway.dev.resource.PolicySpec.Ai.RegexRules.rules:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RegexRule
+	35,  // 106: agentgateway.dev.resource.PolicySpec.Ai.Webhook.forward_header_matches:type_name -> agentgateway.dev.resource.HeaderMatch
+	100, // 107: agentgateway.dev.resource.PolicySpec.Ai.Moderation.model:type_name -> google.protobuf.StringValue
+	18,  // 108: agentgateway.dev.resource.PolicySpec.Ai.Moderation.auth:type_name -> agentgateway.dev.resource.BackendAuthPolicy
+	76,  // 109: agentgateway.dev.resource.PolicySpec.Ai.ResponseGuard.regex:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RegexRules
+	77,  // 110: agentgateway.dev.resource.PolicySpec.Ai.ResponseGuard.webhook:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Webhook
+	79,  // 111: agentgateway.dev.resource.PolicySpec.Ai.RequestGuard.rejection:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RequestRejection
+	76,  // 112: agentgateway.dev.resource.PolicySpec.Ai.RequestGuard.regex:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RegexRules
+	77,  // 113: agentgateway.dev.resource.PolicySpec.Ai.RequestGuard.webhook:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Webhook
+	78,  // 114: agentgateway.dev.resource.PolicySpec.Ai.RequestGuard.openai_moderation:type_name -> agentgateway.dev.resource.PolicySpec.Ai.Moderation
+	81,  // 115: agentgateway.dev.resource.PolicySpec.Ai.PromptGuard.request:type_name -> agentgateway.dev.resource.PolicySpec.Ai.RequestGuard
+	80,  // 116: agentgateway.dev.resource.PolicySpec.Ai.PromptGuard.response:type_name -> agentgateway.dev.resource.PolicySpec.Ai.ResponseGuard
+	65,  // 117: agentgateway.dev.resource.PolicySpec.TransformationPolicy.Transform.set:type_name -> agentgateway.dev.resource.PolicySpec.HeaderTransformation
+	65,  // 118: agentgateway.dev.resource.PolicySpec.TransformationPolicy.Transform.add:type_name -> agentgateway.dev.resource.PolicySpec.HeaderTransformation
+	66,  // 119: agentgateway.dev.resource.PolicySpec.TransformationPolicy.Transform.body:type_name -> agentgateway.dev.resource.PolicySpec.BodyTransformation
+	100, // 120: agentgateway.dev.resource.AIBackend.OpenAI.model:type_name -> google.protobuf.StringValue
+	100, // 121: agentgateway.dev.resource.AIBackend.Gemini.model:type_name -> google.protobuf.StringValue
+	100, // 122: agentgateway.dev.resource.AIBackend.Vertex.model:type_name -> google.protobuf.StringValue
+	100, // 123: agentgateway.dev.resource.AIBackend.Anthropic.model:type_name -> google.protobuf.StringValue
+	100, // 124: agentgateway.dev.resource.AIBackend.Bedrock.model:type_name -> google.protobuf.StringValue
+	100, // 125: agentgateway.dev.resource.AIBackend.Bedrock.guardrail_identifier:type_name -> google.protobuf.StringValue
+	100, // 126: agentgateway.dev.resource.AIBackend.Bedrock.guardrail_version:type_name -> google.protobuf.StringValue
+	88,  // 127: agentgateway.dev.resource.AIBackend.Provider.host_override:type_name -> agentgateway.dev.resource.AIBackend.HostOverride
+	100, // 128: agentgateway.dev.resource.AIBackend.Provider.path_override:type_name -> google.protobuf.StringValue
+	89,  // 129: agentgateway.dev.resource.AIBackend.Provider.openai:type_name -> agentgateway.dev.resource.AIBackend.OpenAI
+	90,  // 130: agentgateway.dev.resource.AIBackend.Provider.gemini:type_name -> agentgateway.dev.resource.AIBackend.Gemini
+	91,  // 131: agentgateway.dev.resource.AIBackend.Provider.vertex:type_name -> agentgateway.dev.resource.AIBackend.Vertex
+	92,  // 132: agentgateway.dev.resource.AIBackend.Provider.anthropic:type_name -> agentgateway.dev.resource.AIBackend.Anthropic
+	93,  // 133: agentgateway.dev.resource.AIBackend.Provider.bedrock:type_name -> agentgateway.dev.resource.AIBackend.Bedrock
+	94,  // 134: agentgateway.dev.resource.AIBackend.ProviderGroup.providers:type_name -> agentgateway.dev.resource.AIBackend.Provider
+	135, // [135:135] is the sub-list for method output_type
+	135, // [135:135] is the sub-list for method input_type
+	135, // [135:135] is the sub-list for extension type_name
+	135, // [135:135] is the sub-list for extension extendee
+	0,   // [0:135] is the sub-list for field type_name
 }
 
 func init() { file_resource_proto_init() }
@@ -7096,6 +7313,7 @@ func file_resource_proto_init() {
 		(*PolicySpec_Jwt)(nil),
 		(*PolicySpec_Transformation)(nil),
 		(*PolicySpec_RemoteRateLimit_)(nil),
+		(*PolicySpec_Csrf)(nil),
 	}
 	file_resource_proto_msgTypes[38].OneofWrappers = []any{
 		(*Backend_Static)(nil),
@@ -7114,11 +7332,18 @@ func file_resource_proto_init() {
 	file_resource_proto_msgTypes[53].OneofWrappers = []any{
 		(*PolicySpec_JWT_Inline)(nil),
 	}
-	file_resource_proto_msgTypes[62].OneofWrappers = []any{
+	file_resource_proto_msgTypes[57].OneofWrappers = []any{
+		(*PolicySpec_StringMatcher_Exact)(nil),
+		(*PolicySpec_StringMatcher_Prefix)(nil),
+		(*PolicySpec_StringMatcher_Suffix)(nil),
+		(*PolicySpec_StringMatcher_SafeRegex)(nil),
+		(*PolicySpec_StringMatcher_Contains)(nil),
+	}
+	file_resource_proto_msgTypes[64].OneofWrappers = []any{
 		(*PolicySpec_Ai_RegexRule_Builtin)(nil),
 		(*PolicySpec_Ai_RegexRule_Regex)(nil),
 	}
-	file_resource_proto_msgTypes[83].OneofWrappers = []any{
+	file_resource_proto_msgTypes[84].OneofWrappers = []any{
 		(*AIBackend_Provider_Openai)(nil),
 		(*AIBackend_Provider_Gemini)(nil),
 		(*AIBackend_Provider_Vertex)(nil),
@@ -7131,7 +7356,7 @@ func file_resource_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_resource_proto_rawDesc), len(file_resource_proto_rawDesc)),
 			NumEnums:      10,
-			NumMessages:   85,
+			NumMessages:   86,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/schema/README.md
+++ b/schema/README.md
@@ -275,6 +275,14 @@ This folder contains JSON schemas for various parts of the project
 |`binds[].listeners[].routes[].policies.transformations.response.set`||
 |`binds[].listeners[].routes[].policies.transformations.response.remove`||
 |`binds[].listeners[].routes[].policies.transformations.response.body`||
+|`binds[].listeners[].routes[].policies.csrf`|Handle CSRF protection by validating request origins against configured allowed origins.|
+|`binds[].listeners[].routes[].policies.csrf.additionalOrigins`|Additional origins that are allowed for CSRF validation|
+|`binds[].listeners[].routes[].policies.csrf.additionalOrigins[].exact`||
+|`binds[].listeners[].routes[].policies.csrf.additionalOrigins[].prefix`||
+|`binds[].listeners[].routes[].policies.csrf.additionalOrigins[].suffix`||
+|`binds[].listeners[].routes[].policies.csrf.additionalOrigins[].contains`||
+|`binds[].listeners[].routes[].policies.csrf.additionalOrigins[].safeRegex`||
+|`binds[].listeners[].routes[].policies.csrf.additionalOrigins[].ignoreCase`||
 |`binds[].listeners[].routes[].policies.timeout`|Timeout requests that exceed the configured duration.|
 |`binds[].listeners[].routes[].policies.timeout.requestTimeout`||
 |`binds[].listeners[].routes[].policies.timeout.backendRequestTimeout`||
@@ -759,6 +767,14 @@ This folder contains JSON schemas for various parts of the project
 |`policies[].policy.transformations.response.set`||
 |`policies[].policy.transformations.response.remove`||
 |`policies[].policy.transformations.response.body`||
+|`policies[].policy.csrf`|Handle CSRF protection by validating request origins against configured allowed origins.|
+|`policies[].policy.csrf.additionalOrigins`|Additional origins that are allowed for CSRF validation|
+|`policies[].policy.csrf.additionalOrigins[].exact`||
+|`policies[].policy.csrf.additionalOrigins[].prefix`||
+|`policies[].policy.csrf.additionalOrigins[].suffix`||
+|`policies[].policy.csrf.additionalOrigins[].contains`||
+|`policies[].policy.csrf.additionalOrigins[].safeRegex`||
+|`policies[].policy.csrf.additionalOrigins[].ignoreCase`||
 |`policies[].policy.timeout`|Timeout requests that exceed the configured duration.|
 |`policies[].policy.timeout.requestTimeout`||
 |`policies[].policy.timeout.backendRequestTimeout`||

--- a/schema/README.md
+++ b/schema/README.md
@@ -276,13 +276,7 @@ This folder contains JSON schemas for various parts of the project
 |`binds[].listeners[].routes[].policies.transformations.response.remove`||
 |`binds[].listeners[].routes[].policies.transformations.response.body`||
 |`binds[].listeners[].routes[].policies.csrf`|Handle CSRF protection by validating request origins against configured allowed origins.|
-|`binds[].listeners[].routes[].policies.csrf.additionalOrigins`|Additional origins that are allowed for CSRF validation|
-|`binds[].listeners[].routes[].policies.csrf.additionalOrigins[].exact`||
-|`binds[].listeners[].routes[].policies.csrf.additionalOrigins[].prefix`||
-|`binds[].listeners[].routes[].policies.csrf.additionalOrigins[].suffix`||
-|`binds[].listeners[].routes[].policies.csrf.additionalOrigins[].contains`||
-|`binds[].listeners[].routes[].policies.csrf.additionalOrigins[].safeRegex`||
-|`binds[].listeners[].routes[].policies.csrf.additionalOrigins[].ignoreCase`||
+|`binds[].listeners[].routes[].policies.csrf.additionalOrigins`||
 |`binds[].listeners[].routes[].policies.timeout`|Timeout requests that exceed the configured duration.|
 |`binds[].listeners[].routes[].policies.timeout.requestTimeout`||
 |`binds[].listeners[].routes[].policies.timeout.backendRequestTimeout`||
@@ -768,13 +762,7 @@ This folder contains JSON schemas for various parts of the project
 |`policies[].policy.transformations.response.remove`||
 |`policies[].policy.transformations.response.body`||
 |`policies[].policy.csrf`|Handle CSRF protection by validating request origins against configured allowed origins.|
-|`policies[].policy.csrf.additionalOrigins`|Additional origins that are allowed for CSRF validation|
-|`policies[].policy.csrf.additionalOrigins[].exact`||
-|`policies[].policy.csrf.additionalOrigins[].prefix`||
-|`policies[].policy.csrf.additionalOrigins[].suffix`||
-|`policies[].policy.csrf.additionalOrigins[].contains`||
-|`policies[].policy.csrf.additionalOrigins[].safeRegex`||
-|`policies[].policy.csrf.additionalOrigins[].ignoreCase`||
+|`policies[].policy.csrf.additionalOrigins`||
 |`policies[].policy.timeout`|Timeout requests that exceed the configured duration.|
 |`policies[].policy.timeout.requestTimeout`||
 |`policies[].policy.timeout.backendRequestTimeout`||

--- a/schema/local.json
+++ b/schema/local.json
@@ -2446,47 +2446,10 @@
                             ],
                             "properties": {
                               "additionalOrigins": {
-                                "description": "Additional origins that are allowed for CSRF validation",
                                 "type": "array",
+                                "uniqueItems": true,
                                 "items": {
-                                  "type": "object",
-                                  "properties": {
-                                    "exact": {
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ]
-                                    },
-                                    "prefix": {
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ]
-                                    },
-                                    "suffix": {
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ]
-                                    },
-                                    "contains": {
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ]
-                                    },
-                                    "safeRegex": {
-                                      "type": [
-                                        "string",
-                                        "null"
-                                      ]
-                                    },
-                                    "ignoreCase": {
-                                      "type": "boolean",
-                                      "default": false
-                                    }
-                                  },
-                                  "additionalProperties": false
+                                  "type": "string"
                                 },
                                 "default": []
                               }
@@ -6991,47 +6954,10 @@
                 ],
                 "properties": {
                   "additionalOrigins": {
-                    "description": "Additional origins that are allowed for CSRF validation",
                     "type": "array",
+                    "uniqueItems": true,
                     "items": {
-                      "type": "object",
-                      "properties": {
-                        "exact": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "prefix": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "suffix": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "contains": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "safeRegex": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "ignoreCase": {
-                          "type": "boolean",
-                          "default": false
-                        }
-                      },
-                      "additionalProperties": false
+                      "type": "string"
                     },
                     "default": []
                   }

--- a/schema/local.json
+++ b/schema/local.json
@@ -2438,6 +2438,62 @@
                             "additionalProperties": false,
                             "default": null
                           },
+                          "csrf": {
+                            "description": "Handle CSRF protection by validating request origins against configured allowed origins.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "additionalOrigins": {
+                                "description": "Additional origins that are allowed for CSRF validation",
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "exact": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    },
+                                    "prefix": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    },
+                                    "suffix": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    },
+                                    "contains": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    },
+                                    "safeRegex": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    },
+                                    "ignoreCase": {
+                                      "type": "boolean",
+                                      "default": false
+                                    }
+                                  },
+                                  "additionalProperties": false
+                                },
+                                "default": []
+                              }
+                            },
+                            "additionalProperties": false,
+                            "default": null
+                          },
                           "timeout": {
                             "description": "Timeout requests that exceed the configured duration.",
                             "type": [
@@ -6922,6 +6978,62 @@
                       }
                     },
                     "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false,
+                "default": null
+              },
+              "csrf": {
+                "description": "Handle CSRF protection by validating request origins against configured allowed origins.",
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "additionalOrigins": {
+                    "description": "Additional origins that are allowed for CSRF validation",
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "exact": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "prefix": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "suffix": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "contains": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "safeRegex": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "ignoreCase": {
+                          "type": "boolean",
+                          "default": false
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "default": []
                   }
                 },
                 "additionalProperties": false,


### PR DESCRIPTION
Add support for CSRF Policy.

Part of [#kgateway/12122](https://github.com/kgateway-dev/kgateway/issues/12122)

## Addtional Notes

Tested this using this config:
```yaml
binds:
- port: 3000
  listeners:
  - protocol: HTTP
    routes:
    - name: csrf-protected-route
      matches:
      - path:
          pathPrefix: /protected
      policies:
        csrf:
          additionalOrigins:
            - "https://www.example.com"
            - "https://trusted.domain.com"
      backends:
      - host: 127.0.0.1:8080

    - name: strict-csrf-route
      matches:
      - path:
          pathPrefix: /strict
      policies:
        csrf:
          additionalOrigins: []
      backends:
      - host: 127.0.0.1:8080
```