### PR TITLE
fix: Bedrock count_tokens response handling

### DIFF
--- a/crates/agentgateway/src/llm/anthropic.rs
+++ b/crates/agentgateway/src/llm/anthropic.rs
@@ -45,6 +45,9 @@ impl Provider {
 			InputFormat::Responses => {
 				unreachable!("Responses format should not be routed to Anthropic provider")
 			},
+			InputFormat::CountTokens => {
+				unreachable!("CountTokens should be handled by process_count_tokens_response")
+			},
 		}
 	}
 }
@@ -76,6 +79,9 @@ pub fn process_response(
 		},
 		InputFormat::Responses => {
 			unreachable!("Responses format should not be routed to Anthropic provider")
+		},
+		InputFormat::CountTokens => {
+			unreachable!("CountTokens should be handled by process_count_tokens_response")
 		},
 	}
 }

--- a/crates/agentgateway/src/llm/universal.rs
+++ b/crates/agentgateway/src/llm/universal.rs
@@ -111,6 +111,9 @@ pub mod passthrough {
 			InputFormat::Responses => {
 				unreachable!("Responses format should not be routed to Universal (OpenAI) provider")
 			},
+			InputFormat::CountTokens => {
+				unreachable!("CountTokens should be handled by process_count_tokens_response")
+			},
 		}
 	}
 


### PR DESCRIPTION
- Fix count_tokens route detection by checking provider type and path suffix instead of re-resolving from rewritten Bedrock path
- Add ModelContextWindowExceeded stop reason support, mapping to Length/incomplete (consistent with Anthropic SDK)