### PR TITLE
feat(llm): adaptive thinking and structured outputs for claude providers

### DIFF
--- a/crates/agentgateway/src/llm/conversion/bedrock.rs
+++ b/crates/agentgateway/src/llm/conversion/bedrock.rs
@@ -429,10 +429,12 @@ pub mod from_completions {
 			completions::ResponseFormat::JsonObject => (
 				None,
 				None,
-				serde_json::json!({ "type": "object", "additionalProperties": true }),
+				std::borrow::Cow::Owned(
+					serde_json::json!({ "type": "object", "additionalProperties": true }),
+				),
 			),
 			completions::ResponseFormat::JsonSchema { json_schema } => {
-				let Some(schema) = json_schema.schema.clone() else {
+				let Some(schema) = json_schema.schema.as_ref() else {
 					tracing::warn!(
 						"Dropping response_format.json_schema for Bedrock conversion because schema is missing"
 					);
@@ -441,12 +443,12 @@ pub mod from_completions {
 				(
 					Some(json_schema.name.clone()),
 					json_schema.description.clone(),
-					schema,
+					std::borrow::Cow::Borrowed(schema),
 				)
 			},
 		};
 
-		let Ok(schema_json) = serde_json::to_string(&schema) else {
+		let Ok(schema_json) = serde_json::to_string(schema.as_ref()) else {
 			tracing::warn!(
 				"Dropping structured output for Bedrock conversion: schema is not serializable"
 			);
@@ -1896,10 +1898,12 @@ pub mod from_responses {
 			responses::TextResponseFormatConfiguration::JsonObject => (
 				None,
 				None,
-				serde_json::json!({ "type": "object", "additionalProperties": true }),
+				std::borrow::Cow::Owned(
+					serde_json::json!({ "type": "object", "additionalProperties": true }),
+				),
 			),
 			responses::TextResponseFormatConfiguration::JsonSchema(json_schema) => {
-				let Some(schema) = json_schema.schema.clone() else {
+				let Some(schema) = json_schema.schema.as_ref() else {
 					tracing::warn!(
 						"Dropping text.format.json_schema for Bedrock conversion because schema is missing"
 					);
@@ -1908,12 +1912,12 @@ pub mod from_responses {
 				(
 					Some(json_schema.name.clone()),
 					json_schema.description.clone(),
-					schema,
+					std::borrow::Cow::Borrowed(schema),
 				)
 			},
 		};
 
-		let Ok(schema_json) = serde_json::to_string(&schema) else {
+		let Ok(schema_json) = serde_json::to_string(schema.as_ref()) else {
 			tracing::warn!("Dropping text.format for Bedrock conversion: schema is not serializable");
 			return None;
 		};

--- a/crates/agentgateway/src/llm/conversion/bedrock.rs
+++ b/crates/agentgateway/src/llm/conversion/bedrock.rs
@@ -329,42 +329,26 @@ pub mod from_completions {
 		});
 		let tool_config = tools.map(|tools| bedrock::ToolConfiguration { tools, tool_choice });
 
-		// Handle thinking configuration similar to Anthropic
-		let thinking = if let Some(budget) = req.vendor_extensions.thinking_budget_tokens {
-			Some(serde_json::json!({
+		let explicit_thinking_budget = req.vendor_extensions.thinking_budget_tokens;
+		let enabled_thinking_budget = explicit_thinking_budget.or_else(|| {
+			req
+				.reasoning_effort
+				.as_ref()
+				.and_then(reasoning_effort_to_enabled_budget)
+		});
+
+		let additional_model_request_fields = enabled_thinking_budget.map(|budget| {
+			serde_json::json!({
 				"thinking": {
 					"type": "enabled",
 					"budget_tokens": budget
 				}
-			}))
-		} else {
-			match &req.reasoning_effort {
-				// Note: Anthropic's minimum budget_tokens is 1024
-				Some(completions::ReasoningEffort::Minimal) | Some(completions::ReasoningEffort::Low) => {
-					Some(serde_json::json!({
-						"thinking": {
-							"type": "enabled",
-							"budget_tokens": 1024
-						}
-					}))
-				},
-				Some(completions::ReasoningEffort::Medium) => Some(serde_json::json!({
-					"thinking": {
-						"type": "enabled",
-						"budget_tokens": 2048
-					}
-				})),
-				Some(completions::ReasoningEffort::High) | Some(completions::ReasoningEffort::Xhigh) => {
-					Some(serde_json::json!({
-						"thinking": {
-							"type": "enabled",
-							"budget_tokens": 4096
-						}
-					}))
-				},
-				Some(completions::ReasoningEffort::None) | None => None,
-			}
-		};
+			})
+		});
+		let output_config = req
+			.response_format
+			.as_ref()
+			.and_then(completions_response_format_to_bedrock_output_config);
 
 		let supports_caching = helpers::supports_prompt_caching(&model_id);
 		let system_content = if system_text.is_empty() {
@@ -400,9 +384,10 @@ pub mod from_completions {
 			messages,
 			system: system_content,
 			inference_config: Some(inference_config),
+			output_config,
 			tool_config,
 			guardrail_config,
-			additional_model_request_fields: thinking,
+			additional_model_request_fields,
 			prompt_variables: None,
 			additional_model_response_field_paths: None,
 			request_metadata: metadata,
@@ -425,6 +410,61 @@ pub mod from_completions {
 		}
 
 		bedrock_request
+	}
+
+	fn reasoning_effort_to_enabled_budget(effort: &completions::ReasoningEffort) -> Option<u64> {
+		match effort {
+			completions::ReasoningEffort::None => None,
+			completions::ReasoningEffort::Minimal | completions::ReasoningEffort::Low => Some(1024),
+			completions::ReasoningEffort::Medium => Some(2048),
+			completions::ReasoningEffort::High | completions::ReasoningEffort::Xhigh => Some(4096),
+		}
+	}
+
+	fn completions_response_format_to_bedrock_output_config(
+		response_format: &completions::ResponseFormat,
+	) -> Option<bedrock::OutputConfig> {
+		let (name, description, schema) = match response_format {
+			completions::ResponseFormat::Text => return None,
+			completions::ResponseFormat::JsonObject => (
+				None,
+				None,
+				serde_json::json!({ "type": "object", "additionalProperties": true }),
+			),
+			completions::ResponseFormat::JsonSchema { json_schema } => {
+				let Some(schema) = json_schema.schema.clone() else {
+					tracing::warn!(
+						"Dropping response_format.json_schema for Bedrock conversion because schema is missing"
+					);
+					return None;
+				};
+				(
+					Some(json_schema.name.clone()),
+					json_schema.description.clone(),
+					schema,
+				)
+			},
+		};
+
+		let Ok(schema_json) = serde_json::to_string(&schema) else {
+			tracing::warn!(
+				"Dropping structured output for Bedrock conversion: schema is not serializable"
+			);
+			return None;
+		};
+
+		Some(bedrock::OutputConfig {
+			text_format: Some(bedrock::OutputFormat {
+				r#type: bedrock::OutputFormatType::JsonSchema,
+				structure: bedrock::OutputFormatStructure {
+					json_schema: bedrock::JsonSchemaDefinition {
+						schema: schema_json,
+						name,
+						description,
+					},
+				},
+			}),
+		})
 	}
 
 	pub fn translate_response(bytes: &Bytes, model: &str) -> Result<Box<dyn ResponseType>, AIError> {
@@ -698,9 +738,39 @@ pub mod from_messages {
 		headers: Option<&http::HeaderMap>,
 	) -> bedrock::ConverseRequest {
 		let mut cache_points_used = 0;
+		// Converse placement note (AWS docs):
+		// - Anthropic-specific params are sent via additionalModelRequestFields for Converse:
+		//   https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference-call.html
+		//   https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html
+		// - Adaptive thinking knob is thinking.type = "adaptive":
+		//   https://docs.aws.amazon.com/bedrock/latest/userguide/claude-messages-adaptive-thinking.html
+		// - Effort knob is output_config.effort in Anthropic request shape:
+		//   https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-anthropic-claude-messages-request-response.html
+		let requested_thinking = req.thinking.as_ref();
+		let requested_output_config = req.output_config.as_ref();
+		let output_config = requested_output_config
+			.and_then(|cfg| cfg.format.as_ref())
+			.and_then(messages_output_format_to_bedrock_output_config);
+		let requested_output_config_json = requested_output_config.and_then(|cfg| {
+			let mut output_config = serde_json::Map::new();
+			if let Some(effort) = cfg.effort {
+				output_config.insert("effort".to_string(), serde_json::json!(effort));
+			}
+			if output_config.is_empty() {
+				// Preserve an explicitly empty output_config when present in the input request.
+				if cfg.format.is_none() {
+					Some(serde_json::Value::Object(output_config))
+				} else {
+					None
+				}
+			} else {
+				Some(serde_json::Value::Object(output_config))
+			}
+		});
 
-		// Check if thinking is enabled (Bedrock constraint: thinking requires specific tool/temp settings)
-		let thinking_enabled = req.thinking.is_some();
+		// Bedrock applies strict inference/tool-choice constraints only to explicit extended thinking.
+		let thinking_enabled = requested_thinking
+			.is_some_and(|thinking| matches!(thinking, messages::ThinkingInput::Enabled { .. }));
 
 		// Convert system prompt to Bedrock format with cache point insertion
 		// Note: Anthropic MessagesRequest.system is Option<SystemPrompt>, Bedrock wants Option<Vec<SystemContentBlock>>
@@ -882,7 +952,7 @@ pub mod from_messages {
 		// Build inference config from typed fields
 		let inference_config = bedrock::InferenceConfiguration {
 			max_tokens: req.max_tokens,
-			// When thinking is enabled, temperature/top_p/top_k must be None (Bedrock constraint)
+			// Extended thinking requires temperature/top_p/top_k to be unset.
 			temperature: if thinking_enabled {
 				None
 			} else {
@@ -952,44 +1022,42 @@ pub mod from_messages {
 			None
 		};
 
-		// Convert thinking from typed field and handle beta headers
-		let mut additional_fields = req.thinking.map(|thinking| match thinking {
-			messages::ThinkingInput::Enabled { budget_tokens } => serde_json::json!({
-				"thinking": {
+		// Build Anthropic model-specific fields under Converse's additionalModelRequestFields.
+		let mut additional_fields = requested_thinking.map(|thinking| {
+			let thinking_json = match thinking {
+				messages::ThinkingInput::Enabled { budget_tokens } => serde_json::json!({
 					"type": "enabled",
 					"budget_tokens": budget_tokens
-				}
-			}),
-			messages::ThinkingInput::Disabled {} => serde_json::json!({
-				"thinking": {
+				}),
+				messages::ThinkingInput::Disabled {} => serde_json::json!({
 					"type": "disabled"
-				}
-			}),
+				}),
+				messages::ThinkingInput::Adaptive {} => serde_json::json!({
+					"type": "adaptive"
+				}),
+			};
+			serde_json::json!({ "thinking": thinking_json })
 		});
+		let mut upsert_additional_field = |key: &str, value: serde_json::Value| {
+			let fields =
+				additional_fields.get_or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
+			fields
+				.as_object_mut()
+				.expect("additional model request fields must be a JSON object")
+				.insert(key.to_string(), value);
+		};
+
+		// Preserve explicit output_config in Anthropic's model-specific envelope.
+		if let Some(output_config) = requested_output_config_json {
+			upsert_additional_field("output_config", output_config);
+		}
 
 		// Extract beta headers from HTTP headers if provided
 		let beta_headers = headers.and_then(|h| helpers::extract_beta_headers(h).ok().flatten());
 
 		if let Some(beta_array) = beta_headers {
-			// Add beta headers to additionalModelRequestFields
-			match additional_fields {
-				Some(ref mut fields) => {
-					if let Some(existing_obj) = fields.as_object_mut() {
-						existing_obj.insert(
-							"anthropic_beta".to_string(),
-							serde_json::Value::Array(beta_array),
-						);
-					}
-				},
-				None => {
-					let mut fields = serde_json::Map::new();
-					fields.insert(
-						"anthropic_beta".to_string(),
-						serde_json::Value::Array(beta_array),
-					);
-					additional_fields = Some(serde_json::Value::Object(fields));
-				},
-			}
+			// Add beta headers to additionalModelRequestFields.
+			upsert_additional_field("anthropic_beta", serde_json::Value::Array(beta_array));
 		}
 
 		// Build guardrail configuration if provider has it configured
@@ -1024,6 +1092,7 @@ pub mod from_messages {
 			messages,
 			system: system_content,
 			inference_config: Some(inference_config),
+			output_config,
 			tool_config,
 			guardrail_config,
 			additional_model_request_fields: additional_fields,
@@ -1032,6 +1101,33 @@ pub mod from_messages {
 			request_metadata: metadata,
 			performance_config: None,
 		}
+	}
+
+	fn messages_output_format_to_bedrock_output_config(
+		format: &messages::OutputFormat,
+	) -> Option<bedrock::OutputConfig> {
+		let schema = match format {
+			messages::OutputFormat::JsonSchema { schema } => schema,
+		};
+		let Ok(schema_json) = serde_json::to_string(schema) else {
+			tracing::warn!(
+				"Dropping output_config.format for Bedrock conversion: schema is not serializable"
+			);
+			return None;
+		};
+
+		Some(bedrock::OutputConfig {
+			text_format: Some(bedrock::OutputFormat {
+				r#type: bedrock::OutputFormatType::JsonSchema,
+				structure: bedrock::OutputFormatStructure {
+					json_schema: bedrock::JsonSchemaDefinition {
+						schema: schema_json,
+						name: None,
+						description: None,
+					},
+				},
+			}),
+		})
 	}
 
 	pub fn translate_response(bytes: &Bytes, model: &str) -> Result<Box<dyn ResponseType>, AIError> {
@@ -1344,13 +1440,22 @@ pub mod from_responses {
 	) -> Result<Vec<u8>, AIError> {
 		let typed =
 			json::convert::<_, responses::CreateResponse>(req).map_err(AIError::RequestMarshal)?;
+		let explicit_thinking_budget = extract_responses_thinking_budget_tokens(req);
 		let model_id = typed.model.clone().unwrap_or_default();
-		let xlated = translate_internal(typed, model_id, provider, headers, prompt_caching);
+		let xlated = translate_internal(
+			typed,
+			explicit_thinking_budget,
+			model_id,
+			provider,
+			headers,
+			prompt_caching,
+		);
 		serde_json::to_vec(&xlated).map_err(AIError::RequestMarshal)
 	}
 
 	pub(super) fn translate_internal(
 		req: responses::CreateResponse,
+		explicit_thinking_budget: Option<u64>,
 		model_id: String,
 		provider: &Provider,
 		headers: Option<&http::HeaderMap>,
@@ -1610,6 +1715,25 @@ pub mod from_responses {
 			top_k: None,
 			stop_sequences: vec![],
 		};
+		let output_config = req
+			.text
+			.as_ref()
+			.and_then(responses_text_format_to_bedrock_output_config);
+		let enabled_thinking_budget = explicit_thinking_budget.or_else(|| {
+			req
+				.reasoning
+				.as_ref()
+				.and_then(|r| r.effort.as_ref())
+				.and_then(responses_reasoning_effort_to_enabled_budget)
+		});
+		let additional_model_request_fields = enabled_thinking_budget.map(|budget| {
+			serde_json::json!({
+				"thinking": {
+					"type": "enabled",
+					"budget_tokens": budget
+				}
+			})
+		});
 
 		// Convert tools from typed Responses API format to Bedrock format
 		let (tools, tool_choice) = if let Some(response_tools) = &req.tools {
@@ -1698,9 +1822,10 @@ pub mod from_responses {
 			messages,
 			system: system_content,
 			inference_config: Some(inference_config),
+			output_config,
 			tool_config,
 			guardrail_config,
-			additional_model_request_fields: None,
+			additional_model_request_fields,
 			prompt_variables: None,
 			additional_model_response_field_paths: None,
 			request_metadata: metadata,
@@ -1743,6 +1868,68 @@ pub mod from_responses {
 		);
 
 		bedrock_request
+	}
+
+	fn extract_responses_thinking_budget_tokens(req: &types::responses::Request) -> Option<u64> {
+		req
+			.vendor_extensions
+			.as_ref()
+			.and_then(|v| v.thinking_budget_tokens)
+	}
+
+	fn responses_reasoning_effort_to_enabled_budget(
+		effort: &responses::ReasoningEffort,
+	) -> Option<u64> {
+		match effort {
+			responses::ReasoningEffort::None => None,
+			responses::ReasoningEffort::Minimal | responses::ReasoningEffort::Low => Some(1024),
+			responses::ReasoningEffort::Medium => Some(2048),
+			responses::ReasoningEffort::High | responses::ReasoningEffort::Xhigh => Some(4096),
+		}
+	}
+
+	fn responses_text_format_to_bedrock_output_config(
+		text: &responses::ResponseTextParam,
+	) -> Option<bedrock::OutputConfig> {
+		let (name, description, schema) = match &text.format {
+			responses::TextResponseFormatConfiguration::Text => return None,
+			responses::TextResponseFormatConfiguration::JsonObject => (
+				None,
+				None,
+				serde_json::json!({ "type": "object", "additionalProperties": true }),
+			),
+			responses::TextResponseFormatConfiguration::JsonSchema(json_schema) => {
+				let Some(schema) = json_schema.schema.clone() else {
+					tracing::warn!(
+						"Dropping text.format.json_schema for Bedrock conversion because schema is missing"
+					);
+					return None;
+				};
+				(
+					Some(json_schema.name.clone()),
+					json_schema.description.clone(),
+					schema,
+				)
+			},
+		};
+
+		let Ok(schema_json) = serde_json::to_string(&schema) else {
+			tracing::warn!("Dropping text.format for Bedrock conversion: schema is not serializable");
+			return None;
+		};
+
+		Some(bedrock::OutputConfig {
+			text_format: Some(bedrock::OutputFormat {
+				r#type: bedrock::OutputFormatType::JsonSchema,
+				structure: bedrock::OutputFormatStructure {
+					json_schema: bedrock::JsonSchemaDefinition {
+						schema: schema_json,
+						name,
+						description,
+					},
+				},
+			}),
+		})
 	}
 
 	pub fn translate_response(bytes: &Bytes, model: &str) -> Result<Box<dyn ResponseType>, AIError> {

--- a/crates/agentgateway/src/llm/tests/anthropic-request_anthropic_reasoning.snap
+++ b/crates/agentgateway/src/llm/tests/anthropic-request_anthropic_reasoning.snap
@@ -1,0 +1,27 @@
+---
+source: crates/agentgateway/src/llm/tests.rs
+assertion_line: 108
+description: "anthropic: request_anthropic_reasoning"
+info:
+  model: claude-opus-4-6
+  max_tokens: 1024
+  thinking:
+    type: adaptive
+  output_config:
+    effort: high
+  messages:
+    - role: user
+      content: Give one concise insight about distributed consensus.
+---
+{
+  "messages": [
+    {
+      "role": "user",
+      "content": "Give one concise insight about distributed consensus."
+    }
+  ],
+  "model": "claude-opus-4-6",
+  "reasoning_effort": "high",
+  "max_completion_tokens": 1024,
+  "stream": false
+}

--- a/crates/agentgateway/src/llm/tests/anthropic-request_full.snap
+++ b/crates/agentgateway/src/llm/tests/anthropic-request_full.snap
@@ -134,5 +134,14 @@ info:
   },
   "metadata": {
     "user_id": "user_12345"
+  },
+  "output_config": {
+    "format": {
+      "type": "json_schema",
+      "schema": {
+        "type": "object",
+        "additionalProperties": true
+      }
+    }
   }
 }

--- a/crates/agentgateway/src/llm/tests/anthropic-request_reasoning_max.snap
+++ b/crates/agentgateway/src/llm/tests/anthropic-request_reasoning_max.snap
@@ -1,0 +1,29 @@
+---
+source: crates/agentgateway/src/llm/tests.rs
+description: "anthropic: request_reasoning_max"
+info:
+  model: claude-opus-4-6
+  messages:
+    - role: user
+      content: Deeply analyze quantum gravity
+  reasoning_effort: xhigh
+---
+{
+  "messages": [
+    {
+      "role": "user",
+      "content": [
+        {
+          "type": "text",
+          "text": "Deeply analyze quantum gravity"
+        }
+      ]
+    }
+  ],
+  "model": "claude-opus-4-6",
+  "max_tokens": 4096,
+  "thinking": {
+    "type": "enabled",
+    "budget_tokens": 4096
+  }
+}

--- a/crates/agentgateway/src/llm/tests/bedrock-completions-request_full.snap
+++ b/crates/agentgateway/src/llm/tests/bedrock-completions-request_full.snap
@@ -107,6 +107,16 @@ info:
       "END"
     ]
   },
+  "outputConfig": {
+    "textFormat": {
+      "type": "json_schema",
+      "structure": {
+        "jsonSchema": {
+          "schema": "{\"type\":\"object\",\"additionalProperties\":true}"
+        }
+      }
+    }
+  },
   "toolConfig": {
     "tools": [
       {

--- a/crates/agentgateway/src/llm/tests/bedrock-messages-request_anthropic_reasoning.snap
+++ b/crates/agentgateway/src/llm/tests/bedrock-messages-request_anthropic_reasoning.snap
@@ -1,0 +1,39 @@
+---
+source: crates/agentgateway/src/llm/tests.rs
+assertion_line: 108
+description: "bedrock-messages: request_anthropic_reasoning"
+info:
+  model: claude-opus-4-6
+  max_tokens: 1024
+  thinking:
+    type: adaptive
+  output_config:
+    effort: high
+  messages:
+    - role: user
+      content: Give one concise insight about distributed consensus.
+---
+{
+  "modelId": "claude-opus-4-6",
+  "messages": [
+    {
+      "role": "user",
+      "content": [
+        {
+          "text": "Give one concise insight about distributed consensus."
+        }
+      ]
+    }
+  ],
+  "inferenceConfig": {
+    "maxTokens": 1024
+  },
+  "additionalModelRequestFields": {
+    "thinking": {
+      "type": "adaptive"
+    },
+    "output_config": {
+      "effort": "high"
+    }
+  }
+}

--- a/crates/agentgateway/src/llm/tests/request_anthropic_reasoning.json
+++ b/crates/agentgateway/src/llm/tests/request_anthropic_reasoning.json
@@ -1,0 +1,16 @@
+{
+  "model": "claude-opus-4-6",
+  "max_tokens": 1024,
+  "thinking": {
+    "type": "adaptive"
+  },
+  "output_config": {
+    "effort": "high"
+  },
+  "messages": [
+    {
+      "role": "user",
+      "content": "Give one concise insight about distributed consensus."
+    }
+  ]
+}

--- a/crates/agentgateway/src/llm/tests/request_reasoning_max.json
+++ b/crates/agentgateway/src/llm/tests/request_reasoning_max.json
@@ -1,0 +1,10 @@
+{
+  "model": "claude-opus-4-6",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Deeply analyze quantum gravity"
+    }
+  ],
+  "reasoning_effort": "xhigh"
+}

--- a/crates/agentgateway/src/llm/tests/vertex-messages-request_anthropic_reasoning.snap
+++ b/crates/agentgateway/src/llm/tests/vertex-messages-request_anthropic_reasoning.snap
@@ -1,0 +1,30 @@
+---
+source: crates/agentgateway/src/llm/tests.rs
+description: "vertex-messages: request_anthropic_reasoning"
+info:
+  model: claude-opus-4-6
+  max_tokens: 1024
+  thinking:
+    type: adaptive
+  output_config:
+    effort: high
+  messages:
+    - role: user
+      content: Give one concise insight about distributed consensus.
+---
+{
+  "messages": [
+    {
+      "role": "user",
+      "content": "Give one concise insight about distributed consensus."
+    }
+  ],
+  "anthropic_version": "vertex-2023-10-16",
+  "max_tokens": 1024,
+  "thinking": {
+    "type": "adaptive"
+  },
+  "output_config": {
+    "effort": "high"
+  }
+}

--- a/crates/agentgateway/src/llm/types/bedrock.rs
+++ b/crates/agentgateway/src/llm/types/bedrock.rs
@@ -149,6 +149,9 @@ pub struct ConverseRequest {
 	/// Inference parameters to pass to the model.
 	#[serde(rename = "inferenceConfig", skip_serializing_if = "Option::is_none")]
 	pub inference_config: Option<InferenceConfiguration>,
+	/// Output configuration for the model response.
+	#[serde(rename = "outputConfig", skip_serializing_if = "Option::is_none")]
+	pub output_config: Option<OutputConfig>,
 	/// Configuration information for the tools that the model can use.
 	#[serde(rename = "toolConfig", skip_serializing_if = "Option::is_none")]
 	pub tool_config: Option<ToolConfiguration>,
@@ -176,6 +179,48 @@ pub struct ConverseRequest {
 	/// Performance configuration.
 	#[serde(rename = "performanceConfig", skip_serializing_if = "Option::is_none")]
 	pub performance_config: Option<PerformanceConfiguration>,
+}
+
+#[derive(Clone, Serialize, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct OutputConfig {
+	/// Structured output parameters to control the model's text response.
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub text_format: Option<OutputFormat>,
+}
+
+#[derive(Clone, Serialize, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct OutputFormat {
+	/// The type of structured output format.
+	pub r#type: OutputFormatType,
+	/// The structure that the model's output must adhere to.
+	pub structure: OutputFormatStructure,
+}
+
+#[derive(Clone, Serialize, Debug, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum OutputFormatType {
+	JsonSchema,
+}
+
+#[derive(Clone, Serialize, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct OutputFormatStructure {
+	/// A JSON schema structure that the model's output must adhere to.
+	pub json_schema: JsonSchemaDefinition,
+}
+
+#[derive(Clone, Serialize, Debug, PartialEq)]
+pub struct JsonSchemaDefinition {
+	/// The JSON schema to constrain the model's output.
+	pub schema: String,
+	/// Optional name for the JSON schema.
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub name: Option<String>,
+	/// Optional description of the JSON schema.
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub description: Option<String>,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]

--- a/crates/agentgateway/src/llm/types/completions.rs
+++ b/crates/agentgateway/src/llm/types/completions.rs
@@ -370,8 +370,8 @@ pub mod typed {
 		ChatCompletionToolChoiceOption as ToolChoiceOption, ChatCompletionToolChoiceOption,
 		ChatCompletionTools as Tool, FinishReason, FunctionCall, FunctionCallStream, FunctionName,
 		FunctionObject, FunctionType, PredictionContent, ReasoningEffort, ResponseFormat,
-		ResponseModalities as ChatCompletionModalities, Role, ServiceTier, StopConfiguration as Stop,
-		ToolChoiceOptions, WebSearchOptions,
+		ResponseFormatJsonSchema, ResponseModalities as ChatCompletionModalities, Role, ServiceTier,
+		StopConfiguration as Stop, ToolChoiceOptions, WebSearchOptions,
 	};
 	use serde::{Deserialize, Serialize};
 

--- a/crates/agentgateway/src/llm/types/messages.rs
+++ b/crates/agentgateway/src/llm/types/messages.rs
@@ -626,6 +626,23 @@ pub mod typed {
 
 		#[serde(skip_serializing_if = "Option::is_none")]
 		pub thinking: Option<ThinkingInput>,
+
+		#[serde(skip_serializing_if = "Option::is_none")]
+		pub output_config: Option<OutputConfig>,
+	}
+
+	#[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq, Default)]
+	pub struct OutputConfig {
+		#[serde(skip_serializing_if = "Option::is_none")]
+		pub effort: Option<ThinkingEffort>,
+		#[serde(skip_serializing_if = "Option::is_none")]
+		pub format: Option<OutputFormat>,
+	}
+
+	#[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq)]
+	#[serde(rename_all = "snake_case", tag = "type")]
+	pub enum OutputFormat {
+		JsonSchema { schema: serde_json::Value },
 	}
 
 	#[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq)]
@@ -633,6 +650,16 @@ pub mod typed {
 	pub enum ThinkingInput {
 		Enabled { budget_tokens: u64 },
 		Disabled {},
+		Adaptive {},
+	}
+
+	#[derive(Clone, Copy, Serialize, Deserialize, Debug, Eq, PartialEq)]
+	#[serde(rename_all = "snake_case")]
+	pub enum ThinkingEffort {
+		Low,
+		Medium,
+		High,
+		Max,
 	}
 
 	/// Response body for the Messages API.

--- a/crates/agentgateway/src/llm/types/responses.rs
+++ b/crates/agentgateway/src/llm/types/responses.rs
@@ -32,7 +32,19 @@ pub struct Request {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub stream: Option<bool>,
 
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub vendor_extensions: Option<RequestVendorExtensions>,
+
 	// Everything else (tools, reasoning, etc.) - passthrough
+	#[serde(flatten, default)]
+	pub rest: serde_json::Value,
+}
+
+#[derive(Debug, Deserialize, Clone, Serialize, Default)]
+pub struct RequestVendorExtensions {
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub thinking_budget_tokens: Option<u64>,
+
 	#[serde(flatten, default)]
 	pub rest: serde_json::Value,
 }
@@ -495,12 +507,12 @@ pub mod typed {
 		IncompleteDetails, InputContent, InputItem, InputMessage, InputParam, InputRole,
 		InputTextContent, InputTokenDetails, Item, MessageItem, OutputContent, OutputItem,
 		OutputMessage, OutputMessageContent, OutputStatus, OutputTextContent, OutputTokenDetails,
-		Response, ResponseCompletedEvent, ResponseContentPartAddedEvent, ResponseContentPartDoneEvent,
-		ResponseCreatedEvent, ResponseErrorEvent, ResponseFailedEvent,
+		ReasoningEffort, Response, ResponseCompletedEvent, ResponseContentPartAddedEvent,
+		ResponseContentPartDoneEvent, ResponseCreatedEvent, ResponseErrorEvent, ResponseFailedEvent,
 		ResponseFunctionCallArgumentsDeltaEvent, ResponseFunctionCallArgumentsDoneEvent,
 		ResponseIncompleteEvent, ResponseOutputItemAddedEvent, ResponseOutputItemDoneEvent,
-		ResponseTextDeltaEvent, ResponseUsage, Role, Status, Tool, ToolChoiceFunction,
-		ToolChoiceOptions, ToolChoiceParam,
+		ResponseTextDeltaEvent, ResponseTextParam, ResponseUsage, Role, Status,
+		TextResponseFormatConfiguration, Tool, ToolChoiceFunction, ToolChoiceOptions, ToolChoiceParam,
 	};
 	use serde::{Deserialize, Serialize};
 


### PR DESCRIPTION
## Summary
This PR finalizes Bedrock support for Anthropic Opus 4.6-era thinking and structured outputs with explicit behavior (no hardcoded model logic).

## What Changed
- Added Bedrock Converse structured output mapping for all request paths:
  - `completions`: `response_format` -> `outputConfig.textFormat`
  - `messages`: `output_config.format` -> `outputConfig.textFormat`
  - `responses`: `text.format` -> `outputConfig.textFormat`
- Kept Anthropic-specific params in `additionalModelRequestFields`.
- Made adaptive thinking explicit-only:
  - no adaptive inference from `reasoning_effort`
  - adaptive only when caller explicitly sends `thinking.type = "adaptive"` (messages path)
- Updated Bedrock reasoning handling:
  - `reasoning_effort` -> enabled thinking budgets (`thinking.type = "enabled"` + `budget_tokens`)
  - explicit `thinking_budget_tokens` overrides effort mapping
- Added responses thinking-budget support:
  - top-level `thinking_budget_tokens`
  - fallback `vendor_extensions.thinking_budget_tokens`
- Updated Bedrock snapshot(s) to match new request shape.
- Added Bedrock Opus 4.6 E2E coverage for responses:
  - reasoning effort path
  - explicit thinking budget path
