### PR TITLE
Support non string ratelimit CEL expressions

### DIFF
--- a/crates/agentgateway/src/cel/mod.rs
+++ b/crates/agentgateway/src/cel/mod.rs
@@ -327,6 +327,20 @@ pub fn value_as_int(v: &Value) -> Option<i64> {
 	}
 }
 
+pub fn value_as_string(v: &Value) -> Option<String> {
+	match v {
+		Value::String(v) => Some(v.to_string()),
+		Value::Bool(v) => Some(v.to_string()),
+		Value::Int(v) => Some(v.to_string()),
+		Value::UInt(v) => Some(v.to_string()),
+		Value::Bytes(v) => {
+			use base64::Engine;
+			Some(base64::prelude::BASE64_STANDARD.encode(v.as_ref()))
+		},
+		_ => None,
+	}
+}
+
 pub struct Executor<'a> {
 	ctx: Context<'a>,
 }

--- a/crates/agentgateway/src/http/remoteratelimit.rs
+++ b/crates/agentgateway/src/http/remoteratelimit.rs
@@ -96,27 +96,24 @@ impl RemoteRateLimit {
 		limit_type: RateLimitType,
 		cost: Option<u64>,
 	) -> RateLimitRequest {
-			let mut descriptors = Vec::with_capacity(self.descriptors.0.len());
-			let candidate_count = self
-				.descriptors
-				.0
-				.iter()
-				.filter(|e| e.limit_type == limit_type)
-				.count();
-			trace!(
-				"ratelimit build_request start: domain={}, type={:?}, cost={:?}, candidates={}",
-				self.domain,
-				limit_type,
-				cost,
-				candidate_count
-			);
-			for desc_entry in self
+		let mut descriptors = Vec::with_capacity(self.descriptors.0.len());
+		let candidate_count = self
+			.descriptors
+			.0
+			.iter()
+			.filter(|e| e.limit_type == limit_type)
+			.count();
+		trace!(
+			"ratelimit build_request start: domain={}, type={:?}, cost={:?}, candidates={}",
+			self.domain, limit_type, cost, candidate_count
+		);
+		for desc_entry in self
 			.descriptors
 			.0
 			.iter()
 			.filter(|e| e.limit_type == limit_type)
 		{
-				if let Some(rl_entries) = Self::eval_descriptor(exec, &desc_entry.entries) {
+			if let Some(rl_entries) = Self::eval_descriptor(exec, &desc_entry.entries) {
 				// Trace evaluated descriptor key/value pairs for visibility
 				let kv_pairs: Vec<String> = rl_entries
 					.iter()
@@ -133,39 +130,36 @@ impl RemoteRateLimit {
 					limit: None,
 					hits_addend: cost,
 				});
-				} else {
-					let attempted: Vec<String> = desc_entry
-						.entries
-						.iter()
-						.map(|d| format!("{}={:?}", d.0, d.1))
-						.collect();
-					trace!(
-						"ratelimit skipped descriptor set (domain: {}, type: {:?}) due to evaluation failure/non-string values: {}",
-						self.domain,
-						limit_type,
-						attempted.join(", ")
-					);
+			} else {
+				let attempted: Vec<String> = desc_entry
+					.entries
+					.iter()
+					.map(|d| format!("{}={:?}", d.0, d.1))
+					.collect();
+				trace!(
+					"ratelimit skipped descriptor set (domain: {}, type: {:?}) due to evaluation failure/non-string values: {}",
+					self.domain,
+					limit_type,
+					attempted.join(", ")
+				);
 			}
 		}
 
-			if descriptors.is_empty() {
-				trace!(
-					"ratelimit built empty descriptor list (domain: {}, type: {:?}); candidates={}, cost={:?}",
-					self.domain,
-					limit_type,
-					candidate_count,
-					cost
-				);
-			} else {
-				trace!(
-					"ratelimit built request descriptors (domain: {}, type: {:?}): count={}",
-					self.domain,
-					limit_type,
-					descriptors.len()
-				);
-			}
+		if descriptors.is_empty() {
+			trace!(
+				"ratelimit built empty descriptor list (domain: {}, type: {:?}); candidates={}, cost={:?}",
+				self.domain, limit_type, candidate_count, cost
+			);
+		} else {
+			trace!(
+				"ratelimit built request descriptors (domain: {}, type: {:?}): count={}",
+				self.domain,
+				limit_type,
+				descriptors.len()
+			);
+		}
 
-			proto::RateLimitRequest {
+		proto::RateLimitRequest {
 			domain: self.domain.clone(),
 			descriptors,
 			// Ignored; we always set the per-descriptor one which allows distinguishing empty vs 0
@@ -186,10 +180,10 @@ impl RemoteRateLimit {
 			.any(|d| d.limit_type == RateLimitType::Tokens)
 		{
 			// Nothing to do
-				trace!(
-					"ratelimit: no token descriptors configured for domain={}, skipping",
-					self.domain
-				);
+			trace!(
+				"ratelimit: no token descriptors configured for domain={}, skipping",
+				self.domain
+			);
 			return Ok((PolicyResponse::default(), None));
 		}
 		let request = self.build_request(exec, RateLimitType::Tokens, Some(cost));
@@ -217,10 +211,10 @@ impl RemoteRateLimit {
 			.any(|d| d.limit_type == RateLimitType::Requests)
 		{
 			// Nothing to do
-				trace!(
-					"ratelimit: no request descriptors configured for domain={}, skipping",
-					self.domain
-				);
+			trace!(
+				"ratelimit: no request descriptors configured for domain={}, skipping",
+				self.domain
+			);
 			return Ok(PolicyResponse::default());
 		}
 		let request = self.build_request(exec, RateLimitType::Requests, None);
@@ -228,30 +222,30 @@ impl RemoteRateLimit {
 		Self::apply(req, cr)
 	}
 
-		async fn check_internal(
+	async fn check_internal(
 		&self,
 		client: PolicyClient,
 		request: proto::RateLimitRequest,
 	) -> Result<proto::RateLimitResponse, ProxyError> {
-			trace!("connecting to {:?}", self.target);
-			let descriptor_summaries: Vec<String> = request
-				.descriptors
-				.iter()
-				.map(|d| {
-					let kvs: Vec<String> = d
-						.entries
-						.iter()
-						.map(|e| format!("{}={}", e.key, e.value))
-						.collect();
-					format!("[hits_addend={:?}; {}]", d.hits_addend, kvs.join(", "))
-				})
-				.collect();
-			trace!(
-				"ratelimit request summary (domain: {}): descriptors={} {}",
-				request.domain,
-				request.descriptors.len(),
-				descriptor_summaries.join(" | ")
-			);
+		trace!("connecting to {:?}", self.target);
+		let descriptor_summaries: Vec<String> = request
+			.descriptors
+			.iter()
+			.map(|d| {
+				let kvs: Vec<String> = d
+					.entries
+					.iter()
+					.map(|e| format!("{}={}", e.key, e.value))
+					.collect();
+				format!("[hits_addend={:?}; {}]", d.hits_addend, kvs.join(", "))
+			})
+			.collect();
+		trace!(
+			"ratelimit request summary (domain: {}): descriptors={} {}",
+			request.domain,
+			request.descriptors.len(),
+			descriptor_summaries.join(" | ")
+		);
 		let chan = GrpcReferenceChannel {
 			target: self.target.clone(),
 			client,
@@ -292,51 +286,36 @@ impl RemoteRateLimit {
 		Ok(res)
 	}
 
-		fn eval_descriptor(exec: &Executor, entries: &Vec<Descriptor>) -> Option<Vec<Entry>> {
-			let mut rl_entries = Vec::with_capacity(entries.len());
-			for Descriptor(k, lookup) in entries {
-				// We drop the entire set if we cannot eval one; emit trace to aid debugging
-				match exec.eval(lookup) {
-					Ok(value) => {
-						let string_value = match value {
-							cel::Value::String(v) => v.to_string(),
-							cel::Value::Bool(v) => v.to_string(),
-							cel::Value::Int(v) => v.to_string(),
-							cel::Value::UInt(v) => v.to_string(),
-							cel::Value::Double(v) => v.to_string(),
-							cel::Value::Bytes(v) => {
-								use base64::Engine;
-								base64::prelude::BASE64_STANDARD.encode(v.as_ref())
-							},
-							cel::Value::Null => "null".to_string(),
-							_ => {
-								trace!(
-									"ratelimit descriptor value not convertible to string: key={}, expr={:?}",
-									k,
-									lookup
-								);
-								return None;
-							},
-						};
-						let entry = Entry {
-							key: k.clone(),
-							value: string_value,
-						};
-						rl_entries.push(entry);
-					},
-					Err(e) => {
+	fn eval_descriptor(exec: &Executor, entries: &Vec<Descriptor>) -> Option<Vec<Entry>> {
+		let mut rl_entries = Vec::with_capacity(entries.len());
+		for Descriptor(k, lookup) in entries {
+			// We drop the entire set if we cannot eval one; emit trace to aid debugging
+			match exec.eval(lookup) {
+				Ok(value) => {
+					let Some(string_value) = cel::value_as_string(&value) else {
 						trace!(
-							"ratelimit failed to evaluate expression: key={}, expr={:?}, error={}",
-							k,
-							lookup,
-							e
+							"ratelimit descriptor value not convertible to string: key={}, expr={:?}",
+							k, lookup
 						);
 						return None;
-					},
-				}
+					};
+					let entry = Entry {
+						key: k.clone(),
+						value: string_value,
+					};
+					rl_entries.push(entry);
+				},
+				Err(e) => {
+					trace!(
+						"ratelimit failed to evaluate expression: key={}, expr={:?}, error={}",
+						k, lookup, e
+					);
+					return None;
+				},
 			}
-			Some(rl_entries)
 		}
+		Some(rl_entries)
+	}
 
 	pub fn expressions(&self) -> impl Iterator<Item = &Expression> {
 		self


### PR DESCRIPTION
`has(jwt)` evaluates to a bool, resulting in the expression being dropped on this line: https://github.com/agentgateway/agentgateway/blob/main/crates/agentgateway/src/http/remoteratelimit.rs#L221 This converts non-string evaluated CEL expressions to strings and adds debug lines. 