### PR TITLE
http: add better version override/detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,7 +192,7 @@ dependencies = [
  "prost-wkt-types",
  "protox",
  "rand 0.9.2",
- "rcgen",
+ "rcgen 0.14.5",
  "regex",
  "reqwest",
  "rmcp",
@@ -1052,6 +1052,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "axum-server"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ab4a3ec9ea8a657c72d99a03a824af695bd0fb5ec639ccbd9cd3543b41a5f9"
+dependencies = [
+ "arc-swap",
+ "bytes",
+ "fs-err",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -4979,6 +5001,19 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time 0.3.44",
+ "yasna",
+]
+
+[[package]]
+name = "rcgen"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fae430c6b28f1ad601274e78b7dffa0546de0b73b4cd32f46723c0c2a16f7a5"
@@ -7425,10 +7460,10 @@ checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 [[package]]
 name = "wiremock"
 version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+source = "git+https://github.com/howardjohn/wiremock-rs?rev=e55f5b96083125fdabc3e62f92790ee15ae3a10d#e55f5b96083125fdabc3e62f92790ee15ae3a10d"
 dependencies = [
  "assert-json-diff",
+ "axum-server",
  "base64 0.22.1",
  "deadpool",
  "futures",
@@ -7438,7 +7473,9 @@ dependencies = [
  "hyper-util",
  "log",
  "once_cell",
+ "rcgen 0.13.2",
  "regex",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [patch.crates-io]
 schemars = { git = "https://github.com/howardjohn/schemars", rev = "4364354fa41897a0c2001d891c0a9a38eafedb82" }
 http-serde = { git = "https://gitlab.com/howardjohn/http-serde", rev = "163f20f551c2cf6032254b6dbbe246b91ce727ad" }
+wiremock = { git = "https://github.com/howardjohn/wiremock-rs", rev = "e55f5b96083125fdabc3e62f92790ee15ae3a10d" }
 
 [workspace]
 resolver = "2"
@@ -190,7 +191,7 @@ tracing-subscriber = { version = "0.3", features = [
     "json",
 ] }
 url = "2.5"
-wiremock = "0.6.3"
+wiremock = { version = "0.6.3", features = ["tls"] }
 x509-parser = { version = "0.18", default-features = false, features = ["verify-aws"] }
 which = "8.0.0"
 cel = { version = "0.11.4", features = [

--- a/crates/agentgateway/src/control/caclient.rs
+++ b/crates/agentgateway/src/control/caclient.rs
@@ -28,7 +28,7 @@ use istio::ca::IstioCertificateRequest;
 use istio::ca::istio_certificate_service_client::IstioCertificateServiceClient;
 
 use crate::control::{AuthSource, RootCert};
-use crate::http::backendtls::BackendTLS;
+use crate::http::backendtls::VersionedBackendTLS;
 
 #[derive(Clone, Debug, thiserror::Error)]
 pub enum Error {
@@ -140,7 +140,7 @@ impl WorkloadCertificate {
 		}
 	}
 
-	pub fn legacy_mtls(&self, identity: Vec<Identity>) -> Result<BackendTLS, Error> {
+	pub fn legacy_mtls(&self, identity: Vec<Identity>) -> Result<VersionedBackendTLS, Error> {
 		// TODO: this is (way) too expensive to build per request
 		let roots = self.roots.clone();
 		let verifier = transport::tls::identity::IdentityVerifier { roots, identity };
@@ -156,12 +156,12 @@ impl WorkloadCertificate {
 		cc.alpn_protocols = vec![b"istio".into()];
 		cc.resumption = Resumption::disabled();
 		// cc.enable_sni = false;
-		Ok(BackendTLS {
+		Ok(VersionedBackendTLS {
 			hostname_override: None,
 			config: Arc::new(cc),
 		})
 	}
-	pub fn hbone_mtls(&self, identity: Vec<Identity>) -> Result<BackendTLS, Error> {
+	pub fn hbone_mtls(&self, identity: Vec<Identity>) -> Result<VersionedBackendTLS, Error> {
 		// TODO: this is (way) too expensive to build per request
 		let roots = self.roots.clone();
 		let verifier = transport::tls::identity::IdentityVerifier { roots, identity };
@@ -177,7 +177,7 @@ impl WorkloadCertificate {
 		cc.alpn_protocols = vec![b"h2".into()];
 		cc.resumption = Resumption::disabled();
 		cc.enable_sni = false;
-		Ok(BackendTLS {
+		Ok(VersionedBackendTLS {
 			hostname_override: None,
 			config: Arc::new(cc),
 		})

--- a/crates/agentgateway/src/control/mod.rs
+++ b/crates/agentgateway/src/control/mod.rs
@@ -16,7 +16,7 @@ use tower::Service;
 
 use crate::client::Transport;
 use crate::http::HeaderValue;
-use crate::http::backendtls::{BackendTLS, SYSTEM_TRUST};
+use crate::http::backendtls::{BackendTLS, PerAlpnConfig, SYSTEM_TRUST};
 use crate::types::agent::Target;
 use crate::*;
 
@@ -56,7 +56,7 @@ impl RootCert {
 		ccb.alpn_protocols = vec![b"h2".to_vec()];
 		Ok(BackendTLS {
 			hostname_override: None,
-			config: Arc::new(ccb),
+			config: PerAlpnConfig::new(Arc::new(ccb), false),
 		})
 	}
 }
@@ -289,7 +289,7 @@ fn get_target(raw: &str, ca: BackendTLS) -> anyhow::Result<(Target, Transport)> 
 
 	let transport = match uri.scheme_str() {
 		Some("http") => Transport::Plaintext,
-		Some("https") => Transport::Tls(ca),
+		Some("https") => Transport::Tls(ca.base_config()),
 		_ => anyhow::bail!("Unsupported scheme: {}", uri.scheme_str().unwrap_or("none")),
 	};
 

--- a/crates/agentgateway/src/http/backendtls.rs
+++ b/crates/agentgateway/src/http/backendtls.rs
@@ -27,26 +27,87 @@ pub static INSECURE_TRUST: Lazy<BackendTLS> = Lazy::new(|| {
 	.unwrap()
 });
 
-// TODO: xds support
+// a ClientConfig stores the ALPN, but we need to set it per request possibly. This struct helps manage that.
+#[derive(Clone, Debug)]
+pub struct PerAlpnConfig {
+	config: Arc<ClientConfig>,
+	allow_custom_alpn: bool,
+	h1: std::sync::OnceLock<Arc<ClientConfig>>,
+	h2: std::sync::OnceLock<Arc<ClientConfig>>,
+}
+
+impl PerAlpnConfig {
+	pub fn new(config: Arc<ClientConfig>, allow_custom_alpn: bool) -> Self {
+		Self {
+			config,
+			allow_custom_alpn,
+			h1: Default::default(),
+			h2: Default::default(),
+		}
+	}
+
+	fn config_for(&self, version_override: Option<http::Version>) -> Arc<ClientConfig> {
+		match version_override {
+			Some(http::Version::HTTP_11) if self.allow_custom_alpn => self
+				.h1
+				.get_or_init(|| {
+					let mut nc = Arc::unwrap_or_clone(self.config.clone());
+					nc.alpn_protocols = vec![b"http/1.1".to_vec()];
+					Arc::new(nc)
+				})
+				.clone(),
+			Some(http::Version::HTTP_2) if self.allow_custom_alpn => self
+				.h2
+				.get_or_init(|| {
+					let mut nc = Arc::unwrap_or_clone(self.config.clone());
+					nc.alpn_protocols = vec![b"h2".to_vec()];
+					Arc::new(nc)
+				})
+				.clone(),
+			_ => self.config.clone(),
+		}
+	}
+}
+
 #[derive(Debug, Clone)]
 pub struct BackendTLS {
+	pub hostname_override: Option<ServerName<'static>>,
+	pub config: PerAlpnConfig,
+}
+
+impl BackendTLS {
+	pub fn base_config(&self) -> VersionedBackendTLS {
+		self.config_for(None)
+	}
+
+	pub fn config_for(&self, version_override: Option<http::Version>) -> VersionedBackendTLS {
+		VersionedBackendTLS {
+			hostname_override: self.hostname_override.clone(),
+			config: self.config.config_for(version_override),
+		}
+	}
+}
+
+#[derive(Debug, Clone)]
+pub struct VersionedBackendTLS {
 	pub hostname_override: Option<ServerName<'static>>,
 	pub config: Arc<ClientConfig>,
 }
 
-impl std::hash::Hash for BackendTLS {
+impl std::hash::Hash for VersionedBackendTLS {
 	fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
 		// Hash the pointer address
 		Arc::as_ptr(&self.config).hash(state);
 	}
 }
 
-impl PartialEq for BackendTLS {
+impl PartialEq for VersionedBackendTLS {
 	fn eq(&self, other: &Self) -> bool {
-		Arc::ptr_eq(&self.config, &other.config)
+		Arc::ptr_eq(&self.config, &other.config) && self.hostname_override == other.hostname_override
 	}
 }
-impl Eq for BackendTLS {}
+
+impl Eq for VersionedBackendTLS {}
 
 impl serde::Serialize for BackendTLS {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -77,6 +138,7 @@ pub struct LocalBackendTLS {
 	alpn: Option<Vec<String>>,
 }
 
+#[derive(Default)]
 pub struct ResolvedBackendTLS {
 	pub cert: Option<Vec<u8>>,
 	pub key: Option<Vec<u8>>,
@@ -128,6 +190,7 @@ impl ResolvedBackendTLS {
 			cc.dangerous()
 				.set_certificate_verifier(Arc::new(tls::insecure::NoVerifier));
 		}
+		let allow_custom_alpn = self.alpn.is_none();
 		if let Some(a) = self.alpn {
 			cc.alpn_protocols = a.into_iter().map(|b| b.as_bytes().to_vec()).collect();
 		} else {
@@ -135,7 +198,7 @@ impl ResolvedBackendTLS {
 		}
 		Ok(BackendTLS {
 			hostname_override: self.hostname.map(|s| s.try_into()).transpose()?,
-			config: Arc::new(cc),
+			config: PerAlpnConfig::new(Arc::new(cc), allow_custom_alpn),
 		})
 	}
 }

--- a/crates/agentgateway/src/http/backendtls.rs
+++ b/crates/agentgateway/src/http/backendtls.rs
@@ -98,6 +98,7 @@ impl std::hash::Hash for VersionedBackendTLS {
 	fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
 		// Hash the pointer address
 		Arc::as_ptr(&self.config).hash(state);
+		self.hostname_override.hash(state);
 	}
 }
 

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -852,7 +852,9 @@ pub async fn build_transport(
 	inputs: &ProxyInputs,
 	backend_call: &BackendCall,
 	backend_tls: Option<BackendTLS>,
+	backend_http_version_override: Option<::http::Version>,
 ) -> Result<Transport, ProxyError> {
+	let backend_tls = backend_tls.map(|btls| btls.config_for(backend_http_version_override));
 	// Check if we need double hbone
 	if let (
 		Some((gw_addr, gw_identity)),
@@ -1241,6 +1243,12 @@ async fn make_backend_call(
 		&inputs,
 		&backend_call,
 		backend_call.backend_policies.backend_tls.clone(),
+		backend_call
+			.backend_policies
+			.http
+			.as_ref()
+			.and_then(|h| h.version)
+			.or(backend_call.http_version_override),
 	)
 	.await?;
 	let call = client::Call {

--- a/crates/agentgateway/src/proxy/tcpproxy.rs
+++ b/crates/agentgateway/src/proxy/tcpproxy.rs
@@ -135,6 +135,8 @@ impl TCPProxy {
 			&inputs,
 			&backend_call,
 			backend_call.backend_policies.backend_tls.clone(),
+			// TODO: for TCP we should actually probably do something here: telling it to not use ALPN at all?
+			None,
 		)
 		.await?;
 

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -86,6 +86,9 @@ pub struct BackendPolicies {
 	pub llm: Option<Arc<llm::Policy>>,
 	pub inference_routing: Option<InferenceRouting>,
 
+	pub http: Option<types::backend::HTTP>,
+	pub tcp: Option<types::backend::TCP>,
+
 	pub request_header_modifier: Option<filters::HeaderModifier>,
 	pub response_header_modifier: Option<filters::HeaderModifier>,
 	pub request_redirect: Option<filters::RequestRedirect>,
@@ -102,6 +105,8 @@ impl BackendPolicies {
 			llm_provider: other.llm_provider.or(self.llm_provider),
 			llm: other.llm.or(self.llm),
 			inference_routing: other.inference_routing.or(self.inference_routing),
+			http: other.http.or(self.http),
+			tcp: other.tcp.or(self.tcp),
 			request_header_modifier: other
 				.request_header_modifier
 				.or(self.request_header_modifier),
@@ -547,6 +552,13 @@ impl Store {
 				},
 				BackendPolicy::AI(p) => {
 					pol.llm.get_or_insert_with(|| p.clone());
+				},
+
+				BackendPolicy::HTTP(p) => {
+					pol.http.get_or_insert_with(|| p.clone());
+				},
+				BackendPolicy::TCP(p) => {
+					pol.tcp.get_or_insert_with(|| p.clone());
 				},
 
 				BackendPolicy::RequestHeaderModifier(p) => {

--- a/crates/agentgateway/src/transport/stream.rs
+++ b/crates/agentgateway/src/transport/stream.rs
@@ -115,13 +115,14 @@ impl Connection for Socket {
 impl hyper_util_fork::client::legacy::connect::Connection for Socket {
 	fn connected(&self) -> hyper_util_fork::client::legacy::connect::Connected {
 		let mut con = hyper_util_fork::client::legacy::connect::Connected::new();
-		if self
+		match self
 			.ext
 			.get::<TLSConnectionInfo>()
 			.and_then(|c| c.negotiated_alpn)
-			== Some(Alpn::H2)
 		{
-			con = con.negotiated_h2()
+			Some(Alpn::H2) => con = con.negotiated_h2(),
+			Some(Alpn::Http11) => con = con.negotiated_h1(),
+			_ => {},
 		}
 		con
 	}

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -27,7 +27,7 @@ use crate::http::{
 };
 use crate::mcp::McpAuthorization;
 use crate::types::discovery::{NamespacedHostname, Service};
-use crate::types::{agent, frontend};
+use crate::types::{agent, backend, frontend};
 use crate::*;
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -1165,6 +1165,10 @@ pub enum BackendPolicy {
 	McpAuthorization(McpAuthorization),
 	McpAuthentication(McpAuthentication),
 	A2a(A2aPolicy),
+	#[serde(rename = "http")]
+	HTTP(backend::HTTP),
+	#[serde(rename = "tcp")]
+	TCP(backend::TCP),
 	#[serde(rename = "backendTLS")]
 	BackendTLS(http::backendtls::BackendTLS),
 	BackendAuth(BackendAuth),

--- a/crates/agentgateway/src/types/backend.rs
+++ b/crates/agentgateway/src/types/backend.rs
@@ -1,0 +1,62 @@
+use crate::apply;
+use crate::transport::stream::TLSConnectionInfo;
+use crate::*;
+
+#[apply(schema!)]
+#[derive(Default)]
+pub struct HTTP {
+	#[serde(with = "http_serde::option::version")]
+	#[cfg_attr(feature = "schema", schemars(with = "Option<String>"))]
+	pub version: Option<::http::Version>,
+}
+
+impl HTTP {
+	pub fn apply(&self, req: &mut http::Request, version_override: Option<::http::Version>) {
+		// Version override comes from a Service having a version specified. A policy is more specific
+		// so we use the policy first.
+		let set_version = match self.version.or(version_override) {
+			Some(v) => Some(v),
+			None => {
+				// There are a few cases here...
+				// In general, we cannot be assured that the downstream and the upstream protocol have anything
+				// to do with each other. Typically, the downstream will ALPN negotiate up to HTTP/2, even
+				// if the backend shouldn't do HTTP/2. So, if TLS is used, we never want to trust the downstream
+				// protocol.
+				// If they are plaintext, however, that means the client very intentionally sent HTTP/2, and we respect that.
+				// Additionally, since gRPC is known to only work over HTTP/2, we special case that.
+				let tls = req.extensions().get::<TLSConnectionInfo>();
+				if tls.is_some() {
+					// Do not trust the downstream, use HTTP/1.1
+					if is_grpc(req) {
+						Some(::http::Version::HTTP_2)
+					} else {
+						Some(::http::Version::HTTP_11)
+					}
+				} else {
+					None
+				}
+			},
+		};
+		match set_version {
+			Some(::http::Version::HTTP_2) => {
+				req.headers_mut().remove(http::header::TRANSFER_ENCODING);
+				*req.version_mut() = ::http::Version::HTTP_2;
+			},
+			Some(::http::Version::HTTP_11) => {
+				*req.version_mut() = ::http::Version::HTTP_11;
+			},
+			_ => {},
+		};
+	}
+}
+
+fn is_grpc(req: &http::Request) -> bool {
+	req
+		.headers()
+		.get(http::header::CONTENT_TYPE)
+		.is_some_and(|value| value.as_bytes().starts_with("application/grpc".as_bytes()))
+}
+
+#[apply(schema!)]
+#[derive(Default)]
+pub struct TCP {}

--- a/crates/agentgateway/src/types/mod.rs
+++ b/crates/agentgateway/src/types/mod.rs
@@ -1,5 +1,6 @@
 pub mod agent;
 mod agent_xds;
+pub mod backend;
 pub mod discovery;
 pub mod frontend;
 pub mod loadbalancer;

--- a/crates/hyper-util-fork/src/client/legacy/connect/mod.rs
+++ b/crates/hyper-util-fork/src/client/legacy/connect/mod.rs
@@ -133,6 +133,7 @@ pub(super) struct Extra(Box<dyn ExtraInner>);
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(super) enum Alpn {
+	H1,
 	H2,
 	None,
 }
@@ -205,9 +206,10 @@ impl Connected {
 		self
 	}
 
-	/// Determines if the connected transport negotiated HTTP/2 as its next protocol.
-	pub fn is_negotiated_h2(&self) -> bool {
-		self.alpn == Alpn::H2
+	/// Set that the connected transport negotiated HTTP/1.1 as its next protocol.
+	pub fn negotiated_h1(mut self) -> Connected {
+		self.alpn = Alpn::H1;
+		self
 	}
 
 	/// Poison this connection


### PR DESCRIPTION
Alternative to https://github.com/agentgateway/agentgateway/pull/598.

This adds the following logic for backend HTTP version selection:
* If the user sets the (new) `http.version`  policy, we always use this.
* If a user has the protocol declared on the Backend, we use that (this is the appProtocol on Service, to-be-added to Backend)
* Else we apply heurstics... (see code comments for why)
   * If the request is TLS, use HTTP/1.1 unless its gRPC and then use HTTP/2
   * If the request is plaintext, use the downstream protocol as the upstream

TODO:
* add an `http.version=useDownstream` mode to explicitly use the downstream protocol
~* If the version is explicitly set in either policy or backend, then force our ALPN to only include that protocol~
