### PR TITLE
fix: respect enableIpv6 config for XDS route socket bindings (#3)

### DIFF
--- a/crates/agentgateway/src/http/route_test.rs
+++ b/crates/agentgateway/src/http/route_test.rs
@@ -15,7 +15,7 @@ use crate::types::agent::{
 use crate::*;
 
 fn run_test(req: &Request, routes: &[(&str, Vec<&str>, Vec<RouteMatch>)]) -> Option<String> {
-	let stores = Stores::new(true);
+	let stores = Stores::with_ipv6_enabled(true);
 	let network = strng::literal!("network");
 	let dummy_dest = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 1000);
 
@@ -859,7 +859,7 @@ fn bench(b: Bencher, (host, route): (u64, u64)) {
 				.collect(),
 		),
 	});
-	let stores = Stores::new(true);
+	let stores = Stores::with_ipv6_enabled(true);
 	let network = strng::literal!("network");
 	let dummy_dest = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 1000);
 	let req = request("http://example.com", http::Method::GET, &[]);

--- a/crates/agentgateway/src/http/route_test.rs
+++ b/crates/agentgateway/src/http/route_test.rs
@@ -15,7 +15,7 @@ use crate::types::agent::{
 use crate::*;
 
 fn run_test(req: &Request, routes: &[(&str, Vec<&str>, Vec<RouteMatch>)]) -> Option<String> {
-	let stores = Stores::new();
+	let stores = Stores::new(true);
 	let network = strng::literal!("network");
 	let dummy_dest = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 1000);
 
@@ -859,7 +859,7 @@ fn bench(b: Bencher, (host, route): (u64, u64)) {
 				.collect(),
 		),
 	});
-	let stores = Stores::new();
+	let stores = Stores::new(true);
 	let network = strng::literal!("network");
 	let dummy_dest = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 1000);
 	let req = request("http://example.com", http::Method::GET, &[]);

--- a/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
@@ -24,7 +24,7 @@ async fn setup() -> (MockServer, Handler) {
 	let parsed = reqwest::Url::parse(&host).unwrap();
 	let config = crate::config::parse_config("{}".to_string(), None).unwrap();
 	let encoder = config.session_encoder.clone();
-	let stores = Stores::new();
+	let stores = Stores::new(config.ipv6_enabled);
 	let client = Client::new(
 		&client::Config {
 			resolver_cfg: ResolverConfig::default(),

--- a/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
@@ -24,7 +24,7 @@ async fn setup() -> (MockServer, Handler) {
 	let parsed = reqwest::Url::parse(&host).unwrap();
 	let config = crate::config::parse_config("{}".to_string(), None).unwrap();
 	let encoder = config.session_encoder.clone();
-	let stores = Stores::new(config.ipv6_enabled);
+	let stores = Stores::with_ipv6_enabled(config.ipv6_enabled);
 	let client = Client::new(
 		&client::Config {
 			resolver_cfg: ResolverConfig::default(),

--- a/crates/agentgateway/src/state_manager.rs
+++ b/crates/agentgateway/src/state_manager.rs
@@ -35,7 +35,7 @@ impl StateManager {
 		awaiting_ready: tokio::sync::watch::Sender<()>,
 	) -> anyhow::Result<Self> {
 		let xds = &config.xds;
-		let stores = Stores::new(config.ipv6_enabled);
+		let stores = Stores::with_ipv6_enabled(config.ipv6_enabled);
 		let xds_client = if let Some(addr) = &xds.address {
 			let connector = control::grpc_connector(
 				client.clone(),

--- a/crates/agentgateway/src/state_manager.rs
+++ b/crates/agentgateway/src/state_manager.rs
@@ -35,7 +35,7 @@ impl StateManager {
 		awaiting_ready: tokio::sync::watch::Sender<()>,
 	) -> anyhow::Result<Self> {
 		let xds = &config.xds;
-		let stores = Stores::new();
+		let stores = Stores::new(config.ipv6_enabled);
 		let xds_client = if let Some(addr) = &xds.address {
 			let connector = control::grpc_connector(
 				client.clone(),

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -1030,15 +1030,7 @@ impl Store {
 	}
 
 	fn insert_xds_bind(&mut self, raw: XdsBind) -> anyhow::Result<()> {
-		let mut bind = Bind::try_from(&raw)?;
-		// Respect the enableIpv6 config for bind address selection,
-		// matching the same logic used in types/local.rs for local config binds.
-		let port = bind.address.port();
-		bind.address = if cfg!(target_family = "unix") && self.ipv6_enabled {
-			SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), port)
-		} else {
-			SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), port)
-		};
+		let mut bind = Bind::try_from_xds(&raw, self.ipv6_enabled)?;
 		// If XDS server pushes the same bind twice (which it shouldn't really do, but oh well),
 		// we need to copy the listeners over.
 		if let Some(old) = self.binds.remove(&bind.key) {
@@ -1334,7 +1326,7 @@ mod tests {
 
 	#[test]
 	fn route_policies_are_kind_scoped() {
-		let mut store = Store::new();
+		let mut store = Store::default();
 		let listener = listener();
 
 		let http_route = route("r", "ns", Some("HTTPRoute"));
@@ -1365,7 +1357,7 @@ mod tests {
 	/// Tests that frontend policies at listener level take precedence over gateway level policies
 	#[test]
 	fn frontend_policy_listener_precedence() {
-		let mut store = Store::new();
+		let mut store = Store::default();
 		let listener = listener();
 
 		// Insert both gateway and listener level frontend policies
@@ -1388,5 +1380,38 @@ mod tests {
 			!access_log.remove.contains("gw_remove"),
 			"Gateway policy should not override listener policy"
 		);
+	}
+
+	#[test]
+	fn xds_bind_uses_ipv4_when_ipv6_disabled() {
+		use std::net::{IpAddr, Ipv4Addr};
+
+		let xds_bind = XdsBind {
+			key: "test-bind".to_string(),
+			port: 8080,
+			protocol: 0, // HTTP
+			tunnel_protocol: 0, // Direct
+		};
+
+		let bind = Bind::try_from_xds(&xds_bind, false).unwrap();
+		assert_eq!(bind.address.port(), 8080);
+		assert_eq!(bind.address.ip(), IpAddr::V4(Ipv4Addr::UNSPECIFIED));
+	}
+
+	#[cfg(target_family = "unix")]
+	#[test]
+	fn xds_bind_uses_ipv6_when_ipv6_enabled_on_unix() {
+		use std::net::{IpAddr, Ipv6Addr};
+
+		let xds_bind = XdsBind {
+			key: "test-bind".to_string(),
+			port: 9090,
+			protocol: 0, // HTTP
+			tunnel_protocol: 0, // Direct
+		};
+
+		let bind = Bind::try_from_xds(&xds_bind, true).unwrap();
+		assert_eq!(bind.address.port(), 9090);
+		assert_eq!(bind.address.ip(), IpAddr::V6(Ipv6Addr::UNSPECIFIED));
 	}
 }

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -331,7 +331,7 @@ pub struct LLMResponsePolicies {
 
 impl Default for Store {
 	fn default() -> Self {
-		Self::new(true)
+		Self::with_ipv6_enabled(true)
 	}
 }
 
@@ -343,7 +343,7 @@ pub struct RoutePath<'a> {
 }
 
 impl Store {
-	pub fn new(ipv6_enabled: bool) -> Self {
+	pub fn with_ipv6_enabled(ipv6_enabled: bool) -> Self {
 		let (tx, _) = tokio::sync::broadcast::channel(1000);
 		Self {
 			ipv6_enabled,

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -1389,7 +1389,7 @@ mod tests {
 		let xds_bind = XdsBind {
 			key: "test-bind".to_string(),
 			port: 8080,
-			protocol: 0, // HTTP
+			protocol: 0,        // HTTP
 			tunnel_protocol: 0, // Direct
 		};
 
@@ -1406,7 +1406,7 @@ mod tests {
 		let xds_bind = XdsBind {
 			key: "test-bind".to_string(),
 			port: 9090,
-			protocol: 0, // HTTP
+			protocol: 0,        // HTTP
 			tunnel_protocol: 0, // Direct
 		};
 

--- a/crates/agentgateway/src/store/mod.rs
+++ b/crates/agentgateway/src/store/mod.rs
@@ -31,15 +31,15 @@ pub struct Stores {
 
 impl Default for Stores {
 	fn default() -> Self {
-		Self::new(true)
+		Self::with_ipv6_enabled(true)
 	}
 }
 
 impl Stores {
-	pub fn new(ipv6_enabled: bool) -> Stores {
+	pub fn with_ipv6_enabled(ipv6_enabled: bool) -> Stores {
 		Stores {
 			discovery: discovery::StoreUpdater::new(Arc::new(RwLock::new(discovery::Store::new()))),
-			binds: binds::StoreUpdater::new(Arc::new(RwLock::new(binds::Store::new(ipv6_enabled)))),
+			binds: binds::StoreUpdater::new(Arc::new(RwLock::new(binds::Store::with_ipv6_enabled(ipv6_enabled)))),
 		}
 	}
 	pub fn read_binds(&self) -> std::sync::RwLockReadGuard<'_, store::BindStore> {

--- a/crates/agentgateway/src/store/mod.rs
+++ b/crates/agentgateway/src/store/mod.rs
@@ -39,7 +39,9 @@ impl Stores {
 	pub fn with_ipv6_enabled(ipv6_enabled: bool) -> Stores {
 		Stores {
 			discovery: discovery::StoreUpdater::new(Arc::new(RwLock::new(discovery::Store::new()))),
-			binds: binds::StoreUpdater::new(Arc::new(RwLock::new(binds::Store::with_ipv6_enabled(ipv6_enabled)))),
+			binds: binds::StoreUpdater::new(Arc::new(RwLock::new(binds::Store::with_ipv6_enabled(
+				ipv6_enabled,
+			)))),
 		}
 	}
 	pub fn read_binds(&self) -> std::sync::RwLockReadGuard<'_, store::BindStore> {

--- a/crates/agentgateway/src/store/mod.rs
+++ b/crates/agentgateway/src/store/mod.rs
@@ -31,15 +31,15 @@ pub struct Stores {
 
 impl Default for Stores {
 	fn default() -> Self {
-		Self::new()
+		Self::new(true)
 	}
 }
 
 impl Stores {
-	pub fn new() -> Stores {
+	pub fn new(ipv6_enabled: bool) -> Stores {
 		Stores {
 			discovery: discovery::StoreUpdater::new(Arc::new(RwLock::new(discovery::Store::new()))),
-			binds: binds::StoreUpdater::new(Arc::new(RwLock::new(binds::Store::new()))),
+			binds: binds::StoreUpdater::new(Arc::new(RwLock::new(binds::Store::new(ipv6_enabled)))),
 		}
 	}
 	pub fn read_binds(&self) -> std::sync::RwLockReadGuard<'_, store::BindStore> {

--- a/crates/agentgateway/src/test_helpers/proxymock.rs
+++ b/crates/agentgateway/src/test_helpers/proxymock.rs
@@ -602,7 +602,7 @@ pub fn setup_proxy_test(cfg: &str) -> anyhow::Result<TestBind> {
 	agent_core::telemetry::testing::setup_test_logging();
 	let config = crate::config::parse_config(cfg.to_string(), None)?;
 	let encoder = config.session_encoder.clone();
-	let stores = Stores::new();
+	let stores = Stores::new(config.ipv6_enabled);
 	let client = client::Client::new(&config.dns, None, Default::default(), None);
 	let (drain_tx, drain_rx) = drain::new();
 	let pi = Arc::new(ProxyInputs {

--- a/crates/agentgateway/src/test_helpers/proxymock.rs
+++ b/crates/agentgateway/src/test_helpers/proxymock.rs
@@ -602,7 +602,7 @@ pub fn setup_proxy_test(cfg: &str) -> anyhow::Result<TestBind> {
 	agent_core::telemetry::testing::setup_test_logging();
 	let config = crate::config::parse_config(cfg.to_string(), None)?;
 	let encoder = config.session_encoder.clone();
-	let stores = Stores::new(config.ipv6_enabled);
+	let stores = Stores::with_ipv6_enabled(config.ipv6_enabled);
 	let client = client::Client::new(&config.dns, None, Default::default(), None);
 	let (drain_tx, drain_rx) = drain::new();
 	let pi = Arc::new(ProxyInputs {

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -497,10 +497,7 @@ impl TryFrom<(proto::agent::Protocol, Option<&proto::agent::TlsConfig>)> for Lis
 }
 
 impl Bind {
-	pub fn try_from_xds(
-		s: &proto::agent::Bind,
-		ipv6_enabled: bool,
-	) -> Result<Self, ProtoError> {
+	pub fn try_from_xds(s: &proto::agent::Bind, ipv6_enabled: bool) -> Result<Self, ProtoError> {
 		let address = if cfg!(target_family = "unix") && ipv6_enabled {
 			SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), s.port as u16)
 		} else {

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::net::{IpAddr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::num::NonZeroU16;
 use std::sync::Arc;
 
@@ -496,13 +496,19 @@ impl TryFrom<(proto::agent::Protocol, Option<&proto::agent::TlsConfig>)> for Lis
 	}
 }
 
-impl TryFrom<&proto::agent::Bind> for Bind {
-	type Error = ProtoError;
-
-	fn try_from(s: &proto::agent::Bind) -> Result<Self, Self::Error> {
+impl Bind {
+	pub fn try_from_xds(
+		s: &proto::agent::Bind,
+		ipv6_enabled: bool,
+	) -> Result<Self, ProtoError> {
+		let address = if cfg!(target_family = "unix") && ipv6_enabled {
+			SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), s.port as u16)
+		} else {
+			SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), s.port as u16)
+		};
 		Ok(Self {
 			key: s.key.clone().into(),
-			address: SocketAddr::from((IpAddr::from([0, 0, 0, 0, 0, 0, 0, 0]), s.port as u16)),
+			address,
 			listeners: Default::default(),
 			protocol: match proto::agent::bind::Protocol::try_from(s.protocol)? {
 				proto::agent::bind::Protocol::Http => BindProtocol::http,


### PR DESCRIPTION
* fix: respect enableIpv6 config for XDS route socket bindings

PR #843 made enableIpv6 affect local config route binds but missed the XDS path. The TryFrom<&proto::agent::Bind> in agent_xds.rs always creates IPv6 [::] addresses regardless of the enableIpv6 config setting.

This fix threads ipv6_enabled through Stores → Store and overrides the bind address in insert_xds_bind() to use IPv4 when IPv6 is disabled, matching the existing logic in types/local.rs.

Fixes [#911](https://github.com/agentgateway/agentgateway/issues/911)