### PR TITLE
fix: builds on macos

### DIFF
--- a/crates/agentgateway-app/src/commands/mod.rs
+++ b/crates/agentgateway-app/src/commands/mod.rs
@@ -1,3 +1,4 @@
-#[cfg(unix)]
+// TODO: fix for unix not just linux
+#[cfg(target_os = "linux")]
 pub(super) mod oneshot;
 pub(super) mod run;

--- a/crates/agentgateway-app/src/lib.rs
+++ b/crates/agentgateway-app/src/lib.rs
@@ -77,17 +77,20 @@ struct Cli {
 	#[command(flatten)]
 	run: RunArgs,
 
+	#[cfg(target_os = "linux")]
 	#[command(subcommand)]
 	command: Option<Commands>,
 }
 
 pub fn run() -> anyhow::Result<()> {
 	let args = Cli::parse();
+	#[cfg(target_os = "linux")]
 	match args.command {
-		#[cfg(unix)]
 		Some(Commands::Oneshot(oneshot)) => commands::oneshot::execute(oneshot),
 		None => commands::run::execute(args.run),
 	}
+	#[cfg(not(target_os = "linux"))]
+	commands::run::execute(args.run)
 }
 
 pub(crate) fn read_config_contents(


### PR DESCRIPTION
`prctl(PR_SET_PDEATHSIG, SIGTERM)` is currently only supported on linux. For now limit this to linux only.

See https://github.com/agentgateway/agentgateway/commit/51122b26efbf4a91fea8e6a5d66a1b419bf2e9fa for a possible unix based solution.