### PR TITLE
local config: refactor to avoid needing to duplicate objects

### DIFF
--- a/crates/agentgateway/src/http/ext_authz.rs
+++ b/crates/agentgateway/src/http/ext_authz.rs
@@ -38,7 +38,7 @@ pub struct ExtAuthzDynamicMetadata {
 	pub metadata: HashMap<String, JsonValue>,
 }
 
-#[apply(schema_ser!)]
+#[apply(schema!)]
 pub struct BodyOptions {
 	/// Maximum size of request body to buffer (default: 8192)
 	#[serde(default)]
@@ -61,7 +61,7 @@ impl Default for BodyOptions {
 	}
 }
 
-#[apply(schema_ser!)]
+#[apply(schema!)]
 #[derive(Default)]
 pub enum FailureMode {
 	Allow,
@@ -70,9 +70,10 @@ pub enum FailureMode {
 	DenyWithStatus(u16),
 }
 
-#[apply(schema_ser!)]
+#[apply(schema!)]
 pub struct ExtAuthz {
 	/// Reference to the external authorization service backend
+	#[serde(flatten)]
 	pub target: Arc<SimpleBackendReference>,
 	/// Additional context to send to the authorization service.
 	/// This maps to the `context_extensions` field of the request, and only allows static values.

--- a/crates/agentgateway/src/http/ext_proc.rs
+++ b/crates/agentgateway/src/http/ext_proc.rs
@@ -118,8 +118,9 @@ impl InferencePoolRouter {
 	}
 }
 
-#[apply(schema_ser!)]
+#[apply(schema!)]
 pub struct ExtProc {
+	#[serde(flatten)]
 	pub target: Arc<SimpleBackendReference>,
 	#[serde(default)]
 	pub failure_mode: FailureMode,

--- a/crates/agentgateway/src/http/filters.rs
+++ b/crates/agentgateway/src/http/filters.rs
@@ -154,8 +154,7 @@ impl DirectResponse {
 	}
 }
 
-#[derive(Debug, Clone, serde::Serialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[apply(schema!)]
 pub struct RequestMirror {
 	pub backend: SimpleBackendReference,
 	// 0.0-1.0

--- a/crates/agentgateway/src/http/remoteratelimit.rs
+++ b/crates/agentgateway/src/http/remoteratelimit.rs
@@ -18,10 +18,10 @@ pub mod proto {
 	tonic::include_proto!("envoy.service.ratelimit.v3");
 }
 
-#[derive(Debug, Clone, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
+#[apply(schema!)]
 pub struct RemoteRateLimit {
 	pub domain: String,
+	#[serde(flatten)]
 	pub target: Arc<SimpleBackendReference>,
 	pub descriptors: Arc<DescriptorSet>,
 }

--- a/crates/agentgateway/src/proxy/mod.rs
+++ b/crates/agentgateway/src/proxy/mod.rs
@@ -323,6 +323,10 @@ pub fn resolve_simple_backend_with_policies(
 				be.inline_policies.clone(),
 			)
 		},
+		SimpleBackendReference::InlineBackend(t) => (
+			SimpleBackend::Opaque(t.to_string().into(), t.clone()),
+			Vec::default(),
+		),
 		SimpleBackendReference::Invalid => (SimpleBackend::Invalid, Vec::default()),
 	};
 	Ok(backend)

--- a/schema/README.md
+++ b/schema/README.md
@@ -123,7 +123,8 @@ This folder contains JSON schemas for various parts of the project
 |`binds[].listeners[].routes[].policies.requestMirror.backend.(1)service.name.namespace`||
 |`binds[].listeners[].routes[].policies.requestMirror.backend.(1)service.name.hostname`||
 |`binds[].listeners[].routes[].policies.requestMirror.backend.(1)service.port`||
-|`binds[].listeners[].routes[].policies.requestMirror.backend.(1)host`||
+|`binds[].listeners[].routes[].policies.requestMirror.backend.(1)host`|Hostname or IP address|
+|`binds[].listeners[].routes[].policies.requestMirror.backend.(1)backend`|Explicit backend reference. Backend must be defined in the top level backends list|
 |`binds[].listeners[].routes[].policies.requestMirror.percentage`||
 |`binds[].listeners[].routes[].policies.directResponse`|Directly respond to the request with a static response.|
 |`binds[].listeners[].routes[].policies.directResponse.body`||
@@ -264,7 +265,8 @@ This folder contains JSON schemas for various parts of the project
 |`binds[].listeners[].routes[].policies.remoteRateLimit.(any)(1)service.name.namespace`||
 |`binds[].listeners[].routes[].policies.remoteRateLimit.(any)(1)service.name.hostname`||
 |`binds[].listeners[].routes[].policies.remoteRateLimit.(any)(1)service.port`||
-|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)(1)host`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)(1)host`|Hostname or IP address|
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)(1)backend`|Explicit backend reference. Backend must be defined in the top level backends list|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.(any)domain`||
 |`binds[].listeners[].routes[].policies.remoteRateLimit.(any)descriptors`||
 |`binds[].listeners[].routes[].policies.remoteRateLimit.(any)descriptors[].entries`||
@@ -301,11 +303,13 @@ This folder contains JSON schemas for various parts of the project
 |`binds[].listeners[].routes[].policies.extAuthz.(any)(1)service.name.namespace`||
 |`binds[].listeners[].routes[].policies.extAuthz.(any)(1)service.name.hostname`||
 |`binds[].listeners[].routes[].policies.extAuthz.(any)(1)service.port`||
-|`binds[].listeners[].routes[].policies.extAuthz.(any)(1)host`||
-|`binds[].listeners[].routes[].policies.extAuthz.(any)context`||
-|`binds[].listeners[].routes[].policies.extAuthz.(any)metadata`||
-|`binds[].listeners[].routes[].policies.extAuthz.(any)failOpen`||
-|`binds[].listeners[].routes[].policies.extAuthz.(any)statusOnError`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)(1)host`|Hostname or IP address|
+|`binds[].listeners[].routes[].policies.extAuthz.(any)(1)backend`|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].policies.extAuthz.(any)context`|Additional context to send to the authorization service.<br>This maps to the `context_extensions` field of the request, and only allows static values.|
+|`binds[].listeners[].routes[].policies.extAuthz.(any)metadata`|Additional metadata to send to the authorization service.<br>This maps to the `metadata_context.filter_metadata` field of the request, and allows dynamic CEL expressions.<br>If unset, by default the `envoy.filters.http.jwt_authn` key is set if the JWT policy is used as well, for compatibility.|
+|`binds[].listeners[].routes[].policies.extAuthz.(any)failureMode`|Behavior when the authorization service is unavailable or returns an error|
+|`binds[].listeners[].routes[].policies.extAuthz.(any)failureMode.(1)denyWithStatus`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)includeRequestHeaders`|Specific headers to include in the authorization request (empty = all headers)|
 |`binds[].listeners[].routes[].policies.extAuthz.(any)includeRequestBody`|Options for including the request body in the authorization request|
 |`binds[].listeners[].routes[].policies.extAuthz.(any)includeRequestBody.maxRequestBytes`|Maximum size of request body to buffer (default: 8192)|
 |`binds[].listeners[].routes[].policies.extAuthz.(any)includeRequestBody.allowPartialMessage`|If true, send partial body when max_request_bytes is reached|
@@ -317,7 +321,8 @@ This folder contains JSON schemas for various parts of the project
 |`binds[].listeners[].routes[].policies.extProc.(any)(1)service.name.namespace`||
 |`binds[].listeners[].routes[].policies.extProc.(any)(1)service.name.hostname`||
 |`binds[].listeners[].routes[].policies.extProc.(any)(1)service.port`||
-|`binds[].listeners[].routes[].policies.extProc.(any)(1)host`||
+|`binds[].listeners[].routes[].policies.extProc.(any)(1)host`|Hostname or IP address|
+|`binds[].listeners[].routes[].policies.extProc.(any)(1)backend`|Explicit backend reference. Backend must be defined in the top level backends list|
 |`binds[].listeners[].routes[].policies.extProc.(any)failureMode`||
 |`binds[].listeners[].routes[].policies.transformations`|Modify requests and responses|
 |`binds[].listeners[].routes[].policies.transformations.request`||
@@ -823,7 +828,8 @@ This folder contains JSON schemas for various parts of the project
 |`binds[].listeners[].tcpRoutes[].backends[].(1)service.name.namespace`||
 |`binds[].listeners[].tcpRoutes[].backends[].(1)service.name.hostname`||
 |`binds[].listeners[].tcpRoutes[].backends[].(1)service.port`||
-|`binds[].listeners[].tcpRoutes[].backends[].(1)host`||
+|`binds[].listeners[].tcpRoutes[].backends[].(1)host`|Hostname or IP address|
+|`binds[].listeners[].tcpRoutes[].backends[].(1)backend`|Explicit backend reference. Backend must be defined in the top level backends list|
 |`binds[].listeners[].tcpRoutes[].backends[].weight`||
 |`binds[].listeners[].tcpRoutes[].backends[].policies`||
 |`binds[].listeners[].tcpRoutes[].backends[].policies.backendTLS`|Send TLS to the backend.|
@@ -855,11 +861,13 @@ This folder contains JSON schemas for various parts of the project
 |`binds[].listeners[].policies.extAuthz.(any)(1)service.name.namespace`||
 |`binds[].listeners[].policies.extAuthz.(any)(1)service.name.hostname`||
 |`binds[].listeners[].policies.extAuthz.(any)(1)service.port`||
-|`binds[].listeners[].policies.extAuthz.(any)(1)host`||
-|`binds[].listeners[].policies.extAuthz.(any)context`||
-|`binds[].listeners[].policies.extAuthz.(any)metadata`||
-|`binds[].listeners[].policies.extAuthz.(any)failOpen`||
-|`binds[].listeners[].policies.extAuthz.(any)statusOnError`||
+|`binds[].listeners[].policies.extAuthz.(any)(1)host`|Hostname or IP address|
+|`binds[].listeners[].policies.extAuthz.(any)(1)backend`|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].policies.extAuthz.(any)context`|Additional context to send to the authorization service.<br>This maps to the `context_extensions` field of the request, and only allows static values.|
+|`binds[].listeners[].policies.extAuthz.(any)metadata`|Additional metadata to send to the authorization service.<br>This maps to the `metadata_context.filter_metadata` field of the request, and allows dynamic CEL expressions.<br>If unset, by default the `envoy.filters.http.jwt_authn` key is set if the JWT policy is used as well, for compatibility.|
+|`binds[].listeners[].policies.extAuthz.(any)failureMode`|Behavior when the authorization service is unavailable or returns an error|
+|`binds[].listeners[].policies.extAuthz.(any)failureMode.(1)denyWithStatus`||
+|`binds[].listeners[].policies.extAuthz.(any)includeRequestHeaders`|Specific headers to include in the authorization request (empty = all headers)|
 |`binds[].listeners[].policies.extAuthz.(any)includeRequestBody`|Options for including the request body in the authorization request|
 |`binds[].listeners[].policies.extAuthz.(any)includeRequestBody.maxRequestBytes`|Maximum size of request body to buffer (default: 8192)|
 |`binds[].listeners[].policies.extAuthz.(any)includeRequestBody.allowPartialMessage`|If true, send partial body when max_request_bytes is reached|
@@ -871,7 +879,8 @@ This folder contains JSON schemas for various parts of the project
 |`binds[].listeners[].policies.extProc.(any)(1)service.name.namespace`||
 |`binds[].listeners[].policies.extProc.(any)(1)service.name.hostname`||
 |`binds[].listeners[].policies.extProc.(any)(1)service.port`||
-|`binds[].listeners[].policies.extProc.(any)(1)host`||
+|`binds[].listeners[].policies.extProc.(any)(1)host`|Hostname or IP address|
+|`binds[].listeners[].policies.extProc.(any)(1)backend`|Explicit backend reference. Backend must be defined in the top level backends list|
 |`binds[].listeners[].policies.extProc.(any)failureMode`||
 |`binds[].listeners[].policies.transformations`|Modify requests and responses|
 |`binds[].listeners[].policies.transformations.request`||
@@ -962,7 +971,8 @@ This folder contains JSON schemas for various parts of the project
 |`policies[].policy.requestMirror.backend.(1)service.name.namespace`||
 |`policies[].policy.requestMirror.backend.(1)service.name.hostname`||
 |`policies[].policy.requestMirror.backend.(1)service.port`||
-|`policies[].policy.requestMirror.backend.(1)host`||
+|`policies[].policy.requestMirror.backend.(1)host`|Hostname or IP address|
+|`policies[].policy.requestMirror.backend.(1)backend`|Explicit backend reference. Backend must be defined in the top level backends list|
 |`policies[].policy.requestMirror.percentage`||
 |`policies[].policy.directResponse`|Directly respond to the request with a static response.|
 |`policies[].policy.directResponse.body`||
@@ -1103,7 +1113,8 @@ This folder contains JSON schemas for various parts of the project
 |`policies[].policy.remoteRateLimit.(any)(1)service.name.namespace`||
 |`policies[].policy.remoteRateLimit.(any)(1)service.name.hostname`||
 |`policies[].policy.remoteRateLimit.(any)(1)service.port`||
-|`policies[].policy.remoteRateLimit.(any)(1)host`||
+|`policies[].policy.remoteRateLimit.(any)(1)host`|Hostname or IP address|
+|`policies[].policy.remoteRateLimit.(any)(1)backend`|Explicit backend reference. Backend must be defined in the top level backends list|
 |`policies[].policy.remoteRateLimit.(any)domain`||
 |`policies[].policy.remoteRateLimit.(any)descriptors`||
 |`policies[].policy.remoteRateLimit.(any)descriptors[].entries`||
@@ -1140,11 +1151,13 @@ This folder contains JSON schemas for various parts of the project
 |`policies[].policy.extAuthz.(any)(1)service.name.namespace`||
 |`policies[].policy.extAuthz.(any)(1)service.name.hostname`||
 |`policies[].policy.extAuthz.(any)(1)service.port`||
-|`policies[].policy.extAuthz.(any)(1)host`||
-|`policies[].policy.extAuthz.(any)context`||
-|`policies[].policy.extAuthz.(any)metadata`||
-|`policies[].policy.extAuthz.(any)failOpen`||
-|`policies[].policy.extAuthz.(any)statusOnError`||
+|`policies[].policy.extAuthz.(any)(1)host`|Hostname or IP address|
+|`policies[].policy.extAuthz.(any)(1)backend`|Explicit backend reference. Backend must be defined in the top level backends list|
+|`policies[].policy.extAuthz.(any)context`|Additional context to send to the authorization service.<br>This maps to the `context_extensions` field of the request, and only allows static values.|
+|`policies[].policy.extAuthz.(any)metadata`|Additional metadata to send to the authorization service.<br>This maps to the `metadata_context.filter_metadata` field of the request, and allows dynamic CEL expressions.<br>If unset, by default the `envoy.filters.http.jwt_authn` key is set if the JWT policy is used as well, for compatibility.|
+|`policies[].policy.extAuthz.(any)failureMode`|Behavior when the authorization service is unavailable or returns an error|
+|`policies[].policy.extAuthz.(any)failureMode.(1)denyWithStatus`||
+|`policies[].policy.extAuthz.(any)includeRequestHeaders`|Specific headers to include in the authorization request (empty = all headers)|
 |`policies[].policy.extAuthz.(any)includeRequestBody`|Options for including the request body in the authorization request|
 |`policies[].policy.extAuthz.(any)includeRequestBody.maxRequestBytes`|Maximum size of request body to buffer (default: 8192)|
 |`policies[].policy.extAuthz.(any)includeRequestBody.allowPartialMessage`|If true, send partial body when max_request_bytes is reached|
@@ -1156,7 +1169,8 @@ This folder contains JSON schemas for various parts of the project
 |`policies[].policy.extProc.(any)(1)service.name.namespace`||
 |`policies[].policy.extProc.(any)(1)service.name.hostname`||
 |`policies[].policy.extProc.(any)(1)service.port`||
-|`policies[].policy.extProc.(any)(1)host`||
+|`policies[].policy.extProc.(any)(1)host`|Hostname or IP address|
+|`policies[].policy.extProc.(any)(1)backend`|Explicit backend reference. Backend must be defined in the top level backends list|
 |`policies[].policy.extProc.(any)failureMode`||
 |`policies[].policy.transformations`|Modify requests and responses|
 |`policies[].policy.transformations.request`||

--- a/schema/local.json
+++ b/schema/local.json
@@ -964,6 +964,7 @@
                                     ]
                                   },
                                   {
+                                    "description": "Service reference. Service must be defined in the top level services list.",
                                     "type": "object",
                                     "properties": {
                                       "service": {
@@ -1004,14 +1005,29 @@
                                     "additionalProperties": false
                                   },
                                   {
+                                    "description": "Hostname or IP address",
                                     "type": "object",
                                     "properties": {
                                       "host": {
+                                        "description": "Hostname or IP address",
                                         "type": "string"
                                       }
                                     },
                                     "required": [
                                       "host"
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "backend": {
+                                        "description": "Explicit backend reference. Backend must be defined in the top level backends list",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "backend"
                                     ],
                                     "additionalProperties": false
                                   }
@@ -1026,7 +1042,8 @@
                             "required": [
                               "backend",
                               "percentage"
-                            ]
+                            ],
+                            "default": null
                           },
                           "directResponse": {
                             "description": "Directly respond to the request with a static response.",
@@ -2283,6 +2300,7 @@
                                     ]
                                   },
                                   {
+                                    "description": "Service reference. Service must be defined in the top level services list.",
                                     "type": "object",
                                     "properties": {
                                       "service": {
@@ -2322,14 +2340,28 @@
                                     ]
                                   },
                                   {
+                                    "description": "Hostname or IP address",
                                     "type": "object",
                                     "properties": {
                                       "host": {
+                                        "description": "Hostname or IP address",
                                         "type": "string"
                                       }
                                     },
                                     "required": [
                                       "host"
+                                    ]
+                                  },
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "backend": {
+                                        "description": "Explicit backend reference. Backend must be defined in the top level backends list",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "backend"
                                     ]
                                   }
                                 ]
@@ -2337,7 +2369,8 @@
                               {
                                 "type": "null"
                               }
-                            ]
+                            ],
+                            "default": null
                           },
                           "jwtAuth": {
                             "description": "Authenticate incoming JWT requests.",
@@ -2614,6 +2647,7 @@
                                 "type": "object",
                                 "properties": {
                                   "context": {
+                                    "description": "Additional context to send to the authorization service.\nThis maps to the `context_extensions` field of the request, and only allows static values.",
                                     "type": [
                                       "object",
                                       "null"
@@ -2623,6 +2657,7 @@
                                     }
                                   },
                                   "metadata": {
+                                    "description": "Additional metadata to send to the authorization service.\nThis maps to the `metadata_context.filter_metadata` field of the request, and allows dynamic CEL expressions.\nIf unset, by default the `envoy.filters.http.jwt_authn` key is set if the JWT policy is used as well, for compatibility.",
                                     "type": [
                                       "object",
                                       "null"
@@ -2631,21 +2666,40 @@
                                       "type": "string"
                                     }
                                   },
-                                  "failOpen": {
-                                    "type": [
-                                      "boolean",
-                                      "null"
+                                  "failureMode": {
+                                    "description": "Behavior when the authorization service is unavailable or returns an error",
+                                    "oneOf": [
+                                      {
+                                        "type": "string",
+                                        "enum": [
+                                          "allow",
+                                          "deny"
+                                        ]
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "denyWithStatus": {
+                                            "type": "integer",
+                                            "format": "uint16",
+                                            "minimum": 0,
+                                            "maximum": 65535
+                                          }
+                                        },
+                                        "required": [
+                                          "denyWithStatus"
+                                        ],
+                                        "additionalProperties": false
+                                      }
                                     ],
-                                    "default": null
+                                    "default": "deny"
                                   },
-                                  "statusOnError": {
-                                    "type": [
-                                      "integer",
-                                      "null"
-                                    ],
-                                    "format": "uint16",
-                                    "minimum": 0,
-                                    "maximum": 65535
+                                  "includeRequestHeaders": {
+                                    "description": "Specific headers to include in the authorization request (empty = all headers)",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
                                   },
                                   "includeRequestBody": {
                                     "description": "Options for including the request body in the authorization request",
@@ -2691,6 +2745,7 @@
                                     ]
                                   },
                                   {
+                                    "description": "Service reference. Service must be defined in the top level services list.",
                                     "type": "object",
                                     "properties": {
                                       "service": {
@@ -2730,14 +2785,28 @@
                                     ]
                                   },
                                   {
+                                    "description": "Hostname or IP address",
                                     "type": "object",
                                     "properties": {
                                       "host": {
+                                        "description": "Hostname or IP address",
                                         "type": "string"
                                       }
                                     },
                                     "required": [
                                       "host"
+                                    ]
+                                  },
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "backend": {
+                                        "description": "Explicit backend reference. Backend must be defined in the top level backends list",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "backend"
                                     ]
                                   }
                                 ]
@@ -2745,7 +2814,8 @@
                               {
                                 "type": "null"
                               }
-                            ]
+                            ],
+                            "default": null
                           },
                           "extProc": {
                             "description": "Extend agentgateway with an external processor",
@@ -2771,6 +2841,7 @@
                                     ]
                                   },
                                   {
+                                    "description": "Service reference. Service must be defined in the top level services list.",
                                     "type": "object",
                                     "properties": {
                                       "service": {
@@ -2810,14 +2881,28 @@
                                     ]
                                   },
                                   {
+                                    "description": "Hostname or IP address",
                                     "type": "object",
                                     "properties": {
                                       "host": {
+                                        "description": "Hostname or IP address",
                                         "type": "string"
                                       }
                                     },
                                     "required": [
                                       "host"
+                                    ]
+                                  },
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "backend": {
+                                        "description": "Explicit backend reference. Backend must be defined in the top level backends list",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "backend"
                                     ]
                                   }
                                 ]
@@ -2825,7 +2910,8 @@
                               {
                                 "type": "null"
                               }
-                            ]
+                            ],
+                            "default": null
                           },
                           "transformations": {
                             "description": "Modify requests and responses",
@@ -7408,6 +7494,7 @@
                               ]
                             },
                             {
+                              "description": "Service reference. Service must be defined in the top level services list.",
                               "type": "object",
                               "properties": {
                                 "service": {
@@ -7447,14 +7534,28 @@
                               ]
                             },
                             {
+                              "description": "Hostname or IP address",
                               "type": "object",
                               "properties": {
                                 "host": {
+                                  "description": "Hostname or IP address",
                                   "type": "string"
                                 }
                               },
                               "required": [
                                 "host"
+                              ]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "backend": {
+                                  "description": "Explicit backend reference. Backend must be defined in the top level backends list",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "backend"
                               ]
                             }
                           ]
@@ -7643,6 +7744,7 @@
                           "type": "object",
                           "properties": {
                             "context": {
+                              "description": "Additional context to send to the authorization service.\nThis maps to the `context_extensions` field of the request, and only allows static values.",
                               "type": [
                                 "object",
                                 "null"
@@ -7652,6 +7754,7 @@
                               }
                             },
                             "metadata": {
+                              "description": "Additional metadata to send to the authorization service.\nThis maps to the `metadata_context.filter_metadata` field of the request, and allows dynamic CEL expressions.\nIf unset, by default the `envoy.filters.http.jwt_authn` key is set if the JWT policy is used as well, for compatibility.",
                               "type": [
                                 "object",
                                 "null"
@@ -7660,21 +7763,40 @@
                                 "type": "string"
                               }
                             },
-                            "failOpen": {
-                              "type": [
-                                "boolean",
-                                "null"
+                            "failureMode": {
+                              "description": "Behavior when the authorization service is unavailable or returns an error",
+                              "oneOf": [
+                                {
+                                  "type": "string",
+                                  "enum": [
+                                    "allow",
+                                    "deny"
+                                  ]
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "denyWithStatus": {
+                                      "type": "integer",
+                                      "format": "uint16",
+                                      "minimum": 0,
+                                      "maximum": 65535
+                                    }
+                                  },
+                                  "required": [
+                                    "denyWithStatus"
+                                  ],
+                                  "additionalProperties": false
+                                }
                               ],
-                              "default": null
+                              "default": "deny"
                             },
-                            "statusOnError": {
-                              "type": [
-                                "integer",
-                                "null"
-                              ],
-                              "format": "uint16",
-                              "minimum": 0,
-                              "maximum": 65535
+                            "includeRequestHeaders": {
+                              "description": "Specific headers to include in the authorization request (empty = all headers)",
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
                             },
                             "includeRequestBody": {
                               "description": "Options for including the request body in the authorization request",
@@ -7720,6 +7842,7 @@
                               ]
                             },
                             {
+                              "description": "Service reference. Service must be defined in the top level services list.",
                               "type": "object",
                               "properties": {
                                 "service": {
@@ -7759,14 +7882,28 @@
                               ]
                             },
                             {
+                              "description": "Hostname or IP address",
                               "type": "object",
                               "properties": {
                                 "host": {
+                                  "description": "Hostname or IP address",
                                   "type": "string"
                                 }
                               },
                               "required": [
                                 "host"
+                              ]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "backend": {
+                                  "description": "Explicit backend reference. Backend must be defined in the top level backends list",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "backend"
                               ]
                             }
                           ]
@@ -7774,7 +7911,8 @@
                         {
                           "type": "null"
                         }
-                      ]
+                      ],
+                      "default": null
                     },
                     "extProc": {
                       "description": "Extend agentgateway with an external processor",
@@ -7800,6 +7938,7 @@
                               ]
                             },
                             {
+                              "description": "Service reference. Service must be defined in the top level services list.",
                               "type": "object",
                               "properties": {
                                 "service": {
@@ -7839,14 +7978,28 @@
                               ]
                             },
                             {
+                              "description": "Hostname or IP address",
                               "type": "object",
                               "properties": {
                                 "host": {
+                                  "description": "Hostname or IP address",
                                   "type": "string"
                                 }
                               },
                               "required": [
                                 "host"
+                              ]
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "backend": {
+                                  "description": "Explicit backend reference. Backend must be defined in the top level backends list",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "backend"
                               ]
                             }
                           ]
@@ -7854,7 +8007,8 @@
                         {
                           "type": "null"
                         }
-                      ]
+                      ],
+                      "default": null
                     },
                     "transformations": {
                       "description": "Modify requests and responses",
@@ -8627,6 +8781,7 @@
                         ]
                       },
                       {
+                        "description": "Service reference. Service must be defined in the top level services list.",
                         "type": "object",
                         "properties": {
                           "service": {
@@ -8667,14 +8822,29 @@
                         "additionalProperties": false
                       },
                       {
+                        "description": "Hostname or IP address",
                         "type": "object",
                         "properties": {
                           "host": {
+                            "description": "Hostname or IP address",
                             "type": "string"
                           }
                         },
                         "required": [
                           "host"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "backend": {
+                            "description": "Explicit backend reference. Backend must be defined in the top level backends list",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "backend"
                         ],
                         "additionalProperties": false
                       }
@@ -8689,7 +8859,8 @@
                 "required": [
                   "backend",
                   "percentage"
-                ]
+                ],
+                "default": null
               },
               "directResponse": {
                 "description": "Directly respond to the request with a static response.",
@@ -9946,6 +10117,7 @@
                         ]
                       },
                       {
+                        "description": "Service reference. Service must be defined in the top level services list.",
                         "type": "object",
                         "properties": {
                           "service": {
@@ -9985,14 +10157,28 @@
                         ]
                       },
                       {
+                        "description": "Hostname or IP address",
                         "type": "object",
                         "properties": {
                           "host": {
+                            "description": "Hostname or IP address",
                             "type": "string"
                           }
                         },
                         "required": [
                           "host"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "backend": {
+                            "description": "Explicit backend reference. Backend must be defined in the top level backends list",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "backend"
                         ]
                       }
                     ]
@@ -10000,7 +10186,8 @@
                   {
                     "type": "null"
                   }
-                ]
+                ],
+                "default": null
               },
               "jwtAuth": {
                 "description": "Authenticate incoming JWT requests.",
@@ -10277,6 +10464,7 @@
                     "type": "object",
                     "properties": {
                       "context": {
+                        "description": "Additional context to send to the authorization service.\nThis maps to the `context_extensions` field of the request, and only allows static values.",
                         "type": [
                           "object",
                           "null"
@@ -10286,6 +10474,7 @@
                         }
                       },
                       "metadata": {
+                        "description": "Additional metadata to send to the authorization service.\nThis maps to the `metadata_context.filter_metadata` field of the request, and allows dynamic CEL expressions.\nIf unset, by default the `envoy.filters.http.jwt_authn` key is set if the JWT policy is used as well, for compatibility.",
                         "type": [
                           "object",
                           "null"
@@ -10294,21 +10483,40 @@
                           "type": "string"
                         }
                       },
-                      "failOpen": {
-                        "type": [
-                          "boolean",
-                          "null"
+                      "failureMode": {
+                        "description": "Behavior when the authorization service is unavailable or returns an error",
+                        "oneOf": [
+                          {
+                            "type": "string",
+                            "enum": [
+                              "allow",
+                              "deny"
+                            ]
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "denyWithStatus": {
+                                "type": "integer",
+                                "format": "uint16",
+                                "minimum": 0,
+                                "maximum": 65535
+                              }
+                            },
+                            "required": [
+                              "denyWithStatus"
+                            ],
+                            "additionalProperties": false
+                          }
                         ],
-                        "default": null
+                        "default": "deny"
                       },
-                      "statusOnError": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ],
-                        "format": "uint16",
-                        "minimum": 0,
-                        "maximum": 65535
+                      "includeRequestHeaders": {
+                        "description": "Specific headers to include in the authorization request (empty = all headers)",
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
                       },
                       "includeRequestBody": {
                         "description": "Options for including the request body in the authorization request",
@@ -10354,6 +10562,7 @@
                         ]
                       },
                       {
+                        "description": "Service reference. Service must be defined in the top level services list.",
                         "type": "object",
                         "properties": {
                           "service": {
@@ -10393,14 +10602,28 @@
                         ]
                       },
                       {
+                        "description": "Hostname or IP address",
                         "type": "object",
                         "properties": {
                           "host": {
+                            "description": "Hostname or IP address",
                             "type": "string"
                           }
                         },
                         "required": [
                           "host"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "backend": {
+                            "description": "Explicit backend reference. Backend must be defined in the top level backends list",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "backend"
                         ]
                       }
                     ]
@@ -10408,7 +10631,8 @@
                   {
                     "type": "null"
                   }
-                ]
+                ],
+                "default": null
               },
               "extProc": {
                 "description": "Extend agentgateway with an external processor",
@@ -10434,6 +10658,7 @@
                         ]
                       },
                       {
+                        "description": "Service reference. Service must be defined in the top level services list.",
                         "type": "object",
                         "properties": {
                           "service": {
@@ -10473,14 +10698,28 @@
                         ]
                       },
                       {
+                        "description": "Hostname or IP address",
                         "type": "object",
                         "properties": {
                           "host": {
+                            "description": "Hostname or IP address",
                             "type": "string"
                           }
                         },
                         "required": [
                           "host"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "backend": {
+                            "description": "Explicit backend reference. Backend must be defined in the top level backends list",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "backend"
                         ]
                       }
                     ]
@@ -10488,7 +10727,8 @@
                   {
                     "type": "null"
                   }
-                ]
+                ],
+                "default": null
               },
               "transformations": {
                 "description": "Modify requests and responses",


### PR DESCRIPTION
Instead of having a custom path, just allow an inline Backend as a first class citizen