### PR TITLE
e2e: do not always pull website fetcher

### DIFF
--- a/controller/test/e2e/features/agentgateway/mcp/testdata/common.yaml
+++ b/controller/test/e2e/features/agentgateway/mcp/testdata/common.yaml
@@ -16,7 +16,6 @@ spec:
       containers:
       - name: mcp-website-fetcher
         image: ghcr.io/kgateway-dev/mcp-website-fetcher:0.0.1
-        imagePullPolicy: Always
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
I am pretty sure this is making the test flaky. we pre-pull it in the
setup phase so pulling again is redundant anyway
