### PR TITLE
docker: switch to chainguard

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -109,7 +109,7 @@ if [ "$TARGETARCH" = "amd64" ]; then
 fi
 EOF
 
-FROM gcr.io/distroless/cc-debian13 AS runner
+FROM cgr.dev/chainguard/glibc-dynamic AS runner
 
 WORKDIR /
 


### PR DESCRIPTION
These are better maintained and trusted