### PR TITLE
fix: fix gcloud auth regression and bump rmcp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,8 +220,9 @@ dependencies = [
  "rcgen 0.14.7",
  "regex",
  "reqwest 0.12.28",
+ "reqwest 0.13.2",
  "rmcp 0.10.0",
- "rmcp 0.14.0",
+ "rmcp 0.15.0",
  "rstest",
  "rustls",
  "rustls-native-certs",
@@ -4954,6 +4955,7 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -5282,7 +5284,9 @@ checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
  "base64",
  "bytes",
+ "encoding_rs",
  "futures-core",
+ "h2",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -5291,8 +5295,10 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -5366,9 +5372,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a621b37a548ff6ab6292d57841eb25785a7f146d89391a19c9f199414bd13da"
+checksum = "1bef41ebc9ebed2c1b1d90203e9d1756091e8a00bbc3107676151f39868ca0ee"
 dependencies = [
  "async-trait",
  "axum",
@@ -5385,7 +5391,7 @@ dependencies = [
  "process-wrap",
  "rand 0.9.2",
  "reqwest 0.12.28",
- "rmcp-macros 0.14.0",
+ "rmcp-macros 0.15.0",
  "schemars 1.0.4",
  "serde",
  "serde_json",
@@ -5415,9 +5421,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b79ed92303f9262db79575aa8c3652581668e9d136be6fd0b9ededa78954c95"
+checksum = "0e88ad84b8b6237a934534a62b379a5be6388915663c0cc598ceb9b3292bbbfe"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,11 +139,10 @@ pwhash = "1"
 rand = "0.10"
 rcgen = { version = "0.14", features = ["pem", "x509-parser"] }
 regex = "1.11"
-reqwest = { version = "0.12", default-features = false, features = [
+reqwest = { version = "0.13", default-features = false, features = [
     "http2",
     "charset",
-    "macos-system-configuration",
-    "rustls-tls",
+    "rustls",
 ] }
 rstest = "0.26"
 rustc_version = "0.4"

--- a/crates/agentgateway/Cargo.toml
+++ b/crates/agentgateway/Cargo.toml
@@ -98,8 +98,11 @@ prost.workspace = true
 rand.workspace = true
 rcgen.workspace = true
 regex.workspace = true
-rmcp = { version = "0.14", features = [
+
+rmcp = { version = "0.15", features = [
     "client",
+    "server",
+    "base64",
     "transport-child-process",
 ] }
 rustls-native-certs.workspace = true
@@ -175,7 +178,7 @@ rstest.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
 which.workspace = true
-rmcp = { version = "0.14", features = [
+rmcp = { version = "0.15", features = [
     "client",
     "server",
     "base64",
@@ -196,6 +199,13 @@ legacy-rmcp = { package = "rmcp", version = "0.10.0", features = ["transport-sse
 ] }
 wiremock.workspace = true
 reqwest.workspace = true
+# TODO(https://github.com/modelcontextprotocol/rust-sdk/pull/667)
+legacyreqwest = { package = "reqwest", version = "0.12", default-features = false, features = [
+    "http2",
+    "charset",
+    "macos-system-configuration",
+    "rustls-tls",
+] }
 
 [lints.clippy]
 # This rule makes code more confusing

--- a/crates/agentgateway/src/mcp/handler.rs
+++ b/crates/agentgateway/src/mcp/handler.rs
@@ -386,6 +386,7 @@ impl Relay {
 				experimental: None,
 				logging: None,
 				tasks: None,
+				extensions: None,
 				tools: Some(ToolsCapability::default()),
 				// These are not supported when multiplexing.
 				prompts: None,
@@ -397,6 +398,7 @@ impl Relay {
 				experimental: None,
 				logging: None,
 				tasks: None,
+				extensions: None,
 				tools: Some(ToolsCapability::default()),
 				prompts: Some(PromptsCapability::default()),
 				resources: Some(ResourcesCapability::default()),

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -424,7 +424,7 @@ pub async fn mcp_streamable_client(
 	use rmcp::model::{ClientCapabilities, ClientInfo, Implementation};
 	use rmcp::transport::StreamableHttpClientTransport;
 	let transport =
-		StreamableHttpClientTransport::<reqwest::Client>::from_uri(format!("http://{s}/mcp"));
+		StreamableHttpClientTransport::<legacyreqwest::Client>::from_uri(format!("http://{s}/mcp"));
 	let client_info = ClientInfo {
 		meta: None,
 		protocol_version: Default::default(),
@@ -435,6 +435,7 @@ pub async fn mcp_streamable_client(
 			title: None,
 			website_url: None,
 			icons: None,
+			description: None,
 		},
 	};
 
@@ -456,7 +457,7 @@ pub async fn mcp_sse_client(s: SocketAddr) -> LegacyService {
 	use legacy_rmcp::ServiceExt;
 	use legacy_rmcp::model::{ClientCapabilities, ClientInfo, Implementation};
 	use legacy_rmcp::transport::SseClientTransport;
-	let transport = SseClientTransport::<reqwest::Client>::start(format!("http://{s}/sse"))
+	let transport = SseClientTransport::<legacyreqwest::Client>::start(format!("http://{s}/sse"))
 		.await
 		.unwrap();
 	let client_info = ClientInfo {

--- a/crates/agentgateway/src/mcp/session.rs
+++ b/crates/agentgateway/src/mcp/session.rs
@@ -616,6 +616,7 @@ fn get_client_info() -> ClientInfo {
 			sampling: None,
 			elicitation: None,
 			tasks: None,
+			extensions: None,
 		},
 		client_info: Implementation {
 			name: "agentgateway".to_string(),

--- a/crates/agentgateway/src/mcp/upstream/openapi/mod.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/mod.rs
@@ -374,6 +374,7 @@ pub(crate) fn parse_openapi_schema(
 								))?
 								.clone();
 							let tool = Tool {
+								execution: None,
 								meta: None,
 								annotations: None,
 								name: Cow::Owned(name.clone()),

--- a/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
@@ -56,6 +56,7 @@ async fn setup() -> (MockServer, Handler) {
 		icons: None,
 		title: None,
 		meta: None,
+		execution: None,
 		input_schema: Arc::new(
 			json!({ // Define a simple schema for testing
 					"type": "object",
@@ -101,6 +102,7 @@ async fn setup() -> (MockServer, Handler) {
 		icons: None,
 		title: None,
 		meta: None,
+		execution: None,
 		input_schema: Arc::new(
 			json!({
 				"type": "object",


### PR DESCRIPTION
Need to install a default TLS provider for rustls for GCP auth to work;
bumping to the latest version added this requirement but didn't notice.
