### PR TITLE
test: mark llm integration tests as skipped if env vars missing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,6 +243,7 @@ dependencies = [
  "sse-stream",
  "stacker",
  "tempfile",
+ "test-with",
  "thiserror 2.0.18",
  "tiktoken-rs",
  "tikv-jemallocator",
@@ -285,6 +286,17 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tracing",
+]
+
+[[package]]
+name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "version_check",
 ]
 
 [[package]]
@@ -455,6 +467,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "asn1-rs"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -478,7 +496,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
  "synstructure",
 ]
 
@@ -490,7 +508,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -564,7 +582,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -575,7 +593,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1063,7 +1081,7 @@ checksum = "604fde5e028fea851ce1d8570bbdc034bec850d157f7569d10f347d06808c05c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1116,7 +1134,7 @@ checksum = "190d6e0622d17e2a28239b55d2829d98b348269adcd4ab86a21d3304aa3500cb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
  "tracing",
 ]
 
@@ -1237,6 +1255,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1276,6 +1306,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1da5ab77c1437701eeff7c88d968729e7766172279eab0676857b3d63af7a6f"
+dependencies = [
+ "borsh-derive",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0686c856aa6aac0c4498f936d7d6a02df690f614c03e4d906d1018062b5c5e2c"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1312,6 +1365,40 @@ name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+
+[[package]]
+name = "byte-unit"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c6d47a4e2961fb8721bcfc54feae6455f2f64e7054f9bc67e875f0e77f4c58d"
+dependencies = [
+ "rust_decimal",
+ "schemars 1.0.4",
+ "serde",
+ "utf8-width",
+]
+
+[[package]]
+name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "byteorder"
@@ -1392,7 +1479,7 @@ dependencies = [
  "macrotest",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1510,7 +1597,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1871,7 +1958,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1885,7 +1972,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1898,7 +1985,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1909,7 +1996,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1920,7 +2007,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1931,7 +2018,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2009,7 +2096,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2019,7 +2106,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2093,7 +2180,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2118,7 +2205,7 @@ checksum = "9556bc800956545d6420a640173e5ba7dfa82f38d3ea5a167eb555bc69ac3323"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2187,7 +2274,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2226,7 +2313,7 @@ checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2349,7 +2436,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf5efcf77a4da27927d3ab0509dec5b0954bb3bc59da5a1de9e52642ebd4cdf9"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "num_cpus",
  "parking_lot",
  "seize",
@@ -2372,6 +2459,21 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -2409,7 +2511,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2446,6 +2548,12 @@ checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -2503,7 +2611,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2723,6 +2831,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.8",
+]
 
 [[package]]
 name = "hashbrown"
@@ -3024,6 +3135,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3089,7 +3216,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -3555,7 +3682,7 @@ dependencies = [
  "quote",
  "regex-syntax 0.8.9",
  "rustc_version",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3620,7 +3747,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "syn",
+ "syn 2.0.114",
  "toml",
 ]
 
@@ -3719,7 +3846,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3730,7 +3857,7 @@ checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3822,6 +3949,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc0287524726960e07b119cebd01678f852f147742ae0d925e6a520dca956126"
 
 [[package]]
+name = "native-tls"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cdede44f9a69cab2899a2049e2c3bd49bf911a157f6a3353d4a91c61abbce44"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe 0.1.6",
+ "openssl-sys",
+ "schannel",
+ "security-framework 2.11.1",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nix"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3904,6 +4048,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
  "bitflags 2.10.0",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -4025,6 +4178,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.10.0",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4088,10 +4260,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl"
+version = "0.10.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "opentelemetry"
@@ -4272,7 +4488,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4333,7 +4549,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4347,6 +4563,17 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "ping"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "122ee1f5a6843bec84fcbd5c6ba3622115337a6b8965b93a61aad347648f4e8d"
+dependencies = [
+ "rand 0.8.5",
+ "socket2 0.4.10",
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "pingora-pool"
@@ -4549,7 +4776,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4580,7 +4807,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4603,7 +4830,7 @@ dependencies = [
  "nix 0.30.1",
  "tokio",
  "tracing",
- "windows",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -4626,7 +4853,7 @@ checksum = "9adf1691c04c0a5ff46ff8f262b58beb07b0dbb61f96f9f54f6cbd82106ed87f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4671,7 +4898,7 @@ dependencies = [
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "regex",
- "syn",
+ "syn 2.0.114",
  "tempfile",
 ]
 
@@ -4685,7 +4912,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4845,6 +5072,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "pulldown-cmark"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4957,6 +5204,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -5127,7 +5380,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -5190,6 +5443,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
+name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5207,10 +5469,12 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -5221,6 +5485,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
@@ -5252,6 +5517,35 @@ dependencies = [
  "libc",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5333,7 +5627,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -5346,7 +5640,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -5374,8 +5668,24 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn",
+ "syn 2.0.114",
  "unicode-ident",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61f703d19852dbf87cbc513643fa81428361eb6940f1ac14fd58155d295a3eb0"
+dependencies = [
+ "arrayvec",
+ "borsh",
+ "bytes",
+ "num-traits",
+ "rand 0.8.5",
+ "rkyv",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -5462,10 +5772,10 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
- "openssl-probe",
+ "openssl-probe 0.2.1",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.5.1",
 ]
 
 [[package]]
@@ -5564,7 +5874,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -5574,6 +5884,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
 name = "secrecy"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5581,6 +5897,19 @@ checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
 dependencies = [
  "serde",
  "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.10.0",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
 ]
 
 [[package]]
@@ -5676,7 +6005,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -5687,7 +6016,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -5794,7 +6123,7 @@ dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -5908,6 +6237,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5936,6 +6271,16 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "socket2"
@@ -6037,7 +6382,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -6149,6 +6494,17 @@ dependencies = [
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
@@ -6175,7 +6531,21 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.35.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3ffa3e4ff2b324a57f7aeb3c349656c7b127c3c189520251a648102a92496e"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -6217,6 +6587,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "tempfile"
 version = "3.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6249,6 +6625,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "test-with"
+version = "0.14.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d75791778b593ea6d76454886a69cd37245c4c9af6fee37c42f024593bf1fb03"
+dependencies = [
+ "byte-unit",
+ "chrono",
+ "num_cpus",
+ "ping",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "reqwest",
+ "syn 2.0.114",
+ "sysinfo",
+ "uzers",
+ "which 8.0.0",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6274,7 +6671,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -6285,7 +6682,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -6451,7 +6848,17 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -6602,7 +7009,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -6627,7 +7034,7 @@ dependencies = [
  "prost-build",
  "prost-types",
  "quote",
- "syn",
+ "syn 2.0.114",
  "tempfile",
  "tonic-build",
 ]
@@ -6734,7 +7141,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -6870,7 +7277,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -6894,7 +7301,7 @@ checksum = "27a7a9b72ba121f6f1f6c3632b85604cac41aedb5ddc70accbebb6cac83de846"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -6971,6 +7378,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
+name = "utf8-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1292c0d970b54115d14f2492fe0170adf21d68a1de108eebc51c1df4f346a091"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6991,6 +7404,16 @@ dependencies = [
  "getrandom 0.3.4",
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "uzers"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76d283dc7e8c901e79e32d077866eaf599156cbf427fffa8289aecc52c5c3f63"
+dependencies = [
+ "libc",
+ "log",
 ]
 
 [[package]]
@@ -7034,6 +7457,12 @@ dependencies = [
  "sval_ref",
  "sval_serde",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vector-map"
@@ -7145,7 +7574,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
  "wasm-bindgen-shared",
 ]
 
@@ -7306,14 +7735,36 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections 0.2.0",
+ "windows-core 0.61.2",
+ "windows-future 0.2.1",
+ "windows-link 0.1.3",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
- "windows-collections",
- "windows-core",
- "windows-future",
- "windows-numerics",
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -7322,7 +7773,20 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core",
+ "windows-core 0.62.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -7340,13 +7804,24 @@ dependencies = [
 
 [[package]]
 name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading 0.1.0",
+]
+
+[[package]]
+name = "windows-future"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core",
+ "windows-core 0.62.2",
  "windows-link 0.2.1",
- "windows-threading",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -7357,7 +7832,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -7368,7 +7843,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -7385,11 +7860,21 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-numerics"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core",
+ "windows-core 0.62.2",
  "windows-link 0.2.1",
 ]
 
@@ -7542,6 +8027,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -7771,7 +8265,7 @@ dependencies = [
  "heck",
  "indexmap 2.13.0",
  "prettyplease",
- "syn",
+ "syn 2.0.114",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -7787,7 +8281,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -7834,6 +8328,15 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "x509-parser"
@@ -7899,7 +8402,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
  "synstructure",
 ]
 
@@ -7920,7 +8423,7 @@ checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -7940,7 +8443,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
  "synstructure",
 ]
 
@@ -7980,7 +8483,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -173,6 +173,7 @@ split-iter = "0.1"
 sse-stream = "0.2"
 stacker = "0.1"
 tempfile = "3.20"
+test-with = "0.14"
 thiserror = "2.0"
 tiktoken-rs = "0.9"
 tokio = { version = "1.48", features = ["full", "macros", "sync"] }

--- a/crates/agentgateway/Cargo.toml
+++ b/crates/agentgateway/Cargo.toml
@@ -173,6 +173,7 @@ divan.workspace = true
 insta.workspace = true
 rstest.workspace = true
 tempfile.workspace = true
+test-with.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
 which.workspace = true
 rmcp = { version = "0.14", features = [

--- a/crates/agentgateway/tests/tests/llm.rs
+++ b/crates/agentgateway/tests/tests/llm.rs
@@ -1,18 +1,20 @@
 use agent_core::telemetry::testing;
 use http::StatusCode;
 use serde_json::json;
-use tracing::warn;
 
 use crate::common::gateway::AgentGateway;
 
 // This module provides real LLM integration tests. These require API keys!
+// Tests are automatically ignored (skipped) at compile time if required
+// environment variables are not set. Set these variables before running:
+//
 // Example running all tests:
+//     AGENTGATEWAY_E2E=true \
 //     AZURE_HOST=xxx.azure.com \
 //     VERTEX_PROJECT=octo-386314 \
 //     GEMINI_API_KEY=`cat ~/.secrets/gemini` \
 //     ANTHROPIC_API_KEY=`cat ~/.secrets/anthropic` \
-//     OPENAI_API_KEY=`cat ~/.secrets/openai`
-//     AGENTGATEWAY_E2E=true \
+//     OPENAI_API_KEY=`cat ~/.secrets/openai` \
 //     cargo test --test integration tests::llm::
 //
 // Note: AGENTGATEWAY_E2E must be set to run any tests.
@@ -94,61 +96,54 @@ binds:
 
 mod openai {
 	use super::*;
+	#[test_with::env(AGENTGATEWAY_E2E, OPENAI_API_KEY)]
 	#[tokio::test]
 	async fn responses() {
-		let Some(gw) = setup("openAI", "OPENAI_API_KEY", "gpt-4.1-nano").await else {
-			return;
-		};
+		let gw = setup("openAI", "OPENAI_API_KEY", "gpt-4.1-nano").await;
 		send_responses(&gw, false).await;
 	}
 
+	#[test_with::env(AGENTGATEWAY_E2E, OPENAI_API_KEY)]
 	#[tokio::test]
 	async fn responses_stream() {
-		let Some(gw) = setup("openAI", "OPENAI_API_KEY", "gpt-4.1-nano").await else {
-			return;
-		};
+		let gw = setup("openAI", "OPENAI_API_KEY", "gpt-4.1-nano").await;
 		send_responses(&gw, true).await;
 	}
 
+	#[test_with::env(AGENTGATEWAY_E2E, OPENAI_API_KEY)]
 	#[tokio::test]
 	async fn completions() {
-		let Some(gw) = setup("openAI", "OPENAI_API_KEY", "gpt-4.1-nano").await else {
-			return;
-		};
+		let gw = setup("openAI", "OPENAI_API_KEY", "gpt-4.1-nano").await;
 		send_completions(&gw, false).await;
 	}
 
+	#[test_with::env(AGENTGATEWAY_E2E, OPENAI_API_KEY)]
 	#[tokio::test]
 	async fn completions_streaming() {
-		let Some(gw) = setup("openAI", "OPENAI_API_KEY", "gpt-4.1-nano").await else {
-			return;
-		};
+		let gw = setup("openAI", "OPENAI_API_KEY", "gpt-4.1-nano").await;
 		send_completions(&gw, true).await;
 	}
 
+	#[test_with::env(AGENTGATEWAY_E2E, OPENAI_API_KEY)]
 	#[tokio::test]
 	#[ignore] // TODO
 	async fn messages() {
-		let Some(gw) = setup("openAI", "OPENAI_API_KEY", "gpt-4.1-nano").await else {
-			return;
-		};
+		let gw = setup("openAI", "OPENAI_API_KEY", "gpt-4.1-nano").await;
 		send_messages(&gw, false).await;
 	}
 
+	#[test_with::env(AGENTGATEWAY_E2E, OPENAI_API_KEY)]
 	#[tokio::test]
 	#[ignore] // TODO
 	async fn messages_streaming() {
-		let Some(gw) = setup("openAI", "OPENAI_API_KEY", "gpt-4.1-nano").await else {
-			return;
-		};
+		let gw = setup("openAI", "OPENAI_API_KEY", "gpt-4.1-nano").await;
 		send_messages(&gw, true).await;
 	}
 
+	#[test_with::env(AGENTGATEWAY_E2E, OPENAI_API_KEY)]
 	#[tokio::test]
 	async fn embeddings() {
-		let Some(gw) = setup("openAI", "OPENAI_API_KEY", "text-embedding-3-small").await else {
-			return;
-		};
+		let gw = setup("openAI", "OPENAI_API_KEY", "text-embedding-3-small").await;
 		send_embeddings(&gw, None).await;
 	}
 }
@@ -156,76 +151,67 @@ mod openai {
 mod bedrock {
 	use super::*;
 
+	#[test_with::env(AGENTGATEWAY_E2E)]
 	#[tokio::test]
 	async fn completions() {
-		let Some(gw) = setup("bedrock", "", "us.amazon.nova-pro-v1:0").await else {
-			return;
-		};
+		let gw = setup("bedrock", "", "us.amazon.nova-pro-v1:0").await;
 		send_completions(&gw, false).await;
 	}
 
+	#[test_with::env(AGENTGATEWAY_E2E)]
 	#[tokio::test]
 	async fn completions_streaming() {
-		let Some(gw) = setup("bedrock", "", "us.amazon.nova-pro-v1:0").await else {
-			return;
-		};
+		let gw = setup("bedrock", "", "us.amazon.nova-pro-v1:0").await;
 		send_completions(&gw, true).await;
 	}
 
+	#[test_with::env(AGENTGATEWAY_E2E)]
 	#[tokio::test]
 	async fn responses() {
-		let Some(gw) = setup("bedrock", "", "us.amazon.nova-pro-v1:0").await else {
-			return;
-		};
+		let gw = setup("bedrock", "", "us.amazon.nova-pro-v1:0").await;
 		send_responses(&gw, false).await;
 	}
 
+	#[test_with::env(AGENTGATEWAY_E2E)]
 	#[tokio::test]
 	async fn responses_streaming() {
-		let Some(gw) = setup("bedrock", "", "us.amazon.nova-pro-v1:0").await else {
-			return;
-		};
+		let gw = setup("bedrock", "", "us.amazon.nova-pro-v1:0").await;
 		send_responses(&gw, true).await;
 	}
 
+	#[test_with::env(AGENTGATEWAY_E2E)]
 	#[tokio::test]
 	async fn messages() {
-		let Some(gw) = setup("bedrock", "", "us.amazon.nova-pro-v1:0").await else {
-			return;
-		};
+		let gw = setup("bedrock", "", "us.amazon.nova-pro-v1:0").await;
 		send_messages(&gw, false).await;
 	}
 
+	#[test_with::env(AGENTGATEWAY_E2E)]
 	#[tokio::test]
 	async fn messages_streaming() {
-		let Some(gw) = setup("bedrock", "", "us.amazon.nova-pro-v1:0").await else {
-			return;
-		};
+		let gw = setup("bedrock", "", "us.amazon.nova-pro-v1:0").await;
 		send_messages(&gw, true).await;
 	}
 
+	#[test_with::env(AGENTGATEWAY_E2E)]
 	#[tokio::test]
 	async fn embeddings_titan() {
-		let Some(gw) = setup("bedrock", "", "amazon.titan-embed-text-v2:0").await else {
-			return;
-		};
+		let gw = setup("bedrock", "", "amazon.titan-embed-text-v2:0").await;
 		send_embeddings(&gw, None).await;
 	}
 
+	#[test_with::env(AGENTGATEWAY_E2E)]
 	#[tokio::test]
 	async fn embeddings_cohere() {
-		let Some(gw) = setup("bedrock", "", "cohere.embed-english-v3").await else {
-			return;
-		};
+		let gw = setup("bedrock", "", "cohere.embed-english-v3").await;
 		// Cohere does not respect overriding the dimension count
 		send_embeddings(&gw, Some(1024)).await;
 	}
 
+	#[test_with::env(AGENTGATEWAY_E2E)]
 	#[tokio::test]
 	async fn token_count() {
-		let Some(gw) = setup("bedrock", "", "anthropic.claude-3-5-haiku-20241022-v1:0").await else {
-			return;
-		};
+		let gw = setup("bedrock", "", "anthropic.claude-3-5-haiku-20241022-v1:0").await;
 		send_anthropic_token_count(&gw).await;
 	}
 }
@@ -233,61 +219,54 @@ mod bedrock {
 mod anthropic {
 	use super::*;
 
+	#[test_with::env(AGENTGATEWAY_E2E, ANTHROPIC_API_KEY)]
 	#[tokio::test]
 	async fn completions() {
-		let Some(gw) = setup("anthropic", "ANTHROPIC_API_KEY", "claude-3-haiku-20240307").await else {
-			return;
-		};
+		let gw = setup("anthropic", "ANTHROPIC_API_KEY", "claude-3-haiku-20240307").await;
 		send_completions(&gw, false).await;
 	}
 
+	#[test_with::env(AGENTGATEWAY_E2E, ANTHROPIC_API_KEY)]
 	#[tokio::test]
 	async fn completions_streaming() {
-		let Some(gw) = setup("anthropic", "ANTHROPIC_API_KEY", "claude-3-haiku-20240307").await else {
-			return;
-		};
+		let gw = setup("anthropic", "ANTHROPIC_API_KEY", "claude-3-haiku-20240307").await;
 		send_completions(&gw, true).await;
 	}
 
+	#[test_with::env(AGENTGATEWAY_E2E, ANTHROPIC_API_KEY)]
 	#[tokio::test]
 	#[ignore]
 	async fn responses() {
-		let Some(gw) = setup("anthropic", "ANTHROPIC_API_KEY", "claude-3-haiku-20240307").await else {
-			return;
-		};
+		let gw = setup("anthropic", "ANTHROPIC_API_KEY", "claude-3-haiku-20240307").await;
 		send_responses(&gw, false).await;
 	}
 
+	#[test_with::env(AGENTGATEWAY_E2E, ANTHROPIC_API_KEY)]
 	#[tokio::test]
 	#[ignore]
 	async fn responses_streaming() {
-		let Some(gw) = setup("anthropic", "ANTHROPIC_API_KEY", "claude-3-haiku-20240307").await else {
-			return;
-		};
+		let gw = setup("anthropic", "ANTHROPIC_API_KEY", "claude-3-haiku-20240307").await;
 		send_responses(&gw, true).await;
 	}
 
+	#[test_with::env(AGENTGATEWAY_E2E, ANTHROPIC_API_KEY)]
 	#[tokio::test]
 	async fn messages() {
-		let Some(gw) = setup("anthropic", "ANTHROPIC_API_KEY", "claude-3-haiku-20240307").await else {
-			return;
-		};
+		let gw = setup("anthropic", "ANTHROPIC_API_KEY", "claude-3-haiku-20240307").await;
 		send_messages(&gw, false).await;
 	}
 
+	#[test_with::env(AGENTGATEWAY_E2E, ANTHROPIC_API_KEY)]
 	#[tokio::test]
 	async fn messages_streaming() {
-		let Some(gw) = setup("anthropic", "ANTHROPIC_API_KEY", "claude-3-haiku-20240307").await else {
-			return;
-		};
+		let gw = setup("anthropic", "ANTHROPIC_API_KEY", "claude-3-haiku-20240307").await;
 		send_messages(&gw, true).await;
 	}
 
+	#[test_with::env(AGENTGATEWAY_E2E, ANTHROPIC_API_KEY)]
 	#[tokio::test]
 	async fn token_count() {
-		let Some(gw) = setup("anthropic", "ANTHROPIC_API_KEY", "claude-3-haiku-20240307").await else {
-			return;
-		};
+		let gw = setup("anthropic", "ANTHROPIC_API_KEY", "claude-3-haiku-20240307").await;
 		send_anthropic_token_count(&gw).await;
 	}
 }
@@ -295,19 +274,17 @@ mod anthropic {
 mod gemini {
 	use super::*;
 
+	#[test_with::env(AGENTGATEWAY_E2E, GEMINI_API_KEY)]
 	#[tokio::test]
 	async fn completions() {
-		let Some(gw) = setup("gemini", "GEMINI_API_KEY", "gemini-2.5-flash").await else {
-			return;
-		};
+		let gw = setup("gemini", "GEMINI_API_KEY", "gemini-2.5-flash").await;
 		send_completions(&gw, false).await;
 	}
 
+	#[test_with::env(AGENTGATEWAY_E2E, GEMINI_API_KEY)]
 	#[tokio::test]
 	async fn completions_streaming() {
-		let Some(gw) = setup("gemini", "GEMINI_API_KEY", "gemini-2.5-flash").await else {
-			return;
-		};
+		let gw = setup("gemini", "GEMINI_API_KEY", "gemini-2.5-flash").await;
 		send_completions(&gw, true).await;
 	}
 }
@@ -315,69 +292,61 @@ mod gemini {
 mod vertex {
 	use super::*;
 
+	#[test_with::env(AGENTGATEWAY_E2E, VERTEX_PROJECT)]
 	#[tokio::test]
 	async fn completions() {
-		let Some(gw) = setup("vertex", "", "google/gemini-2.5-flash-lite").await else {
-			return;
-		};
+		let gw = setup("vertex", "", "google/gemini-2.5-flash-lite").await;
 		send_completions(&gw, false).await;
 	}
 
+	#[test_with::env(AGENTGATEWAY_E2E, VERTEX_PROJECT)]
 	#[tokio::test]
 	async fn completions_to_anthropic() {
-		let Some(gw) = setup("vertex", "", "anthropic/claude-3-haiku").await else {
-			return;
-		};
+		let gw = setup("vertex", "", "anthropic/claude-3-haiku").await;
 		send_completions(&gw, false).await;
 	}
 
+	#[test_with::env(AGENTGATEWAY_E2E, VERTEX_PROJECT)]
 	#[tokio::test]
 	#[ignore]
 	/// TODO(https://github.com/agentgateway/agentgateway/pull/800) support this
 	async fn completions_streaming_to_anthropic() {
-		let Some(gw) = setup("vertex", "", "anthropic/claude-3-haiku").await else {
-			return;
-		};
+		let gw = setup("vertex", "", "anthropic/claude-3-haiku").await;
 		send_completions(&gw, true).await;
 	}
 
+	#[test_with::env(AGENTGATEWAY_E2E, VERTEX_PROJECT)]
 	#[tokio::test]
 	async fn completions_streaming() {
-		let Some(gw) = setup("vertex", "", "google/gemini-2.5-flash-lite").await else {
-			return;
-		};
+		let gw = setup("vertex", "", "google/gemini-2.5-flash-lite").await;
 		send_completions(&gw, true).await;
 	}
 
+	#[test_with::env(AGENTGATEWAY_E2E, VERTEX_PROJECT)]
 	#[tokio::test]
 	async fn messages() {
-		let Some(gw) = setup("vertex", "", "anthropic/claude-3-haiku").await else {
-			return;
-		};
+		let gw = setup("vertex", "", "anthropic/claude-3-haiku").await;
 		send_messages(&gw, false).await;
 	}
 
+	#[test_with::env(AGENTGATEWAY_E2E, VERTEX_PROJECT)]
 	#[tokio::test]
 	async fn messages_streaming() {
-		let Some(gw) = setup("vertex", "", "anthropic/claude-3-haiku").await else {
-			return;
-		};
+		let gw = setup("vertex", "", "anthropic/claude-3-haiku").await;
 		send_messages(&gw, true).await;
 	}
 
+	#[test_with::env(AGENTGATEWAY_E2E, VERTEX_PROJECT)]
 	#[tokio::test]
 	async fn embeddings() {
-		let Some(gw) = setup("vertex", "", "text-embedding-004").await else {
-			return;
-		};
+		let gw = setup("vertex", "", "text-embedding-004").await;
 		send_embeddings(&gw, None).await;
 	}
 
+	#[test_with::env(AGENTGATEWAY_E2E, VERTEX_PROJECT)]
 	#[tokio::test]
 	async fn token_count() {
-		let Some(gw) = setup("vertex", "", "anthropic/claude-3-haiku").await else {
-			return;
-		};
+		let gw = setup("vertex", "", "anthropic/claude-3-haiku").await;
 		send_anthropic_token_count(&gw).await;
 	}
 }
@@ -385,65 +354,48 @@ mod vertex {
 mod azureopenai {
 	use super::*;
 
+	#[test_with::env(AGENTGATEWAY_E2E, AZURE_HOST)]
 	#[tokio::test]
 	async fn completions() {
-		let Some(gw) = setup("azureOpenAI", "", "gpt-4o-mini").await else {
-			return;
-		};
+		let gw = setup("azureOpenAI", "", "gpt-4o-mini").await;
 		send_completions(&gw, false).await;
 	}
 
+	#[test_with::env(AGENTGATEWAY_E2E, AZURE_HOST)]
 	#[tokio::test]
 	async fn completions_streaming() {
-		let Some(gw) = setup("azureOpenAI", "", "gpt-4o-mini").await else {
-			return;
-		};
+		let gw = setup("azureOpenAI", "", "gpt-4o-mini").await;
 		send_completions(&gw, true).await;
 	}
 
+	#[test_with::env(AGENTGATEWAY_E2E, AZURE_HOST)]
 	#[tokio::test]
 	async fn responses() {
-		let Some(gw) = setup("azureOpenAI", "", "gpt-4o-mini").await else {
-			return;
-		};
+		let gw = setup("azureOpenAI", "", "gpt-4o-mini").await;
 		send_responses(&gw, false).await;
 	}
 
+	#[test_with::env(AGENTGATEWAY_E2E, AZURE_HOST)]
 	#[tokio::test]
 	async fn responses_stream() {
-		let Some(gw) = setup("azureOpenAI", "", "gpt-4o-mini").await else {
-			return;
-		};
+		let gw = setup("azureOpenAI", "", "gpt-4o-mini").await;
 		send_responses(&gw, true).await;
 	}
 
+	#[test_with::env(AGENTGATEWAY_E2E, AZURE_HOST)]
 	#[tokio::test]
 	async fn embeddings() {
-		let Some(gw) = setup("azureOpenAI", "", "text-embedding-3-small").await else {
-			return;
-		};
+		let gw = setup("azureOpenAI", "", "text-embedding-3-small").await;
 		send_embeddings(&gw, None).await;
 	}
 }
 
-async fn setup(provider: &str, env: &str, model: &str) -> Option<AgentGateway> {
-	// Explicitly opt in to avoid accidentally using implicit configs
-	if !require_env("AGENTGATEWAY_E2E") {
-		return None;
-	}
-	if !env.is_empty() && !require_env("OPENAI_API_KEY") {
-		return None;
-	}
-	if provider == "vertex" && !require_env("VERTEX_PROJECT") {
-		return None;
-	}
-	if provider == "azureOpenAI" && !require_env("AZURE_HOST") {
-		return None;
-	}
-	let gw = AgentGateway::new(llm_config(provider, env, model))
+async fn setup(provider: &str, env: &str, model: &str) -> AgentGateway {
+	testing::setup_test_logging();
+
+	AgentGateway::new(llm_config(provider, env, model))
 		.await
-		.unwrap();
-	Some(gw)
+		.expect("AgentGateway::new should succeed when environment is properly configured")
 }
 
 fn assert_log(path: &str, streaming: bool, test_id: &str) {
@@ -508,15 +460,6 @@ fn assert_embeddings_log(path: &str, test_id: &str, expected: u64) {
 		enc_format, "float",
 		"unexpected encoding format: {enc_format}"
 	);
-}
-
-fn require_env(var: &str) -> bool {
-	testing::setup_test_logging();
-	let found = std::env::var(var).is_ok();
-	if !found {
-		warn!("environment variable {} not set, skipping test", var);
-	}
-	found
 }
 
 async fn send_completions(gw: &AgentGateway, stream: bool) {


### PR DESCRIPTION
Tries to make it obvious that E2E llm tests are skipped if env vars are not set. Examples of before and after running tests with only some env variables set.

Before:
```
$ AGENTGATEWAY_E2E=true  GEMINI_API_KEY=$(cat ~/.secrets/gemini) ANTHROPIC_API_KEY=$(cat ~/.secrets/anthropic) OPENAI_API_KEY=$(cat ~/.secrets/openai) cargo nextest r --status-level=all --test integration tests::llm
   Compiling agentgateway v0.7.0 (/Users/markuskobler/code/solo/agentgateway/main/crates/agentgateway)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 29.70s
────────────
 Nextest run ID 4ddc2407-e4c4-4794-94af-bae01ad98503 with nextest profile: default
    Starting 33 tests across 1 binary (11 tests skipped)
    ...
        SKIP [         ] agentgateway::integration tests::llm::anthropic::responses
        SKIP [         ] agentgateway::integration tests::llm::anthropic::responses_streaming
        PASS [   0.022s] agentgateway::integration tests::llm::azureopenai::completions
        PASS [   0.021s] agentgateway::integration tests::llm::azureopenai::completions_streaming
        PASS [   0.024s] agentgateway::integration tests::llm::azureopenai::responses_stream
        PASS [   0.024s] agentgateway::integration tests::llm::azureopenai::responses
        PASS [   0.024s] agentgateway::integration tests::llm::azureopenai::embeddings
        PASS [   1.941s] agentgateway::integration tests::llm::anthropic::completions_streaming
        PASS [   1.940s] agentgateway::integration tests::llm::anthropic::token_count
        PASS [   1.941s] agentgateway::integration tests::llm::anthropic::messages_streaming
        SKIP [         ] agentgateway::integration tests::llm::openai::messages
        SKIP [         ] agentgateway::integration tests::llm::openai::messages_streaming
        PASS [   1.940s] agentgateway::integration tests::llm::anthropic::messages
        PASS [   2.413s] agentgateway::integration tests::llm::anthropic::completions
        PASS [   2.534s] agentgateway::integration tests::llm::gemini::completions
        PASS [   0.011s] agentgateway::integration tests::llm::vertex::completions
        SKIP [         ] agentgateway::integration tests::llm::vertex::completions_streaming_to_anthropic
        PASS [   0.010s] agentgateway::integration tests::llm::vertex::completions_streaming
        PASS [   0.010s] agentgateway::integration tests::llm::vertex::completions_to_anthropic
        PASS [   0.011s] agentgateway::integration tests::llm::vertex::embeddings
        PASS [   0.010s] agentgateway::integration tests::llm::vertex::messages
        PASS [   0.678s] agentgateway::integration tests::llm::openai::embeddings
        PASS [   0.011s] agentgateway::integration tests::llm::vertex::messages_streaming
        PASS [   0.010s] agentgateway::integration tests::llm::vertex::token_count
        PASS [   1.219s] agentgateway::integration tests::llm::openai::completions_streaming
        PASS [   1.324s] agentgateway::integration tests::llm::openai::responses
        PASS [   3.289s] agentgateway::integration tests::llm::gemini::completions_streaming
        PASS [   1.568s] agentgateway::integration tests::llm::openai::completions
        PASS [   1.729s] agentgateway::integration tests::llm::openai::responses_stream
        PASS [   4.311s] agentgateway::integration tests::llm::bedrock::embeddings_cohere
        PASS [   4.773s] agentgateway::integration tests::llm::bedrock::embeddings_titan
        PASS [   5.249s] agentgateway::integration tests::llm::bedrock::completions_streaming
        PASS [   5.425s] agentgateway::integration tests::llm::bedrock::messages
        PASS [   5.446s] agentgateway::integration tests::llm::bedrock::responses_streaming
        PASS [   5.805s] agentgateway::integration tests::llm::bedrock::token_count
        PASS [   5.846s] agentgateway::integration tests::llm::bedrock::responses
        PASS [   5.888s] agentgateway::integration tests::llm::bedrock::completions
        PASS [   6.249s] agentgateway::integration tests::llm::bedrock::messages_streaming
────────────
     Summary [   6.250s] 33 tests run: 33 passed, 11 skipped
```

After:
```
$ AGENTGATEWAY_E2E=true GEMINI_API_KEY=$(cat ~/.secrets/gemini) ANTHROPIC_API_KEY=$(cat ~/.secrets/anthropic) OPENAI_API_KEY=$(cat ~/.secrets/openai) cargo nextest r --status-level=all --test integration tests::llm
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.87s
────────────
 Nextest run ID e12adef4-9ea1-4494-887f-015fd941ffc7 with nextest profile: default
    Starting 21 tests across 1 binary (23 tests skipped)
       ...
        SKIP [         ] agentgateway::integration tests::llm::anthropic::responses
        SKIP [         ] agentgateway::integration tests::llm::anthropic::responses_streaming
        SKIP [         ] agentgateway::integration tests::llm::azureopenai::completions
        SKIP [         ] agentgateway::integration tests::llm::azureopenai::completions_streaming
        SKIP [         ] agentgateway::integration tests::llm::azureopenai::embeddings
        SKIP [         ] agentgateway::integration tests::llm::azureopenai::responses
        SKIP [         ] agentgateway::integration tests::llm::azureopenai::responses_stream
        PASS [   1.811s] agentgateway::integration tests::llm::gemini::completions_streaming
        PASS [   1.811s] agentgateway::integration tests::llm::gemini::completions
        PASS [   1.812s] agentgateway::integration tests::llm::anthropic::token_count
        SKIP [         ] agentgateway::integration tests::llm::openai::messages
        SKIP [         ] agentgateway::integration tests::llm::openai::messages_streaming
        PASS [   1.812s] agentgateway::integration tests::llm::anthropic::messages_streaming
        PASS [   2.289s] agentgateway::integration tests::llm::anthropic::completions
        SKIP [         ] agentgateway::integration tests::llm::vertex::completions
        SKIP [         ] agentgateway::integration tests::llm::vertex::completions_streaming
        SKIP [         ] agentgateway::integration tests::llm::vertex::completions_streaming_to_anthropic
        SKIP [         ] agentgateway::integration tests::llm::vertex::completions_to_anthropic
        SKIP [         ] agentgateway::integration tests::llm::vertex::embeddings
        SKIP [         ] agentgateway::integration tests::llm::vertex::messages
        SKIP [         ] agentgateway::integration tests::llm::vertex::messages_streaming
        SKIP [         ] agentgateway::integration tests::llm::vertex::token_count
        PASS [   2.418s] agentgateway::integration tests::llm::anthropic::completions_streaming
        PASS [   0.857s] agentgateway::integration tests::llm::openai::embeddings
        PASS [   2.862s] agentgateway::integration tests::llm::anthropic::messages
        PASS [   1.188s] agentgateway::integration tests::llm::openai::completions_streaming
        PASS [   1.602s] agentgateway::integration tests::llm::openai::responses
        PASS [   1.638s] agentgateway::integration tests::llm::openai::completions
        PASS [   1.777s] agentgateway::integration tests::llm::openai::responses_stream
        PASS [   4.075s] agentgateway::integration tests::llm::bedrock::embeddings_cohere
        PASS [   4.393s] agentgateway::integration tests::llm::bedrock::messages_streaming
        PASS [   4.612s] agentgateway::integration tests::llm::bedrock::messages
        PASS [   4.928s] agentgateway::integration tests::llm::bedrock::embeddings_titan
        PASS [   4.954s] agentgateway::integration tests::llm::bedrock::completions_streaming
        PASS [   5.259s] agentgateway::integration tests::llm::bedrock::responses
        PASS [   5.458s] agentgateway::integration tests::llm::bedrock::token_count
        PASS [   5.718s] agentgateway::integration tests::llm::bedrock::completions
        PASS [   6.071s] agentgateway::integration tests::llm::bedrock::responses_streaming
────────────
     Summary [   6.072s] 21 tests run: 21 passed, 23 skipped
```