### PR TITLE
Align `go.mod` go version with recommendations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/agentgateway/agentgateway
 
-go 1.25.6
+go 1.25.1
 
 replace github.com/agentgateway/agentgateway/api => ./api
 

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/agentgateway/agentgateway/tools
 
-go 1.25.6
+go 1.25.0
 
 tool (
 	github.com/bufbuild/buf/cmd/buf


### PR DESCRIPTION
This is what the go team recommends; no need to make this a high number
since it forces all builders and importers to use that version. We don't
need 1.25.6, we need 1.25.x.

The go version we use for release/test is decoupled.
