### PR TITLE
feat: add Vertex AI support for Anthropic models

### DIFF
--- a/crates/agentgateway/src/llm/conversion/bedrock.rs
+++ b/crates/agentgateway/src/llm/conversion/bedrock.rs
@@ -1118,7 +1118,7 @@ pub mod from_messages {
 
 	fn to_anthropic_message_delta_usage(usage: bedrock::TokenUsage) -> messages::MessageDeltaUsage {
 		messages::MessageDeltaUsage {
-			input_tokens: usage.input_tokens,
+			input_tokens: Some(usage.input_tokens),
 			output_tokens: usage.output_tokens,
 			cache_creation_input_tokens: usage.cache_write_input_tokens,
 			cache_read_input_tokens: usage.cache_read_input_tokens,
@@ -1967,7 +1967,7 @@ pub mod from_anthropic_token_count {
 	}
 }
 
-mod helpers {
+pub(crate) mod helpers {
 	use std::collections::HashMap;
 
 	use crate::llm::AIError;

--- a/crates/agentgateway/src/llm/types/count_tokens.rs
+++ b/crates/agentgateway/src/llm/types/count_tokens.rs
@@ -56,7 +56,7 @@ impl RequestType for Request {
 
 	fn to_vertex_token_count(&self, _headers: &::http::HeaderMap) -> Result<Vec<u8>, AIError> {
 		// Vertex count-tokens uses the same format as Anthropic count-tokens
-		// Just serialize the request as-is (model will be removed by prepare_anthropic_request_body)
+		// Just serialize the request as-is (the model field is kept in the body for count-tokens requests)
 		serde_json::to_vec(self).map_err(AIError::RequestMarshal)
 	}
 }

--- a/crates/agentgateway/src/llm/types/count_tokens.rs
+++ b/crates/agentgateway/src/llm/types/count_tokens.rs
@@ -53,4 +53,10 @@ impl RequestType for Request {
 	fn to_bedrock_token_count(&self, headers: &::http::HeaderMap) -> Result<Vec<u8>, AIError> {
 		conversion::bedrock::from_anthropic_token_count::translate(self, headers)
 	}
+
+	fn to_vertex_token_count(&self, _headers: &::http::HeaderMap) -> Result<Vec<u8>, AIError> {
+		// Vertex count-tokens uses the same format as Anthropic count-tokens
+		// Just serialize the request as-is (model will be removed by prepare_anthropic_request_body)
+		serde_json::to_vec(self).map_err(AIError::RequestMarshal)
+	}
 }

--- a/crates/agentgateway/src/llm/types/messages.rs
+++ b/crates/agentgateway/src/llm/types/messages.rs
@@ -709,8 +709,9 @@ pub mod typed {
 
 	#[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq)]
 	pub struct MessageDeltaUsage {
-		/// Cumulative input tokens
-		pub input_tokens: usize,
+		/// Cumulative input tokens (optional for Vertex AI compatibility)
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		pub input_tokens: Option<usize>,
 		/// Cumulative output tokens
 		pub output_tokens: usize,
 		/// Cumulative cache creation tokens

--- a/crates/agentgateway/src/llm/types/mod.rs
+++ b/crates/agentgateway/src/llm/types/mod.rs
@@ -56,6 +56,12 @@ pub trait RequestType: Send + Sync {
 			"bedrock token count"
 		)))
 	}
+
+	fn to_vertex_token_count(&self, _headers: &::http::HeaderMap) -> Result<Vec<u8>, AIError> {
+		Err(AIError::UnsupportedConversion(strng::literal!(
+			"vertex token count"
+		)))
+	}
 }
 
 /// SimpleChatCompletionMessage is a simplified chat message

--- a/crates/agentgateway/src/llm/vertex.rs
+++ b/crates/agentgateway/src/llm/vertex.rs
@@ -2,6 +2,8 @@ use agent_core::strng;
 use agent_core::strng::Strng;
 use serde_json::{Map, Value};
 
+use crate::http::HeaderMap;
+use crate::llm::conversion::bedrock::helpers::extract_beta_headers;
 use crate::llm::{AIError, RouteType};
 use crate::*;
 
@@ -37,14 +39,76 @@ impl Provider {
 		self.anthropic_model(request_model).is_some()
 	}
 
-	pub fn prepare_anthropic_request_body(&self, body: Vec<u8>) -> Result<Vec<u8>, AIError> {
+	/// Beta features that are not supported on Vertex AI and should be filtered out.
+	const UNSUPPORTED_BETA_FEATURES: &'static [&'static str] = &[
+		"oauth-",       // OAuth features don't apply to Vertex (uses GCP auth instead)
+		"claude-code-", // Claude Code specific features for direct Anthropic API
+	];
+
+	fn is_supported_beta_feature(feature: &str) -> bool {
+		!Self::UNSUPPORTED_BETA_FEATURES
+			.iter()
+			.any(|prefix| feature.starts_with(prefix))
+	}
+
+	pub fn prepare_anthropic_request_body(
+		&self,
+		body: Vec<u8>,
+		headers: &HeaderMap,
+	) -> Result<Vec<u8>, AIError> {
+		self.prepare_anthropic_request_body_internal(body, headers, true, false)
+	}
+
+	/// Prepare request body for count-tokens endpoint.
+	/// Unlike messages, count-tokens needs the model in the body (not in the URL path).
+	pub fn prepare_count_tokens_request_body(
+		&self,
+		body: Vec<u8>,
+		headers: &HeaderMap,
+	) -> Result<Vec<u8>, AIError> {
+		// Keep model (remove_model=false), don't add max_tokens (add_max_tokens=false)
+		self.prepare_anthropic_request_body_internal(body, headers, false, false)
+	}
+
+	fn prepare_anthropic_request_body_internal(
+		&self,
+		body: Vec<u8>,
+		headers: &HeaderMap,
+		remove_model: bool,
+		add_max_tokens: bool,
+	) -> Result<Vec<u8>, AIError> {
 		let mut map: Map<String, Value> =
 			serde_json::from_slice(&body).map_err(AIError::RequestMarshal)?;
 		map.insert(
 			"anthropic_version".to_string(),
 			Value::String(ANTHROPIC_VERSION.to_string()),
 		);
-		map.remove("model");
+		if remove_model {
+			map.remove("model");
+		}
+		if add_max_tokens {
+			map.entry("max_tokens".to_string())
+				.or_insert(Value::Number(1.into()));
+		}
+
+		// Extract anthropic-beta headers and add to body if present
+		// Filter out beta features not supported on Vertex AI
+		if let Some(beta_features) = extract_beta_headers(headers)? {
+			let filtered: Vec<Value> = beta_features
+				.into_iter()
+				.filter(|v| {
+					if let Value::String(s) = v {
+						Self::is_supported_beta_feature(s)
+					} else {
+						true
+					}
+				})
+				.collect();
+			if !filtered.is_empty() {
+				map.insert("anthropic_beta".to_string(), Value::Array(filtered));
+			}
+		}
+
 		serde_json::to_vec(&map).map_err(AIError::RequestMarshal)
 	}
 
@@ -60,11 +124,16 @@ impl Provider {
 			.unwrap_or_else(|| strng::literal!("global"));
 		if let Some(model) = self.anthropic_model(request_model) {
 			return match route {
-				RouteType::AnthropicTokenCount => strng::format!(
-					"/v1/projects/{}/locations/{}/publishers/anthropic/models/count-tokens:rawPredict",
-					self.project_id,
-					location
-				),
+				RouteType::AnthropicTokenCount => {
+					// Vertex AI has a dedicated count-tokens endpoint.
+					// The model is specified in the request body, not the path.
+					// See: https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude/count-tokens
+					strng::format!(
+						"/v1/projects/{}/locations/{}/publishers/anthropic/models/count-tokens:rawPredict",
+						self.project_id,
+						location,
+					)
+				}
 				_ => strng::format!(
 					"/v1/projects/{}/locations/{}/publishers/anthropic/models/{}:{}",
 					self.project_id,
@@ -92,12 +161,11 @@ impl Provider {
 
 	pub fn get_host(&self) -> Strng {
 		match &self.region {
-			None => {
-				strng::literal!("aiplatform.googleapis.com")
-			},
-			Some(region) => {
-				strng::format!("{region}-aiplatform.googleapis.com")
-			},
+			None => strng::literal!("aiplatform.googleapis.com"),
+			// Global endpoint uses the same host as no region - just "aiplatform.googleapis.com"
+			// See: https://github.com/anthropics/anthropic-sdk-typescript/issues/800
+			Some(region) if region == "global" => strng::literal!("aiplatform.googleapis.com"),
+			Some(region) => strng::format!("{region}-aiplatform.googleapis.com"),
 		}
 	}
 }

--- a/examples/vertex-claude-code/config.yaml
+++ b/examples/vertex-claude-code/config.yaml
@@ -1,0 +1,57 @@
+# Vertex AI configuration for Claude Code
+# Usage:
+#   1. Build: cargo build --release
+#   2. Run: ./target/release/agentgateway -f examples/vertex-claude-code/config.yaml
+#   3. Set: export ANTHROPIC_BASE_URL=http://localhost:3000
+#   4. Run claude code as normal
+#
+# Note: Claude Code telemetry (/api/event_logging) is silently discarded (returns 204)
+
+binds:
+- port: 3000
+  listeners:
+  - routes:
+    - name: claude-telemetry
+      matches:
+      - path:
+          pathPrefix: /api/event_logging
+      policies:
+        directResponse:
+          status: 204
+          body: ""
+    - backends:
+      - ai:
+          name: vertex-anthropic
+          provider:
+            vertex:
+              projectId: $ANTHROPIC_VERTEX_PROJECT_ID
+      policies:
+        ai:
+          # Map Anthropic Messages API paths to route types
+          # Note: Claude Code configured for Vertex AI sends requests to Vertex-style paths
+          # like /projects/.../models/{model}:streamRawPredict
+          routes:
+            /v1/messages: messages
+            /count_tokens: anthropicTokenCount
+            # Vertex AI path suffixes (for Claude Code in Vertex mode)
+            ":rawPredict": messages
+            ":streamRawPredict": messages
+          # Map Claude Code model names to Vertex AI format
+          # Claude Code sends: "claude-opus-4-5-20251101" (note: @ becomes - in some contexts)
+          # Vertex needs: "anthropic/claude-opus-4-5@20251101"
+          modelAliases:
+            # Claude Code default models (as of Jan 2026)
+            # Primary model: claude-sonnet-4-5@20250929
+            # Small/fast model: claude-haiku-4-5@20251001
+            "claude-sonnet-4-5@20250929": "anthropic/claude-sonnet-4-5@20250929"
+            "claude-haiku-4-5@20251001": "anthropic/claude-haiku-4-5@20251001"
+            # Opus models (if user sets ANTHROPIC_MODEL)
+            "claude-opus-4-5@20251101": "anthropic/claude-opus-4-5@20251101"
+            # Wildcards map any version to a known working version
+            # (Vertex requires specific model versions)
+            "claude-opus-4-5@*": "anthropic/claude-opus-4-5@20251101"
+            "claude-opus-4-5-*": "anthropic/claude-opus-4-5@20251101"
+            "claude-sonnet-4-5@*": "anthropic/claude-sonnet-4-5@20250929"
+            "claude-sonnet-4-5-*": "anthropic/claude-sonnet-4-5@20250929"
+            "claude-haiku-4-5@*": "anthropic/claude-haiku-4-5@20251001"
+            "claude-haiku-4-5-*": "anthropic/claude-haiku-4-5@20251001"


### PR DESCRIPTION
Adds support for using Anthropic Claude models via Google Cloud Vertex AI, enabling Claude Code and other Anthropic API clients to work through the gateway with Vertex AI as the backend.

Key changes:
- Extract model from Vertex-style URL paths (/projects/.../models/{model}:rawPredict)
- Handle count-tokens requests via Vertex AI rawPredict endpoint
- Convert anthropic-beta headers to request body fields (filtering unsupported features)
- Fix global region endpoint to use aiplatform.googleapis.com (not global-aiplatform)
- Make MessageDeltaUsage.input_tokens optional for Vertex compatibility
- Add example configuration for Claude Code with Vertex AI

Route configuration supports both standard Anthropic paths (/v1/messages) and Vertex-style paths (:rawPredict, :streamRawPredict) for maximum compatibility.

Related to #726 , though that fix is only needed when clients use OpenAI's /v1/chat/completions format against Anthropic models on Vertex. Since Claude Code uses InputFormat::Messages (via the messages route type), we don't need PR #725's streaming fix. Both should be implemented, as without it, streaming responses would fail to parse correctly because Vertex returns Anthropic SSE format for Claude models, not OpenAI format.