### PR TITLE
WIP: feat(llm): translate OpenAI completions streams to Anthropic format

### DIFF
--- a/crates/agentgateway/src/llm/conversion/bedrock.rs
+++ b/crates/agentgateway/src/llm/conversion/bedrock.rs
@@ -1959,11 +1959,13 @@ pub mod from_anthropic_token_count {
 		serde_json::to_vec(&xlated).map_err(AIError::RequestMarshal)
 	}
 
-	pub fn translate_response(bytes: Bytes) -> Result<(Bytes, u64), AIError> {
+	pub fn translate_response(bytes: Bytes) -> Result<types::count_tokens::Response, AIError> {
 		let resp: types::bedrock::CountTokensResponse =
 			serde_json::from_slice(&bytes).map_err(AIError::ResponseParsing)?;
 		// Right now the bedrock response is identical to the anthropic response; no translation needed
-		Ok((bytes, resp.input_tokens as u64))
+		Ok(types::count_tokens::Response {
+			input_tokens: resp.input_tokens as u64,
+		})
 	}
 }
 

--- a/crates/agentgateway/src/llm/conversion/completions.rs
+++ b/crates/agentgateway/src/llm/conversion/completions.rs
@@ -10,6 +10,8 @@ use crate::telemetry::log::AsyncLog;
 use crate::{llm, parse};
 
 pub mod from_messages {
+	use std::collections::HashMap;
+
 	use itertools::Itertools;
 	use messages::{ContentBlock, ThinkingInput, ToolResultContent, ToolResultContentPart};
 	use types::completions::typed as completions;
@@ -18,11 +20,459 @@ pub mod from_messages {
 	use crate::json;
 	use crate::llm::{AIError, types};
 
+	use crate::llm::types::ResponseType;
+	use crate::parse::sse::SseJsonEvent;
+	use crate::telemetry::log::AsyncLog;
+	use agent_core::strng;
+	use bytes::Bytes;
+	use serde_json::Value;
+	use std::time::Instant;
+
 	/// translate an Anthropic messages to an OpenAI completions request
 	pub fn translate(req: &types::messages::Request) -> Result<Vec<u8>, AIError> {
 		let typed = json::convert::<_, messages::Request>(req).map_err(AIError::RequestMarshal)?;
 		let xlated = translate_internal(typed);
 		serde_json::to_vec(&xlated).map_err(AIError::RequestMarshal)
+	}
+
+	pub fn translate_response(bytes: &Bytes) -> Result<Box<dyn ResponseType>, AIError> {
+		let resp =
+			serde_json::from_slice::<completions::Response>(bytes).map_err(AIError::ResponseParsing)?;
+		let anthropic = translate_response_internal(resp);
+		Ok(Box::new(anthropic))
+	}
+
+	fn translate_response_internal(resp: completions::Response) -> types::messages::Response {
+		// Anthropic only supports one choice
+		let choice = resp
+			.choices
+			.into_iter()
+			.next()
+			.unwrap_or(completions::ChatChoice {
+				index: 0,
+				message: completions::ResponseMessage {
+					content: Some("".to_string()),
+					refusal: None,
+					tool_calls: None,
+					role: completions::Role::Assistant,
+					#[allow(deprecated)]
+					function_call: None,
+					audio: None,
+					reasoning_content: None,
+					extra: None,
+				},
+				finish_reason: None,
+				logprobs: None,
+			});
+
+		let content = if let Some(content) = choice.message.content {
+			vec![types::messages::Content {
+				text: Some(content),
+				rest: Default::default(),
+			}]
+		} else if let Some(tool_calls) = choice.message.tool_calls {
+			tool_calls
+				.into_iter()
+				.filter_map(|tc| match tc {
+					completions::MessageToolCalls::Function(f) => {
+						let mut rest = serde_json::Map::new();
+						rest.insert("type".to_string(), "tool_use".into());
+						rest.insert("id".to_string(), f.id.into());
+						rest.insert("name".to_string(), f.function.name.into());
+						if let Ok(input) = serde_json::from_str::<serde_json::Value>(&f.function.arguments) {
+							rest.insert("input".to_string(), input);
+						}
+						Some(types::messages::Content {
+							text: None,
+							rest: rest.into(),
+						})
+					},
+					completions::MessageToolCalls::Custom(_) => None,
+				})
+				.collect()
+		} else {
+			vec![]
+		};
+
+		let stop_reason = choice
+			.finish_reason
+			.map(|r| match r {
+				completions::FinishReason::Stop => "end_turn",
+				completions::FinishReason::Length => "max_tokens",
+				completions::FinishReason::ToolCalls => "tool_use",
+				completions::FinishReason::ContentFilter => "refusal",
+				completions::FinishReason::FunctionCall => "tool_use",
+			})
+			.unwrap_or("end_turn"); // Default?
+
+		types::messages::Response {
+			model: resp.model,
+			usage: types::messages::Usage {
+				input_tokens: resp
+					.usage
+					.as_ref()
+					.map(|u| u.prompt_tokens as u64)
+					.unwrap_or(0),
+				output_tokens: resp
+					.usage
+					.as_ref()
+					.map(|u| u.completion_tokens as u64)
+					.unwrap_or(0),
+				rest: Default::default(),
+			},
+			content,
+			rest: {
+				let mut map = serde_json::Map::new();
+				map.insert("id".to_string(), resp.id.into());
+				map.insert("type".to_string(), "message".into());
+				map.insert("role".to_string(), "assistant".into());
+				map.insert("stop_reason".to_string(), stop_reason.into());
+				map.into()
+			},
+		}
+	}
+
+	pub fn translate_stream(
+		b: crate::http::Body,
+		buffer_limit: usize,
+		log: AsyncLog<crate::llm::LLMInfo>,
+	) -> crate::http::Body {
+		#[derive(Debug)]
+		struct PendingToolCall {
+			id: Option<String>,
+			name: Option<String>,
+			pending_json: String,
+		}
+
+		#[derive(Debug)]
+		enum BlockState {
+			Text { index: usize },
+			ToolUse { index: usize, tool_index: u32 },
+		}
+
+		#[derive(Debug, Default)]
+		struct StreamState {
+			sent_message_start: bool,
+			sent_message_stop: bool,
+			sent_first_token: bool,
+			next_block_index: usize,
+			current_block: Option<BlockState>,
+			tool_block_indices: HashMap<u32, usize>,
+			pending_tool_calls: HashMap<u32, PendingToolCall>,
+			pending_stop_reason: Option<messages::StopReason>,
+			pending_usage: Option<completions::Usage>,
+		}
+
+		fn push_event(
+			events: &mut Vec<(&'static str, messages::MessagesStreamEvent)>,
+			event: messages::MessagesStreamEvent,
+		) {
+			let name = event.event_name();
+			events.push((name, event));
+		}
+
+		fn close_current_block(
+			state: &mut StreamState,
+			events: &mut Vec<(&'static str, messages::MessagesStreamEvent)>,
+		) {
+			if let Some(block) = state.current_block.take() {
+				let index = match block {
+					BlockState::Text { index } | BlockState::ToolUse { index, .. } => index,
+				};
+				push_event(
+					events,
+					messages::MessagesStreamEvent::ContentBlockStop { index },
+				);
+			}
+		}
+
+		fn open_text_block(
+			state: &mut StreamState,
+			events: &mut Vec<(&'static str, messages::MessagesStreamEvent)>,
+		) -> usize {
+			match state.current_block {
+				Some(BlockState::Text { index }) => index,
+				_ => {
+					close_current_block(state, events);
+					let index = state.next_block_index;
+					state.next_block_index += 1;
+					state.current_block = Some(BlockState::Text { index });
+					push_event(
+						events,
+						messages::MessagesStreamEvent::ContentBlockStart {
+							index,
+							content_block: messages::ContentBlock::Text(messages::ContentTextBlock {
+								text: "".to_string(),
+								citations: None,
+								cache_control: None,
+							}),
+						},
+					);
+					index
+				},
+			}
+		}
+
+		fn open_tool_block(
+			state: &mut StreamState,
+			events: &mut Vec<(&'static str, messages::MessagesStreamEvent)>,
+			tool_index: u32,
+			id: String,
+			name: String,
+		) -> usize {
+			match state.current_block {
+				Some(BlockState::ToolUse {
+					index,
+					tool_index: current_index,
+				}) if current_index == tool_index => index,
+				_ => {
+					close_current_block(state, events);
+					let index = *state
+						.tool_block_indices
+						.entry(tool_index)
+						.or_insert_with(|| {
+							let idx = state.next_block_index;
+							state.next_block_index += 1;
+							idx
+						});
+					state.current_block = Some(BlockState::ToolUse { index, tool_index });
+					push_event(
+						events,
+						messages::MessagesStreamEvent::ContentBlockStart {
+							index,
+							content_block: messages::ContentBlock::ToolUse {
+								id,
+								name,
+								input: Value::Object(serde_json::Map::new()),
+								cache_control: None,
+							},
+						},
+					);
+					index
+				},
+			}
+		}
+
+		fn maybe_set_first_token(state: &mut StreamState, log: &AsyncLog<crate::llm::LLMInfo>) {
+			if state.sent_first_token {
+				return;
+			}
+			state.sent_first_token = true;
+			log.non_atomic_mutate(|r| {
+				r.response.first_token = Some(Instant::now());
+			});
+		}
+
+		fn flush_message_end(
+			state: &mut StreamState,
+			events: &mut Vec<(&'static str, messages::MessagesStreamEvent)>,
+			log: &AsyncLog<crate::llm::LLMInfo>,
+			force: bool,
+		) {
+			if state.sent_message_stop {
+				return;
+			}
+			let Some(stop_reason) = state.pending_stop_reason.take() else {
+				return;
+			};
+			let usage = match state.pending_usage.take() {
+				Some(usage) => Some(usage),
+				None if force => None,
+				None => {
+					state.pending_stop_reason = Some(stop_reason);
+					return;
+				},
+			};
+
+			close_current_block(state, events);
+
+			let (input_tokens, output_tokens) = usage
+				.as_ref()
+				.map(|u| (u.prompt_tokens as usize, u.completion_tokens as usize))
+				.unwrap_or((0, 0));
+
+			push_event(
+				events,
+				messages::MessagesStreamEvent::MessageDelta {
+					delta: messages::MessageDelta {
+						stop_reason: Some(stop_reason),
+						stop_sequence: None,
+					},
+					usage: messages::MessageDeltaUsage {
+						input_tokens,
+						output_tokens,
+						cache_creation_input_tokens: None,
+						cache_read_input_tokens: None,
+					},
+				},
+			);
+			push_event(events, messages::MessagesStreamEvent::MessageStop);
+			state.sent_message_stop = true;
+
+			if let Some(usage) = usage {
+				log.non_atomic_mutate(|r| {
+					r.response.input_tokens = Some(usage.prompt_tokens as u64);
+					r.response.output_tokens = Some(usage.completion_tokens as u64);
+					r.response.total_tokens = Some(usage.total_tokens as u64);
+				});
+			}
+		}
+
+		let mut state = StreamState::default();
+
+		crate::parse::sse::json_transform_multi::<
+			completions::StreamResponse,
+			messages::MessagesStreamEvent,
+			_,
+		>(b, buffer_limit, move |evt| {
+			let mut events: Vec<(&'static str, messages::MessagesStreamEvent)> = Vec::new();
+			match evt {
+				SseJsonEvent::Done => {
+					flush_message_end(&mut state, &mut events, &log, true);
+					return events;
+				},
+				SseJsonEvent::Data(Err(e)) => {
+					tracing::warn!(
+						"Failed to parse OpenAI stream response during translation: {}",
+						e
+					);
+					return events;
+				},
+				SseJsonEvent::Data(Ok(f)) => {
+					if !state.sent_message_start {
+						state.sent_message_start = true;
+						push_event(
+							&mut events,
+							messages::MessagesStreamEvent::MessageStart {
+								message: messages::MessagesResponse {
+									id: f.id.clone(),
+									r#type: "message".to_string(),
+									role: messages::Role::Assistant,
+									content: vec![],
+									model: f.model.clone(),
+									stop_reason: None,
+									stop_sequence: None,
+									usage: messages::Usage {
+										input_tokens: 0,
+										output_tokens: 0,
+										cache_creation_input_tokens: None,
+										cache_read_input_tokens: None,
+									},
+								},
+							},
+						);
+
+						log.non_atomic_mutate(|r| r.response.provider_model = Some(strng::new(&f.model)));
+					}
+
+					if let Some(usage) = f.usage {
+						state.pending_usage = Some(usage);
+					}
+
+					if let Some(choice) = f.choices.first() {
+						if let Some(content) = &choice.delta.content {
+							let index = open_text_block(&mut state, &mut events);
+							maybe_set_first_token(&mut state, &log);
+							push_event(
+								&mut events,
+								messages::MessagesStreamEvent::ContentBlockDelta {
+									index,
+									delta: messages::ContentBlockDelta::TextDelta {
+										text: content.clone(),
+									},
+								},
+							);
+						}
+
+						if let Some(tool_calls) = &choice.delta.tool_calls {
+							for tool_call in tool_calls {
+								let tool_index = tool_call.index;
+								let (should_open, id, name, pending_json) = {
+									let entry =
+										state
+											.pending_tool_calls
+											.entry(tool_index)
+											.or_insert(PendingToolCall {
+												id: None,
+												name: None,
+												pending_json: String::new(),
+											});
+									if let Some(id) = &tool_call.id {
+										entry.id = Some(id.clone());
+									}
+									if let Some(function) = &tool_call.function {
+										if let Some(name) = &function.name {
+											entry.name = Some(name.clone());
+										}
+										if let Some(args) = &function.arguments {
+											entry.pending_json.push_str(args);
+										}
+									}
+
+									let should_open = entry.name.is_some() || entry.id.is_some();
+									let id = entry.id.clone();
+									let name = entry.name.clone();
+									let pending_json = if should_open && !entry.pending_json.is_empty() {
+										Some(std::mem::take(&mut entry.pending_json))
+									} else {
+										None
+									};
+									(should_open, id, name, pending_json)
+								};
+
+								if should_open {
+									let id = id.unwrap_or_else(|| format!("tool_call_{tool_index}"));
+									let name = name.unwrap_or_default();
+									let index = open_tool_block(&mut state, &mut events, tool_index, id, name);
+
+									if let Some(pending_json) = pending_json {
+										maybe_set_first_token(&mut state, &log);
+										let delta = messages::ContentBlockDelta::InputJsonDelta {
+											partial_json: pending_json,
+										};
+										push_event(
+											&mut events,
+											messages::MessagesStreamEvent::ContentBlockDelta { index, delta },
+										);
+									}
+								}
+							}
+						}
+
+						if let Some(finish_reason) = &choice.finish_reason {
+							let stop_reason = match finish_reason {
+								completions::FinishReason::Stop => messages::StopReason::EndTurn,
+								completions::FinishReason::Length => messages::StopReason::MaxTokens,
+								completions::FinishReason::ToolCalls => messages::StopReason::ToolUse,
+								completions::FinishReason::ContentFilter => messages::StopReason::Refusal,
+								completions::FinishReason::FunctionCall => messages::StopReason::ToolUse,
+							};
+							state.pending_stop_reason = Some(stop_reason);
+						}
+					}
+
+					if state.pending_stop_reason.is_some() && state.pending_usage.is_some() {
+						flush_message_end(&mut state, &mut events, &log, false);
+					}
+				},
+			}
+			events
+		})
+	}
+
+	pub fn translate_error(bytes: &Bytes) -> Result<Bytes, AIError> {
+		let res = serde_json::from_slice::<completions::ChatCompletionErrorResponse>(bytes)
+			.map_err(AIError::ResponseMarshal)?;
+		let m = messages::MessagesErrorResponse {
+			r#type: "error".to_string(),
+			error: messages::MessagesError {
+				r#type: res.error.r#type,
+				message: res.error.message,
+			},
+		};
+		Ok(Bytes::from(
+			serde_json::to_vec(&m).map_err(AIError::ResponseMarshal)?,
+		))
 	}
 
 	fn translate_internal(req: messages::Request) -> completions::Request {

--- a/crates/agentgateway/src/llm/conversion/messages.rs
+++ b/crates/agentgateway/src/llm/conversion/messages.rs
@@ -357,9 +357,8 @@ pub mod from_completions {
 						};
 						mk(vec![choice], None)
 					},
-					messages::MessagesStreamEvent::MessageDelta { usage, delta: _ } => {
-						// TODO
-						// finish_reason = delta.stop_reason.as_ref().map(translate_stop_reason);
+					messages::MessagesStreamEvent::MessageDelta { usage, delta } => {
+						let finish_reason = delta.stop_reason.as_ref().map(super::translate_stop_reason);
 						log.non_atomic_mutate(|r| {
 							r.response.output_tokens = Some(usage.output_tokens as u64);
 							if let Some(inp) = r.response.input_tokens {
@@ -367,7 +366,12 @@ pub mod from_completions {
 							}
 						});
 						mk(
-							vec![],
+							vec![completions::ChatChoiceStream {
+								index: 0,
+								logprobs: None,
+								delta: Default::default(),
+								finish_reason,
+							}],
 							Some(completions::Usage {
 								prompt_tokens: input_tokens as u32,
 								completion_tokens: usage.output_tokens as u32,

--- a/crates/agentgateway/src/llm/tests/anthropic-response_stream-anthropic_basic.json.snap
+++ b/crates/agentgateway/src/llm/tests/anthropic-response_stream-anthropic_basic.json.snap
@@ -18,4 +18,4 @@ event:
 data: {"id":"msg_016wbjv5k86nxxd8CEZwSQnA","choices":[{"index":0,"delta":{"content":" you with?"}}],"created":123,"model":"claude-3-5-haiku-20241022","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
 
 event: 
-data: {"id":"msg_016wbjv5k86nxxd8CEZwSQnA","choices":[],"created":123,"model":"claude-3-5-haiku-20241022","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":{"prompt_tokens":15,"completion_tokens":21,"total_tokens":36}}
+data: {"id":"msg_016wbjv5k86nxxd8CEZwSQnA","choices":[{"index":0,"delta":{"content":null},"finish_reason":"stop"}],"created":123,"model":"claude-3-5-haiku-20241022","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":{"prompt_tokens":15,"completion_tokens":21,"total_tokens":36}}

--- a/crates/agentgateway/src/llm/tests/anthropic-response_stream-anthropic_thinking.json.snap
+++ b/crates/agentgateway/src/llm/tests/anthropic-response_stream-anthropic_thinking.json.snap
@@ -30,4 +30,4 @@ event:
 data: {"id":"msg_018XasA6jgabsibaUtstx4bg","choices":[{"index":0,"delta":{"content":" you'd like to know more about?"}}],"created":123,"model":"claude-opus-4-1-20250805","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
 
 event: 
-data: {"id":"msg_018XasA6jgabsibaUtstx4bg","choices":[],"created":123,"model":"claude-opus-4-1-20250805","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":{"prompt_tokens":47,"completion_tokens":264,"total_tokens":311}}
+data: {"id":"msg_018XasA6jgabsibaUtstx4bg","choices":[{"index":0,"delta":{"content":null},"finish_reason":"stop"}],"created":123,"model":"claude-opus-4-1-20250805","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":{"prompt_tokens":47,"completion_tokens":264,"total_tokens":311}}

--- a/crates/agentgateway/src/llm/tests/vertex-request_anthropic_prepare.snap
+++ b/crates/agentgateway/src/llm/tests/vertex-request_anthropic_prepare.snap
@@ -1,0 +1,16 @@
+---
+source: crates/agentgateway/src/llm/vertex_tests.rs
+assertion_line: 105
+expression: prepared_json
+---
+{
+  "anthropic_version": "vertex-2023-10-16",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Hello"
+    }
+  ],
+  "stream": true,
+  "max_tokens": 1024
+}

--- a/crates/agentgateway/src/llm/types/count_tokens.rs
+++ b/crates/agentgateway/src/llm/types/count_tokens.rs
@@ -2,14 +2,45 @@ use agent_core::prelude::Strng;
 use agent_core::strng;
 use serde::{Deserialize, Serialize};
 
-use crate::llm::types::RequestType;
-use crate::llm::{AIError, InputFormat, LLMRequest, SimpleChatCompletionMessage, conversion};
+use crate::llm::types::{RequestType, ResponseType};
+use crate::llm::{
+	AIError, InputFormat, LLMRequest, LLMResponse, SimpleChatCompletionMessage, conversion,
+};
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct Request {
 	pub model: Option<String>,
 	#[serde(flatten)]
 	pub rest: serde_json::Map<String, serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize, Clone, Serialize)]
+pub struct Response {
+	pub input_tokens: u64,
+}
+
+impl ResponseType for Response {
+	fn to_llm_response(&self, _include_completion_in_log: bool) -> LLMResponse {
+		LLMResponse {
+			count_tokens: Some(self.input_tokens),
+			..Default::default()
+		}
+	}
+
+	fn set_webhook_choices(
+		&mut self,
+		_choices: Vec<crate::llm::policy::webhook::ResponseChoice>,
+	) -> anyhow::Result<()> {
+		Ok(())
+	}
+
+	fn to_webhook_choices(&self) -> Vec<crate::llm::policy::webhook::ResponseChoice> {
+		vec![]
+	}
+
+	fn serialize(&self) -> serde_json::Result<Vec<u8>> {
+		serde_json::to_vec(&self)
+	}
 }
 
 impl RequestType for Request {
@@ -52,5 +83,9 @@ impl RequestType for Request {
 
 	fn to_bedrock_token_count(&self, headers: &::http::HeaderMap) -> Result<Vec<u8>, AIError> {
 		conversion::bedrock::from_anthropic_token_count::translate(self, headers)
+	}
+
+	fn to_anthropic(&self) -> Result<Vec<u8>, AIError> {
+		serde_json::to_vec(&self).map_err(AIError::RequestMarshal)
 	}
 }

--- a/crates/agentgateway/src/llm/vertex.rs
+++ b/crates/agentgateway/src/llm/vertex.rs
@@ -1,9 +1,20 @@
+//! Vertex AI Provider
+//!
+//! Documentation for Claude on Vertex AI:
+//! - https://platform.claude.com/docs/en/build-with-claude/claude-on-vertex-ai
+//! - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude/use-claude
+//! - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude/count-tokens
+
 use agent_core::strng;
 use agent_core::strng::Strng;
 use serde_json::{Map, Value};
 
 use crate::llm::{AIError, RouteType};
 use crate::*;
+
+#[cfg(test)]
+#[path = "vertex_tests.rs"]
+mod tests;
 
 const ANTHROPIC_VERSION: &str = "vertex-2023-10-16";
 
@@ -25,16 +36,20 @@ impl Provider {
 		self.model.as_deref().or(request_model)
 	}
 
-	fn anthropic_model<'a>(&'a self, request_model: Option<&'a str>) -> Option<Strng> {
+	fn get_anthropic_model_id<'a>(&'a self, request_model: Option<&'a str>) -> Option<Strng> {
 		let model = self.configured_model(request_model)?;
-		model
+		let model = model
 			.strip_prefix("publishers/anthropic/models/")
 			.or_else(|| model.strip_prefix("anthropic/"))
-			.map(strng::new)
+			.unwrap_or(model);
+		Some(strng::new(model))
 	}
 
 	pub fn is_anthropic_model(&self, request_model: Option<&str>) -> bool {
-		self.anthropic_model(request_model).is_some()
+		self
+			.get_anthropic_model_id(request_model)
+			.map(|m| m.contains("claude-"))
+			.unwrap_or(false)
 	}
 
 	pub fn prepare_anthropic_request_body(&self, body: Vec<u8>) -> Result<Vec<u8>, AIError> {
@@ -58,25 +73,33 @@ impl Provider {
 			.region
 			.clone()
 			.unwrap_or_else(|| strng::literal!("global"));
-		if let Some(model) = self.anthropic_model(request_model) {
-			return match route {
-				RouteType::AnthropicTokenCount => strng::format!(
-					"/v1/projects/{}/locations/{}/publishers/anthropic/models/count-tokens:rawPredict",
-					self.project_id,
-					location
-				),
-				_ => strng::format!(
-					"/v1/projects/{}/locations/{}/publishers/anthropic/models/{}:{}",
-					self.project_id,
-					location,
-					model,
-					if streaming {
-						"streamRawPredict"
-					} else {
-						"rawPredict"
-					}
-				),
+
+		let raw_model = self.configured_model(request_model);
+		let is_explicit_anthropic = raw_model
+			.map(|m| m.starts_with("anthropic/") || m.starts_with("publishers/anthropic/models/"))
+			.unwrap_or(false);
+
+		let model = self.get_anthropic_model_id(request_model);
+
+		let use_anthropic_endpoint = match (route, &model) {
+			(RouteType::AnthropicTokenCount, _) => true,
+			(_, Some(m)) => is_explicit_anthropic || m.contains("claude-"),
+			_ => false,
+		};
+
+		if use_anthropic_endpoint && let Some(model) = model {
+			let suffix = match route {
+				RouteType::AnthropicTokenCount => "countTokens",
+				_ if streaming => "streamRawPredict",
+				_ => "rawPredict",
 			};
+			return strng::format!(
+				"/v1/projects/{}/locations/{}/publishers/anthropic/models/{}:{}",
+				self.project_id,
+				location,
+				model,
+				suffix
+			);
 		}
 		let t = if route == RouteType::Embeddings {
 			strng::literal!("embeddings")

--- a/crates/agentgateway/src/llm/vertex_tests.rs
+++ b/crates/agentgateway/src/llm/vertex_tests.rs
@@ -1,0 +1,106 @@
+use super::Provider;
+use crate::llm::RouteType;
+use crate::llm::types::messages;
+use agent_core::strng;
+
+#[test]
+fn test_get_path_for_model_explicit_routes() {
+	let provider = Provider {
+		model: None,
+		region: Some(strng::literal!("us-central1")),
+		project_id: strng::literal!("test-project"),
+	};
+
+	// Test Messages route with an explicitly Anthropic prefixed model
+	let path = provider.get_path_for_model(
+		RouteType::Messages,
+		Some("anthropic/my-custom-model"),
+		false,
+	);
+	assert_eq!(
+		path,
+		"/v1/projects/test-project/locations/us-central1/publishers/anthropic/models/my-custom-model:rawPredict"
+	);
+
+	// Test Messages route with a non-Anthropic model (e.g. gemini) -> Should use Generic Endpoint
+	let path = provider.get_path_for_model(RouteType::Messages, Some("gemini-pro"), false);
+	assert_eq!(
+		path,
+		"/v1/projects/test-project/locations/us-central1/endpoints/openapi/chat/completions"
+	);
+}
+
+#[test]
+fn test_get_path_for_model_completions_route() {
+	let provider = Provider {
+		model: None,
+		region: Some(strng::literal!("us-central1")),
+		project_id: strng::literal!("test-project"),
+	};
+
+	// Test Completions route with non-standard model (should fallback to generic Vertex URL)
+	let path = provider.get_path_for_model(RouteType::Completions, Some("my-custom-model"), false);
+	assert_eq!(
+		path,
+		"/v1/projects/test-project/locations/us-central1/endpoints/openapi/chat/completions"
+	);
+
+	// Test Completions route with Claude model (should detect and use Anthropic URL)
+	let path = provider.get_path_for_model(RouteType::Completions, Some("claude-3-5-sonnet"), false);
+	assert_eq!(
+		path,
+		"/v1/projects/test-project/locations/us-central1/publishers/anthropic/models/claude-3-5-sonnet:rawPredict"
+	);
+}
+
+#[tokio::test]
+async fn test_prepare_anthropic_request_body() {
+	let provider = Provider {
+		model: Some(strng::literal!("claude-3-5-sonnet@20240620")),
+		region: Some(strng::literal!("us-central1")),
+		project_id: strng::literal!("test-project"),
+	};
+
+	let messages_req = messages::Request {
+		model: Some("claude-3-5-sonnet@20240620".to_string()),
+		messages: vec![messages::RequestMessage {
+			role: "user".to_string(),
+			content: Some(messages::RequestContent::Text("Hello".to_string())),
+			rest: Default::default(),
+		}],
+		max_tokens: Some(1024),
+		stream: Some(true),
+		temperature: None,
+		top_p: None,
+		system: None,
+		rest: Default::default(),
+	};
+
+	let body = serde_json::to_vec(&messages_req).unwrap();
+
+	let prepared_body = provider.prepare_anthropic_request_body(body).unwrap();
+
+	let prepared_json: serde_json::Value = serde_json::from_slice(&prepared_body).unwrap();
+
+	insta::with_settings!({
+
+
+
+		snapshot_path => "tests",
+
+
+
+		prepend_module_to_snapshot => false,
+
+
+
+	}, {
+
+
+
+		insta::assert_json_snapshot!("vertex-request_anthropic_prepare", prepared_json);
+
+
+
+	});
+}

--- a/crates/agentgateway/tests/tests/llm.rs
+++ b/crates/agentgateway/tests/tests/llm.rs
@@ -289,47 +289,88 @@ mod gemini {
 mod vertex {
 	use super::*;
 
-	#[tokio::test]
-	async fn completions() {
-		let Some(gw) = setup("vertex", "", "google/gemini-2.5-flash-lite").await else {
-			return;
-		};
-		send_completions(&gw, false).await;
+	// Gemini models use the OpenAI-compatible endpoint
+	mod gemini {
+		use super::*;
+
+		#[tokio::test]
+		async fn completions() {
+			let Some(gw) = setup("vertex", "", "google/gemini-2.5-flash-lite").await else {
+				return;
+			};
+			send_completions(&gw, false).await;
+		}
+
+		#[tokio::test]
+		async fn completions_streaming() {
+			let Some(gw) = setup("vertex", "", "google/gemini-2.5-flash-lite").await else {
+				return;
+			};
+			send_completions(&gw, true).await;
+		}
+
+		#[tokio::test]
+		async fn messages() {
+			let Some(gw) = setup("vertex", "", "google/gemini-2.5-flash-lite").await else {
+				return;
+			};
+			send_messages(&gw, false).await;
+		}
+
+		#[tokio::test]
+		async fn messages_streaming() {
+			let Some(gw) = setup("vertex", "", "google/gemini-2.5-flash-lite").await else {
+				return;
+			};
+			send_messages(&gw, true).await;
+		}
+
+		#[tokio::test]
+		#[ignore]
+		// During testing I have been unable to make embeddings work at all with Vertex.
+		async fn embeddings() {
+			let Some(gw) = setup("vertex", "", "text-embedding-004").await else {
+				return;
+			};
+			send_embeddings(&gw).await;
+		}
 	}
 
-	#[tokio::test]
-	async fn completions_streaming() {
-		let Some(gw) = setup("vertex", "", "google/gemini-2.5-flash-lite").await else {
-			return;
-		};
-		send_completions(&gw, true).await;
-	}
+	// Anthropic models use the rawPredict endpoint
+	mod anthropic {
+		use super::*;
 
-	#[tokio::test]
-	async fn messages() {
-		let Some(gw) = setup("vertex", "", "anthropic/claude-3-haiku").await else {
-			return;
-		};
-		send_messages(&gw, false).await;
-	}
+		#[tokio::test]
+		async fn completions() {
+			let Some(gw) = setup("vertex", "", "anthropic/claude-3-5-sonnet-v2@20241022").await else {
+				return;
+			};
+			send_completions(&gw, false).await;
+		}
 
-	#[tokio::test]
-	async fn messages_streaming() {
-		let Some(gw) = setup("vertex", "", "anthropic/claude-3-haiku").await else {
-			return;
-		};
-		send_messages(&gw, true).await;
-	}
+		#[tokio::test]
+		async fn completions_streaming() {
+			let Some(gw) = setup("vertex", "", "anthropic/claude-3-5-sonnet-v2@20241022").await else {
+				return;
+			};
+			send_completions(&gw, true).await;
+		}
 
-	#[tokio::test]
-	#[ignore]
-	// During testing I have been unable to make embeddings work at all with Vertex, with or without Agentgateway.
-	// This is plausibly from using the OpenAI compatible endpoint?
-	async fn embeddings() {
-		let Some(gw) = setup("vertex", "", "text-embedding-004").await else {
-			return;
-		};
-		send_embeddings(&gw).await;
+		#[tokio::test]
+		async fn messages() {
+			let Some(gw) = setup("vertex", "", "anthropic/claude-3-5-sonnet-v2@20241022").await else {
+				return;
+			};
+			send_messages(&gw, false).await;
+		}
+
+		#[tokio::test]
+		async fn messages_streaming() {
+			let Some(gw) = setup("vertex", "", "anthropic/claude-3-5-sonnet-v2@20241022").await else {
+				return;
+			};
+			send_messages(&gw, true).await;
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/agentgateway/agentgateway/issues/734

Enables native Anthropic Claude support on Google Cloud Vertex AI by leveraging Vertex's ":rawPredict" endpoints, which are near-identical to the standard Anthropic Messages API.

As a side effect (and probably more beneficial than the initial purpose of this PR), this actually enables /v1/messages clients to interact with any `/chat/completions`-compatible backend.  (would need to enable messages input format for the other providers though)

- Supports both Anthropic models (via :rawPredict/:streamRawPredict) and non-Anthropic models (via translation to /v1/chat/completions).
- Adds support for Vertex AI token counting via :countTokens.
- Implements translation logic for OpenAI responses/streams to Anthropic format.

Documentation for Claude on Vertex AI:
- https://platform.claude.com/docs/en/build-with-claude/claude-on-vertex-ai
- https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude/use-claude
- https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude/count-tokens