### PR TITLE
Support /v1/messages format

### DIFF
--- a/crates/agentgateway/src/cel/mod.rs
+++ b/crates/agentgateway/src/cel/mod.rs
@@ -17,7 +17,7 @@ use serde::{Serialize, Serializer};
 
 use crate::http::jwt::Claims;
 use crate::llm;
-use crate::llm::{LLMRequest, LLMResponse};
+use crate::llm::{LLMInfo, LLMRequest};
 use crate::serdes::*;
 use crate::transport::stream::{TCPConnectionInfo, TLSConnectionInfo};
 use crate::types::discovery::Identity;
@@ -233,20 +233,21 @@ impl ContextBuilder {
 		r.prompt = Some(msg);
 	}
 
-	pub fn with_llm_response(&mut self, info: &LLMResponse) {
+	pub fn with_llm_response(&mut self, info: &LLMInfo) {
 		if !self.attributes.contains(LLM_ATTRIBUTE) {
 			return;
 		}
+		let resp = &info.response;
 		if let Some(o) = self.context.llm.as_mut() {
-			o.output_tokens = info.output_tokens;
-			o.total_tokens = info.total_tokens;
-			if let Some(pt) = info.input_tokens_from_response {
+			o.output_tokens = resp.output_tokens;
+			o.total_tokens = resp.total_tokens;
+			if let Some(pt) = resp.input_tokens {
 				// Better info, override
 				o.input_tokens = Some(pt);
 			}
-			o.response_model = info.provider_model.clone();
+			o.response_model = resp.provider_model.clone();
 			// Not always set
-			o.completion = info.completion.clone();
+			o.completion = resp.completion.clone();
 		}
 	}
 

--- a/crates/agentgateway/src/json.rs
+++ b/crates/agentgateway/src/json.rs
@@ -81,3 +81,9 @@ pub fn to_body<T: Serialize>(j: T) -> anyhow::Result<http::Body> {
 	let bytes = serde_json::to_vec(&j)?;
 	Ok(http::Body::from(bytes))
 }
+
+pub fn convert<I: Serialize, O: DeserializeOwned>(input: &I) -> Result<O, serde_json::Error> {
+	let v = serde_json::to_value(input)?;
+	let o = serde_json::from_value::<O>(v)?;
+	Ok(o)
+}

--- a/crates/agentgateway/src/llm/gemini.rs
+++ b/crates/agentgateway/src/llm/gemini.rs
@@ -24,8 +24,8 @@ pub const DEFAULT_PATH: &str = "/v1beta/openai/chat/completions";
 impl Provider {
 	pub async fn process_request(
 		&self,
-		mut req: universal::Request,
-	) -> Result<universal::Request, AIError> {
+		mut req: universal::passthrough::Request,
+	) -> Result<universal::passthrough::Request, AIError> {
 		if let Some(provider_model) = &self.model {
 			req.model = Some(provider_model.to_string());
 		} else if req.model.is_none() {
@@ -34,13 +34,16 @@ impl Provider {
 		// Gemini compat mode is the same!
 		Ok(req)
 	}
-	pub async fn process_response(&self, bytes: &Bytes) -> Result<universal::Response, AIError> {
-		let resp =
-			serde_json::from_slice::<universal::Response>(bytes).map_err(AIError::ResponseParsing)?;
+	pub fn process_response(
+		&self,
+		bytes: &Bytes,
+	) -> Result<universal::passthrough::Response, AIError> {
+		let resp = serde_json::from_slice::<universal::passthrough::Response>(bytes)
+			.map_err(AIError::ResponseParsing)?;
 		Ok(resp)
 	}
 
-	pub async fn process_error(
+	pub fn process_error(
 		&self,
 		bytes: &Bytes,
 	) -> Result<universal::ChatCompletionErrorResponse, AIError> {

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -456,7 +456,7 @@ impl AIProvider {
 		if let Some(p) = policies {
 			// Apply model alias resolution
 			if let Some(model) = req.model()
-			&& let Some(aliased) = p.model_aliases.get(model.as_str())
+				&& let Some(aliased) = p.model_aliases.get(model.as_str())
 			{
 				*model = aliased.to_string();
 			}

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -7,7 +7,6 @@ use agent_core::prelude::Strng;
 use agent_core::strng;
 use axum_extra::headers::authorization::Bearer;
 use headers::{ContentEncoding, HeaderMapExt};
-use itertools::Itertools;
 pub use policy::Policy;
 use rand::Rng;
 use tiktoken_rs::CoreBPE;
@@ -16,7 +15,9 @@ use tiktoken_rs::tokenizer::{Tokenizer, get_tokenizer};
 use crate::http::auth::{AwsAuth, BackendAuth};
 use crate::http::jwt::Claims;
 use crate::http::{Body, Request, Response};
-use crate::llm::universal::{ChatCompletionError, ChatCompletionErrorResponse};
+use crate::llm::universal::{
+	ChatCompletionError, ChatCompletionErrorResponse, RequestType, ResponseType,
+};
 use crate::store::{BackendPolicies, LLMResponsePolicies};
 use crate::telemetry::log::{AsyncLog, RequestLog};
 use crate::types::agent::Target;
@@ -132,10 +133,17 @@ trait Provider {
 pub struct LLMRequest {
 	/// Input tokens derived by tokenizing the request. Not always enabled
 	pub input_tokens: Option<u64>,
+	pub input_format: InputFormat,
 	pub request_model: Strng,
 	pub provider: Strng,
 	pub streaming: bool,
-	pub params: llm::LLMRequestParams,
+	pub params: LLMRequestParams,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum InputFormat {
+	Completions,
+	Messages,
 }
 
 #[derive(Default, Clone, Debug, Serialize)]
@@ -156,23 +164,32 @@ pub struct LLMRequestParams {
 }
 
 #[derive(Debug, Clone)]
-pub struct LLMResponse {
+pub struct LLMInfo {
 	pub request: LLMRequest,
-	pub input_tokens_from_response: Option<u64>,
+	pub response: LLMResponse,
+}
+
+impl LLMInfo {
+	fn new(req: LLMRequest, resp: LLMResponse) -> Self {
+		Self {
+			request: req,
+			response: resp,
+		}
+	}
+	pub fn input_tokens(&self) -> Option<u64> {
+		self.response.input_tokens.or(self.request.input_tokens)
+	}
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct LLMResponse {
+	pub input_tokens: Option<u64>,
 	pub output_tokens: Option<u64>,
 	pub total_tokens: Option<u64>,
 	pub provider_model: Option<Strng>,
 	pub completion: Option<Vec<String>>,
 	// Time to get the first token. Only used for streaming.
 	pub first_token: Option<Instant>,
-}
-
-impl LLMResponse {
-	pub fn input_tokens(&self) -> Option<u64> {
-		self
-			.input_tokens_from_response
-			.or(self.request.input_tokens)
-	}
 }
 
 #[derive(Debug)]
@@ -190,6 +207,15 @@ impl AIProvider {
 			AIProvider::Gemini(_p) => gemini::Provider::NAME,
 			AIProvider::Vertex(_p) => vertex::Provider::NAME,
 			AIProvider::Bedrock(_p) => bedrock::Provider::NAME,
+		}
+	}
+	pub fn override_model(&self) -> Option<Strng> {
+		match self {
+			AIProvider::OpenAI(p) => p.model.clone(),
+			AIProvider::Anthropic(p) => p.model.clone(),
+			AIProvider::Gemini(p) => p.model.clone(),
+			AIProvider::Vertex(p) => p.model.clone(),
+			AIProvider::Bedrock(p) => p.model.clone(),
 		}
 	}
 	pub fn default_connector(&self) -> (Target, BackendPolicies) {
@@ -312,7 +338,7 @@ impl AIProvider {
 		}
 	}
 
-	pub async fn process_request(
+	pub async fn process_completions_request(
 		&self,
 		client: &client::Client,
 		policies: Option<&Policy>,
@@ -322,22 +348,117 @@ impl AIProvider {
 	) -> Result<RequestResult, AIError> {
 		// Buffer the body, max 2mb
 		let buffer_limit = http::buffer_limit(&req);
-		let (mut parts, body) = req.into_parts();
+		let (parts, body) = req.into_parts();
 		let Ok(bytes) = http::read_body_with_limit(body, buffer_limit).await else {
 			return Err(AIError::RequestTooLarge);
 		};
-		let mut req: universal::Request = if let Some(p) = policies {
+		let mut req: universal::passthrough::Request = if let Some(p) = policies {
 			p.unmarshal_request(&bytes)?
 		} else {
 			serde_json::from_slice(bytes.as_ref()).map_err(AIError::RequestParsing)?
 		};
 
+		// If a user doesn't request usage, we will not get token information which we need
+		// We always set it.
+		// TODO?: this may impact the user, if they make assumptions about the stream NOT including usage.
+		// Notably, this adds a final SSE event.
+		// We could actually go remove that on the response, but it would mean we cannot do passthrough-parsing,
+		// so unless we have a compelling use case for it, for now we keep it.
+		if req.stream.unwrap_or_default() && req.stream_options.is_none() {
+			req.stream_options = Some(universal::passthrough::StreamOptions {
+				include_usage: true,
+			});
+		}
+		if let Some(provider_model) = &self.override_model() {
+			req.model = Some(provider_model.to_string());
+		} else if req.model.is_none() {
+			return Err(AIError::MissingField("model not specified".into()));
+		}
+
+		self
+			.process_request(
+				client,
+				policies,
+				InputFormat::Completions,
+				req,
+				parts,
+				tokenize,
+				log,
+			)
+			.await
+	}
+
+	pub async fn process_messages_request(
+		&self,
+		client: &client::Client,
+		policies: Option<&Policy>,
+		req: Request,
+		tokenize: bool,
+		log: &mut Option<&mut RequestLog>,
+	) -> Result<RequestResult, AIError> {
+		// Buffer the body, max 2mb
+		let (parts, body) = req.into_parts();
+		let Ok(bytes) = axum::body::to_bytes(body, 2_097_152).await else {
+			return Err(AIError::RequestTooLarge);
+		};
+		let mut req: anthropic::passthrough::Request = if let Some(p) = policies {
+			p.unmarshal_request(&bytes)?
+		} else {
+			serde_json::from_slice(bytes.as_ref()).map_err(AIError::RequestParsing)?
+		};
+
+		if let Some(provider_model) = &self.override_model() {
+			req.model = Some(provider_model.to_string());
+		} else if req.model.is_none() {
+			return Err(AIError::MissingField("model not specified".into()));
+		}
+
+		self
+			.process_request(
+				client,
+				policies,
+				InputFormat::Messages,
+				req,
+				parts,
+				tokenize,
+				log,
+			)
+			.await
+	}
+
+	#[allow(clippy::too_many_arguments)]
+	async fn process_request(
+		&self,
+		client: &client::Client,
+		policies: Option<&Policy>,
+		original_format: InputFormat,
+		mut req: impl RequestType,
+		mut parts: ::http::request::Parts,
+		tokenize: bool,
+		log: &mut Option<&mut RequestLog>,
+	) -> Result<RequestResult, AIError> {
+		match (original_format, self) {
+			(InputFormat::Completions, _) => {
+				// All provider support completions input
+			},
+			(InputFormat::Messages, AIProvider::Anthropic(_)) => {
+				// Anthropic supports messages input
+			},
+			(m, p) => {
+				// Messages with OpenAI compatible: currently only supports translating the request
+				// Messages with Bedrock: unsupported
+				return Err(AIError::UnsupportedConversion(strng::format!(
+					"{m:?} from provider {}",
+					p.provider()
+				)));
+			},
+		}
 		if let Some(p) = policies {
 			// Apply model alias resolution
-			if let Some(model) = req.model.as_ref()
-				&& let Some(aliased) = p.model_aliases.get(model.as_str())
+			if let Some(model) = req.model()
+			&& let Some(aliased) = p.model_aliases.get(model.as_str())
 			{
-				req.model = Some(aliased.to_string());
+				*model = aliased.to_string();
 			}
 			p.apply_prompt_enrichment(&mut req);
 			let http_headers = &parts.headers;
@@ -352,37 +473,20 @@ impl AIProvider {
 				return Ok(RequestResult::Rejected(dr));
 			}
 		}
-		let llm_info = self.to_llm_request(&req, tokenize).await?;
+		let llm_info = req.to_llm_request(self.provider(), tokenize)?;
 		if let Some(log) = log {
 			let needs_prompt = log.cel.cel_context.with_llm_request(&llm_info);
 			if needs_prompt {
-				log
-					.cel
-					.cel_context
-					.with_llm_prompt(req.messages.iter().map(Into::into).collect_vec())
+				log.cel.cel_context.with_llm_prompt(req.get_messages())
 			}
 		}
 
-		// If a user doesn't request usage, we will not get token information which we need
-		// We always set it.
-		// TODO?: this may impact the user, if they make assumptions about the stream NOT including usage.
-		// Notably, this adds a final SSE event.
-		// We could actually go remove that on the response, but it would mean we cannot do passthrough-parsing,
-		// so unless we have a compelling use case for it, for now we keep it.
-		if req.stream.unwrap_or_default() && req.stream_options.is_none() {
-			req.stream_options = Some(universal::StreamOptions {
-				include_usage: true,
-			});
-		}
-		let resp_json = match self {
-			AIProvider::OpenAI(p) => serde_json::to_vec(&p.process_request(req).await?),
-			AIProvider::Gemini(p) => serde_json::to_vec(&p.process_request(req).await?),
-			AIProvider::Vertex(p) => serde_json::to_vec(&p.process_request(req).await?),
-			AIProvider::Anthropic(p) => serde_json::to_vec(&p.process_request(req).await?),
-			AIProvider::Bedrock(p) => serde_json::to_vec(&p.process_request(req).await?),
+		let new_request = match self {
+			AIProvider::OpenAI(_) | AIProvider::Gemini(_) | AIProvider::Vertex(_) => req.to_openai()?,
+			AIProvider::Anthropic(_) => req.to_anthropic()?,
+			AIProvider::Bedrock(p) => req.to_bedrock(p)?,
 		};
-		let body = resp_json.map_err(AIError::RequestMarshal)?;
-		let resp = Body::from(body);
+		let resp = Body::from(new_request);
 		parts.headers.remove(header::CONTENT_LENGTH);
 		let req = Request::from_parts(parts, resp);
 		Ok(RequestResult::Success(req, llm_info))
@@ -393,7 +497,7 @@ impl AIProvider {
 		client: &client::Client,
 		req: LLMRequest,
 		rate_limit: LLMResponsePolicies,
-		log: AsyncLog<llm::LLMResponse>,
+		log: AsyncLog<llm::LLMInfo>,
 		include_completion_in_log: bool,
 		resp: Response,
 	) -> Result<Response, AIError> {
@@ -411,69 +515,42 @@ impl AIProvider {
 		else {
 			return Err(AIError::ResponseTooLarge);
 		};
-		// 3 cases: success, error properly handled, and unexpected error we need to synthesize
-		let openai_response = self
-			.process_response_status(&req, parts.status, &bytes)
-			.await
-			.unwrap_or_else(|err| {
-				Err(ChatCompletionErrorResponse {
-					event_id: None,
-					error: ChatCompletionError {
-						// Assume its due to the request being invalid, though we don't really know for sure
-						r#type: "invalid_request_error".to_string(),
-						message: format!(
-							"failed to process response body ({err}): {}",
-							std::str::from_utf8(&bytes).unwrap_or("invalid utf8")
-						),
-						param: None,
-						code: None,
-						event_id: None,
-					},
-				})
-			});
-		let (llm_resp, body) = match openai_response {
-			Ok(mut success) => {
-				let llm_resp = LLMResponse {
-					request: req,
-					input_tokens_from_response: success.usage.as_ref().map(|u| u.prompt_tokens as u64),
-					output_tokens: success.usage.as_ref().map(|u| u.completion_tokens as u64),
-					total_tokens: success.usage.as_ref().map(|u| u.total_tokens as u64),
-					provider_model: Some(strng::new(&success.model)),
-					completion: if include_completion_in_log {
-						Some(
-							success
-								.choices
-								.iter()
-								.flat_map(|c| c.message.content.clone())
-								.collect_vec(),
-						)
-					} else {
-						None
-					},
-					first_token: Default::default(),
-				};
-				// Apply response prompt guard
-				if let Some(dr) = Policy::apply_response_prompt_guard(
-					client,
-					&mut success,
-					&parts.headers,
-					&rate_limit.prompt_guard,
-				)
-				.await
-				.map_err(|e| {
-					warn!("failed to apply response prompt guard: {e}");
-					AIError::PromptWebhookError
-				})? {
-					return Ok(dr);
-				}
 
-				let body = serde_json::to_vec(&success).map_err(AIError::ResponseMarshal)?;
-				(llm_resp, body)
-			},
+		// 3 cases: success, error properly handled, and unexpected error we need to synthesize
+		let mut resp = self
+			.process_response_status(&req, parts.status, &bytes)
+			.unwrap_or_else(|e| Err(Self::convert_error(e, &bytes)));
+
+		if let Ok(resp) = &mut resp {
+			// Apply response prompt guard
+			if let Some(dr) = Policy::apply_response_prompt_guard(
+				client,
+				resp.as_mut(),
+				&parts.headers,
+				&rate_limit.prompt_guard,
+			)
+			.await
+			.map_err(|e| {
+				warn!("failed to apply response prompt guard: {e}");
+				AIError::PromptWebhookError
+			})? {
+				return Ok(dr);
+			}
+		}
+
+		let resp = resp.and_then(|resp| {
+			let llm_resp = resp.to_llm_response(include_completion_in_log);
+			let body = resp
+				.serialize()
+				.map_err(AIError::ResponseParsing)
+				.map_err(|e| Self::convert_error(e, &bytes))?;
+			Ok((llm_resp, body))
+		});
+		let (llm_resp, body) = match resp {
+			Ok(resp) => resp,
 			Err(err) => {
 				let llm_resp = LLMResponse {
-					request: req,
-					input_tokens_from_response: None,
+					input_tokens: None,
 					output_tokens: None,
 					total_tokens: None,
 					provider_model: None,
@@ -484,6 +561,7 @@ impl AIProvider {
 				(llm_resp, body)
 			},
 		};
+
 		let body = if let Some(encoding) = encoding {
 			Body::from(
 				http::compression::encode_body(&body, encoding)
@@ -496,38 +574,55 @@ impl AIProvider {
 		parts.headers.remove(header::CONTENT_LENGTH);
 		let resp = Response::from_parts(parts, body);
 
+		let llm_info = LLMInfo::new(req, llm_resp);
 		// In the initial request, we subtracted the approximate request tokens.
 		// Now we should have the real request tokens and the response tokens
-		amend_tokens(rate_limit, &llm_resp);
-		log.store(Some(llm_resp));
+		amend_tokens(rate_limit, &llm_info);
+		log.store(Some(llm_info));
 		Ok(resp)
 	}
 
-	async fn process_response_status(
+	fn convert_error(err: AIError, bytes: &Bytes) -> ChatCompletionErrorResponse {
+		ChatCompletionErrorResponse {
+			event_id: None,
+			error: ChatCompletionError {
+				// Assume its due to the request being invalid, though we don't really know for sure
+				r#type: "invalid_request_error".to_string(),
+				message: format!(
+					"failed to process response body ({err}): {}",
+					std::str::from_utf8(bytes).unwrap_or("invalid utf8")
+				),
+				param: None,
+				code: None,
+				event_id: None,
+			},
+		}
+	}
+
+	fn process_response_status(
 		&self,
 		req: &LLMRequest,
 		status: StatusCode,
 		bytes: &Bytes,
-	) -> Result<Result<universal::Response, ChatCompletionErrorResponse>, AIError> {
+	) -> Result<Result<Box<dyn ResponseType>, ChatCompletionErrorResponse>, AIError> {
 		if status.is_success() {
-			let openai_response = match self {
-				AIProvider::OpenAI(p) => p.process_response(bytes).await?,
-				AIProvider::Gemini(p) => p.process_response(bytes).await?,
-				AIProvider::Vertex(p) => p.process_response(bytes).await?,
-				AIProvider::Anthropic(p) => p.process_response(bytes).await?,
-				AIProvider::Bedrock(p) => {
-					p.process_response(req.request_model.as_str(), bytes)
-						.await?
+			let resp = match self {
+				AIProvider::OpenAI(_) | AIProvider::Gemini(_) | AIProvider::Vertex(_) => {
+					universal::passthrough::process_response(bytes, req.input_format)?
+				},
+				AIProvider::Anthropic(_) => anthropic::process_response(bytes, req.input_format)?,
+				AIProvider::Bedrock(_) => {
+					bedrock::process_response(req.request_model.as_str(), bytes, req.input_format)?
 				},
 			};
-			Ok(Ok(openai_response))
+			Ok(Ok(resp))
 		} else {
 			let openai_response = match self {
-				AIProvider::OpenAI(p) => p.process_error(bytes).await?,
-				AIProvider::Gemini(p) => p.process_error(bytes).await?,
-				AIProvider::Vertex(p) => p.process_error(bytes).await?,
-				AIProvider::Anthropic(p) => p.process_error(bytes).await?,
-				AIProvider::Bedrock(p) => p.process_error(bytes).await?,
+				AIProvider::OpenAI(p) => p.process_error(bytes)?,
+				AIProvider::Gemini(p) => p.process_error(bytes)?,
+				AIProvider::Vertex(p) => p.process_error(bytes)?,
+				AIProvider::Anthropic(p) => p.process_error(bytes)?,
+				AIProvider::Bedrock(p) => p.process_error(bytes)?,
 			};
 			Ok(Err(openai_response))
 		}
@@ -537,24 +632,20 @@ impl AIProvider {
 		&self,
 		req: LLMRequest,
 		rate_limit: LLMResponsePolicies,
-		log: AsyncLog<llm::LLMResponse>,
+		log: AsyncLog<llm::LLMInfo>,
 		include_completion_in_log: bool,
 		resp: Response,
 	) -> Result<Response, AIError> {
 		let model = req.request_model.clone();
+		let input_format = req.input_format;
 		// Store an empty response, as we stream in info we will parse into it
-		let llmresp = LLMResponse {
+		let llmresp = llm::LLMInfo {
 			request: req,
-			input_tokens_from_response: Default::default(),
-			output_tokens: Default::default(),
-			total_tokens: Default::default(),
-			provider_model: Default::default(),
-			completion: Default::default(),
-			first_token: Default::default(),
+			response: LLMResponse::default(),
 		};
 		log.store(Some(llmresp));
 		let resp = match self {
-			AIProvider::Anthropic(p) => p.process_streaming(log, resp).await,
+			AIProvider::Anthropic(p) => p.process_streaming(log, resp, input_format).await,
 			AIProvider::Bedrock(p) => p.process_streaming(log, resp, model.as_str()).await,
 			_ => {
 				self
@@ -567,7 +658,7 @@ impl AIProvider {
 
 	async fn default_process_streaming(
 		&self,
-		log: AsyncLog<llm::LLMResponse>,
+		log: AsyncLog<llm::LLMInfo>,
 		include_completion_in_log: bool,
 		rate_limit: LLMResponsePolicies,
 		resp: Response,
@@ -593,20 +684,20 @@ impl AIProvider {
 						if !saw_token {
 							saw_token = true;
 							log.non_atomic_mutate(|r| {
-								r.first_token = Some(Instant::now());
+								r.response.first_token = Some(Instant::now());
 							});
 						}
 						if !seen_provider {
 							seen_provider = true;
-							log.non_atomic_mutate(|r| r.provider_model = Some(strng::new(&f.model)));
+							log.non_atomic_mutate(|r| r.response.provider_model = Some(strng::new(&f.model)));
 						}
 						if let Some(u) = f.usage {
 							log.non_atomic_mutate(|r| {
-								r.input_tokens_from_response = Some(u.prompt_tokens as u64);
-								r.output_tokens = Some(u.completion_tokens as u64);
-								r.total_tokens = Some(u.total_tokens as u64);
+								r.response.input_tokens = Some(u.prompt_tokens as u64);
+								r.response.output_tokens = Some(u.completion_tokens as u64);
+								r.response.total_tokens = Some(u.total_tokens as u64);
 								if let Some(c) = completion.take() {
-									r.completion = Some(vec![c]);
+									r.response.completion = Some(vec![c]);
 								}
 
 								if let Some(rl) = rate_limit.take() {
@@ -623,7 +714,7 @@ impl AIProvider {
 						// This is useful in case we never see "usage"
 						log.non_atomic_mutate(|r| {
 							if let Some(c) = completion.take() {
-								r.completion = Some(vec![c]);
+								r.response.completion = Some(vec![c]);
 							}
 						});
 					},
@@ -631,48 +722,11 @@ impl AIProvider {
 			})
 		})
 	}
-
-	pub async fn to_llm_request(
-		&self,
-		req: &universal::Request,
-		tokenize: bool,
-	) -> Result<LLMRequest, AIError> {
-		let input_tokens = if tokenize {
-			// TODO: avoid clone, we need it for spawn_blocking though
-			let msg = req.messages.clone();
-			let model = req.model.clone();
-			let tokens = tokio::task::spawn_blocking(move || {
-				let res = num_tokens_from_messages(&model.unwrap_or_default(), &msg)?;
-				Ok::<_, AIError>(res)
-			})
-			.await??;
-			Some(tokens)
-		} else {
-			None
-		};
-		// Pass the original body through
-		let llm = LLMRequest {
-			input_tokens,
-			request_model: req.model.clone().unwrap_or_default().as_str().into(),
-			provider: self.provider(),
-			streaming: req.stream.unwrap_or_default(),
-			params: LLMRequestParams {
-				temperature: req.temperature.map(Into::into),
-				top_p: req.top_p.map(Into::into),
-				frequency_penalty: req.frequency_penalty.map(Into::into),
-				presence_penalty: req.presence_penalty.map(Into::into),
-				seed: req.seed,
-				max_tokens: universal::max_tokens_option(req),
-			},
-		};
-		Ok(llm)
-	}
 }
 
-// TODO: do we always want to spend cost of tokenizing, or just allow skipping and using the response?
 fn num_tokens_from_messages(
 	model: &str,
-	messages: &[universal::RequestMessage],
+	messages: &[universal::passthrough::RequestMessage],
 ) -> Result<u64, AIError> {
 	let tokenizer = get_tokenizer(model).unwrap_or(Tokenizer::Cl100kBase);
 	if tokenizer != Tokenizer::Cl100kBase && tokenizer != Tokenizer::O200kBase {
@@ -688,12 +742,7 @@ fn num_tokens_from_messages(
 		num_tokens += tokens_per_message;
 		// Role is always 1 token
 		num_tokens += 1;
-		// num_tokens += bpe
-		// .encode_with_special_tokens(
-		// 	message.role
-		// )
-		// .len() as u64;
-		if let Some(t) = universal::message_text(message) {
+		if let Some(t) = message.message_text() {
 			num_tokens += bpe
 				.encode_with_special_tokens(
 					// We filter non-text previously
@@ -701,9 +750,40 @@ fn num_tokens_from_messages(
 				)
 				.len() as u64;
 		}
-		if let Some(name) = universal::message_name(message) {
+		if let Some(name) = &message.name {
 			num_tokens += bpe.encode_with_special_tokens(name).len() as u64;
 			num_tokens += tokens_per_name;
+		}
+	}
+	num_tokens += 3; // every reply is primed with <|start|>assistant<|message|>
+	Ok(num_tokens)
+}
+
+fn num_tokens_from_anthropic_messages(
+	model: &str,
+	messages: &[anthropic::passthrough::RequestMessage],
+) -> Result<u64, AIError> {
+	let tokenizer = get_tokenizer(model).unwrap_or(Tokenizer::Cl100kBase);
+	if tokenizer != Tokenizer::Cl100kBase && tokenizer != Tokenizer::O200kBase {
+		// Chat completion is only supported chat models
+		return Err(AIError::UnsupportedModel);
+	}
+	let bpe = get_bpe_from_tokenizer(tokenizer);
+
+	let tokens_per_message = 3;
+
+	let mut num_tokens: u64 = 0;
+	for message in messages {
+		num_tokens += tokens_per_message;
+		// Role is always 1 token
+		num_tokens += 1;
+		if let Some(t) = message.message_text() {
+			num_tokens += bpe
+				.encode_with_special_tokens(
+					// We filter non-text previously
+					t,
+				)
+				.len() as u64;
 		}
 	}
 	num_tokens += 3; // every reply is primed with <|start|>assistant<|message|>
@@ -745,6 +825,8 @@ pub enum AIError {
 	UnsupportedModel,
 	#[error("unsupported content")]
 	UnsupportedContent,
+	#[error("unsupported conversion to {0}")]
+	UnsupportedConversion(Strng),
 	#[error("request was too large")]
 	RequestTooLarge,
 	#[error("response was too large")]
@@ -765,10 +847,10 @@ pub enum AIError {
 	JoinError(#[from] tokio::task::JoinError),
 }
 
-fn amend_tokens(rate_limit: store::LLMResponsePolicies, llm_resp: &LLMResponse) {
+fn amend_tokens(rate_limit: store::LLMResponsePolicies, llm_resp: &LLMInfo) {
 	let input_mismatch = match (
 		llm_resp.request.input_tokens,
-		llm_resp.input_tokens_from_response,
+		llm_resp.response.input_tokens,
 	) {
 		// Already counted 'req'
 		(Some(req), Some(resp)) => (resp as i64) - (req as i64),
@@ -777,7 +859,7 @@ fn amend_tokens(rate_limit: store::LLMResponsePolicies, llm_resp: &LLMResponse) 
 		// No request counted, so count the full response
 		(_, Some(resp)) => resp as i64,
 	};
-	let response = llm_resp.output_tokens.unwrap_or_default();
+	let response = llm_resp.response.output_tokens.unwrap_or_default();
 	let tokens_to_remove = input_mismatch + (response as i64);
 
 	for lrl in &rate_limit.local_rate_limit {

--- a/crates/agentgateway/src/llm/openai.rs
+++ b/crates/agentgateway/src/llm/openai.rs
@@ -22,8 +22,8 @@ pub const DEFAULT_PATH: &str = "/v1/chat/completions";
 impl Provider {
 	pub async fn process_request(
 		&self,
-		mut req: universal::Request,
-	) -> Result<universal::Request, AIError> {
+		mut req: universal::passthrough::Request,
+	) -> Result<universal::passthrough::Request, AIError> {
 		if let Some(provider_model) = &self.model {
 			req.model = Some(provider_model.to_string());
 		} else if req.model.is_none() {
@@ -32,12 +32,15 @@ impl Provider {
 		// This is openai already...
 		Ok(req)
 	}
-	pub async fn process_response(&self, bytes: &Bytes) -> Result<universal::Response, AIError> {
-		let resp =
-			serde_json::from_slice::<universal::Response>(bytes).map_err(AIError::ResponseParsing)?;
+	pub fn process_response(
+		&self,
+		bytes: &Bytes,
+	) -> Result<universal::passthrough::Response, AIError> {
+		let resp = serde_json::from_slice::<universal::passthrough::Response>(bytes)
+			.map_err(AIError::ResponseParsing)?;
 		Ok(resp)
 	}
-	pub async fn process_error(
+	pub fn process_error(
 		&self,
 		bytes: &Bytes,
 	) -> Result<universal::ChatCompletionErrorResponse, AIError> {

--- a/crates/agentgateway/src/llm/tests/anthropic-request_anthropic_basic.snap
+++ b/crates/agentgateway/src/llm/tests/anthropic-request_anthropic_basic.snap
@@ -1,0 +1,21 @@
+---
+source: crates/agentgateway/src/llm/tests.rs
+description: "anthropic: request_anthropic_basic"
+info:
+  model: claude-sonnet-4-20250514
+  max_tokens: 1024
+  messages:
+    - role: user
+      content: "Hello, world"
+---
+{
+  "messages": [
+    {
+      "role": "user",
+      "content": "Hello, world"
+    }
+  ],
+  "model": "claude-sonnet-4-20250514",
+  "max_completion_tokens": 1024,
+  "stream": false
+}

--- a/crates/agentgateway/src/llm/tests/anthropic-request_anthropic_tools.snap
+++ b/crates/agentgateway/src/llm/tests/anthropic-request_anthropic_tools.snap
@@ -1,0 +1,53 @@
+---
+source: crates/agentgateway/src/llm/tests.rs
+description: "anthropic: request_anthropic_tools"
+info:
+  model: claude-opus-4-1-20250805
+  max_tokens: 1024
+  tools:
+    - name: get_weather
+      description: Get the current weather in a given location
+      input_schema:
+        type: object
+        properties:
+          location:
+            type: string
+            description: "The city and state, e.g. San Francisco, CA"
+        required:
+          - location
+  messages:
+    - role: user
+      content: What is the weather like in San Francisco?
+---
+{
+  "messages": [
+    {
+      "role": "user",
+      "content": "What is the weather like in San Francisco?"
+    }
+  ],
+  "model": "claude-opus-4-1-20250805",
+  "max_completion_tokens": 1024,
+  "stream": false,
+  "tools": [
+    {
+      "type": "function",
+      "function": {
+        "name": "get_weather",
+        "description": "Get the current weather in a given location",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "location": {
+              "type": "string",
+              "description": "The city and state, e.g. San Francisco, CA"
+            }
+          },
+          "required": [
+            "location"
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/crates/agentgateway/src/llm/tests/anthropic-request_full.snap
+++ b/crates/agentgateway/src/llm/tests/anthropic-request_full.snap
@@ -14,8 +14,12 @@ info:
       content: This is a recursive implementation of the Fibonacci sequence. It calculates the nth Fibonacci number by adding the previous two numbers.
       name: assistant_1
     - role: user
-      content: Can you optimize it for better performance?
-      name: user_2
+      content:
+        - type: text
+          text: "What's in this image?"
+        - type: image_url
+          image_url:
+            url: "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg"
   max_tokens: 1000
   temperature: 0.7
   top_p: 0.9
@@ -86,15 +90,6 @@ info:
         {
           "type": "text",
           "text": "This is a recursive implementation of the Fibonacci sequence. It calculates the nth Fibonacci number by adding the previous two numbers."
-        }
-      ]
-    },
-    {
-      "role": "user",
-      "content": [
-        {
-          "type": "text",
-          "text": "Can you optimize it for better performance?"
         }
       ]
     }

--- a/crates/agentgateway/src/llm/tests/bedrock-request_full.snap
+++ b/crates/agentgateway/src/llm/tests/bedrock-request_full.snap
@@ -14,8 +14,12 @@ info:
       content: This is a recursive implementation of the Fibonacci sequence. It calculates the nth Fibonacci number by adding the previous two numbers.
       name: assistant_1
     - role: user
-      content: Can you optimize it for better performance?
-      name: user_2
+      content:
+        - type: text
+          text: "What's in this image?"
+        - type: image_url
+          image_url:
+            url: "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg"
   max_tokens: 1000
   temperature: 0.7
   top_p: 0.9
@@ -85,14 +89,6 @@ info:
       "content": [
         {
           "text": "This is a recursive implementation of the Fibonacci sequence. It calculates the nth Fibonacci number by adding the previous two numbers."
-        }
-      ]
-    },
-    {
-      "role": "user",
-      "content": [
-        {
-          "text": "Can you optimize it for better performance?"
         }
       ]
     }

--- a/crates/agentgateway/src/llm/tests/request_anthropic_basic.json
+++ b/crates/agentgateway/src/llm/tests/request_anthropic_basic.json
@@ -1,0 +1,7 @@
+{
+  "model": "claude-sonnet-4-20250514",
+  "max_tokens": 1024,
+  "messages": [
+    {"role": "user", "content": "Hello, world"}
+  ]
+}

--- a/crates/agentgateway/src/llm/tests/request_anthropic_tools.json
+++ b/crates/agentgateway/src/llm/tests/request_anthropic_tools.json
@@ -1,0 +1,28 @@
+{
+  "model": "claude-opus-4-1-20250805",
+  "max_tokens": 1024,
+  "tools": [
+    {
+      "name": "get_weather",
+      "description": "Get the current weather in a given location",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "location": {
+            "type": "string",
+            "description": "The city and state, e.g. San Francisco, CA"
+          }
+        },
+        "required": [
+          "location"
+        ]
+      }
+    }
+  ],
+  "messages": [
+    {
+      "role": "user",
+      "content": "What is the weather like in San Francisco?"
+    }
+  ]
+}

--- a/crates/agentgateway/src/llm/tests/request_full.json
+++ b/crates/agentgateway/src/llm/tests/request_full.json
@@ -18,8 +18,15 @@
     },
     {
       "role": "user",
-      "content": "Can you optimize it for better performance?",
-      "name": "user_2"
+      "content": [
+        { "type": "text", "text": "What's in this image?" },
+        {
+          "type": "image_url",
+          "image_url": {
+            "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg"
+          }
+        }
+      ]
     }
   ],
   "max_tokens": 1000,

--- a/crates/agentgateway/src/llm/universal.rs
+++ b/crates/agentgateway/src/llm/universal.rs
@@ -3,13 +3,17 @@
 
 use std::collections::HashMap;
 
+use crate::llm;
+use crate::llm::bedrock::Provider;
+use crate::llm::{AIError, LLMRequest, LLMResponse};
+use agent_core::strng;
+use agent_core::strng::Strng;
 #[allow(deprecated)]
 #[allow(deprecated_in_future)]
 pub use async_openai::types::ChatCompletionFunctions;
 use async_openai::types::{
 	ChatChoiceLogprobs, ChatCompletionMessageToolCall, ChatCompletionMessageToolCallChunk,
 	ChatCompletionResponseMessageAudio, CompletionUsage, FunctionCallStream, ServiceTierResponse,
-	Stop,
 };
 pub use async_openai::types::{
 	ChatCompletionAudio, ChatCompletionFunctionCall,
@@ -27,13 +31,335 @@ pub use async_openai::types::{
 	ChatCompletionRequestToolMessageContent as RequestToolMessageContent,
 	ChatCompletionRequestUserMessage as RequestUserMessage,
 	ChatCompletionRequestUserMessageContent as RequestUserMessageContent,
-	ChatCompletionStreamOptions as StreamOptions, ChatCompletionTool,
+	ChatCompletionStreamOptions as StreamOptions, ChatCompletionTool, ChatCompletionTool as Tool,
 	ChatCompletionToolChoiceOption as ToolChoiceOption, ChatCompletionToolChoiceOption,
 	ChatCompletionToolType as ToolType, CompletionUsage as Usage, CreateChatCompletionRequest,
-	FinishReason, FunctionCall, PredictionContent, ReasoningEffort, ResponseFormat, Role,
-	ServiceTier, WebSearchOptions,
+	FinishReason, FunctionCall, FunctionName, FunctionObject, PredictionContent, ReasoningEffort,
+	ResponseFormat, Role, ServiceTier, Stop, WebSearchOptions,
 };
 use serde::{Deserialize, Serialize};
+
+pub trait ResponseType: Send + Sync {
+	fn to_llm_response(&self, include_completion_in_log: bool) -> LLMResponse;
+	fn to_webhook_choices(&self) -> Vec<crate::llm::policy::webhook::ResponseChoice>;
+	fn set_webhook_choices(
+		&mut self,
+		resp: Vec<crate::llm::policy::webhook::ResponseChoice>,
+	) -> anyhow::Result<()>;
+	fn serialize(&self) -> serde_json::Result<Vec<u8>>;
+}
+pub trait RequestType: Send + Sync {
+	fn model(&mut self) -> Option<&mut String>;
+	fn prepend_prompts(&mut self, prompts: Vec<llm::SimpleChatCompletionMessage>);
+	fn to_llm_request(&self, provider: Strng, tokenize: bool) -> Result<LLMRequest, AIError>;
+	fn get_messages(&self) -> Vec<llm::SimpleChatCompletionMessage>;
+	fn set_messages(&mut self, messages: Vec<llm::SimpleChatCompletionMessage>);
+
+	fn to_openai(&self) -> Result<Vec<u8>, AIError> {
+		Err(AIError::UnsupportedConversion(strng::literal!("openai")))
+	}
+
+	fn to_anthropic(&self) -> Result<Vec<u8>, AIError> {
+		Err(AIError::UnsupportedConversion(strng::literal!("anthropic")))
+	}
+
+	fn to_bedrock(&self, _provider: &Provider) -> Result<Vec<u8>, AIError> {
+		Err(AIError::UnsupportedConversion(strng::literal!("bedrock")))
+	}
+}
+
+pub mod passthrough {
+	use crate::{json, llm};
+
+	use crate::llm::bedrock::Provider;
+	use crate::llm::policy::webhook::{Message, ResponseChoice};
+	use crate::llm::universal::ResponseType;
+	use crate::llm::{
+		AIError, InputFormat, LLMRequest, LLMRequestParams, LLMResponse, SimpleChatCompletionMessage,
+		anthropic, universal,
+	};
+	use agent_core::strng;
+	use agent_core::strng::Strng;
+	use bytes::Bytes;
+	use itertools::Itertools;
+	use serde::{Deserialize, Serialize};
+
+	pub fn process_response(
+		bytes: &Bytes,
+		input_format: InputFormat,
+	) -> Result<Box<dyn ResponseType>, AIError> {
+		match input_format {
+			InputFormat::Completions => {
+				let resp = serde_json::from_slice::<universal::passthrough::Response>(bytes)
+					.map_err(AIError::ResponseParsing)?;
+
+				Ok(Box::new(resp))
+			},
+			InputFormat::Messages => {
+				let resp =
+					serde_json::from_slice::<universal::Response>(bytes).map_err(AIError::ResponseParsing)?;
+				let anthropic = anthropic::translate_anthropic_response(resp);
+				let passthrough = json::convert::<_, anthropic::passthrough::Response>(&anthropic)
+					.map_err(AIError::ResponseParsing)?;
+				Ok(Box::new(passthrough))
+			},
+		}
+	}
+
+	#[derive(Clone, Debug, Serialize, Deserialize)]
+	pub struct Request {
+		pub messages: Vec<RequestMessage>,
+		#[serde(skip_serializing_if = "Option::is_none")]
+		pub model: Option<String>,
+
+		#[serde(skip_serializing_if = "Option::is_none")]
+		pub top_p: Option<f32>,
+		#[serde(skip_serializing_if = "Option::is_none")]
+		pub temperature: Option<f32>,
+		#[serde(skip_serializing_if = "Option::is_none")]
+		pub stream: Option<bool>,
+		#[serde(skip_serializing_if = "Option::is_none")]
+		pub frequency_penalty: Option<f32>,
+		#[serde(skip_serializing_if = "Option::is_none")]
+		pub presence_penalty: Option<f32>,
+		#[serde(skip_serializing_if = "Option::is_none")]
+		pub seed: Option<i64>,
+		#[serde(skip_serializing_if = "Option::is_none")]
+		pub stream_options: Option<StreamOptions>,
+
+		#[serde(skip_serializing_if = "Option::is_none")]
+		pub max_tokens: Option<u32>,
+		#[serde(skip_serializing_if = "Option::is_none")]
+		pub max_completion_tokens: Option<u32>,
+
+		#[serde(flatten, default)]
+		pub rest: serde_json::Value,
+	}
+
+	/// Options for streaming response. Only set this when you set `stream: true`.
+	#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq)]
+	pub struct StreamOptions {
+		/// If set, an additional chunk will be streamed before the `data: [DONE]` message. The `usage` field on this chunk shows the token usage statistics for the entire request, and the `choices` field will always be an empty array. All other chunks will also include a `usage` field, but with a null value.
+		pub include_usage: bool,
+	}
+
+	#[derive(Debug, Deserialize, Clone, Serialize)]
+	pub struct Response {
+		pub model: String,
+		pub usage: Option<Usage>,
+		/// A list of chat completion choices. Can be more than one if `n` is greater than 1.
+		pub choices: Vec<Choice>,
+		#[serde(flatten, default)]
+		pub rest: serde_json::Value,
+	}
+
+	#[derive(Debug, Deserialize, Clone, Serialize)]
+	pub struct Choice {
+		pub message: ResponseMessage,
+		#[serde(flatten, default)]
+		pub rest: serde_json::Value,
+	}
+
+	#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+	pub struct ResponseMessage {
+		#[serde(skip_serializing_if = "Option::is_none")]
+		pub content: Option<String>,
+		#[serde(skip_serializing_if = "Option::is_none")]
+		pub role: Option<String>,
+		#[serde(flatten, default)]
+		pub rest: serde_json::Value,
+	}
+	#[derive(Debug, Deserialize, Clone, Serialize)]
+	pub struct Usage {
+		/// Number of tokens in the prompt.
+		pub prompt_tokens: u32,
+		/// Number of tokens in the generated completion.
+		pub completion_tokens: u32,
+		/// Total number of tokens used in the request (prompt + completion).
+		pub total_tokens: u32,
+		#[serde(flatten, default)]
+		pub rest: serde_json::Value,
+	}
+
+	impl super::ResponseType for Response {
+		fn to_llm_response(&self, include_completion_in_log: bool) -> LLMResponse {
+			LLMResponse {
+				input_tokens: self.usage.as_ref().map(|u| u.prompt_tokens as u64),
+				output_tokens: self.usage.as_ref().map(|u| u.completion_tokens as u64),
+				total_tokens: self.usage.as_ref().map(|u| u.total_tokens as u64),
+				provider_model: Some(strng::new(&self.model)),
+				completion: if include_completion_in_log {
+					Some(
+						self
+							.choices
+							.iter()
+							.flat_map(|c| c.message.content.clone())
+							.collect_vec(),
+					)
+				} else {
+					None
+				},
+				first_token: Default::default(),
+			}
+		}
+
+		fn set_webhook_choices(&mut self, choices: Vec<ResponseChoice>) -> anyhow::Result<()> {
+			if self.choices.len() != choices.len() {
+				anyhow::bail!("webhook response message count mismatch");
+			}
+			for (m, wh) in self.choices.iter_mut().zip(choices.into_iter()) {
+				m.message.content = Some(wh.message.content.to_string());
+			}
+			Ok(())
+		}
+
+		fn to_webhook_choices(&self) -> Vec<ResponseChoice> {
+			self
+				.choices
+				.iter()
+				.map(|c| {
+					let role = c.message.role.clone().unwrap_or_default().into();
+					let content = c.message.content.clone().unwrap_or_default().into();
+					ResponseChoice {
+						message: Message { role, content },
+					}
+				})
+				.collect()
+		}
+
+		fn serialize(&self) -> serde_json::Result<Vec<u8>> {
+			serde_json::to_vec(&self)
+		}
+	}
+
+	impl super::RequestType for Request {
+		fn model(&mut self) -> Option<&mut String> {
+			self.model.as_mut()
+		}
+		fn prepend_prompts(&mut self, prompts: Vec<llm::SimpleChatCompletionMessage>) {
+			self
+				.messages
+				.splice(..0, prompts.into_iter().map(convert_message));
+		}
+
+		fn to_anthropic(&self) -> Result<Vec<u8>, AIError> {
+			let typed = json::convert::<_, universal::Request>(self).map_err(AIError::RequestMarshal)?;
+			let xlated = anthropic::translate_request(typed);
+			serde_json::to_vec(&xlated).map_err(AIError::RequestMarshal)
+		}
+
+		fn to_bedrock(&self, provider: &Provider) -> Result<Vec<u8>, AIError> {
+			let typed = json::convert::<_, universal::Request>(self).map_err(AIError::RequestMarshal)?;
+			let xlated = llm::bedrock::translate_request(typed, provider);
+			serde_json::to_vec(&xlated).map_err(AIError::RequestMarshal)
+		}
+
+		fn to_openai(&self) -> Result<Vec<u8>, AIError> {
+			serde_json::to_vec(&self).map_err(AIError::RequestMarshal)
+		}
+
+		fn to_llm_request(&self, provider: Strng, tokenize: bool) -> Result<LLMRequest, AIError> {
+			let model = strng::new(self.model.as_deref().unwrap_or_default());
+			let input_tokens = if tokenize {
+				let tokens = crate::llm::num_tokens_from_messages(&model, &self.messages)?;
+				Some(tokens)
+			} else {
+				None
+			};
+			// Pass the original body through
+			let llm = LLMRequest {
+				input_tokens,
+				input_format: InputFormat::Completions,
+				request_model: model,
+				provider,
+				streaming: self.stream.unwrap_or_default(),
+				params: LLMRequestParams {
+					temperature: self.temperature.map(Into::into),
+					top_p: self.top_p.map(Into::into),
+					frequency_penalty: self.frequency_penalty.map(Into::into),
+					presence_penalty: self.presence_penalty.map(Into::into),
+					seed: self.seed,
+					max_tokens: self
+						.max_completion_tokens
+						.or(self.max_tokens)
+						.map(Into::into),
+				},
+			};
+			Ok(llm)
+		}
+
+		fn get_messages(&self) -> Vec<SimpleChatCompletionMessage> {
+			self
+				.messages
+				.iter()
+				.map(|m| {
+					let content = m
+						.content
+						.as_ref()
+						.and_then(|c| match c {
+							Content::Text(t) => Some(strng::new(t)),
+							// TODO?
+							Content::Array(_) => None,
+						})
+						.unwrap_or_default();
+					SimpleChatCompletionMessage {
+						role: strng::new(&m.role),
+						content,
+					}
+				})
+				.collect()
+		}
+
+		fn set_messages(&mut self, messages: Vec<llm::SimpleChatCompletionMessage>) {
+			self.messages = messages.into_iter().map(convert_message).collect();
+		}
+	}
+
+	fn convert_message(r: SimpleChatCompletionMessage) -> RequestMessage {
+		RequestMessage {
+			role: r.role.to_string(),
+			content: Some(Content::Text(r.content.to_string())),
+			name: None,
+			rest: Default::default(),
+		}
+	}
+	#[derive(Clone, Debug, Serialize, Deserialize)]
+	pub struct RequestMessage {
+		pub role: String,
+		#[serde(skip_serializing_if = "Option::is_none")]
+		pub name: Option<String>,
+		#[serde(skip_serializing_if = "Option::is_none")]
+		pub content: Option<Content>,
+		#[serde(flatten, default)]
+		pub rest: serde_json::Value,
+	}
+
+	impl RequestMessage {
+		pub fn message_text(&self) -> Option<&str> {
+			self.content.as_ref().and_then(|c| match c {
+				Content::Text(t) => Some(t.as_str()),
+				// TODO?
+				Content::Array(_) => None,
+			})
+		}
+	}
+
+	#[derive(Clone, Debug, Serialize, Deserialize)]
+	#[serde(untagged)]
+	pub enum Content {
+		Text(String),
+		Array(Vec<ContentPart>),
+	}
+
+	#[derive(Clone, Debug, Serialize, Deserialize)]
+	pub struct ContentPart {
+		pub r#type: String,
+		#[serde(skip_serializing_if = "Option::is_none")]
+		pub text: Option<String>,
+		#[serde(flatten, default)]
+		pub rest: serde_json::Value,
+	}
+}
 
 /// Represents a chat completion response returned by model, based on the provided input.
 #[derive(Debug, Deserialize, Clone, PartialEq, Serialize)]
@@ -377,6 +703,20 @@ pub struct Request {
 	#[allow(deprecated_in_future)]
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub functions: Option<Vec<ChatCompletionFunctions>>,
+
+	/// Agentgateway: vendor specific fields we allow only for internal creation
+	#[serde(flatten, skip_deserializing)]
+	pub vendor_extensions: RequestVendorExtensions,
+}
+
+#[derive(Clone, Debug, Serialize, Default)]
+pub struct RequestVendorExtensions {
+	/// Anthropic
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub top_k: Option<usize>,
+	/// Anthropic
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub thinking_budget_tokens: Option<u64>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/crates/agentgateway/src/llm/vertex.rs
+++ b/crates/agentgateway/src/llm/vertex.rs
@@ -24,8 +24,8 @@ impl super::Provider for Provider {
 impl Provider {
 	pub async fn process_request(
 		&self,
-		mut req: universal::Request,
-	) -> Result<universal::Request, AIError> {
+		mut req: universal::passthrough::Request,
+	) -> Result<universal::passthrough::Request, AIError> {
 		if let Some(provider_model) = &self.model {
 			req.model = Some(provider_model.to_string());
 		} else if req.model.is_none() {
@@ -34,12 +34,15 @@ impl Provider {
 		// Gemini compat mode is the same!
 		Ok(req)
 	}
-	pub async fn process_response(&self, bytes: &Bytes) -> Result<universal::Response, AIError> {
-		let resp =
-			serde_json::from_slice::<universal::Response>(bytes).map_err(AIError::ResponseParsing)?;
+	pub fn process_response(
+		&self,
+		bytes: &Bytes,
+	) -> Result<universal::passthrough::Response, AIError> {
+		let resp = serde_json::from_slice::<universal::passthrough::Response>(bytes)
+			.map_err(AIError::ResponseParsing)?;
 		Ok(resp)
 	}
-	pub async fn process_error(
+	pub fn process_error(
 		&self,
 		bytes: &Bytes,
 	) -> Result<universal::ChatCompletionErrorResponse, AIError> {

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -1035,21 +1035,10 @@ fn resolve_simple_reference(
 
 fn convert_message(
 	m: &proto::agent::policy_spec::ai::Message,
-) -> crate::llm::universal::RequestMessage {
-	match m.role.as_str() {
-		"system" => crate::llm::universal::RequestSystemMessage::from(m.content.clone()).into(),
-		"assistant" => crate::llm::universal::RequestAssistantMessage::from(m.content.clone()).into(),
-		"function" => crate::llm::universal::RequestFunctionMessage {
-			content: Some(m.content.clone()),
-			name: "".to_string(),
-		}
-		.into(),
-		"tool" => crate::llm::universal::RequestToolMessage {
-			content: crate::llm::universal::RequestToolMessageContent::from(m.content.clone()),
-			tool_call_id: "".to_string(),
-		}
-		.into(),
-		_ => crate::llm::universal::RequestUserMessage::from(m.content.clone()).into(),
+) -> crate::llm::SimpleChatCompletionMessage {
+	llm::SimpleChatCompletionMessage {
+		role: strng::new(&m.role),
+		content: strng::new(&m.content),
 	}
 }
 

--- a/schema/README.md
+++ b/schema/README.md
@@ -205,11 +205,11 @@ This folder contains JSON schemas for various parts of the project
 |`binds[].listeners[].routes[].policies.ai.overrides`||
 |`binds[].listeners[].routes[].policies.ai.prompts`||
 |`binds[].listeners[].routes[].policies.ai.prompts.append`||
-|`binds[].listeners[].routes[].policies.ai.prompts.append.role`||
-|`binds[].listeners[].routes[].policies.ai.prompts.append.content`||
+|`binds[].listeners[].routes[].policies.ai.prompts.append[].role`||
+|`binds[].listeners[].routes[].policies.ai.prompts.append[].content`||
 |`binds[].listeners[].routes[].policies.ai.prompts.prepend`||
-|`binds[].listeners[].routes[].policies.ai.prompts.prepend.role`||
-|`binds[].listeners[].routes[].policies.ai.prompts.prepend.content`||
+|`binds[].listeners[].routes[].policies.ai.prompts.prepend[].role`||
+|`binds[].listeners[].routes[].policies.ai.prompts.prepend[].content`||
 |`binds[].listeners[].routes[].policies.ai.modelAliases`||
 |`binds[].listeners[].routes[].policies.backendTLS`|Send TLS to the backend.|
 |`binds[].listeners[].routes[].policies.backendTLS.cert`||
@@ -442,11 +442,11 @@ This folder contains JSON schemas for various parts of the project
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)overrides`||
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)prompts`||
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)prompts.append`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)prompts.append.role`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)prompts.append.content`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)prompts.append[].role`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)prompts.append[].content`||
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)prompts.prepend`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)prompts.prepend.role`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)prompts.prepend.content`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)prompts.prepend[].role`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)prompts.prepend[].content`||
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)modelAliases`||
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)groups`||
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers`||
@@ -551,11 +551,11 @@ This folder contains JSON schemas for various parts of the project
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].overrides`||
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].prompts`||
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].prompts.append`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].prompts.append.role`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].prompts.append.content`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].prompts.append[].role`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].prompts.append[].content`||
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].prompts.prepend`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].prompts.prepend.role`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].prompts.prepend.content`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].prompts.prepend[].role`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].prompts.prepend[].content`||
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].modelAliases`||
 |`binds[].listeners[].routes[].backends[].weight`||
 |`binds[].listeners[].tcpRoutes`||
@@ -699,11 +699,11 @@ This folder contains JSON schemas for various parts of the project
 |`policies[].policy.ai.overrides`||
 |`policies[].policy.ai.prompts`||
 |`policies[].policy.ai.prompts.append`||
-|`policies[].policy.ai.prompts.append.role`||
-|`policies[].policy.ai.prompts.append.content`||
+|`policies[].policy.ai.prompts.append[].role`||
+|`policies[].policy.ai.prompts.append[].content`||
 |`policies[].policy.ai.prompts.prepend`||
-|`policies[].policy.ai.prompts.prepend.role`||
-|`policies[].policy.ai.prompts.prepend.content`||
+|`policies[].policy.ai.prompts.prepend[].role`||
+|`policies[].policy.ai.prompts.prepend[].content`||
 |`policies[].policy.ai.modelAliases`||
 |`policies[].policy.backendTLS`|Send TLS to the backend.|
 |`policies[].policy.backendTLS.cert`||

--- a/schema/local.json
+++ b/schema/local.json
@@ -1762,39 +1762,48 @@
                                 ],
                                 "properties": {
                                   "append": {
-                                    "type": "object",
-                                    "properties": {
-                                      "role": {
-                                        "type": "string"
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "role": {
+                                          "type": "string"
+                                        },
+                                        "content": {
+                                          "type": "string"
+                                        }
                                       },
-                                      "content": {
-                                        "type": "string"
-                                      }
-                                    },
-                                    "additionalProperties": false,
-                                    "required": [
-                                      "role",
-                                      "content"
-                                    ]
+                                      "additionalProperties": false,
+                                      "required": [
+                                        "role",
+                                        "content"
+                                      ]
+                                    }
                                   },
                                   "prepend": {
-                                    "type": "object",
-                                    "properties": {
-                                      "role": {
-                                        "type": "string"
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "role": {
+                                          "type": "string"
+                                        },
+                                        "content": {
+                                          "type": "string"
+                                        }
                                       },
-                                      "content": {
-                                        "type": "string"
-                                      }
-                                    },
-                                    "additionalProperties": false,
-                                    "required": [
-                                      "role",
-                                      "content"
-                                    ]
+                                      "additionalProperties": false,
+                                      "required": [
+                                        "role",
+                                        "content"
+                                      ]
+                                    }
                                   }
                                 },
-                                "additionalProperties": false
+                                "additionalProperties": false,
+                                "required": [
+                                  "prepend"
+                                ]
                               },
                               "modelAliases": {
                                 "type": "object",
@@ -3122,7 +3131,8 @@
                                                         "null"
                                                       ]
                                                     }
-                                                  }
+                                                  },
+                                                  "additionalProperties": false
                                                 }
                                               },
                                               "required": [
@@ -3967,39 +3977,48 @@
                                           ],
                                           "properties": {
                                             "append": {
-                                              "type": "object",
-                                              "properties": {
-                                                "role": {
-                                                  "type": "string"
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "role": {
+                                                    "type": "string"
+                                                  },
+                                                  "content": {
+                                                    "type": "string"
+                                                  }
                                                 },
-                                                "content": {
-                                                  "type": "string"
-                                                }
-                                              },
-                                              "additionalProperties": false,
-                                              "required": [
-                                                "role",
-                                                "content"
-                                              ]
+                                                "additionalProperties": false,
+                                                "required": [
+                                                  "role",
+                                                  "content"
+                                                ]
+                                              }
                                             },
                                             "prepend": {
-                                              "type": "object",
-                                              "properties": {
-                                                "role": {
-                                                  "type": "string"
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "role": {
+                                                    "type": "string"
+                                                  },
+                                                  "content": {
+                                                    "type": "string"
+                                                  }
                                                 },
-                                                "content": {
-                                                  "type": "string"
-                                                }
-                                              },
-                                              "additionalProperties": false,
-                                              "required": [
-                                                "role",
-                                                "content"
-                                              ]
+                                                "additionalProperties": false,
+                                                "required": [
+                                                  "role",
+                                                  "content"
+                                                ]
+                                              }
                                             }
                                           },
-                                          "additionalProperties": false
+                                          "additionalProperties": false,
+                                          "required": [
+                                            "prepend"
+                                          ]
                                         },
                                         "modelAliases": {
                                           "type": "object",
@@ -4117,7 +4136,8 @@
                                                                     "null"
                                                                   ]
                                                                 }
-                                                              }
+                                                              },
+                                                              "additionalProperties": false
                                                             }
                                                           },
                                                           "required": [
@@ -4962,39 +4982,48 @@
                                                       ],
                                                       "properties": {
                                                         "append": {
-                                                          "type": "object",
-                                                          "properties": {
-                                                            "role": {
-                                                              "type": "string"
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "role": {
+                                                                "type": "string"
+                                                              },
+                                                              "content": {
+                                                                "type": "string"
+                                                              }
                                                             },
-                                                            "content": {
-                                                              "type": "string"
-                                                            }
-                                                          },
-                                                          "additionalProperties": false,
-                                                          "required": [
-                                                            "role",
-                                                            "content"
-                                                          ]
+                                                            "additionalProperties": false,
+                                                            "required": [
+                                                              "role",
+                                                              "content"
+                                                            ]
+                                                          }
                                                         },
                                                         "prepend": {
-                                                          "type": "object",
-                                                          "properties": {
-                                                            "role": {
-                                                              "type": "string"
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "role": {
+                                                                "type": "string"
+                                                              },
+                                                              "content": {
+                                                                "type": "string"
+                                                              }
                                                             },
-                                                            "content": {
-                                                              "type": "string"
-                                                            }
-                                                          },
-                                                          "additionalProperties": false,
-                                                          "required": [
-                                                            "role",
-                                                            "content"
-                                                          ]
+                                                            "additionalProperties": false,
+                                                            "required": [
+                                                              "role",
+                                                              "content"
+                                                            ]
+                                                          }
                                                         }
                                                       },
-                                                      "additionalProperties": false
+                                                      "additionalProperties": false,
+                                                      "required": [
+                                                        "prepend"
+                                                      ]
                                                     },
                                                     "modelAliases": {
                                                       "type": "object",
@@ -6350,39 +6379,48 @@
                     ],
                     "properties": {
                       "append": {
-                        "type": "object",
-                        "properties": {
-                          "role": {
-                            "type": "string"
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "role": {
+                              "type": "string"
+                            },
+                            "content": {
+                              "type": "string"
+                            }
                           },
-                          "content": {
-                            "type": "string"
-                          }
-                        },
-                        "additionalProperties": false,
-                        "required": [
-                          "role",
-                          "content"
-                        ]
+                          "additionalProperties": false,
+                          "required": [
+                            "role",
+                            "content"
+                          ]
+                        }
                       },
                       "prepend": {
-                        "type": "object",
-                        "properties": {
-                          "role": {
-                            "type": "string"
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "role": {
+                              "type": "string"
+                            },
+                            "content": {
+                              "type": "string"
+                            }
                           },
-                          "content": {
-                            "type": "string"
-                          }
-                        },
-                        "additionalProperties": false,
-                        "required": [
-                          "role",
-                          "content"
-                        ]
+                          "additionalProperties": false,
+                          "required": [
+                            "role",
+                            "content"
+                          ]
+                        }
                       }
                     },
-                    "additionalProperties": false
+                    "additionalProperties": false,
+                    "required": [
+                      "prepend"
+                    ]
                   },
                   "modelAliases": {
                     "type": "object",


### PR DESCRIPTION
Hacking on https://github.com/agentgateway/agentgateway/pull/434

This introduces a new approach. 

For each input type (Anthropic and OpenAI), we have a minimum struct that has just the fields we need to access to implement a shared interface. This is basically extracting the params, and the text-based requests (for guardrails), the model, etc. The rest of the content is passed through via
```
		#[serde(flatten, default)]
		pub rest: serde_json::Value,
```

For each type we convert **to**, we will need the fully typed struct as well. However, this only needs to include fields we set, not every field (though its fine if it has more fields). 

For same-in-same-out, we directly send this 'passhrough' type (`passthrough input -> Bytes`). For conversion, we translate from `passthrough Input -> typed Input -> typed Output -> Bytes`.

On the response side, we have the same 'passthrough types', with the same logic of whether we convert or not. So for conversion it would be `typed provider Response -> typed requested Response -> passthrough requested Response`. Note we could skip the conversion to `passthrough` but then we need to implement ResponseType for 4 type instead of 2 (which is not a big deal, just not doing it right now). 

For streaming, similar concept. On non-conversion we just use `json_passthrough` instead of `json_transform`.

End result:
* OpenAI --> OpenAI has 100% compatibility with the upstream provider, even if they have provider-specific fields we do not know about
* Anthropic --> Anthropic has 100% compatibility with all Anthropic fields, including streaming.
* Any conversion between types still only allows fields we are aware of.
* We no longer _have_ to include every single field in the API. If we do not convert into the field, its not needed. this means we do not need to play constant catchup for every single provider field (except for conversion cases, of course)
* Claude code works (with anthropic backend)

Currently not implemented:
* Anthropic input to OpenAI output (input part is done, the response mapping is not)
* All bedrock (no blocker, just didn't get to it)