### PR TITLE
feat: /count_tokens for bedrock

### DIFF
--- a/crates/agentgateway/proto/resource.proto
+++ b/crates/agentgateway/proto/resource.proto
@@ -721,6 +721,8 @@ message AIBackend {
     MODELS = 3;
     // Sends requests to upstream as-is without LLM processing
     PASSTHROUGH = 4;
+    // Processes Anthropic /v1/messages/count_tokens format requests
+    ANTHROPIC_TOKEN_COUNT = 5;
   }
   message Provider {
     string name = 1;

--- a/crates/agentgateway/src/llm/anthropic.rs
+++ b/crates/agentgateway/src/llm/anthropic.rs
@@ -967,6 +967,13 @@ pub(super) mod types {
 		Disabled {},
 	}
 
+	#[derive(Clone, Serialize, Deserialize, Debug)]
+	pub struct CountTokensRequest {
+		pub model: String,
+		#[serde(flatten)]
+		pub rest: serde_json::Map<String, serde_json::Value>,
+	}
+
 	/// Response body for the Messages API.
 	#[derive(Debug, Serialize, Deserialize, Clone)]
 	pub struct MessagesResponse {

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -114,6 +114,8 @@ pub enum RouteType {
 	Models,
 	/// Send the request to the upstream LLM provider as-is
 	Passthrough,
+	/// Anthropic /v1/messages/count_tokens
+	AnthropicTokenCount,
 }
 
 #[apply(schema!)]

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -488,6 +488,7 @@ impl TryFrom<&proto::agent::Backend> for Backend {
 										Ok(ProtoRT::Messages) => llm::RouteType::Messages,
 										Ok(ProtoRT::Models) => llm::RouteType::Models,
 										Ok(ProtoRT::Passthrough) => llm::RouteType::Passthrough,
+										Ok(ProtoRT::AnthropicTokenCount) => llm::RouteType::AnthropicTokenCount,
 										Err(_) => {
 											warn!(
 												value = proto_route_type,

--- a/go/api/resource.pb.go
+++ b/go/api/resource.pb.go
@@ -582,6 +582,8 @@ const (
 	AIBackend_MODELS AIBackend_RouteType = 3
 	// Sends requests to upstream as-is without LLM processing
 	AIBackend_PASSTHROUGH AIBackend_RouteType = 4
+	// Processes Anthropic /v1/messages/count_tokens format requests
+	AIBackend_ANTHROPIC_TOKEN_COUNT AIBackend_RouteType = 5
 )
 
 // Enum value maps for AIBackend_RouteType.
@@ -592,13 +594,15 @@ var (
 		2: "MESSAGES",
 		3: "MODELS",
 		4: "PASSTHROUGH",
+		5: "ANTHROPIC_TOKEN_COUNT",
 	}
 	AIBackend_RouteType_value = map[string]int32{
-		"UNSPECIFIED": 0,
-		"COMPLETIONS": 1,
-		"MESSAGES":    2,
-		"MODELS":      3,
-		"PASSTHROUGH": 4,
+		"UNSPECIFIED":           0,
+		"COMPLETIONS":           1,
+		"MESSAGES":              2,
+		"MODELS":                3,
+		"PASSTHROUGH":           4,
+		"ANTHROPIC_TOKEN_COUNT": 5,
 	}
 )
 
@@ -8067,7 +8071,7 @@ const file_resource_proto_rawDesc = "" +
 	"\x04kind\"7\n" +
 	"\rStaticBackend\x12\x12\n" +
 	"\x04host\x18\x01 \x01(\tR\x04host\x12\x12\n" +
-	"\x04port\x18\x02 \x01(\x05R\x04port\"\xf3\f\n" +
+	"\x04port\x18\x02 \x01(\x05R\x04port\"\x8e\r\n" +
 	"\tAIBackend\x12[\n" +
 	"\x0fprovider_groups\x18\x01 \x03(\v22.agentgateway.dev.resource.AIBackend.ProviderGroupR\x0eproviderGroups\x1a6\n" +
 	"\fHostOverride\x12\x12\n" +
@@ -8105,14 +8109,15 @@ const file_resource_proto_rawDesc = "" +
 	"\n" +
 	"\bprovider\x1a\\\n" +
 	"\rProviderGroup\x12K\n" +
-	"\tproviders\x18\x01 \x03(\v2-.agentgateway.dev.resource.AIBackend.ProviderR\tproviders\"X\n" +
+	"\tproviders\x18\x01 \x03(\v2-.agentgateway.dev.resource.AIBackend.ProviderR\tproviders\"s\n" +
 	"\tRouteType\x12\x0f\n" +
 	"\vUNSPECIFIED\x10\x00\x12\x0f\n" +
 	"\vCOMPLETIONS\x10\x01\x12\f\n" +
 	"\bMESSAGES\x10\x02\x12\n" +
 	"\n" +
 	"\x06MODELS\x10\x03\x12\x0f\n" +
-	"\vPASSTHROUGH\x10\x04\"\xd0\x02\n" +
+	"\vPASSTHROUGH\x10\x04\x12\x19\n" +
+	"\x15ANTHROPIC_TOKEN_COUNT\x10\x05\"\xd0\x02\n" +
 	"\n" +
 	"MCPBackend\x12>\n" +
 	"\atargets\x18\x02 \x03(\v2$.agentgateway.dev.resource.MCPTargetR\atargets\x12W\n" +


### PR DESCRIPTION
Count tokens WIP. Just me testing a few scenarios atm

EDIT: 

  1. InvokeModel over Converse - InvokeModel is passthrough (wrap + base64 encode) vs Converse's 130+ lines of message/tool translation. Tradeoff: must inject max_tokens: 1 and anthropic_version to satisfy Bedrock validation.
  2. Passthrough routing, not new RouteType - Uses existing RouteType::Passthrough with path check instead of new enum variant. Keeps count_tokens simple since it doesn't need LLM logging/guards/rate-limits.
  3. Minimal struct with serde flatten - CountTokensRequest extracts only model field for aliasing, uses #[serde(flatten)] for everything else. Provides type safety without parsing messages/tools/system.