### PR TITLE
mcp: use stateless sessions when upstream doesn't use sessions

### DIFF
--- a/crates/agentgateway/src/mcp/handler.rs
+++ b/crates/agentgateway/src/mcp/handler.rs
@@ -102,7 +102,7 @@ impl Relay {
 
 	pub fn set_sessions(&self, sessions: Vec<MCPSession>) {
 		for ((_, us), session) in self.upstreams.iter_named().zip(sessions) {
-			us.set_session_id(&session.session, session.backend);
+			us.set_session_id(session.session.as_deref(), session.backend);
 		}
 	}
 	pub fn count(&self) -> usize {

--- a/crates/agentgateway/src/mcp/session.rs
+++ b/crates/agentgateway/src/mcp/session.rs
@@ -227,7 +227,7 @@ impl Session {
 							.await;
 						if let Some(sessions) = self.relay.get_sessions() {
 							let s = http::sessionpersistence::SessionState::MCP(
-								http::sessionpersistence::MCPSessionState { sessions },
+								http::sessionpersistence::MCPSessionState::new(sessions),
 							);
 							if let Ok(id) = s.encode(&self.encoder) {
 								self.id = id.into();

--- a/crates/agentgateway/src/mcp/upstream/mod.rs
+++ b/crates/agentgateway/src/mcp/upstream/mod.rs
@@ -101,12 +101,12 @@ pub(crate) enum Upstream {
 impl Upstream {
 	pub fn get_session_state(&self) -> Option<http::sessionpersistence::MCPSession> {
 		match self {
-			Upstream::McpStreamable(c) => c.get_session_state(),
+			Upstream::McpStreamable(c) => Some(c.get_session_state()),
 			_ => None,
 		}
 	}
 
-	pub fn set_session_id(&self, id: &str, pinned: Option<SocketAddr>) {
+	pub fn set_session_id(&self, id: Option<&str>, pinned: Option<SocketAddr>) {
 		match self {
 			Upstream::McpStreamable(c) => c.set_session_id(id, pinned),
 			Upstream::McpSSE(_) => {},
@@ -168,9 +168,7 @@ impl Upstream {
 						StreamableHttpPostResponse::Json(_, sid) => sid.as_ref(),
 						StreamableHttpPostResponse::Sse(_, sid) => sid.as_ref(),
 					};
-					if let Some(sid) = sid {
-						c.set_session_id(sid.as_ref(), None)
-					}
+					c.set_session_id(sid.map(|s| s.as_str()), None)
 				}
 				res.try_into().map_err(Into::into)
 			},

--- a/crates/agentgateway/src/mcp/upstream/streamablehttp.rs
+++ b/crates/agentgateway/src/mcp/upstream/streamablehttp.rs
@@ -35,17 +35,17 @@ impl Client {
 		})
 	}
 
-	pub fn get_session_state(&self) -> Option<http::sessionpersistence::MCPSession> {
-		let session_id = self.session_id.load().clone()?;
+	pub fn get_session_state(&self) -> http::sessionpersistence::MCPSession {
+		let session_id = self.session_id.load().clone();
 		let backend = self.http_client.pinned_backend();
-		Some(http::sessionpersistence::MCPSession {
-			session: session_id.to_string(),
+		http::sessionpersistence::MCPSession {
+			session: session_id.map(|s| s.to_string()),
 			backend,
-		})
+		}
 	}
 
-	pub fn set_session_id(&self, s: &str, pinned: Option<SocketAddr>) {
-		self.session_id.store(Some(Arc::new(s.to_string())));
+	pub fn set_session_id(&self, s: Option<&str>, pinned: Option<SocketAddr>) {
+		self.session_id.store(s.map(|s| Arc::new(s.to_string())));
 		if let Some(pinned) = pinned {
 			self.http_client.pin_backend(ResolvedDestination(pinned));
 		}


### PR DESCRIPTION
Before, if the upstream didn't return a session (i.e. is stateless) then
we would not use our own stateless sessions. This makes it so we do.

This leads some edge case -- if there is no session at all, our session
identifier is non-unique, so we add a unique disamiguator.
