### PR TITLE
Fix session cleanup for stateless MCP mode

### DIFF
--- a/crates/agentgateway/src/mcp/session.rs
+++ b/crates/agentgateway/src/mcp/session.rs
@@ -376,7 +376,7 @@ impl SessionManager {
 		self.sessions.read().ok()?.get(id).cloned()
 	}
 
-	/// create_session establishes an MCP session.
+	/// create_session establishes an MCP session and registers it in the session manager.
 	pub fn create_session(&self, relay: Relay) -> Session {
 		let id = session_id();
 		let sess = Session {
@@ -387,6 +387,19 @@ impl SessionManager {
 		let mut sm = self.sessions.write().expect("write lock");
 		sm.insert(id.to_string(), sess.clone());
 		sess
+	}
+
+	/// create_stateless_session creates a session for stateless mode.
+	/// Unlike create_session, this does NOT register the session in the session manager.
+	/// The caller is responsible for calling session.delete_session() when done
+	/// to clean up upstream resources (e.g., stdio processes).
+	pub fn create_stateless_session(&self, relay: Relay) -> Session {
+		let id = session_id();
+		Session {
+			id,
+			relay: Arc::new(relay),
+			tx: None,
+		}
 	}
 
 	/// create_legacy_session establishes a legacy SSE session.

--- a/crates/agentgateway/src/mcp/streamablehttp.rs
+++ b/crates/agentgateway/src/mcp/streamablehttp.rs
@@ -105,8 +105,15 @@ impl StreamableHttpService {
 					);
 				},
 			};
-			let session = self.session_manager.create_session(relay);
-			return session.stateless_send_and_initialize(part, message).await;
+			// Use stateless session - not registered in session manager
+			let session = self.session_manager.create_stateless_session(relay);
+			let response = session
+				.stateless_send_and_initialize(part.clone(), message)
+				.await;
+
+			// Clean up upstream resources (e.g., stdio processes)
+			let _ = session.delete_session(part).await;
+			return response;
 		}
 
 		let session_id = part


### PR DESCRIPTION
Fixes #684

In stateless MCP mode, sessions were never cleaned up after requests completed. This caused processes to accumulate over time and persist indefinitely.

This fix makes sure that `delete_session()` is called after each stateless request to clean up sessions appropriately.