### PR TITLE
hyper-util-fork: ignore forked doc-tests

### DIFF
--- a/crates/hyper-util-fork/src/client/legacy/client.rs
+++ b/crates/hyper-util-fork/src/client/legacy/client.rs
@@ -116,7 +116,7 @@ impl Client<(), ()> {
 	///
 	/// # Example
 	///
-	/// ```
+	/// ```ignore
 	/// # #[cfg(feature = "tokio")]
 	/// # fn run () {
 	/// use std::time::Duration;
@@ -159,7 +159,7 @@ where
 	///
 	/// # Example
 	///
-	/// ```
+	/// ```ignore
 	/// # #[cfg(feature = "tokio")]
 	/// # fn run () {
 	/// use hyper::Uri;
@@ -192,7 +192,7 @@ where
 	///
 	/// # Example
 	///
-	/// ```
+	/// ```ignore
 	/// # #[cfg(feature = "tokio")]
 	/// # fn run () {
 	/// use hyper::{Method, Request};
@@ -957,7 +957,7 @@ fn is_schema_secure(uri: &Uri) -> bool {
 ///
 /// # Example
 ///
-/// ```
+/// ```ignore
 /// # #[cfg(feature = "tokio")]
 /// # fn run () {
 /// use std::time::Duration;
@@ -1020,7 +1020,7 @@ impl Builder {
 	///
 	/// # Example
 	///
-	/// ```
+	/// ```ignore
 	/// # #[cfg(feature = "tokio")]
 	/// # fn run () {
 	/// use std::time::Duration;

--- a/crates/hyper-util-fork/src/client/legacy/connect/capture.rs
+++ b/crates/hyper-util-fork/src/client/legacy/connect/capture.rs
@@ -30,7 +30,7 @@ pub struct CaptureConnection {
 /// The [`CaptureConnection::connection_metadata`] method allows callers to check if a connection has been
 /// established. This is ideal for situations where you are certain the connection has already
 /// been established (e.g. after the response future has already completed).
-/// ```rust
+/// ```ignore
 /// use hyper_util::client::legacy::connect::capture_connection;
 /// let mut request = http::Request::builder()
 ///   .uri("http://foo.com")
@@ -47,7 +47,7 @@ pub struct CaptureConnection {
 /// The [`CaptureConnection::wait_for_connection_metadata`] method returns a future resolves as soon as the
 /// connection is available.
 ///
-/// ```rust
+/// ```ignore
 /// # #[cfg(feature  = "tokio")]
 /// # async fn example() {
 /// use hyper_util::client::legacy::connect::capture_connection;

--- a/crates/hyper-util-fork/src/client/legacy/connect/http.rs
+++ b/crates/hyper-util-fork/src/client/legacy/connect/http.rs
@@ -9,7 +9,7 @@ use crate::rt::TokioIo;
 ///
 /// # Example
 ///
-/// ```
+/// ```ignore
 /// # fn doc(res: http::Response<()>) {
 /// use hyper_util::client::legacy::connect::HttpInfo;
 ///


### PR DESCRIPTION
Skips broken doc tests for the forked `hyper-util` allowing for running `cargo test --workspace`

Example error:
```
no method named `build_http` found for mutable reference `&mut hyper_util_fork::client::legacy::Builder` in the current scope
```

NOTE: its probably best to document using nextest and switch CI over to it possibly using [taiki-e/install-action](https://github.com/taiki-e/install-action)