### PR TITLE
fix(llm): improve vertex/anthropic model handling

### DIFF
--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -649,7 +649,7 @@ impl AIProvider {
 				AIProvider::Bedrock(_) => req.to_bedrock_token_count(parts.headers())?,
 				AIProvider::Vertex(provider) => {
 					let body = req.to_anthropic()?;
-					provider.prepare_anthropic_request_body(body)?
+					provider.prepare_anthropic_count_tokens_body(body)?
 				},
 				_ => {
 					return Err(AIError::UnsupportedConversion(strng::literal!(
@@ -661,7 +661,7 @@ impl AIProvider {
 			match self {
 				AIProvider::Vertex(provider) if provider.is_anthropic_model(Some(request_model)) => {
 					let body = req.to_anthropic()?;
-					provider.prepare_anthropic_request_body(body)?
+					provider.prepare_anthropic_message_body(body)?
 				},
 				AIProvider::OpenAI(_) | AIProvider::Gemini(_) | AIProvider::AzureOpenAI(_) => {
 					req.to_openai()?

--- a/crates/agentgateway/src/llm/tests.rs
+++ b/crates/agentgateway/src/llm/tests.rs
@@ -334,7 +334,7 @@ async fn test_vertex_messages() {
 
 	let request = |input: types::messages::Request| -> Result<Vec<u8>, AIError> {
 		let anthropic_body = serde_json::to_vec(&input).map_err(AIError::RequestMarshal)?;
-		provider.prepare_anthropic_request_body(anthropic_body)
+		provider.prepare_anthropic_message_body(anthropic_body)
 	};
 
 	for r in MESSAGES_REQUESTS {
@@ -512,7 +512,7 @@ async fn test_vertex_count_tokens() {
 
 	let request = |input: types::count_tokens::Request| -> Result<Vec<u8>, AIError> {
 		let anthropic_body = input.to_anthropic()?;
-		provider.prepare_anthropic_request_body(anthropic_body)
+		provider.prepare_anthropic_count_tokens_body(anthropic_body)
 	};
 
 	for r in COUNT_TOKENS_REQUESTS {

--- a/crates/agentgateway/src/llm/tests/vertex-count-tokens-request_count_tokens_basic.snap
+++ b/crates/agentgateway/src/llm/tests/vertex-count-tokens-request_count_tokens_basic.snap
@@ -14,5 +14,6 @@ info:
       "content": "Hello, how are you?"
     }
   ],
+  "model": "anthropic/claude-sonnet-4-5",
   "anthropic_version": "vertex-2023-10-16"
 }

--- a/crates/agentgateway/src/llm/tests/vertex-count-tokens-request_count_tokens_with_system.snap
+++ b/crates/agentgateway/src/llm/tests/vertex-count-tokens-request_count_tokens_with_system.snap
@@ -15,6 +15,7 @@ info:
       "content": "What is the weather today?"
     }
   ],
-  "anthropic_version": "vertex-2023-10-16",
-  "system": "You are a helpful assistant."
+  "model": "anthropic/claude-sonnet-4-5",
+  "system": "You are a helpful assistant.",
+  "anthropic_version": "vertex-2023-10-16"
 }

--- a/crates/agentgateway/src/llm/types/completions.rs
+++ b/crates/agentgateway/src/llm/types/completions.rs
@@ -176,7 +176,7 @@ impl super::RequestType for Request {
 	fn to_vertex(&self, provider: &crate::llm::vertex::Provider) -> Result<Vec<u8>, AIError> {
 		if provider.is_anthropic_model(self.model.as_deref()) {
 			let body = self.to_anthropic()?;
-			provider.prepare_anthropic_request_body(body)
+			provider.prepare_anthropic_message_body(body)
 		} else {
 			self.to_openai()
 		}

--- a/crates/agentgateway/src/llm/types/count_tokens.rs
+++ b/crates/agentgateway/src/llm/types/count_tokens.rs
@@ -66,7 +66,7 @@ impl RequestType for Request {
 
 	fn to_vertex(&self, provider: &crate::llm::vertex::Provider) -> Result<Vec<u8>, AIError> {
 		let body = self.to_anthropic()?;
-		provider.prepare_anthropic_request_body(body)
+		provider.prepare_anthropic_count_tokens_body(body)
 	}
 }
 

--- a/crates/agentgateway/src/llm/types/messages.rs
+++ b/crates/agentgateway/src/llm/types/messages.rs
@@ -215,7 +215,7 @@ impl RequestType for Request {
 	fn to_vertex(&self, provider: &crate::llm::vertex::Provider) -> Result<Vec<u8>, AIError> {
 		if provider.is_anthropic_model(self.model.as_deref()) {
 			let body = self.to_anthropic()?;
-			provider.prepare_anthropic_request_body(body)
+			provider.prepare_anthropic_message_body(body)
 		} else {
 			self.to_openai()
 		}

--- a/crates/agentgateway/src/llm/vertex.rs
+++ b/crates/agentgateway/src/llm/vertex.rs
@@ -25,27 +25,40 @@ impl Provider {
 		self.model.as_deref().or(request_model)
 	}
 
-	fn anthropic_model<'a>(&'a self, request_model: Option<&'a str>) -> Option<Strng> {
-		let model = self.configured_model(request_model)?;
-		model
-			.strip_prefix("publishers/anthropic/models/")
-			.or_else(|| model.strip_prefix("anthropic/"))
-			.map(strng::new)
-	}
-
 	pub fn is_anthropic_model(&self, request_model: Option<&str>) -> bool {
 		self.anthropic_model(request_model).is_some()
 	}
 
-	pub fn prepare_anthropic_request_body(&self, body: Vec<u8>) -> Result<Vec<u8>, AIError> {
-		let mut map: Map<String, Value> =
+	pub fn prepare_anthropic_message_body(&self, body: Vec<u8>) -> Result<Vec<u8>, AIError> {
+		let mut body: Map<String, Value> =
 			serde_json::from_slice(&body).map_err(AIError::RequestMarshal)?;
-		map.insert(
+
+		body.insert(
 			"anthropic_version".to_string(),
 			Value::String(ANTHROPIC_VERSION.to_string()),
 		);
-		map.remove("model");
-		serde_json::to_vec(&map).map_err(AIError::RequestMarshal)
+		body.remove("model");
+
+		serde_json::to_vec(&body).map_err(AIError::RequestMarshal)
+	}
+
+	pub fn prepare_anthropic_count_tokens_body(&self, body: Vec<u8>) -> Result<Vec<u8>, AIError> {
+		let mut body: Map<String, Value> =
+			serde_json::from_slice(&body).map_err(AIError::RequestMarshal)?;
+
+		body.insert(
+			"anthropic_version".to_string(),
+			Value::String(ANTHROPIC_VERSION.to_string()),
+		);
+
+		if let Some(Value::String(model)) = body.get("model") {
+			let normalized = self
+				.configured_model(Some(model))
+				.map(|s| s.to_string())
+				.unwrap_or_else(|| model.clone());
+			body.insert("model".to_string(), Value::String(normalized));
+		}
+		serde_json::to_vec(&body).map_err(AIError::RequestMarshal)
 	}
 
 	pub fn get_path_for_model(
@@ -58,14 +71,26 @@ impl Provider {
 			.region
 			.clone()
 			.unwrap_or_else(|| strng::literal!("global"));
-		if let Some(model) = self.anthropic_model(request_model) {
-			return match route {
-				RouteType::AnthropicTokenCount => strng::format!(
+
+		match (route, self.anthropic_model(request_model)) {
+			(RouteType::AnthropicTokenCount, _) => {
+				strng::format!(
 					"/v1/projects/{}/locations/{}/publishers/anthropic/models/count-tokens:rawPredict",
 					self.project_id,
 					location
-				),
-				_ => strng::format!(
+				)
+			},
+			(RouteType::Embeddings, _) => {
+				let model = self.configured_model(request_model).unwrap_or_default();
+				strng::format!(
+					"/v1/projects/{}/locations/{}/publishers/google/models/{}:predict",
+					self.project_id,
+					location,
+					model
+				)
+			},
+			(_, Some(model)) => {
+				strng::format!(
 					"/v1/projects/{}/locations/{}/publishers/anthropic/models/{}:{}",
 					self.project_id,
 					location,
@@ -75,25 +100,16 @@ impl Provider {
 					} else {
 						"rawPredict"
 					}
-				),
-			};
+				)
+			},
+			_ => {
+				strng::format!(
+					"/v1/projects/{}/locations/{}/endpoints/openapi/chat/completions",
+					self.project_id,
+					location
+				)
+			},
 		}
-
-		if route == RouteType::Embeddings {
-			let model = self.configured_model(request_model).unwrap_or_default();
-			return strng::format!(
-				"/v1/projects/{}/locations/{}/publishers/google/models/{}:predict",
-				self.project_id,
-				location,
-				model
-			);
-		}
-
-		strng::format!(
-			"/v1/projects/{}/locations/{}/endpoints/openapi/chat/completions",
-			self.project_id,
-			location
-		)
 	}
 
 	pub fn get_host(&self) -> Strng {
@@ -105,5 +121,82 @@ impl Provider {
 				strng::format!("{region}-aiplatform.googleapis.com")
 			},
 		}
+	}
+
+	fn anthropic_model<'a>(&'a self, request_model: Option<&'a str>) -> Option<Strng> {
+		let model = self.configured_model(request_model)?;
+
+		// Strip known prefixes
+		let model: &str = model
+			.split_once("publishers/anthropic/models/")
+			.map(|(_, m)| m)
+			.or_else(|| model.strip_prefix("anthropic/"))
+			.or_else(|| {
+				if model.starts_with("claude-") {
+					Some(model)
+				} else {
+					None
+				}
+			})?;
+
+		// Replace -YYYYMMDD with @YYYYMMDD
+		if model.len() > 8 && model.as_bytes()[model.len() - 9] == b'-' {
+			let (base, date) = model.split_at(model.len() - 8);
+			if date.chars().all(|c| c.is_ascii_digit()) {
+				Some(strng::new(format!("{}@{}", &base[..base.len() - 1], date)))
+			} else {
+				Some(strng::new(model))
+			}
+		} else {
+			Some(strng::new(model))
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[rstest::rstest]
+	#[case::strip_publishers_prefix(
+		Some("publishers/anthropic/models/claude-sonnet-4-5-20251001"),
+		None,
+		Some("claude-sonnet-4-5@20251001")
+	)]
+	#[case::strip_anthropic_prefix(
+		Some("anthropic/claude-haiku-4-5-20251001"),
+		None,
+		Some("claude-haiku-4-5@20251001")
+	)]
+	#[case::raw_claude_prefix(None, Some("claude-opus-3-20240229"), Some("claude-opus-3@20240229"))]
+	#[case::no_date_suffix(None, Some("claude-opus-4-6"), Some("claude-opus-4-6"))]
+	#[case::legacy_model(
+		None,
+		Some("claude-3-5-sonnet-20241022"),
+		Some("claude-3-5-sonnet@20241022")
+	)]
+	#[case::non_digit_date_suffix(
+		None,
+		Some("claude-haiku-4-5-2025abcd"),
+		Some("claude-haiku-4-5-2025abcd")
+	)]
+	#[case::non_anthropic_model(None, Some("text-embedding-004"), None)]
+	#[case::provider_model_precedence(
+		Some("anthropic/claude-haiku-4-5-20251001"),
+		Some("anthropic/claude-sonnet-4-5-20251001"),
+		Some("claude-haiku-4-5@20251001")
+	)]
+	fn test_anthropic_model_normalization(
+		#[case] provider: Option<&str>,
+		#[case] req: Option<&str>,
+		#[case] expected: Option<&str>,
+	) {
+		let p = Provider {
+			project_id: strng::new("test-project"),
+			model: provider.map(strng::new),
+			region: None,
+		};
+		let actual = p.anthropic_model(req).map(|m| m.to_string());
+		assert_eq!(actual.as_deref(), expected);
 	}
 }

--- a/crates/agentgateway/tests/tests/llm.rs
+++ b/crates/agentgateway/tests/tests/llm.rs
@@ -44,7 +44,7 @@ fn llm_config(provider: &str, env: &str, model: &str) -> String {
 	} else if provider == "vertex" {
 		r#"
               projectId: $VERTEX_PROJECT
-              region: us-central1
+              region: us-east5
               "#
 	} else if provider == "azureOpenAI" {
 		r#"
@@ -325,7 +325,7 @@ mod vertex {
 
 	#[tokio::test]
 	async fn completions_to_anthropic() {
-		let Some(gw) = setup("vertex", "", "anthropic/claude-3-haiku").await else {
+		let Some(gw) = setup("vertex", "", "claude-haiku-4-5@20251001").await else {
 			return;
 		};
 		send_completions(&gw, false).await;
@@ -333,9 +333,9 @@ mod vertex {
 
 	#[tokio::test]
 	#[ignore]
-	/// TODO(https://github.com/agentgateway/agentgateway/pull/800) support this
+	/// TODO(https://github.com/agentgateway/agentgateway/pull/909) support this
 	async fn completions_streaming_to_anthropic() {
-		let Some(gw) = setup("vertex", "", "anthropic/claude-3-haiku").await else {
+		let Some(gw) = setup("vertex", "", "claude-haiku-4-5@20251001").await else {
 			return;
 		};
 		send_completions(&gw, true).await;
@@ -351,7 +351,7 @@ mod vertex {
 
 	#[tokio::test]
 	async fn messages() {
-		let Some(gw) = setup("vertex", "", "anthropic/claude-3-haiku").await else {
+		let Some(gw) = setup("vertex", "", "claude-haiku-4-5@20251001").await else {
 			return;
 		};
 		send_messages(&gw, false).await;
@@ -359,7 +359,7 @@ mod vertex {
 
 	#[tokio::test]
 	async fn messages_streaming() {
-		let Some(gw) = setup("vertex", "", "anthropic/claude-3-haiku").await else {
+		let Some(gw) = setup("vertex", "", "claude-haiku-4-5@20251001").await else {
 			return;
 		};
 		send_messages(&gw, true).await;
@@ -375,7 +375,7 @@ mod vertex {
 
 	#[tokio::test]
 	async fn token_count() {
-		let Some(gw) = setup("vertex", "", "anthropic/claude-3-haiku").await else {
+		let Some(gw) = setup("vertex", "", "claude-haiku-4-5@20251001").await else {
 			return;
 		};
 		send_anthropic_token_count(&gw).await;


### PR DESCRIPTION
This should address token counting api calls for Vertex AI + Anthropic models by splitting how `Messages` and `AnthropicTokenCount` pass the model.

Tested with `cargo nextest r --test integration`