### PR TITLE
Fix extAuthz configuration display and saving in UI

### DIFF
--- a/ui/src/components/policy/form-renderers.tsx
+++ b/ui/src/components/policy/form-renderers.tsx
@@ -371,10 +371,10 @@ export function renderExtAuthzForm({ data, onChange }: FormRendererProps) {
   return (
     <div className="space-y-6">
       <TargetInput
-        id="target"
+        id="host"
         label="Target (host:port)"
-        value={data.target}
-        onChange={(target) => onChange({ ...data, target })}
+        value={data.host}
+        onChange={(host) => onChange({ ...data, host })}
         placeholder="auth-service.example.com:8080"
         required
       />


### PR DESCRIPTION
## Problem

  The UI was unable to correctly display or save the target host/port for external authorization (extAuthz) policies. The form was reading/writing to data.target but the actual config structure uses data.host due to the
  flattened SimpleLocalBackend in LocalExtAuthz.

## Solution

  Updated the extAuthz form renderer to use the correct field name host instead of target, matching the actual configuration structure where #[serde(flatten)] flattens the SimpleLocalBackend fields into the parent struct.

## Changes

  - ui/src/components/policy/form-renderers.tsx: Changed renderExtAuthzForm to read/write data.host instead of data.target

## Testing

  - Verified extAuthz configuration now displays correctly in UI
  - Confirmed saving changes updates the config properly
  - Context extensions continue to work as expected

 ### AI Assistance Disclosure
This fix was developed with AI assistance (Claude Code) to identify the field name mismatch and implement the correction. The change was tested and verified by myself.