### PR TITLE
feat: Add ipallowlist

### DIFF
--- a/crates/agentgateway/src/http/ipallowlist.rs
+++ b/crates/agentgateway/src/http/ipallowlist.rs
@@ -1,0 +1,277 @@
+use std::net::IpAddr;
+use std::str::FromStr;
+
+use ::http::{StatusCode, header};
+use serde::de::Error;
+
+use crate::http::{PolicyResponse, Request, filters};
+use crate::*;
+
+#[derive(Default, Debug, Clone)]
+enum WildcardOrList<T> {
+	#[default]
+	None,
+	Wildcard,
+	List(Vec<T>),
+}
+
+impl<T> WildcardOrList<T> {
+	fn is_none(&self) -> bool {
+		matches!(self, WildcardOrList::None)
+	}
+}
+
+impl<T: FromStr> TryFrom<Vec<String>> for WildcardOrList<T> {
+	type Error = T::Err;
+
+	fn try_from(value: Vec<String>) -> Result<Self, Self::Error> {
+		if value.contains(&"*".to_string()) {
+			Ok(WildcardOrList::Wildcard)
+		} else if value.is_empty() {
+			Ok(WildcardOrList::None)
+		} else {
+			let vec: Vec<T> = value
+				.into_iter()
+				.map(|v| T::from_str(&v))
+				.collect::<Result<_, _>>()?;
+			Ok(WildcardOrList::List(vec))
+		}
+	}
+}
+
+impl<T: Display> Serialize for WildcardOrList<T> {
+	fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+		match self {
+			WildcardOrList::None => Vec::<String>::new().serialize(serializer),
+			WildcardOrList::Wildcard => vec!["*"].serialize(serializer),
+			WildcardOrList::List(list) => list
+				.iter()
+				.map(ToString::to_string)
+				.collect::<Vec<_>>()
+				.serialize(serializer),
+		}
+	}
+}
+
+#[derive(Debug, Clone)]
+enum IpRange {
+	Single(IpAddr),
+	Cidr(ipnet::IpNet),
+}
+
+impl IpRange {
+	fn contains(&self, ip: IpAddr) -> bool {
+		match self {
+			IpRange::Single(allowed) => allowed == &ip,
+			IpRange::Cidr(network) => network.contains(&ip),
+		}
+	}
+}
+
+impl FromStr for IpRange {
+	type Err = anyhow::Error;
+
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		// Try parsing as CIDR first
+		if let Ok(network) = ipnet::IpNet::from_str(s) {
+			return Ok(IpRange::Cidr(network));
+		}
+		// Otherwise try as single IP
+		if let Ok(ip) = IpAddr::from_str(s) {
+			return Ok(IpRange::Single(ip));
+		}
+		Err(anyhow::anyhow!("Invalid IP address or CIDR: {}", s))
+	}
+}
+
+impl Display for IpRange {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			IpRange::Single(ip) => write!(f, "{}", ip),
+			IpRange::Cidr(network) => write!(f, "{}", network),
+		}
+	}
+}
+
+/// Source from which to extract the client IP address
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+pub enum IpSource {
+	/// Use the remote socket address from the direct connection
+	RemoteAddr,
+	/// Use the X-Forwarded-For header
+	#[default]
+	XForwardedFor,
+}
+
+#[apply(schema_ser!)]
+#[cfg_attr(feature = "schema", schemars(with = "IpAllowlistSerde"))]
+pub struct IpAllowlist {
+	#[serde(skip_serializing_if = "WildcardOrList::is_none")]
+	allowed_ranges: WildcardOrList<IpRange>,
+	#[serde(with = "http_serde::status_code")]
+	#[cfg_attr(feature = "schema", schemars(with = "std::num::NonZeroU16"))]
+	deny_status: StatusCode,
+	#[serde(serialize_with = "ser_string_or_bytes_option")]
+	deny_message: Option<::http::HeaderValue>,
+	ip_source: IpSource,
+	/// Distance from the last hop in X-Forwarded-For header.
+	/// 0 = last hop (rightmost), -1 = second to last, -2 = third to last, etc.
+	/// If the list has fewer IPs than requested, uses the first IP.
+	distance_from_last_hop: i32,
+}
+
+impl<'de> serde::Deserialize<'de> for IpAllowlist {
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: serde::Deserializer<'de>,
+	{
+		IpAllowlist::try_from(IpAllowlistSerde::deserialize(deserializer)?).map_err(D::Error::custom)
+	}
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+pub struct IpAllowlistSerde {
+	#[serde(default)]
+	pub allowed_ips: Vec<String>,
+	#[serde(default = "default_deny_status_code")]
+	pub deny_status_code: u16,
+	#[serde(default)]
+	pub deny_message: Option<String>,
+	#[serde(default)]
+	pub ip_source: IpSource,
+	#[serde(default)]
+	pub distance_from_last_hop: i32,
+}
+
+fn default_deny_status_code() -> u16 {
+	403
+}
+
+impl TryFrom<IpAllowlistSerde> for IpAllowlist {
+	type Error = anyhow::Error;
+	fn try_from(value: IpAllowlistSerde) -> Result<Self, Self::Error> {
+		Ok(IpAllowlist {
+			allowed_ranges: WildcardOrList::try_from(value.allowed_ips)?,
+			deny_status: StatusCode::from_u16(value.deny_status_code)?,
+			deny_message: value
+				.deny_message
+				.map(|msg| http::HeaderValue::from_str(&msg))
+				.transpose()?,
+			ip_source: value.ip_source,
+			distance_from_last_hop: value.distance_from_last_hop,
+		})
+	}
+}
+
+impl IpAllowlist {
+	/// Apply the IP allowlist policy to the request.
+	/// If the source IP is not in the allowlist, returns a direct response with the configured deny status.
+	/// Otherwise, allows the request to continue processing.
+	pub fn apply(&self, req: &mut Request) -> Result<PolicyResponse, filters::Error> {
+		// Extract source IP from request
+		let source_ip = self.extract_source_ip(req)?;
+
+		// Check against allowlist
+		let allowed = match &self.allowed_ranges {
+			WildcardOrList::None => false,    // Empty list = deny all
+			WildcardOrList::Wildcard => true, // "*" = allow all
+			WildcardOrList::List(ranges) => ranges.iter().any(|range| range.contains(source_ip)),
+		};
+
+		// If not allowed, return direct deny response
+		if !allowed {
+			let body = self
+				.deny_message
+				.as_ref()
+				.map(|hv| hv.as_bytes().to_vec())
+				.unwrap_or_else(|| b"Forbidden: IP not allowed".to_vec());
+
+			let response = ::http::Response::builder()
+				.status(self.deny_status)
+				.header(header::CONTENT_TYPE, "text/plain")
+				.body(crate::http::Body::from(body))?;
+
+			return Ok(PolicyResponse {
+				direct_response: Some(response),
+				response_headers: None,
+			});
+		}
+
+		// If allowed, continue processing
+		Ok(PolicyResponse::default())
+	}
+
+	/// Extract the source IP address from the request based on configuration.
+	fn extract_source_ip(&self, req: &Request) -> Result<IpAddr, filters::Error> {
+		match self.ip_source {
+			IpSource::RemoteAddr => {
+				// Use remote socket address
+				if let Some(addr) = req.extensions().get::<std::net::SocketAddr>() {
+					return Ok(addr.ip());
+				}
+				Err(filters::Error::InvalidFilterConfiguration(
+					"Unable to determine remote socket address".to_string(),
+				))
+			},
+			IpSource::XForwardedFor => {
+				// Use X-Forwarded-For header
+				if let Some(xff) = req.headers().get("X-Forwarded-For")
+					&& let Ok(xff_str) = xff.to_str()
+				{
+					return self.extract_ip_from_xff(xff_str);
+				}
+				Err(filters::Error::InvalidFilterConfiguration(
+					"Unable to determine IP from X-Forwarded-For header".to_string(),
+				))
+			},
+		}
+	}
+
+	/// Extract IP from X-Forwarded-For header based on distance_from_last_hop.
+	/// distanceFromLastHop: 0 = last hop (rightmost), -1 = second to last, etc.
+	/// If the list has fewer IPs than requested, uses the first IP.
+	fn extract_ip_from_xff(&self, xff_str: &str) -> Result<IpAddr, filters::Error> {
+		let ips: Vec<&str> = xff_str.split(',').map(|s| s.trim()).collect();
+
+		if ips.is_empty() {
+			return Err(filters::Error::InvalidFilterConfiguration(
+				"X-Forwarded-For header is empty".to_string(),
+			));
+		}
+
+		// Calculate the index based on distance_from_last_hop
+		// distance_from_last_hop = 0 means last (rightmost)
+		// distance_from_last_hop = -1 means second to last
+		// distance_from_last_hop = -2 means third to last, etc.
+		let index = if self.distance_from_last_hop >= 0 {
+			// Positive or zero: count from the end (0 = last)
+			let idx = (ips.len() as i32 - 1 - self.distance_from_last_hop).max(0) as usize;
+			idx.min(ips.len() - 1)
+		} else {
+			// Negative: count from the end (-1 = second to last, -2 = third to last, etc.)
+			// -1 means 1 position before last, so we want len - 1 - 1 = len - 2
+			let offset = (-self.distance_from_last_hop) as usize;
+			if offset >= ips.len() {
+				// If we go past the beginning, use the first IP
+				0
+			} else {
+				ips.len() - 1 - offset
+			}
+		};
+
+		ips[index].parse().map_err(|_| {
+			filters::Error::InvalidFilterConfiguration(format!(
+				"Invalid IP address in X-Forwarded-For header: {}",
+				ips[index]
+			))
+		})
+	}
+}
+
+#[cfg(test)]
+#[path = "ipallowlist_tests.rs"]
+mod tests;

--- a/crates/agentgateway/src/http/ipallowlist_tests.rs
+++ b/crates/agentgateway/src/http/ipallowlist_tests.rs
@@ -1,0 +1,768 @@
+use std::net::{IpAddr, SocketAddr};
+
+use http_body_util::BodyExt;
+
+use crate::http::StatusCode;
+use crate::http::ipallowlist::{IpAllowlist, IpAllowlistSerde, IpSource};
+use crate::http::tests_common::*;
+
+/// Helper to create a request with a socket address in extensions
+fn request_with_ip(ip: &str) -> crate::http::Request {
+	let mut req = request_for_uri("http://test.com/api");
+	let ip_addr: IpAddr = ip.parse().unwrap();
+	let socket_addr = SocketAddr::new(ip_addr, 12345);
+	req.extensions_mut().insert(socket_addr);
+	req
+}
+
+/// Helper to create a request with X-Forwarded-For header
+fn request_with_xff(xff: &str) -> crate::http::Request {
+	request(
+		"http://test.com/api",
+		http::Method::GET,
+		&[("X-Forwarded-For", xff)],
+	)
+}
+
+// ==================== Basic IP Matching Tests ====================
+
+#[test]
+fn test_wildcard_allows_all() {
+	let config = IpAllowlistSerde {
+		allowed_ips: vec!["*".to_string()],
+		deny_status_code: 403,
+		deny_message: None,
+		ip_source: IpSource::RemoteAddr,
+		distance_from_last_hop: 0,
+	};
+	let allowlist: IpAllowlist = config.try_into().unwrap();
+
+	// Test IPv4
+	let mut req = request_with_ip("192.168.1.100");
+	let result = allowlist.apply(&mut req).unwrap();
+	assert!(
+		result.direct_response.is_none(),
+		"wildcard should allow IPv4"
+	);
+
+	// Test IPv6
+	let mut req = request_with_ip("2001:db8::1");
+	let result = allowlist.apply(&mut req).unwrap();
+	assert!(
+		result.direct_response.is_none(),
+		"wildcard should allow IPv6"
+	);
+}
+
+#[test]
+fn test_empty_list_denies_all() {
+	let config = IpAllowlistSerde {
+		allowed_ips: vec![],
+		deny_status_code: 403,
+		deny_message: None,
+		ip_source: IpSource::RemoteAddr,
+		distance_from_last_hop: 0,
+	};
+	let allowlist: IpAllowlist = config.try_into().unwrap();
+
+	let mut req = request_with_ip("192.168.1.100");
+	let result = allowlist.apply(&mut req).unwrap();
+	assert!(
+		result.direct_response.is_some(),
+		"empty list should deny all"
+	);
+
+	let response = result.direct_response.unwrap();
+	assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+
+#[test]
+fn test_single_ipv4_allowed() {
+	let config = IpAllowlistSerde {
+		allowed_ips: vec!["192.168.1.100".to_string()],
+		deny_status_code: 403,
+		deny_message: None,
+		ip_source: IpSource::RemoteAddr,
+		distance_from_last_hop: 0,
+	};
+	let allowlist: IpAllowlist = config.try_into().unwrap();
+
+	// Matching IP should be allowed
+	let mut req = request_with_ip("192.168.1.100");
+	let result = allowlist.apply(&mut req).unwrap();
+	assert!(
+		result.direct_response.is_none(),
+		"matching IP should be allowed"
+	);
+
+	// Different IP should be denied
+	let mut req = request_with_ip("192.168.1.101");
+	let result = allowlist.apply(&mut req).unwrap();
+	assert!(
+		result.direct_response.is_some(),
+		"non-matching IP should be denied"
+	);
+
+	let response = result.direct_response.unwrap();
+	assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+
+#[test]
+fn test_single_ipv6_allowed() {
+	let config = IpAllowlistSerde {
+		allowed_ips: vec!["2001:db8::1".to_string()],
+		deny_status_code: 403,
+		deny_message: None,
+		ip_source: IpSource::RemoteAddr,
+		distance_from_last_hop: 0,
+	};
+	let allowlist: IpAllowlist = config.try_into().unwrap();
+
+	// Matching IP should be allowed
+	let mut req = request_with_ip("2001:db8::1");
+	let result = allowlist.apply(&mut req).unwrap();
+	assert!(
+		result.direct_response.is_none(),
+		"matching IPv6 should be allowed"
+	);
+
+	// Different IP should be denied
+	let mut req = request_with_ip("2001:db8::2");
+	let result = allowlist.apply(&mut req).unwrap();
+	assert!(
+		result.direct_response.is_some(),
+		"non-matching IPv6 should be denied"
+	);
+}
+
+#[test]
+fn test_cidr_ipv4_range() {
+	let config = IpAllowlistSerde {
+		allowed_ips: vec!["192.168.1.0/24".to_string()],
+		deny_status_code: 403,
+		deny_message: None,
+		ip_source: IpSource::RemoteAddr,
+		distance_from_last_hop: 0,
+	};
+	let allowlist: IpAllowlist = config.try_into().unwrap();
+
+	// IPs in range should be allowed
+	let test_cases = vec![
+		("192.168.1.1", true),
+		("192.168.1.100", true),
+		("192.168.1.254", true),
+		("192.168.2.1", false),
+		("192.168.0.255", false),
+		("10.0.0.1", false),
+	];
+
+	for (ip, should_allow) in test_cases {
+		let mut req = request_with_ip(ip);
+		let result = allowlist.apply(&mut req).unwrap();
+		if should_allow {
+			assert!(result.direct_response.is_none(), "{} should be allowed", ip);
+		} else {
+			assert!(result.direct_response.is_some(), "{} should be denied", ip);
+		}
+	}
+}
+
+#[test]
+fn test_cidr_ipv6_range() {
+	let config = IpAllowlistSerde {
+		allowed_ips: vec!["2001:db8::/32".to_string()],
+		deny_status_code: 403,
+		deny_message: None,
+		ip_source: IpSource::RemoteAddr,
+		distance_from_last_hop: 0,
+	};
+	let allowlist: IpAllowlist = config.try_into().unwrap();
+
+	// IPs in range should be allowed
+	let mut req = request_with_ip("2001:db8::1");
+	let result = allowlist.apply(&mut req).unwrap();
+	assert!(
+		result.direct_response.is_none(),
+		"IP in range should be allowed"
+	);
+
+	let mut req = request_with_ip("2001:db8:1::1");
+	let result = allowlist.apply(&mut req).unwrap();
+	assert!(
+		result.direct_response.is_none(),
+		"IP in range should be allowed"
+	);
+
+	// IP out of range should be denied
+	let mut req = request_with_ip("2001:db9::1");
+	let result = allowlist.apply(&mut req).unwrap();
+	assert!(
+		result.direct_response.is_some(),
+		"IP out of range should be denied"
+	);
+}
+
+#[test]
+fn test_multiple_ips_and_ranges() {
+	let config = IpAllowlistSerde {
+		allowed_ips: vec![
+			"10.0.0.1".to_string(),
+			"192.168.1.0/24".to_string(),
+			"2001:db8::1".to_string(),
+		],
+		deny_status_code: 403,
+		deny_message: None,
+		ip_source: IpSource::RemoteAddr,
+		distance_from_last_hop: 0,
+	};
+	let allowlist: IpAllowlist = config.try_into().unwrap();
+
+	// Test single IP match
+	let mut req = request_with_ip("10.0.0.1");
+	let result = allowlist.apply(&mut req).unwrap();
+	assert!(
+		result.direct_response.is_none(),
+		"single IP should be allowed"
+	);
+
+	// Test CIDR range match
+	let mut req = request_with_ip("192.168.1.50");
+	let result = allowlist.apply(&mut req).unwrap();
+	assert!(
+		result.direct_response.is_none(),
+		"IP in CIDR range should be allowed"
+	);
+
+	// Test IPv6 match
+	let mut req = request_with_ip("2001:db8::1");
+	let result = allowlist.apply(&mut req).unwrap();
+	assert!(result.direct_response.is_none(), "IPv6 should be allowed");
+
+	// Test non-matching IP
+	let mut req = request_with_ip("172.16.0.1");
+	let result = allowlist.apply(&mut req).unwrap();
+	assert!(
+		result.direct_response.is_some(),
+		"non-matching IP should be denied"
+	);
+}
+
+// ==================== Custom Status Code and Message Tests ====================
+
+#[test]
+fn test_custom_deny_status_code() {
+	let config = IpAllowlistSerde {
+		allowed_ips: vec!["10.0.0.1".to_string()],
+		deny_status_code: 404,
+		deny_message: None,
+		ip_source: IpSource::RemoteAddr,
+		distance_from_last_hop: 0,
+	};
+	let allowlist: IpAllowlist = config.try_into().unwrap();
+
+	let mut req = request_with_ip("192.168.1.1");
+	let result = allowlist.apply(&mut req).unwrap();
+	assert!(result.direct_response.is_some());
+
+	let response = result.direct_response.unwrap();
+	assert_eq!(
+		response.status(),
+		StatusCode::NOT_FOUND,
+		"should use custom status code 404"
+	);
+}
+
+#[tokio::test]
+async fn test_custom_deny_message() {
+	let config = IpAllowlistSerde {
+		allowed_ips: vec!["10.0.0.1".to_string()],
+		deny_status_code: 403,
+		deny_message: Some("Access denied: IP not authorized".to_string()),
+		ip_source: IpSource::RemoteAddr,
+		distance_from_last_hop: 0,
+	};
+	let allowlist: IpAllowlist = config.try_into().unwrap();
+
+	let mut req = request_with_ip("192.168.1.1");
+	let result = allowlist.apply(&mut req).unwrap();
+	assert!(result.direct_response.is_some());
+
+	let response = result.direct_response.unwrap();
+	assert_eq!(response.status(), StatusCode::FORBIDDEN);
+
+	// Check body contains custom message
+	let body_bytes = response.into_body().collect().await.unwrap().to_bytes();
+	let body_str = String::from_utf8(body_bytes.to_vec()).unwrap();
+	assert_eq!(body_str, "Access denied: IP not authorized");
+}
+
+#[test]
+fn test_custom_status_418_im_a_teapot() {
+	let config = IpAllowlistSerde {
+		allowed_ips: vec!["10.0.0.1".to_string()],
+		deny_status_code: 418,
+		deny_message: Some("I'm a teapot".to_string()),
+		ip_source: IpSource::RemoteAddr,
+		distance_from_last_hop: 0,
+	};
+	let allowlist: IpAllowlist = config.try_into().unwrap();
+
+	let mut req = request_with_ip("192.168.1.1");
+	let result = allowlist.apply(&mut req).unwrap();
+	assert!(result.direct_response.is_some());
+
+	let response = result.direct_response.unwrap();
+	assert_eq!(response.status(), StatusCode::IM_A_TEAPOT);
+}
+
+// ==================== XFF Hop Selection Tests ====================
+
+#[test]
+fn test_xff_last_hop_default() {
+	let config = IpAllowlistSerde {
+		allowed_ips: vec!["203.0.113.5".to_string()],
+		deny_status_code: 403,
+		deny_message: None,
+		ip_source: IpSource::XForwardedFor,
+		distance_from_last_hop: 0, // Last hop (default)
+	};
+	let allowlist: IpAllowlist = config.try_into().unwrap();
+
+	// XFF: client, proxy1, proxy2, proxy3 -> should use proxy3 (last)
+	let mut req = request_with_xff("203.0.113.1, 203.0.113.2, 203.0.113.3, 203.0.113.5");
+	let result = allowlist.apply(&mut req).unwrap();
+	assert!(
+		result.direct_response.is_none(),
+		"last hop (203.0.113.5) should be allowed"
+	);
+
+	// Different last hop should be denied
+	let mut req = request_with_xff("203.0.113.1, 203.0.113.2, 203.0.113.3, 203.0.113.4");
+	let result = allowlist.apply(&mut req).unwrap();
+	assert!(
+		result.direct_response.is_some(),
+		"different last hop should be denied"
+	);
+}
+
+#[test]
+fn test_xff_second_to_last_hop() {
+	let config = IpAllowlistSerde {
+		allowed_ips: vec!["203.0.113.3".to_string()],
+		deny_status_code: 403,
+		deny_message: None,
+		ip_source: IpSource::XForwardedFor,
+		distance_from_last_hop: -1, // Second to last
+	};
+	let allowlist: IpAllowlist = config.try_into().unwrap();
+
+	// XFF: client, proxy1, proxy2, proxy3 -> should use proxy2 (second to last)
+	let mut req = request_with_xff("203.0.113.1, 203.0.113.2, 203.0.113.3, 203.0.113.4");
+	let result = allowlist.apply(&mut req).unwrap();
+	assert!(
+		result.direct_response.is_none(),
+		"second to last hop (203.0.113.3) should be allowed"
+	);
+}
+
+#[test]
+fn test_xff_third_to_last_hop() {
+	let config = IpAllowlistSerde {
+		allowed_ips: vec!["203.0.113.2".to_string()],
+		deny_status_code: 403,
+		deny_message: None,
+		ip_source: IpSource::XForwardedFor,
+		distance_from_last_hop: -2, // Third to last
+	};
+	let allowlist: IpAllowlist = config.try_into().unwrap();
+
+	// XFF: client, proxy1, proxy2, proxy3 -> should use proxy1 (third to last)
+	let mut req = request_with_xff("203.0.113.1, 203.0.113.2, 203.0.113.3, 203.0.113.4");
+	let result = allowlist.apply(&mut req).unwrap();
+	assert!(
+		result.direct_response.is_none(),
+		"third to last hop (203.0.113.2) should be allowed"
+	);
+}
+
+#[test]
+fn test_xff_fourth_to_last_hop() {
+	let config = IpAllowlistSerde {
+		allowed_ips: vec!["203.0.113.1".to_string()],
+		deny_status_code: 403,
+		deny_message: None,
+		ip_source: IpSource::XForwardedFor,
+		distance_from_last_hop: -3, // Fourth to last (first in this case)
+	};
+	let allowlist: IpAllowlist = config.try_into().unwrap();
+
+	// XFF: client, proxy1, proxy2, proxy3 -> should use client (fourth to last = first)
+	let mut req = request_with_xff("203.0.113.1, 203.0.113.2, 203.0.113.3, 203.0.113.4");
+	let result = allowlist.apply(&mut req).unwrap();
+	assert!(
+		result.direct_response.is_none(),
+		"fourth to last hop (203.0.113.1) should be allowed"
+	);
+}
+
+#[test]
+fn test_xff_first_hop_when_list_too_short() {
+	let config = IpAllowlistSerde {
+		allowed_ips: vec!["203.0.113.1".to_string()],
+		deny_status_code: 403,
+		deny_message: None,
+		ip_source: IpSource::XForwardedFor,
+		distance_from_last_hop: -10, // Way beyond list length
+	};
+	let allowlist: IpAllowlist = config.try_into().unwrap();
+
+	// XFF: only 3 IPs, asking for 11th from last -> should use first
+	let mut req = request_with_xff("203.0.113.1, 203.0.113.2, 203.0.113.3");
+	let result = allowlist.apply(&mut req).unwrap();
+	assert!(
+		result.direct_response.is_none(),
+		"should fallback to first hop when list too short"
+	);
+}
+
+#[test]
+fn test_xff_single_ip_in_header() {
+	let config = IpAllowlistSerde {
+		allowed_ips: vec!["203.0.113.1".to_string()],
+		deny_status_code: 403,
+		deny_message: None,
+		ip_source: IpSource::XForwardedFor,
+		distance_from_last_hop: 0,
+	};
+	let allowlist: IpAllowlist = config.try_into().unwrap();
+
+	// Single IP in XFF
+	let mut req = request_with_xff("203.0.113.1");
+	let result = allowlist.apply(&mut req).unwrap();
+	assert!(result.direct_response.is_none(), "single IP should work");
+
+	// Even with distance=-1, should still work (fallback to first)
+	let config = IpAllowlistSerde {
+		allowed_ips: vec!["203.0.113.1".to_string()],
+		deny_status_code: 403,
+		deny_message: None,
+		ip_source: IpSource::XForwardedFor,
+		distance_from_last_hop: -1,
+	};
+	let allowlist: IpAllowlist = config.try_into().unwrap();
+	let mut req = request_with_xff("203.0.113.1");
+	let result = allowlist.apply(&mut req).unwrap();
+	assert!(
+		result.direct_response.is_none(),
+		"should fallback to first when distance too far"
+	);
+}
+
+#[test]
+fn test_xff_with_whitespace() {
+	let config = IpAllowlistSerde {
+		allowed_ips: vec!["203.0.113.3".to_string()],
+		deny_status_code: 403,
+		deny_message: None,
+		ip_source: IpSource::XForwardedFor,
+		distance_from_last_hop: 0,
+	};
+	let allowlist: IpAllowlist = config.try_into().unwrap();
+
+	// XFF with extra whitespace
+	let mut req = request_with_xff("  203.0.113.1  ,  203.0.113.2  ,  203.0.113.3  ");
+	let result = allowlist.apply(&mut req).unwrap();
+	assert!(
+		result.direct_response.is_none(),
+		"should handle whitespace correctly"
+	);
+}
+
+#[test]
+fn test_xff_with_cidr_ranges() {
+	let config = IpAllowlistSerde {
+		allowed_ips: vec!["203.0.113.0/24".to_string()],
+		deny_status_code: 403,
+		deny_message: None,
+		ip_source: IpSource::XForwardedFor,
+		distance_from_last_hop: -1, // Second to last
+	};
+	let allowlist: IpAllowlist = config.try_into().unwrap();
+
+	// XFF with IP in CIDR range at second-to-last position
+	let mut req = request_with_xff("10.0.0.1, 203.0.113.50, 192.168.1.1");
+	let result = allowlist.apply(&mut req).unwrap();
+	assert!(
+		result.direct_response.is_none(),
+		"CIDR range should match second-to-last IP"
+	);
+}
+
+// ==================== IP Source Selection Tests ====================
+
+#[test]
+fn test_ip_source_remote_addr() {
+	let config = IpAllowlistSerde {
+		allowed_ips: vec!["192.168.1.100".to_string()],
+		deny_status_code: 403,
+		deny_message: None,
+		ip_source: IpSource::RemoteAddr,
+		distance_from_last_hop: 0,
+	};
+	let allowlist: IpAllowlist = config.try_into().unwrap();
+
+	// Request with socket addr should work
+	let mut req = request_with_ip("192.168.1.100");
+	let result = allowlist.apply(&mut req).unwrap();
+	assert!(
+		result.direct_response.is_none(),
+		"RemoteAddr source should use socket address"
+	);
+
+	// Request with XFF but configured for RemoteAddr should fail (no socket addr)
+	let mut req = request_with_xff("192.168.1.100");
+	let result = allowlist.apply(&mut req);
+	assert!(
+		result.is_err(),
+		"RemoteAddr source should fail without socket address"
+	);
+}
+
+#[test]
+fn test_ip_source_xff_ignores_socket_addr() {
+	let config = IpAllowlistSerde {
+		allowed_ips: vec!["203.0.113.5".to_string()],
+		deny_status_code: 403,
+		deny_message: None,
+		ip_source: IpSource::XForwardedFor,
+		distance_from_last_hop: 0,
+	};
+	let allowlist: IpAllowlist = config.try_into().unwrap();
+
+	// Create request with both socket addr and XFF - should use XFF
+	let mut req = request(
+		"http://test.com/api",
+		http::Method::GET,
+		&[("X-Forwarded-For", "203.0.113.5")],
+	);
+	let ip_addr: IpAddr = "192.168.1.100".parse().unwrap();
+	let socket_addr = SocketAddr::new(ip_addr, 12345);
+	req.extensions_mut().insert(socket_addr);
+
+	// Should use XFF (203.0.113.5), not socket addr (192.168.1.100)
+	let result = allowlist.apply(&mut req).unwrap();
+	assert!(
+		result.direct_response.is_none(),
+		"XForwardedFor source should use XFF header, not socket addr"
+	);
+}
+
+#[test]
+fn test_xff_source_prefers_xff_over_remote_addr() {
+	// This is the UPDATED test - XFF is now the default and preferred
+	let config = IpAllowlistSerde {
+		allowed_ips: vec!["203.0.113.1".to_string()], // Allow the XFF IP
+		deny_status_code: 403,
+		deny_message: None,
+		ip_source: IpSource::XForwardedFor, // Explicitly XForwardedFor (also the default)
+		distance_from_last_hop: 0,
+	};
+	let allowlist: IpAllowlist = config.try_into().unwrap();
+
+	// Create request with BOTH socket addr AND XFF header
+	let mut req = request(
+		"http://test.com/api",
+		http::Method::GET,
+		&[("X-Forwarded-For", "203.0.113.1")],
+	);
+	// Socket addr is different IP
+	let ip_addr: IpAddr = "192.168.1.100".parse().unwrap();
+	let socket_addr = SocketAddr::new(ip_addr, 12345);
+	req.extensions_mut().insert(socket_addr);
+
+	// Should use XFF (203.0.113.1) and allow, ignoring socket addr (192.168.1.100)
+	let result = allowlist.apply(&mut req).unwrap();
+	assert!(
+		result.direct_response.is_none(),
+		"should use XFF and allow when ip_source=XForwardedFor"
+	);
+
+	// Now test with RemoteAddr - should use socket address
+	let config = IpAllowlistSerde {
+		allowed_ips: vec!["192.168.1.100".to_string()], // Allow the socket IP
+		deny_status_code: 403,
+		deny_message: None,
+		ip_source: IpSource::RemoteAddr,
+		distance_from_last_hop: 0,
+	};
+	let allowlist: IpAllowlist = config.try_into().unwrap();
+
+	let mut req = request(
+		"http://test.com/api",
+		http::Method::GET,
+		&[("X-Forwarded-For", "203.0.113.1")],
+	);
+	let ip_addr: IpAddr = "192.168.1.100".parse().unwrap();
+	let socket_addr = SocketAddr::new(ip_addr, 12345);
+	req.extensions_mut().insert(socket_addr);
+
+	// Should use socket addr (192.168.1.100) and allow, ignoring XFF
+	let result = allowlist.apply(&mut req).unwrap();
+	assert!(
+		result.direct_response.is_none(),
+		"should use RemoteAddr when ip_source=RemoteAddr"
+	);
+}
+
+#[test]
+fn test_default_ip_source_is_xff() {
+	let default_source = IpSource::default();
+	assert_eq!(
+		default_source,
+		IpSource::XForwardedFor,
+		"default IP source should be XForwardedFor"
+	);
+}
+
+// ==================== Error Handling Tests ====================
+
+#[test]
+fn test_request_without_ip_fails_remote_addr() {
+	let config = IpAllowlistSerde {
+		allowed_ips: vec!["192.168.1.100".to_string()],
+		deny_status_code: 403,
+		deny_message: None,
+		ip_source: IpSource::RemoteAddr,
+		distance_from_last_hop: 0,
+	};
+	let allowlist: IpAllowlist = config.try_into().unwrap();
+
+	// Request with no socket addr and RemoteAddr source
+	let mut req = request_for_uri("http://test.com/api");
+	let result = allowlist.apply(&mut req);
+	assert!(
+		result.is_err(),
+		"request without socket addr should fail for RemoteAddr source"
+	);
+}
+
+#[test]
+fn test_request_without_xff_header_fails() {
+	let config = IpAllowlistSerde {
+		allowed_ips: vec!["192.168.1.100".to_string()],
+		deny_status_code: 403,
+		deny_message: None,
+		ip_source: IpSource::XForwardedFor,
+		distance_from_last_hop: 0,
+	};
+	let allowlist: IpAllowlist = config.try_into().unwrap();
+
+	// Request with no XFF header and XForwardedFor source
+	let mut req = request_for_uri("http://test.com/api");
+	let result = allowlist.apply(&mut req);
+	assert!(
+		result.is_err(),
+		"request without XFF header should fail for XForwardedFor source"
+	);
+}
+
+#[test]
+fn test_invalid_ip_in_config_fails() {
+	let config = IpAllowlistSerde {
+		allowed_ips: vec!["not-an-ip".to_string()],
+		deny_status_code: 403,
+		deny_message: None,
+		ip_source: IpSource::RemoteAddr,
+		distance_from_last_hop: 0,
+	};
+	let result: Result<IpAllowlist, _> = config.try_into();
+	assert!(result.is_err(), "invalid IP should fail to parse");
+}
+
+#[test]
+fn test_invalid_cidr_in_config_fails() {
+	let config = IpAllowlistSerde {
+		allowed_ips: vec!["192.168.1.0/999".to_string()],
+		deny_status_code: 403,
+		deny_message: None,
+		ip_source: IpSource::RemoteAddr,
+		distance_from_last_hop: 0,
+	};
+	let result: Result<IpAllowlist, _> = config.try_into();
+	assert!(result.is_err(), "invalid CIDR should fail to parse");
+}
+
+// ==================== Serialization Tests ====================
+
+#[test]
+fn test_serde_roundtrip() {
+	let config = IpAllowlistSerde {
+		allowed_ips: vec![
+			"192.168.1.0/24".to_string(),
+			"10.0.0.1".to_string(),
+			"2001:db8::/32".to_string(),
+		],
+		deny_status_code: 404,
+		deny_message: Some("Custom message".to_string()),
+		ip_source: IpSource::RemoteAddr,
+		distance_from_last_hop: -2,
+	};
+
+	// Serialize to JSON
+	let json = serde_json::to_string(&config).unwrap();
+
+	// Deserialize back
+	let deserialized: IpAllowlistSerde = serde_json::from_str(&json).unwrap();
+
+	assert_eq!(deserialized.allowed_ips, config.allowed_ips);
+	assert_eq!(deserialized.deny_status_code, config.deny_status_code);
+	assert_eq!(deserialized.deny_message, config.deny_message);
+	assert_eq!(deserialized.ip_source, config.ip_source);
+	assert_eq!(
+		deserialized.distance_from_last_hop,
+		config.distance_from_last_hop
+	);
+}
+
+#[test]
+fn test_default_deny_status_code() {
+	let json = r#"{"allowedIps": ["10.0.0.1"]}"#;
+	let config: IpAllowlistSerde = serde_json::from_str(json).unwrap();
+	assert_eq!(
+		config.deny_status_code, 403,
+		"default status code should be 403"
+	);
+	assert_eq!(
+		config.ip_source,
+		IpSource::XForwardedFor,
+		"default ip_source should be XForwardedFor"
+	);
+	assert_eq!(
+		config.distance_from_last_hop, 0,
+		"default distance should be 0"
+	);
+}
+
+#[test]
+fn test_policy_response_structure() {
+	let config = IpAllowlistSerde {
+		allowed_ips: vec!["10.0.0.1".to_string()],
+		deny_status_code: 403,
+		deny_message: None,
+		ip_source: IpSource::RemoteAddr,
+		distance_from_last_hop: 0,
+	};
+	let allowlist: IpAllowlist = config.try_into().unwrap();
+
+	// Test allowed request returns empty PolicyResponse
+	let mut req = request_with_ip("10.0.0.1");
+	let result = allowlist.apply(&mut req).unwrap();
+	assert!(result.direct_response.is_none());
+	assert!(result.response_headers.is_none());
+
+	// Test denied request returns PolicyResponse with direct_response
+	let mut req = request_with_ip("192.168.1.1");
+	let result = allowlist.apply(&mut req).unwrap();
+	assert!(result.direct_response.is_some());
+	assert!(result.response_headers.is_none());
+}

--- a/crates/agentgateway/src/http/mod.rs
+++ b/crates/agentgateway/src/http/mod.rs
@@ -3,6 +3,7 @@ pub mod timeout;
 
 mod buflist;
 pub mod cors;
+pub mod ipallowlist;
 pub mod jwt;
 pub mod localratelimit;
 pub mod retry;

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -155,6 +155,12 @@ async fn apply_request_policies(
 	if let Some(r) = &policies.url_rewrite {
 		r.apply(req).map_err(ProxyError::from)?;
 	}
+	if let Some(ip_allowlist) = &policies.ip_allowlist {
+		ip_allowlist
+			.apply(req)
+			.map_err(ProxyError::from)?
+			.apply(response_policies.headers())?;
+	}
 	if let Some(c) = &policies.cors {
 		c.apply(req)
 			.map_err(ProxyError::from)?

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -150,6 +150,7 @@ pub struct RoutePolicies {
 	pub request_mirror: Vec<filters::RequestMirror>,
 	pub direct_response: Option<filters::DirectResponse>,
 	pub cors: Option<http::cors::Cors>,
+	pub ip_allowlist: Option<http::ipallowlist::IpAllowlist>,
 }
 
 #[derive(Debug, Default)]
@@ -382,6 +383,9 @@ impl Store {
 				},
 				TrafficPolicy::CORS(p) => {
 					pol.cors.get_or_insert_with(|| p.clone());
+				},
+				TrafficPolicy::IpAllowlist(p) => {
+					pol.ip_allowlist.get_or_insert_with(|| p.clone());
 				},
 			}
 		}

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -1157,6 +1157,7 @@ pub enum TrafficPolicy {
 	DirectResponse(filters::DirectResponse),
 	#[serde(rename = "cors")]
 	CORS(http::cors::Cors),
+	IpAllowlist(http::ipallowlist::IpAllowlist),
 }
 
 #[derive(Debug, Clone, serde::Serialize)]

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -743,6 +743,10 @@ struct FilterOrPolicy {
 	#[serde(default)]
 	cors: Option<http::cors::Cors>,
 
+	/// Allow or deny requests based on source IP address.
+	#[serde(default)]
+	ip_allowlist: Option<http::ipallowlist::IpAllowlist>,
+
 	// Policy
 	/// Authorization policies for MCP access.
 	#[serde(default)]
@@ -1117,6 +1121,7 @@ async fn split_policies(
 		request_mirror,
 		direct_response,
 		cors,
+		ip_allowlist,
 		mcp_authorization,
 		mcp_authentication,
 		a2a,
@@ -1166,6 +1171,9 @@ async fn split_policies(
 	}
 	if let Some(p) = cors {
 		route_policies.push(TrafficPolicy::CORS(p));
+	}
+	if let Some(p) = ip_allowlist {
+		route_policies.push(TrafficPolicy::IpAllowlist(p));
 	}
 
 	// Backend policies


### PR DESCRIPTION
## Summary
Implements a flexible IP allowlist traffic policy that validates source IP addresses before processing requests. The feature supports single IPs, CIDR ranges, IPv4/IPv6, and configurable IP source extraction from either remote socket addresses or X-Forwarded-For headers with precise hop selection.

## Problem
AgentGateway currently lacks a built-in mechanism to restrict API access based on client IP addresses. This creates several challenges:

- No native way to enforce IP-based access control at the gateway level
- Organizations must rely on external load balancers or firewalls for IP filtering
- No standardized approach across deployments
- Limited flexibility in multi-proxy environments where the true client IP may be several hops back in the X-Forwarded-For chain

## Solution
This PR implements a comprehensive IP allowlist traffic policy following the existing CORS pattern, with advanced configurability for complex network topologies:

### Core Features

**IP Matching**
- Wildcard (`["*"]`) to allow all IPs (useful for opt-in security models)
- Empty list (`[]`) to deny all IPs (useful for maintenance mode)
- Single IP addresses: `"192.168.1.100"` or `"2001:db8::1"`
- CIDR ranges: `"10.0.0.0/8"` or `"2001:db8::/32"`
- Mixed lists combining IPs and CIDR ranges

**Configurable IP Source**
- `ipSource: "remoteAddr"` - Uses the direct connection's socket address (default for non-proxied deployments)
- `ipSource: "xForwardedFor"` - Uses X-Forwarded-For header (**default**, recommended for proxied deployments)

**X-Forwarded-For Hop Selection**
When using `xForwardedFor` source, the `distanceFromLastHop` parameter allows precise control over which IP to validate:
- `0` = last hop (rightmost IP, closest to gateway) - **default**
- `-1` = second to last hop (one step back)
- `-2` = third to last hop (two steps back)
- `-N` = N+1 hops from the end
- Automatically falls back to first IP if list is shorter than requested distance

**Custom Deny Responses**
- `denyStatusCode` - HTTP status code for denied requests (default: 403)
- `denyMessage` - Custom error message text (default: "Forbidden: IP not allowed")

### Configuration Examples

**Basic IP Allowlist**
```json
{
  "ipAllowlist": {
    "allowedIps": ["203.0.113.10", "198.51.100.0/24"],
    "denyStatusCode": 403,
    "denyMessage": "Access denied"
  }
}
```

**Multi-Proxy Environment**
```json
{
  "ipAllowlist": {
    "allowedIps": ["10.0.0.0/8"],
    "ipSource": "xForwardedFor",
    "distanceFromLastHop": -2
  }
}
```
This validates the third-to-last IP in the X-Forwarded-For chain, useful when you have two trusted proxies (e.g., CDN + load balancer) and want to validate the original client IP.

**Direct Connection (No Proxy)**
```json
{
  "ipAllowlist": {
    "allowedIps": ["192.168.1.0/24"],
    "ipSource": "remoteAddr"
  }
}
```

**Maintenance Mode**
```json
{
  "ipAllowlist": {
    "allowedIps": [],
    "denyStatusCode": 503,
    "denyMessage": "Service temporarily unavailable"
  }
}
```

### Implementation Details

**Architecture**
- Follows existing `Cors`/`CorsSerde` dual-serialization pattern
- Integrated as a `TrafficPolicy` variant applied early in request pipeline (before CORS)
- Uses `WildcardOrList<T>` pattern for efficient matching
- Leverages `ipnet` crate for CIDR operations

**Request Pipeline Position**
IP allowlist is applied **before** CORS and other policies to fail fast on unauthorized IPs, reducing unnecessary processing.

**Files Changed**
- `crates/agentgateway/src/http/ipallowlist.rs` - Core implementation (~270 lines)
- `crates/agentgateway/src/http/ipallowlist_tests.rs` - Comprehensive test suite (~645 lines, 29 tests)
- `crates/agentgateway/src/http/mod.rs` - Module export
- `crates/agentgateway/src/types/agent.rs` - TrafficPolicy enum integration
- `crates/agentgateway/src/types/local.rs` - Route configuration support
- `crates/agentgateway/src/store/binds.rs` - Policy binding logic
- `crates/agentgateway/src/proxy/httpproxy.rs` - Request pipeline integration

### Testing

**Test Coverage (29 tests)**
-  Basic IP Matching (7 tests): wildcards, empty lists, single IPs, CIDR ranges, IPv4/IPv6
-  Custom Status & Messages (3 tests): 403, 404, 418, custom messages
-  XFF Hop Selection (7 tests): last hop, -1, -2, -3, overflow handling, whitespace
-  IP Source Selection (3 tests): RemoteAddr vs XForwardedFor behavior
-  Error Handling (4 tests): invalid IPs/CIDRs, missing sources
-  Serialization (2 tests): roundtrip, defaults
-  Edge Cases (3 tests): single IP in XFF, mixed lists, policy response structure

All tests passing. All linting checks passing.

## Use Cases

**1. Corporate Network Access**
Restrict API access to office IPs:
```json
{"allowedIps": ["203.0.113.0/24", "198.51.100.50"]}
```

**2. Multi-Region CDN**
When behind Cloudflare + AWS ALB, validate the original client IP:
```json
{
  "ipSource": "xForwardedFor",
  "distanceFromLastHop": -2,
  "allowedIps": ["10.0.0.0/8"]
}
```

**3. Development Environment**
Allow localhost and internal network:
```json
{"allowedIps": ["127.0.0.1", "::1", "10.0.0.0/8"]}
```

**4. Staged Rollout**
Use wildcard initially, then tighten:
```json
{"allowedIps": ["*"]}  // Phase 1: allow all, monitor
// Later: {"allowedIps": ["trusted-range"]}  // Phase 2: enforce
```

## Configuration Schema

```typescript
interface IpAllowlist {
  allowedIps: string[];                    // IP addresses or CIDR ranges, ["*"] for all
  denyStatusCode?: number;                 // HTTP status code (default: 403)
  denyMessage?: string;                    // Error message (default: "Forbidden: IP not allowed")
  ipSource?: "remoteAddr" | "xForwardedFor"; // IP source (default: "xForwardedFor")
  distanceFromLastHop?: number;            // XFF hop selection (default: 0 = last)
}
```

## Backwards Compatibility
This is a **new feature** with zero impact on existing deployments:
- No changes to existing traffic policies
- Opt-in only - must be explicitly configured
- Follows established patterns (CORS, JWT, etc.)

## Future Enhancements
Potential future additions (not in this PR):
- Metrics for diagnosing blocked requests
- Shadow mode for rollout for existing deployments