### PR TITLE
Improve clippy support when using jj workspaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ lint:
 
 .PHONY: fix-lint
 fix-lint:
-	cargo clippy --fix --allow-staged --allow-dirty --workspace
+	cargo clippy --fix --allow-staged --allow-dirty --allow-no-vcs --workspace
 	cargo fmt
 
 # test


### PR DESCRIPTION
Fixes `make gen` and `make lint-fix` when using jj workspaces which sadly dont have more than one [.git](https://docs.jj-vcs.dev/latest/git-compatibility/#colocated-jujutsugit-workspaces) repo.