### PR TITLE
Revert "fix: Overlays can delete map elements with 'null'"

### DIFF
--- a/controller/api/v1alpha1/shared/overlay_types.go
+++ b/controller/api/v1alpha1/shared/overlay_types.go
@@ -7,18 +7,16 @@ type ObjectMetadata struct {
 	// Map of string keys and values that can be used to organize and categorize
 	// (scope and select) objects. May match selectors of replication controllers
 	// and services.
-	// A null value signals deletion of that key from the target object's labels.
 	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
 	// +optional
-	Labels map[string]*string `json:"labels,omitempty"`
+	Labels map[string]string `json:"labels,omitempty"`
 
 	// Annotations is an unstructured key value map stored with a resource that may be
 	// set by external tools to store and retrieve arbitrary metadata. They are not
 	// queryable and should be preserved when modifying objects.
-	// A null value signals deletion of that key from the target object's annotations.
 	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
 	// +optional
-	Annotations map[string]*string `json:"annotations,omitempty"`
+	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
 // KubernetesResourceOverlay provides a mechanism to customize generated

--- a/controller/api/v1alpha1/shared/zz_generated.deepcopy.go
+++ b/controller/api/v1alpha1/shared/zz_generated.deepcopy.go
@@ -200,34 +200,16 @@ func (in *ObjectMetadata) DeepCopyInto(out *ObjectMetadata) {
 	*out = *in
 	if in.Labels != nil {
 		in, out := &in.Labels, &out.Labels
-		*out = make(map[string]*string, len(*in))
+		*out = make(map[string]string, len(*in))
 		for key, val := range *in {
-			var outVal *string
-			if val == nil {
-				(*out)[key] = nil
-			} else {
-				inVal := (*in)[key]
-				in, out := &inVal, &outVal
-				*out = new(string)
-				**out = **in
-			}
-			(*out)[key] = outVal
+			(*out)[key] = val
 		}
 	}
 	if in.Annotations != nil {
 		in, out := &in.Annotations, &out.Annotations
-		*out = make(map[string]*string, len(*in))
+		*out = make(map[string]string, len(*in))
 		for key, val := range *in {
-			var outVal *string
-			if val == nil {
-				(*out)[key] = nil
-			} else {
-				inVal := (*in)[key]
-				in, out := &inVal, &outVal
-				*out = new(string)
-				**out = **in
-			}
-			(*out)[key] = outVal
+			(*out)[key] = val
 		}
 	}
 }

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewayparameters.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewayparameters.yaml
@@ -73,7 +73,6 @@ spec:
                           Annotations is an unstructured key value map stored with a resource that may be
                           set by external tools to store and retrieve arbitrary metadata. They are not
                           queryable and should be preserved when modifying objects.
-                          A null value signals deletion of that key from the target object's annotations.
                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
                         type: object
                       labels:
@@ -83,7 +82,6 @@ spec:
                           Map of string keys and values that can be used to organize and categorize
                           (scope and select) objects. May match selectors of replication controllers
                           and services.
-                          A null value signals deletion of that key from the target object's labels.
                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
                         type: object
                     type: object
@@ -327,7 +325,6 @@ spec:
                           Annotations is an unstructured key value map stored with a resource that may be
                           set by external tools to store and retrieve arbitrary metadata. They are not
                           queryable and should be preserved when modifying objects.
-                          A null value signals deletion of that key from the target object's annotations.
                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
                         type: object
                       labels:
@@ -337,7 +334,6 @@ spec:
                           Map of string keys and values that can be used to organize and categorize
                           (scope and select) objects. May match selectors of replication controllers
                           and services.
-                          A null value signals deletion of that key from the target object's labels.
                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
                         type: object
                     type: object
@@ -470,7 +466,6 @@ spec:
                           Annotations is an unstructured key value map stored with a resource that may be
                           set by external tools to store and retrieve arbitrary metadata. They are not
                           queryable and should be preserved when modifying objects.
-                          A null value signals deletion of that key from the target object's annotations.
                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
                         type: object
                       labels:
@@ -480,7 +475,6 @@ spec:
                           Map of string keys and values that can be used to organize and categorize
                           (scope and select) objects. May match selectors of replication controllers
                           and services.
-                          A null value signals deletion of that key from the target object's labels.
                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
                         type: object
                     type: object
@@ -632,7 +626,6 @@ spec:
                           Annotations is an unstructured key value map stored with a resource that may be
                           set by external tools to store and retrieve arbitrary metadata. They are not
                           queryable and should be preserved when modifying objects.
-                          A null value signals deletion of that key from the target object's annotations.
                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
                         type: object
                       labels:
@@ -642,7 +635,6 @@ spec:
                           Map of string keys and values that can be used to organize and categorize
                           (scope and select) objects. May match selectors of replication controllers
                           and services.
-                          A null value signals deletion of that key from the target object's labels.
                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
                         type: object
                     type: object
@@ -717,7 +709,6 @@ spec:
                           Annotations is an unstructured key value map stored with a resource that may be
                           set by external tools to store and retrieve arbitrary metadata. They are not
                           queryable and should be preserved when modifying objects.
-                          A null value signals deletion of that key from the target object's annotations.
                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
                         type: object
                       labels:
@@ -727,7 +718,6 @@ spec:
                           Map of string keys and values that can be used to organize and categorize
                           (scope and select) objects. May match selectors of replication controllers
                           and services.
-                          A null value signals deletion of that key from the target object's labels.
                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
                         type: object
                     type: object

--- a/controller/pkg/deployer/strategicpatch/strategicpatch_test.go
+++ b/controller/pkg/deployer/strategicpatch/strategicpatch_test.go
@@ -41,8 +41,8 @@ func TestOverlayApplier_ApplyOverlays_MetadataLabels(t *testing.T) {
 			AgentgatewayParametersOverlays: agentgateway.AgentgatewayParametersOverlays{
 				Deployment: &shared.KubernetesResourceOverlay{
 					Metadata: &shared.ObjectMetadata{
-						Labels: map[string]*string{
-							"custom-label": ptr.To("custom-value"),
+						Labels: map[string]string{
+							"custom-label": "custom-value",
 						},
 					},
 				},
@@ -73,56 +73,14 @@ func TestOverlayApplier_ApplyOverlays_MetadataLabels(t *testing.T) {
 	assert.Equal(t, "existing-value", result.Labels["existing-label"])
 }
 
-func TestOverlayApplier_ApplyOverlays_MetadataLabelDeletion(t *testing.T) {
-	// Nil pointer values in overlay labels should delete existing keys.
-	params := &agentgateway.AgentgatewayParameters{
-		Spec: agentgateway.AgentgatewayParametersSpec{
-			AgentgatewayParametersOverlays: agentgateway.AgentgatewayParametersOverlays{
-				Deployment: &shared.KubernetesResourceOverlay{
-					Metadata: &shared.ObjectMetadata{
-						Labels: map[string]*string{
-							"label-to-delete": nil,
-							"new-label":       ptr.To("new-value"),
-						},
-					},
-				},
-			},
-		},
-	}
-
-	applier := NewOverlayApplier(params)
-	deployment := &appsv1.Deployment{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "apps/v1",
-			Kind:       "Deployment",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-deployment",
-			Labels: map[string]string{
-				"label-to-delete": "old-value",
-				"label-to-keep":   "keep-value",
-			},
-		},
-	}
-	objs := []client.Object{deployment}
-
-	objs, err := applier.ApplyOverlays(objs)
-	require.NoError(t, err)
-
-	result := objs[0].(*appsv1.Deployment)
-	assert.NotContains(t, result.Labels, "label-to-delete", "nil overlay value should delete the label")
-	assert.Equal(t, "keep-value", result.Labels["label-to-keep"], "unaffected labels should remain")
-	assert.Equal(t, "new-value", result.Labels["new-label"], "new labels should be added")
-}
-
 func TestOverlayApplier_ApplyOverlays_MetadataAnnotations(t *testing.T) {
 	params := &agentgateway.AgentgatewayParameters{
 		Spec: agentgateway.AgentgatewayParametersSpec{
 			AgentgatewayParametersOverlays: agentgateway.AgentgatewayParametersOverlays{
 				Service: &shared.KubernetesResourceOverlay{
 					Metadata: &shared.ObjectMetadata{
-						Annotations: map[string]*string{
-							"custom-annotation": ptr.To("custom-value"),
+						Annotations: map[string]string{
+							"custom-annotation": "custom-value",
 						},
 					},
 				},
@@ -314,17 +272,17 @@ func TestOverlayApplier_ApplyOverlays_MultipleObjects(t *testing.T) {
 			AgentgatewayParametersOverlays: agentgateway.AgentgatewayParametersOverlays{
 				Deployment: &shared.KubernetesResourceOverlay{
 					Metadata: &shared.ObjectMetadata{
-						Labels: map[string]*string{"app": ptr.To("modified")},
+						Labels: map[string]string{"app": "modified"},
 					},
 				},
 				Service: &shared.KubernetesResourceOverlay{
 					Metadata: &shared.ObjectMetadata{
-						Labels: map[string]*string{"svc": ptr.To("modified")},
+						Labels: map[string]string{"svc": "modified"},
 					},
 				},
 				ServiceAccount: &shared.KubernetesResourceOverlay{
 					Metadata: &shared.ObjectMetadata{
-						Labels: map[string]*string{"sa": ptr.To("modified")},
+						Labels: map[string]string{"sa": "modified"},
 					},
 				},
 			},

--- a/controller/pkg/kgateway/deployer/agentgateway_parameters_test.go
+++ b/controller/pkg/kgateway/deployer/agentgateway_parameters_test.go
@@ -108,8 +108,8 @@ func TestAgentgatewayParametersApplier_ApplyOverlaysToObjects(t *testing.T) {
 			AgentgatewayParametersOverlays: agentgateway.AgentgatewayParametersOverlays{
 				Deployment: &shared.KubernetesResourceOverlay{
 					Metadata: &shared.ObjectMetadata{
-						Labels: map[string]*string{
-							"overlay-label": ptr.To("overlay-value"),
+						Labels: map[string]string{
+							"overlay-label": "overlay-value",
 						},
 					},
 					Spec: &apiextensionsv1.JSON{Raw: specPatch},

--- a/controller/test/deployer/internal_helm_test.go
+++ b/controller/test/deployer/internal_helm_test.go
@@ -237,14 +237,9 @@ wIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQBtestcertdata
 				assert.Contains(t, outputYaml, "service-overlay-annotation: from-overlay",
 					"service annotation from overlay should be present")
 
-				// Label removed from Deployment via null value in overlay.
-				// Verify managed-by is absent from the Deployment labels by checking
-				// that instance is immediately followed by name (no managed-by between them).
-				// This substring only appears in the Deployment section (other resources
-				// still have managed-by between these labels).
-				assert.Contains(t, outputYaml,
-					"app.kubernetes.io/instance: gw\n    app.kubernetes.io/name: gw\n    app.kubernetes.io/version: 1.0.0-ci1\n    deployment-overlay-label1",
-					"managed-by label should be removed from Deployment via null overlay")
+				// Label nulled to empty string
+				assert.Contains(t, outputYaml, `app.kubernetes.io/managed-by: ""`,
+					"label should be nulled to empty string")
 
 				// Volume mount added via merge
 				assert.Contains(t, outputYaml, "mountPath: /etc/custom-config",

--- a/controller/test/deployer/testdata/agentgateway-sa-iam-annotations-out.yaml
+++ b/controller/test/deployer/testdata/agentgateway-sa-iam-annotations-out.yaml
@@ -60,6 +60,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
+    app.kubernetes.io/instance: ""
     app.kubernetes.io/managed-by: kgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1

--- a/controller/test/deployer/testdata/agentgateway-strategic-merge-patch-out.yaml
+++ b/controller/test/deployer/testdata/agentgateway-strategic-merge-patch-out.yaml
@@ -67,6 +67,7 @@ metadata:
     deployment-overlay-annotation: from-overlay
   labels:
     app.kubernetes.io/instance: gw
+    app.kubernetes.io/managed-by: ""
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     deployment-overlay-label1: from-overlay


### PR DESCRIPTION
Reverts agentgateway/agentgateway#1065 because the unittests didn't use a real k8s API server. A real k8s rejects any CRD that attempts to use a null map value, and you cannot easily change the CRD because controller-tools is opinionated about that. I don't want to add new 'remove' APIs for this edge case or kustomize a CRD.