### PR TITLE
fix: support append semantics in prompt enrichment

### DIFF
--- a/crates/agentgateway/src/llm/policy.rs
+++ b/crates/agentgateway/src/llm/policy.rs
@@ -187,6 +187,7 @@ impl Policy {
 	pub fn apply_prompt_enrichment(&self, chat: &mut dyn RequestType) {
 		if let Some(prompts) = &self.prompts {
 			chat.prepend_prompts(prompts.prepend.clone());
+			chat.append_prompts(prompts.append.clone());
 		}
 	}
 


### PR DESCRIPTION
## Fix: #674 
Apply `append_prompts` alongside existing `prepend_prompts` to allow enriched system content to be merged at the end of the original prompt, ensuring correct prompt composition.