### PR TITLE
local config: add simplified LLM configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,8 +220,9 @@ dependencies = [
  "rcgen 0.14.7",
  "regex",
  "reqwest 0.12.28",
+ "reqwest 0.13.2",
  "rmcp 0.10.0",
- "rmcp 0.14.0",
+ "rmcp 0.15.0",
  "rstest",
  "rustls",
  "rustls-native-certs",
@@ -4954,6 +4955,7 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -5282,7 +5284,9 @@ checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
  "base64",
  "bytes",
+ "encoding_rs",
  "futures-core",
+ "h2",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -5291,8 +5295,10 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -5366,9 +5372,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a621b37a548ff6ab6292d57841eb25785a7f146d89391a19c9f199414bd13da"
+checksum = "1bef41ebc9ebed2c1b1d90203e9d1756091e8a00bbc3107676151f39868ca0ee"
 dependencies = [
  "async-trait",
  "axum",
@@ -5385,7 +5391,7 @@ dependencies = [
  "process-wrap",
  "rand 0.9.2",
  "reqwest 0.12.28",
- "rmcp-macros 0.14.0",
+ "rmcp-macros 0.15.0",
  "schemars 1.0.4",
  "serde",
  "serde_json",
@@ -5415,9 +5421,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b79ed92303f9262db79575aa8c3652581668e9d136be6fd0b9ededa78954c95"
+checksum = "0e88ad84b8b6237a934534a62b379a5be6388915663c0cc598ceb9b3292bbbfe"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,11 +139,10 @@ pwhash = "1"
 rand = "0.10"
 rcgen = { version = "0.14", features = ["pem", "x509-parser"] }
 regex = "1.11"
-reqwest = { version = "0.12", default-features = false, features = [
+reqwest = { version = "0.13", default-features = false, features = [
     "http2",
     "charset",
-    "macos-system-configuration",
-    "rustls-tls",
+    "rustls",
 ] }
 rstest = "0.26"
 rustc_version = "0.4"

--- a/crates/agentgateway/Cargo.toml
+++ b/crates/agentgateway/Cargo.toml
@@ -15,7 +15,7 @@ ui = []
 schema = ["schemars"]
 tls-ring = ["rustls/ring", "tokio-rustls/ring"]
 internal_benches = ["divan"]
-testing = ["dep:reqwest"]
+testing = []
 
 [dependencies]
 a2a-sdk.workspace = true
@@ -98,8 +98,11 @@ prost.workspace = true
 rand.workspace = true
 rcgen.workspace = true
 regex.workspace = true
-rmcp = { version = "0.14", features = [
+
+rmcp = { version = "0.15", features = [
     "client",
+    "server",
+    "base64",
     "transport-child-process",
 ] }
 rustls-native-certs.workspace = true
@@ -139,7 +142,7 @@ typespec_client_core.workspace = true
 url.workspace = true
 uuid.workspace = true
 x509-parser.workspace = true
-reqwest = { optional = true, workspace = true }
+reqwest = { workspace = true }
 websocket-sans-io.workspace = true
 vector-map.workspace = true
 flagset.workspace = true
@@ -175,7 +178,7 @@ rstest.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
 which.workspace = true
-rmcp = { version = "0.14", features = [
+rmcp = { version = "0.15", features = [
     "client",
     "server",
     "base64",
@@ -196,6 +199,13 @@ legacy-rmcp = { package = "rmcp", version = "0.10.0", features = ["transport-sse
 ] }
 wiremock.workspace = true
 reqwest.workspace = true
+# TODO(https://github.com/modelcontextprotocol/rust-sdk/pull/667)
+legacyreqwest = { package = "reqwest", version = "0.12", default-features = false, features = [
+    "http2",
+    "charset",
+    "macos-system-configuration",
+    "rustls-tls",
+] }
 
 [lints.clippy]
 # This rule makes code more confusing

--- a/crates/agentgateway/src/http/filters.rs
+++ b/crates/agentgateway/src/http/filters.rs
@@ -146,6 +146,7 @@ impl UrlRewrite {
 
 #[apply(schema!)]
 pub struct DirectResponse {
+	#[serde(with = "serde_base64")]
 	pub body: Bytes,
 	#[serde(with = "http_serde::status_code")]
 	#[cfg_attr(feature = "schema", schemars(with = "std::num::NonZeroU16"))]

--- a/crates/agentgateway/src/http/filters.rs
+++ b/crates/agentgateway/src/http/filters.rs
@@ -146,7 +146,7 @@ impl UrlRewrite {
 
 #[apply(schema!)]
 pub struct DirectResponse {
-	#[serde(with = "serde_base64")]
+	#[serde(serialize_with = "serdes::serde_base64::serialize")]
 	pub body: Bytes,
 	#[serde(with = "http_serde::status_code")]
 	#[cfg_attr(feature = "schema", schemars(with = "std::num::NonZeroU16"))]

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -126,6 +126,17 @@ pub enum AIProvider {
 	AzureOpenAI(azureopenai::Provider),
 }
 
+#[apply(schema!)]
+pub enum LocalModelAIProvider {
+	OpenAI,
+	Gemini,
+	Vertex,
+	Anthropic,
+	Bedrock,
+	AzureOpenAI,
+}
+
+
 trait Provider {
 	const NAME: Strng;
 }

--- a/crates/agentgateway/src/llm/vertex.rs
+++ b/crates/agentgateway/src/llm/vertex.rs
@@ -38,6 +38,7 @@ impl Provider {
 			Value::String(ANTHROPIC_VERSION.to_string()),
 		);
 		body.remove("model");
+		body.remove("output_config");
 
 		serde_json::to_vec(&body).map_err(AIError::RequestMarshal)
 	}

--- a/crates/agentgateway/src/mcp/handler.rs
+++ b/crates/agentgateway/src/mcp/handler.rs
@@ -386,6 +386,7 @@ impl Relay {
 				experimental: None,
 				logging: None,
 				tasks: None,
+				extensions: None,
 				tools: Some(ToolsCapability::default()),
 				// These are not supported when multiplexing.
 				prompts: None,
@@ -397,6 +398,7 @@ impl Relay {
 				experimental: None,
 				logging: None,
 				tasks: None,
+				extensions: None,
 				tools: Some(ToolsCapability::default()),
 				prompts: Some(PromptsCapability::default()),
 				resources: Some(ResourcesCapability::default()),

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -424,7 +424,7 @@ pub async fn mcp_streamable_client(
 	use rmcp::model::{ClientCapabilities, ClientInfo, Implementation};
 	use rmcp::transport::StreamableHttpClientTransport;
 	let transport =
-		StreamableHttpClientTransport::<reqwest::Client>::from_uri(format!("http://{s}/mcp"));
+		StreamableHttpClientTransport::<legacyreqwest::Client>::from_uri(format!("http://{s}/mcp"));
 	let client_info = ClientInfo {
 		meta: None,
 		protocol_version: Default::default(),
@@ -435,6 +435,7 @@ pub async fn mcp_streamable_client(
 			title: None,
 			website_url: None,
 			icons: None,
+			description: None,
 		},
 	};
 
@@ -456,7 +457,7 @@ pub async fn mcp_sse_client(s: SocketAddr) -> LegacyService {
 	use legacy_rmcp::ServiceExt;
 	use legacy_rmcp::model::{ClientCapabilities, ClientInfo, Implementation};
 	use legacy_rmcp::transport::SseClientTransport;
-	let transport = SseClientTransport::<reqwest::Client>::start(format!("http://{s}/sse"))
+	let transport = SseClientTransport::<legacyreqwest::Client>::start(format!("http://{s}/sse"))
 		.await
 		.unwrap();
 	let client_info = ClientInfo {

--- a/crates/agentgateway/src/mcp/session.rs
+++ b/crates/agentgateway/src/mcp/session.rs
@@ -616,6 +616,7 @@ fn get_client_info() -> ClientInfo {
 			sampling: None,
 			elicitation: None,
 			tasks: None,
+			extensions: None,
 		},
 		client_info: Implementation {
 			name: "agentgateway".to_string(),

--- a/crates/agentgateway/src/mcp/upstream/openapi/mod.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/mod.rs
@@ -374,6 +374,7 @@ pub(crate) fn parse_openapi_schema(
 								))?
 								.clone();
 							let tool = Tool {
+								execution: None,
 								meta: None,
 								annotations: None,
 								name: Cow::Owned(name.clone()),

--- a/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
@@ -56,6 +56,7 @@ async fn setup() -> (MockServer, Handler) {
 		icons: None,
 		title: None,
 		meta: None,
+		execution: None,
 		input_schema: Arc::new(
 			json!({ // Define a simple schema for testing
 					"type": "object",
@@ -101,6 +102,7 @@ async fn setup() -> (MockServer, Handler) {
 		icons: None,
 		title: None,
 		meta: None,
+		execution: None,
 		input_schema: Arc::new(
 			json!({
 				"type": "object",

--- a/crates/agentgateway/src/parse/passthrough.rs
+++ b/crates/agentgateway/src/parse/passthrough.rs
@@ -82,6 +82,7 @@ where
 			&mut *this.decoder,
 			this.handler,
 		) {
+			tracing::error!("howardjohn: frame error {e}");
 			return Poll::Ready(Some(Err(e)));
 		}
 		// We need more input data - poll the underlying body
@@ -94,6 +95,7 @@ where
 				Some(Ok(frame))
 			},
 			Some(Err(e)) => {
+				tracing::error!("howardjohn: frame error2 {e}");
 				return Poll::Ready(Some(Err(e)));
 			},
 			None => {
@@ -109,7 +111,10 @@ where
 			this.handler,
 		) {
 			Ok(_) => Poll::Ready(frame_to_send),
-			Err(e) => Poll::Ready(Some(Err(e))),
+			Err(e) => {
+				tracing::error!("howardjohn: frame error3 {e}");
+				Poll::Ready(Some(Err(e)))
+			},
 		}
 	}
 }

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -275,6 +275,9 @@ async fn apply_gateway_policies(
 	if let Some(j) = &policies.transformation {
 		j.apply_request(req);
 	}
+	if let Some(v) =  req.headers().get("x-gateway-model-name").cloned() {
+		req.extensions_mut().insert(llm::OverrideModel(v.to_str().unwrap().to_string()));
+	}
 
 	Ok(())
 }

--- a/crates/agentgateway/src/serdes.rs
+++ b/crates/agentgateway/src/serdes.rs
@@ -128,6 +128,35 @@ pub mod serde_dur_option {
 	}
 }
 
+pub mod serde_base64 {
+	use base64::Engine;
+	use base64::prelude::BASE64_STANDARD;
+	use serde::{Deserialize, Deserializer, Serializer};
+
+	pub fn serialize<T, S>(key: &T, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		T: AsRef<[u8]>,
+		S: Serializer,
+	{
+		serializer.serialize_str(&BASE64_STANDARD.encode(key.as_ref()))
+	}
+
+	pub fn deserialize<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+	where
+		D: Deserializer<'de>,
+		T: From<Vec<u8>>,
+	{
+		use serde::de::Error;
+		String::deserialize(deserializer)
+			.and_then(|string| {
+				BASE64_STANDARD
+					.decode(&string)
+					.map_err(|err| Error::custom(err.to_string()))
+			})
+			.map(|bytes| T::from(bytes))
+	}
+}
+
 pub fn ser_display_option<S: Serializer, T: Display>(
 	t: &Option<T>,
 	serializer: S,

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -1914,6 +1914,7 @@ pub enum BackendPolicy {
 	BackendTLS(http::backendtls::BackendTLS),
 	BackendAuth(BackendAuth),
 	InferenceRouting(ext_proc::InferenceRouting),
+	#[serde(rename = "ai")]
 	AI(Arc<llm::Policy>),
 	SessionPersistence(http::sessionpersistence::Policy),
 

--- a/crates/agentgateway/src/types/local_tests.rs
+++ b/crates/agentgateway/src/types/local_tests.rs
@@ -33,7 +33,7 @@ async fn test_config_parsing(test_name: &str) {
 		&yaml_str,
 	)
 	.await
-	.unwrap_or_else(|_| panic!("Failed to normalize config from: {:?}", input_path));
+	.unwrap_or_else(|e| panic!("Failed to normalize config from: {:?} {e}", input_path));
 
 	let output_yaml = serdes::yamlviajson::to_string(&normalized)
 		.expect("Failed to serialize NormalizedLocalConfig to YAML");
@@ -61,4 +61,9 @@ async fn test_mcp_config() {
 #[tokio::test]
 async fn test_llm_config() {
 	test_config_parsing("llm").await;
+}
+
+#[tokio::test]
+async fn test_llm_simple_config() {
+	test_config_parsing("llm_simple").await;
 }

--- a/crates/agentgateway/src/types/local_tests.rs
+++ b/crates/agentgateway/src/types/local_tests.rs
@@ -67,3 +67,8 @@ async fn test_llm_config() {
 async fn test_llm_simple_config() {
 	test_config_parsing("llm_simple").await;
 }
+
+#[tokio::test]
+async fn test_mcp_simple_config() {
+	test_config_parsing("mcp_simple").await;
+}

--- a/crates/agentgateway/src/types/local_tests/basic_config.yaml
+++ b/crates/agentgateway/src/types/local_tests/basic_config.yaml
@@ -1,4 +1,8 @@
 # yaml-language-server: $schema=../../schema/local.json
+frontendPolicies:
+  accessLog:
+    add:
+      user: request.headers['user-agent']
 binds:
 - port: 3000
   listeners:

--- a/crates/agentgateway/src/types/local_tests/basic_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/basic_normalized.snap
@@ -37,7 +37,19 @@ binds:
               - '*'
               maxAge: null
       tcpRoutes: {}
-policies: []
+policies:
+- key: frontend/accessLog
+  name: null
+  target:
+    gateway:
+      gatewayName: name
+      gatewayNamespace: ns
+      listenerName: null
+  policy:
+    frontend:
+      accessLog:
+        add:
+          user: request.headers['user-agent']
 backends:
 - backend:
     mcp:

--- a/crates/agentgateway/src/types/local_tests/llm_simple_config.yaml
+++ b/crates/agentgateway/src/types/local_tests/llm_simple_config.yaml
@@ -2,6 +2,7 @@ frontendPolicies:
   accessLog:
     add:
       user: request.headers["user-agent"]
+
 llm:
   policies:
     jwtAuth:
@@ -14,6 +15,11 @@ llm:
     params:
       model: claude-3-5-haiku-20241022
       apiKey: "sk-123"
+    matches:
+    - headers:
+      - name: "X-Org"
+        value:
+          exact: "engineering"
   - name: gemini-0.5-pro
     provider: vertex
     params:

--- a/crates/agentgateway/src/types/local_tests/llm_simple_config.yaml
+++ b/crates/agentgateway/src/types/local_tests/llm_simple_config.yaml
@@ -1,0 +1,16 @@
+llm:
+  models:
+  - name: claude-3-haiku
+    provider:
+      anthropic:
+        model: claude-3-5-haiku-20241022
+    params:
+      apiKey: "sk-123"
+  #    guardrails: ...
+  #    additionalHeaders: ...
+  - name: thinking
+    provider:
+      anthropic: {}
+    params:
+      model: claude-sonnet-4-5-20250929
+      apiKey: "$ANTHROPIC_API_KEY"

--- a/crates/agentgateway/src/types/local_tests/llm_simple_config.yaml
+++ b/crates/agentgateway/src/types/local_tests/llm_simple_config.yaml
@@ -1,16 +1,34 @@
+frontendPolicies:
+  accessLog:
+    add:
+      "body": variables()
+      wtf: ba
 llm:
+#  policies:
+#    jwtAuth:
+#      issuer: agentgateway.dev
+#      audiences: [test.agentgateway.dev]
+#      jwks: '{"keys":[]}'
   models:
   - name: claude-3-haiku
-    provider:
-      anthropic:
-        model: claude-3-5-haiku-20241022
+    provider: anthropic
     params:
+      model: claude-3-5-haiku-20241022
       apiKey: "sk-123"
+  - name: gemini-0.5-pro
+    provider: vertex
+    params:
+      model: claude-3-5-haiku-20241022
+      apiKey: "sk-123"
+      vertexRegion: global
+      vertexProject: my-vertex-project
   #    guardrails: ...
   #    additionalHeaders: ...
-  - name: thinking
-    provider:
-      anthropic: {}
+  - name: gpt-7-max
+    provider: azureOpenAI
     params:
-      model: claude-sonnet-4-5-20250929
-      apiKey: "$ANTHROPIC_API_KEY"
+      model: gpt-3.5-turbo
+      azureHost: my-azure-openai-endpoint.openai.azure.com
+      azureApiVersion: v1
+  - name: gpt-3.5-turbo
+    provider: openAI

--- a/crates/agentgateway/src/types/local_tests/llm_simple_config.yaml
+++ b/crates/agentgateway/src/types/local_tests/llm_simple_config.yaml
@@ -9,6 +9,9 @@ llm:
       issuer: agentgateway.dev
       audiences: [test.agentgateway.dev]
       jwks: '{"keys":[]}'
+    authorization:
+      rules:
+      - 'jwt.email.endsWith("@example.com")'
   models:
   - name: claude-3-haiku
     provider: anthropic

--- a/crates/agentgateway/src/types/local_tests/llm_simple_config.yaml
+++ b/crates/agentgateway/src/types/local_tests/llm_simple_config.yaml
@@ -1,14 +1,13 @@
 frontendPolicies:
   accessLog:
     add:
-      "body": variables()
-      wtf: ba
+      user: request.headers["user-agent"]
 llm:
-#  policies:
-#    jwtAuth:
-#      issuer: agentgateway.dev
-#      audiences: [test.agentgateway.dev]
-#      jwks: '{"keys":[]}'
+  policies:
+    jwtAuth:
+      issuer: agentgateway.dev
+      audiences: [test.agentgateway.dev]
+      jwks: '{"keys":[]}'
   models:
   - name: claude-3-haiku
     provider: anthropic
@@ -22,8 +21,6 @@ llm:
       apiKey: "sk-123"
       vertexRegion: global
       vertexProject: my-vertex-project
-  #    guardrails: ...
-  #    additionalHeaders: ...
   - name: gpt-7-max
     provider: azureOpenAI
     params:

--- a/crates/agentgateway/src/types/local_tests/llm_simple_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/llm_simple_normalized.snap
@@ -16,56 +16,8 @@ binds:
       hostname: '*'
       protocol: HTTP
       routes:
-        llm:model:gpt-7-max:
-          key: llm:model:gpt-7-max
-          name: model:gpt-7-max
-          namespace: internal
-          matches:
-          - headers:
-            - name: x-gateway-model-name
-              value:
-                exact: gpt-7-max
-            path:
-              pathPrefix: /
-          backends:
-          - weight: 1
-            backend: /llm:gpt-7-max
-          inlinePolicies:
-          - ai:
-              routes:
-                /v1/chat/completions: completions
-                :streamRawPredict: messages
-                /v1/embeddings: embeddings
-                /v1/responses: responses
-                /v1/messages: messages
-                :rawPredict: messages
-                '*': passthrough
-        llm:model:gemini-0.5-pro:
-          key: llm:model:gemini-0.5-pro
-          name: model:gemini-0.5-pro
-          namespace: internal
-          matches:
-          - headers:
-            - name: x-gateway-model-name
-              value:
-                exact: gemini-0.5-pro
-            path:
-              pathPrefix: /
-          backends:
-          - weight: 1
-            backend: /llm:gemini-0.5-pro
-          inlinePolicies:
-          - ai:
-              routes:
-                /v1/chat/completions: completions
-                :streamRawPredict: messages
-                /v1/embeddings: embeddings
-                /v1/responses: responses
-                /v1/messages: messages
-                :rawPredict: messages
-                '*': passthrough
-        llm:model:claude-3-haiku:
-          key: llm:model:claude-3-haiku
+        llm:model:claude-3-haiku:0:
+          key: llm:model:claude-3-haiku:0
           name: model:claude-3-haiku
           namespace: internal
           matches:
@@ -91,21 +43,32 @@ binds:
                 /v1/messages: messages
                 :rawPredict: messages
                 '*': passthrough
-        llm:admin:model-list:
-          key: llm:admin:model-list
-          name: admin:model-list
+        llm:model:gpt-7-max:2:
+          key: llm:model:gpt-7-max:2
+          name: model:gpt-7-max
           namespace: internal
           matches:
-          - path:
-              pathPrefix: /v1/models
-          - path:
-              pathPrefix: /models
+          - headers:
+            - name: x-gateway-model-name
+              value:
+                exact: gpt-7-max
+            path:
+              pathPrefix: /
+          backends:
+          - weight: 1
+            backend: /llm:gpt-7-max
           inlinePolicies:
-          - directResponse:
-              body: eyJkYXRhIjpbeyJpZCI6ImNsYXVkZS0zLWhhaWt1Iiwib2JqZWN0IjoibW9kZWwiLCJjcmVhdGVkIjoxNzcxMjg3OTUzLCJvd25lZF9ieSI6Im9wZW5haSJ9LHsiaWQiOiJnZW1pbmktMC41LXBybyIsIm9iamVjdCI6Im1vZGVsIiwiY3JlYXRlZCI6MTc3MTI4Nzk1Mywib3duZWRfYnkiOiJvcGVuYWkifSx7ImlkIjoiZ3B0LTctbWF4Iiwib2JqZWN0IjoibW9kZWwiLCJjcmVhdGVkIjoxNzcxMjg3OTUzLCJvd25lZF9ieSI6Im9wZW5haSJ9LHsiaWQiOiJncHQtMy41LXR1cmJvIiwib2JqZWN0IjoibW9kZWwiLCJjcmVhdGVkIjoxNzcxMjg3OTUzLCJvd25lZF9ieSI6Im9wZW5haSJ9XSwib2JqZWN0IjoibGlzdCJ9
-              status: 200
-        llm:model:gpt-3.5-turbo:
-          key: llm:model:gpt-3.5-turbo
+          - ai:
+              routes:
+                /v1/chat/completions: completions
+                :streamRawPredict: messages
+                /v1/embeddings: embeddings
+                /v1/responses: responses
+                /v1/messages: messages
+                :rawPredict: messages
+                '*': passthrough
+        llm:model:gpt-3.5-turbo:3:
+          key: llm:model:gpt-3.5-turbo:3
           name: model:gpt-3.5-turbo
           namespace: internal
           matches:
@@ -128,6 +91,43 @@ binds:
                 /v1/messages: messages
                 :rawPredict: messages
                 '*': passthrough
+        llm:model:gemini-0.5-pro:1:
+          key: llm:model:gemini-0.5-pro:1
+          name: model:gemini-0.5-pro
+          namespace: internal
+          matches:
+          - headers:
+            - name: x-gateway-model-name
+              value:
+                exact: gemini-0.5-pro
+            path:
+              pathPrefix: /
+          backends:
+          - weight: 1
+            backend: /llm:gemini-0.5-pro
+          inlinePolicies:
+          - ai:
+              routes:
+                /v1/chat/completions: completions
+                :streamRawPredict: messages
+                /v1/embeddings: embeddings
+                /v1/responses: responses
+                /v1/messages: messages
+                :rawPredict: messages
+                '*': passthrough
+        llm:admin:model-list:
+          key: llm:admin:model-list
+          name: admin:model-list
+          namespace: internal
+          matches:
+          - path:
+              pathPrefix: /v1/models
+          - path:
+              pathPrefix: /models
+          inlinePolicies:
+          - directResponse:
+              body: eyJkYXRhIjpbeyJpZCI6ImNsYXVkZS0zLWhhaWt1Iiwib2JqZWN0IjoibW9kZWwiLCJjcmVhdGVkIjoxNzcxMzcwNTczLCJvd25lZF9ieSI6Im9wZW5haSJ9LHsiaWQiOiJnZW1pbmktMC41LXBybyIsIm9iamVjdCI6Im1vZGVsIiwiY3JlYXRlZCI6MTc3MTM3MDU3Mywib3duZWRfYnkiOiJvcGVuYWkifSx7ImlkIjoiZ3B0LTctbWF4Iiwib2JqZWN0IjoibW9kZWwiLCJjcmVhdGVkIjoxNzcxMzcwNTczLCJvd25lZF9ieSI6Im9wZW5haSJ9LHsiaWQiOiJncHQtMy41LXR1cmJvIiwib2JqZWN0IjoibW9kZWwiLCJjcmVhdGVkIjoxNzcxMzcwNTczLCJvd25lZF9ieSI6Im9wZW5haSJ9XSwib2JqZWN0IjoibGlzdCJ9
+              status: 200
       tcpRoutes: {}
 policies:
 - key: listener/0
@@ -145,6 +145,21 @@ policies:
         providers:
         - issuer: agentgateway.dev
           keys: []
+- key: listener/1
+  name: null
+  target:
+    gateway:
+      gatewayName: name
+      gatewayNamespace: ns
+      listenerName: llm
+  policy:
+    traffic:
+      phase: route
+      authorization:
+        rules:
+          allow:
+          - jwt.email.endsWith("@example.com")
+          deny: []
 - key: llm:transformation
   name:
     kind: Local
@@ -163,7 +178,13 @@ policies:
           add: []
           set:
           - - x-gateway-model-name
-            - json(request.body).model
+            - |2
+
+              request.path.endsWith(":streamRawPredict") || request.path.endsWith(":rawPredict") ?
+              request.path.regexReplace("^.*/publishers/anthropic/models/(.+?):.*", "${1}") :
+              json(request.body).model
+          - - anthropic-beta
+            - request.headers['anthropic-beta'].split(',').filter(v, v.trim() in [])
           remove: []
           body: null
         response:

--- a/crates/agentgateway/src/types/local_tests/llm_simple_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/llm_simple_normalized.snap
@@ -1,0 +1,272 @@
+---
+source: crates/agentgateway/src/types/local_tests.rs
+description: "Config normalization test for llm_simple: YAML -> LocalConfig -> NormalizedLocalConfig -> YAML"
+---
+binds:
+- key: bind/4000
+  address: '[::]:4000'
+  protocol: http
+  tunnelProtocol: direct
+  listeners:
+    llm:
+      key: llm
+      gatewayName: llm
+      gatewayNamespace: internal
+      listenerName: llm
+      hostname: '*'
+      protocol: HTTP
+      routes:
+        llm:model:gemini-0.5-pro:
+          key: llm:model:gemini-0.5-pro
+          name: model:gemini-0.5-pro
+          namespace: internal
+          matches:
+          - headers:
+            - name: x-gateway-model-name
+              value:
+                exact: gemini-0.5-pro
+            path:
+              pathPrefix: /
+          backends:
+          - weight: 1
+            backend: /llm:gemini-0.5-pro
+          inlinePolicies:
+          - ai:
+              routes:
+                /v1/chat/completions: completions
+                /v1/embeddings: embeddings
+                /v1/responses: responses
+                /v1/messages: messages
+                '*': passthrough
+        llm:admin:model-list:
+          key: llm:admin:model-list
+          name: admin:model-list
+          namespace: internal
+          matches:
+          - path:
+              pathPrefix: /v1/models
+          - path:
+              pathPrefix: /models
+          inlinePolicies:
+          - directResponse:
+              body: eyJkYXRhIjpbeyJpZCI6ImNsYXVkZS0zLWhhaWt1Iiwib2JqZWN0IjoibW9kZWwiLCJjcmVhdGVkIjoxNzcxMjgzOTE3LCJvd25lZF9ieSI6Im9wZW5haSJ9LHsiaWQiOiJnZW1pbmktMC41LXBybyIsIm9iamVjdCI6Im1vZGVsIiwiY3JlYXRlZCI6MTc3MTI4MzkxNywib3duZWRfYnkiOiJvcGVuYWkifSx7ImlkIjoiZ3B0LTctbWF4Iiwib2JqZWN0IjoibW9kZWwiLCJjcmVhdGVkIjoxNzcxMjgzOTE3LCJvd25lZF9ieSI6Im9wZW5haSJ9LHsiaWQiOiJncHQtMy41LXR1cmJvIiwib2JqZWN0IjoibW9kZWwiLCJjcmVhdGVkIjoxNzcxMjgzOTE3LCJvd25lZF9ieSI6Im9wZW5haSJ9XSwib2JqZWN0IjoibGlzdCJ9
+              status: 200
+        llm:model:gpt-7-max:
+          key: llm:model:gpt-7-max
+          name: model:gpt-7-max
+          namespace: internal
+          matches:
+          - headers:
+            - name: x-gateway-model-name
+              value:
+                exact: gpt-7-max
+            path:
+              pathPrefix: /
+          backends:
+          - weight: 1
+            backend: /llm:gpt-7-max
+          inlinePolicies:
+          - ai:
+              routes:
+                /v1/chat/completions: completions
+                /v1/embeddings: embeddings
+                /v1/responses: responses
+                /v1/messages: messages
+                '*': passthrough
+        llm:model:gpt-3.5-turbo:
+          key: llm:model:gpt-3.5-turbo
+          name: model:gpt-3.5-turbo
+          namespace: internal
+          matches:
+          - headers:
+            - name: x-gateway-model-name
+              value:
+                exact: gpt-3.5-turbo
+            path:
+              pathPrefix: /
+          backends:
+          - weight: 1
+            backend: /llm:gpt-3.5-turbo
+          inlinePolicies:
+          - ai:
+              routes:
+                /v1/chat/completions: completions
+                /v1/embeddings: embeddings
+                /v1/responses: responses
+                /v1/messages: messages
+                '*': passthrough
+        llm:model:claude-3-haiku:
+          key: llm:model:claude-3-haiku
+          name: model:claude-3-haiku
+          namespace: internal
+          matches:
+          - headers:
+            - name: x-gateway-model-name
+              value:
+                exact: claude-3-haiku
+            path:
+              pathPrefix: /
+          backends:
+          - weight: 1
+            backend: /llm:claude-3-haiku
+          inlinePolicies:
+          - ai:
+              routes:
+                /v1/chat/completions: completions
+                /v1/embeddings: embeddings
+                /v1/responses: responses
+                /v1/messages: messages
+                '*': passthrough
+      tcpRoutes: {}
+policies:
+- key: llm:transformation
+  name:
+    kind: Local
+    name: llm:transformation
+    namespace: internal
+  target:
+    gateway:
+      gatewayName: llm
+      gatewayNamespace: internal
+      listenerName: llm
+  policy:
+    traffic:
+      phase: gateway
+      transformation:
+        request:
+          add: []
+          set:
+          - - x-gateway-model-name
+            - json(request.body).model
+          remove: []
+          body: null
+        response:
+          add: []
+          set: []
+          remove: []
+          body: null
+- key: frontend/accessLog
+  name: null
+  target:
+    gateway:
+      gatewayName: name
+      gatewayNamespace: ns
+      listenerName: null
+  policy:
+    frontend:
+      accessLog:
+        add:
+          body: variables()
+          wtf: ba
+backends:
+- backend:
+    ai:
+      name: llm:claude-3-haiku
+      namespace: ''
+      target:
+        providers:
+        - active:
+            claude-3-haiku:
+              endpoint:
+                name: claude-3-haiku
+                provider:
+                  anthropic:
+                    model: claude-3-5-haiku-20241022
+                hostOverride: null
+                pathOverride: null
+                tokenize: false
+                inlinePolicies:
+                - backendAuth:
+                    key: <redacted>
+              info:
+                health: 1.0
+                request_latency: 0.0
+                pending_requests: 0
+                total_requests: 0
+                evicted_until: null
+          rejected: {}
+  inlinePolicies:
+  - ai: {}
+- backend:
+    ai:
+      name: llm:gemini-0.5-pro
+      namespace: ''
+      target:
+        providers:
+        - active:
+            gemini-0.5-pro:
+              endpoint:
+                name: gemini-0.5-pro
+                provider:
+                  vertex:
+                    model: claude-3-5-haiku-20241022
+                    region: global
+                    projectId: my-vertex-project
+                hostOverride: null
+                pathOverride: null
+                tokenize: false
+                inlinePolicies:
+                - backendAuth:
+                    key: <redacted>
+              info:
+                health: 1.0
+                request_latency: 0.0
+                pending_requests: 0
+                total_requests: 0
+                evicted_until: null
+          rejected: {}
+  inlinePolicies:
+  - ai: {}
+- backend:
+    ai:
+      name: llm:gpt-7-max
+      namespace: ''
+      target:
+        providers:
+        - active:
+            gpt-7-max:
+              endpoint:
+                name: gpt-7-max
+                provider:
+                  azureOpenAI:
+                    model: gpt-3.5-turbo
+                    host: my-azure-openai-endpoint.openai.azure.com
+                    apiVersion: v1
+                hostOverride: null
+                pathOverride: null
+                tokenize: false
+              info:
+                health: 1.0
+                request_latency: 0.0
+                pending_requests: 0
+                total_requests: 0
+                evicted_until: null
+          rejected: {}
+  inlinePolicies:
+  - ai: {}
+- backend:
+    ai:
+      name: llm:gpt-3.5-turbo
+      namespace: ''
+      target:
+        providers:
+        - active:
+            gpt-3.5-turbo:
+              endpoint:
+                name: gpt-3.5-turbo
+                provider:
+                  openAI: {}
+                hostOverride: null
+                pathOverride: null
+                tokenize: false
+              info:
+                health: 1.0
+                request_latency: 0.0
+                pending_requests: 0
+                total_requests: 0
+                evicted_until: null
+          rejected: {}
+  inlinePolicies:
+  - ai: {}
+workloads: []
+services: []

--- a/crates/agentgateway/src/types/local_tests/llm_simple_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/llm_simple_normalized.snap
@@ -10,47 +10,12 @@ binds:
   listeners:
     llm:
       key: llm
-      gatewayName: llm
-      gatewayNamespace: internal
+      gatewayName: name
+      gatewayNamespace: ns
       listenerName: llm
       hostname: '*'
       protocol: HTTP
       routes:
-        llm:model:gemini-0.5-pro:
-          key: llm:model:gemini-0.5-pro
-          name: model:gemini-0.5-pro
-          namespace: internal
-          matches:
-          - headers:
-            - name: x-gateway-model-name
-              value:
-                exact: gemini-0.5-pro
-            path:
-              pathPrefix: /
-          backends:
-          - weight: 1
-            backend: /llm:gemini-0.5-pro
-          inlinePolicies:
-          - ai:
-              routes:
-                /v1/chat/completions: completions
-                /v1/embeddings: embeddings
-                /v1/responses: responses
-                /v1/messages: messages
-                '*': passthrough
-        llm:admin:model-list:
-          key: llm:admin:model-list
-          name: admin:model-list
-          namespace: internal
-          matches:
-          - path:
-              pathPrefix: /v1/models
-          - path:
-              pathPrefix: /models
-          inlinePolicies:
-          - directResponse:
-              body: eyJkYXRhIjpbeyJpZCI6ImNsYXVkZS0zLWhhaWt1Iiwib2JqZWN0IjoibW9kZWwiLCJjcmVhdGVkIjoxNzcxMjgzOTE3LCJvd25lZF9ieSI6Im9wZW5haSJ9LHsiaWQiOiJnZW1pbmktMC41LXBybyIsIm9iamVjdCI6Im1vZGVsIiwiY3JlYXRlZCI6MTc3MTI4MzkxNywib3duZWRfYnkiOiJvcGVuYWkifSx7ImlkIjoiZ3B0LTctbWF4Iiwib2JqZWN0IjoibW9kZWwiLCJjcmVhdGVkIjoxNzcxMjgzOTE3LCJvd25lZF9ieSI6Im9wZW5haSJ9LHsiaWQiOiJncHQtMy41LXR1cmJvIiwib2JqZWN0IjoibW9kZWwiLCJjcmVhdGVkIjoxNzcxMjgzOTE3LCJvd25lZF9ieSI6Im9wZW5haSJ9XSwib2JqZWN0IjoibGlzdCJ9
-              status: 200
         llm:model:gpt-7-max:
           key: llm:model:gpt-7-max
           name: model:gpt-7-max
@@ -69,10 +34,76 @@ binds:
           - ai:
               routes:
                 /v1/chat/completions: completions
+                :streamRawPredict: messages
                 /v1/embeddings: embeddings
                 /v1/responses: responses
                 /v1/messages: messages
+                :rawPredict: messages
                 '*': passthrough
+        llm:model:gemini-0.5-pro:
+          key: llm:model:gemini-0.5-pro
+          name: model:gemini-0.5-pro
+          namespace: internal
+          matches:
+          - headers:
+            - name: x-gateway-model-name
+              value:
+                exact: gemini-0.5-pro
+            path:
+              pathPrefix: /
+          backends:
+          - weight: 1
+            backend: /llm:gemini-0.5-pro
+          inlinePolicies:
+          - ai:
+              routes:
+                /v1/chat/completions: completions
+                :streamRawPredict: messages
+                /v1/embeddings: embeddings
+                /v1/responses: responses
+                /v1/messages: messages
+                :rawPredict: messages
+                '*': passthrough
+        llm:model:claude-3-haiku:
+          key: llm:model:claude-3-haiku
+          name: model:claude-3-haiku
+          namespace: internal
+          matches:
+          - headers:
+            - name: x-org
+              value:
+                exact: engineering
+            - name: x-gateway-model-name
+              value:
+                exact: claude-3-haiku
+            path:
+              pathPrefix: /
+          backends:
+          - weight: 1
+            backend: /llm:claude-3-haiku
+          inlinePolicies:
+          - ai:
+              routes:
+                /v1/chat/completions: completions
+                :streamRawPredict: messages
+                /v1/embeddings: embeddings
+                /v1/responses: responses
+                /v1/messages: messages
+                :rawPredict: messages
+                '*': passthrough
+        llm:admin:model-list:
+          key: llm:admin:model-list
+          name: admin:model-list
+          namespace: internal
+          matches:
+          - path:
+              pathPrefix: /v1/models
+          - path:
+              pathPrefix: /models
+          inlinePolicies:
+          - directResponse:
+              body: eyJkYXRhIjpbeyJpZCI6ImNsYXVkZS0zLWhhaWt1Iiwib2JqZWN0IjoibW9kZWwiLCJjcmVhdGVkIjoxNzcxMjg3OTUzLCJvd25lZF9ieSI6Im9wZW5haSJ9LHsiaWQiOiJnZW1pbmktMC41LXBybyIsIm9iamVjdCI6Im1vZGVsIiwiY3JlYXRlZCI6MTc3MTI4Nzk1Mywib3duZWRfYnkiOiJvcGVuYWkifSx7ImlkIjoiZ3B0LTctbWF4Iiwib2JqZWN0IjoibW9kZWwiLCJjcmVhdGVkIjoxNzcxMjg3OTUzLCJvd25lZF9ieSI6Im9wZW5haSJ9LHsiaWQiOiJncHQtMy41LXR1cmJvIiwib2JqZWN0IjoibW9kZWwiLCJjcmVhdGVkIjoxNzcxMjg3OTUzLCJvd25lZF9ieSI6Im9wZW5haSJ9XSwib2JqZWN0IjoibGlzdCJ9
+              status: 200
         llm:model:gpt-3.5-turbo:
           key: llm:model:gpt-3.5-turbo
           name: model:gpt-3.5-turbo
@@ -91,34 +122,29 @@ binds:
           - ai:
               routes:
                 /v1/chat/completions: completions
+                :streamRawPredict: messages
                 /v1/embeddings: embeddings
                 /v1/responses: responses
                 /v1/messages: messages
-                '*': passthrough
-        llm:model:claude-3-haiku:
-          key: llm:model:claude-3-haiku
-          name: model:claude-3-haiku
-          namespace: internal
-          matches:
-          - headers:
-            - name: x-gateway-model-name
-              value:
-                exact: claude-3-haiku
-            path:
-              pathPrefix: /
-          backends:
-          - weight: 1
-            backend: /llm:claude-3-haiku
-          inlinePolicies:
-          - ai:
-              routes:
-                /v1/chat/completions: completions
-                /v1/embeddings: embeddings
-                /v1/responses: responses
-                /v1/messages: messages
+                :rawPredict: messages
                 '*': passthrough
       tcpRoutes: {}
 policies:
+- key: listener/0
+  name: null
+  target:
+    gateway:
+      gatewayName: name
+      gatewayNamespace: ns
+      listenerName: llm
+  policy:
+    traffic:
+      phase: gateway
+      jwtAuth:
+        mode: optional
+        providers:
+        - issuer: agentgateway.dev
+          keys: []
 - key: llm:transformation
   name:
     kind: Local
@@ -126,8 +152,8 @@ policies:
     namespace: internal
   target:
     gateway:
-      gatewayName: llm
-      gatewayNamespace: internal
+      gatewayName: name
+      gatewayNamespace: ns
       listenerName: llm
   policy:
     traffic:
@@ -156,8 +182,7 @@ policies:
     frontend:
       accessLog:
         add:
-          body: variables()
-          wtf: ba
+          user: request.headers["user-agent"]
 backends:
 - backend:
     ai:
@@ -186,6 +211,9 @@ backends:
                 evicted_until: null
           rejected: {}
   inlinePolicies:
+  - requestHeaderModifier:
+      remove:
+      - x-gateway-model-name
   - ai: {}
 - backend:
     ai:
@@ -216,6 +244,9 @@ backends:
                 evicted_until: null
           rejected: {}
   inlinePolicies:
+  - requestHeaderModifier:
+      remove:
+      - x-gateway-model-name
   - ai: {}
 - backend:
     ai:
@@ -243,6 +274,9 @@ backends:
                 evicted_until: null
           rejected: {}
   inlinePolicies:
+  - requestHeaderModifier:
+      remove:
+      - x-gateway-model-name
   - ai: {}
 - backend:
     ai:
@@ -267,6 +301,9 @@ backends:
                 evicted_until: null
           rejected: {}
   inlinePolicies:
+  - requestHeaderModifier:
+      remove:
+      - x-gateway-model-name
   - ai: {}
 workloads: []
 services: []

--- a/crates/agentgateway/src/types/local_tests/mcp_simple_config.yaml
+++ b/crates/agentgateway/src/types/local_tests/mcp_simple_config.yaml
@@ -1,0 +1,10 @@
+mcp:
+  targets:
+  - name: time
+    stdio:
+      cmd: uvx
+      args: ["mcp-server-time"]
+  - name: everything
+    stdio:
+      cmd: npx
+      args: ["@modelcontextprotocol/server-everything"]

--- a/crates/agentgateway/src/types/local_tests/mcp_simple_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/mcp_simple_normalized.snap
@@ -1,0 +1,51 @@
+---
+source: crates/agentgateway/src/types/local_tests.rs
+description: "Config normalization test for mcp_simple: YAML -> LocalConfig -> NormalizedLocalConfig -> YAML"
+---
+binds:
+- key: bind/3000
+  address: '[::]:3000'
+  protocol: http
+  tunnelProtocol: direct
+  listeners:
+    mcp:
+      key: mcp
+      gatewayName: name
+      gatewayNamespace: ns
+      listenerName: mcp
+      hostname: '*'
+      protocol: HTTP
+      routes:
+        mcp:default:
+          key: mcp:default
+          name: default
+          namespace: internal
+          matches:
+          - path:
+              pathPrefix: /
+          backends:
+          - weight: 1
+            backend: /mcp
+      tcpRoutes: {}
+policies: []
+backends:
+- backend:
+    mcp:
+      name: mcp
+      namespace: ''
+      target:
+        targets:
+        - name: time
+          stdio:
+            cmd: uvx
+            args:
+            - mcp-server-time
+        - name: everything
+          stdio:
+            cmd: npx
+            args:
+            - '@modelcontextprotocol/server-everything'
+        stateful: true
+        alwaysUsePrefix: false
+workloads: []
+services: []

--- a/crates/cel-fork/cel/src/objects.rs
+++ b/crates/cel-fork/cel/src/objects.rs
@@ -944,7 +944,7 @@ impl<'a> Value<'a> {
 							accu = Value::resolve(&comprehension.loop_step, ctx, &with_iter)?;
 						}
 					},
-					t => todo!("Support {t:?}"),
+					_ => return Err(crate::ExecutionError::NoSuchOverload),
 				}
 				let comp_resolver = SingleVarResolver::new(resolver, &comprehension.accu_var, accu);
 				Value::resolve(&comprehension.result, ctx, &comp_resolver)

--- a/schema/config.json
+++ b/schema/config.json
@@ -23269,6 +23269,890 @@
           "host"
         ]
       }
+    },
+    "llm": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "models": {
+          "description": "models defines the set of models that can be served by this gateway. The model name refers to the\nmodel in the users request that is matched; the model sent to the actual LLM can be overriden\non a per-model basis.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "description": "name is the name of the model we are matching from a users request. If params.model is set, that\nwill be used in the request to the LLM provider. If not, the incoming model is used.",
+                "type": "string"
+              },
+              "params": {
+                "description": "params customizes parameters for the outgoing request",
+                "type": "object",
+                "properties": {
+                  "model": {
+                    "description": "The model to send to the provider.\nIf unset, the same model will be used from the request.",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "default": null
+                  },
+                  "apiKey": {
+                    "description": "An API key to attach to the request.\nIf unset this will be automatically detected from the environment.",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "default": null
+                  },
+                  "awsRegion": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "vertexRegion": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "vertexProject": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "azureHost": {
+                    "description": "For Azure: the host of the deployment",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "azureApiVersion": {
+                    "description": "For Azure: the API version to sue",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              },
+              "provider": {
+                "description": "provider of the LLM we are connecting too",
+                "type": "string",
+                "enum": [
+                  "openAI",
+                  "gemini",
+                  "vertex",
+                  "anthropic",
+                  "bedrock",
+                  "azureOpenAI"
+                ]
+              },
+              "defaults": {
+                "description": "defaults allows setting default values for the request. If these are not present in the request body, they will be set.\nTo override even when set, use `overrides`.",
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "additionalProperties": true
+              },
+              "overrides": {
+                "description": "overrides allows setting values for the request, overriding any existing values",
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "additionalProperties": true
+              },
+              "requestHeaders": {
+                "description": "requestHeaders modifies headers in requests to the LLM provider.",
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "add": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "set": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "remove": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "additionalProperties": false,
+                "default": null
+              }
+            },
+            "additionalProperties": false,
+            "required": [
+              "name",
+              "provider"
+            ]
+          }
+        },
+        "policies": {
+          "description": "policies defines policies for handling incoming requests, before a model is selected",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "jwtAuth": {
+              "description": "Authenticate incoming JWT requests.",
+              "anyOf": [
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "mode": {
+                          "oneOf": [
+                            {
+                              "description": "A valid token, issued by a configured issuer, must be present.",
+                              "type": "string",
+                              "const": "strict"
+                            },
+                            {
+                              "description": "If a token exists, validate it.\nThis is the default option.\nWarning: this allows requests without a JWT token!",
+                              "type": "string",
+                              "const": "optional"
+                            },
+                            {
+                              "description": "Requests are never rejected. This is useful for usage of claims in later steps (authorization, logging, etc).\nWarning: this allows requests without a JWT token!",
+                              "type": "string",
+                              "const": "permissive"
+                            }
+                          ],
+                          "default": "optional"
+                        },
+                        "providers": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "issuer": {
+                                "type": "string"
+                              },
+                              "audiences": {
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "jwks": {
+                                "anyOf": [
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "file": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "file"
+                                    ]
+                                  },
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "url": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "url"
+                                    ]
+                                  }
+                                ]
+                              }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                              "issuer",
+                              "jwks"
+                            ]
+                          }
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "providers"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "mode": {
+                          "oneOf": [
+                            {
+                              "description": "A valid token, issued by a configured issuer, must be present.",
+                              "type": "string",
+                              "const": "strict"
+                            },
+                            {
+                              "description": "If a token exists, validate it.\nThis is the default option.\nWarning: this allows requests without a JWT token!",
+                              "type": "string",
+                              "const": "optional"
+                            },
+                            {
+                              "description": "Requests are never rejected. This is useful for usage of claims in later steps (authorization, logging, etc).\nWarning: this allows requests without a JWT token!",
+                              "type": "string",
+                              "const": "permissive"
+                            }
+                          ],
+                          "default": "optional"
+                        },
+                        "issuer": {
+                          "type": "string"
+                        },
+                        "audiences": {
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "jwks": {
+                          "anyOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "file": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "file"
+                              ]
+                            },
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "url": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "url"
+                              ]
+                            }
+                          ]
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "issuer",
+                        "jwks"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "extAuthz": {
+              "description": "Authenticate incoming requests by calling an external authorization server.",
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "protocol": {
+                      "description": "The ext_authz protocol to use. Unless you need to integrate with an HTTP-only server, gRPC is recommended.",
+                      "oneOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "grpc": {
+                              "type": "object",
+                              "properties": {
+                                "context": {
+                                  "description": "Additional context to send to the authorization service.\nThis maps to the `context_extensions` field of the request, and only allows static values.",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  }
+                                },
+                                "metadata": {
+                                  "description": "Additional metadata to send to the authorization service.\nThis maps to the `metadata_context.filter_metadata` field of the request, and allows dynamic CEL expressions.\nIf unset, by default the `envoy.filters.http.jwt_authn` key is set if the JWT policy is used as well, for compatibility.",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "grpc"
+                          ],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "http": {
+                              "type": "object",
+                              "properties": {
+                                "path": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "redirect": {
+                                  "description": "When using the HTTP protocol, and the server returns unauthorized, redirect to the URL resolved by\nthe provided expression rather than directly returning the error.",
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "includeResponseHeaders": {
+                                  "description": "Specific headers from the authorization response will be copied into the request to the backend.",
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "addRequestHeaders": {
+                                  "description": "Specific headers to add in the authorization request (empty = all headers), based on the expression",
+                                  "type": "object",
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  }
+                                },
+                                "metadata": {
+                                  "description": "Metadata to include under the `extauthz` variable, based on the authorization response.",
+                                  "type": "object",
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "http"
+                          ],
+                          "additionalProperties": false
+                        }
+                      ],
+                      "default": {
+                        "grpc": {}
+                      }
+                    },
+                    "failureMode": {
+                      "description": "Behavior when the authorization service is unavailable or returns an error",
+                      "oneOf": [
+                        {
+                          "type": "string",
+                          "enum": [
+                            "allow",
+                            "deny"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "denyWithStatus": {
+                              "type": "integer",
+                              "format": "uint16",
+                              "minimum": 0,
+                              "maximum": 65535
+                            }
+                          },
+                          "required": [
+                            "denyWithStatus"
+                          ],
+                          "additionalProperties": false
+                        }
+                      ],
+                      "default": "deny"
+                    },
+                    "includeRequestHeaders": {
+                      "description": "Specific headers to include in the authorization request.\nIf unset, the gRPC protocol sends all request headers. The HTTP protocol sends only 'Authorization'.",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "includeRequestBody": {
+                      "description": "Options for including the request body in the authorization request",
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "maxRequestBytes": {
+                          "description": "Maximum size of request body to buffer (default: 8192)",
+                          "type": "integer",
+                          "format": "uint32",
+                          "minimum": 0,
+                          "default": 0
+                        },
+                        "allowPartialMessage": {
+                          "description": "If true, send partial body when max_request_bytes is reached",
+                          "type": "boolean",
+                          "default": false
+                        },
+                        "packAsBytes": {
+                          "description": "If true, pack body as raw bytes in gRPC",
+                          "type": "boolean",
+                          "default": false
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "timeout": {
+                      "description": "Timeout for the authorization request (default: 200ms)",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "unevaluatedProperties": false,
+                  "oneOf": [
+                    {
+                      "type": "string",
+                      "enum": [
+                        "invalid"
+                      ]
+                    },
+                    {
+                      "description": "Service reference. Service must be defined in the top level services list.",
+                      "type": "object",
+                      "properties": {
+                        "service": {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "object",
+                              "properties": {
+                                "namespace": {
+                                  "type": "string"
+                                },
+                                "hostname": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "namespace",
+                                "hostname"
+                              ]
+                            },
+                            "port": {
+                              "type": "integer",
+                              "format": "uint16",
+                              "minimum": 0,
+                              "maximum": 65535
+                            }
+                          },
+                          "additionalProperties": false,
+                          "required": [
+                            "name",
+                            "port"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "service"
+                      ]
+                    },
+                    {
+                      "description": "Hostname or IP address",
+                      "type": "object",
+                      "properties": {
+                        "host": {
+                          "description": "Hostname or IP address",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "host"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "backend": {
+                          "description": "Explicit backend reference. Backend must be defined in the top level backends list",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "backend"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null
+            },
+            "extProc": {
+              "description": "Extend agentgateway with an external processor",
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "failureMode": {
+                      "description": "Behavior when the ext_proc service is unavailable or returns an error",
+                      "type": "string",
+                      "enum": [
+                        "failClosed",
+                        "failOpen"
+                      ],
+                      "default": "failClosed"
+                    },
+                    "metadataContext": {
+                      "description": "Additional metadata to send to the external processing service.\nMaps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.",
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "additionalProperties": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "requestAttributes": {
+                      "description": "Maps to the request `attributes` field in ProcessingRequest, and allows dynamic CEL expressions.",
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    },
+                    "responseAttributes": {
+                      "description": "Maps to the response `attributes` field in ProcessingRequest, and allows dynamic CEL expressions.",
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "unevaluatedProperties": false,
+                  "oneOf": [
+                    {
+                      "type": "string",
+                      "enum": [
+                        "invalid"
+                      ]
+                    },
+                    {
+                      "description": "Service reference. Service must be defined in the top level services list.",
+                      "type": "object",
+                      "properties": {
+                        "service": {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "object",
+                              "properties": {
+                                "namespace": {
+                                  "type": "string"
+                                },
+                                "hostname": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "namespace",
+                                "hostname"
+                              ]
+                            },
+                            "port": {
+                              "type": "integer",
+                              "format": "uint16",
+                              "minimum": 0,
+                              "maximum": 65535
+                            }
+                          },
+                          "additionalProperties": false,
+                          "required": [
+                            "name",
+                            "port"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "service"
+                      ]
+                    },
+                    {
+                      "description": "Hostname or IP address",
+                      "type": "object",
+                      "properties": {
+                        "host": {
+                          "description": "Hostname or IP address",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "host"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "backend": {
+                          "description": "Explicit backend reference. Backend must be defined in the top level backends list",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "backend"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null
+            },
+            "transformations": {
+              "description": "Modify requests and responses",
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "request": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "add": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "default": {}
+                    },
+                    "set": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "default": {}
+                    },
+                    "remove": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "default": []
+                    },
+                    "body": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "default": null
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "response": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "add": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "default": {}
+                    },
+                    "set": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "default": {}
+                    },
+                    "remove": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "default": []
+                    },
+                    "body": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "default": null
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false,
+              "default": null
+            },
+            "basicAuth": {
+              "description": "Authenticate incoming requests using Basic Authentication with htpasswd.",
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "htpasswd": {
+                  "description": ".htpasswd file contents/reference",
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "file": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "file"
+                      ]
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "realm": {
+                  "description": "Realm name for the WWW-Authenticate header",
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "default": null
+                },
+                "mode": {
+                  "description": "Validation mode for basic authentication",
+                  "oneOf": [
+                    {
+                      "description": "A valid username/password must be present.",
+                      "type": "string",
+                      "const": "strict"
+                    },
+                    {
+                      "description": "If credentials exist, validate them.\nThis is the default option.\nWarning: this allows requests without credentials!",
+                      "type": "string",
+                      "const": "optional"
+                    }
+                  ],
+                  "default": "optional"
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "htpasswd"
+              ]
+            },
+            "apiKey": {
+              "description": "Authenticate incoming requests using API Keys",
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "keys": {
+                  "description": "List of API keys",
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "key": {
+                        "type": "string"
+                      },
+                      "metadata": true
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                      "key"
+                    ]
+                  }
+                },
+                "mode": {
+                  "description": "Validation mode for API keys",
+                  "oneOf": [
+                    {
+                      "description": "A valid API Key must be present.",
+                      "type": "string",
+                      "const": "strict"
+                    },
+                    {
+                      "description": "If credentials exist, validate them.\nThis is the default option.\nWarning: this allows requests without credentials!",
+                      "type": "string",
+                      "const": "optional"
+                    }
+                  ],
+                  "default": "optional"
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "keys"
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "models"
+      ]
     }
   },
   "additionalProperties": false,

--- a/schema/config.md
+++ b/schema/config.md
@@ -2455,3 +2455,95 @@
 |`backends[].policies.tcp.connectTimeout`||
 |`backends[].policies.tcp.connectTimeout.secs`||
 |`backends[].policies.tcp.connectTimeout.nanos`||
+|`llm`||
+|`llm.models`|models defines the set of models that can be served by this gateway. The model name refers to the<br>model in the users request that is matched; the model sent to the actual LLM can be overriden<br>on a per-model basis.|
+|`llm.models[].name`|name is the name of the model we are matching from a users request. If params.model is set, that<br>will be used in the request to the LLM provider. If not, the incoming model is used.|
+|`llm.models[].params`|params customizes parameters for the outgoing request|
+|`llm.models[].params.model`|The model to send to the provider.<br>If unset, the same model will be used from the request.|
+|`llm.models[].params.apiKey`|An API key to attach to the request.<br>If unset this will be automatically detected from the environment.|
+|`llm.models[].params.awsRegion`||
+|`llm.models[].params.vertexRegion`||
+|`llm.models[].params.vertexProject`||
+|`llm.models[].params.azureHost`|For Azure: the host of the deployment|
+|`llm.models[].params.azureApiVersion`|For Azure: the API version to sue|
+|`llm.models[].provider`|provider of the LLM we are connecting too|
+|`llm.models[].defaults`|defaults allows setting default values for the request. If these are not present in the request body, they will be set.<br>To override even when set, use `overrides`.|
+|`llm.models[].overrides`|overrides allows setting values for the request, overriding any existing values|
+|`llm.models[].requestHeaders`|requestHeaders modifies headers in requests to the LLM provider.|
+|`llm.models[].requestHeaders.add`||
+|`llm.models[].requestHeaders.set`||
+|`llm.models[].requestHeaders.remove`||
+|`llm.policies`|policies defines policies for handling incoming requests, before a model is selected|
+|`llm.policies.jwtAuth`|Authenticate incoming JWT requests.|
+|`llm.policies.jwtAuth.(any)(any)mode`||
+|`llm.policies.jwtAuth.(any)(any)providers`||
+|`llm.policies.jwtAuth.(any)(any)providers[].issuer`||
+|`llm.policies.jwtAuth.(any)(any)providers[].audiences`||
+|`llm.policies.jwtAuth.(any)(any)providers[].jwks`||
+|`llm.policies.jwtAuth.(any)(any)providers[].jwks.(any)file`||
+|`llm.policies.jwtAuth.(any)(any)providers[].jwks.(any)url`||
+|`llm.policies.jwtAuth.(any)(any)mode`||
+|`llm.policies.jwtAuth.(any)(any)issuer`||
+|`llm.policies.jwtAuth.(any)(any)audiences`||
+|`llm.policies.jwtAuth.(any)(any)jwks`||
+|`llm.policies.jwtAuth.(any)(any)jwks.(any)file`||
+|`llm.policies.jwtAuth.(any)(any)jwks.(any)url`||
+|`llm.policies.extAuthz`|Authenticate incoming requests by calling an external authorization server.|
+|`llm.policies.extAuthz.(any)(1)service`||
+|`llm.policies.extAuthz.(any)(1)service.name`||
+|`llm.policies.extAuthz.(any)(1)service.name.namespace`||
+|`llm.policies.extAuthz.(any)(1)service.name.hostname`||
+|`llm.policies.extAuthz.(any)(1)service.port`||
+|`llm.policies.extAuthz.(any)(1)host`|Hostname or IP address|
+|`llm.policies.extAuthz.(any)(1)backend`|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.policies.extAuthz.(any)protocol`|The ext_authz protocol to use. Unless you need to integrate with an HTTP-only server, gRPC is recommended.|
+|`llm.policies.extAuthz.(any)protocol.(1)grpc`||
+|`llm.policies.extAuthz.(any)protocol.(1)grpc.context`|Additional context to send to the authorization service.<br>This maps to the `context_extensions` field of the request, and only allows static values.|
+|`llm.policies.extAuthz.(any)protocol.(1)grpc.metadata`|Additional metadata to send to the authorization service.<br>This maps to the `metadata_context.filter_metadata` field of the request, and allows dynamic CEL expressions.<br>If unset, by default the `envoy.filters.http.jwt_authn` key is set if the JWT policy is used as well, for compatibility.|
+|`llm.policies.extAuthz.(any)protocol.(1)http`||
+|`llm.policies.extAuthz.(any)protocol.(1)http.path`||
+|`llm.policies.extAuthz.(any)protocol.(1)http.redirect`|When using the HTTP protocol, and the server returns unauthorized, redirect to the URL resolved by<br>the provided expression rather than directly returning the error.|
+|`llm.policies.extAuthz.(any)protocol.(1)http.includeResponseHeaders`|Specific headers from the authorization response will be copied into the request to the backend.|
+|`llm.policies.extAuthz.(any)protocol.(1)http.addRequestHeaders`|Specific headers to add in the authorization request (empty = all headers), based on the expression|
+|`llm.policies.extAuthz.(any)protocol.(1)http.metadata`|Metadata to include under the `extauthz` variable, based on the authorization response.|
+|`llm.policies.extAuthz.(any)failureMode`|Behavior when the authorization service is unavailable or returns an error|
+|`llm.policies.extAuthz.(any)failureMode.(1)denyWithStatus`||
+|`llm.policies.extAuthz.(any)includeRequestHeaders`|Specific headers to include in the authorization request.<br>If unset, the gRPC protocol sends all request headers. The HTTP protocol sends only 'Authorization'.|
+|`llm.policies.extAuthz.(any)includeRequestBody`|Options for including the request body in the authorization request|
+|`llm.policies.extAuthz.(any)includeRequestBody.maxRequestBytes`|Maximum size of request body to buffer (default: 8192)|
+|`llm.policies.extAuthz.(any)includeRequestBody.allowPartialMessage`|If true, send partial body when max_request_bytes is reached|
+|`llm.policies.extAuthz.(any)includeRequestBody.packAsBytes`|If true, pack body as raw bytes in gRPC|
+|`llm.policies.extAuthz.(any)timeout`|Timeout for the authorization request (default: 200ms)|
+|`llm.policies.extProc`|Extend agentgateway with an external processor|
+|`llm.policies.extProc.(any)(1)service`||
+|`llm.policies.extProc.(any)(1)service.name`||
+|`llm.policies.extProc.(any)(1)service.name.namespace`||
+|`llm.policies.extProc.(any)(1)service.name.hostname`||
+|`llm.policies.extProc.(any)(1)service.port`||
+|`llm.policies.extProc.(any)(1)host`|Hostname or IP address|
+|`llm.policies.extProc.(any)(1)backend`|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.policies.extProc.(any)failureMode`|Behavior when the ext_proc service is unavailable or returns an error|
+|`llm.policies.extProc.(any)metadataContext`|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
+|`llm.policies.extProc.(any)requestAttributes`|Maps to the request `attributes` field in ProcessingRequest, and allows dynamic CEL expressions.|
+|`llm.policies.extProc.(any)responseAttributes`|Maps to the response `attributes` field in ProcessingRequest, and allows dynamic CEL expressions.|
+|`llm.policies.transformations`|Modify requests and responses|
+|`llm.policies.transformations.request`||
+|`llm.policies.transformations.request.add`||
+|`llm.policies.transformations.request.set`||
+|`llm.policies.transformations.request.remove`||
+|`llm.policies.transformations.request.body`||
+|`llm.policies.transformations.response`||
+|`llm.policies.transformations.response.add`||
+|`llm.policies.transformations.response.set`||
+|`llm.policies.transformations.response.remove`||
+|`llm.policies.transformations.response.body`||
+|`llm.policies.basicAuth`|Authenticate incoming requests using Basic Authentication with htpasswd.|
+|`llm.policies.basicAuth.htpasswd`|.htpasswd file contents/reference|
+|`llm.policies.basicAuth.htpasswd.(any)file`||
+|`llm.policies.basicAuth.realm`|Realm name for the WWW-Authenticate header|
+|`llm.policies.basicAuth.mode`|Validation mode for basic authentication|
+|`llm.policies.apiKey`|Authenticate incoming requests using API Keys|
+|`llm.policies.apiKey.keys`|List of API keys|
+|`llm.policies.apiKey.keys[].key`||
+|`llm.policies.apiKey.keys[].metadata`||
+|`llm.policies.apiKey.mode`|Validation mode for API keys|

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -5368,7 +5368,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.9.tgz",
       "integrity": "sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -6497,7 +6496,6 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
       "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "dompurify": "3.2.7",
         "marked": "14.0.0"


### PR DESCRIPTION
This allows starting with a config like:

```yaml
llm:
  policies:
    jwtAuth:
      issuer: agentgateway.dev
      audiences: [test.agentgateway.dev]
      jwks: '{"keys":[]}'
    authorization:
      rules:
      - 'jwt.email.endsWith("@example.com")'
  models:
  - name: claude-3-haiku
    provider: anthropic
    params:
      model: claude-3-5-haiku-20241022
      apiKey: "sk-123"
    matches:
    - headers:
      - name: "X-Org"
        value:
          exact: "engineering"
  - name: gemini-0.5-pro
    provider: vertex
    params:
      model: claude-3-5-haiku-20241022
      apiKey: "sk-123"
      vertexRegion: global
      vertexProject: my-vertex-project
```

instead of a much more complex http-centric config. 

A few things to figure out...
* Add support for guardrails, auth, etc
* Document/test how to mix the two modes (`llm` and `binds`)