### PR TITLE
fix(mcp): support spec-compliant Mcp-Session-Id header with backwards compatibility

### DIFF
--- a/crates/agentgateway/src/mcp/streamablehttp.rs
+++ b/crates/agentgateway/src/mcp/streamablehttp.rs
@@ -153,7 +153,7 @@ impl StreamableHttpService {
 		let mut resp = session.send(part, message).await;
 
 		if set_session_id {
-			let Ok(sid) = session.id.parse() else {
+			let Ok(sid): Result<http::HeaderValue, _> = session.id.parse() else {
 				return internal_error_response("create session id header");
 			};
 			// Phase 1: Return both headers for backwards compatibility

--- a/crates/agentgateway/src/mcp/streamablehttp.rs
+++ b/crates/agentgateway/src/mcp/streamablehttp.rs
@@ -15,12 +15,13 @@ use crate::*;
 // MCP spec-compliant session header name
 const MCP_SESSION_ID_HEADER: &str = "Mcp-Session-Id";
 
-/// Extract session ID from request headers, checking both spec-compliant and legacy headers.
-/// Prefers MCP_SESSION_ID_HEADER (spec-compliant) over HEADER_SESSION_ID (legacy).
+/// Extract session ID from request headers, checking both spec-compliant and deprecated headers.
+/// Prefers MCP_SESSION_ID_HEADER (spec-compliant) over HEADER_SESSION_ID (deprecated).
+/// Support for HEADER_SESSION_ID will be removed in Phase 3.
 fn get_session_id_from_headers(headers: &http::HeaderMap) -> Option<&str> {
 	headers
 		.get(MCP_SESSION_ID_HEADER)
-		.or_else(|| headers.get(HEADER_SESSION_ID))
+		.or_else(|| headers.get(HEADER_SESSION_ID)) // DEPRECATED: Remove in Phase 3
 		.and_then(|v| v.to_str().ok())
 }
 
@@ -158,7 +159,8 @@ impl StreamableHttpService {
 			// Phase 1: Return both headers for backwards compatibility
 			// Spec-compliant header (primary)
 			resp.headers_mut().insert(MCP_SESSION_ID_HEADER, sid.clone());
-			// Legacy header for existing clients/load balancers
+			// DEPRECATED: Legacy header for existing clients/load balancers
+			// TODO: Remove in Phase 3 after operators migrate to Mcp-Session-Id
 			resp.headers_mut().insert(HEADER_SESSION_ID, sid);
 		}
 		resp

--- a/crates/agentgateway/src/mcp/streamablehttp.rs
+++ b/crates/agentgateway/src/mcp/streamablehttp.rs
@@ -155,8 +155,11 @@ impl StreamableHttpService {
 			let Ok(sid) = session.id.parse() else {
 				return internal_error_response("create session id header");
 			};
-			// Always return the spec-compliant header in responses
-			resp.headers_mut().insert(MCP_SESSION_ID_HEADER, sid);
+			// Phase 1: Return both headers for backwards compatibility
+			// Spec-compliant header (primary)
+			resp.headers_mut().insert(MCP_SESSION_ID_HEADER, sid.clone());
+			// Legacy header for existing clients/load balancers
+			resp.headers_mut().insert(HEADER_SESSION_ID, sid);
 		}
 		resp
 	}

--- a/crates/agentgateway/src/mcp/upstream/streamablehttp.rs
+++ b/crates/agentgateway/src/mcp/upstream/streamablehttp.rs
@@ -205,7 +205,7 @@ impl Client {
 
 	fn maybe_insert_session_id(&self, req: &mut Request) -> Result<(), ClientError> {
 		if let Some(session_id) = self.session_id.load().clone() {
-			let header_value = session_id.as_ref().parse().map_err(ClientError::new)?;
+			let header_value: http::HeaderValue = session_id.as_ref().parse().map_err(ClientError::new)?;
 			// Phase 1: Send both headers for backwards compatibility
 			// Spec-compliant header (primary)
 			req.headers_mut().insert(MCP_SESSION_ID_HEADER, header_value.clone());

--- a/crates/agentgateway/src/mcp/upstream/streamablehttp.rs
+++ b/crates/agentgateway/src/mcp/upstream/streamablehttp.rs
@@ -204,11 +204,12 @@ impl Client {
 
 	fn maybe_insert_session_id(&self, req: &mut Request) -> Result<(), ClientError> {
 		if let Some(session_id) = self.session_id.load().clone() {
-			// Always send the spec-compliant header
-			req.headers_mut().insert(
-				MCP_SESSION_ID_HEADER,
-				session_id.as_ref().parse().map_err(ClientError::new)?,
-			);
+			let header_value = session_id.as_ref().parse().map_err(ClientError::new)?;
+			// Phase 1: Send both headers for backwards compatibility
+			// Spec-compliant header (primary)
+			req.headers_mut().insert(MCP_SESSION_ID_HEADER, header_value.clone());
+			// Legacy header for existing servers
+			req.headers_mut().insert(HEADER_SESSION_ID, header_value);
 		}
 		Ok(())
 	}

--- a/crates/agentgateway/src/mcp/upstream/streamablehttp.rs
+++ b/crates/agentgateway/src/mcp/upstream/streamablehttp.rs
@@ -23,12 +23,13 @@ use crate::{json, *};
 // MCP spec-compliant session header name
 const MCP_SESSION_ID_HEADER: &str = "Mcp-Session-Id";
 
-/// Extract session ID from response headers, checking both spec-compliant and legacy headers.
-/// Prefers MCP_SESSION_ID_HEADER (spec-compliant) over HEADER_SESSION_ID (legacy).
+/// Extract session ID from response headers, checking both spec-compliant and deprecated headers.
+/// Prefers MCP_SESSION_ID_HEADER (spec-compliant) over HEADER_SESSION_ID (deprecated).
+/// Support for HEADER_SESSION_ID will be removed in Phase 3.
 fn get_session_id_from_headers(headers: &http::HeaderMap) -> Option<String> {
 	headers
 		.get(MCP_SESSION_ID_HEADER)
-		.or_else(|| headers.get(HEADER_SESSION_ID))
+		.or_else(|| headers.get(HEADER_SESSION_ID)) // DEPRECATED: Remove in Phase 3
 		.and_then(|v| v.to_str().ok())
 		.map(|s| s.to_string())
 }
@@ -208,7 +209,8 @@ impl Client {
 			// Phase 1: Send both headers for backwards compatibility
 			// Spec-compliant header (primary)
 			req.headers_mut().insert(MCP_SESSION_ID_HEADER, header_value.clone());
-			// Legacy header for existing servers
+			// DEPRECATED: Legacy header for existing servers
+			// TODO: Remove in Phase 3 after all servers upgraded
 			req.headers_mut().insert(HEADER_SESSION_ID, header_value);
 		}
 		Ok(())


### PR DESCRIPTION
## Summary

Implements MCP specification compliance for session ID headers while maintaining full backwards compatibility with existing deployments using the non-standard `mcp-protocol-version` header.

## Problem

AgentGateway currently uses the `mcp-protocol-version` HTTP header for session ID tracking, which violates the MCP specification. According to the spec:

- **Session IDs** should use `Mcp-Session-Id` header
- **Protocol Version** should use `MCP-Protocol-Version` header

This non-compliance causes:
1. Spec-compliant clients to fail with "Session not found" errors
2. Operators to configure load balancers with non-standard headers
3. Semantic confusion mixing unrelated concerns
4. Risk of breaking changes when correcting in the future

## Solution

This PR implements a backwards compatible fix that ensures **zero breaking changes** during Phase 1:

### Server Changes
- **Accepts both** `Mcp-Session-Id` (spec-compliant) and `mcp-protocol-version` (legacy) in incoming requests
- Prefers `Mcp-Session-Id` when both headers are present
- **Returns BOTH headers** in responses for maximum compatibility:
  - `Mcp-Session-Id` (spec-compliant, primary)
  - `mcp-protocol-version` (legacy, for existing clients/load balancers)

### Client Changes
- **Sends BOTH headers** when making requests:
  - `Mcp-Session-Id` (spec-compliant, primary)
  - `mcp-protocol-version` (legacy, for existing servers)
- Reads both headers from responses for backwards compatibility
- Prefers `Mcp-Session-Id` when both headers are present

## Migration Path

This enables gradual migration with zero downtime and zero coordination required:

### Phase 1 (This PR)
- Deploy new agentgateway version
- Both headers are sent/returned
- No breakage for existing deployments
- New deployments can use spec-compliant headers
- Old deployments continue working with legacy headers

### Phase 2 (Operator discretion)
- Operators update load balancer configurations at their own pace
- Change from `mcp-protocol-version` to `Mcp-Session-Id`
- No urgency required - both work

### Phase 3 (Future, separate PR)
- After sufficient adoption of Phase 2
- Deprecate legacy header support
- Add deprecation warnings
- Eventually remove legacy header (breaking change, major version)

## Key Benefits

**Zero Coordination Required:** Operators can upgrade agentgateway and update load balancer configs independently, in any order, without breaking deployments.

**Graceful Migration:** Existing clients, servers, and load balancers continue working unchanged while new deployments adopt spec-compliant behavior.

## Testing

- Code changes are isolated to header extraction and insertion
- Existing tests should pass (legacy behavior still fully supported)
- New behavior is additive - no existing functionality removed

## Load Balancer Configuration

### New Deployments (Recommended)
```yaml
consistentHash:
  httpHeaderName: "Mcp-Session-Id"  # Spec-compliant
```

### Existing Deployments (Still Works)
```yaml
consistentHash:
  httpHeaderName: "mcp-protocol-version"  # Legacy, continues working
```

Both configurations will work correctly with this change.

## References

Fixes #633