### PR TITLE
Fix AI policy sorted routes

### DIFF
--- a/crates/agentgateway/src/llm/policy/tests.rs
+++ b/crates/agentgateway/src/llm/policy/tests.rs
@@ -231,7 +231,7 @@ fn test_resolve_route() {
 	routes.insert(strng::literal!("*"), crate::llm::RouteType::Passthrough);
 
 	let policy = Policy {
-		routes,
+		routes: SortedRoutes::from_iter(routes.into_iter().map(|(k, v)| (strng::new(k), v))),
 		..Default::default()
 	};
 

--- a/schema/config.json
+++ b/schema/config.json
@@ -2000,7 +2000,43 @@
                               "routes": {
                                 "type": "object",
                                 "additionalProperties": {
-                                  "type": "string"
+                                  "oneOf": [
+                                    {
+                                      "description": "OpenAI /v1/chat/completions",
+                                      "type": "string",
+                                      "const": "completions"
+                                    },
+                                    {
+                                      "description": "Anthropic /v1/messages",
+                                      "type": "string",
+                                      "const": "messages"
+                                    },
+                                    {
+                                      "description": "OpenAI /v1/models",
+                                      "type": "string",
+                                      "const": "models"
+                                    },
+                                    {
+                                      "description": "Send the request to the upstream LLM provider as-is",
+                                      "type": "string",
+                                      "const": "passthrough"
+                                    },
+                                    {
+                                      "description": "OpenAI /responses",
+                                      "type": "string",
+                                      "const": "responses"
+                                    },
+                                    {
+                                      "description": "OpenAI /embeddings",
+                                      "type": "string",
+                                      "const": "embeddings"
+                                    },
+                                    {
+                                      "description": "Anthropic /v1/messages/count_tokens",
+                                      "type": "string",
+                                      "const": "anthropicTokenCount"
+                                    }
+                                  ]
                                 }
                               }
                             },
@@ -4188,7 +4224,43 @@
                                     "routes": {
                                       "type": "object",
                                       "additionalProperties": {
-                                        "type": "string"
+                                        "oneOf": [
+                                          {
+                                            "description": "OpenAI /v1/chat/completions",
+                                            "type": "string",
+                                            "const": "completions"
+                                          },
+                                          {
+                                            "description": "Anthropic /v1/messages",
+                                            "type": "string",
+                                            "const": "messages"
+                                          },
+                                          {
+                                            "description": "OpenAI /v1/models",
+                                            "type": "string",
+                                            "const": "models"
+                                          },
+                                          {
+                                            "description": "Send the request to the upstream LLM provider as-is",
+                                            "type": "string",
+                                            "const": "passthrough"
+                                          },
+                                          {
+                                            "description": "OpenAI /responses",
+                                            "type": "string",
+                                            "const": "responses"
+                                          },
+                                          {
+                                            "description": "OpenAI /embeddings",
+                                            "type": "string",
+                                            "const": "embeddings"
+                                          },
+                                          {
+                                            "description": "Anthropic /v1/messages/count_tokens",
+                                            "type": "string",
+                                            "const": "anthropicTokenCount"
+                                          }
+                                        ]
                                       }
                                     }
                                   },
@@ -5953,7 +6025,43 @@
                                                 "routes": {
                                                   "type": "object",
                                                   "additionalProperties": {
-                                                    "type": "string"
+                                                    "oneOf": [
+                                                      {
+                                                        "description": "OpenAI /v1/chat/completions",
+                                                        "type": "string",
+                                                        "const": "completions"
+                                                      },
+                                                      {
+                                                        "description": "Anthropic /v1/messages",
+                                                        "type": "string",
+                                                        "const": "messages"
+                                                      },
+                                                      {
+                                                        "description": "OpenAI /v1/models",
+                                                        "type": "string",
+                                                        "const": "models"
+                                                      },
+                                                      {
+                                                        "description": "Send the request to the upstream LLM provider as-is",
+                                                        "type": "string",
+                                                        "const": "passthrough"
+                                                      },
+                                                      {
+                                                        "description": "OpenAI /responses",
+                                                        "type": "string",
+                                                        "const": "responses"
+                                                      },
+                                                      {
+                                                        "description": "OpenAI /embeddings",
+                                                        "type": "string",
+                                                        "const": "embeddings"
+                                                      },
+                                                      {
+                                                        "description": "Anthropic /v1/messages/count_tokens",
+                                                        "type": "string",
+                                                        "const": "anthropicTokenCount"
+                                                      }
+                                                    ]
                                                   }
                                                 }
                                               },
@@ -7468,7 +7576,43 @@
                                                             "routes": {
                                                               "type": "object",
                                                               "additionalProperties": {
-                                                                "type": "string"
+                                                                "oneOf": [
+                                                                  {
+                                                                    "description": "OpenAI /v1/chat/completions",
+                                                                    "type": "string",
+                                                                    "const": "completions"
+                                                                  },
+                                                                  {
+                                                                    "description": "Anthropic /v1/messages",
+                                                                    "type": "string",
+                                                                    "const": "messages"
+                                                                  },
+                                                                  {
+                                                                    "description": "OpenAI /v1/models",
+                                                                    "type": "string",
+                                                                    "const": "models"
+                                                                  },
+                                                                  {
+                                                                    "description": "Send the request to the upstream LLM provider as-is",
+                                                                    "type": "string",
+                                                                    "const": "passthrough"
+                                                                  },
+                                                                  {
+                                                                    "description": "OpenAI /responses",
+                                                                    "type": "string",
+                                                                    "const": "responses"
+                                                                  },
+                                                                  {
+                                                                    "description": "OpenAI /embeddings",
+                                                                    "type": "string",
+                                                                    "const": "embeddings"
+                                                                  },
+                                                                  {
+                                                                    "description": "Anthropic /v1/messages/count_tokens",
+                                                                    "type": "string",
+                                                                    "const": "anthropicTokenCount"
+                                                                  }
+                                                                ]
                                                               }
                                                             }
                                                           },
@@ -10584,7 +10728,43 @@
                   "routes": {
                     "type": "object",
                     "additionalProperties": {
-                      "type": "string"
+                      "oneOf": [
+                        {
+                          "description": "OpenAI /v1/chat/completions",
+                          "type": "string",
+                          "const": "completions"
+                        },
+                        {
+                          "description": "Anthropic /v1/messages",
+                          "type": "string",
+                          "const": "messages"
+                        },
+                        {
+                          "description": "OpenAI /v1/models",
+                          "type": "string",
+                          "const": "models"
+                        },
+                        {
+                          "description": "Send the request to the upstream LLM provider as-is",
+                          "type": "string",
+                          "const": "passthrough"
+                        },
+                        {
+                          "description": "OpenAI /responses",
+                          "type": "string",
+                          "const": "responses"
+                        },
+                        {
+                          "description": "OpenAI /embeddings",
+                          "type": "string",
+                          "const": "embeddings"
+                        },
+                        {
+                          "description": "Anthropic /v1/messages/count_tokens",
+                          "type": "string",
+                          "const": "anthropicTokenCount"
+                        }
+                      ]
                     }
                   }
                 },
@@ -12787,7 +12967,43 @@
                   "routes": {
                     "type": "object",
                     "additionalProperties": {
-                      "type": "string"
+                      "oneOf": [
+                        {
+                          "description": "OpenAI /v1/chat/completions",
+                          "type": "string",
+                          "const": "completions"
+                        },
+                        {
+                          "description": "Anthropic /v1/messages",
+                          "type": "string",
+                          "const": "messages"
+                        },
+                        {
+                          "description": "OpenAI /v1/models",
+                          "type": "string",
+                          "const": "models"
+                        },
+                        {
+                          "description": "Send the request to the upstream LLM provider as-is",
+                          "type": "string",
+                          "const": "passthrough"
+                        },
+                        {
+                          "description": "OpenAI /responses",
+                          "type": "string",
+                          "const": "responses"
+                        },
+                        {
+                          "description": "OpenAI /embeddings",
+                          "type": "string",
+                          "const": "embeddings"
+                        },
+                        {
+                          "description": "Anthropic /v1/messages/count_tokens",
+                          "type": "string",
+                          "const": "anthropicTokenCount"
+                        }
+                      ]
                     }
                   }
                 },


### PR DESCRIPTION
Fixes https://github.com/agentgateway/agentgateway/issues/727 

Now `resolve_route` matches longest-suffix-match with the wildcard as fallback. 

This change also sorts the routes so that the config_dump will also show sorted routes in the order they are applied to make it easier to debug:
```
  "policies": [
    {
      "key": "backend/default/openai:ai:default/openai",
      "name": {
        "kind": "AgentgatewayPolicy",
        "name": "openai",
        "namespace": "default"
      },
      "target": {
        "backend": {
          "backend": {
            "name": "openai",
            "namespace": "default"
          }
        }
      },
      "policy": {
        "backend": {
          "aI": {
            "defaults": {},
            "overrides": {},
            "routes": {
              "/v1/chat/completions": "completions",
              "/v1/responses": "responses",
              "*": "passthrough"
            }
          }
        }
      }
    }
  ],
```