### PR TITLE
Ignore libc::prctl and libc::PR_SET_PDEATHSIG for macos

### DIFF
--- a/crates/agentgateway-app/src/commands/oneshot.rs
+++ b/crates/agentgateway-app/src/commands/oneshot.rs
@@ -37,6 +37,7 @@ fn spawn_subprocess(args: &OneshotArgs) -> anyhow::Result<SpawnedSubprocess> {
 	unsafe {
 		command.pre_exec(move || {
 			#[cfg(target_os = "linux")]
+			// Terminate when parent terminates...
 			if libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGTERM) != 0 {
 				return Err(std::io::Error::last_os_error());
 			}

--- a/crates/agentgateway-app/src/commands/oneshot.rs
+++ b/crates/agentgateway-app/src/commands/oneshot.rs
@@ -36,7 +36,7 @@ fn spawn_subprocess(args: &OneshotArgs) -> anyhow::Result<SpawnedSubprocess> {
 	configure_subprocess_output(&mut command, args.agentgateway_output.as_ref())?;
 	unsafe {
 		command.pre_exec(move || {
-			// Terminate when parent terminates...
+			#[cfg(target_os = "linux")]
 			if libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGTERM) != 0 {
 				return Err(std::io::Error::last_os_error());
 			}


### PR DESCRIPTION
`libc::prctl` and `libc::PR_SET_PDEATHSIG` are Linux-only APIs.

This is a pre-existing bug on main and it was introduced by  https://github.com/agentgateway/agentgateway/commit/dc05567c543bcb4cc89ec0995938ae75314318d6