### PR TITLE
Unblocking the gateway from xDS handlers

### DIFF
--- a/crates/xds/src/client.rs
+++ b/crates/xds/src/client.rs
@@ -702,6 +702,11 @@ impl AdsClient {
 			),
 		};
 
+		if let Some(block_ready) = self.block_ready.as_mut() {
+			info!("unblocking gateway");
+			_ = block_ready.send(());
+		}
+
 		send
 			.send(DeltaDiscoveryRequest {
 				type_url,              // this is owned, OK to move


### PR DESCRIPTION
A fix for [Issue 478](https://github.com/agentgateway/agentgateway/issues/478)

It looks like the ultimate problem is that we the proxy is stuck at [line 79](https://github.com/agentgateway/agentgateway/blob/main/crates/agentgateway/src/app.rs#L79) waiting for a notification from StateManager.

While this unblocks the proxy, I am not sure if this is the right place to put.

