### PR TITLE
Use IPv6 :: address for XDS binds

### DIFF
--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -491,7 +491,7 @@ impl TryFrom<&proto::agent::Bind> for Bind {
 	fn try_from(s: &proto::agent::Bind) -> Result<Self, Self::Error> {
 		Ok(Self {
 			key: s.key.clone().into(),
-			address: SocketAddr::from((IpAddr::from([0, 0, 0, 0]), s.port as u16)),
+			address: SocketAddr::from((IpAddr::from([0, 0, 0, 0, 0, 0, 0, 0]), s.port as u16)),
 			listeners: Default::default(),
 			protocol: match proto::agent::bind::Protocol::try_from(s.protocol)? {
 				proto::agent::bind::Protocol::Http => BindProtocol::http,


### PR DESCRIPTION
Addressing https://github.com/agentgateway/agentgateway/issues/819

It will bind to both IPv6 and IPv4.

Unsure what will happen on Windows, and unfortunately I don't any means to test it.