### PR TITLE
mcp: fix regression in error handling

### DIFF
--- a/crates/agentgateway/src/proxy/mod.rs
+++ b/crates/agentgateway/src/proxy/mod.rs
@@ -263,7 +263,7 @@ impl ProxyError {
 			ProxyError::MCP(mcp::Error::CreateSseUrl(_)) => StatusCode::BAD_REQUEST,
 			ProxyError::MCP(mcp::Error::EstablishGetStream(_)) => StatusCode::INTERNAL_SERVER_ERROR,
 			ProxyError::MCP(mcp::Error::ForwardLegacySse(_)) => StatusCode::INTERNAL_SERVER_ERROR,
-			ProxyError::MCP(mcp::Error::UpstreamError(ref e)) => e.0.status(),
+			ProxyError::MCP(mcp::Error::UpstreamError(e)) => return e.0.map(http::Body::from),
 			ProxyError::MCP(mcp::Error::SendError(_, _)) => StatusCode::INTERNAL_SERVER_ERROR,
 			// Note: we do not return a 401/403 here, as the obscure that it was rejected due to auth
 			ProxyError::MCP(mcp::Error::Authorization(_, _, _)) => StatusCode::INTERNAL_SERVER_ERROR,


### PR DESCRIPTION
Before, we forwarded the full error from upstream if the request failed.
A fix to improve error handling made it so we just forward the status.
However, this strips things like www-authenticate headers.
