### PR TITLE
mcp: better propogate errors up

### DIFF
--- a/crates/agentgateway/src/http/jwt.rs
+++ b/crates/agentgateway/src/http/jwt.rs
@@ -323,7 +323,11 @@ impl<'de> Deserialize<'de> for Claims {
 }
 
 impl Jwt {
-	pub async fn apply(&self, log: &mut RequestLog, req: &mut Request) -> Result<(), TokenError> {
+	pub async fn apply(
+		&self,
+		log: Option<&mut RequestLog>,
+		req: &mut Request,
+	) -> Result<(), TokenError> {
 		let Ok(TypedHeader(Authorization(bearer))) = req
 			.extract_parts::<TypedHeader<Authorization<Bearer>>>()
 			.await
@@ -343,7 +347,9 @@ impl Jwt {
 			},
 			Err(e) => return Err(e),
 		};
-		if let Some(serde_json::Value::String(sub)) = claims.inner.get("sub") {
+		if let Some(serde_json::Value::String(sub)) = claims.inner.get("sub")
+			&& let Some(log) = log
+		{
 			log.jwt_sub = Some(sub.to_string());
 		};
 		// Remove the token.

--- a/crates/agentgateway/src/http/jwt_tests.rs
+++ b/crates/agentgateway/src/http/jwt_tests.rs
@@ -209,7 +209,7 @@ pub async fn test_apply_strict_missing_token() {
 	// Minimal RequestLog
 	let mut req_log = make_min_req_log();
 
-	let res = jwt.apply(&mut req_log, &mut req).await;
+	let res = jwt.apply(Some(&mut req_log), &mut req).await;
 	assert!(matches!(res, Err(super::TokenError::Missing)));
 }
 
@@ -223,7 +223,7 @@ pub async fn test_apply_permissive_no_token_ok() {
 	};
 	let mut req = crate::http::Request::new(crate::http::Body::empty());
 	let mut log = make_min_req_log();
-	let res = jwt.apply(&mut log, &mut req).await;
+	let res = jwt.apply(Some(&mut log), &mut req).await;
 	assert!(res.is_ok());
 	assert!(req.extensions().get::<super::Claims>().is_none());
 }
@@ -242,7 +242,7 @@ pub async fn test_apply_permissive_invalid_token_ok_and_keeps_header() {
 		crate::http::HeaderValue::from_static("Bearer invalid-token"),
 	);
 	let mut log = make_min_req_log();
-	let res = jwt.apply(&mut log, &mut req).await;
+	let res = jwt.apply(Some(&mut log), &mut req).await;
 	assert!(res.is_ok());
 	// Header should remain present on failure in permissive mode
 	assert!(
@@ -275,7 +275,7 @@ pub async fn test_apply_permissive_valid_token_inserts_claims_and_removes_header
 		crate::http::HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
 	);
 	let mut log = make_min_req_log();
-	let res = jwt.apply(&mut log, &mut req).await;
+	let res = jwt.apply(Some(&mut log), &mut req).await;
 	assert!(res.is_ok());
 	assert!(
 		req
@@ -296,7 +296,7 @@ pub async fn test_apply_optional_no_token_ok() {
 	};
 	let mut req = crate::http::Request::new(crate::http::Body::empty());
 	let mut log = make_min_req_log();
-	let res = jwt.apply(&mut log, &mut req).await;
+	let res = jwt.apply(Some(&mut log), &mut req).await;
 	assert!(res.is_ok());
 	assert!(req.extensions().get::<super::Claims>().is_none());
 }
@@ -315,7 +315,7 @@ pub async fn test_apply_optional_invalid_token_err() {
 		crate::http::HeaderValue::from_static("Bearer invalid-token"),
 	);
 	let mut log = make_min_req_log();
-	let res = jwt.apply(&mut log, &mut req).await;
+	let res = jwt.apply(Some(&mut log), &mut req).await;
 	assert!(matches!(res, Err(TokenError::InvalidHeader(_))));
 }
 
@@ -339,7 +339,7 @@ pub async fn test_apply_optional_valid_token_inserts_claims_and_removes_header()
 		crate::http::HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
 	);
 	let mut log = make_min_req_log();
-	let res = jwt.apply(&mut log, &mut req).await;
+	let res = jwt.apply(Some(&mut log), &mut req).await;
 	assert!(res.is_ok());
 	assert!(
 		req

--- a/crates/agentgateway/src/http/mod.rs
+++ b/crates/agentgateway/src/http/mod.rs
@@ -52,7 +52,9 @@ impl Deref for SendDirectResponse {
 impl SendDirectResponse {
 	pub async fn new(response: Response) -> Result<Self, Error> {
 		let (head, bytes) = read_response_body(response).await?;
-		Ok(SendDirectResponse(::http::Response::from_parts(head, bytes)))
+		Ok(SendDirectResponse(::http::Response::from_parts(
+			head, bytes,
+		)))
 	}
 }
 
@@ -175,7 +177,6 @@ use bytes::Bytes;
 use cel::Value;
 use http::uri::PathAndQuery;
 use http_body::{Frame, SizeHint};
-use http_body_util::BodyExt;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use tower_serve_static::private::mime;
 use url::Url;
@@ -605,7 +606,9 @@ pub async fn read_body(req: Request) -> Result<Bytes, axum_core::Error> {
 	read_body_with_limit(req.into_body(), lim).await
 }
 
-pub async fn read_response_body(resp: Response) -> Result<(::http::response::Parts, Bytes), axum_core::Error> {
+pub async fn read_response_body(
+	resp: Response,
+) -> Result<(::http::response::Parts, Bytes), axum_core::Error> {
 	let lim = response_buffer_limit(&resp);
 	let (h, b) = resp.into_parts();
 	read_body_with_limit(b, lim).await.map(|b| (h, b))

--- a/crates/agentgateway/src/http/mod.rs
+++ b/crates/agentgateway/src/http/mod.rs
@@ -30,6 +30,32 @@ pub type Body = axum_core::body::Body;
 pub type Request = ::http::Request<Body>;
 pub type Response = ::http::Response<Body>;
 
+// SendDirectResponse is a Response that has been buffered so that it is Send.
+pub struct SendDirectResponse(pub ::http::Response<Bytes>);
+
+impl Debug for SendDirectResponse {
+	fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("SendDirectResponse")
+			.field("status", &self.0.status())
+			.finish()
+	}
+}
+
+impl Deref for SendDirectResponse {
+	type Target = ::http::Response<Bytes>;
+
+	fn deref(&self) -> &Self::Target {
+		&self.0
+	}
+}
+
+impl SendDirectResponse {
+	pub async fn new(response: Response) -> Result<Self, Error> {
+		let (head, bytes) = read_response_body(response).await?;
+		Ok(SendDirectResponse(::http::Response::from_parts(head, bytes)))
+	}
+}
+
 pub fn version_str(v: &http::Version) -> &'static str {
 	match *v {
 		http::Version::HTTP_09 => "HTTP/0.9",
@@ -136,6 +162,7 @@ impl RequestOrResponse<'_> {
 }
 
 use std::fmt::{Debug, Formatter};
+use std::ops::Deref;
 use std::pin::Pin;
 use std::str::FromStr;
 use std::task::{Context, Poll};
@@ -148,6 +175,7 @@ use bytes::Bytes;
 use cel::Value;
 use http::uri::PathAndQuery;
 use http_body::{Frame, SizeHint};
+use http_body_util::BodyExt;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use tower_serve_static::private::mime;
 use url::Url;
@@ -575,6 +603,12 @@ pub fn response_buffer_limit(resp: &Response) -> usize {
 pub async fn read_body(req: Request) -> Result<Bytes, axum_core::Error> {
 	let lim = buffer_limit(&req);
 	read_body_with_limit(req.into_body(), lim).await
+}
+
+pub async fn read_response_body(resp: Response) -> Result<(::http::response::Parts, Bytes), axum_core::Error> {
+	let lim = response_buffer_limit(&resp);
+	let (h, b) = resp.into_parts();
+	read_body_with_limit(b, lim).await.map(|b| (h, b))
 }
 
 pub async fn read_body_with_limit(body: Body, limit: usize) -> Result<Bytes, axum_core::Error> {

--- a/crates/agentgateway/src/json.rs
+++ b/crates/agentgateway/src/json.rs
@@ -45,12 +45,12 @@ fn parse_index(s: &str) -> Option<usize> {
 	s.parse().ok()
 }
 
-pub async fn from_request_body<T: DeserializeOwned>(req: Request) -> Result<T, http::Error>  {
+pub async fn from_request_body<T: DeserializeOwned>(req: Request) -> Result<T, http::Error> {
 	let lim = http::buffer_limit(&req);
 	from_body_with_limit(req.into_body(), lim).await
 }
 
-pub async fn from_response_body<T: DeserializeOwned>(resp: Response) -> Result<T, http::Error>  {
+pub async fn from_response_body<T: DeserializeOwned>(resp: Response) -> Result<T, http::Error> {
 	let lim = http::response_buffer_limit(&resp);
 	from_body_with_limit(resp.into_body(), lim).await
 }

--- a/crates/agentgateway/src/json.rs
+++ b/crates/agentgateway/src/json.rs
@@ -45,12 +45,12 @@ fn parse_index(s: &str) -> Option<usize> {
 	s.parse().ok()
 }
 
-pub async fn from_request_body<T: DeserializeOwned>(req: Request) -> anyhow::Result<T> {
+pub async fn from_request_body<T: DeserializeOwned>(req: Request) -> Result<T, http::Error>  {
 	let lim = http::buffer_limit(&req);
 	from_body_with_limit(req.into_body(), lim).await
 }
 
-pub async fn from_response_body<T: DeserializeOwned>(resp: Response) -> anyhow::Result<T> {
+pub async fn from_response_body<T: DeserializeOwned>(resp: Response) -> Result<T, http::Error>  {
 	let lim = http::response_buffer_limit(&resp);
 	from_body_with_limit(resp.into_body(), lim).await
 }
@@ -58,10 +58,10 @@ pub async fn from_response_body<T: DeserializeOwned>(resp: Response) -> anyhow::
 pub async fn from_body_with_limit<T: DeserializeOwned>(
 	body: http::Body,
 	limit: usize,
-) -> anyhow::Result<T> {
+) -> Result<T, http::Error> {
 	let bytes = http::read_body_with_limit(body, limit).await?;
 	// Try to parse the response body as JSON
-	let t = serde_json::from_slice::<T>(bytes.as_ref())?;
+	let t = serde_json::from_slice::<T>(bytes.as_ref()).map_err(http::Error::new)?;
 	Ok(t)
 }
 

--- a/crates/agentgateway/src/mcp/mod.rs
+++ b/crates/agentgateway/src/mcp/mod.rs
@@ -10,6 +10,7 @@ mod upstream;
 use std::fmt::{Display, Write};
 use std::sync::Arc;
 
+use crate::http::SendDirectResponse;
 use crate::proxy::ProxyError;
 use axum_core::BoxError;
 use prometheus_client::encoding::{EncodeLabelValue, LabelValueEncoder};
@@ -17,8 +18,6 @@ pub use rbac::{McpAuthorization, McpAuthorizationSet, ResourceId, ResourceType};
 use rmcp::model::RequestId;
 pub use router::App;
 use thiserror::Error;
-use crate::http::SendDirectResponse;
-use crate::mcp::upstream::UpstreamError;
 
 #[cfg(test)]
 #[path = "mcp_tests.rs"]
@@ -49,7 +48,7 @@ pub enum Error {
 	#[error("send error: {}", .1)]
 	SendError(Option<RequestId>, String),
 	// Intentionally do NOT say its not authorized; we hide the existence of the tool
-	#[error("Unknown {0}: {1}")]
+	#[error("Unknown {1}: {2}")]
 	Authorization(RequestId, String, String),
 	#[error("failed to process session_id query parameter")]
 	InvalidSessionIdQuery,

--- a/crates/agentgateway/src/mcp/mod.rs
+++ b/crates/agentgateway/src/mcp/mod.rs
@@ -7,9 +7,10 @@ mod sse;
 mod streamablehttp;
 mod upstream;
 
-use std::fmt::{Display, Error, Write};
+use std::fmt::{Display, Write};
 use std::sync::Arc;
 
+use crate::proxy::ProxyError;
 use axum_core::BoxError;
 use prometheus_client::encoding::{EncodeLabelValue, LabelValueEncoder};
 pub use rbac::{McpAuthorization, McpAuthorizationSet, ResourceId, ResourceType};
@@ -19,6 +20,39 @@ use thiserror::Error;
 #[cfg(test)]
 #[path = "mcp_tests.rs"]
 mod tests;
+
+#[derive(Error, Debug)]
+pub enum Error {
+	#[error("method not allowed; must be GET, POST, or DELETE")]
+	MethodNotAllowed,
+	#[error("client must accept both application/json and text/event-stream")]
+	InvalidAccept,
+	#[error("client must send application/json")]
+	InvalidContentType,
+	#[error("fail to deserialize request body: {0}")]
+	Deserialize(anyhow::Error),
+	#[error("fail to create session: {0}")]
+	StartSession(crate::http::Error),
+	#[error("session not found")]
+	UnknownSession,
+	#[error("session header is required for non-initialize requests")]
+	MissingSessionHeader,
+	#[error("session ID is required")]
+	SessionIdRequired,
+	#[error("invalid session ID header")]
+	InvalidSessionIdHeader,
+}
+
+impl From<Error> for ProxyError {
+	fn from(value: Error) -> Self {
+		ProxyError::MCP(value)
+	}
+}
+impl<T> From<Error> for Result<T, ProxyError> {
+	fn from(val: Error) -> Self {
+		Err(ProxyError::MCP(val))
+	}
+}
 
 #[derive(Error, Debug)]
 pub enum ClientError {
@@ -43,7 +77,7 @@ pub enum MCPOperation {
 }
 
 impl EncodeLabelValue for MCPOperation {
-	fn encode(&self, encoder: &mut LabelValueEncoder) -> Result<(), Error> {
+	fn encode(&self, encoder: &mut LabelValueEncoder) -> Result<(), std::fmt::Error> {
 		encoder.write_str(&self.to_string())
 	}
 }

--- a/crates/agentgateway/src/mcp/router.rs
+++ b/crates/agentgateway/src/mcp/router.rs
@@ -3,10 +3,6 @@ use std::sync::Arc;
 use agent_core::prelude::Strng;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use axum_core::RequestExt;
-use axum_extra::TypedHeader;
-use axum_extra::headers::Authorization;
-use axum_extra::headers::authorization::Bearer;
 use bytes::Bytes;
 use http::Method;
 use http::uri::PathAndQuery;
@@ -77,7 +73,7 @@ impl App {
 		backend_policies: BackendPolicies,
 		mut req: Request,
 		log: AsyncLog<MCPInfo>,
-	) -> Response {
+	) -> Result<Response, ProxyError> {
 		let backends = {
 			let binds = self.state.read_binds();
 			let nt = backend
@@ -106,13 +102,7 @@ impl App {
 						always_use_prefix: backend.always_use_prefix,
 					}))
 				})
-				.collect::<Result<Vec<_>, _>>();
-			let Ok(nt) = nt else {
-				return ::http::Response::builder()
-					.status(StatusCode::INTERNAL_SERVER_ERROR)
-					.body(axum::body::Body::from("failed to resolve MCP backend"))
-					.unwrap();
-			};
+				.collect::<Result<Vec<_>, _>>()?;
 
 			McpBackendGroup {
 				targets: nt,
@@ -152,45 +142,26 @@ impl App {
 						"MCP auth configured; validating Authorization header (mode={:?})",
 						auth.mode
 					);
-					match req
-						.extract_parts::<TypedHeader<Authorization<Bearer>>>()
+					auth
+						.jwt_validator
+						.apply(None, &mut req)
 						.await
-					{
-						Ok(TypedHeader(Authorization(bearer))) => {
-							debug!("Authorization header present; validating JWT token");
-							match auth.jwt_validator.validate_claims(bearer.token()) {
-								Ok(claims) => {
-									debug!("JWT validation succeeded; inserting verified claims into context");
-									// Populate context with verified JWT claims before continuing
-									req.headers_mut().remove(http::header::AUTHORIZATION);
-									req.extensions_mut().insert(claims);
-								},
-								Err(_e) => {
-									warn!("JWT validation failed; returning 401 (error: {:?})", _e);
-									return Self::create_auth_required_response(&req, auth).into_response();
-								},
-							}
-						},
-						Err(_missing_header) => {
-							// Enforce strict mode when Authorization header is missing
-							if matches!(auth.mode, jwt::Mode::Strict) {
-								debug!("Missing Authorization header and MCP auth is STRICT; returning 401");
-								return Self::create_auth_required_response(&req, auth).into_response();
-							}
-							// Optional/Permissive: continue without JWT
-							debug!(
-								"Missing Authorization header but MCP auth not STRICT; continuing without JWT"
-							);
-						},
-					}
+						.map_err(|e| {
+							Self::create_auth_required_response(
+								ProxyError::JwtAuthenticationFailure(e),
+								&req,
+								auth,
+							)
+						})?;
 				},
 				// if mcp authn is configured but JWT already validated (claims exist from previous layer),
 				// reject because we cannot validate MCP-specific auth requirements
 				(Some(auth), true) => {
-					warn!(
-						"MCP backend authentication configured but JWT token already validated and stripped by Gateway or Route level policy"
-					);
-					return Self::create_auth_required_response(&req, auth).into_response();
+					return Err(Self::create_auth_required_response(
+						ProxyError::ProcessingString("MCP backend authentication configured but JWT token already validated and stripped by Gateway or Route level policy".to_string()),
+						&req,
+						auth
+					));
 				},
 				// if no mcp authn is configured, do nothing
 				(None, _) => {
@@ -218,28 +189,35 @@ impl App {
 					},
 					sm,
 				);
-				sse.handle(req).await
+				Ok(sse.handle(req).await)
 			},
-			(path, _, Some(auth)) if path.ends_with("client-registration") => self
-				.client_registration(req, auth, client.clone())
-				.await
-				.map_err(|e| {
-					warn!("client_registration error: {}", e);
-					StatusCode::INTERNAL_SERVER_ERROR
-				})
-				.into_response(),
-			(path, _, Some(auth)) if path.starts_with("/.well-known/oauth-protected-resource") => self
-				.protected_resource_metadata(req, auth)
-				.await
-				.into_response(),
-			(path, _, Some(auth)) if path.starts_with("/.well-known/oauth-authorization-server") => self
-				.authorization_server_metadata(req, auth, client.clone())
-				.await
-				.map_err(|e| {
-					warn!("authorization_server_metadata error: {}", e);
-					StatusCode::INTERNAL_SERVER_ERROR
-				})
-				.into_response(),
+			// TODO: indicate this is a DirectResponse
+			(path, _, Some(auth)) if path.ends_with("client-registration") => Ok(
+				self
+					.client_registration(req, auth, client.clone())
+					.await
+					.map_err(|e| {
+						warn!("client_registration error: {}", e);
+						StatusCode::INTERNAL_SERVER_ERROR
+					})
+					.into_response(),
+			),
+			(path, _, Some(auth)) if path.starts_with("/.well-known/oauth-protected-resource") => Ok(
+				self
+					.protected_resource_metadata(req, auth)
+					.await
+					.into_response(),
+			),
+			(path, _, Some(auth)) if path.starts_with("/.well-known/oauth-authorization-server") => Ok(
+				self
+					.authorization_server_metadata(req, auth, client.clone())
+					.await
+					.map_err(|e| {
+						warn!("authorization_server_metadata error: {}", e);
+						StatusCode::INTERNAL_SERVER_ERROR
+					})
+					.into_response(),
+			),
 			_ => {
 				// Assume this is streamable HTTP otherwise
 				let streamable = StreamableHttpService::new(
@@ -283,7 +261,11 @@ pub struct McpTarget {
 }
 
 impl App {
-	fn create_auth_required_response(req: &Request, auth: &McpAuthentication) -> Response {
+	fn create_auth_required_response(
+		inner: ProxyError,
+		req: &Request,
+		auth: &McpAuthentication,
+	) -> ProxyError {
 		let request_path = req.uri().path();
 		// If the `resource` is explicitly configured, use that as the base. otherwise, derive it from the
 		// the request URL
@@ -304,19 +286,7 @@ impl App {
 			"Bearer resource_metadata=\"{proxy_url}/.well-known/oauth-protected-resource{request_path}\""
 		);
 
-		::http::Response::builder()
-			.status(StatusCode::UNAUTHORIZED)
-			.header("www-authenticate", www_authenticate_value)
-			.header("content-type", "application/json")
-			.body(axum::body::Body::from(Bytes::from(
-				r#"{"error":"unauthorized","error_description":"JWT token required"}"#,
-			)))
-			.unwrap_or_else(|_| {
-				::http::Response::builder()
-					.status(StatusCode::INTERNAL_SERVER_ERROR)
-					.body(axum::body::Body::empty())
-					.unwrap()
-			})
+		ProxyError::McpJwtAuthenticationFailure(Box::new(inner), www_authenticate_value)
 	}
 
 	async fn protected_resource_metadata(&self, req: Request, auth: McpAuthentication) -> Response {

--- a/crates/agentgateway/src/mcp/session.rs
+++ b/crates/agentgateway/src/mcp/session.rs
@@ -23,6 +23,7 @@ use crate::mcp::mergestream::Messages;
 use crate::mcp::streamablehttp::{ServerSseMessage, StreamableHttpPostResponse};
 use crate::mcp::upstream::{IncomingRequestContext, UpstreamError};
 use crate::mcp::{ClientError, MCPOperation, rbac};
+use crate::proxy::ProxyError;
 use crate::{mcp, *};
 
 #[derive(Debug, Clone)]
@@ -35,15 +36,16 @@ pub struct Session {
 
 impl Session {
 	/// send a message to upstream server(s)
-	pub async fn send(&mut self, parts: Parts, message: ClientJsonRpcMessage) -> Response {
+	pub async fn send(
+		&mut self,
+		parts: Parts,
+		message: ClientJsonRpcMessage,
+	) -> Result<Response, ProxyError> {
 		let req_id = match &message {
 			ClientJsonRpcMessage::Request(r) => Some(r.id.clone()),
 			_ => None,
 		};
-		self
-			.send_internal(parts, message)
-			.await
-			.unwrap_or_else(Self::handle_error(req_id))
+		Self::handle_error(req_id, self.send_internal(parts, message).await).await
 	}
 	/// send a message to upstream server(s), when using stateless mode. In stateless mode, every message
 	/// is wrapped in an InitializeRequest (except the actual InitializeRequest from the downstream).
@@ -53,7 +55,7 @@ impl Session {
 		&mut self,
 		parts: Parts,
 		message: ClientJsonRpcMessage,
-	) -> Response {
+	) -> Result<Response, ProxyError> {
 		let is_init = matches!(&message, ClientJsonRpcMessage::Request(r) if matches!(&r.request, &ClientRequest::InitializeRequest(_)));
 		if !is_init {
 			// first, send the initialize
@@ -62,15 +64,12 @@ impl Session {
 				params: get_client_info(),
 				extensions: Default::default(),
 			};
-			let res = self
+			let _ = self
 				.send(
 					parts.clone(),
 					ClientJsonRpcMessage::request(init_request.into(), RequestId::Number(0)),
 				)
-				.await;
-			if !res.status().is_success() {
-				return res;
-			}
+				.await?;
 
 			// And we need to notify as well.
 			let notification = ClientJsonRpcMessage::notification(
@@ -80,17 +79,14 @@ impl Session {
 				}
 				.into(),
 			);
-			let res = self.send(parts.clone(), notification).await;
-			if !res.status().is_success() {
-				return res;
-			}
+			let _ = self.send(parts.clone(), notification).await?;
 		}
 		// Now we can send the message like normal
 		self.send(parts, message).await
 	}
 
 	/// delete any active sessions
-	pub async fn delete_session(&self, parts: Parts) -> Response {
+	pub async fn delete_session(&self, parts: Parts) -> Result<Response, ProxyError> {
 		let ctx = IncomingRequestContext::new(&parts);
 		let (_span, log, _cel) = mcp::handler::setup_request_log(parts, "delete_session");
 		let session_id = self.id.to_string();
@@ -98,11 +94,7 @@ impl Session {
 			// NOTE: l.method_name keep None to respect the metrics logic: not handle GET, DELETE.
 			l.session_id = Some(session_id);
 		});
-		self
-			.relay
-			.send_fanout_deletion(ctx)
-			.await
-			.unwrap_or_else(Self::handle_error(None))
+		Self::handle_error(None, self.relay.send_fanout_deletion(ctx).await).await
 	}
 
 	/// forward_legacy_sse takes an upstream Response and forwards all messages to the SSE data stream.
@@ -121,20 +113,20 @@ impl Session {
 			Some(ct) if ct.as_bytes().starts_with(EVENT_STREAM_MIME_TYPE.as_bytes()) => {
 				trace!("forward SSE got SSE stream response");
 				let event_stream = SseStream::from_byte_stream(resp.into_body().into_data_stream()).boxed();
-				Ok(StreamableHttpPostResponse::Sse(event_stream, None))
+				StreamableHttpPostResponse::Sse(event_stream, None)
 			},
 			Some(ct) if ct.as_bytes().starts_with(JSON_MIME_TYPE.as_bytes()) => {
 				trace!("forward SSE got single JSON response");
 				let message = json::from_response_body::<ServerJsonRpcMessage>(resp)
 					.await
 					.map_err(ClientError::new)?;
-				Ok(StreamableHttpPostResponse::Json(message, None))
+				StreamableHttpPostResponse::Json(message, None)
 			},
 			_ => {
 				trace!("forward SSE got accepted, no action needed");
 				return Ok(());
 			},
-		}?;
+		};
 		let mut ms: Messages = sse.try_into()?;
 		tokio::spawn(async move {
 			while let Some(Ok(msg)) = ms.next().await {
@@ -147,7 +139,7 @@ impl Session {
 	}
 
 	/// get_stream establishes a stream for server-sent messages
-	pub async fn get_stream(&self, parts: Parts) -> Response {
+	pub async fn get_stream(&self, parts: Parts) -> Result<Response, ProxyError> {
 		let ctx = IncomingRequestContext::new(&parts);
 		let (_span, log, _cel) = mcp::handler::setup_request_log(parts, "get_stream");
 		let session_id = self.id.to_string();
@@ -155,55 +147,29 @@ impl Session {
 			// NOTE: l.method_name keep None to respect the metrics logic: which do not want to handle GET, DELETE.
 			l.session_id = Some(session_id);
 		});
-		self
-			.relay
-			.send_fanout_get(ctx)
-			.await
-			.unwrap_or_else(Self::handle_error(None))
+		Self::handle_error(None, self.relay.send_fanout_get(ctx).await).await
 	}
 
-	fn handle_error(req_id: Option<RequestId>) -> impl FnOnce(UpstreamError) -> Response {
-		move |e| {
-			if let UpstreamError::Http(ClientError::Status(resp)) = e {
-				// Forward response as-is
-				return *resp;
-			}
-			// Handle authorization errors specially - return "Unknown" error
-			// to avoid leaking information about resource existence
-			if let UpstreamError::Authorization {
+	async fn handle_error(
+		req_id: Option<RequestId>,
+		d: Result<Response, UpstreamError>,
+	) -> Result<Response, ProxyError> {
+		match d {
+			Ok(r) => Ok(r),
+			Err(UpstreamError::Http(ClientError::Status(resp))) => {
+				let resp = http::SendDirectResponse::new(*resp)
+					.await
+					.map_err(ProxyError::Body)?;
+				Err(mcp::Error::UpstreamError(Box::new(resp)).into())
+			},
+			Err(UpstreamError::Authorization {
 				resource_type,
 				resource_name,
-			} = &e
-				&& let Some(ref req_id) = req_id
-				&& let Ok(body) = serde_json::to_string(&JsonRpcError {
-					jsonrpc: Default::default(),
-					id: req_id.clone(),
-					error: ErrorData {
-						code: ErrorCode::INVALID_PARAMS,
-						message: format!("Unknown {resource_type}: {resource_name}").into(),
-						data: None,
-					},
-				}) {
-				return http_json_error(StatusCode::OK, body);
-			}
-			let err = if let Some(req_id) = req_id {
-				serde_json::to_string(&JsonRpcError {
-					jsonrpc: Default::default(),
-					id: req_id,
-					error: ErrorData {
-						code: ErrorCode::INTERNAL_ERROR,
-						message: format!("failed to send message: {e}",).into(),
-						data: None,
-					},
-				})
-				.ok()
-			} else {
-				None
-			};
-			http_error(
-				StatusCode::INTERNAL_SERVER_ERROR,
-				err.unwrap_or_else(|| format!("failed to send message: {e}")),
-			)
+			}) if req_id.is_some() => Err(
+				mcp::Error::Authorization(req_id.unwrap(), resource_type.into(), resource_name.into())
+					.into(),
+			),
+			Err(e) => Err(mcp::Error::SendError(req_id, e.to_string()).into()),
 		}
 	}
 
@@ -549,7 +515,8 @@ impl SessionManager {
 			let mut sm = self.sessions.write().expect("write lock");
 			sm.remove(id)?
 		};
-		Some(sess.delete_session(parts).await)
+		// Swallow the error
+		Some(sess.delete_session(parts).await.ok()?)
 	}
 }
 

--- a/crates/agentgateway/src/mcp/streamablehttp.rs
+++ b/crates/agentgateway/src/mcp/streamablehttp.rs
@@ -118,7 +118,7 @@ impl StreamableHttpService {
 
 			// Clean up upstream resources (e.g., stdio processes)
 			let _ = session.delete_session(part).await;
-			return Ok(response);
+			return response;
 		}
 
 		let session_id = part
@@ -134,8 +134,7 @@ impl StreamableHttpService {
 				return mcp::Error::UnknownSession.into();
 			};
 
-			let resp = session.send(part, message).await;
-			return Ok(resp);
+			return session.send(part, message).await;
 		}
 
 		// No session header... we need to create one, if it is an initialize
@@ -146,7 +145,7 @@ impl StreamableHttpService {
 		}
 		let relay = (self.service_factory)().map_err(mcp::Error::StartSession)?;
 		let mut session = self.session_manager.create_session(relay);
-		let mut resp = session.send(part, message).await;
+		let mut resp = session.send(part, message).await?;
 
 		let Ok(sid) = session.id.parse() else {
 			return mcp::Error::InvalidSessionIdHeader.into();
@@ -180,7 +179,7 @@ impl StreamableHttpService {
 		};
 
 		let (parts, _) = request.into_parts();
-		Ok(session.get_stream(parts).await)
+		session.get_stream(parts).await
 	}
 
 	pub async fn handle_delete(&self, request: Request) -> Result<Response, ProxyError> {

--- a/crates/agentgateway/src/mcp/streamablehttp.rs
+++ b/crates/agentgateway/src/mcp/streamablehttp.rs
@@ -63,10 +63,6 @@ impl StreamableHttpService {
 
 	pub async fn handle(&self, request: Request) -> Result<Response, ProxyError> {
 		let method = request.method().clone();
-		let allowed_methods = match self.config.stateful_mode {
-			true => "GET, POST, DELETE",
-			false => "POST",
-		};
 
 		match (method, self.config.stateful_mode) {
 			(http::Method::POST, _) => self.handle_post(request).await,

--- a/crates/agentgateway/src/mcp/streamablehttp.rs
+++ b/crates/agentgateway/src/mcp/streamablehttp.rs
@@ -9,6 +9,7 @@ use rmcp::transport::common::http_header::{
 use crate::http::{Request, Response};
 use crate::mcp::handler::Relay;
 use crate::mcp::session::SessionManager;
+use crate::proxy::ProxyError;
 use crate::*;
 
 #[derive(Debug, Clone)]
@@ -60,7 +61,7 @@ impl StreamableHttpService {
 		}
 	}
 
-	pub async fn handle(&self, request: Request) -> Response {
+	pub async fn handle(&self, request: Request) -> Result<Response, ProxyError> {
 		let method = request.method().clone();
 		let allowed_methods = match self.config.stateful_mode {
 			true => "GET, POST, DELETE",
@@ -72,19 +73,11 @@ impl StreamableHttpService {
 			// if we're not in stateful mode, we don't support GET or DELETE because there is no session
 			(http::Method::GET, true) => self.handle_get(request).await,
 			(http::Method::DELETE, true) => self.handle_delete(request).await,
-			_ => {
-				// Handle other methods or return an error
-
-				::http::Response::builder()
-					.status(http::StatusCode::METHOD_NOT_ALLOWED)
-					.header(http::header::ALLOW, allowed_methods)
-					.body(http::Body::from("Method Not Allowed"))
-					.expect("valid response")
-			},
+			_ => Err(ProxyError::MCP(mcp::Error::MethodNotAllowed)),
 		}
 	}
 
-	pub async fn handle_post(&self, request: Request) -> Response {
+	pub async fn handle_post(&self, request: Request) -> Result<Response, ProxyError> {
 		// check accept header
 		if !request
 			.headers()
@@ -93,10 +86,7 @@ impl StreamableHttpService {
 			.is_some_and(|header| {
 				header.contains(JSON_MIME_TYPE) && header.contains(EVENT_STREAM_MIME_TYPE)
 			}) {
-			return http_error(
-				StatusCode::NOT_ACCEPTABLE,
-				"Not Acceptable: Client must accept both application/json and text/event-stream",
-			);
+			return mcp::Error::InvalidAccept.into();
 		}
 
 		// check content type
@@ -106,10 +96,7 @@ impl StreamableHttpService {
 			.and_then(|header| header.to_str().ok())
 			.is_some_and(|header| header.starts_with(JSON_MIME_TYPE))
 		{
-			return http_error(
-				StatusCode::UNSUPPORTED_MEDIA_TYPE,
-				"Unsupported Media Type: Client must send application/json",
-			);
+			return mcp::Error::InvalidContentType.into();
 		}
 
 		let limit = http::buffer_limit(&request);
@@ -117,23 +104,12 @@ impl StreamableHttpService {
 		let message = match json::from_body_with_limit::<ClientJsonRpcMessage>(body, limit).await {
 			Ok(b) => b,
 			Err(e) => {
-				return http_error(
-					StatusCode::BAD_REQUEST,
-					format!("fail to deserialize request body: {e}"),
-				);
+				return mcp::Error::Deserialize(e).into();
 			},
 		};
 
 		if !self.config.stateful_mode {
-			let relay = match (self.service_factory)() {
-				Ok(r) => r,
-				Err(e) => {
-					return http_error(
-						StatusCode::INTERNAL_SERVER_ERROR,
-						format!("fail to create relay: {e}"),
-					);
-				},
-			};
+			let relay = (self.service_factory)().map_err(mcp::Error::StartSession)?;
 			// Use stateless session - not registered in session manager
 			let mut session = self.session_manager.create_stateless_session(relay);
 			let response = session
@@ -142,7 +118,7 @@ impl StreamableHttpService {
 
 			// Clean up upstream resources (e.g., stdio processes)
 			let _ = session.delete_session(part).await;
-			return response;
+			return Ok(response);
 		}
 
 		let session_id = part
@@ -155,43 +131,32 @@ impl StreamableHttpService {
 				.session_manager
 				.get_or_resume_session(session_id, self.service_factory.clone())
 			else {
-				return http_error(http::StatusCode::NOT_FOUND, "Session not found");
+				return mcp::Error::UnknownSession.into();
 			};
 
 			let resp = session.send(part, message).await;
-			return resp;
+			return Ok(resp);
 		}
 
 		// No session header... we need to create one, if it is an initialize
 		if let ClientJsonRpcMessage::Request(req) = &message
 			&& !matches!(req.request, ClientRequest::InitializeRequest(_))
 		{
-			return http_error(
-				StatusCode::UNPROCESSABLE_ENTITY,
-				"session header is required for non-initialize requests",
-			);
+			return mcp::Error::MissingSessionHeader.into();
 		}
-		let relay = match (self.service_factory)() {
-			Ok(r) => r,
-			Err(e) => {
-				return http_error(
-					StatusCode::INTERNAL_SERVER_ERROR,
-					format!("fail to create relay: {e}"),
-				);
-			},
-		};
+		let relay = (self.service_factory)().map_err(mcp::Error::StartSession)?;
 		let mut session = self.session_manager.create_session(relay);
 		let mut resp = session.send(part, message).await;
 
 		let Ok(sid) = session.id.parse() else {
-			return internal_error_response("create session id header");
+			return mcp::Error::InvalidSessionIdHeader.into();
 		};
 		resp.headers_mut().insert(HEADER_SESSION_ID, sid);
 		self.session_manager.insert_session(session);
-		resp
+		Ok(resp)
 	}
 
-	pub async fn handle_get(&self, request: Request) -> Response {
+	pub async fn handle_get(&self, request: Request) -> Result<Response, ProxyError> {
 		// check accept header
 		if !request
 			.headers()
@@ -199,10 +164,7 @@ impl StreamableHttpService {
 			.and_then(|header| header.to_str().ok())
 			.is_some_and(|header| header.contains(EVENT_STREAM_MIME_TYPE))
 		{
-			return http_error(
-				StatusCode::NOT_ACCEPTABLE,
-				"Not Acceptable: Client must accept text/event-stream",
-			);
+			return mcp::Error::InvalidAccept.into();
 		}
 
 		let Some(session_id) = request
@@ -210,54 +172,36 @@ impl StreamableHttpService {
 			.get(HEADER_SESSION_ID)
 			.and_then(|v| v.to_str().ok())
 		else {
-			return http_error(StatusCode::UNPROCESSABLE_ENTITY, "Session ID is required");
+			return mcp::Error::SessionIdRequired.into();
 		};
 
 		let Some(session) = self.session_manager.get_session(session_id) else {
-			return http_error(http::StatusCode::NOT_FOUND, "Session not found");
+			return mcp::Error::UnknownSession.into();
 		};
 
 		let (parts, _) = request.into_parts();
-		session.get_stream(parts).await
+		Ok(session.get_stream(parts).await)
 	}
 
-	pub async fn handle_delete(&self, request: Request) -> Response {
+	pub async fn handle_delete(&self, request: Request) -> Result<Response, ProxyError> {
 		// check session id
 		let session_id = request
 			.headers()
 			.get(HEADER_SESSION_ID)
 			.and_then(|v| v.to_str().ok());
 		let Some(session_id) = session_id else {
-			// unauthorized
-			return http_error(
-				StatusCode::UNAUTHORIZED,
-				"Unauthorized: Session ID is required",
-			);
+			return mcp::Error::SessionIdRequired.into();
 		};
 		let session_id = session_id.to_string();
 		let (parts, _) = request.into_parts();
-		self
-			.session_manager
-			.delete_session(&session_id, parts)
-			.await
-			.unwrap_or_else(accepted_response)
+		Ok(
+			self
+				.session_manager
+				.delete_session(&session_id, parts)
+				.await
+				.unwrap_or_else(accepted_response),
+		)
 	}
-}
-
-fn http_error(status: StatusCode, body: impl Into<http::Body>) -> Response {
-	::http::Response::builder()
-		.status(status)
-		.body(body.into())
-		.expect("valid response")
-}
-
-fn internal_error_response(context: &str) -> Response {
-	::http::Response::builder()
-		.status(StatusCode::INTERNAL_SERVER_ERROR)
-		.body(http::Body::from(format!(
-			"Encounter an error when {context}"
-		)))
-		.expect("valid response")
 }
 
 fn accepted_response() -> Response {

--- a/crates/agentgateway/src/mcp/upstream/mod.rs
+++ b/crates/agentgateway/src/mcp/upstream/mod.rs
@@ -20,6 +20,7 @@ use crate::mcp::{mergestream, upstream};
 use crate::proxy::httpproxy::PolicyClient;
 use crate::types::agent::McpTargetSpec;
 use crate::*;
+use crate::proxy::ProxyError;
 
 #[derive(Debug, Clone)]
 pub struct IncomingRequestContext {
@@ -77,6 +78,8 @@ pub enum UpstreamError {
 	Http(#[from] mcp::ClientError),
 	#[error("openapi upstream error: {0}")]
 	OpenAPIError(#[from] anyhow::Error),
+	#[error("{0}")]
+	Proxy(#[from] ProxyError),
 	#[error("stdio upstream error: {0}")]
 	Stdio(#[from] io::Error),
 	#[error("upstream closed on send")]

--- a/crates/agentgateway/src/mcp/upstream/mod.rs
+++ b/crates/agentgateway/src/mcp/upstream/mod.rs
@@ -17,10 +17,10 @@ use crate::mcp::mergestream::Messages;
 use crate::mcp::router::{McpBackendGroup, McpTarget};
 use crate::mcp::streamablehttp::StreamableHttpPostResponse;
 use crate::mcp::{mergestream, upstream};
+use crate::proxy::ProxyError;
 use crate::proxy::httpproxy::PolicyClient;
 use crate::types::agent::McpTargetSpec;
 use crate::*;
-use crate::proxy::ProxyError;
 
 #[derive(Debug, Clone)]
 pub struct IncomingRequestContext {

--- a/crates/agentgateway/src/mcp/upstream/sse.rs
+++ b/crates/agentgateway/src/mcp/upstream/sse.rs
@@ -113,7 +113,7 @@ impl ClientCore {
 
 		ctx.apply(&mut req);
 
-		let resp = self.http_client.call(req).await.map_err(ClientError::new)?;
+		let resp = self.http_client.call(req).await?;
 
 		if resp.status() == http::StatusCode::ACCEPTED {
 			return Err(ClientError::new(anyhow!("expected an SSE stream")));

--- a/crates/agentgateway/src/mcp/upstream/streamablehttp.rs
+++ b/crates/agentgateway/src/mcp/upstream/streamablehttp.rs
@@ -89,7 +89,7 @@ impl Client {
 
 		ctx.apply(&mut req);
 
-		let resp = self.http_client.call(req).await.map_err(ClientError::new)?;
+		let resp = self.http_client.call(req).await?;
 
 		if resp.status() == http::StatusCode::ACCEPTED {
 			return Ok(StreamableHttpPostResponse::Accepted);
@@ -147,7 +147,7 @@ impl Client {
 
 		ctx.apply(&mut req);
 
-		let resp = self.http_client.call(req).await.map_err(ClientError::new)?;
+		let resp = self.http_client.call(req).await?;
 
 		if !resp.status().is_success() {
 			return Err(ClientError::Status(Box::new(resp)));
@@ -169,7 +169,7 @@ impl Client {
 
 		ctx.apply(&mut req);
 
-		let resp = self.http_client.call(req).await.map_err(ClientError::new)?;
+		let resp = self.http_client.call(req).await?;
 
 		if !resp.status().is_success() {
 			return Err(ClientError::Status(Box::new(resp)));

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -72,7 +72,7 @@ async fn apply_request_policies(
 	response_policies: &mut ResponsePolicies,
 ) -> Result<(), ProxyResponse> {
 	if let Some(j) = &policies.jwt {
-		j.apply(log, req)
+		j.apply(Some(log), req)
 			.await
 			.map_err(|e| ProxyResponse::from(ProxyError::JwtAuthenticationFailure(e)))?;
 	}
@@ -243,7 +243,7 @@ async fn apply_gateway_policies(
 	response_headers: &mut HeaderMap,
 ) -> Result<(), ProxyResponse> {
 	if let Some(j) = &policies.jwt {
-		j.apply(log, req)
+		j.apply(Some(log), req)
 			.await
 			.map_err(|e| ProxyResponse::from(ProxyError::JwtAuthenticationFailure(e)))?;
 	}
@@ -1323,7 +1323,6 @@ async fn make_backend_call(
 					.clone()
 					.mcp_state
 					.serve(inputs, name, backend, policies, req, mcp_response_log)
-					.map(Ok)
 					.await
 			}));
 		},

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -6,7 +6,6 @@ use std::sync::Arc;
 use ::http::uri::PathAndQuery;
 use ::http::{HeaderMap, header};
 use anyhow::anyhow;
-use futures_util::FutureExt;
 use headers::HeaderMapExt;
 use hyper::body::Incoming;
 use hyper::upgrade::OnUpgrade;

--- a/crates/agentgateway/src/serdes.rs
+++ b/crates/agentgateway/src/serdes.rs
@@ -344,7 +344,7 @@ impl FileInlineOrRemote {
 					)
 					.await
 					.context(format!("fetch {url}"))?;
-				return crate::json::from_response_body::<T>(resp).await;
+				return crate::json::from_response_body::<T>(resp).await.map_err(Into::into);
 			},
 		};
 		serde_json::from_str(&s).map_err(Into::into)

--- a/crates/agentgateway/src/serdes.rs
+++ b/crates/agentgateway/src/serdes.rs
@@ -344,7 +344,9 @@ impl FileInlineOrRemote {
 					)
 					.await
 					.context(format!("fetch {url}"))?;
-				return crate::json::from_response_body::<T>(resp).await.map_err(Into::into);
+				return crate::json::from_response_body::<T>(resp)
+					.await
+					.map_err(Into::into);
 			},
 		};
 		serde_json::from_str(&s).map_err(Into::into)

--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -768,6 +768,10 @@ impl Drop for DropOnLog {
 		let span_id = log.outgoing_span.as_ref().map(|id| id.span_id());
 
 		let fields = cel_exec.fields;
+		let reason = log.reason.and_then(|r| match r {
+			ProxyResponseReason::Upstream => None,
+			_ => Some(r),
+		});
 
 		let mut kv = vec![
 			("gateway", route_identifier.gateway.as_deref().map(display)),
@@ -939,6 +943,7 @@ impl Drop for DropOnLog {
 			),
 			("retry.attempt", log.retry_attempt.display()),
 			("error", log.error.quoted()),
+			("reason", reason.display()),
 			("duration", Some(dur.as_str().into())),
 		];
 		if enable_trace && let Some(t) = &log.tracer {


### PR DESCRIPTION
Before, we made everything a raw http::Response in the mcp layer. The rest of the proxy had no clue, what if any error there was. This was very hard to debug things since we see nothing.


Before:
```
2026-01-30T00:02:12.784635Z	info	request  http.status=500 protocol=mcp mcp.method=initialize 
  mcp.session.id=f3115c32-8e1d-4858-b377-fbdd1a8be7bb duration=32ms
```

After:
```
2026-01-30T00:01:50.985093Z	info	request http.status=500 protocol=mcp mcp.method=initialize 
  mcp.session.id=15b8736f-76ee-48b7-b773-d4d5c260c8d5 error="mcp: send error: http upstream error: http request failed: upstream call failed: Connect: Connection refused (os error 111)" 
  reason=MCP duration=297ms
```