### PR TITLE
Add the `agentgateway_http_request_duration_seconds` histogram metric.

### DIFF
--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -668,6 +668,12 @@ impl Drop for DropOnLog {
 				.get_or_create(&http_labels)
 				.inc_by(log.response_bytes);
 		}
+		// Record HTTP request duration for all requests
+		log
+			.metrics
+			.http_request_duration
+			.get_or_create(&http_labels)
+			.observe(duration.as_secs_f64());
 
 		Self::add_llm_metrics(
 			&log,

--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -671,7 +671,7 @@ impl Drop for DropOnLog {
 		// Record HTTP request duration for all requests
 		log
 			.metrics
-			.http_request_duration
+			.request_duration
 			.get_or_create(&http_labels)
 			.observe(duration.as_secs_f64());
 

--- a/crates/agentgateway/src/telemetry/metrics.rs
+++ b/crates/agentgateway/src/telemetry/metrics.rs
@@ -101,7 +101,8 @@ pub struct BuildLabel {
 #[derive(Debug)]
 pub struct Metrics {
 	pub requests: Counter,
-	pub downstream_connection: TCPCounter,
+	pub request_duration: Histogram<HTTPLabels>,
+	pub response_bytes: Family<HTTPLabels, counter::Counter>,
 
 	pub mcp_requests: Family<MCPCall, counter::Counter>,
 
@@ -110,15 +111,13 @@ pub struct Metrics {
 	pub gen_ai_time_per_output_token: Histogram<GenAILabels>,
 	pub gen_ai_time_to_first_token: Histogram<GenAILabels>,
 
-	pub response_bytes: Family<HTTPLabels, counter::Counter>,
+	pub tls_handshake_duration: Histogram<TCPLabels>,
 
-	pub http_request_duration: Histogram<HTTPLabels>,
-
+	pub downstream_connection: TCPCounter,
 	pub tcp_downstream_rx_bytes: Family<TCPLabels, counter::Counter>,
 	pub tcp_downstream_tx_bytes: Family<TCPLabels, counter::Counter>,
 
 	pub upstream_connect_duration: Histogram<ConnectLabels>,
-	pub tls_handshake_duration: Histogram<TCPLabels>,
 }
 
 // FilteredRegistry is a wrapper around Registry that allows to filter out certain metrics.
@@ -269,12 +268,12 @@ impl Metrics {
 				);
 				m
 			},
-			http_request_duration: {
+			request_duration: {
 				let m = Family::<HTTPLabels, _>::new_with_constructor(move || {
 					PromHistogram::new(HTTP_REQUEST_DURATION_BUCKET)
 				});
 				registry.register_with_unit(
-					"http_request_duration",
+					"request_duration",
 					"Duration of HTTP requests (seconds)",
 					Unit::Seconds,
 					m.clone(),


### PR DESCRIPTION
## Summary

This PR adds the `agentgateway_http_request_duration_seconds` histogram metric to complete the RED (Rate, Errors, Duration) metrics suite for comprehensive service observability.

## Motivation

Currently, Agentgateway tracks request rates (`agentgateway_requests_total`) and errors (via the `reason` label), but lacks a general HTTP request duration metric. While Gen AI request durations are tracked, standard HTTP/MCP requests have no duration metrics, making it impossible to:

- Track P50/P95/P99 latency for non-Gen AI traffic
- Set performance SLOs/SLAs
- Identify slow endpoints
- Detect performance regressions
