### PR TITLE
Stateful MCP routing for service backends

### DIFF
--- a/crates/agentgateway/src/client/mod.rs
+++ b/crates/agentgateway/src/client/mod.rs
@@ -211,6 +211,9 @@ impl From<Option<VersionedBackendTLS>> for Transport {
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 struct PoolKey(Target, SocketAddr, Transport, ::http::Version);
 
+#[derive(Debug, Clone, Copy)]
+pub struct ResolvedDestination(pub SocketAddr);
+
 impl Transport {
 	pub fn scheme(&self) -> Scheme {
 		match self {
@@ -743,6 +746,7 @@ impl Client {
 		resp
 			.extensions_mut()
 			.insert(transport::BufferLimit::new(buffer_limit));
+		resp.extensions_mut().insert(ResolvedDestination(dest));
 		Ok(resp)
 	}
 }

--- a/crates/agentgateway/src/mcp/router.rs
+++ b/crates/agentgateway/src/mcp/router.rs
@@ -104,7 +104,10 @@ impl App {
 					.unwrap();
 			};
 			(
-				McpBackendGroup { targets: nt },
+				McpBackendGroup {
+					targets: nt,
+					stateful: backend.stateful,
+				},
 				authorization_policies,
 				authn,
 			)
@@ -219,6 +222,7 @@ impl App {
 #[derive(Debug, Clone)]
 pub struct McpBackendGroup {
 	pub targets: Vec<Arc<McpTarget>>,
+	pub stateful: bool,
 }
 
 #[derive(Debug)]

--- a/crates/agentgateway/src/mcp/upstream/client.rs
+++ b/crates/agentgateway/src/mcp/upstream/client.rs
@@ -1,0 +1,82 @@
+use std::sync::{Arc, Mutex};
+
+use crate::client::ResolvedDestination;
+use crate::proxy::ProxyError;
+use crate::proxy::httpproxy::PolicyClient;
+use crate::store::BackendPolicies;
+use crate::types::agent::SimpleBackend;
+
+/// HTTP client for MCP upstream backends with optional stateful session affinity.
+/// Used by all HTTP-based MCP upstream transports (SSE, StreamableHTTP, OpenAPI).
+///
+/// When `stateful` is true, this client captures the resolved backend address
+/// from the first response and pins all subsequent requests to that same endpoint.
+/// This ensures session affinity for stateful MCP backends with multiple replicas.
+#[derive(Debug, Clone)]
+pub(crate) struct McpHttpClient {
+	client: PolicyClient,
+	backend: Arc<SimpleBackend>,
+	base_policies: BackendPolicies,
+	pinned_dest: Arc<Mutex<Option<ResolvedDestination>>>,
+	stateful: bool,
+}
+
+impl McpHttpClient {
+	pub fn new(
+		client: PolicyClient,
+		backend: SimpleBackend,
+		policies: BackendPolicies,
+		stateful: bool,
+	) -> Self {
+		Self {
+			client,
+			backend: Arc::new(backend),
+			base_policies: policies,
+			pinned_dest: Arc::new(Mutex::new(None)),
+			stateful,
+		}
+	}
+
+	pub async fn call(
+		&self,
+		req: http::Request<crate::http::Body>,
+	) -> Result<http::Response<crate::http::Body>, ProxyError> {
+		let mut policies = self.base_policies.clone();
+
+		if self.stateful
+			&& policies.override_dest.is_none()
+			&& let Some(pinned) = *self.pinned_dest.lock().unwrap()
+		{
+			tracing::trace!(
+				backend = %self.backend.name(),
+				endpoint = %pinned.0,
+				"using pinned backend endpoint"
+			);
+			policies.override_dest = Some(pinned.0);
+		}
+
+		let resp = self
+			.client
+			.call_with_default_policies(req, &self.backend, policies)
+			.await?;
+
+		// Capture resolved destination on first request if stateful
+		if self.stateful
+			&& self.pinned_dest.lock().unwrap().is_none()
+			&& let Some(resolved) = resp.extensions().get::<ResolvedDestination>()
+		{
+			tracing::debug!(
+				backend = %self.backend.name(),
+				endpoint = %resolved.0,
+				"pinned stateful MCP session to backend endpoint"
+			);
+			*self.pinned_dest.lock().unwrap() = Some(*resolved);
+		}
+
+		Ok(resp)
+	}
+
+	pub fn backend(&self) -> &SimpleBackend {
+		&self.backend
+	}
+}

--- a/crates/agentgateway/src/mcp/upstream/mod.rs
+++ b/crates/agentgateway/src/mcp/upstream/mod.rs
@@ -250,7 +250,10 @@ impl UpstreamGroup {
 
 				let http_client = McpHttpClient::new(
 					self.client.clone(),
-					target.backend.clone().expect("there must be a backend for MCP"),
+					target
+						.backend
+						.clone()
+						.expect("there must be a backend for MCP"),
 					target.backend_policies.clone(),
 					self.backend.stateful,
 				);

--- a/crates/agentgateway/src/mcp/upstream/mod.rs
+++ b/crates/agentgateway/src/mcp/upstream/mod.rs
@@ -1,9 +1,12 @@
+mod client;
 mod openapi;
 mod sse;
 mod stdio;
 mod streamablehttp;
 
 use std::io;
+
+pub(crate) use client::McpHttpClient;
 
 use rmcp::model::{ClientNotification, ClientRequest, JsonRpcRequest};
 use rmcp::transport::TokioChildProcess;
@@ -221,15 +224,17 @@ impl UpstreamGroup {
 					"" => "/sse",
 					_ => sse.path.as_str(),
 				};
-				let client = sse::Client::new(
+
+				let upstream_client = McpHttpClient::new(
+					self.client.clone(),
 					target
 						.backend
 						.clone()
 						.expect("there must be a backend for SSE"),
-					path.into(),
-					self.client.clone(),
 					target.backend_policies.clone(),
-				)?;
+					self.backend.stateful,
+				);
+				let client = sse::Client::new(upstream_client, path.into())?;
 
 				upstream::Upstream::McpSSE(client)
 			},
@@ -242,15 +247,14 @@ impl UpstreamGroup {
 					"" => "/mcp",
 					_ => mcp.path.as_str(),
 				};
-				let client = streamablehttp::Client::new(
-					target
-						.backend
-						.clone()
-						.expect("there must be a backend for MCP"),
-					path.into(),
+
+				let http_client = McpHttpClient::new(
 					self.client.clone(),
+					target.backend.clone().expect("there must be a backend for MCP"),
 					target.backend_policies.clone(),
-				)?;
+					self.backend.stateful,
+				);
+				let client = streamablehttp::Client::new(http_client, path.into())?;
 
 				upstream::Upstream::McpStreamable(client)
 			},
@@ -293,16 +297,21 @@ impl UpstreamGroup {
 						e
 					)
 				})?;
-				upstream::Upstream::OpenAPI(Box::new(openapi::Handler {
-					backend: target
+
+				let http_client = McpHttpClient::new(
+					self.client.clone(),
+					target
 						.backend
 						.clone()
 						.expect("there must be a backend for OpenAPI"),
-					client: self.client.clone(),
-					default_policies: target.backend_policies.clone(),
+					target.backend_policies.clone(),
+					self.backend.stateful,
+				);
+				upstream::Upstream::OpenAPI(Box::new(openapi::Handler::new(
+					http_client,
 					tools,  // From parse_openapi_schema
 					prefix, // From get_server_prefix
-				}))
+				)))
 			},
 		};
 

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -93,6 +93,11 @@ pub struct BackendPolicies {
 	pub response_header_modifier: Option<filters::HeaderModifier>,
 	pub request_redirect: Option<filters::RequestRedirect>,
 	pub request_mirror: Vec<filters::RequestMirror>,
+
+	/// Internal-only override for destination endpoint selection.
+	/// Used for stateful MCP routing (session affinity).
+	/// Not exposed through config - set programmatically only.
+	pub override_dest: Option<std::net::SocketAddr>,
 }
 
 impl BackendPolicies {
@@ -119,6 +124,7 @@ impl BackendPolicies {
 			} else {
 				other.request_mirror
 			},
+			override_dest: other.override_dest.or(self.override_dest),
 		}
 	}
 	/// build the inference routing configuration. This may be a NO-OP config.


### PR DESCRIPTION
This PR addresses the issue raised here: https://github.com/agentgateway/agentgateway/issues/573

For stateful MCP targets, I implemented a pinning mechanism to ensure all requests from a session go to the same backend replica.

## Problem

When you have multiple endpoints (e.g., k8s Service with multiple pods), requests are getting round-robined. This breaks MCP sessions since each backend maintains its own session state independently.

So you'd get:
- Request 1 → Pod A (session starts)
- Request 2 → Pod B (no session, fails)
- Request 3 → Pod C (no session, fails)

## Solution

When `stateful: true` is set on an MCP backend, the gateway now pins each session to a specific endpoint using a "pick on first call" approach.

- Each MCP session creates its own `Relay` → `UpstreamGroup` → MCP clients
- MCP HTTP clients are wrapped in `McpHttpClient`, which handles optional session affinity
- On the **first request**: Standard round-robin endpoint selection happens via `SimpleBackend::Service`
- The HTTP client captures the resolved `SocketAddr` from the response extensions (`ResolvedDestination`)
- On **subsequent requests**: The pinned address is injected via `BackendPolicies.override_dest` to force endpoint selection
- The backend stays as `SimpleBackend::Service` (no conversion needed), but endpoint selection is overridden

This approach reuses the existing infrastructure:
- `override_dest` in `BackendPolicies` (already used by inference routing for AI backends)
- `ResolvedDestination` extension (captures actual endpoint used by HTTP client)
- Per-session isolation (each session's `McpHttpClient` has its own pinning state)

Each session still independently picks an endpoint using the normal load balancing on first call, so traffic is distributed evenly across replicas—but once a session picks its endpoint, it sticks with it.

Now you get:
- Request 1 → Pod A (round-robin, captured)
- Request 2 → Pod A (pinned via override_dest)
- Request 3 → Pod A (pinned via override_dest)

## Changes

- Created `McpHttpClient` wrapper (`mcp/upstream/client.rs`) that encapsulates HTTP client + policies + optional session affinity
- Added pinning logic: capture `ResolvedDestination` from first response, apply `override_dest` on subsequent requests
- Refactored SSE, StreamableHTTP, and OpenAPI clients to use shared `McpHttpClient` (eliminated code duplication)
- Reused existing `override_dest` field for endpoint override
- Added structured logging to track pinning events (`debug` for initial pin, `trace` for usage)

## Testing logs
I tested the implementation with MCP inspector, and here are the AGW debug logs and the MCP target snippet
```
"backends": [
    {
      "backend": {
        "mcp": {
          "name": "tenant/mcp-backend",
          "target": {
            "targets": [
              {
                "name": "mcp-server",
                "mcp": {
                  "backend": {
                    "service": {
                      "name": "tenant/mcp-server.tenant.svc.cluster.local",
                      "port": 3005
                    }
                  },
                  "path": "/mcp"
                }
              }
            ],
            "stateful": true,
            "alwaysUsePrefix": false
          }
        }
      }
    }
]
```
Logs:
First request:
```
{"level":"debug","time":"2025-11-20T16:58:23.956664Z","scope":"agentgateway::proxy::httpproxy","message":"selected listener","bind":"8443/default/agentlink","listener":"https-listener-tenant-test-ai-proxy"}
{"level":"debug","time":"2025-11-20T16:58:23.956705Z","scope":"agentgateway::proxy::httpproxy","message":"selected route","bind":"8443/default/agentlink","listener":"https-listener-tenant-test-ai-proxy","route":"route-tenant-test-ai-proxy-default"}
{"level":"trace","time":"2025-11-20T16:58:23.956740Z","scope":"agentgateway::proxy::httpproxy","message":"no retries"}
{"level":"debug","time":"2025-11-20T16:58:23.956870Z","scope":"agentgateway::mcp::upstream","message":"initializing target: mcp-server"}
{"level":"trace","time":"2025-11-20T16:58:23.956888Z","scope":"agentgateway::mcp::upstream","message":"connecting to target: mcp-server"}
{"level":"debug","time":"2025-11-20T16:58:23.956891Z","scope":"agentgateway::mcp::upstream","message":"starting streamable http transport for target: mcp-server"}
{"level":"trace","time":"2025-11-20T16:58:23.957012Z","scope":"agentgateway::client","message":"sending request",...
...

{"level":"debug","time":"2025-11-20T16:58:23.957296Z","scope":"upstream tcp","message":"connected","endpoint":"[::ffff:10.1.6.94]:3005","transport":"plaintext","connect_ms":"0"}
{"level":"trace","time":"2025-11-20T16:58:23.957310Z","scope":"hyper_util_fork::client::legacy::client","message":"http1 handshake complete, spawning background dispatcher task"}
{"level":"trace","time":"2025-11-20T16:58:23.957316Z","scope":"hyper_util_fork::client::legacy::client","message":"waiting for connection to be ready"}
{"level":"trace","time":"2025-11-20T16:58:23.957330Z","scope":"hyper_util_fork::client::legacy::client","message":"connection is ready"}
...
{"level":"debug","time":"2025-11-20T16:58:23.966196Z","scope":"upstream request","target":"[::ffff:10.1.6.94]:3005","endpoint":"[::ffff:10.1.6.94]:3005","transport":"plaintext","http.method":"POST","http.host":"mcp-server.tenant.svc.cluster.local:3005","http.path":"/mcp","http.version":"HTTP/1.1","http.status":200,"duration":"9ms"}
{"level":"debug","time":"2025-11-20T16:58:23.966852Z","scope":"agentgateway::mcp::upstream::client","message":"pinned stateful MCP session to backend endpoint","backend":"service/tenant/mcp-server.tenant.svc.cluster.local:3005","endpoint":"[::ffff:10.1.6.94]:3005"}
```
Subsequent requests:
```
{"level":"debug","time":"2025-11-20T16:58:24.591151Z","scope":"agentgateway::proxy::httpproxy","message":"selected listener","bind":"8443/default/agentlink","listener":"https-listener-tenant-test-ai-proxy"}
{"level":"debug","time":"2025-11-20T16:58:24.591187Z","scope":"agentgateway::proxy::httpproxy","message":"selected route","bind":"8443/default/agentlink","listener":"https-listener-tenant-test-ai-proxy","route":"route-tenant-test-ai-proxy-default"}
{"level":"trace","time":"2025-11-20T16:58:24.591229Z","scope":"agentgateway::proxy::httpproxy","message":"no retries"}
{"level":"trace","time":"2025-11-20T16:58:24.591535Z","scope":"agentgateway::mcp::upstream::client","message":"using pinned backend endpoint","backend":"service/tenant/mcp-server.tenant.svc.cluster.local:3005","endpoint":"[::ffff:10.1.6.94]:3005"}
{"level":"trace","time":"2025-11-20T16:58:24.591635Z","scope":"agentgateway::client","message":"sending request","req":"Request { method: POST, uri: http://mcp-server.tenant.svc.cluster.local:3005/mcp, version: HTTP/1.1, headers: {\"content-type\": \"application/json\", \"accept\": \"text/event-stream, application/json\", \"mcp-session-id\": \"5fab764d-57e0-4f77-9751-a93d3869d3fd\", \"x-envoy-external-address\": \"127.0.0.1\", \"user-agent\": \"curl/8.7.1\", \"x-forwarded-for\": \"10.1.6.90\", \"x-forwarded-proto\": \"https\"}, body: Body(UnsyncBoxBody) }","key":"PoolKey(Address([::ffff:10.1.6.94]:3005), [::ffff:10.1.6.94]:3005, Plaintext, HTTP/1.1)"}
...
{"level":"info","time":"2025-11-20T16:58:24.595491Z","scope":"request","gateway":"default/agentlink","listener":"https","route":"","src.addr":"10.1.6.90:40736","http.method":"POST","http.host":"ai-test.default.example.org","http.path":"/mcp","http.version":"HTTP/1.1","http.status":200,"protocol":"mcp","mcp.method":"tools/list","mcp.resource.type":"tool","duration":"4ms"}
```
Let me know if this looks OK, I can follow up with some tests.
