### PR TITLE
Extend backend context for telemetry with protocol and backend_type

### DIFF
--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -392,6 +392,10 @@ impl HTTPProxy {
 			log.cel.ctx().with_request_body(body);
 		}
 
+		if let Some(backend_info) = &log.backend_info {
+			log.cel.ctx().with_backend(backend_info);
+		}
+
 		let trace_parent = trc::TraceParent::from_request(&req);
 		let trace_sampled = log.trace_sampled(trace_parent.as_ref());
 		if trace_sampled {
@@ -962,7 +966,10 @@ async fn make_backend_call(
 		},
 		_ => {},
 	};
-	log.add(|l| l.endpoint = Some(backend_call.target.clone()));
+	log.add(|l| {
+		l.endpoint = Some(backend_call.target.clone());
+		l.backend_info = Some(backend.backend_info());
+	});
 
 	let policies = match backend_call.default_policies.clone() {
 		Some(def) => def.merge(policies),

--- a/crates/agentgateway/src/telemetry/metrics.rs
+++ b/crates/agentgateway/src/telemetry/metrics.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 use crate::mcp::MCPOperation;
 use crate::proxy::ProxyResponseReason;
 use crate::types::agent::BindProtocol;
-use agent_core::metrics::{CustomField, DefaultedUnknown, EncodeArc, EncodeDisplay};
+use agent_core::metrics::{CustomField, DefaultedUnknown, EncodeArc, EncodeDebug, EncodeDisplay};
 use agent_core::strng::RichStrng;
 use agent_core::version;
 use prometheus_client::encoding::EncodeLabelSet;
@@ -25,7 +25,7 @@ pub struct RouteIdentifier {
 #[derive(Clone, Hash, Default, Debug, PartialEq, Eq, EncodeLabelSet)]
 pub struct HTTPLabels {
 	pub backend: DefaultedUnknown<RichStrng>,
-	pub backend_type: DefaultedUnknown<RichStrng>,
+	pub protocol: DefaultedUnknown<EncodeDebug<crate::cel::BackendProtocol>>,
 
 	pub method: DefaultedUnknown<EncodeDisplay<http::Method>>,
 	pub status: DefaultedUnknown<EncodeDisplay<u16>>,
@@ -44,7 +44,6 @@ pub struct GenAILabels {
 	pub gen_ai_system: DefaultedUnknown<RichStrng>,
 	pub gen_ai_request_model: DefaultedUnknown<RichStrng>,
 	pub gen_ai_response_model: DefaultedUnknown<RichStrng>,
-	pub backend_type: DefaultedUnknown<RichStrng>,
 
 	#[prometheus(flatten)]
 	pub route: RouteIdentifier,
@@ -68,7 +67,6 @@ pub struct MCPCall {
 	pub resource_type: DefaultedUnknown<MCPOperation>,
 	pub server: DefaultedUnknown<RichStrng>,
 	pub resource: DefaultedUnknown<RichStrng>,
-	pub backend_type: DefaultedUnknown<RichStrng>,
 
 	#[prometheus(flatten)]
 	pub route: RouteIdentifier,

--- a/crates/agentgateway/src/telemetry/metrics.rs
+++ b/crates/agentgateway/src/telemetry/metrics.rs
@@ -25,6 +25,7 @@ pub struct RouteIdentifier {
 #[derive(Clone, Hash, Default, Debug, PartialEq, Eq, EncodeLabelSet)]
 pub struct HTTPLabels {
 	pub backend: DefaultedUnknown<RichStrng>,
+	pub backend_type: DefaultedUnknown<RichStrng>,
 
 	pub method: DefaultedUnknown<EncodeDisplay<http::Method>>,
 	pub status: DefaultedUnknown<EncodeDisplay<u16>>,
@@ -43,6 +44,7 @@ pub struct GenAILabels {
 	pub gen_ai_system: DefaultedUnknown<RichStrng>,
 	pub gen_ai_request_model: DefaultedUnknown<RichStrng>,
 	pub gen_ai_response_model: DefaultedUnknown<RichStrng>,
+	pub backend_type: DefaultedUnknown<RichStrng>,
 
 	#[prometheus(flatten)]
 	pub route: RouteIdentifier,
@@ -66,6 +68,7 @@ pub struct MCPCall {
 	pub resource_type: DefaultedUnknown<MCPOperation>,
 	pub server: DefaultedUnknown<RichStrng>,
 	pub resource: DefaultedUnknown<RichStrng>,
+	pub backend_type: DefaultedUnknown<RichStrng>,
 
 	#[prometheus(flatten)]
 	pub route: RouteIdentifier,

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -426,6 +426,21 @@ impl SimpleBackend {
 			SimpleBackend::Invalid => strng::format!("invalid"),
 		}
 	}
+
+	pub fn backend_type(&self) -> cel::BackendType {
+		match self {
+			SimpleBackend::Service(_, _) => cel::BackendType::Service,
+			SimpleBackend::Opaque(_, _) => cel::BackendType::Static,
+			SimpleBackend::Invalid => cel::BackendType::Unknown,
+		}
+	}
+
+	pub fn backend_info(&self) -> BackendInfo {
+		BackendInfo {
+			backend_type: self.backend_type(),
+			backend_name: self.name(),
+		}
+	}
 }
 
 impl BackendReference {
@@ -454,11 +469,22 @@ impl Backend {
 		}
 	}
 
-	pub fn backend_type(&self) -> &'static str {
+	pub fn backend_type(&self) -> cel::BackendType {
 		match self {
-			Backend::AI(_, _) => "ai",
-			Backend::MCP(_, _) => "mcp",
-			_ => "other",
+			Backend::Service(_, _) => cel::BackendType::Service,
+			Backend::Opaque(_, _) => cel::BackendType::Static,
+			Backend::MCP(_, _) => cel::BackendType::MCP,
+			Backend::AI(_, _) => cel::BackendType::AI,
+			Backend::Dynamic { .. } => cel::BackendType::Dynamic,
+			Backend::Invalid => cel::BackendType::Unknown,
+		}
+	}
+
+	pub fn backend_protocol(&self) -> Option<cel::BackendProtocol> {
+		match self {
+			Backend::MCP(_, _) => Some(cel::BackendProtocol::mcp),
+			Backend::AI(_, _) => Some(cel::BackendProtocol::llm),
+			_ => None,
 		}
 	}
 
@@ -472,7 +498,7 @@ impl Backend {
 
 #[derive(Debug, Clone)]
 pub struct BackendInfo {
-	pub backend_type: &'static str,
+	pub backend_type: cel::BackendType,
 	pub backend_name: BackendName,
 }
 
@@ -1217,15 +1243,14 @@ mod tests {
 			strng::new("test-opaque"),
 			crate::types::agent::Target::Hostname(strng::new("example.com"), 443),
 		);
-		assert_eq!(opaque_backend.backend_type(), "other");
-		assert_eq!(opaque_backend.backend_info().backend_type, "other");
+		assert_eq!(opaque_backend.backend_type(), cel::BackendType::Static);
+		assert_eq!(opaque_backend.backend_info().backend_type, cel::BackendType::Static);
 
 		let invalid_backend = Backend::Invalid;
-		assert_eq!(invalid_backend.backend_type(), "other");
-		assert_eq!(invalid_backend.backend_info().backend_type, "other");
+		assert_eq!(invalid_backend.backend_type(), cel::BackendType::Unknown);
+		assert_eq!(invalid_backend.backend_info().backend_type, cel::BackendType::Unknown);
 
 		let info = opaque_backend.backend_info();
-		assert_eq!(info.backend_type, "other");
 		assert_eq!(info.backend_name, strng::new("test-opaque"));
 	}
 

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -1244,11 +1244,17 @@ mod tests {
 			crate::types::agent::Target::Hostname(strng::new("example.com"), 443),
 		);
 		assert_eq!(opaque_backend.backend_type(), cel::BackendType::Static);
-		assert_eq!(opaque_backend.backend_info().backend_type, cel::BackendType::Static);
+		assert_eq!(
+			opaque_backend.backend_info().backend_type,
+			cel::BackendType::Static
+		);
 
 		let invalid_backend = Backend::Invalid;
 		assert_eq!(invalid_backend.backend_type(), cel::BackendType::Unknown);
-		assert_eq!(invalid_backend.backend_info().backend_type, cel::BackendType::Unknown);
+		assert_eq!(
+			invalid_backend.backend_info().backend_type,
+			cel::BackendType::Unknown
+		);
 
 		let info = opaque_backend.backend_info();
 		assert_eq!(info.backend_name, strng::new("test-opaque"));

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -453,6 +453,27 @@ impl Backend {
 			Backend::Invalid => strng::format!("invalid"),
 		}
 	}
+
+	pub fn backend_type(&self) -> &'static str {
+		match self {
+			Backend::AI(_, _) => "ai",
+			Backend::MCP(_, _) => "mcp",
+			_ => "other",
+		}
+	}
+
+	pub fn backend_info(&self) -> BackendInfo {
+		BackendInfo {
+			backend_type: self.backend_type(),
+			backend_name: self.name(),
+		}
+	}
+}
+
+#[derive(Debug, Clone)]
+pub struct BackendInfo {
+	pub backend_type: &'static str,
+	pub backend_name: BackendName,
 }
 
 pub type BackendName = Strng;
@@ -1189,6 +1210,24 @@ impl Display for Target {
 #[cfg(test)]
 mod tests {
 	use super::*;
+
+	#[test]
+	fn test_backend_type_categorization() {
+		let opaque_backend = Backend::Opaque(
+			strng::new("test-opaque"),
+			crate::types::agent::Target::Hostname(strng::new("example.com"), 443),
+		);
+		assert_eq!(opaque_backend.backend_type(), "other");
+		assert_eq!(opaque_backend.backend_info().backend_type, "other");
+
+		let invalid_backend = Backend::Invalid;
+		assert_eq!(invalid_backend.backend_type(), "other");
+		assert_eq!(invalid_backend.backend_info().backend_type, "other");
+
+		let info = opaque_backend.backend_info();
+		assert_eq!(info.backend_type, "other");
+		assert_eq!(info.backend_name, strng::new("test-opaque"));
+	}
 
 	#[test]
 	fn test_parse_key_ec_p256() {

--- a/crates/core/src/metrics.rs
+++ b/crates/core/src/metrics.rs
@@ -1,4 +1,4 @@
-use std::fmt::{Display, Error, Write};
+use std::fmt::{Debug, Display, Error, Write};
 use std::mem;
 use std::sync::Arc;
 
@@ -212,6 +212,28 @@ impl<T: Display> From<T> for EncodeDisplay<T> {
 impl<T: Display> From<Option<T>> for DefaultedUnknown<EncodeDisplay<T>> {
 	fn from(t: Option<T>) -> Self {
 		DefaultedUnknown(t.map(EncodeDisplay::from))
+	}
+}
+
+#[derive(Hash, PartialEq, Eq, Clone, Debug)]
+// EncodeDebug is a wrapper around a type that will be encoded with display
+pub struct EncodeDebug<T>(T);
+
+impl<T: Debug> EncodeLabelValue for EncodeDebug<T> {
+	fn encode(&self, writer: &mut LabelValueEncoder) -> Result<(), std::fmt::Error> {
+		write!(writer, "{:?}", self.0)
+	}
+}
+
+impl<T: Debug> From<T> for EncodeDebug<T> {
+	fn from(value: T) -> Self {
+		EncodeDebug(value)
+	}
+}
+
+impl<T: Debug> From<Option<T>> for DefaultedUnknown<EncodeDebug<T>> {
+	fn from(t: Option<T>) -> Self {
+		DefaultedUnknown(t.map(EncodeDebug::from))
 	}
 }
 

--- a/examples/a2a/config.yaml
+++ b/examples/a2a/config.yaml
@@ -1,4 +1,11 @@
 # yaml-language-server: $schema=../../schema/local.json
+config:
+  logging:
+    format: json
+    #    filter: 'response.code != 500'
+    fields:
+      add:
+        backend: backend
 binds:
 - port: 3000
   listeners:

--- a/schema/README.md
+++ b/schema/README.md
@@ -910,4 +910,8 @@ This folder contains JSON schemas for various parts of the project
 |`mcp.(any)(1)resource`||
 |`mcp.(any)(1)resource.target`|The target of the resource|
 |`mcp.(any)(1)resource.name`|The name of the resource|
+|`backend`|`backend` contains information about the backend being used.|
+|`backend.name`|The name of the backend being used. For example, `my-service` or `service/my-namespace/my-service:8080`.|
+|`backend.type`|The type of backend. For example, `ai`, `mcp`, `static`, `dynamic`, or `service`.|
+|`backend.protocol`|The protocol of backend. For example, `http`, `tcp`, `a2a`, `mcp`, or `llm`.|
 |`extauthz`|`extauthz` contains dynamic metadata from ext_authz filters|

--- a/schema/cel.json
+++ b/schema/cel.json
@@ -402,6 +402,48 @@
         }
       ]
     },
+    "backend": {
+      "description": "`backend` contains information about the backend being used.",
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "name": {
+          "description": "The name of the backend being used. For example, `my-service` or `service/my-namespace/my-service:8080`.",
+          "type": "string"
+        },
+        "type": {
+          "description": "The type of backend. For example, `ai`, `mcp`, `static`, `dynamic`, or `service`.",
+          "type": "string",
+          "enum": [
+            "ai",
+            "mcp",
+            "static",
+            "dynamic",
+            "service",
+            "unknown"
+          ]
+        },
+        "protocol": {
+          "description": "The protocol of backend. For example, `http`, `tcp`, `a2a`, `mcp`, or `llm`.",
+          "type": "string",
+          "enum": [
+            "http",
+            "tcp",
+            "a2a",
+            "mcp",
+            "llm"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "type",
+        "protocol"
+      ]
+    },
     "extauthz": {
       "description": "`extauthz` contains dynamic metadata from ext_authz filters",
       "type": [


### PR DESCRIPTION
This PR adds backend type into logs, metrics, traces.

Example log line:
```console
2025-10-14T10:40:00.664353Z     info    request gateway=kgateway-system/agentgateway listener=http route=kgateway-system/openai endpoint=api.openai.com:443 src.addr=10.244.0.1:16300 http.method=POST http.host=172.18.1.130 http.path=/openai http.version=HTTP/1.1 http.status=200 trace.id=e50b001ece1c7c15a3bfb9220ee5b6e6 span.id=33156fe1f382c9be backend=kgateway-system/openai backend.type=ai gen_ai.operation.name=chat gen_ai.provider.name=openai gen_ai.request.model=gpt-3.5-turbo gen_ai.response.model=gpt-3.5-turbo-0125 gen_ai.usage.input_tokens=39 gen_ai.usage.output_tokens=182 duration=1909ms
```

Example time series:
```
# TYPE agentgateway_gen_ai_client_token_usage histogram
agentgateway_gen_ai_client_token_usage_sum{gen_ai_token_type="output",gen_ai_operation_name="chat",gen_ai_system="openai",gen_ai_request_model="gpt-3.5-turbo",gen_ai_response_model="gpt-3.5-turbo-0125",backend_type="ai",bind="80/kgateway-system/agentgateway",gateway="kgateway-system/agentgateway",listener="http",route="kgateway-system/openai",route_rule="unknown"} 177.0
```

Example span attribute for a trace:
```json
{
  "backend": "kgateway-system/openai",
  "backend_type": "ai",
  "duration": "2171ms",
  "endpoint": "api.openai.com:443",
  "gateway": "kgateway-system/agentgateway",
  "gen_ai": {
    "operation": {
      "name": "chat"
    },
    "provider": {
      "name": "openai"
    },
    "request": {
      "model": "gpt-3.5-turbo"
    },
    "response": {
      "model": "gpt-3.5-turbo-0125"
    },
    "usage": {
      "input_tokens": "39",
      "output_tokens": "173"
    }
  },
  "http": {
    "host": "172.18.1.130",
    "method": "POST",
    "path": "/openai",
    "status": "200",
    "version": "HTTP/1.1"
  },
  "listener": "http",
  "network": {
    "protocol": {
      "version": "1.1"
    }
  },
  "route": "kgateway-system/openai",
  "span": {
    "id": "345cc410db69e81f"
  },
  "src": {
    "addr": "10.244.0.1:59291"
  },
  "trace": {
    "id": "152ef2a3c6d941ee97d0b4486ed93d45"
  },
  "url": {
    "scheme": "http"
  }
}
```

Fixes https://github.com/agentgateway/agentgateway/issues/537


---

Commit https://github.com/agentgateway/agentgateway/pull/541/commits/7a1d3e6a63a46d9637d7b2b0ee1e383b986869fe changes what we have by default. It surfaces only `protocol`, while `backend_type` can be enabled.

Span attrributes with this change:
```json
{
  "duration": "4330ms",
  "endpoint": "api.openai.com:443",
  "gateway": "kgateway-system/agentgateway",
  "gen_ai": {
    "operation": {
      "name": "chat"
    },
    "provider": {
      "name": "openai"
    },
    "request": {
      "model": "gpt-3.5-turbo"
    },
    "response": {
      "model": "gpt-3.5-turbo-0125"
    },
    "usage": {
      "input_tokens": "39",
      "output_tokens": "176"
    }
  },
  "http": {
    "host": "172.18.1.130",
    "method": "POST",
    "path": "/openai",
    "status": "200",
    "version": "HTTP/1.1"
  },
  "listener": "http",
  "network": {
    "protocol": {
      "version": "1.1"
    }
  },
  "protocol": "llm",
  "route": "kgateway-system/openai",
  "span": {
    "id": "ad17c990d9c70dce"
  },
  "src": {
    "addr": "10.244.0.1:62626"
  },
  "trace": {
    "id": "20d80fcee459cf03fb88b5a32f4dc625"
  },
  "url": {
    "scheme": "http"
  }
}
```