### PR TITLE
mcp: implement downstream session persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,6 +143,7 @@ dependencies = [
  "atomic_float",
  "aws-config",
  "aws-credential-types",
+ "aws-lc-rs",
  "aws-sigv4",
  "aws_event_stream_parser",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ aws-config = "1.8"
 aws-credential-types = "1.2"
 aws_event_stream_parser = "0.1"
 aws-sigv4 = "1.3"
+aws-lc-rs = "1.15"
 axum = { version = "0.8", features = ["macros"] }
 axum-core = "0.5"
 axum-extra = { version = "0.12", features = ["json-lines", "typed-header"] }

--- a/crates/agentgateway/Cargo.toml
+++ b/crates/agentgateway/Cargo.toml
@@ -32,6 +32,7 @@ atomic_float.workspace = true
 aws-config.workspace = true
 aws-credential-types.workspace = true
 aws-sigv4.workspace = true
+aws-lc-rs.workspace = true
 aws_event_stream_parser.workspace = true
 axum-core.workspace = true
 axum-extra.workspace = true
@@ -135,6 +136,7 @@ uuid.workspace = true
 x509-parser.workspace = true
 reqwest = { optional = true, workspace = true }
 websocket-sans-io.workspace = true
+
 
 # Linux only dependencies
 [target.'cfg(target_family = "unix")'.dependencies]

--- a/crates/agentgateway/src/app.rs
+++ b/crates/agentgateway/src/app.rs
@@ -121,7 +121,7 @@ pub async fn run(config: Arc<Config>) -> anyhow::Result<Bound> {
 		upstream: client.clone(),
 		ca,
 
-		mcp_state: mcp::App::new(stores.clone()),
+		mcp_state: mcp::App::new(stores.clone(), config.session_encoder.clone()),
 	};
 
 	let gw = proxy::Gateway::new(Arc::new(pi), drain_rx.clone());

--- a/crates/agentgateway/src/http/mod.rs
+++ b/crates/agentgateway/src/http/mod.rs
@@ -20,6 +20,7 @@ pub mod ext_proc;
 pub mod outlierdetection;
 mod peekbody;
 pub mod remoteratelimit;
+pub mod sessionpersistence;
 #[cfg(any(test, feature = "internal_benches"))]
 pub mod tests_common;
 pub mod transformation_cel;

--- a/crates/agentgateway/src/http/sessionpersistence.rs
+++ b/crates/agentgateway/src/http/sessionpersistence.rs
@@ -1,0 +1,188 @@
+use crate::*;
+
+#[apply(schema!)]
+pub struct Policy {}
+
+#[apply(schema!)]
+#[serde(tag = "t")]
+pub enum SessionState {
+	#[serde(rename = "http")]
+	HTTP(HTTPSessionState),
+	#[serde(rename = "mcp")]
+	MCP(MCPSessionState),
+}
+
+impl SessionState {
+	pub fn encode(&self, encoder: &Encoder) -> Result<String, Error> {
+		encoder.encrypt(&serde_json::to_string(self)?)
+	}
+
+	pub fn decode(session_id: &str, encoder: &Encoder) -> Result<SessionState, Error> {
+		let session = encoder.decrypt(session_id)?;
+		let state = serde_json::from_slice::<SessionState>(&session)
+			.map_err(|_| Error::InvalidSessionEncoding)?;
+		Ok(state)
+	}
+}
+
+#[apply(schema!)]
+pub struct HTTPSessionState {
+	pub backend: SocketAddr,
+}
+
+#[apply(schema!)]
+pub struct MCPSessionState {
+	#[serde(rename = "s")]
+	pub sessions: Vec<MCPSession>,
+}
+
+#[apply(schema!)]
+pub struct MCPSession {
+	#[serde(rename = "s")]
+	pub session: String,
+	#[serde(rename = "b")]
+	pub backend: SocketAddr,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+	#[error("invalid session encoding")]
+	InvalidSessionEncoding,
+	#[error("invalid session format: {0}")]
+	InvalidSessionFormat(#[from] serde_json::Error),
+	#[error("encryption: {0}")]
+	Encryption(#[from] aes::Error),
+}
+
+#[derive(Debug, Clone)]
+pub enum Encoder {
+	Base64(base64::Encoder),
+	Aes(Arc<aes::Encoder>),
+}
+
+impl Encoder {
+	pub fn base64() -> Encoder {
+		Encoder::Base64(base64::Encoder)
+	}
+	pub fn aes(key: &str) -> anyhow::Result<Encoder> {
+		let key = hex::decode(key)?;
+		// AES-256-GCM requires a 32-byte key (64 hex characters when encoded with `openssl rand -hex 32`).
+		if key.len() != 32 {
+			anyhow::bail!(
+				"invalid AES-256-GCM key length: expected 32 bytes (64 hex characters), got {} bytes ({} hex characters)",
+				key.len(),
+				key.len() * 2,
+			);
+		}
+		let enc = aes::Encoder::new(key.as_ref())?;
+		Ok(Encoder::Aes(Arc::new(enc)))
+	}
+}
+
+impl Serialize for Encoder {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: Serializer,
+	{
+		match self {
+			Encoder::Base64(_) => serializer.serialize_str("base64"),
+			Encoder::Aes(_) => serializer.serialize_str("aes"),
+		}
+	}
+}
+
+impl Encoder {
+	pub fn encrypt(&self, plaintext: &str) -> Result<String, Error> {
+		match self {
+			Encoder::Base64(e) => Ok(e.encrypt(plaintext)),
+			Encoder::Aes(e) => e.encrypt(plaintext).map_err(Into::into),
+		}
+	}
+	pub fn decrypt(&self, encoded: &str) -> Result<Vec<u8>, Error> {
+		match self {
+			Encoder::Base64(e) => e
+				.decrypt(encoded)
+				.map_err(|_| Error::InvalidSessionEncoding),
+			Encoder::Aes(e) => e.decrypt(encoded).map_err(Into::into),
+		}
+	}
+}
+
+mod base64 {
+	use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+
+	#[derive(Debug, Clone)]
+	pub struct Encoder;
+
+	impl Encoder {
+		pub fn encrypt(&self, plaintext: &str) -> String {
+			URL_SAFE_NO_PAD.encode(plaintext)
+		}
+		pub fn decrypt(&self, encoded: &str) -> Result<Vec<u8>, base64::DecodeError> {
+			URL_SAFE_NO_PAD.decode(encoded)
+		}
+	}
+}
+
+mod aes {
+	use aws_lc_rs::aead::{AES_256_GCM, Aad, Nonce, RandomizedNonceKey};
+	use base64::{Engine, engine::general_purpose::STANDARD};
+
+	#[derive(Debug)]
+	pub struct Encoder {
+		key: RandomizedNonceKey,
+	}
+
+	impl Encoder {
+		/// Create from a 32-byte key
+		pub fn new(key: &[u8]) -> Result<Self, Error> {
+			let key = RandomizedNonceKey::new(&AES_256_GCM, key).map_err(|_| Error::InvalidKey)?;
+			Ok(Self { key })
+		}
+
+		/// Encrypt and base64 encode
+		pub fn encrypt(&self, plaintext: &str) -> Result<String, Error> {
+			let mut in_out: Vec<u8> = plaintext.as_bytes().to_vec();
+			// Seal automatically generates a random nonce and prepends it
+			let nonce = self
+				.key
+				.seal_in_place_append_tag(Aad::empty(), &mut in_out)
+				.map_err(|_| Error::EncryptionFailed)?;
+
+			// Format: nonce || ciphertext+tag
+			let mut result = nonce.as_ref().to_vec();
+			result.extend_from_slice(&in_out);
+			// Base64 encode
+			Ok(STANDARD.encode(&result))
+		}
+
+		/// Decode and decrypt
+		pub fn decrypt(&self, encoded: &str) -> Result<Vec<u8>, Error> {
+			// Base64 decode
+			let data = STANDARD.decode(encoded).map_err(|_| Error::InvalidFormat)?;
+
+			// Extract nonce and ciphertext
+			let (nonce_bytes, ciphertext) = data.split_at(12);
+			let nonce =
+				Nonce::try_assume_unique_for_key(nonce_bytes).map_err(|_| Error::InvalidFormat)?;
+			let mut in_out = ciphertext.to_vec();
+			let plaintext = self
+				.key
+				.open_in_place(nonce, Aad::empty(), &mut in_out)
+				.map_err(|_| Error::DecryptionFailed)?;
+			Ok(plaintext.to_vec())
+		}
+	}
+
+	#[derive(Debug, thiserror::Error)]
+	pub enum Error {
+		#[error("invalid key")]
+		InvalidKey,
+		#[error("encryption failed")]
+		EncryptionFailed,
+		#[error("decryption failed")]
+		DecryptionFailed,
+		#[error("invalid format")]
+		InvalidFormat,
+	}
+}

--- a/crates/agentgateway/src/lib.rs
+++ b/crates/agentgateway/src/lib.rs
@@ -87,6 +87,9 @@ pub struct RawConfig {
 	/// Readiness probe server address in the format "ip:port"
 	readiness_addr: Option<String>,
 
+	/// Configuration for stateful session management
+	session: Option<RawSession>,
+
 	#[serde(default, with = "serde_dur_option")]
 	#[cfg_attr(feature = "schema", schemars(with = "Option<String>"))]
 	connection_termination_deadline: Option<Duration>,
@@ -190,6 +193,15 @@ pub struct RawHBONE {
 	#[serde(with = "serde_dur_option")]
 	#[cfg_attr(feature = "schema", schemars(with = "Option<String>"))]
 	pool_unused_release_timeout: Option<Duration>,
+}
+
+#[apply(schema_de!)]
+pub struct RawSession {
+	/// The signing key to be used. If not set, sessions will not be encrypted.
+	/// For example, generated via `openssl rand -hex 32`.
+	#[cfg_attr(feature = "schema", schemars(with = "String"))]
+	#[serde(serialize_with = "ser_redact", deserialize_with = "deser_key")]
+	key: secrecy::SecretString,
 }
 
 #[apply(schema_de!)]
@@ -378,6 +390,7 @@ pub struct Config {
 	pub dns: client::Config,
 	pub proxy_metadata: ProxyMetadata,
 	pub threading_mode: ThreadingMode,
+	pub session_encoder: http::sessionpersistence::Encoder,
 	/// Handle for tasks/spans emitted on the admin runtime.
 	#[serde(skip)]
 	pub admin_runtime_handle: Option<tokio::runtime::Handle>,

--- a/crates/agentgateway/src/mcp/router.rs
+++ b/crates/agentgateway/src/mcp/router.rs
@@ -15,6 +15,7 @@ use tracing::{debug, warn};
 use crate::cel::ContextBuilder;
 use crate::http::authorization::RuleSets;
 use crate::http::jwt::Claims;
+use crate::http::sessionpersistence::Encoder;
 use crate::http::*;
 use crate::json::from_body_with_limit;
 use crate::mcp::handler::Relay;
@@ -40,8 +41,8 @@ pub struct App {
 }
 
 impl App {
-	pub fn new(state: Stores) -> Self {
-		let session: Arc<SessionManager> = Arc::new(Default::default());
+	pub fn new(state: Stores, encoder: Encoder) -> Self {
+		let session: Arc<SessionManager> = Arc::new(crate::mcp::session::SessionManager::new(encoder));
 		Self { state, session }
 	}
 

--- a/crates/agentgateway/src/mcp/sse.rs
+++ b/crates/agentgateway/src/mcp/sse.rs
@@ -70,7 +70,7 @@ impl LegacySSEService {
 			},
 		};
 
-		let Some(session) = self.session_manager.get_session(&session_id) else {
+		let Some(mut session) = self.session_manager.get_session(&session_id) else {
 			return http_error(http::StatusCode::NOT_FOUND, "Session not found");
 		};
 

--- a/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
@@ -22,6 +22,7 @@ async fn setup() -> (MockServer, Handler) {
 	let host = server.uri();
 	let parsed = reqwest::Url::parse(&host).unwrap();
 	let config = crate::config::parse_config("{}".to_string(), None).unwrap();
+	let encoder = config.session_encoder.clone();
 	let stores = Stores::new();
 	let client = Client::new(
 		&client::Config {
@@ -43,7 +44,7 @@ async fn setup() -> (MockServer, Handler) {
 		upstream: client.clone(),
 		ca: None,
 
-		mcp_state: mcp::router::App::new(stores.clone()),
+		mcp_state: mcp::router::App::new(stores.clone(), encoder),
 	});
 
 	let client = PolicyClient { inputs: pi.clone() };

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -214,6 +214,8 @@ async fn apply_backend_policies(
 		request_header_modifier,
 		response_header_modifier,
 		request_redirect,
+		// TODO: implement session persistence
+		session_persistence: _,
 		// Applied elsewhere
 		request_mirror: _,
 		// Applied elsewhere

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -106,6 +106,8 @@ pub struct BackendPolicies {
 	pub request_redirect: Option<filters::RequestRedirect>,
 	pub request_mirror: Vec<filters::RequestMirror>,
 
+	pub session_persistence: Option<http::sessionpersistence::Policy>,
+
 	/// Internal-only override for destination endpoint selection.
 	/// Used for stateful MCP routing (session affinity).
 	/// Not exposed through config - set programmatically only.
@@ -138,6 +140,7 @@ impl BackendPolicies {
 			} else {
 				other.request_mirror
 			},
+			session_persistence: other.session_persistence.or(self.session_persistence),
 			override_dest: other.override_dest.or(self.override_dest),
 		}
 	}
@@ -605,6 +608,9 @@ impl Store {
 				},
 				BackendPolicy::RequestRedirect(p) => {
 					pol.request_redirect.get_or_insert_with(|| p.clone());
+				},
+				BackendPolicy::SessionPersistence(p) => {
+					pol.session_persistence.get_or_insert_with(|| p.clone());
 				},
 				BackendPolicy::RequestMirror(p) => {
 					if pol.request_mirror.is_empty() {

--- a/crates/agentgateway/src/test_helpers/proxymock.rs
+++ b/crates/agentgateway/src/test_helpers/proxymock.rs
@@ -599,6 +599,7 @@ impl TestBind {
 pub fn setup_proxy_test(cfg: &str) -> anyhow::Result<TestBind> {
 	agent_core::telemetry::testing::setup_test_logging();
 	let config = crate::config::parse_config(cfg.to_string(), None)?;
+	let encoder = config.session_encoder.clone();
 	let stores = Stores::new();
 	let client = client::Client::new(&config.dns, None, Default::default(), None);
 	let (drain_tx, drain_rx) = drain::new();
@@ -613,7 +614,7 @@ pub fn setup_proxy_test(cfg: &str) -> anyhow::Result<TestBind> {
 		upstream: client.clone(),
 		ca: None,
 
-		mcp_state: mcp::App::new(stores.clone()),
+		mcp_state: mcp::App::new(stores.clone(), encoder),
 	});
 	Ok(TestBind {
 		pi,

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -1913,6 +1913,7 @@ pub enum BackendPolicy {
 	BackendAuth(BackendAuth),
 	InferenceRouting(ext_proc::InferenceRouting),
 	AI(Arc<llm::Policy>),
+	SessionPersistence(http::sessionpersistence::Policy),
 
 	RequestHeaderModifier(filters::HeaderModifier),
 	ResponseHeaderModifier(filters::HeaderModifier),

--- a/schema/config.json
+++ b/schema/config.json
@@ -100,6 +100,23 @@
             "null"
           ]
         },
+        "session": {
+          "description": "Configuration for stateful session management",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "key": {
+              "description": "The signing key to be used. If not set, sessions will not be encrypted.\nFor example, generated via `openssl rand -hex 32`.",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "key"
+          ]
+        },
         "connectionTerminationDeadline": {
           "type": [
             "string",

--- a/schema/config.md
+++ b/schema/config.md
@@ -18,6 +18,8 @@
 |`config.adminAddr`|Admin UI address in the format "ip:port"|
 |`config.statsAddr`|Stats/metrics server address in the format "ip:port"|
 |`config.readinessAddr`|Readiness probe server address in the format "ip:port"|
+|`config.session`|Configuration for stateful session management|
+|`config.session.key`|The signing key to be used. If not set, sessions will not be encrypted.<br>For example, generated via `openssl rand -hex 32`.|
 |`config.connectionTerminationDeadline`||
 |`config.connectionMinTerminationDeadline`||
 |`config.workerThreads`||


### PR DESCRIPTION
There are two relevant portions of session persistence in MCP:
1. If there are multiple replicas of a single MCP backend, we want to make sure we consistently hit the same one (for Kubernetes). Technically, the backend MCP server *could* share session state across pods, but this I have seen 0 examples doing such. This is already implemented and happens transparently.
2. If I have multiple replicas of Agentgateway, or restart it, we want to ensure existing sessions are not broken.

This PR implements (2).

Before: the downstream session was a random UUID and stored in memory in a hashmap

With this PR: the downstream session is an encoding of the internal state. The clients (per spec) send the encoded state back, and we decode it. This makes us entirely stateless in the proxy itself; all "state" is passed on each request by the client (transparently to them).

Currently this state includes the backend IP (so (1) continues to work) and the upstream session ID. This is designed to be extensible in the future if needed. Sessions can be encoded through two mechanisms:
* Base64 encoding (obviously, this is NOT encryption). Suitable if the internal IPs are acceptable to be exposed to end users.
* AES-GCM encryption. Users pass a 32bit key (hex encoded) to be used as the signing key. In Kgateway we can automatically generate this.

The end result is that you can run N Agentgateway replicas (and scale them up/down, restart, etc) and N MCP backend replicas and retain a persistent session across them.