### PR TITLE
Small metrics and logs fixes

### DIFF
--- a/crates/agentgateway-app/src/main.rs
+++ b/crates/agentgateway-app/src/main.rs
@@ -126,7 +126,7 @@ fn copy_binary(copy_self: PathBuf) -> anyhow::Result<()> {
 
 async fn validate(contents: String, filename: Option<PathBuf>) -> anyhow::Result<()> {
 	let config = agentgateway::config::parse_config(contents, filename)?;
-	let client = client::Client::new(&config.dns, None, BackendConfig::default());
+	let client = client::Client::new(&config.dns, None, BackendConfig::default(), None);
 	if let Some(cfg) = config.xds.local_config {
 		let cs = cfg.read_to_string().await?;
 		agentgateway::types::local::NormalizedLocalConfig::from(client, cs.as_str()).await?;

--- a/crates/agentgateway/src/app.rs
+++ b/crates/agentgateway/src/app.rs
@@ -56,7 +56,7 @@ pub async fn run(config: Arc<Config>) -> anyhow::Result<Bound> {
 	// TODO: metric for version
 
 	// TODO: use for XDS
-	let control_client = client::Client::new(&config.dns, None, config.backend.clone());
+	let control_client = client::Client::new(&config.dns, None, config.backend.clone(), None);
 	let ca = if let Some(cfg) = &config.ca {
 		Some(Arc::new(caclient::CaClient::new(
 			control_client.clone(),
@@ -68,7 +68,16 @@ pub async fn run(config: Arc<Config>) -> anyhow::Result<Bound> {
 	let pool = ca
 		.clone()
 		.map(|ca| agent_hbone::pool::WorkloadHBONEPool::new(config.hbone.clone(), ca));
-	let client = client::Client::new(&config.dns, pool, config.backend.clone());
+	// Build metrics and then the upstream client with metrics wired in
+	let sub_registry = metrics::sub_registry(&mut registry);
+	let tracer = trc::Tracer::new(&config.tracing)?;
+	let metrics_handle = Arc::new(crate::metrics::Metrics::new(sub_registry));
+	let client = client::Client::new(
+		&config.dns,
+		pool,
+		config.backend.clone(),
+		Some(metrics_handle.clone()),
+	);
 
 	let (xds_tx, xds_rx) = tokio::sync::watch::channel(());
 	let state_mgr =
@@ -98,13 +107,11 @@ pub async fn run(config: Arc<Config>) -> anyhow::Result<Bound> {
 	#[cfg(feature = "ui")]
 	info!("serving UI at http://{}/ui", config.admin_addr);
 
-	let sub_registry = metrics::sub_registry(&mut registry);
-	let tracer = trc::Tracer::new(&config.tracing)?;
 	let pi = ProxyInputs {
 		cfg: config.clone(),
 		stores: stores.clone(),
 		tracer: tracer.clone(),
-		metrics: Arc::new(crate::metrics::Metrics::new(sub_registry)),
+		metrics: metrics_handle.clone(),
 		upstream: client.clone(),
 		ca,
 

--- a/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
@@ -29,6 +29,7 @@ async fn setup() -> (MockServer, Handler) {
 		},
 		None,
 		BackendConfig::default(),
+		None,
 	);
 	let pi = Arc::new(ProxyInputs {
 		cfg: Arc::new(config),

--- a/crates/agentgateway/src/proxy/gateway.rs
+++ b/crates/agentgateway/src/proxy/gateway.rs
@@ -329,10 +329,7 @@ impl Gateway {
 		};
 		let transport_labels = TCPLabels {
 			bind: Some(&bind_name).into(),
-			gateway: selected_listener
-				.as_ref()
-				.map(|l| &l.gateway_name)
-				.into(),
+			gateway: selected_listener.as_ref().map(|l| &l.gateway_name).into(),
 			listener: selected_listener.as_ref().map(|l| &l.name).into(),
 			protocol: transport_protocol,
 		};

--- a/crates/agentgateway/src/proxy/gateway.rs
+++ b/crates/agentgateway/src/proxy/gateway.rs
@@ -432,16 +432,18 @@ impl Gateway {
 			} else {
 				BindProtocol::tls
 			};
-			inp
-				.metrics
-				.tls_handshake_duration
-				.get_or_create(&TCPLabels {
-					bind: Some(&bind).into(),
-					gateway: Some(&best.gateway_name).into(),
-					listener: Some(&best.name).into(),
-					protocol,
-				})
-				.observe(tls_dur.as_secs_f64());
+			if inp.metrics.enable_connect_duration_metrics {
+				inp
+					.metrics
+					.tls_handshake_duration
+					.get_or_create(&TCPLabels {
+						bind: Some(&bind).into(),
+						gateway: Some(&best.gateway_name).into(),
+						listener: Some(&best.name).into(),
+						protocol,
+					})
+					.observe(tls_dur.as_secs_f64());
+			}
 			Ok((best, Socket::from_tls(ext, counter, tls.into())?))
 		};
 		tokio::time::timeout(to, handshake).await?

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -538,6 +538,11 @@ impl HTTPProxy {
 		let selected_backend =
 			select_backend(selected_route.as_ref(), &req).ok_or(ProxyError::NoValidBackends)?;
 		let selected_backend = resolve_backend(selected_backend, self.inputs.as_ref())?;
+		// Set backend info as soon as we have resolved to add the metric labels
+		log.backend_info = Some(selected_backend.backend.backend_info());
+		if let Some(bp) = selected_backend.backend.backend_protocol() {
+			log.backend_protocol = Some(bp)
+		}
 		response_policies.backend_filters = selected_backend
 			.filters
 			.iter()

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -475,7 +475,7 @@ impl HTTPProxy {
 		// Record the matched path for tracing/logging span names
 		log.path_match = Some(match &path_match {
 			crate::types::agent::PathMatch::Exact(p) => p.to_string(),
-			crate::types::agent::PathMatch::PathPrefix(p) => format!("{}*", p),
+			crate::types::agent::PathMatch::PathPrefix(p) => format!("{}/*", p),
 			crate::types::agent::PathMatch::Regex(r, _) => r.as_str().to_string(),
 		});
 

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -472,6 +472,12 @@ impl HTTPProxy {
 		.ok_or(ProxyError::RouteNotFound)?;
 		log.route_rule_name = selected_route.rule_name.clone();
 		log.route_name = Some(selected_route.route_name.clone());
+		// Record the matched path for tracing/logging span names
+		log.path_match = Some(match &path_match {
+			crate::types::agent::PathMatch::Exact(p) => p.to_string(),
+			crate::types::agent::PathMatch::PathPrefix(p) => format!("{}*", p),
+			crate::types::agent::PathMatch::Regex(r, _) => r.as_str().to_string(),
+		});
 
 		debug!(bind=%bind_name, listener=%selected_listener.key, route=%selected_route.key, "selected route");
 

--- a/crates/agentgateway/src/proxy/request_builder.rs
+++ b/crates/agentgateway/src/proxy/request_builder.rs
@@ -21,6 +21,7 @@ pub struct Request {
 	body: Option<Body>,
 	version: Version,
 	extensions: Extensions,
+	path_match: Option<String>,
 }
 
 /// A builder to construct the properties of a `Request`.
@@ -42,6 +43,7 @@ impl Request {
 			body: None,
 			version: Version::default(),
 			extensions: Extensions::new(),
+			path_match: None,
 		}
 	}
 
@@ -318,6 +320,13 @@ impl RequestBuilder {
 		self
 	}
 
+	pub fn path_match(mut self, path_match: String) -> Self {
+		if let Ok(ref mut req) = self.request {
+			req.path_match = Some(path_match);
+		}
+		self
+	}
+
 	pub fn build(self) -> Result<crate::http::Request, crate::http::Error> {
 		let req = crate::http::Request::try_from(self.request?)?;
 		Ok(req)
@@ -387,6 +396,7 @@ impl TryFrom<crate::http::Request> for Request {
 			body: Some(body),
 			version,
 			extensions,
+			path_match: None,
 		})
 	}
 }

--- a/crates/agentgateway/src/proxy/tcpproxy.rs
+++ b/crates/agentgateway/src/proxy/tcpproxy.rs
@@ -133,6 +133,20 @@ impl TCPProxy {
 		)
 		.await?;
 
+		// export rx/tx bytes on drop
+		let mut connection = connection;
+		let labels = TCPLabels {
+			bind: Some(&self.bind_name).into(),
+			gateway: Some(&self.selected_listener.gateway_name).into(),
+			listener: Some(&self.selected_listener.name).into(),
+			protocol: if log.tls_info.is_some() {
+				BindProtocol::tls
+			} else {
+				BindProtocol::tcp
+			},
+		};
+		connection.set_transport_metrics(self.inputs.metrics.clone(), labels);
+
 		inputs
 			.upstream
 			.call_tcp(client::TCPCall {

--- a/crates/agentgateway/src/telemetry/metrics.rs
+++ b/crates/agentgateway/src/telemetry/metrics.rs
@@ -227,7 +227,7 @@ impl Metrics {
 			},
 			tls_handshake_duration: {
 				let m = Family::<TCPLabels, _>::new_with_constructor(move || {
-					PromHistogram::new(REQUEST_DURATION_BUCKET)
+					PromHistogram::new(CONNECT_DURATION_BUCKET)
 				});
 				registry.register(
 					"tls_handshake_duration",

--- a/crates/agentgateway/src/telemetry/metrics.rs
+++ b/crates/agentgateway/src/telemetry/metrics.rs
@@ -14,6 +14,8 @@ use prometheus_client::metrics::histogram::Histogram as PromHistogram;
 use prometheus_client::metrics::info::Info;
 use prometheus_client::registry::{Registry, Unit};
 
+const ENV_ENABLE_CONNECT_DURATION_METRICS: &str = "ENABLE_CONNECT_DURATION_METRICS";
+
 #[derive(Clone, Hash, Default, Debug, PartialEq, Eq, EncodeLabelSet)]
 pub struct RouteIdentifier {
 	pub bind: DefaultedUnknown<RichStrng>,
@@ -242,7 +244,7 @@ impl Metrics {
 				);
 				m
 			},
-			enable_connect_duration_metrics: match env::var("ENABLE_CONNECT_DURATION_METRICS") {
+			enable_connect_duration_metrics: match env::var(ENV_ENABLE_CONNECT_DURATION_METRICS) {
 				Ok(v) => matches!(v.as_str(), "1" | "true" | "TRUE" | "True"),
 				Err(_) => false,
 			},

--- a/crates/agentgateway/src/telemetry/metrics.rs
+++ b/crates/agentgateway/src/telemetry/metrics.rs
@@ -105,6 +105,9 @@ pub struct Metrics {
 	pub gen_ai_time_to_first_token: Histogram<GenAILabels>,
 
 	pub response_bytes: Family<HTTPLabels, counter::Counter>,
+
+	pub tcp_rx_bytes: Family<TCPLabels, counter::Counter>,
+	pub tcp_tx_bytes: Family<TCPLabels, counter::Counter>,
 }
 
 impl Metrics {
@@ -178,6 +181,26 @@ impl Metrics {
 				registry.register_with_unit(
 					"response_bytes",
 					"Total HTTP response bytes sent",
+					Unit::Bytes,
+					m.clone(),
+				);
+				m
+			},
+			tcp_rx_bytes: {
+				let m = Family::<TCPLabels, _>::default();
+				registry.register_with_unit(
+					"tcp_rx_bytes",
+					"Total TCP bytes received per connection labels",
+					Unit::Bytes,
+					m.clone(),
+				);
+				m
+			},
+			tcp_tx_bytes: {
+				let m = Family::<TCPLabels, _>::default();
+				registry.register_with_unit(
+					"tcp_tx_bytes",
+					"Total TCP bytes transmitted per connection labels",
 					Unit::Bytes,
 					m.clone(),
 				);

--- a/crates/agentgateway/src/telemetry/metrics.rs
+++ b/crates/agentgateway/src/telemetry/metrics.rs
@@ -216,7 +216,7 @@ impl Metrics {
 			},
 			upstream_connect_duration: {
 				let m = Family::<ConnectLabels, _>::new_with_constructor(move || {
-					PromHistogram::new(REQUEST_DURATION_BUCKET)
+					PromHistogram::new(CONNECT_DURATION_BUCKET)
 				});
 				registry.register(
 					"upstream_connect_duration",
@@ -258,6 +258,30 @@ const TOKEN_USAGE_BUCKET: [f64; 14] = [
 // https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-metrics/#metric-gen_aiserverrequestduration
 const REQUEST_DURATION_BUCKET: [f64; 14] = [
 	0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.64, 1.28, 2.56, 5.12, 10.24, 20.48, 40.96, 81.92,
+];
+// Finer-grained buckets for TCP/TLS connect where many observations are <10ms.
+// Keep in seconds to match Prometheus conventions.
+const CONNECT_DURATION_BUCKET: [f64; 20] = [
+	0.0005, // 0.5 ms
+	0.001,  // 1 ms
+	0.002,  // 2 ms
+	0.003,  // 3 ms
+	0.004,  // 4 ms
+	0.005,  // 5 ms
+	0.0075, // 7.5 ms
+	0.01,   // 10 ms
+	0.0125, // 12.5 ms
+	0.015,  // 15 ms
+	0.0175, // 17.5 ms
+	0.02,   // 20 ms
+	0.03,   // 30 ms
+	0.04,   // 40 ms
+	0.06,   // 60 ms
+	0.08,   // 80 ms
+	0.12,   // 120 ms
+	0.16,   // 160 ms
+	0.32,   // 320 ms
+	0.64,   // 640 ms
 ];
 // https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-metrics/#metric-gen_aiservertime_per_output_token
 // NOTE: the spec has SHOULD, but is not smart enough to handle the faster LLMs.

--- a/crates/agentgateway/src/telemetry/metrics.rs
+++ b/crates/agentgateway/src/telemetry/metrics.rs
@@ -11,7 +11,7 @@ use prometheus_client::metrics::counter;
 use prometheus_client::metrics::family::Family;
 use prometheus_client::metrics::histogram::Histogram as PromHistogram;
 use prometheus_client::metrics::info::Info;
-use prometheus_client::registry::Registry;
+use prometheus_client::registry::{Registry, Unit};
 
 #[derive(Clone, Hash, Default, Debug, PartialEq, Eq, EncodeLabelSet)]
 pub struct RouteIdentifier {
@@ -103,6 +103,8 @@ pub struct Metrics {
 	pub gen_ai_request_duration: Histogram<GenAILabels>,
 	pub gen_ai_time_per_output_token: Histogram<GenAILabels>,
 	pub gen_ai_time_to_first_token: Histogram<GenAILabels>,
+
+	pub response_bytes: Family<HTTPLabels, counter::Counter>,
 }
 
 impl Metrics {
@@ -170,6 +172,17 @@ impl Metrics {
 			gen_ai_request_duration,
 			gen_ai_time_per_output_token,
 			gen_ai_time_to_first_token,
+
+			response_bytes: {
+				let m = Family::<HTTPLabels, _>::default();
+				registry.register_with_unit(
+					"response_bytes",
+					"Total HTTP response bytes sent",
+					Unit::Bytes,
+					m.clone(),
+				);
+				m
+			},
 		}
 	}
 }

--- a/crates/agentgateway/src/telemetry/metrics.rs
+++ b/crates/agentgateway/src/telemetry/metrics.rs
@@ -259,29 +259,26 @@ const TOKEN_USAGE_BUCKET: [f64; 14] = [
 const REQUEST_DURATION_BUCKET: [f64; 14] = [
 	0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.64, 1.28, 2.56, 5.12, 10.24, 20.48, 40.96, 81.92,
 ];
-// Finer-grained buckets for TCP/TLS connect where many observations are <10ms.
-// Keep in seconds to match Prometheus conventions.
-const CONNECT_DURATION_BUCKET: [f64; 20] = [
+// Finer-grained, exponentially growing buckets for TCP/TLS connect.
+// Keep in seconds (Prometheus convention). Use ~x2 growth to cover long tail.
+const CONNECT_DURATION_BUCKET: [f64; 17] = [
 	0.0005, // 0.5 ms
 	0.001,  // 1 ms
 	0.002,  // 2 ms
-	0.003,  // 3 ms
 	0.004,  // 4 ms
-	0.005,  // 5 ms
-	0.0075, // 7.5 ms
-	0.01,   // 10 ms
-	0.0125, // 12.5 ms
-	0.015,  // 15 ms
-	0.0175, // 17.5 ms
-	0.02,   // 20 ms
-	0.03,   // 30 ms
-	0.04,   // 40 ms
-	0.06,   // 60 ms
-	0.08,   // 80 ms
-	0.12,   // 120 ms
-	0.16,   // 160 ms
-	0.32,   // 320 ms
-	0.64,   // 640 ms
+	0.008,  // 8 ms
+	0.016,  // 16 ms
+	0.032,  // 32 ms
+	0.064,  // 64 ms
+	0.128,  // 128 ms
+	0.256,  // 256 ms
+	0.512,  // 512 ms
+	1.024,  // ~1.0 s
+	2.048,  // ~2.0 s
+	4.096,  // ~4.1 s
+	8.192,  // ~8.2 s
+	16.384, // ~16.4 s
+	32.768, // ~32.8 s
 ];
 // https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-metrics/#metric-gen_aiservertime_per_output_token
 // NOTE: the spec has SHOULD, but is not smart enough to handle the faster LLMs.

--- a/crates/agentgateway/src/telemetry/metrics.rs
+++ b/crates/agentgateway/src/telemetry/metrics.rs
@@ -1,3 +1,4 @@
+use std::env;
 use std::fmt::Debug;
 
 use crate::mcp::MCPOperation;
@@ -116,6 +117,9 @@ pub struct Metrics {
 
 	pub upstream_connect_duration: Histogram<ConnectLabels>,
 	pub tls_handshake_duration: Histogram<TCPLabels>,
+
+	// Feature flag controlling emission of connect/tls duration histograms
+	pub enable_connect_duration_metrics: bool,
 }
 
 impl Metrics {
@@ -237,6 +241,10 @@ impl Metrics {
 					m.clone(),
 				);
 				m
+			},
+			enable_connect_duration_metrics: match env::var("ENABLE_CONNECT_DURATION_METRICS") {
+				Ok(v) => matches!(v.as_str(), "1" | "true" | "TRUE" | "True"),
+				Err(_) => false,
 			},
 		}
 	}

--- a/crates/agentgateway/src/telemetry/metrics.rs
+++ b/crates/agentgateway/src/telemetry/metrics.rs
@@ -188,7 +188,7 @@ impl Metrics {
 				let m = Family::<HTTPLabels, _>::default();
 				registry.register_with_unit(
 					"response",
-					"Total HTTP response bytes sent",
+					"Total HTTP response bytes received",
 					Unit::Bytes,
 					m.clone(),
 				);
@@ -207,7 +207,7 @@ impl Metrics {
 			tcp_downstream_tx_bytes: {
 				let m = Family::<TCPLabels, _>::default();
 				registry.register_with_unit(
-					"downstream_transmitted",
+					"downstream_sent",
 					"Total TCP bytes transmitted per connection labels",
 					Unit::Bytes,
 					m.clone(),
@@ -263,25 +263,17 @@ const REQUEST_DURATION_BUCKET: [f64; 14] = [
 ];
 // Finer-grained, exponentially growing buckets for TCP/TLS connect.
 // Keep in seconds (Prometheus convention). Prioritize sub-second resolution, with a few larger outlier buckets.
-const CONNECT_DURATION_BUCKET: [f64; 18] = [
+const CONNECT_DURATION_BUCKET: [f64; 10] = [
 	0.0005, // 0.5 ms
-	0.001,  // 1 ms
-	0.0017, // 1.7 ms
-	0.003,  // 3 ms
-	0.005,  // 5 ms
-	0.0085, // 8.5 ms
-	0.015,  // 15 ms
-	0.025,  // 25 ms
-	0.042,  // 42 ms
-	0.07,   // 70 ms
-	0.12,   // 120 ms
-	0.2,    // 200 ms
-	0.34,   // 340 ms
-	0.57,   // 570 ms
-	1.0,    // 1 s
-	2.0,    // 2 s (outlier)
-	4.0,    // 4 s (outlier)
-	8.0,    // 8 s (outlier)
+	0.0015, // 1.5 ms
+	0.0043, // 4.3 ms
+	0.0126, // 12.6 ms
+	0.0368, // 36.8 ms
+	0.108,  // 108 ms
+	0.316,  // 316 ms
+	0.924,  // 924 ms
+	2.71,   // 2.71 s
+	8.0,    // 8 s
 ];
 // https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-metrics/#metric-gen_aiservertime_per_output_token
 // NOTE: the spec has SHOULD, but is not smart enough to handle the faster LLMs.

--- a/crates/agentgateway/src/test_helpers/proxymock.rs
+++ b/crates/agentgateway/src/test_helpers/proxymock.rs
@@ -437,7 +437,7 @@ pub fn setup_proxy_test(cfg: &str) -> anyhow::Result<TestBind> {
 	agent_core::telemetry::testing::setup_test_logging();
 	let config = crate::config::parse_config(cfg.to_string(), None)?;
 	let stores = Stores::new();
-	let client = client::Client::new(&config.dns, None, Default::default());
+	let client = client::Client::new(&config.dns, None, Default::default(), None);
 	let (drain_tx, drain_rx) = drain::new();
 	let pi = Arc::new(ProxyInputs {
 		cfg: Arc::new(config),

--- a/crates/agentgateway/src/transport/stream.rs
+++ b/crates/agentgateway/src/transport/stream.rs
@@ -477,12 +477,12 @@ impl Drop for Metrics {
 		{
 			ctx
 				.metrics
-				.tcp_tx_bytes
+				.tcp_downstream_tx_bytes
 				.get_or_create(&ctx.labels)
 				.inc_by(tx);
 			ctx
 				.metrics
-				.tcp_rx_bytes
+				.tcp_downstream_rx_bytes
 				.get_or_create(&ctx.labels)
 				.inc_by(rx);
 		}

--- a/crates/agentgateway/src/transport/stream.rs
+++ b/crates/agentgateway/src/transport/stream.rs
@@ -471,19 +471,19 @@ impl Drop for Metrics {
 			return;
 		}
 		// Export counters if a metrics context is present
-		if let Some(ctx) = &self.ctx {
-			if let Some((tx, rx)) = self.counter.take().map(|c| c.load()) {
-				ctx
-					.metrics
-					.tcp_tx_bytes
-					.get_or_create(&ctx.labels)
-					.inc_by(tx);
-				ctx
-					.metrics
-					.tcp_rx_bytes
-					.get_or_create(&ctx.labels)
-					.inc_by(rx);
-			}
+		if let Some(ctx) = &self.ctx
+			&& let Some((tx, rx)) = self.counter.take().map(|c| c.load())
+		{
+			ctx
+				.metrics
+				.tcp_tx_bytes
+				.get_or_create(&ctx.labels)
+				.inc_by(tx);
+			ctx
+				.metrics
+				.tcp_rx_bytes
+				.get_or_create(&ctx.labels)
+				.inc_by(rx);
 		}
 		let (sent, recv) = if let Some((a, b)) = self.counter.take().map(|counter| counter.load()) {
 			(Some(a), Some(b))

--- a/crates/agentgateway/src/transport/stream.rs
+++ b/crates/agentgateway/src/transport/stream.rs
@@ -471,8 +471,9 @@ impl Drop for Metrics {
 			return;
 		}
 		// Export counters if a metrics context is present
+		let counts = self.counter.take().map(|c| c.load());
 		if let Some(ctx) = &self.ctx
-			&& let Some((tx, rx)) = self.counter.take().map(|c| c.load())
+			&& let Some((tx, rx)) = counts
 		{
 			ctx
 				.metrics
@@ -485,7 +486,7 @@ impl Drop for Metrics {
 				.get_or_create(&ctx.labels)
 				.inc_by(rx);
 		}
-		let (sent, recv) = if let Some((a, b)) = self.counter.take().map(|counter| counter.load()) {
+		let (sent, recv) = if let Some((a, b)) = counts {
 			(Some(a), Some(b))
 		} else {
 			(None, None)

--- a/crates/agentgateway/src/transport/stream.rs
+++ b/crates/agentgateway/src/transport/stream.rs
@@ -16,6 +16,7 @@ use tokio::net::TcpStream;
 use tokio_rustls::TlsStream;
 use tracing::event;
 
+use crate::telemetry::metrics::{Metrics as TelemetryMetrics, TCPLabels};
 use crate::types::discovery::Identity;
 
 #[derive(Debug, Clone)]
@@ -60,6 +61,7 @@ pub struct HBONEConnectionInfo {
 pub struct Metrics {
 	counter: Option<BytesCounter>,
 	logging: LoggingMode,
+	ctx: Option<TransportMetricsCtx>,
 }
 
 impl Metrics {
@@ -67,8 +69,15 @@ impl Metrics {
 		Self {
 			counter: Some(Default::default()),
 			logging: LoggingMode::default(),
+			ctx: None,
 		}
 	}
+}
+
+#[derive(Debug, Clone)]
+pub struct TransportMetricsCtx {
+	pub metrics: std::sync::Arc<TelemetryMetrics>,
+	pub labels: TCPLabels,
 }
 
 #[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
@@ -119,6 +128,14 @@ impl hyper_util_fork::client::legacy::connect::Connection for Socket {
 impl Socket {
 	pub fn into_parts(self) -> (Extension, Metrics, SocketType) {
 		(self.ext, self.metrics, self.inner)
+	}
+
+	pub fn set_transport_metrics(
+		&mut self,
+		metrics: std::sync::Arc<TelemetryMetrics>,
+		labels: TCPLabels,
+	) {
+		self.metrics.ctx = Some(TransportMetricsCtx { metrics, labels });
 	}
 
 	pub fn from_memory(stream: DuplexStream, info: TCPConnectionInfo) -> Self {
@@ -181,8 +198,7 @@ impl Socket {
 		Socket {
 			ext,
 			inner: SocketType::Hbone(hbone),
-			// TODO: we probably want a counter here...
-			metrics: Default::default(),
+			metrics: Metrics::with_counter(),
 		}
 	}
 
@@ -454,7 +470,21 @@ impl Drop for Metrics {
 		if self.logging == LoggingMode::None {
 			return;
 		}
-		// let src = self.tcp().peer_addr;
+		// Export counters if a metrics context is present
+		if let Some(ctx) = &self.ctx {
+			if let Some((tx, rx)) = self.counter.take().map(|c| c.load()) {
+				ctx
+					.metrics
+					.tcp_tx_bytes
+					.get_or_create(&ctx.labels)
+					.inc_by(tx);
+				ctx
+					.metrics
+					.tcp_rx_bytes
+					.get_or_create(&ctx.labels)
+					.inc_by(rx);
+			}
+		}
 		let (sent, recv) = if let Some((a, b)) = self.counter.take().map(|counter| counter.load()) {
 			(Some(a), Some(b))
 		} else {

--- a/crates/agentgateway/src/ui.rs
+++ b/crates/agentgateway/src/ui.rs
@@ -54,7 +54,7 @@ impl UiHandler {
 			.layer(add_cors_layer())
 			.with_state(App {
 				state: cfg.clone(),
-				client: client::Client::new(&cfg.dns, None, Default::default()),
+				client: client::Client::new(&cfg.dns, None, Default::default(), None),
 			});
 		Self { router }
 	}


### PR DESCRIPTION
Example metrics with TCPRoute from kgateway with env to enable connection duration metrics:
```
kind: GatewayParameters
apiVersion: gateway.kgateway.dev/v1alpha1
metadata:
  name: kgateway
spec:
  kube:
    agentgateway:
      enabled: true
      logLevel: trace
      image:
        tag: d723f1f5a
      env:
        - name: ENABLE_CONNECT_DURATION_METRICS
          value: "true"
```
Metrics:
```
# HELP agentgateway_xds_connection_terminations The total number of completed connections to xds server (unstable).
# TYPE agentgateway_xds_connection_terminations counter
# HELP agentgateway_xds_message Total number of messages received (unstable).
# TYPE agentgateway_xds_message counter
agentgateway_xds_message_total{url="type.googleapis.com/agentgateway.dev.resource.Resource"} 1
agentgateway_xds_message_total{url="type.googleapis.com/agentgateway.dev.workload.Address"} 3
# HELP agentgateway_xds_message_bytes Total number of bytes received (unstable).
# TYPE agentgateway_xds_message_bytes counter
# UNIT agentgateway_xds_message_bytes bytes
agentgateway_xds_message_bytes_total{url="type.googleapis.com/agentgateway.dev.workload.Address"} 8332
agentgateway_xds_message_bytes_total{url="type.googleapis.com/agentgateway.dev.resource.Resource"} 305
# HELP agentgateway_build Agentgateway build information.
# TYPE agentgateway_build info
agentgateway_build_info{tag="unknown"} 1
# HELP agentgateway_gen_ai_client_token_usage Number of tokens used per request.
# TYPE agentgateway_gen_ai_client_token_usage histogram
# HELP agentgateway_gen_ai_server_request_duration Duration of generative AI request.
# TYPE agentgateway_gen_ai_server_request_duration histogram
# HELP agentgateway_gen_ai_server_time_per_output_token Time to generate each output token for a given request.
# TYPE agentgateway_gen_ai_server_time_per_output_token histogram
# HELP agentgateway_gen_ai_server_time_to_first_token Time to generate the first token for a given request.
# TYPE agentgateway_gen_ai_server_time_to_first_token histogram
# HELP agentgateway_requests The total number of HTTP requests sent.
# TYPE agentgateway_requests counter
# HELP agentgateway_downstream_connections The total number of downstream connections established.
# TYPE agentgateway_downstream_connections counter
agentgateway_downstream_connections_total{bind="8080/default/tcp-gw-for-test",gateway="default/tcp-gw-for-test",listener="tcp",protocol="tcp"} 2105
# HELP agentgateway_mcp_requests Total number of MCP tool calls.
# TYPE agentgateway_mcp_requests counter
# HELP agentgateway_response_bytes Total HTTP response bytes received.
# TYPE agentgateway_response_bytes counter
# UNIT agentgateway_response_bytes bytes
# HELP agentgateway_downstream_received_bytes Total TCP bytes received per connection labels.
# TYPE agentgateway_downstream_received_bytes counter
# UNIT agentgateway_downstream_received_bytes bytes
agentgateway_downstream_received_bytes_total{bind="8080/default/tcp-gw-for-test",gateway="default/tcp-gw-for-test",listener="tcp",protocol="tcp"} 166390
# HELP agentgateway_downstream_sent_bytes Total TCP bytes transmitted per connection labels.
# TYPE agentgateway_downstream_sent_bytes counter
# UNIT agentgateway_downstream_sent_bytes bytes
agentgateway_downstream_sent_bytes_total{bind="8080/default/tcp-gw-for-test",gateway="default/tcp-gw-for-test",listener="tcp",protocol="tcp"} 848090
# HELP agentgateway_upstream_connect_duration_seconds Duration to establish upstream connection (seconds).
# TYPE agentgateway_upstream_connect_duration_seconds histogram
# UNIT agentgateway_upstream_connect_duration_seconds seconds
agentgateway_upstream_connect_duration_seconds_sum{transport="plaintext"} 0.008
agentgateway_upstream_connect_duration_seconds_count{transport="plaintext"} 2105
agentgateway_upstream_connect_duration_seconds_bucket{le="0.0005",transport="plaintext"} 2101
agentgateway_upstream_connect_duration_seconds_bucket{le="0.0015",transport="plaintext"} 2104
agentgateway_upstream_connect_duration_seconds_bucket{le="0.0043",transport="plaintext"} 2104
agentgateway_upstream_connect_duration_seconds_bucket{le="0.0126",transport="plaintext"} 2105
agentgateway_upstream_connect_duration_seconds_bucket{le="0.0368",transport="plaintext"} 2105
agentgateway_upstream_connect_duration_seconds_bucket{le="0.108",transport="plaintext"} 2105
agentgateway_upstream_connect_duration_seconds_bucket{le="0.316",transport="plaintext"} 2105
agentgateway_upstream_connect_duration_seconds_bucket{le="0.924",transport="plaintext"} 2105
agentgateway_upstream_connect_duration_seconds_bucket{le="2.71",transport="plaintext"} 2105
agentgateway_upstream_connect_duration_seconds_bucket{le="8.0",transport="plaintext"} 2105
agentgateway_upstream_connect_duration_seconds_bucket{le="+Inf",transport="plaintext"} 2105
# HELP agentgateway_tls_handshake_duration_seconds Duration to complete inbound TLS/HTTPS handshake (seconds).
# TYPE agentgateway_tls_handshake_duration_seconds histogram
# UNIT agentgateway_tls_handshake_duration_seconds seconds
# EOF

```

Connection duration metrics not enabled:
```
# HELP agentgateway_xds_connection_terminations The total number of completed connections to xds server (unstable).
# TYPE agentgateway_xds_connection_terminations counter
# HELP agentgateway_xds_message Total number of messages received (unstable).
# TYPE agentgateway_xds_message counter
agentgateway_xds_message_total{url="type.googleapis.com/agentgateway.dev.workload.Address"} 5
agentgateway_xds_message_total{url="type.googleapis.com/agentgateway.dev.resource.Resource"} 1
# HELP agentgateway_xds_message_bytes Total number of bytes received (unstable).
# TYPE agentgateway_xds_message_bytes counter
# UNIT agentgateway_xds_message_bytes bytes
agentgateway_xds_message_bytes_total{url="type.googleapis.com/agentgateway.dev.workload.Address"} 8827
agentgateway_xds_message_bytes_total{url="type.googleapis.com/agentgateway.dev.resource.Resource"} 305
# HELP agentgateway_build Agentgateway build information.
# TYPE agentgateway_build info
agentgateway_build_info{tag="unknown"} 1
# HELP agentgateway_gen_ai_client_token_usage Number of tokens used per request.
# TYPE agentgateway_gen_ai_client_token_usage histogram
# HELP agentgateway_gen_ai_server_request_duration Duration of generative AI request.
# TYPE agentgateway_gen_ai_server_request_duration histogram
# HELP agentgateway_gen_ai_server_time_per_output_token Time to generate each output token for a given request.
# TYPE agentgateway_gen_ai_server_time_per_output_token histogram
# HELP agentgateway_gen_ai_server_time_to_first_token Time to generate the first token for a given request.
# TYPE agentgateway_gen_ai_server_time_to_first_token histogram
# HELP agentgateway_requests The total number of HTTP requests sent.
# TYPE agentgateway_requests counter
# HELP agentgateway_downstream_connections The total number of downstream connections established.
# TYPE agentgateway_downstream_connections counter
agentgateway_downstream_connections_total{bind="8080/default/tcp-gw-for-test",gateway="default/tcp-gw-for-test",listener="tcp",protocol="tcp"} 604
# HELP agentgateway_mcp_requests Total number of MCP tool calls.
# TYPE agentgateway_mcp_requests counter
# HELP agentgateway_response_bytes Total HTTP response bytes received.
# TYPE agentgateway_response_bytes counter
# UNIT agentgateway_response_bytes bytes
# HELP agentgateway_downstream_received_bytes Total TCP bytes received per connection labels.
# TYPE agentgateway_downstream_received_bytes counter
# UNIT agentgateway_downstream_received_bytes bytes
agentgateway_downstream_received_bytes_total{bind="8080/default/tcp-gw-for-test",gateway="default/tcp-gw-for-test",listener="tcp",protocol="tcp"} 41812
# HELP agentgateway_downstream_sent_bytes Total TCP bytes transmitted per connection labels.
# TYPE agentgateway_downstream_sent_bytes counter
# UNIT agentgateway_downstream_sent_bytes bytes
agentgateway_downstream_sent_bytes_total{bind="8080/default/tcp-gw-for-test",gateway="default/tcp-gw-for-test",listener="tcp",protocol="tcp"} 213172
# HELP agentgateway_upstream_connect_duration_seconds Duration to establish upstream connection (seconds).
# TYPE agentgateway_upstream_connect_duration_seconds histogram
# UNIT agentgateway_upstream_connect_duration_seconds seconds
# HELP agentgateway_tls_handshake_duration_seconds Duration to complete inbound TLS/HTTPS handshake (seconds).
# TYPE agentgateway_tls_handshake_duration_seconds histogram
# UNIT agentgateway_tls_handshake_duration_seconds seconds
# EOF

```

HTTPRoute example:
```
# TYPE agentgateway_requests counter
agentgateway_requests_total{backend="service/default/httpbin.default.svc.cluster.local:8000",protocol="http",method="GET",status="200",reason="Upstream",bind="8080/default/http-gw-for-test",gateway="default/http-gw-for-test",listener="http",route="default/httpbin",route_rule="unknown"} 10
# HELP agentgateway_downstream_connections The total number of downstream connections established.
# TYPE agentgateway_downstream_connections counter
agentgateway_downstream_connections_total{bind="8080/default/http-gw-for-test",gateway="unknown",listener="unknown",protocol="http"} 10
# HELP agentgateway_mcp_requests Total number of MCP tool calls.
# TYPE agentgateway_mcp_requests counter
# HELP agentgateway_response_bytes Total HTTP response bytes sent.
# TYPE agentgateway_response_bytes counter
# UNIT agentgateway_response_bytes bytes
agentgateway_response_bytes_total{backend="service/default/httpbin.default.svc.cluster.local:8000",protocol="http",method="GET",status="200",reason="Upstream",bind="8080/default/http-gw-for-test",gateway="default/http-gw-for-test",listener="http",route="default/httpbin",route_rule="unknown"} 1090
# HELP agentgateway_downstream_received_bytes Total TCP bytes received per connection labels.
# TYPE agentgateway_downstream_received_bytes counter
# UNIT agentgateway_downstream_received_bytes bytes
agentgateway_downstream_received_bytes_total{bind="8080/default/http-gw-for-test",gateway="unknown",listener="unknown",protocol="http"} 860
# HELP agentgateway_downstream_transmitted_bytes Total TCP bytes transmitted per connection labels.
# TYPE agentgateway_downstream_transmitted_bytes counter
# UNIT agentgateway_downstream_transmitted_bytes bytes
agentgateway_downstream_transmitted_bytes_total{bind="8080/default/http-gw-for-test",gateway="unknown",listener="unknown",protocol="http"} 3390
# HELP agentgateway_upstream_connect_duration_seconds Duration to establish upstream connection (seconds).
```