### PR TITLE
Gateway policies and ext_proc enhancements

### DIFF
--- a/crates/agentgateway/src/client/mod.rs
+++ b/crates/agentgateway/src/client/mod.rs
@@ -6,6 +6,7 @@ use std::task;
 
 use ::http::Uri;
 use ::http::uri::{Authority, Scheme};
+use async_trait::async_trait;
 use azure_core::error::ResultExt;
 use azure_core::http::BufResponse;
 use futures::TryStreamExt;
@@ -23,7 +24,6 @@ use crate::transport::stream::{LoggingMode, Socket};
 use crate::transport::{hbone, stream};
 use crate::types::agent::Target;
 use crate::*;
-use async_trait::async_trait;
 
 #[derive(Clone)]
 pub struct Client {

--- a/crates/agentgateway/src/control/mod.rs
+++ b/crates/agentgateway/src/control/mod.rs
@@ -4,11 +4,6 @@ use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::Arc;
 
-use crate::client::Transport;
-use crate::http::HeaderValue;
-use crate::http::backendtls::{BackendTLS, SYSTEM_TRUST};
-use crate::types::agent::Target;
-use crate::*;
 use ::http::Uri;
 use ::http::uri::Authority;
 use agent_xds::ClientTrait;
@@ -17,6 +12,12 @@ use rustls::ClientConfig;
 use secrecy::{ExposeSecret, SecretString};
 use tonic::body::Body;
 use tower::Service;
+
+use crate::client::Transport;
+use crate::http::HeaderValue;
+use crate::http::backendtls::{BackendTLS, SYSTEM_TRUST};
+use crate::types::agent::Target;
+use crate::*;
 
 pub mod caclient;
 

--- a/crates/agentgateway/src/http/auth.rs
+++ b/crates/agentgateway/src/http/auth.rs
@@ -344,15 +344,15 @@ mod aws {
 }
 
 mod azure {
-	use crate::{
-		client,
-		http::auth::{AzureAuth, AzureAuthCredentialSource, AzureUserAssignedIdentity},
-	};
+	use std::sync::Arc;
+
 	use azure_core::credentials::TokenCredential;
 	use azure_identity::UserAssignedId;
 	use secrecy::ExposeSecret;
-	use std::sync::Arc;
 	use tracing::trace;
+
+	use crate::client;
+	use crate::http::auth::{AzureAuth, AzureAuthCredentialSource, AzureUserAssignedIdentity};
 
 	const SCOPES: &[&str] = &["https://cognitiveservices.azure.com/.default"];
 	fn token_credential_from_auth(

--- a/crates/agentgateway/src/http/csrf.rs
+++ b/crates/agentgateway/src/http/csrf.rs
@@ -1,5 +1,6 @@
-use ::http::{Method, StatusCode, header};
 use std::collections::HashSet;
+
+use ::http::{Method, StatusCode, header};
 
 use crate::http::{PolicyResponse, Request, filters};
 use crate::*;

--- a/crates/agentgateway/src/http/ext_proc.rs
+++ b/crates/agentgateway/src/http/ext_proc.rs
@@ -1,5 +1,7 @@
 use std::convert::Infallible;
+use std::sync::atomic::{AtomicBool, Ordering};
 
+use ::http::HeaderMap;
 use anyhow::anyhow;
 use bytes::Bytes;
 use http_body::{Body, Frame};
@@ -13,14 +15,34 @@ use tokio_stream::StreamExt;
 use tokio_stream::wrappers::ReceiverStream;
 
 use crate::http::ext_proc::proto::{
-	BodyMutation, BodyResponse, HeadersResponse, HttpBody, HttpHeaders, HttpTrailers,
-	ProcessingRequest, ProcessingResponse,
+	BodyMutation, BodyResponse, HeaderMutation, HeadersResponse, HttpBody, HttpHeaders, HttpTrailers,
+	ImmediateResponse, ProcessingRequest, ProcessingResponse, processing_response,
 };
-use crate::http::{HeaderName, HeaderValue};
+use crate::http::{HeaderName, HeaderValue, PolicyResponse};
 use crate::proxy::ProxyError;
 use crate::proxy::httpproxy::PolicyClient;
 use crate::types::agent::SimpleBackendReference;
 use crate::*;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+	#[error("failed to send request")]
+	RequestSend,
+	#[error("no more response messages")]
+	NoMoreResponses,
+	#[error("no more responses")]
+	ResponseDropped,
+	#[error("failed to buffer body: {0}")]
+	BodyBuffer(String),
+	#[error(transparent)]
+	InvalidHeaderName(#[from] http::header::InvalidHeaderName),
+	#[error(transparent)]
+	InvalidHeaderValue(#[from] http::header::InvalidHeaderValue),
+}
+
+#[cfg(test)]
+#[path = "ext_proc_tests.rs"]
+mod tests;
 
 #[allow(warnings)]
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -28,8 +50,8 @@ pub mod proto {
 	tonic::include_proto!("envoy.service.ext_proc.v3");
 }
 
-#[derive(Default, Debug, Copy, Clone, PartialEq, Eq, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
+#[apply(schema!)]
+#[derive(Default, Copy, PartialEq, Eq)]
 pub enum FailureMode {
 	#[default]
 	FailClosed,
@@ -45,13 +67,17 @@ pub struct InferenceRouting {
 
 #[derive(Debug, Default)]
 pub struct InferencePoolRouter {
-	ext_proc: Option<ExtProc>,
+	ext_proc: Option<ExtProcInstance>,
 }
 
 impl InferenceRouting {
 	pub fn build(&self, client: PolicyClient) -> InferencePoolRouter {
 		InferencePoolRouter {
-			ext_proc: Some(ExtProc::new(client, self.target.clone(), self.failure_mode)),
+			ext_proc: Some(ExtProcInstance::new(
+				client,
+				self.target.clone(),
+				self.failure_mode,
+			)),
 		}
 	}
 }
@@ -60,16 +86,13 @@ impl InferencePoolRouter {
 	pub async fn mutate_request(
 		&mut self,
 		req: &mut http::Request,
-	) -> Result<Option<SocketAddr>, ProxyError> {
+	) -> Result<(Option<SocketAddr>, PolicyResponse), ProxyError> {
 		let Some(ext_proc) = &mut self.ext_proc else {
-			return Ok(None);
+			return Ok((None, Default::default()));
 		};
 		let r = std::mem::take(req);
-		*req = ext_proc
-			.mutate_request(r)
-			.await
-			.context("ext_proc request call")
-			.map_err(ProxyError::Processing)?;
+		let (new_req, pr) = ext_proc.mutate_request(r).await?;
+		*req = new_req;
 		let dest = req
 			.headers()
 			.get(HeaderName::from_static("x-gateway-destination-endpoint"))
@@ -77,43 +100,96 @@ impl InferencePoolRouter {
 			.map(|v| v.parse::<SocketAddr>())
 			.transpose()
 			.map_err(|e| ProxyError::Processing(anyhow!("EPP returned invalid address: {e}")))?;
-		Ok(dest)
+		Ok((dest, pr.unwrap_or_default()))
 	}
 
-	pub async fn mutate_response(&mut self, resp: &mut http::Response) -> Result<(), ProxyError> {
+	pub async fn mutate_response(
+		&mut self,
+		resp: &mut http::Response,
+	) -> Result<PolicyResponse, ProxyError> {
 		let Some(ext_proc) = &mut self.ext_proc else {
-			return Ok(());
+			return Ok(Default::default());
 		};
 		let r = std::mem::take(resp);
-		*resp = ext_proc
-			.mutate_response(r)
-			.await
-			.context("ext_proc response call")
-			.map_err(ProxyError::Processing)?;
-		Ok(())
+		let (new_resp, pr) = ext_proc.mutate_response(r).await?;
+		*resp = new_resp;
+		Ok(pr.unwrap_or_default())
+	}
+}
+
+#[apply(schema_ser!)]
+pub struct ExtProc {
+	pub target: Arc<SimpleBackendReference>,
+	#[serde(default)]
+	pub failure_mode: FailureMode,
+}
+
+impl ExtProc {
+	pub fn build(&self, client: PolicyClient) -> ExtProcRequest {
+		ExtProcRequest {
+			ext_proc: Some(ExtProcInstance::new(
+				client,
+				self.target.clone(),
+				self.failure_mode,
+			)),
+		}
+	}
+}
+
+#[derive(Debug)]
+pub struct ExtProcRequest {
+	ext_proc: Option<ExtProcInstance>,
+}
+
+impl ExtProcRequest {
+	pub async fn mutate_request(
+		&mut self,
+		req: &mut http::Request,
+	) -> Result<PolicyResponse, ProxyError> {
+		let Some(ext_proc) = &mut self.ext_proc else {
+			return Ok(PolicyResponse::default());
+		};
+		let r = std::mem::take(req);
+		let (new_req, pr) = ext_proc.mutate_request(r).await?;
+		*req = new_req;
+		Ok(pr.unwrap_or_default())
+	}
+
+	pub async fn mutate_response(
+		&mut self,
+		resp: &mut http::Response,
+	) -> Result<PolicyResponse, ProxyError> {
+		let Some(ext_proc) = &mut self.ext_proc else {
+			return Ok(PolicyResponse::default());
+		};
+		let r = std::mem::take(resp);
+		let (new_resp, pr) = ext_proc.mutate_response(r).await?;
+		*resp = new_resp;
+		Ok(pr.unwrap_or_default())
 	}
 }
 
 // Very experimental support for ext_proc
 #[derive(Debug)]
-pub struct ExtProc {
+struct ExtProcInstance {
 	failure_mode: FailureMode,
-	skipped: bool,
+	skipped: Arc<AtomicBool>,
 	tx_req: Sender<ProcessingRequest>,
-	rx_resp: Receiver<ProcessingResponse>,
+	rx_resp_for_request: Option<Receiver<ProcessingResponse>>,
+	rx_resp_for_response: Option<Receiver<ProcessingResponse>>,
 }
 
-impl ExtProc {
-	pub fn new(
+impl ExtProcInstance {
+	fn new(
 		client: PolicyClient,
 		target: Arc<SimpleBackendReference>,
 		failure_mode: FailureMode,
-	) -> ExtProc {
+	) -> ExtProcInstance {
 		trace!("connecting to {:?}", target);
 		let chan = GrpcReferenceChannel { target, client };
 		let mut c = proto::external_processor_client::ExternalProcessorClient::new(chan);
 		let (tx_req, rx_req) = tokio::sync::mpsc::channel(10);
-		let (tx_resp, rx_resp) = tokio::sync::mpsc::channel(10);
+		let (tx_resp, mut rx_resp) = tokio::sync::mpsc::channel(10);
 		let req_stream = tokio_stream::wrappers::ReceiverStream::new(rx_req);
 		tokio::task::spawn(async move {
 			// Spawn a task to handle processing requests.
@@ -128,42 +204,63 @@ impl ExtProc {
 			trace!("initial stream established");
 			let mut responses = responses.into_inner();
 			while let Ok(Some(item)) = responses.message().await {
-				trace!("received response item");
+				trace!("received response item {item:?}");
 				let _ = tx_resp.send(item).await;
 			}
 		});
+		let (tx_resp_for_request, rx_resp_for_request) = tokio::sync::mpsc::channel(1);
+		let (tx_resp_for_response, rx_resp_for_response) = tokio::sync::mpsc::channel(1);
+		tokio::task::spawn(async move {
+			while let Some(item) = rx_resp.recv().await {
+				trace!("received response item {item:?}");
+				match &item.response {
+					Some(processing_response::Response::ResponseBody(_))
+					| Some(processing_response::Response::ResponseHeaders(_))
+					| Some(processing_response::Response::ResponseTrailers(_)) => {
+						let _ = tx_resp_for_response.send(item).await;
+					},
+					Some(processing_response::Response::RequestBody(_))
+					| Some(processing_response::Response::RequestHeaders(_))
+					| Some(processing_response::Response::RequestTrailers(_)) => {
+						let _ = tx_resp_for_request.send(item).await;
+					},
+					Some(processing_response::Response::ImmediateResponse(_)) => {
+						// In this case we aren't sure which is going to handle things...
+						// Send to both
+						let _ = tx_resp_for_request.send(item.clone()).await;
+						let _ = tx_resp_for_response.send(item).await;
+					},
+					None => {},
+				}
+			}
+		});
 		Self {
-			skipped: false,
+			skipped: Default::default(),
 			failure_mode,
 			tx_req,
-			rx_resp,
+			rx_resp_for_request: Some(rx_resp_for_request),
+			rx_resp_for_response: Some(rx_resp_for_response),
 		}
 	}
 
-	async fn recv(&mut self) -> anyhow::Result<ProcessingResponse> {
-		self
-			.rx_resp
-			.recv()
-			.await
-			.ok_or(anyhow::anyhow!("no more response messages"))
+	async fn send_request(&mut self, req: ProcessingRequest) -> Result<(), Error> {
+		self.tx_req.send(req).await.map_err(|_| Error::RequestSend)
 	}
 
-	async fn send_request(&mut self, req: ProcessingRequest) -> anyhow::Result<()> {
-		if let Err(e) = self.tx_req.send(req).await {
-			anyhow::bail!("failed to send ext_proc request: {e}");
-		};
-		Ok(())
-	}
-
-	pub async fn mutate_request(&mut self, req: http::Request) -> anyhow::Result<http::Request> {
-		let headers = to_header_map(req.headers());
+	pub async fn mutate_request(
+		&mut self,
+		req: http::Request,
+	) -> Result<(http::Request, Option<PolicyResponse>), Error> {
+		let headers = req_to_header_map(&req);
 		let buffer = http::buffer_limit(&req);
 		let (parts, body) = req.into_parts();
 
 		// For fail open we need a copy of the body. There is definitely a better way to do this, but for
 		// now its good enough?
 		let (body_copy, body) = if self.failure_mode == FailureMode::FailOpen {
-			let buffered = http::read_body_with_limit(body, buffer).await?;
+			let buffered = http::read_body_with_limit(body, buffer)
+				.await
+				.map_err(|e| Error::BodyBuffer(e.to_string()))?;
 			(Some(buffered.clone()), http::Body::from(buffered))
 		} else {
 			(None, body)
@@ -189,6 +286,7 @@ impl ExtProc {
 				while let Some(Ok(frame)) = stream.next().await {
 					let preq = if frame.is_data() {
 						let frame = frame.into_data().expect("already checked");
+						trace!("sending request body chunk...",);
 						processing_request(Request::RequestBody(HttpBody {
 							body: frame.into(),
 							end_of_stream: false,
@@ -218,45 +316,92 @@ impl ExtProc {
 			});
 		}
 		// Now we need to build the new body. This is going to be streamed in from the ext_proc server.
-		let (mut tx_chunk, rx_chunk) = tokio::sync::mpsc::channel(1);
+		let (tx_chunk, rx_chunk) = tokio::sync::mpsc::channel(1);
+
 		let body = http_body_util::StreamBody::new(ReceiverStream::new(rx_chunk));
 		let mut req = http::Request::from_parts(parts, http::Body::new(body));
-		loop {
-			// Loop through all the ext_proc responses and process them
-			let resp = match self.recv().await {
-				Ok(r) => r,
-				Err(e) => {
-					if self.failure_mode == FailureMode::FailOpen {
-						self.skipped = true;
+		req.headers_mut().remove(http::header::CONTENT_LENGTH);
+		let (tx_done, rx_done) = tokio::sync::oneshot::channel();
+		let mut rx = self
+			.rx_resp_for_request
+			.take()
+			.expect("mutate_request called twice");
+		let failure_mode = self.failure_mode;
+		let skipped = self.skipped.clone();
+		tokio::task::spawn(async move {
+			let mut req = Some(req);
+			let mut tx_done = Some(tx_done);
+			let mut tx_chunkh = Some(tx_chunk);
+			loop {
+				// Loop through all the ext_proc responses and process them
+				let Some(presp) = rx.recv().await else {
+					trace!("done receiving request");
+					if failure_mode == FailureMode::FailOpen
+						&& let Some(req) = req.take()
+						&& let Some(tx_done) = tx_done.take()
+					{
+						trace!("fail open triggered");
+						skipped.store(true, Ordering::SeqCst);
 						let (parts, _) = req.into_parts();
-						return Ok(http::Request::from_parts(
-							parts,
-							http::Body::from(body_copy.unwrap()),
-						));
-					} else {
-						return Err(e);
+						let new_req = http::Request::from_parts(parts, http::Body::from(body_copy.unwrap()));
+						let _ = tx_done.send(Ok((new_req, None)));
+						tx_chunkh.take();
 					}
-				},
-			};
-			if handle_response_for_request_mutation(had_body, &mut req, &mut tx_chunk, resp).await? {
-				trace!("request complete!");
-				return Ok(req);
+					return;
+				};
+				if let Some(resp) = to_immediate_response(&presp) {
+					trace!("got immediate response in request handler");
+					let _ = tx_done
+						.take()
+						.unwrap()
+						.send(Ok((http::Request::default(), Some(resp))));
+					tx_chunkh.take();
+					return;
+				}
+				let Some(tx_chunk) = tx_chunkh.as_mut() else {
+					return;
+				};
+				let r = handle_response_for_request_mutation(had_body, req.as_mut(), tx_chunk, presp).await;
+				match r {
+					Ok((headers_done, eos)) => {
+						if headers_done
+							&& let Some(req) = req.take()
+							&& let Some(tx_done) = tx_done.take()
+						{
+							trace!("request complete!");
+							let _ = tx_done.send(Ok((req, None)));
+						}
+						if eos || !had_body {
+							trace!("request EOS!");
+							tx_chunkh.take();
+						}
+					},
+					Err(e) => {
+						warn!("error {e:?}");
+						return;
+					},
+				}
 			}
-		}
+		});
+		rx_done.await.map_err(|_| Error::ResponseDropped)?
 	}
-
-	pub async fn mutate_response(&mut self, req: http::Response) -> anyhow::Result<http::Response> {
-		if self.skipped {
-			return Ok(req);
+	pub async fn mutate_response(
+		&mut self,
+		req: http::Response,
+	) -> Result<(http::Response, Option<PolicyResponse>), Error> {
+		if self.skipped.load(Ordering::SeqCst) {
+			return Ok((req, None));
 		}
-		let headers = to_header_map(req.headers());
+		let headers = resp_to_header_map(&req);
 		let (parts, body) = req.into_parts();
 
+		let end_of_stream = body.is_end_stream();
 		let preq = processing_request(Request::ResponseHeaders(HttpHeaders {
 			headers,
 			attributes: Default::default(),
-			end_of_stream: false,
+			end_of_stream,
 		}));
+		let had_body = !end_of_stream;
 
 		// Send the request headers to ext_proc.
 		self.send_request(preq).await?;
@@ -264,63 +409,149 @@ impl ExtProc {
 		// We will spin off a task that is going to pipe the body to the ext_proc server as we read it.
 		let tx = self.tx_req.clone();
 
+		if had_body {
+			tokio::task::spawn(async move {
+				let mut stream = BodyStream::new(body);
+				while let Some(Ok(frame)) = stream.next().await {
+					let preq = if frame.is_data() {
+						let frame = frame.into_data().expect("already checked");
+						processing_request(Request::ResponseBody(HttpBody {
+							body: frame.into(),
+							end_of_stream: false,
+						}))
+					} else if frame.is_trailers() {
+						let frame = frame.into_trailers().expect("already checked");
+						processing_request(Request::ResponseTrailers(HttpTrailers {
+							trailers: to_header_map(&frame),
+						}))
+					} else {
+						panic!("unknown type")
+					};
+					trace!("sending response body chunk...");
+					let Ok(()) = tx.send(preq).await else {
+						// TODO: on error here we need a way to signal to the outer task to fail fast
+						return;
+					};
+				}
+				// Now that the body is done, send end of stream
+				let preq = processing_request(Request::ResponseBody(HttpBody {
+					body: Default::default(),
+					end_of_stream: true,
+				}));
+				let _ = tx.send(preq).await;
+				trace!("body response done");
+			});
+		}
+		// Now we need to build the new body. This is going to be streamed in from the ext_proc server.
+		let (tx_chunk, rx_chunk) = tokio::sync::mpsc::channel(1);
+		let body = http_body_util::StreamBody::new(ReceiverStream::new(rx_chunk));
+		let mut resp = http::Response::from_parts(parts, http::Body::new(body));
+		resp.headers_mut().remove(http::header::CONTENT_LENGTH);
+		let (tx_done, rx_done) = tokio::sync::oneshot::channel();
+		let mut rx = self
+			.rx_resp_for_response
+			.take()
+			.expect("mutate_request called twice");
 		tokio::task::spawn(async move {
-			let mut stream = BodyStream::new(body);
-			while let Some(Ok(frame)) = stream.next().await {
-				let preq = if frame.is_data() {
-					let frame = frame.into_data().expect("already checked");
-					processing_request(Request::ResponseBody(HttpBody {
-						body: frame.into(),
-						end_of_stream: false,
-					}))
-				} else if frame.is_trailers() {
-					let frame = frame.into_trailers().expect("already checked");
-					processing_request(Request::ResponseTrailers(HttpTrailers {
-						trailers: to_header_map(&frame),
-					}))
-				} else {
-					panic!("unknown type")
-				};
-				trace!("sending response body chunk...");
-				let Ok(()) = tx.send(preq).await else {
-					// TODO: on error here we need a way to signal to the outer task to fail fast
+			let mut resp = Some(resp);
+			let mut tx_done = Some(tx_done);
+			let mut tx_chunkh = Some(tx_chunk);
+			loop {
+				// Loop through all the ext_proc responses and process them
+				let Some(presp) = rx.recv().await else {
+					trace!("done receiving response");
 					return;
 				};
+				if let Some(resp) = to_immediate_response(&presp) {
+					trace!("got immediate response in response handler");
+					let _ = tx_done
+						.take()
+						.unwrap()
+						.send(Ok((http::Response::default(), Some(resp))));
+					tx_chunkh.take();
+					return;
+				}
+				let Some(tx_chunk) = tx_chunkh.as_mut() else {
+					trace!("body done, skipping");
+					return;
+				};
+				let r =
+					handle_response_for_response_mutation(had_body, resp.as_mut(), tx_chunk, presp).await;
+				match r {
+					Ok((headers_done, eos)) => {
+						if headers_done
+							&& let Some(resp) = resp.take()
+							&& let Some(tx_done) = tx_done.take()
+						{
+							trace!("response complete!");
+							let _ = tx_done.send(Ok((resp, None)));
+						}
+						if eos || !had_body {
+							trace!("response EOS!");
+							tx_chunkh.take();
+						}
+					},
+					Err(e) => {
+						warn!("error {e:?}");
+						return;
+						// return tx_done.take().expect("must be called once").send(Err(e));
+					},
+				}
 			}
-			// Now that the body is done, send end of stream
-			let preq = processing_request(Request::ResponseBody(HttpBody {
-				body: Default::default(),
-				end_of_stream: true,
-			}));
-			let _ = tx.send(preq).await;
-			trace!("body response done");
 		});
-		// Now we need to build the new body. This is going to be streamed in from the ext_proc server.
-		let (mut tx_chunk, rx_chunk) = tokio::sync::mpsc::channel(1);
-		let body = http_body_util::StreamBody::new(ReceiverStream::new(rx_chunk));
-		let mut req = http::Response::from_parts(parts, http::Body::new(body));
-		loop {
-			// Loop through all the ext_proc responses and process them
-			let resp = self.recv().await?;
-			if handle_response_for_response_mutation(&mut req, &mut tx_chunk, resp).await? {
-				trace!("response complete!");
-				return Ok(req);
+		rx_done.await.map_err(|_| Error::ResponseDropped)?
+	}
+}
+
+fn to_immediate_response(rp: &ProcessingResponse) -> Option<PolicyResponse> {
+	match &rp.response {
+		Some(Response::ImmediateResponse(ir)) => {
+			let ImmediateResponse {
+				status,
+				headers,
+				body,
+				grpc_status: _,
+				details: _,
+			} = ir;
+			let mut rb =
+				::http::response::Builder::new().status(status.map(|s| s.code).unwrap_or(200) as u16);
+
+			if let Some(hm) = rb.headers_mut() {
+				let _ = apply_header_mutations(hm, headers.as_ref());
 			}
-		}
+			let resp = rb
+				.body(http::Body::from(body.to_string()))
+				.map_err(|e| ProxyError::Processing(e.into()))
+				.unwrap();
+			Some(crate::http::PolicyResponse {
+				direct_response: Some(resp),
+				response_headers: None,
+			})
+		},
+		_ => None,
 	}
 }
 
 // handle_response_for_request_mutation handles a single ext_proc response. If it returns 'true' we are done processing.
 async fn handle_response_for_request_mutation(
 	had_body: bool,
-	req: &mut http::Request,
+	req: Option<&mut http::Request>,
 	body_tx: &mut Sender<Result<Frame<Bytes>, Infallible>>,
 	presp: ProcessingResponse,
-) -> anyhow::Result<bool> {
+) -> Result<(bool, bool), Error> {
+	let res = matches!(presp.response, Some(Response::RequestHeaders(_)));
 	let cr = match presp.response {
+		Some(Response::RequestHeaders(HeadersResponse { response: None })) => {
+			trace!("no headers");
+			return Ok((res, false));
+		},
 		Some(Response::RequestHeaders(HeadersResponse { response: Some(cr) })) => {
 			trace!("got request headers back");
 			cr
+		},
+		Some(Response::RequestBody(BodyResponse { response: None })) => {
+			trace!("got empty request body back");
+			return Ok((res, true));
 		},
 		Some(Response::RequestBody(BodyResponse { response: Some(cr) })) => {
 			trace!("got request body back");
@@ -328,39 +559,22 @@ async fn handle_response_for_request_mutation(
 		},
 		msg => {
 			// In theory, there can trailers too. EPP never sends them
-			warn!("ignoring {msg:?}");
-			return Ok(false);
+			warn!("ignoring response during request {msg:?}");
+			return Ok((res, false));
 		},
 	};
-	if let Some(h) = cr.header_mutation {
-		for rm in &h.remove_headers {
-			req.headers_mut().remove(rm);
-		}
-		for set in h.set_headers {
-			let Some(h) = set.header else {
-				continue;
-			};
-			let hk = HeaderName::try_from(h.key)?;
-			if hk == http::header::CONTENT_LENGTH {
-				debug!("skipping invalid content-length");
-				// The EPP actually sets content-length to an invalid value, so don't respect it.
-				// https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/943
-				continue;
-			}
-			req
-				.headers_mut()
-				.insert(hk, HeaderValue::from_bytes(h.raw_value.as_slice())?);
-		}
+	if let Some(req) = req {
+		apply_header_mutations(req.headers_mut(), cr.header_mutation.as_ref())?;
 	}
-	req.headers_mut().remove(http::header::CONTENT_LENGTH);
 	if let Some(BodyMutation { mutation: Some(b) }) = cr.body_mutation {
 		match b {
 			Mutation::StreamedResponse(bb) => {
 				let eos = bb.end_of_stream;
 				let by = bytes::Bytes::from(bb.body);
 				let _ = body_tx.send(Ok(Frame::data(by.clone()))).await;
+
 				trace!(eos, "got stream request body");
-				return Ok(eos);
+				return Ok((res, eos));
 			},
 			Mutation::Body(_) => {
 				warn!("Body() not valid for streaming mode, skipping...");
@@ -371,55 +585,73 @@ async fn handle_response_for_request_mutation(
 		}
 	} else if !had_body {
 		trace!("got headers back and do not expect body; we are done");
-		return Ok(true);
+		return Ok((res, true));
 	}
 	trace!("still waiting for response...");
-	Ok(false)
+	Ok((res, false))
 }
 
-// handle_response_for_response_mutation handles a single ext_proc response. If it returns 'true' we are done processing.
-async fn handle_response_for_response_mutation(
-	req: &mut http::Response,
-	body_tx: &mut Sender<Result<Frame<Bytes>, Infallible>>,
-	presp: ProcessingResponse,
-) -> anyhow::Result<bool> {
-	let cr = match presp.response {
-		Some(Response::ResponseHeaders(HeadersResponse { response: Some(cr) })) => cr,
-		Some(Response::ResponseBody(BodyResponse { response: Some(cr) })) => cr,
-		msg => {
-			// In theory, there can trailers too. EPP never sends them
-			warn!("ignoring {msg:?}");
-			return Ok(false);
-		},
-	};
-	if let Some(h) = cr.header_mutation {
+fn apply_header_mutations(
+	headers: &mut HeaderMap,
+	h: Option<&HeaderMutation>,
+) -> Result<(), Error> {
+	if let Some(h) = h {
 		for rm in &h.remove_headers {
-			req.headers_mut().remove(rm);
+			headers.remove(rm);
 		}
-		for set in h.set_headers {
-			let Some(h) = set.header else {
+		for set in &h.set_headers {
+			let Some(h) = &set.header else {
 				continue;
 			};
-			let hk = HeaderName::try_from(h.key)?;
+			let hk = HeaderName::try_from(h.key.as_str())?;
 			if hk == http::header::CONTENT_LENGTH {
 				debug!("skipping invalid content-length");
 				// The EPP actually sets content-length to an invalid value, so don't respect it.
 				// https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/943
 				continue;
 			}
-			req
-				.headers_mut()
-				.insert(hk, HeaderValue::from_bytes(h.raw_value.as_slice())?);
+			headers.insert(hk, HeaderValue::from_bytes(h.raw_value.as_slice())?);
 		}
 	}
-	req.headers_mut().remove(http::header::CONTENT_LENGTH);
+	Ok(())
+}
+
+// handle_response_for_response_mutation handles a single ext_proc response. If it returns 'true' we are done processing.
+async fn handle_response_for_response_mutation(
+	had_body: bool,
+	resp: Option<&mut http::Response>,
+	body_tx: &mut Sender<Result<Frame<Bytes>, Infallible>>,
+	presp: ProcessingResponse,
+) -> Result<(bool, bool), Error> {
+	let res = matches!(presp.response, Some(Response::ResponseHeaders(_)));
+	let cr = match presp.response {
+		Some(Response::ResponseHeaders(HeadersResponse { response: None })) => {
+			trace!("no headers");
+			return Ok((res, false));
+		},
+		Some(Response::ResponseHeaders(HeadersResponse { response: Some(cr) })) => cr,
+		Some(Response::ResponseBody(BodyResponse { response: Some(cr) })) => cr,
+		Some(Response::ResponseBody(BodyResponse { response: None })) => {
+			trace!("got empty response body back");
+			return Ok((res, true));
+		},
+		msg => {
+			// In theory, there can trailers too. EPP never sends them
+			warn!("ignoring {msg:?}");
+			return Ok((res, false));
+		},
+	};
+	if let Some(resp) = resp {
+		apply_header_mutations(resp.headers_mut(), cr.header_mutation.as_ref())?;
+	}
 	if let Some(BodyMutation { mutation: Some(b) }) = cr.body_mutation {
 		match b {
 			Mutation::StreamedResponse(bb) => {
 				let eos = bb.end_of_stream;
 				let by = bytes::Bytes::from(bb.body);
 				let _ = body_tx.send(Ok(Frame::data(by.clone()))).await;
-				return Ok(eos);
+				trace!(%eos, "got body chunk");
+				return Ok((res, eos));
 			},
 			Mutation::Body(_) => {
 				warn!("Body() not valid for streaming mode, skipping...");
@@ -428,18 +660,50 @@ async fn handle_response_for_response_mutation(
 				warn!("ClearBody() not valid for streaming mode, skipping...");
 			},
 		}
+	} else if !had_body {
+		trace!("got headers back and do not expect body; we are done");
+		return Ok((res, true));
 	}
-	trace!("still waiting for response...");
-	Ok(false)
+	trace!("still waiting for response for response...");
+	Ok((res, false))
+}
+
+fn req_to_header_map(req: &http::Request) -> Option<proto::HeaderMap> {
+	to_header_map_extra(
+		req.headers(),
+		&[
+			(":path", req.uri().path()),
+			(":method", req.method().as_str()),
+			(":scheme", req.uri().scheme_str().unwrap_or("http")),
+			(
+				":authority",
+				req.uri().authority().map(|a| a.as_str()).unwrap_or(""),
+			),
+		],
+	)
+}
+
+fn resp_to_header_map(res: &http::Response) -> Option<proto::HeaderMap> {
+	to_header_map_extra(res.headers(), &[(":status", res.status().as_str())])
 }
 
 fn to_header_map(headers: &http::HeaderMap) -> Option<proto::HeaderMap> {
+	to_header_map_extra(headers, &[])
+}
+fn to_header_map_extra(
+	headers: &http::HeaderMap,
+	extra: &[(&str, &str)],
+) -> Option<proto::HeaderMap> {
 	let h = headers
 		.iter()
 		.map(|(k, v)| proto::HeaderValue {
 			key: k.to_string(),
 			raw_value: v.as_bytes().to_vec(),
 		})
+		.chain(extra.iter().map(|(k, v)| proto::HeaderValue {
+			key: k.to_string(),
+			raw_value: v.as_bytes().to_vec(),
+		}))
 		.collect_vec();
 	Some(proto::HeaderMap { headers: h })
 }

--- a/crates/agentgateway/src/http/ext_proc_tests.rs
+++ b/crates/agentgateway/src/http/ext_proc_tests.rs
@@ -1,0 +1,416 @@
+use ::http::Method;
+use hyper_util::client::legacy::Client;
+use tokio::sync::mpsc;
+use tokio::sync::mpsc::Sender;
+use tonic::Status;
+use wiremock::MockServer;
+
+use crate::http::ext_proc::proto;
+use crate::http::ext_proc::proto::{
+	BodyMutation, CommonResponse, HeaderMutation, HeaderValue, HeaderValueOption, HttpHeaders,
+	ProcessingResponse, body_mutation,
+};
+use crate::http::{Body, ext_proc};
+use crate::test_helpers::extprocmock::{
+	ExtProcMock, ExtProcMockInstance, Handler, immediate_response, request_body_response,
+	request_header_response, response_body_response,
+};
+use crate::test_helpers::proxymock::*;
+use crate::types::agent::{Policy, PolicyTarget, SimpleBackendReference, TargetedPolicy};
+use crate::*;
+
+#[tokio::test]
+async fn nop_ext_proc() {
+	let mock = body_mock(b"").await;
+	let (_mock, _ext_proc, _bind, io) = setup_ext_proc_mock(
+		mock,
+		ext_proc::FailureMode::FailClosed,
+		ExtProcMock::new(NopExtProc::default),
+		"{}",
+	)
+	.await;
+	let res = send_request(io, Method::POST, "http://lo").await;
+	assert_eq!(res.status(), 200);
+	let body = read_body_raw(res.into_body()).await;
+	assert_eq!(body.as_ref(), b"");
+}
+
+#[tokio::test]
+async fn nop_ext_proc_body() {
+	let mock = body_mock(b"original").await;
+	let (_mock, _ext_proc, _bind, io) = setup_ext_proc_mock(
+		mock,
+		ext_proc::FailureMode::FailClosed,
+		ExtProcMock::new(NopExtProc::default),
+		"{}",
+	)
+	.await;
+	let res = send_request_body(io, Method::GET, "http://lo", b"request").await;
+	assert_eq!(res.status(), 200);
+	let body = read_body_raw(res.into_body()).await;
+	// Server returns no body
+	assert_eq!(body.as_ref(), b"");
+}
+
+#[tokio::test]
+async fn body_based_router() {
+	let mock = simple_mock().await;
+	let (_mock, _ext_proc, _bind, io) = setup_ext_proc_mock(
+		mock,
+		ext_proc::FailureMode::FailClosed,
+		ExtProcMock::new(|| BBRExtProc::new(false)),
+		"{}",
+	)
+	.await;
+	let res = send_request_body(io, Method::POST, "http://lo", b"request").await;
+	assert_eq!(res.status(), 200);
+	let body = read_body(res.into_body()).await;
+	assert_eq!(
+		body
+			.headers
+			.get("x-gateway-model-name")
+			.unwrap()
+			.to_str()
+			.unwrap(),
+		"my-model-name"
+	);
+}
+
+#[tokio::test]
+async fn body_based_router_buffer_body() {
+	let mock = simple_mock().await;
+	let (_mock, _ext_proc, _bind, io) = setup_ext_proc_mock(
+		mock,
+		ext_proc::FailureMode::FailClosed,
+		ExtProcMock::new(|| BBRExtProc::new(true)),
+		"{}",
+	)
+	.await;
+	let res = send_request_body(io, Method::POST, "http://lo", b"request").await;
+	assert_eq!(res.status(), 200);
+	let body = read_body(res.into_body()).await;
+	assert_eq!(
+		body
+			.headers
+			.get("x-gateway-model-name")
+			.unwrap()
+			.to_str()
+			.unwrap(),
+		"my-model-name"
+	);
+}
+
+#[tokio::test]
+async fn immediate_response_request() {
+	let mock = simple_mock().await;
+	let (_mock, _ext_proc, _bind, io) = setup_ext_proc_mock(
+		mock,
+		ext_proc::FailureMode::FailClosed,
+		ExtProcMock::new(ImmediateResponseExtProc::default),
+		"{}",
+	)
+	.await;
+	let res = send_request_body(io, Method::POST, "http://lo", b"request").await;
+	assert_eq!(res.status(), 202);
+	let body = read_body_raw(res.into_body()).await;
+	assert_eq!(body.as_ref(), b"immediate");
+}
+
+#[tokio::test]
+async fn immediate_response_response() {
+	let mock = simple_mock().await;
+	let (_mock, _ext_proc, _bind, io) = setup_ext_proc_mock(
+		mock,
+		ext_proc::FailureMode::FailClosed,
+		ExtProcMock::new(ImmediateResponseExtProcResponse::default),
+		"{}",
+	)
+	.await;
+	let res = send_request_body(io, Method::POST, "http://lo", b"request").await;
+	assert_eq!(res.status(), 202);
+	let body = read_body_raw(res.into_body()).await;
+	assert_eq!(body.as_ref(), b"immediate");
+}
+
+#[tokio::test]
+async fn failure_fail_closed() {
+	let mock = simple_mock().await;
+	let (_mock, _ext_proc, _bind, io) = setup_ext_proc_mock(
+		mock,
+		ext_proc::FailureMode::FailClosed,
+		ExtProcMock::new(FailureExtProcResponse::default),
+		"{}",
+	)
+	.await;
+	let res = send_request_body(io, Method::POST, "http://lo", b"request").await;
+	assert_eq!(res.status(), 500);
+	let body = read_body_raw(res.into_body()).await;
+	assert_eq!(body.as_ref(), b"ext_proc failed: no more responses");
+}
+
+#[tokio::test]
+async fn failure_fail_open() {
+	let mock = simple_mock().await;
+	let (_mock, _ext_proc, _bind, io) = setup_ext_proc_mock(
+		mock,
+		ext_proc::FailureMode::FailOpen,
+		ExtProcMock::new(FailureExtProcResponse::default),
+		"{}",
+	)
+	.await;
+	let res = send_request_body(io, Method::POST, "http://lo", b"request").await;
+	assert_eq!(res.status(), 200);
+	let body = read_body(res.into_body()).await;
+	assert_eq!(body.body.as_ref(), b"request");
+}
+
+pub async fn setup_ext_proc_mock<T: Handler + Send + Sync + 'static>(
+	mock: MockServer,
+	failure_mode: ext_proc::FailureMode,
+	mock_ext_proc: ExtProcMock<T>,
+	config: &str,
+) -> (
+	MockServer,
+	ExtProcMockInstance,
+	TestBind,
+	Client<MemoryConnector, Body>,
+) {
+	let ext_proc = mock_ext_proc.spawn().await;
+
+	let t = setup_proxy_test(config)
+		.unwrap()
+		.with_backend(*mock.address())
+		.with_backend(ext_proc.address)
+		.with_bind(simple_bind(basic_route(*mock.address())))
+		.with_policy(TargetedPolicy {
+			name: strng::new("ext_proc"),
+			target: PolicyTarget::Route("route".into()),
+			policy: Policy::ExtProc(ext_proc::ExtProc {
+				target: Arc::new(SimpleBackendReference::Backend(
+					ext_proc.address.to_string().into(),
+				)),
+				failure_mode,
+			}),
+		});
+	let io = t.serve_http(strng::new("bind"));
+	(mock, ext_proc, t, io)
+}
+
+#[derive(Debug, Default)]
+struct NopExtProc {
+	sent_req_body: bool,
+	sent_resp_body: bool,
+}
+
+#[async_trait::async_trait]
+impl Handler for NopExtProc {
+	async fn handle_request_body(
+		&mut self,
+		_body: &proto::HttpBody,
+		sender: &mpsc::Sender<Result<ProcessingResponse, Status>>,
+	) -> Result<(), Status> {
+		if !self.sent_req_body {
+			let _ = sender.send(request_body_response(None)).await;
+		}
+		self.sent_req_body = true;
+		Ok(())
+	}
+
+	async fn handle_response_body(
+		&mut self,
+		_body: &proto::HttpBody,
+		sender: &mpsc::Sender<Result<ProcessingResponse, Status>>,
+	) -> Result<(), Status> {
+		if !self.sent_resp_body {
+			let _ = sender.send(response_body_response(None)).await;
+		}
+		self.sent_resp_body = true;
+		Ok(())
+	}
+}
+
+/// Simulate GIE body based router
+#[derive(Debug)]
+struct BBRExtProc {
+	req_body: Vec<u8>,
+	buffer_body: bool,
+	res_body: Vec<u8>,
+}
+
+impl BBRExtProc {
+	pub fn new(buffer_body: bool) -> Self {
+		Self {
+			buffer_body,
+			req_body: Default::default(),
+			res_body: Default::default(),
+		}
+	}
+}
+
+// https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/2a187ea174ed2fafd22e6aff8cb13e532dc7604e/pkg/bbr/handlers/server.go#L74
+#[async_trait::async_trait]
+impl Handler for BBRExtProc {
+	async fn handle_request_headers(
+		&mut self,
+		headers: &HttpHeaders,
+		sender: &Sender<Result<ProcessingResponse, Status>>,
+	) -> Result<(), Status> {
+		if headers.end_of_stream {
+			let _ = sender.send(request_header_response(None)).await;
+		}
+		Ok(())
+	}
+
+	async fn handle_request_body(
+		&mut self,
+		body: &proto::HttpBody,
+		sender: &mpsc::Sender<Result<ProcessingResponse, Status>>,
+	) -> Result<(), Status> {
+		self.req_body.extend_from_slice(&body.body);
+		if body.end_of_stream {
+			let _ = sender
+				.send(request_header_response(Some(CommonResponse {
+					header_mutation: Some(HeaderMutation {
+						set_headers: vec![HeaderValueOption {
+							header: Some(HeaderValue {
+								key: "X-Gateway-Model-Name".to_string(),
+								raw_value: b"my-model-name".to_vec(),
+							}),
+							append: None,
+						}],
+						remove_headers: vec![],
+					}),
+					..Default::default()
+				})))
+				.await;
+			let _ = sender
+				.send(request_body_response(Some(CommonResponse {
+					body_mutation: Some(BodyMutation {
+						mutation: Some(body_mutation::Mutation::StreamedResponse(
+							proto::StreamedBodyResponse {
+								body: self.req_body.clone(),
+								end_of_stream: true,
+							},
+						)),
+					}),
+					..Default::default()
+				})))
+				.await;
+		}
+		Ok(())
+	}
+
+	async fn handle_response_body(
+		&mut self,
+		body: &proto::HttpBody,
+		sender: &mpsc::Sender<Result<ProcessingResponse, Status>>,
+	) -> Result<(), Status> {
+		if self.buffer_body {
+			self.res_body.extend_from_slice(&body.body);
+			if body.end_of_stream {
+				let _ = sender
+					.send(response_body_response(Some(CommonResponse {
+						body_mutation: Some(BodyMutation {
+							mutation: Some(body_mutation::Mutation::StreamedResponse(
+								proto::StreamedBodyResponse {
+									body: self.res_body.clone(),
+									end_of_stream: true,
+								},
+							)),
+						}),
+						..Default::default()
+					})))
+					.await;
+			}
+		} else {
+			let _ = sender
+				.send(response_body_response(Some(CommonResponse {
+					body_mutation: Some(BodyMutation {
+						mutation: Some(body_mutation::Mutation::StreamedResponse(
+							proto::StreamedBodyResponse {
+								body: body.body.clone(),
+								end_of_stream: body.end_of_stream,
+							},
+						)),
+					}),
+					..Default::default()
+				})))
+				.await;
+		}
+		Ok(())
+	}
+}
+
+#[derive(Debug, Default)]
+struct ImmediateResponseExtProc {}
+
+#[async_trait::async_trait]
+impl Handler for ImmediateResponseExtProc {
+	async fn handle_request_headers(
+		&mut self,
+		_: &HttpHeaders,
+		sender: &mpsc::Sender<Result<ProcessingResponse, Status>>,
+	) -> Result<(), Status> {
+		let _ = sender
+			.send(immediate_response(proto::ImmediateResponse {
+				status: Some(proto::HttpStatus { code: 202 }),
+				body: "immediate".to_string(),
+				headers: None,
+				grpc_status: None,
+				details: "".to_string(),
+			}))
+			.await;
+		Ok(())
+	}
+}
+
+#[derive(Debug, Default)]
+struct ImmediateResponseExtProcResponse {
+	sent_req_body: bool,
+}
+
+#[async_trait::async_trait]
+impl Handler for ImmediateResponseExtProcResponse {
+	async fn handle_request_body(
+		&mut self,
+		_body: &proto::HttpBody,
+		sender: &mpsc::Sender<Result<ProcessingResponse, Status>>,
+	) -> Result<(), Status> {
+		if !self.sent_req_body {
+			let _ = sender.send(request_body_response(None)).await;
+		}
+		self.sent_req_body = true;
+		Ok(())
+	}
+
+	async fn handle_response_headers(
+		&mut self,
+		_headers: &HttpHeaders,
+		sender: &Sender<Result<ProcessingResponse, Status>>,
+	) -> Result<(), Status> {
+		let _ = sender
+			.send(immediate_response(proto::ImmediateResponse {
+				status: Some(proto::HttpStatus { code: 202 }),
+				body: "immediate".to_string(),
+				headers: None,
+				grpc_status: None,
+				details: "".to_string(),
+			}))
+			.await;
+		Ok(())
+	}
+}
+
+#[derive(Debug, Default)]
+struct FailureExtProcResponse {}
+
+#[async_trait::async_trait]
+impl Handler for FailureExtProcResponse {
+	async fn handle_request_headers(
+		&mut self,
+		_: &HttpHeaders,
+		_: &mpsc::Sender<Result<ProcessingResponse, Status>>,
+	) -> Result<(), Status> {
+		Err(Status::failed_precondition("injected test error"))
+	}
+}

--- a/crates/agentgateway/src/http/jwt_tests.rs
+++ b/crates/agentgateway/src/http/jwt_tests.rs
@@ -1,6 +1,7 @@
-use super::Provider;
 use itertools::Itertools;
 use serde_json::json;
+
+use super::Provider;
 
 #[test]
 pub fn test_azure_jwks() {

--- a/crates/agentgateway/src/http/mod.rs
+++ b/crates/agentgateway/src/http/mod.rs
@@ -34,8 +34,6 @@ use std::fmt::Debug;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use crate::proxy::{ProxyError, ProxyResponse};
-use crate::transport::BufferLimit;
 pub use ::http::uri::{Authority, Scheme};
 pub use ::http::{
 	HeaderMap, HeaderName, HeaderValue, Method, StatusCode, Uri, header, status, uri,
@@ -44,6 +42,9 @@ use bytes::Bytes;
 use http_body::{Frame, SizeHint};
 use tower_serve_static::private::mime;
 use url::Url;
+
+use crate::proxy::{ProxyError, ProxyResponse};
+use crate::transport::BufferLimit;
 
 pub mod x_headers {
 	use http::HeaderName;

--- a/crates/agentgateway/src/lib.rs
+++ b/crates/agentgateway/src/lib.rs
@@ -44,10 +44,11 @@ pub mod types;
 mod ui;
 pub mod util;
 
-use crate::control::{AuthSource, RootCert};
-use crate::telemetry::trc::Protocol;
 use control::caclient;
 use telemetry::{metrics, trc};
+
+use crate::control::{AuthSource, RootCert};
+use crate::telemetry::trc::Protocol;
 
 #[derive(serde::Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]

--- a/crates/agentgateway/src/llm/bedrock.rs
+++ b/crates/agentgateway/src/llm/bedrock.rs
@@ -465,9 +465,10 @@ pub(super) fn translate_stream(
 }
 
 pub(super) mod types {
+	use std::collections::HashMap;
+
 	use bytes::Bytes;
 	use serde::{Deserialize, Serialize};
-	use std::collections::HashMap;
 
 	#[derive(Copy, Clone, Deserialize, Serialize, Debug, Default)]
 	#[serde(rename_all = "camelCase")]

--- a/crates/agentgateway/src/llm/policy.rs
+++ b/crates/agentgateway/src/llm/policy.rs
@@ -511,7 +511,6 @@ fn default_body() -> Bytes {
 mod webhook {
 	use ::http::header::CONTENT_TYPE;
 	use ::http::{HeaderMap, HeaderValue, header};
-
 	use serde::{Deserialize, Serialize};
 
 	use crate::client::Client;

--- a/crates/agentgateway/src/llm/tests.rs
+++ b/crates/agentgateway/src/llm/tests.rs
@@ -1,10 +1,12 @@
-use super::*;
+use std::fs;
+use std::path::Path;
+
 use agent_core::strng;
 use http_body_util::BodyExt;
 use serde::de::DeserializeOwned;
 use serde_json::Value;
-use std::fs;
-use std::path::Path;
+
+use super::*;
 
 fn test_response<T: DeserializeOwned>(
 	test_name: &str,

--- a/crates/agentgateway/src/mcp/router.rs
+++ b/crates/agentgateway/src/mcp/router.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use agent_core::prelude::Strng;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
@@ -6,7 +8,6 @@ use http::Method;
 use itertools::Itertools;
 use prometheus_client::registry::Registry;
 use rmcp::transport::StreamableHttpServerConfig;
-use std::sync::Arc;
 use tracing::warn;
 
 use crate::cel::ContextBuilder;

--- a/crates/agentgateway/src/proxy/mod.rs
+++ b/crates/agentgateway/src/proxy/mod.rs
@@ -7,7 +7,7 @@ pub mod tcpproxy;
 pub use gateway::Gateway;
 use hyper_util_fork::client::legacy::Error as HyperError;
 
-use crate::http::{HeaderValue, Response, StatusCode};
+use crate::http::{HeaderValue, Response, StatusCode, ext_proc};
 use crate::types::agent::{Backend, BackendReference, SimpleBackend, SimpleBackendReference};
 use crate::*;
 
@@ -70,6 +70,8 @@ pub enum ProxyError {
 	RequestTimeout,
 	#[error("processing failed: {0}")]
 	Processing(anyhow::Error),
+	#[error("ext_proc failed: {0}")]
+	ExtProc(#[from] ext_proc::Error),
 	#[error("processing failed: {0}")]
 	ProcessingString(String),
 	#[error("rate limit exceeded")]
@@ -108,6 +110,7 @@ impl ProxyError {
 			ProxyError::BackendAuthenticationFailed(_) => StatusCode::INTERNAL_SERVER_ERROR,
 			ProxyError::InvalidBackendType => StatusCode::INTERNAL_SERVER_ERROR,
 			ProxyError::TransformationFailure => StatusCode::INTERNAL_SERVER_ERROR,
+			ProxyError::ExtProc(_) => StatusCode::INTERNAL_SERVER_ERROR,
 			ProxyError::CsrfValidationFailed => StatusCode::FORBIDDEN,
 
 			ProxyError::UpgradeFailed(_, _) => StatusCode::BAD_GATEWAY,

--- a/crates/agentgateway/src/proxy/tcpproxy.rs
+++ b/crates/agentgateway/src/proxy/tcpproxy.rs
@@ -1,6 +1,7 @@
-use rand::prelude::IndexedRandom;
 use std::net::SocketAddr;
 use std::sync::Arc;
+
+use rand::prelude::IndexedRandom;
 
 use crate::proxy::ProxyError;
 use crate::telemetry::log;

--- a/crates/agentgateway/src/state_manager.rs
+++ b/crates/agentgateway/src/state_manager.rs
@@ -186,11 +186,13 @@ impl LocalClient {
 		info!("loaded config from {:?}", self.cfg);
 
 		// Sync the state
-		let next_binds =
-			self
-				.stores
-				.binds
-				.sync_local(config.binds, config.policies, config.backends, prev.binds);
+		let next_binds = self.stores.binds.sync_local(
+			config.binds,
+			config.policies,
+			config.gateway_policies,
+			config.backends,
+			prev.binds,
+		);
 		let next_discovery =
 			self
 				.stores

--- a/crates/agentgateway/src/store/mod.rs
+++ b/crates/agentgateway/src/store/mod.rs
@@ -3,7 +3,8 @@ mod binds;
 use std::sync::Arc;
 
 pub use binds::{
-	BackendPolicies, LLMRequestPolicies, LLMResponsePolicies, RoutePolicies, Store as BindStore,
+	BackendPolicies, GatewayPolicies, LLMRequestPolicies, LLMResponsePolicies, RoutePolicies,
+	Store as BindStore,
 };
 use serde::{Serialize, Serializer};
 mod discovery;

--- a/crates/agentgateway/src/test_helpers/extprocmock.rs
+++ b/crates/agentgateway/src/test_helpers/extprocmock.rs
@@ -1,0 +1,233 @@
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use tokio_stream;
+use tonic::{Request, Response as TonicResponse, Status, Streaming};
+
+use crate::http::ext_proc::proto::external_processor_server::{
+	ExternalProcessor, ExternalProcessorServer,
+};
+use crate::http::ext_proc::proto::{
+	self, CommonResponse, HttpHeaders, HttpTrailers, ProcessingRequest, ProcessingResponse,
+	processing_request, processing_response,
+};
+use crate::*;
+
+pub fn request_header_response(cr: Option<CommonResponse>) -> Result<ProcessingResponse, Status> {
+	Ok(ProcessingResponse {
+		response: Some(processing_response::Response::RequestHeaders(
+			proto::HeadersResponse { response: cr },
+		)),
+		..Default::default()
+	})
+}
+
+pub fn request_body_response(cr: Option<CommonResponse>) -> Result<ProcessingResponse, Status> {
+	Ok(ProcessingResponse {
+		response: Some(processing_response::Response::RequestBody(
+			proto::BodyResponse { response: cr },
+		)),
+		..Default::default()
+	})
+}
+
+pub fn response_header_response(cr: Option<CommonResponse>) -> Result<ProcessingResponse, Status> {
+	Ok(ProcessingResponse {
+		response: Some(processing_response::Response::ResponseHeaders(
+			proto::HeadersResponse { response: cr },
+		)),
+		..Default::default()
+	})
+}
+pub fn response_body_response(cr: Option<CommonResponse>) -> Result<ProcessingResponse, Status> {
+	Ok(ProcessingResponse {
+		response: Some(processing_response::Response::ResponseBody(
+			proto::BodyResponse { response: cr },
+		)),
+		..Default::default()
+	})
+}
+
+pub fn immediate_response(cr: proto::ImmediateResponse) -> Result<ProcessingResponse, Status> {
+	Ok(ProcessingResponse {
+		response: Some(processing_response::Response::ImmediateResponse(cr)),
+		..Default::default()
+	})
+}
+
+#[async_trait]
+pub trait Handler {
+	async fn handle_request_headers(
+		&mut self,
+		_headers: &HttpHeaders,
+		sender: &mpsc::Sender<Result<ProcessingResponse, Status>>,
+	) -> Result<(), Status> {
+		let _ = sender.send(request_header_response(None)).await;
+		Ok(())
+	}
+
+	async fn handle_request_body(
+		&mut self,
+		_body: &proto::HttpBody,
+		sender: &mpsc::Sender<Result<ProcessingResponse, Status>>,
+	) -> Result<(), Status> {
+		let _ = sender.send(request_body_response(None)).await;
+		Ok(())
+	}
+
+	async fn handle_response_headers(
+		&mut self,
+		_headers: &HttpHeaders,
+		sender: &mpsc::Sender<Result<ProcessingResponse, Status>>,
+	) -> Result<(), Status> {
+		let _ = sender.send(response_header_response(None)).await;
+		Ok(())
+	}
+
+	async fn handle_response_body(
+		&mut self,
+		_body: &proto::HttpBody,
+		sender: &mpsc::Sender<Result<ProcessingResponse, Status>>,
+	) -> Result<(), Status> {
+		let _ = sender.send(response_body_response(None)).await;
+		Ok(())
+	}
+
+	async fn handle_request_trailers(
+		&mut self,
+		_trailers: &HttpTrailers,
+		_sender: &mpsc::Sender<Result<ProcessingResponse, Status>>,
+	) -> Result<(), Status> {
+		Ok(())
+	}
+
+	async fn handle_response_trailers(
+		&mut self,
+		_trailers: &HttpTrailers,
+		_sender: &mpsc::Sender<Result<ProcessingResponse, Status>>,
+	) -> Result<(), Status> {
+		Ok(())
+	}
+}
+
+/// Mock ext_proc server for testing
+pub struct ExtProcMock<T> {
+	handler: Arc<dyn Fn() -> T + Send + Sync + 'static>,
+}
+
+pub struct ExtProcMockInstance {
+	pub address: SocketAddr,
+	handle: JoinHandle<()>,
+}
+
+impl Drop for ExtProcMockInstance {
+	fn drop(&mut self) {
+		self.handle.abort();
+	}
+}
+
+impl<T> Clone for ExtProcMock<T> {
+	fn clone(&self) -> Self {
+		Self {
+			handler: self.handler.clone(),
+		}
+	}
+}
+
+impl<T> ExtProcMock<T>
+where
+	T: Handler + Send + Sync + 'static,
+{
+	/// Create a new mock with default configuration
+	pub fn new(handler: impl Fn() -> T + Send + Sync + 'static) -> Self {
+		Self {
+			handler: Arc::new(handler),
+		}
+	}
+
+	pub async fn spawn(&self) -> ExtProcMockInstance {
+		use hyper::server::conn::http2;
+		let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+
+		let addr = listener.local_addr().unwrap();
+		let s: ExtProcMock<T> = self.clone();
+		let srv = ExternalProcessorServer::new(s);
+		let task = tokio::spawn(async move {
+			while let Ok((socket, _)) = listener.accept().await {
+				let srv = srv.clone();
+				tokio::spawn(async move {
+					if let Err(err) = http2::Builder::new(::hyper_util::rt::TokioExecutor::new())
+						.serve_connection(
+							hyper_util::rt::TokioIo::new(socket),
+							super::hyper_tower::TowerToHyperService::new(srv),
+						)
+						.await
+					{
+						error!("Error serving connection: {:?}", err);
+					}
+				});
+			}
+		});
+		ExtProcMockInstance {
+			address: addr,
+			handle: task,
+		}
+	}
+}
+
+#[tonic::async_trait]
+impl<T> ExternalProcessor for ExtProcMock<T>
+where
+	T: Handler + Send + Sync + 'static,
+{
+	type ProcessStream = tokio_stream::wrappers::ReceiverStream<Result<ProcessingResponse, Status>>;
+
+	async fn process(
+		&self,
+		request: Request<Streaming<ProcessingRequest>>,
+	) -> Result<TonicResponse<Self::ProcessStream>, Status> {
+		let (tx, rx) = mpsc::channel(32);
+
+		let mut handler = (self.handler.clone())();
+
+		tokio::spawn(async move {
+			let mut request_stream = request.into_inner();
+
+			while let Some(request_result) = request_stream.message().await? {
+				trace!("Received request: {:?}", request_result.request);
+				match request_result.request {
+					Some(processing_request::Request::RequestHeaders(headers)) => {
+						handler.handle_request_headers(&headers, &tx).await?;
+					},
+					Some(processing_request::Request::RequestBody(body)) => {
+						handler.handle_request_body(&body, &tx).await?;
+					},
+					Some(processing_request::Request::ResponseHeaders(headers)) => {
+						handler.handle_response_headers(&headers, &tx).await?;
+					},
+					Some(processing_request::Request::ResponseBody(body)) => {
+						handler.handle_response_body(&body, &tx).await?;
+					},
+					Some(processing_request::Request::RequestTrailers(trailers)) => {
+						handler.handle_request_trailers(&trailers, &tx).await?;
+					},
+					Some(processing_request::Request::ResponseTrailers(trailers)) => {
+						handler.handle_response_trailers(&trailers, &tx).await?;
+					},
+					None => {
+						// Invalid request
+						continue;
+					},
+				}
+			}
+			Ok::<(), Status>(())
+		});
+
+		Ok(TonicResponse::new(
+			tokio_stream::wrappers::ReceiverStream::new(rx),
+		))
+	}
+}

--- a/crates/agentgateway/src/test_helpers/hyper_tower.rs
+++ b/crates/agentgateway/src/test_helpers/hyper_tower.rs
@@ -1,0 +1,71 @@
+use pin_project_lite::pin_project;
+use tonic::Status;
+use tonic::body::Body;
+use tower::{BoxError, ServiceExt};
+
+// Copied from https://github.com/hyperium/tonic/blob/34b863b1d2a204ef3dd871ec86860fc92aafb451/examples/src/tls_rustls/server.rs
+
+/// An adaptor which converts a [`tower::Service`] to a [`hyper::service::Service`].
+///
+/// The [`hyper::service::Service`] trait is used by hyper to handle incoming requests,
+/// and does not support the `poll_ready` method that is used by tower services.
+///
+/// This is provided here because the equivalent adaptor in hyper-util does not support
+/// tonic::body::Body bodies.
+#[derive(Debug, Clone)]
+pub struct TowerToHyperService<S> {
+	service: S,
+}
+
+impl<S> TowerToHyperService<S> {
+	/// Create a new `TowerToHyperService` from a tower service.
+	pub fn new(service: S) -> Self {
+		Self { service }
+	}
+}
+
+impl<S> hyper::service::Service<hyper::Request<hyper::body::Incoming>> for TowerToHyperService<S>
+where
+	S: tower::Service<hyper::Request<Body>> + Clone,
+	S::Error: Into<BoxError> + 'static,
+{
+	type Response = S::Response;
+	type Error = BoxError;
+	type Future = TowerToHyperServiceFuture<S, hyper::Request<Body>>;
+
+	fn call(&self, req: hyper::Request<hyper::body::Incoming>) -> Self::Future {
+		use http_body_util::BodyExt;
+		let req = req.map(|incoming| Body::new(incoming.map_err(|err| Status::from_error(err.into()))));
+		TowerToHyperServiceFuture {
+			future: self.service.clone().oneshot(req),
+		}
+	}
+}
+
+pin_project! {
+		/// Future returned by [`TowerToHyperService`].
+		#[derive(Debug)]
+		pub struct TowerToHyperServiceFuture<S, R>
+		where
+				S: tower::Service<R>,
+		{
+				#[pin]
+				future: tower::util::Oneshot<S, R>,
+		}
+}
+
+impl<S, R> std::future::Future for TowerToHyperServiceFuture<S, R>
+where
+	S: tower::Service<R>,
+	S::Error: Into<BoxError> + 'static,
+{
+	type Output = Result<S::Response, BoxError>;
+
+	#[inline]
+	fn poll(
+		self: std::pin::Pin<&mut Self>,
+		cx: &mut std::task::Context<'_>,
+	) -> std::task::Poll<Self::Output> {
+		self.project().future.poll(cx).map_err(Into::into)
+	}
+}

--- a/crates/agentgateway/src/test_helpers/mod.rs
+++ b/crates/agentgateway/src/test_helpers/mod.rs
@@ -1,1 +1,3 @@
+pub mod extprocmock;
+mod hyper_tower;
 pub mod proxymock;

--- a/crates/agentgateway/tests/common/compare.rs
+++ b/crates/agentgateway/tests/common/compare.rs
@@ -147,7 +147,11 @@ binds:
 
 		let mut cmd = Command::new("envoy");
 		cmd
-			.args(["-c", &config_file.to_string_lossy()])
+			.args([
+				"-c",
+				&config_file.to_string_lossy(),
+				"--disable-hot-restart",
+			])
 			.stdout(Stdio::piped())
 			.stderr(Stdio::piped());
 

--- a/crates/xds/src/client.rs
+++ b/crates/xds/src/client.rs
@@ -1,3 +1,10 @@
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::fmt::{Debug, Display, Formatter};
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Duration;
+use std::{fmt, mem};
+
 use agent_core::metrics::{IncrementRecorder, Recorder};
 use agent_core::strng;
 use agent_core::strng::Strng;
@@ -6,12 +13,6 @@ use prost::{DecodeError, EncodeError};
 use prost_types::value::Kind;
 use prost_types::{Struct, Value};
 use split_iter::Splittable;
-use std::collections::{BTreeMap, HashMap, HashSet};
-use std::fmt::{Debug, Display, Formatter};
-use std::pin::Pin;
-use std::task::{Context, Poll};
-use std::time::Duration;
-use std::{fmt, mem};
 use thiserror::Error;
 use tokio::sync::{mpsc, oneshot};
 use tonic::body::Body;

--- a/schema/README.md
+++ b/schema/README.md
@@ -283,6 +283,14 @@ This folder contains JSON schemas for various parts of the project
 |`binds[].listeners[].routes[].policies.extAuthz.(any)context`||
 |`binds[].listeners[].routes[].policies.extAuthz.(any)failOpen`||
 |`binds[].listeners[].routes[].policies.extAuthz.(any)statusOnError`||
+|`binds[].listeners[].routes[].policies.extProc`|Extend agentgateway with an external processor|
+|`binds[].listeners[].routes[].policies.extProc.(any)(1)service`||
+|`binds[].listeners[].routes[].policies.extProc.(any)(1)service.name`||
+|`binds[].listeners[].routes[].policies.extProc.(any)(1)service.name.namespace`||
+|`binds[].listeners[].routes[].policies.extProc.(any)(1)service.name.hostname`||
+|`binds[].listeners[].routes[].policies.extProc.(any)(1)service.port`||
+|`binds[].listeners[].routes[].policies.extProc.(any)(1)host`||
+|`binds[].listeners[].routes[].policies.extProc.(any)failureMode`||
 |`binds[].listeners[].routes[].policies.transformations`|Modify requests and responses|
 |`binds[].listeners[].routes[].policies.transformations.request`||
 |`binds[].listeners[].routes[].policies.transformations.request.add`||
@@ -769,6 +777,14 @@ This folder contains JSON schemas for various parts of the project
 |`policies[].policy.extAuthz.(any)context`||
 |`policies[].policy.extAuthz.(any)failOpen`||
 |`policies[].policy.extAuthz.(any)statusOnError`||
+|`policies[].policy.extProc`|Extend agentgateway with an external processor|
+|`policies[].policy.extProc.(any)(1)service`||
+|`policies[].policy.extProc.(any)(1)service.name`||
+|`policies[].policy.extProc.(any)(1)service.name.namespace`||
+|`policies[].policy.extProc.(any)(1)service.name.hostname`||
+|`policies[].policy.extProc.(any)(1)service.port`||
+|`policies[].policy.extProc.(any)(1)host`||
+|`policies[].policy.extProc.(any)failureMode`||
 |`policies[].policy.transformations`|Modify requests and responses|
 |`policies[].policy.transformations.request`||
 |`policies[].policy.transformations.request.add`||
@@ -789,6 +805,50 @@ This folder contains JSON schemas for various parts of the project
 |`policies[].policy.retry.attempts`||
 |`policies[].policy.retry.backoff`||
 |`policies[].policy.retry.codes`||
+|`gatewayPolicies`|gatewayPolicies define policies that run at the Gateway level. This includes a subset of possible<br>policy types.<br>In general, normal (route level) policies should be used, except you need the policy to influence<br>routing.|
+|`gatewayPolicies[].name`||
+|`gatewayPolicies[].target`||
+|`gatewayPolicies[].target.(1)gateway`||
+|`gatewayPolicies[].target.(1)listener`||
+|`gatewayPolicies[].target.(1)route`||
+|`gatewayPolicies[].target.(1)routeRule`||
+|`gatewayPolicies[].target.(1)service`||
+|`gatewayPolicies[].target.(1)backend`||
+|`gatewayPolicies[].target.(1)subBackend`||
+|`gatewayPolicies[].policy`||
+|`gatewayPolicies[].policy.extProc`|Extend agentgateway with an external processor|
+|`gatewayPolicies[].policy.extProc.(any)(1)service`||
+|`gatewayPolicies[].policy.extProc.(any)(1)service.name`||
+|`gatewayPolicies[].policy.extProc.(any)(1)service.name.namespace`||
+|`gatewayPolicies[].policy.extProc.(any)(1)service.name.hostname`||
+|`gatewayPolicies[].policy.extProc.(any)(1)service.port`||
+|`gatewayPolicies[].policy.extProc.(any)(1)host`||
+|`gatewayPolicies[].policy.extProc.(any)failureMode`||
+|`gatewayPolicies[].policy.jwtAuth`|Authenticate incoming JWT requests.|
+|`gatewayPolicies[].policy.jwtAuth.(any)(any)mode`||
+|`gatewayPolicies[].policy.jwtAuth.(any)(any)providers`||
+|`gatewayPolicies[].policy.jwtAuth.(any)(any)providers[].issuer`||
+|`gatewayPolicies[].policy.jwtAuth.(any)(any)providers[].audiences`||
+|`gatewayPolicies[].policy.jwtAuth.(any)(any)providers[].jwks`||
+|`gatewayPolicies[].policy.jwtAuth.(any)(any)providers[].jwks.(any)file`||
+|`gatewayPolicies[].policy.jwtAuth.(any)(any)providers[].jwks.(any)url`||
+|`gatewayPolicies[].policy.jwtAuth.(any)(any)mode`||
+|`gatewayPolicies[].policy.jwtAuth.(any)(any)issuer`||
+|`gatewayPolicies[].policy.jwtAuth.(any)(any)audiences`||
+|`gatewayPolicies[].policy.jwtAuth.(any)(any)jwks`||
+|`gatewayPolicies[].policy.jwtAuth.(any)(any)jwks.(any)file`||
+|`gatewayPolicies[].policy.jwtAuth.(any)(any)jwks.(any)url`||
+|`gatewayPolicies[].policy.transformations`|Modify requests and responses|
+|`gatewayPolicies[].policy.transformations.request`||
+|`gatewayPolicies[].policy.transformations.request.add`||
+|`gatewayPolicies[].policy.transformations.request.set`||
+|`gatewayPolicies[].policy.transformations.request.remove`||
+|`gatewayPolicies[].policy.transformations.request.body`||
+|`gatewayPolicies[].policy.transformations.response`||
+|`gatewayPolicies[].policy.transformations.response.add`||
+|`gatewayPolicies[].policy.transformations.response.set`||
+|`gatewayPolicies[].policy.transformations.response.remove`||
+|`gatewayPolicies[].policy.transformations.response.body`||
 |`workloads`||
 |`services`||
 ## CEL context

--- a/schema/local.json
+++ b/schema/local.json
@@ -2516,6 +2516,86 @@
                               }
                             ]
                           },
+                          "extProc": {
+                            "description": "Extend agentgateway with an external processor",
+                            "anyOf": [
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "failureMode": {
+                                    "type": "string",
+                                    "enum": [
+                                      "failClosed",
+                                      "failOpen"
+                                    ],
+                                    "default": "failClosed"
+                                  }
+                                },
+                                "unevaluatedProperties": false,
+                                "oneOf": [
+                                  {
+                                    "type": "string",
+                                    "enum": [
+                                      "invalid"
+                                    ]
+                                  },
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "service": {
+                                        "type": "object",
+                                        "properties": {
+                                          "name": {
+                                            "type": "object",
+                                            "properties": {
+                                              "namespace": {
+                                                "type": "string"
+                                              },
+                                              "hostname": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "namespace",
+                                              "hostname"
+                                            ]
+                                          },
+                                          "port": {
+                                            "type": "integer",
+                                            "format": "uint16",
+                                            "minimum": 0,
+                                            "maximum": 65535
+                                          }
+                                        },
+                                        "additionalProperties": false,
+                                        "required": [
+                                          "name",
+                                          "port"
+                                        ]
+                                      }
+                                    },
+                                    "required": [
+                                      "service"
+                                    ]
+                                  },
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "host"
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
                           "transformations": {
                             "description": "Modify requests and responses",
                             "type": [
@@ -7024,6 +7104,86 @@
                   }
                 ]
               },
+              "extProc": {
+                "description": "Extend agentgateway with an external processor",
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "failureMode": {
+                        "type": "string",
+                        "enum": [
+                          "failClosed",
+                          "failOpen"
+                        ],
+                        "default": "failClosed"
+                      }
+                    },
+                    "unevaluatedProperties": false,
+                    "oneOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "invalid"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "service": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "object",
+                                "properties": {
+                                  "namespace": {
+                                    "type": "string"
+                                  },
+                                  "hostname": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "namespace",
+                                  "hostname"
+                                ]
+                              },
+                              "port": {
+                                "type": "integer",
+                                "format": "uint16",
+                                "minimum": 0,
+                                "maximum": 65535
+                              }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                              "name",
+                              "port"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "service"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "host": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "host"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
               "transformations": {
                 "description": "Modify requests and responses",
                 "type": [
@@ -7185,6 +7345,445 @@
                 "required": [
                   "codes"
                 ],
+                "default": null
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "target",
+          "policy"
+        ]
+      }
+    },
+    "gatewayPolicies": {
+      "description": "gatewayPolicies define policies that run at the Gateway level. This includes a subset of possible\npolicy types.\nIn general, normal (route level) policies should be used, except you need the policy to influence\nrouting.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "target": {
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "gateway": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "gateway"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "listener": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "listener"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "route": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "route"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "routeRule": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "routeRule"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "service": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "service"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "backend": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "backend"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "subBackend": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "subBackend"
+                ],
+                "additionalProperties": false
+              }
+            ]
+          },
+          "policy": {
+            "type": "object",
+            "properties": {
+              "extProc": {
+                "description": "Extend agentgateway with an external processor",
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "failureMode": {
+                        "type": "string",
+                        "enum": [
+                          "failClosed",
+                          "failOpen"
+                        ],
+                        "default": "failClosed"
+                      }
+                    },
+                    "unevaluatedProperties": false,
+                    "oneOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "invalid"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "service": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "object",
+                                "properties": {
+                                  "namespace": {
+                                    "type": "string"
+                                  },
+                                  "hostname": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "namespace",
+                                  "hostname"
+                                ]
+                              },
+                              "port": {
+                                "type": "integer",
+                                "format": "uint16",
+                                "minimum": 0,
+                                "maximum": 65535
+                              }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                              "name",
+                              "port"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "service"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "host": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "host"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "jwtAuth": {
+                "description": "Authenticate incoming JWT requests.",
+                "anyOf": [
+                  {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "mode": {
+                            "oneOf": [
+                              {
+                                "description": "A valid token, issued by a configured issuer, must be present.",
+                                "type": "string",
+                                "const": "strict"
+                              },
+                              {
+                                "description": "If a token exists, validate it.\nThis is the default option.\nWarning: this allows requests without a JWT token!",
+                                "type": "string",
+                                "const": "optional"
+                              },
+                              {
+                                "description": "Requests are never rejected. This is useful for usage of claims in later steps (authorization, logging, etc).\nWarning: this allows requests without a JWT token!",
+                                "type": "string",
+                                "const": "permissive"
+                              }
+                            ],
+                            "default": "optional"
+                          },
+                          "providers": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "issuer": {
+                                  "type": "string"
+                                },
+                                "audiences": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "jwks": {
+                                  "anyOf": [
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "file": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "file"
+                                      ]
+                                    },
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "url": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "url"
+                                      ]
+                                    }
+                                  ]
+                                }
+                              },
+                              "additionalProperties": false,
+                              "required": [
+                                "issuer",
+                                "audiences",
+                                "jwks"
+                              ]
+                            }
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "providers"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "mode": {
+                            "oneOf": [
+                              {
+                                "description": "A valid token, issued by a configured issuer, must be present.",
+                                "type": "string",
+                                "const": "strict"
+                              },
+                              {
+                                "description": "If a token exists, validate it.\nThis is the default option.\nWarning: this allows requests without a JWT token!",
+                                "type": "string",
+                                "const": "optional"
+                              },
+                              {
+                                "description": "Requests are never rejected. This is useful for usage of claims in later steps (authorization, logging, etc).\nWarning: this allows requests without a JWT token!",
+                                "type": "string",
+                                "const": "permissive"
+                              }
+                            ],
+                            "default": "optional"
+                          },
+                          "issuer": {
+                            "type": "string"
+                          },
+                          "audiences": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "jwks": {
+                            "anyOf": [
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "file": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "file"
+                                ]
+                              },
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "url": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "url"
+                                ]
+                              }
+                            ]
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "issuer",
+                          "audiences",
+                          "jwks"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "transformations": {
+                "description": "Modify requests and responses",
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "request": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "add": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "default": {}
+                      },
+                      "set": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "default": {}
+                      },
+                      "remove": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "default": []
+                      },
+                      "body": {
+                        "type": [
+                          "string",
+                          "null"
+                        ],
+                        "default": null
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "response": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "add": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "default": {}
+                      },
+                      "set": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "default": {}
+                      },
+                      "remove": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "default": []
+                      },
+                      "body": {
+                        "type": [
+                          "string",
+                          "null"
+                        ],
+                        "default": null
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false,
                 "default": null
               }
             },


### PR DESCRIPTION
This PR adds two new concepts:
* A new "Gateway Policy". Unlike route policies, these apply *before* route selection. This is critical for policies that should impact routes.
* A new ext_proc policy. Expand the ext_proc logic to not just meet the GIE ext_proc server but also general purpose ones. Note: this still imlements only a subset of the API, in particular you cannot turn off sending headers, and body MUST be full_duplex_streaming mode.