### PR TITLE
AgentgatewayPolicy: support extensionRef

### DIFF
--- a/controller/pkg/agentgateway/plugins/traffic_plugin.go
+++ b/controller/pkg/agentgateway/plugins/traffic_plugin.go
@@ -416,6 +416,24 @@ func translatePolicyToAgw(
 	return agwPolicies, errors.Join(errs...)
 }
 
+func TranslateInlineTrafficPolicy(
+	ctx PolicyCtx,
+	namespace string,
+	traffic *agentgateway.Traffic,
+) ([]*api.TrafficPolicySpec, error) {
+	dummy := &agentgateway.AgentgatewayPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "inline_policy",
+			Namespace: namespace,
+		},
+		Spec: agentgateway.AgentgatewayPolicySpec{Traffic: traffic},
+	}
+	res, err := translateTrafficPolicyToAgw(ctx, dummy, nil)
+	return slices.MapFilter(res, func(e AgwPolicy) **api.TrafficPolicySpec {
+		return ptr.Of(e.Policy.GetTraffic())
+	}), err
+}
+
 func translateTrafficPolicyToAgw(
 	ctx PolicyCtx,
 	policy *agentgateway.AgentgatewayPolicy,

--- a/controller/pkg/agentgateway/translator/conversion.go
+++ b/controller/pkg/agentgateway/translator/conversion.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/agentgateway/agentgateway/api"
 	v1alpha2 "github.com/agentgateway/agentgateway/controller/api/v1alpha1/agentgateway"
+	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/plugins"
 	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/utils"
 	"github.com/agentgateway/agentgateway/controller/pkg/kgateway/wellknown"
 	"github.com/agentgateway/agentgateway/controller/pkg/pluginsdk/reporter"
@@ -411,13 +412,14 @@ func BuildAgwTrafficPolicyFilters(
 			}
 			policies = append(policies, h)
 		case gwv1.HTTPRouteFilterExtensionRef:
-			err := createAgwExtensionRefFilter(filter.ExtensionRef)
+			extPolicies, err := createAgwExtensionRefFilter(ctx, ns, filter.ExtensionRef)
 			if err != nil {
 				if policyError == nil {
 					policyError = err
 				}
 				continue
 			}
+			policies = append(policies, extPolicies...)
 		default:
 			return nil, &reporter.RouteCondition{
 				Type:    gwv1.RouteConditionAccepted,
@@ -1625,21 +1627,66 @@ func toRouteKind(g schema.GroupVersionKind) gwv1.RouteGroupKind {
 
 // createAgwExtensionRefFilter creates Agw filter from Gateway API ExtensionRef filter
 func createAgwExtensionRefFilter(
+	ctx RouteContext,
+	ns string,
 	extensionRef *gwv1.LocalObjectReference,
-) *reporter.RouteCondition {
+) ([]*api.TrafficPolicySpec, *reporter.RouteCondition) {
 	if extensionRef == nil {
-		return nil
+		return nil, nil
 	}
 
-	// TODO: support other types of extension refs (TrafficPolicySpec, etc.) https://github.com/kgateway-dev/kgateway/issues/12037
-
-	// Unsupported ExtensionRef
-	return &reporter.RouteCondition{
-		Type:    gwv1.RouteConditionAccepted,
-		Status:  metav1.ConditionFalse,
-		Reason:  gwv1.RouteReasonIncompatibleFilters,
-		Message: fmt.Sprintf("unsupported ExtensionRef: %s/%s", extensionRef.Group, extensionRef.Kind),
+	if string(extensionRef.Group) != wellknown.AgentgatewayPolicyGVK.Group || string(extensionRef.Kind) != wellknown.AgentgatewayPolicyGVK.Kind {
+		return nil, &reporter.RouteCondition{
+			Type:    gwv1.RouteConditionAccepted,
+			Status:  metav1.ConditionFalse,
+			Reason:  gwv1.RouteReasonIncompatibleFilters,
+			Message: fmt.Sprintf("unsupported ExtensionRef: %s/%s", extensionRef.Group, extensionRef.Kind),
+		}
 	}
+
+	key := ns + "/" + string(extensionRef.Name)
+	policy := ptr.Flatten(krt.FetchOne(ctx.Krt, ctx.Policies, krt.FilterKey(key)))
+	if policy == nil {
+		return nil, &reporter.RouteCondition{
+			Type:    gwv1.RouteConditionAccepted,
+			Status:  metav1.ConditionFalse,
+			Reason:  gwv1.RouteReasonIncompatibleFilters,
+			Message: fmt.Sprintf("extensionRef %s not found", key),
+		}
+	}
+	if policy.Spec.Traffic == nil {
+		return nil, &reporter.RouteCondition{
+			Type:    gwv1.RouteConditionAccepted,
+			Status:  metav1.ConditionFalse,
+			Reason:  gwv1.RouteReasonIncompatibleFilters,
+			Message: fmt.Sprintf("extensionRef %s does not define spec.traffic", key),
+		}
+	}
+
+	inlinePolicies, err := plugins.TranslateInlineTrafficPolicy(
+		plugins.PolicyCtx{
+			Krt: ctx.Krt,
+			Collections: &plugins.AgwCollections{
+				Services:           ctx.Services,
+				Secrets:            ctx.Secrets,
+				SecretsByNamespace: ctx.SecretsByNS,
+				ConfigMaps:         ctx.ConfigMaps,
+				InferencePools:     ctx.InferencePools,
+				Backends:           ctx.Backends,
+			},
+		},
+		policy.Namespace,
+		policy.Spec.Traffic,
+	)
+	if err != nil {
+		return inlinePolicies, &reporter.RouteCondition{
+			Type:    gwv1.RouteConditionAccepted,
+			Status:  metav1.ConditionFalse,
+			Reason:  gwv1.RouteReasonIncompatibleFilters,
+			Message: fmt.Sprintf("failed to translate extensionRef %s: %v", key, err),
+		}
+	}
+	return inlinePolicies, nil
 }
 
 func routeGroupKindEqual(rgk1, rgk2 gwv1.RouteGroupKind) bool {

--- a/controller/pkg/agentgateway/translator/route_collections.go
+++ b/controller/pkg/agentgateway/translator/route_collections.go
@@ -545,10 +545,14 @@ type RouteContextInputs struct {
 	Grants         ReferenceGrants
 	RouteParents   RouteParents
 	Services       krt.Collection[*corev1.Service]
+	Secrets        krt.Collection[*corev1.Secret]
+	SecretsByNS    krt.Index[string, *corev1.Secret]
+	ConfigMaps     krt.Collection[*corev1.ConfigMap]
 	InferencePools krt.Collection[*inf.InferencePool]
 	Namespaces     krt.Collection[*corev1.Namespace]
 	ServiceEntries krt.Collection[*networkingclient.ServiceEntry]
 	Backends       krt.Collection[*agentgateway.AgentgatewayBackend]
+	Policies       krt.Collection[*agentgateway.AgentgatewayPolicy]
 	ControllerName string
 }
 

--- a/controller/pkg/agentgateway/translator/testdata/routes/httproute-extensionref-agentgatewaypolicy.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/routes/httproute-extensionref-agentgatewaypolicy.yaml
@@ -1,0 +1,99 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: extensionref-inline-policy
+  namespace: default
+spec:
+  parentRefs:
+  - name: test-gateway
+  hostnames:
+  - example.com
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /inline
+    filters:
+    - type: ExtensionRef
+      extensionRef:
+        group: agentgateway.dev
+        kind: AgentgatewayPolicy
+        name: inline-csrf
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: inline-csrf
+  namespace: default
+spec:
+  targetSelectors:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    matchLabels:
+      app: ignored
+  traffic:
+    csrf:
+      additionalOrigins:
+      - https://example.com
+      - https://app.example.com
+
+---
+# Output
+output:
+- gateway:
+    Name: test-gateway
+    Namespace: default
+  resource:
+    route:
+      backends:
+      - backend:
+          port: 8080
+          service:
+            hostname: infra-backend-v1.default.svc.cluster.local
+            namespace: default
+        weight: 1
+      hostnames:
+      - example.com
+      key: default/extensionref-inline-policy.0.0.http
+      listenerKey: default/test-gateway.http
+      matches:
+      - path:
+          pathPrefix: /inline
+      name:
+        kind: HTTPRoute
+        name: extensionref-inline-policy
+        namespace: default
+      trafficPolicies:
+      - csrf:
+          additionalOrigins:
+          - https://example.com
+          - https://app.example.com
+status:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    name: extensionref-inline-policy
+    namespace: default
+  spec: null
+  status:
+    parents:
+    - conditions:
+      - lastTransitionTime: fake
+        message: ""
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: ""
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      controllerName: agentgateway.dev/agentgateway
+      parentRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: test-gateway
+        namespace: default

--- a/controller/pkg/kgateway/agentgatewaysyncer/syncer.go
+++ b/controller/pkg/kgateway/agentgatewaysyncer/syncer.go
@@ -323,10 +323,14 @@ func (s *Syncer) buildAgwResources(
 		RouteParents:   routeParents,
 		ControllerName: s.controllerName,
 		Services:       s.agwCollections.Services,
+		Secrets:        s.agwCollections.Secrets,
+		SecretsByNS:    s.agwCollections.SecretsByNamespace,
+		ConfigMaps:     s.agwCollections.ConfigMaps,
 		Namespaces:     s.agwCollections.Namespaces,
 		ServiceEntries: s.agwCollections.ServiceEntries,
 		InferencePools: s.agwCollections.InferencePools,
 		Backends:       s.agwCollections.Backends,
+		Policies:       s.agwCollections.AgentgatewayPolicies,
 	}
 
 	agwRoutes, routeAttachments, ancestorBackends := translator.AgwRouteCollection(s.statusCollections, s.agwCollections.HTTPRoutes, s.agwCollections.GRPCRoutes, s.agwCollections.TCPRoutes, s.agwCollections.TLSRoutes, routeInputs, krtopts)


### PR DESCRIPTION
Fixes https://github.com/agentgateway/agentgateway/issues/972

    A quirk here: today we require targetSelector or targetRefs. To do this
    well, we would stop requiring that. But I worry people will accidentally
    forget and have a useless policy. Probably we want to make a status
    message to say "this policy is not used" but then we need a more complex
    Route --> Policy index that I don't really want to deal with?
