### PR TITLE
feat: pass extauthz metadata to Bedrock requestMetadata

### DIFF
--- a/crates/agentgateway/src/llm/tests.rs
+++ b/crates/agentgateway/src/llm/tests.rs
@@ -136,7 +136,7 @@ async fn test_bedrock() {
 		guardrail_identifier: None,
 		guardrail_version: None,
 	};
-	let request = |i| Ok(bedrock::translate_request_completions(i, &provider));
+	let request = |i| Ok(bedrock::translate_request_completions(i, &provider, None));
 	for r in ALL_REQUESTS {
 		test_request("bedrock", r, request);
 	}

--- a/crates/agentgateway/src/llm/universal.rs
+++ b/crates/agentgateway/src/llm/universal.rs
@@ -255,10 +255,10 @@ pub mod passthrough {
 		fn to_bedrock(
 			&self,
 			provider: &Provider,
-			_headers: Option<&::http::HeaderMap>,
+			headers: Option<&::http::HeaderMap>,
 		) -> Result<Vec<u8>, AIError> {
 			let typed = json::convert::<_, universal::Request>(self).map_err(AIError::RequestMarshal)?;
-			let xlated = llm::bedrock::translate_request_completions(typed, provider);
+			let xlated = llm::bedrock::translate_request_completions(typed, provider, headers);
 			serde_json::to_vec(&xlated).map_err(AIError::RequestMarshal)
 		}
 


### PR DESCRIPTION
Flattens nested extauthz JSON into Bedrock's requestMetadata field for observability and log filtering. AWS validates constraints server-side.