### PR TITLE
fix: Overlays can delete map elements with 'null'

### DIFF
--- a/controller/api/v1alpha1/shared/overlay_types.go
+++ b/controller/api/v1alpha1/shared/overlay_types.go
@@ -7,16 +7,18 @@ type ObjectMetadata struct {
 	// Map of string keys and values that can be used to organize and categorize
 	// (scope and select) objects. May match selectors of replication controllers
 	// and services.
+	// A null value signals deletion of that key from the target object's labels.
 	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
 	// +optional
-	Labels map[string]string `json:"labels,omitempty"`
+	Labels map[string]*string `json:"labels,omitempty"`
 
 	// Annotations is an unstructured key value map stored with a resource that may be
 	// set by external tools to store and retrieve arbitrary metadata. They are not
 	// queryable and should be preserved when modifying objects.
+	// A null value signals deletion of that key from the target object's annotations.
 	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
 	// +optional
-	Annotations map[string]string `json:"annotations,omitempty"`
+	Annotations map[string]*string `json:"annotations,omitempty"`
 }
 
 // KubernetesResourceOverlay provides a mechanism to customize generated

--- a/controller/api/v1alpha1/shared/zz_generated.deepcopy.go
+++ b/controller/api/v1alpha1/shared/zz_generated.deepcopy.go
@@ -200,16 +200,34 @@ func (in *ObjectMetadata) DeepCopyInto(out *ObjectMetadata) {
 	*out = *in
 	if in.Labels != nil {
 		in, out := &in.Labels, &out.Labels
-		*out = make(map[string]string, len(*in))
+		*out = make(map[string]*string, len(*in))
 		for key, val := range *in {
-			(*out)[key] = val
+			var outVal *string
+			if val == nil {
+				(*out)[key] = nil
+			} else {
+				inVal := (*in)[key]
+				in, out := &inVal, &outVal
+				*out = new(string)
+				**out = **in
+			}
+			(*out)[key] = outVal
 		}
 	}
 	if in.Annotations != nil {
 		in, out := &in.Annotations, &out.Annotations
-		*out = make(map[string]string, len(*in))
+		*out = make(map[string]*string, len(*in))
 		for key, val := range *in {
-			(*out)[key] = val
+			var outVal *string
+			if val == nil {
+				(*out)[key] = nil
+			} else {
+				inVal := (*in)[key]
+				in, out := &inVal, &outVal
+				*out = new(string)
+				**out = **in
+			}
+			(*out)[key] = outVal
 		}
 	}
 }

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewayparameters.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewayparameters.yaml
@@ -73,6 +73,7 @@ spec:
                           Annotations is an unstructured key value map stored with a resource that may be
                           set by external tools to store and retrieve arbitrary metadata. They are not
                           queryable and should be preserved when modifying objects.
+                          A null value signals deletion of that key from the target object's annotations.
                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
                         type: object
                       labels:
@@ -82,6 +83,7 @@ spec:
                           Map of string keys and values that can be used to organize and categorize
                           (scope and select) objects. May match selectors of replication controllers
                           and services.
+                          A null value signals deletion of that key from the target object's labels.
                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
                         type: object
                     type: object
@@ -325,6 +327,7 @@ spec:
                           Annotations is an unstructured key value map stored with a resource that may be
                           set by external tools to store and retrieve arbitrary metadata. They are not
                           queryable and should be preserved when modifying objects.
+                          A null value signals deletion of that key from the target object's annotations.
                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
                         type: object
                       labels:
@@ -334,6 +337,7 @@ spec:
                           Map of string keys and values that can be used to organize and categorize
                           (scope and select) objects. May match selectors of replication controllers
                           and services.
+                          A null value signals deletion of that key from the target object's labels.
                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
                         type: object
                     type: object
@@ -466,6 +470,7 @@ spec:
                           Annotations is an unstructured key value map stored with a resource that may be
                           set by external tools to store and retrieve arbitrary metadata. They are not
                           queryable and should be preserved when modifying objects.
+                          A null value signals deletion of that key from the target object's annotations.
                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
                         type: object
                       labels:
@@ -475,6 +480,7 @@ spec:
                           Map of string keys and values that can be used to organize and categorize
                           (scope and select) objects. May match selectors of replication controllers
                           and services.
+                          A null value signals deletion of that key from the target object's labels.
                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
                         type: object
                     type: object
@@ -626,6 +632,7 @@ spec:
                           Annotations is an unstructured key value map stored with a resource that may be
                           set by external tools to store and retrieve arbitrary metadata. They are not
                           queryable and should be preserved when modifying objects.
+                          A null value signals deletion of that key from the target object's annotations.
                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
                         type: object
                       labels:
@@ -635,6 +642,7 @@ spec:
                           Map of string keys and values that can be used to organize and categorize
                           (scope and select) objects. May match selectors of replication controllers
                           and services.
+                          A null value signals deletion of that key from the target object's labels.
                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
                         type: object
                     type: object
@@ -709,6 +717,7 @@ spec:
                           Annotations is an unstructured key value map stored with a resource that may be
                           set by external tools to store and retrieve arbitrary metadata. They are not
                           queryable and should be preserved when modifying objects.
+                          A null value signals deletion of that key from the target object's annotations.
                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
                         type: object
                       labels:
@@ -718,6 +727,7 @@ spec:
                           Map of string keys and values that can be used to organize and categorize
                           (scope and select) objects. May match selectors of replication controllers
                           and services.
+                          A null value signals deletion of that key from the target object's labels.
                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
                         type: object
                     type: object

--- a/controller/pkg/deployer/strategicpatch/strategicpatch.go
+++ b/controller/pkg/deployer/strategicpatch/strategicpatch.go
@@ -136,73 +136,88 @@ func (a *OverlayApplier) ApplyOverlays(objs []client.Object) ([]client.Object, e
 	return objs, nil
 }
 
-// applyOverlay applies a KubernetesResourceOverlay to a single object.
+// applyOverlay applies a KubernetesResourceOverlay to a single object using
+// a unified strategic merge patch. Both metadata (labels/annotations) and spec
+// overlays are combined into a single SMP patch and applied atomically.
 func applyOverlay(obj client.Object, overlay *shared.KubernetesResourceOverlay, gvk schema.GroupVersionKind) (client.Object, error) {
-	// Apply metadata first
+	patch := make(map[string]json.RawMessage)
+
 	if overlay.Metadata != nil {
-		if overlay.Metadata.Labels != nil {
-			existingLabels := obj.GetLabels()
-			if existingLabels == nil {
-				existingLabels = make(map[string]string)
+		metaPatch := buildMetadataPatch(overlay.Metadata)
+		if metaPatch != nil {
+			metaBytes, err := json.Marshal(metaPatch)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal metadata patch: %w", err)
 			}
-			maps.Copy(existingLabels, overlay.Metadata.Labels)
-			obj.SetLabels(existingLabels)
-		}
-		if overlay.Metadata.Annotations != nil {
-			existingAnnotations := obj.GetAnnotations()
-			if existingAnnotations == nil {
-				existingAnnotations = make(map[string]string)
-			}
-			maps.Copy(existingAnnotations, overlay.Metadata.Annotations)
-			obj.SetAnnotations(existingAnnotations)
+			patch["metadata"] = metaBytes
 		}
 	}
 
-	// Apply spec overlay using strategic merge patch if present
 	if overlay.Spec != nil && len(overlay.Spec.Raw) > 0 {
-		return applySpecOverlay(obj, overlay.Spec.Raw, gvk)
+		patch["spec"] = overlay.Spec.Raw
 	}
 
-	return obj, nil
-}
+	if len(patch) == 0 {
+		return obj, nil
+	}
 
-// applySpecOverlay applies a spec overlay using strategic merge patch semantics.
-func applySpecOverlay(obj client.Object, patchBytes []byte, gvk schema.GroupVersionKind) (client.Object, error) {
-	// Get the schema for strategic merge patch
 	dataObj, err := getDataObjectForGVK(gvk)
 	if err != nil {
 		return nil, fmt.Errorf("unsupported kind %s for strategic merge patch: %w", gvk.Kind, err)
 	}
 
-	// Serialize the original object to JSON
 	originalBytes, err := json.Marshal(obj)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal original object: %w", err)
 	}
 
-	// The patch from the user is for the spec field, but strategic merge patch
-	// expects the full object structure. Wrap the patch in a spec field.
-	wrappedPatch := map[string]json.RawMessage{
-		"spec": patchBytes,
-	}
-	wrappedPatchBytes, err := json.Marshal(wrappedPatch)
+	patchBytes, err := json.Marshal(patch)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal wrapped patch: %w", err)
+		return nil, fmt.Errorf("failed to marshal patch: %w", err)
 	}
 
-	// Apply strategic merge patch
-	patchedBytes, err := strategicpatch.StrategicMergePatch(originalBytes, wrappedPatchBytes, dataObj)
+	patchedBytes, err := strategicpatch.StrategicMergePatch(originalBytes, patchBytes, dataObj)
 	if err != nil {
 		return nil, fmt.Errorf("failed to apply strategic merge patch: %w", err)
 	}
 
-	// Deserialize back to the object
 	patchedObj, err := deserializeToObject(patchedBytes, gvk)
 	if err != nil {
 		return nil, fmt.Errorf("failed to deserialize patched object: %w", err)
 	}
 
 	return patchedObj, nil
+}
+
+// buildMetadataPatch converts ObjectMetadata into a JSON-compatible map where
+// empty string values become nil (JSON null). This is needed because YAML null
+// deserializes to "" in map[string]string, and SMP uses null to delete map keys.
+func buildMetadataPatch(meta *shared.ObjectMetadata) map[string]any {
+	result := make(map[string]any)
+	if meta.Labels != nil {
+		result["labels"] = stringMapToNullable(meta.Labels)
+	}
+	if meta.Annotations != nil {
+		result["annotations"] = stringMapToNullable(meta.Annotations)
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}
+
+// stringMapToNullable converts a map[string]string to map[string]any where
+// empty string values become nil (JSON null), enabling key deletion via SMP.
+func stringMapToNullable(m map[string]string) map[string]any {
+	result := make(map[string]any, len(m))
+	for k, v := range m {
+		if v == "" {
+			result[k] = nil
+		} else {
+			result[k] = v
+		}
+	}
+	return result
 }
 
 // getDataObjectForGVK returns an empty object of the appropriate type for strategic merge patch.
@@ -251,6 +266,23 @@ func deserializeToObject(data []byte, gvk schema.GroupVersionKind) (client.Objec
 	clientObj.GetObjectKind().SetGroupVersionKind(gvk)
 
 	return clientObj, nil
+}
+
+// mergeMetadataMap merges overlay values into existing metadata.
+// Empty string values in the overlay cause the key to be deleted
+// since YAML null deserializes to "" in map[string]string.
+func mergeMetadataMap(existing, overlay map[string]string) map[string]string {
+	if existing == nil {
+		existing = make(map[string]string)
+	}
+	for k, v := range overlay {
+		if v == "" {
+			delete(existing, k)
+		} else {
+			existing[k] = v
+		}
+	}
+	return existing
 }
 
 // createPodDisruptionBudget creates a PodDisruptionBudget for the given Deployment
@@ -338,20 +370,10 @@ func createVerticalPodAutoscaler(deployment *appsv1.Deployment, overlay *shared.
 	// Apply the overlay - for VPA we need to handle it specially since it's unstructured
 	if overlay.Metadata != nil {
 		if overlay.Metadata.Labels != nil {
-			existingLabels := vpa.GetLabels()
-			if existingLabels == nil {
-				existingLabels = make(map[string]string)
-			}
-			maps.Copy(existingLabels, overlay.Metadata.Labels)
-			vpa.SetLabels(existingLabels)
+			vpa.SetLabels(mergeMetadataMap(vpa.GetLabels(), overlay.Metadata.Labels))
 		}
 		if overlay.Metadata.Annotations != nil {
-			existingAnnotations := vpa.GetAnnotations()
-			if existingAnnotations == nil {
-				existingAnnotations = make(map[string]string)
-			}
-			maps.Copy(existingAnnotations, overlay.Metadata.Annotations)
-			vpa.SetAnnotations(existingAnnotations)
+			vpa.SetAnnotations(mergeMetadataMap(vpa.GetAnnotations(), overlay.Metadata.Annotations))
 		}
 	}
 

--- a/controller/pkg/deployer/strategicpatch/strategicpatch_test.go
+++ b/controller/pkg/deployer/strategicpatch/strategicpatch_test.go
@@ -41,8 +41,8 @@ func TestOverlayApplier_ApplyOverlays_MetadataLabels(t *testing.T) {
 			AgentgatewayParametersOverlays: agentgateway.AgentgatewayParametersOverlays{
 				Deployment: &shared.KubernetesResourceOverlay{
 					Metadata: &shared.ObjectMetadata{
-						Labels: map[string]string{
-							"custom-label": "custom-value",
+						Labels: map[string]*string{
+							"custom-label": ptr.To("custom-value"),
 						},
 					},
 				},
@@ -74,16 +74,15 @@ func TestOverlayApplier_ApplyOverlays_MetadataLabels(t *testing.T) {
 }
 
 func TestOverlayApplier_ApplyOverlays_MetadataLabelDeletion(t *testing.T) {
-	// Empty string values in overlay labels should delete existing keys.
-	// This is how YAML null is represented in map[string]string.
+	// Nil pointer values in overlay labels should delete existing keys.
 	params := &agentgateway.AgentgatewayParameters{
 		Spec: agentgateway.AgentgatewayParametersSpec{
 			AgentgatewayParametersOverlays: agentgateway.AgentgatewayParametersOverlays{
 				Deployment: &shared.KubernetesResourceOverlay{
 					Metadata: &shared.ObjectMetadata{
-						Labels: map[string]string{
-							"label-to-delete": "",
-							"new-label":       "new-value",
+						Labels: map[string]*string{
+							"label-to-delete": nil,
+							"new-label":       ptr.To("new-value"),
 						},
 					},
 				},
@@ -111,7 +110,7 @@ func TestOverlayApplier_ApplyOverlays_MetadataLabelDeletion(t *testing.T) {
 	require.NoError(t, err)
 
 	result := objs[0].(*appsv1.Deployment)
-	assert.NotContains(t, result.Labels, "label-to-delete", "empty string overlay value should delete the label")
+	assert.NotContains(t, result.Labels, "label-to-delete", "nil overlay value should delete the label")
 	assert.Equal(t, "keep-value", result.Labels["label-to-keep"], "unaffected labels should remain")
 	assert.Equal(t, "new-value", result.Labels["new-label"], "new labels should be added")
 }
@@ -122,8 +121,8 @@ func TestOverlayApplier_ApplyOverlays_MetadataAnnotations(t *testing.T) {
 			AgentgatewayParametersOverlays: agentgateway.AgentgatewayParametersOverlays{
 				Service: &shared.KubernetesResourceOverlay{
 					Metadata: &shared.ObjectMetadata{
-						Annotations: map[string]string{
-							"custom-annotation": "custom-value",
+						Annotations: map[string]*string{
+							"custom-annotation": ptr.To("custom-value"),
 						},
 					},
 				},
@@ -315,17 +314,17 @@ func TestOverlayApplier_ApplyOverlays_MultipleObjects(t *testing.T) {
 			AgentgatewayParametersOverlays: agentgateway.AgentgatewayParametersOverlays{
 				Deployment: &shared.KubernetesResourceOverlay{
 					Metadata: &shared.ObjectMetadata{
-						Labels: map[string]string{"app": "modified"},
+						Labels: map[string]*string{"app": ptr.To("modified")},
 					},
 				},
 				Service: &shared.KubernetesResourceOverlay{
 					Metadata: &shared.ObjectMetadata{
-						Labels: map[string]string{"svc": "modified"},
+						Labels: map[string]*string{"svc": ptr.To("modified")},
 					},
 				},
 				ServiceAccount: &shared.KubernetesResourceOverlay{
 					Metadata: &shared.ObjectMetadata{
-						Labels: map[string]string{"sa": "modified"},
+						Labels: map[string]*string{"sa": ptr.To("modified")},
 					},
 				},
 			},

--- a/controller/pkg/kgateway/deployer/agentgateway_parameters_test.go
+++ b/controller/pkg/kgateway/deployer/agentgateway_parameters_test.go
@@ -108,8 +108,8 @@ func TestAgentgatewayParametersApplier_ApplyOverlaysToObjects(t *testing.T) {
 			AgentgatewayParametersOverlays: agentgateway.AgentgatewayParametersOverlays{
 				Deployment: &shared.KubernetesResourceOverlay{
 					Metadata: &shared.ObjectMetadata{
-						Labels: map[string]string{
-							"overlay-label": "overlay-value",
+						Labels: map[string]*string{
+							"overlay-label": ptr.To("overlay-value"),
 						},
 					},
 					Spec: &apiextensionsv1.JSON{Raw: specPatch},

--- a/controller/test/deployer/internal_helm_test.go
+++ b/controller/test/deployer/internal_helm_test.go
@@ -237,9 +237,14 @@ wIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQBtestcertdata
 				assert.Contains(t, outputYaml, "service-overlay-annotation: from-overlay",
 					"service annotation from overlay should be present")
 
-				// Label nulled to empty string
-				assert.Contains(t, outputYaml, `app.kubernetes.io/managed-by: ""`,
-					"label should be nulled to empty string")
+				// Label removed from Deployment via null value in overlay.
+				// Verify managed-by is absent from the Deployment labels by checking
+				// that instance is immediately followed by name (no managed-by between them).
+				// This substring only appears in the Deployment section (other resources
+				// still have managed-by between these labels).
+				assert.Contains(t, outputYaml,
+					"app.kubernetes.io/instance: gw\n    app.kubernetes.io/name: gw\n    app.kubernetes.io/version: 1.0.0-ci1\n    deployment-overlay-label1",
+					"managed-by label should be removed from Deployment via null overlay")
 
 				// Volume mount added via merge
 				assert.Contains(t, outputYaml, "mountPath: /etc/custom-config",

--- a/controller/test/deployer/testdata/agentgateway-sa-iam-annotations-out.yaml
+++ b/controller/test/deployer/testdata/agentgateway-sa-iam-annotations-out.yaml
@@ -60,7 +60,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app.kubernetes.io/instance: ""
     app.kubernetes.io/managed-by: kgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1

--- a/controller/test/deployer/testdata/agentgateway-strategic-merge-patch-out.yaml
+++ b/controller/test/deployer/testdata/agentgateway-strategic-merge-patch-out.yaml
@@ -67,7 +67,6 @@ metadata:
     deployment-overlay-annotation: from-overlay
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: ""
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     deployment-overlay-label1: from-overlay


### PR DESCRIPTION
Fixes a TODO:
```
    metadata:
      labels:
        # You'd think this would remove the app.kubernetes.io/instance label,
        # but it just sets the label to the empty string. TODO(chandler):
        # Figure out the incantation to cause removal of the label.
        app.kubernetes.io/instance: null
```