### PR TITLE
feat: Support optional JWT audience validation

### DIFF
--- a/crates/agentgateway/src/http/jwt_tests.rs
+++ b/crates/agentgateway/src/http/jwt_tests.rs
@@ -24,7 +24,7 @@ pub fn test_azure_jwks() {
 	let p = Provider::from_jwks(
 		jwks,
 		"https://login.microsoftonline.com/test/v2.0".to_string(),
-		vec!["test-aud".to_string()],
+		Some(vec!["test-aud".to_string()]),
 	)
 	.unwrap();
 	assert_eq!(
@@ -52,7 +52,7 @@ pub fn test_basic_jwks() {
 	let p = Provider::from_jwks(
 		jwks,
 		"https://example.com".to_string(),
-		vec!["test-aud".to_string()],
+		Some(vec!["test-aud".to_string()]),
 	)
 	.unwrap();
 	assert_eq!(

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -1195,7 +1195,7 @@ impl McpAuthentication {
 		Ok(http::jwt::LocalJwtConfig::Single {
 			mode: http::jwt::Mode::Optional,
 			issuer: self.issuer.clone(),
-			audiences: vec![self.audience.clone()],
+			audiences: Some(vec![self.audience.clone()]),
 			jwks: FileInlineOrRemote::Remote {
 				url: if !self.jwks_url.is_empty() {
 					self.jwks_url.parse()?

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -955,11 +955,16 @@ impl TryFrom<&proto::agent::TrafficPolicySpec> for TrafficPolicy {
 				};
 				let jwk_set: jsonwebtoken::jwk::JwkSet = serde_json::from_str(&jwks_json)
 					.map_err(|e| ProtoError::Generic(format!("failed to parse JWKS: {e}")))?;
+				let audiences = if jwt.audiences.is_empty() {
+					None
+				} else {
+					Some(jwt.audiences.clone())
+				};
 				let jwt_auth = http::jwt::Jwt::from_jwks(
 					jwk_set,
 					mode,
 					jwt.issuer.clone(),
-					Some(jwt.audiences.clone()),
+					audiences,
 				)
 				.map_err(|e| ProtoError::Generic(format!("failed to create JWT config: {e}")))?;
 				TrafficPolicy::JwtAuth(jwt_auth)

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -955,9 +955,13 @@ impl TryFrom<&proto::agent::TrafficPolicySpec> for TrafficPolicy {
 				};
 				let jwk_set: jsonwebtoken::jwk::JwkSet = serde_json::from_str(&jwks_json)
 					.map_err(|e| ProtoError::Generic(format!("failed to parse JWKS: {e}")))?;
-				let jwt_auth =
-					http::jwt::Jwt::from_jwks(jwk_set, mode, jwt.issuer.clone(), jwt.audiences.clone())
-						.map_err(|e| ProtoError::Generic(format!("failed to create JWT config: {e}")))?;
+				let jwt_auth = http::jwt::Jwt::from_jwks(
+					jwk_set,
+					mode,
+					jwt.issuer.clone(),
+					Some(jwt.audiences.clone()),
+				)
+				.map_err(|e| ProtoError::Generic(format!("failed to create JWT config: {e}")))?;
 				TrafficPolicy::JwtAuth(jwt_auth)
 			},
 			Some(tps::Kind::Transformation(tp)) => {

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -960,13 +960,8 @@ impl TryFrom<&proto::agent::TrafficPolicySpec> for TrafficPolicy {
 				} else {
 					Some(jwt.audiences.clone())
 				};
-				let jwt_auth = http::jwt::Jwt::from_jwks(
-					jwk_set,
-					mode,
-					jwt.issuer.clone(),
-					audiences,
-				)
-				.map_err(|e| ProtoError::Generic(format!("failed to create JWT config: {e}")))?;
+				let jwt_auth = http::jwt::Jwt::from_jwks(jwk_set, mode, jwt.issuer.clone(), audiences)
+					.map_err(|e| ProtoError::Generic(format!("failed to create JWT config: {e}")))?;
 				TrafficPolicy::JwtAuth(jwt_auth)
 			},
 			Some(tps::Kind::Transformation(tp)) => {

--- a/schema/local.json
+++ b/schema/local.json
@@ -2344,7 +2344,10 @@
                                               "type": "string"
                                             },
                                             "audiences": {
-                                              "type": "array",
+                                              "type": [
+                                                "array",
+                                                "null"
+                                              ],
                                               "items": {
                                                 "type": "string"
                                               }
@@ -2382,7 +2385,6 @@
                                           "additionalProperties": false,
                                           "required": [
                                             "issuer",
-                                            "audiences",
                                             "jwks"
                                           ]
                                         }
@@ -2420,7 +2422,10 @@
                                         "type": "string"
                                       },
                                       "audiences": {
-                                        "type": "array",
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
                                         "items": {
                                           "type": "string"
                                         }
@@ -2458,7 +2463,6 @@
                                     "additionalProperties": false,
                                     "required": [
                                       "issuer",
-                                      "audiences",
                                       "jwks"
                                     ]
                                   }
@@ -5540,7 +5544,10 @@
                                         "type": "string"
                                       },
                                       "audiences": {
-                                        "type": "array",
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
                                         "items": {
                                           "type": "string"
                                         }
@@ -5578,7 +5585,6 @@
                                     "additionalProperties": false,
                                     "required": [
                                       "issuer",
-                                      "audiences",
                                       "jwks"
                                     ]
                                   }
@@ -5616,7 +5622,10 @@
                                   "type": "string"
                                 },
                                 "audiences": {
-                                  "type": "array",
+                                  "type": [
+                                    "array",
+                                    "null"
+                                  ],
                                   "items": {
                                     "type": "string"
                                   }
@@ -5654,7 +5663,6 @@
                               "additionalProperties": false,
                               "required": [
                                 "issuer",
-                                "audiences",
                                 "jwks"
                               ]
                             }
@@ -7918,7 +7926,10 @@
                                   "type": "string"
                                 },
                                 "audiences": {
-                                  "type": "array",
+                                  "type": [
+                                    "array",
+                                    "null"
+                                  ],
                                   "items": {
                                     "type": "string"
                                   }
@@ -7956,7 +7967,6 @@
                               "additionalProperties": false,
                               "required": [
                                 "issuer",
-                                "audiences",
                                 "jwks"
                               ]
                             }
@@ -7994,7 +8004,10 @@
                             "type": "string"
                           },
                           "audiences": {
-                            "type": "array",
+                            "type": [
+                              "array",
+                              "null"
+                            ],
                             "items": {
                               "type": "string"
                             }
@@ -8032,7 +8045,6 @@
                         "additionalProperties": false,
                         "required": [
                           "issuer",
-                          "audiences",
                           "jwks"
                         ]
                       }


### PR DESCRIPTION
Resolve #590 

---

- This pull request updates the JWT authentication logic to make the `audiences` field optional throughout the codebase, rather than required.
  - This allows JWT validation to be performed even when no audiences are specified, and disables audience validation in that case.
  - The schema and related code have been updated to reflect this change.
