### PR TITLE
refactor: helm chart cleanup to avoid merge calls that do not merge

### DIFF
--- a/controller/pkg/kgateway/helm/agentgateway/templates/service.yaml
+++ b/controller/pkg/kgateway/helm/agentgateway/templates/service.yaml
@@ -3,14 +3,12 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "kgateway.gateway.fullname" . }}
+  {{- with $gateway.gatewayAnnotations }}
   annotations:
-    {{- toYaml (merge
-      ($gateway.gatewayAnnotations| default dict)
-    ) | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
-    {{- toYaml (merge
-      (include "kgateway.gateway.allLabels" . | fromYaml)
-    ) | nindent 4 }}
+    {{- include "kgateway.gateway.allLabels" . | nindent 4 }}
 spec:
   type: LoadBalancer
   {{- with $gateway.service.loadBalancerIP }}

--- a/controller/pkg/kgateway/helm/agentgateway/templates/serviceaccount.yaml
+++ b/controller/pkg/kgateway/helm/agentgateway/templates/serviceaccount.yaml
@@ -3,12 +3,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "kgateway.gateway.fullname" . }}
+  {{- with $gateway.gatewayAnnotations }}
   annotations:
-    {{- toYaml (merge
-      ($gateway.gatewayAnnotations| default dict)
-    ) | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
-    {{- toYaml (merge
-      (include "kgateway.gateway.allLabels" . | fromYaml)
-    ) | nindent 4 }}
+    {{- include "kgateway.gateway.allLabels" . | nindent 4 }}
 automountServiceAccountToken: false


### PR DESCRIPTION
Once upon a time, we merged two things together. With overlays, we no longer do. Clean it up.

Test plan: internal_helm_test.go is excellent here.