### PR TITLE
More mcp traces attributes

### DIFF
--- a/crates/agentgateway/src/mcp/mod.rs
+++ b/crates/agentgateway/src/mcp/mod.rs
@@ -66,4 +66,6 @@ pub struct MCPInfo {
 	pub resource_name: Option<String>,
 	pub target_name: Option<String>,
 	pub resource: Option<MCPOperation>,
+	/// JSON-serialized arguments for tools/call (truncated for safety)
+	pub call_arguments: Option<String>,
 }

--- a/crates/agentgateway/src/mcp/upstream/client.rs
+++ b/crates/agentgateway/src/mcp/upstream/client.rs
@@ -37,6 +37,10 @@ impl McpHttpClient {
 		}
 	}
 
+	pub fn metrics(&self) -> Arc<crate::telemetry::metrics::Metrics> {
+		self.client.inputs.metrics.clone()
+	}
+
 	pub async fn call(
 		&self,
 		req: http::Request<crate::http::Body>,

--- a/crates/agentgateway/src/mcp/upstream/mod.rs
+++ b/crates/agentgateway/src/mcp/upstream/mod.rs
@@ -56,6 +56,9 @@ impl IncomingRequestContext {
 			req.extensions_mut().insert(claims.clone());
 		}
 	}
+	pub fn otel_parent_context(&self) -> opentelemetry::Context {
+		agent_core::trcng::extract_context_from_request(&self.headers)
+	}
 }
 
 #[derive(Debug, Error)]

--- a/crates/agentgateway/src/mcp/upstream/stdio.rs
+++ b/crates/agentgateway/src/mcp/upstream/stdio.rs
@@ -100,7 +100,7 @@ impl Process {
 					},
 					Some(msg) = proc.receive() => {
 						match msg {
-							JsonRpcMessage::Response(res) => {
+							ServerJsonRpcMessage::Response(res) => {
 								let req_id = res.id.clone();
 								if let Some(sender) = pending_requests_clone.lock().unwrap().remove(&req_id) {
 									let _ = sender.send(ServerJsonRpcMessage::Response(res));

--- a/crates/agentgateway/src/mcp/upstream/stdio.rs
+++ b/crates/agentgateway/src/mcp/upstream/stdio.rs
@@ -6,8 +6,8 @@ use std::sync::{Arc, Mutex};
 use agent_core::prelude::*;
 use futures_util::TryFutureExt;
 use rmcp::model::{
-	ClientJsonRpcMessage, ClientNotification, ClientRequest, JsonRpcMessage, JsonRpcRequest,
-	RequestId, ServerJsonRpcMessage,
+	ClientJsonRpcMessage, ClientNotification, ClientRequest, JsonRpcRequest, RequestId,
+	ServerJsonRpcMessage,
 };
 use rmcp::transport::{TokioChildProcess, Transport};
 use tokio::sync::mpsc::Sender;
@@ -49,7 +49,7 @@ impl Process {
 
 		self
 			.sender
-			.send((JsonRpcMessage::Request(req), ctx.clone()))
+			.send((ClientJsonRpcMessage::Request(req), ctx.clone()))
 			.await
 			.map_err(|_| UpstreamError::Send)?;
 
@@ -68,7 +68,7 @@ impl Process {
 	) -> Result<(), UpstreamError> {
 		self
 			.sender
-			.send((JsonRpcMessage::notification(req), ctx.clone()))
+			.send((ClientJsonRpcMessage::notification(req), ctx.clone()))
 			.await
 			.map_err(|_| UpstreamError::Send)?;
 		Ok(())

--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -765,6 +765,10 @@ impl Drop for DropOnLog {
 			),
 			("route", route_identifier.route.as_deref().map(display)),
 			("endpoint", log.endpoint.display()),
+			(
+				"rpc.service",
+				log.backend_info.as_ref().map(|i| display(&i.backend_name)),
+			),
 			("src.addr", Some(display(&log.tcp_info.peer_addr))),
 			("http.method", log.method.display()),
 			("http.host", log.host.display()),
@@ -815,9 +819,31 @@ impl Drop for DropOnLog {
 					.map(display),
 			),
 			(
+				"mcp.method.name",
+				mcp
+					.as_ref()
+					.and_then(|m| m.method_name.as_ref())
+					.map(display),
+			),
+			(
+				"mcp.resource.uri",
+				mcp
+					.as_ref()
+					.and_then(|m| m.resource_name.as_ref())
+					.map(display),
+			),
+			// OpenTelemetry Gen AI Semantic Conventions: capture tool call arguments
+			(
+				"gen_ai.tool.call.arguments",
+				mcp.as_ref()
+					.and_then(|m| m.call_arguments.as_ref())
+					.map(display),
+			),
+			(
 				"inferencepool.selected_endpoint",
 				log.inference_pool.display(),
 			),
+			("mcp.session.pinned_endpoint", log.endpoint.display()),
 			// OpenTelemetry Gen AI Semantic Conventions v1.37.0
 			(
 				"gen_ai.operation.name",
@@ -892,6 +918,10 @@ impl Drop for DropOnLog {
 					.as_ref()
 					.and_then(|l| l.params.seed)
 					.map(Into::into),
+			),
+			(
+				"rpc.response.size",
+				Some((log.response_bytes as i64).into()),
 			),
 			("retry.attempt", log.retry_attempt.display()),
 			("error", log.error.quoted()),

--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -406,8 +406,14 @@ impl DropOnLog {
 		custom_metric_fields: &CustomField,
 	) {
 		if let Some(llm_response) = &llm_response {
+			let operation_name = match llm_response.request.input_format {
+				llm::InputFormat::Messages => strng::literal!("messages"),
+				llm::InputFormat::Completions => strng::literal!("completions"),
+				llm::InputFormat::Responses => strng::literal!("responses"),
+				llm::InputFormat::CountTokens => strng::literal!("count_tokens"),
+			};
 			let gen_ai_labels = Arc::new(GenAILabels {
-				gen_ai_operation_name: strng::literal!("chat").into(),
+				gen_ai_operation_name: operation_name.into(),
 				gen_ai_system: llm_response.request.provider.clone().into(),
 				gen_ai_request_model: llm_response.request.request_model.clone().into(),
 				gen_ai_response_model: llm_response.response.provider_model.clone().into(),


### PR DESCRIPTION

<img width="616" height="622" alt="image" src="https://github.com/user-attachments/assets/aeebb718-e5e7-40e4-9c2f-040dba86e75f" />


```
Span #0
    Trace ID       : 9899cb70dae2a8b8cfc665f35d81a5e7
    Parent ID      : 6a4227b609bf03fe
    ID             : 1dc6eee83af6ea24
    Name           : mcp.upstream.sse.tools/call
    Kind           : Client
    Start time     : 2025-12-08 20:58:11.305330719 +0000 UTC
    End time       : 2025-12-08 20:58:11.312966386 +0000 UTC
    Status code    : Unset
    Status message :
Attributes:
     -> rpc.system: Str(jsonrpc)
     -> rpc.jsonrpc.version: Str(2.0)
     -> server.address: Str(mcp-website-fetcher.default.svc.cluster.local)
     -> server.port: Int(80)
     -> network.protocol.name: Str(http)
     -> rpc.request.size: Int(144)
     -> rpc.service: Str(mcp-website-fetcher.default.svc.cluster.local:80)
     -> rpc.method: Str(tools/call)
     -> rpc.request.id: Str(1)
Span #1
    Trace ID       : 9899cb70dae2a8b8cfc665f35d81a5e7
    Parent ID      : 6a4227b609bf03fe
    ID             : 7c61c1f59ed5d3f2
    Name           : tools/call
    Kind           : Server
    Start time     : 2025-12-08 20:58:11.305238386 +0000 UTC
    End time       : 2025-12-08 20:58:11.854059803 +0000 UTC
    Status code    : Unset
    Status message :
ResourceSpans #1
Resource SchemaURL:
Resource attributes:
     -> service.name: Str(agentgateway)
     -> telemetry.sdk.name: Str(opentelemetry)
     -> telemetry.sdk.language: Str(rust)
     -> service.version: Str(v0.6.0-323-gd6d5ea0fb)
     -> telemetry.sdk.version: Str(0.31.0)
ScopeSpans #0
ScopeSpans SchemaURL:
InstrumentationScope agentgateway
Span #0
    Trace ID       : 9899cb70dae2a8b8cfc665f35d81a5e7
    Parent ID      :
    ID             : 6a4227b609bf03fe
    Name           : POST /*
    Kind           : Server
    Start time     : 2025-12-08 20:58:11.304301594 +0000 UTC
    End time       : 2025-12-08 20:58:11.854347511 +0000 UTC
    Status code    : Unset
    Status message :
Attributes:
     -> gateway: Str(default/agent-gateway)
     -> listener: Str(http)
     -> route: Str(default/mcp-route)
     -> src.addr: Str(127.0.0.1:50494)
     -> http.method: Str(POST)
     -> http.host: Str(localhost)
     -> http.path: Str(/)
     -> http.version: Str(HTTP/1.1)
     -> http.status: Int(200)
     -> trace.id: Str(9899cb70dae2a8b8cfc665f35d81a5e7)
     -> span.id: Str(6a4227b609bf03fe)
     -> protocol: Str(mcp)
     -> mcp.method: Str(tools/call)
     -> mcp.target: Str(mcp-target)
     -> mcp.resource.type: Str(tool)
     -> mcp.resource.name: Str(fetch)
     -> duration: Str(549ms)
     -> url.scheme: Str(http)
     -> network.protocol.version: Str(1.1)
     -> rpc.system: Str(jsonrpc)
     -> rpc.jsonrpc.version: Str(2.0)
     -> network.protocol.name: Str(http)
     -> rpc.request.size: Int(144)
     -> server.address: Str(localhost:8080)
```

