### PR TITLE
Update config json-schema location

### DIFF
--- a/examples/a2a/config.yaml
+++ b/examples/a2a/config.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=../../schema/local.json
+# yaml-language-server: $schema=../../schema/config.json
 config:
   logging:
     format: json
@@ -13,10 +13,10 @@ binds:
     - policies:
         cors:
           allowOrigins:
-            - "*"
+          - "*"
           allowHeaders:
-            - content-type
-            - cache-control
+          - content-type
+          - cache-control
         # Mark this route as a2a traffic
         a2a: {}
       backends:

--- a/examples/authorization/config.yaml
+++ b/examples/authorization/config.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=../../schema/local.json
+# yaml-language-server: $schema=../../schema/config.json
 binds:
 - port: 3000
   listeners:

--- a/examples/basic/config.yaml
+++ b/examples/basic/config.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=../../schema/local.json
+# yaml-language-server: $schema=../../schema/config.json
 binds:
 - port: 3000
   listeners:
@@ -6,11 +6,11 @@ binds:
     - policies:
         cors:
           allowOrigins:
-            - "*"
+          - "*"
           allowHeaders:
-            - mcp-protocol-version
-            - content-type
-            - cache-control
+          - mcp-protocol-version
+          - content-type
+          - cache-control
       backends:
       - mcp:
           targets:

--- a/examples/http/config.yaml
+++ b/examples/http/config.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=../../schema/local.json
+# yaml-language-server: $schema=../../schema/config.json
 binds:
 - port: 3000
   listeners:
@@ -20,7 +20,6 @@ binds:
             regex: "test-[0-9]"
       backends:
       - host: 127.0.0.1:8080
-
     - name: policy-example
       policies:
         # CORS headers to set
@@ -37,7 +36,7 @@ binds:
           add:
             x-req-added: value
           remove:
-            - x-illegal-header
+          - x-illegal-header
         # Modify response headers
         responseHeaderModifier:
           set:
@@ -65,7 +64,6 @@ binds:
           requestTimeout: 1s
       backends:
       - host: 127.0.0.1:8080
-
     - name: direct-response
       matches:
       - path:
@@ -74,7 +72,6 @@ binds:
         directResponse:
           body: "hello!"
           status: 200
-
     - name: ip-rules
       matches:
       - path:
@@ -82,8 +79,8 @@ binds:
       policies:
         authorization:
           rules:
-            - |
-              cidr("127.0.0.1/8").containsIP(source.address)
+          - |
+            cidr("127.0.0.1/8").containsIP(source.address)
         directResponse:
           body: "hello!"
           status: 200

--- a/examples/mcp-authentication/config.yaml
+++ b/examples/mcp-authentication/config.yaml
@@ -1,8 +1,7 @@
-# yaml-language-server: $schema=../../schema/local.json
+# yaml-language-server: $schema=../../schema/config.json
 binds:
 - listeners:
   - routes:
-
     # --- Scenario A: Local stdio MCP + Spec-compliant External Authorization Server
     # Exposes:
     #   - MCP server (streamable HTTP) at /stdio/mcp
@@ -44,7 +43,6 @@ binds:
             - query
             resourceDocumentation: http://localhost:3000/stdio/docs
             resourcePolicyUri: http://localhost:3000/stdio/policies
-
     # --- Scenario B: Remote MCP over HTTPS + Spec-compliant Authorization Server
     # Proxies to a remote MCP server and serves the same resource metadata locally.
     - backends:
@@ -81,8 +79,6 @@ binds:
             - query
             resourceDocumentation: http://localhost:3000/remote/docs
             resourcePolicyUri: http://localhost:3000/remote/policies
-
-
     # --- Scenario C: Local stdio MCP + Keycloak adaptation (non-spec provider)
     # When the provider isn't spec-compliant, enable an adapter that exposes modified
     # oauth-authorization-server endpoints while still validating JWTs.
@@ -130,49 +126,47 @@ binds:
             - query
             resourceDocumentation: http://localhost:3000/keycloak/docs
             resourcePolicyUri: http://localhost:3000/keycloak/policies
-
-    # Example configuration for Auth0:
-    # - backends:
-    #   - mcp:
-    #       targets:
-    #       - name: everything
-    #         stdio:
-    #           args:
-    #           - '@modelcontextprotocol/server-everything'
-    #           cmd: npx
-    #   matches:
-    #   - path:
-    #       exact: /auth0/mcp
-    #   - path:
-    #       exact: /.well-known/oauth-protected-resource/auth0/mcp
-    #   - path:
-    #       exact: /.well-known/oauth-authorization-server/auth0/mcp
-    #   policies:
-    #     cors:
-    #       allowHeaders:
-    #       - mcp-protocol-version
-    #       - content-type
-    #       allowOrigins:
-    #       - '*'
-    #     mcpAuthentication:
-    #       issuer: https://dev-y6sikgx3n3shy7ci.eu.auth0.com
-    #       audiences:
-    #       - urn:agent-gateway
-    #       jwksUrl: https://dev-y6sikgx3n3shy7ci.eu.auth0.com/.well-known/jwks.json
-    #       provider:
-    #         auth0: {}
-    #       resourceMetadata:
-    #         resource: http://localhost:3000/auth0/mcp
-    #         scopesSupported:  
-    #         - profile
-    #         - offline_access
-    #         - openid
-    #         bearerMethodsSupported:
-    #         - header
-    #         - body
-    #         - query
-    #         resourceDocumentation: http://localhost:3000/keycloak/docs
-    #         resourcePolicyUri: http://localhost:3000/keycloak/policies
-
+            # Example configuration for Auth0:
+            # - backends:
+            #   - mcp:
+            #       targets:
+            #       - name: everything
+            #         stdio:
+            #           args:
+            #           - '@modelcontextprotocol/server-everything'
+            #           cmd: npx
+            #   matches:
+            #   - path:
+            #       exact: /auth0/mcp
+            #   - path:
+            #       exact: /.well-known/oauth-protected-resource/auth0/mcp
+            #   - path:
+            #       exact: /.well-known/oauth-authorization-server/auth0/mcp
+            #   policies:
+            #     cors:
+            #       allowHeaders:
+            #       - mcp-protocol-version
+            #       - content-type
+            #       allowOrigins:
+            #       - '*'
+            #     mcpAuthentication:
+            #       issuer: https://dev-y6sikgx3n3shy7ci.eu.auth0.com
+            #       audiences:
+            #       - urn:agent-gateway
+            #       jwksUrl: https://dev-y6sikgx3n3shy7ci.eu.auth0.com/.well-known/jwks.json
+            #       provider:
+            #         auth0: {}
+            #       resourceMetadata:
+            #         resource: http://localhost:3000/auth0/mcp
+            #         scopesSupported:
+            #         - profile
+            #         - offline_access
+            #         - openid
+            #         bearerMethodsSupported:
+            #         - header
+            #         - body
+            #         - query
+            #         resourceDocumentation: http://localhost:3000/keycloak/docs
+            #         resourcePolicyUri: http://localhost:3000/keycloak/policies
   # Public port to listen on
   port: 3000

--- a/examples/multiplex/config.yaml
+++ b/examples/multiplex/config.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=../../schema/local.json
+# yaml-language-server: $schema=../../schema/config.json
 binds:
 - port: 3000
   listeners:

--- a/examples/oauth2-proxy/config.yaml
+++ b/examples/oauth2-proxy/config.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=../../schema/local.json
+# yaml-language-server: $schema=../../schema/config.json
 frontendPolicies:
   accessLog:
     add:
@@ -24,7 +24,6 @@ binds:
       backends:
       # In this example, we run oauth2-proxy over localhost. Adjust accordingly.
       - host: localhost:4180
-
     # All other traffic goes to our application
     - name: application
       backends:
@@ -33,9 +32,9 @@ binds:
         extAuthz:
           host: localhost:4180
           includeRequestHeaders:
-            # By default, only the Authorization header is included.
-            # Oauth2 proxy uses the 'cookie' header for tokens, so include that
-            - cookie
+          # By default, only the Authorization header is included.
+          # Oauth2 proxy uses the 'cookie' header for tokens, so include that
+          - cookie
           protocol:
             http:
               # For all requests, we send to /oauth2/auth.

--- a/examples/openapi/config.yaml
+++ b/examples/openapi/config.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=../../schema/local.json
+# yaml-language-server: $schema=../../schema/config.json
 binds:
 - port: 3000
   listeners:

--- a/examples/tailscale-auth/config.yaml
+++ b/examples/tailscale-auth/config.yaml
@@ -1,6 +1,5 @@
-# yaml-language-server: $schema=../../schema/local.json
+# yaml-language-server: $schema=../../schema/config.json
 config: {}
-
 frontendPolicies:
   accessLog:
     add:

--- a/examples/telemetry/config.yaml
+++ b/examples/telemetry/config.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=../../schema/local.json
+# yaml-language-server: $schema=../../schema/config.json
 config:
   tracing:
     otlpEndpoint: http://localhost:4317

--- a/examples/tls/config.yaml
+++ b/examples/tls/config.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=../../schema/local.json
+# yaml-language-server: $schema=../../schema/config.json
 binds:
 - port: 3000
   listeners:


### PR DESCRIPTION
Small quality-of-life improvement for editing example configs by renaming `schema/local.json` to `schema/config.json`.

---

The YAML files have been formatted using a formatter that follows Go/Kubernetes YAML indentation style. I can remove this formatting if you prefer the change to be as minimal as possible.