### PR TITLE
mcp/openapi: handle compressed responses in tool calls

### DIFF
--- a/crates/agentgateway/src/mcp/upstream/openapi/mod.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/mod.rs
@@ -11,7 +11,6 @@ use rmcp::model::{ClientRequest, JsonObject, JsonRpcRequest, Tool};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
-use crate::json;
 use crate::mcp::mergestream;
 use crate::mcp::mergestream::Messages;
 use crate::mcp::upstream::{IncomingRequestContext, UpstreamError};

--- a/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
@@ -460,6 +460,42 @@ async fn test_call_tool_invalid_path_param_value() {
 }
 
 #[tokio::test]
+async fn test_call_tool_with_compressed_response() {
+	let (server, handler) = setup().await;
+
+	let user_id = "compressed-user";
+	let expected_response = json!({ "id": user_id, "name": "Compressed User", "data": "This is a longer response that benefits from compression" });
+
+	// Encode the response body with gzip
+	let response_json = serde_json::to_vec(&expected_response).unwrap();
+	let compressed_body = crate::http::compression::encode_body(&response_json, "gzip")
+		.await
+		.unwrap();
+
+	Mock::given(method("GET"))
+		.and(path(format!("/users/{user_id}")))
+		.respond_with(
+			ResponseTemplate::new(200)
+				.insert_header("Content-Encoding", "gzip")
+				.set_body_bytes(compressed_body),
+		)
+		.mount(&server)
+		.await;
+
+	let args = json!({ "path": { "user_id": user_id } });
+	let result = handler
+		.call_tool(
+			"get_user",
+			Some(args.as_object().unwrap().clone()),
+			&IncomingRequestContext::empty(),
+		)
+		.await;
+
+	assert!(result.is_ok());
+	assert_eq!(result.unwrap(), expected_response);
+}
+
+#[tokio::test]
 async fn test_normalize_url_path_empty_prefix() {
 	// Test the fix for double slash issue when prefix is empty (host/port config)
 	let result = super::normalize_url_path("", "/mqtt/healthcheck");


### PR DESCRIPTION
Add support for decompressing gzip/deflate/brotli responses in OpenAPI tool calls. Previously, compressed responses would fail to parse.

- Use HeaderMapExt to extract Content-Encoding header
- Decompress response body before JSON parsing
- Add test for gzip-compressed responses
Issue: https://github.com/agentgateway/agentgateway/issues/621