### PR TITLE
OpenAI realtime support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,6 +253,7 @@ dependencies = [
  "typespec_client_core",
  "url",
  "uuid 1.19.0",
+ "websocket-sans-io",
  "which 8.0.0",
  "wiremock",
  "x509-parser",
@@ -3922,6 +3923,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nonmax"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
+
+[[package]]
 name = "notify"
 version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7276,6 +7283,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2878ef029c47c6e8cf779119f20fcf52bde7ad42a731b2a304bc221df17571e"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "websocket-sans-io"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa5439c933ff8343c918c8a7f7f853937bafb79217068276359cb335ef9cd23b"
+dependencies = [
+ "nonmax",
+ "tinyvec",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ anyhow = "1.0"
 arc-swap = "1.7.1"
 arcstr = { version = "1.2", features = ["serde"] }
 assert_matches = "1.5.0"
-async-openai = { version = "0.32.2", default-features = false, features = ["chat-completion-types", "embedding-types", "moderation-types", "response-types"] }
+async-openai = { version = "0.32.2", default-features = false, features = ["chat-completion-types", "embedding-types", "moderation-types", "response-types", "realtime-types"] }
 async-stream = "0.3"
 async-trait = "0.1"
 aws-config = "1.8"
@@ -193,6 +193,7 @@ uuid = { version = "1.11", features = ["v4"] }
 wiremock = { version = "0.6", features = ["tls"] }
 x509-parser = { version = "0.18", default-features = false, features = ["verify-aws"] }
 which = "8.0"
+websocket-sans-io = '0.1'
 cel = { git = "https://github.com/cel-rust/cel-rust", rev = "5d2e19934db441ad7dd2eeca62da1b5b238f41f8", features = [
     "json",
     "regex",

--- a/crates/agentgateway/Cargo.toml
+++ b/crates/agentgateway/Cargo.toml
@@ -132,6 +132,7 @@ url.workspace = true
 uuid.workspace = true
 x509-parser.workspace = true
 reqwest = { optional = true, workspace = true }
+websocket-sans-io.workspace = true
 
 # Linux only dependencies
 [target.'cfg(target_family = "unix")'.dependencies]

--- a/crates/agentgateway/proto/resource.proto
+++ b/crates/agentgateway/proto/resource.proto
@@ -780,6 +780,8 @@ message BackendPolicySpec {
       ANTHROPIC_TOKEN_COUNT = 6;
       // Processes OpenAI /v1/embeddings format requests
       EMBEDDINGS = 7;
+      // OpenAI /v1/realtime
+      REALTIME = 8;
     }
 
     // Routes defines how to identify the type of LLM request to handle.

--- a/crates/agentgateway/src/http/mod.rs
+++ b/crates/agentgateway/src/http/mod.rs
@@ -322,6 +322,10 @@ pub fn modify_uri(
 	Ok(())
 }
 
+pub fn as_url(uri: &Uri) -> anyhow::Result<Url> {
+	Ok(Url::parse(&uri.to_string())?)
+}
+
 pub fn modify_url(
 	uri: &mut Uri,
 	f: impl FnOnce(&mut Url) -> anyhow::Result<()>,

--- a/crates/agentgateway/src/llm/openai.rs
+++ b/crates/agentgateway/src/llm/openai.rs
@@ -22,6 +22,7 @@ pub fn path(route: RouteType) -> &'static str {
 		RouteType::Responses => "/v1/responses",
 		// For Embeddings we forward to the embeddings endpoint
 		RouteType::Embeddings => "/v1/embeddings",
+		RouteType::Realtime => "/v1/realtime",
 		// All others get translated down to completions
 		_ => "/v1/chat/completions",
 	}

--- a/crates/agentgateway/src/llm/universal.rs
+++ b/crates/agentgateway/src/llm/universal.rs
@@ -112,6 +112,9 @@ pub mod passthrough {
 			InputFormat::CountTokens => {
 				unreachable!("CountTokens should be handled by process_count_tokens_response")
 			},
+			InputFormat::Realtime => {
+				unreachable!("Realtime should be handled by websocket upgrade")
+			},
 		}
 	}
 

--- a/crates/agentgateway/src/parse/mod.rs
+++ b/crates/agentgateway/src/parse/mod.rs
@@ -2,6 +2,7 @@ pub mod aws_sse;
 pub mod passthrough;
 pub mod sse;
 pub mod transform;
+pub mod websocket;
 
 #[cfg(test)]
 #[path = "parse_tests.rs"]

--- a/crates/agentgateway/src/parse/websocket.rs
+++ b/crates/agentgateway/src/parse/websocket.rs
@@ -1,0 +1,148 @@
+use crate::llm::{LLMInfo, LLMResponse};
+use crate::telemetry::log::AsyncLog;
+use async_openai::types::realtime::RealtimeResponseUsage;
+use bytes::{Bytes, BytesMut};
+use serde::{Deserialize, Serialize};
+use std::io::{Error, IoSlice};
+use std::pin::Pin;
+use std::task::{Context, Poll, ready};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use websocket_sans_io::{FrameInfo, Opcode, WebsocketFrameEvent};
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ResponseDoneEvent {
+	/// The response resource.
+	pub response: ResponseResource,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ResponseResource {
+	/// Usage statistics for the response.
+	pub usage: Option<RealtimeResponseUsage>,
+}
+
+struct Parser<IO> {
+	inner: IO,
+	decoder: websocket_sans_io::WebsocketFrameDecoder,
+	buf: BytesMut,
+	log: AsyncLog<LLMInfo>,
+}
+
+impl<IO> Parser<IO> {
+	fn emit(&self, data: Bytes) {
+		let Ok(data) = str::from_utf8(&data) else {
+			return;
+		};
+		if data.contains("response.done") {
+			let Ok(typed) = serde_json::from_str::<ResponseDoneEvent>(data) else {
+				return;
+			};
+			if let Some(usage) = typed.response.usage {
+				// TODO: do we need to parse the request side to get the request model?
+				// it seems like we get an event from the server with the same thing.
+				// also, the model can change... so what do we report??
+				self.log.non_atomic_mutate(|r| {
+					r.response = LLMResponse {
+						input_tokens: Some(usage.input_tokens as u64),
+						output_tokens: Some(usage.output_tokens as u64),
+						total_tokens: Some(usage.total_tokens as u64),
+						provider_model: None,
+						completion: None,
+						first_token: None,
+						count_tokens: None,
+					}
+				});
+			}
+		}
+	}
+}
+
+impl<IO: AsyncWrite + Unpin + 'static> AsyncWrite for Parser<IO> {
+	fn poll_write(
+		mut self: Pin<&mut Self>,
+		cx: &mut Context<'_>,
+		buf: &[u8],
+	) -> Poll<Result<usize, Error>> {
+		Pin::new(&mut self.inner).poll_write(cx, buf)
+	}
+
+	fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
+		Pin::new(&mut self.inner).poll_flush(cx)
+	}
+
+	fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
+		Pin::new(&mut self.inner).poll_shutdown(cx)
+	}
+
+	fn poll_write_vectored(
+		mut self: Pin<&mut Self>,
+		cx: &mut Context<'_>,
+		bufs: &[IoSlice<'_>],
+	) -> Poll<Result<usize, Error>> {
+		Pin::new(&mut self.inner).poll_write_vectored(cx, bufs)
+	}
+
+	fn is_write_vectored(&self) -> bool {
+		self.inner.is_write_vectored()
+	}
+}
+impl<IO: AsyncRead + Unpin + 'static> AsyncRead for Parser<IO> {
+	fn poll_read(
+		mut self: Pin<&mut Self>,
+		cx: &mut Context<'_>,
+		buf: &mut ReadBuf<'_>,
+	) -> Poll<std::io::Result<()>> {
+		let orig = buf.filled().len();
+		ready!(Pin::new(&mut self.inner).poll_read(cx, buf)?);
+		let n = buf.filled().len() - orig;
+		if n == 0 {
+			// EOF
+			return Poll::Ready(Ok(()));
+		}
+		let mut processed_offset = 0;
+		loop {
+			let unprocessed_part_of_buf = &buf.filled()[processed_offset..n];
+			// Websocket logic needs owned copy to apply the mask. However, we need to keep the untouched stuff
+			// so we are not modifying the response.
+			let Ok(ret) = self.decoder.add_data(&mut unprocessed_part_of_buf.to_vec());
+			processed_offset += ret.consumed_bytes;
+
+			if ret.event.is_none() && ret.consumed_bytes == 0 {
+				return Poll::Ready(Ok(()));
+			}
+
+			match ret.event {
+				Some(WebsocketFrameEvent::PayloadChunk {
+					original_opcode: Opcode::Text,
+				}) => {
+					self
+						.buf
+						.extend_from_slice(&unprocessed_part_of_buf[0..ret.consumed_bytes]);
+				},
+				Some(WebsocketFrameEvent::End {
+					frame_info: FrameInfo { fin: true, .. },
+					original_opcode: Opcode::Text,
+				}) => {
+					let got = self.buf.split();
+					self.emit(got.freeze());
+				},
+				_ => (),
+			}
+		}
+	}
+}
+
+pub async fn parser2<IO>(
+	body: IO,
+	log: AsyncLog<LLMInfo>,
+) -> impl AsyncRead + AsyncWrite + Unpin + 'static
+where
+	IO: AsyncRead + AsyncWrite + Unpin + 'static,
+{
+	Parser {
+		inner: body,
+		decoder: websocket_sans_io::WebsocketFrameDecoder::new(),
+		buf: Default::default(),
+		log,
+	}
+}

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -935,11 +935,11 @@ async fn handle_upgrade(
 		};
 		let mut server = TokioIo::new(response_upgraded);
 		if let Some(log) = log.as_ref()
-			&& let Some(llm_req) = dbg!(log.llm_request.as_ref())
+			&& let Some(llm_req) = log.llm_request.as_ref()
 			&& llm_req.input_format == InputFormat::Realtime
 		{
 			let llm = log.llm_response.clone();
-			let mut server = parse::websocket::parser2(server, llm).await;
+			let mut server = parse::websocket::parser(server, llm).await;
 			let _ = agent_core::copy::copy_bidirectional(
 				&mut TokioIo::new(req),
 				&mut server,

--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -391,6 +391,9 @@ impl DropOnLog {
 	pub fn as_mut(&mut self) -> Option<&mut RequestLog> {
 		self.log.as_mut()
 	}
+	pub fn as_ref(&self) -> Option<&RequestLog> {
+		self.log.as_ref()
+	}
 	pub fn with(&mut self, f: impl FnOnce(&mut RequestLog)) {
 		if let Some(l) = self.log.as_mut() {
 			f(l)

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -201,6 +201,7 @@ fn convert_route_type(proto_rt: i32) -> llm::RouteType {
 		Ok(ProtoRT::Responses) => llm::RouteType::Responses,
 		Ok(ProtoRT::AnthropicTokenCount) => llm::RouteType::AnthropicTokenCount,
 		Ok(ProtoRT::Embeddings) => llm::RouteType::Embeddings,
+		Ok(ProtoRT::Realtime) => llm::RouteType::Realtime,
 		Err(_) => {
 			warn!(
 				"Unknown proto RouteType value {}, defaulting to Completions",

--- a/go/api/resource.pb.go
+++ b/go/api/resource.pb.go
@@ -745,6 +745,8 @@ const (
 	BackendPolicySpec_Ai_ANTHROPIC_TOKEN_COUNT BackendPolicySpec_Ai_RouteType = 6
 	// Processes OpenAI /v1/embeddings format requests
 	BackendPolicySpec_Ai_EMBEDDINGS BackendPolicySpec_Ai_RouteType = 7
+	// OpenAI /v1/realtime
+	BackendPolicySpec_Ai_REALTIME BackendPolicySpec_Ai_RouteType = 8
 )
 
 // Enum value maps for BackendPolicySpec_Ai_RouteType.
@@ -758,6 +760,7 @@ var (
 		5: "RESPONSES",
 		6: "ANTHROPIC_TOKEN_COUNT",
 		7: "EMBEDDINGS",
+		8: "REALTIME",
 	}
 	BackendPolicySpec_Ai_RouteType_value = map[string]int32{
 		"UNSPECIFIED":           0,
@@ -768,6 +771,7 @@ var (
 		"RESPONSES":             5,
 		"ANTHROPIC_TOKEN_COUNT": 6,
 		"EMBEDDINGS":            7,
+		"REALTIME":              8,
 	}
 )
 
@@ -9933,7 +9937,7 @@ const file_resource_proto_rawDesc = "" +
 	"\vPolicyPhase\x12\t\n" +
 	"\x05ROUTE\x10\x00\x12\v\n" +
 	"\aGATEWAY\x10\x01B\x06\n" +
-	"\x04kind\"\xb02\n" +
+	"\x04kind\"\xbe2\n" +
 	"\x11BackendPolicySpec\x12D\n" +
 	"\x03a2a\x18\x01 \x01(\v20.agentgateway.dev.resource.BackendPolicySpec.A2aH\x00R\x03a2a\x12l\n" +
 	"\x11inference_routing\x18\x02 \x01(\v2=.agentgateway.dev.resource.BackendPolicySpec.InferenceRoutingH\x00R\x10inferenceRouting\x12Z\n" +
@@ -9950,7 +9954,7 @@ const file_resource_proto_rawDesc = "" +
 	"\x0erequest_mirror\x18\v \x01(\v2).agentgateway.dev.resource.RequestMirrorsH\x00R\rrequestMirror\x12]\n" +
 	"\fbackend_http\x18\f \x01(\v28.agentgateway.dev.resource.BackendPolicySpec.BackendHTTPH\x00R\vbackendHttp\x12Z\n" +
 	"\vbackend_tcp\x18\r \x01(\v27.agentgateway.dev.resource.BackendPolicySpec.BackendTCPH\x00R\n" +
-	"backendTcp\x1a\xe0\x19\n" +
+	"backendTcp\x1a\xee\x19\n" +
 	"\x02Ai\x12^\n" +
 	"\fprompt_guard\x18\x01 \x01(\v2;.agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuardR\vpromptGuard\x12Y\n" +
 	"\bdefaults\x18\x02 \x03(\v2=.agentgateway.dev.resource.BackendPolicySpec.Ai.DefaultsEntryR\bdefaults\x12\\\n" +
@@ -10031,7 +10035,7 @@ const file_resource_proto_rawDesc = "" +
 	"\x12ACTION_UNSPECIFIED\x10\x00\x12\b\n" +
 	"\x04MASK\x10\x01\x12\n" +
 	"\n" +
-	"\x06REJECT\x10\x02\"\x92\x01\n" +
+	"\x06REJECT\x10\x02\"\xa0\x01\n" +
 	"\tRouteType\x12\x0f\n" +
 	"\vUNSPECIFIED\x10\x00\x12\x0f\n" +
 	"\vCOMPLETIONS\x10\x01\x12\f\n" +
@@ -10042,7 +10046,8 @@ const file_resource_proto_rawDesc = "" +
 	"\tRESPONSES\x10\x05\x12\x19\n" +
 	"\x15ANTHROPIC_TOKEN_COUNT\x10\x06\x12\x0e\n" +
 	"\n" +
-	"EMBEDDINGS\x10\a\x1a\x05\n" +
+	"EMBEDDINGS\x10\a\x12\f\n" +
+	"\bREALTIME\x10\b\x1a\x05\n" +
 	"\x03A2a\x1a\x92\x02\n" +
 	"\x10InferenceRouting\x12T\n" +
 	"\x0fendpoint_picker\x18\x01 \x01(\v2+.agentgateway.dev.resource.BackendReferenceR\x0eendpointPicker\x12l\n" +

--- a/schema/config.json
+++ b/schema/config.json
@@ -2659,6 +2659,11 @@
                                       "const": "embeddings"
                                     },
                                     {
+                                      "description": "OpenAI /realtime (websockets)",
+                                      "type": "string",
+                                      "const": "realtime"
+                                    },
+                                    {
                                       "description": "Anthropic /v1/messages/count_tokens",
                                       "type": "string",
                                       "const": "anthropicTokenCount"
@@ -4889,6 +4894,11 @@
                                             "const": "embeddings"
                                           },
                                           {
+                                            "description": "OpenAI /realtime (websockets)",
+                                            "type": "string",
+                                            "const": "realtime"
+                                          },
+                                          {
                                             "description": "Anthropic /v1/messages/count_tokens",
                                             "type": "string",
                                             "const": "anthropicTokenCount"
@@ -6696,6 +6706,11 @@
                                                         "const": "embeddings"
                                                       },
                                                       {
+                                                        "description": "OpenAI /realtime (websockets)",
+                                                        "type": "string",
+                                                        "const": "realtime"
+                                                      },
+                                                      {
                                                         "description": "Anthropic /v1/messages/count_tokens",
                                                         "type": "string",
                                                         "const": "anthropicTokenCount"
@@ -8251,6 +8266,11 @@
                                                                     "description": "OpenAI /embeddings",
                                                                     "type": "string",
                                                                     "const": "embeddings"
+                                                                  },
+                                                                  {
+                                                                    "description": "OpenAI /realtime (websockets)",
+                                                                    "type": "string",
+                                                                    "const": "realtime"
                                                                   },
                                                                   {
                                                                     "description": "Anthropic /v1/messages/count_tokens",
@@ -12032,6 +12052,11 @@
                           "const": "embeddings"
                         },
                         {
+                          "description": "OpenAI /realtime (websockets)",
+                          "type": "string",
+                          "const": "realtime"
+                        },
+                        {
                           "description": "Anthropic /v1/messages/count_tokens",
                           "type": "string",
                           "const": "anthropicTokenCount"
@@ -14277,6 +14302,11 @@
                           "const": "embeddings"
                         },
                         {
+                          "description": "OpenAI /realtime (websockets)",
+                          "type": "string",
+                          "const": "realtime"
+                        },
+                        {
                           "description": "Anthropic /v1/messages/count_tokens",
                           "type": "string",
                           "const": "anthropicTokenCount"
@@ -14851,6 +14881,11 @@
                 "description": "OpenAI /embeddings",
                 "type": "string",
                 "const": "embeddings"
+              },
+              {
+                "description": "OpenAI /realtime (websockets)",
+                "type": "string",
+                "const": "realtime"
               },
               {
                 "description": "Anthropic /v1/messages/count_tokens",


### PR DESCRIPTION
Example config:

```yaml
# yaml-language-server: $schema=../schema/config.json
config: {}
binds:
- port: 12347
  listeners:
  - name: default
    protocol: HTTP
    routes:
    - policies:
        backendAuth:
          key:
            file: $HOME/.secrets/openai
        transformations:
          request:
            # TODO? currently we cannot support per-message-deflate, so just drop it entirely.
            remove:
              - sec-websocket-extensions
      backends:
      - ai:
          name: openai
          provider:
            openAI: {}
        policies:
          http:
            # OpenAI negotiates up to HTTP/2 but requires HTTP/1.1. Explicitly downgrade
            version: HTTP/1.1
          # The auth token is in the `sec-websocket-protocol` value, and they reject adding it to
          # Authorization. Unclear the best option, for now we disable adding our own auth.
          backendAuth:
            passthrough: {}
          ai:
            routes:
              /v1/chat/completions: completions
              /v1/messages: messages
              /v1/models: passthrough
              /v1/realtime: realtime
              "*": passthrough
```