### PR TITLE
Fix MCP attributes

### DIFF
--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -763,7 +763,7 @@ impl Drop for DropOnLog {
 					.map(display),
 			),
 			(
-				"mcp.resource",
+				"mcp.resource.type",
 				mcp.as_ref().and_then(|m| m.resource.as_ref()).map(display),
 			),
 			(


### PR DESCRIPTION
Currently, certain (e.g. list) MCP tool calls have properly formatted span attributes, such as:
```json
{
  "duration": "2ms",
  "gateway": "kgateway-system/agentgateway",
  "http": {
    "host": "localhost",
    "method": "POST",
    "path": "/mcp",
    "status": "200",
    "version": "HTTP/1.1"
  },
  "listener": "http",
  "mcp": {
    "method": "tools/list",
    "resource": "tool"
  },
  "network": {
    "protocol": {
      "version": "1.1"
    }
  },
  "protocol": "mcp",
  "route": "default/mcp",
  "span": {
    "id": "89ed006513d1506c"
  },
  "src": {
    "addr": "127.0.0.1:57408"
  },
  "trace": {
    "id": "4644806982ea0cc57b3a679b5025376e"
  },
  "url": {
    "scheme": "http"
  }
}
```

However, using actual tools will produce the following attributes, which is not correct JSON due to duplicated keys (`resource`), such as

```json
{
   "duration":"2ms",
   "gateway":"kgateway-system\/agentgateway",
   "http":{
      "host":"localhost",
      "method":"POST",
      "path":"\/mcp",
      "status":"200",
      "version":"HTTP\/1.1"
   },
   "listener":"http",
   "mcp":{
      "method":"tools\/call",
      "resource":"tool",
      "resource":{   <-------------------- duplicated key
         "name":"echo"
      },
      "target":"mcp-server-everything-3001"
   },
   "network":{
      "protocol":{
         "version":"1.1"
      }
   },
   "protocol":"mcp",
   "route":"default\/mcp",
   "span":{
      "id":"6a2cb8a1f249968b"
   },
   "src":{
      "addr":"127.0.0.1:41212"
   },
   "trace":{
      "id":"32bd5e2b924f860fc4df61f83f1e708b"
   },
   "url":{
      "scheme":"http"
   }
}
```

This PR fixes this by making a tool call look like this: `mcp.resource: { type: "tool", name: "echo" }`