### PR TITLE
upgrade github actions and standardize on explicit latest os releases

### DIFF
--- a/.github/workflows/debug_cache.yml
+++ b/.github/workflows/debug_cache.yml
@@ -15,10 +15,10 @@ on:
         type: string
 jobs:
   cache-upload:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Restore cache
         uses: Andrej730/cache/restore@e294f7d180f76c94062d0251c60fe7362ce6667d
@@ -28,7 +28,7 @@ jobs:
           key: ${{ github.event.inputs.cache_key }}
 
       - name: Upload cached folder as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: cache-artifact
           path: |

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -2,9 +2,11 @@ name: Branch
 
 on:
   push:
-    branches: [ "main" ]
+    branches:
+      - "main"
   pull_request:
-    branches: [ "main" ]
+    branches:
+      - "main"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
@@ -21,7 +23,9 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os:
+        - ubuntu-24.04
+        - windows-latest
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v6
@@ -31,7 +35,7 @@ jobs:
         toolchain: "${{ env.RUST_VERSION }}"
     - uses: Swatinem/rust-cache@v2
       # Github cache is too tiny to handle the full matrix :-(
-      if: ${{ matrix.os == 'ubuntu-latest' }}
+      if: ${{ matrix.os == 'ubuntu-24.04' }}
       with:
         # Github cache will restore from 'main' OR the current branch.
         # If we cache PR branches, we may evict the 'main' cache and end up with no cache hits at all.
@@ -40,16 +44,16 @@ jobs:
     - name: Test
       run: make test
     - name: Validate
-      if: ${{ matrix.os == 'ubuntu-latest' }}
+      if: ${{ matrix.os == 'ubuntu-24.04' }}
       run: make validate
 
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v6
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6
       with:
-        node-version: 23
+        node-version: 24
     - name: Install Rust
       uses: dtolnay/rust-toolchain@master
       with:
@@ -69,15 +73,15 @@ jobs:
 
   #### UI jobs ####
   ui-lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     defaults:
       run:
         working-directory: ui
     steps:
     - uses: actions/checkout@v6
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6
       with:
-        node-version: 23
+        node-version: 24
     - name: Lint
       run: |
         npm ci
@@ -85,7 +89,7 @@ jobs:
 
   #### Controller jobs ####
   controller-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v6
     - uses: actions/setup-go@v6
@@ -98,7 +102,7 @@ jobs:
       run: go test -race ./...
 
   controller-lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v6
     - uses: actions/setup-go@v6
@@ -118,7 +122,7 @@ jobs:
       run: make generate-apis check-clean-repo
 
   controller-e2e:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v6
     - name: Install Rust
@@ -147,13 +151,13 @@ jobs:
         CGO_ENABLED=0 PERSIST_INSTALL=true go test -tags=e2e -v ./controller/test/e2e/tests -run '^TestAgentgatewayIntegration'
     - name: Archive bug report directory on failure
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: bug-report
         path: ./controller/_test/bug_report/kind
         retention-days: 2
     - name: Upload cargo timings
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: cargo-timings-e2e
         path: target/cargo-timings/cargo-timing*.html
@@ -164,7 +168,7 @@ jobs:
         cat controller/_test/ci-step-timings.log >> $GITHUB_STEP_SUMMARY
 
   controller-conformance:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v6
     - name: Install Rust
@@ -191,7 +195,7 @@ jobs:
       run: |
         make -C controller all-conformance
     - name: Upload cargo timings
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: cargo-timings-conformance
         path: target/cargo-timings/cargo-timing*.html
@@ -201,12 +205,12 @@ jobs:
         cat-yamls () {
           local files=("$@")
           local count=$#
-          
+
           for ((i=0; i<count-1; i++)); do
           cat "${files[i]}"
           echo -e "\n---"
           done
-          
+
           if [ $count -gt 0 ]; then
           cat "${files[count-1]}"
           fi

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -20,12 +20,13 @@ env:
 
 jobs:
   #### Proxy jobs ####
-  test:
+  proxy-test:
     strategy:
       matrix:
         os:
         - ubuntu-24.04
-        - windows-latest
+        - windows-2025
+        # - macos-15 disabled for now
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v6
@@ -35,7 +36,7 @@ jobs:
         toolchain: "${{ env.RUST_VERSION }}"
     - uses: Swatinem/rust-cache@v2
       # Github cache is too tiny to handle the full matrix :-(
-      if: ${{ matrix.os == 'ubuntu-24.04' }}
+      if: ${{ startsWith(matrix.os, 'ubuntu-') }}
       with:
         # Github cache will restore from 'main' OR the current branch.
         # If we cache PR branches, we may evict the 'main' cache and end up with no cache hits at all.
@@ -44,29 +45,33 @@ jobs:
     - name: Test
       run: make test
     - name: Validate
-      if: ${{ matrix.os == 'ubuntu-24.04' }}
+      if: ${{ startsWith(matrix.os, 'ubuntu-') }}
       run: make validate
 
-  lint:
-    runs-on: ubuntu-24.04
+  proxy-lint:
+    strategy:
+      matrix:
+        os:
+        - ubuntu-24.04
+        - windows-2025
+        - macos-15
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v6
-    - uses: actions/setup-node@v6
-      with:
-        node-version: 24
     - name: Install Rust
       uses: dtolnay/rust-toolchain@master
       with:
         toolchain: "${{ env.RUST_VERSION }}"
     - uses: Swatinem/rust-cache@v2
+      if: ${{ startsWith(matrix.os, 'ubuntu-') }}
       with:
         # Github cache will restore from 'main' OR the current branch.
         # If we cache PR branches, we may evict the 'main' cache and end up with no cache hits at all.
         # Ideally, we would have main be 'high priority' and not be evicted but I don't think thats possible.
         save-if: ${{ github.ref == 'refs/heads/main' }}
-    - name: Add Go bin to PATH
-      run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
     - name: Generation
+      # Only check schema generation on linux
+      if: ${{ startsWith(matrix.os, 'ubuntu-') }}
       run: make generate-schema check-clean-repo
     - name: Lint
       run: make lint

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -23,10 +23,13 @@ jobs:
   proxy-test:
     strategy:
       matrix:
-        os:
-        - ubuntu-24.04
-        - windows-2025
-        # - macos-15 disabled for now
+        include:
+        - os: ubuntu-24.04
+          validate: true
+        - os: windows-2025
+          validate: false
+        - os: macos-15
+          validate: false
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v6
@@ -45,17 +48,11 @@ jobs:
     - name: Test
       run: make test
     - name: Validate
-      if: ${{ startsWith(matrix.os, 'ubuntu-') }}
+      if: ${{ matrix.validate }}
       run: make validate
 
   proxy-lint:
-    strategy:
-      matrix:
-        os:
-        - ubuntu-24.04
-        - windows-2025
-        - macos-15
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v6
     - name: Install Rust
@@ -63,15 +60,12 @@ jobs:
       with:
         toolchain: "${{ env.RUST_VERSION }}"
     - uses: Swatinem/rust-cache@v2
-      if: ${{ startsWith(matrix.os, 'ubuntu-') }}
       with:
         # Github cache will restore from 'main' OR the current branch.
         # If we cache PR branches, we may evict the 'main' cache and end up with no cache hits at all.
         # Ideally, we would have main be 'high priority' and not be evicted but I don't think thats possible.
         save-if: ${{ github.ref == 'refs/heads/main' }}
     - name: Generation
-      # Only check schema generation on linux
-      if: ${{ startsWith(matrix.os, 'ubuntu-') }}
       run: make generate-schema check-clean-repo
     - name: Lint
       run: make lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,14 +15,14 @@ on:
         type: boolean
 
 env:
-  REGISTRY_IMAGE: ghcr.io/${{ github.repository_owner }}/agentgateway
-  CONTROLLER_REGISTRY_IMAGE: ghcr.io/${{ github.repository_owner }}/controller
-  # Note: /charts is added to this
-  CHART_REGISTRY_IMAGE_BASE: ghcr.io/${{ github.repository_owner }}
   CARGO_TERM_COLOR: always
   CI: true
   RUST_VERSION: "1.93.1"
   GO_VERSION: "1.25.7"
+  REGISTRY_IMAGE: ghcr.io/${{ github.repository_owner }}/agentgateway
+  CONTROLLER_REGISTRY_IMAGE: ghcr.io/${{ github.repository_owner }}/controller
+  # Note: /charts is added to this
+  CHART_REGISTRY_IMAGE_BASE: ghcr.io/${{ github.repository_owner }}
 
 jobs:
   setup:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -477,15 +477,12 @@ jobs:
             features: jemalloc
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-musl
-            # TODO: arm64 build fails with jemalloc for some reason?
+            # TODO: arm64 build fails with jemalloc for some reason? https://github.com/tikv/jemallocator/issues/146
             features: default
           - os: macos-26
             target: aarch64-apple-darwin
             features: default
-          - os: macos-15-intel
-            target: x86_64-apple-darwin
-            features: default
-          - os: windows-latest
+          - os: windows-2025
             target: x86_64-pc-windows-msvc
             features: default
     steps:
@@ -549,8 +546,6 @@ jobs:
         mkdir outputs
         mv release-binary-macos-26/agentgateway outputs/agentgateway-darwin-arm64
         sha256sum outputs/agentgateway-darwin-arm64 > outputs/agentgateway-darwin-arm64.sha256
-        mv release-binary-macos-15-intel/agentgateway outputs/agentgateway-darwin-amd64
-        sha256sum outputs/agentgateway-darwin-amd64 > outputs/agentgateway-darwin-amd64.sha256
         mv release-binary-ubuntu-24.04/agentgateway outputs/agentgateway-linux-amd64
         sha256sum outputs/agentgateway-linux-amd64 > outputs/agentgateway-linux-amd64.sha256
         mv release-binary-ubuntu-24.04-arm/agentgateway outputs/agentgateway-linux-arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,14 @@ env:
   CONTROLLER_REGISTRY_IMAGE: ghcr.io/${{ github.repository_owner }}/controller
   # Note: /charts is added to this
   CHART_REGISTRY_IMAGE_BASE: ghcr.io/${{ github.repository_owner }}
+  CARGO_TERM_COLOR: always
+  CI: true
+  RUST_VERSION: "1.93.1"
+  GO_VERSION: "1.25.7"
 
 jobs:
   setup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
@@ -52,9 +56,9 @@ jobs:
       matrix:
         include:
           - platform: linux/amd64
-            os: ubuntu-latest
+            os: ubuntu-24.04
           - platform: linux/arm64
-            os: ubuntu-22.04-arm
+            os: ubuntu-24.04-arm
     env:
       VERSION: ${{ needs.setup.outputs.version }}
     steps:
@@ -75,7 +79,7 @@ jobs:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
@@ -100,7 +104,7 @@ jobs:
         touch "${{ runner.temp }}/digests/${digest#sha256:}"
 
     - name: Upload digest
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: digests-${{ env.PLATFORM_PAIR }}
         path: ${{ runner.temp }}/digests/*
@@ -108,7 +112,7 @@ jobs:
         retention-days: 1
 
   push-image:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       packages: write
@@ -120,7 +124,7 @@ jobs:
       VERSION: ${{ needs.setup.outputs.version }}
     steps:
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3.9.2
+        uses: sigstore/cosign-installer@v3
 
       - name: Download digests
         uses: actions/download-artifact@v4
@@ -172,9 +176,9 @@ jobs:
       matrix:
         include:
           - platform: linux/amd64
-            os: ubuntu-latest
+            os: ubuntu-24.04
           - platform: linux/arm64
-            os: ubuntu-22.04-arm
+            os: ubuntu-24.04-arm
     env:
       VERSION: ${{ needs.setup.outputs.version }}
     steps:
@@ -196,7 +200,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
@@ -222,7 +226,7 @@ jobs:
         touch "${{ runner.temp }}/digests-musl/${digest#sha256:}"
 
     - name: Upload digest
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: digests-musl-${{ env.PLATFORM_PAIR }}
         path: ${{ runner.temp }}/digests-musl/*
@@ -230,7 +234,7 @@ jobs:
         retention-days: 1
 
   musl-push-image:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       packages: write
@@ -242,7 +246,7 @@ jobs:
       VERSION: ${{ needs.setup.outputs.version }}
     steps:
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3.9.2
+        uses: sigstore/cosign-installer@v3
 
       - name: Download digests
         uses: actions/download-artifact@v4
@@ -294,10 +298,10 @@ jobs:
       matrix:
         include:
           - platform: linux/amd64
-            os: ubuntu-latest
+            os: ubuntu-24.04
             goarch: amd64
           - platform: linux/arm64
-            os: ubuntu-22.04-arm
+            os: ubuntu-24.04-arm
             goarch: arm64
     defaults:
       run:
@@ -311,7 +315,7 @@ jobs:
         echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
       working-directory: .
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v3
@@ -321,9 +325,9 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
-        go-version: '1.25.7'
+        go-version: "${{ env.GO_VERSION }}"
         cache-dependency-path: |
           **/*.sum
 
@@ -368,7 +372,7 @@ jobs:
         touch "${{ runner.temp }}/controller-digests/${digest#sha256:}"
 
     - name: Upload digest
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: controller-digests-${{ env.PLATFORM_PAIR }}
         path: ${{ runner.temp }}/controller-digests/*
@@ -376,7 +380,7 @@ jobs:
         retention-days: 1
 
   push-controller-image:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       packages: write
@@ -388,7 +392,7 @@ jobs:
       VERSION: ${{ needs.setup.outputs.version }}
     steps:
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3.9.2
+        uses: sigstore/cosign-installer@v3
 
       - name: Download digests
         uses: actions/download-artifact@v4
@@ -467,15 +471,15 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             target: x86_64-unknown-linux-musl
             # Performance is horrendous on musl without jemalloc
             features: jemalloc
-          - os: ubuntu-22.04-arm
+          - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-musl
             # TODO: arm64 build fails with jemalloc for some reason?
             features: default
-          - os: macos-latest
+          - os: macos-26
             target: aarch64-apple-darwin
             features: default
           - os: macos-15-intel
@@ -486,13 +490,14 @@ jobs:
             features: default
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+      uses: actions/checkout@v6
+    - uses: actions/setup-node@v6
       with:
-        node-version: 23
+        node-version: 24
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@master
       with:
+        toolchain: "${{ env.RUST_VERSION }}"
         targets: ${{ matrix.target }}
     # TODO: build this in a separate job and just copy it over
     - name: Build UI
@@ -501,7 +506,7 @@ jobs:
         npm install
         npm run build
     - name: Install musl-tools
-      if: ${{ matrix.os == 'ubuntu-22.04-arm' || matrix.os == 'ubuntu-latest' }}
+      if: ${{ startsWith(matrix.os, 'ubuntu-') }}
       run: |
         sudo apt-get update
         sudo apt-get install -y musl-tools
@@ -514,7 +519,7 @@ jobs:
       run: |
         git status
     - name: Upload Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: release-binary-${{ matrix.os }}
         path: |
@@ -529,7 +534,7 @@ jobs:
     - push-controller-image
     - push-helm-charts
     - build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     steps:
@@ -542,13 +547,13 @@ jobs:
       run: |
         ls -R
         mkdir outputs
-        mv release-binary-macos-latest/agentgateway outputs/agentgateway-darwin-arm64
+        mv release-binary-macos-26/agentgateway outputs/agentgateway-darwin-arm64
         sha256sum outputs/agentgateway-darwin-arm64 > outputs/agentgateway-darwin-arm64.sha256
         mv release-binary-macos-15-intel/agentgateway outputs/agentgateway-darwin-amd64
         sha256sum outputs/agentgateway-darwin-amd64 > outputs/agentgateway-darwin-amd64.sha256
-        mv release-binary-ubuntu-latest/agentgateway outputs/agentgateway-linux-amd64
+        mv release-binary-ubuntu-24.04/agentgateway outputs/agentgateway-linux-amd64
         sha256sum outputs/agentgateway-linux-amd64 > outputs/agentgateway-linux-amd64.sha256
-        mv release-binary-ubuntu-22.04-arm/agentgateway outputs/agentgateway-linux-arm64
+        mv release-binary-ubuntu-24.04-arm/agentgateway outputs/agentgateway-linux-arm64
         sha256sum outputs/agentgateway-linux-arm64 > outputs/agentgateway-linux-arm64.sha256
         mv release-binary-windows-latest/agentgateway.exe outputs/agentgateway-windows-amd64.exe
         sha256sum outputs/agentgateway-windows-amd64.exe > outputs/agentgateway-windows-amd64.exe.sha256

--- a/crates/agentgateway-app/src/commands/run.rs
+++ b/crates/agentgateway-app/src/commands/run.rs
@@ -1,4 +1,3 @@
-use std::env;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -99,7 +98,7 @@ fn spawn_readiness(_: &Bound) {}
 #[cfg(unix)]
 fn spawn_readiness(bound: &Bound) {
 	use std::os::fd::{FromRawFd, OwnedFd};
-	if let Some(ready_fd) = env::var("READY_FD")
+	if let Some(ready_fd) = std::env::var("READY_FD")
 		.ok()
 		.and_then(|v| {
 			let fd: i32 = v.parse().ok()?;

--- a/crates/agentgateway-app/tests/app.rs
+++ b/crates/agentgateway-app/tests/app.rs
@@ -1,0 +1,4 @@
+#[test]
+fn test_compiles() {
+	let _ = agentgateway_app::run as fn() -> anyhow::Result<()>;
+}


### PR DESCRIPTION
* Updating runners to explicit `ubuntu-24.04` & `ubuntu-24.04-arm` across jobs
* Upgraded Actions versions to latest stable releases
* Bumped Node from a dev release to LTS 24
* Migrated release.yaml to same env `RUST_VERSION` `GO_VERSION` setup
* Enable tests on macos with a basic test to ensure agentgateway-app builds on linux, mac, win