### PR TITLE
mcp: enhance observability and route discovery plumbing

### DIFF
--- a/crates/agentgateway/src/mcp/upstream/client.rs
+++ b/crates/agentgateway/src/mcp/upstream/client.rs
@@ -20,6 +20,7 @@ pub(crate) struct McpHttpClient {
 	base_policies: BackendPolicies,
 	pinned_dest: Arc<Mutex<Option<ResolvedDestination>>>,
 	stateful: bool,
+	target_name: String,
 }
 
 impl McpHttpClient {
@@ -28,6 +29,7 @@ impl McpHttpClient {
 		backend: SimpleBackend,
 		policies: BackendPolicies,
 		stateful: bool,
+		target_name: String,
 	) -> Self {
 		Self {
 			client,
@@ -35,6 +37,7 @@ impl McpHttpClient {
 			base_policies: policies,
 			pinned_dest: Arc::new(Mutex::new(None)),
 			stateful,
+			target_name,
 		}
 	}
 
@@ -49,6 +52,7 @@ impl McpHttpClient {
 			&& let Some(pinned) = *self.pinned_dest.lock().unwrap()
 		{
 			tracing::trace!(
+				target = %self.target_name,
 				backend = %self.backend,
 				endpoint = %pinned.0,
 				"using pinned backend endpoint"
@@ -74,6 +78,7 @@ impl McpHttpClient {
 
 	pub fn pin_backend(&self, resolved: ResolvedDestination) {
 		tracing::debug!(
+			target = %self.target_name,
 			backend = %self.backend,
 			endpoint = %resolved.0,
 			"pinned stateful MCP session to backend endpoint"

--- a/crates/agentgateway/src/mcp/upstream/mod.rs
+++ b/crates/agentgateway/src/mcp/upstream/mod.rs
@@ -258,6 +258,7 @@ impl UpstreamGroup {
 						.expect("there must be a backend for SSE"),
 					target.backend_policies.clone(),
 					self.backend.stateful,
+					target.name.to_string(),
 				);
 				let client = sse::Client::new(upstream_client, path.into())?;
 
@@ -281,6 +282,7 @@ impl UpstreamGroup {
 						.expect("there must be a backend for MCP"),
 					target.backend_policies.clone(),
 					self.backend.stateful,
+					target.name.to_string(),
 				);
 				let client = streamablehttp::Client::new(http_client, path.into())?;
 
@@ -334,6 +336,7 @@ impl UpstreamGroup {
 						.expect("there must be a backend for OpenAPI"),
 					target.backend_policies.clone(),
 					self.backend.stateful,
+					target.name.to_string(),
 				);
 				upstream::Upstream::OpenAPI(Box::new(openapi::Handler::new(
 					http_client,

--- a/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
@@ -148,8 +148,13 @@ async fn setup() -> (MockServer, Handler) {
 			parsed.port().unwrap_or(8080),
 		),
 	);
-	let upstream_client =
-		super::super::McpHttpClient::new(client, backend, BackendPolicies::default(), false);
+	let upstream_client = super::super::McpHttpClient::new(
+		client,
+		backend,
+		BackendPolicies::default(),
+		false,
+		"test-target".to_string(),
+	);
 	let handler = Handler::new(
 		upstream_client,
 		vec![

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -1498,6 +1498,10 @@ impl RouteSet {
 	pub fn is_empty(&self) -> bool {
 		self.inner.is_empty()
 	}
+
+	pub fn iter(&self) -> impl Iterator<Item = &Arc<Route>> {
+		self.all.values()
+	}
 }
 
 #[derive(Debug, Clone, Default)]
@@ -2326,5 +2330,46 @@ InvalidKeyData
 		assert_eq!(matches.len(), 2);
 		assert_eq!(matches[0], HostnameMatchRef::Exact("localhost"));
 		assert_eq!(matches[1], HostnameMatchRef::None);
+	}
+
+	#[test]
+	fn test_route_set_iter() {
+		// Create test routes with unique keys
+		let route1 = Route {
+			key: strng::new("route-1"),
+			name: RouteName::default(),
+			hostnames: vec![],
+			matches: vec![],
+			backends: vec![],
+			inline_policies: vec![],
+		};
+		let route2 = Route {
+			key: strng::new("route-2"),
+			name: RouteName::default(),
+			hostnames: vec![],
+			matches: vec![],
+			backends: vec![],
+			inline_policies: vec![],
+		};
+		let route3 = Route {
+			key: strng::new("route-3"),
+			name: RouteName::default(),
+			hostnames: vec![],
+			matches: vec![],
+			backends: vec![],
+			inline_policies: vec![],
+		};
+
+		// Build RouteSet
+		let route_set = RouteSet::from_list(vec![route1, route2, route3]);
+
+		// Call iter() and collect keys
+		let keys: std::collections::HashSet<_> = route_set.iter().map(|r| r.key.clone()).collect();
+
+		// Verify all routes are returned
+		assert_eq!(keys.len(), 3);
+		assert!(keys.contains(&strng::new("route-1")));
+		assert!(keys.contains(&strng::new("route-2")));
+		assert!(keys.contains(&strng::new("route-3")));
 	}
 }


### PR DESCRIPTION
- Add target_name to McpHttpClient to enable logical tracing of upstream calls (e.g., "github-mcp" instead of anonymous IP addresses).
- Implement RouteSet::iter() to provide a public API for route discovery, enabling Management UI and service-based pinning features.
- Add unit test for RouteSet iterator verification.