### PR TITLE
feat(llm): accept /v1/messages InputFormat for chat/completions backends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -534,9 +534,9 @@ dependencies = [
 
 [[package]]
 name = "async-openai"
-version = "0.32.4"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4d91c2005832450ad9ac92411b9d4cec39e30be21adc76553efc47f812d59c7"
+checksum = "b3ef6d66e53b3ec8ed4bae8e6dcdda75c0f5b4f67faba78fac1b09434cb4f2fc"
 dependencies = [
  "bytes",
  "derive_builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ anyhow = "1.0"
 arc-swap = "1.7.1"
 arcstr = { version = "1.2", features = ["serde"] }
 assert_matches = "1.5.0"
-async-openai = { version = "0.32.2", default-features = false, features = ["chat-completion-types", "embedding-types", "moderation-types", "response-types", "realtime-types"] }
+async-openai = { version = "0.33.0", default-features = false, features = ["chat-completion-types", "moderation-types", "response-types", "realtime-types"] }
 async-stream = "0.3"
 async-trait = "0.1"
 aws-config = "1.8"

--- a/crates/agentgateway/src/llm/bedrock.rs
+++ b/crates/agentgateway/src/llm/bedrock.rs
@@ -26,6 +26,16 @@ impl super::Provider for Provider {
 }
 
 impl Provider {
+	pub fn is_anthropic_model(&self, request_model: Option<&str>) -> bool {
+		let model = self
+			.model
+			.as_deref()
+			.or(request_model)
+			.unwrap_or_default()
+			.to_ascii_lowercase();
+		model.contains("anthropic.claude")
+	}
+
 	pub fn get_path_for_route(
 		&self,
 		route_type: super::RouteType,

--- a/crates/agentgateway/src/llm/conversion/completions.rs
+++ b/crates/agentgateway/src/llm/conversion/completions.rs
@@ -5,16 +5,139 @@ use tracing::debug;
 
 use crate::http::Response;
 use crate::llm::{AmendOnDrop, types};
-use crate::parse;
+use crate::{llm, parse};
+use bytes::Bytes;
+
+/// Parse a Google error response, handling both single object and array-wrapped formats.
+/// Google's OpenAI-compatible endpoints consistently return `[{"error": {...}}]`
+/// rather than `{"error": {...}}` when using the Vertex AI shim.
+pub(crate) fn parse_google_error(
+	bytes: &Bytes,
+) -> Result<types::completions::typed::GoogleErrorResponse, llm::AIError> {
+	serde_json::from_slice::<types::completions::typed::GoogleErrorResponse>(bytes).or_else(|_| {
+		serde_json::from_slice::<Vec<types::completions::typed::GoogleErrorResponse>>(bytes)
+			.map_err(llm::AIError::ResponseParsing)?
+			.into_iter()
+			.next()
+			.ok_or_else(|| {
+				llm::AIError::InvalidResponse(agent_core::strng::literal!(
+					"error response missing error details"
+				))
+			})
+	})
+}
+
+pub(crate) fn google_error_type(error: &types::completions::typed::GoogleError) -> &'static str {
+	match error.status.as_deref() {
+		Some("INVALID_ARGUMENT") | Some("FAILED_PRECONDITION") => "invalid_request_error",
+		Some("NOT_FOUND") => "not_found_error",
+		Some("PERMISSION_DENIED") | Some("UNAUTHENTICATED") => "authentication_error",
+		Some("RESOURCE_EXHAUSTED") => "rate_limit_error",
+		_ => "api_error",
+	}
+}
+
+pub(crate) fn parse_chat_completion_error(
+	bytes: &Bytes,
+) -> Result<types::completions::typed::ChatCompletionErrorResponse, llm::AIError> {
+	serde_json::from_slice::<types::completions::typed::ChatCompletionErrorResponse>(bytes)
+		.map_err(llm::AIError::ResponseParsing)
+}
+
+/// Translate a Google error response into an OpenAI Chat Completions error response.
+pub fn translate_google_error(bytes: &Bytes) -> Result<Bytes, llm::AIError> {
+	let res = parse_google_error(bytes)?;
+	let m = types::completions::typed::ChatCompletionErrorResponse {
+		event_id: None,
+		error: types::completions::typed::ChatCompletionError {
+			r#type: Some(google_error_type(&res.error).to_string()),
+			message: res.error.message.clone(),
+			param: None,
+			code: res.error.status.clone(),
+			event_id: None,
+		},
+	};
+	Ok(Bytes::from(
+		serde_json::to_vec(&m).map_err(llm::AIError::ResponseMarshal)?,
+	))
+}
+
+pub(crate) fn parse_data_url(url: &str) -> Option<(&str, &str)> {
+	let raw = url.strip_prefix("data:")?;
+	let (meta, data) = raw.split_once(',')?;
+	let (media_type, encoding) = meta.split_once(';')?;
+	if !encoding.eq_ignore_ascii_case("base64") {
+		return None;
+	}
+	Some((media_type, data))
+}
+
+pub(crate) fn extract_system_text(
+	msg: &types::completions::typed::RequestMessage,
+) -> Option<String> {
+	fn normalize_text(text: &str) -> Option<String> {
+		if text.trim().is_empty() {
+			None
+		} else {
+			Some(text.to_string())
+		}
+	}
+
+	match msg {
+		types::completions::typed::RequestMessage::System(system) => match &system.content {
+			types::completions::typed::RequestSystemMessageContent::Text(text) => normalize_text(text),
+			types::completions::typed::RequestSystemMessageContent::Array(parts) => {
+				let text = parts
+					.iter()
+					.map(|part| match part {
+						types::completions::typed::RequestSystemMessageContentPart::Text(text) => {
+							text.text.as_str()
+						},
+					})
+					.filter(|text| !text.trim().is_empty())
+					.collect::<Vec<_>>()
+					.join("\n");
+				normalize_text(&text)
+			},
+		},
+		types::completions::typed::RequestMessage::Developer(developer) => match &developer.content {
+			types::completions::typed::RequestDeveloperMessageContent::Text(text) => normalize_text(text),
+			types::completions::typed::RequestDeveloperMessageContent::Array(parts) => {
+				let text = parts
+					.iter()
+					.map(|part| match part {
+						types::completions::typed::RequestDeveloperMessageContentPart::Text(text) => {
+							text.text.as_str()
+						},
+					})
+					.filter(|text| !text.trim().is_empty())
+					.collect::<Vec<_>>()
+					.join("\n");
+				normalize_text(&text)
+			},
+		},
+		_ => None,
+	}
+}
 
 pub mod from_messages {
+	use std::collections::{HashMap, HashSet};
+
 	use itertools::Itertools;
-	use messages::{ContentBlock, ToolResultContent, ToolResultContentPart};
+	use messages::{ToolResultContent, ToolResultContentPart};
 	use types::completions::typed as completions;
 	use types::messages::typed as messages;
 
 	use crate::json;
 	use crate::llm::{AIError, types};
+
+	use crate::llm::types::ResponseType;
+	use crate::parse::sse::SseJsonEvent;
+	use crate::telemetry::log::AsyncLog;
+	use agent_core::strng;
+	use bytes::Bytes;
+	use serde_json::Value;
+	use std::time::Instant;
 
 	/// translate an Anthropic messages to an OpenAI completions request
 	pub fn translate(req: &types::messages::Request) -> Result<Vec<u8>, AIError> {
@@ -23,6 +146,471 @@ pub mod from_messages {
 		serde_json::to_vec(&xlated).map_err(AIError::RequestMarshal)
 	}
 
+	pub fn translate_response(bytes: &Bytes) -> Result<Box<dyn ResponseType>, AIError> {
+		let resp =
+			serde_json::from_slice::<completions::Response>(bytes).map_err(AIError::ResponseParsing)?;
+		let anthropic = translate_response_internal(resp)?;
+		Ok(Box::new(anthropic))
+	}
+
+	fn translate_response_internal(
+		resp: completions::Response,
+	) -> Result<messages::MessagesResponse, AIError> {
+		let completions::Response {
+			id,
+			choices,
+			model,
+			usage,
+			..
+		} = resp;
+		// Anthropic only supports one choice
+		let choice = choices
+			.into_iter()
+			.next()
+			.ok_or_else(|| AIError::InvalidResponse(strng::literal!("chat response missing choices")))?;
+
+		let mut content: Vec<messages::ContentBlock> = Vec::new();
+		if let Some(text) = choice.message.content {
+			content.push(messages::ContentBlock::Text(messages::ContentTextBlock {
+				text,
+				citations: None,
+				cache_control: None,
+			}));
+		}
+		if let Some(tool_calls) = choice.message.tool_calls {
+			content.extend(tool_calls.into_iter().filter_map(|tc| match tc {
+				completions::MessageToolCalls::Function(f) => {
+					let input =
+						serde_json::from_str::<serde_json::Value>(&f.function.arguments).unwrap_or_default();
+					Some(messages::ContentBlock::ToolUse {
+						id: f.id,
+						name: f.function.name,
+						input,
+						cache_control: None,
+					})
+				},
+				completions::MessageToolCalls::Custom(_) => None,
+			}));
+		}
+
+		let stop_reason = choice
+			.finish_reason
+			.map(|r| match r {
+				completions::FinishReason::Stop => messages::StopReason::EndTurn,
+				completions::FinishReason::Length => messages::StopReason::MaxTokens,
+				completions::FinishReason::ToolCalls => messages::StopReason::ToolUse,
+				completions::FinishReason::ContentFilter => messages::StopReason::EndTurn,
+				completions::FinishReason::FunctionCall => messages::StopReason::ToolUse,
+			})
+			.unwrap_or(messages::StopReason::EndTurn);
+
+		Ok(messages::MessagesResponse {
+			id,
+			r#type: "message".to_string(),
+			role: messages::Role::Assistant,
+			model,
+			stop_reason: Some(stop_reason),
+			stop_sequence: None,
+			usage: messages::Usage {
+				input_tokens: usage
+					.as_ref()
+					.map(|u| u.prompt_tokens as usize)
+					.unwrap_or(0),
+				output_tokens: usage
+					.as_ref()
+					.map(|u| u.completion_tokens as usize)
+					.unwrap_or(0),
+				cache_creation_input_tokens: None,
+				cache_read_input_tokens: None,
+			},
+			content,
+		})
+	}
+
+	pub fn translate_stream(
+		b: crate::http::Body,
+		buffer_limit: usize,
+		log: AsyncLog<crate::llm::LLMInfo>,
+	) -> crate::http::Body {
+		#[derive(Debug)]
+		struct PendingToolCall {
+			id: Option<String>,
+			name: Option<String>,
+			pending_json: String,
+		}
+
+		#[derive(Debug, Default)]
+		struct StreamState {
+			sent_message_start: bool,
+			sent_message_stop: bool,
+			sent_first_token: bool,
+			next_block_index: usize,
+			text_block_index: Option<usize>,
+			tool_block_indices: HashMap<u32, usize>,
+			open_tool_blocks: HashSet<u32>,
+			pending_tool_calls: HashMap<u32, PendingToolCall>,
+			pending_stop_reason: Option<messages::StopReason>,
+			pending_usage: Option<completions::Usage>,
+		}
+
+		fn push_event(
+			events: &mut Vec<(&'static str, messages::MessagesStreamEvent)>,
+			event: messages::MessagesStreamEvent,
+		) {
+			let name = event.event_name();
+			events.push((name, event));
+		}
+
+		fn close_text_block(
+			state: &mut StreamState,
+			events: &mut Vec<(&'static str, messages::MessagesStreamEvent)>,
+		) {
+			if let Some(index) = state.text_block_index.take() {
+				push_event(
+					events,
+					messages::MessagesStreamEvent::ContentBlockStop { index },
+				);
+			}
+		}
+
+		fn close_all_tool_blocks(
+			state: &mut StreamState,
+			events: &mut Vec<(&'static str, messages::MessagesStreamEvent)>,
+		) {
+			let mut blocks: Vec<(u32, usize)> = state
+				.open_tool_blocks
+				.iter()
+				.filter_map(|tool_index| {
+					state
+						.tool_block_indices
+						.get(tool_index)
+						.map(|index| (*tool_index, *index))
+				})
+				.collect();
+			blocks.sort_by_key(|(_, index)| *index);
+			for (tool_index, index) in blocks {
+				push_event(
+					events,
+					messages::MessagesStreamEvent::ContentBlockStop { index },
+				);
+				state.open_tool_blocks.remove(&tool_index);
+			}
+		}
+
+		fn open_text_block(
+			state: &mut StreamState,
+			events: &mut Vec<(&'static str, messages::MessagesStreamEvent)>,
+		) -> usize {
+			if let Some(index) = state.text_block_index {
+				return index;
+			}
+			close_all_tool_blocks(state, events);
+			let index = state.next_block_index;
+			state.next_block_index += 1;
+			state.text_block_index = Some(index);
+			push_event(
+				events,
+				messages::MessagesStreamEvent::ContentBlockStart {
+					index,
+					content_block: messages::ContentBlock::Text(messages::ContentTextBlock {
+						text: "".to_string(),
+						citations: None,
+						cache_control: None,
+					}),
+				},
+			);
+			index
+		}
+
+		fn open_tool_block(
+			state: &mut StreamState,
+			events: &mut Vec<(&'static str, messages::MessagesStreamEvent)>,
+			tool_index: u32,
+			id: String,
+			name: String,
+		) -> usize {
+			close_text_block(state, events);
+			let index = *state
+				.tool_block_indices
+				.entry(tool_index)
+				.or_insert_with(|| {
+					let idx = state.next_block_index;
+					state.next_block_index += 1;
+					idx
+				});
+
+			// Keep each tool-use block open across interleaved deltas to avoid
+			// emitting duplicate start events for the same block index.
+			if state.open_tool_blocks.insert(tool_index) {
+				push_event(
+					events,
+					messages::MessagesStreamEvent::ContentBlockStart {
+						index,
+						content_block: messages::ContentBlock::ToolUse {
+							id,
+							name,
+							input: Value::Object(serde_json::Map::new()),
+							cache_control: None,
+						},
+					},
+				);
+			}
+			index
+		}
+
+		fn maybe_set_first_token(state: &mut StreamState, log: &AsyncLog<crate::llm::LLMInfo>) {
+			if state.sent_first_token {
+				return;
+			}
+			state.sent_first_token = true;
+			log.non_atomic_mutate(|r| {
+				r.response.first_token = Some(Instant::now());
+			});
+		}
+
+		fn flush_message_end(
+			state: &mut StreamState,
+			events: &mut Vec<(&'static str, messages::MessagesStreamEvent)>,
+			log: &AsyncLog<crate::llm::LLMInfo>,
+			force: bool,
+		) {
+			if state.sent_message_stop {
+				return;
+			}
+			let stop_reason = match state.pending_stop_reason.take() {
+				Some(stop_reason) => stop_reason,
+				None if force => messages::StopReason::EndTurn,
+				None => return,
+			};
+			let usage = match state.pending_usage.take() {
+				Some(usage) => Some(usage),
+				None if force => None,
+				None => {
+					state.pending_stop_reason = Some(stop_reason);
+					return;
+				},
+			};
+
+			close_text_block(state, events);
+			close_all_tool_blocks(state, events);
+
+			let (input_tokens, output_tokens) = usage
+				.as_ref()
+				.map(|u| (u.prompt_tokens as usize, u.completion_tokens as usize))
+				.unwrap_or((0, 0));
+
+			push_event(
+				events,
+				messages::MessagesStreamEvent::MessageDelta {
+					delta: messages::MessageDelta {
+						stop_reason: Some(stop_reason),
+						stop_sequence: None,
+					},
+					usage: messages::MessageDeltaUsage {
+						input_tokens,
+						output_tokens,
+						cache_creation_input_tokens: None,
+						cache_read_input_tokens: None,
+					},
+				},
+			);
+			push_event(events, messages::MessagesStreamEvent::MessageStop);
+			state.sent_message_stop = true;
+
+			if let Some(usage) = usage {
+				log.non_atomic_mutate(|r| {
+					r.response.input_tokens = Some(usage.prompt_tokens as u64);
+					r.response.output_tokens = Some(usage.completion_tokens as u64);
+					r.response.total_tokens = Some(usage.total_tokens as u64);
+				});
+			}
+		}
+
+		let mut state = StreamState::default();
+
+		crate::parse::sse::json_transform_multi::<
+			completions::StreamResponse,
+			messages::MessagesStreamEvent,
+			_,
+		>(b, buffer_limit, move |evt| {
+			let mut events: Vec<(&'static str, messages::MessagesStreamEvent)> = Vec::new();
+			match evt {
+				SseJsonEvent::Done => {
+					flush_message_end(&mut state, &mut events, &log, true);
+					return events;
+				},
+				SseJsonEvent::Data(Err(e)) => {
+					tracing::warn!(
+						"Failed to parse OpenAI stream response during translation: {}",
+						e
+					);
+					return events;
+				},
+				SseJsonEvent::Data(Ok(f)) => {
+					if !state.sent_message_start {
+						state.sent_message_start = true;
+						push_event(
+							&mut events,
+							messages::MessagesStreamEvent::MessageStart {
+								message: messages::MessagesResponse {
+									id: f.id.clone(),
+									r#type: "message".to_string(),
+									role: messages::Role::Assistant,
+									content: vec![],
+									model: f.model.clone(),
+									stop_reason: None,
+									stop_sequence: None,
+									usage: messages::Usage {
+										input_tokens: 0,
+										output_tokens: 0,
+										cache_creation_input_tokens: None,
+										cache_read_input_tokens: None,
+									},
+								},
+							},
+						);
+
+						log.non_atomic_mutate(|r| r.response.provider_model = Some(strng::new(&f.model)));
+					}
+
+					if let Some(usage) = f.usage {
+						state.pending_usage = Some(usage);
+					}
+
+					if let Some(choice) = f.choices.first() {
+						if let Some(content) = &choice.delta.content {
+							let index = open_text_block(&mut state, &mut events);
+							maybe_set_first_token(&mut state, &log);
+							push_event(
+								&mut events,
+								messages::MessagesStreamEvent::ContentBlockDelta {
+									index,
+									delta: messages::ContentBlockDelta::TextDelta {
+										text: content.clone(),
+									},
+								},
+							);
+						}
+
+						if let Some(tool_calls) = &choice.delta.tool_calls {
+							for tool_call in tool_calls {
+								let tool_index = tool_call.index;
+								let (should_open, id, name, pending_json) = {
+									let entry =
+										state
+											.pending_tool_calls
+											.entry(tool_index)
+											.or_insert(PendingToolCall {
+												id: None,
+												name: None,
+												pending_json: String::new(),
+											});
+									if let Some(id) = &tool_call.id {
+										entry.id = Some(id.clone());
+									}
+									if let Some(function) = &tool_call.function {
+										if let Some(name) = &function.name {
+											entry.name = Some(name.clone());
+										}
+										if let Some(args) = &function.arguments {
+											entry.pending_json.push_str(args);
+										}
+									}
+
+									let should_open = entry.name.is_some();
+									let id = entry.id.clone();
+									let name = entry.name.clone();
+									let pending_json = if should_open && !entry.pending_json.is_empty() {
+										Some(std::mem::take(&mut entry.pending_json))
+									} else {
+										None
+									};
+									(should_open, id, name, pending_json)
+								};
+
+								if should_open {
+									let id = id.unwrap_or_else(|| format!("tool_call_{tool_index}"));
+									let name = name.unwrap_or_default();
+									let index = open_tool_block(&mut state, &mut events, tool_index, id, name);
+
+									if let Some(pending_json) = pending_json {
+										maybe_set_first_token(&mut state, &log);
+										let delta = messages::ContentBlockDelta::InputJsonDelta {
+											partial_json: pending_json,
+										};
+										push_event(
+											&mut events,
+											messages::MessagesStreamEvent::ContentBlockDelta { index, delta },
+										);
+									}
+								}
+							}
+						}
+
+						if let Some(finish_reason) = &choice.finish_reason {
+							let stop_reason = match finish_reason {
+								completions::FinishReason::Stop => messages::StopReason::EndTurn,
+								completions::FinishReason::Length => messages::StopReason::MaxTokens,
+								completions::FinishReason::ToolCalls => messages::StopReason::ToolUse,
+								completions::FinishReason::ContentFilter => messages::StopReason::Refusal,
+								completions::FinishReason::FunctionCall => messages::StopReason::ToolUse,
+							};
+							state.pending_stop_reason = Some(stop_reason);
+						}
+					}
+
+					if state.pending_stop_reason.is_some() && state.pending_usage.is_some() {
+						flush_message_end(&mut state, &mut events, &log, false);
+					}
+				},
+			}
+			events
+		})
+	}
+
+	fn normalized_error_type(status: ::http::StatusCode, error_type: Option<&str>) -> &str {
+		error_type.unwrap_or(match status {
+			::http::StatusCode::BAD_REQUEST => "invalid_request_error",
+			::http::StatusCode::UNAUTHORIZED | ::http::StatusCode::FORBIDDEN => "authentication_error",
+			::http::StatusCode::NOT_FOUND => "not_found_error",
+			::http::StatusCode::TOO_MANY_REQUESTS => "rate_limit_error",
+			_ => "api_error",
+		})
+	}
+
+	pub fn translate_error(bytes: &Bytes, status: ::http::StatusCode) -> Result<Bytes, AIError> {
+		let res = super::parse_chat_completion_error(bytes)?;
+		let m = messages::MessagesErrorResponse {
+			r#type: "error".to_string(),
+			error: messages::MessagesError {
+				r#type: normalized_error_type(status, res.error.r#type.as_deref()).to_string(),
+				message: res.error.message,
+			},
+		};
+		Ok(Bytes::from(
+			serde_json::to_vec(&m).map_err(AIError::ResponseMarshal)?,
+		))
+	}
+
+	/// Convert an Anthropic image source JSON value into an OpenAI-compatible URL string.
+	/// Base64 sources become `data:` URIs; URL sources pass through directly.
+	fn anthropic_source_to_url(source: &serde_json::Value) -> Option<String> {
+		let source_type = source.get("type")?.as_str()?;
+		match source_type {
+			"base64" => {
+				let media_type = source.get("media_type")?.as_str()?;
+				let data = source.get("data")?.as_str()?;
+				Some(format!("data:{media_type};base64,{data}"))
+			},
+			"url" => {
+				let url = source.get("url")?.as_str()?;
+				Some(url.to_string())
+			},
+			_ => None,
+		}
+	}
+
+	#[allow(deprecated)]
 	fn translate_internal(req: messages::Request) -> completions::Request {
 		let messages::Request {
 			messages,
@@ -77,19 +665,19 @@ pub mod from_messages {
 		if let Some(system) = system {
 			let system_text = match system {
 				messages::SystemPrompt::Text(text) => text,
-				messages::SystemPrompt::Blocks(blocks) => {
-					// Join all text blocks into a single string
-					blocks
-						.into_iter()
-						.map(|block| match block {
-							messages::SystemContentBlock::Text { text, .. } => text,
-						})
-						.collect::<Vec<_>>()
-						.join("\n")
-				},
+				messages::SystemPrompt::Blocks(blocks) => blocks
+					.into_iter()
+					.map(|block| match block {
+						messages::SystemContentBlock::Text { text, .. } => text,
+					})
+					.collect::<Vec<_>>()
+					.join("\n"),
 			};
 			msgs.push(completions::RequestMessage::System(
-				completions::RequestSystemMessage::from(system_text),
+				completions::RequestSystemMessage {
+					content: completions::RequestSystemMessageContent::Text(system_text),
+					name: None,
+				},
 			));
 		}
 
@@ -97,73 +685,77 @@ pub mod from_messages {
 		for msg in messages {
 			match msg.role {
 				messages::Role::User => {
-					let mut user_text = String::new();
+					let mut parts: Vec<completions::RequestUserMessageContentPart> = Vec::new();
+
 					for block in msg.content {
 						match block {
 							messages::ContentBlock::Text(messages::ContentTextBlock { text, .. }) => {
-								if !user_text.is_empty() {
-									user_text.push('\n');
+								parts.push(completions::RequestUserMessageContentPart::Text(
+									completions::RequestMessageContentPartText { text },
+								));
+							},
+							messages::ContentBlock::Image(messages::ContentImageBlock { source, .. }) => {
+								if let Some(url) = anthropic_source_to_url(&source) {
+									parts.push(completions::RequestUserMessageContentPart::ImageUrl(
+										completions::RequestMessageContentPartImage {
+											image_url: completions::ImageUrl { url, detail: None },
+										},
+									));
 								}
-								user_text.push_str(&text);
 							},
 							messages::ContentBlock::ToolResult {
 								tool_use_id,
 								content,
 								..
 							} => {
-								msgs.push(
+								let tool_content = match content {
+									ToolResultContent::Text(t) => completions::RequestToolMessageContent::Text(t),
+									ToolResultContent::Array(arr) => completions::RequestToolMessageContent::Array(
+										arr
+											.into_iter()
+											.filter_map(|p| match p {
+												ToolResultContentPart::Text { text, .. } => {
+													Some(completions::RequestToolMessageContentPart::Text(
+														completions::RequestMessageContentPartText { text },
+													))
+												},
+												_ => None,
+											})
+											.collect_vec(),
+									),
+								};
+								msgs.push(completions::RequestMessage::Tool(
 									completions::RequestToolMessage {
+										content: tool_content,
 										tool_call_id: tool_use_id,
-										content: match content {
-											ToolResultContent::Text(t) => t.into(),
-											ToolResultContent::Array(parts) => {
-												completions::RequestToolMessageContent::Array(
-													parts
-														.into_iter()
-														.filter_map(|p| match p {
-															ToolResultContentPart::Text { text, .. } => Some(
-																completions::RequestToolMessageContentPart::Text(text.into()),
-															),
-															// Other types are not supported
-															_ => None,
-														})
-														.collect_vec(),
-												)
-											},
-										},
-									}
-									.into(),
-								);
+									},
+								));
 							},
-							// Image content is not directly supported in universal::Message::User in this form.
-							// This would require a different content format not represented here.
-							messages::ContentBlock::Image { .. } => {}, /* Image content is not directly supported in universal::Message::User in this form. */
-							// This would require a different content format not represented here.
-							// ToolUse blocks are expected from assistants, not users.
 							messages::ContentBlock::ServerToolUse { .. }
-							| messages::ContentBlock::ToolUse { .. } => {}, /* ToolUse blocks are expected from assistants, not users. */
-
-							// Other content block types are not expected from the user in a request.
+							| messages::ContentBlock::ToolUse { .. } => {},
 							_ => {},
 						}
 					}
-					if !user_text.is_empty() {
-						msgs.push(
+
+					if !parts.is_empty() {
+						msgs.push(completions::RequestMessage::User(
 							completions::RequestUserMessage {
-								content: user_text.into(),
+								content: completions::RequestUserMessageContent::Array(parts),
 								name: None,
-							}
-							.into(),
-						);
+							},
+						));
 					}
 				},
 				messages::Role::Assistant => {
-					let mut assistant_text = None;
+					let mut assistant_text = String::new();
 					let mut tool_calls: Vec<completions::MessageToolCalls> = Vec::new();
 					for block in msg.content {
 						match block {
 							messages::ContentBlock::Text(messages::ContentTextBlock { text, .. }) => {
-								assistant_text = Some(text);
+								if !assistant_text.is_empty() {
+									assistant_text.push('\n');
+								}
+								assistant_text.push_str(&text);
 							},
 							messages::ContentBlock::ToolUse {
 								id, name, input, ..
@@ -173,41 +765,47 @@ pub mod from_messages {
 										id,
 										function: completions::FunctionCall {
 											name,
-											// It's assumed that the input is a JSON object that can be stringified.
 											arguments: serde_json::to_string(&input).unwrap_or_default(),
 										},
 									},
 								));
 							},
-							ContentBlock::Thinking { .. } => {
+							messages::ContentBlock::Thinking { .. } => {
 								// TODO
 							},
-							ContentBlock::RedactedThinking { .. } => {
+							messages::ContentBlock::RedactedThinking { .. } => {
 								// TODO
 							},
-							// Other content block types are not expected from the assistant in a request.
 							_ => {},
 						}
 					}
-					if assistant_text.is_some() || !tool_calls.is_empty() {
-						msgs.push(
+					if !assistant_text.is_empty() || !tool_calls.is_empty() {
+						msgs.push(completions::RequestMessage::Assistant(
 							completions::RequestAssistantMessage {
-								content: assistant_text.map(Into::into),
+								content: if assistant_text.is_empty() {
+									None
+								} else {
+									Some(completions::RequestAssistantMessageContent::Text(
+										assistant_text,
+									))
+								},
+								name: None,
 								tool_calls: if tool_calls.is_empty() {
 									None
 								} else {
 									Some(tool_calls)
 								},
-								..Default::default()
-							}
-							.into(),
-						);
+								refusal: None,
+								audio: None,
+								function_call: None,
+							},
+						));
 					}
 				},
 			}
 		}
 
-		let tools = tools
+		let tools: Vec<completions::Tool> = tools
 			.into_iter()
 			.flat_map(|tools| tools.into_iter())
 			.map(|tool| {
@@ -221,35 +819,48 @@ pub mod from_messages {
 				})
 			})
 			.collect_vec();
+
+		let mut parallel_tool_calls = None;
 		let tool_choice = tool_choice.map(|choice| match choice {
-			messages::ToolChoice::Auto => {
+			messages::ToolChoice::Auto {
+				disable_parallel_tool_use,
+			} => {
+				parallel_tool_calls = disable_parallel_tool_use.map(|d| !d);
 				completions::ToolChoiceOption::Mode(completions::ToolChoiceOptions::Auto)
 			},
-			messages::ToolChoice::Any => {
+			messages::ToolChoice::Any {
+				disable_parallel_tool_use,
+			} => {
+				parallel_tool_calls = disable_parallel_tool_use.map(|d| !d);
 				completions::ToolChoiceOption::Mode(completions::ToolChoiceOptions::Required)
 			},
-			messages::ToolChoice::Tool { name } => {
+			messages::ToolChoice::Tool {
+				name,
+				disable_parallel_tool_use,
+			} => {
+				parallel_tool_calls = disable_parallel_tool_use.map(|d| !d);
 				completions::ToolChoiceOption::Function(completions::NamedToolChoice {
 					function: completions::FunctionName { name },
 				})
 			},
-			messages::ToolChoice::None => {
+			messages::ToolChoice::None {} => {
 				completions::ToolChoiceOption::Mode(completions::ToolChoiceOptions::None)
 			},
 		});
 
-		// Carry request-scoped metadata forward for downstream guardrail providers (e.g. Bedrock Guardrails,
-		// Model Armor) while still mapping the common `user_id` to OpenAI's `user` field.
-		//
-		// `messages.metadata.fields` is a string map, which fits cleanly into OpenAI's free-form `metadata` object.
+		// Preserve the common `user_id` field when mapping Messages -> OpenAI chat completions.
+		// The rest of `messages.metadata` is handled only on provider-native Messages paths.
+		// Forwarding it here breaks OpenAI-compatible backends because `metadata` requires `store=true`,
+		// which agentgateway does not set on this path.
 		let user_id = metadata
 			.as_ref()
 			.and_then(|m| m.fields.get("user_id").cloned());
-		let metadata_json = metadata.and_then(|m| {
-			serde_json::to_value(m.fields)
-				.ok()
-				.filter(|v| !matches!(v, serde_json::Value::Object(map) if map.is_empty()))
-		});
+
+		let stop = if stop_sequences.is_empty() {
+			None
+		} else {
+			Some(completions::Stop::StringArray(stop_sequences))
+		};
 
 		completions::Request {
 			model: Some(model),
@@ -258,16 +869,11 @@ pub mod from_messages {
 			temperature,
 			top_p,
 			max_completion_tokens: Some(max_tokens as u32),
-			stop: if stop_sequences.is_empty() {
-				None
-			} else {
-				Some(completions::Stop::StringArray(stop_sequences))
-			},
+			max_tokens: None,
+			stop,
 			tools: if tools.is_empty() { None } else { Some(tools) },
 			tool_choice,
-			parallel_tool_calls: None,
 			user: user_id,
-
 			vendor_extensions: completions::RequestVendorExtensions {
 				top_k,
 				thinking_budget_tokens: thinking.as_ref().and_then(|t| match t {
@@ -275,9 +881,21 @@ pub mod from_messages {
 					_ => None,
 				}),
 			},
-
-			// The following OpenAI fields are not supported by Anthropic and are set to None:
+			stream_options: if stream {
+				Some(completions::StreamOptions {
+					include_usage: Some(true),
+					include_obfuscation: None,
+				})
+			} else {
+				None
+			},
 			frequency_penalty: None,
+			presence_penalty: None,
+			seed: None,
+			// Fields not applicable from Anthropic Messages
+			store: None,
+			reasoning_effort,
+			metadata: None,
 			logit_bias: None,
 			logprobs: None,
 			top_logprobs: None,
@@ -285,21 +903,14 @@ pub mod from_messages {
 			modalities: None,
 			prediction: None,
 			audio: None,
-			presence_penalty: None,
 			response_format,
-			seed: None,
 			#[allow(deprecated)]
 			function_call: None,
 			#[allow(deprecated)]
 			functions: None,
-			metadata: metadata_json,
-			#[allow(deprecated)]
-			max_tokens: None,
 			service_tier: None,
+			parallel_tool_calls,
 			web_search_options: None,
-			stream_options: None,
-			store: None,
-			reasoning_effort,
 		}
 	}
 }

--- a/crates/agentgateway/src/llm/conversion/completions.rs
+++ b/crates/agentgateway/src/llm/conversion/completions.rs
@@ -129,11 +129,10 @@ pub mod from_messages {
 	use types::messages::typed as messages;
 
 	use crate::json;
-	use crate::llm::{AIError, types};
+	use crate::llm::{AIError, AmendOnDrop, types};
 
 	use crate::llm::types::ResponseType;
 	use crate::parse::sse::SseJsonEvent;
-	use crate::telemetry::log::AsyncLog;
 	use agent_core::strng;
 	use bytes::Bytes;
 	use serde_json::Value;
@@ -230,7 +229,7 @@ pub mod from_messages {
 	pub fn translate_stream(
 		b: crate::http::Body,
 		buffer_limit: usize,
-		log: AsyncLog<crate::llm::LLMInfo>,
+		log: AmendOnDrop,
 	) -> crate::http::Body {
 		#[derive(Debug)]
 		struct PendingToolCall {
@@ -358,7 +357,7 @@ pub mod from_messages {
 			index
 		}
 
-		fn maybe_set_first_token(state: &mut StreamState, log: &AsyncLog<crate::llm::LLMInfo>) {
+		fn maybe_set_first_token(state: &mut StreamState, log: &AmendOnDrop) {
 			if state.sent_first_token {
 				return;
 			}
@@ -371,7 +370,7 @@ pub mod from_messages {
 		fn flush_message_end(
 			state: &mut StreamState,
 			events: &mut Vec<(&'static str, messages::MessagesStreamEvent)>,
-			log: &AsyncLog<crate::llm::LLMInfo>,
+			log: &AmendOnDrop,
 			force: bool,
 		) {
 			if state.sent_message_stop {
@@ -621,7 +620,7 @@ pub mod from_messages {
 			stream,
 			temperature,
 			top_p,
-			top_k,
+			top_k: _,
 			tools,
 			tool_choice,
 			metadata,
@@ -874,13 +873,9 @@ pub mod from_messages {
 			tools: if tools.is_empty() { None } else { Some(tools) },
 			tool_choice,
 			user: user_id,
-			vendor_extensions: completions::RequestVendorExtensions {
-				top_k,
-				thinking_budget_tokens: thinking.as_ref().and_then(|t| match t {
-					messages::ThinkingInput::Enabled { budget_tokens } => Some(*budget_tokens),
-					_ => None,
-				}),
-			},
+			// Internal vendor extensions are only for completions-originated requests.
+			// messages -> completions should emit OpenAI-compatible payloads only.
+			vendor_extensions: completions::RequestVendorExtensions::default(),
 			stream_options: if stream {
 				Some(completions::StreamOptions {
 					include_usage: Some(true),

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -283,7 +283,7 @@ impl AIProvider {
 					backend_auth: Some(BackendAuth::Gcp(GcpAuth::default())),
 					..Default::default()
 				};
-				(Target::Hostname(p.get_host(), 443), bp)
+				(Target::Hostname(p.get_host(None), 443), bp)
 			},
 			AIProvider::Anthropic(_) => (Target::Hostname(anthropic::DEFAULT_HOST, 443), btls),
 			AIProvider::Bedrock(p) => {
@@ -370,7 +370,7 @@ impl AIProvider {
 				http::modify_req(req, |req| {
 					http::modify_uri(req, |uri| {
 						uri.path_and_query = Some(PathAndQuery::from_str(&path)?);
-						uri.authority = Some(Authority::from_str(&provider.get_host())?);
+						uri.authority = Some(Authority::from_str(&provider.get_host(request_model))?);
 						Ok(())
 					})?;
 					Ok(())
@@ -559,6 +559,32 @@ impl AIProvider {
 			.read_body_and_default_model::<types::count_tokens::Request>(policies, req, log)
 			.await?;
 
+		// Some Anthropic-compatible clients (e.g. Claude Code) always call
+		// `/v1/messages/count_tokens`. For providers/models without a native
+		// count-tokens endpoint, we must still answer this route, so we fall
+		// back to local token estimation using the normalized messages payload.
+		let use_local = match self {
+			AIProvider::Anthropic(_) => false,
+			AIProvider::Bedrock(p) => !p.is_anthropic_model(req.model.as_deref()),
+			AIProvider::Vertex(p) => !p.is_anthropic_model(req.model.as_deref()),
+			_ => true,
+		};
+		if use_local {
+			let messages = req.get_messages();
+			let model = req.model.as_deref().unwrap_or_default();
+			let count = num_tokens_from_messages(model, &messages)?;
+			let body = serde_json::to_vec(&types::count_tokens::Response {
+				input_tokens: count,
+			})
+			.map_err(AIError::ResponseMarshal)?;
+			let resp = ::http::Response::builder()
+				.status(::http::StatusCode::OK)
+				.header(::http::header::CONTENT_TYPE, "application/json")
+				.body(Body::from(body))
+				.expect("failed to build count_tokens response");
+			return Ok(RequestResult::Rejected(resp));
+		}
+
 		self
 			.process_request(
 				backend_info,
@@ -594,10 +620,16 @@ impl AIProvider {
 				// OpenAI supports responses input (Bedrock supports responses input via translation)
 			},
 			(
-				AIProvider::Anthropic(_) | AIProvider::Bedrock(_) | AIProvider::Vertex(_),
+				AIProvider::Anthropic(_)
+				| AIProvider::Bedrock(_)
+				| AIProvider::Vertex(_)
+				| AIProvider::OpenAI(_)
+				| AIProvider::Gemini(_)
+				| AIProvider::AzureOpenAI(_),
 				InputFormat::Messages,
 			) => {
 				// Anthropic supports messages input (Bedrock & Vertex support assuming serving Anthropic models)
+				// OpenAI/Gemini/AzureOpenAI support messages via translation to chat completions
 			},
 			(
 				AIProvider::Anthropic(_) | AIProvider::Bedrock(_) | AIProvider::Vertex(_),
@@ -616,7 +648,7 @@ impl AIProvider {
 				// OpenAI compatible, Gemini, Bedrock, or Vertex
 			},
 			(p, m) => {
-				// Messages with OpenAI compatible: currently only supports translating the request
+				// Unsupported provider/format combination.
 				return Err(AIError::UnsupportedConversion(strng::format!(
 					"{m:?} from provider {}",
 					p.provider()
@@ -746,7 +778,7 @@ impl AIProvider {
 		// embeddings has simplified response handling
 		if req.input_format == InputFormat::Embeddings {
 			if !parts.status.is_success() {
-				let body = self.process_error(&req, &bytes)?;
+				let body = self.process_error(&req, parts.status, &bytes)?;
 				parts.headers.remove(header::CONTENT_LENGTH);
 				let resp = Response::from_parts(parts, body.into());
 				let llm_info = LLMInfo::new(req, LLMResponse::default());
@@ -783,7 +815,7 @@ impl AIProvider {
 		}
 
 		let (llm_resp, body) = if !parts.status.is_success() {
-			let body = self.process_error(&req, &bytes)?;
+			let body = self.process_error(&req, parts.status, &bytes)?;
 			(LLMResponse::default(), body)
 		} else {
 			let mut resp = self.process_success(&req, &bytes)?;
@@ -848,11 +880,8 @@ impl AIProvider {
 					AIError::ResponseParsing(e)
 				})?,
 			)),
-			// Responses with OpenAI: just passthrough
-			(
-				AIProvider::OpenAI(_) | AIProvider::Gemini(_) | AIProvider::AzureOpenAI(_),
-				InputFormat::Responses,
-			) => Ok(Box::new(
+			// Responses with OpenAI/AzureOpenAI: just passthrough
+			(AIProvider::OpenAI(_) | AIProvider::AzureOpenAI(_), InputFormat::Responses) => Ok(Box::new(
 				serde_json::from_slice::<types::responses::Response>(bytes).map_err(|e| {
 					warn!(
 						error = %e,
@@ -862,11 +891,27 @@ impl AIProvider {
 					AIError::ResponseParsing(e)
 				})?,
 			)),
+			// Vertex messages: passthrough only for Anthropic models, otherwise translate from completions
+			(AIProvider::Vertex(p), InputFormat::Messages) => {
+				if p.is_anthropic_model(Some(&req.request_model)) {
+					Ok(Box::new(
+						serde_json::from_slice::<types::messages::Response>(bytes)
+							.map_err(AIError::ResponseParsing)?,
+					))
+				} else {
+					conversion::completions::from_messages::translate_response(bytes)
+				}
+			},
 			// Anthropic messages: passthrough
-			(AIProvider::Anthropic(_) | AIProvider::Vertex(_), InputFormat::Messages) => Ok(Box::new(
+			(AIProvider::Anthropic(_), InputFormat::Messages) => Ok(Box::new(
 				serde_json::from_slice::<types::messages::Response>(bytes)
 					.map_err(AIError::ResponseParsing)?,
 			)),
+			// OpenAI/Gemini/AzureOpenAI messages: translate from chat completions
+			(
+				AIProvider::OpenAI(_) | AIProvider::Gemini(_) | AIProvider::AzureOpenAI(_),
+				InputFormat::Messages,
+			) => conversion::completions::from_messages::translate_response(bytes),
 			// Supported paths with conversion...
 			(AIProvider::Anthropic(_), InputFormat::Completions) => {
 				conversion::messages::from_completions::translate_response(bytes)
@@ -890,9 +935,6 @@ impl AIProvider {
 					))
 				}
 			},
-			(_, InputFormat::Messages) => Err(AIError::UnsupportedConversion(strng::literal!(
-				"this provider does not support Messages"
-			))),
 			(_, InputFormat::Responses) => Err(AIError::UnsupportedConversion(strng::literal!(
 				"this provider does not support Responses"
 			))),
@@ -916,6 +958,10 @@ impl AIProvider {
 		include_completion_in_log: bool,
 		resp: Response,
 	) -> Result<Response, AIError> {
+		let is_vertex_anthropic = match self {
+			AIProvider::Vertex(p) => p.is_anthropic_model(Some(&req.request_model)),
+			_ => false,
+		};
 		let model = req.request_model.clone();
 		let input_format = req.input_format;
 		// Store an empty response, as we stream in info we will parse into it
@@ -943,16 +989,28 @@ impl AIProvider {
 		Ok(match (self, input_format) {
 			// Completions with OpenAI: just passthrough
 			(
-				AIProvider::OpenAI(_)
-				| AIProvider::Gemini(_)
-				| AIProvider::AzureOpenAI(_)
-				| AIProvider::Vertex(_),
+				AIProvider::OpenAI(_) | AIProvider::Gemini(_) | AIProvider::AzureOpenAI(_),
 				InputFormat::Completions,
 			) => conversion::completions::passthrough_stream(
 				AmendOnDrop::new(log, rate_limit),
 				include_completion_in_log,
 				resp,
 			),
+			// Vertex completions: passthrough for OpenAI-compatible models, translate for Anthropic models
+			(AIProvider::Vertex(_), InputFormat::Completions) if is_vertex_anthropic => resp.map(|b| {
+				conversion::messages::from_completions::translate_stream(
+					b,
+					buffer,
+					AmendOnDrop::new(log, rate_limit),
+				)
+			}),
+			(AIProvider::Vertex(_), InputFormat::Completions) => {
+				conversion::completions::passthrough_stream(
+					AmendOnDrop::new(log, rate_limit),
+					include_completion_in_log,
+					resp,
+				)
+			},
 			// Responses with OpenAI: just passthrough
 			(
 				AIProvider::OpenAI(_)
@@ -963,10 +1021,22 @@ impl AIProvider {
 			) => resp.map(|b| {
 				conversion::responses::passthrough_stream(b, buffer, AmendOnDrop::new(log, rate_limit))
 			}),
-			// Anthropic messages: passthrough
-			(AIProvider::Anthropic(_) | AIProvider::Vertex(_), InputFormat::Messages) => resp.map(|b| {
+			// Vertex messages: passthrough only for Anthropic models, otherwise translate from completions
+			(AIProvider::Vertex(_), InputFormat::Messages) if is_vertex_anthropic => resp.map(|b| {
 				conversion::messages::passthrough_stream(b, buffer, AmendOnDrop::new(log, rate_limit))
 			}),
+			(AIProvider::Vertex(_), InputFormat::Messages) => {
+				resp.map(|b| conversion::completions::from_messages::translate_stream(b, buffer, log))
+			},
+			// Anthropic messages: passthrough
+			(AIProvider::Anthropic(_), InputFormat::Messages) => resp.map(|b| {
+				conversion::messages::passthrough_stream(b, buffer, AmendOnDrop::new(log, rate_limit))
+			}),
+			// OpenAI/Gemini/AzureOpenAI messages: translate from chat completions
+			(
+				AIProvider::OpenAI(_) | AIProvider::Gemini(_) | AIProvider::AzureOpenAI(_),
+				InputFormat::Messages,
+			) => resp.map(|b| conversion::completions::from_messages::translate_stream(b, buffer, log)),
 			// Supported paths with conversion...
 			(AIProvider::Anthropic(_), InputFormat::Completions) => resp.map(|b| {
 				conversion::messages::from_completions::translate_stream(
@@ -1011,17 +1081,12 @@ impl AIProvider {
 					)
 				})
 			},
-			(_, InputFormat::Messages) => {
-				return Err(AIError::UnsupportedConversion(strng::literal!(
-					"this provider does not support Messages for streaming"
-				)));
-			},
 			(_, InputFormat::Realtime) => {
 				return Err(AIError::UnsupportedConversion(strng::literal!(
 					"realtime does not use streaming codepath"
 				)));
 			},
-			(AIProvider::Anthropic(_), InputFormat::Responses) => {
+			(_, InputFormat::Responses) => {
 				return Err(AIError::UnsupportedConversion(strng::literal!(
 					"this provider does not support Responses for streaming"
 				)));
@@ -1060,19 +1125,52 @@ impl AIProvider {
 		Ok((parts, req))
 	}
 
-	fn process_error(&self, req: &LLMRequest, bytes: &Bytes) -> Result<Bytes, AIError> {
+	fn process_error(
+		&self,
+		req: &LLMRequest,
+		status: ::http::StatusCode,
+		bytes: &Bytes,
+	) -> Result<Bytes, AIError> {
 		match (self, req.input_format) {
 			(
-				AIProvider::OpenAI(_)
-				| AIProvider::Gemini(_)
-				| AIProvider::AzureOpenAI(_)
-				| AIProvider::Vertex(_),
+				AIProvider::OpenAI(_) | AIProvider::AzureOpenAI(_),
 				InputFormat::Completions | InputFormat::Responses | InputFormat::Embeddings,
 			) => {
 				// Passthrough; nothing needed
 				Ok(bytes.clone())
 			},
-			(AIProvider::Anthropic(_) | AIProvider::Vertex(_), InputFormat::Messages) => {
+			(AIProvider::Gemini(_), InputFormat::Completions) => {
+				conversion::completions::translate_google_error(bytes)
+			},
+			(AIProvider::Gemini(_), InputFormat::Embeddings) => {
+				// Passthrough; Gemini embeddings endpoint already returns OpenAI-compatible errors.
+				Ok(bytes.clone())
+			},
+			(AIProvider::Vertex(p), InputFormat::Completions) => {
+				if p.is_anthropic_model(Some(&req.request_model)) {
+					Ok(bytes.clone())
+				} else {
+					conversion::completions::translate_google_error(bytes)
+				}
+			},
+			(AIProvider::Vertex(_), InputFormat::Embeddings) => {
+				// Passthrough; Vertex embeddings endpoint already returns OpenAI-compatible errors.
+				Ok(bytes.clone())
+			},
+			(AIProvider::OpenAI(_) | AIProvider::AzureOpenAI(_), InputFormat::Messages) => {
+				conversion::completions::from_messages::translate_error(bytes, status)
+			},
+			(AIProvider::Gemini(_), InputFormat::Messages) => {
+				conversion::messages::translate_google_error(bytes)
+			},
+			(AIProvider::Vertex(p), InputFormat::Messages) => {
+				if p.is_anthropic_model(Some(&req.request_model)) {
+					Ok(bytes.clone())
+				} else {
+					conversion::messages::translate_google_error(bytes)
+				}
+			},
+			(AIProvider::Anthropic(_), InputFormat::Messages) => {
 				// Passthrough; nothing needed
 				Ok(bytes.clone())
 			},
@@ -1141,37 +1239,6 @@ fn num_tokens_from_messages(
 	Ok(num_tokens)
 }
 
-fn num_tokens_from_anthropic_messages(
-	model: &str,
-	messages: &[types::messages::RequestMessage],
-) -> Result<u64, AIError> {
-	let tokenizer = get_tokenizer(model).unwrap_or(Tokenizer::Cl100kBase);
-	if tokenizer != Tokenizer::Cl100kBase && tokenizer != Tokenizer::O200kBase {
-		// Chat completion is only supported chat models
-		return Err(AIError::UnsupportedModel);
-	}
-	let bpe = get_bpe_from_tokenizer(tokenizer);
-
-	let tokens_per_message = 3;
-
-	let mut num_tokens: u64 = 0;
-	for message in messages {
-		num_tokens += tokens_per_message;
-		// Role is always 1 token
-		num_tokens += 1;
-		if let Some(t) = message.message_text() {
-			num_tokens += bpe
-				.encode_with_special_tokens(
-					// We filter non-text previously
-					t,
-				)
-				.len() as u64;
-		}
-	}
-	num_tokens += 3; // every reply is primed with <|start|>assistant<|message|>
-	Ok(num_tokens)
-}
-
 /// Tokenizers take about 200ms to load and are lazy loaded. This loads them on demand, outside the
 /// request path
 pub fn preload_tokenizers() {
@@ -1222,6 +1289,8 @@ pub enum AIError {
 	RequestMarshal(serde_json::Error),
 	#[error("failed to parse response: {0}")]
 	ResponseParsing(serde_json::Error),
+	#[error("invalid response: {0}")]
+	InvalidResponse(Strng),
 	#[error("failed to marshal response: {0}")]
 	ResponseMarshal(serde_json::Error),
 	#[error("unsupported content encoding: {0}")]

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -1025,9 +1025,13 @@ impl AIProvider {
 			(AIProvider::Vertex(_), InputFormat::Messages) if is_vertex_anthropic => resp.map(|b| {
 				conversion::messages::passthrough_stream(b, buffer, AmendOnDrop::new(log, rate_limit))
 			}),
-			(AIProvider::Vertex(_), InputFormat::Messages) => {
-				resp.map(|b| conversion::completions::from_messages::translate_stream(b, buffer, log))
-			},
+			(AIProvider::Vertex(_), InputFormat::Messages) => resp.map(|b| {
+				conversion::completions::from_messages::translate_stream(
+					b,
+					buffer,
+					AmendOnDrop::new(log, rate_limit),
+				)
+			}),
 			// Anthropic messages: passthrough
 			(AIProvider::Anthropic(_), InputFormat::Messages) => resp.map(|b| {
 				conversion::messages::passthrough_stream(b, buffer, AmendOnDrop::new(log, rate_limit))
@@ -1036,7 +1040,13 @@ impl AIProvider {
 			(
 				AIProvider::OpenAI(_) | AIProvider::Gemini(_) | AIProvider::AzureOpenAI(_),
 				InputFormat::Messages,
-			) => resp.map(|b| conversion::completions::from_messages::translate_stream(b, buffer, log)),
+			) => resp.map(|b| {
+				conversion::completions::from_messages::translate_stream(
+					b,
+					buffer,
+					AmendOnDrop::new(log, rate_limit),
+				)
+			}),
 			// Supported paths with conversion...
 			(AIProvider::Anthropic(_), InputFormat::Completions) => resp.map(|b| {
 				conversion::messages::from_completions::translate_stream(

--- a/crates/agentgateway/src/llm/tests.rs
+++ b/crates/agentgateway/src/llm/tests.rs
@@ -131,6 +131,60 @@ const COUNT_TOKENS_REQUESTS: &[&str] = &[
 	"request_count_tokens_with_system",
 ];
 const EMBEDDINGS_REQUESTS: &[&str] = &["request_embeddings_basic", "request_embeddings_array"];
+const STREAM_FIXTURE_BEDROCK_BASIC: &str = "response_stream-bedrock_basic.bin";
+const STREAM_FIXTURE_ANTHROPIC_BASIC: &str = "response_stream-anthropic_basic.json";
+const STREAM_FIXTURE_ANTHROPIC_THINKING: &str = "response_stream-anthropic_thinking.json";
+const STREAM_FIXTURE_ANTHROPIC_TOOL: &str = "response_stream-anthropic_tool.json";
+
+fn llm_request(
+	input_format: InputFormat,
+	provider: &str,
+	model: &str,
+	streaming: bool,
+) -> LLMRequest {
+	LLMRequest {
+		input_tokens: None,
+		input_format,
+		request_model: strng::new(model),
+		provider: strng::new(provider),
+		streaming,
+		params: LLMRequestParams::default(),
+		prompt: None,
+	}
+}
+
+fn provider_message_adapters() -> Vec<(&'static str, AIProvider)> {
+	vec![
+		(
+			"openai",
+			AIProvider::OpenAI(openai::Provider {
+				model: Some(strng::new("gpt-4.1")),
+			}),
+		),
+		(
+			"gemini",
+			AIProvider::Gemini(gemini::Provider {
+				model: Some(strng::new("gemini-2.5-pro")),
+			}),
+		),
+		(
+			"azure",
+			AIProvider::AzureOpenAI(azureopenai::Provider {
+				model: Some(strng::new("gpt-4.1")),
+				host: strng::new("example.openai.azure.com"),
+				api_version: None,
+			}),
+		),
+		(
+			"vertex",
+			AIProvider::Vertex(vertex::Provider {
+				model: Some(strng::new("gemini-2.5-pro")),
+				region: Some(strng::new("us-central1")),
+				project_id: strng::new("test-project-123"),
+			}),
+		),
+	]
+}
 
 #[tokio::test]
 async fn test_bedrock_embeddings() {
@@ -230,7 +284,7 @@ async fn test_bedrock_completions() {
 	};
 	test_streaming(
 		"bedrock-completions",
-		"response_stream-bedrock_basic.bin",
+		STREAM_FIXTURE_BEDROCK_BASIC,
 		stream_response,
 	)
 	.await;
@@ -266,7 +320,7 @@ async fn test_bedrock_messages() {
 	};
 	test_streaming(
 		"bedrock-messages",
-		"response_stream-bedrock_basic.bin",
+		STREAM_FIXTURE_BEDROCK_BASIC,
 		stream_response,
 	)
 	.await;
@@ -302,7 +356,7 @@ async fn test_bedrock_responses() {
 	};
 	test_streaming(
 		"bedrock-response",
-		"response_stream-bedrock_basic.bin",
+		STREAM_FIXTURE_BEDROCK_BASIC,
 		stream_response,
 	)
 	.await;
@@ -333,7 +387,7 @@ async fn test_vertex_messages() {
 	let stream_response = |body, log| Ok(conversion::messages::passthrough_stream(body, 1024, log));
 	test_streaming(
 		"vertex-messages",
-		"response_stream-anthropic_basic.json",
+		STREAM_FIXTURE_ANTHROPIC_BASIC,
 		stream_response,
 	)
 	.await;
@@ -514,6 +568,271 @@ fn test_messages_output_config_format_maps_to_openai_response_format() {
 	);
 }
 
+#[test]
+fn test_messages_to_completions_stream_sets_include_usage_stream_option() {
+	let req: types::messages::Request = serde_json::from_value(serde_json::json!({
+		"model": "gpt-4.1",
+		"max_tokens": 64,
+		"stream": true,
+		"messages": [
+			{"role": "user", "content": "hello"}
+		]
+	}))
+	.expect("valid messages request");
+
+	let out = conversion::completions::from_messages::translate(&req)
+		.expect("messages -> completions translation should succeed");
+	let value: Value =
+		serde_json::from_slice(&out).expect("translated completions request should parse");
+
+	assert_eq!(value["stream"], serde_json::json!(true));
+	assert_eq!(
+		value["stream_options"]["include_usage"],
+		serde_json::json!(true)
+	);
+}
+
+#[test]
+fn test_messages_to_completions_non_stream_omits_stream_options() {
+	let req: types::messages::Request = serde_json::from_value(serde_json::json!({
+		"model": "gpt-4.1",
+		"max_tokens": 64,
+		"stream": false,
+		"messages": [
+			{"role": "user", "content": "hello"}
+		]
+	}))
+	.expect("valid messages request");
+
+	let out = conversion::completions::from_messages::translate(&req)
+		.expect("messages -> completions translation should succeed");
+	let value: Value =
+		serde_json::from_slice(&out).expect("translated completions request should parse");
+
+	assert_eq!(value["stream"], serde_json::json!(false));
+	assert!(
+		value.get("stream_options").is_none(),
+		"non-stream request should not include stream_options: {value}"
+	);
+}
+
+#[test]
+fn test_messages_to_completions_drops_assistant_thinking_blocks_but_keeps_text_and_tool_use() {
+	let req: types::messages::Request = serde_json::from_value(serde_json::json!({
+		"model": "gpt-4.1",
+		"max_tokens": 64,
+		"messages": [
+			{"role": "user", "content": "hello"},
+			{
+				"role": "assistant",
+				"content": [
+					{"type": "thinking", "thinking": "internal chain of thought", "signature": "sig_123"},
+					{"type": "redacted_thinking", "data": "opaque"},
+					{"type": "text", "text": "final answer"},
+					{"type": "tool_use", "id": "call_1", "name": "lookup", "input": {"q": "x"}}
+				]
+			}
+		]
+	}))
+	.expect("valid messages request");
+
+	let out = conversion::completions::from_messages::translate(&req)
+		.expect("messages -> completions translation should succeed");
+	let value: Value =
+		serde_json::from_slice(&out).expect("translated completions request should parse");
+
+	let msgs = value["messages"]
+		.as_array()
+		.expect("translated messages should be an array");
+	let assistant = msgs
+		.iter()
+		.find(|m| m["role"] == "assistant")
+		.expect("assistant message should be present");
+
+	assert_eq!(assistant["content"], serde_json::json!("final answer"));
+	assert_eq!(
+		assistant["tool_calls"][0]["id"],
+		serde_json::json!("call_1")
+	);
+	assert_eq!(
+		assistant["tool_calls"][0]["function"]["name"],
+		serde_json::json!("lookup")
+	);
+	assert!(
+		!assistant.to_string().contains("redacted_thinking")
+			&& !assistant.to_string().contains("thinking"),
+		"assistant message should not include thinking blocks: {assistant}"
+	);
+}
+
+#[test]
+fn test_messages_to_completions_preserves_parallel_tool_calls_preference() {
+	let req: types::messages::Request = serde_json::from_value(serde_json::json!({
+		"model": "gpt-4.1",
+		"max_tokens": 64,
+		"messages": [{"role": "user", "content": "hello"}],
+		"tool_choice": {
+			"type": "auto",
+			"disable_parallel_tool_use": true
+		}
+	}))
+	.expect("valid messages request");
+
+	let out = conversion::completions::from_messages::translate(&req)
+		.expect("messages -> completions translation should succeed");
+	let value: serde_json::Value =
+		serde_json::from_slice(&out).expect("translated completions request should parse");
+
+	assert_eq!(value["parallel_tool_calls"], serde_json::json!(false));
+
+	let req: types::messages::Request = serde_json::from_value(serde_json::json!({
+		"model": "gpt-4.1",
+		"max_tokens": 64,
+		"messages": [{"role": "user", "content": "hello"}],
+		"tool_choice": {
+			"type": "any",
+			"disable_parallel_tool_use": false
+		}
+	}))
+	.expect("valid messages request");
+
+	let out = conversion::completions::from_messages::translate(&req)
+		.expect("messages -> completions translation should succeed");
+	let value: serde_json::Value =
+		serde_json::from_slice(&out).expect("translated completions request should parse");
+
+	assert_eq!(value["parallel_tool_calls"], serde_json::json!(true));
+}
+
+#[test]
+fn test_messages_to_completions_omits_assistant_message_when_only_thinking_blocks() {
+	let req: types::messages::Request = serde_json::from_value(serde_json::json!({
+		"model": "gpt-4.1",
+		"max_tokens": 64,
+		"messages": [
+			{"role": "user", "content": "hello"},
+			{
+				"role": "assistant",
+				"content": [
+					{"type": "thinking", "thinking": "internal chain of thought", "signature": "sig_123"},
+					{"type": "redacted_thinking", "data": "opaque"}
+				]
+			}
+		]
+	}))
+	.expect("valid messages request");
+
+	let out = conversion::completions::from_messages::translate(&req)
+		.expect("messages -> completions translation should succeed");
+	let value: Value =
+		serde_json::from_slice(&out).expect("translated completions request should parse");
+
+	let msgs = value["messages"]
+		.as_array()
+		.expect("translated messages should be an array");
+	assert_eq!(
+		msgs.len(),
+		1,
+		"assistant-only thinking blocks should be dropped"
+	);
+	assert_eq!(msgs[0]["role"], serde_json::json!("user"));
+	assert_eq!(
+		msgs[0]["content"],
+		serde_json::json!([{"type": "text", "text": "hello"}])
+	);
+}
+
+#[test]
+fn test_completions_to_messages_synthesizes_auto_tool_choice_for_parallel_preference() {
+	let req: types::completions::Request = serde_json::from_value(serde_json::json!({
+		"model": "gpt-4.1",
+		"parallel_tool_calls": false,
+		"messages": [{"role": "user", "content": "hello"}],
+		"tools": [{
+			"type": "function",
+			"function": {
+				"name": "get_weather",
+				"description": "Get weather",
+				"parameters": {
+					"type": "object",
+					"properties": {"location": {"type": "string"}},
+					"required": ["location"]
+				}
+			}
+		}]
+	}))
+	.expect("valid completions request");
+
+	let out = conversion::messages::from_completions::translate(&req)
+		.expect("completions -> messages translation should succeed");
+	let value: Value =
+		serde_json::from_slice(&out).expect("translated messages request should parse");
+
+	assert_eq!(
+		value["tool_choice"],
+		serde_json::json!({
+			"type": "auto",
+			"disable_parallel_tool_use": true
+		})
+	);
+}
+
+#[test]
+fn test_completions_to_messages_does_not_synthesize_tool_choice_without_tools() {
+	let req: types::completions::Request = serde_json::from_value(serde_json::json!({
+		"model": "gpt-4.1",
+		"parallel_tool_calls": false,
+		"messages": [{"role": "user", "content": "hello"}]
+	}))
+	.expect("valid completions request");
+
+	let out = conversion::messages::from_completions::translate(&req)
+		.expect("completions -> messages translation should succeed");
+	let value: Value =
+		serde_json::from_slice(&out).expect("translated messages request should parse");
+
+	assert!(
+		value.get("tool_choice").is_none(),
+		"tool_choice should be omitted when no tools are present: {value}"
+	);
+}
+
+#[test]
+fn test_completions_to_messages_preserves_explicit_tool_choice_and_parallel_preference() {
+	let req: types::completions::Request = serde_json::from_value(serde_json::json!({
+		"model": "gpt-4.1",
+		"parallel_tool_calls": false,
+		"tool_choice": "required",
+		"messages": [{"role": "user", "content": "hello"}],
+		"tools": [{
+			"type": "function",
+			"function": {
+				"name": "get_weather",
+				"description": "Get weather",
+				"parameters": {
+					"type": "object",
+					"properties": {"location": {"type": "string"}},
+					"required": ["location"]
+				}
+			}
+		}]
+	}))
+	.expect("valid completions request");
+
+	let out = conversion::messages::from_completions::translate(&req)
+		.expect("completions -> messages translation should succeed");
+	let value: Value =
+		serde_json::from_slice(&out).expect("translated messages request should parse");
+
+	assert_eq!(
+		value["tool_choice"],
+		serde_json::json!({
+			"type": "any",
+			"disable_parallel_tool_use": true
+		})
+	);
+}
+
 #[tokio::test]
 async fn test_completions_to_messages() {
 	let response = |i| conversion::messages::from_completions::translate_response(&i);
@@ -526,18 +845,14 @@ async fn test_completions_to_messages() {
 			i, 1024, log,
 		))
 	};
+	test_streaming("anthropic", STREAM_FIXTURE_ANTHROPIC_BASIC, stream_response).await;
 	test_streaming(
 		"anthropic",
-		"response_stream-anthropic_basic.json",
+		STREAM_FIXTURE_ANTHROPIC_THINKING,
 		stream_response,
 	)
 	.await;
-	test_streaming(
-		"anthropic",
-		"response_stream-anthropic_thinking.json",
-		stream_response,
-	)
-	.await;
+	test_streaming("anthropic", STREAM_FIXTURE_ANTHROPIC_TOOL, stream_response).await;
 
 	let request = |i| conversion::messages::from_completions::translate(&i);
 	for r in COMPLETION_REQUESTS {
@@ -546,6 +861,372 @@ async fn test_completions_to_messages() {
 	for r in ANTHROPIC_COMPLETION_REQUESTS {
 		test_request("anthropic", r, request);
 	}
+}
+
+#[test]
+fn test_completions_from_messages_rejects_empty_choices() {
+	let response = serde_json::json!({
+		"id": "chatcmpl-empty",
+		"object": "chat.completion",
+		"created": 123,
+		"model": "gpt-4.1",
+		"choices": [],
+		"usage": null,
+		"service_tier": null,
+		"system_fingerprint": null
+	});
+	let bytes = Bytes::from(response.to_string());
+
+	let out = conversion::completions::from_messages::translate_response(&bytes);
+	assert!(matches!(out, Err(AIError::InvalidResponse(_))));
+}
+
+#[test]
+fn test_completions_from_messages_preserves_multiple_assistant_text_blocks() {
+	let req: types::messages::Request = serde_json::from_value(serde_json::json!({
+		"model": "gpt-4.1",
+		"max_tokens": 32,
+		"messages": [
+			{
+				"role": "assistant",
+				"content": [
+					{"type": "text", "text": "first"},
+					{"type": "text", "text": "second"}
+				]
+			}
+		]
+	}))
+	.expect("valid messages request");
+
+	let out =
+		conversion::completions::from_messages::translate(&req).expect("translation should work");
+	let value: serde_json::Value = serde_json::from_slice(&out).expect("valid translated request");
+	assert_eq!(value["messages"][0]["content"], "first\nsecond");
+}
+
+#[tokio::test]
+async fn test_completions_from_messages_stream_done_without_finish_reason_emits_message_stop() {
+	let input = concat!(
+		"data: {\"id\":\"cmpl-2\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hello\"}}],\"created\":123,\"model\":\"gpt-4.1\",\"service_tier\":null,\"system_fingerprint\":null,\"object\":\"chat.completion.chunk\",\"usage\":null}\n\n",
+		"data: {\"id\":\"cmpl-2\",\"choices\":[],\"created\":123,\"model\":\"gpt-4.1\",\"service_tier\":null,\"system_fingerprint\":null,\"object\":\"chat.completion.chunk\",\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":1,\"total_tokens\":6}}\n\n",
+		"data: [DONE]\n\n"
+	);
+	let out = conversion::completions::from_messages::translate_stream(
+		Body::from(input.as_bytes().to_vec()),
+		1024 * 1024,
+		AsyncLog::default(),
+	)
+	.collect()
+	.await
+	.expect("stream should be readable")
+	.to_bytes();
+	let out = std::str::from_utf8(&out).expect("stream is utf-8");
+
+	assert!(
+		out.contains("\"type\":\"message_stop\""),
+		"stream missing message_stop:\n{out}"
+	);
+	assert!(
+		out.contains("\"stop_reason\":\"end_turn\""),
+		"stream missing end_turn stop_reason:\n{out}"
+	);
+}
+
+#[tokio::test]
+async fn test_completions_from_messages_stream_interleaved_tool_calls_single_block_start_per_index()
+{
+	let input = concat!(
+		"data: {\"id\":\"cmpl-1\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_0\",\"type\":\"function\",\"function\":{\"name\":\"foo\",\"arguments\":\"{\\\"a\\\":\"}}]}}],\"created\":123,\"model\":\"gpt-4.1\",\"service_tier\":null,\"system_fingerprint\":null,\"object\":\"chat.completion.chunk\",\"usage\":null}\n\n",
+		"data: {\"id\":\"cmpl-1\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":1,\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"bar\",\"arguments\":\"{\\\"b\\\":\"}}]}}],\"created\":123,\"model\":\"gpt-4.1\",\"service_tier\":null,\"system_fingerprint\":null,\"object\":\"chat.completion.chunk\",\"usage\":null}\n\n",
+		"data: {\"id\":\"cmpl-1\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"type\":\"function\",\"function\":{\"arguments\":\"1}\"}}]}}],\"created\":123,\"model\":\"gpt-4.1\",\"service_tier\":null,\"system_fingerprint\":null,\"object\":\"chat.completion.chunk\",\"usage\":null}\n\n",
+		"data: {\"id\":\"cmpl-1\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"tool_calls\"}],\"created\":123,\"model\":\"gpt-4.1\",\"service_tier\":null,\"system_fingerprint\":null,\"object\":\"chat.completion.chunk\",\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":3,\"total_tokens\":8}}\n\n",
+		"data: [DONE]\n\n"
+	);
+
+	let out = conversion::completions::from_messages::translate_stream(
+		Body::from(input.as_bytes().to_vec()),
+		1024 * 1024,
+		AsyncLog::default(),
+	)
+	.collect()
+	.await
+	.expect("stream should be readable")
+	.to_bytes();
+	let out = std::str::from_utf8(&out).expect("stream is utf-8");
+
+	let idx0 = out
+		.matches("\"type\":\"content_block_start\",\"index\":0")
+		.count();
+	let idx1 = out
+		.matches("\"type\":\"content_block_start\",\"index\":1")
+		.count();
+	assert_eq!(idx0, 1, "tool index 0 block started multiple times:\n{out}");
+	assert_eq!(idx1, 1, "tool index 1 block started multiple times:\n{out}");
+}
+
+#[tokio::test]
+async fn test_completions_from_messages_stream_waits_for_tool_name_before_open() {
+	let input = concat!(
+		"data: {\"id\":\"cmpl-3\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_0\",\"type\":\"function\",\"function\":{\"arguments\":\"{\\\"a\\\":\"}}]}}],\"created\":123,\"model\":\"gpt-4.1\",\"service_tier\":null,\"system_fingerprint\":null,\"object\":\"chat.completion.chunk\",\"usage\":null}\n\n",
+		"data: {\"id\":\"cmpl-3\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"type\":\"function\",\"function\":{\"name\":\"foo\",\"arguments\":\"1}\"}}]}}],\"created\":123,\"model\":\"gpt-4.1\",\"service_tier\":null,\"system_fingerprint\":null,\"object\":\"chat.completion.chunk\",\"usage\":null}\n\n",
+		"data: {\"id\":\"cmpl-3\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"tool_calls\"}],\"created\":123,\"model\":\"gpt-4.1\",\"service_tier\":null,\"system_fingerprint\":null,\"object\":\"chat.completion.chunk\",\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":3,\"total_tokens\":8}}\n\n",
+		"data: [DONE]\n\n"
+	);
+
+	let out = conversion::completions::from_messages::translate_stream(
+		Body::from(input.as_bytes().to_vec()),
+		1024 * 1024,
+		AsyncLog::default(),
+	)
+	.collect()
+	.await
+	.expect("stream should be readable")
+	.to_bytes();
+	let out = std::str::from_utf8(&out).expect("stream is utf-8");
+
+	assert!(
+		!out.contains("\"name\":\"\""),
+		"tool block should not be opened with empty name:\n{out}"
+	);
+	assert!(
+		out.contains("\"name\":\"foo\""),
+		"tool block should include resolved tool name:\n{out}"
+	);
+}
+
+#[tokio::test]
+async fn test_completions_from_messages_stream_text_then_tool_reindexes_tool_calls() {
+	let input = concat!(
+		"event: message_start\n",
+		"data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[],\"model\":\"claude-3\",\"stop_reason\":null,\"stop_sequence\":null,\"usage\":{\"input_tokens\":10,\"output_tokens\":1}}}\n\n",
+		"event: content_block_start\n",
+		"data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"Thinking...\"}}\n\n",
+		"event: content_block_delta\n",
+		"data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Thinking...\"}}\n\n",
+		"event: content_block_stop\n",
+		"data: {\"type\":\"content_block_stop\",\"index\":0}\n\n",
+		"event: content_block_start\n",
+		"data: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"tool_use\",\"id\":\"call_1\",\"name\":\"tool\",\"input\":{}}}\n\n",
+		"event: content_block_delta\n",
+		"data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{}\"}}\n\n",
+		"event: message_delta\n",
+		"data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\",\"stop_sequence\":null},\"usage\":{\"input_tokens\":10,\"output_tokens\":20}}\n\n",
+		"event: message_stop\n",
+		"data: {\"type\":\"message_stop\"}\n\n",
+		"data: [DONE]\n\n"
+	);
+
+	let out = conversion::messages::from_completions::translate_stream(
+		Body::from(input.as_bytes().to_vec()),
+		1024 * 1024,
+		AmendOnDrop::new(AsyncLog::default(), LLMResponsePolicies::default()),
+	)
+	.collect()
+	.await
+	.expect("stream should be readable")
+	.to_bytes();
+	let out = std::str::from_utf8(&out).expect("stream is utf-8");
+
+	// Check that we have tool_calls with index 0
+	assert!(
+		out.contains(r#""tool_calls":[{"index":0"#),
+		"tool call should be re-indexed to 0:\n{out}"
+	);
+	// Check that we DO NOT have tool_calls with index 1
+	assert!(
+		!out.contains(r#""tool_calls":[{"index":1"#),
+		"tool call should not use raw index 1:\n{out}"
+	);
+}
+
+#[test]
+fn test_process_success_messages_uses_completions_translation_for_provider_adapters() {
+	let test_dir = Path::new("src/llm/tests");
+	let input_path = test_dir.join("response_basic.json");
+	let body = Bytes::from(fs::read(input_path).expect("Failed to read provider response fixture"));
+
+	let expected = conversion::completions::from_messages::translate_response(&body)
+		.expect("expected translation should succeed")
+		.serialize()
+		.expect("expected translation should serialize");
+	let expected: Value =
+		serde_json::from_slice(&expected).expect("expected response should be JSON");
+
+	for (name, provider) in provider_message_adapters() {
+		let req = llm_request(InputFormat::Messages, name, "gpt-4.1", false);
+		let got = provider
+			.process_success(&req, &body)
+			.unwrap_or_else(|e| panic!("{name}: process_success failed: {e}"))
+			.serialize()
+			.unwrap_or_else(|e| panic!("{name}: failed to serialize translated response: {e}"));
+		let got: Value = serde_json::from_slice(&got)
+			.unwrap_or_else(|e| panic!("{name}: invalid translated JSON: {e}"));
+		assert_eq!(got, expected, "{name}: translated response mismatch");
+	}
+}
+
+#[tokio::test]
+async fn test_process_streaming_messages_uses_completions_translation_for_provider_adapters() {
+	let stream = concat!(
+		"data: {\"id\":\"cmpl-routing\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hello\"}}],\"created\":123,\"model\":\"gpt-4.1\",\"service_tier\":null,\"system_fingerprint\":null,\"object\":\"chat.completion.chunk\",\"usage\":null}\n\n",
+		"data: {\"id\":\"cmpl-routing\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"created\":123,\"model\":\"gpt-4.1\",\"service_tier\":null,\"system_fingerprint\":null,\"object\":\"chat.completion.chunk\",\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":1,\"total_tokens\":6}}\n\n",
+		"data: [DONE]\n\n"
+	);
+	let stream_bytes = stream.as_bytes().to_vec();
+	let expected = conversion::completions::from_messages::translate_stream(
+		Body::from(stream_bytes.clone()),
+		1024 * 1024,
+		AsyncLog::default(),
+	)
+	.collect()
+	.await
+	.expect("expected translated stream should be readable")
+	.to_bytes();
+
+	for (name, provider) in provider_message_adapters() {
+		let req = llm_request(InputFormat::Messages, name, "gpt-4.1", true);
+		let resp = ::http::Response::builder()
+			.status(::http::StatusCode::OK)
+			.header(::http::header::CONTENT_TYPE, "text/event-stream")
+			.body(Body::from(stream_bytes.clone()))
+			.expect("failed to build provider stream response");
+
+		let out = provider
+			.process_streaming(
+				req,
+				crate::store::LLMResponsePolicies::default(),
+				AsyncLog::default(),
+				false,
+				resp,
+			)
+			.await
+			.unwrap_or_else(|e| panic!("{name}: process_streaming failed: {e}"))
+			.into_body()
+			.collect()
+			.await
+			.unwrap_or_else(|e| panic!("{name}: translated stream read failed: {e}"))
+			.to_bytes();
+
+		assert_eq!(out, expected, "{name}: streaming translation mismatch");
+	}
+}
+
+#[tokio::test]
+async fn test_process_streaming_vertex_anthropic_completions_uses_messages_translation() {
+	let test_dir = Path::new("src/llm/tests");
+	let stream_path = test_dir.join("response_stream-anthropic_basic.json");
+	let stream_bytes = fs::read(stream_path).expect("Failed to read anthropic stream fixture");
+	let expected = conversion::messages::from_completions::translate_stream(
+		Body::from(stream_bytes.clone()),
+		1024 * 1024,
+		AmendOnDrop::new(AsyncLog::default(), LLMResponsePolicies::default()),
+	)
+	.collect()
+	.await
+	.expect("expected translated stream should be readable")
+	.to_bytes();
+
+	let provider = AIProvider::Vertex(vertex::Provider {
+		model: None,
+		region: Some(strng::new("us-central1")),
+		project_id: strng::new("test-project-123"),
+	});
+	let req = llm_request(
+		InputFormat::Completions,
+		"vertex",
+		"anthropic/claude-sonnet-4-5-20251001",
+		true,
+	);
+	let resp = ::http::Response::builder()
+		.status(::http::StatusCode::OK)
+		.header(::http::header::CONTENT_TYPE, "text/event-stream")
+		.body(Body::from(stream_bytes))
+		.expect("failed to build provider stream response");
+
+	let got = provider
+		.process_streaming(
+			req,
+			crate::store::LLMResponsePolicies::default(),
+			AsyncLog::default(),
+			false,
+			resp,
+		)
+		.await
+		.expect("vertex anthropic completions streaming should be translated")
+		.into_body()
+		.collect()
+		.await
+		.expect("translated stream should be readable")
+		.to_bytes();
+
+	assert_eq!(
+		got, expected,
+		"vertex anthropic completions streaming translation mismatch"
+	);
+}
+
+#[test]
+fn test_roundtrip_completions_messages_preserves_tool_call_and_tool_result_semantics() {
+	let source: types::completions::Request = serde_json::from_value(serde_json::json!({
+		"model": "gpt-4.1",
+		"messages": [
+			{"role": "system", "content": "system instruction"},
+			{"role": "developer", "content": "developer instruction"},
+			{"role": "user", "content": "please call the tool"},
+			{
+				"role": "assistant",
+				"content": "calling tool",
+				"tool_calls": [
+					{
+						"id": "call_123",
+						"type": "function",
+						"function": {
+							"name": "lookup_weather",
+							"arguments": "{\"city\":\"Paris\"}"
+						}
+					}
+				]
+			},
+			{"role": "tool", "tool_call_id": "call_123", "content": "sunny"}
+		],
+		"max_tokens": 64
+	}))
+	.expect("valid source completion request");
+
+	let messages = conversion::messages::from_completions::translate(&source)
+		.expect("completions -> messages should succeed");
+	let roundtrip = conversion::completions::from_messages::translate(
+		&serde_json::from_slice::<types::messages::Request>(&messages)
+			.expect("translated messages request should deserialize"),
+	)
+	.expect("messages -> completions should succeed");
+	let roundtrip: Value =
+		serde_json::from_slice(&roundtrip).expect("roundtrip completions should deserialize");
+
+	let msgs = roundtrip["messages"]
+		.as_array()
+		.expect("roundtrip messages should be an array");
+	assert!(
+		msgs.iter().any(|m| {
+			m["role"] == "assistant"
+				&& m["tool_calls"].is_array()
+				&& m["tool_calls"][0]["id"] == "call_123"
+				&& m["tool_calls"][0]["function"]["name"] == "lookup_weather"
+		}),
+		"assistant tool call not preserved in roundtrip: {roundtrip}"
+	);
+	assert!(
+		msgs.iter().any(|m| {
+			m["role"] == "tool" && m["tool_call_id"] == "call_123" && m["content"] == "sunny"
+		}),
+		"tool result not preserved in roundtrip: {roundtrip}"
+	);
+	assert!(
+		msgs
+			.iter()
+			.any(|m| m["role"] == "system" && m["content"] == "system instruction\ndeveloper instruction"),
+		"system+developer prompt merge missing in roundtrip: {roundtrip}"
+	);
 }
 
 fn apply_test_prompts<R: RequestType + Serialize>(mut r: R) -> Result<Vec<u8>, AIError> {
@@ -719,5 +1400,49 @@ fn test_get_messages() {
 		"messages_get_messages",
 		&input_raw,
 		&input_path,
+	);
+}
+
+#[test]
+fn test_messages_set_messages_roundtrip_preserves_system_field() {
+	use crate::llm::types::RequestType;
+	use crate::llm::types::SimpleChatCompletionMessage;
+
+	let mut req = types::messages::Request {
+		model: Some("claude-haiku-4-5-20251001".to_string()),
+		system: Some(types::messages::TextBlock::Text(
+			"original system".to_string(),
+		)),
+		messages: vec![types::messages::RequestMessage {
+			role: "user".to_string(),
+			content: Some(types::messages::ContentBlock::Text("hello".to_string())),
+			rest: Default::default(),
+		}],
+		..Default::default()
+	};
+
+	let mut msgs = req.get_messages();
+	msgs[0] = SimpleChatCompletionMessage {
+		role: strng::literal!("system"),
+		content: strng::literal!("masked system"),
+	};
+	req.set_messages(msgs);
+
+	match req.system {
+		Some(types::messages::TextBlock::Array(ref parts)) => {
+			assert_eq!(parts.len(), 1, "expected one system prompt after roundtrip");
+			match &parts[0] {
+				types::messages::TextPart::Text { text, .. } => {
+					assert_eq!(text, "masked system");
+				},
+				other => panic!("unexpected system prompt block: {other:?}"),
+			}
+		},
+		other => panic!("expected system prompts in array form, got: {other:?}"),
+	}
+
+	assert!(
+		req.messages.iter().all(|m| m.role != "system"),
+		"system messages must not be stored inside messages[]"
 	);
 }

--- a/crates/agentgateway/src/llm/tests.rs
+++ b/crates/agentgateway/src/llm/tests.rs
@@ -569,6 +569,45 @@ fn test_messages_output_config_format_maps_to_openai_response_format() {
 }
 
 #[test]
+fn test_messages_to_completions_preserves_user_id_but_omits_internal_fields() {
+	let request: types::messages::Request = serde_json::from_value(json!({
+		"model": "gpt-4.1",
+		"max_tokens": 64,
+		"top_k": 42,
+		"thinking": {
+			"type": "enabled",
+			"budget_tokens": 2048
+		},
+		"metadata": {
+			"user_id": "user-123",
+			"other_field": "must_not_forward"
+		},
+		"messages": [
+			{
+				"role": "user",
+				"content": "hello"
+			}
+		]
+	}))
+	.expect("valid messages request");
+
+	let translated = conversion::completions::from_messages::translate(&request)
+		.expect("messages->completions translation");
+	let translated: Value =
+		serde_json::from_slice(&translated).expect("translated request should be valid json");
+
+	assert_eq!(translated["user"], json!("user-123"));
+	assert!(
+		translated.get("metadata").is_none(),
+		"messages.metadata should not be forwarded to OpenAI-compatible requests: {translated}"
+	);
+	assert!(
+		translated.get("vendor_extensions").is_none(),
+		"internal vendor extensions must not be serialized into OpenAI-compatible requests: {translated}"
+	);
+}
+
+#[test]
 fn test_messages_to_completions_stream_sets_include_usage_stream_option() {
 	let req: types::messages::Request = serde_json::from_value(serde_json::json!({
 		"model": "gpt-4.1",
@@ -914,7 +953,7 @@ async fn test_completions_from_messages_stream_done_without_finish_reason_emits_
 	let out = conversion::completions::from_messages::translate_stream(
 		Body::from(input.as_bytes().to_vec()),
 		1024 * 1024,
-		AsyncLog::default(),
+		AmendOnDrop::new(AsyncLog::default(), LLMResponsePolicies::default()),
 	)
 	.collect()
 	.await
@@ -946,7 +985,7 @@ async fn test_completions_from_messages_stream_interleaved_tool_calls_single_blo
 	let out = conversion::completions::from_messages::translate_stream(
 		Body::from(input.as_bytes().to_vec()),
 		1024 * 1024,
-		AsyncLog::default(),
+		AmendOnDrop::new(AsyncLog::default(), LLMResponsePolicies::default()),
 	)
 	.collect()
 	.await
@@ -976,7 +1015,7 @@ async fn test_completions_from_messages_stream_waits_for_tool_name_before_open()
 	let out = conversion::completions::from_messages::translate_stream(
 		Body::from(input.as_bytes().to_vec()),
 		1024 * 1024,
-		AsyncLog::default(),
+		AmendOnDrop::new(AsyncLog::default(), LLMResponsePolicies::default()),
 	)
 	.collect()
 	.await
@@ -1076,7 +1115,7 @@ async fn test_process_streaming_messages_uses_completions_translation_for_provid
 	let expected = conversion::completions::from_messages::translate_stream(
 		Body::from(stream_bytes.clone()),
 		1024 * 1024,
-		AsyncLog::default(),
+		AmendOnDrop::new(AsyncLog::default(), LLMResponsePolicies::default()),
 	)
 	.collect()
 	.await

--- a/crates/agentgateway/src/llm/tests/anthropic-request_anthropic_basic.snap
+++ b/crates/agentgateway/src/llm/tests/anthropic-request_anthropic_basic.snap
@@ -12,7 +12,12 @@ info:
   "messages": [
     {
       "role": "user",
-      "content": "Hello, world"
+      "content": [
+        {
+          "type": "text",
+          "text": "Hello, world"
+        }
+      ]
     }
   ],
   "model": "claude-sonnet-4-20250514",

--- a/crates/agentgateway/src/llm/tests/anthropic-request_anthropic_reasoning.snap
+++ b/crates/agentgateway/src/llm/tests/anthropic-request_anthropic_reasoning.snap
@@ -17,7 +17,12 @@ info:
   "messages": [
     {
       "role": "user",
-      "content": "Give one concise insight about distributed consensus."
+      "content": [
+        {
+          "type": "text",
+          "text": "Give one concise insight about distributed consensus."
+        }
+      ]
     }
   ],
   "model": "claude-opus-4-6",

--- a/crates/agentgateway/src/llm/tests/anthropic-request_anthropic_tools.snap
+++ b/crates/agentgateway/src/llm/tests/anthropic-request_anthropic_tools.snap
@@ -2,7 +2,7 @@
 source: crates/agentgateway/src/llm/tests.rs
 description: "anthropic: request_anthropic_tools"
 info:
-  model: claude-opus-4-1-20250805
+  model: claude-opus-4-6
   max_tokens: 1024
   tools:
     - name: get_weather
@@ -23,10 +23,15 @@ info:
   "messages": [
     {
       "role": "user",
-      "content": "What is the weather like in San Francisco?"
+      "content": [
+        {
+          "type": "text",
+          "text": "What is the weather like in San Francisco?"
+        }
+      ]
     }
   ],
-  "model": "claude-opus-4-1-20250805",
+  "model": "claude-opus-4-6",
   "max_completion_tokens": 1024,
   "stream": false,
   "tools": [

--- a/crates/agentgateway/src/llm/tests/anthropic-request_full.snap
+++ b/crates/agentgateway/src/llm/tests/anthropic-request_full.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/agentgateway/src/llm/tests.rs
+assertion_line: 108
 description: "anthropic: request_full"
 info:
   model: gpt-4-turbo-preview
@@ -19,7 +20,7 @@ info:
           text: "What's in this image?"
         - type: image_url
           image_url:
-            url: "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg"
+            url: "https://upload.wikimedia.org/wikipedia/commons/4/47/PNG_transparency_demonstration_1.png"
   max_tokens: 1000
   temperature: 0.7
   top_p: 0.9
@@ -90,6 +91,22 @@ info:
         {
           "type": "text",
           "text": "This is a recursive implementation of the Fibonacci sequence. It calculates the nth Fibonacci number by adding the previous two numbers."
+        }
+      ]
+    },
+    {
+      "role": "user",
+      "content": [
+        {
+          "type": "text",
+          "text": "What's in this image?"
+        },
+        {
+          "type": "image",
+          "source": {
+            "type": "url",
+            "url": "https://upload.wikimedia.org/wikipedia/commons/4/47/PNG_transparency_demonstration_1.png"
+          }
         }
       ]
     }

--- a/crates/agentgateway/src/llm/tests/anthropic-request_tool-call.snap
+++ b/crates/agentgateway/src/llm/tests/anthropic-request_tool-call.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/agentgateway/src/llm/tests.rs
+assertion_line: 108
 description: "anthropic: request_tool-call"
 info:
   model: gpt-3.5-turbo
@@ -31,11 +32,26 @@ info:
       ]
     },
     {
+      "role": "assistant",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "call_iMGPsr4Xx1u0G5sOzFsTCbQU",
+          "name": "get_weather",
+          "input": {
+            "format": "celsius",
+            "location": "Columbus, OH"
+          }
+        }
+      ]
+    },
+    {
       "role": "user",
       "content": [
         {
-          "type": "text",
-          "text": "{ \"temperature\": 15, \"condition\": \"Cloudy\" }"
+          "type": "tool_result",
+          "tool_use_id": "call_iMGPsr4Xx1u0G5sOzFsTCbQU",
+          "content": "{ \"temperature\": 15, \"condition\": \"Cloudy\" }"
         }
       ]
     }

--- a/crates/agentgateway/src/llm/tests/anthropic-response_anthropic_basic.snap
+++ b/crates/agentgateway/src/llm/tests/anthropic-response_anthropic_basic.snap
@@ -5,7 +5,7 @@ info:
   id: msg_012JYtNYb8sv6Hb67TcGT7xW
   type: message
   role: assistant
-  model: claude-3-5-haiku-20241022
+  model: claude-haiku-4-5-20251001
   content:
     - type: text
       text: Hi there! How are you doing today? Is there anything I can help you with?
@@ -19,7 +19,7 @@ info:
     service_tier: standard
 ---
 {
-  "model": "claude-3-5-haiku-20241022",
+  "model": "claude-haiku-4-5-20251001",
   "usage": {
     "prompt_tokens": 15,
     "completion_tokens": 21,

--- a/crates/agentgateway/src/llm/tests/anthropic-response_anthropic_thinking.snap
+++ b/crates/agentgateway/src/llm/tests/anthropic-response_anthropic_thinking.snap
@@ -5,7 +5,7 @@ info:
   id: msg_01BE9GBzjs95TqdG8FeUanUn
   type: message
   role: assistant
-  model: claude-opus-4-1-20250805
+  model: claude-opus-4-6
   content:
     - type: thinking
       thinking: The user is asking me about the current weather in San Francisco
@@ -25,7 +25,7 @@ info:
     service_tier: standard
 ---
 {
-  "model": "claude-opus-4-1-20250805",
+  "model": "claude-opus-4-6",
   "usage": {
     "prompt_tokens": 47,
     "completion_tokens": 251,

--- a/crates/agentgateway/src/llm/tests/anthropic-response_anthropic_tool.snap
+++ b/crates/agentgateway/src/llm/tests/anthropic-response_anthropic_tool.snap
@@ -4,7 +4,7 @@ description: src/llm/tests/response_anthropic_tool.json
 info:
   id: msg_01Aq9w938a90dw8q
   type: message
-  model: claude-opus-4-1-20250805
+  model: claude-opus-4-6
   stop_reason: tool_use
   role: assistant
   content:
@@ -24,7 +24,7 @@ info:
     service_tier: standard
 ---
 {
-  "model": "claude-opus-4-1-20250805",
+  "model": "claude-opus-4-6",
   "usage": {
     "prompt_tokens": 558,
     "completion_tokens": 48,

--- a/crates/agentgateway/src/llm/tests/anthropic-response_stream-anthropic_basic.json.snap
+++ b/crates/agentgateway/src/llm/tests/anthropic-response_stream-anthropic_basic.json.snap
@@ -1,21 +1,22 @@
 ---
 source: crates/agentgateway/src/llm/tests.rs
+assertion_line: 77
 description: src/llm/tests/response_stream-anthropic_basic.json
 ---
 event: 
-data: {"id":"msg_016wbjv5k86nxxd8CEZwSQnA","choices":[{"index":0,"delta":{"content":"Hi there! How are"}}],"created":123,"model":"claude-3-5-haiku-20241022","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
+data: {"id":"msg_016wbjv5k86nxxd8CEZwSQnA","choices":[{"index":0,"delta":{"content":"Hi there! How are"}}],"created":123,"model":"claude-haiku-4-5-20251001","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
 
 event: 
-data: {"id":"msg_016wbjv5k86nxxd8CEZwSQnA","choices":[{"index":0,"delta":{"content":" you doing today?"}}],"created":123,"model":"claude-3-5-haiku-20241022","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
+data: {"id":"msg_016wbjv5k86nxxd8CEZwSQnA","choices":[{"index":0,"delta":{"content":" you doing today?"}}],"created":123,"model":"claude-haiku-4-5-20251001","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
 
 event: 
-data: {"id":"msg_016wbjv5k86nxxd8CEZwSQnA","choices":[{"index":0,"delta":{"content":" Is"}}],"created":123,"model":"claude-3-5-haiku-20241022","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
+data: {"id":"msg_016wbjv5k86nxxd8CEZwSQnA","choices":[{"index":0,"delta":{"content":" Is"}}],"created":123,"model":"claude-haiku-4-5-20251001","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
 
 event: 
-data: {"id":"msg_016wbjv5k86nxxd8CEZwSQnA","choices":[{"index":0,"delta":{"content":" there anything I can help"}}],"created":123,"model":"claude-3-5-haiku-20241022","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
+data: {"id":"msg_016wbjv5k86nxxd8CEZwSQnA","choices":[{"index":0,"delta":{"content":" there anything I can help"}}],"created":123,"model":"claude-haiku-4-5-20251001","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
 
 event: 
-data: {"id":"msg_016wbjv5k86nxxd8CEZwSQnA","choices":[{"index":0,"delta":{"content":" you with?"}}],"created":123,"model":"claude-3-5-haiku-20241022","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
+data: {"id":"msg_016wbjv5k86nxxd8CEZwSQnA","choices":[{"index":0,"delta":{"content":" you with?"}}],"created":123,"model":"claude-haiku-4-5-20251001","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
 
 event: 
-data: {"id":"msg_016wbjv5k86nxxd8CEZwSQnA","choices":[],"created":123,"model":"claude-3-5-haiku-20241022","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":{"prompt_tokens":15,"completion_tokens":21,"total_tokens":36,"prompt_tokens_details":{"cached_tokens":0},"cache_read_input_tokens":0,"cache_creation_input_tokens":0}}
+data: {"id":"msg_016wbjv5k86nxxd8CEZwSQnA","choices":[{"index":0,"delta":{"content":null},"finish_reason":"stop"}],"created":123,"model":"claude-haiku-4-5-20251001","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":{"prompt_tokens":15,"completion_tokens":21,"total_tokens":36,"prompt_tokens_details":{"cached_tokens":0},"cache_read_input_tokens":0,"cache_creation_input_tokens":0}}

--- a/crates/agentgateway/src/llm/tests/anthropic-response_stream-anthropic_thinking.json.snap
+++ b/crates/agentgateway/src/llm/tests/anthropic-response_stream-anthropic_thinking.json.snap
@@ -1,33 +1,31 @@
 ---
 source: crates/agentgateway/src/llm/tests.rs
+assertion_line: 77
 description: src/llm/tests/response_stream-anthropic_thinking.json
 ---
 event: 
-data: {"id":"msg_018XasA6jgabsibaUtstx4bg","choices":[{"index":0,"delta":{"content":null,"reasoning_content":"The user is"}}],"created":123,"model":"claude-opus-4-1-20250805","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
+data: {"id":"msg_018XasA6jgabsibaUtstx4bg","choices":[{"index":0,"delta":{"content":null,"reasoning_content":"The user is"}}],"created":123,"model":"claude-opus-4-6","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
 
 event: 
-data: {"id":"msg_018XasA6jgabsibaUtstx4bg","choices":[{"index":0,"delta":{"content":null,"reasoning_content":" asking me about the weather in"}}],"created":123,"model":"claude-opus-4-1-20250805","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
+data: {"id":"msg_018XasA6jgabsibaUtstx4bg","choices":[{"index":0,"delta":{"content":null,"reasoning_content":" asking me about the weather in"}}],"created":123,"model":"claude-opus-4-6","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
 
 event: 
-data: {"id":"msg_018XasA6jgabsibaUtstx4bg","choices":[{"index":0,"delta":{"content":null,"reasoning_content":" San Francisco. However, I don"}}],"created":123,"model":"claude-opus-4-1-20250805","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
+data: {"id":"msg_018XasA6jgabsibaUtstx4bg","choices":[{"index":0,"delta":{"content":null,"reasoning_content":" San Francisco. However, I don"}}],"created":123,"model":"claude-opus-4-6","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
 
 event: 
-data: {"id":"msg_018XasA6jgabsibaUtstx4bg","choices":[{"index":0,"delta":{"content":null,"reasoning_content":"d suggest how they can get current weather information."}}],"created":123,"model":"claude-opus-4-1-20250805","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
+data: {"id":"msg_018XasA6jgabsibaUtstx4bg","choices":[{"index":0,"delta":{"content":null,"reasoning_content":"d suggest how they can get current weather information."}}],"created":123,"model":"claude-opus-4-6","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
 
 event: 
-data: {"id":"msg_018XasA6jgabsibaUtstx4bg","choices":[{"index":0,"delta":{"content":null}}],"created":123,"model":"claude-opus-4-1-20250805","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
+data: {"id":"msg_018XasA6jgabsibaUtstx4bg","choices":[{"index":0,"delta":{"content":"I don't have access to real"}}],"created":123,"model":"claude-opus-4-6","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
 
 event: 
-data: {"id":"msg_018XasA6jgabsibaUtstx4bg","choices":[{"index":0,"delta":{"content":"I don't have access to real"}}],"created":123,"model":"claude-opus-4-1-20250805","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
+data: {"id":"msg_018XasA6jgabsibaUtstx4bg","choices":[{"index":0,"delta":{"content":"\" in your browser\n\nIs there something"}}],"created":123,"model":"claude-opus-4-6","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
 
 event: 
-data: {"id":"msg_018XasA6jgabsibaUtstx4bg","choices":[{"index":0,"delta":{"content":"\" in your browser\n\nIs there something"}}],"created":123,"model":"claude-opus-4-1-20250805","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
+data: {"id":"msg_018XasA6jgabsibaUtstx4bg","choices":[{"index":0,"delta":{"content":" specific about San Francisco's climate patterns"}}],"created":123,"model":"claude-opus-4-6","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
 
 event: 
-data: {"id":"msg_018XasA6jgabsibaUtstx4bg","choices":[{"index":0,"delta":{"content":" specific about San Francisco's climate patterns"}}],"created":123,"model":"claude-opus-4-1-20250805","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
+data: {"id":"msg_018XasA6jgabsibaUtstx4bg","choices":[{"index":0,"delta":{"content":" you'd like to know more about?"}}],"created":123,"model":"claude-opus-4-6","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
 
 event: 
-data: {"id":"msg_018XasA6jgabsibaUtstx4bg","choices":[{"index":0,"delta":{"content":" you'd like to know more about?"}}],"created":123,"model":"claude-opus-4-1-20250805","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
-
-event: 
-data: {"id":"msg_018XasA6jgabsibaUtstx4bg","choices":[],"created":123,"model":"claude-opus-4-1-20250805","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":{"prompt_tokens":47,"completion_tokens":264,"total_tokens":311,"prompt_tokens_details":{"cached_tokens":0},"cache_read_input_tokens":0,"cache_creation_input_tokens":0}}
+data: {"id":"msg_018XasA6jgabsibaUtstx4bg","choices":[{"index":0,"delta":{"content":null},"finish_reason":"stop"}],"created":123,"model":"claude-opus-4-6","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":{"prompt_tokens":47,"completion_tokens":264,"total_tokens":311,"prompt_tokens_details":{"cached_tokens":0},"cache_read_input_tokens":0,"cache_creation_input_tokens":0}}

--- a/crates/agentgateway/src/llm/tests/anthropic-response_stream-anthropic_tool.json.snap
+++ b/crates/agentgateway/src/llm/tests/anthropic-response_stream-anthropic_tool.json.snap
@@ -3,10 +3,13 @@ source: crates/agentgateway/src/llm/tests.rs
 description: src/llm/tests/response_stream-anthropic_tool.json
 ---
 event: 
-data: {"id":"","choices":[{"index":0,"delta":{"content":null}}],"created":123,"model":"claude-3-5-sonnet-20241022","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
+data: {"id":"","choices":[{"index":0,"delta":{"content":null,"tool_calls":[{"index":0,"id":"","type":"function","function":{"name":"get_weather","arguments":null}}]}}],"created":123,"model":"claude-3-5-sonnet-20241022","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
 
 event: 
-data: {"id":"","choices":[],"created":123,"model":"claude-3-5-sonnet-20241022","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":{"prompt_tokens":12,"completion_tokens":5,"total_tokens":17}}
+data: {"id":"","choices":[{"index":0,"delta":{"content":null,"tool_calls":[{"index":0,"id":null,"type":null,"function":{"name":null,"arguments":"{\"location\": \"San Francisco\"}"}}]}}],"created":123,"model":"claude-3-5-sonnet-20241022","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
+
+event: 
+data: {"id":"","choices":[{"index":0,"delta":{"content":null},"finish_reason":"tool_calls"}],"created":123,"model":"claude-3-5-sonnet-20241022","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":{"prompt_tokens":12,"completion_tokens":5,"total_tokens":17}}
 
 event: 
 data: [DONE]

--- a/crates/agentgateway/src/llm/tests/bedrock-completions-request_full.snap
+++ b/crates/agentgateway/src/llm/tests/bedrock-completions-request_full.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/agentgateway/src/llm/tests.rs
+assertion_line: 108
 description: "bedrock-completions: request_full"
 info:
   model: gpt-4-turbo-preview
@@ -19,7 +20,7 @@ info:
           text: "What's in this image?"
         - type: image_url
           image_url:
-            url: "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg"
+            url: "https://upload.wikimedia.org/wikipedia/commons/4/47/PNG_transparency_demonstration_1.png"
   max_tokens: 1000
   temperature: 0.7
   top_p: 0.9
@@ -89,6 +90,14 @@ info:
       "content": [
         {
           "text": "This is a recursive implementation of the Fibonacci sequence. It calculates the nth Fibonacci number by adding the previous two numbers."
+        }
+      ]
+    },
+    {
+      "role": "user",
+      "content": [
+        {
+          "text": "What's in this image?"
         }
       ]
     }

--- a/crates/agentgateway/src/llm/tests/bedrock-completions-request_tool-call.snap
+++ b/crates/agentgateway/src/llm/tests/bedrock-completions-request_tool-call.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/agentgateway/src/llm/tests.rs
+assertion_line: 108
 description: "bedrock-completions: request_tool-call"
 info:
   model: gpt-3.5-turbo
@@ -31,10 +32,33 @@ info:
       ]
     },
     {
+      "role": "assistant",
+      "content": [
+        {
+          "toolUse": {
+            "toolUseId": "call_iMGPsr4Xx1u0G5sOzFsTCbQU",
+            "name": "get_weather",
+            "input": {
+              "format": "celsius",
+              "location": "Columbus, OH"
+            }
+          }
+        }
+      ]
+    },
+    {
       "role": "user",
       "content": [
         {
-          "text": "{ \"temperature\": 15, \"condition\": \"Cloudy\" }"
+          "toolResult": {
+            "toolUseId": "call_iMGPsr4Xx1u0G5sOzFsTCbQU",
+            "content": [
+              {
+                "text": "{ \"temperature\": 15, \"condition\": \"Cloudy\" }"
+              }
+            ],
+            "status": null
+          }
         }
       ]
     }

--- a/crates/agentgateway/src/llm/tests/bedrock-messages-request_anthropic_tools.snap
+++ b/crates/agentgateway/src/llm/tests/bedrock-messages-request_anthropic_tools.snap
@@ -2,7 +2,7 @@
 source: crates/agentgateway/src/llm/tests.rs
 description: "bedrock-messages: request_anthropic_tools"
 info:
-  model: claude-opus-4-1-20250805
+  model: claude-opus-4-6
   max_tokens: 1024
   tools:
     - name: get_weather
@@ -20,7 +20,7 @@ info:
       content: What is the weather like in San Francisco?
 ---
 {
-  "modelId": "claude-opus-4-1-20250805",
+  "modelId": "claude-opus-4-6",
   "messages": [
     {
       "role": "user",

--- a/crates/agentgateway/src/llm/tests/bedrock-messages-response_bedrock_basic.snap
+++ b/crates/agentgateway/src/llm/tests/bedrock-messages-response_bedrock_basic.snap
@@ -1,10 +1,27 @@
 ---
 source: crates/agentgateway/src/llm/tests.rs
 description: src/llm/tests/response_bedrock_basic.json
-info: "{\n  \"output\": {\n    \"message\": {\n      \"role\": \"assistant\",\n      \"content\": [\n        {\n          \"text\": \"Hello world\"\n        }\n      ]\n    }\n  },\n  \"stopReason\": \"end_turn\",\n  \"usage\": {\n    \"inputTokens\": 18,\n    \"outputTokens\": 46,\n    \"totalTokens\": 64\n  },\n  \"metrics\": {\n    \"latencyMs\": 2083\n  }\n}"
+info:
+  output:
+    message:
+      role: assistant
+      content:
+        - text: Hello world
+  stopReason: end_turn
+  usage:
+    inputTokens: 18
+    outputTokens: 46
+    totalTokens: 64
+  metrics:
+    latencyMs: 2083
 ---
 {
+  "id": "[id]",
+  "type": "message",
+  "role": "assistant",
   "model": "fake-model",
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
   "usage": {
     "input_tokens": 18,
     "output_tokens": 46
@@ -14,10 +31,5 @@ info: "{\n  \"output\": {\n    \"message\": {\n      \"role\": \"assistant\",\n 
       "text": "Hello world",
       "type": "text"
     }
-  ],
-  "id": "[id]",
-  "type": "message",
-  "role": "assistant",
-  "stop_reason": "end_turn",
-  "stop_sequence": null
+  ]
 }

--- a/crates/agentgateway/src/llm/tests/bedrock-messages-response_bedrock_tool.snap
+++ b/crates/agentgateway/src/llm/tests/bedrock-messages-response_bedrock_tool.snap
@@ -1,10 +1,30 @@
 ---
 source: crates/agentgateway/src/llm/tests.rs
 description: src/llm/tests/response_bedrock_tool.json
-info: "{\n  \"output\": {\n    \"message\": {\n      \"role\": \"assistant\",\n      \"content\": [\n        {\n          \"toolUse\": {\n            \"toolUseId\": \"tooluse_kZJMlvQmRJ6eAyJE5GIl7Q\",\n            \"name\": \"top_song\",\n            \"input\": {\n              \"sign\": \"WZPZ\"\n            }\n          }\n        },\n        {\n          \"toolUse\": {\n            \"toolUseId\": \"tooluse_kZJMlvQmRJ6eAyxxx\",\n            \"name\": \"hello\",\n            \"input\": {\n              \"sign\": \"world\"\n            }\n          }\n        }\n      ]\n    }\n  },\n  \"stopReason\": \"tool_use\"\n}"
+info:
+  output:
+    message:
+      role: assistant
+      content:
+        - toolUse:
+            toolUseId: tooluse_kZJMlvQmRJ6eAyJE5GIl7Q
+            name: top_song
+            input:
+              sign: WZPZ
+        - toolUse:
+            toolUseId: tooluse_kZJMlvQmRJ6eAyxxx
+            name: hello
+            input:
+              sign: world
+  stopReason: tool_use
 ---
 {
+  "id": "[id]",
+  "type": "message",
+  "role": "assistant",
   "model": "fake-model",
+  "stop_reason": "tool_use",
+  "stop_sequence": null,
   "usage": {
     "input_tokens": 0,
     "output_tokens": 0
@@ -26,10 +46,5 @@ info: "{\n  \"output\": {\n    \"message\": {\n      \"role\": \"assistant\",\n 
         "sign": "world"
       }
     }
-  ],
-  "id": "[id]",
-  "type": "message",
-  "role": "assistant",
-  "stop_reason": "tool_use",
-  "stop_sequence": null
+  ]
 }

--- a/crates/agentgateway/src/llm/tests/completions_get_messages.snap
+++ b/crates/agentgateway/src/llm/tests/completions_get_messages.snap
@@ -19,7 +19,7 @@ info:
           text: "What's in this image?"
         - type: image_url
           image_url:
-            url: "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg"
+            url: "https://upload.wikimedia.org/wikipedia/commons/4/47/PNG_transparency_demonstration_1.png"
   max_tokens: 1000
   temperature: 0.7
   top_p: 0.9

--- a/crates/agentgateway/src/llm/tests/messages_get_messages.snap
+++ b/crates/agentgateway/src/llm/tests/messages_get_messages.snap
@@ -19,7 +19,7 @@ info:
           text: "What's in this image?"
         - type: image_url
           image_url:
-            url: "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg"
+            url: "https://upload.wikimedia.org/wikipedia/commons/4/47/PNG_transparency_demonstration_1.png"
   max_tokens: 1000
   temperature: 0.7
   top_p: 0.9

--- a/crates/agentgateway/src/llm/tests/request_anthropic_tools.json
+++ b/crates/agentgateway/src/llm/tests/request_anthropic_tools.json
@@ -1,5 +1,5 @@
 {
-  "model": "claude-opus-4-1-20250805",
+  "model": "claude-opus-4-6",
   "max_tokens": 1024,
   "tools": [
     {

--- a/crates/agentgateway/src/llm/tests/request_full.json
+++ b/crates/agentgateway/src/llm/tests/request_full.json
@@ -23,7 +23,7 @@
         {
           "type": "image_url",
           "image_url": {
-            "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg"
+            "url": "https://upload.wikimedia.org/wikipedia/commons/4/47/PNG_transparency_demonstration_1.png"
           }
         }
       ]

--- a/crates/agentgateway/src/llm/tests/response_anthropic_basic.json
+++ b/crates/agentgateway/src/llm/tests/response_anthropic_basic.json
@@ -2,7 +2,7 @@
   "id": "msg_012JYtNYb8sv6Hb67TcGT7xW",
   "type": "message",
   "role": "assistant",
-  "model": "claude-3-5-haiku-20241022",
+  "model": "claude-haiku-4-5-20251001",
   "content": [
     {
       "type": "text",

--- a/crates/agentgateway/src/llm/tests/response_anthropic_thinking.json
+++ b/crates/agentgateway/src/llm/tests/response_anthropic_thinking.json
@@ -2,7 +2,7 @@
   "id": "msg_01BE9GBzjs95TqdG8FeUanUn",
   "type": "message",
   "role": "assistant",
-  "model": "claude-opus-4-1-20250805",
+  "model": "claude-opus-4-6",
   "content": [
     {
       "type": "thinking",

--- a/crates/agentgateway/src/llm/tests/response_anthropic_tool.json
+++ b/crates/agentgateway/src/llm/tests/response_anthropic_tool.json
@@ -1,7 +1,7 @@
 {
   "id": "msg_01Aq9w938a90dw8q",
   "type": "message",
-  "model": "claude-opus-4-1-20250805",
+  "model": "claude-opus-4-6",
   "stop_reason": "tool_use",
   "role": "assistant",
   "content": [

--- a/crates/agentgateway/src/llm/tests/response_stream-anthropic_basic.json
+++ b/crates/agentgateway/src/llm/tests/response_stream-anthropic_basic.json
@@ -1,5 +1,5 @@
 event: message_start
-data: {"type":"message_start","message":{"id":"msg_016wbjv5k86nxxd8CEZwSQnA","type":"message","role":"assistant","model":"claude-3-5-haiku-20241022","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":15,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":5,"service_tier":"standard"}}    }
+data: {"type":"message_start","message":{"id":"msg_016wbjv5k86nxxd8CEZwSQnA","type":"message","role":"assistant","model":"claude-haiku-4-5-20251001","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":15,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":5,"service_tier":"standard"}}    }
 
 event: content_block_start
 data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}      }

--- a/crates/agentgateway/src/llm/tests/response_stream-anthropic_thinking.json
+++ b/crates/agentgateway/src/llm/tests/response_stream-anthropic_thinking.json
@@ -1,5 +1,5 @@
 event: message_start
-data: {"type":"message_start","message":{"id":"msg_018XasA6jgabsibaUtstx4bg","type":"message","role":"assistant","model":"claude-opus-4-1-20250805","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":47,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":4,"service_tier":"standard"}}      }
+data: {"type":"message_start","message":{"id":"msg_018XasA6jgabsibaUtstx4bg","type":"message","role":"assistant","model":"claude-opus-4-6","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":47,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":4,"service_tier":"standard"}}      }
 
 event: content_block_start
 data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":"","signature":""}       }

--- a/crates/agentgateway/src/llm/tests/vertex-messages-request_anthropic_tools.snap
+++ b/crates/agentgateway/src/llm/tests/vertex-messages-request_anthropic_tools.snap
@@ -2,7 +2,7 @@
 source: crates/agentgateway/src/llm/tests.rs
 description: "vertex-messages: request_anthropic_tools"
 info:
-  model: claude-opus-4-1-20250805
+  model: claude-opus-4-6
   max_tokens: 1024
   tools:
     - name: get_weather

--- a/crates/agentgateway/src/llm/tests/vertex-messages-response_anthropic_basic.snap
+++ b/crates/agentgateway/src/llm/tests/vertex-messages-response_anthropic_basic.snap
@@ -5,7 +5,7 @@ info:
   id: msg_012JYtNYb8sv6Hb67TcGT7xW
   type: message
   role: assistant
-  model: claude-3-5-haiku-20241022
+  model: claude-haiku-4-5-20251001
   content:
     - type: text
       text: Hi there! How are you doing today? Is there anything I can help you with?
@@ -19,7 +19,12 @@ info:
     service_tier: standard
 ---
 {
-  "model": "claude-3-5-haiku-20241022",
+  "id": "[id]",
+  "type": "message",
+  "role": "assistant",
+  "model": "claude-haiku-4-5-20251001",
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
   "usage": {
     "input_tokens": 15,
     "output_tokens": 21,
@@ -32,10 +37,5 @@ info:
       "text": "Hi there! How are you doing today? Is there anything I can help you with?",
       "type": "text"
     }
-  ],
-  "id": "[id]",
-  "type": "message",
-  "role": "assistant",
-  "stop_reason": "end_turn",
-  "stop_sequence": null
+  ]
 }

--- a/crates/agentgateway/src/llm/tests/vertex-messages-response_anthropic_tool.snap
+++ b/crates/agentgateway/src/llm/tests/vertex-messages-response_anthropic_tool.snap
@@ -4,7 +4,7 @@ description: src/llm/tests/response_anthropic_tool.json
 info:
   id: msg_01Aq9w938a90dw8q
   type: message
-  model: claude-opus-4-1-20250805
+  model: claude-opus-4-6
   stop_reason: tool_use
   role: assistant
   content:
@@ -24,7 +24,12 @@ info:
     service_tier: standard
 ---
 {
-  "model": "claude-opus-4-1-20250805",
+  "id": "[id]",
+  "type": "message",
+  "role": "assistant",
+  "model": "claude-opus-4-6",
+  "stop_reason": "tool_use",
+  "stop_sequence": null,
   "usage": {
     "input_tokens": 558,
     "output_tokens": 48,
@@ -46,9 +51,5 @@ info:
         "unit": "celsius"
       }
     }
-  ],
-  "id": "[id]",
-  "type": "message",
-  "stop_reason": "tool_use",
-  "role": "assistant"
+  ]
 }

--- a/crates/agentgateway/src/llm/tests/vertex-messages-response_stream-anthropic_basic.json.snap
+++ b/crates/agentgateway/src/llm/tests/vertex-messages-response_stream-anthropic_basic.json.snap
@@ -3,7 +3,7 @@ source: crates/agentgateway/src/llm/tests.rs
 description: src/llm/tests/response_stream-anthropic_basic.json
 ---
 event: message_start
-data: {"type":"message_start","message":{"id":"msg_016wbjv5k86nxxd8CEZwSQnA","type":"message","role":"assistant","model":"claude-3-5-haiku-20241022","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":15,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":5,"service_tier":"standard"}}    }
+data: {"type":"message_start","message":{"id":"msg_016wbjv5k86nxxd8CEZwSQnA","type":"message","role":"assistant","model":"claude-haiku-4-5-20251001","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":15,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":5,"service_tier":"standard"}}    }
 
 event: content_block_start
 data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}      }

--- a/crates/agentgateway/src/llm/types/count_tokens.rs
+++ b/crates/agentgateway/src/llm/types/count_tokens.rs
@@ -45,9 +45,7 @@ impl RequestType for Request {
 	}
 
 	fn get_messages(&self) -> Vec<SimpleChatCompletionMessage> {
-		unimplemented!(
-			"get_messages is used for prompt guard; prompt guard is disable for token counting."
-		)
+		messages::get_messages_helper(&self.messages, &self.system)
 	}
 
 	fn set_messages(&mut self, _messages: Vec<SimpleChatCompletionMessage>) {

--- a/crates/agentgateway/src/llm/vertex.rs
+++ b/crates/agentgateway/src/llm/vertex.rs
@@ -112,7 +112,7 @@ impl Provider {
 		}
 	}
 
-	pub fn get_host(&self) -> Strng {
+	pub fn get_host(&self, _request_model: Option<&str>) -> Strng {
 		match &self.region {
 			None => {
 				strng::literal!("aiplatform.googleapis.com")

--- a/crates/agentgateway/src/types/local_tests/llm_simple_config.yaml
+++ b/crates/agentgateway/src/types/local_tests/llm_simple_config.yaml
@@ -16,7 +16,7 @@ llm:
   - name: claude-3-haiku
     provider: anthropic
     params:
-      model: claude-3-5-haiku-20241022
+      model: claude-haiku-4-5-20251001
       apiKey: "sk-123"
     matches:
     - headers:
@@ -26,7 +26,7 @@ llm:
   - name: gemini-0.5-pro
     provider: vertex
     params:
-      model: claude-3-5-haiku-20241022
+      model: claude-haiku-4-5-20251001
       apiKey: "sk-123"
       vertexRegion: global
       vertexProject: my-vertex-project

--- a/crates/agentgateway/src/types/local_tests/llm_simple_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/llm_simple_normalized.snap
@@ -213,7 +213,7 @@ backends:
                     name: claude-3-haiku
                     provider:
                       anthropic:
-                        model: claude-3-5-haiku-20241022
+                        model: claude-haiku-4-5-20251001
                     hostOverride: ~
                     pathOverride: ~
                     tokenize: false
@@ -244,7 +244,7 @@ backends:
                     name: gemini-0.5-pro
                     provider:
                       vertex:
-                        model: claude-3-5-haiku-20241022
+                        model: claude-haiku-4-5-20251001
                         region: global
                         projectId: my-vertex-project
                     hostOverride: ~


### PR DESCRIPTION
- implement Anthropic /v1/messages <-> OpenAI-style /v1/chat/completions translation across request, non-stream response, stream, and error paths
- extend role/content mapping in both directions, including tool calls, tool results, system/developer handling, and multimodal user content
- improve streaming translation sequencing and finish behavior (tool block lifecycle, done handling, and missing-finish edge cases)
- wire Messages InputFormat behavior consistently for OpenAI-compatible providers (OpenAI, Azure OpenAI, Vertex non-Anthropic, Gemini)
- fix Bedrock tool-result mapping for completions/responses translations to avoid forcing success status when source APIs do not carry explicit status
- add/expand translation tests for request/response/stream/error parity, roundtrip semantics, and edge-case regressions; refresh affected fixtures/snapshots
- bump async-openai to 0.32.4