### PR TITLE
chore: add binary for Intel Macs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -263,6 +263,9 @@ jobs:
           - os: macos-latest
             target: aarch64-apple-darwin
             features: default
+          - os: macos-15-intel
+            target: amd64-apple-darwin
+            features: default
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             features: default
@@ -327,6 +330,8 @@ jobs:
         mkdir outputs
         mv release-binary-macos-latest/agentgateway outputs/agentgateway-darwin-arm64
         sha256sum outputs/agentgateway-darwin-arm64 > outputs/agentgateway-darwin-arm64.sha256
+        mv release-binary-macos-latest/agentgateway outputs/agentgateway-darwin-amd64
+        sha256sum outputs/agentgateway-darwin-amd64 > outputs/agentgateway-darwin-amd64.sha256
         mv release-binary-ubuntu-latest/agentgateway outputs/agentgateway-linux-amd64
         sha256sum outputs/agentgateway-linux-amd64 > outputs/agentgateway-linux-amd64.sha256
         mv release-binary-ubuntu-22.04-arm/agentgateway outputs/agentgateway-linux-arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -264,7 +264,7 @@ jobs:
             target: aarch64-apple-darwin
             features: default
           - os: macos-15-intel
-            target: amd64-apple-darwin
+            target: x86_64-apple-darwin
             features: default
           - os: windows-latest
             target: x86_64-pc-windows-msvc
@@ -330,7 +330,7 @@ jobs:
         mkdir outputs
         mv release-binary-macos-latest/agentgateway outputs/agentgateway-darwin-arm64
         sha256sum outputs/agentgateway-darwin-arm64 > outputs/agentgateway-darwin-arm64.sha256
-        mv release-binary-macos-latest/agentgateway outputs/agentgateway-darwin-amd64
+        mv release-binary-macos-15-intel/agentgateway outputs/agentgateway-darwin-amd64
         sha256sum outputs/agentgateway-darwin-amd64 > outputs/agentgateway-darwin-amd64.sha256
         mv release-binary-ubuntu-latest/agentgateway outputs/agentgateway-linux-amd64
         sha256sum outputs/agentgateway-linux-amd64 > outputs/agentgateway-linux-amd64.sha256


### PR DESCRIPTION
This PR adds the following changes: 
* an additional OS in the build matrix for Intel Macs: `macos-15-intel`; 
* an additional target for Rust on Intel Macs: `x86_64-apple-darwin`;
* and adds a file containing the `SHA256` for the built binary for Intel Macs.

Merging should close #307

cc: @howardjohn 
