### PR TITLE
feat: Support MCP Authn when configured by xDS

### DIFF
--- a/crates/agentgateway/proto/resource.proto
+++ b/crates/agentgateway/proto/resource.proto
@@ -716,7 +716,7 @@ message BackendPolicySpec {
 
   message McpAuthentication {
     message ResourceMetadata {
-      map<string, string> extra = 1;
+      map<string, google.protobuf.Value> extra = 1;
     }
 
     enum McpIDP {

--- a/crates/agentgateway/proto/resource.proto
+++ b/crates/agentgateway/proto/resource.proto
@@ -725,7 +725,7 @@ message BackendPolicySpec {
     }
 
     string issuer = 1;
-    string audience = 2;
+    repeated string audiences = 2;
     string jwks_inline = 3;
     McpIDP provider = 4;
     ResourceMetadata resource_metadata = 5;

--- a/crates/agentgateway/proto/resource.proto
+++ b/crates/agentgateway/proto/resource.proto
@@ -716,7 +716,7 @@ message BackendPolicySpec {
 
   message McpAuthentication {
     message ResourceMetadata {
-      map<string, google.protobuf.Value> extra = 1;
+      map<string, string> extra = 1;
     }
 
     enum McpIDP {

--- a/crates/agentgateway/proto/resource.proto
+++ b/crates/agentgateway/proto/resource.proto
@@ -726,12 +726,9 @@ message BackendPolicySpec {
 
     string issuer = 1;
     string audience = 2;
-    McpIDP provider = 3;
-    ResourceMetadata resource_metadata = 4;
-    oneof jwks_source {
-      string jwks_url = 5;
-      string jwks_inline = 6;
-    }
+    string jwks_inline = 3;
+    McpIDP provider = 4;
+    ResourceMetadata resource_metadata = 5;
   }
 
   oneof kind {

--- a/crates/agentgateway/proto/resource.proto
+++ b/crates/agentgateway/proto/resource.proto
@@ -726,9 +726,12 @@ message BackendPolicySpec {
 
     string issuer = 1;
     string audience = 2;
-    string jwks_url = 3;
-    McpIDP provider = 4;
-    ResourceMetadata resource_metadata = 5;
+    McpIDP provider = 3;
+    ResourceMetadata resource_metadata = 4;
+    oneof jwks_source {
+      string jwks_url = 5;
+      string jwks_inline = 6;
+    }
   }
 
   oneof kind {

--- a/crates/agentgateway/src/mcp/router.rs
+++ b/crates/agentgateway/src/mcp/router.rs
@@ -179,7 +179,9 @@ impl App {
 				// if mcp authn is configured but JWT already validated (claims exist from previous layer),
 				// reject because we cannot validate MCP-specific auth requirements
 				(Some(auth), _, true) => {
-					warn!("MCP backend authentication configured but JWT token already validated and stripped by Gateway or Route level policy");
+					warn!(
+						"MCP backend authentication configured but JWT token already validated and stripped by Gateway or Route level policy"
+					);
 					return Self::create_auth_required_response(&req, auth).into_response();
 				},
 				// if no mcp authn is configured, do nothing
@@ -376,7 +378,7 @@ impl App {
 		// Normalize issuer URL by removing trailing slashes to avoid double-slash in path
 		let issuer = auth.issuer.trim_end_matches('/');
 		let ureq = ::http::Request::builder()
-			.uri(format!("{}/.well-known/oauth-authorization-server", issuer))
+			.uri(format!("{issuer}/.well-known/oauth-authorization-server"))
 			.body(Body::empty())?;
 		let upstream = client.simple_call(ureq).await?;
 		let limit = crate::http::response_buffer_limit(&upstream);
@@ -425,7 +427,7 @@ impl App {
 			.body(axum::body::Body::from(Bytes::from(serde_json::to_string(
 				&resp,
 			)?)))
-			.map_err(|e| anyhow::anyhow!("Failed to build response: {}", e))?;
+			.map_err(|e| anyhow::anyhow!("Failed to build response: {e}"))?;
 
 		Ok(response)
 	}
@@ -439,7 +441,7 @@ impl App {
 		// Normalize issuer URL by removing trailing slashes to avoid double-slash in path
 		let issuer = auth.issuer.trim_end_matches('/');
 		let ureq = ::http::Request::builder()
-			.uri(format!("{}/clients-registrations/openid-connect", issuer))
+			.uri(format!("{issuer}/clients-registrations/openid-connect"))
 			.method(Method::POST)
 			.body(req.into_body())?;
 

--- a/crates/agentgateway/src/mcp/router.rs
+++ b/crates/agentgateway/src/mcp/router.rs
@@ -176,8 +176,14 @@ impl App {
 				(Some(auth), None, false) => {
 					return Self::create_auth_required_response(&req, auth).into_response();
 				},
-				// if no mcp authn is configured or JWT already validated (claims exist), do nothing
-				_ => {},
+				// if mcp authn is configured but JWT already validated (claims exist from previous layer),
+				// reject because we cannot validate MCP-specific auth requirements
+				(Some(auth), _, true) => {
+					warn!("MCP backend authentication configured but JWT token already validated and stripped by Gateway or Route level policy");
+					return Self::create_auth_required_response(&req, auth).into_response();
+				},
+				// if no mcp authn is configured, do nothing
+				(None, _, _) => {},
 			}
 		}
 

--- a/crates/agentgateway/src/mcp/router.rs
+++ b/crates/agentgateway/src/mcp/router.rs
@@ -165,7 +165,7 @@ impl App {
 					Err(_e) => {
 						// MCP authn uses optional mode by default, so if the token is invalid, we return a 401
 						return Self::create_auth_required_response(&req, auth).into_response();
-					}
+					},
 				}
 			}
 			// If no token is present, continue without authentication since MCP authn uses optional mode by default

--- a/crates/agentgateway/src/mcp/router.rs
+++ b/crates/agentgateway/src/mcp/router.rs
@@ -391,7 +391,10 @@ impl App {
 				else {
 					anyhow::bail!("authorization_endpoint missing");
 				};
-				ae.push_str(&format!("?audience={}", auth.audience));
+				// If the user provided multiple audiences with auth0, just prepend the first one
+				if let Some(aud) = auth.audiences.first() {
+					ae.push_str(&format!("?audience={}", aud));
+				}
 			},
 			Some(McpIDP::Keycloak { .. }) => {
 				// Keycloak does not support RFC 8707.

--- a/crates/agentgateway/src/mcp/router.rs
+++ b/crates/agentgateway/src/mcp/router.rs
@@ -11,7 +11,7 @@ use bytes::Bytes;
 use http::Method;
 use http::uri::PathAndQuery;
 use rmcp::transport::StreamableHttpServerConfig;
-use tracing::{warn, debug};
+use tracing::{debug, warn};
 
 use crate::cel::ContextBuilder;
 use crate::http::jwt::Claims;
@@ -145,7 +145,7 @@ impl App {
 		ctx.with_extauthz(&req);
 
 		// `response` is not valid here, since we run authz first
-		// MCP context is added later. The context is inserted after 
+		// MCP context is added later. The context is inserted after
 		// authentication so it can include verified claims
 
 		// skip well-known OAuth endpoints for authn

--- a/crates/agentgateway/src/serdes.rs
+++ b/crates/agentgateway/src/serdes.rs
@@ -309,6 +309,14 @@ pub enum FileInlineOrRemote {
 	},
 }
 
+impl Default for FileInlineOrRemote {
+	fn default() -> Self {
+		FileInlineOrRemote::Remote {
+			url: "".parse().unwrap(),
+		}
+	}
+}
+
 impl FileInlineOrRemote {
 	pub async fn load<T: DeserializeOwned>(&self, client: Client) -> anyhow::Result<T> {
 		let s = match self {

--- a/crates/agentgateway/src/serdes.rs
+++ b/crates/agentgateway/src/serdes.rs
@@ -309,14 +309,6 @@ pub enum FileInlineOrRemote {
 	},
 }
 
-impl Default for FileInlineOrRemote {
-	fn default() -> Self {
-		FileInlineOrRemote::Remote {
-			url: "".parse().unwrap(),
-		}
-	}
-}
-
 impl FileInlineOrRemote {
 	pub async fn load<T: DeserializeOwned>(&self, client: Client) -> anyhow::Result<T> {
 		let s = match self {

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -1282,27 +1282,24 @@ impl ResourceMetadata {
 	}
 }
 
-#[apply(schema!)]
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct McpAuthentication {
 	pub issuer: String,
 	pub audiences: Vec<String>,
 	pub provider: Option<McpIDP>,
 	pub resource_metadata: ResourceMetadata,
-	#[serde(skip)]
-	pub jwt_validator: Option<Arc<crate::http::jwt::Jwt>>,
+	pub jwt_validator: Arc<crate::http::jwt::Jwt>,
 }
 
 // Non-xds config for MCP authentication
-#[apply(schema!)]
+#[apply(schema_de!)]
 pub struct LocalMcpAuthentication {
 	pub issuer: String,
 	pub audiences: Vec<String>,
 	pub provider: Option<McpIDP>,
 	pub resource_metadata: ResourceMetadata,
-	#[serde(skip_serializing)]
 	pub jwks: FileInlineOrRemote,
-	#[serde(skip)]
-	pub jwt_validator: Option<Arc<crate::http::jwt::Jwt>>,
 }
 
 impl LocalMcpAuthentication {
@@ -1345,7 +1342,7 @@ impl LocalMcpAuthentication {
 			audiences: self.audiences.clone(),
 			provider: self.provider.clone(),
 			resource_metadata: self.resource_metadata.clone(),
-			jwt_validator: Some(Arc::new(jwt)),
+			jwt_validator: Arc::new(jwt),
 		})
 	}
 }

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -1285,7 +1285,7 @@ impl ResourceMetadata {
 #[apply(schema!)]
 pub struct McpAuthentication {
 	pub issuer: String,
-	pub audience: String,
+	pub audiences: Vec<String>,
 	pub provider: Option<McpIDP>,
 	pub resource_metadata: ResourceMetadata,
 	#[serde(skip_serializing)]
@@ -1317,7 +1317,7 @@ impl McpAuthentication {
 		Ok(http::jwt::LocalJwtConfig::Single {
 			mode: http::jwt::Mode::Optional,
 			issuer: self.issuer.clone(),
-			audiences: Some(vec![self.audience.clone()]),
+			audiences: Some(self.audiences.clone()),
 			jwks,
 		})
 	}

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -1288,17 +1288,11 @@ pub struct McpAuthentication {
 	pub audience: String,
 	pub provider: Option<McpIDP>,
 	pub resource_metadata: ResourceMetadata,
-	#[serde(skip, default = "default_empty_remote_jwks")]
+	#[serde(skip)]
 	pub jwks: FileInlineOrRemote,
 	#[serde(skip)]
+	// currently only used in xds mode
 	pub jwt_validator: Option<Arc<crate::http::jwt::Jwt>>,
-}
-
-fn default_empty_remote_jwks() -> FileInlineOrRemote {
-	// Empty URL will trigger auto-derivation in as_jwt()
-	FileInlineOrRemote::Remote {
-		url: "".parse().unwrap(),
-	}
 }
 
 impl McpAuthentication {

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -1288,9 +1288,17 @@ pub struct McpAuthentication {
 	pub audience: String,
 	pub provider: Option<McpIDP>,
 	pub resource_metadata: ResourceMetadata,
+	#[serde(skip, default = "default_empty_remote_jwks")]
 	pub jwks: FileInlineOrRemote,
 	#[serde(skip)]
-	pub jwt_validator: Option<crate::http::jwt::Jwt>,
+	pub jwt_validator: Option<Arc<crate::http::jwt::Jwt>>,
+}
+
+fn default_empty_remote_jwks() -> FileInlineOrRemote {
+	// Empty URL will trigger auto-derivation in as_jwt()
+	FileInlineOrRemote::Remote {
+		url: "".parse().unwrap(),
+	}
 }
 
 impl McpAuthentication {

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -1297,21 +1297,19 @@ pub struct McpAuthentication {
 impl McpAuthentication {
 	pub fn as_jwt(&self) -> anyhow::Result<http::jwt::LocalJwtConfig> {
 		let jwks = match &self.jwks {
-			FileInlineOrRemote::Remote { url } => {
-				FileInlineOrRemote::Remote {
-					url: if !url.to_string().is_empty() {
-						url.clone()
-					} else {
-						match &self.provider {
-							None | Some(McpIDP::Auth0 { .. }) => {
-								format!("{}/.well-known/jwks.json", self.issuer).parse()?
-							},
-							Some(McpIDP::Keycloak { .. }) => {
-								format!("{}/protocol/openid-connect/certs", self.issuer).parse()?
-							},
-						}
-					},
-				}
+			FileInlineOrRemote::Remote { url } => FileInlineOrRemote::Remote {
+				url: if !url.to_string().is_empty() {
+					url.clone()
+				} else {
+					match &self.provider {
+						None | Some(McpIDP::Auth0 { .. }) => {
+							format!("{}/.well-known/jwks.json", self.issuer).parse()?
+						},
+						Some(McpIDP::Keycloak { .. }) => {
+							format!("{}/protocol/openid-connect/certs", self.issuer).parse()?
+						},
+					}
+				},
 			},
 			FileInlineOrRemote::Inline(_) | FileInlineOrRemote::File { .. } => self.jwks.clone(),
 		};
@@ -1373,7 +1371,7 @@ impl TryFrom<&str> for Target {
 
 	fn try_from(hostport: &str) -> Result<Self, Self::Error> {
 		let Some((host, port)) = hostport.split_once(":") else {
-			anyhow::bail!("invalid host:port: {}", hostport);
+			anyhow::bail!("invalid host:port: {hostport}");
 		};
 		let port: u16 = port.parse()?;
 		(host, port).try_into()

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -1288,10 +1288,9 @@ pub struct McpAuthentication {
 	pub audience: String,
 	pub provider: Option<McpIDP>,
 	pub resource_metadata: ResourceMetadata,
-	#[serde(skip)]
+	#[serde(skip_serializing)]
 	pub jwks: FileInlineOrRemote,
 	#[serde(skip)]
-	// currently only used in xds mode
 	pub jwt_validator: Option<Arc<crate::http::jwt::Jwt>>,
 }
 

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -1297,7 +1297,6 @@ pub struct McpAuthentication {
 pub struct LocalMcpAuthentication {
 	pub issuer: String,
 	pub audiences: Vec<String>,
-	pub jwks_url: String,
 	pub provider: Option<McpIDP>,
 	pub resource_metadata: ResourceMetadata,
 	#[serde(skip_serializing)]

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -143,7 +143,7 @@ impl TryFrom<&proto::agent::backend_policy_spec::McpAuthentication> for McpAuthe
 				extra: Default::default(),
 			},
 			jwks,
-			jwt_validator: Some(jwt_validator),
+			jwt_validator: Some(std::sync::Arc::new(jwt_validator)),
 		})
 	}
 }

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -116,7 +116,7 @@ impl TryFrom<&proto::agent::backend_policy_spec::McpAuthentication> for McpAuthe
 			ProtoError::Generic(format!("failed to parse JWKS for MCP Authentication: {e}"))
 		})?;
 
-		let audiences = Some(vec![m.audience.clone()]);
+		let audiences = Some(m.audiences.clone());
 		let jwt_provider = http::jwt::Provider::from_jwks(jwk_set, m.issuer.clone(), audiences)
 			.map_err(|e| {
 				ProtoError::Generic(format!(
@@ -132,7 +132,7 @@ impl TryFrom<&proto::agent::backend_policy_spec::McpAuthentication> for McpAuthe
 
 		Ok(McpAuthentication {
 			issuer: m.issuer.clone(),
-			audience: m.audience.clone(),
+			audiences: m.audiences.clone(),
 			provider,
 			resource_metadata: ResourceMetadata {
 				extra: Default::default(),

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -148,7 +148,7 @@ impl TryFrom<&proto::agent::backend_policy_spec::McpAuthentication> for McpAuthe
 					.unwrap_or_default();
 				ResourceMetadata { extra }
 			},
-			jwt_validator: Some(std::sync::Arc::new(jwt_validator)),
+			jwt_validator: std::sync::Arc::new(jwt_validator),
 		})
 	}
 }

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -140,8 +140,7 @@ impl TryFrom<&proto::agent::backend_policy_spec::McpAuthentication> for McpAuthe
 						rm.extra
 							.iter()
 							.map(|(k, v)| {
-								let val = serde_json::to_value(v)
-									.unwrap_or(serde_json::Value::Null);
+								let val = serde_json::to_value(v).unwrap_or(serde_json::Value::Null);
 								(k.clone(), val)
 							})
 							.collect::<std::collections::BTreeMap<_, _>>()

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -134,8 +134,22 @@ impl TryFrom<&proto::agent::backend_policy_spec::McpAuthentication> for McpAuthe
 			issuer: m.issuer.clone(),
 			audiences: m.audiences.clone(),
 			provider,
-			resource_metadata: ResourceMetadata {
-				extra: Default::default(),
+			resource_metadata: {
+				let extra = m
+					.resource_metadata
+					.as_ref()
+					.map(|rm| {
+						rm.extra
+							.iter()
+							.map(|(k, v)| {
+								let val = serde_json::from_str::<serde_json::Value>(v)
+									.unwrap_or(serde_json::Value::String(v.clone()));
+								(k.clone(), val)
+							})
+							.collect::<std::collections::BTreeMap<_, _>>()
+					})
+					.unwrap_or_default();
+				ResourceMetadata { extra }
 			},
 			jwks,
 			jwt_validator: Some(std::sync::Arc::new(jwt_validator)),

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -21,10 +21,10 @@ use crate::store::LocalWorkload;
 use crate::types::agent::{
 	A2aPolicy, Authorization, Backend, BackendName, BackendPolicy, BackendReference,
 	BackendWithPolicies, Bind, BindName, FrontendPolicy, GatewayName, Listener, ListenerKey,
-	ListenerProtocol, ListenerSet, LocalMcpAuthentication, McpAuthentication, McpBackend, McpTarget, McpTargetName,
-	McpTargetSpec, OpenAPITarget, PathMatch, PolicyName, PolicyPhase, PolicyTarget, PolicyType,
-	Route, RouteBackendReference, RouteMatch, RouteName, RouteRuleName, RouteSet, ServerTLSConfig,
-	SimpleBackendReference, SseTargetSpec, StreamableHTTPTargetSpec, TCPRoute,
+	ListenerProtocol, ListenerSet, LocalMcpAuthentication, McpAuthentication, McpBackend, McpTarget,
+	McpTargetName, McpTargetSpec, OpenAPITarget, PathMatch, PolicyName, PolicyPhase, PolicyTarget,
+	PolicyType, Route, RouteBackendReference, RouteMatch, RouteName, RouteRuleName, RouteSet,
+	ServerTLSConfig, SimpleBackendReference, SseTargetSpec, StreamableHTTPTargetSpec, TCPRoute,
 	TCPRouteBackendReference, TCPRouteSet, Target, TargetedPolicy, TrafficPolicy,
 };
 use crate::types::discovery::{NamespacedHostname, Service};

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -21,7 +21,7 @@ use crate::store::LocalWorkload;
 use crate::types::agent::{
 	A2aPolicy, Authorization, Backend, BackendName, BackendPolicy, BackendReference,
 	BackendWithPolicies, Bind, BindName, FrontendPolicy, GatewayName, Listener, ListenerKey,
-	ListenerProtocol, ListenerSet, McpAuthentication, McpBackend, McpTarget, McpTargetName,
+	ListenerProtocol, ListenerSet, LocalMcpAuthentication, McpAuthentication, McpBackend, McpTarget, McpTargetName,
 	McpTargetSpec, OpenAPITarget, PathMatch, PolicyName, PolicyPhase, PolicyTarget, PolicyType,
 	Route, RouteBackendReference, RouteMatch, RouteName, RouteRuleName, RouteSet, ServerTLSConfig,
 	SimpleBackendReference, SseTargetSpec, StreamableHTTPTargetSpec, TCPRoute,
@@ -768,7 +768,7 @@ struct FilterOrPolicy {
 	authorization: Option<Authorization>,
 	/// Authentication for MCP clients.
 	#[serde(default)]
-	mcp_authentication: Option<McpAuthentication>,
+	mcp_authentication: Option<LocalMcpAuthentication>,
 	/// Mark this traffic as A2A to enable A2A processing and telemetry.
 	#[serde(default)]
 	a2a: Option<A2aPolicy>,
@@ -1171,9 +1171,10 @@ async fn split_policies(client: Client, pol: FilterOrPolicy) -> Result<ResolvedP
 		backend_policies.push(BackendPolicy::McpAuthorization(p))
 	}
 	if let Some(p) = mcp_authentication {
-		let jp = p.as_jwt()?;
-		backend_policies.push(BackendPolicy::McpAuthentication(p));
-		route_policies.push(TrafficPolicy::JwtAuth(jp.try_into(client.clone()).await?));
+		// Translate local MCP authn into runtime authn with a ready JWT validator.
+		let authn: McpAuthentication = p.translate(client.clone()).await?;
+		backend_policies.push(BackendPolicy::McpAuthentication(authn));
+		// Do NOT inject a separate route-level JwtAuth; MCP router handles validation using jwt_validator.
 	}
 	if let Some(p) = a2a {
 		backend_policies.push(BackendPolicy::A2a(p))

--- a/examples/mcp-authentication/config.yaml
+++ b/examples/mcp-authentication/config.yaml
@@ -30,7 +30,8 @@ binds:
           - '*'
         mcpAuthentication:
           issuer: http://localhost:9000
-          audience: http://localhost:3000/stdio/mcp
+          audiences:
+          - http://localhost:3000/stdio/mcp
           jwks:
             url: http://localhost:9000/.well-known/jwks.json
           resourceMetadata:
@@ -66,7 +67,8 @@ binds:
           - '*'
         mcpAuthentication:
           issuer: http://localhost:9000
-          audience: http://localhost:3000/remote/mcp
+          audiences:
+          - http://localhost:3000/remote/mcp
           jwks:
             url: http://localhost:9000/.well-known/jwks.json
           resourceMetadata:
@@ -110,7 +112,8 @@ binds:
           - '*'
         mcpAuthentication:
           issuer: http://localhost:7080/realms/mcp
-          audience: mcp_proxy
+          audiences:
+          - mcp_proxy
           jwks:
             url: http://localhost:7080/realms/mcp/protocol/openid-connect/certs
           provider:
@@ -153,7 +156,8 @@ binds:
     #       - '*'
     #     mcpAuthentication:
     #       issuer: https://dev-y6sikgx3n3shy7ci.eu.auth0.com
-    #       audience: urn:agent-gateway
+    #       audiences:
+    #       - urn:agent-gateway
     #       jwks:
     #         url: https://dev-y6sikgx3n3shy7ci.eu.auth0.com/.well-known/jwks.json
     #       provider:

--- a/examples/mcp-authentication/config.yaml
+++ b/examples/mcp-authentication/config.yaml
@@ -32,8 +32,7 @@ binds:
           issuer: http://localhost:9000
           audiences:
           - http://localhost:3000/stdio/mcp
-          jwks:
-            url: http://localhost:9000/.well-known/jwks.json
+          jwksUrl: http://localhost:9000/.well-known/jwks.json
           resourceMetadata:
             resource: http://localhost:3000/stdio/mcp
             scopesSupported:
@@ -69,8 +68,7 @@ binds:
           issuer: http://localhost:9000
           audiences:
           - http://localhost:3000/remote/mcp
-          jwks:
-            url: http://localhost:9000/.well-known/jwks.json
+          jwksUrl: http://localhost:9000/.well-known/jwks.json
           resourceMetadata:
             resource: http://localhost:3000/remote/mcp
             scopesSupported:
@@ -114,8 +112,7 @@ binds:
           issuer: http://localhost:7080/realms/mcp
           audiences:
           - mcp_proxy
-          jwks:
-            url: http://localhost:7080/realms/mcp/protocol/openid-connect/certs
+          jwksUrl: http://localhost:7080/realms/mcp/protocol/openid-connect/certs
           provider:
             keycloak: {}
           resourceMetadata:
@@ -158,8 +155,7 @@ binds:
     #       issuer: https://dev-y6sikgx3n3shy7ci.eu.auth0.com
     #       audiences:
     #       - urn:agent-gateway
-    #       jwks:
-    #         url: https://dev-y6sikgx3n3shy7ci.eu.auth0.com/.well-known/jwks.json
+    #       jwksUrl: https://dev-y6sikgx3n3shy7ci.eu.auth0.com/.well-known/jwks.json
     #       provider:
     #         auth0: {}
     #       resourceMetadata:

--- a/examples/mcp-authentication/config.yaml
+++ b/examples/mcp-authentication/config.yaml
@@ -30,8 +30,9 @@ binds:
           - '*'
         mcpAuthentication:
           issuer: http://localhost:9000
-          jwksUrl: http://localhost:9000/.well-known/jwks.json
           audience: http://localhost:3000/stdio/mcp
+          jwks:
+            url: http://localhost:9000/.well-known/jwks.json
           resourceMetadata:
             resource: http://localhost:3000/stdio/mcp
             scopesSupported:
@@ -65,8 +66,9 @@ binds:
           - '*'
         mcpAuthentication:
           issuer: http://localhost:9000
-          jwksUrl: http://localhost:9000/.well-known/jwks.json
           audience: http://localhost:3000/remote/mcp
+          jwks:
+            url: http://localhost:9000/.well-known/jwks.json
           resourceMetadata:
             resource: http://localhost:3000/remote/mcp
             scopesSupported:
@@ -108,8 +110,9 @@ binds:
           - '*'
         mcpAuthentication:
           issuer: http://localhost:7080/realms/mcp
-          jwksUrl: http://localhost:7080/realms/mcp/protocol/openid-connect/certs
           audience: mcp_proxy
+          jwks:
+            url: http://localhost:7080/realms/mcp/protocol/openid-connect/certs
           provider:
             keycloak: {}
           resourceMetadata:
@@ -150,8 +153,9 @@ binds:
     #       - '*'
     #     mcpAuthentication:
     #       issuer: https://dev-y6sikgx3n3shy7ci.eu.auth0.com
-    #       jwksUrl: https://dev-y6sikgx3n3shy7ci.eu.auth0.com/.well-known/jwks.json
     #       audience: urn:agent-gateway
+    #       jwks:
+    #         url: https://dev-y6sikgx3n3shy7ci.eu.auth0.com/.well-known/jwks.json
     #       provider:
     #         auth0: {}
     #       resourceMetadata:

--- a/examples/mcp-authentication/config.yaml
+++ b/examples/mcp-authentication/config.yaml
@@ -32,7 +32,8 @@ binds:
           issuer: http://localhost:9000
           audiences:
           - http://localhost:3000/stdio/mcp
-          jwksUrl: http://localhost:9000/.well-known/jwks.json
+          jwks:
+            url: http://localhost:9000/.well-known/jwks.json
           resourceMetadata:
             resource: http://localhost:3000/stdio/mcp
             scopesSupported:
@@ -68,7 +69,8 @@ binds:
           issuer: http://localhost:9000
           audiences:
           - http://localhost:3000/remote/mcp
-          jwksUrl: http://localhost:9000/.well-known/jwks.json
+          jwks:
+            url: http://localhost:9000/.well-known/jwks.json
           resourceMetadata:
             resource: http://localhost:3000/remote/mcp
             scopesSupported:
@@ -112,7 +114,8 @@ binds:
           issuer: http://localhost:7080/realms/mcp
           audiences:
           - mcp_proxy
-          jwksUrl: http://localhost:7080/realms/mcp/protocol/openid-connect/certs
+          jwks:
+            url: http://localhost:7080/realms/mcp/protocol/openid-connect/certs
           provider:
             keycloak: {}
           resourceMetadata:

--- a/go/api/resource.pb.go
+++ b/go/api/resource.pb.go
@@ -7958,8 +7958,8 @@ func (x *BackendPolicySpec_Ai_PromptCaching) GetMinTokens() uint32 {
 }
 
 type BackendPolicySpec_McpAuthentication_ResourceMetadata struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Extra         map[string]string      `protobuf:"bytes,1,rep,name=extra,proto3" json:"extra,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	state         protoimpl.MessageState     `protogen:"open.v1"`
+	Extra         map[string]*structpb.Value `protobuf:"bytes,1,rep,name=extra,proto3" json:"extra,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -7994,7 +7994,7 @@ func (*BackendPolicySpec_McpAuthentication_ResourceMetadata) Descriptor() ([]byt
 	return file_resource_proto_rawDescGZIP(), []int{38, 7, 0}
 }
 
-func (x *BackendPolicySpec_McpAuthentication_ResourceMetadata) GetExtra() map[string]string {
+func (x *BackendPolicySpec_McpAuthentication_ResourceMetadata) GetExtra() map[string]*structpb.Value {
 	if x != nil {
 		return x.Extra
 	}
@@ -8966,7 +8966,7 @@ const file_resource_proto_rawDesc = "" +
 	"\vPolicyPhase\x12\t\n" +
 	"\x05ROUTE\x10\x00\x12\v\n" +
 	"\aGATEWAY\x10\x01B\x06\n" +
-	"\x04kind\"\x95.\n" +
+	"\x04kind\"\xad.\n" +
 	"\x11BackendPolicySpec\x12D\n" +
 	"\x03a2a\x18\x01 \x01(\v20.agentgateway.dev.resource.BackendPolicySpec.A2aH\x00R\x03a2a\x12l\n" +
 	"\x11inference_routing\x18\x02 \x01(\v2=.agentgateway.dev.resource.BackendPolicySpec.InferenceRoutingH\x00R\x10inferenceRouting\x12Z\n" +
@@ -9092,20 +9092,20 @@ const file_resource_proto_rawDesc = "" +
 	"\x0fconnect_timeout\x18\x02 \x01(\v2\x19.google.protobuf.DurationR\x0econnectTimeout\x1a<\n" +
 	"\x10McpAuthorization\x12\x14\n" +
 	"\x05allow\x18\x01 \x03(\tR\x05allow\x12\x12\n" +
-	"\x04deny\x18\x02 \x03(\tR\x04deny\x1a\xaf\x04\n" +
+	"\x04deny\x18\x02 \x03(\tR\x04deny\x1a\xc7\x04\n" +
 	"\x11McpAuthentication\x12\x16\n" +
 	"\x06issuer\x18\x01 \x01(\tR\x06issuer\x12\x1c\n" +
 	"\taudiences\x18\x02 \x03(\tR\taudiences\x12\x1f\n" +
 	"\vjwks_inline\x18\x03 \x01(\tR\n" +
 	"jwksInline\x12a\n" +
 	"\bprovider\x18\x04 \x01(\x0e2E.agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.McpIDPR\bprovider\x12|\n" +
-	"\x11resource_metadata\x18\x05 \x01(\v2O.agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadataR\x10resourceMetadata\x1a\xbe\x01\n" +
+	"\x11resource_metadata\x18\x05 \x01(\v2O.agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadataR\x10resourceMetadata\x1a\xd6\x01\n" +
 	"\x10ResourceMetadata\x12p\n" +
-	"\x05extra\x18\x01 \x03(\v2Z.agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntryR\x05extra\x1a8\n" +
+	"\x05extra\x18\x01 \x03(\v2Z.agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntryR\x05extra\x1aP\n" +
 	"\n" +
 	"ExtraEntry\x12\x10\n" +
-	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"!\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12,\n" +
+	"\x05value\x18\x02 \x01(\v2\x16.google.protobuf.ValueR\x05value:\x028\x01\"!\n" +
 	"\x06McpIDP\x12\t\n" +
 	"\x05AUTH0\x10\x00\x12\f\n" +
 	"\bKEYCLOAK\x10\x01B\x06\n" +
@@ -9374,6 +9374,7 @@ var file_resource_proto_goTypes = []any{
 	(*wrapperspb.StringValue)(nil),  // 134: google.protobuf.StringValue
 	(*structpb.Struct)(nil),         // 135: google.protobuf.Struct
 	(*wrapperspb.BytesValue)(nil),   // 136: google.protobuf.BytesValue
+	(*structpb.Value)(nil),          // 137: google.protobuf.Value
 }
 var file_resource_proto_depIdxs = []int32{
 	21,  // 0: agentgateway.dev.resource.Resource.bind:type_name -> agentgateway.dev.resource.Bind
@@ -9552,32 +9553,33 @@ var file_resource_proto_depIdxs = []int32{
 	114, // 173: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.request:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard
 	113, // 174: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.response:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard
 	121, // 175: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.extra:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntry
-	134, // 176: agentgateway.dev.resource.AIBackend.OpenAI.model:type_name -> google.protobuf.StringValue
-	134, // 177: agentgateway.dev.resource.AIBackend.Gemini.model:type_name -> google.protobuf.StringValue
-	134, // 178: agentgateway.dev.resource.AIBackend.Vertex.model:type_name -> google.protobuf.StringValue
-	134, // 179: agentgateway.dev.resource.AIBackend.Anthropic.model:type_name -> google.protobuf.StringValue
-	134, // 180: agentgateway.dev.resource.AIBackend.Bedrock.model:type_name -> google.protobuf.StringValue
-	134, // 181: agentgateway.dev.resource.AIBackend.Bedrock.guardrail_identifier:type_name -> google.protobuf.StringValue
-	134, // 182: agentgateway.dev.resource.AIBackend.Bedrock.guardrail_version:type_name -> google.protobuf.StringValue
-	134, // 183: agentgateway.dev.resource.AIBackend.AzureOpenAI.model:type_name -> google.protobuf.StringValue
-	134, // 184: agentgateway.dev.resource.AIBackend.AzureOpenAI.api_version:type_name -> google.protobuf.StringValue
-	122, // 185: agentgateway.dev.resource.AIBackend.Provider.host_override:type_name -> agentgateway.dev.resource.AIBackend.HostOverride
-	134, // 186: agentgateway.dev.resource.AIBackend.Provider.path_override:type_name -> google.protobuf.StringValue
-	123, // 187: agentgateway.dev.resource.AIBackend.Provider.openai:type_name -> agentgateway.dev.resource.AIBackend.OpenAI
-	124, // 188: agentgateway.dev.resource.AIBackend.Provider.gemini:type_name -> agentgateway.dev.resource.AIBackend.Gemini
-	125, // 189: agentgateway.dev.resource.AIBackend.Provider.vertex:type_name -> agentgateway.dev.resource.AIBackend.Vertex
-	126, // 190: agentgateway.dev.resource.AIBackend.Provider.anthropic:type_name -> agentgateway.dev.resource.AIBackend.Anthropic
-	127, // 191: agentgateway.dev.resource.AIBackend.Provider.bedrock:type_name -> agentgateway.dev.resource.AIBackend.Bedrock
-	128, // 192: agentgateway.dev.resource.AIBackend.Provider.azureopenai:type_name -> agentgateway.dev.resource.AIBackend.AzureOpenAI
-	131, // 193: agentgateway.dev.resource.AIBackend.Provider.routes:type_name -> agentgateway.dev.resource.AIBackend.Provider.RoutesEntry
-	58,  // 194: agentgateway.dev.resource.AIBackend.Provider.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	129, // 195: agentgateway.dev.resource.AIBackend.ProviderGroup.providers:type_name -> agentgateway.dev.resource.AIBackend.Provider
-	16,  // 196: agentgateway.dev.resource.AIBackend.Provider.RoutesEntry.value:type_name -> agentgateway.dev.resource.AIBackend.RouteType
-	197, // [197:197] is the sub-list for method output_type
-	197, // [197:197] is the sub-list for method input_type
-	197, // [197:197] is the sub-list for extension type_name
-	197, // [197:197] is the sub-list for extension extendee
-	0,   // [0:197] is the sub-list for field type_name
+	137, // 176: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntry.value:type_name -> google.protobuf.Value
+	134, // 177: agentgateway.dev.resource.AIBackend.OpenAI.model:type_name -> google.protobuf.StringValue
+	134, // 178: agentgateway.dev.resource.AIBackend.Gemini.model:type_name -> google.protobuf.StringValue
+	134, // 179: agentgateway.dev.resource.AIBackend.Vertex.model:type_name -> google.protobuf.StringValue
+	134, // 180: agentgateway.dev.resource.AIBackend.Anthropic.model:type_name -> google.protobuf.StringValue
+	134, // 181: agentgateway.dev.resource.AIBackend.Bedrock.model:type_name -> google.protobuf.StringValue
+	134, // 182: agentgateway.dev.resource.AIBackend.Bedrock.guardrail_identifier:type_name -> google.protobuf.StringValue
+	134, // 183: agentgateway.dev.resource.AIBackend.Bedrock.guardrail_version:type_name -> google.protobuf.StringValue
+	134, // 184: agentgateway.dev.resource.AIBackend.AzureOpenAI.model:type_name -> google.protobuf.StringValue
+	134, // 185: agentgateway.dev.resource.AIBackend.AzureOpenAI.api_version:type_name -> google.protobuf.StringValue
+	122, // 186: agentgateway.dev.resource.AIBackend.Provider.host_override:type_name -> agentgateway.dev.resource.AIBackend.HostOverride
+	134, // 187: agentgateway.dev.resource.AIBackend.Provider.path_override:type_name -> google.protobuf.StringValue
+	123, // 188: agentgateway.dev.resource.AIBackend.Provider.openai:type_name -> agentgateway.dev.resource.AIBackend.OpenAI
+	124, // 189: agentgateway.dev.resource.AIBackend.Provider.gemini:type_name -> agentgateway.dev.resource.AIBackend.Gemini
+	125, // 190: agentgateway.dev.resource.AIBackend.Provider.vertex:type_name -> agentgateway.dev.resource.AIBackend.Vertex
+	126, // 191: agentgateway.dev.resource.AIBackend.Provider.anthropic:type_name -> agentgateway.dev.resource.AIBackend.Anthropic
+	127, // 192: agentgateway.dev.resource.AIBackend.Provider.bedrock:type_name -> agentgateway.dev.resource.AIBackend.Bedrock
+	128, // 193: agentgateway.dev.resource.AIBackend.Provider.azureopenai:type_name -> agentgateway.dev.resource.AIBackend.AzureOpenAI
+	131, // 194: agentgateway.dev.resource.AIBackend.Provider.routes:type_name -> agentgateway.dev.resource.AIBackend.Provider.RoutesEntry
+	58,  // 195: agentgateway.dev.resource.AIBackend.Provider.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	129, // 196: agentgateway.dev.resource.AIBackend.ProviderGroup.providers:type_name -> agentgateway.dev.resource.AIBackend.Provider
+	16,  // 197: agentgateway.dev.resource.AIBackend.Provider.RoutesEntry.value:type_name -> agentgateway.dev.resource.AIBackend.RouteType
+	198, // [198:198] is the sub-list for method output_type
+	198, // [198:198] is the sub-list for method input_type
+	198, // [198:198] is the sub-list for extension type_name
+	198, // [198:198] is the sub-list for extension extendee
+	0,   // [0:198] is the sub-list for field type_name
 }
 
 func init() { file_resource_proto_init() }

--- a/go/api/resource.pb.go
+++ b/go/api/resource.pb.go
@@ -7165,15 +7165,11 @@ type BackendPolicySpec_McpAuthentication struct {
 	state            protoimpl.MessageState                                `protogen:"open.v1"`
 	Issuer           string                                                `protobuf:"bytes,1,opt,name=issuer,proto3" json:"issuer,omitempty"`
 	Audience         string                                                `protobuf:"bytes,2,opt,name=audience,proto3" json:"audience,omitempty"`
-	Provider         BackendPolicySpec_McpAuthentication_McpIDP            `protobuf:"varint,3,opt,name=provider,proto3,enum=agentgateway.dev.resource.BackendPolicySpec_McpAuthentication_McpIDP" json:"provider,omitempty"`
-	ResourceMetadata *BackendPolicySpec_McpAuthentication_ResourceMetadata `protobuf:"bytes,4,opt,name=resource_metadata,json=resourceMetadata,proto3" json:"resource_metadata,omitempty"`
-	// Types that are valid to be assigned to JwksSource:
-	//
-	//	*BackendPolicySpec_McpAuthentication_JwksUrl
-	//	*BackendPolicySpec_McpAuthentication_JwksInline
-	JwksSource    isBackendPolicySpec_McpAuthentication_JwksSource `protobuf_oneof:"jwks_source"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	JwksInline       string                                                `protobuf:"bytes,3,opt,name=jwks_inline,json=jwksInline,proto3" json:"jwks_inline,omitempty"`
+	Provider         BackendPolicySpec_McpAuthentication_McpIDP            `protobuf:"varint,4,opt,name=provider,proto3,enum=agentgateway.dev.resource.BackendPolicySpec_McpAuthentication_McpIDP" json:"provider,omitempty"`
+	ResourceMetadata *BackendPolicySpec_McpAuthentication_ResourceMetadata `protobuf:"bytes,5,opt,name=resource_metadata,json=resourceMetadata,proto3" json:"resource_metadata,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *BackendPolicySpec_McpAuthentication) Reset() {
@@ -7220,6 +7216,13 @@ func (x *BackendPolicySpec_McpAuthentication) GetAudience() string {
 	return ""
 }
 
+func (x *BackendPolicySpec_McpAuthentication) GetJwksInline() string {
+	if x != nil {
+		return x.JwksInline
+	}
+	return ""
+}
+
 func (x *BackendPolicySpec_McpAuthentication) GetProvider() BackendPolicySpec_McpAuthentication_McpIDP {
 	if x != nil {
 		return x.Provider
@@ -7232,49 +7235,6 @@ func (x *BackendPolicySpec_McpAuthentication) GetResourceMetadata() *BackendPoli
 		return x.ResourceMetadata
 	}
 	return nil
-}
-
-func (x *BackendPolicySpec_McpAuthentication) GetJwksSource() isBackendPolicySpec_McpAuthentication_JwksSource {
-	if x != nil {
-		return x.JwksSource
-	}
-	return nil
-}
-
-func (x *BackendPolicySpec_McpAuthentication) GetJwksUrl() string {
-	if x != nil {
-		if x, ok := x.JwksSource.(*BackendPolicySpec_McpAuthentication_JwksUrl); ok {
-			return x.JwksUrl
-		}
-	}
-	return ""
-}
-
-func (x *BackendPolicySpec_McpAuthentication) GetJwksInline() string {
-	if x != nil {
-		if x, ok := x.JwksSource.(*BackendPolicySpec_McpAuthentication_JwksInline); ok {
-			return x.JwksInline
-		}
-	}
-	return ""
-}
-
-type isBackendPolicySpec_McpAuthentication_JwksSource interface {
-	isBackendPolicySpec_McpAuthentication_JwksSource()
-}
-
-type BackendPolicySpec_McpAuthentication_JwksUrl struct {
-	JwksUrl string `protobuf:"bytes,5,opt,name=jwks_url,json=jwksUrl,proto3,oneof"`
-}
-
-type BackendPolicySpec_McpAuthentication_JwksInline struct {
-	JwksInline string `protobuf:"bytes,6,opt,name=jwks_inline,json=jwksInline,proto3,oneof"`
-}
-
-func (*BackendPolicySpec_McpAuthentication_JwksUrl) isBackendPolicySpec_McpAuthentication_JwksSource() {
-}
-
-func (*BackendPolicySpec_McpAuthentication_JwksInline) isBackendPolicySpec_McpAuthentication_JwksSource() {
 }
 
 type BackendPolicySpec_Ai_Message struct {
@@ -9006,7 +8966,7 @@ const file_resource_proto_rawDesc = "" +
 	"\vPolicyPhase\x12\t\n" +
 	"\x05ROUTE\x10\x00\x12\v\n" +
 	"\aGATEWAY\x10\x01B\x06\n" +
-	"\x04kind\"\xd9.\n" +
+	"\x04kind\"\xab.\n" +
 	"\x11BackendPolicySpec\x12D\n" +
 	"\x03a2a\x18\x01 \x01(\v20.agentgateway.dev.resource.BackendPolicySpec.A2aH\x00R\x03a2a\x12l\n" +
 	"\x11inference_routing\x18\x02 \x01(\v2=.agentgateway.dev.resource.BackendPolicySpec.InferenceRoutingH\x00R\x10inferenceRouting\x12Z\n" +
@@ -9132,15 +9092,14 @@ const file_resource_proto_rawDesc = "" +
 	"\x0fconnect_timeout\x18\x02 \x01(\v2\x19.google.protobuf.DurationR\x0econnectTimeout\x1a<\n" +
 	"\x10McpAuthorization\x12\x14\n" +
 	"\x05allow\x18\x01 \x03(\tR\x05allow\x12\x12\n" +
-	"\x04deny\x18\x02 \x03(\tR\x04deny\x1a\xf3\x04\n" +
+	"\x04deny\x18\x02 \x03(\tR\x04deny\x1a\xc5\x04\n" +
 	"\x11McpAuthentication\x12\x16\n" +
 	"\x06issuer\x18\x01 \x01(\tR\x06issuer\x12\x1a\n" +
-	"\baudience\x18\x02 \x01(\tR\baudience\x12a\n" +
-	"\bprovider\x18\x03 \x01(\x0e2E.agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.McpIDPR\bprovider\x12|\n" +
-	"\x11resource_metadata\x18\x04 \x01(\v2O.agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadataR\x10resourceMetadata\x12\x1b\n" +
-	"\bjwks_url\x18\x05 \x01(\tH\x00R\ajwksUrl\x12!\n" +
-	"\vjwks_inline\x18\x06 \x01(\tH\x00R\n" +
-	"jwksInline\x1a\xd6\x01\n" +
+	"\baudience\x18\x02 \x01(\tR\baudience\x12\x1f\n" +
+	"\vjwks_inline\x18\x03 \x01(\tR\n" +
+	"jwksInline\x12a\n" +
+	"\bprovider\x18\x04 \x01(\x0e2E.agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.McpIDPR\bprovider\x12|\n" +
+	"\x11resource_metadata\x18\x05 \x01(\v2O.agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadataR\x10resourceMetadata\x1a\xd6\x01\n" +
 	"\x10ResourceMetadata\x12p\n" +
 	"\x05extra\x18\x01 \x03(\v2Z.agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntryR\x05extra\x1aP\n" +
 	"\n" +
@@ -9149,8 +9108,7 @@ const file_resource_proto_rawDesc = "" +
 	"\x05value\x18\x02 \x01(\v2\x16.google.protobuf.ValueR\x05value:\x028\x01\"!\n" +
 	"\x06McpIDP\x12\t\n" +
 	"\x05AUTH0\x10\x00\x12\f\n" +
-	"\bKEYCLOAK\x10\x01B\r\n" +
-	"\vjwks_sourceB\x06\n" +
+	"\bKEYCLOAK\x10\x01B\x06\n" +
 	"\x04kind\"\xcc\x02\n" +
 	"\x06Policy\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12?\n" +
@@ -9755,10 +9713,6 @@ func file_resource_proto_init() {
 	}
 	file_resource_proto_msgTypes[61].OneofWrappers = []any{
 		(*TrafficPolicySpec_JWTProvider_Inline)(nil),
-	}
-	file_resource_proto_msgTypes[85].OneofWrappers = []any{
-		(*BackendPolicySpec_McpAuthentication_JwksUrl)(nil),
-		(*BackendPolicySpec_McpAuthentication_JwksInline)(nil),
 	}
 	file_resource_proto_msgTypes[88].OneofWrappers = []any{
 		(*BackendPolicySpec_Ai_RegexRule_Builtin)(nil),

--- a/go/api/resource.pb.go
+++ b/go/api/resource.pb.go
@@ -7165,11 +7165,15 @@ type BackendPolicySpec_McpAuthentication struct {
 	state            protoimpl.MessageState                                `protogen:"open.v1"`
 	Issuer           string                                                `protobuf:"bytes,1,opt,name=issuer,proto3" json:"issuer,omitempty"`
 	Audience         string                                                `protobuf:"bytes,2,opt,name=audience,proto3" json:"audience,omitempty"`
-	JwksUrl          string                                                `protobuf:"bytes,3,opt,name=jwks_url,json=jwksUrl,proto3" json:"jwks_url,omitempty"`
-	Provider         BackendPolicySpec_McpAuthentication_McpIDP            `protobuf:"varint,4,opt,name=provider,proto3,enum=agentgateway.dev.resource.BackendPolicySpec_McpAuthentication_McpIDP" json:"provider,omitempty"`
-	ResourceMetadata *BackendPolicySpec_McpAuthentication_ResourceMetadata `protobuf:"bytes,5,opt,name=resource_metadata,json=resourceMetadata,proto3" json:"resource_metadata,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	Provider         BackendPolicySpec_McpAuthentication_McpIDP            `protobuf:"varint,3,opt,name=provider,proto3,enum=agentgateway.dev.resource.BackendPolicySpec_McpAuthentication_McpIDP" json:"provider,omitempty"`
+	ResourceMetadata *BackendPolicySpec_McpAuthentication_ResourceMetadata `protobuf:"bytes,4,opt,name=resource_metadata,json=resourceMetadata,proto3" json:"resource_metadata,omitempty"`
+	// Types that are valid to be assigned to JwksSource:
+	//
+	//	*BackendPolicySpec_McpAuthentication_JwksUrl
+	//	*BackendPolicySpec_McpAuthentication_JwksInline
+	JwksSource    isBackendPolicySpec_McpAuthentication_JwksSource `protobuf_oneof:"jwks_source"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *BackendPolicySpec_McpAuthentication) Reset() {
@@ -7216,13 +7220,6 @@ func (x *BackendPolicySpec_McpAuthentication) GetAudience() string {
 	return ""
 }
 
-func (x *BackendPolicySpec_McpAuthentication) GetJwksUrl() string {
-	if x != nil {
-		return x.JwksUrl
-	}
-	return ""
-}
-
 func (x *BackendPolicySpec_McpAuthentication) GetProvider() BackendPolicySpec_McpAuthentication_McpIDP {
 	if x != nil {
 		return x.Provider
@@ -7235,6 +7232,49 @@ func (x *BackendPolicySpec_McpAuthentication) GetResourceMetadata() *BackendPoli
 		return x.ResourceMetadata
 	}
 	return nil
+}
+
+func (x *BackendPolicySpec_McpAuthentication) GetJwksSource() isBackendPolicySpec_McpAuthentication_JwksSource {
+	if x != nil {
+		return x.JwksSource
+	}
+	return nil
+}
+
+func (x *BackendPolicySpec_McpAuthentication) GetJwksUrl() string {
+	if x != nil {
+		if x, ok := x.JwksSource.(*BackendPolicySpec_McpAuthentication_JwksUrl); ok {
+			return x.JwksUrl
+		}
+	}
+	return ""
+}
+
+func (x *BackendPolicySpec_McpAuthentication) GetJwksInline() string {
+	if x != nil {
+		if x, ok := x.JwksSource.(*BackendPolicySpec_McpAuthentication_JwksInline); ok {
+			return x.JwksInline
+		}
+	}
+	return ""
+}
+
+type isBackendPolicySpec_McpAuthentication_JwksSource interface {
+	isBackendPolicySpec_McpAuthentication_JwksSource()
+}
+
+type BackendPolicySpec_McpAuthentication_JwksUrl struct {
+	JwksUrl string `protobuf:"bytes,5,opt,name=jwks_url,json=jwksUrl,proto3,oneof"`
+}
+
+type BackendPolicySpec_McpAuthentication_JwksInline struct {
+	JwksInline string `protobuf:"bytes,6,opt,name=jwks_inline,json=jwksInline,proto3,oneof"`
+}
+
+func (*BackendPolicySpec_McpAuthentication_JwksUrl) isBackendPolicySpec_McpAuthentication_JwksSource() {
+}
+
+func (*BackendPolicySpec_McpAuthentication_JwksInline) isBackendPolicySpec_McpAuthentication_JwksSource() {
 }
 
 type BackendPolicySpec_Ai_Message struct {
@@ -8966,7 +9006,7 @@ const file_resource_proto_rawDesc = "" +
 	"\vPolicyPhase\x12\t\n" +
 	"\x05ROUTE\x10\x00\x12\v\n" +
 	"\aGATEWAY\x10\x01B\x06\n" +
-	"\x04kind\"\xa5.\n" +
+	"\x04kind\"\xd9.\n" +
 	"\x11BackendPolicySpec\x12D\n" +
 	"\x03a2a\x18\x01 \x01(\v20.agentgateway.dev.resource.BackendPolicySpec.A2aH\x00R\x03a2a\x12l\n" +
 	"\x11inference_routing\x18\x02 \x01(\v2=.agentgateway.dev.resource.BackendPolicySpec.InferenceRoutingH\x00R\x10inferenceRouting\x12Z\n" +
@@ -9092,13 +9132,15 @@ const file_resource_proto_rawDesc = "" +
 	"\x0fconnect_timeout\x18\x02 \x01(\v2\x19.google.protobuf.DurationR\x0econnectTimeout\x1a<\n" +
 	"\x10McpAuthorization\x12\x14\n" +
 	"\x05allow\x18\x01 \x03(\tR\x05allow\x12\x12\n" +
-	"\x04deny\x18\x02 \x03(\tR\x04deny\x1a\xbf\x04\n" +
+	"\x04deny\x18\x02 \x03(\tR\x04deny\x1a\xf3\x04\n" +
 	"\x11McpAuthentication\x12\x16\n" +
 	"\x06issuer\x18\x01 \x01(\tR\x06issuer\x12\x1a\n" +
-	"\baudience\x18\x02 \x01(\tR\baudience\x12\x19\n" +
-	"\bjwks_url\x18\x03 \x01(\tR\ajwksUrl\x12a\n" +
-	"\bprovider\x18\x04 \x01(\x0e2E.agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.McpIDPR\bprovider\x12|\n" +
-	"\x11resource_metadata\x18\x05 \x01(\v2O.agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadataR\x10resourceMetadata\x1a\xd6\x01\n" +
+	"\baudience\x18\x02 \x01(\tR\baudience\x12a\n" +
+	"\bprovider\x18\x03 \x01(\x0e2E.agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.McpIDPR\bprovider\x12|\n" +
+	"\x11resource_metadata\x18\x04 \x01(\v2O.agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadataR\x10resourceMetadata\x12\x1b\n" +
+	"\bjwks_url\x18\x05 \x01(\tH\x00R\ajwksUrl\x12!\n" +
+	"\vjwks_inline\x18\x06 \x01(\tH\x00R\n" +
+	"jwksInline\x1a\xd6\x01\n" +
 	"\x10ResourceMetadata\x12p\n" +
 	"\x05extra\x18\x01 \x03(\v2Z.agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntryR\x05extra\x1aP\n" +
 	"\n" +
@@ -9107,7 +9149,8 @@ const file_resource_proto_rawDesc = "" +
 	"\x05value\x18\x02 \x01(\v2\x16.google.protobuf.ValueR\x05value:\x028\x01\"!\n" +
 	"\x06McpIDP\x12\t\n" +
 	"\x05AUTH0\x10\x00\x12\f\n" +
-	"\bKEYCLOAK\x10\x01B\x06\n" +
+	"\bKEYCLOAK\x10\x01B\r\n" +
+	"\vjwks_sourceB\x06\n" +
 	"\x04kind\"\xcc\x02\n" +
 	"\x06Policy\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12?\n" +
@@ -9712,6 +9755,10 @@ func file_resource_proto_init() {
 	}
 	file_resource_proto_msgTypes[61].OneofWrappers = []any{
 		(*TrafficPolicySpec_JWTProvider_Inline)(nil),
+	}
+	file_resource_proto_msgTypes[85].OneofWrappers = []any{
+		(*BackendPolicySpec_McpAuthentication_JwksUrl)(nil),
+		(*BackendPolicySpec_McpAuthentication_JwksInline)(nil),
 	}
 	file_resource_proto_msgTypes[88].OneofWrappers = []any{
 		(*BackendPolicySpec_Ai_RegexRule_Builtin)(nil),

--- a/go/api/resource.pb.go
+++ b/go/api/resource.pb.go
@@ -7958,8 +7958,8 @@ func (x *BackendPolicySpec_Ai_PromptCaching) GetMinTokens() uint32 {
 }
 
 type BackendPolicySpec_McpAuthentication_ResourceMetadata struct {
-	state         protoimpl.MessageState     `protogen:"open.v1"`
-	Extra         map[string]*structpb.Value `protobuf:"bytes,1,rep,name=extra,proto3" json:"extra,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Extra         map[string]string      `protobuf:"bytes,1,rep,name=extra,proto3" json:"extra,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -7994,7 +7994,7 @@ func (*BackendPolicySpec_McpAuthentication_ResourceMetadata) Descriptor() ([]byt
 	return file_resource_proto_rawDescGZIP(), []int{38, 7, 0}
 }
 
-func (x *BackendPolicySpec_McpAuthentication_ResourceMetadata) GetExtra() map[string]*structpb.Value {
+func (x *BackendPolicySpec_McpAuthentication_ResourceMetadata) GetExtra() map[string]string {
 	if x != nil {
 		return x.Extra
 	}
@@ -8966,7 +8966,7 @@ const file_resource_proto_rawDesc = "" +
 	"\vPolicyPhase\x12\t\n" +
 	"\x05ROUTE\x10\x00\x12\v\n" +
 	"\aGATEWAY\x10\x01B\x06\n" +
-	"\x04kind\"\xad.\n" +
+	"\x04kind\"\x95.\n" +
 	"\x11BackendPolicySpec\x12D\n" +
 	"\x03a2a\x18\x01 \x01(\v20.agentgateway.dev.resource.BackendPolicySpec.A2aH\x00R\x03a2a\x12l\n" +
 	"\x11inference_routing\x18\x02 \x01(\v2=.agentgateway.dev.resource.BackendPolicySpec.InferenceRoutingH\x00R\x10inferenceRouting\x12Z\n" +
@@ -9092,20 +9092,20 @@ const file_resource_proto_rawDesc = "" +
 	"\x0fconnect_timeout\x18\x02 \x01(\v2\x19.google.protobuf.DurationR\x0econnectTimeout\x1a<\n" +
 	"\x10McpAuthorization\x12\x14\n" +
 	"\x05allow\x18\x01 \x03(\tR\x05allow\x12\x12\n" +
-	"\x04deny\x18\x02 \x03(\tR\x04deny\x1a\xc7\x04\n" +
+	"\x04deny\x18\x02 \x03(\tR\x04deny\x1a\xaf\x04\n" +
 	"\x11McpAuthentication\x12\x16\n" +
 	"\x06issuer\x18\x01 \x01(\tR\x06issuer\x12\x1c\n" +
 	"\taudiences\x18\x02 \x03(\tR\taudiences\x12\x1f\n" +
 	"\vjwks_inline\x18\x03 \x01(\tR\n" +
 	"jwksInline\x12a\n" +
 	"\bprovider\x18\x04 \x01(\x0e2E.agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.McpIDPR\bprovider\x12|\n" +
-	"\x11resource_metadata\x18\x05 \x01(\v2O.agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadataR\x10resourceMetadata\x1a\xd6\x01\n" +
+	"\x11resource_metadata\x18\x05 \x01(\v2O.agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadataR\x10resourceMetadata\x1a\xbe\x01\n" +
 	"\x10ResourceMetadata\x12p\n" +
-	"\x05extra\x18\x01 \x03(\v2Z.agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntryR\x05extra\x1aP\n" +
+	"\x05extra\x18\x01 \x03(\v2Z.agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntryR\x05extra\x1a8\n" +
 	"\n" +
 	"ExtraEntry\x12\x10\n" +
-	"\x03key\x18\x01 \x01(\tR\x03key\x12,\n" +
-	"\x05value\x18\x02 \x01(\v2\x16.google.protobuf.ValueR\x05value:\x028\x01\"!\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"!\n" +
 	"\x06McpIDP\x12\t\n" +
 	"\x05AUTH0\x10\x00\x12\f\n" +
 	"\bKEYCLOAK\x10\x01B\x06\n" +
@@ -9374,7 +9374,6 @@ var file_resource_proto_goTypes = []any{
 	(*wrapperspb.StringValue)(nil),  // 134: google.protobuf.StringValue
 	(*structpb.Struct)(nil),         // 135: google.protobuf.Struct
 	(*wrapperspb.BytesValue)(nil),   // 136: google.protobuf.BytesValue
-	(*structpb.Value)(nil),          // 137: google.protobuf.Value
 }
 var file_resource_proto_depIdxs = []int32{
 	21,  // 0: agentgateway.dev.resource.Resource.bind:type_name -> agentgateway.dev.resource.Bind
@@ -9553,33 +9552,32 @@ var file_resource_proto_depIdxs = []int32{
 	114, // 173: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.request:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard
 	113, // 174: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.response:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard
 	121, // 175: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.extra:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntry
-	137, // 176: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntry.value:type_name -> google.protobuf.Value
-	134, // 177: agentgateway.dev.resource.AIBackend.OpenAI.model:type_name -> google.protobuf.StringValue
-	134, // 178: agentgateway.dev.resource.AIBackend.Gemini.model:type_name -> google.protobuf.StringValue
-	134, // 179: agentgateway.dev.resource.AIBackend.Vertex.model:type_name -> google.protobuf.StringValue
-	134, // 180: agentgateway.dev.resource.AIBackend.Anthropic.model:type_name -> google.protobuf.StringValue
-	134, // 181: agentgateway.dev.resource.AIBackend.Bedrock.model:type_name -> google.protobuf.StringValue
-	134, // 182: agentgateway.dev.resource.AIBackend.Bedrock.guardrail_identifier:type_name -> google.protobuf.StringValue
-	134, // 183: agentgateway.dev.resource.AIBackend.Bedrock.guardrail_version:type_name -> google.protobuf.StringValue
-	134, // 184: agentgateway.dev.resource.AIBackend.AzureOpenAI.model:type_name -> google.protobuf.StringValue
-	134, // 185: agentgateway.dev.resource.AIBackend.AzureOpenAI.api_version:type_name -> google.protobuf.StringValue
-	122, // 186: agentgateway.dev.resource.AIBackend.Provider.host_override:type_name -> agentgateway.dev.resource.AIBackend.HostOverride
-	134, // 187: agentgateway.dev.resource.AIBackend.Provider.path_override:type_name -> google.protobuf.StringValue
-	123, // 188: agentgateway.dev.resource.AIBackend.Provider.openai:type_name -> agentgateway.dev.resource.AIBackend.OpenAI
-	124, // 189: agentgateway.dev.resource.AIBackend.Provider.gemini:type_name -> agentgateway.dev.resource.AIBackend.Gemini
-	125, // 190: agentgateway.dev.resource.AIBackend.Provider.vertex:type_name -> agentgateway.dev.resource.AIBackend.Vertex
-	126, // 191: agentgateway.dev.resource.AIBackend.Provider.anthropic:type_name -> agentgateway.dev.resource.AIBackend.Anthropic
-	127, // 192: agentgateway.dev.resource.AIBackend.Provider.bedrock:type_name -> agentgateway.dev.resource.AIBackend.Bedrock
-	128, // 193: agentgateway.dev.resource.AIBackend.Provider.azureopenai:type_name -> agentgateway.dev.resource.AIBackend.AzureOpenAI
-	131, // 194: agentgateway.dev.resource.AIBackend.Provider.routes:type_name -> agentgateway.dev.resource.AIBackend.Provider.RoutesEntry
-	58,  // 195: agentgateway.dev.resource.AIBackend.Provider.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	129, // 196: agentgateway.dev.resource.AIBackend.ProviderGroup.providers:type_name -> agentgateway.dev.resource.AIBackend.Provider
-	16,  // 197: agentgateway.dev.resource.AIBackend.Provider.RoutesEntry.value:type_name -> agentgateway.dev.resource.AIBackend.RouteType
-	198, // [198:198] is the sub-list for method output_type
-	198, // [198:198] is the sub-list for method input_type
-	198, // [198:198] is the sub-list for extension type_name
-	198, // [198:198] is the sub-list for extension extendee
-	0,   // [0:198] is the sub-list for field type_name
+	134, // 176: agentgateway.dev.resource.AIBackend.OpenAI.model:type_name -> google.protobuf.StringValue
+	134, // 177: agentgateway.dev.resource.AIBackend.Gemini.model:type_name -> google.protobuf.StringValue
+	134, // 178: agentgateway.dev.resource.AIBackend.Vertex.model:type_name -> google.protobuf.StringValue
+	134, // 179: agentgateway.dev.resource.AIBackend.Anthropic.model:type_name -> google.protobuf.StringValue
+	134, // 180: agentgateway.dev.resource.AIBackend.Bedrock.model:type_name -> google.protobuf.StringValue
+	134, // 181: agentgateway.dev.resource.AIBackend.Bedrock.guardrail_identifier:type_name -> google.protobuf.StringValue
+	134, // 182: agentgateway.dev.resource.AIBackend.Bedrock.guardrail_version:type_name -> google.protobuf.StringValue
+	134, // 183: agentgateway.dev.resource.AIBackend.AzureOpenAI.model:type_name -> google.protobuf.StringValue
+	134, // 184: agentgateway.dev.resource.AIBackend.AzureOpenAI.api_version:type_name -> google.protobuf.StringValue
+	122, // 185: agentgateway.dev.resource.AIBackend.Provider.host_override:type_name -> agentgateway.dev.resource.AIBackend.HostOverride
+	134, // 186: agentgateway.dev.resource.AIBackend.Provider.path_override:type_name -> google.protobuf.StringValue
+	123, // 187: agentgateway.dev.resource.AIBackend.Provider.openai:type_name -> agentgateway.dev.resource.AIBackend.OpenAI
+	124, // 188: agentgateway.dev.resource.AIBackend.Provider.gemini:type_name -> agentgateway.dev.resource.AIBackend.Gemini
+	125, // 189: agentgateway.dev.resource.AIBackend.Provider.vertex:type_name -> agentgateway.dev.resource.AIBackend.Vertex
+	126, // 190: agentgateway.dev.resource.AIBackend.Provider.anthropic:type_name -> agentgateway.dev.resource.AIBackend.Anthropic
+	127, // 191: agentgateway.dev.resource.AIBackend.Provider.bedrock:type_name -> agentgateway.dev.resource.AIBackend.Bedrock
+	128, // 192: agentgateway.dev.resource.AIBackend.Provider.azureopenai:type_name -> agentgateway.dev.resource.AIBackend.AzureOpenAI
+	131, // 193: agentgateway.dev.resource.AIBackend.Provider.routes:type_name -> agentgateway.dev.resource.AIBackend.Provider.RoutesEntry
+	58,  // 194: agentgateway.dev.resource.AIBackend.Provider.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	129, // 195: agentgateway.dev.resource.AIBackend.ProviderGroup.providers:type_name -> agentgateway.dev.resource.AIBackend.Provider
+	16,  // 196: agentgateway.dev.resource.AIBackend.Provider.RoutesEntry.value:type_name -> agentgateway.dev.resource.AIBackend.RouteType
+	197, // [197:197] is the sub-list for method output_type
+	197, // [197:197] is the sub-list for method input_type
+	197, // [197:197] is the sub-list for extension type_name
+	197, // [197:197] is the sub-list for extension extendee
+	0,   // [0:197] is the sub-list for field type_name
 }
 
 func init() { file_resource_proto_init() }

--- a/go/api/resource.pb.go
+++ b/go/api/resource.pb.go
@@ -7164,7 +7164,7 @@ func (x *BackendPolicySpec_McpAuthorization) GetDeny() []string {
 type BackendPolicySpec_McpAuthentication struct {
 	state            protoimpl.MessageState                                `protogen:"open.v1"`
 	Issuer           string                                                `protobuf:"bytes,1,opt,name=issuer,proto3" json:"issuer,omitempty"`
-	Audience         string                                                `protobuf:"bytes,2,opt,name=audience,proto3" json:"audience,omitempty"`
+	Audiences        []string                                              `protobuf:"bytes,2,rep,name=audiences,proto3" json:"audiences,omitempty"`
 	JwksInline       string                                                `protobuf:"bytes,3,opt,name=jwks_inline,json=jwksInline,proto3" json:"jwks_inline,omitempty"`
 	Provider         BackendPolicySpec_McpAuthentication_McpIDP            `protobuf:"varint,4,opt,name=provider,proto3,enum=agentgateway.dev.resource.BackendPolicySpec_McpAuthentication_McpIDP" json:"provider,omitempty"`
 	ResourceMetadata *BackendPolicySpec_McpAuthentication_ResourceMetadata `protobuf:"bytes,5,opt,name=resource_metadata,json=resourceMetadata,proto3" json:"resource_metadata,omitempty"`
@@ -7209,11 +7209,11 @@ func (x *BackendPolicySpec_McpAuthentication) GetIssuer() string {
 	return ""
 }
 
-func (x *BackendPolicySpec_McpAuthentication) GetAudience() string {
+func (x *BackendPolicySpec_McpAuthentication) GetAudiences() []string {
 	if x != nil {
-		return x.Audience
+		return x.Audiences
 	}
-	return ""
+	return nil
 }
 
 func (x *BackendPolicySpec_McpAuthentication) GetJwksInline() string {
@@ -8966,7 +8966,7 @@ const file_resource_proto_rawDesc = "" +
 	"\vPolicyPhase\x12\t\n" +
 	"\x05ROUTE\x10\x00\x12\v\n" +
 	"\aGATEWAY\x10\x01B\x06\n" +
-	"\x04kind\"\xab.\n" +
+	"\x04kind\"\xad.\n" +
 	"\x11BackendPolicySpec\x12D\n" +
 	"\x03a2a\x18\x01 \x01(\v20.agentgateway.dev.resource.BackendPolicySpec.A2aH\x00R\x03a2a\x12l\n" +
 	"\x11inference_routing\x18\x02 \x01(\v2=.agentgateway.dev.resource.BackendPolicySpec.InferenceRoutingH\x00R\x10inferenceRouting\x12Z\n" +
@@ -9092,10 +9092,10 @@ const file_resource_proto_rawDesc = "" +
 	"\x0fconnect_timeout\x18\x02 \x01(\v2\x19.google.protobuf.DurationR\x0econnectTimeout\x1a<\n" +
 	"\x10McpAuthorization\x12\x14\n" +
 	"\x05allow\x18\x01 \x03(\tR\x05allow\x12\x12\n" +
-	"\x04deny\x18\x02 \x03(\tR\x04deny\x1a\xc5\x04\n" +
+	"\x04deny\x18\x02 \x03(\tR\x04deny\x1a\xc7\x04\n" +
 	"\x11McpAuthentication\x12\x16\n" +
-	"\x06issuer\x18\x01 \x01(\tR\x06issuer\x12\x1a\n" +
-	"\baudience\x18\x02 \x01(\tR\baudience\x12\x1f\n" +
+	"\x06issuer\x18\x01 \x01(\tR\x06issuer\x12\x1c\n" +
+	"\taudiences\x18\x02 \x03(\tR\taudiences\x12\x1f\n" +
 	"\vjwks_inline\x18\x03 \x01(\tR\n" +
 	"jwksInline\x12a\n" +
 	"\bprovider\x18\x04 \x01(\x0e2E.agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.McpIDPR\bprovider\x12|\n" +

--- a/schema/README.md
+++ b/schema/README.md
@@ -142,7 +142,7 @@ This folder contains JSON schemas for various parts of the project
 |`binds[].listeners[].routes[].policies.authorization.rules`||
 |`binds[].listeners[].routes[].policies.mcpAuthentication`|Authentication for MCP clients.|
 |`binds[].listeners[].routes[].policies.mcpAuthentication.issuer`||
-|`binds[].listeners[].routes[].policies.mcpAuthentication.audience`||
+|`binds[].listeners[].routes[].policies.mcpAuthentication.audiences`||
 |`binds[].listeners[].routes[].policies.mcpAuthentication.provider`||
 |`binds[].listeners[].routes[].policies.mcpAuthentication.provider.(any)(1)auth0`||
 |`binds[].listeners[].routes[].policies.mcpAuthentication.provider.(any)(1)keycloak`||
@@ -999,7 +999,7 @@ This folder contains JSON schemas for various parts of the project
 |`policies[].policy.authorization.rules`||
 |`policies[].policy.mcpAuthentication`|Authentication for MCP clients.|
 |`policies[].policy.mcpAuthentication.issuer`||
-|`policies[].policy.mcpAuthentication.audience`||
+|`policies[].policy.mcpAuthentication.audiences`||
 |`policies[].policy.mcpAuthentication.provider`||
 |`policies[].policy.mcpAuthentication.provider.(any)(1)auth0`||
 |`policies[].policy.mcpAuthentication.provider.(any)(1)keycloak`||

--- a/schema/README.md
+++ b/schema/README.md
@@ -143,7 +143,6 @@ This folder contains JSON schemas for various parts of the project
 |`binds[].listeners[].routes[].policies.mcpAuthentication`|Authentication for MCP clients.|
 |`binds[].listeners[].routes[].policies.mcpAuthentication.issuer`||
 |`binds[].listeners[].routes[].policies.mcpAuthentication.audiences`||
-|`binds[].listeners[].routes[].policies.mcpAuthentication.jwksUrl`||
 |`binds[].listeners[].routes[].policies.mcpAuthentication.provider`||
 |`binds[].listeners[].routes[].policies.mcpAuthentication.provider.(any)(1)auth0`||
 |`binds[].listeners[].routes[].policies.mcpAuthentication.provider.(any)(1)keycloak`||
@@ -1001,7 +1000,6 @@ This folder contains JSON schemas for various parts of the project
 |`policies[].policy.mcpAuthentication`|Authentication for MCP clients.|
 |`policies[].policy.mcpAuthentication.issuer`||
 |`policies[].policy.mcpAuthentication.audiences`||
-|`policies[].policy.mcpAuthentication.jwksUrl`||
 |`policies[].policy.mcpAuthentication.provider`||
 |`policies[].policy.mcpAuthentication.provider.(any)(1)auth0`||
 |`policies[].policy.mcpAuthentication.provider.(any)(1)keycloak`||

--- a/schema/README.md
+++ b/schema/README.md
@@ -143,11 +143,13 @@ This folder contains JSON schemas for various parts of the project
 |`binds[].listeners[].routes[].policies.mcpAuthentication`|Authentication for MCP clients.|
 |`binds[].listeners[].routes[].policies.mcpAuthentication.issuer`||
 |`binds[].listeners[].routes[].policies.mcpAuthentication.audience`||
-|`binds[].listeners[].routes[].policies.mcpAuthentication.jwksUrl`||
 |`binds[].listeners[].routes[].policies.mcpAuthentication.provider`||
 |`binds[].listeners[].routes[].policies.mcpAuthentication.provider.(any)(1)auth0`||
 |`binds[].listeners[].routes[].policies.mcpAuthentication.provider.(any)(1)keycloak`||
 |`binds[].listeners[].routes[].policies.mcpAuthentication.resourceMetadata`||
+|`binds[].listeners[].routes[].policies.mcpAuthentication.jwks`||
+|`binds[].listeners[].routes[].policies.mcpAuthentication.jwks.(any)file`||
+|`binds[].listeners[].routes[].policies.mcpAuthentication.jwks.(any)url`||
 |`binds[].listeners[].routes[].policies.a2a`|Mark this traffic as A2A to enable A2A processing and telemetry.|
 |`binds[].listeners[].routes[].policies.ai`|Mark this as LLM traffic to enable LLM processing.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard`||
@@ -998,11 +1000,13 @@ This folder contains JSON schemas for various parts of the project
 |`policies[].policy.mcpAuthentication`|Authentication for MCP clients.|
 |`policies[].policy.mcpAuthentication.issuer`||
 |`policies[].policy.mcpAuthentication.audience`||
-|`policies[].policy.mcpAuthentication.jwksUrl`||
 |`policies[].policy.mcpAuthentication.provider`||
 |`policies[].policy.mcpAuthentication.provider.(any)(1)auth0`||
 |`policies[].policy.mcpAuthentication.provider.(any)(1)keycloak`||
 |`policies[].policy.mcpAuthentication.resourceMetadata`||
+|`policies[].policy.mcpAuthentication.jwks`||
+|`policies[].policy.mcpAuthentication.jwks.(any)file`||
+|`policies[].policy.mcpAuthentication.jwks.(any)url`||
 |`policies[].policy.a2a`|Mark this traffic as A2A to enable A2A processing and telemetry.|
 |`policies[].policy.ai`|Mark this as LLM traffic to enable LLM processing.|
 |`policies[].policy.ai.promptGuard`||

--- a/schema/README.md
+++ b/schema/README.md
@@ -143,6 +143,7 @@ This folder contains JSON schemas for various parts of the project
 |`binds[].listeners[].routes[].policies.mcpAuthentication`|Authentication for MCP clients.|
 |`binds[].listeners[].routes[].policies.mcpAuthentication.issuer`||
 |`binds[].listeners[].routes[].policies.mcpAuthentication.audiences`||
+|`binds[].listeners[].routes[].policies.mcpAuthentication.jwksUrl`||
 |`binds[].listeners[].routes[].policies.mcpAuthentication.provider`||
 |`binds[].listeners[].routes[].policies.mcpAuthentication.provider.(any)(1)auth0`||
 |`binds[].listeners[].routes[].policies.mcpAuthentication.provider.(any)(1)keycloak`||
@@ -1000,6 +1001,7 @@ This folder contains JSON schemas for various parts of the project
 |`policies[].policy.mcpAuthentication`|Authentication for MCP clients.|
 |`policies[].policy.mcpAuthentication.issuer`||
 |`policies[].policy.mcpAuthentication.audiences`||
+|`policies[].policy.mcpAuthentication.jwksUrl`||
 |`policies[].policy.mcpAuthentication.provider`||
 |`policies[].policy.mcpAuthentication.provider.(any)(1)auth0`||
 |`policies[].policy.mcpAuthentication.provider.(any)(1)keycloak`||

--- a/schema/local.json
+++ b/schema/local.json
@@ -1184,9 +1184,6 @@
                                   "type": "string"
                                 }
                               },
-                              "jwksUrl": {
-                                "type": "string"
-                              },
                               "provider": {
                                 "anyOf": [
                                   {
@@ -1263,7 +1260,6 @@
                             "required": [
                               "issuer",
                               "audiences",
-                              "jwksUrl",
                               "resourceMetadata",
                               "jwks"
                             ],
@@ -9259,9 +9255,6 @@
                       "type": "string"
                     }
                   },
-                  "jwksUrl": {
-                    "type": "string"
-                  },
                   "provider": {
                     "anyOf": [
                       {
@@ -9338,7 +9331,6 @@
                 "required": [
                   "issuer",
                   "audiences",
-                  "jwksUrl",
                   "resourceMetadata",
                   "jwks"
                 ],

--- a/schema/local.json
+++ b/schema/local.json
@@ -1181,9 +1181,6 @@
                               "audience": {
                                 "type": "string"
                               },
-                              "jwksUrl": {
-                                "type": "string"
-                              },
                               "provider": {
                                 "anyOf": [
                                   {
@@ -1224,14 +1221,44 @@
                               "resourceMetadata": {
                                 "type": "object",
                                 "additionalProperties": true
+                              },
+                              "jwks": {
+                                "anyOf": [
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "file": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "file"
+                                    ]
+                                  },
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "url": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "url"
+                                    ]
+                                  }
+                                ],
+                                "writeOnly": true
                               }
                             },
                             "additionalProperties": false,
                             "required": [
                               "issuer",
                               "audience",
-                              "jwksUrl",
-                              "resourceMetadata"
+                              "resourceMetadata",
+                              "jwks"
                             ],
                             "default": null
                           },
@@ -9222,9 +9249,6 @@
                   "audience": {
                     "type": "string"
                   },
-                  "jwksUrl": {
-                    "type": "string"
-                  },
                   "provider": {
                     "anyOf": [
                       {
@@ -9265,14 +9289,44 @@
                   "resourceMetadata": {
                     "type": "object",
                     "additionalProperties": true
+                  },
+                  "jwks": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "file": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "file"
+                        ]
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "url": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "url"
+                        ]
+                      }
+                    ],
+                    "writeOnly": true
                   }
                 },
                 "additionalProperties": false,
                 "required": [
                   "issuer",
                   "audience",
-                  "jwksUrl",
-                  "resourceMetadata"
+                  "resourceMetadata",
+                  "jwks"
                 ],
                 "default": null
               },

--- a/schema/local.json
+++ b/schema/local.json
@@ -1184,6 +1184,9 @@
                                   "type": "string"
                                 }
                               },
+                              "jwksUrl": {
+                                "type": "string"
+                              },
                               "provider": {
                                 "anyOf": [
                                   {
@@ -1260,6 +1263,7 @@
                             "required": [
                               "issuer",
                               "audiences",
+                              "jwksUrl",
                               "resourceMetadata",
                               "jwks"
                             ],
@@ -9255,6 +9259,9 @@
                       "type": "string"
                     }
                   },
+                  "jwksUrl": {
+                    "type": "string"
+                  },
                   "provider": {
                     "anyOf": [
                       {
@@ -9331,6 +9338,7 @@
                 "required": [
                   "issuer",
                   "audiences",
+                  "jwksUrl",
                   "resourceMetadata",
                   "jwks"
                 ],

--- a/schema/local.json
+++ b/schema/local.json
@@ -1178,8 +1178,11 @@
                               "issuer": {
                                 "type": "string"
                               },
-                              "audience": {
-                                "type": "string"
+                              "audiences": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
                               },
                               "provider": {
                                 "anyOf": [
@@ -1256,7 +1259,7 @@
                             "additionalProperties": false,
                             "required": [
                               "issuer",
-                              "audience",
+                              "audiences",
                               "resourceMetadata",
                               "jwks"
                             ],
@@ -9246,8 +9249,11 @@
                   "issuer": {
                     "type": "string"
                   },
-                  "audience": {
-                    "type": "string"
+                  "audiences": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
                   },
                   "provider": {
                     "anyOf": [
@@ -9324,7 +9330,7 @@
                 "additionalProperties": false,
                 "required": [
                   "issuer",
-                  "audience",
+                  "audiences",
                   "resourceMetadata",
                   "jwks"
                 ],

--- a/schema/local.json
+++ b/schema/local.json
@@ -1252,8 +1252,7 @@
                                       "url"
                                     ]
                                   }
-                                ],
-                                "writeOnly": true
+                                ]
                               }
                             },
                             "additionalProperties": false,
@@ -1262,8 +1261,7 @@
                               "audiences",
                               "resourceMetadata",
                               "jwks"
-                            ],
-                            "default": null
+                            ]
                           },
                           "a2a": {
                             "description": "Mark this traffic as A2A to enable A2A processing and telemetry.",
@@ -9323,8 +9321,7 @@
                           "url"
                         ]
                       }
-                    ],
-                    "writeOnly": true
+                    ]
                   }
                 },
                 "additionalProperties": false,
@@ -9333,8 +9330,7 @@
                   "audiences",
                   "resourceMetadata",
                   "jwks"
-                ],
-                "default": null
+                ]
               },
               "a2a": {
                 "description": "Mark this traffic as A2A to enable A2A processing and telemetry.",


### PR DESCRIPTION
Currently, agentgateway only supports MCP authentication configured locally.

Under the hood, local config creates a route-level JWT policy for MCP authentication. We can't take this same approach when configured via xDS, since config arrives dynamically and expecting the control plane to configure route-level policies for all routes that reference an MCP backend would be quite complex in practice.

Instead, I've implemented JWT validation for MCP authentication similar to how backend policies work. MCP Authentication now includes JWT verification directly, which avoids the introduction of a backend JWT policy that only works with MCP backends.

I've also updated the MCP authentication proto/xds code to expect inline JWKS, since we expect the control plane to handle JWKS fetch.

Since MCP backends seem to bypass the normal apply_backend_policies flow (they return early in make_backend_call), JWT validation is currently applied directly in the MCP router.