### PR TITLE
gha: cache only on main

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -44,6 +44,11 @@ jobs:
     - uses: Swatinem/rust-cache@v2
       # Github cache is too tiny to handle the full matrix :-(
       if: ${{ matrix.os == 'ubuntu-22.04-arm' || matrix.os == 'ubuntu-latest' }}
+      with:
+        # Github cache will restore from 'main' OR the current branch.
+        # If we cache PR branches, we may evict the 'main' cache and end up with no cache hits at all.
+        # Ideally, we would have main be 'high priority' and not be evicted but I don't think thats possible.
+        save-if: ${{ github.ref == 'refs/heads/main' }}
 
     - name: Build UI
       run: |
@@ -81,6 +86,11 @@ jobs:
     - uses: Swatinem/rust-cache@v2
       # Github cache is too tiny to handle the full matrix :-(
       if: ${{ matrix.os == 'ubuntu-22.04-arm' || matrix.os == 'ubuntu-latest' }}
+      with:
+        # Github cache will restore from 'main' OR the current branch.
+        # If we cache PR branches, we may evict the 'main' cache and end up with no cache hits at all.
+        # Ideally, we would have main be 'high priority' and not be evicted but I don't think thats possible.
+        save-if: ${{ github.ref == 'refs/heads/main' }}
     - name: Add Go bin to PATH
       shell: bash
       run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
@@ -103,6 +113,11 @@ jobs:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
     - uses: Swatinem/rust-cache@v2
+      with:
+        # Github cache will restore from 'main' OR the current branch.
+        # If we cache PR branches, we may evict the 'main' cache and end up with no cache hits at all.
+        # Ideally, we would have main be 'high priority' and not be evicted but I don't think thats possible.
+        save-if: ${{ github.ref == 'refs/heads/main' }}
     - name: Add Go bin to PATH
       run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
     - name: Generation


### PR DESCRIPTION
GHA will look for caches from the current branch (i.e. refs/pull/BLAH/merge) and fallback to main https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching#cache-key-matching We are at the max capacity for our cache so constantly evicting entries Therefor, new PRs (say PR-1) evict the main entries, and then PR-2 has no cache to read from

One fix seems to be to only save entries for main but ideally we had like low priority PR entries that cannot evict main entries?