### PR TITLE
feat: add native OpenTelemetry Gen AI v1.37.0 semantic conventions

### DIFF
--- a/crates/agentgateway/src/llm/bedrock.rs
+++ b/crates/agentgateway/src/llm/bedrock.rs
@@ -36,7 +36,7 @@ pub struct Provider {
 }
 
 impl super::Provider for Provider {
-	const NAME: Strng = strng::literal!("bedrock");
+	const NAME: Strng = strng::literal!("aws.bedrock");
 }
 
 impl Provider {

--- a/crates/agentgateway/src/llm/gemini.rs
+++ b/crates/agentgateway/src/llm/gemini.rs
@@ -15,7 +15,7 @@ pub struct Provider {
 }
 
 impl super::Provider for Provider {
-	const NAME: Strng = strng::literal!("gemini");
+	const NAME: Strng = strng::literal!("gcp.gemini");
 }
 pub const DEFAULT_HOST_STR: &str = "generativelanguage.googleapis.com";
 pub const DEFAULT_HOST: Strng = strng::literal!(DEFAULT_HOST_STR);

--- a/crates/agentgateway/src/llm/vertex.rs
+++ b/crates/agentgateway/src/llm/vertex.rs
@@ -18,7 +18,7 @@ pub struct Provider {
 }
 
 impl super::Provider for Provider {
-	const NAME: Strng = strng::literal!("vertex");
+	const NAME: Strng = strng::literal!("gcp.vertex_ai");
 }
 
 impl Provider {

--- a/crates/agentgateway/src/proxy/gateway_test.rs
+++ b/crates/agentgateway/src/proxy/gateway_test.rs
@@ -81,11 +81,12 @@ async fn llm_openai() {
 	);
 
 	let want = json!({
-		"llm.provider": "openai",
-		"llm.request.model": "replaceme",
-		"llm.response.model": "gpt-3.5-turbo-0125",
-		"llm.request.tokens": 17,
-		"llm.response.tokens": 23
+		"gen_ai.operation.name": "chat",
+		"gen_ai.provider.name": "openai",
+		"gen_ai.request.model": "replaceme",
+		"gen_ai.response.model": "gpt-3.5-turbo-0125",
+		"gen_ai.usage.input_tokens": 17,
+		"gen_ai.usage.output_tokens": 23
 	});
 	assert_llm(io, include_bytes!("../llm/tests/request_basic.json"), want).await;
 }
@@ -101,11 +102,12 @@ async fn llm_openai_tokenize() {
 	);
 
 	let want = json!({
-		"llm.provider": "openai",
-		"llm.request.model": "replaceme",
-		"llm.response.model": "gpt-3.5-turbo-0125",
-		"llm.request.tokens": 17,
-		"llm.response.tokens": 23
+		"gen_ai.operation.name": "chat",
+		"gen_ai.provider.name": "openai",
+		"gen_ai.request.model": "replaceme",
+		"gen_ai.response.model": "gpt-3.5-turbo-0125",
+		"gen_ai.usage.input_tokens": 17,
+		"gen_ai.usage.output_tokens": 23
 	});
 	assert_llm(io, include_bytes!("../llm/tests/request_basic.json"), want).await;
 }
@@ -134,11 +136,12 @@ async fn llm_log_body() {
 	);
 
 	let want = json!({
-		"llm.provider": "openai",
-		"llm.request.model": "replaceme",
-		"llm.response.model": "gpt-3.5-turbo-0125",
-		"llm.request.tokens": 17,
-		"llm.response.tokens": 23,
+		"gen_ai.operation.name": "chat",
+		"gen_ai.provider.name": "openai",
+		"gen_ai.request.model": "replaceme",
+		"gen_ai.response.model": "gpt-3.5-turbo-0125",
+		"gen_ai.usage.input_tokens": 17,
+		"gen_ai.usage.output_tokens": 23,
 		"completion": ["Sorry, I couldn't find the name of the LLM provider. Could you please provide more information or context?"],
 		"prompt": [
 			{"role":"system","content":"You are a helpful assistant."},

--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -699,6 +699,85 @@ impl Drop for DropOnLog {
 					.and_then(|l| l.response.output_tokens)
 					.map(Into::into),
 			),
+			// OpenTelemetry Gen AI Semantic Conventions v1.37.0
+			(
+				"gen_ai.operation.name",
+				log.llm_request.as_ref().map(|_| "chat".into()),
+			),
+			(
+				"gen_ai.provider.name",
+				log.llm_request.as_ref().map(|l| display(&l.provider)),
+			),
+			(
+				"gen_ai.system",
+				log.llm_request.as_ref().map(|l| display(&l.provider)),
+			),
+			(
+				"gen_ai.request.model",
+				log.llm_request.as_ref().map(|l| display(&l.request_model)),
+			),
+			(
+				"gen_ai.response.model",
+				llm_response
+					.as_ref()
+					.and_then(|l| l.response.provider_model.display()),
+			),
+			("gen_ai.usage.input_tokens", input_tokens.map(Into::into)),
+			(
+				"gen_ai.usage.output_tokens",
+				llm_response
+					.as_ref()
+					.and_then(|l| l.response.output_tokens)
+					.map(Into::into),
+			),
+			(
+				"gen_ai.request.temperature",
+				log
+					.llm_request
+					.as_ref()
+					.and_then(|l| l.params.temperature)
+					.map(Into::into),
+			),
+			(
+				"gen_ai.request.top_p",
+				log
+					.llm_request
+					.as_ref()
+					.and_then(|l| l.params.top_p)
+					.map(Into::into),
+			),
+			(
+				"gen_ai.request.max_tokens",
+				log
+					.llm_request
+					.as_ref()
+					.and_then(|l| l.params.max_tokens)
+					.map(|v| (v as i64).into()),
+			),
+			(
+				"gen_ai.request.frequency_penalty",
+				log
+					.llm_request
+					.as_ref()
+					.and_then(|l| l.params.frequency_penalty)
+					.map(Into::into),
+			),
+			(
+				"gen_ai.request.presence_penalty",
+				log
+					.llm_request
+					.as_ref()
+					.and_then(|l| l.params.presence_penalty)
+					.map(Into::into),
+			),
+			(
+				"gen_ai.request.seed",
+				log
+					.llm_request
+					.as_ref()
+					.and_then(|l| l.params.seed)
+					.map(Into::into),
+			),
 			("retry.attempt", log.retry_attempt.display()),
 			("error", log.error.quoted()),
 			("duration", Some(dur.as_str().into())),

--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -677,28 +677,6 @@ impl Drop for DropOnLog {
 				"inferencepool.selected_endpoint",
 				log.inference_pool.display(),
 			),
-			(
-				"llm.provider",
-				log.llm_request.as_ref().map(|l| display(&l.provider)),
-			),
-			(
-				"llm.request.model",
-				log.llm_request.as_ref().map(|l| display(&l.request_model)),
-			),
-			("llm.request.tokens", input_tokens.map(Into::into)),
-			(
-				"llm.response.model",
-				llm_response
-					.as_ref()
-					.and_then(|l| l.response.provider_model.display()),
-			),
-			(
-				"llm.response.tokens",
-				llm_response
-					.as_ref()
-					.and_then(|l| l.response.output_tokens)
-					.map(Into::into),
-			),
 			// OpenTelemetry Gen AI Semantic Conventions v1.37.0
 			(
 				"gen_ai.operation.name",
@@ -706,10 +684,6 @@ impl Drop for DropOnLog {
 			),
 			(
 				"gen_ai.provider.name",
-				log.llm_request.as_ref().map(|l| display(&l.provider)),
-			),
-			(
-				"gen_ai.system",
 				log.llm_request.as_ref().map(|l| display(&l.provider)),
 			),
 			(


### PR DESCRIPTION
Adds native OpenTelemetry Gen AI v1.37.0 attributes for zero-config OTLP compatibility.

## Changes

Emit 13 gen_ai.* attributes automatically:
- Required: gen_ai.operation.name, gen_ai.provider.name
- Usage: gen_ai.usage.input_tokens, gen_ai.usage.output_tokens
- Request params: temperature, top_p, max_tokens, frequency_penalty, presence_penalty, seed
- Models: gen_ai.request.model, gen_ai.response.model
- Backward compat: gen_ai.system (v1.28.0)

Update provider names to v1.37.0 spec:
- bedrock → aws.bedrock
- gemini → gcp.gemini
- vertex → gcp.vertex_ai

## Impact

Zero-config OTLP works with Langfuse, Datadog, Grafana, Honeycomb, etc.

Existing llm.* namespace unchanged - CEL configs still work.

If you filter on provider names, update your filters to use new names.