### PR TITLE
fix(mcp/authz): return JSON-RPC error instead of 500 for unauthorized calls

### DIFF
--- a/crates/agentgateway/src/mcp/upstream/mod.rs
+++ b/crates/agentgateway/src/mcp/upstream/mod.rs
@@ -60,8 +60,11 @@ impl IncomingRequestContext {
 
 #[derive(Debug, Error)]
 pub enum UpstreamError {
-	#[error("unauthorized tool call")]
-	Authorization,
+	#[error("unknown {resource_type}: {resource_name}")]
+	Authorization {
+		resource_type: String,
+		resource_name: String,
+	},
 	#[error("invalid request: {0}")]
 	InvalidRequest(String),
 	#[error("unsupported method: {0}")]


### PR DESCRIPTION

When a client attempts to access a tool, prompt, or resource that they are not authorized to use, the gateway now returns a proper JSON-RPC error with INVALID_PARAMS code (-32602) and message 'Unknown {type}: {name}' instead of a 500 Internal Server Error.

This implements Option B from the issue https://github.com/agentgateway/agentgateway/issues/758 to enhance security by avoiding leaking information about resource existence, making unauthorized access indistinguishable from accessing non-existent resources.

Changes:
- Refactored UpstreamError::Authorization to include resource_type and resource_name fields
- Added http_json_error helper for JSON content-type responses
- Updated session.rs to return proper JSON-RPC error for authorization failures
- Added comprehensive tests for tool, prompt, and resource authorization denial scenarios

Fixes #758