### PR TITLE
feat: add wildcard pattern matching for model aliases

### DIFF
--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -537,7 +537,7 @@ impl AIProvider {
 
 				// Apply model alias resolution (consistent with other routes)
 				if let Some(p) = policies
-					&& let Some(aliased) = p.model_aliases.get(count_req.model.as_str())
+					&& let Some(aliased) = p.resolve_model_alias(count_req.model.as_str())
 				{
 					count_req.model = aliased.to_string();
 				}
@@ -606,7 +606,7 @@ impl AIProvider {
 		if let Some(p) = policies {
 			// Apply model alias resolution
 			if let Some(model) = req.model()
-				&& let Some(aliased) = p.model_aliases.get(model.as_str())
+				&& let Some(aliased) = p.resolve_model_alias(model.as_str())
 			{
 				*model = aliased.to_string();
 			}

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -229,16 +229,20 @@ impl LLMRequestPolicies {
 			return Arc::new(route_policies);
 		};
 
+		// Backend aliases replace route aliases entirely (consistent with defaults/overrides)
+		let (merged_aliases, merged_wildcard_patterns) = if be.model_aliases.is_empty() {
+			(re.model_aliases.clone(), Arc::clone(&re.wildcard_patterns))
+		} else {
+			(be.model_aliases.clone(), Arc::clone(&be.wildcard_patterns))
+		};
+
 		route_policies.llm = Some(Arc::new(llm::Policy {
 			prompt_guard: be.prompt_guard.clone().or_else(|| re.prompt_guard.clone()),
 			defaults: be.defaults.clone().or_else(|| re.defaults.clone()),
 			overrides: be.overrides.clone().or_else(|| re.overrides.clone()),
 			prompts: be.prompts.clone().or_else(|| re.prompts.clone()),
-			model_aliases: if be.model_aliases.is_empty() {
-				re.model_aliases.clone()
-			} else {
-				be.model_aliases.clone()
-			},
+			model_aliases: merged_aliases,
+			wildcard_patterns: merged_wildcard_patterns,
 			prompt_caching: be
 				.prompt_caching
 				.clone()

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -198,7 +198,7 @@ fn convert_backend_ai_policy(
 		})
 	});
 
-	Ok(llm::Policy {
+	let mut policy = llm::Policy {
 		prompt_guard: prompt_guard.transpose()?,
 		defaults: Some(
 			ai.defaults
@@ -218,8 +218,14 @@ fn convert_backend_ai_policy(
 			.iter()
 			.map(|(k, v)| (strng::new(k), strng::new(v)))
 			.collect(),
+		wildcard_patterns: Arc::new(Vec::new()), // Will be populated by compile_model_alias_patterns()
 		prompt_caching: ai.prompt_caching.as_ref().map(convert_prompt_caching),
-	})
+	};
+
+	// Compile wildcard patterns from model_aliases
+	policy.compile_model_alias_patterns();
+
+	Ok(policy)
 }
 
 impl TryFrom<proto::agent::BackendAuthPolicy> for BackendAuth {

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -682,7 +682,8 @@ impl LocalBackendPolicies {
 		if let Some(p) = backend_auth {
 			pols.push(BackendPolicy::BackendAuth(p))
 		}
-		if let Some(p) = ai {
+		if let Some(mut p) = ai {
+			p.compile_model_alias_patterns();
 			pols.push(BackendPolicy::AI(Arc::new(p)))
 		}
 		Ok(pols)
@@ -1186,7 +1187,8 @@ async fn split_policies(client: Client, pol: FilterOrPolicy) -> Result<ResolvedP
 	}
 
 	// Route policies
-	if let Some(p) = ai {
+	if let Some(mut p) = ai {
+		p.compile_model_alias_patterns();
 		route_policies.push(TrafficPolicy::AI(Arc::new(p)))
 	}
 	if let Some(p) = jwt_auth {


### PR DESCRIPTION
Add support for wildcard patterns in model aliases, enabling more flexible model name mapping with patterns like `claude-*` or `claude-haiku-*`.

## Example usage

```yaml
modelAliases:
  "claude-haiku-*": "us.anthropic.claude-haiku-4-5-20251001-v1:0"
  "claude-opus-4-1-*": "anthropic.claude-opus-4-1-20250805-v1:0"
  "claude-sonnet-*": "anthropic.claude-3-5-sonnet-20241022-v2:0"
```

This reduces verbose exact-match configurations by automatically handling date variants and version suffixes (e.g., `-v1:0`, `-v2:0`, `-latest`).

## Implementation

- Added `ModelAliasPattern` struct to represent compiled wildcard patterns
- Patterns are compiled once at policy creation using regex
- Resolution uses O(1) exact match first, then O(n) pattern matching
- Patterns sorted by specificity (longer = more specific) for correct precedence
- Wrapped in Arc to avoid cloning compiled regex during policy merging

## Changes

- `policy.rs`: Added `ModelAliasPattern` struct, `compile_model_alias_patterns()` and `resolve_model_alias()` methods, test
- `mod.rs`: Changed `model_aliases.get()` to `resolve_model_alias()`
- `binds.rs`: Updated policy merging to handle `wildcard_patterns` with Arc
- `agent_xds.rs`: Compile patterns after XDS proto conversion
- `local.rs`: Compile patterns after local config deserialization

## Performance

- Exact matches remain O(1) via HashMap lookup
- Wildcard matching is O(n) but only for non-exact matches
- No regex recompilation during request processing