### PR TITLE
Add support for OpenAI /responses API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,8 +497,9 @@ dependencies = [
 
 [[package]]
 name = "async-openai"
-version = "0.29.0"
-source = "git+https://github.com/howardjohn/async-openai?rev=c95098beac2c65132c8a7b7c7bf39a9ad6479acb#c95098beac2c65132c8a7b7c7bf39a9ad6479acb"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bf39a15c8d613eb61892dc9a287c02277639ebead41ee611ad23aaa613f1a82"
 dependencies = [
  "async-openai-macros",
  "backoff",
@@ -507,7 +508,7 @@ dependencies = [
  "derive_builder",
  "eventsource-stream",
  "futures",
- "rand 0.8.5",
+ "rand 0.9.2",
  "reqwest",
  "reqwest-eventsource",
  "secrecy",
@@ -523,7 +524,8 @@ dependencies = [
 [[package]]
 name = "async-openai-macros"
 version = "0.1.0"
-source = "git+https://github.com/howardjohn/async-openai?rev=c95098beac2c65132c8a7b7c7bf39a9ad6479acb#c95098beac2c65132c8a7b7c7bf39a9ad6479acb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0289cba6d5143bfe8251d57b4a8cac036adf158525a76533a7082ba65ec76398"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,5 @@
 [patch.crates-io]
 schemars = { git = "https://github.com/howardjohn/schemars", rev = "4364354fa41897a0c2001d891c0a9a38eafedb82" }
-# Remove after v0.29.2
-async-openai = { git = "https://github.com/howardjohn/async-openai", rev = "c95098beac2c65132c8a7b7c7bf39a9ad6479acb" }
 http-serde = { git = "https://gitlab.com/howardjohn/http-serde", rev = "163f20f551c2cf6032254b6dbbe246b91ce727ad" }
 
 [workspace]
@@ -43,7 +41,7 @@ anyhow = "1.0"
 arc-swap = "1.7.1"
 arcstr = { version = "1.2", features = ["serde"] }
 assert_matches = "1.5.0"
-async-openai = { version = "0.29.0", default-features = false }
+async-openai = { version = "0.30.1", default-features = false }
 async-stream = "0.3"
 async-trait = "0.1"
 aws-config = "1.8"

--- a/crates/agentgateway/proto/resource.proto
+++ b/crates/agentgateway/proto/resource.proto
@@ -721,6 +721,8 @@ message AIBackend {
     MODELS = 3;
     // Sends requests to upstream as-is without LLM processing
     PASSTHROUGH = 4;
+    // Processes OpenAI /responses format requests
+    RESPONSES = 5;
   }
   message Provider {
     string name = 1;

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -515,6 +515,9 @@ impl AIProvider {
 			(InputFormat::Responses, AIProvider::OpenAI(_)) => {
 				// OpenAI supports responses input
 			},
+			(InputFormat::Responses, AIProvider::Bedrock(_)) => {
+				// Bedrock supports responses input via translation
+			},
 			(m, p) => {
 				// Messages with OpenAI compatible: currently only supports translating the request
 				return Err(AIError::UnsupportedConversion(strng::format!(

--- a/crates/agentgateway/src/llm/openai.rs
+++ b/crates/agentgateway/src/llm/openai.rs
@@ -235,6 +235,17 @@ pub mod responses {
 				// Passthrough - just serialize
 				serde_json::to_vec(&self).map_err(AIError::RequestMarshal)
 			}
+
+			fn to_bedrock(
+				&self,
+				provider: &crate::llm::bedrock::Provider,
+				headers: Option<&::http::HeaderMap>,
+			) -> Result<Vec<u8>, AIError> {
+				let bedrock_request = crate::llm::bedrock::translate_request_to_converse_from_responses(
+					self, provider, headers,
+				)?;
+				serde_json::to_vec(&bedrock_request).map_err(AIError::RequestMarshal)
+			}
 		}
 
 		impl ResponseType for Response {

--- a/crates/agentgateway/src/llm/openai.rs
+++ b/crates/agentgateway/src/llm/openai.rs
@@ -29,3 +29,369 @@ impl Provider {
 		Ok(resp)
 	}
 }
+
+pub mod responses {
+	use async_openai::types::responses::{
+		ContentType, Input, InputContent, InputItem, InputMessage, OutputContent, ResponseEvent, Role,
+	};
+	use bytes::Bytes;
+
+	use crate::llm::universal::{RequestType, ResponseType};
+	use crate::llm::{AIError, InputFormat, LLMRequest, LLMRequestParams, LLMResponse};
+
+	pub mod passthrough {
+		use super::*;
+		use serde::{Deserialize, Serialize};
+
+		#[derive(Debug, Deserialize, Clone, Serialize)]
+		pub struct Request {
+			// Required field for prompt enrichment/guards
+			pub input: Input,
+
+			// Fields we actually read for routing/telemetry
+			#[serde(skip_serializing_if = "Option::is_none")]
+			pub model: Option<String>,
+
+			#[serde(skip_serializing_if = "Option::is_none")]
+			pub max_output_tokens: Option<u32>,
+
+			#[serde(skip_serializing_if = "Option::is_none")]
+			pub temperature: Option<f32>,
+
+			#[serde(skip_serializing_if = "Option::is_none")]
+			pub top_p: Option<f32>,
+
+			#[serde(skip_serializing_if = "Option::is_none")]
+			pub stream: Option<bool>,
+
+			// Everything else (tools, reasoning, etc.) - passthrough
+			#[serde(flatten, default)]
+			pub rest: serde_json::Value,
+		}
+
+		#[derive(Debug, Deserialize, Clone, Serialize)]
+		pub struct Response {
+			pub id: String,
+			pub status: String,
+			pub output: Vec<OutputContent>,
+			pub model: String,
+			#[serde(skip_serializing_if = "Option::is_none")]
+			pub usage: Option<Usage>,
+			#[serde(flatten, default)]
+			pub rest: serde_json::Value,
+		}
+
+		#[derive(Debug, Deserialize, Clone, Serialize)]
+		pub struct Usage {
+			pub input_tokens: u64,
+			pub output_tokens: u64,
+			#[serde(flatten, default)]
+			pub rest: serde_json::Value,
+		}
+
+		impl RequestType for Request {
+			fn model(&mut self) -> Option<&mut String> {
+				self.model.as_mut()
+			}
+
+			fn prepend_prompts(&mut self, prompts: Vec<crate::llm::SimpleChatCompletionMessage>) {
+				if prompts.is_empty() {
+					return;
+				}
+
+				// Convert prepend prompts to InputItems
+				let prepend_items: Vec<InputItem> = prompts
+					.into_iter()
+					.map(|msg| {
+						let role = match msg.role.as_str() {
+							"assistant" => Role::Assistant,
+							"system" => Role::System,
+							"developer" => Role::Developer,
+							_ => Role::User,
+						};
+
+						InputItem::Message(InputMessage {
+							kind: Default::default(),
+							role,
+							content: InputContent::TextInput(msg.content.to_string()),
+						})
+					})
+					.collect();
+
+				// Convert existing input to Items format if needed
+				let mut items = match &self.input {
+					Input::Text(text) => {
+						vec![InputItem::Message(InputMessage {
+							kind: Default::default(),
+							role: Role::User,
+							content: InputContent::TextInput(text.clone()),
+						})]
+					},
+					Input::Items(existing_items) => existing_items.clone(),
+				};
+
+				// Prepend the new prompts
+				items.splice(0..0, prepend_items);
+
+				self.input = Input::Items(items);
+			}
+
+			fn to_llm_request(
+				&self,
+				provider: agent_core::strng::Strng,
+				tokenize: bool,
+			) -> Result<LLMRequest, AIError> {
+				let model = agent_core::strng::new(self.model.as_deref().unwrap_or_default());
+				let input_tokens = if tokenize {
+					let tokens = crate::llm::num_tokens_from_responses_input(&model, &self.input)?;
+					Some(tokens)
+				} else {
+					None
+				};
+
+				Ok(LLMRequest {
+					input_tokens,
+					input_format: InputFormat::Responses,
+					request_model: model,
+					provider,
+					streaming: self.stream.unwrap_or_default(),
+					params: LLMRequestParams {
+						temperature: self.temperature.map(Into::into),
+						top_p: self.top_p.map(Into::into),
+						frequency_penalty: None,
+						presence_penalty: None,
+						seed: None,
+						max_tokens: self.max_output_tokens.map(Into::into),
+					},
+				})
+			}
+
+			fn get_messages(&self) -> Vec<crate::llm::SimpleChatCompletionMessage> {
+				match &self.input {
+					Input::Text(text) => {
+						vec![crate::llm::SimpleChatCompletionMessage {
+							role: agent_core::strng::literal!("user"),
+							content: agent_core::strng::new(text),
+						}]
+					},
+					Input::Items(items) => items
+						.iter()
+						.filter_map(|item| match item {
+							InputItem::Message(msg) => {
+								let content = match &msg.content {
+									InputContent::TextInput(text) => agent_core::strng::new(text),
+									InputContent::InputItemContentList(parts) => {
+										// Extract text from all content parts
+										let text = parts
+											.iter()
+											.filter_map(|part| match part {
+												ContentType::InputText(input_text) => Some(input_text.text.as_str()),
+												_ => None,
+											})
+											.collect::<Vec<_>>()
+											.join("\n");
+										agent_core::strng::new(&text)
+									},
+								};
+
+								let role = match msg.role {
+									Role::User => agent_core::strng::literal!("user"),
+									Role::Assistant => agent_core::strng::literal!("assistant"),
+									Role::System => agent_core::strng::literal!("system"),
+									Role::Developer => agent_core::strng::literal!("developer"),
+								};
+
+								Some(crate::llm::SimpleChatCompletionMessage { role, content })
+							},
+							_ => None,
+						})
+						.collect(),
+				}
+			}
+
+			fn set_messages(&mut self, messages: Vec<crate::llm::SimpleChatCompletionMessage>) {
+				let items: Vec<InputItem> = messages
+					.into_iter()
+					.map(|msg| {
+						let role = match msg.role.as_str() {
+							"assistant" => Role::Assistant,
+							"system" => Role::System,
+							"developer" => Role::Developer,
+							_ => Role::User,
+						};
+
+						InputItem::Message(InputMessage {
+							kind: Default::default(),
+							role,
+							content: InputContent::TextInput(msg.content.to_string()),
+						})
+					})
+					.collect();
+
+				self.input = Input::Items(items);
+			}
+
+			fn to_openai(&self) -> Result<Vec<u8>, AIError> {
+				// Passthrough - just serialize
+				serde_json::to_vec(&self).map_err(AIError::RequestMarshal)
+			}
+		}
+
+		impl ResponseType for Response {
+			fn to_llm_response(&self, include_completion_in_log: bool) -> LLMResponse {
+				LLMResponse {
+					input_tokens: self.usage.as_ref().map(|u| u.input_tokens),
+					output_tokens: self.usage.as_ref().map(|u| u.output_tokens),
+					total_tokens: self
+						.usage
+						.as_ref()
+						.map(|u| u.input_tokens + u.output_tokens),
+					provider_model: Some(agent_core::strng::new(&self.model)),
+					completion: if include_completion_in_log {
+						Some(
+							self
+								.output
+								.iter()
+								.filter_map(|o| match o {
+									OutputContent::Message(msg) => Some(msg),
+									_ => None,
+								})
+								.flat_map(|msg| {
+									msg.content.iter().filter_map(|c| match c {
+										async_openai::types::responses::Content::OutputText(t) => Some(t.text.clone()),
+										_ => None,
+									})
+								})
+								.collect(),
+						)
+					} else {
+						None
+					},
+					first_token: Default::default(),
+				}
+			}
+
+			fn set_webhook_choices(
+				&mut self,
+				choices: Vec<crate::llm::policy::webhook::ResponseChoice>,
+			) -> anyhow::Result<()> {
+				// Filter only Message outputs (ignore tool calls, reasoning, etc.)
+				let message_outputs: Vec<_> = self
+					.output
+					.iter_mut()
+					.filter_map(|o| match o {
+						OutputContent::Message(msg) => Some(msg),
+						_ => None,
+					})
+					.collect();
+
+				if message_outputs.len() != choices.len() {
+					anyhow::bail!("webhook response message count mismatch");
+				}
+
+				for (msg, wh) in message_outputs.into_iter().zip(choices.into_iter()) {
+					// Replace message content with webhook's modified content
+					use async_openai::types::responses::{Content, OutputText};
+					msg.content = vec![Content::OutputText(OutputText {
+						text: wh.message.content.to_string(),
+						annotations: vec![],
+					})];
+				}
+				Ok(())
+			}
+
+			fn to_webhook_choices(&self) -> Vec<crate::llm::policy::webhook::ResponseChoice> {
+				self
+					.output
+					.iter()
+					.filter_map(|o| match o {
+						OutputContent::Message(msg) => {
+							// Extract text from message content
+							let content = msg
+								.content
+								.iter()
+								.filter_map(|c| match c {
+									async_openai::types::responses::Content::OutputText(t) => Some(t.text.clone()),
+									_ => None,
+								})
+								.collect::<Vec<_>>()
+								.join("\n");
+
+							Some(crate::llm::policy::webhook::ResponseChoice {
+								message: crate::llm::policy::webhook::Message {
+									role: "assistant".into(),
+									content: content.into(),
+								},
+							})
+						},
+						_ => None, // Ignore non-message outputs (tool calls, reasoning, etc.)
+					})
+					.collect()
+			}
+
+			fn serialize(&self) -> serde_json::Result<Vec<u8>> {
+				serde_json::to_vec(&self)
+			}
+		}
+	}
+
+	pub fn process_response(bytes: &Bytes) -> Result<Box<dyn ResponseType>, AIError> {
+		let resp =
+			serde_json::from_slice::<passthrough::Response>(bytes).map_err(AIError::ResponseParsing)?;
+		Ok(Box::new(resp))
+	}
+
+	pub async fn process_streaming(
+		log: crate::telemetry::log::AsyncLog<crate::llm::LLMInfo>,
+		resp: crate::http::Response,
+	) -> crate::http::Response {
+		let buffer_limit = crate::http::response_buffer_limit(&resp);
+		let mut saw_token = false;
+
+		resp.map(|b| {
+			crate::parse::sse::json_passthrough::<ResponseEvent>(b, buffer_limit, move |event| {
+				let Some(Ok(event)) = event else {
+					return;
+				};
+
+				match event {
+					ResponseEvent::ResponseCreated(created) => {
+						log.non_atomic_mutate(|r| {
+							if let Some(model) = &created.response.model {
+								r.response.provider_model = Some(agent_core::strng::new(model));
+							}
+							if let Some(usage) = &created.response.usage {
+								r.response.input_tokens = Some(usage.input_tokens as u64);
+								r.response.output_tokens = Some(usage.output_tokens as u64);
+								r.response.total_tokens = Some(usage.total_tokens as u64);
+							}
+						});
+					},
+					ResponseEvent::ResponseOutputTextDelta(_) => {
+						if !saw_token {
+							saw_token = true;
+							log.non_atomic_mutate(|r| {
+								r.response.first_token = Some(std::time::Instant::now());
+							});
+						}
+					},
+					ResponseEvent::ResponseCompleted(completed) => {
+						log.non_atomic_mutate(|r| {
+							if let Some(model) = &completed.response.model {
+								r.response.provider_model = Some(agent_core::strng::new(model));
+							}
+							if let Some(usage) = &completed.response.usage {
+								r.response.input_tokens = Some(usage.input_tokens as u64);
+								r.response.output_tokens = Some(usage.output_tokens as u64);
+								r.response.total_tokens = Some(usage.total_tokens as u64);
+							}
+						});
+					},
+					_ => {
+						// Ignore other events
+					},
+				}
+			})
+		})
+	}
+}

--- a/crates/agentgateway/src/llm/tests.rs
+++ b/crates/agentgateway/src/llm/tests.rs
@@ -193,3 +193,25 @@ async fn test_anthropic() {
 		test_request("anthropic", r, request);
 	}
 }
+
+#[test]
+fn test_openai_responses() {
+	use openai::responses::passthrough;
+
+	let test_dir = Path::new("src/llm/tests");
+
+	let test_name = "response_openai_basic";
+	// Read input JSON
+	let input_path = test_dir.join(format!("{test_name}.json"));
+	let openai_str = &fs::read_to_string(&input_path).expect("Failed to read input file");
+	let openai_raw: Value = serde_json::from_str(openai_str).expect("Failed to parse input json");
+	let openai: passthrough::Response =
+		serde_json::from_str(openai_str).expect("Failed to parse input JSON");
+	let t = serde_json::to_string_pretty(&openai).unwrap();
+	let t2 = serde_json::to_string_pretty(&openai_raw).unwrap();
+	assert_eq!(
+		serde_json::from_str::<Value>(&t).unwrap(),
+		serde_json::from_str::<Value>(&t2).unwrap(),
+		"{t}\n{t2}"
+	);
+}

--- a/crates/agentgateway/src/llm/tests/response_openai_basic.json
+++ b/crates/agentgateway/src/llm/tests/response_openai_basic.json
@@ -1,0 +1,33 @@
+{
+  "id": "resp_abc123",
+  "object": "response",
+  "created_at": 1234567890,
+  "model": "gpt-4o",
+  "status": "completed",
+  "output": [
+    {
+      "type": "message",
+      "id": "msg_001",
+      "role": "assistant",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "text": "Hello! How can I help you today?",
+          "annotations": []
+        }
+      ]
+    }
+  ],
+  "usage": {
+    "input_tokens": 10,
+    "input_tokens_details": {
+      "cached_tokens": 0
+    },
+    "output_tokens": 8,
+    "output_tokens_details": {
+      "reasoning_tokens": 0
+    },
+    "total_tokens": 18
+  }
+}

--- a/crates/agentgateway/src/llm/universal.rs
+++ b/crates/agentgateway/src/llm/universal.rs
@@ -107,6 +107,10 @@ pub mod passthrough {
 					.map_err(AIError::ResponseParsing)?;
 				Ok(Box::new(passthrough))
 			},
+			InputFormat::Responses => {
+				// Responses format is OpenAI-specific, handled separately
+				unreachable!("Responses format should be handled in openai::responses module")
+			},
 		}
 	}
 

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -985,9 +985,9 @@ async fn make_backend_call(
 			// and parsing the request to build the LLMRequest for logging/etc, and applying LLM policies like
 			// prompt enrichment, prompt guard, etc.
 			match route_type {
-				RouteType::Completions | RouteType::Messages => {
-					let r = if route_type == RouteType::Completions {
-						llm
+				RouteType::Completions | RouteType::Messages | RouteType::Responses => {
+					let r = match route_type {
+						RouteType::Completions => llm
 							.provider
 							.process_completions_request(
 								&backend_info,
@@ -997,9 +997,8 @@ async fn make_backend_call(
 								&mut log,
 							)
 							.await
-							.map_err(|e| ProxyError::Processing(e.into()))?
-					} else {
-						llm
+							.map_err(|e| ProxyError::Processing(e.into()))?,
+						RouteType::Messages => llm
 							.provider
 							.process_messages_request(
 								&backend_info,
@@ -1009,7 +1008,19 @@ async fn make_backend_call(
 								&mut log,
 							)
 							.await
-							.map_err(|e| ProxyError::Processing(e.into()))?
+							.map_err(|e| ProxyError::Processing(e.into()))?,
+						RouteType::Responses => llm
+							.provider
+							.process_responses_request(
+								&backend_info,
+								route_policies.llm.as_deref(),
+								req,
+								llm.tokenize,
+								&mut log,
+							)
+							.await
+							.map_err(|e| ProxyError::Processing(e.into()))?,
+						_ => unreachable!(),
 					};
 					let (mut req, llm_request) = match r {
 						RequestResult::Success(r, lr) => (r, lr),

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -488,6 +488,7 @@ impl TryFrom<&proto::agent::Backend> for Backend {
 										Ok(ProtoRT::Messages) => llm::RouteType::Messages,
 										Ok(ProtoRT::Models) => llm::RouteType::Models,
 										Ok(ProtoRT::Passthrough) => llm::RouteType::Passthrough,
+										Ok(ProtoRT::Responses) => llm::RouteType::Responses,
 										Err(_) => {
 											warn!(
 												value = proto_route_type,

--- a/go/api/resource.pb.go
+++ b/go/api/resource.pb.go
@@ -582,6 +582,8 @@ const (
 	AIBackend_MODELS AIBackend_RouteType = 3
 	// Sends requests to upstream as-is without LLM processing
 	AIBackend_PASSTHROUGH AIBackend_RouteType = 4
+	// Processes OpenAI /responses format requests
+	AIBackend_RESPONSES AIBackend_RouteType = 5
 )
 
 // Enum value maps for AIBackend_RouteType.
@@ -592,6 +594,7 @@ var (
 		2: "MESSAGES",
 		3: "MODELS",
 		4: "PASSTHROUGH",
+		5: "RESPONSES",
 	}
 	AIBackend_RouteType_value = map[string]int32{
 		"UNSPECIFIED": 0,
@@ -599,6 +602,7 @@ var (
 		"MESSAGES":    2,
 		"MODELS":      3,
 		"PASSTHROUGH": 4,
+		"RESPONSES":   5,
 	}
 )
 
@@ -8067,7 +8071,7 @@ const file_resource_proto_rawDesc = "" +
 	"\x04kind\"7\n" +
 	"\rStaticBackend\x12\x12\n" +
 	"\x04host\x18\x01 \x01(\tR\x04host\x12\x12\n" +
-	"\x04port\x18\x02 \x01(\x05R\x04port\"\xf3\f\n" +
+	"\x04port\x18\x02 \x01(\x05R\x04port\"\x82\r\n" +
 	"\tAIBackend\x12[\n" +
 	"\x0fprovider_groups\x18\x01 \x03(\v22.agentgateway.dev.resource.AIBackend.ProviderGroupR\x0eproviderGroups\x1a6\n" +
 	"\fHostOverride\x12\x12\n" +
@@ -8105,14 +8109,15 @@ const file_resource_proto_rawDesc = "" +
 	"\n" +
 	"\bprovider\x1a\\\n" +
 	"\rProviderGroup\x12K\n" +
-	"\tproviders\x18\x01 \x03(\v2-.agentgateway.dev.resource.AIBackend.ProviderR\tproviders\"X\n" +
+	"\tproviders\x18\x01 \x03(\v2-.agentgateway.dev.resource.AIBackend.ProviderR\tproviders\"g\n" +
 	"\tRouteType\x12\x0f\n" +
 	"\vUNSPECIFIED\x10\x00\x12\x0f\n" +
 	"\vCOMPLETIONS\x10\x01\x12\f\n" +
 	"\bMESSAGES\x10\x02\x12\n" +
 	"\n" +
 	"\x06MODELS\x10\x03\x12\x0f\n" +
-	"\vPASSTHROUGH\x10\x04\"\xd0\x02\n" +
+	"\vPASSTHROUGH\x10\x04\x12\r\n" +
+	"\tRESPONSES\x10\x05\"\xd0\x02\n" +
 	"\n" +
 	"MCPBackend\x12>\n" +
 	"\atargets\x18\x02 \x03(\v2$.agentgateway.dev.resource.MCPTargetR\atargets\x12W\n" +


### PR DESCRIPTION
Implements passthrough support for OpenAI's /responses API endpoint (similar to anthropic passthrough) using the existing `async-openai` create