### PR TITLE
Fix remote ratelimit header values

### DIFF
--- a/crates/agentgateway/src/http/remoteratelimit.rs
+++ b/crates/agentgateway/src/http/remoteratelimit.rs
@@ -331,10 +331,12 @@ fn process_headers(hm: &mut HeaderMap, headers: Vec<proto::HeaderValue>) {
 		let Ok(hn) = HeaderName::from_bytes(h.key.as_bytes()) else {
 			continue;
 		};
-		let hv = if h.raw_value.is_empty() {
-			HeaderValue::from_bytes(h.key.as_bytes())
-		} else {
+		let hv = if !h.value.is_empty() {
+			HeaderValue::from_bytes(h.value.as_bytes())
+		} else if !h.raw_value.is_empty() {
 			HeaderValue::from_bytes(&h.raw_value)
+		} else {
+			continue;
 		};
 		let Ok(hv) = hv else {
 			continue;


### PR DESCRIPTION
Hi!
I was testing the remote ratelimiting capabilities and discovered that the retry-after header was invalid, having the string value "Retry-After" instead of the actual seconds.

## Issue
External rate limiter was returning `retry-after: Retry-After` instead of the actual retry time in seconds.

The `process_headers` function only checked the `raw_value` field in the protobuf `HeaderValue`, but most rate limiters (including envoyproxy/ratelimit) set the `value` field instead. When `raw_value` was empty, the code fell back to using the header name as the value, which is why we got `retry-after: Retry-After`.

This applies to all response headers coming from the RateLimit service.

## Fix
Now checks the `value` field first, then falls back to `raw_value`. If both are empty, skip the header entirely.

### Before:
```
curl -i -k https://test.example.com:8443/mcp -H "ratelimit: true" \
  --resolve test.example.com:8443:127.0.0.1 \
  -H "Content-Type: application/json" \
  -H "Accept: application/json, text/event-stream" \
  -d '{
    "jsonrpc": "2.0",
    "method": "initialize",
    "params": {
      "protocolVersion": "2024-11-05",
      "capabilities": {},
      "clientInfo": {
        "name": "test-client",
        "version": "1.0.0"
      }
    },
    "id": 1
  }'
HTTP/1.1 429 Too Many Requests
retry-after: Retry-After
x-request-id: 0566cbb0-6505-4102-b919-003ddea49786
content-length: 0
date: Sun, 23 Nov 2025 18:23:53 GMT
```
### After
```
curl -i -k https://test.example.com:8443/mcp -H "ratelimit: true" \
  --resolve test.example.com:8443:127.0.0.1 \
  -H "Content-Type: application/json" \
  -H "Accept: application/json, text/event-stream" \
  -d '{
    "jsonrpc": "2.0",
    "method": "initialize",
    "params": {
      "protocolVersion": "2024-11-05",
      "capabilities": {},
      "clientInfo": {
        "name": "test-client",
        "version": "1.0.0"
      }
    },
    "id": 1
  }'
HTTP/1.1 429 Too Many Requests
retry-after: 2126
x-request-id: efe385f6-adc2-47ab-9779-384a732871b1
content-length: 0
date: Sun, 23 Nov 2025 18:24:34 GMT
```

