### PR TITLE
Fix OpenAPI tool response by populating 'content' with serialized 'structuredContent'

### DIFF
--- a/crates/agentgateway/src/mcp/upstream/openapi/mod.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/mod.rs
@@ -644,10 +644,17 @@ impl Handler {
 				let res = self
 					.call_tool(ctr.params.name.as_ref(), ctr.params.arguments, ctx)
 					.await?;
+
+				// Serialize structured content to JSON string for backwards compatibility
+				// Per MCP spec https://modelcontextprotocol.io/specification/2025-06-18/server/tools#structured-content:
+				//   "a tool that returns structured content SHOULD also return the serialized JSON in a TextContent block"
+				let serialized_content = serde_json::to_string(&res)
+					.map_err(|e| anyhow::anyhow!("Failed to serialize tool response: {}", e))?;
+
 				Messages::from_result(
 					id,
 					CallToolResult {
-						content: vec![],
+						content: vec![Content::text(serialized_content)],
 						structured_content: Some(res),
 						is_error: None,
 						meta: None,

--- a/crates/agentgateway/src/mcp/upstream/openapi/mod.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/mod.rs
@@ -648,6 +648,7 @@ impl Handler {
 				// Serialize structured content to JSON string for backwards compatibility
 				// Per MCP spec https://modelcontextprotocol.io/specification/2025-06-18/server/tools#structured-content:
 				//   "a tool that returns structured content SHOULD also return the serialized JSON in a TextContent block"
+				// Note: This part of the spec is in flux, see https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1624
 				let serialized_content = serde_json::to_string(&res)
 					.map_err(|e| anyhow::anyhow!("Failed to serialize tool response: {}", e))?;
 

--- a/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
@@ -836,13 +836,20 @@ async fn test_call_tool_structured_content_fallback() {
 				meta: None,
 				task: None,
 				name: "get_user".into(),
-				arguments: Some(json!({ "path": { "user_id": user_id } }).as_object().unwrap().clone()),
+				arguments: Some(
+					json!({ "path": { "user_id": user_id } })
+						.as_object()
+						.unwrap()
+						.clone(),
+				),
 			},
 			extensions: Extensions::default(),
-		})
+		}),
 	};
 
-	let result = handler.send_message(request, &IncomingRequestContext::empty()).await;
+	let result = handler
+		.send_message(request, &IncomingRequestContext::empty())
+		.await;
 	assert!(result.is_ok(), "send_message should succeed");
 
 	let messages = result.unwrap();
@@ -850,7 +857,10 @@ async fn test_call_tool_structured_content_fallback() {
 	// Convert Messages to Vec to inspect CallToolResult
 	use futures_util::StreamExt;
 	let mut message_stream = messages;
-	let message_result = message_stream.next().await.expect("Should receive at least one message");
+	let message_result = message_stream
+		.next()
+		.await
+		.expect("Should receive at least one message");
 
 	// Handle the Result<JsonRpcMessage, ClientError> wrapper
 	let server_msg = message_result.expect("Message processing should succeed");
@@ -860,31 +870,58 @@ async fn test_call_tool_structured_content_fallback() {
 	};
 
 	let ServerResult::CallToolResult(call_result) = &response.result else {
-		panic!("Response should contain CallToolResult, got: {:?}", response.result);
+		panic!(
+			"Response should contain CallToolResult, got: {:?}",
+			response.result
+		);
 	};
 
 	// Test 1: content field should NOT be empty (our backwards compatibility fix)
-	assert!(!call_result.content.is_empty(), "content field should not be empty after our fix");
-	assert_eq!(call_result.content.len(), 1, "content should have exactly one item");
+	assert!(
+		!call_result.content.is_empty(),
+		"content field should not be empty after our fix"
+	);
+	assert_eq!(
+		call_result.content.len(),
+		1,
+		"content should have exactly one item"
+	);
 
 	// Test 2: structured_content should contain the original JSON
-	assert!(call_result.structured_content.is_some(), "structured_content should be populated");
+	assert!(
+		call_result.structured_content.is_some(),
+		"structured_content should be populated"
+	);
 	let structured_content = call_result.structured_content.as_ref().unwrap();
-	assert_eq!(*structured_content, expected_response, "structured_content should contain original API response");
+	assert_eq!(
+		*structured_content, expected_response,
+		"structured_content should contain original API response"
+	);
 
 	// Test 3: content[0] should contain serialized JSON as text
-	let content_item = call_result.content.first().expect("content should have at least one item");
+	let content_item = call_result
+		.content
+		.first()
+		.expect("content should have at least one item");
 
 	let RawContent::Text(text_content) = &content_item.raw else {
-		panic!("content[0] should be Text content type, got: {:?}", content_item.raw);
+		panic!(
+			"content[0] should be Text content type, got: {:?}",
+			content_item.raw
+		);
 	};
 
 	let serialized_json = &text_content.text;
-	let parsed_from_content: serde_json::Value = serde_json::from_str(serialized_json)
-		.expect("content should contain valid JSON string");
-	assert_eq!(parsed_from_content, expected_response, "content should contain serialized version of API response");
+	let parsed_from_content: serde_json::Value =
+		serde_json::from_str(serialized_json).expect("content should contain valid JSON string");
+	assert_eq!(
+		parsed_from_content, expected_response,
+		"content should contain serialized version of API response"
+	);
 
 	// Test 4: Both fields should represent the same data
-	assert_eq!(parsed_from_content, *structured_content, "content and structured_content should represent the same data");
+	assert_eq!(
+		parsed_from_content, *structured_content,
+		"content and structured_content should represent the same data"
+	);
 }
-

--- a/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
@@ -808,3 +808,92 @@ async fn test_headers_not_in_schema_are_ignored() {
 	);
 	assert_eq!(result.unwrap(), expected_response);
 }
+
+#[tokio::test]
+async fn test_call_tool_backwards_compatibility() {
+	// Test that CallToolResult has both content and structured_content populated
+	// This verifies our backwards compatibility fix for langchain-mcp-adapter
+	let (server, handler) = setup().await;
+
+	let user_id = "test123";
+	let expected_response = json!({ "id": user_id, "name": "Test User", "status": "active" });
+
+	Mock::given(method("GET"))
+		.and(path(format!("/users/{user_id}")))
+		.respond_with(ResponseTemplate::new(200).set_body_json(&expected_response))
+		.mount(&server)
+		.await;
+
+	// Test the MCP message handling directly
+	use rmcp::model::*;
+
+	let request = JsonRpcRequest {
+		jsonrpc: JsonRpcVersion2_0,
+		id: RequestId::String("test-123".into()),
+		request: ClientRequest::CallToolRequest(CallToolRequest {
+			method: CallToolRequestMethod,
+			params: CallToolRequestParam {
+				name: "get_user".into(),
+				arguments: Some(json!({ "path": { "user_id": user_id } }).as_object().unwrap().clone()),
+			},
+			extensions: Extensions::default(),
+		})
+	};
+
+	let result = handler.send_message(request, &IncomingRequestContext::empty()).await;
+	assert!(result.is_ok(), "send_message should succeed");
+
+	let messages = result.unwrap();
+
+	// Convert Messages to Vec to inspect CallToolResult
+	use futures_util::StreamExt;
+	let message_vec: Vec<_> = messages.collect().await;
+	assert_eq!(message_vec.len(), 1, "should receive exactly one message");
+
+	if let Some(message_result) = message_vec.first() {
+		// Handle the Result<JsonRpcMessage, ClientError> wrapper
+		match message_result {
+			Ok(server_msg) => {
+				if let JsonRpcMessage::Response(response) = server_msg {
+					if let ServerResult::CallToolResult(call_result) = &response.result {
+
+						// Test 1: content field should NOT be empty (our backwards compatibility fix)
+						assert!(!call_result.content.is_empty(), "content field should not be empty after our fix");
+						assert_eq!(call_result.content.len(), 1, "content should have exactly one item");
+
+						// Test 2: structured_content should contain the original JSON
+						assert!(call_result.structured_content.is_some(), "structured_content should be populated");
+						let structured_content = call_result.structured_content.as_ref().unwrap();
+						assert_eq!(*structured_content, expected_response, "structured_content should contain original API response");
+
+						// Test 3: content[0] should contain serialized JSON as text
+						if let Some(content_item) = call_result.content.first() {
+							if let RawContent::Text(text_content) = &content_item.raw {
+								let serialized_json = &text_content.text;
+								let parsed_from_content: serde_json::Value = serde_json::from_str(serialized_json)
+									.expect("content should contain valid JSON string");
+								assert_eq!(parsed_from_content, expected_response, "content should contain serialized version of API response");
+
+								// Test 4: Both fields should represent the same data
+								assert_eq!(parsed_from_content, *structured_content, "content and structured_content should represent the same data");
+							} else {
+								panic!("content[0] should be Text content type, got: {:?}", content_item.raw);
+							}
+						}
+
+					} else {
+						panic!("Response should contain CallToolResult, got: {:?}", response.result);
+					}
+				} else {
+					panic!("Should receive a Response message, got: {:?}", server_msg);
+				}
+			}
+			Err(e) => {
+				panic!("Message processing failed with error: {:?}", e);
+			}
+		}
+	} else {
+		panic!("Should receive at least one message");
+	}
+}
+


### PR DESCRIPTION
This change addresses backwards compatibility with MCP clients that expect the content field to be populated. Per the MCP spec, a tool that returns structured content SHOULD also return the serialized JSON in a TextContent block.

Changes:
- Serialize structured_content to JSON and populate the content field
- Add comprehensive test to verify both fields are populated correctly
- Add MCP spec link for reference

This closes issue https://github.com/agentgateway/agentgateway/issues/715