### PR TITLE
chore: consolidate openai token counting and bedrock cleanup

### DIFF
--- a/crates/agentgateway/src/llm/types/completions.rs
+++ b/crates/agentgateway/src/llm/types/completions.rs
@@ -170,7 +170,8 @@ impl super::RequestType for Request {
 	fn to_llm_request(&self, provider: Strng, tokenize: bool) -> Result<LLMRequest, AIError> {
 		let model = strng::new(self.model.as_deref().unwrap_or_default());
 		let input_tokens = if tokenize {
-			let tokens = crate::llm::num_tokens_from_messages(&model, &self.messages)?;
+			let messages = self.get_messages();
+			let tokens = crate::llm::num_tokens_from_messages(&model, &messages)?;
 			Some(tokens)
 		} else {
 			None
@@ -229,8 +230,8 @@ impl super::RequestType for Request {
 fn convert_message(r: SimpleChatCompletionMessage) -> RequestMessage {
 	RequestMessage {
 		role: r.role.to_string(),
-		content: Some(Content::Text(r.content.to_string())),
 		name: None,
+		content: Some(Content::Text(r.content.to_string())),
 		rest: Default::default(),
 	}
 }

--- a/crates/agentgateway/src/llm/types/messages.rs
+++ b/crates/agentgateway/src/llm/types/messages.rs
@@ -121,8 +121,8 @@ impl RequestType for Request {
 				presence_penalty: None,
 				seed: None,
 				max_tokens: self.max_tokens,
-				dimensions: None,
 				encoding_format: None,
+				dimensions: None,
 			},
 		};
 		Ok(llm)

--- a/crates/agentgateway/src/llm/types/responses.rs
+++ b/crates/agentgateway/src/llm/types/responses.rs
@@ -230,12 +230,12 @@ impl RequestType for Request {
 	fn to_llm_request(&self, provider: Strng, tokenize: bool) -> Result<LLMRequest, AIError> {
 		let model = strng::new(self.model.as_deref().unwrap_or_default());
 		let input_tokens = if tokenize {
-			let tokens = crate::llm::num_tokens_from_responses_input(&model, &self.input)?;
+			let messages = self.get_messages();
+			let tokens = crate::llm::num_tokens_from_messages(&model, &messages)?;
 			Some(tokens)
 		} else {
 			None
 		};
-
 		Ok(LLMRequest {
 			input_tokens,
 			input_format: InputFormat::Responses,
@@ -249,8 +249,8 @@ impl RequestType for Request {
 				presence_penalty: None,
 				seed: None,
 				max_tokens: self.max_output_tokens.map(Into::into),
-				dimensions: None,
 				encoding_format: None,
+				dimensions: None,
 			},
 		})
 	}


### PR DESCRIPTION
- Consolidate OpenAI-style token counting into a single function using normalized SimpleChatCompletionMessage, removing the redundant num_tokens_from_responses_input silo.

- NOTE: token estimation now only counts text in normalized messages; non-text Responses items (tool calls, images, files) are ignored unless a provider count_tokens endpoint is used.

- Update SimpleChatCompletionMessage to include an optional 'name' field. This fixes a token counting accuracy regression for named messages and prevents the loss of agent identities in gateway logs and security webhooks during normalization.

- Refactor Bedrock conversion signatures to take model_id: String directly, removing redundant unwrap_or_default() calls from core translation logic.

- Simplify Bedrock-to-Responses stream handler by collapsing identical match arms for content part initialization.