### PR TITLE
feat(cel): uuid added to cel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "uuid 1.18.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,6 +194,7 @@ tracing-subscriber = { version = "0.3", features = [
     "json",
 ] }
 url = "2.5"
+uuid = { version = "1.11", features = ["v4"] }
 wiremock = { version = "0.6.3", features = ["tls"] }
 x509-parser = { version = "0.18", default-features = false, features = ["verify-aws"] }
 which = "8.0.0"

--- a/crates/celx/Cargo.toml
+++ b/crates/celx/Cargo.toml
@@ -17,6 +17,7 @@ ipnet.workspace = true
 regex.workspace = true
 serde_json.workspace = true
 serde.workspace = true
+uuid.workspace = true
 
 [dev-dependencies]
 anyhow.workspace = true

--- a/crates/celx/src/function_tests.rs
+++ b/crates/celx/src/function_tests.rs
@@ -231,7 +231,7 @@ fn uuid() {
 	assert_eq!(uuid_str.chars().nth(18).unwrap(), '-');
 	assert_eq!(uuid_str.chars().nth(23).unwrap(), '-');
 	// Test that it conforms to UUID version 4 format specifications
-	// The 13th character (at index 14) should be '4' (version field)
+	// The version field (at index 14, the 15th character) should be '4'
 	assert_eq!(
 		uuid_str.chars().nth(14).unwrap(),
 		'4',

--- a/crates/celx/src/function_tests.rs
+++ b/crates/celx/src/function_tests.rs
@@ -230,6 +230,20 @@ fn uuid() {
 	assert_eq!(uuid_str.chars().nth(13).unwrap(), '-');
 	assert_eq!(uuid_str.chars().nth(18).unwrap(), '-');
 	assert_eq!(uuid_str.chars().nth(23).unwrap(), '-');
+	// Test that it conforms to UUID version 4 format specifications
+	// The 13th character (at index 14) should be '4' (version field)
+	assert_eq!(
+		uuid_str.chars().nth(14).unwrap(),
+		'4',
+		"UUID version field should be '4'"
+	);
+	// The 17th character (at index 19) should be one of '8', '9', 'a', or 'b' (variant field)
+	let variant_char = uuid_str.chars().nth(19).unwrap();
+	assert!(
+		['8', '9', 'a', 'b'].contains(&variant_char),
+		"UUID variant field should be '8', '9', 'a', or 'b', got '{}'",
+		variant_char
+	);
 	// Test that multiple calls return different UUIDs
 	let result2 = eval(expr).unwrap().json().unwrap();
 	assert_ne!(

--- a/crates/celx/src/function_tests.rs
+++ b/crates/celx/src/function_tests.rs
@@ -217,6 +217,26 @@ fn cidr() {
 	assert(json!(true), expr);
 }
 
+#[test]
+fn uuid() {
+	// Test that uuid() returns a string
+	let expr = r#"uuid()"#;
+	let result = eval(expr).unwrap().json().unwrap();
+	assert!(result.is_string(), "uuid() should return a string");
+	// Test that it's formatted like a UUID (8-4-4-4-12 hex digits)
+	let uuid_str = result.as_str().unwrap();
+	assert_eq!(uuid_str.len(), 36, "UUID should be 36 characters long");
+	assert_eq!(uuid_str.chars().nth(8).unwrap(), '-');
+	assert_eq!(uuid_str.chars().nth(13).unwrap(), '-');
+	assert_eq!(uuid_str.chars().nth(18).unwrap(), '-');
+	assert_eq!(uuid_str.chars().nth(23).unwrap(), '-');
+	// Test that multiple calls return different UUIDs
+	let result2 = eval(expr).unwrap().json().unwrap();
+	assert_ne!(
+		result, result2,
+		"Multiple uuid() calls should return different values"
+	);
+}
 fn assert(want: serde_json::Value, expr: &str) {
 	assert_eq!(
 		want,

--- a/crates/celx/src/function_tests.rs
+++ b/crates/celx/src/function_tests.rs
@@ -237,7 +237,7 @@ fn uuid() {
 		'4',
 		"UUID version field should be '4'"
 	);
-	// The 17th character (at index 19) should be one of '8', '9', 'a', or 'b' (variant field)
+	// The variant field (at index 19, i.e., the 20th character) should be one of '8', '9', 'a', or 'b'
 	let variant_char = uuid_str.chars().nth(19).unwrap();
 	assert!(
 		['8', '9', 'a', 'b'].contains(&variant_char),

--- a/crates/celx/src/general.rs
+++ b/crates/celx/src/general.rs
@@ -9,6 +9,7 @@ use ::cel::{Context, FunctionContext, ResolveResult, Value};
 use rand::random_range;
 use serde::ser::Error;
 use serde::{Serialize, Serializer};
+use uuid::Uuid;
 
 pub fn insert_all(ctx: &mut Context<'_>) {
 	// Custom to agentgateway
@@ -214,17 +215,7 @@ pub fn regex_replace(
 }
 
 fn uuid_generate() -> Arc<String> {
-	use rand::Rng;
-	let mut rng = rand::rng();
-	let uuid = format!(
-		"{:08x}-{:04x}-{:04x}-{:04x}-{:012x}",
-		rng.random::<u32>(),
-		rng.random::<u16>(),
-		(rng.random::<u16>() & 0x0fff) | 0x4000, // Version 4
-		(rng.random::<u16>() & 0x3fff) | 0x8000, // Variant 1
-		rng.random::<u64>() & 0xffffffffffff
-	);
-	Arc::new(uuid)
+	Arc::new(Uuid::new_v4().to_string())
 }
 
 fn default(ftx: &FunctionContext, exp: Expression, d: Value) -> ResolveResult {

--- a/crates/celx/src/general.rs
+++ b/crates/celx/src/general.rs
@@ -28,6 +28,7 @@ pub fn insert_all(ctx: &mut Context<'_>) {
 	ctx.add_function("default", default);
 	ctx.add_function("regexReplace", regex_replace);
 	ctx.add_function("fail", fail);
+	ctx.add_function("uuid", uuid_generate);
 
 	// Using the go name, base64.encode is blocked by https://github.com/cel-rust/cel-rust/issues/103 (namespacing)
 	ctx.add_function("base64Encode", base64_encode);
@@ -210,6 +211,20 @@ pub fn regex_replace(
 		)),
 		Err(err) => Err(ftx.error(format!("'{regex}' not a valid regex:\n{err}"))),
 	}
+}
+
+fn uuid_generate() -> Arc<String> {
+	use rand::Rng;
+	let mut rng = rand::rng();
+	let uuid = format!(
+		"{:08x}-{:04x}-{:04x}-{:04x}-{:012x}",
+		rng.random::<u32>(),
+		rng.random::<u16>(),
+		(rng.random::<u16>() & 0x0fff) | 0x4000, // Version 4
+		(rng.random::<u16>() & 0x3fff) | 0x8000, // Variant 1
+		rng.random::<u64>() & 0xffffffffffff
+	);
+	Arc::new(uuid)
 }
 
 fn default(ftx: &FunctionContext, exp: Expression, d: Value) -> ResolveResult {


### PR DESCRIPTION
Add the ability of the CEL to create a UUID. This is useful when injecting headers into a request to be able to track a request from the beginning to the end.