### PR TITLE
local config: give useful errors on AI issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,6 +204,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde-transcode",
+ "serde-untagged",
  "serde_json",
  "serde_json_path_to_error",
  "serde_regex",
@@ -5499,6 +5500,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "590c0e25c2a5bb6e85bf5c1bce768ceb86b316e7a01bdf07d2cb4ec2271990e2"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde-untagged"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9faf48a4a2d2693be24c6289dbe26552776eb7737074e6722891fadbe6c5058"
+dependencies = [
+ "erased-serde",
+ "serde",
+ "serde_core",
+ "typeid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,6 +159,7 @@ serde_json = { version = "1.0", features = ["preserve_order"] }
 serde_json_path_to_error = "0.1"
 serde_regex = "1.1"
 serde_yaml = "0.9"
+serde-untagged = "0.1"
 stacker = "0.1"
 shellexpand = "3.1"
 socket2 = "0.6"

--- a/crates/agentgateway/Cargo.toml
+++ b/crates/agentgateway/Cargo.toml
@@ -109,6 +109,7 @@ serde_regex.workspace = true
 serde_urlencoded.workspace = true
 serde_with.workspace = true
 serde_yaml.workspace = true
+serde-untagged.workspace = true
 stacker.workspace = true
 shellexpand.workspace = true
 socket2.workspace = true

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -178,6 +178,7 @@ pub enum LocalBackend {
 
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[cfg_attr(feature = "schema", schemars(untagged, deny_unknown_fields))]
 #[allow(clippy::large_enum_variant)] // Size is not sensitive for local config
 pub enum LocalAIBackend {
 	Provider(LocalNamedAIProvider),

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -176,14 +176,40 @@ pub enum LocalBackend {
 	Invalid,
 }
 
-#[apply(schema_de!)]
-#[serde(untagged)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[allow(clippy::large_enum_variant)] // Size is not sensitive for local config
 pub enum LocalAIBackend {
 	Provider(LocalNamedAIProvider),
 	Groups { groups: Vec<LocalAIProviders> },
 }
 
+// Custom impl to avoid terrible 'not match any variant of untagged' errors.
+impl<'de> Deserialize<'de> for LocalAIBackend {
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		serde_untagged::UntaggedEnumVisitor::new()
+			.map(|map| {
+				let v: serde_json::Value = map.deserialize()?;
+
+				if let serde_json::Value::Object(m) = &v
+					&& m.len() == 1
+					&& let Some(g) = m.get("groups")
+				{
+					Ok(LocalAIBackend::Groups {
+						groups: Vec::<LocalAIProviders>::deserialize(g).map_err(serde::de::Error::custom)?,
+					})
+				} else {
+					Ok(LocalAIBackend::Provider(
+						LocalNamedAIProvider::deserialize(&v).map_err(serde::de::Error::custom)?,
+					))
+				}
+			})
+			.deserialize(deserializer)
+	}
+}
 #[apply(schema_de!)]
 pub struct LocalAIProviders {
 	providers: Vec<LocalNamedAIProvider>,


### PR DESCRIPTION
After:
```
Error: binds[0].listeners[0].routes[7].backends[0]: unknown field `backendTLS`, expected one of `name`, `provider`, `hostOverride`, `pathOverride`, `tokenize`, `routes`, `policies` at line 1 column 2257
```

Before:
```
Error: binds[0].listeners[0].routes[7].backends[0]: data did not match any variant of untagged enum LocalAIBackend at line 1 column 2257
```