### PR TITLE
feat(llm): add Embeddings route type for /v1/embeddings

### DIFF
--- a/crates/agentgateway/proto/resource.proto
+++ b/crates/agentgateway/proto/resource.proto
@@ -760,6 +760,8 @@ message BackendPolicySpec {
       RESPONSES = 5;
       // Processes Anthropic /v1/messages/count_tokens format requests
       ANTHROPIC_TOKEN_COUNT = 6;
+      // Processes OpenAI /v1/embeddings format requests
+      EMBEDDINGS = 7;
     }
 
     // Routes defines how to identify the type of LLM request to handle.

--- a/crates/agentgateway/src/llm/openai.rs
+++ b/crates/agentgateway/src/llm/openai.rs
@@ -20,6 +20,7 @@ pub fn path(route: RouteType) -> &'static str {
 	match route {
 		// For Responses we forward to the responses endpoint
 		RouteType::Responses => "/v1/responses",
+		// For Embeddings we forward to the embeddings endpoint
 		RouteType::Embeddings => "/v1/embeddings",
 		// All others get translated down to completions
 		_ => "/v1/chat/completions",

--- a/crates/agentgateway/src/llm/policy/tests.rs
+++ b/crates/agentgateway/src/llm/policy/tests.rs
@@ -224,6 +224,10 @@ fn test_resolve_route() {
 		strng::literal!("/v1/messages"),
 		crate::llm::RouteType::Messages,
 	);
+	routes.insert(
+		strng::literal!("/v1/embeddings"),
+		crate::llm::RouteType::Embeddings,
+	);
 	routes.insert(strng::literal!("*"), crate::llm::RouteType::Passthrough);
 
 	let policy = Policy {
@@ -244,6 +248,11 @@ fn test_resolve_route() {
 	assert_eq!(
 		policy.resolve_route("/v1/messages"),
 		crate::llm::RouteType::Messages
+	);
+	// Embeddings route
+	assert_eq!(
+		policy.resolve_route("/v1/embeddings"),
+		crate::llm::RouteType::Embeddings
 	);
 	// Wildcard fallback
 	assert_eq!(

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -200,6 +200,7 @@ fn convert_route_type(proto_rt: i32) -> llm::RouteType {
 		Ok(ProtoRT::Passthrough) => llm::RouteType::Passthrough,
 		Ok(ProtoRT::Responses) => llm::RouteType::Responses,
 		Ok(ProtoRT::AnthropicTokenCount) => llm::RouteType::AnthropicTokenCount,
+		Ok(ProtoRT::Embeddings) => llm::RouteType::Embeddings,
 		Err(_) => {
 			warn!(
 				"Unknown proto RouteType value {}, defaulting to Completions",

--- a/go/api/resource.pb.go
+++ b/go/api/resource.pb.go
@@ -634,6 +634,8 @@ const (
 	BackendPolicySpec_Ai_RESPONSES BackendPolicySpec_Ai_RouteType = 5
 	// Processes Anthropic /v1/messages/count_tokens format requests
 	BackendPolicySpec_Ai_ANTHROPIC_TOKEN_COUNT BackendPolicySpec_Ai_RouteType = 6
+	// Processes OpenAI /v1/embeddings format requests
+	BackendPolicySpec_Ai_EMBEDDINGS BackendPolicySpec_Ai_RouteType = 7
 )
 
 // Enum value maps for BackendPolicySpec_Ai_RouteType.
@@ -646,6 +648,7 @@ var (
 		4: "PASSTHROUGH",
 		5: "RESPONSES",
 		6: "ANTHROPIC_TOKEN_COUNT",
+		7: "EMBEDDINGS",
 	}
 	BackendPolicySpec_Ai_RouteType_value = map[string]int32{
 		"UNSPECIFIED":           0,
@@ -655,6 +658,7 @@ var (
 		"PASSTHROUGH":           4,
 		"RESPONSES":             5,
 		"ANTHROPIC_TOKEN_COUNT": 6,
+		"EMBEDDINGS":            7,
 	}
 )
 
@@ -9784,7 +9788,7 @@ const file_resource_proto_rawDesc = "" +
 	"\vPolicyPhase\x12\t\n" +
 	"\x05ROUTE\x10\x00\x12\v\n" +
 	"\aGATEWAY\x10\x01B\x06\n" +
-	"\x04kind\"\xd01\n" +
+	"\x04kind\"\xe01\n" +
 	"\x11BackendPolicySpec\x12D\n" +
 	"\x03a2a\x18\x01 \x01(\v20.agentgateway.dev.resource.BackendPolicySpec.A2aH\x00R\x03a2a\x12l\n" +
 	"\x11inference_routing\x18\x02 \x01(\v2=.agentgateway.dev.resource.BackendPolicySpec.InferenceRoutingH\x00R\x10inferenceRouting\x12Z\n" +
@@ -9801,7 +9805,7 @@ const file_resource_proto_rawDesc = "" +
 	"\x0erequest_mirror\x18\v \x01(\v2).agentgateway.dev.resource.RequestMirrorsH\x00R\rrequestMirror\x12]\n" +
 	"\fbackend_http\x18\f \x01(\v28.agentgateway.dev.resource.BackendPolicySpec.BackendHTTPH\x00R\vbackendHttp\x12Z\n" +
 	"\vbackend_tcp\x18\r \x01(\v27.agentgateway.dev.resource.BackendPolicySpec.BackendTCPH\x00R\n" +
-	"backendTcp\x1a\xc4\x19\n" +
+	"backendTcp\x1a\xd4\x19\n" +
 	"\x02Ai\x12^\n" +
 	"\fprompt_guard\x18\x01 \x01(\v2;.agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuardR\vpromptGuard\x12Y\n" +
 	"\bdefaults\x18\x02 \x03(\v2=.agentgateway.dev.resource.BackendPolicySpec.Ai.DefaultsEntryR\bdefaults\x12\\\n" +
@@ -9880,7 +9884,7 @@ const file_resource_proto_rawDesc = "" +
 	"\x12ACTION_UNSPECIFIED\x10\x00\x12\b\n" +
 	"\x04MASK\x10\x01\x12\n" +
 	"\n" +
-	"\x06REJECT\x10\x02\"\x82\x01\n" +
+	"\x06REJECT\x10\x02\"\x92\x01\n" +
 	"\tRouteType\x12\x0f\n" +
 	"\vUNSPECIFIED\x10\x00\x12\x0f\n" +
 	"\vCOMPLETIONS\x10\x01\x12\f\n" +
@@ -9889,7 +9893,9 @@ const file_resource_proto_rawDesc = "" +
 	"\x06MODELS\x10\x03\x12\x0f\n" +
 	"\vPASSTHROUGH\x10\x04\x12\r\n" +
 	"\tRESPONSES\x10\x05\x12\x19\n" +
-	"\x15ANTHROPIC_TOKEN_COUNT\x10\x06\x1a\x05\n" +
+	"\x15ANTHROPIC_TOKEN_COUNT\x10\x06\x12\x0e\n" +
+	"\n" +
+	"EMBEDDINGS\x10\a\x1a\x05\n" +
 	"\x03A2a\x1a\x92\x02\n" +
 	"\x10InferenceRouting\x12T\n" +
 	"\x0fendpoint_picker\x18\x01 \x01(\v2+.agentgateway.dev.resource.BackendReferenceR\x0eendpointPicker\x12l\n" +


### PR DESCRIPTION
## Summary

Add support for routing OpenAI /v1/embeddings requests through agentgateway.

This enables users to configure embedding routes in their AI backend configuration, similar to how chat completions, messages, and responses are routed today.

## Changes

- **proto**: Add `EMBEDDINGS = 7` to `RouteType` enum in `resource.proto`
- **llm/mod.rs**: Add `Embeddings` variant to Rust `RouteType` enum  
- **llm/openai.rs**: Add `/v1/embeddings` path handling for OpenAI provider
- **proxy/httpproxy.rs**: Handle `Embeddings` route type (passthrough-style, similar to `Passthrough`)
- **types/agent_xds.rs**: Add proto-to-Rust conversion for `Embeddings`
- **go/api/resource.pb.go**: Regenerate Go proto bindings with `EMBEDDINGS = 7`
- **llm/policy/tests.rs**: Add test coverage for Embeddings route resolution

## Scope & Limitations

**Currently supported:** OpenAI provider only

The `/v1/embeddings` path mapping is only implemented for the OpenAI provider. Other providers (Anthropic, Bedrock, Gemini, etc.) don't have dedicated embeddings path handling - they'll fall through to their default LLM path, which may not be semantically correct.

If there's demand for other providers' embedding APIs, we can add dedicated handling in a follow-up.

## Design Decision: Passthrough-style handling

Embeddings requests are handled similarly to `Passthrough` - they bypass LLM policies (prompt guard, enrichment) and token-based rate limiting. This is intentional because:

1. **No prompt content**: Embeddings requests don't have chat messages to guard/enrich
2. **Different cost model**: Embeddings have their own pricing separate from completion tokens
3. **Simple forwarding**: The main value is correct path rewriting (`/v1/embeddings`)

## Usage

In agentgateway config (YAML), route types use camelCase:

```yaml
listeners:
  - name: ai
    port: 8080
    routes:
      - backends:
          - ai:
              llm:
                openai: {}
              policy:
                routes:
                  /v1/embeddings: embeddings
                  /v1/chat/completions: completions
                  "*": passthrough
```

> **Note**: The kgateway `AgentgatewayPolicy` CRD integration will be done in a separate PR after this lands.

## Related

Fixes kgateway-dev/kgateway#12911

## Test Plan

- [x] `cargo check --package agentgateway` - build succeeds
- [x] `cargo test --package agentgateway -- route` - route tests pass
- [x] `cargo test --package agentgateway -- llm::policy::tests` - LLM policy tests pass (includes new Embeddings test)