### PR TITLE
docs: add Codespaces quickstart to DEVELOPMENT.md

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,4 +1,4 @@
-## Quickstart (GitHub, no local install)
+# Quickstart (GitHub, no local install)
 
 1. Click **Code → Create codespace on main**.
 2. In the terminal:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,3 +1,15 @@
+## Quickstart (GitHub, no local install)
+
+1. Click **Code → Create codespace on main**.
+2. In the terminal:
+   cargo fmt --all
+   cargo clippy --all -- -D warnings
+   cargo test --all
+3. If you touched the UI:
+   cd ui
+   npm ci
+   npm test
+
 # Local Development
 
 This page contains instructions on how to run everything locally.


### PR DESCRIPTION
Adds a minimal GitHub Codespaces quickstart so new contributors can format, lint, and test without local setup