### PR TITLE
fix:  CEL executor for transformations to include extAuthz metadata

### DIFF
--- a/crates/agentgateway/src/cel/mod.rs
+++ b/crates/agentgateway/src/cel/mod.rs
@@ -225,9 +225,10 @@ impl ContextBuilder {
 		self.context.basic_auth = Some(info.clone())
 	}
 
-	pub fn with_extauthz(&mut self, req: &crate::http::Request) {
+	// returns true if there were any changes made
+	pub fn with_extauthz(&mut self, req: &crate::http::Request) -> bool {
 		if !self.attributes.contains(EXTAUTHZ_ATTRIBUTE) {
-			return;
+			return false;
 		}
 
 		// Extract dynamic metadata from ext_authz if present
@@ -245,6 +246,9 @@ impl ContextBuilder {
 					self.context.extauthz = Some(ext_authz_metadata.metadata.clone());
 				}
 			}
+			true
+		} else {
+			false
 		}
 	}
 

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -131,7 +131,13 @@ async fn apply_request_policies(
 	.apply(response_policies.headers())?;
 
 	if let Some(j) = &policies.transformation {
-		j.apply_request(req, build_ctx(&exec, log)?);
+		// Build fresh executor to include extAuthz data
+		let transform_exec = log
+			.cel
+			.ctx()
+			.build()
+			.map_err(|_| ProxyError::ProcessingString("failed to build cel context".to_string()))?;
+		j.apply_request(req, &transform_exec);
 	}
 
 	if let Some(csrf) = &policies.csrf {
@@ -282,7 +288,13 @@ async fn apply_gateway_policies(
 	.apply(response_headers)?;
 
 	if let Some(j) = &policies.transformation {
-		j.apply_request(req, build_ctx(&exec, log)?);
+		// Build fresh executor to include extAuthz data
+		let transform_exec = log
+			.cel
+			.ctx()
+			.build()
+			.map_err(|_| ProxyError::ProcessingString("failed to build cel context".to_string()))?;
+		j.apply_request(req, &transform_exec);
 	}
 
 	Ok(())


### PR DESCRIPTION
Fixes issue where CEL transformations cannot access extAuthz metadata because the shared executor is cached before extAuthz runs.

Problem:
- Shared CEL executor is built and cached via OnceCell before extAuthz runs
- ExtAuthz adds metadata to context after executor is cached
- Transformations use cached executor with null/missing extAuthz data

Solution:
Build fresh CEL executor for transformations after extAuthz has run, ensuring the executor includes updated context with extAuthz metadata.

Related: https://github.com/agentgateway/agentgateway/issues/650