### PR TITLE
fix: exclude Map from literal expression optimization

### DIFF
--- a/crates/cel-fork/cel/src/functions.rs
+++ b/crates/cel-fork/cel/src/functions.rs
@@ -745,6 +745,18 @@ mod tests {
 	}
 
 	#[test]
+	fn test_map_with_variable() {
+		assert_eq!(
+			test_script_vars(
+				r#"list.map(c, {"key": c}).size() == 2"#,
+				&[("list", vec!["a", "b"].into())]
+			),
+			Ok(true.into()),
+			"map with map literal containing variable"
+		);
+	}
+
+	#[test]
 	fn test_filter() {
 		[("filter list", "[1, 2, 3].filter(x, x > 2) == [3]")]
 			.iter()

--- a/crates/cel-fork/cel/src/optimize.rs
+++ b/crates/cel-fork/cel/src/optimize.rs
@@ -11,7 +11,7 @@ use crate::parser::Expression;
 use crate::{IdedExpr, Value};
 
 fn is_lit(e: &Expr) -> bool {
-	matches!(e, Expr::Literal(_) | Expr::Inline(_) | Expr::Map(_))
+	matches!(e, Expr::Literal(_) | Expr::Inline(_))
 }
 
 fn as_value(e: IdedExpr) -> Value<'static> {
@@ -190,6 +190,7 @@ mod test {
 	use serde::{Serialize, Serializer};
 
 	use crate::common::ast::{CallExpr, Expr};
+
 	use crate::objects::{Opaque, OpaqueValue};
 	use crate::{Context, ExecutionError, FunctionContext, IdedExpr, Program, ResolveResult, Value};
 


### PR DESCRIPTION
Fixes optimization issue where Map expressions were incorrectly treated as literals, preventing proper variable resolution in map operations. Adds test case to verify map literals containing variables work correctly.