### PR TITLE
fix stack overflow with large OpenAPI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,6 +213,7 @@ dependencies = [
  "shellexpand",
  "socket2 0.6.1",
  "sse-stream",
+ "stacker",
  "tempfile",
  "thiserror 2.0.17",
  "tiktoken-rs",
@@ -395,6 +396,15 @@ name = "anyhow"
 version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
+name = "ar_archive_writer"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c269894b6fe5e9d7ada0cf69b5bf847ff35bc25fc271f08e1d080fce80339a"
+dependencies = [
+ "object 0.32.2",
+]
 
 [[package]]
 name = "arc-swap"
@@ -1114,7 +1124,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object",
+ "object 0.37.3",
  "rustc-demangle",
  "windows-link 0.2.1",
 ]
@@ -3945,6 +3955,15 @@ dependencies = [
 
 [[package]]
 name = "object"
+version = "0.32.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
@@ -4716,6 +4735,16 @@ dependencies = [
  "miette 7.6.0",
  "prost-types",
  "thiserror 2.0.17",
+]
+
+[[package]]
+name = "psm"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d11f2fedc3b7dafdc2851bc52f277377c5473d378859be234bc7ebb593144d01"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
 ]
 
 [[package]]
@@ -5793,6 +5822,19 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stacker"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1f8b29fb42aafcea4edeeb6b2f2d7ecd0d969c48b4cf0d2e64aafc471dd6e59"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "static_assertions"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,6 +159,7 @@ serde_json = { version = "1.0", features = ["preserve_order"] }
 serde_json_path_to_error = "0.1"
 serde_regex = "1.1"
 serde_yaml = "0.9"
+stacker = "0.1"
 shellexpand = "3.1"
 socket2 = "0.6"
 split-iter = "0.1"

--- a/crates/agentgateway/Cargo.toml
+++ b/crates/agentgateway/Cargo.toml
@@ -109,6 +109,7 @@ serde_regex.workspace = true
 serde_urlencoded.workspace = true
 serde_with.workspace = true
 serde_yaml.workspace = true
+stacker.workspace = true
 shellexpand.workspace = true
 socket2.workspace = true
 sse-stream.workspace = true

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -613,7 +613,11 @@ where
 		},
 		Serde::Inline(s) => s,
 	};
-	let schema: OpenAPI = yamlviajson::from_str(s.as_str()).map_err(serde::de::Error::custom)?;
+	// OpenAPI can be huge, so grow our stack
+	let schema: OpenAPI = stacker::grow(2 * 1024 * 1024, || {
+		yamlviajson::from_str(s.as_str()).map_err(serde::de::Error::custom)
+	})?;
+
 	Ok(Arc::new(schema))
 }
 


### PR DESCRIPTION
`bash -c 'ulimit -s 1024 && cargo run -- -f examples/openapi/config.yaml --validate-only'`

to reproduce. Notably, windows has a lower default