### PR TITLE
Enable ext_proc gRCP initial_metadata

### DIFF
--- a/crates/agentgateway/src/test_helpers/extprocmock.rs
+++ b/crates/agentgateway/src/test_helpers/extprocmock.rs
@@ -86,6 +86,8 @@ pub fn response_header_response_with_dynamic_metadata(
 
 #[async_trait]
 pub trait Handler {
+	async fn on_stream_start(&mut self, _metadata: &tonic::metadata::MetadataMap) {}
+
 	async fn on_request(&mut self, _request: &ProcessingRequest) {}
 
 	async fn handle_request_headers(
@@ -221,7 +223,11 @@ where
 
 		let mut handler = (self.handler.clone())();
 
+		let metadata = request.metadata().clone();
+
 		tokio::spawn(async move {
+			handler.on_stream_start(&metadata).await;
+
 			let mut request_stream = request.into_inner();
 
 			while let Some(request_result) = request_stream.message().await? {

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -1334,6 +1334,7 @@ impl TryFrom<&proto::agent::TrafficPolicySpec> for TrafficPolicy {
 				TrafficPolicy::ExtProc(http::ext_proc::ExtProc {
 					target: Arc::new(target),
 					failure_mode,
+					initial_metadata: None,
 					request_attributes: to_cel_attrs(&ep.request_attributes),
 					response_attributes: to_cel_attrs(&ep.response_attributes),
 				})

--- a/schema/config.json
+++ b/schema/config.json
@@ -3838,6 +3838,16 @@
                                     ],
                                     "default": "failClosed"
                                   },
+                                  "initialMetadata": {
+                                    "description": "Initial metadata applied as HTTP/2 headers when establishing the gRPC stream.\nSupports CEL expressions evaluated with full request context.",
+                                    "type": [
+                                      "object",
+                                      "null"
+                                    ],
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    }
+                                  },
                                   "requestAttributes": {
                                     "description": "Maps to the request `attributes` field in ProcessingRequest, and allows dynamic CEL expressions.",
                                     "type": [
@@ -9703,6 +9713,16 @@
                               ],
                               "default": "failClosed"
                             },
+                            "initialMetadata": {
+                              "description": "Initial metadata applied as HTTP/2 headers when establishing the gRPC stream.\nSupports CEL expressions evaluated with full request context.",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "additionalProperties": {
+                                "type": "string"
+                              }
+                            },
                             "requestAttributes": {
                               "description": "Maps to the request `attributes` field in ProcessingRequest, and allows dynamic CEL expressions.",
                               "type": [
@@ -13648,6 +13668,16 @@
                           "failOpen"
                         ],
                         "default": "failClosed"
+                      },
+                      "initialMetadata": {
+                        "description": "Initial metadata applied as HTTP/2 headers when establishing the gRPC stream.\nSupports CEL expressions evaluated with full request context.",
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "additionalProperties": {
+                          "type": "string"
+                        }
                       },
                       "requestAttributes": {
                         "description": "Maps to the request `attributes` field in ProcessingRequest, and allows dynamic CEL expressions.",

--- a/schema/config.md
+++ b/schema/config.md
@@ -415,6 +415,7 @@
 |`binds[].listeners[].routes[].policies.extProc.(any)(1)host`|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.extProc.(any)(1)backend`|Explicit backend reference. Backend must be defined in the top level backends list|
 |`binds[].listeners[].routes[].policies.extProc.(any)failureMode`|Behavior when the ext_proc service is unavailable or returns an error|
+|`binds[].listeners[].routes[].policies.extProc.(any)initialMetadata`|Initial metadata applied as HTTP/2 headers when establishing the gRPC stream.<br>Supports CEL expressions evaluated with full request context.|
 |`binds[].listeners[].routes[].policies.extProc.(any)requestAttributes`|Maps to the request `attributes` field in ProcessingRequest, and allows dynamic CEL expressions.|
 |`binds[].listeners[].routes[].policies.extProc.(any)responseAttributes`|Maps to the response `attributes` field in ProcessingRequest, and allows dynamic CEL expressions.|
 |`binds[].listeners[].routes[].policies.transformations`|Modify requests and responses|
@@ -1035,6 +1036,7 @@
 |`binds[].listeners[].policies.extProc.(any)(1)host`|Hostname or IP address|
 |`binds[].listeners[].policies.extProc.(any)(1)backend`|Explicit backend reference. Backend must be defined in the top level backends list|
 |`binds[].listeners[].policies.extProc.(any)failureMode`|Behavior when the ext_proc service is unavailable or returns an error|
+|`binds[].listeners[].policies.extProc.(any)initialMetadata`|Initial metadata applied as HTTP/2 headers when establishing the gRPC stream.<br>Supports CEL expressions evaluated with full request context.|
 |`binds[].listeners[].policies.extProc.(any)requestAttributes`|Maps to the request `attributes` field in ProcessingRequest, and allows dynamic CEL expressions.|
 |`binds[].listeners[].policies.extProc.(any)responseAttributes`|Maps to the response `attributes` field in ProcessingRequest, and allows dynamic CEL expressions.|
 |`binds[].listeners[].policies.transformations`|Modify requests and responses|
@@ -1445,6 +1447,7 @@
 |`policies[].policy.extProc.(any)(1)host`|Hostname or IP address|
 |`policies[].policy.extProc.(any)(1)backend`|Explicit backend reference. Backend must be defined in the top level backends list|
 |`policies[].policy.extProc.(any)failureMode`|Behavior when the ext_proc service is unavailable or returns an error|
+|`policies[].policy.extProc.(any)initialMetadata`|Initial metadata applied as HTTP/2 headers when establishing the gRPC stream.<br>Supports CEL expressions evaluated with full request context.|
 |`policies[].policy.extProc.(any)requestAttributes`|Maps to the request `attributes` field in ProcessingRequest, and allows dynamic CEL expressions.|
 |`policies[].policy.extProc.(any)responseAttributes`|Maps to the response `attributes` field in ProcessingRequest, and allows dynamic CEL expressions.|
 |`policies[].policy.transformations`|Modify requests and responses|


### PR DESCRIPTION
Fixes #760 and follows the changes in #836.

This aims to support similar functionally to envoys ext_proc [grpc_initial_metadata](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/http/ext_proc/v3/ext_proc.proto)