### PR TITLE
Support listener level frontendpolicy

### DIFF
--- a/crates/agentgateway/src/proxy/gateway.rs
+++ b/crates/agentgateway/src/proxy/gateway.rs
@@ -453,15 +453,8 @@ impl Gateway {
 			hyper::service::service_fn(move |mut req| {
 				let proxy = proxy.clone();
 				let connection = connection.clone();
-				let policies = policies.clone();
-
 				req.extensions_mut().insert(BufferLimit::new(buffer));
-				async move {
-					proxy
-						.proxy(connection, &policies, req)
-						.map(Ok::<_, Infallible>)
-						.await
-				}
+				async move { proxy.proxy(connection, req).map(Ok::<_, Infallible>).await }
 			}),
 		);
 		// Wrap it in the graceful watcher, will ensure GOAWAY/Connect:clone when we shutdown

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -370,7 +370,6 @@ impl HTTPProxy {
 	pub async fn proxy(
 		&self,
 		connection: Arc<Extension>,
-		policies: &FrontendPolices,
 		mut req: ::http::Request<Incoming>,
 	) -> Response {
 		let start = Instant::now();
@@ -383,7 +382,7 @@ impl HTTPProxy {
 		let tcp = connection
 			.get::<TCPConnectionInfo>()
 			.expect("tcp connection must be set");
-		let mut log = RequestLog::new(
+		let log = RequestLog::new(
 			log::CelLogging::new(
 				self.inputs.cfg.logging.clone(),
 				self.inputs.cfg.tracing.clone(),
@@ -393,10 +392,6 @@ impl HTTPProxy {
 			start_time,
 			tcp.clone(),
 		);
-		policies.register_cel_expressions(log.cel.ctx());
-		if let Some(lp) = &policies.access_log {
-			apply_logging_policy_to_log(&mut log, lp);
-		}
 		let mut log: DropOnLog = log.into();
 
 		// Setup ResponsePolicies outside of proxy_internal, so we have can unconditionally run them even on errors
@@ -509,85 +504,33 @@ impl HTTPProxy {
 		// Now check if we actually have a listener - fail after tracing is set up
 		let selected_listener = selected_listener
 			.or_else(|| bind.listeners.best_match(&host))
-			.ok_or(ProxyError::ListenerNotFound)?;
+			.ok_or(ProxyError::ListenerNotFound);
+		let selected_listener = match selected_listener {
+			Ok(l) => {
+				debug!(bind=%bind_name, listener=%l.key, "selected listener");
+				let frontend_policies = inputs
+					.stores
+					.read_binds()
+					.listener_frontend_policies(&l.name);
+
+				self
+					.handle_frontend_policies(&frontend_policies, log, &mut req)
+					.await;
+				l
+			},
+			Err(e) => {
+				let frontend_policies = inputs
+					.stores
+					.read_binds()
+					.frontend_policies(self.inputs.cfg.gateway_ref());
+				self
+					.handle_frontend_policies(&frontend_policies, log, &mut req)
+					.await;
+				return Err(e.into());
+			},
+		};
 		log.bind_name = Some(bind_name.clone());
 		log.listener_name = Some(selected_listener.name.clone());
-		debug!(bind=%bind_name, listener=%selected_listener.key, "selected listener");
-
-		// Check for per-frontend sampling overrides first, before we decide sampling
-		let frontend_policies = inputs
-			.stores
-			.read_binds()
-			.listener_frontend_policies(&selected_listener.name);
-
-		frontend_policies.register_cel_expressions(log.cel.ctx());
-
-		if let Some(lp) = &frontend_policies.access_log {
-			apply_logging_policy_to_log(log, lp);
-		}
-		// Record request now. We may do it later as well, after we have more expressions registered.
-		Self::apply_request_to_cel(log, &mut req).await;
-
-		if let Some(tp) = frontend_policies.tracing.as_deref() {
-			// Apply sampling overrides if present
-			if let Some(rs) = &tp.config.random_sampling {
-				log.cel.tracing_sampler.random_sampling = Some(rs.clone());
-				log.cel.cel_context.register_expression(rs.as_ref());
-			}
-			if let Some(cs) = &tp.config.client_sampling {
-				log.cel.tracing_sampler.client_sampling = Some(cs.clone());
-				log.cel.cel_context.register_expression(cs.as_ref());
-			}
-			// Re-apply request so any newly required attributes are captured before sampling
-			Self::apply_request_to_cel(log, &mut req).await;
-		}
-
-		let trace_parent = trc::TraceParent::from_request(&req);
-		let trace_sampled = log.trace_sampled(trace_parent.as_ref());
-
-		// Use dynamic tracer from frontend policy if available, otherwise use static tracer
-		if trace_sampled {
-			log.tracer = if let Some(tp) = frontend_policies.tracing.as_deref() {
-				debug!(
-					resources_count=%tp.config.resources.len(),
-					attrs_count=%tp.config.attributes.len(),
-					"Using dynamic tracer from frontend policy"
-				);
-
-				tp.get_or_init(self.policy_client())
-					.map(|t| Some(t.clone()))
-					.unwrap_or_else(|e| {
-						debug!("failed to initialize dynamic tracer, falling back to static tracer: {e:?}");
-						self.inputs.tracer.clone()
-					})
-			} else {
-				debug!("No frontend tracing policy found, using static tracer");
-				self.inputs.tracer.clone()
-			};
-			// Register CEL expressions from the tracer
-			if let Some(tracer) = &log.tracer {
-				log.cel.register(tracer.fields.as_ref());
-			}
-
-			// Now create outgoing span with the correct tracer already set
-			let ns = match trace_parent {
-				Some(tp) => {
-					// Build a new span off the existing trace
-					let ns = tp.new_span();
-					log.incoming_span = Some(tp);
-					ns
-				},
-				None => {
-					// Build an entirely new trace
-					let mut ns = TraceParent::new();
-					ns.flags = 1;
-					ns
-				},
-			};
-			ns.insert_header(&mut req);
-			req.extensions_mut().insert(ns.clone());
-			log.outgoing_span = Some(ns);
-		}
 
 		let mut gateway_policies = inputs
 			.stores
@@ -815,6 +758,82 @@ impl HTTPProxy {
 			}
 		}
 		unreachable!()
+	}
+
+	async fn handle_frontend_policies(
+		&self,
+		frontend_policies: &FrontendPolices,
+		log: &mut RequestLog,
+		req: &mut Request,
+	) {
+		frontend_policies.register_cel_expressions(log.cel.ctx());
+
+		if let Some(lp) = &frontend_policies.access_log {
+			apply_logging_policy_to_log(log, lp);
+		}
+		// Record request now. We may do it later as well, after we have more expressions registered.
+		Self::apply_request_to_cel(log, req).await;
+
+		if let Some(tp) = frontend_policies.tracing.as_deref() {
+			// Apply sampling overrides if present
+			if let Some(rs) = &tp.config.random_sampling {
+				log.cel.tracing_sampler.random_sampling = Some(rs.clone());
+				log.cel.cel_context.register_expression(rs.as_ref());
+			}
+			if let Some(cs) = &tp.config.client_sampling {
+				log.cel.tracing_sampler.client_sampling = Some(cs.clone());
+				log.cel.cel_context.register_expression(cs.as_ref());
+			}
+			// Re-apply request so any newly required attributes are captured before sampling
+			Self::apply_request_to_cel(log, req).await;
+		}
+
+		let trace_parent = trc::TraceParent::from_request(&req);
+		let trace_sampled = log.trace_sampled(trace_parent.as_ref());
+
+		// Use dynamic tracer from frontend policy if available, otherwise use static tracer
+		if trace_sampled {
+			log.tracer = if let Some(tp) = frontend_policies.tracing.as_deref() {
+				debug!(
+					resources_count=%tp.config.resources.len(),
+					attrs_count=%tp.config.attributes.len(),
+					"Using dynamic tracer from frontend policy"
+				);
+
+				tp.get_or_init(self.policy_client())
+					.map(|t| Some(t.clone()))
+					.unwrap_or_else(|e| {
+						debug!("failed to initialize dynamic tracer, falling back to static tracer: {e:?}");
+						self.inputs.tracer.clone()
+					})
+			} else {
+				debug!("No frontend tracing policy found, using static tracer");
+				self.inputs.tracer.clone()
+			};
+			// Register CEL expressions from the tracer
+			if let Some(tracer) = &log.tracer {
+				log.cel.register(tracer.fields.as_ref());
+			}
+
+			// Now create outgoing span with the correct tracer already set
+			let ns = match trace_parent {
+				Some(tp) => {
+					// Build a new span off the existing trace
+					let ns = tp.new_span();
+					log.incoming_span = Some(tp);
+					ns
+				},
+				None => {
+					// Build an entirely new trace
+					let mut ns = TraceParent::new();
+					ns.flags = 1;
+					ns
+				},
+			};
+			ns.insert_header(req);
+			req.extensions_mut().insert(ns.clone());
+			log.outgoing_span = Some(ns);
+		}
 	}
 
 	fn detect_misdirected(

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -788,7 +788,7 @@ impl HTTPProxy {
 			Self::apply_request_to_cel(log, req).await;
 		}
 
-		let trace_parent = trc::TraceParent::from_request(&req);
+		let trace_parent = trc::TraceParent::from_request(req);
 		let trace_sampled = log.trace_sampled(trace_parent.as_ref());
 
 		// Use dynamic tracer from frontend policy if available, otherwise use static tracer

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -68,6 +68,25 @@ pub struct FrontendPolices {
 }
 
 impl FrontendPolices {
+	pub fn set_if_empty(&mut self, rule: &FrontendPolicy) {
+		match rule {
+			FrontendPolicy::HTTP(p) => {
+				self.http.get_or_insert_with(|| p.clone());
+			},
+			FrontendPolicy::TLS(p) => {
+				self.tls.get_or_insert_with(|| p.clone());
+			},
+			FrontendPolicy::TCP(p) => {
+				self.tcp.get_or_insert_with(|| p.clone());
+			},
+			FrontendPolicy::AccessLog(p) => {
+				self.access_log.get_or_insert_with(|| p.clone());
+			},
+			FrontendPolicy::Tracing(p) => {
+				self.tracing.get_or_insert_with(|| p.clone());
+			},
+		}
+	}
 	pub fn register_cel_expressions(&self, ctx: &mut ContextBuilder) {
 		let Some(frontend::LoggingPolicy {
 			filter,
@@ -643,25 +662,22 @@ impl Store {
 			.filter_map(|p| p.policy.as_frontend());
 
 		let mut pol = FrontendPolices::default();
-		for rule in rules {
-			match rule {
-				FrontendPolicy::HTTP(p) => {
-					pol.http.get_or_insert_with(|| p.clone());
-				},
-				FrontendPolicy::TLS(p) => {
-					pol.tls.get_or_insert_with(|| p.clone());
-				},
-				FrontendPolicy::TCP(p) => {
-					pol.tcp.get_or_insert_with(|| p.clone());
-				},
-				FrontendPolicy::AccessLog(p) => {
-					pol.access_log.get_or_insert_with(|| p.clone());
-				},
-				FrontendPolicy::Tracing(p) => {
-					pol.tracing.get_or_insert_with(|| p.clone());
-				},
-			}
-		}
+		rules.for_each(|r| pol.set_if_empty(r));
+		pol
+	}
+
+	pub fn listener_frontend_policies(&self, name: &ListenerName) -> FrontendPolices {
+		let gateway = self.policies_by_target.get(&name.as_gateway_target_ref());
+		let listener = self.policies_by_target.get(&name.as_listener_target_ref());
+		let rules = listener
+			.iter()
+			.copied()
+			.flatten()
+			.chain(gateway.iter().copied().flatten())
+			.filter_map(|n| self.policies_by_key.get(n))
+			.filter_map(|p| p.policy.as_frontend());
+		let mut pol = FrontendPolices::default();
+		rules.for_each(|r| pol.set_if_empty(r));
 		pol
 	}
 
@@ -1174,6 +1190,10 @@ fn preload_tokenizers() {
 
 #[cfg(test)]
 mod tests {
+	use frozen_collections::FzHashSet;
+
+	use crate::{telemetry::log::OrderedStringMap, types::frontend::LoggingPolicy};
+
 	use super::*;
 	use std::time::Duration;
 
@@ -1225,6 +1245,71 @@ mod tests {
 		pol
 	}
 
+	fn create_access_log_policy(remove_item: &str) -> FrontendPolicy {
+		FrontendPolicy::AccessLog(LoggingPolicy {
+			filter: None,
+			add: Arc::new(OrderedStringMap::default()),
+			remove: Arc::new(FzHashSet::new(vec![remove_item.into()])),
+		})
+	}
+
+	fn insert_policy_at_level(
+		store: &mut Store,
+		listener: &ListenerName,
+		policy_name: &str,
+		for_listener: bool,
+		remove_item: &str,
+	) {
+		let policy_key = strng::new(policy_name);
+		let listener_name = if for_listener {
+			Some(listener.listener_name.clone())
+		} else {
+			None
+		};
+		let target = PolicyTarget::Gateway(ListenerTarget {
+			gateway_name: listener.gateway_name.clone(),
+			gateway_namespace: listener.gateway_namespace.clone(),
+			listener_name,
+		});
+		let policy = TargetedPolicy {
+			key: policy_key.clone(),
+			name: None,
+			target: target.clone(),
+			policy: agent::PolicyType::Frontend(create_access_log_policy(remove_item)),
+		};
+
+		store
+			.policies_by_key
+			.insert(policy_key.clone(), Arc::new(policy));
+		store
+			.policies_by_target
+			.entry(target.clone())
+			.or_default()
+			.insert(policy_key);
+	}
+
+	fn insert_gateway_level_frontend_policy(
+		store: &mut Store,
+		listener: &ListenerName,
+		remove_item: &str,
+	) {
+		insert_policy_at_level(store, listener, "gw_frontend_policy", false, remove_item);
+	}
+
+	fn insert_listener_level_frontend_policy(
+		store: &mut Store,
+		listener: &ListenerName,
+		remove_item: &str,
+	) {
+		insert_policy_at_level(
+			store,
+			listener,
+			"listener_frontend_policy",
+			true,
+			remove_item,
+		);
+	}
+
 	#[test]
 	fn route_policies_are_kind_scoped() {
 		let mut store = Store::new();
@@ -1253,5 +1338,33 @@ mod tests {
 			&[],
 		);
 		assert_eq!(grpc_pols.timeout, Some(grpc_timeout));
+	}
+
+	/// Tests that frontend policies at listener level take precedence over gateway level policies
+	#[test]
+	fn frontend_policy_listener_precedence() {
+		let mut store = Store::new();
+		let listener = listener();
+
+		// Insert both gateway and listener level frontend policies
+		insert_gateway_level_frontend_policy(&mut store, &listener, "gw_remove");
+		insert_listener_level_frontend_policy(&mut store, &listener, "listener_remove");
+
+		let merged_pols = store.listener_frontend_policies(&listener);
+		// Verify that listener policy takes precedence over gateway policy
+		assert!(
+			merged_pols.access_log.is_some(),
+			"Expected access log policy to be present"
+		);
+
+		let access_log = merged_pols.access_log.as_ref().unwrap();
+		assert!(
+			access_log.remove.contains("listener_remove"),
+			"Expected listener policy to take precedence for remove field"
+		);
+		assert!(
+			!access_log.remove.contains("gw_remove"),
+			"Gateway policy should not override listener policy"
+		);
 	}
 }


### PR DESCRIPTION
Solve #825.
Currently, agentgateway does not support logging/tracing policies on TCP/TLS listeners, so this change applies to HTTP only.
For HTTP:
* if no matching listener is found, use the Gateway-level FrontendPolicy to configure logging and tracing. 
* If a listener is matched, use the listener-level policy instead.