### PR TITLE
xds: accept invalid server TLS and reject at runtime

### DIFF
--- a/crates/agentgateway/src/proxy/gateway.rs
+++ b/crates/agentgateway/src/proxy/gateway.rs
@@ -8,6 +8,7 @@ use agent_core::drain;
 use agent_core::drain::{DrainUpgrader, DrainWatcher};
 use anyhow::anyhow;
 use bytes::Bytes;
+use futures::pin_mut;
 use futures_util::FutureExt;
 use http::StatusCode;
 use hyper_util::rt::TokioIo;
@@ -292,8 +293,14 @@ impl Gateway {
 			},
 			BindProtocol::tcp => Self::proxy_tcp(bind_name, inputs, None, raw_stream, drain).await,
 			BindProtocol::tls => {
-				match Self::maybe_terminate_tls(inputs.clone(), raw_stream, &policies, bind_name.clone())
-					.await
+				match Self::maybe_terminate_tls(
+					inputs.clone(),
+					raw_stream,
+					&policies,
+					bind_name.clone(),
+					false,
+				)
+				.await
 				{
 					Ok((selected_listener, stream)) => {
 						Self::proxy_tcp(bind_name, inputs, Some(selected_listener), stream, drain).await
@@ -306,7 +313,7 @@ impl Gateway {
 
 							src.addr = %peer_addr,
 							protocol = ?bind_protocol,
-							error = ?e,
+							error = ?e.to_string(),
 
 							"failed to terminate TLS",
 						);
@@ -314,8 +321,14 @@ impl Gateway {
 				}
 			},
 			BindProtocol::https => {
-				match Self::maybe_terminate_tls(inputs.clone(), raw_stream, &policies, bind_name.clone())
-					.await
+				match Self::maybe_terminate_tls(
+					inputs.clone(),
+					raw_stream,
+					&policies,
+					bind_name.clone(),
+					true,
+				)
+				.await
 				{
 					Ok((selected_listener, stream)) => {
 						let _ = Self::proxy(
@@ -336,7 +349,7 @@ impl Gateway {
 
 							src.addr = %peer_addr,
 							protocol = ?bind_protocol,
-							error = ?e,
+							error = ?e.to_string(),
 
 							"failed to terminate TLS",
 						);
@@ -478,6 +491,7 @@ impl Gateway {
 		raw_stream: Socket,
 		policies: &FrontendPolices,
 		bind: BindName,
+		is_https: bool,
 	) -> anyhow::Result<(Arc<Listener>, Socket)> {
 		let def = frontend::TLS::default();
 		let to = policies.tls.as_ref().unwrap_or(&def).tls_handshake_timeout;
@@ -488,8 +502,24 @@ impl Gateway {
 			let inner = Socket::new_rewind(inner);
 			let acceptor =
 				tokio_rustls::LazyConfigAcceptor::new(rustls::server::Acceptor::default(), inner);
+			pin_mut!(acceptor);
 			let tls_start = std::time::Instant::now();
-			let mut start = acceptor.await?;
+			let mut start = match acceptor.as_mut().await {
+				Ok(start) => start,
+				Err(e) => {
+					if is_https
+						&& let Some(io) = acceptor.take_io()
+						&& let Some(data) = io.buffered()
+						&& tls_looks_like_http(data)
+					{
+						anyhow::bail!("client sent an HTTP request to an HTTPS listener: {e}");
+						// TODO(https://github.com/rustls/tokio-rustls/pull/147): write
+						// let _ = io.write_all(b"HTTP/1.0 400 Bad Request\r\n\r\nclient sent an HTTP request to an HTTPS listener\n").await;
+						// let _ = io.shutdown().await;
+					}
+					anyhow::bail!(e);
+				},
+			};
 			let ch = start.client_hello();
 			let sni = ch.server_name().unwrap_or_default();
 			let best = listeners
@@ -498,7 +528,7 @@ impl Gateway {
 			match best.protocol.tls(alpn) {
 				Some(Err(e)) => {
 					// There is a TLS config for this listener, but its invalid. Reject the connection
-					return Err(e);
+					Err(e)
 				},
 				Some(Ok(cfg)) => {
 					let tokio_rustls::StartHandshake { accepted, io, .. } = start;
@@ -622,6 +652,15 @@ impl Gateway {
 		)
 		.await;
 	}
+}
+
+fn tls_looks_like_http(d: Bytes) -> bool {
+	d.starts_with(b"GET /")
+		|| d.starts_with(b"POST /")
+		|| d.starts_with(b"HEAD /")
+		|| d.starts_with(b"PUT /")
+		|| d.starts_with(b"OPTIONS /")
+		|| d.starts_with(b"DELETE /")
 }
 
 fn bind_protocol(inp: Arc<ProxyInputs>, bind: BindName) -> BindProtocol {

--- a/crates/agentgateway/src/transport/rewind.rs
+++ b/crates/agentgateway/src/transport/rewind.rs
@@ -24,6 +24,14 @@ impl RewindSocket {
 		}
 	}
 
+	pub fn buffered(&self) -> Option<Bytes> {
+		if let State::Filling(b) = &self.state {
+			Some(b.clone().freeze())
+		} else {
+			None
+		}
+	}
+
 	pub fn rewind(&mut self) {
 		match std::mem::replace(&mut self.state, State::Draining(None)) {
 			State::Filling(b) => {

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -303,17 +303,9 @@ impl TryFrom<(proto::agent::Protocol, Option<&proto::agent::TlsConfig>)> for Lis
 		match (value.0, value.1) {
 			(Protocol::Unknown, _) => Err(ProtoError::EnumParse("unknown protocol".into())),
 			(Protocol::Http, None) => Ok(ListenerProtocol::HTTP),
-			(Protocol::Https, Some(tls)) => Ok(ListenerProtocol::HTTPS(
-				tls
-					.try_into()
-					.map_err(|e| ProtoError::Generic(format!("{e}")))?,
-			)),
+			(Protocol::Https, Some(tls)) => Ok(ListenerProtocol::HTTPS(tls.into())),
 			// TLS termination
-			(Protocol::Tls, Some(tls)) => Ok(ListenerProtocol::TLS(Some(
-				tls
-					.try_into()
-					.map_err(|e| ProtoError::Generic(format!("{e}")))?,
-			))),
+			(Protocol::Tls, Some(tls)) => Ok(ListenerProtocol::TLS(Some(tls.into()))),
 			// TLS passthrough
 			(Protocol::Tls, None) => Ok(ListenerProtocol::TLS(None)),
 			(Protocol::Tcp, None) => Ok(ListenerProtocol::TCP),


### PR DESCRIPTION
still need to do for backend