### PR TITLE
feat: add workload identity mTLS for HTTPS listeners

### DIFF
--- a/crates/agentgateway/proto/resource.proto
+++ b/crates/agentgateway/proto/resource.proto
@@ -141,6 +141,11 @@ message TLSConfig {
   bytes private_key = 2;
   // Root to verify client certificates. If not set, mTLS will not be used
   optional bytes root = 3;
+  // Use workload identity certificates from Istio CA instead of static cert/key.
+  // When true, cert and private_key are ignored and certificates are obtained
+  // dynamically from the mesh CA. Requires CA_ADDRESS, TRUST_DOMAIN, NAMESPACE,
+  // and SERVICE_ACCOUNT environment variables to be configured.
+  bool workload_identity = 4;
 }
 
 enum Protocol {

--- a/crates/agentgateway/src/control/caclient.rs
+++ b/crates/agentgateway/src/control/caclient.rs
@@ -1,8 +1,9 @@
 use std::cmp;
+use std::collections::HashMap;
 use std::io::Cursor;
 use std::str::FromStr;
-use std::sync::Arc;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::sync::{Arc, RwLock};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use rustls::client::Resumption;
 use rustls::server::VerifierBuilderError;
@@ -74,15 +75,25 @@ pub struct Expiration {
 	pub not_after: SystemTime,
 }
 
-#[derive(Debug)]
 pub struct WorkloadCertificate {
-	// server_config: Arc<ServerConfig>,
-	// client_config: Arc<ClientConfig>,
 	roots: Arc<RootCertStore>,
 	chain: Vec<Certificate>,
 	private_key: PrivateKeyDer<'static>,
 	expiry: Expiration,
 	identity: Identity,
+	/// Cache for outbound mTLS client configs, keyed by sorted destination identities.
+	/// This ensures connection pooling works correctly (pool keys use Arc pointer equality).
+	legacy_mtls_cache: RwLock<HashMap<Vec<Identity>, VersionedBackendTLS>>,
+	hbone_mtls_cache: RwLock<HashMap<Vec<Identity>, VersionedBackendTLS>>,
+}
+
+impl std::fmt::Debug for WorkloadCertificate {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("WorkloadCertificate")
+			.field("identity", &self.identity)
+			.field("expiry", &self.expiry)
+			.finish_non_exhaustive()
+	}
 }
 
 impl WorkloadCertificate {
@@ -126,6 +137,8 @@ impl WorkloadCertificate {
 			private_key: key,
 			chain: cert_and_chain,
 			identity,
+			legacy_mtls_cache: RwLock::new(HashMap::new()),
+			hbone_mtls_cache: RwLock::new(HashMap::new()),
 		})
 	}
 	pub fn is_expired(&self) -> bool {
@@ -141,13 +154,34 @@ impl WorkloadCertificate {
 	}
 
 	pub fn legacy_mtls(&self, identity: Vec<Identity>) -> Result<VersionedBackendTLS, Error> {
-		// TODO: this is (way) too expensive to build per request
+		// Normalize identity order for consistent cache keys
+		let mut cache_key = identity;
+		cache_key.sort();
+
+		// Check cache with read lock first (fast path)
+		{
+			let reader = self.legacy_mtls_cache.read().unwrap();
+			if let Some(cached) = reader.get(&cache_key) {
+				return Ok(cached.clone());
+			}
+		}
+
+		// Acquire write lock and double-check (another thread may have inserted)
+		let mut writer = self.legacy_mtls_cache.write().unwrap();
+		if let Some(cached) = writer.get(&cache_key) {
+			return Ok(cached.clone());
+		}
+
+		// Build new config while holding write lock to prevent duplicate builds
 		let roots = self.roots.clone();
-		let verifier = transport::tls::identity::IdentityVerifier { roots, identity };
+		let verifier = transport::tls::identity::IdentityVerifier {
+			roots,
+			identity: cache_key.clone(),
+		};
 		let mut cc = ClientConfig::builder_with_provider(transport::tls::provider())
 			.with_protocol_versions(transport::tls::ALL_TLS_VERSIONS)
 			.expect("client config must be valid")
-			.dangerous() // Customer verifier is requires "dangerous" opt-in
+			.dangerous() // Custom verifier requires "dangerous" opt-in
 			.with_custom_certificate_verifier(Arc::new(verifier))
 			.with_client_auth_cert(
 				self.chain.iter().map(|c| c.der.clone()).collect(),
@@ -155,20 +189,44 @@ impl WorkloadCertificate {
 			)?;
 		cc.alpn_protocols = vec![b"istio".into()];
 		cc.resumption = Resumption::disabled();
-		// cc.enable_sni = false;
-		Ok(VersionedBackendTLS {
+
+		let result = VersionedBackendTLS {
 			hostname_override: None,
 			config: Arc::new(cc),
-		})
+		};
+		writer.insert(cache_key, result.clone());
+
+		Ok(result)
 	}
 	pub fn hbone_mtls(&self, identity: Vec<Identity>) -> Result<VersionedBackendTLS, Error> {
-		// TODO: this is (way) too expensive to build per request
+		// Normalize identity order for consistent cache keys
+		let mut cache_key = identity;
+		cache_key.sort();
+
+		// Check cache with read lock first (fast path)
+		{
+			let reader = self.hbone_mtls_cache.read().unwrap();
+			if let Some(cached) = reader.get(&cache_key) {
+				return Ok(cached.clone());
+			}
+		}
+
+		// Acquire write lock and double-check (another thread may have inserted)
+		let mut writer = self.hbone_mtls_cache.write().unwrap();
+		if let Some(cached) = writer.get(&cache_key) {
+			return Ok(cached.clone());
+		}
+
+		// Build new config while holding write lock to prevent duplicate builds
 		let roots = self.roots.clone();
-		let verifier = transport::tls::identity::IdentityVerifier { roots, identity };
+		let verifier = transport::tls::identity::IdentityVerifier {
+			roots,
+			identity: cache_key.clone(),
+		};
 		let mut cc = ClientConfig::builder_with_provider(transport::tls::provider())
 			.with_protocol_versions(transport::tls::ALL_TLS_VERSIONS)
 			.expect("client config must be valid")
-			.dangerous() // Customer verifier is requires "dangerous" opt-in
+			.dangerous() // Custom verifier requires "dangerous" opt-in
 			.with_custom_certificate_verifier(Arc::new(verifier))
 			.with_client_auth_cert(
 				self.chain.iter().map(|c| c.der.clone()).collect(),
@@ -177,34 +235,58 @@ impl WorkloadCertificate {
 		cc.alpn_protocols = vec![b"h2".into()];
 		cc.resumption = Resumption::disabled();
 		cc.enable_sni = false;
-		Ok(VersionedBackendTLS {
+
+		let result = VersionedBackendTLS {
 			hostname_override: None,
 			config: Arc::new(cc),
-		})
+		};
+		writer.insert(cache_key, result.clone());
+
+		Ok(result)
 	}
+	/// Create a TLS ServerConfig for terminating HBONE (ambient mesh) connections.
 	pub fn hbone_termination(&self) -> Result<ServerConfig, Error> {
+		self.mtls_server_config(None)
+	}
+
+	/// Create a TLS ServerConfig for HTTPS listeners using workload identity mTLS.
+	///
+	/// ALPN protocols:
+	/// - `istio`: For clients with Istio sidecars (mesh mTLS)
+	/// - `h2`, `http/1.1`: For direct HTTP clients without sidecars
+	pub fn https_mtls_termination(&self) -> Result<ServerConfig, Error> {
+		const HTTPS_ALPN: &[&[u8]] = &[b"istio", b"h2", b"http/1.1"];
+		self.mtls_server_config(Some(HTTPS_ALPN))
+	}
+
+	fn mtls_server_config(&self, alpn: Option<&[&[u8]]>) -> Result<ServerConfig, Error> {
 		let Identity::Spiffe { trust_domain, .. } = &self.identity;
 
-		// TODO: this istoo expensive to build per request
-		let roots = self.roots.clone();
-		let raw_client_cert_verifier = rustls::server::WebPkiClientVerifier::builder_with_provider(
-			roots.clone(),
+		let raw_verifier = rustls::server::WebPkiClientVerifier::builder_with_provider(
+			self.roots.clone(),
 			transport::tls::provider(),
 		)
 		.build()?;
-		let client_cert_verifier = transport::tls::trustdomain::TrustDomainVerifier::new(
-			raw_client_cert_verifier,
+
+		let verifier = transport::tls::trustdomain::TrustDomainVerifier::new(
+			raw_verifier,
 			Some(trust_domain.clone()),
 		);
-		let sc = ServerConfig::builder_with_provider(transport::tls::provider())
+
+		let mut config = ServerConfig::builder_with_provider(transport::tls::provider())
 			.with_protocol_versions(transport::tls::ALL_TLS_VERSIONS)
 			.expect("server config must be valid")
-			.with_client_cert_verifier(client_cert_verifier)
+			.with_client_cert_verifier(verifier)
 			.with_single_cert(
 				self.chain.iter().map(|c| c.der.clone()).collect(),
 				self.private_key.clone_key(),
 			)?;
-		Ok(sc)
+
+		if let Some(protocols) = alpn {
+			config.alpn_protocols = protocols.iter().map(|p| p.to_vec()).collect();
+		}
+
+		Ok(config)
 	}
 }
 
@@ -308,6 +390,13 @@ fn expiration(cert: X509Certificate) -> Expiration {
 	}
 }
 
+/// Initial backoff delay after a failed certificate fetch.
+const INITIAL_BACKOFF: Duration = Duration::from_secs(1);
+/// Maximum backoff delay between retry attempts.
+const MAX_BACKOFF: Duration = Duration::from_secs(120);
+/// How often to check if refresh is needed when we have a valid certificate.
+const CHECK_INTERVAL: Duration = Duration::from_secs(30);
+
 #[derive(Debug, Clone, Default)]
 enum CertificateState {
 	#[default]
@@ -374,47 +463,81 @@ impl CaClient {
 		config: Config,
 		state_tx: watch::Sender<CertificateState>,
 	) {
-		let mut interval = tokio::time::interval(Duration::from_secs(30)); // Check every 30 seconds
-
-		// Start with an immediate fetch
-		if let Err(e) = Self::fetch_and_update_certificate(client.clone(), &config, &state_tx).await {
-			error!("Initial certificate fetch failed: {:?}", e);
-			let _ = state_tx.send(CertificateState::Error(e));
-		}
+		let mut backoff = INITIAL_BACKOFF;
+		let mut next_attempt = Instant::now();
 
 		loop {
-			interval.tick().await;
+			// Sleep until next attempt time
+			tokio::time::sleep_until(next_attempt.into()).await;
 
-			// Check if we need to renew
-			let should_renew = {
+			// Check current state to determine what to do
+			let (should_fetch, valid_cert_expiry) = {
 				let state = state_tx.borrow();
 				match &*state {
 					CertificateState::Available(cert) => {
-						let refresh_at = cert.refresh_at();
-						SystemTime::now() >= refresh_at
+						let needs_refresh = SystemTime::now() >= cert.refresh_at();
+						let expiry = if cert.is_expired() {
+							None
+						} else {
+							Some(cert.expiry.not_after)
+						};
+						(needs_refresh, expiry)
 					},
-					CertificateState::Error(_) | CertificateState::NotReady => true,
+					CertificateState::Error(_) | CertificateState::NotReady => (true, None),
 				}
 			};
 
-			if should_renew {
-				info!("Renewing certificate for identity: {}", config.identity);
+			if !should_fetch {
+				// Certificate is valid and doesn't need refresh yet, check again later
+				next_attempt = Instant::now() + CHECK_INTERVAL;
+				continue;
+			}
 
-				match Self::fetch_and_update_certificate(client.clone(), &config, &state_tx).await {
-					Ok(_) => {
-						info!(
-							"Successfully renewed certificate for identity: {}",
-							config.identity
+			info!("Fetching certificate for identity: {}", config.identity);
+
+			match Self::fetch_and_update_certificate(client.clone(), &config, &state_tx).await {
+				Ok(_) => {
+					info!(
+						"Successfully fetched certificate for identity: {}",
+						config.identity
+					);
+					// Reset backoff on success
+					backoff = INITIAL_BACKOFF;
+					// Schedule next check based on normal interval
+					next_attempt = Instant::now() + CHECK_INTERVAL;
+				},
+				Err(e) => {
+					// Calculate retry delay, capping at cert expiry if we have a valid cert
+					let retry_delay = match valid_cert_expiry {
+						Some(expiry) => {
+							// Cap retry at cert expiry to maximize renewal attempts
+							let until_expiry = expiry
+								.duration_since(SystemTime::now())
+								.unwrap_or(Duration::ZERO);
+							cmp::min(backoff, until_expiry)
+						},
+						None => backoff,
+					};
+
+					if valid_cert_expiry.is_some() {
+						// We still have a valid certificate - keep using it, retry with backoff
+						warn!(
+							"Certificate refresh failed for {}, retaining valid certificate: {}. Retrying in {:?}",
+							config.identity, e, retry_delay
 						);
-					},
-					Err(e) => {
+						// Don't update state - keep the valid certificate
+					} else {
+						// No valid certificate available - set error state
 						error!(
-							"Failed to renew certificate for identity {}: {}",
-							config.identity, e
+							"Certificate fetch failed for {} with no valid fallback: {}. Retrying in {:?}",
+							config.identity, e, retry_delay
 						);
 						let _ = state_tx.send(CertificateState::Error(e));
-					},
-				}
+					}
+					// Schedule retry
+					next_attempt = Instant::now() + retry_delay;
+					backoff = cmp::min(MAX_BACKOFF, backoff * 2);
+				},
 			}
 		}
 	}
@@ -424,8 +547,6 @@ impl CaClient {
 		config: &Config,
 		state_tx: &watch::Sender<CertificateState>,
 	) -> Result<(), Error> {
-		info!("Fetching certificate for identity: {}", config.identity);
-
 		let svc = control::grpc_connector(
 			client,
 			config.address.clone(),

--- a/crates/agentgateway/src/proxy/gateway_test.rs
+++ b/crates/agentgateway/src/proxy/gateway_test.rs
@@ -249,11 +249,12 @@ async fn tls_termination() {
 			hostname: strng::new("*.example.com"),
 			protocol: ListenerProtocol::HTTPS(
 				types::local::LocalTLSServerConfig {
-					cert: "../../examples/tls/certs/cert.pem".into(),
-					key: "../../examples/tls/certs/key.pem".into(),
+					cert: Some("../../examples/tls/certs/cert.pem".into()),
+					key: Some("../../examples/tls/certs/key.pem".into()),
 					root: None,
+					workload_identity: false,
 				}
-				.try_into()
+				.into_termination()
 				.unwrap(),
 			),
 			tcp_routes: Default::default(),

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -407,9 +407,25 @@ impl TryFrom<(proto::agent::Protocol, Option<&proto::agent::TlsConfig>)> for Lis
 		match (value.0, value.1) {
 			(Protocol::Unknown, _) => Err(ProtoError::EnumParse("unknown protocol".into())),
 			(Protocol::Http, None) => Ok(ListenerProtocol::HTTP),
-			(Protocol::Https, Some(tls)) => Ok(ListenerProtocol::HTTPS(tls.into())),
-			// TLS termination
-			(Protocol::Tls, Some(tls)) => Ok(ListenerProtocol::TLS(Some(tls.into()))),
+			(Protocol::Https, Some(tls)) => {
+				if tls.workload_identity {
+					Ok(ListenerProtocol::HTTPS(TlsTermination::WorkloadIdentity))
+				} else {
+					Ok(ListenerProtocol::HTTPS(TlsTermination::Static(tls.into())))
+				}
+			},
+			// TLS termination (workload identity not supported - use HTTPS for mesh mTLS)
+			(Protocol::Tls, Some(tls)) => {
+				if tls.workload_identity {
+					Err(ProtoError::Generic(
+						"workload_identity is not supported for TLS protocol; use HTTPS instead".into(),
+					))
+				} else {
+					Ok(ListenerProtocol::TLS(Some(TlsTermination::Static(
+						tls.into(),
+					))))
+				}
+			},
 			// TLS passthrough
 			(Protocol::Tls, None) => Ok(ListenerProtocol::TLS(None)),
 			(Protocol::Tcp, None) => Ok(ListenerProtocol::TCP),

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 
 use ::http::Uri;
 use agent_core::prelude::Strng;
-use anyhow::{Error, anyhow, bail};
+use anyhow::{Context, Error, anyhow, bail};
 use itertools::Itertools;
 use macro_rules_attribute::apply;
 use openapiv3::OpenAPI;
@@ -27,8 +27,8 @@ use crate::types::agent::{
 	PolicyPhase, PolicyTarget, PolicyType, ResourceName, Route, RouteBackendReference, RouteMatch,
 	RouteName, RouteSet, ServerTLSConfig, SimpleBackend, SimpleBackendReference,
 	SimpleBackendWithPolicies, SseTargetSpec, StreamableHTTPTargetSpec, TCPRoute,
-	TCPRouteBackendReference, TCPRouteSet, Target, TargetedPolicy, TrafficPolicy, TunnelProtocol,
-	TypedResourceName,
+	TCPRouteBackendReference, TCPRouteSet, Target, TargetedPolicy, TlsTermination, TrafficPolicy,
+	TunnelProtocol, TypedResourceName,
 };
 use crate::types::discovery::{NamespacedHostname, Service};
 use crate::types::{backend, frontend};
@@ -132,13 +132,43 @@ enum LocalListenerProtocol {
 	HBONE,
 }
 
+/// TLS configuration for a listener.
+///
+/// Either provide `cert` and `key` paths for static certificates,
+/// or set `workloadIdentity: true` to use Istio workload identity.
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 pub struct LocalTLSServerConfig {
-	pub cert: PathBuf,
-	pub key: PathBuf,
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub cert: Option<PathBuf>,
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub key: Option<PathBuf>,
+	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub root: Option<PathBuf>,
+	#[serde(default, skip_serializing_if = "std::ops::Not::not")]
+	pub workload_identity: bool,
+}
+
+impl LocalTLSServerConfig {
+	/// Convert to `TlsTermination`, validating and reading certificate files from disk.
+	pub fn into_termination(self) -> anyhow::Result<TlsTermination> {
+		match (self.workload_identity, self.cert, self.key) {
+			(true, None, None) => Ok(TlsTermination::WorkloadIdentity),
+			(true, Some(_), _) | (true, _, Some(_)) => {
+				bail!("cert/key must not be set when workloadIdentity is true")
+			},
+			(false, Some(cert), Some(key)) => Ok(TlsTermination::Static(build_static_tls_config(
+				cert, key, self.root,
+			)?)),
+			(false, None, None) => {
+				bail!("tls requires either workloadIdentity: true or cert/key paths")
+			},
+			(false, Some(_), None) | (false, None, Some(_)) => {
+				bail!("both cert and key are required")
+			},
+		}
+	}
 }
 
 #[apply(schema_de!)]
@@ -916,10 +946,18 @@ async fn convert(
 			// Windows and IPv6 don't mix well apparently?
 			SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), b.port)
 		};
+		let protocol = detect_bind_protocol(&ls);
+		// Validate TLS mode consistency: can't mix workload identity and static certs
+		if protocol == BindProtocol::tls && ls.workload_identity_mode().is_none() {
+			bail!(
+				"cannot mix workload identity and static TLS listeners on bind {}",
+				bind_name
+			);
+		}
 		let b = Bind {
 			key: bind_name,
 			address: sockaddr,
-			protocol: detect_bind_protocol(&ls),
+			protocol,
 			listeners: ls,
 			tunnel_protocol: b.tunnel_protocol,
 		};
@@ -1022,17 +1060,24 @@ async fn convert_listener(
 			if routes.is_none() {
 				bail!("protocol HTTPS requires 'routes'")
 			}
-			ListenerProtocol::HTTPS(
-				tls
-					.ok_or(anyhow!("HTTPS listener requires 'tls'"))?
-					.try_into()?,
-			)
+			let tls_config = tls.ok_or_else(|| anyhow!("HTTPS listener requires 'tls'"))?;
+			ListenerProtocol::HTTPS(tls_config.into_termination()?)
 		},
 		LocalListenerProtocol::TLS => {
 			if tcp_routes.is_none() {
 				bail!("protocol TLS requires 'tcpRoutes'")
 			}
-			ListenerProtocol::TLS(tls.map(TryInto::try_into).transpose()?)
+			let tls_config = match tls {
+				Some(cfg) => {
+					let termination = cfg.into_termination()?;
+					if matches!(termination, TlsTermination::WorkloadIdentity) {
+						bail!("workloadIdentity is not supported for TLS protocol; use HTTPS instead")
+					}
+					Some(termination)
+				},
+				None => None,
+			};
+			ListenerProtocol::TLS(tls_config)
 		},
 		LocalListenerProtocol::TCP => {
 			if tcp_routes.is_none() {
@@ -1426,40 +1471,104 @@ fn mcp_to_simple_backend_and_ref(
 	(bref, backend)
 }
 
-impl TryInto<ServerTLSConfig> for LocalTLSServerConfig {
-	type Error = anyhow::Error;
+fn build_static_tls_config(
+	cert_path: PathBuf,
+	key_path: PathBuf,
+	root_path: Option<PathBuf>,
+) -> anyhow::Result<ServerTLSConfig> {
+	let cert = fs_err::read(&cert_path)
+		.with_context(|| format!("failed to read certificate from {}", cert_path.display()))?;
+	let cert_chain = crate::types::agent::parse_cert(&cert)?;
 
-	fn try_into(self) -> Result<ServerTLSConfig, Self::Error> {
-		let cert = fs_err::read(self.cert)?;
-		let cert_chain = crate::types::agent::parse_cert(&cert)?;
-		let key = fs_err::read(self.key)?;
-		let private_key = crate::types::agent::parse_key(&key)?;
+	let key = fs_err::read(&key_path)
+		.with_context(|| format!("failed to read private key from {}", key_path.display()))?;
+	let private_key = crate::types::agent::parse_key(&key)?;
 
-		let ccb = ServerConfig::builder_with_provider(transport::tls::provider())
-			.with_protocol_versions(transport::tls::ALL_TLS_VERSIONS)
-			.expect("server config must be valid");
+	let builder = ServerConfig::builder_with_provider(transport::tls::provider())
+		.with_protocol_versions(transport::tls::ALL_TLS_VERSIONS)
+		.expect("server config must be valid");
 
-		let ccb = if let Some(root) = self.root {
-			let root = fs_err::read(root)?;
-			let mut roots_store = rustls::RootCertStore::empty();
-			let mut reader = std::io::BufReader::new(Cursor::new(root));
+	let builder = match root_path {
+		Some(root) => {
+			let root_cert = fs_err::read(&root)
+				.with_context(|| format!("failed to read root CA from {}", root.display()))?;
+			let mut roots = rustls::RootCertStore::empty();
+			let mut reader = std::io::BufReader::new(Cursor::new(root_cert));
 			let certs = rustls_pemfile::certs(&mut reader).collect::<Result<Vec<_>, _>>()?;
-			roots_store.add_parsable_certificates(certs);
-			let verify = rustls::server::WebPkiClientVerifier::builder_with_provider(
-				Arc::new(roots_store),
+			roots.add_parsable_certificates(certs);
+
+			let verifier = rustls::server::WebPkiClientVerifier::builder_with_provider(
+				Arc::new(roots),
 				transport::tls::provider(),
 			)
 			.build()?;
-			ccb.with_client_cert_verifier(verify)
-		} else {
-			ccb.with_no_client_auth()
-		};
-		let mut ccb = ccb.with_single_cert(cert_chain, private_key)?;
-		ccb.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
-		Ok(ServerTLSConfig::new(Arc::new(ccb)))
-	}
+			builder.with_client_cert_verifier(verifier)
+		},
+		None => builder.with_no_client_auth(),
+	};
+
+	let mut config = builder.with_single_cert(cert_chain, private_key)?;
+	config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
+
+	Ok(ServerTLSConfig::new(Arc::new(config)))
 }
 
 fn local_name(name: Strng) -> ResourceName {
 	ResourceName::new(name, "".into())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn tls_config(
+		cert: Option<&str>,
+		key: Option<&str>,
+		workload_identity: bool,
+	) -> LocalTLSServerConfig {
+		LocalTLSServerConfig {
+			cert: cert.map(Into::into),
+			key: key.map(Into::into),
+			root: None,
+			workload_identity,
+		}
+	}
+
+	#[test]
+	fn test_tls_config_workload_identity() {
+		assert!(matches!(
+			tls_config(None, None, true).into_termination().unwrap(),
+			TlsTermination::WorkloadIdentity
+		));
+	}
+
+	#[test]
+	fn test_tls_config_invalid() {
+		// workload_identity + cert
+		assert!(
+			tls_config(Some("c.pem"), None, true)
+				.into_termination()
+				.is_err()
+		);
+		// workload_identity + key
+		assert!(
+			tls_config(None, Some("k.pem"), true)
+				.into_termination()
+				.is_err()
+		);
+		// Neither workload_identity nor certs
+		assert!(tls_config(None, None, false).into_termination().is_err());
+		// cert without key
+		assert!(
+			tls_config(Some("c.pem"), None, false)
+				.into_termination()
+				.is_err()
+		);
+		// key without cert
+		assert!(
+			tls_config(None, Some("k.pem"), false)
+				.into_termination()
+				.is_err()
+		);
+	}
 }

--- a/go/api/resource.pb.go
+++ b/go/api/resource.pb.go
@@ -2210,9 +2210,14 @@ type TLSConfig struct {
 	Cert       []byte                 `protobuf:"bytes,1,opt,name=cert,proto3" json:"cert,omitempty"`
 	PrivateKey []byte                 `protobuf:"bytes,2,opt,name=private_key,json=privateKey,proto3" json:"private_key,omitempty"`
 	// Root to verify client certificates. If not set, mTLS will not be used
-	Root          []byte `protobuf:"bytes,3,opt,name=root,proto3,oneof" json:"root,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Root []byte `protobuf:"bytes,3,opt,name=root,proto3,oneof" json:"root,omitempty"`
+	// Use workload identity certificates from Istio CA instead of static cert/key.
+	// When true, cert and private_key are ignored and certificates are obtained
+	// dynamically from the mesh CA. Requires CA_ADDRESS, TRUST_DOMAIN, NAMESPACE,
+	// and SERVICE_ACCOUNT environment variables to be configured.
+	WorkloadIdentity bool `protobuf:"varint,4,opt,name=workload_identity,json=workloadIdentity,proto3" json:"workload_identity,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *TLSConfig) Reset() {
@@ -2264,6 +2269,13 @@ func (x *TLSConfig) GetRoot() []byte {
 		return x.Root
 	}
 	return nil
+}
+
+func (x *TLSConfig) GetWorkloadIdentity() bool {
+	if x != nil {
+		return x.WorkloadIdentity
+	}
+	return false
 }
 
 type Timeout struct {
@@ -9565,12 +9577,13 @@ const file_resource_proto_rawDesc = "" +
 	"\x03mcp\x18\x05 \x01(\v2%.agentgateway.dev.resource.MCPBackendH\x00R\x03mcp\x12J\n" +
 	"\adynamic\x18\x06 \x01(\v2..agentgateway.dev.resource.DynamicForwardProxyH\x00R\adynamic\x12U\n" +
 	"\x0finline_policies\x18\a \x03(\v2,.agentgateway.dev.resource.BackendPolicySpecR\x0einlinePoliciesB\x06\n" +
-	"\x04kind\"b\n" +
+	"\x04kind\"\x8f\x01\n" +
 	"\tTLSConfig\x12\x12\n" +
 	"\x04cert\x18\x01 \x01(\fR\x04cert\x12\x1f\n" +
 	"\vprivate_key\x18\x02 \x01(\fR\n" +
 	"privateKey\x12\x17\n" +
-	"\x04root\x18\x03 \x01(\fH\x00R\x04root\x88\x01\x01B\a\n" +
+	"\x04root\x18\x03 \x01(\fH\x00R\x04root\x88\x01\x01\x12+\n" +
+	"\x11workload_identity\x18\x04 \x01(\bR\x10workloadIdentityB\a\n" +
 	"\x05_root\"\x82\x01\n" +
 	"\aTimeout\x123\n" +
 	"\arequest\x18\x01 \x01(\v2\x19.google.protobuf.DurationR\arequest\x12B\n" +

--- a/schema/README.md
+++ b/schema/README.md
@@ -67,10 +67,11 @@ This folder contains JSON schemas for various parts of the project
 |`binds[].listeners[].gatewayName`||
 |`binds[].listeners[].hostname`|Can be a wildcard|
 |`binds[].listeners[].protocol`||
-|`binds[].listeners[].tls`||
+|`binds[].listeners[].tls`|TLS configuration for a listener.<br><br>Either provide `cert` and `key` paths for static certificates,<br>or set `workloadIdentity: true` to use Istio workload identity.|
 |`binds[].listeners[].tls.cert`||
 |`binds[].listeners[].tls.key`||
 |`binds[].listeners[].tls.root`||
+|`binds[].listeners[].tls.workloadIdentity`||
 |`binds[].listeners[].routes`||
 |`binds[].listeners[].routes[].name`||
 |`binds[].listeners[].routes[].namespace`||

--- a/schema/local.json
+++ b/schema/local.json
@@ -465,29 +465,35 @@
                   ]
                 },
                 "tls": {
+                  "description": "TLS configuration for a listener.\n\nEither provide `cert` and `key` paths for static certificates,\nor set `workloadIdentity: true` to use Istio workload identity.",
                   "type": [
                     "object",
                     "null"
                   ],
                   "properties": {
                     "cert": {
-                      "type": "string"
+                      "type": [
+                        "string",
+                        "null"
+                      ]
                     },
                     "key": {
-                      "type": "string"
+                      "type": [
+                        "string",
+                        "null"
+                      ]
                     },
                     "root": {
                       "type": [
                         "string",
                         "null"
                       ]
+                    },
+                    "workloadIdentity": {
+                      "type": "boolean"
                     }
                   },
-                  "additionalProperties": false,
-                  "required": [
-                    "cert",
-                    "key"
-                  ]
+                  "additionalProperties": false
                 },
                 "routes": {
                   "type": [


### PR DESCRIPTION
Allow agentgateway to use Istio CA certificates instead of static cert files for HTTPS listeners, enabling mesh-native mTLS with automatic certificate rotation.

Config:
  listeners:
  - protocol: HTTPS tls: workloadIdentity: true  # instead of cert/key paths

Changes:
- Proto/XDS: Added workload_identity field to TLSConfig
- Local config: Added TLSSource enum, validation logic (into_tls_source)
- Gateway: New terminate_https() path using CA client for cert acquisition; rejects mixing static + workload identity on same bind
- CA client: Added legacy_mtls_termination() with Istio mesh ALPNs

Requires: CA_ADDRESS, TRUST_DOMAIN, NAMESPACE, SERVICE_ACCOUNT env vars