### PR TITLE
Copy tcp routes when inserting listener

### DIFF
--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -887,8 +887,10 @@ impl Store {
 			let mut bind = Arc::unwrap_or_clone(b.clone());
 			// If this is a listener update, copy things over
 			if let Some(old) = bind.listeners.remove(&lis.key) {
-				debug!("listener update, copy old routes over");
-				lis.routes = Arc::unwrap_or_clone(old).routes;
+				debug!("listener update, copy old routes and tcp routes over");
+				let old = Arc::unwrap_or_clone(old);
+				lis.routes = old.routes;
+				lis.tcp_routes = old.tcp_routes;
 			}
 			// Insert any staged routes
 			for (k, v) in self.staged_routes.remove(&lis.key).into_iter().flatten() {


### PR DESCRIPTION
This addresses the issue with tcp routes disappearing from the existing listeners on every xDS reconnection, when used in congestion with https://github.com/kgateway-dev/kgateway/ operator.

I'm not 100% sure why routes are copied here in the first place, since in case of xDS `insert_route` and `insert_tcp_route` will be called as well, but maybe there're other use-cases I'm not aware of. Overall this seems racy, but I'm just going with the flow for now.