### PR TITLE
feat: add anthropic-beta header allowlist for Bedrock

### DIFF
--- a/crates/agentgateway/proto/resource.proto
+++ b/crates/agentgateway/proto/resource.proto
@@ -663,6 +663,8 @@ message BackendPolicySpec {
     // Model aliases - map from alias name to actual model name
     map<string, string> model_aliases = 5;
     PromptCaching prompt_caching = 6;
+    // List of allowed Anthropic beta feature headers (e.g., "prompt-caching-2024-07-31")
+    repeated string anthropic_beta_allowlist = 7;
   }
   message A2a {
   }
@@ -804,6 +806,7 @@ message AIBackend {
     string region = 2;
     google.protobuf.StringValue guardrail_identifier = 3;
     google.protobuf.StringValue guardrail_version = 4;
+    repeated string anthropic_beta_headers = 5;
   }
   message AzureOpenAI {
     google.protobuf.StringValue model = 1;

--- a/crates/agentgateway/src/llm/anthropic.rs
+++ b/crates/agentgateway/src/llm/anthropic.rs
@@ -1407,7 +1407,7 @@ pub mod passthrough {
 			&self,
 			provider: &crate::llm::bedrock::Provider,
 			headers: Option<&::http::HeaderMap>,
-			_prompt_caching: Option<&crate::llm::policy::PromptCachingConfig>,
+			_policies: Option<&crate::llm::policy::Policy>,
 		) -> Result<Vec<u8>, AIError> {
 			let typed = json::convert::<_, anthropic::types::MessagesRequest>(self)
 				.map_err(AIError::RequestMarshal)?;

--- a/crates/agentgateway/src/llm/openai.rs
+++ b/crates/agentgateway/src/llm/openai.rs
@@ -244,17 +244,13 @@ pub mod responses {
 				&self,
 				provider: &crate::llm::bedrock::Provider,
 				headers: Option<&::http::HeaderMap>,
-				prompt_caching: Option<&crate::llm::policy::PromptCachingConfig>,
+				policies: Option<&crate::llm::policy::Policy>,
 			) -> Result<Vec<u8>, AIError> {
 				// Convert passthrough Request to typed CreateResponse (same pattern as Anthropic Messages)
 				let typed =
 					crate::json::convert::<_, CreateResponse>(self).map_err(AIError::RequestMarshal)?;
-				let bedrock_request = crate::llm::bedrock::translate_request_responses(
-					&typed,
-					provider,
-					headers,
-					prompt_caching,
-				)?;
+				let bedrock_request =
+					crate::llm::bedrock::translate_request_responses(&typed, provider, headers, policies)?;
 				serde_json::to_vec(&bedrock_request).map_err(AIError::RequestMarshal)
 			}
 		}

--- a/crates/agentgateway/src/llm/policy.rs
+++ b/crates/agentgateway/src/llm/policy.rs
@@ -32,6 +32,8 @@ pub struct Policy {
 	pub model_aliases: HashMap<Strng, Strng>,
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub prompt_caching: Option<PromptCachingConfig>,
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub anthropic_beta_allowlist: Vec<Strng>,
 }
 
 #[apply(schema!)]

--- a/crates/agentgateway/src/llm/universal.rs
+++ b/crates/agentgateway/src/llm/universal.rs
@@ -67,7 +67,7 @@ pub trait RequestType: Send + Sync {
 		&self,
 		_provider: &Provider,
 		_headers: Option<&::http::HeaderMap>,
-		_prompt_caching: Option<&crate::llm::policy::PromptCachingConfig>,
+		_policies: Option<&crate::llm::policy::Policy>,
 	) -> Result<Vec<u8>, AIError> {
 		Err(AIError::UnsupportedConversion(strng::literal!("bedrock")))
 	}
@@ -260,11 +260,10 @@ pub mod passthrough {
 			&self,
 			provider: &Provider,
 			headers: Option<&::http::HeaderMap>,
-			prompt_caching: Option<&crate::llm::policy::PromptCachingConfig>,
+			policies: Option<&crate::llm::policy::Policy>,
 		) -> Result<Vec<u8>, AIError> {
 			let typed = json::convert::<_, universal::Request>(self).map_err(AIError::RequestMarshal)?;
-			let xlated =
-				llm::bedrock::translate_request_completions(typed, provider, headers, prompt_caching);
+			let xlated = llm::bedrock::translate_request_completions(typed, provider, headers, policies);
 			serde_json::to_vec(&xlated).map_err(AIError::RequestMarshal)
 		}
 

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -1172,6 +1172,7 @@ async fn make_backend_call(
 							route_type,
 							Some(&llm_request),
 							llm.use_default_policies(),
+							llm_request_policies.llm.as_deref(),
 						)
 						.map_err(ProxyError::Processing)?;
 
@@ -1206,7 +1207,7 @@ async fn make_backend_call(
 					// We do not need LLM policies nor token-based rate limits, etc.
 					llm
 						.provider
-						.setup_request(&mut req, route_type, None, true)
+						.setup_request(&mut req, route_type, None, true, None)
 						.map_err(ProxyError::Processing)?;
 					(req, LLMResponsePolicies::default(), None)
 				},
@@ -1224,6 +1225,7 @@ async fn make_backend_call(
 							route_type,
 							Some(&llm_request),
 							llm.use_default_policies(),
+							llm_request_policies.llm.as_deref(),
 						)
 						.map_err(ProxyError::Processing)?;
 

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -243,6 +243,11 @@ impl LLMRequestPolicies {
 				.prompt_caching
 				.clone()
 				.or_else(|| re.prompt_caching.clone()),
+			anthropic_beta_allowlist: if be.anthropic_beta_allowlist.is_empty() {
+				re.anthropic_beta_allowlist.clone()
+			} else {
+				be.anthropic_beta_allowlist.clone()
+			},
 		}));
 		Arc::new(route_policies)
 	}

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -219,6 +219,7 @@ fn convert_backend_ai_policy(
 			.map(|(k, v)| (strng::new(k), strng::new(v)))
 			.collect(),
 		prompt_caching: ai.prompt_caching.as_ref().map(convert_prompt_caching),
+		anthropic_beta_allowlist: ai.anthropic_beta_allowlist.iter().map(strng::new).collect(),
 	})
 }
 
@@ -1702,6 +1703,7 @@ mod tests {
 				prompts: None,
 				model_aliases: Default::default(),
 				prompt_caching: None,
+				anthropic_beta_allowlist: vec![],
 			})),
 		};
 

--- a/go/api/resource.pb.go
+++ b/go/api/resource.pb.go
@@ -6749,8 +6749,10 @@ type BackendPolicySpec_Ai struct {
 	// Model aliases - map from alias name to actual model name
 	ModelAliases  map[string]string                   `protobuf:"bytes,5,rep,name=model_aliases,json=modelAliases,proto3" json:"model_aliases,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	PromptCaching *BackendPolicySpec_Ai_PromptCaching `protobuf:"bytes,6,opt,name=prompt_caching,json=promptCaching,proto3" json:"prompt_caching,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	// List of allowed Anthropic beta feature headers (e.g., "prompt-caching-2024-07-31")
+	AnthropicBetaAllowlist []string `protobuf:"bytes,7,rep,name=anthropic_beta_allowlist,json=anthropicBetaAllowlist,proto3" json:"anthropic_beta_allowlist,omitempty"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
 }
 
 func (x *BackendPolicySpec_Ai) Reset() {
@@ -6821,6 +6823,13 @@ func (x *BackendPolicySpec_Ai) GetModelAliases() map[string]string {
 func (x *BackendPolicySpec_Ai) GetPromptCaching() *BackendPolicySpec_Ai_PromptCaching {
 	if x != nil {
 		return x.PromptCaching
+	}
+	return nil
+}
+
+func (x *BackendPolicySpec_Ai) GetAnthropicBetaAllowlist() []string {
+	if x != nil {
+		return x.AnthropicBetaAllowlist
 	}
 	return nil
 }
@@ -8246,13 +8255,14 @@ func (x *AIBackend_Anthropic) GetModel() *wrapperspb.StringValue {
 }
 
 type AIBackend_Bedrock struct {
-	state               protoimpl.MessageState  `protogen:"open.v1"`
-	Model               *wrapperspb.StringValue `protobuf:"bytes,1,opt,name=model,proto3" json:"model,omitempty"`
-	Region              string                  `protobuf:"bytes,2,opt,name=region,proto3" json:"region,omitempty"`
-	GuardrailIdentifier *wrapperspb.StringValue `protobuf:"bytes,3,opt,name=guardrail_identifier,json=guardrailIdentifier,proto3" json:"guardrail_identifier,omitempty"`
-	GuardrailVersion    *wrapperspb.StringValue `protobuf:"bytes,4,opt,name=guardrail_version,json=guardrailVersion,proto3" json:"guardrail_version,omitempty"`
-	unknownFields       protoimpl.UnknownFields
-	sizeCache           protoimpl.SizeCache
+	state                protoimpl.MessageState  `protogen:"open.v1"`
+	Model                *wrapperspb.StringValue `protobuf:"bytes,1,opt,name=model,proto3" json:"model,omitempty"`
+	Region               string                  `protobuf:"bytes,2,opt,name=region,proto3" json:"region,omitempty"`
+	GuardrailIdentifier  *wrapperspb.StringValue `protobuf:"bytes,3,opt,name=guardrail_identifier,json=guardrailIdentifier,proto3" json:"guardrail_identifier,omitempty"`
+	GuardrailVersion     *wrapperspb.StringValue `protobuf:"bytes,4,opt,name=guardrail_version,json=guardrailVersion,proto3" json:"guardrail_version,omitempty"`
+	AnthropicBetaHeaders []string                `protobuf:"bytes,5,rep,name=anthropic_beta_headers,json=anthropicBetaHeaders,proto3" json:"anthropic_beta_headers,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *AIBackend_Bedrock) Reset() {
@@ -8309,6 +8319,13 @@ func (x *AIBackend_Bedrock) GetGuardrailIdentifier() *wrapperspb.StringValue {
 func (x *AIBackend_Bedrock) GetGuardrailVersion() *wrapperspb.StringValue {
 	if x != nil {
 		return x.GuardrailVersion
+	}
+	return nil
+}
+
+func (x *AIBackend_Bedrock) GetAnthropicBetaHeaders() []string {
+	if x != nil {
+		return x.AnthropicBetaHeaders
 	}
 	return nil
 }
@@ -8966,7 +8983,7 @@ const file_resource_proto_rawDesc = "" +
 	"\vPolicyPhase\x12\t\n" +
 	"\x05ROUTE\x10\x00\x12\v\n" +
 	"\aGATEWAY\x10\x01B\x06\n" +
-	"\x04kind\"\xa5.\n" +
+	"\x04kind\"\xdf.\n" +
 	"\x11BackendPolicySpec\x12D\n" +
 	"\x03a2a\x18\x01 \x01(\v20.agentgateway.dev.resource.BackendPolicySpec.A2aH\x00R\x03a2a\x12l\n" +
 	"\x11inference_routing\x18\x02 \x01(\v2=.agentgateway.dev.resource.BackendPolicySpec.InferenceRoutingH\x00R\x10inferenceRouting\x12Z\n" +
@@ -8983,14 +9000,15 @@ const file_resource_proto_rawDesc = "" +
 	"\x0erequest_mirror\x18\v \x01(\v2).agentgateway.dev.resource.RequestMirrorsH\x00R\rrequestMirror\x12]\n" +
 	"\fbackend_http\x18\f \x01(\v28.agentgateway.dev.resource.BackendPolicySpec.BackendHTTPH\x00R\vbackendHttp\x12Z\n" +
 	"\vbackend_tcp\x18\r \x01(\v27.agentgateway.dev.resource.BackendPolicySpec.BackendTCPH\x00R\n" +
-	"backendTcp\x1a\x83\x17\n" +
+	"backendTcp\x1a\xbd\x17\n" +
 	"\x02Ai\x12^\n" +
 	"\fprompt_guard\x18\x01 \x01(\v2;.agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuardR\vpromptGuard\x12Y\n" +
 	"\bdefaults\x18\x02 \x03(\v2=.agentgateway.dev.resource.BackendPolicySpec.Ai.DefaultsEntryR\bdefaults\x12\\\n" +
 	"\toverrides\x18\x03 \x03(\v2>.agentgateway.dev.resource.BackendPolicySpec.Ai.OverridesEntryR\toverrides\x12Z\n" +
 	"\aprompts\x18\x04 \x01(\v2@.agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichmentR\aprompts\x12f\n" +
 	"\rmodel_aliases\x18\x05 \x03(\v2A.agentgateway.dev.resource.BackendPolicySpec.Ai.ModelAliasesEntryR\fmodelAliases\x12d\n" +
-	"\x0eprompt_caching\x18\x06 \x01(\v2=.agentgateway.dev.resource.BackendPolicySpec.Ai.PromptCachingR\rpromptCaching\x1a7\n" +
+	"\x0eprompt_caching\x18\x06 \x01(\v2=.agentgateway.dev.resource.BackendPolicySpec.Ai.PromptCachingR\rpromptCaching\x128\n" +
+	"\x18anthropic_beta_allowlist\x18\a \x03(\tR\x16anthropicBetaAllowlist\x1a7\n" +
 	"\aMessage\x12\x12\n" +
 	"\x04role\x18\x01 \x01(\tR\x04role\x12\x18\n" +
 	"\acontent\x18\x02 \x01(\tR\acontent\x1a\xb6\x01\n" +
@@ -9127,7 +9145,7 @@ const file_resource_proto_rawDesc = "" +
 	"\rStaticBackend\x12\x12\n" +
 	"\x04host\x18\x01 \x01(\tR\x04host\x12\x12\n" +
 	"\x04port\x18\x02 \x01(\x05R\x04port\"\x15\n" +
-	"\x13DynamicForwardProxy\"\xe2\x0f\n" +
+	"\x13DynamicForwardProxy\"\x98\x10\n" +
 	"\tAIBackend\x12[\n" +
 	"\x0fprovider_groups\x18\x01 \x03(\v22.agentgateway.dev.resource.AIBackend.ProviderGroupR\x0eproviderGroups\x1a6\n" +
 	"\fHostOverride\x12\x12\n" +
@@ -9143,12 +9161,13 @@ const file_resource_proto_rawDesc = "" +
 	"\n" +
 	"project_id\x18\x03 \x01(\tR\tprojectId\x1a?\n" +
 	"\tAnthropic\x122\n" +
-	"\x05model\x18\x01 \x01(\v2\x1c.google.protobuf.StringValueR\x05model\x1a\xf1\x01\n" +
+	"\x05model\x18\x01 \x01(\v2\x1c.google.protobuf.StringValueR\x05model\x1a\xa7\x02\n" +
 	"\aBedrock\x122\n" +
 	"\x05model\x18\x01 \x01(\v2\x1c.google.protobuf.StringValueR\x05model\x12\x16\n" +
 	"\x06region\x18\x02 \x01(\tR\x06region\x12O\n" +
 	"\x14guardrail_identifier\x18\x03 \x01(\v2\x1c.google.protobuf.StringValueR\x13guardrailIdentifier\x12I\n" +
-	"\x11guardrail_version\x18\x04 \x01(\v2\x1c.google.protobuf.StringValueR\x10guardrailVersion\x1a\x94\x01\n" +
+	"\x11guardrail_version\x18\x04 \x01(\v2\x1c.google.protobuf.StringValueR\x10guardrailVersion\x124\n" +
+	"\x16anthropic_beta_headers\x18\x05 \x03(\tR\x14anthropicBetaHeaders\x1a\x94\x01\n" +
 	"\vAzureOpenAI\x122\n" +
 	"\x05model\x18\x01 \x01(\v2\x1c.google.protobuf.StringValueR\x05model\x12\x12\n" +
 	"\x04host\x18\x02 \x01(\tR\x04host\x12=\n" +

--- a/schema/README.md
+++ b/schema/README.md
@@ -223,6 +223,7 @@ This folder contains JSON schemas for various parts of the project
 |`binds[].listeners[].routes[].policies.ai.promptCaching.cacheMessages`||
 |`binds[].listeners[].routes[].policies.ai.promptCaching.cacheTools`||
 |`binds[].listeners[].routes[].policies.ai.promptCaching.minTokens`||
+|`binds[].listeners[].routes[].policies.ai.anthropicBetaAllowlist`||
 |`binds[].listeners[].routes[].policies.backendTLS`|Send TLS to the backend.|
 |`binds[].listeners[].routes[].policies.backendTLS.cert`||
 |`binds[].listeners[].routes[].policies.backendTLS.key`||
@@ -497,6 +498,7 @@ This folder contains JSON schemas for various parts of the project
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptCaching.cacheMessages`||
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptCaching.cacheTools`||
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptCaching.minTokens`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.anthropicBetaAllowlist`||
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.backendTLS`|Send TLS to the backend.|
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.backendTLS.cert`||
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.backendTLS.key`||
@@ -652,6 +654,7 @@ This folder contains JSON schemas for various parts of the project
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptCaching.cacheMessages`||
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptCaching.cacheTools`||
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptCaching.minTokens`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.anthropicBetaAllowlist`||
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.backendTLS`|Send TLS to the backend.|
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.backendTLS.cert`||
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.backendTLS.key`||
@@ -781,6 +784,7 @@ This folder contains JSON schemas for various parts of the project
 |`binds[].listeners[].routes[].backends[].policies.ai.promptCaching.cacheMessages`||
 |`binds[].listeners[].routes[].backends[].policies.ai.promptCaching.cacheTools`||
 |`binds[].listeners[].routes[].backends[].policies.ai.promptCaching.minTokens`||
+|`binds[].listeners[].routes[].backends[].policies.ai.anthropicBetaAllowlist`||
 |`binds[].listeners[].routes[].backends[].policies.backendTLS`|Send TLS to the backend.|
 |`binds[].listeners[].routes[].backends[].policies.backendTLS.cert`||
 |`binds[].listeners[].routes[].backends[].policies.backendTLS.key`||
@@ -1078,6 +1082,7 @@ This folder contains JSON schemas for various parts of the project
 |`policies[].policy.ai.promptCaching.cacheMessages`||
 |`policies[].policy.ai.promptCaching.cacheTools`||
 |`policies[].policy.ai.promptCaching.minTokens`||
+|`policies[].policy.ai.anthropicBetaAllowlist`||
 |`policies[].policy.backendTLS`|Send TLS to the backend.|
 |`policies[].policy.backendTLS.cert`||
 |`policies[].policy.backendTLS.key`||

--- a/schema/local.json
+++ b/schema/local.json
@@ -1927,6 +1927,12 @@
                                   }
                                 },
                                 "additionalProperties": false
+                              },
+                              "anthropicBetaAllowlist": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
                               }
                             },
                             "additionalProperties": false,
@@ -4031,6 +4037,12 @@
                                         }
                                       },
                                       "additionalProperties": false
+                                    },
+                                    "anthropicBetaAllowlist": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
                                     }
                                   },
                                   "additionalProperties": false,
@@ -5717,6 +5729,12 @@
                                                     }
                                                   },
                                                   "additionalProperties": false
+                                                },
+                                                "anthropicBetaAllowlist": {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "string"
+                                                  }
                                                 }
                                               },
                                               "additionalProperties": false,
@@ -7153,6 +7171,12 @@
                                                                 }
                                                               },
                                                               "additionalProperties": false
+                                                            },
+                                                            "anthropicBetaAllowlist": {
+                                                              "type": "array",
+                                                              "items": {
+                                                                "type": "string"
+                                                              }
                                                             }
                                                           },
                                                           "additionalProperties": false,
@@ -9968,6 +9992,12 @@
                       }
                     },
                     "additionalProperties": false
+                  },
+                  "anthropicBetaAllowlist": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
                   }
                 },
                 "additionalProperties": false,


### PR DESCRIPTION
Add optional anthropic_beta_headers configuration field to Bedrock provider to control which anthropic-beta features are allowed through to Bedrock's Converse API.

When configured with a list of features, only headers matching the allowlist are translated to Bedrock's additionalModelRequestFields.anthropic_beta array. When not configured (None), all anthropic-beta headers pass through without filtering, maintaining backward compatibility and forward compatibility with future beta features.

Changes:
- Add anthropic_beta_headers field to Bedrock provider proto and struct
- Implement allowlist filtering in extract_beta_headers function
- Add XDS configuration mapping for runtime configuration
- Add test coverage for allowlist filtering behavior
- Regenerate Go protobuf bindings and JSON schema