### PR TITLE
feat: enable route and gateway targeting for backend policies

### DIFF
--- a/crates/agentgateway/src/mcp/router.rs
+++ b/crates/agentgateway/src/mcp/router.rs
@@ -86,13 +86,8 @@ impl App {
 						.backend()
 						.map(|b| crate::proxy::resolve_simple_backend_with_policies(b, &pi))
 						.transpose()?;
-					let inline_pols = if let Some((_, pol)) = &be {
-						&[pol.as_slice()][..]
-					} else {
-						&[]
-					};
-					let backend_policies =
-						binds.backend_policies(None, None, Some(t.name.clone()), inline_pols, None, None);
+					let inline_pols = be.as_ref().map(|pol| pol.1.as_slice());
+					let backend_policies = binds.sub_backend_policies(t.name.clone(), inline_pols);
 					Ok::<_, ProxyError>(Arc::new(McpTarget {
 						name: t.name.clone(),
 						spec: t.spec.clone(),

--- a/crates/agentgateway/src/mcp/router.rs
+++ b/crates/agentgateway/src/mcp/router.rs
@@ -92,7 +92,7 @@ impl App {
 						&[]
 					};
 					let backend_policies =
-						binds.backend_policies(None, None, Some(t.name.clone()), inline_pols);
+						binds.backend_policies(None, None, Some(t.name.clone()), inline_pols, None, None);
 					Ok::<_, ProxyError>(Arc::new(McpTarget {
 						name: t.name.clone(),
 						spec: t.spec.clone(),

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -30,6 +30,7 @@ use crate::llm::{LLMRequest, RequestResult, RouteType};
 use crate::proxy::{ProxyError, ProxyResponse, ProxyResponseReason, resolve_simple_backend};
 use crate::store::{
 	BackendPolicies, FrontendPolices, GatewayPolicies, LLMRequestPolicies, LLMResponsePolicies,
+	RoutePath,
 };
 use crate::telemetry::log;
 use crate::telemetry::log::{AsyncLog, DropOnLog, LogBody, RequestLog};
@@ -541,15 +542,17 @@ impl HTTPProxy {
 
 		debug!(bind=%bind_name, listener=%selected_listener.key, route=%selected_route.key, "selected route");
 
-		let mut route_policies = {
-			inputs.stores.read_binds().route_policies(
-				selected_route.rule_name.clone(),
-				selected_route.route_name.clone(),
-				selected_listener.key.clone(),
-				selected_listener.gateway_name.clone(),
-				&selected_route.inline_policies,
-			)
+		let route_path = RoutePath {
+			route_rule: selected_route.rule_name.clone(),
+			route: selected_route.route_name.clone(),
+			listener: selected_listener.key.clone(),
+			gateway: selected_listener.gateway_name.clone(),
 		};
+
+		let mut route_policies = inputs
+			.stores
+			.read_binds()
+			.route_policies(route_path.clone(), &selected_route.inline_policies);
 		// Register all expressions
 		route_policies.register_cel_expressions(log.cel.ctx());
 		// This is unfortunate but we record the request twice possibly; we want to record it as early as possible
@@ -584,8 +587,7 @@ impl HTTPProxy {
 			self.inputs.as_ref(),
 			&selected_backend.backend,
 			&selected_backend.inline_policies,
-			Some(selected_route.route_name.clone()),
-			Some(selected_listener.gateway_name.clone()),
+			Some(route_path.clone()),
 		);
 		log.backend_info = Some(selected_backend.backend.backend.backend_info());
 		if let Some(bp) = selected_backend.backend.backend.backend_protocol() {
@@ -868,8 +870,7 @@ fn get_backend_policies(
 	inputs: &ProxyInputs,
 	backend: &BackendWithPolicies,
 	inline_policies: &[BackendPolicy],
-	route: Option<RouteName>,
-	gateway: Option<GatewayName>,
+	path: Option<RoutePath>,
 ) -> BackendPolicies {
 	let service = match &backend.backend {
 		Backend::Service(svc, _) => Some(strng::format!("{}/{}", svc.namespace, svc.hostname)),
@@ -877,12 +878,15 @@ fn get_backend_policies(
 	};
 
 	inputs.stores.read_binds().backend_policies(
-		Some(backend.backend.name()),
+		backend.backend.name(),
 		service,
-		None,
+		// Precedence: Selector < Backend inline < backendRef inline
+		// Note this differs from the logical chain of objects (Route -> backendRef -> backend),
+		// because a backendRef is actually more specific: its one *specific usage* of the backend.
+		// For example, we may say to use TLS for a Backend, but in a specific TLSRoute backendRef we disable
+		// as it is already TLS.
 		&[&backend.inline_policies, inline_policies],
-		route,
-		gateway,
+		path,
 	)
 }
 
@@ -914,14 +918,10 @@ async fn make_backend_call(
 				// The typical MCP flow will apply the top level Backend policies as default_policies
 				// When we passthrough, we should preserve this behavior.
 				let target_name = target.name();
-				let policies = inputs.stores.read_binds().backend_policies(
-					None,
-					None,
-					Some(target_name),
-					&[&inline_policies],
-					None,
-					None,
-				);
+				let policies = inputs
+					.stores
+					.read_binds()
+					.sub_backend_policies(target_name, Some(&inline_policies));
 
 				(&Backend::from(target), base_policies.merge(policies))
 			} else {
@@ -948,11 +948,10 @@ async fn make_backend_call(
 			let (provider, handle) = ai.select_provider().ok_or(ProxyError::NoHealthyEndpoints)?;
 			log.add(move |l| l.request_handle = Some(handle));
 			let k = strng::format!("{}/{}", n, provider.name);
-			let sub_backend_policies =
-				inputs
-					.stores
-					.read_binds()
-					.backend_policies(None, None, Some(k), &[], None, None);
+			let sub_backend_policies = inputs
+				.stores
+				.read_binds()
+				.sub_backend_policies(k, Some(&provider.inline_policies));
 
 			let (target, provider_defaults) = match &provider.host_override {
 				Some(target) => (
@@ -1547,7 +1546,7 @@ impl PolicyClient {
 	}
 	pub async fn call(&self, req: Request, backend: SimpleBackend) -> Result<Response, ProxyError> {
 		let backend = Backend::from(backend).into();
-		let pols = get_backend_policies(&self.inputs, &backend, &[], None, None);
+		let pols = get_backend_policies(&self.inputs, &backend, &[], None);
 		make_backend_call(
 			self.inputs.clone(),
 			Arc::new(LLMRequestPolicies::default()),
@@ -1580,13 +1579,7 @@ impl PolicyClient {
 		defaults: BackendPolicies,
 	) -> Pin<Box<dyn Future<Output = Result<Response, ProxyError>> + Send + '_>> {
 		let backend = Backend::from(backend.clone()).into();
-		let pols = defaults.merge(get_backend_policies(
-			&self.inputs,
-			&backend,
-			&[],
-			None,
-			None,
-		));
+		let pols = defaults.merge(get_backend_policies(&self.inputs, &backend, &[], None));
 		Box::pin(async move {
 			make_backend_call(
 				self.inputs.clone(),

--- a/crates/agentgateway/src/proxy/tcpproxy.rs
+++ b/crates/agentgateway/src/proxy/tcpproxy.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use crate::proxy::httpproxy::BackendCall;
 use crate::proxy::{ProxyError, httpproxy};
-use crate::store::BackendPolicies;
+use crate::store::{BackendPolicies, RoutePath};
 use crate::telemetry::log;
 use crate::telemetry::log::{DropOnLog, RequestLog};
 use crate::telemetry::metrics::TCPLabels;
@@ -91,11 +91,19 @@ impl TCPProxy {
 		log.route_rule_name = selected_route.rule_name.clone();
 		log.route_name = Some(selected_route.route_name.clone());
 
+		let route_path = RoutePath {
+			route_rule: selected_route.rule_name.clone(),
+			route: selected_route.route_name.clone(),
+			listener: selected_listener.key.clone(),
+			gateway: selected_listener.gateway_name.clone(),
+		};
+
+
 		debug!(bind=%bind_name, listener=%selected_listener.key, route=%selected_route.key, "selected route");
 		let selected_backend =
 			select_tcp_backend(selected_route.as_ref()).ok_or(ProxyError::NoValidBackends)?;
 		let selected_backend = resolve_backend(selected_backend, self.inputs.as_ref())?;
-		let backend_policies = get_backend_policies(&self.inputs, &selected_backend.backend);
+		let backend_policies = get_backend_policies(&self.inputs, &selected_backend.backend, route_path);
 
 		let backend_call = match &selected_backend.backend {
 			SimpleBackend::Service(svc, port) => httpproxy::build_service_call(
@@ -194,7 +202,7 @@ fn resolve_backend(
 	})
 }
 
-pub fn get_backend_policies(inputs: &ProxyInputs, backend: &SimpleBackend) -> BackendPolicies {
+pub fn get_backend_policies(inputs: &ProxyInputs, backend: &SimpleBackend, route_path: RoutePath) -> BackendPolicies {
 	let service = match backend {
 		SimpleBackend::Service(svc, _) => Some(strng::format!("{}/{}", svc.namespace, svc.hostname)),
 		_ => None,
@@ -203,5 +211,5 @@ pub fn get_backend_policies(inputs: &ProxyInputs, backend: &SimpleBackend) -> Ba
 	inputs
 		.stores
 		.read_binds()
-		.backend_policies(Some(backend.name()), service, None, &[], None, None)
+		.backend_policies(backend.name(), service, &[], Some(route_path))
 }

--- a/crates/agentgateway/src/proxy/tcpproxy.rs
+++ b/crates/agentgateway/src/proxy/tcpproxy.rs
@@ -98,12 +98,12 @@ impl TCPProxy {
 			gateway: selected_listener.gateway_name.clone(),
 		};
 
-
 		debug!(bind=%bind_name, listener=%selected_listener.key, route=%selected_route.key, "selected route");
 		let selected_backend =
 			select_tcp_backend(selected_route.as_ref()).ok_or(ProxyError::NoValidBackends)?;
 		let selected_backend = resolve_backend(selected_backend, self.inputs.as_ref())?;
-		let backend_policies = get_backend_policies(&self.inputs, &selected_backend.backend, route_path);
+		let backend_policies =
+			get_backend_policies(&self.inputs, &selected_backend.backend, route_path);
 
 		let backend_call = match &selected_backend.backend {
 			SimpleBackend::Service(svc, port) => httpproxy::build_service_call(
@@ -202,7 +202,11 @@ fn resolve_backend(
 	})
 }
 
-pub fn get_backend_policies(inputs: &ProxyInputs, backend: &SimpleBackend, route_path: RoutePath) -> BackendPolicies {
+pub fn get_backend_policies(
+	inputs: &ProxyInputs,
+	backend: &SimpleBackend,
+	route_path: RoutePath,
+) -> BackendPolicies {
 	let service = match backend {
 		SimpleBackend::Service(svc, _) => Some(strng::format!("{}/{}", svc.namespace, svc.hostname)),
 		_ => None,

--- a/crates/agentgateway/src/proxy/tcpproxy.rs
+++ b/crates/agentgateway/src/proxy/tcpproxy.rs
@@ -203,5 +203,5 @@ pub fn get_backend_policies(inputs: &ProxyInputs, backend: &SimpleBackend) -> Ba
 	inputs
 		.stores
 		.read_binds()
-		.backend_policies(Some(backend.name()), service, None, &[])
+		.backend_policies(Some(backend.name()), service, None, &[], None, None)
 }

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -455,7 +455,7 @@ impl Store {
 			None,
 			Some(sub_backend),
 			if let Some(s) = &inline_policies {
-				std::slice::from_ref(&s)
+				std::slice::from_ref(s)
 			} else {
 				&[]
 			},
@@ -484,6 +484,7 @@ impl Store {
 		)
 	}
 
+	#[allow(clippy::too_many_arguments)]
 	fn internal_backend_policies(
 		&self,
 		backend: Option<BackendName>,

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -255,6 +255,16 @@ impl Default for Store {
 		Self::new()
 	}
 }
+
+// RoutePath describes the objects traversed to reach the given route
+#[derive(Debug, Clone)]
+pub struct RoutePath {
+	pub gateway: GatewayName,
+	pub listener: ListenerKey,
+	pub route: RouteName,
+	pub route_rule: Option<RouteRuleName>,
+}
+
 impl Store {
 	pub fn new() -> Self {
 		let (tx, _) = tokio::sync::broadcast::channel(1000);
@@ -276,27 +286,25 @@ impl Store {
 		tokio_stream::wrappers::BroadcastStream::new(sub)
 	}
 
-	pub fn route_policies(
-		&self,
-		route_rule: Option<RouteRuleName>,
-		route: RouteName,
-		listener: ListenerKey,
-		gateway: GatewayName,
-		inline: &[TrafficPolicy],
-	) -> RoutePolicies {
+	pub fn route_policies(&self, path: RoutePath, inline: &[TrafficPolicy]) -> RoutePolicies {
 		// Changes we must do:
 		// * Index the store by the target
 		// * Avoid the N lookups, or at least the boilerplate, for each type
 		// Changes we may want to consider:
 		// * We do this lookup under one lock, but we will lookup backend rules and listener rules under a different
 		//   lock. This can lead to inconsistent state..
-		let gateway = self.policies_by_target.get(&PolicyTarget::Gateway(gateway));
+		let gateway = self
+			.policies_by_target
+			.get(&PolicyTarget::Gateway(path.gateway));
 		let listener = self
 			.policies_by_target
-			.get(&PolicyTarget::Listener(listener));
-		let route = self.policies_by_target.get(&PolicyTarget::Route(route));
-		let route_rule =
-			route_rule.and_then(|rr| self.policies_by_target.get(&PolicyTarget::RouteRule(rr)));
+			.get(&PolicyTarget::Listener(path.listener));
+		let route = self
+			.policies_by_target
+			.get(&PolicyTarget::Route(path.route));
+		let route_rule = path
+			.route_rule
+			.and_then(|rr| self.policies_by_target.get(&PolicyTarget::RouteRule(rr)));
 		let rules = route_rule
 			.iter()
 			.copied()
@@ -434,15 +442,58 @@ impl Store {
 
 		pol
 	}
-
+	// sub_backend_policies looks up the sub-backends policies. Generally, these will be queried separately
+	// from the primary backend policies and then merged, just due to the lifecycle of when the sub-backend
+	// is selected.
+	pub fn sub_backend_policies(
+		&self,
+		sub_backend: SubBackendName,
+		inline_policies: Option<&[BackendPolicy]>,
+	) -> BackendPolicies {
+		self.internal_backend_policies(
+			None,
+			None,
+			Some(sub_backend),
+			if let Some(s) = &inline_policies {
+				std::slice::from_ref(&s)
+			} else {
+				&[]
+			},
+			None,
+			None,
+			None,
+			None,
+		)
+	}
 	pub fn backend_policies(
+		&self,
+		backend: BackendName,
+		service: Option<ServiceName>,
+		inline_policies: &[&[BackendPolicy]],
+		path: Option<RoutePath>,
+	) -> BackendPolicies {
+		self.internal_backend_policies(
+			Some(backend),
+			service,
+			None,
+			inline_policies,
+			path.as_ref().map(|p| p.gateway.clone()),
+			path.as_ref().map(|p| p.listener.clone()),
+			path.as_ref().map(|p| p.route.clone()),
+			path.as_ref().and_then(|p| p.route_rule.clone()),
+		)
+	}
+
+	fn internal_backend_policies(
 		&self,
 		backend: Option<BackendName>,
 		service: Option<ServiceName>,
 		sub_backend: Option<SubBackendName>,
 		inline_policies: &[&[BackendPolicy]],
-		route: Option<RouteName>,
 		gateway: Option<GatewayName>,
+		listener: Option<ListenerKey>,
+		route: Option<RouteName>,
+		route_rule: Option<RouteRuleName>,
 	) -> BackendPolicies {
 		let backend_rules =
 			backend.and_then(|t| self.policies_by_target.get(&PolicyTarget::Backend(t)));
@@ -450,19 +501,25 @@ impl Store {
 			service.and_then(|t| self.policies_by_target.get(&PolicyTarget::Service(t)));
 		let sub_backend_rules =
 			sub_backend.and_then(|t| self.policies_by_target.get(&PolicyTarget::SubBackend(t)));
+		let route_rule_rules =
+			route_rule.and_then(|t| self.policies_by_target.get(&PolicyTarget::RouteRule(t)));
 		let route_rules = route.and_then(|t| self.policies_by_target.get(&PolicyTarget::Route(t)));
+		let listener_rules =
+			listener.and_then(|t| self.policies_by_target.get(&PolicyTarget::Listener(t)));
 		let gateway_rules =
 			gateway.and_then(|t| self.policies_by_target.get(&PolicyTarget::Gateway(t)));
 
-		// Route > SubBackend > Backend > Service > Gateway
+		// RouteRule > Route > SubBackend > Backend > Service > Gateway
 		// Most specific (route context) to least specific (gateway-wide default)
-		let rules = route_rules
+		let rules = route_rule_rules
 			.iter()
 			.copied()
 			.flatten()
 			.chain(sub_backend_rules.iter().copied().flatten())
+			.chain(route_rules.iter().copied().flatten())
 			.chain(backend_rules.iter().copied().flatten())
 			.chain(service_rules.iter().copied().flatten())
+			.chain(listener_rules.iter().copied().flatten())
 			.chain(gateway_rules.iter().copied().flatten())
 			.filter_map(|n| self.policies_by_name.get(n))
 			.filter_map(|p| p.policy.as_backend());

--- a/crates/agentgateway/src/store/mod.rs
+++ b/crates/agentgateway/src/store/mod.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 pub use binds::{
 	BackendPolicies, FrontendPolices, GatewayPolicies, LLMRequestPolicies, LLMResponsePolicies,
-	RoutePolicies, Store as BindStore, RoutePath,
+	RoutePath, RoutePolicies, Store as BindStore,
 };
 use serde::{Serialize, Serializer};
 mod discovery;

--- a/crates/agentgateway/src/store/mod.rs
+++ b/crates/agentgateway/src/store/mod.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 pub use binds::{
 	BackendPolicies, FrontendPolices, GatewayPolicies, LLMRequestPolicies, LLMResponsePolicies,
-	RoutePolicies, Store as BindStore,
+	RoutePolicies, Store as BindStore, RoutePath,
 };
 use serde::{Serialize, Serializer};
 mod discovery;


### PR DESCRIPTION
Adds support for BackendPolicy to target Route and Gateway in addition to the existing Backend/SubBackend/Service targets. This enables route-specific backend policy overrides, allowing different routes to apply different backend configurations (model aliases, prompt caching, etc.) when using the same backend.

## Changes

- Extended backend_policies() to accept route and gateway context
- Added policy lookups for Route-targeted and Gateway-targeted backend policies
- Updated precedence chain: Route > SubBackend > Backend > Service > Gateway
- Updated all call sites to pass route/gateway context where available

## Use Case

This allows configurations like:
- Route A → Backend X with model_aliases set 1
- Route B → Backend X with model_aliases set 2

Backend policies can now be targeted at:
- Route level: Applied when that route uses any backend
- Gateway level: Applied to all backends in that gateway (lowest priority)

## Precedence

Route-targeted backend policies have highest priority (most specific), followed by backend-specific targeting (SubBackend > Backend > Service), with Gateway-targeted policies as the catch-all default (least specific).