### PR TITLE
llm: Anthropic model fixes when using vertex.ai provider

### DIFF
--- a/crates/agentgateway/src/llm/conversion/messages.rs
+++ b/crates/agentgateway/src/llm/conversion/messages.rs
@@ -401,7 +401,7 @@ fn translate_stop_reason(resp: &messages::StopReason) -> completions::FinishReas
 
 pub fn passthrough_stream(b: Body, buffer_limit: usize, log: AsyncLog<LLMInfo>) -> Body {
 	let mut saw_token = false;
-	// https://docs.anthropic.com/en/docs/build-with-claude/streaming
+	// https://platform.claude.com/docs/en/build-with-claude/streaming
 	parse::sse::json_passthrough::<messages::MessagesStreamEvent>(b, buffer_limit, move |f| {
 		// ignore errors... what else can we do?
 		let Some(Ok(f)) = f else { return };

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -940,7 +940,7 @@ impl AIProvider {
 				// Passthrough; nothing needed
 				Ok(bytes.clone())
 			},
-			(AIProvider::Anthropic(_), InputFormat::Messages) => {
+			(AIProvider::Anthropic(_) | AIProvider::Vertex(_), InputFormat::Messages) => {
 				// Passthrough; nothing needed
 				Ok(bytes.clone())
 			},

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -565,11 +565,11 @@ impl AIProvider {
 			(InputFormat::Completions, _) => {
 				// All providers support completions input
 			},
-			(InputFormat::Messages, AIProvider::Anthropic(_)) => {
-				// Anthropic supports messages input
-			},
-			(InputFormat::Messages, AIProvider::Bedrock(_)) => {
-				// Bedrock supports messages input (Anthropic passthrough)
+			(
+				InputFormat::Messages,
+				AIProvider::Anthropic(_) | AIProvider::Bedrock(_) | AIProvider::Vertex(_),
+			) => {
+				// Anthropic supports messages input (Bedrock & Vertex support assuming serving Anthropic models)
 			},
 			(InputFormat::Responses, AIProvider::OpenAI(_)) => {
 				// OpenAI supports responses input
@@ -754,10 +754,7 @@ impl AIProvider {
 		match (self, req.input_format) {
 			// Completions with OpenAI: just passthrough
 			(
-				AIProvider::OpenAI(_)
-				| AIProvider::Gemini(_)
-				| AIProvider::AzureOpenAI(_)
-				| AIProvider::Vertex(_),
+				AIProvider::OpenAI(_) | AIProvider::Gemini(_) | AIProvider::AzureOpenAI(_),
 				InputFormat::Completions,
 			) => Ok(Box::new(
 				serde_json::from_slice::<types::completions::Response>(bytes)
@@ -765,17 +762,14 @@ impl AIProvider {
 			)),
 			// Responses with OpenAI: just passthrough
 			(
-				AIProvider::OpenAI(_)
-				| AIProvider::Gemini(_)
-				| AIProvider::AzureOpenAI(_)
-				| AIProvider::Vertex(_),
+				AIProvider::OpenAI(_) | AIProvider::Gemini(_) | AIProvider::AzureOpenAI(_),
 				InputFormat::Responses,
 			) => Ok(Box::new(
 				serde_json::from_slice::<types::responses::Response>(bytes)
 					.map_err(AIError::ResponseParsing)?,
 			)),
 			// Anthropic messages: passthrough
-			(AIProvider::Anthropic(_), InputFormat::Messages) => Ok(Box::new(
+			(AIProvider::Anthropic(_) | AIProvider::Vertex(_), InputFormat::Messages) => Ok(Box::new(
 				serde_json::from_slice::<types::messages::Response>(bytes)
 					.map_err(AIError::ResponseParsing)?,
 			)),
@@ -791,6 +785,16 @@ impl AIProvider {
 			},
 			(AIProvider::Bedrock(_), InputFormat::Responses) => {
 				conversion::bedrock::from_responses::translate_response(bytes, &req.request_model)
+			},
+			(AIProvider::Vertex(p), InputFormat::Completions) => {
+				if p.is_anthropic_model(Some(&req.request_model)) {
+					conversion::messages::from_completions::translate_response(bytes)
+				} else {
+					Ok(Box::new(
+						serde_json::from_slice::<types::completions::Response>(bytes)
+							.map_err(AIError::ResponseParsing)?,
+					))
+				}
 			},
 			(_, InputFormat::Messages) => Err(AIError::UnsupportedConversion(strng::literal!(
 				"this provider does not support Messages"
@@ -851,7 +855,7 @@ impl AIProvider {
 				InputFormat::Responses,
 			) => resp.map(|b| conversion::responses::passthrough_stream(b, buffer, log)),
 			// Anthropic messages: passthrough
-			(AIProvider::Anthropic(_), InputFormat::Messages) => {
+			(AIProvider::Anthropic(_) | AIProvider::Vertex(_), InputFormat::Messages) => {
 				resp.map(|b| conversion::messages::passthrough_stream(b, buffer, log))
 			},
 			// Supported paths with conversion...

--- a/crates/agentgateway/src/llm/tests/vertex-messages-request_anthropic_basic.snap
+++ b/crates/agentgateway/src/llm/tests/vertex-messages-request_anthropic_basic.snap
@@ -1,0 +1,20 @@
+---
+source: crates/agentgateway/src/llm/tests.rs
+description: "vertex-messages: request_anthropic_basic"
+info:
+  model: claude-sonnet-4-20250514
+  max_tokens: 1024
+  messages:
+    - role: user
+      content: "Hello, world"
+---
+{
+  "anthropic_version": "vertex-2023-10-16",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Hello, world"
+    }
+  ],
+  "max_tokens": 1024
+}

--- a/crates/agentgateway/src/llm/tests/vertex-messages-request_anthropic_tools.snap
+++ b/crates/agentgateway/src/llm/tests/vertex-messages-request_anthropic_tools.snap
@@ -1,0 +1,49 @@
+---
+source: crates/agentgateway/src/llm/tests.rs
+description: "vertex-messages: request_anthropic_tools"
+info:
+  model: claude-opus-4-1-20250805
+  max_tokens: 1024
+  tools:
+    - name: get_weather
+      description: Get the current weather in a given location
+      input_schema:
+        type: object
+        properties:
+          location:
+            type: string
+            description: "The city and state, e.g. San Francisco, CA"
+        required:
+          - location
+  messages:
+    - role: user
+      content: What is the weather like in San Francisco?
+---
+{
+  "anthropic_version": "vertex-2023-10-16",
+  "messages": [
+    {
+      "role": "user",
+      "content": "What is the weather like in San Francisco?"
+    }
+  ],
+  "max_tokens": 1024,
+  "tools": [
+    {
+      "name": "get_weather",
+      "description": "Get the current weather in a given location",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "location": {
+            "type": "string",
+            "description": "The city and state, e.g. San Francisco, CA"
+          }
+        },
+        "required": [
+          "location"
+        ]
+      }
+    }
+  ]
+}

--- a/crates/agentgateway/src/llm/tests/vertex-messages-response_anthropic_basic.snap
+++ b/crates/agentgateway/src/llm/tests/vertex-messages-response_anthropic_basic.snap
@@ -1,0 +1,41 @@
+---
+source: crates/agentgateway/src/llm/tests.rs
+description: src/llm/tests/response_anthropic_basic.json
+info:
+  id: msg_012JYtNYb8sv6Hb67TcGT7xW
+  type: message
+  role: assistant
+  model: claude-3-5-haiku-20241022
+  content:
+    - type: text
+      text: Hi there! How are you doing today? Is there anything I can help you with?
+  stop_reason: end_turn
+  stop_sequence: ~
+  usage:
+    input_tokens: 15
+    cache_creation_input_tokens: 0
+    cache_read_input_tokens: 0
+    output_tokens: 21
+    service_tier: standard
+---
+{
+  "model": "claude-3-5-haiku-20241022",
+  "usage": {
+    "input_tokens": 15,
+    "output_tokens": 21,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 0,
+    "service_tier": "standard"
+  },
+  "content": [
+    {
+      "text": "Hi there! How are you doing today? Is there anything I can help you with?",
+      "type": "text"
+    }
+  ],
+  "id": "[id]",
+  "type": "message",
+  "role": "assistant",
+  "stop_reason": "end_turn",
+  "stop_sequence": null
+}

--- a/crates/agentgateway/src/llm/tests/vertex-messages-response_anthropic_tool.snap
+++ b/crates/agentgateway/src/llm/tests/vertex-messages-response_anthropic_tool.snap
@@ -1,0 +1,54 @@
+---
+source: crates/agentgateway/src/llm/tests.rs
+description: src/llm/tests/response_anthropic_tool.json
+info:
+  id: msg_01Aq9w938a90dw8q
+  type: message
+  model: claude-opus-4-1-20250805
+  stop_reason: tool_use
+  role: assistant
+  content:
+    - type: text
+      text: "<thinking>I need to call the get_weather function, and the user wants SF, which is likely San Francisco, CA.</thinking>"
+    - type: tool_use
+      id: toolu_01A09q90qw90lq917835lq9
+      name: get_weather
+      input:
+        location: "San Francisco, CA"
+        unit: celsius
+  usage:
+    input_tokens: 558
+    cache_creation_input_tokens: 0
+    cache_read_input_tokens: 0
+    output_tokens: 48
+    service_tier: standard
+---
+{
+  "model": "claude-opus-4-1-20250805",
+  "usage": {
+    "input_tokens": 558,
+    "output_tokens": 48,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 0,
+    "service_tier": "standard"
+  },
+  "content": [
+    {
+      "text": "<thinking>I need to call the get_weather function, and the user wants SF, which is likely San Francisco, CA.</thinking>",
+      "type": "text"
+    },
+    {
+      "type": "tool_use",
+      "id": "toolu_01A09q90qw90lq917835lq9",
+      "name": "get_weather",
+      "input": {
+        "location": "San Francisco, CA",
+        "unit": "celsius"
+      }
+    }
+  ],
+  "id": "[id]",
+  "type": "message",
+  "stop_reason": "tool_use",
+  "role": "assistant"
+}

--- a/crates/agentgateway/src/llm/tests/vertex-messages-response_stream-anthropic_basic.json.snap
+++ b/crates/agentgateway/src/llm/tests/vertex-messages-response_stream-anthropic_basic.json.snap
@@ -1,0 +1,36 @@
+---
+source: crates/agentgateway/src/llm/tests.rs
+description: src/llm/tests/response_stream-anthropic_basic.json
+---
+event: message_start
+data: {"type":"message_start","message":{"id":"msg_016wbjv5k86nxxd8CEZwSQnA","type":"message","role":"assistant","model":"claude-3-5-haiku-20241022","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":15,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":5,"service_tier":"standard"}}    }
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}      }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi there! How are"}    }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" you doing today?"}           }
+
+event: ping
+data: {"type": "ping"}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" Is"}  }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" there anything I can help"}               }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" you with?"}            }
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0           }
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":15,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":21}            }
+
+event: message_stop
+data: {"type":"message_stop"            }

--- a/crates/agentgateway/src/llm/vertex.rs
+++ b/crates/agentgateway/src/llm/vertex.rs
@@ -7,9 +7,7 @@ use crate::*;
 
 const ANTHROPIC_VERSION: &str = "vertex-2023-10-16";
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[apply(schema!)]
 pub struct Provider {
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub model: Option<Strng>,

--- a/crates/agentgateway/src/llm/vertex.rs
+++ b/crates/agentgateway/src/llm/vertex.rs
@@ -61,17 +61,24 @@ impl Provider {
 			.clone()
 			.unwrap_or_else(|| strng::literal!("global"));
 		if let Some(model) = self.anthropic_model(request_model) {
-			return strng::format!(
-				"/v1/projects/{}/locations/{}/publishers/anthropic/models/{}:{}",
-				self.project_id,
-				location,
-				model,
-				if streaming {
-					"streamRawPredict"
-				} else {
-					"rawPredict"
-				}
-			);
+			return match route {
+				RouteType::AnthropicTokenCount => strng::format!(
+					"/v1/projects/{}/locations/{}/publishers/anthropic/models/count-tokens:rawPredict",
+					self.project_id,
+					location
+				),
+				_ => strng::format!(
+					"/v1/projects/{}/locations/{}/publishers/anthropic/models/{}:{}",
+					self.project_id,
+					location,
+					model,
+					if streaming {
+						"streamRawPredict"
+					} else {
+						"rawPredict"
+					}
+				),
+			};
 		}
 		let t = if route == RouteType::Embeddings {
 			strng::literal!("embeddings")
@@ -79,7 +86,7 @@ impl Provider {
 			strng::literal!("chat/completions")
 		};
 		strng::format!(
-			"/v1beta1/projects/{}/locations/{}/endpoints/openapi/{t}",
+			"/v1/projects/{}/locations/{}/endpoints/openapi/{t}",
 			self.project_id,
 			location
 		)

--- a/crates/agentgateway/tests/tests/llm.rs
+++ b/crates/agentgateway/tests/tests/llm.rs
@@ -43,6 +43,7 @@ fn llm_config(provider: &str, env: &str, model: &str) -> String {
 	} else if provider == "vertex" {
 		r#"
               projectId: $VERTEX_PROJECT
+              region: us-central1
               "#
 	} else if provider == "azureOpenAI" {
 		r#"
@@ -303,6 +304,22 @@ mod vertex {
 			return;
 		};
 		send_completions(&gw, true).await;
+	}
+
+	#[tokio::test]
+	async fn messages() {
+		let Some(gw) = setup("vertex", "", "anthropic/claude-3-haiku").await else {
+			return;
+		};
+		send_messages(&gw, false).await;
+	}
+
+	#[tokio::test]
+	async fn messages_streaming() {
+		let Some(gw) = setup("vertex", "", "anthropic/claude-3-haiku").await else {
+			return;
+		};
+		send_messages(&gw, true).await;
 	}
 
 	#[tokio::test]

--- a/schema/config.json
+++ b/schema/config.json
@@ -5652,6 +5652,7 @@
                                                       "type": "string"
                                                     }
                                                   },
+                                                  "additionalProperties": false,
                                                   "required": [
                                                     "projectId"
                                                   ]
@@ -7214,6 +7215,7 @@
                                                                   "type": "string"
                                                                 }
                                                               },
+                                                              "additionalProperties": false,
                                                               "required": [
                                                                 "projectId"
                                                               ]


### PR DESCRIPTION
This issue came up while testing Anthropic models served via vertex ai. Example configs for both anthropic and openai:

**Anthropic model**
```yaml
binds:
- port: 3000
  listeners:
  - name: vertex-anthropic
    routes:
    - backends:
      - ai:
          name: vertex
          provider:
            vertex:
              projectId: $PROJECT_ID
              model: anthropic/claude-haiku-4-5
      policies:
        ai:
          routes:
            /v1/messages: messages # Anthropic format
            /v1/chat/completions: completions # OpenAI old format
            /v1/responses: responses # OpenAI new format
            "*": passthrough
        backendAuth:
          gcp: {}
```

Vertex/Anthropic request:
```json
{
  "anthropic_version": "vertex-2023-10-16",
  "stream": false,
  "max_tokens": 128,
  "temperature": 1,
  "messages": [
    {"role": "user","content": [{"type": "text", "text": "What sort of model are you?" }]}
  ]
}
```

**OpenAI compatible model**
```yaml
binds:
- port: 3000
  listeners:
  - name: vertex-openai
    routes:
    - backends:
      - ai:
          name: vertex
          provider:
            vertex:
              projectId: $PROJECT_ID
              region: us-east5
              model: meta/llama-4-maverick-17b-128e-instruct-maas
      policies:
        ai:
          routes:
            /v1/chat/completions: completions # OpenAI old format
            "*": passthrough
        backendAuth:
          gcp: {}
```

Example llama request:
```json
{
  "model": "meta/llama-4-maverick-17b-128e-instruct-maas",
  "stream": false,
  "max_tokens": 128,
  "temperature": 1,
  "messages": [{ "role": "user", "content": "What sort of model are you?" }]
}
```