### PR TITLE
cel: reduce builds of the context when not needed

### DIFF
--- a/crates/agentgateway/src/http/transformation_cel.rs
+++ b/crates/agentgateway/src/http/transformation_cel.rs
@@ -227,8 +227,21 @@ impl<'a> RequestOrResponse<'a> {
 }
 
 impl Transformation {
+	pub fn has_request(&self) -> bool {
+		self.request.body.is_some()
+			|| !self.request.add.is_empty()
+			|| !self.request.set.is_empty()
+			|| !self.request.remove.is_empty()
+	}
 	pub fn apply_request(&self, req: &mut crate::http::Request, exec: &cel::Executor<'_>) {
 		Self::apply(req.into(), self.request.as_ref(), exec)
+	}
+
+	pub fn has_response(&self) -> bool {
+		self.response.body.is_some()
+			|| !self.response.add.is_empty()
+			|| !self.response.set.is_empty()
+			|| !self.response.remove.is_empty()
 	}
 
 	pub fn apply_response(&self, resp: &mut crate::http::Response, exec: &cel::Executor<'_>) {

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -1,5 +1,4 @@
 use std::net::SocketAddr;
-use std::ops::Deref;
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -133,10 +132,10 @@ async fn apply_request_policies(
 	}
 	.apply(response_policies.headers())?;
 
-	if let Some(j) = &policies.transformation {
-		if j.has_request() {
-			j.apply_request(req, build_ctx(&exec, log)?);
-		}
+	if let Some(j) = &policies.transformation
+		&& j.has_request()
+	{
+		j.apply_request(req, build_ctx(&exec, log)?);
 	}
 
 	if let Some(csrf) = &policies.csrf {
@@ -291,10 +290,10 @@ async fn apply_gateway_policies(
 	}
 	.apply(response_headers)?;
 
-	if let Some(j) = &policies.transformation {
-		if j.has_request() {
-			j.apply_request(req, build_ctx(&exec, log)?);
-		}
+	if let Some(j) = &policies.transformation
+		&& j.has_request()
+	{
+		j.apply_request(req, build_ctx(&exec, log)?);
 	}
 
 	Ok(())
@@ -1603,15 +1602,15 @@ impl ResponsePolicies {
 			rhm.apply(resp.headers_mut()).map_err(ProxyError::from)?;
 		}
 		let exec = once_cell::sync::OnceCell::new();
-		if let Some(j) = &self.transformation {
-			if j.has_response() {
-				j.apply_response(resp, build_ctx(&exec, log)?);
-			}
+		if let Some(j) = &self.transformation
+			&& j.has_response()
+		{
+			j.apply_response(resp, build_ctx(&exec, log)?);
 		}
-		if let Some(j) = &self.gateway_transformation {
-			if j.has_response() {
-				j.apply_response(resp, build_ctx(&exec, log)?);
-			}
+		if let Some(j) = &self.gateway_transformation
+			&& j.has_response()
+		{
+			j.apply_response(resp, build_ctx(&exec, log)?);
 		}
 
 		// ext_proc is only intended to run on responses from upstream


### PR DESCRIPTION
Before, if I had a request transformation, it would trigger the response to also build.