### PR TITLE
default region for aws backends

### DIFF
--- a/crates/agentgateway/proto/resource.proto
+++ b/crates/agentgateway/proto/resource.proto
@@ -189,7 +189,7 @@ message AwsExplicitConfig {
   string access_key_id = 1;
   // AWS Secret Access Key for authentication
   string secret_access_key = 2;
-  // AWS Region (e.g., "us-west-2", "us-east-1")
+  // AWS Region (e.g., "us-west-2", "us-east-1"). Optional for AWS backends.
   string region = 3;
   // Optional session token for temporary credentials
   optional string session_token = 4;

--- a/crates/agentgateway/src/http/auth_tests.rs
+++ b/crates/agentgateway/src/http/auth_tests.rs
@@ -3,6 +3,7 @@ use serde_json::Map;
 
 use super::*;
 use crate::http::jwt::Claims;
+use crate::llm::bedrock::AwsRegion;
 use crate::test_helpers::proxymock::setup_proxy_test;
 
 #[tokio::test]
@@ -40,4 +41,183 @@ async fn test_backend_auth_passthrough_happy_path() {
 	assert!(auth.is_sensitive());
 	// Claims remain
 	assert!(req.extensions().get::<Claims>().is_some());
+}
+
+#[tokio::test]
+async fn test_backend_auth_key() {
+	// Test Key authentication
+	let mut req = crate::http::Request::new(crate::http::Body::empty());
+	let t = setup_proxy_test("{}").expect("setup proxy inputs");
+	let inputs = t.inputs();
+
+	let backend_info = BackendInfo {
+		target: BackendTarget::Backend {
+			name: Default::default(),
+			namespace: Default::default(),
+			section: None,
+		},
+		inputs,
+	};
+
+	let key_auth = BackendAuth::Key(SecretString::new("my-secret-key".into()));
+	apply_backend_auth(&backend_info, &key_auth, &mut req)
+		.await
+		.expect("apply backend auth");
+
+	let auth = req
+		.headers()
+		.get(http::header::AUTHORIZATION)
+		.expect("authorization header must be set");
+	assert_eq!(auth.to_str().unwrap(), "Bearer my-secret-key");
+	assert!(auth.is_sensitive());
+}
+
+#[tokio::test]
+async fn test_aws_sign_request_explicit_region() {
+	// Test AWS signing with explicit region in config
+	let mut req = crate::http::Request::new(crate::http::Body::empty());
+	*req.uri_mut() = "https://bedrock-runtime.us-west-2.amazonaws.com/model/invoke"
+		.parse()
+		.unwrap();
+	*req.method_mut() = http::Method::POST;
+
+	let aws_auth = AwsAuth::ExplicitConfig {
+		access_key_id: SecretString::new("AKIAIOSFODNN7EXAMPLE".into()),
+		secret_access_key: SecretString::new("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY".into()),
+		region: Some("us-west-2".to_string()),
+		session_token: None,
+	};
+
+	// No default region in request extensions.
+
+	// Should use the explicit region and attempt signing
+	// Will fail on credentials but should not fail on region
+	aws::sign_request(&mut req, &aws_auth)
+		.await
+		.expect("signing failed");
+	// get the signature header
+	let auth = req
+		.headers()
+		.get(http::header::AUTHORIZATION)
+		.expect("authorization header must be set");
+
+	// Part 2
+	// now, repeat with adefault region to make sure explicit region takes precedence
+	let mut req = crate::http::Request::new(crate::http::Body::empty());
+	*req.uri_mut() = "https://bedrock-runtime.us-west-2.amazonaws.com/model/invoke"
+		.parse()
+		.unwrap();
+	*req.method_mut() = http::Method::POST;
+
+	// Insert default AwsRegion into request extensions
+	req.extensions_mut().insert(AwsRegion {
+		region: "eu-central-1".to_string(),
+	});
+
+	// Should use the explicit region and attempt signing
+	// Will fail on credentials but should not fail on region
+	aws::sign_request(&mut req, &aws_auth)
+		.await
+		.expect("signing failed");
+	// get the signature header
+	let auth2 = req
+		.headers()
+		.get(http::header::AUTHORIZATION)
+		.expect("authorization header must be set");
+
+	assert_eq!(auth, auth2, "Signatures should match with explicit region");
+}
+
+#[tokio::test]
+async fn test_aws_sign_requestallback() {
+	// Test AWS signing falls back tohen not specified in config
+	let mut req = crate::http::Request::new(crate::http::Body::empty());
+	*req.uri_mut() = "https://bedrock-runtime.eu-west-1.amazonaws.com/model/invoke"
+		.parse()
+		.unwrap();
+	*req.method_mut() = http::Method::POST;
+
+	let aws_auth = AwsAuth::ExplicitConfig {
+		access_key_id: SecretString::new("AKIAIOSFODNN7EXAMPLE".into()),
+		secret_access_key: SecretString::new("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY".into()),
+		region: None, // No region in config
+		session_token: None,
+	};
+
+	// Insert default AwsRegion into request extensions
+	req.extensions_mut().insert(AwsRegion {
+		region: "eu-west-1".to_string(),
+	});
+
+	// Should use the default region in the extension
+	aws::sign_request(&mut req, &aws_auth)
+		.await
+		.expect("signing failed");
+}
+
+#[tokio::test]
+async fn test_aws_sign_request_no_region_error() {
+	// Test AWS signing fails with clear error when no region available
+	let mut req = crate::http::Request::new(crate::http::Body::empty());
+	*req.uri_mut() = "https://bedrock-runtime.amazonaws.com/model/invoke"
+		.parse()
+		.unwrap();
+	*req.method_mut() = http::Method::POST;
+
+	let aws_auth = AwsAuth::ExplicitConfig {
+		access_key_id: SecretString::new("AKIAIOSFODNN7EXAMPLE".into()),
+		secret_access_key: SecretString::new("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY".into()),
+		region: None, // No region in config
+		session_token: None,
+	};
+
+	// No default region in request extensions.
+
+	// Should fail with specific "Region must be specified" error
+	let result = aws::sign_request(&mut req, &aws_auth).await;
+	assert!(result.is_err(), "Should fail without region");
+
+	let err = result.unwrap_err().to_string();
+	assert!(
+		err.contains("Region must be specified"),
+		"Error should mention missing region, got: {}",
+		err
+	);
+}
+
+#[tokio::test]
+async fn test_aws_sign_request_implicit_with_extension() {
+	// Test AWS signing with implicit auth uses region from request extensions
+	// Set temporary AWS credentials in environment for test consistency
+	unsafe {
+		std::env::set_var("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE");
+		std::env::set_var(
+			"AWS_SECRET_ACCESS_KEY",
+			"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+		);
+	}
+
+	let mut req = crate::http::Request::new(crate::http::Body::empty());
+	*req.uri_mut() = "https://bedrock-runtime.ap-southeast-1.amazonaws.com/model/invoke"
+		.parse()
+		.unwrap();
+	*req.method_mut() = http::Method::POST;
+
+	// Insert AwsRegion into request extensions
+	req.extensions_mut().insert(AwsRegion {
+		region: "ap-southeast-1".to_string(),
+	});
+
+	let aws_auth = AwsAuth::Implicit {};
+
+	// Should use region from request extensions
+	let result = aws::sign_request(&mut req, &aws_auth).await;
+
+	// Clean up environment variables
+	unsafe {
+		std::env::remove_var("AWS_ACCESS_KEY_ID");
+		std::env::remove_var("AWS_SECRET_ACCESS_KEY");
+	}
+
+	result.expect("signing failed");
 }

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -317,7 +317,11 @@ impl TryFrom<proto::agent::BackendAuthPolicy> for BackendAuth {
 					Some(proto::agent::aws::Kind::ExplicitConfig(config)) => AwsAuth::ExplicitConfig {
 						access_key_id: config.access_key_id.into(),
 						secret_access_key: config.secret_access_key.into(),
-						region: config.region,
+						region: if config.region.is_empty() {
+							None
+						} else {
+							Some(config.region.clone())
+						},
 						session_token: config.session_token.map(|token| token.into()),
 					},
 					Some(proto::agent::aws::Kind::Implicit(_)) => AwsAuth::Implicit {},

--- a/go/api/resource.pb.go
+++ b/go/api/resource.pb.go
@@ -2619,7 +2619,7 @@ type AwsExplicitConfig struct {
 	AccessKeyId string `protobuf:"bytes,1,opt,name=access_key_id,json=accessKeyId,proto3" json:"access_key_id,omitempty"`
 	// AWS Secret Access Key for authentication
 	SecretAccessKey string `protobuf:"bytes,2,opt,name=secret_access_key,json=secretAccessKey,proto3" json:"secret_access_key,omitempty"`
-	// AWS Region (e.g., "us-west-2", "us-east-1")
+	// AWS Region (e.g., "us-west-2", "us-east-1"). Optional for AWS backends.
 	Region string `protobuf:"bytes,3,opt,name=region,proto3" json:"region,omitempty"`
 	// Optional session token for temporary credentials
 	SessionToken  *string `protobuf:"bytes,4,opt,name=session_token,json=sessionToken,proto3,oneof" json:"session_token,omitempty"` // TODO: make service configurable

--- a/schema/local.json
+++ b/schema/local.json
@@ -2126,7 +2126,10 @@
                                                 "type": "string"
                                               },
                                               "region": {
-                                                "type": "string"
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ]
                                               },
                                               "sessionToken": {
                                                 "type": [
@@ -2138,8 +2141,7 @@
                                             "additionalProperties": false,
                                             "required": [
                                               "accessKeyId",
-                                              "secretAccessKey",
-                                              "region"
+                                              "secretAccessKey"
                                             ]
                                           },
                                           {
@@ -4308,7 +4310,10 @@
                                                       "type": "string"
                                                     },
                                                     "region": {
-                                                      "type": "string"
+                                                      "type": [
+                                                        "string",
+                                                        "null"
+                                                      ]
                                                     },
                                                     "sessionToken": {
                                                       "type": [
@@ -4320,8 +4325,7 @@
                                                   "additionalProperties": false,
                                                   "required": [
                                                     "accessKeyId",
-                                                    "secretAccessKey",
-                                                    "region"
+                                                    "secretAccessKey"
                                                   ]
                                                 },
                                                 {
@@ -5992,7 +5996,10 @@
                                                                   "type": "string"
                                                                 },
                                                                 "region": {
-                                                                  "type": "string"
+                                                                  "type": [
+                                                                    "string",
+                                                                    "null"
+                                                                  ]
                                                                 },
                                                                 "sessionToken": {
                                                                   "type": [
@@ -6004,8 +6011,7 @@
                                                               "additionalProperties": false,
                                                               "required": [
                                                                 "accessKeyId",
-                                                                "secretAccessKey",
-                                                                "region"
+                                                                "secretAccessKey"
                                                               ]
                                                             },
                                                             {
@@ -7426,7 +7432,10 @@
                                                                               "type": "string"
                                                                             },
                                                                             "region": {
-                                                                              "type": "string"
+                                                                              "type": [
+                                                                                "string",
+                                                                                "null"
+                                                                              ]
                                                                             },
                                                                             "sessionToken": {
                                                                               "type": [
@@ -7438,8 +7447,7 @@
                                                                           "additionalProperties": false,
                                                                           "required": [
                                                                             "accessKeyId",
-                                                                            "secretAccessKey",
-                                                                            "region"
+                                                                            "secretAccessKey"
                                                                           ]
                                                                         },
                                                                         {
@@ -10431,7 +10439,10 @@
                                     "type": "string"
                                   },
                                   "region": {
-                                    "type": "string"
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
                                   },
                                   "sessionToken": {
                                     "type": [
@@ -10443,8 +10454,7 @@
                                 "additionalProperties": false,
                                 "required": [
                                   "accessKeyId",
-                                  "secretAccessKey",
-                                  "region"
+                                  "secretAccessKey"
                                 ]
                               },
                               {


### PR DESCRIPTION
this way users won't need to specify it twice if they add an auth policy