### PR TITLE
Ensure JWT claims are available to route‑level CEL expressions

### DIFF
--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -370,14 +370,8 @@ impl HTTPProxy {
 		);
 		log.version = Some(req.version());
 
-		log
-			.cel
-			.ctx()
-			.with_source(&log.tcp_info, log.tls_info.as_ref());
-		let needs_body = log.cel.ctx().with_request(&req, log.start_time.clone());
-		if needs_body && let Ok(body) = crate::http::inspect_body(&mut req).await {
-			log.cel.ctx().with_request_body(body);
-		}
+		// Record request now. We may do it later as well, after we have more expressions registered.
+		Self::apply_request_to_cel(log, &mut req).await;
 
 		let trace_parent = trc::TraceParent::from_request(&req);
 		let trace_sampled = log.trace_sampled(trace_parent.as_ref());
@@ -419,18 +413,9 @@ impl HTTPProxy {
 			selected_listener.gateway_name.clone(),
 		);
 		gateway_policies.register_cel_expressions(log.cel.ctx());
-		log
-			.cel
-			.ctx()
-			.with_source(&log.tcp_info, log.tls_info.as_ref());
 		// This is unfortunate but we record the request twice possibly; we want to record it as early as possible
-		// so we can do logging, etc when we find no routes.
-		// But we may find new expressions that now need the request.
-		// it is zero-cost at runtime to do it twice so NBD.
-		let needs_body = log.cel.ctx().with_request(&req, log.start_time.clone());
-		if needs_body && let Ok(body) = crate::http::inspect_body(&mut req).await {
-			log.cel.ctx().with_request_body(body);
-		}
+		// (for logging, etc) and also after we register the expressions since new fields may be available.
+		Self::apply_request_to_cel(log, &mut req).await;
 
 		let mut response_headers = HeaderMap::new();
 		let mut maybe_gateway_ext_proc = gateway_policies
@@ -478,19 +463,9 @@ impl HTTPProxy {
 		};
 		// Register all expressions
 		route_policies.register_cel_expressions(log.cel.ctx());
-
-		log
-			.cel
-			.ctx()
-			.with_source(&log.tcp_info, log.tls_info.as_ref());
 		// This is unfortunate but we record the request twice possibly; we want to record it as early as possible
-		// so we can do logging, etc when we find no routes.
-		// But we may find new expressions that now need the request.
-		// it is zero-cost at runtime to do it twice so NBD.
-		let needs_body = log.cel.ctx().with_request(&req, log.start_time.clone());
-		if needs_body && let Ok(body) = crate::http::inspect_body(&mut req).await {
-			log.cel.ctx().with_request_body(body);
-		}
+		// (for logging, etc) and also after we register the expressions since new fields may be available.
+		Self::apply_request_to_cel(log, &mut req).await;
 
 		let maybe_ext_proc = route_policies
 			.ext_proc
@@ -503,13 +478,6 @@ impl HTTPProxy {
 		response_policies.gateway_transformation = gateway_policies.transformation.clone();
 		response_policies.ext_proc = maybe_ext_proc;
 		response_policies.gateway_ext_proc = maybe_gateway_ext_proc;
-		// Ensure JWT claims are available in CEL after registering route expressions.
-		// If JWT auth ran at the gateway phase, `with_jwt` might have been a no-op because
-		// the `jwt` attribute wasn't registered yet. Claims are stored on the request
-		// extensions, so we can add them to the CEL context now that route attributes are known.
-		if let Some(claims) = req.extensions().get::<crate::http::jwt::Claims>() {
-			log.cel.ctx().with_jwt(claims);
-		}
 		apply_request_policies(
 			&route_policies,
 			self.policy_client(),
@@ -637,6 +605,20 @@ impl HTTPProxy {
 			last_res = Some(res);
 		}
 		unreachable!()
+	}
+
+	async fn apply_request_to_cel(log: &mut RequestLog, req: &mut Request) {
+		log
+			.cel
+			.ctx()
+			.with_source(&log.tcp_info, log.tls_info.as_ref());
+		let needs_body = log.cel.ctx().with_request(req, log.start_time.clone());
+		if needs_body && let Ok(body) = crate::http::inspect_body(req).await {
+			log.cel.ctx().with_request_body(body);
+		}
+		if let Some(claims) = req.extensions().get::<crate::http::jwt::Claims>() {
+			log.cel.ctx().with_jwt(claims);
+		}
 	}
 
 	#[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
Summary
- Problem: Route‑level authorization/transformation rules referencing `jwt.*` could fail even with a valid JWT token. In the gateway phase, we validate JWT and attempt to put claims into CEL via `with_jwt()`, but at that time the `jwt` attribute may not yet be registered (route policies are registered later). As a result, `with_jwt()` is a no‑op and route CEL cannot see claims.
- Root cause: Attribute‑gated CEL context population. `with_jwt()` only sets values if the `jwt` attribute was registered up front.
- Fix: After registering route CEL expressions, re‑add JWT claims from the request extensions to the CEL context. This guarantees availability for route‑level rules without changing overall control flow.

Changes
- crates/agentgateway/src/proxy/httpproxy.rs
  - After `route_policies.register_cel_expressions(...)` and before `apply_request_policies(...)`, add:
    ```rust
    if let Some(claims) = req.extensions().get::<crate::http::jwt::Claims>() {
        log.cel.ctx().with_jwt(claims);
    }
    ```
  - This is a conditional, no‑overhead call when JWT is not used.

Behavior
- Backward compatible: no change unless JWT is enabled and route rules reference `jwt.*`.
- Does not change gateway vs. route policy order; simply ensures claims are present when route expressions require them.
- No security model change: tokens are still verified at gateway phase; route phase just reads already‑verified claims.

Motivation / Example
- Users often write CEL authorization like:
  ```yaml
  policies:
    authorization:
      rules:
        - has(jwt.metadata) && has(jwt.metadata.credit_balance) && jwt.metadata.credit_balance > 0
  ```
  Without this fix, the same rule could evaluate to false at route phase even with a valid token, because `jwt` wasn’t materialized in CEL.

Testing
- Unit sanity:
  - Request with JWT (valid) + route rule using `jwt.*` → allowed.
  - Request with JWT (valid) + route rule `has(jwt.metadata)` → true.
  - Request without JWT + `Mode::Optional` → allowed (rule can guard with `has(jwt)` where desired).
- Integration:
  - Enable gateway `jwtAuth` and a route‑level authorization rule reading `jwt.metadata.credit_balance`.
  - Send a signed token (RS256) with `metadata.credit_balance: 100` → 200 OK.
  - Remove `metadata.credit_balance` → 403 (rule fails as expected).

Alternatives considered
- Make `with_jwt()` unconditional (ignore attribute registration). Simpler code, but diverges from the lazy attribute model used for other fields.
- Pre‑register `jwt` at gateway phase. Harder to reason about cross‑phase expression ownership.
- The proposed change is smallest and least invasive.

Compatibility & Risk
- No breaking schema/API changes.
- No behavioral change when JWT is disabled or route policies don’t reference `jwt`.
- Negligible performance impact (single conditional lookup and assign).

Checklist
- [x] Minimal, targeted change
- [x] Backward compatible
- [x] Tested path: route authorization with `jwt.*`

