### PR TITLE
mcp: negotiate protocol version from initialize request

### DIFF
--- a/crates/agentgateway/src/mcp/handler.rs
+++ b/crates/agentgateway/src/mcp/handler.rs
@@ -137,8 +137,8 @@ impl Relay {
 		})
 	}
 
-	pub fn merge_initialize(&self) -> Box<MergeFn> {
-		let info = self.get_info();
+	pub fn merge_initialize(&self, pv: ProtocolVersion) -> Box<MergeFn> {
+		let info = self.get_info(pv);
 		Box::new(move |_| {
 			// For now, we just send our own info. In the future, we should merge the results from each upstream.
 			Ok(info.into())
@@ -337,9 +337,9 @@ impl Relay {
 
 		Ok(accepted_response())
 	}
-	fn get_info(&self) -> ServerInfo {
+	fn get_info(&self, pv: ProtocolVersion) -> ServerInfo {
 		ServerInfo {
-			protocol_version: ProtocolVersion::V_2025_06_18,
+			protocol_version: pv,
 			capabilities: ServerCapabilities {
 				completions: None,
 				experimental: None,

--- a/crates/agentgateway/src/mcp/session.rs
+++ b/crates/agentgateway/src/mcp/session.rs
@@ -198,10 +198,11 @@ impl Session {
 				});
 				let ctx = IncomingRequestContext::new(parts);
 				match &mut r.request {
-					ClientRequest::InitializeRequest(_) => {
+					ClientRequest::InitializeRequest(ir) => {
+						let pv = ir.params.protocol_version.clone();
 						self
 							.relay
-							.send_fanout(r, ctx, self.relay.merge_initialize())
+							.send_fanout(r, ctx, self.relay.merge_initialize(pv))
 							.await
 					},
 					ClientRequest::ListToolsRequest(_) => {


### PR DESCRIPTION
https://modelcontextprotocol.io/specification/2025-06-18/basic/lifecycle#version-negotiation https://modelcontextprotocol.io/specification/2025-06-18/changelog

there isn't really changes in the protocol that we could not support, unless they try to do batch calls which i don't think anyone does. So for now, safe to just mirror their version I think