### PR TITLE
Use configured trust domain for XDS workloads when not set

### DIFF
--- a/crates/agentgateway/src/state_manager.rs
+++ b/crates/agentgateway/src/state_manager.rs
@@ -35,7 +35,8 @@ impl StateManager {
 		awaiting_ready: tokio::sync::watch::Sender<()>,
 	) -> anyhow::Result<Self> {
 		let xds = &config.xds;
-		let stores = Stores::with_ipv6_enabled(config.ipv6_enabled);
+		let discovery_defaults = crate::types::discovery::DiscoveryDefaults::from_config(&config);
+		let stores = Stores::new(config.ipv6_enabled, discovery_defaults);
 		let xds_client = if let Some(addr) = &xds.address {
 			let connector = control::grpc_connector(
 				client.clone(),

--- a/crates/agentgateway/src/store/mod.rs
+++ b/crates/agentgateway/src/store/mod.rs
@@ -2,6 +2,8 @@ mod binds;
 
 use std::sync::Arc;
 
+use agent_core::prelude::*;
+
 pub use binds::{
 	BackendPolicies, FrontendPolices, GatewayPolicies, LLMRequestPolicies, LLMResponsePolicies,
 	RoutePath, RoutePolicies, Store as BindStore,
@@ -10,12 +12,12 @@ use serde::{Serialize, Serializer};
 mod discovery;
 use std::sync::RwLock;
 
+use crate::store;
+use crate::types::discovery::DiscoveryDefaults;
 pub use binds::PreviousState as BindPreviousState;
 pub use discovery::{
 	LocalWorkload, PreviousState as DiscoveryPreviousState, Store as DiscoveryStore, WorkloadStore,
 };
-
-use crate::store;
 
 #[derive(Clone, Debug)]
 pub enum Event<T> {
@@ -37,8 +39,12 @@ impl Default for Stores {
 
 impl Stores {
 	pub fn with_ipv6_enabled(ipv6_enabled: bool) -> Stores {
+		Stores::new(ipv6_enabled, DiscoveryDefaults::default())
+	}
+
+	pub fn new(ipv6_enabled: bool, discovery_defaults: DiscoveryDefaults) -> Stores {
 		Stores {
-			discovery: discovery::StoreUpdater::new(Arc::new(RwLock::new(discovery::Store::new()))),
+			discovery: discovery::StoreUpdater::with_defaults(discovery_defaults),
 			binds: binds::StoreUpdater::new(Arc::new(RwLock::new(binds::Store::with_ipv6_enabled(
 				ipv6_enabled,
 			)))),


### PR DESCRIPTION
When XDS returns a Workload without a trustDomain, it's currently using `cluster.local` as the default.
This PR uses the one configured in `AgentgatewayParameters`'s `spec.ca` instead (if specified).

E.g.:
```yaml
apiVersion: agentgateway.dev/v1alpha1
kind: AgentgatewayParameters
metadata:
  name: agwp
  namespace: default
spec:
  ca:
    trustDomain: cluster.example
```