### PR TITLE
fix(mcp/openapi): mcp spec requires CallToolResult structuredContent to be objects

### DIFF
--- a/crates/agentgateway/src/mcp/upstream/openapi/mod.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/mod.rs
@@ -772,8 +772,13 @@ impl Handler {
 			.await?
 			.1;
 
-			let body = serde_json::from_slice::<serde_json::Value>(&body_bytes)?;
-			Ok(body)
+			// Wrap responses that are not structuredContent compliant in object
+			Ok(json!({ "data":
+				match serde_json::from_slice::<serde_json::Value>(&body_bytes)? {
+					Value::Object(obj) => return Ok(Value::Object(obj)),
+					Value::Null => return Ok(Value::Null),
+					data => data,
+			}}))
 		} else {
 			let lim = crate::http::response_buffer_limit(&response);
 			let body = String::from_utf8(


### PR DESCRIPTION
**Issue:** OpenAPI responses that return arrays are not [spec-compliant](https://modelcontextprotocol.io/specification/2025-06-18/schema#calltoolresult) and are marked as invalid by tools that validate the CallToolResult schema, such as the official MCP inspector.

This change wraps arrays in an object keyed by data.
