### PR TITLE
Add support for HTTP ext_authz, with oauth2_proxy example

### DIFF
--- a/crates/agentgateway/src/client/mod.rs
+++ b/crates/agentgateway/src/client/mod.rs
@@ -738,8 +738,16 @@ impl Client {
 
 			duration = dur,
 		);
-
 		let mut resp = resp?.map(http::Body::new);
+
+		event!(
+			target: "upstream response",
+			parent: None,
+			tracing::Level::TRACE,
+
+			response =?resp
+		);
+
 		resp
 			.extensions_mut()
 			.insert(transport::BufferLimit::new(buffer_limit));

--- a/crates/agentgateway/src/http/transformation_cel.rs
+++ b/crates/agentgateway/src/http/transformation_cel.rs
@@ -5,7 +5,8 @@ use ::http::StatusCode;
 use ::http::{HeaderName, HeaderValue, header};
 use agent_core::prelude::Strng;
 use cel::Value;
-use serde_with::{SerializeAs, serde_as};
+use serde_with::{DeserializeAs, SerializeAs, serde_as};
+use std::str::FromStr;
 
 #[derive(Default)]
 #[apply(schema_de!)]
@@ -137,6 +138,19 @@ where
 		S: Serializer,
 	{
 		source.as_ref().serialize(serializer)
+	}
+}
+impl<'de, T> DeserializeAs<'de, T> for SerAsStr
+where
+	T: FromStr,
+	<T as FromStr>::Err: std::fmt::Display,
+{
+	fn deserialize_as<D>(deserializer: D) -> Result<T, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		let s = <&str>::deserialize(deserializer)?;
+		s.parse().map_err(serde::de::Error::custom)
 	}
 }
 

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -192,6 +192,16 @@ impl RoutePolicies {
 		if let Some(rrl) = &self.authorization {
 			rrl.register(ctx)
 		};
+		if let Some(extauthz) = &self.ext_authz {
+			if let Some(m) = &extauthz.metadata {
+				for v in m.values() {
+					ctx.register_expression(v);
+				}
+			}
+			if let Some(e) = &extauthz.redirect {
+				ctx.register_expression(&e);
+			}
+		}
 	}
 }
 

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -984,6 +984,8 @@ impl TryFrom<&proto::agent::TrafficPolicySpec> for TrafficPolicy {
 					})
 					.collect::<Result<_, _>>()?;
 				TrafficPolicy::ExtAuthz(http::ext_authz::ExtAuthz {
+					protocol: Default::default(),
+					redirect: None,
 					target: Arc::new(target),
 					context: Some(ea.context.clone()),
 					metadata: if metadata.is_empty() {
@@ -992,6 +994,7 @@ impl TryFrom<&proto::agent::TrafficPolicySpec> for TrafficPolicy {
 						Some(metadata)
 					},
 					failure_mode,
+					include_response_headers: Vec::new(),
 					include_request_headers: ea
 						.include_request_headers
 						.iter()

--- a/examples/oauth2-proxy/config.yaml
+++ b/examples/oauth2-proxy/config.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=../../schema/local.json
+config: {}
+
+frontendPolicies:
+  accessLog:
+    add:
+      github.user: 'request.headers["x-auth-request-user"]'
+      github.email: 'request.headers["x-auth-request-email"]'
+binds:
+- port: 80
+  listeners:
+  - name: default
+    protocol: HTTP
+    routes:
+    # For traffic to the Oauth2 proxy, send to the proxy. This is used for signing in, etc.
+    - name: oauth2-proxy
+      matches:
+        - path:
+            pathPrefix: /oauth2
+      backends:
+      - host: localhost:4180
+    # All other traffic goes to our application
+    - name: application
+      policies:
+        extAuthz:
+          host: localhost:4180
+          # TODO: path
+          protocol: http
+          redirect: '"/oauth2/start?rd=/"'
+          includeResponseHeaders:
+            - x-auth-request-email
+            - x-auth-request-user
+
+      backends:
+      - host: localhost:8080

--- a/examples/oauth2-proxy/docker-compose.yaml
+++ b/examples/oauth2-proxy/docker-compose.yaml
@@ -1,0 +1,18 @@
+services:
+  oauth2-proxy:
+    image: quay.io/oauth2-proxy/oauth2-proxy:latest
+    container_name: oauth2-proxy
+    restart: unless-stopped
+    ports:
+    - "4180:4180"
+    command:
+    - --provider=github
+    - --email-domain=*
+    - --upstream=file:///dev/null
+    - --http-address=0.0.0.0:4180
+    - --set-xauthrequest
+    environment:
+      OAUTH2_PROXY_CLIENT_ID: ${OAUTH2_PROXY_CLIENT_ID}
+      OAUTH2_PROXY_CLIENT_SECRET: ${OAUTH2_PROXY_CLIENT_SECRET}
+      OAUTH2_PROXY_COOKIE_SECRET: ${OAUTH2_PROXY_COOKIE_SECRET}
+      OAUTH2_PROXY_COOKIE_SECURE: false


### PR DESCRIPTION
TODO:

- [x] Fix dummy host
- [x] Make it impossible to configure HTTP settings on gRPC and vise-versa
- [ ] Add xDS bindings
- [ ] check if response headers should be inserted or appended
- [ ] find a way to make the headers accessible to CEL
- [ ] Add readme to example