### PR TITLE
llm: Prompt Enrichment enabling prepend and append for system and message prompts

### DIFF
--- a/crates/agentgateway/src/llm/policy/mod.rs
+++ b/crates/agentgateway/src/llm/policy/mod.rs
@@ -279,7 +279,12 @@ impl Policy {
 
 	pub fn apply_prompt_enrichment(&self, chat: &mut dyn RequestType) {
 		if let Some(prompts) = &self.prompts {
-			chat.prepend_prompts(prompts.prepend.clone());
+			if prompts.prepend.len() > 0 {
+				chat.prepend_prompts(prompts.prepend.clone());
+			}
+			if prompts.append.len() > 0 {
+				chat.append_prompts(prompts.append.clone());
+			}
 		}
 	}
 

--- a/crates/agentgateway/src/llm/policy/mod.rs
+++ b/crates/agentgateway/src/llm/policy/mod.rs
@@ -279,10 +279,10 @@ impl Policy {
 
 	pub fn apply_prompt_enrichment(&self, chat: &mut dyn RequestType) {
 		if let Some(prompts) = &self.prompts {
-			if prompts.prepend.len() > 0 {
+			if !prompts.prepend.is_empty() {
 				chat.prepend_prompts(prompts.prepend.clone());
 			}
-			if prompts.append.len() > 0 {
+			if !prompts.append.is_empty() {
 				chat.append_prompts(prompts.append.clone());
 			}
 		}

--- a/crates/agentgateway/src/llm/policy/mod.rs
+++ b/crates/agentgateway/src/llm/policy/mod.rs
@@ -197,9 +197,11 @@ impl Default for PromptCachingConfig {
 }
 
 #[apply(schema!)]
+#[cfg_attr(feature = "schema", schemars(extend("minProperties" = 1)))]
 pub struct PromptEnrichment {
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub append: Vec<crate::llm::SimpleChatCompletionMessage>,
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub prepend: Vec<crate::llm::SimpleChatCompletionMessage>,
 }
 

--- a/crates/agentgateway/src/llm/tests.rs
+++ b/crates/agentgateway/src/llm/tests.rs
@@ -5,6 +5,7 @@ use agent_core::strng;
 use http_body_util::BodyExt;
 use serde::de::DeserializeOwned;
 use serde_json::Value;
+use types::{RequestType, SimpleChatCompletionMessage, messages};
 
 use super::*;
 
@@ -285,4 +286,144 @@ async fn test_completions_to_messages() {
 	for r in COMPLETION_REQUESTS {
 		test_request("anthropic", r, request);
 	}
+}
+
+#[test]
+fn test_messages_prepend_prompts_with_system() {
+	let mut req = messages::Request {
+		model: Some("claude-4-5-sonnet".to_string()),
+		messages: vec![messages::RequestMessage {
+			role: "user".to_string(),
+			content: Some(messages::RequestContent::Text("Hello".to_string())),
+			rest: Default::default(),
+		}],
+		system: None,
+		top_p: None,
+		temperature: None,
+		stream: None,
+		max_tokens: None,
+		rest: Default::default(),
+	};
+
+	req.prepend_prompts(vec![
+		SimpleChatCompletionMessage {
+			role: strng::new("system"),
+			content: strng::new("You are a helpful assistant."),
+		},
+		SimpleChatCompletionMessage {
+			role: strng::new("user"),
+			content: strng::new("Context: This is important."),
+		},
+	]);
+
+	assert!(req.system.is_some());
+	match &req.system {
+		Some(messages::RequestContent::Text(text)) => {
+			assert_eq!(text, "You are a helpful assistant.");
+		},
+		_ => panic!("Expected system Text content"),
+	}
+
+	assert_eq!(req.messages.len(), 2);
+	assert_eq!(req.messages[0].role, "user");
+	match &req.messages[0].content {
+		Some(messages::RequestContent::Text(text)) => {
+			assert_eq!(text, "Context: This is important.");
+		},
+		_ => panic!("Expected Text content"),
+	}
+	assert_eq!(req.messages[1].role, "user");
+	match &req.messages[1].content {
+		Some(messages::RequestContent::Text(text)) => {
+			assert_eq!(text, "Hello");
+		},
+		_ => panic!("Expected Text content"),
+	}
+}
+
+#[test]
+fn test_messages_prepend_prompts_with_existing_system_string() {
+	let mut req = messages::Request {
+		model: Some("claude-4-5-sonnet".to_string()),
+		messages: vec![messages::RequestMessage {
+			role: "user".to_string(),
+			content: Some(messages::RequestContent::Text("Hello".to_string())),
+			rest: Default::default(),
+		}],
+		system: Some(messages::RequestContent::Text(
+			"You are an expert.".to_string(),
+		)),
+		top_p: None,
+		temperature: None,
+		stream: None,
+		max_tokens: None,
+		rest: Default::default(),
+	};
+
+	req.prepend_prompts(vec![SimpleChatCompletionMessage {
+		role: strng::new("system"),
+		content: strng::new("Additional context."),
+	}]);
+
+	match &req.system {
+		Some(messages::RequestContent::Array(arr)) => {
+			assert_eq!(arr.len(), 2);
+			assert_eq!(arr[0].r#type, "text");
+			assert_eq!(arr[0].text.as_deref(), Some("Additional context."));
+			assert_eq!(arr[1].r#type, "text");
+			assert_eq!(arr[1].text.as_deref(), Some("You are an expert."));
+		},
+		_ => panic!("Expected system Array content"),
+	}
+	assert_eq!(req.messages.len(), 1);
+}
+
+#[test]
+fn test_messages_prepend_prompts_with_system_array() {
+	let mut req = messages::Request {
+		model: Some("claude-4-5-sonnet".to_string()),
+		messages: vec![messages::RequestMessage {
+			role: "user".to_string(),
+			content: Some(messages::RequestContent::Text("World".to_string())),
+			rest: Default::default(),
+		}],
+		system: Some(messages::RequestContent::Array(vec![
+			messages::ContentPart {
+				r#type: "text".to_string(),
+				text: Some("You are an expert.".to_string()),
+				rest: Default::default(),
+			},
+		])),
+		top_p: None,
+		temperature: None,
+		stream: None,
+		max_tokens: None,
+		rest: Default::default(),
+	};
+
+	req.prepend_prompts(vec![
+		SimpleChatCompletionMessage {
+			role: strng::new("system"),
+			content: strng::new("Additional context."),
+		},
+		SimpleChatCompletionMessage {
+			role: strng::new("user"),
+			content: strng::new("Hello"),
+		},
+	]);
+
+	match &req.system {
+		Some(messages::RequestContent::Array(arr)) => {
+			assert_eq!(arr.len(), 2);
+			assert_eq!(arr[0].r#type, "text");
+			assert_eq!(arr[0].text.as_deref(), Some("Additional context."));
+			assert_eq!(arr[1].r#type, "text");
+			assert_eq!(arr[1].text.as_deref(), Some("You are an expert."));
+		},
+		_ => panic!("Expected system Array content"),
+	}
+
+	assert_eq!(req.messages.len(), 2);
+	assert_eq!(req.messages[0].message_text().unwrap(), "Hello");
+	assert_eq!(req.messages[1].message_text().unwrap(), "World");
 }

--- a/crates/agentgateway/src/llm/tests.rs
+++ b/crates/agentgateway/src/llm/tests.rs
@@ -308,27 +308,28 @@ fn test_messages_prepend_prompts_with_system() {
 	req.prepend_prompts(vec![
 		SimpleChatCompletionMessage {
 			role: strng::new("system"),
-			content: strng::new("You are a helpful assistant."),
+			content: strng::new("You are a helpful assistant"),
 		},
 		SimpleChatCompletionMessage {
 			role: strng::new("user"),
-			content: strng::new("Context: This is important."),
+			content: strng::new("Context: This is important"),
 		},
 	]);
 
-	assert!(req.system.is_some());
 	match &req.system {
-		Some(messages::RequestContent::Text(text)) => {
-			assert_eq!(text, "You are a helpful assistant.");
+		Some(messages::RequestContent::Array(arr)) => {
+			assert_eq!(arr.len(), 1);
+			assert_eq!(arr[0].r#type, "text");
+			assert_eq!(arr[0].text.as_deref(), Some("You are a helpful assistant"));
 		},
-		_ => panic!("Expected system Text content"),
+		_ => panic!("Expected system Array content"),
 	}
 
 	assert_eq!(req.messages.len(), 2);
 	assert_eq!(req.messages[0].role, "user");
 	match &req.messages[0].content {
 		Some(messages::RequestContent::Text(text)) => {
-			assert_eq!(text, "Context: This is important.");
+			assert_eq!(text, "Context: This is important");
 		},
 		_ => panic!("Expected Text content"),
 	}
@@ -351,7 +352,7 @@ fn test_messages_prepend_prompts_with_existing_system_string() {
 			rest: Default::default(),
 		}],
 		system: Some(messages::RequestContent::Text(
-			"You are an expert.".to_string(),
+			"You are an expert".to_string(),
 		)),
 		top_p: None,
 		temperature: None,
@@ -362,16 +363,16 @@ fn test_messages_prepend_prompts_with_existing_system_string() {
 
 	req.prepend_prompts(vec![SimpleChatCompletionMessage {
 		role: strng::new("system"),
-		content: strng::new("Additional context."),
+		content: strng::new("Additional context"),
 	}]);
 
 	match &req.system {
 		Some(messages::RequestContent::Array(arr)) => {
 			assert_eq!(arr.len(), 2);
 			assert_eq!(arr[0].r#type, "text");
-			assert_eq!(arr[0].text.as_deref(), Some("Additional context."));
+			assert_eq!(arr[0].text.as_deref(), Some("Additional context"));
 			assert_eq!(arr[1].r#type, "text");
-			assert_eq!(arr[1].text.as_deref(), Some("You are an expert."));
+			assert_eq!(arr[1].text.as_deref(), Some("You are an expert"));
 		},
 		_ => panic!("Expected system Array content"),
 	}
@@ -390,7 +391,7 @@ fn test_messages_prepend_prompts_with_system_array() {
 		system: Some(messages::RequestContent::Array(vec![
 			messages::ContentPart {
 				r#type: "text".to_string(),
-				text: Some("You are an expert.".to_string()),
+				text: Some("You are an expert".to_string()),
 				rest: Default::default(),
 			},
 		])),
@@ -404,7 +405,7 @@ fn test_messages_prepend_prompts_with_system_array() {
 	req.prepend_prompts(vec![
 		SimpleChatCompletionMessage {
 			role: strng::new("system"),
-			content: strng::new("Additional context."),
+			content: strng::new("Additional context"),
 		},
 		SimpleChatCompletionMessage {
 			role: strng::new("user"),
@@ -416,9 +417,9 @@ fn test_messages_prepend_prompts_with_system_array() {
 		Some(messages::RequestContent::Array(arr)) => {
 			assert_eq!(arr.len(), 2);
 			assert_eq!(arr[0].r#type, "text");
-			assert_eq!(arr[0].text.as_deref(), Some("Additional context."));
+			assert_eq!(arr[0].text.as_deref(), Some("Additional context"));
 			assert_eq!(arr[1].r#type, "text");
-			assert_eq!(arr[1].text.as_deref(), Some("You are an expert."));
+			assert_eq!(arr[1].text.as_deref(), Some("You are an expert"));
 		},
 		_ => panic!("Expected system Array content"),
 	}

--- a/crates/agentgateway/src/llm/tests/anthropic-request_anthropic_with_system.snap
+++ b/crates/agentgateway/src/llm/tests/anthropic-request_anthropic_with_system.snap
@@ -1,0 +1,51 @@
+---
+source: crates/agentgateway/src/llm/tests.rs
+description: "anthropic: request_anthropic_with_system"
+info:
+  model: claude-sonnet-4-20250514
+  max_tokens: 1024
+  system: system prompt
+  messages:
+    - role: user
+      content: "Hello, world"
+---
+{
+  "model": "claude-sonnet-4-20250514",
+  "messages": [
+    {
+      "role": "user",
+      "content": "prepend user message"
+    },
+    {
+      "role": "assistant",
+      "content": "prepend assistant message"
+    },
+    {
+      "role": "user",
+      "content": "Hello, world"
+    },
+    {
+      "role": "user",
+      "content": "append user message"
+    },
+    {
+      "role": "assistant",
+      "content": "append assistant prompt"
+    }
+  ],
+  "system": [
+    {
+      "type": "text",
+      "text": "prepend system prompt"
+    },
+    {
+      "type": "text",
+      "text": "system prompt"
+    },
+    {
+      "type": "text",
+      "text": "append system prompt"
+    }
+  ],
+  "max_tokens": 1024
+}

--- a/crates/agentgateway/src/llm/tests/openai-request_openai_with_inputs.snap
+++ b/crates/agentgateway/src/llm/tests/openai-request_openai_with_inputs.snap
@@ -1,0 +1,79 @@
+---
+source: crates/agentgateway/src/llm/tests.rs
+description: "openai: request_openai_with_inputs"
+info:
+  model: gpt-4o
+  max_tokens: 1024
+  input:
+    - type: message
+      role: user
+      content:
+        - type: input_text
+          text: "Hello, world"
+---
+{
+  "input": [
+    {
+      "type": "message",
+      "content": [
+        {
+          "type": "input_text",
+          "text": "prepend system prompt"
+        }
+      ],
+      "role": "system"
+    },
+    {
+      "type": "message",
+      "content": [
+        {
+          "type": "input_text",
+          "text": "prepend user message"
+        }
+      ],
+      "role": "user"
+    },
+    {
+      "type": "message",
+      "role": "assistant",
+      "content": "prepend assistant message"
+    },
+    {
+      "type": "message",
+      "content": [
+        {
+          "type": "input_text",
+          "text": "Hello, world"
+        }
+      ],
+      "role": "user"
+    },
+    {
+      "type": "message",
+      "content": [
+        {
+          "type": "input_text",
+          "text": "append user message"
+        }
+      ],
+      "role": "user"
+    },
+    {
+      "type": "message",
+      "content": [
+        {
+          "type": "input_text",
+          "text": "append system prompt"
+        }
+      ],
+      "role": "system"
+    },
+    {
+      "type": "message",
+      "role": "assistant",
+      "content": "append assistant prompt"
+    }
+  ],
+  "model": "gpt-4o",
+  "max_tokens": 1024
+}

--- a/crates/agentgateway/src/llm/tests/openai-request_openai_with_messages.snap
+++ b/crates/agentgateway/src/llm/tests/openai-request_openai_with_messages.snap
@@ -1,0 +1,44 @@
+---
+source: crates/agentgateway/src/llm/tests.rs
+description: "openai: request_openai_with_messages"
+info:
+  model: gpt-4o
+  max_tokens: 1024
+  messages:
+    - role: user
+      content: "Hello, world"
+---
+{
+  "messages": [
+    {
+      "role": "system",
+      "content": "prepend system prompt"
+    },
+    {
+      "role": "user",
+      "content": "prepend user message"
+    },
+    {
+      "role": "assistant",
+      "content": "prepend assistant message"
+    },
+    {
+      "role": "user",
+      "content": "Hello, world"
+    },
+    {
+      "role": "user",
+      "content": "append user message"
+    },
+    {
+      "role": "system",
+      "content": "append system prompt"
+    },
+    {
+      "role": "assistant",
+      "content": "append assistant prompt"
+    }
+  ],
+  "model": "gpt-4o",
+  "max_tokens": 1024
+}

--- a/crates/agentgateway/src/llm/tests/request_anthropic_with_system.json
+++ b/crates/agentgateway/src/llm/tests/request_anthropic_with_system.json
@@ -1,0 +1,6 @@
+{
+  "model": "claude-sonnet-4-20250514",
+  "max_tokens": 1024,
+  "system": "system prompt",
+  "messages": [{ "role": "user", "content": "Hello, world" }]
+}

--- a/crates/agentgateway/src/llm/tests/request_openai_with_inputs.json
+++ b/crates/agentgateway/src/llm/tests/request_openai_with_inputs.json
@@ -1,0 +1,11 @@
+{
+  "model": "gpt-4o",
+  "max_tokens": 1024,
+  "input": [
+    {
+      "type": "message",
+      "role": "user",
+      "content": [{ "type": "input_text", "text": "Hello, world" }]
+    }
+  ]
+}

--- a/crates/agentgateway/src/llm/tests/request_openai_with_messages.json
+++ b/crates/agentgateway/src/llm/tests/request_openai_with_messages.json
@@ -1,0 +1,10 @@
+{
+  "model": "gpt-4o",
+  "max_tokens": 1024,
+  "messages": [
+    {
+      "role": "user",
+      "content": "Hello, world"
+    }
+  ]
+}

--- a/crates/agentgateway/src/llm/tests/vertex-messages-request_anthropic_basic.snap
+++ b/crates/agentgateway/src/llm/tests/vertex-messages-request_anthropic_basic.snap
@@ -1,0 +1,20 @@
+---
+source: crates/agentgateway/src/llm/tests.rs
+description: "vertex-messages: request_anthropic_basic"
+info:
+  model: claude-sonnet-4-20250514
+  max_tokens: 1024
+  messages:
+    - role: user
+      content: "Hello, world"
+---
+{
+  "anthropic_version": "vertex-2023-10-16",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Hello, world"
+    }
+  ],
+  "max_tokens": 1024
+}

--- a/crates/agentgateway/src/llm/tests/vertex-messages-request_anthropic_tools.snap.new
+++ b/crates/agentgateway/src/llm/tests/vertex-messages-request_anthropic_tools.snap.new
@@ -1,0 +1,50 @@
+---
+source: crates/agentgateway/src/llm/tests.rs
+assertion_line: 109
+description: "vertex-messages: request_anthropic_tools"
+info:
+  model: claude-opus-4-1-20250805
+  max_tokens: 1024
+  tools:
+    - name: get_weather
+      description: Get the current weather in a given location
+      input_schema:
+        type: object
+        properties:
+          location:
+            type: string
+            description: "The city and state, e.g. San Francisco, CA"
+        required:
+          - location
+  messages:
+    - role: user
+      content: What is the weather like in San Francisco?
+---
+{
+  "anthropic_version": "vertex-2023-10-16",
+  "messages": [
+    {
+      "role": "user",
+      "content": "What is the weather like in San Francisco?"
+    }
+  ],
+  "max_tokens": 1024,
+  "tools": [
+    {
+      "name": "get_weather",
+      "description": "Get the current weather in a given location",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "location": {
+            "type": "string",
+            "description": "The city and state, e.g. San Francisco, CA"
+          }
+        },
+        "required": [
+          "location"
+        ]
+      }
+    }
+  ]
+}

--- a/crates/agentgateway/src/llm/tests/vertex-messages-response_anthropic_basic.snap
+++ b/crates/agentgateway/src/llm/tests/vertex-messages-response_anthropic_basic.snap
@@ -1,0 +1,41 @@
+---
+source: crates/agentgateway/src/llm/tests.rs
+description: src/llm/tests/response_anthropic_basic.json
+info:
+  id: msg_012JYtNYb8sv6Hb67TcGT7xW
+  type: message
+  role: assistant
+  model: claude-3-5-haiku-20241022
+  content:
+    - type: text
+      text: Hi there! How are you doing today? Is there anything I can help you with?
+  stop_reason: end_turn
+  stop_sequence: ~
+  usage:
+    input_tokens: 15
+    cache_creation_input_tokens: 0
+    cache_read_input_tokens: 0
+    output_tokens: 21
+    service_tier: standard
+---
+{
+  "model": "claude-3-5-haiku-20241022",
+  "usage": {
+    "input_tokens": 15,
+    "output_tokens": 21,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 0,
+    "service_tier": "standard"
+  },
+  "content": [
+    {
+      "text": "Hi there! How are you doing today? Is there anything I can help you with?",
+      "type": "text"
+    }
+  ],
+  "id": "[id]",
+  "type": "message",
+  "role": "assistant",
+  "stop_reason": "end_turn",
+  "stop_sequence": null
+}

--- a/crates/agentgateway/src/llm/tests/vertex-messages-response_anthropic_tool.snap
+++ b/crates/agentgateway/src/llm/tests/vertex-messages-response_anthropic_tool.snap
@@ -1,0 +1,54 @@
+---
+source: crates/agentgateway/src/llm/tests.rs
+description: src/llm/tests/response_anthropic_tool.json
+info:
+  id: msg_01Aq9w938a90dw8q
+  type: message
+  model: claude-opus-4-1-20250805
+  stop_reason: tool_use
+  role: assistant
+  content:
+    - type: text
+      text: "<thinking>I need to call the get_weather function, and the user wants SF, which is likely San Francisco, CA.</thinking>"
+    - type: tool_use
+      id: toolu_01A09q90qw90lq917835lq9
+      name: get_weather
+      input:
+        location: "San Francisco, CA"
+        unit: celsius
+  usage:
+    input_tokens: 558
+    cache_creation_input_tokens: 0
+    cache_read_input_tokens: 0
+    output_tokens: 48
+    service_tier: standard
+---
+{
+  "model": "claude-opus-4-1-20250805",
+  "usage": {
+    "input_tokens": 558,
+    "output_tokens": 48,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 0,
+    "service_tier": "standard"
+  },
+  "content": [
+    {
+      "text": "<thinking>I need to call the get_weather function, and the user wants SF, which is likely San Francisco, CA.</thinking>",
+      "type": "text"
+    },
+    {
+      "type": "tool_use",
+      "id": "toolu_01A09q90qw90lq917835lq9",
+      "name": "get_weather",
+      "input": {
+        "location": "San Francisco, CA",
+        "unit": "celsius"
+      }
+    }
+  ],
+  "id": "[id]",
+  "type": "message",
+  "stop_reason": "tool_use",
+  "role": "assistant"
+}

--- a/crates/agentgateway/src/llm/tests/vertex-messages-response_stream-anthropic_basic.json.snap
+++ b/crates/agentgateway/src/llm/tests/vertex-messages-response_stream-anthropic_basic.json.snap
@@ -1,0 +1,36 @@
+---
+source: crates/agentgateway/src/llm/tests.rs
+description: src/llm/tests/response_stream-anthropic_basic.json
+---
+event: message_start
+data: {"type":"message_start","message":{"id":"msg_016wbjv5k86nxxd8CEZwSQnA","type":"message","role":"assistant","model":"claude-3-5-haiku-20241022","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":15,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":5,"service_tier":"standard"}}    }
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}      }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi there! How are"}    }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" you doing today?"}           }
+
+event: ping
+data: {"type": "ping"}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" Is"}  }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" there anything I can help"}               }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" you with?"}            }
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0           }
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":15,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":21}            }
+
+event: message_stop
+data: {"type":"message_stop"            }

--- a/crates/agentgateway/src/llm/types/completions.rs
+++ b/crates/agentgateway/src/llm/types/completions.rs
@@ -150,6 +150,12 @@ impl super::RequestType for Request {
 			.splice(..0, prompts.into_iter().map(convert_message));
 	}
 
+	fn append_prompts(&mut self, prompts: Vec<llm::types::SimpleChatCompletionMessage>) {
+		self
+			.messages
+			.extend(prompts.into_iter().map(convert_message));
+	}
+
 	fn to_anthropic(&self) -> Result<Vec<u8>, AIError> {
 		conversion::messages::from_completions::translate(self)
 	}

--- a/crates/agentgateway/src/llm/types/count_tokens.rs
+++ b/crates/agentgateway/src/llm/types/count_tokens.rs
@@ -21,6 +21,10 @@ impl RequestType for Request {
 		// TODO: this would help since we can then count the pre-pending
 	}
 
+	fn append_prompts(&mut self, _prompts: Vec<SimpleChatCompletionMessage>) {
+		// TODO: this would help since we can then count the appending
+	}
+
 	fn to_llm_request(&self, provider: Strng, _tokenize: bool) -> Result<LLMRequest, AIError> {
 		let model = strng::new(self.model.as_deref().unwrap_or_default());
 		Ok(LLMRequest {

--- a/crates/agentgateway/src/llm/types/embeddings.rs
+++ b/crates/agentgateway/src/llm/types/embeddings.rs
@@ -35,6 +35,10 @@ impl RequestType for Request {
 		// Ignored
 	}
 
+	fn append_prompts(&mut self, _prompts: Vec<SimpleChatCompletionMessage>) {
+		// Ignored
+	}
+
 	fn to_llm_request(&self, provider: Strng, _tokenize: bool) -> Result<LLMRequest, AIError> {
 		let model = strng::new(self.model.as_deref().unwrap_or_default());
 		Ok(LLMRequest {

--- a/crates/agentgateway/src/llm/types/messages.rs
+++ b/crates/agentgateway/src/llm/types/messages.rs
@@ -17,6 +17,9 @@ pub struct Request {
 	pub messages: Vec<RequestMessage>,
 
 	#[serde(skip_serializing_if = "Option::is_none")]
+	pub system: Option<RequestContent>,
+
+	#[serde(skip_serializing_if = "Option::is_none")]
 	pub top_p: Option<f32>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub temperature: Option<f32>,
@@ -93,10 +96,55 @@ impl RequestType for Request {
 	fn model(&mut self) -> &mut Option<String> {
 		&mut self.model
 	}
+
 	fn prepend_prompts(&mut self, prompts: Vec<SimpleChatCompletionMessage>) {
+		if prompts.is_empty() {
+			return;
+		}
+
+		let (system_prompts, message_prompts): (Vec<_>, Vec<_>) = prompts
+			.into_iter()
+			.partition(|p| p.role.as_str() == "system");
+
+		if !system_prompts.is_empty() {
+			match &mut self.system {
+				Some(RequestContent::Text(existing)) => {
+					let prepend_text = system_prompts
+						.into_iter()
+						.map(|p| p.content.to_string())
+						.collect::<Vec<_>>()
+						.join("\n\n");
+
+					*existing = format!("{}\n\n{}", prepend_text, existing);
+				},
+				Some(RequestContent::Array(existing)) => {
+					existing.splice(
+						..0,
+						system_prompts.into_iter().map(|p| ContentPart {
+							r#type: "text".to_string(),
+							text: Some(p.content.to_string()),
+							rest: Default::default(),
+						}),
+					);
+				},
+				None => {
+					self.system = Some(RequestContent::Array(
+						system_prompts
+							.into_iter()
+							.map(|p| ContentPart {
+								r#type: "text".to_string(),
+								text: Some(p.content.to_string()),
+								rest: Default::default(),
+							})
+							.collect(),
+					));
+				},
+			}
+		}
+
 		self
 			.messages
-			.splice(..0, prompts.into_iter().map(Into::into));
+			.splice(..0, message_prompts.into_iter().map(Into::into));
 	}
 
 	fn to_llm_request(&self, provider: Strng, tokenize: bool) -> Result<LLMRequest, AIError> {

--- a/crates/agentgateway/src/llm/types/mod.rs
+++ b/crates/agentgateway/src/llm/types/mod.rs
@@ -29,6 +29,7 @@ pub trait ResponseType: Send + Sync {
 pub trait RequestType: Send + Sync {
 	fn model(&mut self) -> &mut Option<String>;
 	fn prepend_prompts(&mut self, prompts: Vec<SimpleChatCompletionMessage>);
+	fn append_prompts(&mut self, prompts: Vec<SimpleChatCompletionMessage>);
 	fn to_llm_request(&self, provider: Strng, tokenize: bool) -> Result<LLMRequest, AIError>;
 	fn get_messages(&self) -> Vec<SimpleChatCompletionMessage>;
 	fn set_messages(&mut self, messages: Vec<SimpleChatCompletionMessage>);

--- a/schema/config.json
+++ b/schema/config.json
@@ -2622,9 +2622,7 @@
                                   }
                                 },
                                 "additionalProperties": false,
-                                "required": [
-                                  "prepend"
-                                ]
+                                "minProperties": 1
                               },
                               "modelAliases": {
                                 "type": "object",
@@ -4857,9 +4855,7 @@
                                         }
                                       },
                                       "additionalProperties": false,
-                                      "required": [
-                                        "prepend"
-                                      ]
+                                      "minProperties": 1
                                     },
                                     "modelAliases": {
                                       "type": "object",
@@ -6669,9 +6665,7 @@
                                                     }
                                                   },
                                                   "additionalProperties": false,
-                                                  "required": [
-                                                    "prepend"
-                                                  ]
+                                                  "minProperties": 1
                                                 },
                                                 "modelAliases": {
                                                   "type": "object",
@@ -8231,9 +8225,7 @@
                                                                 }
                                                               },
                                                               "additionalProperties": false,
-                                                              "required": [
-                                                                "prepend"
-                                                              ]
+                                                              "minProperties": 1
                                                             },
                                                             "modelAliases": {
                                                               "type": "object",
@@ -12186,9 +12178,7 @@
                       }
                     },
                     "additionalProperties": false,
-                    "required": [
-                      "prepend"
-                    ]
+                    "minProperties": 1
                   },
                   "modelAliases": {
                     "type": "object",
@@ -14436,9 +14426,7 @@
                       }
                     },
                     "additionalProperties": false,
-                    "required": [
-                      "prepend"
-                    ]
+                    "minProperties": 1
                   },
                   "modelAliases": {
                     "type": "object",
@@ -15017,9 +15005,7 @@
             }
           },
           "additionalProperties": false,
-          "required": [
-            "prepend"
-          ]
+          "minProperties": 1
         },
         "modelAliases": {
           "type": "object",


### PR DESCRIPTION
Fixes #674 adding support for prepending and appending prompts to Anthropic `Messages` & OpenAI `Completions/Responses` formats.