### PR TITLE
Add support to fetch openapi schema using url

### DIFF
--- a/crates/agentgateway/src/http/mod.rs
+++ b/crates/agentgateway/src/http/mod.rs
@@ -601,9 +601,14 @@ pub fn response_buffer_limit(resp: &Response) -> usize {
 		.unwrap_or(2_097_152)
 }
 
-pub async fn read_body(req: Request) -> Result<Bytes, axum_core::Error> {
+pub async fn read_req_body(req: Request) -> Result<Bytes, axum_core::Error> {
 	let lim = buffer_limit(&req);
 	read_body_with_limit(req.into_body(), lim).await
+}
+
+pub async fn read_resp_body(resp: Response) -> Result<Bytes, axum_core::Error> {
+	let lim = response_buffer_limit(&resp);
+	read_body_with_limit(resp.into_body(), lim).await
 }
 
 pub async fn read_response_body(

--- a/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
@@ -17,7 +17,10 @@ use crate::proxy::httpproxy::PolicyClient;
 use crate::serdes::FileInlineOrRemote;
 use crate::store::{BackendPolicies, Stores};
 use crate::types::agent::{Backend, ResourceName, SimpleBackend, Target};
-use crate::types::local::{LocalBackend, LocalMcpBackend, LocalMcpTarget, LocalMcpTargetSpec, McpBackendHost, McpStatefulMode};
+use crate::types::local::{
+	LocalBackend, LocalMcpBackend, LocalMcpTarget, LocalMcpTargetSpec, McpBackendHost,
+	McpStatefulMode,
+};
 use crate::{BackendConfig, ProxyInputs, client, mcp};
 
 // Helper to create a handler and mock server for tests
@@ -937,199 +940,207 @@ async fn test_call_tool_structured_content_fallback() {
 }
 
 #[tokio::test]
- async fn test_openapi_from_url() {
- 	// Test creating LocalMcpTargetSpec::OpenAPI with URL schema and converting to runtime backend
- 	let server = MockServer::start().await;
+async fn test_openapi_from_url() {
+	// Test creating LocalMcpTargetSpec::OpenAPI with URL schema and converting to runtime backend
+	let server = MockServer::start().await;
 
-    // Mock OpenAPI schema response
- 	let openapi_json = json!({
- 		"openapi": "3.0.0",
- 		"info": {
- 			"title": "User API",
- 			"version": "1.0.0"
- 		},
- 		"paths": {
- 			"/users/{user_id}": {
- 				"get": {
- 					"summary": "Get user details",
- 					"parameters": [
- 						{
- 							"name": "user_id",
- 							"in": "path",
- 							"required": true,
- 							"schema": {
- 								"type": "string"
- 							}
- 						}
- 					],
- 					"responses": {
- 						"200": {
- 							"description": "User details",
- 							"content": {
- 								"application/json": {
- 									"schema": {
- 										"type": "object",
- 										"properties": {
- 											"id": {"type": "string"},
- 											"name": {"type": "string"}
- 										}
- 									}
- 								}
- 							}
- 						}
- 					}
- 				}
- 			},
- 			"/users": {
- 				"post": {
- 					"summary": "Create a new user",
- 					"requestBody": {
- 						"required": true,
- 						"content": {
- 							"application/json": {
- 								"schema": {
- 									"type": "object",
- 									"properties": {
- 										"name": {"type": "string"},
- 										"email": {"type": "string"}
- 									},
- 									"required": ["name", "email"]
- 								}
- 							}
- 						}
- 					},
- 					"responses": {
- 						"201": {
- 							"description": "User created",
- 							"content": {
- 								"application/json": {
- 									"schema": {
- 										"type": "object",
- 										"properties": {
- 											"id": {"type": "string"},
- 											"name": {"type": "string"},
- 											"email": {"type": "string"}
- 										}
- 									}
- 								}
- 							}
- 						}
- 					}
- 				}
- 			}
- 		}
- 	});
+	// Mock OpenAPI schema response
+	let openapi_json = json!({
+		"openapi": "3.0.0",
+		"info": {
+			"title": "User API",
+			"version": "1.0.0"
+		},
+		"paths": {
+			"/users/{user_id}": {
+				"get": {
+					"summary": "Get user details",
+					"parameters": [
+						{
+							"name": "user_id",
+							"in": "path",
+							"required": true,
+							"schema": {
+								"type": "string"
+							}
+						}
+					],
+					"responses": {
+						"200": {
+							"description": "User details",
+							"content": {
+								"application/json": {
+									"schema": {
+										"type": "object",
+										"properties": {
+											"id": {"type": "string"},
+											"name": {"type": "string"}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			},
+			"/users": {
+				"post": {
+					"summary": "Create a new user",
+					"requestBody": {
+						"required": true,
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"name": {"type": "string"},
+										"email": {"type": "string"}
+									},
+									"required": ["name", "email"]
+								}
+							}
+						}
+					},
+					"responses": {
+						"201": {
+							"description": "User created",
+							"content": {
+								"application/json": {
+									"schema": {
+										"type": "object",
+										"properties": {
+											"id": {"type": "string"},
+											"name": {"type": "string"},
+											"email": {"type": "string"}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	});
 
- 	Mock::given(method("GET"))
- 		.and(path("/openapi.json"))
- 		.respond_with(ResponseTemplate::new(200).set_body_json(&openapi_json))
- 		.mount(&server)
- 		.await;
+	Mock::given(method("GET"))
+		.and(path("/openapi.json"))
+		.respond_with(ResponseTemplate::new(200).set_body_json(&openapi_json))
+		.mount(&server)
+		.await;
 
- 	// Create client
- 	let client = Client::new(
- 		&client::Config {
- 			resolver_cfg: ResolverConfig::default(),
- 			resolver_opts: ResolverOpts::default(),
- 		},
- 		None,
- 		BackendConfig::default(),
- 		None,
- 	);
+	// Create client
+	let client = Client::new(
+		&client::Config {
+			resolver_cfg: ResolverConfig::default(),
+			resolver_opts: ResolverOpts::default(),
+		},
+		None,
+		BackendConfig::default(),
+		None,
+	);
 
- 	// Create LocalMcpTargetSpec::OpenAPI with remote URL schema
- 	let schema_url = format!("{}/openapi.json", server.uri());
+	// Create LocalMcpTargetSpec::OpenAPI with remote URL schema
+	let schema_url = format!("{}/openapi.json", server.uri());
 
- 	// Use serde_json to create McpBackendHost since fields are private
- 	let backend_json = json!({
- 		"host": "https://api.users.com"
- 	});
- 	let backend: McpBackendHost = serde_json::from_value(backend_json).unwrap();
+	// Use serde_json to create McpBackendHost since fields are private
+	let backend_json = json!({
+		"host": "https://api.users.com"
+	});
+	let backend: McpBackendHost = serde_json::from_value(backend_json).unwrap();
 
- 	let local_target_spec = LocalMcpTargetSpec::OpenAPI {
- 		backend,
- 		schema: FileInlineOrRemote::Remote {
- 			url: schema_url.parse().unwrap(),
- 		},
- 	};
+	let local_target_spec = LocalMcpTargetSpec::OpenAPI {
+		backend,
+		schema: FileInlineOrRemote::Remote {
+			url: schema_url.parse().unwrap(),
+		},
+	};
 
- 	// Create a LocalBackend::MCP to test the full conversion pipeline
- 	let local_backend = LocalBackend::MCP(LocalMcpBackend {
- 		targets: vec![Arc::new(LocalMcpTarget {
- 			name: "users-api".into(),
- 			spec: local_target_spec,
- 			policies: None,
- 		})],
- 		stateful_mode: McpStatefulMode::Stateful,
- 		prefix_mode: None,
- 	});
+	// Create a LocalBackend::MCP to test the full conversion pipeline
+	let local_backend = LocalBackend::MCP(LocalMcpBackend {
+		targets: vec![Arc::new(LocalMcpTarget {
+			name: "users-api".into(),
+			spec: local_target_spec,
+			policies: None,
+		})],
+		stateful_mode: McpStatefulMode::Stateful,
+		prefix_mode: None,
+	});
 
- 	// Convert to runtime backends
- 	let backend_name = ResourceName::new("test-users".into(), "".into());
- 	let result = local_backend.as_backends(backend_name, client).await;
+	// Convert to runtime backends
+	let backend_name = ResourceName::new("test-users".into(), "".into());
+	let result = local_backend.as_backends(backend_name, client).await;
 
- 	// Verify the conversion succeeded
- 	assert!(result.is_ok(), "Should successfully convert LocalBackend::MCP with remote OpenAPI schema");
- 	let backends = result.unwrap();
+	// Verify the conversion succeeded
+	assert!(
+		result.is_ok(),
+		"Should successfully convert LocalBackend::MCP with remote OpenAPI schema"
+	);
+	let backends = result.unwrap();
 
- 	// Should have at least one backend
- 	assert!(!backends.is_empty(), "Should have at least one backend");
+	// Should have at least one backend
+	assert!(!backends.is_empty(), "Should have at least one backend");
 
- 	// Find the MCP backend
- 	let mcp_backend = backends.iter().find(|b| matches!(b.backend, Backend::MCP(_, _)));
- 	assert!(mcp_backend.is_some(), "Should contain an MCP backend");
+	// Find the MCP backend
+	let mcp_backend = backends
+		.iter()
+		.find(|b| matches!(b.backend, Backend::MCP(_, _)));
+	assert!(mcp_backend.is_some(), "Should contain an MCP backend");
 
- 	if let Some(backend_with_policies) = mcp_backend {
- 		if let Backend::MCP(_, mcp_backend) = &backend_with_policies.backend {
- 			assert_eq!(mcp_backend.targets.len(), 1);
+	if let Some(backend_with_policies) = mcp_backend {
+		if let Backend::MCP(_, mcp_backend) = &backend_with_policies.backend {
+			assert_eq!(mcp_backend.targets.len(), 1);
 
- 			// Verify the target was converted to OpenAPI
- 			let target = &mcp_backend.targets[0];
- 			assert_eq!(target.name.as_str(), "users-api");
+			// Verify the target was converted to OpenAPI
+			let target = &mcp_backend.targets[0];
+			assert_eq!(target.name.as_str(), "users-api");
 
- 			// Verify it's an OpenAPI target spec with the fetched schema
- 			if let crate::types::agent::McpTargetSpec::OpenAPI(openapi_target) = &target.spec {
- 				let schema = &openapi_target.schema;
- 				assert_eq!(schema.openapi, "3.0.0");
- 				assert_eq!(schema.info.title, "User API");
- 				assert_eq!(schema.info.version, "1.0.0");
+			// Verify it's an OpenAPI target spec with the fetched schema
+			if let crate::types::agent::McpTargetSpec::OpenAPI(openapi_target) = &target.spec {
+				let schema = &openapi_target.schema;
+				assert_eq!(schema.openapi, "3.0.0");
+				assert_eq!(schema.info.title, "User API");
+				assert_eq!(schema.info.version, "1.0.0");
 
- 				// Check if paths contains the expected paths
- 				let has_users_path = schema.paths.paths.contains_key("/users");
- 				assert!(has_users_path, "Schema should contain /users path");
+				// Check if paths contains the expected paths
+				let has_users_path = schema.paths.paths.contains_key("/users");
+				assert!(has_users_path, "Schema should contain /users path");
 
- 				let has_users_id_path = schema.paths.paths.contains_key("/users/{user_id}");
- 				assert!(has_users_id_path, "Schema should contain /users/{{user_id}} path");
+				let has_users_id_path = schema.paths.paths.contains_key("/users/{user_id}");
+				assert!(
+					has_users_id_path,
+					"Schema should contain /users/{{user_id}} path"
+				);
 
- 				// Verify the path details were preserved
- 				if let Some(path_item_ref) = schema.paths.paths.get("/users/{user_id}") {
- 					match path_item_ref {
- 						ReferenceOr::Item(path_item) => {
- 							if let Some(get_op) = &path_item.get {
- 								assert_eq!(get_op.summary.as_deref(), Some("Get user details"));
- 							}
- 						}
- 						ReferenceOr::Reference { reference: _ } => {
- 							panic!("Expected path item, got reference");
- 						}
- 					}
- 				}
+				// Verify the path details were preserved
+				if let Some(path_item_ref) = schema.paths.paths.get("/users/{user_id}") {
+					match path_item_ref {
+						ReferenceOr::Item(path_item) => {
+							if let Some(get_op) = &path_item.get {
+								assert_eq!(get_op.summary.as_deref(), Some("Get user details"));
+							}
+						},
+						ReferenceOr::Reference { reference: _ } => {
+							panic!("Expected path item, got reference");
+						},
+					}
+				}
 
- 				if let Some(path_item_ref) = schema.paths.paths.get("/users") {
- 					match path_item_ref {
- 						ReferenceOr::Item(path_item) => {
- 							if let Some(post_op) = &path_item.post {
- 								assert_eq!(post_op.summary.as_deref(), Some("Create a new user"));
- 							}
- 						}
- 						ReferenceOr::Reference { reference: _ } => {
- 							panic!("Expected path item, got reference");
- 						}
- 					}
- 				}
- 			} else {
- 				panic!("Expected OpenAPI target spec, got {:?}", target.spec);
- 			}
- 		}
- 	}
- }
+				if let Some(path_item_ref) = schema.paths.paths.get("/users") {
+					match path_item_ref {
+						ReferenceOr::Item(path_item) => {
+							if let Some(post_op) = &path_item.post {
+								assert_eq!(post_op.summary.as_deref(), Some("Create a new user"));
+							}
+						},
+						ReferenceOr::Reference { reference: _ } => {
+							panic!("Expected path item, got reference");
+						},
+					}
+				}
+			} else {
+				panic!("Expected OpenAPI target spec, got {:?}", target.spec);
+			}
+		}
+	}
+}

--- a/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
@@ -1087,60 +1087,60 @@ async fn test_openapi_from_url() {
 		.find(|b| matches!(b.backend, Backend::MCP(_, _)));
 	assert!(mcp_backend.is_some(), "Should contain an MCP backend");
 
-	if let Some(backend_with_policies) = mcp_backend {
-		if let Backend::MCP(_, mcp_backend) = &backend_with_policies.backend {
-			assert_eq!(mcp_backend.targets.len(), 1);
+	if let Some(backend_with_policies) = mcp_backend
+		&& let Backend::MCP(_, mcp_backend) = &backend_with_policies.backend
+	{
+		assert_eq!(mcp_backend.targets.len(), 1);
 
-			// Verify the target was converted to OpenAPI
-			let target = &mcp_backend.targets[0];
-			assert_eq!(target.name.as_str(), "users-api");
+		// Verify the target was converted to OpenAPI
+		let target = &mcp_backend.targets[0];
+		assert_eq!(target.name.as_str(), "users-api");
 
-			// Verify it's an OpenAPI target spec with the fetched schema
-			if let crate::types::agent::McpTargetSpec::OpenAPI(openapi_target) = &target.spec {
-				let schema = &openapi_target.schema;
-				assert_eq!(schema.openapi, "3.0.0");
-				assert_eq!(schema.info.title, "User API");
-				assert_eq!(schema.info.version, "1.0.0");
+		// Verify it's an OpenAPI target spec with the fetched schema
+		if let crate::types::agent::McpTargetSpec::OpenAPI(openapi_target) = &target.spec {
+			let schema = &openapi_target.schema;
+			assert_eq!(schema.openapi, "3.0.0");
+			assert_eq!(schema.info.title, "User API");
+			assert_eq!(schema.info.version, "1.0.0");
 
-				// Check if paths contains the expected paths
-				let has_users_path = schema.paths.paths.contains_key("/users");
-				assert!(has_users_path, "Schema should contain /users path");
+			// Check if paths contains the expected paths
+			let has_users_path = schema.paths.paths.contains_key("/users");
+			assert!(has_users_path, "Schema should contain /users path");
 
-				let has_users_id_path = schema.paths.paths.contains_key("/users/{user_id}");
-				assert!(
-					has_users_id_path,
-					"Schema should contain /users/{{user_id}} path"
-				);
+			let has_users_id_path = schema.paths.paths.contains_key("/users/{user_id}");
+			assert!(
+				has_users_id_path,
+				"Schema should contain /users/{{user_id}} path"
+			);
 
-				// Verify the path details were preserved
-				if let Some(path_item_ref) = schema.paths.paths.get("/users/{user_id}") {
-					match path_item_ref {
-						ReferenceOr::Item(path_item) => {
-							if let Some(get_op) = &path_item.get {
-								assert_eq!(get_op.summary.as_deref(), Some("Get user details"));
-							}
-						},
-						ReferenceOr::Reference { reference: _ } => {
-							panic!("Expected path item, got reference");
-						},
-					}
+			// Verify the path details were preserved
+			if let Some(path_item_ref) = schema.paths.paths.get("/users/{user_id}") {
+				match path_item_ref {
+					ReferenceOr::Item(path_item) => {
+						if let Some(get_op) = &path_item.get {
+							assert_eq!(get_op.summary.as_deref(), Some("Get user details"));
+						}
+					},
+					ReferenceOr::Reference { reference: _ } => {
+						panic!("Expected path item, got reference");
+					},
 				}
-
-				if let Some(path_item_ref) = schema.paths.paths.get("/users") {
-					match path_item_ref {
-						ReferenceOr::Item(path_item) => {
-							if let Some(post_op) = &path_item.post {
-								assert_eq!(post_op.summary.as_deref(), Some("Create a new user"));
-							}
-						},
-						ReferenceOr::Reference { reference: _ } => {
-							panic!("Expected path item, got reference");
-						},
-					}
-				}
-			} else {
-				panic!("Expected OpenAPI target spec, got {:?}", target.spec);
 			}
+
+			if let Some(path_item_ref) = schema.paths.paths.get("/users") {
+				match path_item_ref {
+					ReferenceOr::Item(path_item) => {
+						if let Some(post_op) = &path_item.post {
+							assert_eq!(post_op.summary.as_deref(), Some("Create a new user"));
+						}
+					},
+					ReferenceOr::Reference { reference: _ } => {
+						panic!("Expected path item, got reference");
+					},
+				}
+			}
+		} else {
+			panic!("Expected OpenAPI target spec, got {:?}", target.spec);
 		}
 	}
 }

--- a/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use agent_core::{metrics, strng};
 use hickory_resolver::config::{ResolverConfig, ResolverOpts};
+use openapiv3::ReferenceOr;
 use prometheus_client::registry::Registry;
 use rmcp::model::Tool;
 use rstest::rstest;
@@ -13,8 +14,10 @@ use wiremock::{Match, Mock, MockServer, Request, ResponseTemplate};
 use super::*;
 use crate::client::Client;
 use crate::proxy::httpproxy::PolicyClient;
+use crate::serdes::FileInlineOrRemote;
 use crate::store::{BackendPolicies, Stores};
-use crate::types::agent::{ResourceName, SimpleBackend, Target};
+use crate::types::agent::{Backend, ResourceName, SimpleBackend, Target};
+use crate::types::local::{LocalBackend, LocalMcpBackend, LocalMcpTarget, LocalMcpTargetSpec, McpBackendHost, McpStatefulMode};
 use crate::{BackendConfig, ProxyInputs, client, mcp};
 
 // Helper to create a handler and mock server for tests
@@ -932,3 +935,201 @@ async fn test_call_tool_structured_content_fallback() {
 		"content and structured_content should represent the same data"
 	);
 }
+
+#[tokio::test]
+ async fn test_openapi_from_url() {
+ 	// Test creating LocalMcpTargetSpec::OpenAPI with URL schema and converting to runtime backend
+ 	let server = MockServer::start().await;
+
+    // Mock OpenAPI schema response
+ 	let openapi_json = json!({
+ 		"openapi": "3.0.0",
+ 		"info": {
+ 			"title": "User API",
+ 			"version": "1.0.0"
+ 		},
+ 		"paths": {
+ 			"/users/{user_id}": {
+ 				"get": {
+ 					"summary": "Get user details",
+ 					"parameters": [
+ 						{
+ 							"name": "user_id",
+ 							"in": "path",
+ 							"required": true,
+ 							"schema": {
+ 								"type": "string"
+ 							}
+ 						}
+ 					],
+ 					"responses": {
+ 						"200": {
+ 							"description": "User details",
+ 							"content": {
+ 								"application/json": {
+ 									"schema": {
+ 										"type": "object",
+ 										"properties": {
+ 											"id": {"type": "string"},
+ 											"name": {"type": "string"}
+ 										}
+ 									}
+ 								}
+ 							}
+ 						}
+ 					}
+ 				}
+ 			},
+ 			"/users": {
+ 				"post": {
+ 					"summary": "Create a new user",
+ 					"requestBody": {
+ 						"required": true,
+ 						"content": {
+ 							"application/json": {
+ 								"schema": {
+ 									"type": "object",
+ 									"properties": {
+ 										"name": {"type": "string"},
+ 										"email": {"type": "string"}
+ 									},
+ 									"required": ["name", "email"]
+ 								}
+ 							}
+ 						}
+ 					},
+ 					"responses": {
+ 						"201": {
+ 							"description": "User created",
+ 							"content": {
+ 								"application/json": {
+ 									"schema": {
+ 										"type": "object",
+ 										"properties": {
+ 											"id": {"type": "string"},
+ 											"name": {"type": "string"},
+ 											"email": {"type": "string"}
+ 										}
+ 									}
+ 								}
+ 							}
+ 						}
+ 					}
+ 				}
+ 			}
+ 		}
+ 	});
+
+ 	Mock::given(method("GET"))
+ 		.and(path("/openapi.json"))
+ 		.respond_with(ResponseTemplate::new(200).set_body_json(&openapi_json))
+ 		.mount(&server)
+ 		.await;
+
+ 	// Create client
+ 	let client = Client::new(
+ 		&client::Config {
+ 			resolver_cfg: ResolverConfig::default(),
+ 			resolver_opts: ResolverOpts::default(),
+ 		},
+ 		None,
+ 		BackendConfig::default(),
+ 		None,
+ 	);
+
+ 	// Create LocalMcpTargetSpec::OpenAPI with remote URL schema
+ 	let schema_url = format!("{}/openapi.json", server.uri());
+
+ 	// Use serde_json to create McpBackendHost since fields are private
+ 	let backend_json = json!({
+ 		"host": "https://api.users.com"
+ 	});
+ 	let backend: McpBackendHost = serde_json::from_value(backend_json).unwrap();
+
+ 	let local_target_spec = LocalMcpTargetSpec::OpenAPI {
+ 		backend,
+ 		schema: FileInlineOrRemote::Remote {
+ 			url: schema_url.parse().unwrap(),
+ 		},
+ 	};
+
+ 	// Create a LocalBackend::MCP to test the full conversion pipeline
+ 	let local_backend = LocalBackend::MCP(LocalMcpBackend {
+ 		targets: vec![Arc::new(LocalMcpTarget {
+ 			name: "users-api".into(),
+ 			spec: local_target_spec,
+ 			policies: None,
+ 		})],
+ 		stateful_mode: McpStatefulMode::Stateful,
+ 		prefix_mode: None,
+ 	});
+
+ 	// Convert to runtime backends
+ 	let backend_name = ResourceName::new("test-users".into(), "".into());
+ 	let result = local_backend.as_backends(backend_name, client).await;
+
+ 	// Verify the conversion succeeded
+ 	assert!(result.is_ok(), "Should successfully convert LocalBackend::MCP with remote OpenAPI schema");
+ 	let backends = result.unwrap();
+
+ 	// Should have at least one backend
+ 	assert!(!backends.is_empty(), "Should have at least one backend");
+
+ 	// Find the MCP backend
+ 	let mcp_backend = backends.iter().find(|b| matches!(b.backend, Backend::MCP(_, _)));
+ 	assert!(mcp_backend.is_some(), "Should contain an MCP backend");
+
+ 	if let Some(backend_with_policies) = mcp_backend {
+ 		if let Backend::MCP(_, mcp_backend) = &backend_with_policies.backend {
+ 			assert_eq!(mcp_backend.targets.len(), 1);
+
+ 			// Verify the target was converted to OpenAPI
+ 			let target = &mcp_backend.targets[0];
+ 			assert_eq!(target.name.as_str(), "users-api");
+
+ 			// Verify it's an OpenAPI target spec with the fetched schema
+ 			if let crate::types::agent::McpTargetSpec::OpenAPI(openapi_target) = &target.spec {
+ 				let schema = &openapi_target.schema;
+ 				assert_eq!(schema.openapi, "3.0.0");
+ 				assert_eq!(schema.info.title, "User API");
+ 				assert_eq!(schema.info.version, "1.0.0");
+
+ 				// Check if paths contains the expected paths
+ 				let has_users_path = schema.paths.paths.contains_key("/users");
+ 				assert!(has_users_path, "Schema should contain /users path");
+
+ 				let has_users_id_path = schema.paths.paths.contains_key("/users/{user_id}");
+ 				assert!(has_users_id_path, "Schema should contain /users/{{user_id}} path");
+
+ 				// Verify the path details were preserved
+ 				if let Some(path_item_ref) = schema.paths.paths.get("/users/{user_id}") {
+ 					match path_item_ref {
+ 						ReferenceOr::Item(path_item) => {
+ 							if let Some(get_op) = &path_item.get {
+ 								assert_eq!(get_op.summary.as_deref(), Some("Get user details"));
+ 							}
+ 						}
+ 						ReferenceOr::Reference { reference: _ } => {
+ 							panic!("Expected path item, got reference");
+ 						}
+ 					}
+ 				}
+
+ 				if let Some(path_item_ref) = schema.paths.paths.get("/users") {
+ 					match path_item_ref {
+ 						ReferenceOr::Item(path_item) => {
+ 							if let Some(post_op) = &path_item.post {
+ 								assert_eq!(post_op.summary.as_deref(), Some("Create a new user"));
+ 							}
+ 						}
+ 						ReferenceOr::Reference { reference: _ } => {
+ 							panic!("Expected path item, got reference");
+ 						}
+ 					}
+ 				}
+ 			} else {
+ 				panic!("Expected OpenAPI target spec, got {:?}", target.spec);
+ 			}
+ 		}
+ 	}
+ }

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -438,7 +438,11 @@ impl LocalBackend {
 		})
 	}
 
-	pub async fn as_backends(&self, name: ResourceName, client: client::Client) -> anyhow::Result<Vec<BackendWithPolicies>> {
+	pub async fn as_backends(
+		&self,
+		name: ResourceName,
+		client: client::Client,
+	) -> anyhow::Result<Vec<BackendWithPolicies>> {
 		Ok(match self {
 			LocalBackend::Service { .. } => vec![], // These stay as references
 			LocalBackend::Opaque(tgt) => vec![Backend::Opaque(name, tgt.clone()).into()],
@@ -481,7 +485,7 @@ impl LocalBackend {
 							let openapi_schema = schema.load_openapi_schema(client.clone()).await?;
 							McpTargetSpec::OpenAPI(OpenAPITarget {
 								backend: bref,
-								schema: openapi_schema.into()
+								schema: openapi_schema.into(),
 							})
 						},
 					};
@@ -1579,7 +1583,9 @@ async fn convert_mcp_config(
 		tunnel_protocol: TunnelProtocol::Direct,
 	};
 
-	let backends = LocalBackend::MCP(backend).as_backends(local_name(strng::new("mcp")), client).await?;
+	let backends = LocalBackend::MCP(backend)
+		.as_backends(local_name(strng::new("mcp")), client)
+		.await?;
 
 	Ok((bind, vec![], backends))
 }
@@ -1755,7 +1761,10 @@ async fn convert_route(
 			LocalBackend::Dynamic {} => BackendReference::Backend("dynamic".into()),
 			_ => BackendReference::Backend(strng::format!("/{}", backend_key)),
 		};
-		let backends = b.backend.as_backends(be_name.clone(), client.clone()).await?;
+		let backends = b
+			.backend
+			.as_backends(be_name.clone(), client.clone())
+			.await?;
 		let bref = RouteBackendReference {
 			weight: b.weight,
 			backend: bref,

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -35,7 +35,6 @@ use anyhow::{Error, anyhow, bail};
 use bytes::Bytes;
 use itertools::Itertools;
 use macro_rules_attribute::apply;
-use openapiv3::OpenAPI;
 use secrecy::SecretString;
 
 // Windows has different output, for now easier to just not deal with it
@@ -439,7 +438,7 @@ impl LocalBackend {
 		})
 	}
 
-	pub fn as_backends(&self, name: ResourceName) -> anyhow::Result<Vec<BackendWithPolicies>> {
+	pub async fn as_backends(&self, name: ResourceName, client: client::Client) -> anyhow::Result<Vec<BackendWithPolicies>> {
 		Ok(match self {
 			LocalBackend::Service { .. } => vec![], // These stay as references
 			LocalBackend::Opaque(tgt) => vec![Backend::Opaque(name, tgt.clone()).into()],
@@ -479,9 +478,10 @@ impl LocalBackend {
 							if let Some(b) = be {
 								backends.push(Self::make_backend(b, t.policies.clone(), tls)?);
 							}
+							let openapi_schema = schema.load_openapi_schema(client.clone()).await?;
 							McpTargetSpec::OpenAPI(OpenAPITarget {
 								backend: bref,
-								schema,
+								schema: openapi_schema.into()
 							})
 						},
 					};
@@ -634,9 +634,8 @@ pub enum LocalMcpTargetSpec {
 	OpenAPI {
 		#[serde(flatten)]
 		backend: McpBackendHost,
-		#[serde(deserialize_with = "types::agent::de_openapi")]
 		#[cfg_attr(feature = "schema", schemars(with = "serde_json::value::RawValue"))]
-		schema: Arc<OpenAPI>,
+		schema: serdes::FileInlineOrRemote,
 	},
 }
 
@@ -1523,7 +1522,7 @@ async fn convert_mcp_config(
 	} = mcp_config;
 
 	let resolved_policies = if let Some(pol) = policies {
-		split_policies(client, pol).await?
+		split_policies(client.clone(), pol).await?
 	} else {
 		ResolvedPolicies::default()
 	};
@@ -1581,7 +1580,7 @@ async fn convert_mcp_config(
 		tunnel_protocol: TunnelProtocol::Direct,
 	};
 
-	let backends = LocalBackend::MCP(backend).as_backends(local_name(strng::new("mcp")))?;
+	let backends = LocalBackend::MCP(backend).as_backends(local_name(strng::new("mcp")), client).await?;
 
 	Ok((bind, vec![], backends))
 }
@@ -1757,7 +1756,7 @@ async fn convert_route(
 			LocalBackend::Dynamic {} => BackendReference::Backend("dynamic".into()),
 			_ => BackendReference::Backend(strng::format!("/{}", backend_key)),
 		};
-		let backends = b.backend.as_backends(be_name.clone())?;
+		let backends = b.backend.as_backends(be_name.clone(), client.clone()).await?;
 		let bref = RouteBackendReference {
 			weight: b.weight,
 			backend: bref,

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -634,7 +634,6 @@ pub enum LocalMcpTargetSpec {
 	OpenAPI {
 		#[serde(flatten)]
 		backend: McpBackendHost,
-		#[cfg_attr(feature = "schema", schemars(with = "serde_json::value::RawValue"))]
 		schema: serdes::FileInlineOrRemote,
 	},
 }

--- a/schema/config.json
+++ b/schema/config.json
@@ -3928,7 +3928,9 @@
                     "null"
                   ]
                 },
-                "schema": true
+                "schema": {
+                  "$ref": "#/$defs/FileInlineOrRemote"
+                }
               },
               "additionalProperties": false,
               "required": [

--- a/schema/config.md
+++ b/schema/config.md
@@ -762,6 +762,8 @@
 |`binds[].listeners[].routes[].backends[].(1)mcp.targets[].(1)openapi.port`||
 |`binds[].listeners[].routes[].backends[].(1)mcp.targets[].(1)openapi.path`||
 |`binds[].listeners[].routes[].backends[].(1)mcp.targets[].(1)openapi.schema`||
+|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].(1)openapi.schema.(any)file`||
+|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].(1)openapi.schema.(any)url`||
 |`binds[].listeners[].routes[].backends[].(1)mcp.targets[].name`||
 |`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies`||
 |`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.requestHeaderModifier`|Headers to be modified in the request.|
@@ -3096,6 +3098,8 @@
 |`mcp.targets[].(1)openapi.port`||
 |`mcp.targets[].(1)openapi.path`||
 |`mcp.targets[].(1)openapi.schema`||
+|`mcp.targets[].(1)openapi.schema.(any)file`||
+|`mcp.targets[].(1)openapi.schema.(any)url`||
 |`mcp.targets[].name`||
 |`mcp.targets[].policies`||
 |`mcp.targets[].policies.requestHeaderModifier`|Headers to be modified in the request.|


### PR DESCRIPTION
Enables loading OpenAPI schemas via  URLs, in addition to the existing file and inline options.
Issue https://github.com/agentgateway/agentgateway/issues/756

Changed OpenAPITarget.schema to deserialize into FileInlineOrRemote and skips serialization. Made LocalBackend::as_backends async and load the schema before creating McpTargetSpec::OpenAPI
Added test `test_openapi_from_url` to validate an openapi json can be parsed 
