### PR TITLE
cel: accept invalid expressions and make them fail

### DIFF
--- a/crates/agentgateway/src/cel/functions.rs
+++ b/crates/agentgateway/src/cel/functions.rs
@@ -31,6 +31,7 @@ pub fn insert_all(ctx: &mut Context<'_>) {
 	ctx.add_function("random", || random_range(0.0..=1.0));
 	ctx.add_function("default", default);
 	ctx.add_function("regexReplace", regex_replace);
+	ctx.add_function("fail", fail);
 
 	// Using the go name, base64.encode is blocked by https://github.com/cel-rust/cel-rust/issues/103 (namespacing)
 	ctx.add_function("base64Encode", base64_encode);
@@ -176,6 +177,10 @@ fn must_map(v: Value) -> Result<Map, cel::ExecutionError> {
 		Value::Map(map) => Ok(map),
 		_ => Err(v.error_expected_type(ValueType::Map)),
 	}
+}
+
+fn fail(ftx: &FunctionContext, v: Arc<String>) -> ResolveResult {
+	Err(ftx.error(format!("fail() called: {v}")))
 }
 
 fn json_parse(ftx: &FunctionContext, v: Value) -> ResolveResult {

--- a/crates/agentgateway/src/cel/functions_tests.rs
+++ b/crates/agentgateway/src/cel/functions_tests.rs
@@ -5,7 +5,7 @@ use crate::cel::{ContextBuilder, Error, Expression};
 
 fn eval(expr: &str) -> Result<Value, Error> {
 	let mut cb = ContextBuilder::new();
-	let exp = Expression::new(expr)?;
+	let exp = Expression::new_strict(expr)?;
 	cb.register_expression(&exp);
 	let exec = cb.build()?;
 	exec.eval(&exp)

--- a/crates/agentgateway/src/cel/tests.rs
+++ b/crates/agentgateway/src/cel/tests.rs
@@ -10,7 +10,7 @@ use crate::http::Body;
 
 fn eval_request(expr: &str, req: crate::http::Request) -> Result<Value, Error> {
 	let mut cb = ContextBuilder::new();
-	let exp = Expression::new(expr)?;
+	let exp = Expression::new_strict(expr)?;
 	cb.register_expression(&exp);
 	cb.with_request(&req, "".to_string());
 	let exec = cb.build()?;
@@ -19,7 +19,7 @@ fn eval_request(expr: &str, req: crate::http::Request) -> Result<Value, Error> {
 
 #[test]
 fn test_eval() {
-	let expr = Arc::new(Expression::new(r#"request.method"#).unwrap());
+	let expr = Arc::new(Expression::new_strict(r#"request.method"#).unwrap());
 	let req = ::http::Request::builder()
 		.method(Method::GET)
 		.header("x-example", "value")
@@ -109,7 +109,7 @@ fn with_profiling(name: &str, f: impl FnOnce()) {
 #[divan::bench]
 #[cfg(target_family = "unix")]
 fn bench_lookup(b: Bencher) {
-	let expr = Arc::new(Expression::new(r#"request.method"#).unwrap());
+	let expr = Arc::new(Expression::new_strict(r#"request.method"#).unwrap());
 	let req = ::http::Request::builder()
 		.method(Method::GET)
 		.header("x-example", "value")
@@ -130,7 +130,7 @@ fn bench_lookup(b: Bencher) {
 #[divan::bench]
 fn bench_with_response(b: Bencher) {
 	let expr = Arc::new(
-		Expression::new(r#"response.status == 200 && response.headers["x-example"] == "value""#)
+		Expression::new_strict(r#"response.status == 200 && response.headers["x-example"] == "value""#)
 			.unwrap(),
 	);
 	b.with_inputs(|| {
@@ -152,7 +152,7 @@ fn bench_with_response(b: Bencher) {
 #[divan::bench]
 #[cfg(target_family = "unix")]
 fn benchmark_register_build(b: Bencher) {
-	let expr = Arc::new(Expression::new(r#"1 + 2 == 3"#).unwrap());
+	let expr = Arc::new(Expression::new_strict(r#"1 + 2 == 3"#).unwrap());
 	with_profiling("full", || {
 		b.with_inputs(|| {
 			::http::Response::builder()

--- a/crates/agentgateway/src/config.rs
+++ b/crates/agentgateway/src/config.rs
@@ -272,7 +272,7 @@ pub fn parse_config(contents: String, filename: Option<PathBuf>) -> anyhow::Resu
 							fields
 								.add
 								.iter()
-								.map(|(k, v)| cel::Expression::new(v).map(|v| (k.clone(), Arc::new(v))))
+								.map(|(k, v)| cel::Expression::new_strict(v).map(|v| (k.clone(), Arc::new(v))))
 								.collect::<Result<_, _>>()?,
 						),
 					})
@@ -283,14 +283,14 @@ pub fn parse_config(contents: String, filename: Option<PathBuf>) -> anyhow::Resu
 				.tracing
 				.as_ref()
 				.and_then(|t| t.random_sampling.as_ref().map(|c| c.0.as_str()))
-				.map(cel::Expression::new)
+				.map(cel::Expression::new_strict)
 				.transpose()?
 				.map(Arc::new),
 			client_sampling: raw
 				.tracing
 				.as_ref()
 				.and_then(|t| t.client_sampling.as_ref().map(|c| c.0.as_str()))
-				.map(cel::Expression::new)
+				.map(cel::Expression::new_strict)
 				.transpose()?
 				.map(Arc::new),
 		},
@@ -299,7 +299,7 @@ pub fn parse_config(contents: String, filename: Option<PathBuf>) -> anyhow::Resu
 				.logging
 				.as_ref()
 				.and_then(|l| l.filter.as_ref())
-				.map(cel::Expression::new)
+				.map(cel::Expression::new_strict)
 				.transpose()?
 				.map(Arc::new),
 			level: match raw.logging.as_ref().and_then(|l| l.level.as_ref()) {
@@ -322,7 +322,7 @@ pub fn parse_config(contents: String, filename: Option<PathBuf>) -> anyhow::Resu
 							fields
 								.add
 								.iter()
-								.map(|(k, v)| cel::Expression::new(v).map(|v| (k.clone(), Arc::new(v))))
+								.map(|(k, v)| cel::Expression::new_strict(v).map(|v| (k.clone(), Arc::new(v))))
 								.collect::<Result<_, _>>()?,
 						),
 					})
@@ -348,7 +348,7 @@ pub fn parse_config(contents: String, filename: Option<PathBuf>) -> anyhow::Resu
 							add: fields
 								.add
 								.iter()
-								.map(|(k, v)| cel::Expression::new(v).map(|v| (k.clone(), Arc::new(v))))
+								.map(|(k, v)| cel::Expression::new_strict(v).map(|v| (k.clone(), Arc::new(v))))
 								.collect::<Result<_, _>>()?,
 						})
 					})

--- a/crates/agentgateway/src/http/authorization.rs
+++ b/crates/agentgateway/src/http/authorization.rs
@@ -78,11 +78,6 @@ impl PolicySet {
 	pub fn new(allow: Vec<Arc<cel::Expression>>, deny: Vec<Arc<cel::Expression>>) -> Self {
 		Self { allow, deny }
 	}
-
-	pub fn add(&mut self, p: impl Into<String>) -> Result<(), cel::Error> {
-		self.allow.push(Arc::new(cel::Expression::new(p)?));
-		Ok(())
-	}
 }
 
 pub fn se_policies<S: Serializer>(t: &PolicySet, serializer: S) -> Result<S::Ok, S::Error> {
@@ -107,14 +102,14 @@ where
 				rule: RuleTypeSerde::Allow(allow),
 			}
 			| RuleSerde::PlainString(allow) => res.allow.push(
-				cel::Expression::new(&allow)
+				cel::Expression::new_strict(&allow)
 					.map(Arc::new)
 					.map_err(|e| serde::de::Error::custom(e.to_string()))?,
 			),
 			RuleSerde::Object {
 				rule: RuleTypeSerde::Deny(deny),
 			} => res.deny.push(
-				cel::Expression::new(deny)
+				cel::Expression::new_strict(deny)
 					.map(Arc::new)
 					.map_err(|e| serde::de::Error::custom(e.to_string()))?,
 			),

--- a/crates/agentgateway/src/http/authorization_tests.rs
+++ b/crates/agentgateway/src/http/authorization_tests.rs
@@ -13,7 +13,9 @@ use crate::mcp::{ResourceId, ResourceType};
 fn create_policy_set(policies: Vec<&str>) -> PolicySet {
 	let mut policy_set = PolicySet::default();
 	for p in policies.into_iter() {
-		policy_set.add(p).expect("Failed to parse policy");
+		policy_set
+			.allow
+			.push(Arc::new(cel::Expression::new_strict(p).unwrap()));
 	}
 	policy_set
 }

--- a/crates/agentgateway/src/http/remoteratelimit.rs
+++ b/crates/agentgateway/src/http/remoteratelimit.rs
@@ -57,7 +57,7 @@ where
 	let raw = Vec::<KV>::deserialize(deserializer)?;
 	let parsed: Vec<_> = raw
 		.into_iter()
-		.map(|i| cel::Expression::new(i.value).map(|v| Descriptor(i.key, v)))
+		.map(|i| cel::Expression::new_strict(i.value).map(|v| Descriptor(i.key, v)))
 		.collect::<Result<_, _>>()
 		.map_err(|e| serde::de::Error::custom(e.to_string()))?;
 	Ok(Arc::new(parsed))

--- a/crates/agentgateway/src/http/transformation_cel_tests.rs
+++ b/crates/agentgateway/src/http/transformation_cel_tests.rs
@@ -15,7 +15,7 @@ fn build<const N: usize>(items: [(&str, &str); N]) -> Transformation {
 		}),
 		response: None,
 	};
-	Transformation::try_from(c).unwrap()
+	Transformation::try_from_local_config(c, true).unwrap()
 }
 
 #[test]
@@ -50,7 +50,7 @@ async fn test_transformation_body() {
 			..Default::default()
 		}),
 	};
-	let xfm = Transformation::try_from(c).unwrap();
+	let xfm = Transformation::try_from_local_config(c, true).unwrap();
 	let mut ctx = ContextBuilder::new();
 	for e in xfm.expressions() {
 		ctx.register_expression(e)

--- a/crates/agentgateway/src/proxy/gateway_test.rs
+++ b/crates/agentgateway/src/proxy/gateway_test.rs
@@ -187,7 +187,7 @@ async fn direct_response() {
 		}),
 		request: None,
 	};
-	let xfm = Transformation::try_from(xfm).unwrap();
+	let xfm = Transformation::try_from_local_config(xfm, true).unwrap();
 	let bind = base_gateway(&mock).with_route(Route {
 		key: "route2".into(),
 		route_name: "route2".into(),


### PR DESCRIPTION
This provides better semantics for XDS servers: rather than dropping the entire config, we treat it as failed. So if I wanted to transform `x-foo: 'badexpr('`, x-foo would get stripped essentially -- just like if I hit a runtime error like `x-foo: some.field.that.does.not.exist`.