### PR TITLE
route: do not split up routes by match

### DIFF
--- a/controller/pkg/agentgateway/translator/conversion.go
+++ b/controller/pkg/agentgateway/translator/conversion.go
@@ -41,9 +41,9 @@ import (
 
 // ConvertHTTPRouteToAgw converts a HTTPRouteRule to an agentgateway HTTPRoute
 func ConvertHTTPRouteToAgw(ctx RouteContext, r gwv1.HTTPRouteRule,
-	obj *gwv1.HTTPRoute, pos int, matchPos int,
+	obj *gwv1.HTTPRoute, pos int,
 ) (*api.Route, *reporter.RouteCondition) {
-	routeRuleKey := strconv.Itoa(pos) + "." + strconv.Itoa(matchPos)
+	routeRuleKey := strconv.Itoa(pos)
 	res := &api.Route{
 		// unique for route rule
 		Key:  utils.InternalRouteRuleKey(obj.Namespace, obj.Name, routeRuleKey),

--- a/controller/pkg/agentgateway/translator/conversion.go
+++ b/controller/pkg/agentgateway/translator/conversion.go
@@ -181,7 +181,8 @@ func ConvertGRPCRouteToAgw(ctx RouteContext, r gwv1.GRPCRouteRule,
 	routeRuleKey := strconv.Itoa(pos)
 	res := &api.Route{
 		// unique for route rule
-		Key:         utils.InternalRouteRuleKey(obj.Namespace, obj.Name, routeRuleKey),
+		// Add .grpc suffix to distinguish from HTTP
+		Key:         utils.InternalRouteRuleKey(obj.Namespace, obj.Name, routeRuleKey) + ".grpc",
 		Name:        utils.RouteName(wellknown.GRPCRouteKind, obj.Namespace, obj.Name, r.Name),
 		ListenerKey: "",
 	}

--- a/controller/pkg/agentgateway/translator/route_collections.go
+++ b/controller/pkg/agentgateway/translator/route_collections.go
@@ -49,19 +49,9 @@ func AgwRouteCollection(
 			route := obj.Spec
 			return ctx, func(yield func(AgwRoute, *reporter.RouteCondition) bool) {
 				for n, r := range route.Rules {
-					// split the rule to make sure each rule has up to one match
-					matches := slices.Reference(r.Matches)
-					if len(matches) == 0 {
-						matches = append(matches, nil)
-					}
-					for idx, m := range matches {
-						if m != nil {
-							r.Matches = []gwv1.HTTPRouteMatch{*m}
-						}
-						res, err := ConvertHTTPRouteToAgw(ctx, r, obj, n, idx)
-						if !yield(AgwRoute{Route: res}, err) {
-							return
-						}
+					res, err := ConvertHTTPRouteToAgw(ctx, r, obj, n)
+					if !yield(AgwRoute{Route: res}, err) {
+						return
 					}
 				}
 			}

--- a/controller/pkg/agentgateway/translator/testdata/backends/backendtlspolicy.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/backends/backendtlspolicy.yaml
@@ -121,7 +121,7 @@ output:
             hostname: infra-backend-v2.default.svc.cluster.local
             namespace: default
         weight: 1
-      key: default/test-route.0.0.http
+      key: default/test-route.0.http
       listenerKey: default/test-gateway.http
       name:
         kind: HTTPRoute

--- a/controller/pkg/agentgateway/translator/testdata/backends/inferencepool.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/backends/inferencepool.yaml
@@ -106,7 +106,7 @@ output:
         weight: 1
       hostnames:
       - external.example.com
-      key: default/external-service-route.0.0.http
+      key: default/external-service-route.0.http
       listenerKey: default/example-gateway.http
       name:
         kind: HTTPRoute

--- a/controller/pkg/agentgateway/translator/testdata/backends/serviceentry-with-network.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/backends/serviceentry-with-network.yaml
@@ -150,7 +150,7 @@ output:
         weight: 1
       hostnames:
       - api.example.com
-      key: default/multi-network-route.0.0.http
+      key: default/multi-network-route.0.http
       listenerKey: default/example-gateway.http
       name:
         kind: HTTPRoute

--- a/controller/pkg/agentgateway/translator/testdata/backends/serviceentry.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/backends/serviceentry.yaml
@@ -80,7 +80,7 @@ output:
         weight: 1
       hostnames:
       - external.example.com
-      key: default/external-service-route.0.0.http
+      key: default/external-service-route.0.http
       listenerKey: default/example-gateway.http
       name:
         kind: HTTPRoute

--- a/controller/pkg/agentgateway/translator/testdata/routes/grpc-header-route.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/routes/grpc-header-route.yaml
@@ -46,7 +46,7 @@ output:
         weight: 1
       hostnames:
       - grpc.example.com
-      key: default/grpc-header-route.0.http
+      key: default/grpc-header-route.0.grpc.http
       listenerKey: default/test-gateway.http
       matches:
       - headers:

--- a/controller/pkg/agentgateway/translator/testdata/routes/grpc-invalid.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/routes/grpc-invalid.yaml
@@ -26,7 +26,7 @@ output:
     route:
       backends:
       - {}
-      key: default/example-grpc-route.0.http
+      key: default/example-grpc-route.0.grpc.http
       listenerKey: default/test-gateway.http
       matches:
       - path:

--- a/controller/pkg/agentgateway/translator/testdata/routes/grpc-missing-backend.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/routes/grpc-missing-backend.yaml
@@ -29,7 +29,7 @@ output:
             hostname: example-grpc-svc.default.svc.cluster.local
             namespace: default
         weight: 1
-      key: default/example-grpc-route.0.http
+      key: default/example-grpc-route.0.grpc.http
       listenerKey: default/test-gateway.http
       matches:
       - path:

--- a/controller/pkg/agentgateway/translator/testdata/routes/grpc-multi.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/routes/grpc-multi.yaml
@@ -61,7 +61,7 @@ output:
         weight: 50
       hostnames:
       - grpc.example.com
-      key: default/grpc-header-route.0.http
+      key: default/grpc-header-route.0.grpc.http
       listenerKey: default/test-gateway.http
       matches:
       - path:

--- a/controller/pkg/agentgateway/translator/testdata/routes/httproute-filters.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/routes/httproute-filters.yaml
@@ -151,7 +151,7 @@ output:
         weight: 1
       hostnames:
       - example.com
-      key: default/request-multiple-mirrors-headers.0.0.http
+      key: default/request-multiple-mirrors-headers.0.http
       listenerKey: default/test-gateway.http
       matches:
       - path:
@@ -203,7 +203,7 @@ output:
         weight: 1
       hostnames:
       - example.com
-      key: default/request-multiple-mirrors-headers.1.0.http
+      key: default/request-multiple-mirrors-headers.1.http
       listenerKey: default/test-gateway.http
       matches:
       - path:
@@ -238,7 +238,7 @@ output:
         weight: 1
       hostnames:
       - example.com
-      key: default/request-multiple-mirrors-headers.2.0.http
+      key: default/request-multiple-mirrors-headers.2.http
       listenerKey: default/test-gateway.http
       matches:
       - path:
@@ -266,7 +266,7 @@ output:
     route:
       hostnames:
       - example.com
-      key: default/request-multiple-mirrors-headers.3.0.http
+      key: default/request-multiple-mirrors-headers.3.http
       listenerKey: default/test-gateway.http
       matches:
       - path:
@@ -293,7 +293,7 @@ output:
         weight: 1
       hostnames:
       - example.com
-      key: default/request-multiple-mirrors-headers.4.0.http
+      key: default/request-multiple-mirrors-headers.4.http
       listenerKey: default/test-gateway.http
       matches:
       - path:
@@ -319,7 +319,7 @@ output:
         weight: 1
       hostnames:
       - example.com
-      key: default/request-multiple-mirrors-headers.5.0.http
+      key: default/request-multiple-mirrors-headers.5.http
       listenerKey: default/test-gateway.http
       matches:
       - path:
@@ -347,7 +347,7 @@ output:
     route:
       hostnames:
       - example.com
-      key: default/request-multiple-mirrors-headers.6.0.http
+      key: default/request-multiple-mirrors-headers.6.http
       listenerKey: default/test-gateway.http
       matches:
       - path:

--- a/controller/pkg/agentgateway/translator/testdata/routes/httproute-missing-dest.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/routes/httproute-missing-dest.yaml
@@ -25,7 +25,7 @@ output:
             hostname: unknown.default.svc.cluster.local
             namespace: default
         weight: 1
-      key: default/missing-dest.0.0.http
+      key: default/missing-dest.0.http
       listenerKey: default/test-gateway.http
       name:
         kind: HTTPRoute

--- a/controller/pkg/agentgateway/translator/testdata/routes/httproute-timeout-retry.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/routes/httproute-timeout-retry.yaml
@@ -56,7 +56,7 @@ output:
         weight: 1
       hostnames:
       - example.com
-      key: default/request-multiple-mirrors-headers.0.0.http
+      key: default/request-multiple-mirrors-headers.0.http
       listenerKey: default/test-gateway.http
       matches:
       - path:
@@ -83,7 +83,7 @@ output:
         weight: 1
       hostnames:
       - example.com
-      key: default/request-multiple-mirrors-headers.1.0.http
+      key: default/request-multiple-mirrors-headers.1.http
       listenerKey: default/test-gateway.http
       matches:
       - path:
@@ -109,7 +109,7 @@ output:
         weight: 1
       hostnames:
       - example.com
-      key: default/request-multiple-mirrors-headers.2.0.http
+      key: default/request-multiple-mirrors-headers.2.http
       listenerKey: default/test-gateway.http
       matches:
       - path:

--- a/controller/pkg/agentgateway/translator/testdata/routes/inferencepool.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/routes/inferencepool.yaml
@@ -58,7 +58,7 @@ output:
             hostname: gateway-pool.default.inference.cluster.local
             namespace: default
         weight: 1
-      key: default/gateway-route.0.0.http
+      key: default/gateway-route.0.http
       listenerKey: default/test-gateway.http
       name:
         kind: HTTPRoute

--- a/controller/pkg/agentgateway/translator/testdata/routes/matchers.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/routes/matchers.yaml
@@ -44,7 +44,7 @@ output:
         weight: 1
       hostnames:
       - api.example.com
-      key: default/exact-match-route.0.0.http
+      key: default/exact-match-route.0.http
       listenerKey: default/test-gateway.http
       matches:
       - headers:
@@ -70,7 +70,7 @@ output:
         weight: 1
       hostnames:
       - api.example.com
-      key: default/exact-match-route.1.0.http
+      key: default/exact-match-route.1.http
       listenerKey: default/test-gateway.http
       matches:
       - path:

--- a/controller/pkg/agentgateway/translator/testdata/routes/multi-match.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/routes/multi-match.yaml
@@ -12,7 +12,10 @@ spec:
   - matches:
     - path:
         type: PathPrefix
-        value: /api
+        value: /api1
+    - path:
+        type: PathPrefix
+        value: /api2
     backendRefs:
     - name: test-service
       port: 80
@@ -37,7 +40,9 @@ output:
       listenerKey: default/test-gateway.http
       matches:
       - path:
-          pathPrefix: /api
+          pathPrefix: /api1
+      - path:
+          pathPrefix: /api2
       name:
         kind: HTTPRoute
         name: test-route

--- a/controller/pkg/agentgateway/translator/testdata/routes/multi-rule-grpc-route.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/routes/multi-rule-grpc-route.yaml
@@ -40,7 +40,7 @@ output:
         weight: 1
       hostnames:
       - grpc.example.com
-      key: default/multi-rule-grpc-route.0.http
+      key: default/multi-rule-grpc-route.0.grpc.http
       listenerKey: default/test-gateway.http
       matches:
       - path:
@@ -63,7 +63,7 @@ output:
         weight: 1
       hostnames:
       - grpc.example.com
-      key: default/multi-rule-grpc-route.1.http
+      key: default/multi-rule-grpc-route.1.grpc.http
       listenerKey: default/test-gateway.http
       matches:
       - path:

--- a/controller/pkg/agentgateway/translator/testdata/routes/simple-grpc-route.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/routes/simple-grpc-route.yaml
@@ -33,7 +33,7 @@ output:
         weight: 1
       hostnames:
       - grpc.example.com
-      key: default/test-grpc-route.0.http
+      key: default/test-grpc-route.0.grpc.http
       listenerKey: default/test-gateway.http
       matches:
       - path:

--- a/controller/pkg/agentgateway/translator/testdata/routes/two-routes-same-gateway.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/routes/two-routes-same-gateway.yaml
@@ -52,7 +52,7 @@ output:
         weight: 1
       hostnames:
       - example.com
-      key: default/test-route-1.0.0.http
+      key: default/test-route-1.0.http
       listenerKey: default/test-gateway.http
       matches:
       - path:
@@ -75,7 +75,7 @@ output:
         weight: 1
       hostnames:
       - example2.com
-      key: default/test-route-2.0.0.http
+      key: default/test-route-2.0.http
       listenerKey: default/test-gateway.http
       matches:
       - path:


### PR DESCRIPTION
This is an Istio-ism that is not relevant to AGW. its much more
efficient to join them.
