### PR TITLE
client: do not swallow logs from Body

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /target
 .vscode
 .idea
+.run
 .DS_Store
 .venv
 *.local


### PR DESCRIPTION
Have had 2 issues of 'error from body', this makes them visible.
