### PR TITLE
feat(controller): HBONE_GATEWAY tunnel protocol support

### DIFF
--- a/controller/pkg/agentgateway/translator/conditions.go
+++ b/controller/pkg/agentgateway/translator/conditions.go
@@ -2,6 +2,7 @@ package translator
 
 import (
 	"istio.io/istio/pilot/pkg/model/kstatus"
+	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/maps"
 	"istio.io/istio/pkg/slices"
@@ -145,6 +146,9 @@ func GenerateSupportedKinds(l gwv1.Listener) ([]gwv1.RouteGroupKind, bool) {
 			supported = append(supported, toRouteKind(wellknown.TCPRouteGVK))
 		}
 		// UDP route not support
+	case gwv1.ProtocolType(protocol.HBONE):
+		// HBONE is a tunnel terminator — routes attach to inner listeners, not here.
+		supported = []gwv1.RouteGroupKind{}
 	}
 	if l.AllowedRoutes != nil && len(l.AllowedRoutes.Kinds) > 0 {
 		// We need to filter down to only ones we actually support

--- a/controller/pkg/agentgateway/translator/testdata/gateways/hbone-listener.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/gateways/hbone-listener.yaml
@@ -1,0 +1,80 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: test-gateway
+  namespace: default
+spec:
+  gatewayClassName: agentgateway
+  listeners:
+    - name: hbone
+      port: 15008
+      protocol: HBONE
+
+---
+# Output
+output:
+- gateway:
+    Name: test-gateway
+    Namespace: default
+  resource:
+    bind:
+      key: 15008/default/test-gateway
+      port: 15008
+      tunnelProtocol: HBONE_GATEWAY
+- gateway:
+    Name: test-gateway
+    Namespace: default
+  resource:
+    listener:
+      bindKey: 15008/default/test-gateway
+      key: default/test-gateway.hbone
+      name:
+        gatewayName: test-gateway
+        gatewayNamespace: default
+        listenerName: hbone
+      protocol: HBONE
+status:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: Gateway
+  metadata:
+    name: test-gateway
+    namespace: default
+  spec: null
+  status:
+    attachedListenerSets: 0
+    conditions:
+    - lastTransitionTime: fake
+      message: ""
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: fake
+      message: Successfully programmed Gateway
+      reason: Programmed
+      status: "True"
+      type: Programmed
+    listeners:
+    - attachedRoutes: 0
+      conditions:
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: hbone
+      supportedKinds: []

--- a/controller/pkg/syncer/syncer.go
+++ b/controller/pkg/syncer/syncer.go
@@ -11,6 +11,7 @@ import (
 	"istio.io/istio/pilot/pkg/serviceregistry/kube/controller/ambient"
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config/mesh"
+	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/kube/krt"
 	"istio.io/istio/pkg/network"
 	"istio.io/istio/pkg/ptr"
@@ -409,6 +410,7 @@ func (s *Syncer) buildAgwResources(gateways krt.Collection[*translator.GatewayLi
 		port, _ := strconv.Atoi(object.Key)
 		uniq := sets.New[types.NamespacedName]()
 		protocol := api.Bind_Protocol(0)
+		var tunnelProtocol = api.Bind_DIRECT
 		for _, gw := range object.Objects {
 			uniq.Insert(types.NamespacedName{
 				Namespace: gw.ParentGateway.Namespace,
@@ -417,14 +419,18 @@ func (s *Syncer) buildAgwResources(gateways krt.Collection[*translator.GatewayLi
 			// TODO: better handle conflicts of protocols. For now, we arbitrarily treat TLS > plain
 			if gw.Conflict == "" {
 				protocol = max(protocol, s.getBindProtocol(gw))
+				if tp := s.getTunnelProtocol(gw); tp != api.Bind_DIRECT {
+					tunnelProtocol = tp
+				}
 			}
 		}
 		return slices.Map(uniq.UnsortedList(), func(e types.NamespacedName) agwir.AgwResource {
 			bind := translator.AgwBind{
 				Bind: &api.Bind{
-					Key:      object.Key + "/" + e.String(),
-					Port:     uint32(port), //nolint:gosec // G115: port is always in valid port range
-					Protocol: protocol,
+					Key:            object.Key + "/" + e.String(),
+					Port:           uint32(port), //nolint:gosec // G115: port is always in valid port range
+					Protocol:       protocol,
+					TunnelProtocol: tunnelProtocol,
 				},
 			}
 			return translator.ToResourceForGateway(e, bind)
@@ -570,6 +576,8 @@ func (s *Syncer) getProtocolAndTLSConfig(obj *translator.GatewayListener) (api.P
 		return api.Protocol_TLS, tlsConfig, true
 	case gwv1.TCPProtocolType:
 		return api.Protocol_TCP, nil, true
+	case gwv1.ProtocolType(protocol.HBONE):
+		return api.Protocol_HBONE, nil, true
 	default:
 		return api.Protocol_HTTP, nil, false // Unsupported protocol
 	}
@@ -586,8 +594,23 @@ func (s *Syncer) getBindProtocol(obj *translator.GatewayListener) api.Bind_Proto
 		return api.Bind_TLS
 	case gwv1.TCPProtocolType:
 		return api.Bind_TCP
+	case gwv1.ProtocolType(protocol.HBONE):
+		// HBONE uses HTTP/2 CONNECT framing; bind protocol is HTTP.
+		return api.Bind_HTTP
 	default:
 		return api.Bind_HTTP
+	}
+}
+
+// getTunnelProtocol maps a Gateway listener protocol to its tunnel protocol.
+// HBONE listeners use HBONE_GATEWAY mode: the proxy terminates inbound HBONE
+// and routes CONNECT requests to local binds.
+func (s *Syncer) getTunnelProtocol(obj *translator.GatewayListener) api.Bind_TunnelProtocol {
+	switch obj.ParentInfo.Protocol {
+	case gwv1.ProtocolType(protocol.HBONE):
+		return api.Bind_HBONE_GATEWAY
+	default:
+		return api.Bind_DIRECT
 	}
 }
 

--- a/controller/pkg/syncer/syncer.go
+++ b/controller/pkg/syncer/syncer.go
@@ -595,7 +595,9 @@ func (s *Syncer) getBindProtocol(obj *translator.GatewayListener) api.Bind_Proto
 	case gwv1.TCPProtocolType:
 		return api.Bind_TCP
 	case gwv1.ProtocolType(protocol.HBONE):
-		// HBONE uses HTTP/2 CONNECT framing; bind protocol is HTTP.
+		// The bind protocol is not used for HBONE_GATEWAY in the data plane;
+		// the actual inner protocol is determined at runtime from the other
+		// listeners on the same port. Return HTTP as a placeholder.
 		return api.Bind_HTTP
 	default:
 		return api.Bind_HTTP


### PR DESCRIPTION
## Summary

Adds HBONE_GATEWAY tunnel protocol support to the agentgateway Go controller, enabling agentgateway to be natively enrolled in an Istio ambient mesh as an ingress or east-west gateway.

> **Note:** The Rust proxy code for this feature was already merged via #1179 (thanks @howardjohn for splitting that out). This PR contains only the remaining Go controller changes.

### What this does

When a Gateway listener uses `protocol: HBONE`, the controller now:
- Sets `tunnel_protocol: HBONE_GATEWAY` on the Bind (not `HBONE_WAYPOINT`)
- Sets `protocol: HBONE` on the Listener
- Returns empty `supportedKinds` — the HBONE listener is a tunnel terminator, so routes attach to inner listeners (HTTP, GRPC, etc.), not to the HBONE listener itself

### HBONE_GATEWAY vs HBONE_WAYPOINT

Per [review feedback](https://github.com/agentgateway/agentgateway/pull/994#discussion_r2908391989):

- **HBONE_GATEWAY**: Terminates inbound HBONE and routes CONNECT requests to local binds. Used for mesh-enrolled ingress gateways and multicluster east-west gateways. Controlled by agentgateway's own controller. ← **this PR**
- **HBONE_WAYPOINT**: Acts as a service mesh waypoint proxy with policy/route processing. Controlled by istiod. Deferred to the Istio team's ongoing waypoint work.

### Changes

- `controller/pkg/kgateway/agentgatewaysyncer/syncer.go`: Add HBONE cases to `getProtocolAndTLSConfig()`, `getBindProtocol()`, new `getTunnelProtocol()` function, wire `tunnelProtocol` into Bind creation
- `controller/pkg/agentgateway/translator/conditions.go`: HBONE returns empty supported route kinds
- `controller/pkg/agentgateway/translator/testdata/gateways/hbone-listener.yaml`: Golden test

## Test plan
- [x] Golden test verifies HBONE listener produces `tunnelProtocol: HBONE_GATEWAY`
- [x] All existing golden tests pass
- [x] Full controller test suite passes (`go test ./controller/...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)