### PR TITLE
Fix MCP StreamableHTTP parsing errors for empty data fields 

### DIFF
--- a/crates/agentgateway/src/mcp/mergestream.rs
+++ b/crates/agentgateway/src/mcp/mergestream.rs
@@ -65,6 +65,7 @@ impl TryFrom<StreamableHttpPostResponse> for Messages {
 							.and_then(|item| {
 								item
 									.data
+									.filter(|data| !data.is_empty())
 									.map(|data| {
 										serde_json::from_str::<ServerJsonRpcMessage>(&data).map_err(ClientError::new)
 									})

--- a/crates/agentgateway/src/mcp/upstream/sse.rs
+++ b/crates/agentgateway/src/mcp/upstream/sse.rs
@@ -45,6 +45,9 @@ impl crate::mcp::upstream::stdio::MCPTransport for SseClient {
 			let Some(data) = raw.data else {
 				continue;
 			};
+			if data.is_empty() {
+				continue;
+			}
 			match serde_json::from_str::<ServerJsonRpcMessage>(&data) {
 				Err(e) => {
 					// Not a hard error, for now?


### PR DESCRIPTION
Hi, 
When testing Streamable HTTP with `@modelcontextprotocol/server-everything`, I discovered that agentgateway fails to parse responses that contain empty `data:` fields. The server sends responses like:

```
< HTTP/1.1 200 OK
< X-Powered-By: Express
< Access-Control-Allow-Origin: *
< Access-Control-Expose-Headers: mcp-session-id,last-event-id,mcp-protocol-version
< Content-Type: text/event-stream
< Cache-Control: no-cache
< Connection: keep-alive
< mcp-session-id: a9969752-79e6-47f4-acc6-3862404eb159
< Date: Thu, 27 Nov 2025 22:46:40 GMT
< Transfer-Encoding: chunked
<
id: 918fb472-19c9-40c2-8f63-40d3cf181c52_1764283600574_u8qieq1w
data:

event: message
id: 918fb472-19c9-40c2-8f63-40d3cf181c52_1764283600574_xj1103yy
data: {"result":{"protocolVersion":"2025-06-18","capabilities":{"prompts":{},"resources":{"subscribe":true},"tools":{},"logging":{},"completions":{}},"serverInfo":{"name":"example-servers/everything","title":"Everything Example Server","version":"1.0.0"},"instructions"...
```

This causes agentgateway to fail with:
```
"http request failed: EOF while parsing a value at line 1 column 0"
```

When processing StreamableHTTP responses, the code attempts to deserialize empty data fields as JSON, which fails since there's no content to parse. 

Empty data fields are valid in event streams and carry no payload, so they should be ignored by clients.

## Testing

Verified with curl requests through agentgateway that previously failed with EOF errors now successfully proxy MCP initialize requests to `mcp-server-everything`.
Before:
```
curl -i https://mcp.example.com:8443/mcp \
  -H "Content-Type: application/json" \
  -H "Accept: application/json, text/event-stream" \
  -d '{
    "jsonrpc": "2.0",
    "method": "initialize",
    "params": {
      "protocolVersion": "2025-06-18",
      "capabilities": {},
      "clientInfo": {
        "name": "test-client",
        "version": "1.0.0"
      }
    },
    "id": 1
  }'
HTTP/2 200
content-type: text/event-stream
cache-control: no-cache
date: Thu, 27 Nov 2025 22:54:49 GMT

data: {"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"http request failed: EOF while parsing a value at line 1 column 0"}}
```
After:
```
curl -i https://mcp.example.com:8443/mcp \
  -H "Content-Type: application/json" \
  -H "Accept: application/json, text/event-stream" \
  -d '{
    "jsonrpc": "2.0",
    "method": "initialize",
    "params": {
      "protocolVersion": "2025-06-18",
      "capabilities": {},
      "clientInfo": {
        "name": "test-client",
        "version": "1.0.0"
      }
    },
    "id": 1
  }'
HTTP/2 200
content-type: text/event-stream
cache-control: no-cache
date: Thu, 27 Nov 2025 23:26:27 GMT

data: {"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05","capabilities":{"prompts":{},"resources":{},"tools":{}},"serverInfo":{"name":"rmcp","version":"0.8.5"},"instructions":"This server is a gateway to a set of mcp servers. It is responsible for routing requests to the correct server and aggregating the results."}}
```