### PR TITLE
Unify tracing

### DIFF
--- a/crates/agentgateway/src/http/ext_proc.rs
+++ b/crates/agentgateway/src/http/ext_proc.rs
@@ -73,9 +73,11 @@ pub struct InferencePoolRouter {
 }
 
 impl InferenceRouting {
-	pub fn build(&self, client: PolicyClient) -> InferencePoolRouter {
-		// Prefer request-scoped span writer from the client (plumbed from request logs).
-		let span_writer = client.span_writer.clone();
+	pub fn build(
+		&self,
+		client: PolicyClient,
+		span_writer: Option<SpanWriter>,
+	) -> InferencePoolRouter {
 		InferencePoolRouter {
 			ext_proc: Some(ExtProcInstance::new(
 				client,
@@ -131,9 +133,7 @@ pub struct ExtProc {
 }
 
 impl ExtProc {
-	pub fn build(&self, client: PolicyClient) -> ExtProcRequest {
-		// Prefer request-scoped span writer from the client (plumbed from request logs).
-		let span_writer = client.span_writer.clone();
+	pub fn build(&self, client: PolicyClient, span_writer: Option<SpanWriter>) -> ExtProcRequest {
 		ExtProcRequest {
 			ext_proc: Some(ExtProcInstance::new(
 				client,

--- a/crates/agentgateway/src/llm/policy/mod.rs
+++ b/crates/agentgateway/src/llm/policy/mod.rs
@@ -241,7 +241,6 @@ impl Policy {
 	) -> anyhow::Result<Option<Response>> {
 		let client = PolicyClient {
 			inputs: backend_info.inputs.clone(),
-			span_writer: span_writer.clone(),
 		};
 		for g in self
 			.prompt_guard

--- a/crates/agentgateway/src/llm/policy/moderation.rs
+++ b/crates/agentgateway/src/llm/policy/moderation.rs
@@ -6,6 +6,7 @@ use crate::json;
 use crate::llm::RequestType;
 use crate::llm::policy::Moderation;
 use crate::proxy::httpproxy::PolicyClient;
+use crate::telemetry::log::SpanWriter;
 use crate::types::agent::{BackendPolicy, ResourceName, SimpleBackend, Target};
 
 pub async fn send_request(
@@ -13,6 +14,7 @@ pub async fn send_request(
 	claims: Option<Claims>,
 	client: &PolicyClient,
 	moderation: &Moderation,
+	span_writer: Option<SpanWriter>,
 ) -> anyhow::Result<async_openai::types::CreateModerationResponse> {
 	let model = moderation
 		.model
@@ -46,7 +48,7 @@ pub async fn send_request(
 		Target::Hostname(strng::literal!("api.openai.com"), 443),
 	);
 	let resp = client
-		.call_with_explicit_policies(req, mock_be, pols)
+		.call_with_explicit_policies(req, mock_be, pols, span_writer)
 		.await?;
 	let resp: async_openai::types::CreateModerationResponse = json::from_response_body(resp).await?;
 	Ok(resp)

--- a/crates/agentgateway/src/llm/policy/webhook.rs
+++ b/crates/agentgateway/src/llm/policy/webhook.rs
@@ -3,6 +3,7 @@ use ::http::{HeaderMap, HeaderValue, header};
 use serde::{Deserialize, Serialize};
 
 use crate::proxy::httpproxy::PolicyClient;
+use crate::telemetry::log::SpanWriter;
 use crate::types::agent::SimpleBackendReference;
 use crate::*;
 
@@ -175,9 +176,10 @@ pub async fn send_request(
 	target: &SimpleBackendReference,
 	http_headers: &HeaderMap,
 	messages: Vec<Message>,
+	span_writer: Option<SpanWriter>,
 ) -> anyhow::Result<GuardrailsPromptResponse> {
 	let whr = build_request_for_request(http_headers, messages)?;
-	let res = Box::pin(client.call_reference(whr, target)).await?;
+	let res = Box::pin(client.call_reference(whr, target, span_writer)).await?;
 	let parsed = json::from_response_body(res).await?;
 	Ok(parsed)
 }
@@ -187,9 +189,10 @@ pub async fn send_response(
 	target: &SimpleBackendReference,
 	http_headers: &HeaderMap,
 	choices: Vec<ResponseChoice>,
+	span_writer: Option<SpanWriter>,
 ) -> anyhow::Result<GuardrailsResponseResponse> {
 	let whr = build_request_for_response(http_headers, choices)?;
-	let res = client.call_reference(whr, target).await?;
+	let res = client.call_reference(whr, target, span_writer).await?;
 	let parsed = json::from_response_body(res).await?;
 	Ok(parsed)
 }

--- a/crates/agentgateway/src/mcp/router.rs
+++ b/crates/agentgateway/src/mcp/router.rs
@@ -125,10 +125,7 @@ impl App {
 		};
 		let sm = self.session.clone();
 		let sw = span_writer.clone();
-		let client = PolicyClient {
-			inputs: pi.clone(),
-			span_writer: sw.clone(),
-		};
+		let client = PolicyClient { inputs: pi.clone() };
 		let authorization_policies = backend_policies
 			.mcp_authorization
 			.unwrap_or_else(|| McpAuthorizationSet::new(RuleSets::from(Vec::new())));

--- a/crates/agentgateway/src/mcp/upstream/client.rs
+++ b/crates/agentgateway/src/mcp/upstream/client.rs
@@ -4,6 +4,7 @@ use crate::client::ResolvedDestination;
 use crate::proxy::ProxyError;
 use crate::proxy::httpproxy::PolicyClient;
 use crate::store::BackendPolicies;
+use crate::telemetry::log::SpanWriter;
 use crate::types::agent::SimpleBackend;
 
 /// HTTP client for MCP upstream backends with optional stateful session affinity.
@@ -40,6 +41,7 @@ impl McpHttpClient {
 	pub async fn call(
 		&self,
 		req: http::Request<crate::http::Body>,
+		span_writer: Option<SpanWriter>,
 	) -> Result<http::Response<crate::http::Body>, ProxyError> {
 		let mut policies = self.base_policies.clone();
 
@@ -57,7 +59,7 @@ impl McpHttpClient {
 
 		let resp = self
 			.client
-			.call_with_default_policies(req, &self.backend, policies)
+			.call_with_default_policies(req, &self.backend, policies, span_writer)
 			.await?;
 
 		// Capture resolved destination on first request if stateful

--- a/crates/agentgateway/src/mcp/upstream/openapi/mod.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/mod.rs
@@ -750,7 +750,7 @@ impl Handler {
 
 		ctx.apply(&mut request);
 
-		let response = self.http_client.call(request).await?;
+		let response = self.http_client.call(request, ctx.span_writer()).await?;
 
 		// Read response body
 		let status = response.status();

--- a/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
@@ -46,7 +46,10 @@ async fn setup() -> (MockServer, Handler) {
 		mcp_state: mcp::router::App::new(stores.clone()),
 	});
 
-	let client = PolicyClient { inputs: pi.clone() };
+	let client = PolicyClient {
+		inputs: pi.clone(),
+		span_writer: None,
+	};
 	// Define a sample tool for testing
 	let test_tool_get = Tool {
 		name: Cow::Borrowed("get_user"),

--- a/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
@@ -46,10 +46,7 @@ async fn setup() -> (MockServer, Handler) {
 		mcp_state: mcp::router::App::new(stores.clone()),
 	});
 
-	let client = PolicyClient {
-		inputs: pi.clone(),
-		span_writer: None,
-	};
+	let client = PolicyClient { inputs: pi.clone() };
 	// Define a sample tool for testing
 	let test_tool_get = Tool {
 		name: Cow::Borrowed("get_user"),

--- a/crates/agentgateway/src/mcp/upstream/sse.rs
+++ b/crates/agentgateway/src/mcp/upstream/sse.rs
@@ -91,7 +91,11 @@ impl ClientCore {
 
 		ctx.apply(&mut req);
 
-		let resp = self.http_client.call(req).await.map_err(ClientError::new)?;
+		let resp = self
+			.http_client
+			.call(req, ctx.span_writer())
+			.await
+			.map_err(ClientError::new)?;
 
 		if !resp.status().is_success() {
 			return Err(ClientError::Status(Box::new(resp)));
@@ -114,7 +118,11 @@ impl ClientCore {
 
 		ctx.apply(&mut req);
 
-		let resp = self.http_client.call(req).await.map_err(ClientError::new)?;
+		let resp = self
+			.http_client
+			.call(req, ctx.span_writer())
+			.await
+			.map_err(ClientError::new)?;
 
 		if resp.status() == http::StatusCode::ACCEPTED {
 			return Err(ClientError::new(anyhow!("expected an SSE stream")));

--- a/crates/agentgateway/src/mcp/upstream/streamablehttp.rs
+++ b/crates/agentgateway/src/mcp/upstream/streamablehttp.rs
@@ -76,7 +76,11 @@ impl Client {
 
 		ctx.apply(&mut req);
 
-		let resp = self.http_client.call(req).await.map_err(ClientError::new)?;
+		let resp = self
+			.http_client
+			.call(req, ctx.span_writer())
+			.await
+			.map_err(ClientError::new)?;
 
 		if resp.status() == http::StatusCode::ACCEPTED {
 			return Ok(StreamableHttpPostResponse::Accepted);
@@ -134,7 +138,11 @@ impl Client {
 
 		ctx.apply(&mut req);
 
-		let resp = self.http_client.call(req).await.map_err(ClientError::new)?;
+		let resp = self
+			.http_client
+			.call(req, ctx.span_writer())
+			.await
+			.map_err(ClientError::new)?;
 
 		if !resp.status().is_success() {
 			return Err(ClientError::Status(Box::new(resp)));
@@ -156,7 +164,11 @@ impl Client {
 
 		ctx.apply(&mut req);
 
-		let resp = self.http_client.call(req).await.map_err(ClientError::new)?;
+		let resp = self
+			.http_client
+			.call(req, ctx.span_writer())
+			.await
+			.map_err(ClientError::new)?;
 
 		if !resp.status().is_success() {
 			return Err(ClientError::Status(Box::new(resp)));

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -142,9 +142,13 @@ impl BackendPolicies {
 		}
 	}
 	/// build the inference routing configuration. This may be a NO-OP config.
-	pub fn build_inference(&self, client: PolicyClient) -> ext_proc::InferencePoolRouter {
+	pub fn build_inference(
+		&self,
+		client: PolicyClient,
+		span_writer: Option<crate::telemetry::log::SpanWriter>,
+	) -> ext_proc::InferencePoolRouter {
 		if let Some(inference) = &self.inference_routing {
-			inference.build(client)
+			inference.build(client, span_writer)
 		} else {
 			ext_proc::InferencePoolRouter::default()
 		}

--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -935,7 +935,7 @@ impl Drop for DropOnLog {
 		if enable_trace && let Some(t) = &log.tracer {
 			t.send(&log, &cel_exec, kv.as_slice());
 			// Flush any buffered spans created during request processing.
-			// Best effort: if the lock is poisoned, we skip flushing.
+			// Does best effort, if the lock is poisoned, skip flushing.
 			if let Ok(mut spans) = log.trace_spans.lock() {
 				for sb in spans.drain(..) {
 					sb.start(t.tracer.as_ref()).end();


### PR DESCRIPTION
Example trace:
```
Span #2
    Trace ID       : a51dc97d694814a92afda5e466997366
    Parent ID      :
    ID             : f9d5e2220d3bb70c
    Name           : GET /*
    Kind           : Server
    Start time     : 2025-12-26 21:58:27.898206172 +0000 UTC
    End time       : 2025-12-26 21:58:27.899033672 +0000 UTC
    Status code    : Unset
    Status message :
Attributes:
     -> gateway: Str(agentgateway-system/agentgateway-proxy)
     -> listener: Str(http)
     -> route: Str(default/httpbin)
     -> endpoint: Str(10.101.0.16:8080)
     -> src.addr: Str(127.0.0.1:45838)
     -> http.method: Str(GET)
     -> http.host: Str(www.example.com)
     -> http.path: Str(/headers)
     -> http.version: Str(HTTP/1.1)
     -> http.status: Int(200)
     -> trace.id: Str(a51dc97d694814a92afda5e466997366)
     -> span.id: Str(f9d5e2220d3bb70c)
     -> protocol: Str(http)
     -> duration: Str(0ms)
     -> url.scheme: Str(http)
     -> network.protocol.version: Str(1.1)
Span #3
    Trace ID       : a51dc97d694814a92afda5e466997366
    Parent ID      :
    ID             : 5a29f7983bf687f5
    Name           : upstream 10.101.0.16:8080
    Kind           : Server
    Start time     : 2025-12-26 21:58:27.898546589 +0000 UTC
    End time       : 2025-12-26 21:58:27.899035464 +0000 UTC
    Status code    : Unset
    Status message :
Links:
SpanLink #0
     -> Trace ID: a51dc97d694814a92afda5e466997366
     -> ID: f9d5e2220d3bb70c
     -> TraceState:
     -> DroppedAttributesCount: 0
	{"resource": {"service.instance.id": "b9a86e1e-d89f-4b2b-8927-ced6486e16c3", "service.name": "otelcol-contrib", "service.version": "0.128.0"}, "otelcol.component.id": "debug", "otelcol.component.kind": "exporter", "otelcol.signal": "traces"}
```

TODO:
- Currently just testing with link, do we want to also set the parent context in addition to adding a link? 
