### PR TITLE
support for Anthropic models with Vertex

### DIFF
--- a/crates/agentgateway/src/llm/anthropic.rs
+++ b/crates/agentgateway/src/llm/anthropic.rs
@@ -47,15 +47,12 @@ impl Provider {
 			},
 		}
 	}
+}
 
-	pub fn process_error(
-		&self,
-		bytes: &Bytes,
-	) -> Result<universal::ChatCompletionErrorResponse, AIError> {
-		let resp =
-			serde_json::from_slice::<MessagesErrorResponse>(bytes).map_err(AIError::ResponseParsing)?;
-		translate_error(resp)
-	}
+pub fn process_error(bytes: &Bytes) -> Result<universal::ChatCompletionErrorResponse, AIError> {
+	let resp =
+		serde_json::from_slice::<MessagesErrorResponse>(bytes).map_err(AIError::ResponseParsing)?;
+	translate_error(resp)
 }
 
 pub fn process_response(

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -789,15 +789,14 @@ impl AIProvider {
 			let openai_response = match self {
 				AIProvider::Vertex(provider) => {
 					if provider.is_anthropic_model(Some(request_model)) {
-						let anthropic_provider = anthropic::Provider { model: None };
-						anthropic_provider.process_error(bytes)?
+						anthropic::process_error(bytes)?
 					} else {
 						provider.process_error(bytes)?
 					}
 				},
 				AIProvider::OpenAI(p) => p.process_error(bytes)?,
 				AIProvider::Gemini(p) => p.process_error(bytes)?,
-				AIProvider::Anthropic(p) => p.process_error(bytes)?,
+				AIProvider::Anthropic(_) => anthropic::process_error(bytes)?,
 				AIProvider::Bedrock(p) => p.process_error(bytes)?,
 				AIProvider::AzureOpenAI(p) => p.process_error(bytes)?,
 			};

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -309,7 +309,9 @@ impl AIProvider {
 				Ok(())
 			}),
 			AIProvider::Vertex(provider) => {
-				let path = provider.get_path_for_model();
+				let request_model = llm_request.map(|l| l.request_model.as_str());
+				let streaming = llm_request.map(|l| l.streaming).unwrap_or(false);
+				let path = provider.get_path_for_model(request_model, streaming);
 				http::modify_req(req, |req| {
 					http::modify_uri(req, |uri| {
 						uri.path_and_query = Some(PathAndQuery::from_str(&path)?);
@@ -628,7 +630,12 @@ impl AIProvider {
 			}
 		}
 
+		let request_model = llm_info.request_model.as_str();
 		let new_request = match self {
+			AIProvider::Vertex(provider) if provider.is_anthropic_model(Some(request_model)) => {
+				let body = req.to_anthropic()?;
+				provider.prepare_anthropic_request_body(body)?
+			},
 			AIProvider::OpenAI(_)
 			| AIProvider::Gemini(_)
 			| AIProvider::Vertex(_)
@@ -759,12 +766,17 @@ impl AIProvider {
 		status: StatusCode,
 		bytes: &Bytes,
 	) -> Result<Result<Box<dyn ResponseType>, ChatCompletionErrorResponse>, AIError> {
+		let request_model = req.request_model.as_str();
 		if status.is_success() {
 			let resp = match self {
-				AIProvider::OpenAI(_)
-				| AIProvider::Gemini(_)
-				| AIProvider::Vertex(_)
-				| AIProvider::AzureOpenAI(_) => {
+				AIProvider::Vertex(provider) => {
+					if provider.is_anthropic_model(Some(request_model)) {
+						anthropic::process_response(bytes, req.input_format)?
+					} else {
+						universal::passthrough::process_response(bytes, req.input_format)?
+					}
+				},
+				AIProvider::OpenAI(_) | AIProvider::Gemini(_) | AIProvider::AzureOpenAI(_) => {
 					universal::passthrough::process_response(bytes, req.input_format)?
 				},
 				AIProvider::Anthropic(_) => anthropic::process_response(bytes, req.input_format)?,
@@ -775,9 +787,16 @@ impl AIProvider {
 			Ok(Ok(resp))
 		} else {
 			let openai_response = match self {
+				AIProvider::Vertex(provider) => {
+					if provider.is_anthropic_model(Some(request_model)) {
+						let anthropic_provider = anthropic::Provider { model: None };
+						anthropic_provider.process_error(bytes)?
+					} else {
+						provider.process_error(bytes)?
+					}
+				},
 				AIProvider::OpenAI(p) => p.process_error(bytes)?,
 				AIProvider::Gemini(p) => p.process_error(bytes)?,
-				AIProvider::Vertex(p) => p.process_error(bytes)?,
 				AIProvider::Anthropic(p) => p.process_error(bytes)?,
 				AIProvider::Bedrock(p) => p.process_error(bytes)?,
 				AIProvider::AzureOpenAI(p) => p.process_error(bytes)?,

--- a/crates/agentgateway/src/llm/vertex.rs
+++ b/crates/agentgateway/src/llm/vertex.rs
@@ -4,7 +4,11 @@ use bytes::Bytes;
 
 use super::universal;
 use crate::llm::AIError;
+use crate::llm::anthropic;
 use crate::*;
+use serde_json::{Map, Value};
+
+const ANTHROPIC_VERSION: &str = "vertex-2023-10-16";
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -22,19 +26,69 @@ impl super::Provider for Provider {
 }
 
 impl Provider {
+	fn configured_model<'a>(&'a self, request_model: Option<&'a str>) -> Option<&'a str> {
+		self.model.as_deref().or(request_model)
+	}
+
+	fn anthropic_model<'a>(&'a self, request_model: Option<&'a str>) -> Option<Strng> {
+		let model = self.configured_model(request_model)?;
+		model
+			.strip_prefix("publishers/anthropic/models/")
+			.or_else(|| model.strip_prefix("anthropic/"))
+			.map(strng::new)
+	}
+
+	pub fn is_anthropic_model(&self, request_model: Option<&str>) -> bool {
+		self.anthropic_model(request_model).is_some()
+	}
+
+	pub fn prepare_anthropic_request_body(&self, body: Vec<u8>) -> Result<Vec<u8>, AIError> {
+		let mut map: Map<String, Value> =
+			serde_json::from_slice(&body).map_err(AIError::RequestMarshal)?;
+		map.insert(
+			"anthropic_version".to_string(),
+			Value::String(ANTHROPIC_VERSION.to_string()),
+		);
+		map.remove("model");
+		serde_json::to_vec(&map).map_err(AIError::RequestMarshal)
+	}
+
 	pub fn process_error(
 		&self,
 		bytes: &Bytes,
 	) -> Result<universal::ChatCompletionErrorResponse, AIError> {
-		let resp = serde_json::from_slice::<universal::ChatCompletionErrorResponse>(bytes)
-			.map_err(AIError::ResponseParsing)?;
-		Ok(resp)
+		match serde_json::from_slice::<universal::ChatCompletionErrorResponse>(bytes) {
+			Ok(resp) => Ok(resp),
+			Err(_) => {
+				let anthropic_error =
+					serde_json::from_slice::<anthropic::types::MessagesErrorResponse>(bytes)
+						.map_err(AIError::ResponseParsing)?;
+				anthropic::translate_error(anthropic_error)
+			},
+		}
 	}
-	pub fn get_path_for_model(&self) -> Strng {
+	pub fn get_path_for_model(&self, request_model: Option<&str>, streaming: bool) -> Strng {
+		let location = self
+			.region
+			.clone()
+			.unwrap_or_else(|| strng::literal!("global"));
+		if let Some(model) = self.anthropic_model(request_model) {
+			return strng::format!(
+				"/v1/projects/{}/locations/{}/publishers/anthropic/models/{}:{}",
+				self.project_id,
+				location,
+				model,
+				if streaming {
+					"streamRawPredict"
+				} else {
+					"rawPredict"
+				}
+			);
+		}
 		strng::format!(
 			"/v1beta1/projects/{}/locations/{}/endpoints/openapi/chat/completions",
 			self.project_id,
-			self.region.as_ref().unwrap_or(&strng::literal!("global"))
+			location
 		)
 	}
 	pub fn get_host(&self) -> Strng {

--- a/crates/agentgateway/src/llm/vertex.rs
+++ b/crates/agentgateway/src/llm/vertex.rs
@@ -4,7 +4,6 @@ use bytes::Bytes;
 
 use super::universal;
 use crate::llm::AIError;
-use crate::llm::anthropic;
 use crate::*;
 use serde_json::{Map, Value};
 

--- a/crates/agentgateway/src/llm/vertex.rs
+++ b/crates/agentgateway/src/llm/vertex.rs
@@ -57,15 +57,9 @@ impl Provider {
 		&self,
 		bytes: &Bytes,
 	) -> Result<universal::ChatCompletionErrorResponse, AIError> {
-		match serde_json::from_slice::<universal::ChatCompletionErrorResponse>(bytes) {
-			Ok(resp) => Ok(resp),
-			Err(_) => {
-				let anthropic_error =
-					serde_json::from_slice::<anthropic::types::MessagesErrorResponse>(bytes)
-						.map_err(AIError::ResponseParsing)?;
-				anthropic::translate_error(anthropic_error)
-			},
-		}
+		let resp = serde_json::from_slice::<universal::ChatCompletionErrorResponse>(bytes)
+			.map_err(AIError::ResponseParsing)?;
+		Ok(resp)
 	}
 	pub fn get_path_for_model(&self, request_model: Option<&str>, streaming: bool) -> Strng {
 		let location = self


### PR DESCRIPTION
Add support for using Anthropic models with Vertex AI.

Added logic to detect anthropic model based on the model prefix. For anthropic models, we need to set the correct path (get_path_for_model) and add the `anthropic_version` to the request body. We also treat the response as an Anthropic response


Test locally with this config:
```
binds:
- port: 3000
  listeners:
  - routes:
    - backends:
      - ai:
          name: vertex
          provider:
            vertex:
              projectId: <your project>
              model: anthropic/claude-sonnet-4-5@20250929 
```


Run agentgateway: `cargo run -- -f config.yaml`

Send request
```
curl -s "localhost:3000" -H content-type:application/json  -d '{
   "model": "",
   "messages": [
     {
       "role": "user",
       "content": "Write me a short poem about Kubernetes and clouds."
     }
   ]
 }' | jq
```
