### PR TITLE
Made config.enableIpv6 affect the route socket bindings

### DIFF
--- a/crates/agentgateway-app/src/main.rs
+++ b/crates/agentgateway-app/src/main.rs
@@ -131,7 +131,7 @@ async fn validate(contents: String, filename: Option<PathBuf>) -> anyhow::Result
 	if let Some(cfg) = config.xds.local_config.as_ref() {
 		let cs = cfg.read_to_string().await?;
 		agentgateway::types::local::NormalizedLocalConfig::from(
-            Arc::new(config),
+			Arc::new(config),
 			client,
 			ListenerTarget {
 				gateway_name: strng::literal!("default"),

--- a/crates/agentgateway-app/src/main.rs
+++ b/crates/agentgateway-app/src/main.rs
@@ -128,9 +128,10 @@ fn copy_binary(copy_self: PathBuf) -> anyhow::Result<()> {
 async fn validate(contents: String, filename: Option<PathBuf>) -> anyhow::Result<()> {
 	let config = agentgateway::config::parse_config(contents, filename)?;
 	let client = client::Client::new(&config.dns, None, BackendConfig::default(), None);
-	if let Some(cfg) = config.xds.local_config {
+	if let Some(cfg) = config.xds.local_config.as_ref() {
 		let cs = cfg.read_to_string().await?;
 		agentgateway::types::local::NormalizedLocalConfig::from(
+            Arc::new(config),
 			client,
 			ListenerTarget {
 				gateway_name: strng::literal!("default"),

--- a/crates/agentgateway-app/src/main.rs
+++ b/crates/agentgateway-app/src/main.rs
@@ -131,7 +131,7 @@ async fn validate(contents: String, filename: Option<PathBuf>) -> anyhow::Result
 	if let Some(cfg) = config.xds.local_config.as_ref() {
 		let cs = cfg.read_to_string().await?;
 		agentgateway::types::local::NormalizedLocalConfig::from(
-			Arc::new(config),
+			&config,
 			client,
 			ListenerTarget {
 				gateway_name: strng::literal!("default"),

--- a/crates/agentgateway/src/app.rs
+++ b/crates/agentgateway/src/app.rs
@@ -84,7 +84,7 @@ pub async fn run(config: Arc<Config>) -> anyhow::Result<Bound> {
 
 	let (xds_tx, xds_rx) = tokio::sync::watch::channel(());
 	let state_mgr =
-		state_manager::StateManager::new(&config.xds, control_client.clone(), xds_metrics, xds_tx)
+		state_manager::StateManager::new(config.clone(), control_client.clone(), xds_metrics, xds_tx)
 			.await?;
 	let mut xds_rx_for_task = xds_rx.clone();
 	tokio::spawn(async move {

--- a/crates/agentgateway/src/config.rs
+++ b/crates/agentgateway/src/config.rs
@@ -225,7 +225,7 @@ pub fn parse_config(contents: String, filename: Option<PathBuf>) -> anyhow::Resu
 	};
 
 	Ok(crate::Config {
-        ipv6_enabled,
+		ipv6_enabled,
 		network: network.into(),
 		admin_addr,
 		stats_addr,

--- a/crates/agentgateway/src/config.rs
+++ b/crates/agentgateway/src/config.rs
@@ -225,6 +225,7 @@ pub fn parse_config(contents: String, filename: Option<PathBuf>) -> anyhow::Resu
 	};
 
 	Ok(crate::Config {
+        ipv6_enabled,
 		network: network.into(),
 		admin_addr,
 		stats_addr,

--- a/crates/agentgateway/src/lib.rs
+++ b/crates/agentgateway/src/lib.rs
@@ -355,7 +355,7 @@ impl schemars::JsonSchema for StringBoolFloat {
 #[derive(serde::Serialize, Clone, Debug)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct Config {
-    pub ipv6_enabled: bool,
+	pub ipv6_enabled: bool,
 	pub network: Strng,
 	#[serde(with = "serde_dur")]
 	pub termination_max_deadline: Duration,

--- a/crates/agentgateway/src/lib.rs
+++ b/crates/agentgateway/src/lib.rs
@@ -355,6 +355,7 @@ impl schemars::JsonSchema for StringBoolFloat {
 #[derive(serde::Serialize, Clone, Debug)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct Config {
+    pub ipv6_enabled: bool,
 	pub network: Strng,
 	#[serde(with = "serde_dur")]
 	pub termination_max_deadline: Duration,

--- a/crates/agentgateway/src/state_manager.rs
+++ b/crates/agentgateway/src/state_manager.rs
@@ -187,7 +187,7 @@ impl LocalClient {
 	async fn reload_config(&self, prev: PreviousState) -> anyhow::Result<PreviousState> {
 		let config_content = self.cfg.read_to_string().await?;
 		let config = crate::types::local::NormalizedLocalConfig::from(
-			self.config.clone(),
+			&self.config,
 			self.client.clone(),
 			self.gateway.clone(),
 			config_content.as_str(),

--- a/crates/agentgateway/src/state_manager.rs
+++ b/crates/agentgateway/src/state_manager.rs
@@ -34,7 +34,7 @@ impl StateManager {
 		xds_metrics: agent_xds::Metrics,
 		awaiting_ready: tokio::sync::watch::Sender<()>,
 	) -> anyhow::Result<Self> {
-		let xds = &config.clone().xds;
+		let xds = &config.xds;
 		let stores = Stores::new();
 		let xds_client = if xds.address.is_some() {
 			let connector = control::grpc_connector(
@@ -60,7 +60,7 @@ impl StateManager {
 		};
 		if let Some(cfg) = &xds.local_config {
 			let local_client = LocalClient {
-				config,
+				config: config.clone(),
 				stores: stores.clone(),
 				cfg: cfg.clone(),
 				client,

--- a/crates/agentgateway/src/state_manager.rs
+++ b/crates/agentgateway/src/state_manager.rs
@@ -34,7 +34,7 @@ impl StateManager {
 		xds_metrics: agent_xds::Metrics,
 		awaiting_ready: tokio::sync::watch::Sender<()>,
 	) -> anyhow::Result<Self> {
-        let xds = &config.clone().xds;
+		let xds = &config.clone().xds;
 		let stores = Stores::new();
 		let xds_client = if xds.address.is_some() {
 			let connector = control::grpc_connector(
@@ -60,7 +60,7 @@ impl StateManager {
 		};
 		if let Some(cfg) = &xds.local_config {
 			let local_client = LocalClient {
-                config,
+				config,
 				stores: stores.clone(),
 				cfg: cfg.clone(),
 				client,
@@ -90,7 +90,7 @@ impl StateManager {
 /// LocalClient serves as a local file reader alternative for XDS. This is intended for testing.
 #[derive(Debug, Clone)]
 pub struct LocalClient {
-    config: Arc<crate::Config>,
+	config: Arc<crate::Config>,
 	pub cfg: ConfigSource,
 	pub stores: Stores,
 	pub client: Client,
@@ -187,7 +187,7 @@ impl LocalClient {
 	async fn reload_config(&self, prev: PreviousState) -> anyhow::Result<PreviousState> {
 		let config_content = self.cfg.read_to_string().await?;
 		let config = crate::types::local::NormalizedLocalConfig::from(
-            self.config.clone(),
+			self.config.clone(),
 			self.client.clone(),
 			self.gateway.clone(),
 			config_content.as_str(),

--- a/crates/agentgateway/src/state_manager.rs
+++ b/crates/agentgateway/src/state_manager.rs
@@ -29,26 +29,26 @@ pub const ADP_TYPE: Strng =
 
 impl StateManager {
 	pub async fn new(
-		config: &crate::XDSConfig,
+		config: Arc<crate::Config>,
 		client: client::Client,
 		xds_metrics: agent_xds::Metrics,
 		awaiting_ready: tokio::sync::watch::Sender<()>,
 	) -> anyhow::Result<Self> {
+        let xds = &config.clone().xds;
 		let stores = Stores::new();
-
-		let xds_client = if config.address.is_some() {
+		let xds_client = if xds.address.is_some() {
 			let connector = control::grpc_connector(
 				client.clone(),
-				config.address.as_ref().unwrap().clone(),
-				config.auth.clone(),
-				config.ca_cert.clone(),
+				xds.address.as_ref().unwrap().clone(),
+				xds.auth.clone(),
+				xds.ca_cert.clone(),
 			)
 			.await?;
 			Some(
 				agent_xds::Config::new(
 					agent_xds::GrpcClient::new(connector),
-					config.gateway.clone(),
-					config.namespace.clone(),
+					xds.gateway.clone(),
+					xds.namespace.clone(),
 				)
 				.with_watched_handler::<XdsAddress>(ADDRESS_TYPE, stores.clone().discovery.clone())
 				.with_watched_handler::<ADPResource>(ADP_TYPE, stores.clone().binds.clone())
@@ -58,14 +58,15 @@ impl StateManager {
 		} else {
 			None
 		};
-		if let Some(cfg) = &config.local_config {
+		if let Some(cfg) = &xds.local_config {
 			let local_client = LocalClient {
+                config,
 				stores: stores.clone(),
 				cfg: cfg.clone(),
 				client,
 				gateway: ListenerTarget {
-					gateway_name: config.gateway.clone(),
-					gateway_namespace: config.namespace.clone(),
+					gateway_name: xds.gateway.clone(),
+					gateway_namespace: xds.namespace.clone(),
 					listener_name: None,
 				},
 			};
@@ -89,6 +90,7 @@ impl StateManager {
 /// LocalClient serves as a local file reader alternative for XDS. This is intended for testing.
 #[derive(Debug, Clone)]
 pub struct LocalClient {
+    config: Arc<crate::Config>,
 	pub cfg: ConfigSource,
 	pub stores: Stores,
 	pub client: Client,
@@ -185,6 +187,7 @@ impl LocalClient {
 	async fn reload_config(&self, prev: PreviousState) -> anyhow::Result<PreviousState> {
 		let config_content = self.cfg.read_to_string().await?;
 		let config = crate::types::local::NormalizedLocalConfig::from(
+            self.config.clone(),
 			self.client.clone(),
 			self.gateway.clone(),
 			config_content.as_str(),

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -36,7 +36,7 @@ use crate::*;
 
 impl NormalizedLocalConfig {
 	pub async fn from(
-        config: Arc<crate::Config>,
+		config: Arc<crate::Config>,
 		client: client::Client,
 		gateway_name: ListenerTarget,
 		s: &str,
@@ -888,7 +888,7 @@ struct TCPFilterOrPolicy {
 async fn convert(
 	client: client::Client,
 	gateway: ListenerTarget,
-    config: Arc<crate::Config>,
+	config: Arc<crate::Config>,
 	i: LocalConfig,
 ) -> anyhow::Result<NormalizedLocalConfig> {
 	let LocalConfig {

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -36,7 +36,7 @@ use crate::*;
 
 impl NormalizedLocalConfig {
 	pub async fn from(
-		config: Arc<crate::Config>,
+		config: &crate::Config,
 		client: client::Client,
 		gateway_name: ListenerTarget,
 		s: &str,
@@ -888,7 +888,7 @@ struct TCPFilterOrPolicy {
 async fn convert(
 	client: client::Client,
 	gateway: ListenerTarget,
-	config: Arc<crate::Config>,
+	config: &crate::Config,
 	i: LocalConfig,
 ) -> anyhow::Result<NormalizedLocalConfig> {
 	let LocalConfig {

--- a/crates/agentgateway/src/ui.rs
+++ b/crates/agentgateway/src/ui.rs
@@ -107,7 +107,7 @@ async fn write_config(
 		yamlviajson::to_string(&config_json).map_err(|e| ErrorResponse::Anyhow(e.into()))?;
 
 	if let Err(e) = crate::types::local::NormalizedLocalConfig::from(
-        &app.state,
+		&app.state,
 		app.client.clone(),
 		app.state.gateway(),
 		yaml_content.as_str(),

--- a/crates/agentgateway/src/ui.rs
+++ b/crates/agentgateway/src/ui.rs
@@ -107,6 +107,7 @@ async fn write_config(
 		yamlviajson::to_string(&config_json).map_err(|e| ErrorResponse::Anyhow(e.into()))?;
 
 	if let Err(e) = crate::types::local::NormalizedLocalConfig::from(
+        &app.state,
 		app.client.clone(),
 		app.state.gateway(),
 		yaml_content.as_str(),


### PR DESCRIPTION
# Overview
Have the same config property that the other binds (admin UI, readiness and stats) use, also affect IPv4 vs IPv6 sockets for each bind,
to allow configuration which supplements the choice of port binding which already exists. I.e. specifying the following configuration
affects route port bindings (i.e. client access points):
```yaml
config:
	enableIpv6: <true | false>
```


# Tickets
* INS JIRA: https://instaclustr.atlassian.net/browse/INS-39453
* Upstream GitHub issue: https://github.com/agentgateway/agentgateway/issues/835