### PR TITLE
Disable write access for xds, display policies in ui

### DIFF
--- a/ui/src/app/page.tsx
+++ b/ui/src/app/page.tsx
@@ -29,11 +29,13 @@ import {
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import Link from "next/link";
 import { LoadingState } from "@/components/loading-state";
+import { useXdsMode } from "@/hooks/use-xds-mode";
 
 export default function Home() {
   const { isLoading, setIsLoading } = useLoading();
-  const { setConfig, isConnected, connectionError, binds, targets } = useServer();
+  const { setConfig, isConnected, connectionError, binds } = useServer();
   const { showWizard, handleWizardComplete, handleWizardSkip, restartWizard } = useWizard();
+  const xds = useXdsMode();
 
   const [configUpdateMessage] = useState<{
     success: boolean;
@@ -134,7 +136,12 @@ export default function Home() {
     const protocols: { [key: string]: number } = {};
     binds?.forEach((bind) => {
       bind.listeners.forEach((listener) => {
-        const protocol = listener.protocol || "HTTP";
+        const protocol =
+          typeof listener.protocol === "string"
+            ? listener.protocol
+            : listener.protocol && typeof listener.protocol === "object"
+              ? Object.keys(listener.protocol as Record<string, unknown>)[0] || "HTTP"
+              : "HTTP";
         protocols[protocol] = (protocols[protocol] || 0) + 1;
       });
     });
@@ -214,13 +221,20 @@ export default function Home() {
               Get started by configuring your first port bind and listener to begin routing traffic.
             </p>
             <div className="flex flex-col sm:flex-row gap-3 justify-center">
-              <Button asChild>
-                <Link href="/listeners">
+              {xds ? (
+                <Button disabled className="opacity-50 cursor-not-allowed">
                   <Plus className="h-4 w-4 mr-2" />
                   Create First Listener
-                </Link>
-              </Button>
-              <Button variant="outline" onClick={handleRestartWizard}>
+                </Button>
+              ) : (
+                <Button asChild>
+                  <Link href="/listeners">
+                    <Plus className="h-4 w-4 mr-2" />
+                    Create First Listener
+                  </Link>
+                </Button>
+              )}
+              <Button variant="outline" onClick={handleRestartWizard} disabled={xds}>
                 <Settings className="h-4 w-4 mr-2" />
                 Run Setup Wizard
               </Button>
@@ -402,24 +416,57 @@ export default function Home() {
             </CardHeader>
             <CardContent>
               <div className="space-y-3">
-                <Button asChild variant="outline" className="w-full justify-start">
-                  <Link href="/listeners">
+                {xds ? (
+                  <Button
+                    variant="outline"
+                    className="w-full justify-start opacity-50 cursor-not-allowed"
+                    disabled
+                  >
                     <Plus className="h-4 w-4 mr-2" />
                     Add Listener
-                  </Link>
-                </Button>
-                <Button asChild variant="outline" className="w-full justify-start">
-                  <Link href="/routes">
+                  </Button>
+                ) : (
+                  <Button asChild variant="outline" className="w-full justify-start">
+                    <Link href="/listeners">
+                      <Plus className="h-4 w-4 mr-2" />
+                      Add Listener
+                    </Link>
+                  </Button>
+                )}
+                {xds ? (
+                  <Button
+                    variant="outline"
+                    className="w-full justify-start opacity-50 cursor-not-allowed"
+                    disabled
+                  >
                     <Route className="h-4 w-4 mr-2" />
                     Create Route
-                  </Link>
-                </Button>
-                <Button asChild variant="outline" className="w-full justify-start">
-                  <Link href="/policies">
+                  </Button>
+                ) : (
+                  <Button asChild variant="outline" className="w-full justify-start">
+                    <Link href="/routes">
+                      <Route className="h-4 w-4 mr-2" />
+                      Create Route
+                    </Link>
+                  </Button>
+                )}
+                {xds ? (
+                  <Button
+                    variant="outline"
+                    className="w-full justify-start opacity-50 cursor-not-allowed"
+                    disabled
+                  >
                     <Shield className="h-4 w-4 mr-2" />
                     Configure Policy
-                  </Link>
-                </Button>
+                  </Button>
+                ) : (
+                  <Button asChild variant="outline" className="w-full justify-start">
+                    <Link href="/policies">
+                      <Shield className="h-4 w-4 mr-2" />
+                      Configure Policy
+                    </Link>
+                  </Button>
+                )}
                 <Button asChild variant="outline" className="w-full justify-start">
                   <Link href="/playground">
                     <Code className="h-4 w-4 mr-2" />

--- a/ui/src/app/policies/page.tsx
+++ b/ui/src/app/policies/page.tsx
@@ -4,11 +4,16 @@ import { PolicyConfig } from "@/components/policy-config";
 import { useServer } from "@/lib/server-context";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { AlertCircle, Shield } from "lucide-react";
-import { useState, useEffect } from "react";
-import { fetchBinds } from "@/lib/api";
+import { useState, useEffect, useCallback } from "react";
+import { fetchBinds, fetchConfig } from "@/lib/api";
+import { useXdsMode } from "@/hooks/use-xds-mode";
+import { AppliedPolicy } from "@/lib/types";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
 
 export default function PoliciesPage() {
   const { connectionError } = useServer();
+  const xds = useXdsMode();
   const [isLoading, setIsLoading] = useState(true);
   const [policyStats, setPolicyStats] = useState({
     totalPolicies: 0,
@@ -17,6 +22,9 @@ export default function PoliciesPage() {
     routingPolicies: 0,
     bindsWithPolicies: 0,
   });
+  const [appliedPolicies, setAppliedPolicies] = useState<AppliedPolicy[]>([]);
+  const [appliedLoading, setAppliedLoading] = useState<boolean>(false);
+  const [appliedError, setAppliedError] = useState<string | null>(null);
 
   const getPolicyCategories = (policies: any) => {
     const categories = new Set<string>();
@@ -55,7 +63,7 @@ export default function PoliciesPage() {
     return Array.from(categories);
   };
 
-  const loadPolicyStats = async () => {
+  const loadPolicyStats = useCallback(async () => {
     try {
       const binds = await fetchBinds();
       let totalPolicies = 0;
@@ -96,11 +104,35 @@ export default function PoliciesPage() {
     } finally {
       setIsLoading(false);
     }
-  };
+  }, []);
+
+  const loadAppliedPolicies = useCallback(async () => {
+    if (!xds) {
+      setAppliedPolicies([]);
+      return;
+    }
+    setAppliedLoading(true);
+    setAppliedError(null);
+    try {
+      const cfg = await fetchConfig();
+      const nonRoute = (cfg.appliedPolicies || []).filter((p) => !p.target?.route);
+      setAppliedPolicies(nonRoute);
+    } catch (e: any) {
+      console.error("Error loading applied policies:", e);
+      setAppliedError("Failed to load applied policies");
+    } finally {
+      setAppliedLoading(false);
+    }
+  }, [xds]);
 
   useEffect(() => {
     loadPolicyStats();
-  }, []);
+  }, [loadPolicyStats]);
+
+  useEffect(() => {
+    // Only in XDS mode do we have applied policies from config dump
+    loadAppliedPolicies();
+  }, [loadAppliedPolicies]);
 
   return (
     <div className="container mx-auto py-8 px-4">
@@ -146,6 +178,68 @@ export default function PoliciesPage() {
           )}
         </div>
       </div>
+
+      {xds && (
+        <div className="mb-8">
+          <div className="flex items-center justify-between mb-3">
+            <h2 className="text-xl font-semibold">Applied policies (non-inline)</h2>
+            <Badge variant="secondary">XDS</Badge>
+          </div>
+          <p className="text-sm text-muted-foreground mb-4">
+            These are non-inline policies that can be applied to different targets.
+          </p>
+
+          {appliedLoading ? (
+            <div className="text-sm text-muted-foreground">Loading applied policies…</div>
+          ) : appliedError ? (
+            <Alert variant="destructive" className="mb-4">
+              <AlertCircle className="h-4 w-4" />
+              <AlertDescription>{appliedError}</AlertDescription>
+            </Alert>
+          ) : appliedPolicies.length === 0 ? (
+            <Card>
+              <CardContent className="py-6">
+                <div className="text-sm text-muted-foreground">
+                  No non-route applied policies found.
+                </div>
+              </CardContent>
+            </Card>
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              {appliedPolicies.map((p: AppliedPolicy) => {
+                const isService = !!p.target?.backend?.service;
+                const isBackend = !!p.target?.backend?.backend;
+                const targetLabel = isService
+                  ? `${p.target!.backend!.service!.namespace}/${p.target!.backend!.service!.hostname}`
+                  : isBackend
+                    ? `${p.target!.backend!.backend!.namespace}/${p.target!.backend!.backend!.name}`
+                    : "Unknown target";
+                return (
+                  <Card key={p.key}>
+                    <CardHeader className="pb-2">
+                      <div className="flex items-center justify-between">
+                        <div className="font-medium">
+                          {p.name.kind} {p.name.namespace}/{p.name.name}
+                        </div>
+                        <Badge variant="outline">{isService ? "Service" : "Backend"}</Badge>
+                      </div>
+                      <div className="text-xs text-muted-foreground mt-1">
+                        Target: {targetLabel}
+                      </div>
+                    </CardHeader>
+                    <CardContent>
+                      <div className="text-xs text-muted-foreground mb-1">Policy</div>
+                      <pre className="text-xs bg-muted/50 rounded p-3 overflow-auto">
+                        {JSON.stringify(p.policy, null, 2)}
+                      </pre>
+                    </CardContent>
+                  </Card>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      )}
 
       {connectionError ? (
         <Alert variant="destructive" className="mb-6">

--- a/ui/src/components/backend-config.tsx
+++ b/ui/src/components/backend-config.tsx
@@ -10,6 +10,7 @@ import {
   useBackendOperations,
 } from "@/lib/backend-hooks";
 import { BackendTable, AddBackendDialog } from "@/components/backend/backend-components";
+import { useXdsMode } from "@/hooks/use-xds-mode";
 
 export function BackendConfig() {
   const {
@@ -46,8 +47,10 @@ export function BackendConfig() {
   } = useBackendDialogs();
 
   const { isSubmitting, addBackend, deleteBackend } = useBackendOperations();
+  const xds = useXdsMode();
 
   // Load backends on component mount
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     loadBackends();
   }, []);
@@ -94,6 +97,8 @@ export function BackendConfig() {
             resetBackendForm(binds);
             openAddDialog();
           }}
+          disabled={xds}
+          className={xds ? "opacity-50 cursor-not-allowed" : undefined}
         >
           <Plus className="mr-2 h-4 w-4" />
           Add Backend

--- a/ui/src/components/backend/backend-components.tsx
+++ b/ui/src/components/backend/backend-components.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from "react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -66,6 +68,7 @@ import {
   getBackendPolicyTypes,
   canDeleteBackend,
 } from "@/lib/backend-utils";
+import { useXdsMode } from "@/hooks/use-xds-mode";
 
 const getEnvAsRecord = (env: unknown): Record<string, string> => {
   return typeof env === "object" && env !== null ? (env as Record<string, string>) : {};
@@ -106,6 +109,7 @@ export const BackendTable: React.FC<BackendTableProps> = ({
   onDeleteBackend,
   isSubmitting,
 }) => {
+  const xds = useXdsMode();
   return (
     <div className="space-y-4">
       {Array.from(backendsByBind.entries()).map(([port, backendContexts]) => {
@@ -242,6 +246,8 @@ export const BackendTable: React.FC<BackendTableProps> = ({
                                   variant="ghost"
                                   size="icon"
                                   onClick={() => onEditBackend(backendContext)}
+                                  disabled={xds}
+                                  className={xds ? "opacity-50 cursor-not-allowed" : undefined}
                                 >
                                   <Edit className="h-4 w-4" />
                                 </Button>
@@ -291,8 +297,8 @@ export const BackendTable: React.FC<BackendTableProps> = ({
                                       variant="ghost"
                                       size="icon"
                                       onClick={() => onDeleteBackend(backendContext)}
-                                      className="text-destructive hover:text-destructive"
-                                      disabled={isSubmitting}
+                                      className={`text-destructive hover:text-destructive ${xds ? "opacity-50 cursor-not-allowed" : ""}`}
+                                      disabled={isSubmitting || xds}
                                     >
                                       <Trash2 className="h-4 w-4" />
                                     </Button>

--- a/ui/src/components/listener-config.tsx
+++ b/ui/src/components/listener-config.tsx
@@ -55,6 +55,7 @@ import { useServer } from "@/lib/server-context";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { useXdsMode } from "@/hooks/use-xds-mode";
 
 interface ListenerConfigProps {
   isAddingListener?: boolean;
@@ -109,6 +110,7 @@ export function ListenerConfig({
   setIsAddingListener = () => {},
 }: ListenerConfigProps) {
   const { refreshListeners } = useServer();
+  const xds = useXdsMode();
   const [binds, setBinds] = useState<BindWithBackendsAndRoutes[]>([]);
   const [expandedBinds, setExpandedBinds] = useState<Set<number>>(new Set());
   const [isLoading, setIsLoading] = useState(true);
@@ -140,7 +142,7 @@ export function ListenerConfig({
     isOpen: false,
   });
 
-  const [deleteConfigDialog, setDeleteConfigDialog] = useState<DeleteConfigDialogState>({
+  const [_deleteConfigDialog, setDeleteConfigDialog] = useState<DeleteConfigDialogState>({
     isOpen: false,
     bindPort: 0,
     listenerIndex: -1,
@@ -155,7 +157,7 @@ export function ListenerConfig({
 
     // Count backends across all routes
     if (listener.routes && listener.routes.length > 0) {
-      listener.routes.forEach((route, routeIndex) => {
+      listener.routes.forEach((route, _routeIndex) => {
         if (route.backends && route.backends.length > 0) {
           backendCount += route.backends.length;
         }
@@ -206,6 +208,7 @@ export function ListenerConfig({
     }
   };
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     loadBinds();
   }, []);
@@ -363,7 +366,7 @@ export function ListenerConfig({
     return `${protocol}://${hostname}:${port}`;
   };
 
-  const hasJWTAuth = (listener: Listener) => {
+  const _hasJWTAuth = (listener: Listener) => {
     return (
       listener.routes?.some(
         (route) => route.policies?.jwtAuth || route.policies?.mcpAuthentication
@@ -375,8 +378,21 @@ export function ListenerConfig({
     return !!listener.tls;
   };
 
-  const hasRBAC = (listener: Listener) => {
+  const _hasRBAC = (listener: Listener) => {
     return listener.routes?.some((route) => route.policies?.mcpAuthorization) || false;
+  };
+
+  const getProtocolString = (protocol: unknown): ListenerProtocol => {
+    if (typeof protocol === "string") {
+      return protocol as ListenerProtocol;
+    }
+    if (protocol && typeof protocol === "object") {
+      const keys = Object.keys(protocol as Record<string, unknown>);
+      if (keys.length > 0) {
+        return keys[0] as ListenerProtocol;
+      }
+    }
+    return ListenerProtocol.HTTP;
   };
 
   if (isLoading) {
@@ -391,7 +407,12 @@ export function ListenerConfig({
   return (
     <div className="space-y-6">
       <div className="flex gap-2">
-        <Button onClick={() => setIsAddingBind(true)} variant="outline">
+        <Button
+          onClick={() => setIsAddingBind(true)}
+          variant="outline"
+          disabled={xds}
+          className={xds ? "opacity-50 cursor-not-allowed" : undefined}
+        >
           <Plus className="mr-2 h-4 w-4" />
           Add Bind
         </Button>
@@ -445,7 +466,8 @@ export function ListenerConfig({
                               bindPort: bind.port,
                             });
                           }}
-                          className="text-destructive hover:text-destructive"
+                          disabled={xds}
+                          className={`text-destructive hover:text-destructive ${xds ? "opacity-50 cursor-not-allowed" : ""}`}
                         >
                           <Trash2 className="h-4 w-4" />
                         </Button>
@@ -463,7 +485,8 @@ export function ListenerConfig({
                       <Button
                         size="sm"
                         onClick={() => handleAddListenerToBind(bind.port)}
-                        className="h-8"
+                        disabled={xds}
+                        className={`h-8 ${xds ? "opacity-50 cursor-not-allowed" : ""}`}
                       >
                         <Plus className="mr-2 h-3 w-3" />
                         Add Listener
@@ -506,12 +529,18 @@ export function ListenerConfig({
                                 </TableCell>
                                 <TableCell>
                                   <Badge variant="outline">
-                                    {listener.protocol || ListenerProtocol.HTTP}
+                                    {getProtocolString(listener.protocol)}
                                   </Badge>
                                 </TableCell>
                                 <TableCell>{listener.hostname || "localhost"}</TableCell>
                                 <TableCell className="font-mono text-sm">
-                                  {getDisplayEndpoint(listener, bind.port)}
+                                  {getDisplayEndpoint(
+                                    {
+                                      ...listener,
+                                      protocol: getProtocolString(listener.protocol),
+                                    },
+                                    bind.port
+                                  )}
                                 </TableCell>
                                 <TableCell>
                                   <Badge variant="outline">
@@ -564,7 +593,8 @@ export function ListenerConfig({
                                         </DropdownMenuItem>
                                         {hasTLS(listener) && (
                                           <DropdownMenuItem
-                                            className="text-destructive"
+                                            className={`text-destructive ${xds ? "opacity-50 cursor-not-allowed" : ""}`}
+                                            disabled={xds}
                                             onClick={() => {
                                               setDeleteConfigDialog({
                                                 isOpen: true,
@@ -605,7 +635,8 @@ export function ListenerConfig({
                                         listenerIndex,
                                       })
                                     }
-                                    className="text-destructive hover:text-destructive"
+                                    disabled={xds}
+                                    className={`text-destructive hover:text-destructive ${xds ? "opacity-50 cursor-not-allowed" : ""}`}
                                   >
                                     <Trash2 className="h-4 w-4" />
                                   </Button>
@@ -657,7 +688,7 @@ export function ListenerConfig({
             >
               Cancel
             </Button>
-            <Button onClick={handleAddBind} disabled={isSubmitting}>
+            <Button onClick={handleAddBind} disabled={isSubmitting || xds}>
               {isSubmitting ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
               Add Bind
             </Button>
@@ -782,7 +813,7 @@ export function ListenerConfig({
             </Button>
             <Button
               onClick={handleAddListener}
-              disabled={isSubmitting || !newListener.targetBindPort}
+              disabled={isSubmitting || !newListener.targetBindPort || xds}
             >
               {isSubmitting ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
               Add Listener
@@ -885,7 +916,8 @@ export function ListenerConfig({
                   handleDeleteListener(deleteDialog.listenerName);
                 }
               }}
-              disabled={isSubmitting}
+              disabled={isSubmitting || xds}
+              className={xds ? "opacity-50 cursor-not-allowed" : undefined}
             >
               {isSubmitting ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
               Delete

--- a/ui/src/components/policy-config.tsx
+++ b/ui/src/components/policy-config.tsx
@@ -58,6 +58,7 @@ import {
 } from "@/components/policy/form-renderers";
 import { POLICY_TYPES, PolicyType } from "@/lib/policy-constants";
 import { getDefaultPolicyData } from "@/lib/policy-defaults";
+import { useXdsMode } from "@/hooks/use-xds-mode";
 
 interface RouteWithContext {
   route: RouteType | TcpRoute;
@@ -84,6 +85,7 @@ export function PolicyConfig() {
   const [selectedRoute, setSelectedRoute] = useState<RouteWithContext | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const xds = useXdsMode();
 
   const [policyDialog, setPolicyDialog] = useState<PolicyDialogState>({
     isOpen: false,
@@ -488,7 +490,8 @@ export function PolicyConfig() {
                             handleAddPolicy(selectedRoute, type as PolicyType);
                           }
                         }}
-                        className="flex-1"
+                        className={`flex-1 ${xds ? "opacity-50 cursor-not-allowed" : ""}`}
+                        disabled={xds}
                       >
                         {hasPolicy ? (
                           <>
@@ -507,8 +510,8 @@ export function PolicyConfig() {
                           variant="outline"
                           size="sm"
                           onClick={() => handleDeletePolicy(selectedRoute, type as PolicyType)}
-                          className="text-destructive hover:text-destructive"
-                          disabled={isSubmitting}
+                          className={`text-destructive hover:text-destructive ${xds ? "opacity-50 cursor-not-allowed" : ""}`}
+                          disabled={isSubmitting || xds}
                         >
                           <Trash2 className="h-3 w-3" />
                         </Button>
@@ -584,7 +587,11 @@ export function PolicyConfig() {
             >
               Cancel
             </Button>
-            <Button onClick={handleSavePolicy} disabled={isSubmitting}>
+            <Button
+              onClick={handleSavePolicy}
+              disabled={isSubmitting || xds}
+              className={xds ? "opacity-50 cursor-not-allowed" : undefined}
+            >
               {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
               Save Policy
             </Button>

--- a/ui/src/components/policy/form-renderers.tsx
+++ b/ui/src/components/policy/form-renderers.tsx
@@ -12,7 +12,7 @@ import {
 } from "@/components/ui/select";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Trash2, Plus } from "lucide-react";
-import { formatArrayForInput, handleArrayInput, handleNumberArrayInput } from "@/lib/policy-utils";
+import { formatArrayForInput, handleNumberArrayInput } from "@/lib/policy-utils";
 import { McpAuthorizationRule } from "@/lib/types";
 import {
   ArrayInput,
@@ -1532,7 +1532,7 @@ export function renderAiForm({ data, onChange }: FormRendererProps) {
   );
 }
 
-export function renderA2aForm({ data, onChange }: FormRendererProps) {
+export function renderA2aForm({ data: _data, onChange: _onChange }: FormRendererProps) {
   return (
     <div className="space-y-6">
       <div className="bg-muted/50 border rounded-lg p-4">

--- a/ui/src/components/route-config.tsx
+++ b/ui/src/components/route-config.tsx
@@ -16,6 +16,7 @@ import {
   EditRouteDialog,
   EditTcpRouteDialog,
 } from "@/components/route/route-components";
+import { useXdsMode } from "@/hooks/use-xds-mode";
 
 export function RouteConfig() {
   const {
@@ -55,8 +56,10 @@ export function RouteConfig() {
 
   const { isSubmitting, addRoute, editRoute, editTcpRoute, deleteRoute, deleteTcpRoute } =
     useRouteOperations();
+  const xds = useXdsMode();
 
   // Load routes on component mount
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     loadRoutes();
   }, []);
@@ -137,7 +140,11 @@ export function RouteConfig() {
   return (
     <div className="space-y-6">
       <div className="flex justify-end">
-        <Button onClick={() => setIsAddRouteDialogOpen(true)}>
+        <Button
+          onClick={() => setIsAddRouteDialogOpen(true)}
+          disabled={xds}
+          className={xds ? "opacity-50 cursor-not-allowed" : undefined}
+        >
           <Plus className="mr-2 h-4 w-4" />
           Add Route
         </Button>
@@ -157,6 +164,7 @@ export function RouteConfig() {
           onEditTcpRoute={handleEditTcpRouteClick}
           onDeleteRoute={handleDeleteRoute}
           onDeleteTcpRoute={handleDeleteTcpRoute}
+          xds={xds}
         />
       )}
 
@@ -194,6 +202,7 @@ export function RouteConfig() {
         onEditRoute={handleEditRoute}
         onCancel={handleCancelDialogs}
         isSubmitting={isSubmitting}
+        xds={xds}
       />
 
       <EditTcpRouteDialog
@@ -210,6 +219,7 @@ export function RouteConfig() {
         onEditTcpRoute={handleEditTcpRoute}
         onCancel={handleCancelDialogs}
         isSubmitting={isSubmitting}
+        xds={xds}
       />
     </div>
   );

--- a/ui/src/components/route/route-components.tsx
+++ b/ui/src/components/route/route-components.tsx
@@ -48,6 +48,7 @@ import {
   ROUTE_TYPE_CONFIGS,
 } from "@/lib/route-constants";
 import { isTcpListener, getPathDisplayString } from "@/lib/route-utils";
+import { ListenerProtocol } from "@/lib/types";
 
 interface RouteTableProps {
   allRoutesByBind: Map<number, CombinedRouteWithContext[]>;
@@ -57,6 +58,7 @@ interface RouteTableProps {
   onEditTcpRoute: (tcpRoute: TcpRouteWithContext) => void;
   onDeleteRoute: (route: RouteWithContext) => void;
   onDeleteTcpRoute: (tcpRoute: TcpRouteWithContext) => void;
+  xds: boolean;
 }
 
 export const RouteTable: React.FC<RouteTableProps> = ({
@@ -67,6 +69,7 @@ export const RouteTable: React.FC<RouteTableProps> = ({
   onEditTcpRoute,
   onDeleteRoute,
   onDeleteTcpRoute,
+  xds,
 }) => {
   return (
     <div className="space-y-4">
@@ -228,6 +231,8 @@ export const RouteTable: React.FC<RouteTableProps> = ({
                                     onEditTcpRoute(tcpRouteContext);
                                   }
                                 }}
+                                disabled={xds}
+                                className={xds ? "opacity-50 cursor-not-allowed" : undefined}
                               >
                                 <Edit className="h-4 w-4" />
                               </Button>
@@ -253,7 +258,10 @@ export const RouteTable: React.FC<RouteTableProps> = ({
                                     onDeleteTcpRoute(tcpRouteContext);
                                   }
                                 }}
-                                className="text-destructive hover:text-destructive"
+                                disabled={xds}
+                                className={`text-destructive hover:text-destructive ${
+                                  xds ? "opacity-50 cursor-not-allowed" : ""
+                                }`}
                               >
                                 <Trash2 className="h-4 w-4" />
                               </Button>
@@ -304,6 +312,19 @@ export const AddRouteDialog: React.FC<AddRouteDialogProps> = ({
   onCancel,
   isSubmitting,
 }) => {
+  const getProtocolString = (protocol: unknown): ListenerProtocol | "HTTP" => {
+    if (typeof protocol === "string") {
+      return protocol as ListenerProtocol;
+    }
+    if (protocol && typeof protocol === "object") {
+      const keys = Object.keys(protocol as Record<string, unknown>);
+      if (keys.length > 0) {
+        return keys[0] as ListenerProtocol;
+      }
+    }
+    return "HTTP";
+  };
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-2xl">
@@ -335,7 +356,7 @@ export const AddRouteDialog: React.FC<AddRouteDialogProps> = ({
                 </div>
                 <p className="text-xs text-muted-foreground mt-1">
                   Route type automatically determined by listener protocol:{" "}
-                  {selectedListener.listener.protocol || "HTTP"}
+                  {getProtocolString(selectedListener.listener.protocol)}
                 </p>
               </div>
             </div>
@@ -391,7 +412,7 @@ export const AddRouteDialog: React.FC<AddRouteDialogProps> = ({
               </p>
             )}
             <div className="grid gap-2">
-              {availableListeners.map((item, index) => {
+              {availableListeners.map((item) => {
                 const isSelected =
                   selectedListener &&
                   (selectedListener.listener.name || "unnamed") ===
@@ -408,7 +429,7 @@ export const AddRouteDialog: React.FC<AddRouteDialogProps> = ({
                   >
                     <Network className="mr-2 h-4 w-4" />
                     {item.listener.name || `Unnamed`} (Port {item.bind.port}) -{" "}
-                    {item.listener.protocol || "HTTP"}
+                    {getProtocolString(item.listener.protocol)}
                   </Button>
                 );
               })}
@@ -556,6 +577,7 @@ interface EditRouteDialogProps {
   onEditRoute: () => void;
   onCancel: () => void;
   isSubmitting: boolean;
+  xds: boolean;
 }
 
 export const EditRouteDialog: React.FC<EditRouteDialogProps> = ({
@@ -567,6 +589,7 @@ export const EditRouteDialog: React.FC<EditRouteDialogProps> = ({
   onEditRoute,
   onCancel,
   isSubmitting,
+  xds,
 }) => {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -698,7 +721,11 @@ export const EditRouteDialog: React.FC<EditRouteDialogProps> = ({
           <Button variant="outline" onClick={onCancel}>
             Cancel
           </Button>
-          <Button onClick={onEditRoute} disabled={isSubmitting}>
+          <Button
+            onClick={onEditRoute}
+            disabled={isSubmitting || xds}
+            className={xds ? "opacity-50 cursor-not-allowed" : undefined}
+          >
             {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
             Update Route
           </Button>
@@ -717,6 +744,7 @@ interface EditTcpRouteDialogProps {
   onEditTcpRoute: () => void;
   onCancel: () => void;
   isSubmitting: boolean;
+  xds: boolean;
 }
 
 export const EditTcpRouteDialog: React.FC<EditTcpRouteDialogProps> = ({
@@ -728,6 +756,7 @@ export const EditTcpRouteDialog: React.FC<EditTcpRouteDialogProps> = ({
   onEditTcpRoute,
   onCancel,
   isSubmitting,
+  xds,
 }) => {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -801,7 +830,11 @@ export const EditTcpRouteDialog: React.FC<EditTcpRouteDialogProps> = ({
           <Button variant="outline" onClick={onCancel}>
             Cancel
           </Button>
-          <Button onClick={onEditTcpRoute} disabled={isSubmitting}>
+          <Button
+            onClick={onEditTcpRoute}
+            disabled={isSubmitting || xds}
+            className={xds ? "opacity-50 cursor-not-allowed" : undefined}
+          >
             {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
             Update TCP Route
           </Button>

--- a/ui/src/components/target-item.tsx
+++ b/ui/src/components/target-item.tsx
@@ -1,8 +1,11 @@
+"use client";
+
 import { TargetType, TargetWithType } from "@/lib/types";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Edit2, Trash2 } from "lucide-react";
 import { TooltipProvider, Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { useXdsMode } from "@/hooks/use-xds-mode";
 
 interface TargetItemProps {
   target: TargetWithType;
@@ -37,6 +40,7 @@ export default function TargetItem({
   isUpdating,
 }: TargetItemProps) {
   const targetType = getTargetType(target as TargetWithType);
+  const xds = useXdsMode();
 
   return (
     <div className="flex items-center justify-between w-full">
@@ -84,8 +88,8 @@ export default function TargetItem({
           variant="ghost"
           size="icon"
           onClick={() => onDelete(index)}
-          className="h-8 w-8 ml-2 text-muted-foreground hover:bg-primary/20 flex-shrink-0"
-          disabled={isUpdating}
+          className={`h-8 w-8 ml-2 text-muted-foreground hover:bg-primary/20 flex-shrink-0 ${xds ? "opacity-50 cursor-not-allowed" : ""}`}
+          disabled={isUpdating || xds}
         >
           <Trash2 className="h-4 w-4" />
         </Button>
@@ -94,8 +98,8 @@ export default function TargetItem({
           variant="ghost"
           size="icon"
           onClick={() => onEdit(target)}
-          className="h-8 w-8 ml-2 text-muted-foreground hover:bg-primary/20 flex-shrink-0"
-          disabled={isUpdating}
+          className={`h-8 w-8 ml-2 text-muted-foreground hover:bg-primary/20 flex-shrink-0 ${xds ? "opacity-50 cursor-not-allowed" : ""}`}
+          disabled={isUpdating || xds}
         >
           <Edit2 className="h-4 w-4" />
         </Button>

--- a/ui/src/lib/backend-hooks.ts
+++ b/ui/src/lib/backend-hooks.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { Backend, Route, Listener, Bind } from "@/lib/types";
 import { fetchConfig, updateConfig } from "@/lib/api";
 import { useServer } from "@/lib/server-context";

--- a/ui/src/lib/backend-utils.ts
+++ b/ui/src/lib/backend-utils.ts
@@ -556,7 +556,7 @@ export const parseUrl = (url: string): { host: string; port: string; path: strin
     const path = urlObj.pathname + urlObj.search;
 
     return { host, port, path };
-  } catch (err) {
+  } catch {
     // Invalid URL, return empty values
     return { host: "", port: "", path: "" };
   }

--- a/ui/src/lib/configMapper.ts
+++ b/ui/src/lib/configMapper.ts
@@ -25,6 +25,7 @@ export function configDumpToLocalConfig(configDump: any): LocalConfig {
     binds: [],
     workloads: configDump.workloads || [],
     services: configDump.services || [],
+    appliedPolicies: configDump.policies || [],
   };
 
   const backends = (configDump.backends || []).map((b: any) => mapToBackend(b)).filter(Boolean);

--- a/ui/src/lib/route-hooks.ts
+++ b/ui/src/lib/route-hooks.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { Route as RouteType, TcpRoute, Listener, Bind } from "@/lib/types";
 import { fetchBinds, updateConfig, fetchConfig } from "@/lib/api";
 import { useServer } from "@/lib/server-context";

--- a/ui/src/lib/route-utils.ts
+++ b/ui/src/lib/route-utils.ts
@@ -3,7 +3,12 @@ import { DEFAULT_HTTP_ROUTE_FORM, DEFAULT_TCP_ROUTE_FORM } from "./route-constan
 
 // Helper function to determine if a listener protocol supports TCP routes
 export const isTcpListener = (listener: Listener): boolean => {
-  const protocol = listener.protocol || "HTTP";
+  const protocol =
+    typeof listener.protocol === "string"
+      ? listener.protocol
+      : listener.protocol && typeof listener.protocol === "object"
+        ? Object.keys(listener.protocol as Record<string, unknown>)[0] || "HTTP"
+        : "HTTP";
   return protocol === "TCP" || protocol === "TLS";
 };
 

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -5,6 +5,7 @@ export interface LocalConfig {
   binds: Bind[];
   workloads?: any[];
   services?: any[];
+  appliedPolicies?: AppliedPolicy[];
 }
 
 export interface Bind {
@@ -104,6 +105,28 @@ export interface Policies {
   extAuthz?: any;
   timeout?: TimeoutPolicy | null;
   retry?: RetryPolicy | null;
+}
+
+// Top-level applied policy entries from config dump
+export interface AppliedPolicy {
+  key: string;
+  name: {
+    kind: string;
+    name: string;
+    namespace: string;
+  };
+  target: {
+    backend?: {
+      backend?: { name: string; namespace: string };
+      service?: { hostname: string; namespace: string };
+    };
+    route?: { name: string; namespace: string };
+  };
+  // Keep flexible to match varying shapes in dump; narrow types over time
+  policy: {
+    backend?: Partial<Policies>;
+    traffic?: Record<string, unknown>;
+  };
 }
 
 export interface TcpPolicies {


### PR DESCRIPTION
Fixes https://github.com/agentgateway/agentgateway/issues/555 

- Disables edit access in xds mode by greying out:

<img width="181" height="429" alt="image" src="https://github.com/user-attachments/assets/cfb73c7a-1d03-4ff6-9d47-e796c8a46326" />
<img width="181" height="597" alt="image" src="https://github.com/user-attachments/assets/e5a44ad8-71ac-4c4e-a989-38097c22c260" />
<img width="181" height="377" alt="image" src="https://github.com/user-attachments/assets/0db49c5d-9a28-4098-a576-2f7beaecc0ea" />
<img width="502" height="328" alt="image" src="https://github.com/user-attachments/assets/3ae5c2d7-6992-4178-938a-5997e3caecfa" />
<img width="502" height="328" alt="image" src="https://github.com/user-attachments/assets/93170fee-6fa6-4cec-b270-4ca9465d9026" />

- Displays non-inlined policies on the Policy page:
<img width="1728" height="916" alt="image" src="https://github.com/user-attachments/assets/c46d5043-6b70-4960-9889-e98cf05478fe" />


