### PR TITLE
fix(ui): resolve A2A policies onto routes in XDS/Kubernetes mode

### DIFF
--- a/ui/src/app/playground/page.tsx
+++ b/ui/src/app/playground/page.tsx
@@ -194,8 +194,7 @@ export default function PlaygroundPage() {
 
     const backend = route.route.backends[0]; // Use first backend to determine type
     if (backend.mcp) return "mcp";
-    if (backend.ai) return "a2a"; // Treat AI backends as A2A for now
-    return "http"; // Host, Service, etc.
+    return "http"; // AI, Host, Service, etc.
   };
 
   const updateRequestFromRoute = useCallback((routeInfo: RouteInfo) => {


### PR DESCRIPTION
## Summary

Fixes #978 — In XDS/Kubernetes mode, A2A backend policies are delivered as separate policy objects in the `/config_dump` response rather than being inline on routes (as they are in file-based config mode). The UI's `configMapper.ts` was storing these as `appliedPolicies` but never connecting them back to the routes whose service backends they target. This caused:

1. **A2A backends showing as "Service"** in the Backends tab and Playground
2. **AI/LLM backends incorrectly classified as "A2A"** in the Playground, causing `localhost:NaN` endpoint errors and failed agent card fetches

## Changes

### `ui/src/lib/configMapper.ts`
- Added `buildA2aPolicyLookup()` that extracts A2A backend policies from the config dump's top-level `policies` array and indexes them by target service `hostname:port`
- Updated `mapToRoute()` to resolve A2A policies onto routes by matching service backend targets against the lookup. Sets `route.policies.a2a = {}` when a match is found
- Also handles inline A2A policies from `routeData.inlinePolicies` (for completeness)

### `ui/src/app/playground/page.tsx`
- Removed `if (backend.ai) return "a2a"` from `getRouteBackendType()` — AI backends should not be classified as A2A. The correct detection path is via `route.policies.a2a`, which now works in XDS mode thanks to the configMapper fix.

## How it works

The config dump in XDS mode has this structure:

```
config_dump.policies[] → [{ target: { backend: { service: { hostname, port } } }, policy: { backend: { a2a: {} } } }]
config_dump.binds[].listeners[].routes[].backends[] → [{ service: { name: "ns/fqdn", port } }]
```

The fix builds a `Map<"hostname:port", true>` from the policies, then during route mapping checks if any of the route's service backends match a policy target. This mirrors how the proxy itself resolves policies at runtime in `store/binds.rs::backend_policies()`.

## Test plan

- [ ] Verify A2A backends show with A2A indicator in Backends tab (XDS mode)
- [ ] Verify A2A routes show as "A2A" type in Playground (XDS mode)  
- [ ] Verify Playground can connect to A2A backends and fetch agent cards
- [ ] Verify AI/LLM backends no longer show as A2A in Playground
- [ ] Verify file-based config mode still works (policies already inline on routes)
- [ ] Run `npm run lint` — passes with no new warnings/errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)