### PR TITLE
fix deny-only MCP authorization policies incorrectly deny all resources

### DIFF
--- a/crates/agentgateway/src/http/authorization.rs
+++ b/crates/agentgateway/src/http/authorization.rs
@@ -148,8 +148,9 @@ impl RuleSets {
 		if rule_sets.iter().any(|r| r.allows(exec)) {
 			return true;
 		}
-		// Else deny
-		false
+		// If only deny rules exist (no allow rules), default to allow (denylist semantics).
+		// If allow rules exist but none matched, default to deny (allowlist semantics).
+		!rule_sets.iter().any(|r| r.has_allow_rules())
 	}
 
 	pub fn is_empty(&self) -> bool {
@@ -164,6 +165,10 @@ impl RuleSet {
 
 	pub fn has_rules(&self) -> bool {
 		!self.rules.allow.is_empty() || !self.rules.deny.is_empty()
+	}
+
+	pub fn has_allow_rules(&self) -> bool {
+		!self.rules.allow.is_empty()
 	}
 	pub fn denies(&self, exec: &cel::Executor) -> bool {
 		if self.rules.deny.is_empty() {

--- a/crates/agentgateway/src/http/authorization_tests.rs
+++ b/crates/agentgateway/src/http/authorization_tests.rs
@@ -217,10 +217,7 @@ fn test_stacked_deny_policies() {
 	assert_matches!(rs.validate(&exec), false);
 
 	// "echo" is not denied by either policy, so it should be allowed
-	let mcp = ResourceType::Tool(ResourceId::new(
-		"server".to_string(),
-		"echo".to_string(),
-	));
+	let mcp = ResourceType::Tool(ResourceId::new("server".to_string(), "echo".to_string()));
 	let exec = cel::Executor::new_mcp(req.as_ref(), &mcp);
 	assert_matches!(rs.validate(&exec), true);
 }

--- a/crates/agentgateway/src/http/authorization_tests.rs
+++ b/crates/agentgateway/src/http/authorization_tests.rs
@@ -19,6 +19,16 @@ fn create_policy_set(policies: Vec<&str>) -> PolicySet {
 	policy_set
 }
 
+fn create_deny_policy_set(policies: Vec<&str>) -> PolicySet {
+	let mut policy_set = PolicySet::default();
+	for p in policies.into_iter() {
+		policy_set
+			.deny
+			.push(Arc::new(cel::Expression::new_strict(p).unwrap()));
+	}
+	policy_set
+}
+
 #[test]
 fn test_rbac_reject_exact_match() {
 	let policies = vec![r#"mcp.tool.name == "increment" && jwt.user == "admin""#];
@@ -133,6 +143,129 @@ fn test_rbac_check_array_contains_match() {
 	let exec = cel::Executor::new_mcp(req.as_ref(), &mcp);
 
 	assert_matches!(rs.validate(&exec), true);
+}
+
+#[test]
+fn test_deny_only_non_matching_allows() {
+	// A deny-only policy targeting "increment" should allow other tools
+	let deny_policies = vec![r#"mcp.tool.name == "increment""#];
+	let rbac = RuleSet::new(create_deny_policy_set(deny_policies));
+	let mut ctx = ContextBuilder::new();
+	let rs = RuleSets::from(vec![rbac.clone()]);
+	rs.register(&mut ctx);
+
+	let req = req(json!({"sub": "1234567890"}));
+	let mcp = ResourceType::Tool(ResourceId::new(
+		"server".to_string(),
+		"decrement".to_string(),
+	));
+	let exec = cel::Executor::new_mcp(req.as_ref(), &mcp);
+
+	// "decrement" does not match the deny rule, so it should be allowed
+	assert_matches!(rs.validate(&exec), true);
+}
+
+#[test]
+fn test_deny_only_matching_denies() {
+	// A deny-only policy targeting "increment" should deny that tool
+	let deny_policies = vec![r#"mcp.tool.name == "increment""#];
+	let rbac = RuleSet::new(create_deny_policy_set(deny_policies));
+	let mut ctx = ContextBuilder::new();
+	let rs = RuleSets::from(vec![rbac.clone()]);
+	rs.register(&mut ctx);
+
+	let req = req(json!({"sub": "1234567890"}));
+	let mcp = ResourceType::Tool(ResourceId::new(
+		"server".to_string(),
+		"increment".to_string(),
+	));
+	let exec = cel::Executor::new_mcp(req.as_ref(), &mcp);
+
+	assert_matches!(rs.validate(&exec), false);
+}
+
+#[test]
+fn test_stacked_deny_policies() {
+	// Two deny-only RuleSets: one denies "increment", another denies "decrement"
+	// Other tools should still be allowed
+	let rbac1 = RuleSet::new(create_deny_policy_set(vec![
+		r#"mcp.tool.name == "increment""#,
+	]));
+	let rbac2 = RuleSet::new(create_deny_policy_set(vec![
+		r#"mcp.tool.name == "decrement""#,
+	]));
+	let mut ctx = ContextBuilder::new();
+	let rs = RuleSets::from(vec![rbac1, rbac2]);
+	rs.register(&mut ctx);
+
+	let req = req(json!({"sub": "1234567890"}));
+
+	// "increment" is denied by first policy
+	let mcp = ResourceType::Tool(ResourceId::new(
+		"server".to_string(),
+		"increment".to_string(),
+	));
+	let exec = cel::Executor::new_mcp(req.as_ref(), &mcp);
+	assert_matches!(rs.validate(&exec), false);
+
+	// "decrement" is denied by second policy
+	let mcp = ResourceType::Tool(ResourceId::new(
+		"server".to_string(),
+		"decrement".to_string(),
+	));
+	let exec = cel::Executor::new_mcp(req.as_ref(), &mcp);
+	assert_matches!(rs.validate(&exec), false);
+
+	// "echo" is not denied by either policy, so it should be allowed
+	let mcp = ResourceType::Tool(ResourceId::new(
+		"server".to_string(),
+		"echo".to_string(),
+	));
+	let exec = cel::Executor::new_mcp(req.as_ref(), &mcp);
+	assert_matches!(rs.validate(&exec), true);
+}
+
+#[test]
+fn test_mixed_allow_deny_default_deny() {
+	// When both allow and deny rules exist, unmatched resources default to deny
+	let policy_set = PolicySet::new(
+		vec![Arc::new(
+			cel::Expression::new_strict(r#"mcp.tool.name == "allowed_tool""#).unwrap(),
+		)],
+		vec![Arc::new(
+			cel::Expression::new_strict(r#"mcp.tool.name == "denied_tool""#).unwrap(),
+		)],
+	);
+	let rbac = RuleSet::new(policy_set);
+	let mut ctx = ContextBuilder::new();
+	let rs = RuleSets::from(vec![rbac]);
+	rs.register(&mut ctx);
+
+	let req = req(json!({"sub": "1234567890"}));
+
+	// "allowed_tool" matches allow rule → allowed
+	let mcp = ResourceType::Tool(ResourceId::new(
+		"server".to_string(),
+		"allowed_tool".to_string(),
+	));
+	let exec = cel::Executor::new_mcp(req.as_ref(), &mcp);
+	assert_matches!(rs.validate(&exec), true);
+
+	// "denied_tool" matches deny rule → denied (deny takes precedence)
+	let mcp = ResourceType::Tool(ResourceId::new(
+		"server".to_string(),
+		"denied_tool".to_string(),
+	));
+	let exec = cel::Executor::new_mcp(req.as_ref(), &mcp);
+	assert_matches!(rs.validate(&exec), false);
+
+	// "other_tool" matches neither → denied (allowlist semantics when allow rules exist)
+	let mcp = ResourceType::Tool(ResourceId::new(
+		"server".to_string(),
+		"other_tool".to_string(),
+	));
+	let exec = cel::Executor::new_mcp(req.as_ref(), &mcp);
+	assert_matches!(rs.validate(&exec), false);
 }
 
 #[divan::bench]

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -446,9 +446,8 @@ async fn authorization_deny_with_request_header_filters_per_agent() {
 			HeaderName::from_static("x-agent-name"),
 			HeaderValue::from_static(agent_name),
 		);
-		let config =
-			StreamableHttpClientTransportConfig::with_uri(format!("http://{addr}/mcp"))
-				.custom_headers(headers);
+		let config = StreamableHttpClientTransportConfig::with_uri(format!("http://{addr}/mcp"))
+			.custom_headers(headers);
 		let transport = StreamableHttpClientTransport::from_config(config);
 		let client_info = ClientInfo {
 			meta: None,

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -347,6 +347,175 @@ async fn authorization_denied_returns_unknown_resource_error() {
 	}
 }
 
+/// Test that a deny policy targeting a specific tool filters only that tool from list_tools,
+/// while leaving all other tools accessible.
+#[tokio::test]
+async fn authorization_deny_specific_tool_filters_only_that_tool() {
+	let mock = mock_streamable_http_server(true).await;
+
+	// Create a deny policy that only denies the "echo" tool
+	let deny_echo_policy = McpAuthorization::new(RuleSet::new(PolicySet::new(
+		vec![],
+		vec![Arc::new(
+			cel::Expression::new_strict(r#"mcp.tool.name == "echo""#).unwrap(),
+		)],
+	)));
+
+	let (_bind, io) = setup_proxy_policies(
+		&mock,
+		true,
+		false,
+		vec![BackendPolicy::McpAuthorization(deny_echo_policy)],
+	)
+	.await;
+
+	let client = mcp_streamable_client(io).await;
+
+	// List tools - "echo" should be filtered out, all others should remain
+	let tools = client.list_tools(None).await.unwrap();
+	let tool_names: Vec<String> = tools
+		.tools
+		.into_iter()
+		.map(|t| t.name.to_string())
+		.sorted()
+		.collect();
+
+	// The mock server has: increment, decrement, get_value, say_hello, echo, sum, echo_http
+	// After denying "echo", we should have all except "echo"
+	assert!(
+		!tool_names.contains(&"echo".to_string()),
+		"echo should be denied but was found in tools: {:?}",
+		tool_names
+	);
+	assert!(
+		tool_names.contains(&"increment".to_string()),
+		"increment should be allowed but was not found in tools: {:?}",
+		tool_names
+	);
+	assert!(
+		tool_names.contains(&"decrement".to_string()),
+		"decrement should be allowed but was not found in tools: {:?}",
+		tool_names
+	);
+	assert!(
+		tool_names.len() >= 5,
+		"Expected at least 5 tools after denying 1, got {}: {:?}",
+		tool_names.len(),
+		tool_names
+	);
+}
+
+/// Test that a deny policy using request.headers correctly filters tools per-agent.
+/// This exercises the router.rs fix that registers authorization policies on the log's
+/// CEL context so the request snapshot includes headers needed by CEL expressions.
+#[tokio::test]
+async fn authorization_deny_with_request_header_filters_per_agent() {
+	use std::collections::HashMap;
+
+	use ::http::{HeaderName, HeaderValue};
+	use rmcp::ServiceExt;
+	use rmcp::model::{ClientCapabilities, ClientInfo, Implementation};
+	use rmcp::transport::StreamableHttpClientTransport;
+	use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
+
+	let mock = mock_streamable_http_server(true).await;
+
+	// Deny "echo" only when request header x-agent-name == "agent-one"
+	let deny_policy = McpAuthorization::new(RuleSet::new(PolicySet::new(
+		vec![],
+		vec![Arc::new(
+			cel::Expression::new_strict(
+				r#"mcp.tool.name == "echo" && request.headers["x-agent-name"] == "agent-one""#,
+			)
+			.unwrap(),
+		)],
+	)));
+
+	let (_bind, io) = setup_proxy_policies(
+		&mock,
+		true,
+		false,
+		vec![BackendPolicy::McpAuthorization(deny_policy)],
+	)
+	.await;
+
+	// Helper to create a client with custom headers
+	let make_client = |addr: SocketAddr, agent_name: &'static str| async move {
+		let mut headers = HashMap::new();
+		headers.insert(
+			HeaderName::from_static("x-agent-name"),
+			HeaderValue::from_static(agent_name),
+		);
+		let config =
+			StreamableHttpClientTransportConfig::with_uri(format!("http://{addr}/mcp"))
+				.custom_headers(headers);
+		let transport = StreamableHttpClientTransport::from_config(config);
+		let client_info = ClientInfo {
+			meta: None,
+			protocol_version: Default::default(),
+			capabilities: ClientCapabilities::default(),
+			client_info: Implementation {
+				name: format!("test-{agent_name}"),
+				version: "0.0.1".to_string(),
+				title: None,
+				website_url: None,
+				icons: None,
+				description: None,
+			},
+		};
+		client_info
+			.serve(transport)
+			.await
+			.expect("client should connect")
+	};
+
+	// Agent-one: "echo" should be denied
+	let client1 = make_client(io, "agent-one").await;
+	let tools1: Vec<String> = client1
+		.list_tools(None)
+		.await
+		.unwrap()
+		.tools
+		.into_iter()
+		.map(|t| t.name.to_string())
+		.sorted()
+		.collect();
+
+	assert!(
+		!tools1.contains(&"echo".to_string()),
+		"agent-one should NOT see 'echo' but tools were: {:?}",
+		tools1
+	);
+	assert!(
+		tools1.contains(&"increment".to_string()),
+		"agent-one should still see 'increment' but tools were: {:?}",
+		tools1
+	);
+
+	// Agent-two: "echo" should be allowed (header doesn't match deny rule)
+	let client2 = make_client(io, "agent-two").await;
+	let tools2: Vec<String> = client2
+		.list_tools(None)
+		.await
+		.unwrap()
+		.tools
+		.into_iter()
+		.map(|t| t.name.to_string())
+		.sorted()
+		.collect();
+
+	assert!(
+		tools2.contains(&"echo".to_string()),
+		"agent-two SHOULD see 'echo' but tools were: {:?}",
+		tools2
+	);
+	assert!(
+		tools2.contains(&"increment".to_string()),
+		"agent-two should still see 'increment' but tools were: {:?}",
+		tools2
+	);
+}
+
 async fn standard_assertions(client: RunningService<RoleClient, InitializeRequestParams>) {
 	let tools = client.list_tools(None).await.unwrap();
 	let t = tools

--- a/crates/agentgateway/src/mcp/router.rs
+++ b/crates/agentgateway/src/mcp/router.rs
@@ -116,6 +116,9 @@ impl App {
 
 		let mut ctx = ContextBuilder::new();
 		authorization_policies.register(&mut ctx);
+		// Also register on the log's context so that `take_and_snapshot` knows to
+		// capture request attributes (e.g. headers) needed by authorization CEL expressions.
+		authorization_policies.register(log.cel.ctx());
 		ctx.maybe_buffer_request_body(&mut req).await;
 
 		// `response` is not valid here, since we run authz first

--- a/crates/agentgateway/src/mcp/router.rs
+++ b/crates/agentgateway/src/mcp/router.rs
@@ -114,12 +114,8 @@ impl App {
 		logy.store(Some(MCPInfo::default()));
 		req.extensions_mut().insert(logy);
 
-		let mut ctx = ContextBuilder::new();
-		authorization_policies.register(&mut ctx);
-		// Also register on the log's context so that `take_and_snapshot` knows to
-		// capture request attributes (e.g. headers) needed by authorization CEL expressions.
 		authorization_policies.register(log.cel.ctx());
-		ctx.maybe_buffer_request_body(&mut req).await;
+		log.cel.ctx().maybe_buffer_request_body(&mut req).await;
 
 		// `response` is not valid here, since we run authz first
 		// MCP context is added later. The context is inserted after

--- a/crates/agentgateway/src/mcp/router.rs
+++ b/crates/agentgateway/src/mcp/router.rs
@@ -4,7 +4,6 @@ use agent_core::prelude::Strng;
 use axum::response::Response;
 
 use crate::ProxyInputs;
-use crate::cel::ContextBuilder;
 use crate::http::authorization::RuleSets;
 use crate::http::sessionpersistence::Encoder;
 use crate::http::*;


### PR DESCRIPTION
# Description

When an MCP authorization policy uses `action: Deny` with a specific tool match expression (e.g., `mcp.tool.name == "echo"`), all tools are denied instead of just the matched one. The `Allow` action works correctly.

**Root cause 1** (`authorization.rs`): `RuleSets::validate()` has a hardcoded `false` default at the end of its evaluation chain. When only deny rules exist and none match the current resource, execution falls through to this default and incorrectly denies it. The fix makes the default dynamic: if only deny rules exist, default to allow (denylist semantics); if allow rules exist but none matched, default to deny (allowlist semantics).

**Root cause 2** (`router.rs`): MCP authorization CEL expressions that reference `request.headers` (e.g., for per-agent deny rules) silently fail because the request snapshot is never created. The authorization policies are registered on a local `ContextBuilder` but not on the log's `ContextBuilder`, which is what `take_and_snapshot` uses to decide whether to capture request attributes. The fix registers authorization policies on both.

# Testing
Manual e2e testing in a kind cluster using the MCP everything server (@modelcontextprotocol/server-everything) as the upstream backend:

1. Single deny policy — applied a policy denying the echo tool:
```
apiVersion: agentgateway.dev/v1alpha1
kind: AgentgatewayPolicy
spec:
  targetRefs:
  - group: agentgateway.dev
    kind: AgentgatewayBackend
    name: mcp-backend
  backend:
    mcp:
      authorization:
        action: Deny
        policy:
          matchExpressions:
          - 'mcp.tool.name == "echo"'
```

Result: tools/list returned 9 tools with echo excluded (out of 10 total tools); tools/call for echo returned `-32602 Unknown tool: echo`; all other tools callable normally.

2. Stacked deny policies — added a second policy denying add:
```
apiVersion: agentgateway.dev/v1alpha1
kind: AgentgatewayPolicy
spec:
  targetRefs:
  - group: agentgateway.dev
    kind: AgentgatewayBackend
    name: mcp-backend
  backend:
    mcp:
      authorization:
        action: Deny
        policy:
          matchExpressions:
          - 'mcp.tool.name == "add"'
```
Result: tools/list returned 8 tools with both echo and add excluded (out of 10 total tools); tools/call blocked for both; all other tools worked.

3. Per-agent deny policies — replaced with two header-scoped policies:
```
# Policy 1: deny "echo" for agent-one only
apiVersion: agentgateway.dev/v1alpha1
kind: AgentgatewayPolicy
spec:
  targetRefs:
  - group: agentgateway.dev
    kind: AgentgatewayBackend
    name: mcp-backend
  backend:
    mcp:
      authorization:
        action: Deny
        policy:
          matchExpressions:
          - 'mcp.tool.name == "echo" && request.headers["x-agent-name"] == "agent-one"'
---
# Policy 2: deny "add" for agent-two only
apiVersion: agentgateway.dev/v1alpha1
kind: AgentgatewayPolicy
spec:
  targetRefs:
  - group: agentgateway.dev
    kind: AgentgatewayBackend
    name: mcp-backend
  backend:
    mcp:
      authorization:
        action: Deny
        policy:
          matchExpressions:
          - 'mcp.tool.name == "add" && request.headers["x-agent-name"] == "agent-two"'
```

Results:

| Agent | Header | echo | add | Other tools |
|-|-|-|-|-|
| agent-one | x-agent-name: agent-one | Denied | Allowed | Allowed |
| agent-two | x-agent-name: agent-two | Allowed | Denied | Allowed |

# Additional Notes

**Behavior matrix after fix:**

| Rules present | Matched deny | Matched allow | Default | Semantic |
|-|-|-|-|-|
| None | — | — | allow | No restrictions |
| Deny only | yes | — | deny | Denylist hit |
| Deny only | no | — | **allow** | Denylist miss (FIXED) |
| Allow only | — | yes | allow | Allowlist hit |
| Allow only | — | no | deny | Allowlist miss |
| Both | yes | — | deny | Deny takes precedence |
| Both | no | yes | allow | Allow hit |
| Both | no | no | deny | Neither matched |