### PR TITLE
Better support for policies when connecting to policy backends

### DIFF
--- a/api/resource.pb.go
+++ b/api/resource.pb.go
@@ -7008,7 +7008,6 @@ type TrafficPolicySpec_ExternalAuth struct {
 	StatusOnError         *uint32                                     `protobuf:"varint,5,opt,name=status_on_error,json=statusOnError,proto3,oneof" json:"status_on_error,omitempty"`
 	IncludeRequestHeaders []string                                    `protobuf:"bytes,6,rep,name=include_request_headers,json=includeRequestHeaders,proto3" json:"include_request_headers,omitempty"`
 	IncludeRequestBody    *TrafficPolicySpec_ExternalAuth_BodyOptions `protobuf:"bytes,7,opt,name=include_request_body,json=includeRequestBody,proto3" json:"include_request_body,omitempty"`
-	Timeout               *durationpb.Duration                        `protobuf:"bytes,8,opt,name=timeout,proto3" json:"timeout,omitempty"`
 	unknownFields         protoimpl.UnknownFields
 	sizeCache             protoimpl.SizeCache
 }
@@ -7099,13 +7098,6 @@ func (x *TrafficPolicySpec_ExternalAuth) GetIncludeRequestHeaders() []string {
 func (x *TrafficPolicySpec_ExternalAuth) GetIncludeRequestBody() *TrafficPolicySpec_ExternalAuth_BodyOptions {
 	if x != nil {
 		return x.IncludeRequestBody
-	}
-	return nil
-}
-
-func (x *TrafficPolicySpec_ExternalAuth) GetTimeout() *durationpb.Duration {
-	if x != nil {
-		return x.Timeout
 	}
 	return nil
 }
@@ -10727,7 +10719,7 @@ const file_resource_proto_rawDesc = "" +
 	"\x05value\x18\x02 \x01(\tR\x05valueB\x06\n" +
 	"\x04kind\"?\n" +
 	"\x14JWTValidationOptions\x12'\n" +
-	"\x0frequired_claims\x18\x01 \x03(\tR\x0erequiredClaims\"\xee:\n" +
+	"\x0frequired_claims\x18\x01 \x03(\tR\x0erequiredClaims\"\xc8:\n" +
 	"\x11TrafficPolicySpec\x12N\n" +
 	"\x05phase\x18\x01 \x01(\x0e28.agentgateway.dev.resource.TrafficPolicySpec.PolicyPhaseR\x05phase\x12>\n" +
 	"\atimeout\x18\x02 \x01(\v2\".agentgateway.dev.resource.TimeoutH\x00R\atimeout\x128\n" +
@@ -10781,7 +10773,7 @@ const file_resource_proto_rawDesc = "" +
 	"\x04type\x18\x04 \x01(\x0e2@.agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit.TypeR\x04type\"\x1e\n" +
 	"\x04Type\x12\v\n" +
 	"\aREQUEST\x10\x00\x12\t\n" +
-	"\x05TOKEN\x10\x01\x1a\x85\x0e\n" +
+	"\x05TOKEN\x10\x01\x1a\xdf\r\n" +
 	"\fExternalAuth\x12C\n" +
 	"\x06target\x18\x01 \x01(\v2+.agentgateway.dev.resource.BackendReferenceR\x06target\x12\\\n" +
 	"\x04grpc\x18\x02 \x01(\v2F.agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocolH\x00R\x04grpc\x12\\\n" +
@@ -10789,8 +10781,7 @@ const file_resource_proto_rawDesc = "" +
 	"\ffailure_mode\x18\x04 \x01(\x0e2E.agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.FailureModeR\vfailureMode\x12+\n" +
 	"\x0fstatus_on_error\x18\x05 \x01(\rH\x01R\rstatusOnError\x88\x01\x01\x126\n" +
 	"\x17include_request_headers\x18\x06 \x03(\tR\x15includeRequestHeaders\x12w\n" +
-	"\x14include_request_body\x18\a \x01(\v2E.agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.BodyOptionsR\x12includeRequestBody\x123\n" +
-	"\atimeout\x18\b \x01(\v2\x19.google.protobuf.DurationR\atimeout\x1a\x91\x01\n" +
+	"\x14include_request_body\x18\a \x01(\v2E.agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.BodyOptionsR\x12includeRequestBody\x1a\x91\x01\n" +
 	"\vBodyOptions\x12*\n" +
 	"\x11max_request_bytes\x18\x01 \x01(\rR\x0fmaxRequestBytes\x122\n" +
 	"\x15allow_partial_message\x18\x02 \x01(\bR\x13allowPartialMessage\x12\"\n" +
@@ -10824,7 +10815,7 @@ const file_resource_proto_rawDesc = "" +
 	"\x10DENY_WITH_STATUS\x10\x02B\n" +
 	"\n" +
 	"\bprotocolB\x12\n" +
-	"\x10_status_on_error\x1a0\n" +
+	"\x10_status_on_errorJ\x04\b\b\x10\tR\atimeout\x1a0\n" +
 	"\x04RBAC\x12\x14\n" +
 	"\x05allow\x18\x01 \x03(\tR\x05allow\x12\x12\n" +
 	"\x04deny\x18\x02 \x03(\tR\x04deny\x1a\xd3\x01\n" +
@@ -11535,93 +11526,92 @@ var file_resource_proto_depIdxs = []int32{
 	114, // 137: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.http:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol
 	10,  // 138: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.failure_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.FailureMode
 	112, // 139: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.include_request_body:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.BodyOptions
-	166, // 140: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.timeout:type_name -> google.protobuf.Duration
-	70,  // 141: agentgateway.dev.resource.TrafficPolicySpec.JWTProvider.jwt_validation_options:type_name -> agentgateway.dev.resource.JWTValidationOptions
-	11,  // 142: agentgateway.dev.resource.TrafficPolicySpec.JWT.mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.JWT.Mode
-	100, // 143: agentgateway.dev.resource.TrafficPolicySpec.JWT.providers:type_name -> agentgateway.dev.resource.TrafficPolicySpec.JWTProvider
-	12,  // 144: agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication.mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication.Mode
-	119, // 145: agentgateway.dev.resource.TrafficPolicySpec.APIKey.api_keys:type_name -> agentgateway.dev.resource.TrafficPolicySpec.APIKey.User
-	13,  // 146: agentgateway.dev.resource.TrafficPolicySpec.APIKey.mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.APIKey.Mode
-	120, // 147: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.request:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform
-	120, // 148: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.response:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform
-	78,  // 149: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.target:type_name -> agentgateway.dev.resource.BackendReference
-	14,  // 150: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.failure_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.FailureMode
-	121, // 151: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.request_attributes:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.RequestAttributesEntry
-	122, // 152: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.response_attributes:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ResponseAttributesEntry
-	124, // 153: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.metadata_context:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.MetadataContextEntry
-	15,  // 154: agentgateway.dev.resource.TrafficPolicySpec.HostRewrite.mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HostRewrite.Mode
-	111, // 155: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor.entries:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Entry
-	7,   // 156: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor.type:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Type
-	115, // 157: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.context:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.ContextEntry
-	116, // 158: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.metadata:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.MetadataEntry
-	117, // 159: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.add_request_headers:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.AddRequestHeadersEntry
-	118, // 160: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.metadata:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.MetadataEntry
-	167, // 161: agentgateway.dev.resource.TrafficPolicySpec.APIKey.User.metadata:type_name -> google.protobuf.Struct
-	105, // 162: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.set:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HeaderTransformation
-	105, // 163: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.add:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HeaderTransformation
-	106, // 164: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.body:type_name -> agentgateway.dev.resource.TrafficPolicySpec.BodyTransformation
-	125, // 165: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext.context:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext.ContextEntry
-	123, // 166: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.MetadataContextEntry.value:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext
-	145, // 167: agentgateway.dev.resource.BackendPolicySpec.Ai.prompt_guard:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard
-	147, // 168: agentgateway.dev.resource.BackendPolicySpec.Ai.defaults:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.DefaultsEntry
-	148, // 169: agentgateway.dev.resource.BackendPolicySpec.Ai.overrides:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.OverridesEntry
-	149, // 170: agentgateway.dev.resource.BackendPolicySpec.Ai.transformations:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.TransformationsEntry
-	135, // 171: agentgateway.dev.resource.BackendPolicySpec.Ai.prompts:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment
-	150, // 172: agentgateway.dev.resource.BackendPolicySpec.Ai.model_aliases:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ModelAliasesEntry
-	146, // 173: agentgateway.dev.resource.BackendPolicySpec.Ai.prompt_caching:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptCaching
-	151, // 174: agentgateway.dev.resource.BackendPolicySpec.Ai.routes:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RoutesEntry
-	78,  // 175: agentgateway.dev.resource.BackendPolicySpec.InferenceRouting.endpoint_picker:type_name -> agentgateway.dev.resource.BackendReference
-	19,  // 176: agentgateway.dev.resource.BackendPolicySpec.InferenceRouting.failure_mode:type_name -> agentgateway.dev.resource.BackendPolicySpec.InferenceRouting.FailureMode
-	20,  // 177: agentgateway.dev.resource.BackendPolicySpec.BackendTLS.verification:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTLS.VerificationMode
-	79,  // 178: agentgateway.dev.resource.BackendPolicySpec.BackendTLS.alpn:type_name -> agentgateway.dev.resource.Alpn
-	21,  // 179: agentgateway.dev.resource.BackendPolicySpec.BackendHTTP.version:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendHTTP.HttpVersion
-	166, // 180: agentgateway.dev.resource.BackendPolicySpec.BackendHTTP.request_timeout:type_name -> google.protobuf.Duration
-	68,  // 181: agentgateway.dev.resource.BackendPolicySpec.BackendTCP.keepalive:type_name -> agentgateway.dev.resource.KeepaliveConfig
-	166, // 182: agentgateway.dev.resource.BackendPolicySpec.BackendTCP.connect_timeout:type_name -> google.protobuf.Duration
-	22,  // 183: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.provider:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.McpIDP
-	152, // 184: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.resource_metadata:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata
-	23,  // 185: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.mode:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.Mode
-	70,  // 186: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.jwt_validation_options:type_name -> agentgateway.dev.resource.JWTValidationOptions
-	134, // 187: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment.append:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Message
-	134, // 188: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment.prepend:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Message
-	16,  // 189: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRule.builtin:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.BuiltinRegexRule
-	17,  // 190: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules.action:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ActionKind
-	136, // 191: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules.rules:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRule
-	78,  // 192: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.backend:type_name -> agentgateway.dev.resource.BackendReference
-	58,  // 193: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.forward_header_matches:type_name -> agentgateway.dev.resource.HeaderMatch
-	72,  // 194: agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	72,  // 195: agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	72,  // 196: agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	142, // 197: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.rejection:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestRejection
-	137, // 198: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.regex:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules
-	138, // 199: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.webhook:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook
-	141, // 200: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.google_model_armor:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor
-	140, // 201: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.bedrock_guardrails:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails
-	142, // 202: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.rejection:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestRejection
-	137, // 203: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.regex:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules
-	138, // 204: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.webhook:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook
-	139, // 205: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.openai_moderation:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation
-	141, // 206: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.google_model_armor:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor
-	140, // 207: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.bedrock_guardrails:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails
-	144, // 208: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.request:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard
-	143, // 209: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.response:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard
-	18,  // 210: agentgateway.dev.resource.BackendPolicySpec.Ai.RoutesEntry.value:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RouteType
-	153, // 211: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.extra:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntry
-	168, // 212: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntry.value:type_name -> google.protobuf.Value
-	154, // 213: agentgateway.dev.resource.AIBackend.Provider.host_override:type_name -> agentgateway.dev.resource.AIBackend.HostOverride
-	155, // 214: agentgateway.dev.resource.AIBackend.Provider.openai:type_name -> agentgateway.dev.resource.AIBackend.OpenAI
-	156, // 215: agentgateway.dev.resource.AIBackend.Provider.gemini:type_name -> agentgateway.dev.resource.AIBackend.Gemini
-	157, // 216: agentgateway.dev.resource.AIBackend.Provider.vertex:type_name -> agentgateway.dev.resource.AIBackend.Vertex
-	158, // 217: agentgateway.dev.resource.AIBackend.Provider.anthropic:type_name -> agentgateway.dev.resource.AIBackend.Anthropic
-	159, // 218: agentgateway.dev.resource.AIBackend.Provider.bedrock:type_name -> agentgateway.dev.resource.AIBackend.Bedrock
-	160, // 219: agentgateway.dev.resource.AIBackend.Provider.azureopenai:type_name -> agentgateway.dev.resource.AIBackend.AzureOpenAI
-	72,  // 220: agentgateway.dev.resource.AIBackend.Provider.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	161, // 221: agentgateway.dev.resource.AIBackend.ProviderGroup.providers:type_name -> agentgateway.dev.resource.AIBackend.Provider
-	222, // [222:222] is the sub-list for method output_type
-	222, // [222:222] is the sub-list for method input_type
-	222, // [222:222] is the sub-list for extension type_name
-	222, // [222:222] is the sub-list for extension extendee
-	0,   // [0:222] is the sub-list for field type_name
+	70,  // 140: agentgateway.dev.resource.TrafficPolicySpec.JWTProvider.jwt_validation_options:type_name -> agentgateway.dev.resource.JWTValidationOptions
+	11,  // 141: agentgateway.dev.resource.TrafficPolicySpec.JWT.mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.JWT.Mode
+	100, // 142: agentgateway.dev.resource.TrafficPolicySpec.JWT.providers:type_name -> agentgateway.dev.resource.TrafficPolicySpec.JWTProvider
+	12,  // 143: agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication.mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication.Mode
+	119, // 144: agentgateway.dev.resource.TrafficPolicySpec.APIKey.api_keys:type_name -> agentgateway.dev.resource.TrafficPolicySpec.APIKey.User
+	13,  // 145: agentgateway.dev.resource.TrafficPolicySpec.APIKey.mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.APIKey.Mode
+	120, // 146: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.request:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform
+	120, // 147: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.response:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform
+	78,  // 148: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.target:type_name -> agentgateway.dev.resource.BackendReference
+	14,  // 149: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.failure_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.FailureMode
+	121, // 150: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.request_attributes:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.RequestAttributesEntry
+	122, // 151: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.response_attributes:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ResponseAttributesEntry
+	124, // 152: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.metadata_context:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.MetadataContextEntry
+	15,  // 153: agentgateway.dev.resource.TrafficPolicySpec.HostRewrite.mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HostRewrite.Mode
+	111, // 154: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor.entries:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Entry
+	7,   // 155: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor.type:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Type
+	115, // 156: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.context:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.ContextEntry
+	116, // 157: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.metadata:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.MetadataEntry
+	117, // 158: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.add_request_headers:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.AddRequestHeadersEntry
+	118, // 159: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.metadata:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.MetadataEntry
+	167, // 160: agentgateway.dev.resource.TrafficPolicySpec.APIKey.User.metadata:type_name -> google.protobuf.Struct
+	105, // 161: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.set:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HeaderTransformation
+	105, // 162: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.add:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HeaderTransformation
+	106, // 163: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.body:type_name -> agentgateway.dev.resource.TrafficPolicySpec.BodyTransformation
+	125, // 164: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext.context:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext.ContextEntry
+	123, // 165: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.MetadataContextEntry.value:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext
+	145, // 166: agentgateway.dev.resource.BackendPolicySpec.Ai.prompt_guard:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard
+	147, // 167: agentgateway.dev.resource.BackendPolicySpec.Ai.defaults:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.DefaultsEntry
+	148, // 168: agentgateway.dev.resource.BackendPolicySpec.Ai.overrides:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.OverridesEntry
+	149, // 169: agentgateway.dev.resource.BackendPolicySpec.Ai.transformations:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.TransformationsEntry
+	135, // 170: agentgateway.dev.resource.BackendPolicySpec.Ai.prompts:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment
+	150, // 171: agentgateway.dev.resource.BackendPolicySpec.Ai.model_aliases:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ModelAliasesEntry
+	146, // 172: agentgateway.dev.resource.BackendPolicySpec.Ai.prompt_caching:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptCaching
+	151, // 173: agentgateway.dev.resource.BackendPolicySpec.Ai.routes:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RoutesEntry
+	78,  // 174: agentgateway.dev.resource.BackendPolicySpec.InferenceRouting.endpoint_picker:type_name -> agentgateway.dev.resource.BackendReference
+	19,  // 175: agentgateway.dev.resource.BackendPolicySpec.InferenceRouting.failure_mode:type_name -> agentgateway.dev.resource.BackendPolicySpec.InferenceRouting.FailureMode
+	20,  // 176: agentgateway.dev.resource.BackendPolicySpec.BackendTLS.verification:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTLS.VerificationMode
+	79,  // 177: agentgateway.dev.resource.BackendPolicySpec.BackendTLS.alpn:type_name -> agentgateway.dev.resource.Alpn
+	21,  // 178: agentgateway.dev.resource.BackendPolicySpec.BackendHTTP.version:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendHTTP.HttpVersion
+	166, // 179: agentgateway.dev.resource.BackendPolicySpec.BackendHTTP.request_timeout:type_name -> google.protobuf.Duration
+	68,  // 180: agentgateway.dev.resource.BackendPolicySpec.BackendTCP.keepalive:type_name -> agentgateway.dev.resource.KeepaliveConfig
+	166, // 181: agentgateway.dev.resource.BackendPolicySpec.BackendTCP.connect_timeout:type_name -> google.protobuf.Duration
+	22,  // 182: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.provider:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.McpIDP
+	152, // 183: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.resource_metadata:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata
+	23,  // 184: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.mode:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.Mode
+	70,  // 185: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.jwt_validation_options:type_name -> agentgateway.dev.resource.JWTValidationOptions
+	134, // 186: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment.append:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Message
+	134, // 187: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment.prepend:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Message
+	16,  // 188: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRule.builtin:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.BuiltinRegexRule
+	17,  // 189: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules.action:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ActionKind
+	136, // 190: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules.rules:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRule
+	78,  // 191: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.backend:type_name -> agentgateway.dev.resource.BackendReference
+	58,  // 192: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.forward_header_matches:type_name -> agentgateway.dev.resource.HeaderMatch
+	72,  // 193: agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	72,  // 194: agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	72,  // 195: agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	142, // 196: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.rejection:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestRejection
+	137, // 197: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.regex:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules
+	138, // 198: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.webhook:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook
+	141, // 199: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.google_model_armor:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor
+	140, // 200: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.bedrock_guardrails:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails
+	142, // 201: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.rejection:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestRejection
+	137, // 202: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.regex:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules
+	138, // 203: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.webhook:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook
+	139, // 204: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.openai_moderation:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation
+	141, // 205: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.google_model_armor:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor
+	140, // 206: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.bedrock_guardrails:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails
+	144, // 207: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.request:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard
+	143, // 208: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.response:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard
+	18,  // 209: agentgateway.dev.resource.BackendPolicySpec.Ai.RoutesEntry.value:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RouteType
+	153, // 210: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.extra:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntry
+	168, // 211: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntry.value:type_name -> google.protobuf.Value
+	154, // 212: agentgateway.dev.resource.AIBackend.Provider.host_override:type_name -> agentgateway.dev.resource.AIBackend.HostOverride
+	155, // 213: agentgateway.dev.resource.AIBackend.Provider.openai:type_name -> agentgateway.dev.resource.AIBackend.OpenAI
+	156, // 214: agentgateway.dev.resource.AIBackend.Provider.gemini:type_name -> agentgateway.dev.resource.AIBackend.Gemini
+	157, // 215: agentgateway.dev.resource.AIBackend.Provider.vertex:type_name -> agentgateway.dev.resource.AIBackend.Vertex
+	158, // 216: agentgateway.dev.resource.AIBackend.Provider.anthropic:type_name -> agentgateway.dev.resource.AIBackend.Anthropic
+	159, // 217: agentgateway.dev.resource.AIBackend.Provider.bedrock:type_name -> agentgateway.dev.resource.AIBackend.Bedrock
+	160, // 218: agentgateway.dev.resource.AIBackend.Provider.azureopenai:type_name -> agentgateway.dev.resource.AIBackend.AzureOpenAI
+	72,  // 219: agentgateway.dev.resource.AIBackend.Provider.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	161, // 220: agentgateway.dev.resource.AIBackend.ProviderGroup.providers:type_name -> agentgateway.dev.resource.AIBackend.Provider
+	221, // [221:221] is the sub-list for method output_type
+	221, // [221:221] is the sub-list for method input_type
+	221, // [221:221] is the sub-list for extension type_name
+	221, // [221:221] is the sub-list for extension extendee
+	0,   // [0:221] is the sub-list for field type_name
 }
 
 func init() { file_resource_proto_init() }

--- a/crates/agentgateway/proto/resource.proto
+++ b/crates/agentgateway/proto/resource.proto
@@ -623,7 +623,8 @@ message TrafficPolicySpec {
     optional uint32 status_on_error = 5;
     repeated string include_request_headers = 6;
     BodyOptions include_request_body = 7;
-    google.protobuf.Duration timeout = 8;
+    reserved 8;
+    reserved "timeout";
   }
   message RBAC {
     repeated string allow = 1;

--- a/crates/agentgateway/src/http/ext_authz.rs
+++ b/crates/agentgateway/src/http/ext_authz.rs
@@ -123,7 +123,7 @@ pub struct ExtAuthz {
 	#[serde(deserialize_with = "crate::types::local::de_from_local_backend_policy")]
 	#[cfg_attr(
 		feature = "schema",
-		schemars(with = "crate::types::local::SimpleLocalBackendPolicies")
+		schemars(with = "Option<crate::types::local::SimpleLocalBackendPolicies>")
 	)]
 	pub policies: Vec<BackendPolicy>,
 	/// The ext_authz protocol to use. Unless you need to integrate with an HTTP-only server, gRPC is recommended.

--- a/crates/agentgateway/src/http/ext_authz.rs
+++ b/crates/agentgateway/src/http/ext_authz.rs
@@ -22,8 +22,8 @@ use crate::http::{
 use crate::proxy::ProxyError;
 use crate::proxy::httpproxy::PolicyClient;
 use crate::transport::stream::{TCPConnectionInfo, TLSConnectionInfo};
-use crate::types::agent::SimpleBackendReference;
-use crate::{serde_dur_option, *};
+use crate::types::agent::{BackendPolicy, SimpleBackendReference};
+use crate::*;
 #[cfg(test)]
 #[path = "ext_authz_tests.rs"]
 mod tests;
@@ -118,6 +118,14 @@ pub struct ExtAuthz {
 	/// Reference to the external authorization service backend
 	#[serde(flatten)]
 	pub target: Arc<SimpleBackendReference>,
+	/// Policies to connect to the backend
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	#[serde(deserialize_with = "crate::types::local::de_from_local_backend_policy")]
+	#[cfg_attr(
+		feature = "schema",
+		schemars(with = "crate::types::local::SimpleLocalBackendPolicies")
+	)]
+	pub policies: Vec<BackendPolicy>,
 	/// The ext_authz protocol to use. Unless you need to integrate with an HTTP-only server, gRPC is recommended.
 	#[serde(default)]
 	pub protocol: Protocol,
@@ -131,14 +139,6 @@ pub struct ExtAuthz {
 	/// Options for including the request body in the authorization request
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub include_request_body: Option<BodyOptions>,
-	/// Timeout for the authorization request (default: 200ms)
-	#[serde(
-		default,
-		skip_serializing_if = "Option::is_none",
-		with = "serde_dur_option"
-	)]
-	#[cfg_attr(feature = "schema", schemars(with = "Option<String>"))]
-	pub timeout: Option<Duration>,
 }
 
 impl ExtAuthz {
@@ -230,9 +230,8 @@ impl ExtAuthz {
 		};
 		let chan = GrpcReferenceChannel {
 			target: self.target.clone(),
+			policies: self.policies.clone(),
 			client,
-			// Set the request timeout. This can be overridden by a timeout on the Backend object itself.
-			timeout: Some(self.timeout.unwrap_or(Duration::from_millis(200))),
 		};
 		let mut grpc_client = AuthorizationClient::new(chan);
 		// Get connection info with proper error handling
@@ -604,11 +603,10 @@ impl ExtAuthz {
 			let resv = http::HeaderOrPseudoValue::from_cel_result(hn, res);
 			http::RequestOrResponse::Request(&mut check_req).apply_header(hn, resv, false);
 		}
-		// Set the request timeout. This can be overridden by a timeout on the Backend object itself.
-		let timeout_duration = self.timeout.unwrap_or(Duration::from_millis(200));
+		// Set the default request timeout. This can be overridden by a timeout on the Backend object itself.
 		check_req
 			.extensions_mut()
-			.insert(BackendRequestTimeout(timeout_duration));
+			.insert(BackendRequestTimeout(Duration::from_millis(200)));
 		let resp = client.call_reference(check_req, &self.target).await;
 		let mut resp = match resp {
 			Ok(r) => r,

--- a/crates/agentgateway/src/http/ext_authz_tests.rs
+++ b/crates/agentgateway/src/http/ext_authz_tests.rs
@@ -12,6 +12,7 @@ impl Default for ExtAuthz {
 	fn default() -> Self {
 		Self {
 			target: Arc::new(SimpleBackendReference::Invalid),
+			policies: Default::default(),
 			failure_mode: FailureMode::default(),
 			include_request_headers: Vec::new(),
 			include_request_body: None,
@@ -19,7 +20,6 @@ impl Default for ExtAuthz {
 				context: None,
 				metadata: None,
 			},
-			timeout: None,
 		}
 	}
 }

--- a/crates/agentgateway/src/http/ext_proc.rs
+++ b/crates/agentgateway/src/http/ext_proc.rs
@@ -146,7 +146,7 @@ pub struct ExtProc {
 	#[serde(deserialize_with = "crate::types::local::de_from_local_backend_policy")]
 	#[cfg_attr(
 		feature = "schema",
-		schemars(with = "crate::types::local::SimpleLocalBackendPolicies")
+		schemars(with = "Option<crate::types::local::SimpleLocalBackendPolicies>")
 	)]
 	pub policies: Vec<BackendPolicy>,
 	/// Behavior when the ext_proc service is unavailable or returns an error

--- a/crates/agentgateway/src/http/ext_proc.rs
+++ b/crates/agentgateway/src/http/ext_proc.rs
@@ -23,11 +23,10 @@ use crate::http::ext_proc::proto::{
 	HttpHeaders, HttpTrailers, ImmediateResponse, Metadata, ProcessingRequest, ProcessingResponse,
 	processing_response,
 };
-use crate::http::filters::BackendRequestTimeout;
 use crate::http::{HeaderName, HeaderOrPseudo, HeaderValue, PolicyResponse};
 use crate::proxy::ProxyError;
 use crate::proxy::httpproxy::PolicyClient;
-use crate::types::agent::SimpleBackendReference;
+use crate::types::agent::{BackendPolicy, SimpleBackendReference};
 use crate::*;
 
 /// The namespace key used for ext_proc attributes in ProcessingRequest.attributes
@@ -90,6 +89,7 @@ impl InferenceRouting {
 		InferencePoolRouter {
 			ext_proc: Some(ExtProcInstance::new(
 				client,
+				Vec::new(),
 				self.target.clone(),
 				self.failure_mode,
 				None,
@@ -141,6 +141,14 @@ pub struct ExtProc {
 	/// Reference to the external processing service backend
 	#[serde(flatten)]
 	pub target: Arc<SimpleBackendReference>,
+	/// Policies to connect to the backend
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	#[serde(deserialize_with = "crate::types::local::de_from_local_backend_policy")]
+	#[cfg_attr(
+		feature = "schema",
+		schemars(with = "crate::types::local::SimpleLocalBackendPolicies")
+	)]
+	pub policies: Vec<BackendPolicy>,
 	/// Behavior when the ext_proc service is unavailable or returns an error
 	#[serde(default)]
 	pub failure_mode: FailureMode,
@@ -163,6 +171,7 @@ impl ExtProc {
 		ExtProcRequest {
 			ext_proc: Some(ExtProcInstance::new(
 				client,
+				self.policies.clone(),
 				self.target.clone(),
 				self.failure_mode,
 				self.metadata_context.clone(),
@@ -242,6 +251,7 @@ struct ExtProcInstance {
 impl ExtProcInstance {
 	fn new(
 		client: PolicyClient,
+		policies: Vec<BackendPolicy>,
 		target: Arc<SimpleBackendReference>,
 		failure_mode: FailureMode,
 		metadata_context: Option<HashMap<String, HashMap<String, Arc<cel::Expression>>>>,
@@ -252,7 +262,7 @@ impl ExtProcInstance {
 		let chan = GrpcReferenceChannel {
 			target,
 			client,
-			timeout: None,
+			policies,
 		};
 		let mut c = proto::external_processor_client::ExternalProcessorClient::new(chan);
 		let (tx_req, rx_req) = tokio::sync::mpsc::channel(10);
@@ -1098,7 +1108,7 @@ fn eval_to_struct(
 pub struct GrpcReferenceChannel {
 	pub target: Arc<SimpleBackendReference>,
 	pub client: PolicyClient,
-	pub timeout: Option<Duration>,
+	pub policies: Vec<BackendPolicy>,
 }
 
 impl tower::Service<::http::Request<tonic::body::Body>> for GrpcReferenceChannel {
@@ -1110,10 +1120,7 @@ impl tower::Service<::http::Request<tonic::body::Body>> for GrpcReferenceChannel
 		Ok(()).into()
 	}
 
-	fn call(&mut self, mut req: ::http::Request<tonic::body::Body>) -> Self::Future {
-		if let Some(timeout) = self.timeout {
-			req.extensions_mut().insert(BackendRequestTimeout(timeout));
-		};
+	fn call(&mut self, req: ::http::Request<tonic::body::Body>) -> Self::Future {
 		let client = self.client.clone();
 		let target = self.target.clone();
 		let req = req.map(http::Body::new);

--- a/crates/agentgateway/src/http/ext_proc_tests.rs
+++ b/crates/agentgateway/src/http/ext_proc_tests.rs
@@ -216,6 +216,7 @@ pub async fn setup_ext_proc_mock_with_meta<T: Handler + Send + Sync + 'static>(
 				kind: None,
 			}),
 			policy: TrafficPolicy::ExtProc(ext_proc::ExtProc {
+				policies: Default::default(),
 				target: Arc::new(SimpleBackendReference::Backend(strng::format!(
 					"/{}",
 					ext_proc.address

--- a/crates/agentgateway/src/http/remoteratelimit.rs
+++ b/crates/agentgateway/src/http/remoteratelimit.rs
@@ -53,7 +53,10 @@ pub struct RemoteRateLimit {
 	/// Policies to connect to the backend
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	#[serde(deserialize_with = "crate::types::local::de_from_local_backend_policy")]
-	#[cfg_attr(feature = "schema", schemars(with = "crate::types::local::SimpleLocalBackendPolicies"))]
+	#[cfg_attr(
+		feature = "schema",
+		schemars(with = "crate::types::local::SimpleLocalBackendPolicies")
+	)]
 	pub policies: Vec<BackendPolicy>,
 	pub descriptors: Arc<DescriptorSet>,
 	/// Behavior when the remote rate limit service is unavailable or returns an error.

--- a/crates/agentgateway/src/http/remoteratelimit.rs
+++ b/crates/agentgateway/src/http/remoteratelimit.rs
@@ -9,7 +9,7 @@ use crate::http::remoteratelimit::proto::{RateLimitDescriptor, RateLimitRequest}
 use crate::http::{HeaderName, HeaderValue, PolicyResponse, Request};
 use crate::proxy::ProxyError;
 use crate::proxy::httpproxy::PolicyClient;
-use crate::types::agent::SimpleBackendReference;
+use crate::types::agent::{BackendPolicy, SimpleBackendReference};
 use crate::*;
 
 #[cfg(test)]
@@ -50,15 +50,12 @@ pub struct RemoteRateLimit {
 	pub domain: String,
 	#[serde(flatten)]
 	pub target: Arc<SimpleBackendReference>,
+	/// Policies to connect to the backend
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	#[serde(deserialize_with = "crate::types::local::de_from_local_backend_policy")]
+	#[cfg_attr(feature = "schema", schemars(with = "crate::types::local::SimpleLocalBackendPolicies"))]
+	pub policies: Vec<BackendPolicy>,
 	pub descriptors: Arc<DescriptorSet>,
-	/// Timeout for the request
-	#[serde(
-		default,
-		skip_serializing_if = "Option::is_none",
-		with = "serde_dur_option"
-	)]
-	#[cfg_attr(feature = "schema", schemars(with = "Option<String>"))]
-	pub timeout: Option<Duration>,
 	/// Behavior when the remote rate limit service is unavailable or returns an error.
 	/// Defaults to failClosed, denying requests with a 500 status on service failure.
 	#[serde(default)]
@@ -323,8 +320,8 @@ impl RemoteRateLimit {
 		);
 		let chan = GrpcReferenceChannel {
 			target: self.target.clone(),
+			policies: self.policies.clone(),
 			client,
-			timeout: self.timeout,
 		};
 		let mut client = RateLimitServiceClient::new(chan);
 		let resp = client.should_rate_limit(request).await;

--- a/crates/agentgateway/src/http/remoteratelimit.rs
+++ b/crates/agentgateway/src/http/remoteratelimit.rs
@@ -55,7 +55,7 @@ pub struct RemoteRateLimit {
 	#[serde(deserialize_with = "crate::types::local::de_from_local_backend_policy")]
 	#[cfg_attr(
 		feature = "schema",
-		schemars(with = "crate::types::local::SimpleLocalBackendPolicies")
+		schemars(with = "Option<crate::types::local::SimpleLocalBackendPolicies>")
 	)]
 	pub policies: Vec<BackendPolicy>,
 	pub descriptors: Arc<DescriptorSet>,

--- a/crates/agentgateway/src/http/remoteratelimit_tests.rs
+++ b/crates/agentgateway/src/http/remoteratelimit_tests.rs
@@ -9,9 +9,9 @@ use crate::http::localratelimit::RateLimitType;
 fn make_rate_limit(descriptor_entries: Vec<DescriptorEntry>) -> RemoteRateLimit {
 	RemoteRateLimit {
 		domain: "test-domain".to_string(),
+		policies: Default::default(),
 		target: Arc::new(SimpleBackendReference::Invalid),
 		descriptors: Arc::new(DescriptorSet(descriptor_entries)),
-		timeout: None,
 		failure_mode: FailureMode::default(),
 	}
 }

--- a/crates/agentgateway/src/llm/policy/mod.rs
+++ b/crates/agentgateway/src/llm/policy/mod.rs
@@ -6,7 +6,6 @@ use crate::llm::{AIError, RequestType, ResponseType};
 use crate::proxy::httpproxy::PolicyClient;
 use crate::telemetry::log::RequestLog;
 use crate::types::agent::{BackendPolicy, HeaderMatch, HeaderValueMatch, SimpleBackendReference};
-use crate::types::local::LocalBackendPolicies;
 use crate::*;
 use ::http::HeaderMap;
 use bytes::Bytes;
@@ -1061,8 +1060,8 @@ pub struct Moderation {
 	/// Model to use. Defaults to `omni-moderation-latest`
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub model: Option<Strng>,
-	#[serde(deserialize_with = "de_from_local_backend_policy")]
-	#[cfg_attr(feature = "schema", schemars(with = "LocalBackendPolicies"))]
+	#[serde(deserialize_with = "crate::types::local::de_from_local_backend_policy")]
+	#[cfg_attr(feature = "schema", schemars(with = "crate::types::local::SimpleLocalBackendPolicies"))]
 	pub policies: Vec<BackendPolicy>,
 }
 
@@ -1076,12 +1075,8 @@ pub struct BedrockGuardrails {
 	/// AWS region where the guardrail is deployed
 	pub region: Strng,
 	/// Backend policies for AWS authentication (optional, defaults to implicit AWS auth)
-	#[serde(
-		default,
-		deserialize_with = "de_from_local_backend_policy_opt",
-		skip_serializing_if = "Vec::is_empty"
-	)]
-	#[cfg_attr(feature = "schema", schemars(with = "Option<LocalBackendPolicies>"))]
+	#[serde(deserialize_with = "crate::types::local::de_from_local_backend_policy")]
+	#[cfg_attr(feature = "schema", schemars(with = "crate::types::local::SimpleLocalBackendPolicies"))]
 	pub policies: Vec<BackendPolicy>,
 }
 
@@ -1096,36 +1091,9 @@ pub struct GoogleModelArmor {
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub location: Option<Strng>,
 	/// Backend policies for GCP authentication (optional, defaults to implicit GCP auth)
-	#[serde(
-		default,
-		deserialize_with = "de_from_local_backend_policy_opt",
-		skip_serializing_if = "Vec::is_empty"
-	)]
-	#[cfg_attr(feature = "schema", schemars(with = "Option<LocalBackendPolicies>"))]
+	#[serde(deserialize_with = "crate::types::local::de_from_local_backend_policy")]
+	#[cfg_attr(feature = "schema", schemars(with = "crate::types::local::SimpleLocalBackendPolicies"))]
 	pub policies: Vec<BackendPolicy>,
-}
-
-pub fn de_from_local_backend_policy<'de: 'a, 'a, D>(
-	deserializer: D,
-) -> Result<Vec<BackendPolicy>, D::Error>
-where
-	D: Deserializer<'de>,
-{
-	let s = LocalBackendPolicies::deserialize(deserializer)?;
-	s.translate().map_err(serde::de::Error::custom)
-}
-
-pub fn de_from_local_backend_policy_opt<'de: 'a, 'a, D>(
-	deserializer: D,
-) -> Result<Vec<BackendPolicy>, D::Error>
-where
-	D: Deserializer<'de>,
-{
-	let s = Option::<LocalBackendPolicies>::deserialize(deserializer)?;
-	match s {
-		Some(policies) => policies.translate().map_err(serde::de::Error::custom),
-		None => Ok(Vec::new()),
-	}
 }
 
 #[apply(schema!)]

--- a/crates/agentgateway/src/llm/policy/mod.rs
+++ b/crates/agentgateway/src/llm/policy/mod.rs
@@ -1061,7 +1061,10 @@ pub struct Moderation {
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub model: Option<Strng>,
 	#[serde(deserialize_with = "crate::types::local::de_from_local_backend_policy")]
-	#[cfg_attr(feature = "schema", schemars(with = "crate::types::local::SimpleLocalBackendPolicies"))]
+	#[cfg_attr(
+		feature = "schema",
+		schemars(with = "crate::types::local::SimpleLocalBackendPolicies")
+	)]
 	pub policies: Vec<BackendPolicy>,
 }
 
@@ -1076,7 +1079,10 @@ pub struct BedrockGuardrails {
 	pub region: Strng,
 	/// Backend policies for AWS authentication (optional, defaults to implicit AWS auth)
 	#[serde(deserialize_with = "crate::types::local::de_from_local_backend_policy")]
-	#[cfg_attr(feature = "schema", schemars(with = "crate::types::local::SimpleLocalBackendPolicies"))]
+	#[cfg_attr(
+		feature = "schema",
+		schemars(with = "crate::types::local::SimpleLocalBackendPolicies")
+	)]
 	pub policies: Vec<BackendPolicy>,
 }
 
@@ -1092,7 +1098,10 @@ pub struct GoogleModelArmor {
 	pub location: Option<Strng>,
 	/// Backend policies for GCP authentication (optional, defaults to implicit GCP auth)
 	#[serde(deserialize_with = "crate::types::local::de_from_local_backend_policy")]
-	#[cfg_attr(feature = "schema", schemars(with = "crate::types::local::SimpleLocalBackendPolicies"))]
+	#[cfg_attr(
+		feature = "schema",
+		schemars(with = "crate::types::local::SimpleLocalBackendPolicies")
+	)]
 	pub policies: Vec<BackendPolicy>,
 }
 

--- a/crates/agentgateway/src/llm/policy/mod.rs
+++ b/crates/agentgateway/src/llm/policy/mod.rs
@@ -1063,7 +1063,7 @@ pub struct Moderation {
 	#[serde(deserialize_with = "crate::types::local::de_from_local_backend_policy")]
 	#[cfg_attr(
 		feature = "schema",
-		schemars(with = "crate::types::local::SimpleLocalBackendPolicies")
+		schemars(with = "Option<crate::types::local::SimpleLocalBackendPolicies>")
 	)]
 	pub policies: Vec<BackendPolicy>,
 }
@@ -1081,7 +1081,7 @@ pub struct BedrockGuardrails {
 	#[serde(deserialize_with = "crate::types::local::de_from_local_backend_policy")]
 	#[cfg_attr(
 		feature = "schema",
-		schemars(with = "crate::types::local::SimpleLocalBackendPolicies")
+		schemars(with = "Option<crate::types::local::SimpleLocalBackendPolicies>")
 	)]
 	pub policies: Vec<BackendPolicy>,
 }
@@ -1100,7 +1100,7 @@ pub struct GoogleModelArmor {
 	#[serde(deserialize_with = "crate::types::local::de_from_local_backend_policy")]
 	#[cfg_attr(
 		feature = "schema",
-		schemars(with = "crate::types::local::SimpleLocalBackendPolicies")
+		schemars(with = "Option<crate::types::local::SimpleLocalBackendPolicies>")
 	)]
 	pub policies: Vec<BackendPolicy>,
 }

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -1905,8 +1905,16 @@ pub struct PolicyClient {
 impl PolicyClient {
 	pub async fn call_reference(
 		&self,
+		req: Request,
+		backend_ref: &SimpleBackendReference,
+	) -> Result<Response, ProxyError> {
+		self.call_reference_with_policies(req, backend_ref, Vec::new()).await
+	}
+	pub async fn call_reference_with_policies(
+		&self,
 		mut req: Request,
 		backend_ref: &SimpleBackendReference,
+		policies: Vec<BackendPolicy>,
 	) -> Result<Response, ProxyError> {
 		let backend = resolve_simple_backend(backend_ref, self.inputs.as_ref())?;
 		trace!("resolved {:?} to {:?}", backend_ref, &backend);
@@ -1925,7 +1933,7 @@ impl PolicyClient {
 		.map_err(ProxyError::Processing)?;
 
 		let backend = BackendWithPolicies::from(backend);
-		let pols = get_backend_policies(&self.inputs, &backend, &[], None);
+		let pols = get_backend_policies(&self.inputs, &backend, policies.as_ref(), None);
 		self
 			.internal_call_with_policies(req, backend.backend, pols)
 			.await

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -1908,7 +1908,9 @@ impl PolicyClient {
 		req: Request,
 		backend_ref: &SimpleBackendReference,
 	) -> Result<Response, ProxyError> {
-		self.call_reference_with_policies(req, backend_ref, Vec::new()).await
+		self
+			.call_reference_with_policies(req, backend_ref, Vec::new())
+			.await
 	}
 	pub async fn call_reference_with_policies(
 		&self,

--- a/crates/agentgateway/src/telemetry/trc.rs
+++ b/crates/agentgateway/src/telemetry/trc.rs
@@ -16,7 +16,7 @@ pub use traceparent::TraceParent;
 
 use crate::cel;
 use crate::telemetry::log::{CelLoggingExecutor, LoggingFields, RequestLog};
-use crate::types::agent::{SimpleBackendReference, TracingConfig};
+use crate::types::agent::{BackendPolicy, SimpleBackendReference, TracingConfig};
 
 #[derive(Clone, Debug)]
 pub struct Tracer {
@@ -124,6 +124,7 @@ impl Tracer {
 			let exporter = PolicyGrpcSpanExporter::new(
 				policy_client.inputs.clone(),
 				Arc::new(config.provider_backend.clone()),
+				config.policies.clone(),
 				exporter_runtime.clone(),
 			);
 			opentelemetry_sdk::trace::SdkTracerProvider::builder()
@@ -343,13 +344,14 @@ impl PolicyGrpcSpanExporter {
 	fn new(
 		inputs: Arc<crate::ProxyInputs>,
 		target: Arc<SimpleBackendReference>,
+		policies: Vec<BackendPolicy>,
 		runtime: tokio::runtime::Handle,
 	) -> Self {
 		use crate::http::ext_proc::GrpcReferenceChannel;
 		let channel = GrpcReferenceChannel {
 			target,
+			policies,
 			client: crate::proxy::httpproxy::PolicyClient { inputs },
-			timeout: None,
 		};
 		let tonic_client = opentelemetry_proto::tonic::collector::trace::v1::trace_service_client::TraceServiceClient::new(
 			channel,

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -1620,7 +1620,7 @@ pub struct TracingConfig {
 	#[serde(deserialize_with = "crate::types::local::de_from_local_backend_policy")]
 	#[cfg_attr(
 		feature = "schema",
-		schemars(with = "crate::types::local::SimpleLocalBackendPolicies")
+		schemars(with = "Option<crate::types::local::SimpleLocalBackendPolicies>")
 	)]
 	pub policies: Vec<BackendPolicy>,
 	/// Span attributes to add, keyed by attribute name.

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -1615,6 +1615,11 @@ pub struct TargetedPolicy {
 pub struct TracingConfig {
 	#[serde(flatten)]
 	pub provider_backend: SimpleBackendReference,
+	/// Policies to connect to the backend
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	#[serde(deserialize_with = "crate::types::local::de_from_local_backend_policy")]
+	#[cfg_attr(feature = "schema", schemars(with = "crate::types::local::SimpleLocalBackendPolicies"))]
+	pub policies: Vec<BackendPolicy>,
 	/// Span attributes to add, keyed by attribute name.
 	#[serde(default)]
 	pub attributes: OrderedStringMap<Arc<cel::Expression>>,

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -1618,7 +1618,10 @@ pub struct TracingConfig {
 	/// Policies to connect to the backend
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	#[serde(deserialize_with = "crate::types::local::de_from_local_backend_policy")]
-	#[cfg_attr(feature = "schema", schemars(with = "crate::types::local::SimpleLocalBackendPolicies"))]
+	#[cfg_attr(
+		feature = "schema",
+		schemars(with = "crate::types::local::SimpleLocalBackendPolicies")
+	)]
 	pub policies: Vec<BackendPolicy>,
 	/// Span attributes to add, keyed by attribute name.
 	#[serde(default)]

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -1215,7 +1215,6 @@ impl TryFrom<&proto::agent::TrafficPolicySpec> for TrafficPolicy {
 							allow_partial_message: body_opts.allow_partial_message,
 							pack_as_bytes: body_opts.pack_as_bytes,
 						});
-				let timeout = ea.timeout.map(convert_duration);
 				let protocol = match ea
 					.protocol
 					.as_ref()
@@ -1278,6 +1277,8 @@ impl TryFrom<&proto::agent::TrafficPolicySpec> for TrafficPolicy {
 				TrafficPolicy::ExtAuthz(http::ext_authz::ExtAuthz {
 					protocol,
 					target: Arc::new(target),
+					// Not supported inline from xDS
+					policies: Vec::new(),
 					failure_mode,
 					include_request_headers: ea
 						.include_request_headers
@@ -1293,7 +1294,6 @@ impl TryFrom<&proto::agent::TrafficPolicySpec> for TrafficPolicy {
 						)
 						.collect(),
 					include_request_body,
-					timeout,
 				})
 			},
 			Some(tps::Kind::Authorization(rbac)) => {
@@ -1396,9 +1396,9 @@ impl TryFrom<&proto::agent::TrafficPolicySpec> for TrafficPolicy {
 				TrafficPolicy::RemoteRateLimit(http::remoteratelimit::RemoteRateLimit {
 					domain: rrl.domain.clone(),
 					target: Arc::new(target),
+					// Not supported inline from xDS
+					policies: Vec::new(),
 					descriptors: Arc::new(http::remoteratelimit::DescriptorSet(descriptors)),
-					// Not supported over XDS; use a timeout on the backend itself
-					timeout: None,
 					failure_mode,
 				})
 			},
@@ -1429,6 +1429,8 @@ impl TryFrom<&proto::agent::TrafficPolicySpec> for TrafficPolicy {
 				}
 				TrafficPolicy::ExtProc(http::ext_proc::ExtProc {
 					target: Arc::new(target),
+					// Not supported inline from xDS
+					policies: Vec::new(),
 					failure_mode,
 					request_attributes: to_cel_attrs(&ep.request_attributes),
 					response_attributes: to_cel_attrs(&ep.response_attributes),
@@ -1781,6 +1783,8 @@ impl TryFrom<&proto::agent::frontend_policy_spec::Tracing> for types::agent::Tra
 
 		Ok(types::agent::TracingConfig {
 			provider_backend,
+			// Not supported inline from xDS
+			policies: Vec::new(),
 			attributes,
 			resources,
 			remove: t.remove.clone(),

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -416,12 +416,18 @@ impl LocalAIBackend {
 }
 
 impl LocalBackend {
-	fn make_backend(
+	fn make_mcp_backend(
 		b: Backend,
-		policies: Option<LocalBackendPolicies>,
+		policies: Option<MCPLocalBackendPolicies>,
 		tls: bool,
 	) -> Result<BackendWithPolicies, anyhow::Error> {
 		let mut inline_policies = policies
+			.map(|p| LocalBackendPolicies {
+				simple: p.simple,
+				mcp_authorization: p.mcp_authorization,
+				a2a: None,
+				ai: None,
+			})
 			.map(LocalBackendPolicies::translate)
 			.transpose()?
 			.unwrap_or_default();
@@ -455,7 +461,7 @@ impl LocalBackend {
 							let (backend, path, tls) = backend.process()?;
 							let (bref, be) = mcp_to_simple_backend_and_ref(local_name(name.clone()), backend);
 							if let Some(b) = be {
-								backends.push(Self::make_backend(b, t.policies.clone(), tls)?);
+								backends.push(Self::make_mcp_backend(b, t.policies.clone(), tls)?);
 							}
 							McpTargetSpec::Sse(SseTargetSpec {
 								backend: bref,
@@ -466,7 +472,7 @@ impl LocalBackend {
 							let (backend, path, tls) = backend.process()?;
 							let (bref, be) = mcp_to_simple_backend_and_ref(local_name(name.clone()), backend);
 							if let Some(b) = be {
-								backends.push(Self::make_backend(b, t.policies.clone(), tls)?);
+								backends.push(Self::make_mcp_backend(b, t.policies.clone(), tls)?);
 							}
 							McpTargetSpec::Mcp(StreamableHTTPTargetSpec {
 								backend: bref,
@@ -478,7 +484,7 @@ impl LocalBackend {
 							let (backend, _, tls) = backend.process()?;
 							let (bref, be) = mcp_to_simple_backend_and_ref(local_name(name.clone()), backend);
 							if let Some(b) = be {
-								backends.push(Self::make_backend(b, t.policies.clone(), tls)?);
+								backends.push(Self::make_mcp_backend(b, t.policies.clone(), tls)?);
 							}
 							let openapi_schema = schema.load_openapi_schema(client.clone()).await?;
 							McpTargetSpec::OpenAPI(OpenAPITarget {
@@ -566,7 +572,7 @@ pub struct LocalMcpTarget {
 	#[serde(flatten)]
 	pub spec: LocalMcpTargetSpec,
 	#[serde(default, skip_serializing_if = "Option::is_none")]
-	pub policies: Option<LocalBackendPolicies>,
+	pub policies: Option<MCPLocalBackendPolicies>,
 }
 
 #[apply(schema_de!)]
@@ -792,7 +798,7 @@ impl From<LocalGatewayPolicy> for FilterOrPolicy {
 
 #[apply(schema_de!)]
 #[derive(Default)]
-pub struct LocalBackendPolicies {
+pub struct SimpleLocalBackendPolicies {
 	// Filters. Keep in sync with RouteFilter
 	/// Headers to be modified in the request.
 	#[serde(default)]
@@ -806,15 +812,6 @@ pub struct LocalBackendPolicies {
 	#[serde(default)]
 	pub request_redirect: Option<filters::RequestRedirect>,
 
-	/// Authorization policies for MCP access.
-	#[serde(default)]
-	pub mcp_authorization: Option<McpAuthorization>,
-	/// Mark this traffic as A2A to enable A2A processing and telemetry.
-	#[serde(default)]
-	pub a2a: Option<A2aPolicy>,
-	/// Mark this as LLM traffic to enable LLM processing.
-	#[serde(default)]
-	pub ai: Option<llm::Policy>,
 	/// Send TLS to the backend.
 	#[serde(rename = "backendTLS", default)]
 	pub backend_tls: Option<http::backendtls::LocalBackendTLS>,
@@ -830,19 +827,49 @@ pub struct LocalBackendPolicies {
 	pub tcp: Option<backend::TCP>,
 }
 
+#[apply(schema_de!)]
+#[derive(Default)]
+pub struct MCPLocalBackendPolicies {
+	#[serde(flatten)]
+	simple: SimpleLocalBackendPolicies,
+	/// Authorization policies for MCP access.
+	#[serde(default)]
+	pub mcp_authorization: Option<McpAuthorization>,
+}
+
+#[apply(schema_de!)]
+#[derive(Default)]
+pub struct LocalBackendPolicies {
+	#[serde(flatten)]
+	simple: SimpleLocalBackendPolicies,
+
+	/// Authorization policies for MCP access.
+	#[serde(default)]
+	pub mcp_authorization: Option<McpAuthorization>,
+	/// Mark this traffic as A2A to enable A2A processing and telemetry.
+	#[serde(default)]
+	pub a2a: Option<A2aPolicy>,
+	/// Mark this as LLM traffic to enable LLM processing.
+	#[serde(default)]
+	pub ai: Option<llm::Policy>,
+}
+
 impl LocalBackendPolicies {
 	pub fn translate(self) -> anyhow::Result<Vec<BackendPolicy>> {
 		let LocalBackendPolicies {
-			request_header_modifier,
-			response_header_modifier,
-			request_redirect,
+			simple:
+				SimpleLocalBackendPolicies {
+					request_header_modifier,
+					response_header_modifier,
+					request_redirect,
+					backend_tls,
+					backend_auth,
+					http,
+					tcp,
+				},
 			mcp_authorization,
 			a2a,
 			ai,
-			backend_tls,
-			backend_auth,
-			http,
-			tcp,
 		} = self;
 		let mut pols = vec![];
 		if let Some(p) = tcp {
@@ -2086,4 +2113,19 @@ impl TryInto<ServerTLSConfig> for LocalTLSServerConfig {
 
 fn local_name(name: Strng) -> ResourceName {
 	ResourceName::new(name, "".into())
+}
+
+pub fn de_from_local_backend_policy<'de: 'a, 'a, D>(
+	deserializer: D,
+) -> Result<Vec<BackendPolicy>, D::Error>
+where
+	D: Deserializer<'de>,
+{
+	let s = SimpleLocalBackendPolicies::deserialize(deserializer)?;
+	LocalBackendPolicies {
+		simple: s,
+		..Default::default()
+	}
+	.translate()
+	.map_err(serde::de::Error::custom)
 }

--- a/schema/config.json
+++ b/schema/config.json
@@ -2044,13 +2044,17 @@
           ]
         },
         "policies": {
-          "$ref": "#/$defs/SimpleLocalBackendPolicies"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SimpleLocalBackendPolicies"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
-      "additionalProperties": false,
-      "required": [
-        "policies"
-      ]
+      "additionalProperties": false
     },
     "SimpleLocalBackendPolicies": {
       "type": "object",
@@ -2582,15 +2586,21 @@
         },
         "policies": {
           "description": "Backend policies for AWS authentication (optional, defaults to implicit AWS auth)",
-          "$ref": "#/$defs/SimpleLocalBackendPolicies"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SimpleLocalBackendPolicies"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "additionalProperties": false,
       "required": [
         "guardrailIdentifier",
         "guardrailVersion",
-        "region",
-        "policies"
+        "region"
       ]
     },
     "GoogleModelArmor": {
@@ -2614,14 +2624,20 @@
         },
         "policies": {
           "description": "Backend policies for GCP authentication (optional, defaults to implicit GCP auth)",
-          "$ref": "#/$defs/SimpleLocalBackendPolicies"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SimpleLocalBackendPolicies"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "additionalProperties": false,
       "required": [
         "templateId",
-        "projectId",
-        "policies"
+        "projectId"
       ]
     },
     "ResponseGuard": {
@@ -2836,7 +2852,14 @@
         },
         "policies": {
           "description": "Policies to connect to the backend",
-          "$ref": "#/$defs/SimpleLocalBackendPolicies"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SimpleLocalBackendPolicies"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "descriptors": {
           "$ref": "#/$defs/DescriptorSet"
@@ -3179,7 +3202,14 @@
       "properties": {
         "policies": {
           "description": "Policies to connect to the backend",
-          "$ref": "#/$defs/SimpleLocalBackendPolicies"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SimpleLocalBackendPolicies"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "protocol": {
           "description": "The ext_authz protocol to use. Unless you need to integrate with an HTTP-only server, gRPC is recommended.",
@@ -3428,7 +3458,14 @@
       "properties": {
         "policies": {
           "description": "Policies to connect to the backend",
-          "$ref": "#/$defs/SimpleLocalBackendPolicies"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SimpleLocalBackendPolicies"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "failureMode": {
           "description": "Behavior when the ext_proc service is unavailable or returns an error",
@@ -4949,7 +4986,14 @@
       "properties": {
         "policies": {
           "description": "Policies to connect to the backend",
-          "$ref": "#/$defs/SimpleLocalBackendPolicies"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SimpleLocalBackendPolicies"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "attributes": {
           "description": "Span attributes to add, keyed by attribute name.",

--- a/schema/config.json
+++ b/schema/config.json
@@ -2044,7 +2044,7 @@
           ]
         },
         "policies": {
-          "$ref": "#/$defs/LocalBackendPolicies"
+          "$ref": "#/$defs/SimpleLocalBackendPolicies"
         }
       },
       "additionalProperties": false,
@@ -2052,7 +2052,7 @@
         "policies"
       ]
     },
-    "LocalBackendPolicies": {
+    "SimpleLocalBackendPolicies": {
       "type": "object",
       "properties": {
         "requestHeaderModifier": {
@@ -2084,42 +2084,6 @@
           "anyOf": [
             {
               "$ref": "#/$defs/RequestRedirect"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "mcpAuthorization": {
-          "description": "Authorization policies for MCP access.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/McpAuthorization"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "a2a": {
-          "description": "Mark this traffic as A2A to enable A2A processing and telemetry.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/A2aPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "ai": {
-          "description": "Mark this as LLM traffic to enable LLM processing.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Policy"
             },
             {
               "type": "null"
@@ -2618,21 +2582,15 @@
         },
         "policies": {
           "description": "Backend policies for AWS authentication (optional, defaults to implicit AWS auth)",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/LocalBackendPolicies"
-            },
-            {
-              "type": "null"
-            }
-          ]
+          "$ref": "#/$defs/SimpleLocalBackendPolicies"
         }
       },
       "additionalProperties": false,
       "required": [
         "guardrailIdentifier",
         "guardrailVersion",
-        "region"
+        "region",
+        "policies"
       ]
     },
     "GoogleModelArmor": {
@@ -2656,20 +2614,14 @@
         },
         "policies": {
           "description": "Backend policies for GCP authentication (optional, defaults to implicit GCP auth)",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/LocalBackendPolicies"
-            },
-            {
-              "type": "null"
-            }
-          ]
+          "$ref": "#/$defs/SimpleLocalBackendPolicies"
         }
       },
       "additionalProperties": false,
       "required": [
         "templateId",
-        "projectId"
+        "projectId",
+        "policies"
       ]
     },
     "ResponseGuard": {
@@ -2882,15 +2834,12 @@
         "domain": {
           "type": "string"
         },
+        "policies": {
+          "description": "Policies to connect to the backend",
+          "$ref": "#/$defs/SimpleLocalBackendPolicies"
+        },
         "descriptors": {
           "$ref": "#/$defs/DescriptorSet"
-        },
-        "timeout": {
-          "description": "Timeout for the request",
-          "type": [
-            "string",
-            "null"
-          ]
         },
         "failureMode": {
           "description": "Behavior when the remote rate limit service is unavailable or returns an error.\nDefaults to failClosed, denying requests with a 500 status on service failure.",
@@ -3228,6 +3177,10 @@
     "ExtAuthz": {
       "type": "object",
       "properties": {
+        "policies": {
+          "description": "Policies to connect to the backend",
+          "$ref": "#/$defs/SimpleLocalBackendPolicies"
+        },
         "protocol": {
           "description": "The ext_authz protocol to use. Unless you need to integrate with an HTTP-only server, gRPC is recommended.",
           "$ref": "#/$defs/Protocol2",
@@ -3256,13 +3209,6 @@
             {
               "type": "null"
             }
-          ]
-        },
-        "timeout": {
-          "description": "Timeout for the authorization request (default: 200ms)",
-          "type": [
-            "string",
-            "null"
           ]
         }
       },
@@ -3480,6 +3426,10 @@
     "ExtProc": {
       "type": "object",
       "properties": {
+        "policies": {
+          "description": "Policies to connect to the backend",
+          "$ref": "#/$defs/SimpleLocalBackendPolicies"
+        },
         "failureMode": {
           "description": "Behavior when the ext_proc service is unavailable or returns an error",
           "$ref": "#/$defs/FailureMode3",
@@ -3851,7 +3801,7 @@
         "policies": {
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalBackendPolicies"
+              "$ref": "#/$defs/MCPLocalBackendPolicies"
             },
             {
               "type": "null"
@@ -4006,6 +3956,107 @@
           ]
         }
       ]
+    },
+    "MCPLocalBackendPolicies": {
+      "type": "object",
+      "properties": {
+        "requestHeaderModifier": {
+          "description": "Headers to be modified in the request.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/HeaderModifier"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "responseHeaderModifier": {
+          "description": "Headers to be modified in the response.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/HeaderModifier"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "requestRedirect": {
+          "description": "Directly respond to the request with a redirect.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RequestRedirect"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "backendTLS": {
+          "description": "Send TLS to the backend.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LocalBackendTLS"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "backendAuth": {
+          "description": "Authenticate to the backend.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BackendAuth"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "http": {
+          "description": "Specify HTTP settings for the backend",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/HTTP"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "tcp": {
+          "description": "Specify TCP settings for the backend",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TCP"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "mcpAuthorization": {
+          "description": "Authorization policies for MCP access.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/McpAuthorization"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "additionalProperties": false
     },
     "McpStatefulMode": {
       "type": "string",
@@ -4273,6 +4324,131 @@
       "required": [
         "host"
       ]
+    },
+    "LocalBackendPolicies": {
+      "type": "object",
+      "properties": {
+        "requestHeaderModifier": {
+          "description": "Headers to be modified in the request.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/HeaderModifier"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "responseHeaderModifier": {
+          "description": "Headers to be modified in the response.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/HeaderModifier"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "requestRedirect": {
+          "description": "Directly respond to the request with a redirect.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RequestRedirect"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "backendTLS": {
+          "description": "Send TLS to the backend.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LocalBackendTLS"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "backendAuth": {
+          "description": "Authenticate to the backend.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BackendAuth"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "http": {
+          "description": "Specify HTTP settings for the backend",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/HTTP"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "tcp": {
+          "description": "Specify TCP settings for the backend",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TCP"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "mcpAuthorization": {
+          "description": "Authorization policies for MCP access.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/McpAuthorization"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "a2a": {
+          "description": "Mark this traffic as A2A to enable A2A processing and telemetry.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/A2aPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "ai": {
+          "description": "Mark this as LLM traffic to enable LLM processing.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Policy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "additionalProperties": false
     },
     "LocalAIProviders": {
       "type": "object",
@@ -4771,6 +4947,10 @@
       "description": "Configuration for dynamic tracing policy",
       "type": "object",
       "properties": {
+        "policies": {
+          "description": "Policies to connect to the backend",
+          "$ref": "#/$defs/SimpleLocalBackendPolicies"
+        },
         "attributes": {
           "description": "Span attributes to add, keyed by attribute name.",
           "$ref": "#/$defs/OrderedStringMap_Expression",

--- a/schema/config.md
+++ b/schema/config.md
@@ -202,10 +202,6 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestRedirect.path.(any)(1)full`||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestRedirect.path.(any)(1)prefix`||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestRedirect.status`||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.mcpAuthorization`|Authorization policies for MCP access.|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.mcpAuthorization.rules`||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.a2a`|Mark this traffic as A2A to enable A2A processing and telemetry.|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.ai`|Mark this as LLM traffic to enable LLM processing.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendTLS`|Send TLS to the backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendTLS.cert`||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendTLS.key`||
@@ -276,10 +272,6 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestRedirect.path.(any)(1)full`||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestRedirect.path.(any)(1)prefix`||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestRedirect.status`||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.mcpAuthorization`|Authorization policies for MCP access.|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.mcpAuthorization.rules`||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.a2a`|Mark this traffic as A2A to enable A2A processing and telemetry.|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.ai`|Mark this as LLM traffic to enable LLM processing.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendTLS`|Send TLS to the backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendTLS.cert`||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendTLS.key`||
@@ -350,10 +342,6 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestRedirect.path.(any)(1)full`||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestRedirect.path.(any)(1)prefix`||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestRedirect.status`||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.mcpAuthorization`|Authorization policies for MCP access.|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.mcpAuthorization.rules`||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.a2a`|Mark this traffic as A2A to enable A2A processing and telemetry.|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.ai`|Mark this as LLM traffic to enable LLM processing.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendTLS`|Send TLS to the backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendTLS.cert`||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendTLS.key`||
@@ -451,10 +439,6 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestRedirect.path.(any)(1)full`||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestRedirect.path.(any)(1)prefix`||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestRedirect.status`||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.mcpAuthorization`|Authorization policies for MCP access.|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.mcpAuthorization.rules`||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.a2a`|Mark this traffic as A2A to enable A2A processing and telemetry.|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.ai`|Mark this as LLM traffic to enable LLM processing.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendTLS`|Send TLS to the backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendTLS.cert`||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendTLS.key`||
@@ -525,10 +509,6 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestRedirect.path.(any)(1)full`||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestRedirect.path.(any)(1)prefix`||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestRedirect.status`||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.mcpAuthorization`|Authorization policies for MCP access.|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.mcpAuthorization.rules`||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.a2a`|Mark this traffic as A2A to enable A2A processing and telemetry.|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.ai`|Mark this as LLM traffic to enable LLM processing.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendTLS`|Send TLS to the backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendTLS.cert`||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendTLS.key`||
@@ -649,12 +629,77 @@
 |`binds[].listeners[].routes[].policies.remoteRateLimit.(any)(1)host`|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.(any)(1)backend`|Explicit backend reference. Backend must be defined in the top level backends list|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.(any)domain`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies`|Policies to connect to the backend|
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.requestHeaderModifier`|Headers to be modified in the request.|
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.requestHeaderModifier.add`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.requestHeaderModifier.set`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.requestHeaderModifier.remove`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.responseHeaderModifier`|Headers to be modified in the response.|
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.responseHeaderModifier.add`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.responseHeaderModifier.set`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.responseHeaderModifier.remove`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.requestRedirect`|Directly respond to the request with a redirect.|
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.requestRedirect.scheme`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.requestRedirect.authority`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.requestRedirect.authority.(any)(1)full`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.requestRedirect.authority.(any)(1)host`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.requestRedirect.authority.(any)(1)port`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.requestRedirect.path`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.requestRedirect.path.(any)(1)full`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.requestRedirect.path.(any)(1)prefix`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.requestRedirect.status`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.backendTLS`|Send TLS to the backend.|
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.backendTLS.cert`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.backendTLS.key`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.backendTLS.root`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.backendTLS.hostname`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.backendTLS.insecure`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.backendTLS.insecureHost`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.backendTLS.alpn`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.backendTLS.subjectAltNames`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.backendAuth`|Authenticate to the backend.|
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.backendAuth.(any)(1)passthrough`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.backendAuth.(any)(1)key`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.backendAuth.(any)(1)key.(any)file`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.backendAuth.(any)(1)gcp`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.backendAuth.(any)(1)gcp.(any)type`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.backendAuth.(any)(1)gcp.(any)audience`|Audience for the token. If not set, the destination host will be used.|
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.backendAuth.(any)(1)gcp.(any)type`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.backendAuth.(any)(1)aws`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.backendAuth.(any)(1)aws.(any)accessKeyId`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.backendAuth.(any)(1)aws.(any)secretAccessKey`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.backendAuth.(any)(1)aws.(any)region`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.backendAuth.(any)(1)aws.(any)sessionToken`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.backendAuth.(any)(1)azure`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.tenant_id`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_id`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_secret`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)clientId`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)objectId`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)resourceId`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)workloadIdentity`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.backendAuth.(any)(1)azure.(1)developerImplicit`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.http`|Specify HTTP settings for the backend|
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.http.version`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.http.requestTimeout`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.tcp`|Specify TCP settings for the backend|
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.tcp.keepalives`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.tcp.keepalives.enabled`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.tcp.keepalives.time`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.tcp.keepalives.interval`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.tcp.keepalives.retries`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.tcp.connectTimeout`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.tcp.connectTimeout.secs`||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)policies.tcp.connectTimeout.nanos`||
 |`binds[].listeners[].routes[].policies.remoteRateLimit.(any)descriptors`||
 |`binds[].listeners[].routes[].policies.remoteRateLimit.(any)descriptors[].entries`||
 |`binds[].listeners[].routes[].policies.remoteRateLimit.(any)descriptors[].entries[].key`||
 |`binds[].listeners[].routes[].policies.remoteRateLimit.(any)descriptors[].entries[].value`||
 |`binds[].listeners[].routes[].policies.remoteRateLimit.(any)descriptors[].type`||
-|`binds[].listeners[].routes[].policies.remoteRateLimit.(any)timeout`|Timeout for the request|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.(any)failureMode`|Behavior when the remote rate limit service is unavailable or returns an error.<br>Defaults to failClosed, denying requests with a 500 status on service failure.|
 |`binds[].listeners[].routes[].policies.jwtAuth`|Authenticate incoming JWT requests.|
 |`binds[].listeners[].routes[].policies.jwtAuth.(any)(any)mode`||
@@ -692,6 +737,72 @@
 |`binds[].listeners[].routes[].policies.extAuthz.(any)(1)service.port`||
 |`binds[].listeners[].routes[].policies.extAuthz.(any)(1)host`|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.extAuthz.(any)(1)backend`|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies`|Policies to connect to the backend|
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.requestHeaderModifier`|Headers to be modified in the request.|
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.requestHeaderModifier.add`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.requestHeaderModifier.set`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.requestHeaderModifier.remove`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.responseHeaderModifier`|Headers to be modified in the response.|
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.responseHeaderModifier.add`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.responseHeaderModifier.set`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.responseHeaderModifier.remove`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.requestRedirect`|Directly respond to the request with a redirect.|
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.requestRedirect.scheme`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.requestRedirect.authority`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.requestRedirect.authority.(any)(1)full`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.requestRedirect.authority.(any)(1)host`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.requestRedirect.authority.(any)(1)port`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.requestRedirect.path`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.requestRedirect.path.(any)(1)full`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.requestRedirect.path.(any)(1)prefix`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.requestRedirect.status`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.backendTLS`|Send TLS to the backend.|
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.backendTLS.cert`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.backendTLS.key`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.backendTLS.root`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.backendTLS.hostname`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.backendTLS.insecure`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.backendTLS.insecureHost`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.backendTLS.alpn`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.backendTLS.subjectAltNames`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.backendAuth`|Authenticate to the backend.|
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.backendAuth.(any)(1)passthrough`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.backendAuth.(any)(1)key`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.backendAuth.(any)(1)key.(any)file`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.backendAuth.(any)(1)gcp`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.backendAuth.(any)(1)gcp.(any)type`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.backendAuth.(any)(1)gcp.(any)audience`|Audience for the token. If not set, the destination host will be used.|
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.backendAuth.(any)(1)gcp.(any)type`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.backendAuth.(any)(1)aws`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.backendAuth.(any)(1)aws.(any)accessKeyId`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.backendAuth.(any)(1)aws.(any)secretAccessKey`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.backendAuth.(any)(1)aws.(any)region`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.backendAuth.(any)(1)aws.(any)sessionToken`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.backendAuth.(any)(1)azure`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.tenant_id`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_id`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_secret`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)clientId`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)objectId`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)resourceId`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)workloadIdentity`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)developerImplicit`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.http`|Specify HTTP settings for the backend|
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.http.version`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.http.requestTimeout`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.tcp`|Specify TCP settings for the backend|
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.tcp.keepalives`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.tcp.keepalives.enabled`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.tcp.keepalives.time`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.tcp.keepalives.interval`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.tcp.keepalives.retries`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.tcp.connectTimeout`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.tcp.connectTimeout.secs`||
+|`binds[].listeners[].routes[].policies.extAuthz.(any)policies.tcp.connectTimeout.nanos`||
 |`binds[].listeners[].routes[].policies.extAuthz.(any)protocol`|The ext_authz protocol to use. Unless you need to integrate with an HTTP-only server, gRPC is recommended.|
 |`binds[].listeners[].routes[].policies.extAuthz.(any)protocol.(1)grpc`||
 |`binds[].listeners[].routes[].policies.extAuthz.(any)protocol.(1)grpc.context`|Additional context to send to the authorization service.<br>This maps to the `context_extensions` field of the request, and only allows static values.|
@@ -709,7 +820,6 @@
 |`binds[].listeners[].routes[].policies.extAuthz.(any)includeRequestBody.maxRequestBytes`|Maximum size of request body to buffer (default: 8192)|
 |`binds[].listeners[].routes[].policies.extAuthz.(any)includeRequestBody.allowPartialMessage`|If true, send partial body when max_request_bytes is reached|
 |`binds[].listeners[].routes[].policies.extAuthz.(any)includeRequestBody.packAsBytes`|If true, pack body as raw bytes in gRPC|
-|`binds[].listeners[].routes[].policies.extAuthz.(any)timeout`|Timeout for the authorization request (default: 200ms)|
 |`binds[].listeners[].routes[].policies.extProc`|Extend agentgateway with an external processor|
 |`binds[].listeners[].routes[].policies.extProc.(any)(1)service`||
 |`binds[].listeners[].routes[].policies.extProc.(any)(1)service.name`||
@@ -718,6 +828,72 @@
 |`binds[].listeners[].routes[].policies.extProc.(any)(1)service.port`||
 |`binds[].listeners[].routes[].policies.extProc.(any)(1)host`|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.extProc.(any)(1)backend`|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].policies.extProc.(any)policies`|Policies to connect to the backend|
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.requestHeaderModifier`|Headers to be modified in the request.|
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.requestHeaderModifier.add`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.requestHeaderModifier.set`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.requestHeaderModifier.remove`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.responseHeaderModifier`|Headers to be modified in the response.|
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.responseHeaderModifier.add`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.responseHeaderModifier.set`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.responseHeaderModifier.remove`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.requestRedirect`|Directly respond to the request with a redirect.|
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.requestRedirect.scheme`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.requestRedirect.authority`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.requestRedirect.authority.(any)(1)full`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.requestRedirect.authority.(any)(1)host`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.requestRedirect.authority.(any)(1)port`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.requestRedirect.path`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.requestRedirect.path.(any)(1)full`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.requestRedirect.path.(any)(1)prefix`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.requestRedirect.status`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.backendTLS`|Send TLS to the backend.|
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.backendTLS.cert`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.backendTLS.key`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.backendTLS.root`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.backendTLS.hostname`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.backendTLS.insecure`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.backendTLS.insecureHost`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.backendTLS.alpn`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.backendTLS.subjectAltNames`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.backendAuth`|Authenticate to the backend.|
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.backendAuth.(any)(1)passthrough`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.backendAuth.(any)(1)key`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.backendAuth.(any)(1)key.(any)file`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.backendAuth.(any)(1)gcp`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.backendAuth.(any)(1)gcp.(any)type`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.backendAuth.(any)(1)gcp.(any)audience`|Audience for the token. If not set, the destination host will be used.|
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.backendAuth.(any)(1)gcp.(any)type`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.backendAuth.(any)(1)aws`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.backendAuth.(any)(1)aws.(any)accessKeyId`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.backendAuth.(any)(1)aws.(any)secretAccessKey`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.backendAuth.(any)(1)aws.(any)region`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.backendAuth.(any)(1)aws.(any)sessionToken`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.backendAuth.(any)(1)azure`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.tenant_id`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_id`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_secret`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)clientId`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)objectId`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)resourceId`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)workloadIdentity`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.backendAuth.(any)(1)azure.(1)developerImplicit`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.http`|Specify HTTP settings for the backend|
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.http.version`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.http.requestTimeout`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.tcp`|Specify TCP settings for the backend|
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.tcp.keepalives`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.tcp.keepalives.enabled`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.tcp.keepalives.time`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.tcp.keepalives.interval`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.tcp.keepalives.retries`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.tcp.connectTimeout`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.tcp.connectTimeout.secs`||
+|`binds[].listeners[].routes[].policies.extProc.(any)policies.tcp.connectTimeout.nanos`||
 |`binds[].listeners[].routes[].policies.extProc.(any)failureMode`|Behavior when the ext_proc service is unavailable or returns an error|
 |`binds[].listeners[].routes[].policies.extProc.(any)metadataContext`|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
 |`binds[].listeners[].routes[].policies.extProc.(any)requestAttributes`|Maps to the request `attributes` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -791,105 +967,6 @@
 |`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.requestRedirect.path.(any)(1)full`||
 |`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.requestRedirect.path.(any)(1)prefix`||
 |`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.requestRedirect.status`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.mcpAuthorization`|Authorization policies for MCP access.|
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.mcpAuthorization.rules`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.a2a`|Mark this traffic as A2A to enable A2A processing and telemetry.|
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai`|Mark this as LLM traffic to enable LLM processing.|
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.request`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.request[].(1)regex`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.request[].(1)regex.action`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.request[].(1)regex.rules`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.request[].(1)regex.rules[].(any)builtin`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.request[].(1)regex.rules[].(any)pattern`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.request[].(1)webhook`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.request[].(1)webhook.target`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.request[].(1)webhook.target.(1)service`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.request[].(1)webhook.target.(1)service.name`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.request[].(1)webhook.target.(1)service.name.namespace`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.request[].(1)webhook.target.(1)service.name.hostname`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.request[].(1)webhook.target.(1)service.port`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.request[].(1)webhook.target.(1)host`|Hostname or IP address|
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.request[].(1)webhook.target.(1)backend`|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.request[].(1)webhook.forwardHeaderMatches`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.request[].(1)webhook.forwardHeaderMatches[].name`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.request[].(1)webhook.forwardHeaderMatches[].value`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.request[].(1)webhook.forwardHeaderMatches[].value.(1)exact`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.request[].(1)webhook.forwardHeaderMatches[].value.(1)regex`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.request[].(1)openAIModeration`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.request[].(1)openAIModeration.model`|Model to use. Defaults to `omni-moderation-latest`|
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.request[].(1)openAIModeration.policies`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.request[].(1)bedrockGuardrails`|Configuration for AWS Bedrock Guardrails integration.|
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.guardrailIdentifier`|The unique identifier of the guardrail|
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.guardrailVersion`|The version of the guardrail|
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.region`|AWS region where the guardrail is deployed|
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies`|Backend policies for AWS authentication (optional, defaults to implicit AWS auth)|
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.request[].(1)googleModelArmor`|Configuration for Google Cloud Model Armor integration.|
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.request[].(1)googleModelArmor.templateId`|The template ID for the Model Armor configuration|
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.request[].(1)googleModelArmor.projectId`|The GCP project ID|
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.request[].(1)googleModelArmor.location`|The GCP region (default: us-central1)|
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies`|Backend policies for GCP authentication (optional, defaults to implicit GCP auth)|
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.request[].rejection`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.request[].rejection.body`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.request[].rejection.status`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.request[].rejection.headers`|Optional headers to add, set, or remove from the rejection response|
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.request[].rejection.headers.add`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.request[].rejection.headers.set`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.request[].rejection.headers.remove`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.response`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.response[].(1)regex`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.response[].(1)regex.action`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.response[].(1)regex.rules`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.response[].(1)regex.rules[].(any)builtin`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.response[].(1)regex.rules[].(any)pattern`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.response[].(1)webhook`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.response[].(1)webhook.target`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.response[].(1)webhook.target.(1)service`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.response[].(1)webhook.target.(1)service.name`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.response[].(1)webhook.target.(1)service.name.namespace`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.response[].(1)webhook.target.(1)service.name.hostname`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.response[].(1)webhook.target.(1)service.port`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.response[].(1)webhook.target.(1)host`|Hostname or IP address|
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.response[].(1)webhook.target.(1)backend`|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.response[].(1)webhook.forwardHeaderMatches`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.response[].(1)webhook.forwardHeaderMatches[].name`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.response[].(1)webhook.forwardHeaderMatches[].value`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.response[].(1)webhook.forwardHeaderMatches[].value.(1)exact`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.response[].(1)webhook.forwardHeaderMatches[].value.(1)regex`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.response[].(1)bedrockGuardrails`|Configuration for AWS Bedrock Guardrails integration.|
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.guardrailIdentifier`|The unique identifier of the guardrail|
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.guardrailVersion`|The version of the guardrail|
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.region`|AWS region where the guardrail is deployed|
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies`|Backend policies for AWS authentication (optional, defaults to implicit AWS auth)|
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.response[].(1)googleModelArmor`|Configuration for Google Cloud Model Armor integration.|
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.response[].(1)googleModelArmor.templateId`|The template ID for the Model Armor configuration|
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.response[].(1)googleModelArmor.projectId`|The GCP project ID|
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.response[].(1)googleModelArmor.location`|The GCP region (default: us-central1)|
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies`|Backend policies for GCP authentication (optional, defaults to implicit GCP auth)|
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.response[].rejection`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.response[].rejection.body`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.response[].rejection.status`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.response[].rejection.headers`|Optional headers to add, set, or remove from the rejection response|
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.response[].rejection.headers.add`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.response[].rejection.headers.set`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptGuard.response[].rejection.headers.remove`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.defaults`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.overrides`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.transformations`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.prompts`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.prompts.append`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.prompts.append[].role`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.prompts.append[].content`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.prompts.prepend`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.prompts.prepend[].role`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.prompts.prepend[].content`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.modelAliases`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptCaching`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptCaching.cacheSystem`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptCaching.cacheMessages`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptCaching.cacheTools`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.promptCaching.minTokens`||
-|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.ai.routes`||
 |`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.backendTLS`|Send TLS to the backend.|
 |`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.backendTLS.cert`||
 |`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.backendTLS.key`||
@@ -937,6 +1014,8 @@
 |`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.tcp.connectTimeout`||
 |`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.tcp.connectTimeout.secs`||
 |`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.tcp.connectTimeout.nanos`||
+|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.mcpAuthorization`|Authorization policies for MCP access.|
+|`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.mcpAuthorization.rules`||
 |`binds[].listeners[].routes[].backends[].(1)mcp.statefulMode`||
 |`binds[].listeners[].routes[].backends[].(1)mcp.prefixMode`||
 |`binds[].listeners[].routes[].backends[].(1)ai`||
@@ -983,105 +1062,6 @@
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.requestRedirect.path.(any)(1)full`||
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.requestRedirect.path.(any)(1)prefix`||
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.requestRedirect.status`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.mcpAuthorization`|Authorization policies for MCP access.|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.mcpAuthorization.rules`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.a2a`|Mark this traffic as A2A to enable A2A processing and telemetry.|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai`|Mark this as LLM traffic to enable LLM processing.|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)regex`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)regex.action`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)regex.rules`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)regex.rules[].(any)builtin`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)regex.rules[].(any)pattern`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)webhook`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)webhook.target`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)webhook.target.(1)service`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)webhook.target.(1)service.name`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)webhook.target.(1)service.name.namespace`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)webhook.target.(1)service.name.hostname`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)webhook.target.(1)service.port`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)webhook.target.(1)host`|Hostname or IP address|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)webhook.target.(1)backend`|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)webhook.forwardHeaderMatches`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)webhook.forwardHeaderMatches[].name`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)webhook.forwardHeaderMatches[].value`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)webhook.forwardHeaderMatches[].value.(1)exact`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)webhook.forwardHeaderMatches[].value.(1)regex`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.model`|Model to use. Defaults to `omni-moderation-latest`|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails`|Configuration for AWS Bedrock Guardrails integration.|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.guardrailIdentifier`|The unique identifier of the guardrail|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.guardrailVersion`|The version of the guardrail|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.region`|AWS region where the guardrail is deployed|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies`|Backend policies for AWS authentication (optional, defaults to implicit AWS auth)|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor`|Configuration for Google Cloud Model Armor integration.|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.templateId`|The template ID for the Model Armor configuration|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.projectId`|The GCP project ID|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.location`|The GCP region (default: us-central1)|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies`|Backend policies for GCP authentication (optional, defaults to implicit GCP auth)|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].rejection`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].rejection.body`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].rejection.status`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].rejection.headers`|Optional headers to add, set, or remove from the rejection response|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].rejection.headers.add`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].rejection.headers.set`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].rejection.headers.remove`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)regex`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)regex.action`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)regex.rules`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)regex.rules[].(any)builtin`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)regex.rules[].(any)pattern`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)webhook`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)webhook.target`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)webhook.target.(1)service`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)webhook.target.(1)service.name`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)webhook.target.(1)service.name.namespace`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)webhook.target.(1)service.name.hostname`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)webhook.target.(1)service.port`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)webhook.target.(1)host`|Hostname or IP address|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)webhook.target.(1)backend`|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)webhook.forwardHeaderMatches`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)webhook.forwardHeaderMatches[].name`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)webhook.forwardHeaderMatches[].value`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)webhook.forwardHeaderMatches[].value.(1)exact`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)webhook.forwardHeaderMatches[].value.(1)regex`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails`|Configuration for AWS Bedrock Guardrails integration.|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.guardrailIdentifier`|The unique identifier of the guardrail|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.guardrailVersion`|The version of the guardrail|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.region`|AWS region where the guardrail is deployed|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies`|Backend policies for AWS authentication (optional, defaults to implicit AWS auth)|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor`|Configuration for Google Cloud Model Armor integration.|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.templateId`|The template ID for the Model Armor configuration|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.projectId`|The GCP project ID|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.location`|The GCP region (default: us-central1)|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies`|Backend policies for GCP authentication (optional, defaults to implicit GCP auth)|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].rejection`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].rejection.body`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].rejection.status`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].rejection.headers`|Optional headers to add, set, or remove from the rejection response|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].rejection.headers.add`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].rejection.headers.set`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].rejection.headers.remove`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.defaults`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.overrides`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.transformations`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.prompts`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.prompts.append`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.prompts.append[].role`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.prompts.append[].content`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.prompts.prepend`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.prompts.prepend[].role`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.prompts.prepend[].content`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.modelAliases`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptCaching`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptCaching.cacheSystem`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptCaching.cacheMessages`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptCaching.cacheTools`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptCaching.minTokens`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.routes`||
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.backendTLS`|Send TLS to the backend.|
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.backendTLS.cert`||
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.backendTLS.key`||
@@ -1129,6 +1109,430 @@
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.tcp.connectTimeout`||
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.tcp.connectTimeout.secs`||
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.tcp.connectTimeout.nanos`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.mcpAuthorization`|Authorization policies for MCP access.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.mcpAuthorization.rules`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.a2a`|Mark this traffic as A2A to enable A2A processing and telemetry.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai`|Mark this as LLM traffic to enable LLM processing.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)regex`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)regex.action`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)regex.rules`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)regex.rules[].(any)builtin`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)regex.rules[].(any)pattern`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)webhook`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)webhook.target`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)webhook.target.(1)service`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)webhook.target.(1)service.name`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)webhook.target.(1)service.name.namespace`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)webhook.target.(1)service.name.hostname`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)webhook.target.(1)service.port`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)webhook.target.(1)host`|Hostname or IP address|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)webhook.target.(1)backend`|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)webhook.forwardHeaderMatches`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)webhook.forwardHeaderMatches[].name`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)webhook.forwardHeaderMatches[].value`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)webhook.forwardHeaderMatches[].value.(1)exact`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)webhook.forwardHeaderMatches[].value.(1)regex`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.model`|Model to use. Defaults to `omni-moderation-latest`|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestHeaderModifier`|Headers to be modified in the request.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestHeaderModifier.add`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestHeaderModifier.set`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestHeaderModifier.remove`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.responseHeaderModifier`|Headers to be modified in the response.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.responseHeaderModifier.add`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.responseHeaderModifier.set`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.responseHeaderModifier.remove`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestRedirect`|Directly respond to the request with a redirect.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestRedirect.scheme`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestRedirect.authority`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestRedirect.authority.(any)(1)full`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestRedirect.authority.(any)(1)host`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestRedirect.authority.(any)(1)port`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestRedirect.path`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestRedirect.path.(any)(1)full`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestRedirect.path.(any)(1)prefix`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestRedirect.status`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendTLS`|Send TLS to the backend.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendTLS.cert`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendTLS.key`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendTLS.root`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendTLS.hostname`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendTLS.insecure`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendTLS.insecureHost`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendTLS.alpn`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendTLS.subjectAltNames`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth`|Authenticate to the backend.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)passthrough`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)key`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)key.(any)file`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)gcp`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)gcp.(any)type`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)gcp.(any)audience`|Audience for the token. If not set, the destination host will be used.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)gcp.(any)type`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)aws`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)aws.(any)accessKeyId`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)aws.(any)secretAccessKey`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)aws.(any)region`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)aws.(any)sessionToken`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)azure`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)azure.(1)explicitConfig`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.tenant_id`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_id`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_secret`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)clientId`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)objectId`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)resourceId`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)workloadIdentity`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)azure.(1)developerImplicit`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.http`|Specify HTTP settings for the backend|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.http.version`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.http.requestTimeout`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.tcp`|Specify TCP settings for the backend|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.tcp.keepalives`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.tcp.keepalives.enabled`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.tcp.keepalives.time`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.tcp.keepalives.interval`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.tcp.keepalives.retries`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.tcp.connectTimeout`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.tcp.connectTimeout.secs`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)openAIModeration.policies.tcp.connectTimeout.nanos`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails`|Configuration for AWS Bedrock Guardrails integration.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.guardrailIdentifier`|The unique identifier of the guardrail|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.guardrailVersion`|The version of the guardrail|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.region`|AWS region where the guardrail is deployed|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies`|Backend policies for AWS authentication (optional, defaults to implicit AWS auth)|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestHeaderModifier`|Headers to be modified in the request.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestHeaderModifier.add`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestHeaderModifier.set`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestHeaderModifier.remove`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.responseHeaderModifier`|Headers to be modified in the response.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.responseHeaderModifier.add`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.responseHeaderModifier.set`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.responseHeaderModifier.remove`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestRedirect`|Directly respond to the request with a redirect.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestRedirect.scheme`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestRedirect.authority`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestRedirect.authority.(any)(1)full`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestRedirect.authority.(any)(1)host`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestRedirect.authority.(any)(1)port`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestRedirect.path`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestRedirect.path.(any)(1)full`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestRedirect.path.(any)(1)prefix`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestRedirect.status`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendTLS`|Send TLS to the backend.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendTLS.cert`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendTLS.key`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendTLS.root`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendTLS.hostname`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendTLS.insecure`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendTLS.insecureHost`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendTLS.alpn`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendTLS.subjectAltNames`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth`|Authenticate to the backend.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)passthrough`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)key`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)key.(any)file`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)gcp`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)gcp.(any)type`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)gcp.(any)audience`|Audience for the token. If not set, the destination host will be used.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)gcp.(any)type`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)aws`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)aws.(any)accessKeyId`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)aws.(any)secretAccessKey`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)aws.(any)region`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)aws.(any)sessionToken`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.tenant_id`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_id`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_secret`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)clientId`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)objectId`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)resourceId`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)workloadIdentity`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)developerImplicit`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.http`|Specify HTTP settings for the backend|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.http.version`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.http.requestTimeout`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.tcp`|Specify TCP settings for the backend|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.tcp.keepalives`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.tcp.keepalives.enabled`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.tcp.keepalives.time`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.tcp.keepalives.interval`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.tcp.keepalives.retries`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.tcp.connectTimeout`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.tcp.connectTimeout.secs`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.tcp.connectTimeout.nanos`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor`|Configuration for Google Cloud Model Armor integration.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.templateId`|The template ID for the Model Armor configuration|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.projectId`|The GCP project ID|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.location`|The GCP region (default: us-central1)|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies`|Backend policies for GCP authentication (optional, defaults to implicit GCP auth)|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestHeaderModifier`|Headers to be modified in the request.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestHeaderModifier.add`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestHeaderModifier.set`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestHeaderModifier.remove`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.responseHeaderModifier`|Headers to be modified in the response.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.responseHeaderModifier.add`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.responseHeaderModifier.set`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.responseHeaderModifier.remove`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestRedirect`|Directly respond to the request with a redirect.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestRedirect.scheme`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestRedirect.authority`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestRedirect.authority.(any)(1)full`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestRedirect.authority.(any)(1)host`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestRedirect.authority.(any)(1)port`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestRedirect.path`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestRedirect.path.(any)(1)full`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestRedirect.path.(any)(1)prefix`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestRedirect.status`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendTLS`|Send TLS to the backend.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendTLS.cert`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendTLS.key`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendTLS.root`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendTLS.hostname`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendTLS.insecure`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendTLS.insecureHost`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendTLS.alpn`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendTLS.subjectAltNames`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth`|Authenticate to the backend.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)passthrough`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)key`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)key.(any)file`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)gcp`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)gcp.(any)type`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)gcp.(any)audience`|Audience for the token. If not set, the destination host will be used.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)gcp.(any)type`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)aws`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)aws.(any)accessKeyId`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)aws.(any)secretAccessKey`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)aws.(any)region`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)aws.(any)sessionToken`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.tenant_id`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_id`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_secret`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)clientId`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)objectId`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)resourceId`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)workloadIdentity`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)developerImplicit`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.http`|Specify HTTP settings for the backend|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.http.version`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.http.requestTimeout`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.tcp`|Specify TCP settings for the backend|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.tcp.keepalives`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.tcp.keepalives.enabled`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.tcp.keepalives.time`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.tcp.keepalives.interval`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.tcp.keepalives.retries`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.tcp.connectTimeout`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.tcp.connectTimeout.secs`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].(1)googleModelArmor.policies.tcp.connectTimeout.nanos`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].rejection`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].rejection.body`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].rejection.status`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].rejection.headers`|Optional headers to add, set, or remove from the rejection response|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].rejection.headers.add`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].rejection.headers.set`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.request[].rejection.headers.remove`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)regex`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)regex.action`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)regex.rules`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)regex.rules[].(any)builtin`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)regex.rules[].(any)pattern`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)webhook`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)webhook.target`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)webhook.target.(1)service`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)webhook.target.(1)service.name`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)webhook.target.(1)service.name.namespace`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)webhook.target.(1)service.name.hostname`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)webhook.target.(1)service.port`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)webhook.target.(1)host`|Hostname or IP address|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)webhook.target.(1)backend`|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)webhook.forwardHeaderMatches`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)webhook.forwardHeaderMatches[].name`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)webhook.forwardHeaderMatches[].value`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)webhook.forwardHeaderMatches[].value.(1)exact`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)webhook.forwardHeaderMatches[].value.(1)regex`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails`|Configuration for AWS Bedrock Guardrails integration.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.guardrailIdentifier`|The unique identifier of the guardrail|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.guardrailVersion`|The version of the guardrail|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.region`|AWS region where the guardrail is deployed|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies`|Backend policies for AWS authentication (optional, defaults to implicit AWS auth)|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestHeaderModifier`|Headers to be modified in the request.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestHeaderModifier.add`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestHeaderModifier.set`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestHeaderModifier.remove`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.responseHeaderModifier`|Headers to be modified in the response.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.responseHeaderModifier.add`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.responseHeaderModifier.set`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.responseHeaderModifier.remove`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestRedirect`|Directly respond to the request with a redirect.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestRedirect.scheme`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestRedirect.authority`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestRedirect.authority.(any)(1)full`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestRedirect.authority.(any)(1)host`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestRedirect.authority.(any)(1)port`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestRedirect.path`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestRedirect.path.(any)(1)full`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestRedirect.path.(any)(1)prefix`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestRedirect.status`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendTLS`|Send TLS to the backend.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendTLS.cert`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendTLS.key`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendTLS.root`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendTLS.hostname`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendTLS.insecure`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendTLS.insecureHost`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendTLS.alpn`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendTLS.subjectAltNames`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth`|Authenticate to the backend.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)passthrough`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)key`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)key.(any)file`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)gcp`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)gcp.(any)type`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)gcp.(any)audience`|Audience for the token. If not set, the destination host will be used.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)gcp.(any)type`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)aws`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)aws.(any)accessKeyId`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)aws.(any)secretAccessKey`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)aws.(any)region`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)aws.(any)sessionToken`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.tenant_id`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_id`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_secret`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)clientId`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)objectId`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)resourceId`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)workloadIdentity`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)developerImplicit`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.http`|Specify HTTP settings for the backend|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.http.version`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.http.requestTimeout`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.tcp`|Specify TCP settings for the backend|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.tcp.keepalives`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.tcp.keepalives.enabled`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.tcp.keepalives.time`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.tcp.keepalives.interval`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.tcp.keepalives.retries`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.tcp.connectTimeout`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.tcp.connectTimeout.secs`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.tcp.connectTimeout.nanos`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor`|Configuration for Google Cloud Model Armor integration.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.templateId`|The template ID for the Model Armor configuration|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.projectId`|The GCP project ID|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.location`|The GCP region (default: us-central1)|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies`|Backend policies for GCP authentication (optional, defaults to implicit GCP auth)|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestHeaderModifier`|Headers to be modified in the request.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestHeaderModifier.add`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestHeaderModifier.set`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestHeaderModifier.remove`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.responseHeaderModifier`|Headers to be modified in the response.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.responseHeaderModifier.add`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.responseHeaderModifier.set`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.responseHeaderModifier.remove`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestRedirect`|Directly respond to the request with a redirect.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestRedirect.scheme`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestRedirect.authority`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestRedirect.authority.(any)(1)full`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestRedirect.authority.(any)(1)host`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestRedirect.authority.(any)(1)port`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestRedirect.path`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestRedirect.path.(any)(1)full`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestRedirect.path.(any)(1)prefix`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestRedirect.status`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendTLS`|Send TLS to the backend.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendTLS.cert`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendTLS.key`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendTLS.root`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendTLS.hostname`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendTLS.insecure`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendTLS.insecureHost`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendTLS.alpn`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendTLS.subjectAltNames`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth`|Authenticate to the backend.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)passthrough`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)key`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)key.(any)file`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)gcp`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)gcp.(any)type`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)gcp.(any)audience`|Audience for the token. If not set, the destination host will be used.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)gcp.(any)type`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)aws`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)aws.(any)accessKeyId`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)aws.(any)secretAccessKey`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)aws.(any)region`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)aws.(any)sessionToken`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.tenant_id`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_id`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_secret`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)clientId`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)objectId`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)resourceId`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)workloadIdentity`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)developerImplicit`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.http`|Specify HTTP settings for the backend|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.http.version`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.http.requestTimeout`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.tcp`|Specify TCP settings for the backend|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.tcp.keepalives`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.tcp.keepalives.enabled`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.tcp.keepalives.time`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.tcp.keepalives.interval`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.tcp.keepalives.retries`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.tcp.connectTimeout`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.tcp.connectTimeout.secs`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].(1)googleModelArmor.policies.tcp.connectTimeout.nanos`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].rejection`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].rejection.body`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].rejection.status`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].rejection.headers`|Optional headers to add, set, or remove from the rejection response|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].rejection.headers.add`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].rejection.headers.set`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptGuard.response[].rejection.headers.remove`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.defaults`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.overrides`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.transformations`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.prompts`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.prompts.append`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.prompts.append[].role`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.prompts.append[].content`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.prompts.prepend`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.prompts.prepend[].role`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.prompts.prepend[].content`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.modelAliases`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptCaching`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptCaching.cacheSystem`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptCaching.cacheMessages`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptCaching.cacheTools`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.promptCaching.minTokens`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)policies.ai.routes`||
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)groups`||
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers`||
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].name`||
@@ -1174,105 +1578,6 @@
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.requestRedirect.path.(any)(1)full`||
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.requestRedirect.path.(any)(1)prefix`||
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.requestRedirect.status`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.mcpAuthorization`|Authorization policies for MCP access.|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.mcpAuthorization.rules`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.a2a`|Mark this traffic as A2A to enable A2A processing and telemetry.|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai`|Mark this as LLM traffic to enable LLM processing.|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)regex`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)regex.action`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)regex.rules`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)regex.rules[].(any)builtin`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)regex.rules[].(any)pattern`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)webhook`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)webhook.target`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)webhook.target.(1)service`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)webhook.target.(1)service.name`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)webhook.target.(1)service.name.namespace`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)webhook.target.(1)service.name.hostname`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)webhook.target.(1)service.port`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)webhook.target.(1)host`|Hostname or IP address|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)webhook.target.(1)backend`|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)webhook.forwardHeaderMatches`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)webhook.forwardHeaderMatches[].name`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)webhook.forwardHeaderMatches[].value`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)webhook.forwardHeaderMatches[].value.(1)exact`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)webhook.forwardHeaderMatches[].value.(1)regex`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.model`|Model to use. Defaults to `omni-moderation-latest`|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails`|Configuration for AWS Bedrock Guardrails integration.|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.guardrailIdentifier`|The unique identifier of the guardrail|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.guardrailVersion`|The version of the guardrail|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.region`|AWS region where the guardrail is deployed|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies`|Backend policies for AWS authentication (optional, defaults to implicit AWS auth)|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor`|Configuration for Google Cloud Model Armor integration.|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.templateId`|The template ID for the Model Armor configuration|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.projectId`|The GCP project ID|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.location`|The GCP region (default: us-central1)|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies`|Backend policies for GCP authentication (optional, defaults to implicit GCP auth)|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].rejection`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].rejection.body`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].rejection.status`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].rejection.headers`|Optional headers to add, set, or remove from the rejection response|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].rejection.headers.add`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].rejection.headers.set`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].rejection.headers.remove`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)regex`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)regex.action`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)regex.rules`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)regex.rules[].(any)builtin`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)regex.rules[].(any)pattern`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)webhook`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)webhook.target`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)webhook.target.(1)service`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)webhook.target.(1)service.name`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)webhook.target.(1)service.name.namespace`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)webhook.target.(1)service.name.hostname`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)webhook.target.(1)service.port`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)webhook.target.(1)host`|Hostname or IP address|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)webhook.target.(1)backend`|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)webhook.forwardHeaderMatches`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)webhook.forwardHeaderMatches[].name`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)webhook.forwardHeaderMatches[].value`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)webhook.forwardHeaderMatches[].value.(1)exact`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)webhook.forwardHeaderMatches[].value.(1)regex`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails`|Configuration for AWS Bedrock Guardrails integration.|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.guardrailIdentifier`|The unique identifier of the guardrail|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.guardrailVersion`|The version of the guardrail|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.region`|AWS region where the guardrail is deployed|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies`|Backend policies for AWS authentication (optional, defaults to implicit AWS auth)|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor`|Configuration for Google Cloud Model Armor integration.|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.templateId`|The template ID for the Model Armor configuration|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.projectId`|The GCP project ID|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.location`|The GCP region (default: us-central1)|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies`|Backend policies for GCP authentication (optional, defaults to implicit GCP auth)|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].rejection`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].rejection.body`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].rejection.status`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].rejection.headers`|Optional headers to add, set, or remove from the rejection response|
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].rejection.headers.add`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].rejection.headers.set`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].rejection.headers.remove`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.defaults`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.overrides`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.transformations`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.prompts`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.prompts.append`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.prompts.append[].role`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.prompts.append[].content`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.prompts.prepend`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.prompts.prepend[].role`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.prompts.prepend[].content`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.modelAliases`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptCaching`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptCaching.cacheSystem`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptCaching.cacheMessages`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptCaching.cacheTools`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptCaching.minTokens`||
-|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.routes`||
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.backendTLS`|Send TLS to the backend.|
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.backendTLS.cert`||
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.backendTLS.key`||
@@ -1320,6 +1625,430 @@
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.tcp.connectTimeout`||
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.tcp.connectTimeout.secs`||
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.tcp.connectTimeout.nanos`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.mcpAuthorization`|Authorization policies for MCP access.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.mcpAuthorization.rules`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.a2a`|Mark this traffic as A2A to enable A2A processing and telemetry.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai`|Mark this as LLM traffic to enable LLM processing.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)regex`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)regex.action`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)regex.rules`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)regex.rules[].(any)builtin`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)regex.rules[].(any)pattern`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)webhook`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)webhook.target`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)webhook.target.(1)service`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)webhook.target.(1)service.name`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)webhook.target.(1)service.name.namespace`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)webhook.target.(1)service.name.hostname`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)webhook.target.(1)service.port`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)webhook.target.(1)host`|Hostname or IP address|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)webhook.target.(1)backend`|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)webhook.forwardHeaderMatches`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)webhook.forwardHeaderMatches[].name`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)webhook.forwardHeaderMatches[].value`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)webhook.forwardHeaderMatches[].value.(1)exact`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)webhook.forwardHeaderMatches[].value.(1)regex`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.model`|Model to use. Defaults to `omni-moderation-latest`|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestHeaderModifier`|Headers to be modified in the request.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestHeaderModifier.add`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestHeaderModifier.set`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestHeaderModifier.remove`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.responseHeaderModifier`|Headers to be modified in the response.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.responseHeaderModifier.add`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.responseHeaderModifier.set`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.responseHeaderModifier.remove`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestRedirect`|Directly respond to the request with a redirect.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestRedirect.scheme`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestRedirect.authority`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestRedirect.authority.(any)(1)full`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestRedirect.authority.(any)(1)host`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestRedirect.authority.(any)(1)port`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestRedirect.path`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestRedirect.path.(any)(1)full`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestRedirect.path.(any)(1)prefix`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestRedirect.status`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendTLS`|Send TLS to the backend.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendTLS.cert`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendTLS.key`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendTLS.root`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendTLS.hostname`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendTLS.insecure`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendTLS.insecureHost`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendTLS.alpn`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendTLS.subjectAltNames`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth`|Authenticate to the backend.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)passthrough`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)key`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)key.(any)file`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)gcp`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)gcp.(any)type`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)gcp.(any)audience`|Audience for the token. If not set, the destination host will be used.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)gcp.(any)type`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)aws`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)aws.(any)accessKeyId`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)aws.(any)secretAccessKey`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)aws.(any)region`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)aws.(any)sessionToken`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)azure`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)azure.(1)explicitConfig`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.tenant_id`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_id`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_secret`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)clientId`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)objectId`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)resourceId`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)workloadIdentity`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)azure.(1)developerImplicit`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.http`|Specify HTTP settings for the backend|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.http.version`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.http.requestTimeout`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.tcp`|Specify TCP settings for the backend|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.tcp.keepalives`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.tcp.keepalives.enabled`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.tcp.keepalives.time`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.tcp.keepalives.interval`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.tcp.keepalives.retries`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.tcp.connectTimeout`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.tcp.connectTimeout.secs`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.tcp.connectTimeout.nanos`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails`|Configuration for AWS Bedrock Guardrails integration.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.guardrailIdentifier`|The unique identifier of the guardrail|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.guardrailVersion`|The version of the guardrail|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.region`|AWS region where the guardrail is deployed|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies`|Backend policies for AWS authentication (optional, defaults to implicit AWS auth)|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestHeaderModifier`|Headers to be modified in the request.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestHeaderModifier.add`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestHeaderModifier.set`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestHeaderModifier.remove`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.responseHeaderModifier`|Headers to be modified in the response.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.responseHeaderModifier.add`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.responseHeaderModifier.set`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.responseHeaderModifier.remove`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestRedirect`|Directly respond to the request with a redirect.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestRedirect.scheme`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestRedirect.authority`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestRedirect.authority.(any)(1)full`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestRedirect.authority.(any)(1)host`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestRedirect.authority.(any)(1)port`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestRedirect.path`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestRedirect.path.(any)(1)full`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestRedirect.path.(any)(1)prefix`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestRedirect.status`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendTLS`|Send TLS to the backend.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendTLS.cert`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendTLS.key`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendTLS.root`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendTLS.hostname`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendTLS.insecure`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendTLS.insecureHost`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendTLS.alpn`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendTLS.subjectAltNames`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth`|Authenticate to the backend.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)passthrough`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)key`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)key.(any)file`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)gcp`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)gcp.(any)type`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)gcp.(any)audience`|Audience for the token. If not set, the destination host will be used.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)gcp.(any)type`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)aws`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)aws.(any)accessKeyId`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)aws.(any)secretAccessKey`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)aws.(any)region`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)aws.(any)sessionToken`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.tenant_id`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_id`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_secret`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)clientId`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)objectId`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)resourceId`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)workloadIdentity`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)developerImplicit`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.http`|Specify HTTP settings for the backend|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.http.version`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.http.requestTimeout`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.tcp`|Specify TCP settings for the backend|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.tcp.keepalives`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.tcp.keepalives.enabled`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.tcp.keepalives.time`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.tcp.keepalives.interval`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.tcp.keepalives.retries`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.tcp.connectTimeout`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.tcp.connectTimeout.secs`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.tcp.connectTimeout.nanos`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor`|Configuration for Google Cloud Model Armor integration.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.templateId`|The template ID for the Model Armor configuration|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.projectId`|The GCP project ID|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.location`|The GCP region (default: us-central1)|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies`|Backend policies for GCP authentication (optional, defaults to implicit GCP auth)|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestHeaderModifier`|Headers to be modified in the request.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestHeaderModifier.add`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestHeaderModifier.set`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestHeaderModifier.remove`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.responseHeaderModifier`|Headers to be modified in the response.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.responseHeaderModifier.add`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.responseHeaderModifier.set`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.responseHeaderModifier.remove`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestRedirect`|Directly respond to the request with a redirect.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestRedirect.scheme`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestRedirect.authority`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestRedirect.authority.(any)(1)full`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestRedirect.authority.(any)(1)host`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestRedirect.authority.(any)(1)port`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestRedirect.path`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestRedirect.path.(any)(1)full`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestRedirect.path.(any)(1)prefix`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestRedirect.status`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendTLS`|Send TLS to the backend.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendTLS.cert`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendTLS.key`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendTLS.root`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendTLS.hostname`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendTLS.insecure`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendTLS.insecureHost`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendTLS.alpn`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendTLS.subjectAltNames`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth`|Authenticate to the backend.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)passthrough`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)key`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)key.(any)file`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)gcp`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)gcp.(any)type`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)gcp.(any)audience`|Audience for the token. If not set, the destination host will be used.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)gcp.(any)type`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)aws`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)aws.(any)accessKeyId`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)aws.(any)secretAccessKey`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)aws.(any)region`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)aws.(any)sessionToken`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.tenant_id`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_id`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_secret`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)clientId`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)objectId`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)resourceId`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)workloadIdentity`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)developerImplicit`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.http`|Specify HTTP settings for the backend|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.http.version`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.http.requestTimeout`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.tcp`|Specify TCP settings for the backend|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.tcp.keepalives`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.tcp.keepalives.enabled`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.tcp.keepalives.time`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.tcp.keepalives.interval`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.tcp.keepalives.retries`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.tcp.connectTimeout`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.tcp.connectTimeout.secs`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.tcp.connectTimeout.nanos`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].rejection`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].rejection.body`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].rejection.status`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].rejection.headers`|Optional headers to add, set, or remove from the rejection response|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].rejection.headers.add`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].rejection.headers.set`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.request[].rejection.headers.remove`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)regex`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)regex.action`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)regex.rules`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)regex.rules[].(any)builtin`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)regex.rules[].(any)pattern`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)webhook`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)webhook.target`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)webhook.target.(1)service`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)webhook.target.(1)service.name`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)webhook.target.(1)service.name.namespace`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)webhook.target.(1)service.name.hostname`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)webhook.target.(1)service.port`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)webhook.target.(1)host`|Hostname or IP address|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)webhook.target.(1)backend`|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)webhook.forwardHeaderMatches`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)webhook.forwardHeaderMatches[].name`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)webhook.forwardHeaderMatches[].value`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)webhook.forwardHeaderMatches[].value.(1)exact`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)webhook.forwardHeaderMatches[].value.(1)regex`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails`|Configuration for AWS Bedrock Guardrails integration.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.guardrailIdentifier`|The unique identifier of the guardrail|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.guardrailVersion`|The version of the guardrail|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.region`|AWS region where the guardrail is deployed|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies`|Backend policies for AWS authentication (optional, defaults to implicit AWS auth)|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestHeaderModifier`|Headers to be modified in the request.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestHeaderModifier.add`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestHeaderModifier.set`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestHeaderModifier.remove`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.responseHeaderModifier`|Headers to be modified in the response.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.responseHeaderModifier.add`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.responseHeaderModifier.set`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.responseHeaderModifier.remove`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestRedirect`|Directly respond to the request with a redirect.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestRedirect.scheme`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestRedirect.authority`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestRedirect.authority.(any)(1)full`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestRedirect.authority.(any)(1)host`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestRedirect.authority.(any)(1)port`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestRedirect.path`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestRedirect.path.(any)(1)full`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestRedirect.path.(any)(1)prefix`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestRedirect.status`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendTLS`|Send TLS to the backend.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendTLS.cert`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendTLS.key`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendTLS.root`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendTLS.hostname`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendTLS.insecure`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendTLS.insecureHost`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendTLS.alpn`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendTLS.subjectAltNames`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth`|Authenticate to the backend.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)passthrough`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)key`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)key.(any)file`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)gcp`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)gcp.(any)type`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)gcp.(any)audience`|Audience for the token. If not set, the destination host will be used.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)gcp.(any)type`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)aws`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)aws.(any)accessKeyId`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)aws.(any)secretAccessKey`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)aws.(any)region`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)aws.(any)sessionToken`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.tenant_id`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_id`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_secret`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)clientId`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)objectId`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)resourceId`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)workloadIdentity`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)developerImplicit`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.http`|Specify HTTP settings for the backend|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.http.version`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.http.requestTimeout`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.tcp`|Specify TCP settings for the backend|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.tcp.keepalives`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.tcp.keepalives.enabled`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.tcp.keepalives.time`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.tcp.keepalives.interval`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.tcp.keepalives.retries`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.tcp.connectTimeout`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.tcp.connectTimeout.secs`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.tcp.connectTimeout.nanos`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor`|Configuration for Google Cloud Model Armor integration.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.templateId`|The template ID for the Model Armor configuration|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.projectId`|The GCP project ID|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.location`|The GCP region (default: us-central1)|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies`|Backend policies for GCP authentication (optional, defaults to implicit GCP auth)|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestHeaderModifier`|Headers to be modified in the request.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestHeaderModifier.add`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestHeaderModifier.set`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestHeaderModifier.remove`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.responseHeaderModifier`|Headers to be modified in the response.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.responseHeaderModifier.add`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.responseHeaderModifier.set`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.responseHeaderModifier.remove`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestRedirect`|Directly respond to the request with a redirect.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestRedirect.scheme`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestRedirect.authority`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestRedirect.authority.(any)(1)full`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestRedirect.authority.(any)(1)host`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestRedirect.authority.(any)(1)port`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestRedirect.path`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestRedirect.path.(any)(1)full`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestRedirect.path.(any)(1)prefix`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestRedirect.status`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendTLS`|Send TLS to the backend.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendTLS.cert`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendTLS.key`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendTLS.root`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendTLS.hostname`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendTLS.insecure`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendTLS.insecureHost`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendTLS.alpn`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendTLS.subjectAltNames`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth`|Authenticate to the backend.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)passthrough`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)key`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)key.(any)file`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)gcp`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)gcp.(any)type`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)gcp.(any)audience`|Audience for the token. If not set, the destination host will be used.|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)gcp.(any)type`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)aws`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)aws.(any)accessKeyId`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)aws.(any)secretAccessKey`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)aws.(any)region`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)aws.(any)sessionToken`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.tenant_id`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_id`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_secret`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)clientId`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)objectId`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)resourceId`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)workloadIdentity`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)developerImplicit`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.http`|Specify HTTP settings for the backend|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.http.version`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.http.requestTimeout`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.tcp`|Specify TCP settings for the backend|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.tcp.keepalives`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.tcp.keepalives.enabled`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.tcp.keepalives.time`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.tcp.keepalives.interval`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.tcp.keepalives.retries`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.tcp.connectTimeout`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.tcp.connectTimeout.secs`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.tcp.connectTimeout.nanos`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].rejection`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].rejection.body`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].rejection.status`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].rejection.headers`|Optional headers to add, set, or remove from the rejection response|
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].rejection.headers.add`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].rejection.headers.set`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptGuard.response[].rejection.headers.remove`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.defaults`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.overrides`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.transformations`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.prompts`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.prompts.append`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.prompts.append[].role`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.prompts.append[].content`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.prompts.prepend`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.prompts.prepend[].role`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.prompts.prepend[].content`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.modelAliases`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptCaching`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptCaching.cacheSystem`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptCaching.cacheMessages`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptCaching.cacheTools`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.promptCaching.minTokens`||
+|`binds[].listeners[].routes[].backends[].(1)ai.(any)groups[].providers[].policies.ai.routes`||
 |`binds[].listeners[].routes[].backends[].weight`||
 |`binds[].listeners[].routes[].backends[].policies`||
 |`binds[].listeners[].routes[].backends[].policies.requestHeaderModifier`|Headers to be modified in the request.|
@@ -1340,105 +2069,6 @@
 |`binds[].listeners[].routes[].backends[].policies.requestRedirect.path.(any)(1)full`||
 |`binds[].listeners[].routes[].backends[].policies.requestRedirect.path.(any)(1)prefix`||
 |`binds[].listeners[].routes[].backends[].policies.requestRedirect.status`||
-|`binds[].listeners[].routes[].backends[].policies.mcpAuthorization`|Authorization policies for MCP access.|
-|`binds[].listeners[].routes[].backends[].policies.mcpAuthorization.rules`||
-|`binds[].listeners[].routes[].backends[].policies.a2a`|Mark this traffic as A2A to enable A2A processing and telemetry.|
-|`binds[].listeners[].routes[].backends[].policies.ai`|Mark this as LLM traffic to enable LLM processing.|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)regex`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)regex.action`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)regex.rules`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)regex.rules[].(any)builtin`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)regex.rules[].(any)pattern`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)webhook`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)webhook.target`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)webhook.target.(1)service`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)webhook.target.(1)service.name`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)webhook.target.(1)service.name.namespace`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)webhook.target.(1)service.name.hostname`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)webhook.target.(1)service.port`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)webhook.target.(1)host`|Hostname or IP address|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)webhook.target.(1)backend`|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)webhook.forwardHeaderMatches`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)webhook.forwardHeaderMatches[].name`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)webhook.forwardHeaderMatches[].value`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)webhook.forwardHeaderMatches[].value.(1)exact`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)webhook.forwardHeaderMatches[].value.(1)regex`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.model`|Model to use. Defaults to `omni-moderation-latest`|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails`|Configuration for AWS Bedrock Guardrails integration.|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.guardrailIdentifier`|The unique identifier of the guardrail|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.guardrailVersion`|The version of the guardrail|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.region`|AWS region where the guardrail is deployed|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies`|Backend policies for AWS authentication (optional, defaults to implicit AWS auth)|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor`|Configuration for Google Cloud Model Armor integration.|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.templateId`|The template ID for the Model Armor configuration|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.projectId`|The GCP project ID|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.location`|The GCP region (default: us-central1)|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies`|Backend policies for GCP authentication (optional, defaults to implicit GCP auth)|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].rejection`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].rejection.body`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].rejection.status`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].rejection.headers`|Optional headers to add, set, or remove from the rejection response|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].rejection.headers.add`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].rejection.headers.set`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].rejection.headers.remove`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)regex`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)regex.action`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)regex.rules`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)regex.rules[].(any)builtin`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)regex.rules[].(any)pattern`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)webhook`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)webhook.target`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)webhook.target.(1)service`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)webhook.target.(1)service.name`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)webhook.target.(1)service.name.namespace`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)webhook.target.(1)service.name.hostname`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)webhook.target.(1)service.port`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)webhook.target.(1)host`|Hostname or IP address|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)webhook.target.(1)backend`|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)webhook.forwardHeaderMatches`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)webhook.forwardHeaderMatches[].name`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)webhook.forwardHeaderMatches[].value`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)webhook.forwardHeaderMatches[].value.(1)exact`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)webhook.forwardHeaderMatches[].value.(1)regex`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails`|Configuration for AWS Bedrock Guardrails integration.|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.guardrailIdentifier`|The unique identifier of the guardrail|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.guardrailVersion`|The version of the guardrail|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.region`|AWS region where the guardrail is deployed|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies`|Backend policies for AWS authentication (optional, defaults to implicit AWS auth)|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor`|Configuration for Google Cloud Model Armor integration.|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.templateId`|The template ID for the Model Armor configuration|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.projectId`|The GCP project ID|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.location`|The GCP region (default: us-central1)|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies`|Backend policies for GCP authentication (optional, defaults to implicit GCP auth)|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].rejection`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].rejection.body`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].rejection.status`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].rejection.headers`|Optional headers to add, set, or remove from the rejection response|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].rejection.headers.add`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].rejection.headers.set`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].rejection.headers.remove`||
-|`binds[].listeners[].routes[].backends[].policies.ai.defaults`||
-|`binds[].listeners[].routes[].backends[].policies.ai.overrides`||
-|`binds[].listeners[].routes[].backends[].policies.ai.transformations`||
-|`binds[].listeners[].routes[].backends[].policies.ai.prompts`||
-|`binds[].listeners[].routes[].backends[].policies.ai.prompts.append`||
-|`binds[].listeners[].routes[].backends[].policies.ai.prompts.append[].role`||
-|`binds[].listeners[].routes[].backends[].policies.ai.prompts.append[].content`||
-|`binds[].listeners[].routes[].backends[].policies.ai.prompts.prepend`||
-|`binds[].listeners[].routes[].backends[].policies.ai.prompts.prepend[].role`||
-|`binds[].listeners[].routes[].backends[].policies.ai.prompts.prepend[].content`||
-|`binds[].listeners[].routes[].backends[].policies.ai.modelAliases`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptCaching`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptCaching.cacheSystem`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptCaching.cacheMessages`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptCaching.cacheTools`||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptCaching.minTokens`||
-|`binds[].listeners[].routes[].backends[].policies.ai.routes`||
 |`binds[].listeners[].routes[].backends[].policies.backendTLS`|Send TLS to the backend.|
 |`binds[].listeners[].routes[].backends[].policies.backendTLS.cert`||
 |`binds[].listeners[].routes[].backends[].policies.backendTLS.key`||
@@ -1486,6 +2116,430 @@
 |`binds[].listeners[].routes[].backends[].policies.tcp.connectTimeout`||
 |`binds[].listeners[].routes[].backends[].policies.tcp.connectTimeout.secs`||
 |`binds[].listeners[].routes[].backends[].policies.tcp.connectTimeout.nanos`||
+|`binds[].listeners[].routes[].backends[].policies.mcpAuthorization`|Authorization policies for MCP access.|
+|`binds[].listeners[].routes[].backends[].policies.mcpAuthorization.rules`||
+|`binds[].listeners[].routes[].backends[].policies.a2a`|Mark this traffic as A2A to enable A2A processing and telemetry.|
+|`binds[].listeners[].routes[].backends[].policies.ai`|Mark this as LLM traffic to enable LLM processing.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)regex`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)regex.action`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)regex.rules`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)regex.rules[].(any)builtin`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)regex.rules[].(any)pattern`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)webhook`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)webhook.target`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)webhook.target.(1)service`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)webhook.target.(1)service.name`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)webhook.target.(1)service.name.namespace`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)webhook.target.(1)service.name.hostname`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)webhook.target.(1)service.port`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)webhook.target.(1)host`|Hostname or IP address|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)webhook.target.(1)backend`|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)webhook.forwardHeaderMatches`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)webhook.forwardHeaderMatches[].name`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)webhook.forwardHeaderMatches[].value`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)webhook.forwardHeaderMatches[].value.(1)exact`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)webhook.forwardHeaderMatches[].value.(1)regex`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.model`|Model to use. Defaults to `omni-moderation-latest`|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestHeaderModifier`|Headers to be modified in the request.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestHeaderModifier.add`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestHeaderModifier.set`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestHeaderModifier.remove`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.responseHeaderModifier`|Headers to be modified in the response.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.responseHeaderModifier.add`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.responseHeaderModifier.set`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.responseHeaderModifier.remove`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestRedirect`|Directly respond to the request with a redirect.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestRedirect.scheme`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestRedirect.authority`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestRedirect.authority.(any)(1)full`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestRedirect.authority.(any)(1)host`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestRedirect.authority.(any)(1)port`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestRedirect.path`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestRedirect.path.(any)(1)full`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestRedirect.path.(any)(1)prefix`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestRedirect.status`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendTLS`|Send TLS to the backend.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendTLS.cert`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendTLS.key`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendTLS.root`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendTLS.hostname`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendTLS.insecure`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendTLS.insecureHost`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendTLS.alpn`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendTLS.subjectAltNames`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth`|Authenticate to the backend.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)passthrough`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)key`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)key.(any)file`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)gcp`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)gcp.(any)type`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)gcp.(any)audience`|Audience for the token. If not set, the destination host will be used.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)gcp.(any)type`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)aws`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)aws.(any)accessKeyId`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)aws.(any)secretAccessKey`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)aws.(any)region`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)aws.(any)sessionToken`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)azure`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)azure.(1)explicitConfig`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.tenant_id`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_id`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_secret`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)clientId`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)objectId`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)resourceId`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)workloadIdentity`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)azure.(1)developerImplicit`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.http`|Specify HTTP settings for the backend|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.http.version`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.http.requestTimeout`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.tcp`|Specify TCP settings for the backend|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.tcp.keepalives`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.tcp.keepalives.enabled`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.tcp.keepalives.time`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.tcp.keepalives.interval`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.tcp.keepalives.retries`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.tcp.connectTimeout`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.tcp.connectTimeout.secs`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.tcp.connectTimeout.nanos`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails`|Configuration for AWS Bedrock Guardrails integration.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.guardrailIdentifier`|The unique identifier of the guardrail|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.guardrailVersion`|The version of the guardrail|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.region`|AWS region where the guardrail is deployed|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies`|Backend policies for AWS authentication (optional, defaults to implicit AWS auth)|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestHeaderModifier`|Headers to be modified in the request.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestHeaderModifier.add`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestHeaderModifier.set`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestHeaderModifier.remove`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.responseHeaderModifier`|Headers to be modified in the response.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.responseHeaderModifier.add`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.responseHeaderModifier.set`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.responseHeaderModifier.remove`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestRedirect`|Directly respond to the request with a redirect.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestRedirect.scheme`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestRedirect.authority`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestRedirect.authority.(any)(1)full`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestRedirect.authority.(any)(1)host`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestRedirect.authority.(any)(1)port`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestRedirect.path`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestRedirect.path.(any)(1)full`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestRedirect.path.(any)(1)prefix`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestRedirect.status`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendTLS`|Send TLS to the backend.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendTLS.cert`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendTLS.key`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendTLS.root`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendTLS.hostname`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendTLS.insecure`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendTLS.insecureHost`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendTLS.alpn`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendTLS.subjectAltNames`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth`|Authenticate to the backend.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)passthrough`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)key`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)key.(any)file`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)gcp`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)gcp.(any)type`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)gcp.(any)audience`|Audience for the token. If not set, the destination host will be used.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)gcp.(any)type`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)aws`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)aws.(any)accessKeyId`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)aws.(any)secretAccessKey`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)aws.(any)region`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)aws.(any)sessionToken`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.tenant_id`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_id`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_secret`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)clientId`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)objectId`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)resourceId`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)workloadIdentity`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)developerImplicit`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.http`|Specify HTTP settings for the backend|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.http.version`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.http.requestTimeout`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.tcp`|Specify TCP settings for the backend|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.tcp.keepalives`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.tcp.keepalives.enabled`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.tcp.keepalives.time`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.tcp.keepalives.interval`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.tcp.keepalives.retries`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.tcp.connectTimeout`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.tcp.connectTimeout.secs`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.tcp.connectTimeout.nanos`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor`|Configuration for Google Cloud Model Armor integration.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.templateId`|The template ID for the Model Armor configuration|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.projectId`|The GCP project ID|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.location`|The GCP region (default: us-central1)|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies`|Backend policies for GCP authentication (optional, defaults to implicit GCP auth)|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestHeaderModifier`|Headers to be modified in the request.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestHeaderModifier.add`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestHeaderModifier.set`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestHeaderModifier.remove`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.responseHeaderModifier`|Headers to be modified in the response.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.responseHeaderModifier.add`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.responseHeaderModifier.set`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.responseHeaderModifier.remove`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestRedirect`|Directly respond to the request with a redirect.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestRedirect.scheme`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestRedirect.authority`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestRedirect.authority.(any)(1)full`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestRedirect.authority.(any)(1)host`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestRedirect.authority.(any)(1)port`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestRedirect.path`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestRedirect.path.(any)(1)full`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestRedirect.path.(any)(1)prefix`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestRedirect.status`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendTLS`|Send TLS to the backend.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendTLS.cert`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendTLS.key`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendTLS.root`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendTLS.hostname`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendTLS.insecure`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendTLS.insecureHost`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendTLS.alpn`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendTLS.subjectAltNames`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth`|Authenticate to the backend.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)passthrough`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)key`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)key.(any)file`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)gcp`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)gcp.(any)type`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)gcp.(any)audience`|Audience for the token. If not set, the destination host will be used.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)gcp.(any)type`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)aws`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)aws.(any)accessKeyId`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)aws.(any)secretAccessKey`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)aws.(any)region`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)aws.(any)sessionToken`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.tenant_id`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_id`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_secret`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)clientId`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)objectId`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)resourceId`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)workloadIdentity`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)developerImplicit`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.http`|Specify HTTP settings for the backend|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.http.version`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.http.requestTimeout`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.tcp`|Specify TCP settings for the backend|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.tcp.keepalives`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.tcp.keepalives.enabled`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.tcp.keepalives.time`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.tcp.keepalives.interval`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.tcp.keepalives.retries`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.tcp.connectTimeout`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.tcp.connectTimeout.secs`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.tcp.connectTimeout.nanos`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].rejection`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].rejection.body`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].rejection.status`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].rejection.headers`|Optional headers to add, set, or remove from the rejection response|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].rejection.headers.add`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].rejection.headers.set`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].rejection.headers.remove`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)regex`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)regex.action`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)regex.rules`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)regex.rules[].(any)builtin`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)regex.rules[].(any)pattern`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)webhook`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)webhook.target`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)webhook.target.(1)service`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)webhook.target.(1)service.name`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)webhook.target.(1)service.name.namespace`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)webhook.target.(1)service.name.hostname`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)webhook.target.(1)service.port`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)webhook.target.(1)host`|Hostname or IP address|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)webhook.target.(1)backend`|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)webhook.forwardHeaderMatches`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)webhook.forwardHeaderMatches[].name`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)webhook.forwardHeaderMatches[].value`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)webhook.forwardHeaderMatches[].value.(1)exact`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)webhook.forwardHeaderMatches[].value.(1)regex`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails`|Configuration for AWS Bedrock Guardrails integration.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.guardrailIdentifier`|The unique identifier of the guardrail|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.guardrailVersion`|The version of the guardrail|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.region`|AWS region where the guardrail is deployed|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies`|Backend policies for AWS authentication (optional, defaults to implicit AWS auth)|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestHeaderModifier`|Headers to be modified in the request.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestHeaderModifier.add`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestHeaderModifier.set`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestHeaderModifier.remove`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.responseHeaderModifier`|Headers to be modified in the response.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.responseHeaderModifier.add`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.responseHeaderModifier.set`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.responseHeaderModifier.remove`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestRedirect`|Directly respond to the request with a redirect.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestRedirect.scheme`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestRedirect.authority`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestRedirect.authority.(any)(1)full`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestRedirect.authority.(any)(1)host`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestRedirect.authority.(any)(1)port`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestRedirect.path`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestRedirect.path.(any)(1)full`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestRedirect.path.(any)(1)prefix`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestRedirect.status`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendTLS`|Send TLS to the backend.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendTLS.cert`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendTLS.key`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendTLS.root`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendTLS.hostname`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendTLS.insecure`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendTLS.insecureHost`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendTLS.alpn`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendTLS.subjectAltNames`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth`|Authenticate to the backend.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)passthrough`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)key`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)key.(any)file`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)gcp`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)gcp.(any)type`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)gcp.(any)audience`|Audience for the token. If not set, the destination host will be used.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)gcp.(any)type`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)aws`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)aws.(any)accessKeyId`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)aws.(any)secretAccessKey`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)aws.(any)region`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)aws.(any)sessionToken`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.tenant_id`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_id`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_secret`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)clientId`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)objectId`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)resourceId`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)workloadIdentity`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)developerImplicit`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.http`|Specify HTTP settings for the backend|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.http.version`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.http.requestTimeout`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.tcp`|Specify TCP settings for the backend|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.tcp.keepalives`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.tcp.keepalives.enabled`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.tcp.keepalives.time`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.tcp.keepalives.interval`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.tcp.keepalives.retries`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.tcp.connectTimeout`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.tcp.connectTimeout.secs`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.tcp.connectTimeout.nanos`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor`|Configuration for Google Cloud Model Armor integration.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.templateId`|The template ID for the Model Armor configuration|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.projectId`|The GCP project ID|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.location`|The GCP region (default: us-central1)|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies`|Backend policies for GCP authentication (optional, defaults to implicit GCP auth)|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestHeaderModifier`|Headers to be modified in the request.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestHeaderModifier.add`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestHeaderModifier.set`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestHeaderModifier.remove`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.responseHeaderModifier`|Headers to be modified in the response.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.responseHeaderModifier.add`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.responseHeaderModifier.set`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.responseHeaderModifier.remove`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestRedirect`|Directly respond to the request with a redirect.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestRedirect.scheme`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestRedirect.authority`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestRedirect.authority.(any)(1)full`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestRedirect.authority.(any)(1)host`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestRedirect.authority.(any)(1)port`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestRedirect.path`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestRedirect.path.(any)(1)full`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestRedirect.path.(any)(1)prefix`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestRedirect.status`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendTLS`|Send TLS to the backend.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendTLS.cert`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendTLS.key`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendTLS.root`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendTLS.hostname`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendTLS.insecure`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendTLS.insecureHost`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendTLS.alpn`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendTLS.subjectAltNames`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth`|Authenticate to the backend.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)passthrough`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)key`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)key.(any)file`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)gcp`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)gcp.(any)type`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)gcp.(any)audience`|Audience for the token. If not set, the destination host will be used.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)gcp.(any)type`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)aws`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)aws.(any)accessKeyId`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)aws.(any)secretAccessKey`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)aws.(any)region`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)aws.(any)sessionToken`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.tenant_id`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_id`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_secret`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)clientId`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)objectId`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)resourceId`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)workloadIdentity`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)developerImplicit`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.http`|Specify HTTP settings for the backend|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.http.version`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.http.requestTimeout`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.tcp`|Specify TCP settings for the backend|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.tcp.keepalives`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.tcp.keepalives.enabled`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.tcp.keepalives.time`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.tcp.keepalives.interval`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.tcp.keepalives.retries`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.tcp.connectTimeout`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.tcp.connectTimeout.secs`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.tcp.connectTimeout.nanos`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].rejection`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].rejection.body`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].rejection.status`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].rejection.headers`|Optional headers to add, set, or remove from the rejection response|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].rejection.headers.add`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].rejection.headers.set`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].rejection.headers.remove`||
+|`binds[].listeners[].routes[].backends[].policies.ai.defaults`||
+|`binds[].listeners[].routes[].backends[].policies.ai.overrides`||
+|`binds[].listeners[].routes[].backends[].policies.ai.transformations`||
+|`binds[].listeners[].routes[].backends[].policies.ai.prompts`||
+|`binds[].listeners[].routes[].backends[].policies.ai.prompts.append`||
+|`binds[].listeners[].routes[].backends[].policies.ai.prompts.append[].role`||
+|`binds[].listeners[].routes[].backends[].policies.ai.prompts.append[].content`||
+|`binds[].listeners[].routes[].backends[].policies.ai.prompts.prepend`||
+|`binds[].listeners[].routes[].backends[].policies.ai.prompts.prepend[].role`||
+|`binds[].listeners[].routes[].backends[].policies.ai.prompts.prepend[].content`||
+|`binds[].listeners[].routes[].backends[].policies.ai.modelAliases`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptCaching`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptCaching.cacheSystem`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptCaching.cacheMessages`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptCaching.cacheTools`||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptCaching.minTokens`||
+|`binds[].listeners[].routes[].backends[].policies.ai.routes`||
 |`binds[].listeners[].tcpRoutes`||
 |`binds[].listeners[].tcpRoutes[].name`||
 |`binds[].listeners[].tcpRoutes[].namespace`||
@@ -1547,6 +2601,72 @@
 |`binds[].listeners[].policies.extAuthz.(any)(1)service.port`||
 |`binds[].listeners[].policies.extAuthz.(any)(1)host`|Hostname or IP address|
 |`binds[].listeners[].policies.extAuthz.(any)(1)backend`|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].policies.extAuthz.(any)policies`|Policies to connect to the backend|
+|`binds[].listeners[].policies.extAuthz.(any)policies.requestHeaderModifier`|Headers to be modified in the request.|
+|`binds[].listeners[].policies.extAuthz.(any)policies.requestHeaderModifier.add`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.requestHeaderModifier.set`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.requestHeaderModifier.remove`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.responseHeaderModifier`|Headers to be modified in the response.|
+|`binds[].listeners[].policies.extAuthz.(any)policies.responseHeaderModifier.add`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.responseHeaderModifier.set`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.responseHeaderModifier.remove`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.requestRedirect`|Directly respond to the request with a redirect.|
+|`binds[].listeners[].policies.extAuthz.(any)policies.requestRedirect.scheme`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.requestRedirect.authority`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.requestRedirect.authority.(any)(1)full`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.requestRedirect.authority.(any)(1)host`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.requestRedirect.authority.(any)(1)port`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.requestRedirect.path`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.requestRedirect.path.(any)(1)full`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.requestRedirect.path.(any)(1)prefix`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.requestRedirect.status`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.backendTLS`|Send TLS to the backend.|
+|`binds[].listeners[].policies.extAuthz.(any)policies.backendTLS.cert`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.backendTLS.key`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.backendTLS.root`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.backendTLS.hostname`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.backendTLS.insecure`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.backendTLS.insecureHost`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.backendTLS.alpn`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.backendTLS.subjectAltNames`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.backendAuth`|Authenticate to the backend.|
+|`binds[].listeners[].policies.extAuthz.(any)policies.backendAuth.(any)(1)passthrough`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.backendAuth.(any)(1)key`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.backendAuth.(any)(1)key.(any)file`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.backendAuth.(any)(1)gcp`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.backendAuth.(any)(1)gcp.(any)type`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.backendAuth.(any)(1)gcp.(any)audience`|Audience for the token. If not set, the destination host will be used.|
+|`binds[].listeners[].policies.extAuthz.(any)policies.backendAuth.(any)(1)gcp.(any)type`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.backendAuth.(any)(1)aws`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.backendAuth.(any)(1)aws.(any)accessKeyId`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.backendAuth.(any)(1)aws.(any)secretAccessKey`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.backendAuth.(any)(1)aws.(any)region`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.backendAuth.(any)(1)aws.(any)sessionToken`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.backendAuth.(any)(1)azure`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.tenant_id`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_id`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_secret`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)clientId`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)objectId`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)resourceId`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)workloadIdentity`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)developerImplicit`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.http`|Specify HTTP settings for the backend|
+|`binds[].listeners[].policies.extAuthz.(any)policies.http.version`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.http.requestTimeout`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.tcp`|Specify TCP settings for the backend|
+|`binds[].listeners[].policies.extAuthz.(any)policies.tcp.keepalives`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.tcp.keepalives.enabled`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.tcp.keepalives.time`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.tcp.keepalives.interval`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.tcp.keepalives.retries`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.tcp.connectTimeout`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.tcp.connectTimeout.secs`||
+|`binds[].listeners[].policies.extAuthz.(any)policies.tcp.connectTimeout.nanos`||
 |`binds[].listeners[].policies.extAuthz.(any)protocol`|The ext_authz protocol to use. Unless you need to integrate with an HTTP-only server, gRPC is recommended.|
 |`binds[].listeners[].policies.extAuthz.(any)protocol.(1)grpc`||
 |`binds[].listeners[].policies.extAuthz.(any)protocol.(1)grpc.context`|Additional context to send to the authorization service.<br>This maps to the `context_extensions` field of the request, and only allows static values.|
@@ -1564,7 +2684,6 @@
 |`binds[].listeners[].policies.extAuthz.(any)includeRequestBody.maxRequestBytes`|Maximum size of request body to buffer (default: 8192)|
 |`binds[].listeners[].policies.extAuthz.(any)includeRequestBody.allowPartialMessage`|If true, send partial body when max_request_bytes is reached|
 |`binds[].listeners[].policies.extAuthz.(any)includeRequestBody.packAsBytes`|If true, pack body as raw bytes in gRPC|
-|`binds[].listeners[].policies.extAuthz.(any)timeout`|Timeout for the authorization request (default: 200ms)|
 |`binds[].listeners[].policies.extProc`|Extend agentgateway with an external processor|
 |`binds[].listeners[].policies.extProc.(any)(1)service`||
 |`binds[].listeners[].policies.extProc.(any)(1)service.name`||
@@ -1573,6 +2692,72 @@
 |`binds[].listeners[].policies.extProc.(any)(1)service.port`||
 |`binds[].listeners[].policies.extProc.(any)(1)host`|Hostname or IP address|
 |`binds[].listeners[].policies.extProc.(any)(1)backend`|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].policies.extProc.(any)policies`|Policies to connect to the backend|
+|`binds[].listeners[].policies.extProc.(any)policies.requestHeaderModifier`|Headers to be modified in the request.|
+|`binds[].listeners[].policies.extProc.(any)policies.requestHeaderModifier.add`||
+|`binds[].listeners[].policies.extProc.(any)policies.requestHeaderModifier.set`||
+|`binds[].listeners[].policies.extProc.(any)policies.requestHeaderModifier.remove`||
+|`binds[].listeners[].policies.extProc.(any)policies.responseHeaderModifier`|Headers to be modified in the response.|
+|`binds[].listeners[].policies.extProc.(any)policies.responseHeaderModifier.add`||
+|`binds[].listeners[].policies.extProc.(any)policies.responseHeaderModifier.set`||
+|`binds[].listeners[].policies.extProc.(any)policies.responseHeaderModifier.remove`||
+|`binds[].listeners[].policies.extProc.(any)policies.requestRedirect`|Directly respond to the request with a redirect.|
+|`binds[].listeners[].policies.extProc.(any)policies.requestRedirect.scheme`||
+|`binds[].listeners[].policies.extProc.(any)policies.requestRedirect.authority`||
+|`binds[].listeners[].policies.extProc.(any)policies.requestRedirect.authority.(any)(1)full`||
+|`binds[].listeners[].policies.extProc.(any)policies.requestRedirect.authority.(any)(1)host`||
+|`binds[].listeners[].policies.extProc.(any)policies.requestRedirect.authority.(any)(1)port`||
+|`binds[].listeners[].policies.extProc.(any)policies.requestRedirect.path`||
+|`binds[].listeners[].policies.extProc.(any)policies.requestRedirect.path.(any)(1)full`||
+|`binds[].listeners[].policies.extProc.(any)policies.requestRedirect.path.(any)(1)prefix`||
+|`binds[].listeners[].policies.extProc.(any)policies.requestRedirect.status`||
+|`binds[].listeners[].policies.extProc.(any)policies.backendTLS`|Send TLS to the backend.|
+|`binds[].listeners[].policies.extProc.(any)policies.backendTLS.cert`||
+|`binds[].listeners[].policies.extProc.(any)policies.backendTLS.key`||
+|`binds[].listeners[].policies.extProc.(any)policies.backendTLS.root`||
+|`binds[].listeners[].policies.extProc.(any)policies.backendTLS.hostname`||
+|`binds[].listeners[].policies.extProc.(any)policies.backendTLS.insecure`||
+|`binds[].listeners[].policies.extProc.(any)policies.backendTLS.insecureHost`||
+|`binds[].listeners[].policies.extProc.(any)policies.backendTLS.alpn`||
+|`binds[].listeners[].policies.extProc.(any)policies.backendTLS.subjectAltNames`||
+|`binds[].listeners[].policies.extProc.(any)policies.backendAuth`|Authenticate to the backend.|
+|`binds[].listeners[].policies.extProc.(any)policies.backendAuth.(any)(1)passthrough`||
+|`binds[].listeners[].policies.extProc.(any)policies.backendAuth.(any)(1)key`||
+|`binds[].listeners[].policies.extProc.(any)policies.backendAuth.(any)(1)key.(any)file`||
+|`binds[].listeners[].policies.extProc.(any)policies.backendAuth.(any)(1)gcp`||
+|`binds[].listeners[].policies.extProc.(any)policies.backendAuth.(any)(1)gcp.(any)type`||
+|`binds[].listeners[].policies.extProc.(any)policies.backendAuth.(any)(1)gcp.(any)audience`|Audience for the token. If not set, the destination host will be used.|
+|`binds[].listeners[].policies.extProc.(any)policies.backendAuth.(any)(1)gcp.(any)type`||
+|`binds[].listeners[].policies.extProc.(any)policies.backendAuth.(any)(1)aws`||
+|`binds[].listeners[].policies.extProc.(any)policies.backendAuth.(any)(1)aws.(any)accessKeyId`||
+|`binds[].listeners[].policies.extProc.(any)policies.backendAuth.(any)(1)aws.(any)secretAccessKey`||
+|`binds[].listeners[].policies.extProc.(any)policies.backendAuth.(any)(1)aws.(any)region`||
+|`binds[].listeners[].policies.extProc.(any)policies.backendAuth.(any)(1)aws.(any)sessionToken`||
+|`binds[].listeners[].policies.extProc.(any)policies.backendAuth.(any)(1)azure`||
+|`binds[].listeners[].policies.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig`||
+|`binds[].listeners[].policies.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret`||
+|`binds[].listeners[].policies.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.tenant_id`||
+|`binds[].listeners[].policies.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_id`||
+|`binds[].listeners[].policies.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_secret`||
+|`binds[].listeners[].policies.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity`||
+|`binds[].listeners[].policies.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity`||
+|`binds[].listeners[].policies.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)clientId`||
+|`binds[].listeners[].policies.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)objectId`||
+|`binds[].listeners[].policies.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)resourceId`||
+|`binds[].listeners[].policies.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)workloadIdentity`||
+|`binds[].listeners[].policies.extProc.(any)policies.backendAuth.(any)(1)azure.(1)developerImplicit`||
+|`binds[].listeners[].policies.extProc.(any)policies.http`|Specify HTTP settings for the backend|
+|`binds[].listeners[].policies.extProc.(any)policies.http.version`||
+|`binds[].listeners[].policies.extProc.(any)policies.http.requestTimeout`||
+|`binds[].listeners[].policies.extProc.(any)policies.tcp`|Specify TCP settings for the backend|
+|`binds[].listeners[].policies.extProc.(any)policies.tcp.keepalives`||
+|`binds[].listeners[].policies.extProc.(any)policies.tcp.keepalives.enabled`||
+|`binds[].listeners[].policies.extProc.(any)policies.tcp.keepalives.time`||
+|`binds[].listeners[].policies.extProc.(any)policies.tcp.keepalives.interval`||
+|`binds[].listeners[].policies.extProc.(any)policies.tcp.keepalives.retries`||
+|`binds[].listeners[].policies.extProc.(any)policies.tcp.connectTimeout`||
+|`binds[].listeners[].policies.extProc.(any)policies.tcp.connectTimeout.secs`||
+|`binds[].listeners[].policies.extProc.(any)policies.tcp.connectTimeout.nanos`||
 |`binds[].listeners[].policies.extProc.(any)failureMode`|Behavior when the ext_proc service is unavailable or returns an error|
 |`binds[].listeners[].policies.extProc.(any)metadataContext`|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
 |`binds[].listeners[].policies.extProc.(any)requestAttributes`|Maps to the request `attributes` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -1633,6 +2818,72 @@
 |`frontendPolicies.tracing.(any)(1)service.port`||
 |`frontendPolicies.tracing.(any)(1)host`|Hostname or IP address|
 |`frontendPolicies.tracing.(any)(1)backend`|Explicit backend reference. Backend must be defined in the top level backends list|
+|`frontendPolicies.tracing.(any)policies`|Policies to connect to the backend|
+|`frontendPolicies.tracing.(any)policies.requestHeaderModifier`|Headers to be modified in the request.|
+|`frontendPolicies.tracing.(any)policies.requestHeaderModifier.add`||
+|`frontendPolicies.tracing.(any)policies.requestHeaderModifier.set`||
+|`frontendPolicies.tracing.(any)policies.requestHeaderModifier.remove`||
+|`frontendPolicies.tracing.(any)policies.responseHeaderModifier`|Headers to be modified in the response.|
+|`frontendPolicies.tracing.(any)policies.responseHeaderModifier.add`||
+|`frontendPolicies.tracing.(any)policies.responseHeaderModifier.set`||
+|`frontendPolicies.tracing.(any)policies.responseHeaderModifier.remove`||
+|`frontendPolicies.tracing.(any)policies.requestRedirect`|Directly respond to the request with a redirect.|
+|`frontendPolicies.tracing.(any)policies.requestRedirect.scheme`||
+|`frontendPolicies.tracing.(any)policies.requestRedirect.authority`||
+|`frontendPolicies.tracing.(any)policies.requestRedirect.authority.(any)(1)full`||
+|`frontendPolicies.tracing.(any)policies.requestRedirect.authority.(any)(1)host`||
+|`frontendPolicies.tracing.(any)policies.requestRedirect.authority.(any)(1)port`||
+|`frontendPolicies.tracing.(any)policies.requestRedirect.path`||
+|`frontendPolicies.tracing.(any)policies.requestRedirect.path.(any)(1)full`||
+|`frontendPolicies.tracing.(any)policies.requestRedirect.path.(any)(1)prefix`||
+|`frontendPolicies.tracing.(any)policies.requestRedirect.status`||
+|`frontendPolicies.tracing.(any)policies.backendTLS`|Send TLS to the backend.|
+|`frontendPolicies.tracing.(any)policies.backendTLS.cert`||
+|`frontendPolicies.tracing.(any)policies.backendTLS.key`||
+|`frontendPolicies.tracing.(any)policies.backendTLS.root`||
+|`frontendPolicies.tracing.(any)policies.backendTLS.hostname`||
+|`frontendPolicies.tracing.(any)policies.backendTLS.insecure`||
+|`frontendPolicies.tracing.(any)policies.backendTLS.insecureHost`||
+|`frontendPolicies.tracing.(any)policies.backendTLS.alpn`||
+|`frontendPolicies.tracing.(any)policies.backendTLS.subjectAltNames`||
+|`frontendPolicies.tracing.(any)policies.backendAuth`|Authenticate to the backend.|
+|`frontendPolicies.tracing.(any)policies.backendAuth.(any)(1)passthrough`||
+|`frontendPolicies.tracing.(any)policies.backendAuth.(any)(1)key`||
+|`frontendPolicies.tracing.(any)policies.backendAuth.(any)(1)key.(any)file`||
+|`frontendPolicies.tracing.(any)policies.backendAuth.(any)(1)gcp`||
+|`frontendPolicies.tracing.(any)policies.backendAuth.(any)(1)gcp.(any)type`||
+|`frontendPolicies.tracing.(any)policies.backendAuth.(any)(1)gcp.(any)audience`|Audience for the token. If not set, the destination host will be used.|
+|`frontendPolicies.tracing.(any)policies.backendAuth.(any)(1)gcp.(any)type`||
+|`frontendPolicies.tracing.(any)policies.backendAuth.(any)(1)aws`||
+|`frontendPolicies.tracing.(any)policies.backendAuth.(any)(1)aws.(any)accessKeyId`||
+|`frontendPolicies.tracing.(any)policies.backendAuth.(any)(1)aws.(any)secretAccessKey`||
+|`frontendPolicies.tracing.(any)policies.backendAuth.(any)(1)aws.(any)region`||
+|`frontendPolicies.tracing.(any)policies.backendAuth.(any)(1)aws.(any)sessionToken`||
+|`frontendPolicies.tracing.(any)policies.backendAuth.(any)(1)azure`||
+|`frontendPolicies.tracing.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig`||
+|`frontendPolicies.tracing.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret`||
+|`frontendPolicies.tracing.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.tenant_id`||
+|`frontendPolicies.tracing.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_id`||
+|`frontendPolicies.tracing.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_secret`||
+|`frontendPolicies.tracing.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity`||
+|`frontendPolicies.tracing.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity`||
+|`frontendPolicies.tracing.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)clientId`||
+|`frontendPolicies.tracing.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)objectId`||
+|`frontendPolicies.tracing.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)resourceId`||
+|`frontendPolicies.tracing.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)workloadIdentity`||
+|`frontendPolicies.tracing.(any)policies.backendAuth.(any)(1)azure.(1)developerImplicit`||
+|`frontendPolicies.tracing.(any)policies.http`|Specify HTTP settings for the backend|
+|`frontendPolicies.tracing.(any)policies.http.version`||
+|`frontendPolicies.tracing.(any)policies.http.requestTimeout`||
+|`frontendPolicies.tracing.(any)policies.tcp`|Specify TCP settings for the backend|
+|`frontendPolicies.tracing.(any)policies.tcp.keepalives`||
+|`frontendPolicies.tracing.(any)policies.tcp.keepalives.enabled`||
+|`frontendPolicies.tracing.(any)policies.tcp.keepalives.time`||
+|`frontendPolicies.tracing.(any)policies.tcp.keepalives.interval`||
+|`frontendPolicies.tracing.(any)policies.tcp.keepalives.retries`||
+|`frontendPolicies.tracing.(any)policies.tcp.connectTimeout`||
+|`frontendPolicies.tracing.(any)policies.tcp.connectTimeout.secs`||
+|`frontendPolicies.tracing.(any)policies.tcp.connectTimeout.nanos`||
 |`frontendPolicies.tracing.(any)attributes`|Span attributes to add, keyed by attribute name.|
 |`frontendPolicies.tracing.(any)resources`|Resource attributes to add to the tracer provider (OTel `Resource`).<br>This can be used to set things like `service.name` dynamically.|
 |`frontendPolicies.tracing.(any)remove`|Attribute keys to remove from the emitted span attributes.<br><br>This is applied before `attributes` are evaluated/added, so it can be used to drop<br>default attributes or avoid duplication.|
@@ -1772,10 +3023,6 @@
 |`policies[].policy.ai.promptGuard.request[].(1)openAIModeration.policies.requestRedirect.path.(any)(1)full`||
 |`policies[].policy.ai.promptGuard.request[].(1)openAIModeration.policies.requestRedirect.path.(any)(1)prefix`||
 |`policies[].policy.ai.promptGuard.request[].(1)openAIModeration.policies.requestRedirect.status`||
-|`policies[].policy.ai.promptGuard.request[].(1)openAIModeration.policies.mcpAuthorization`|Authorization policies for MCP access.|
-|`policies[].policy.ai.promptGuard.request[].(1)openAIModeration.policies.mcpAuthorization.rules`||
-|`policies[].policy.ai.promptGuard.request[].(1)openAIModeration.policies.a2a`|Mark this traffic as A2A to enable A2A processing and telemetry.|
-|`policies[].policy.ai.promptGuard.request[].(1)openAIModeration.policies.ai`|Mark this as LLM traffic to enable LLM processing.|
 |`policies[].policy.ai.promptGuard.request[].(1)openAIModeration.policies.backendTLS`|Send TLS to the backend.|
 |`policies[].policy.ai.promptGuard.request[].(1)openAIModeration.policies.backendTLS.cert`||
 |`policies[].policy.ai.promptGuard.request[].(1)openAIModeration.policies.backendTLS.key`||
@@ -1846,10 +3093,6 @@
 |`policies[].policy.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestRedirect.path.(any)(1)full`||
 |`policies[].policy.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestRedirect.path.(any)(1)prefix`||
 |`policies[].policy.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestRedirect.status`||
-|`policies[].policy.ai.promptGuard.request[].(1)bedrockGuardrails.policies.mcpAuthorization`|Authorization policies for MCP access.|
-|`policies[].policy.ai.promptGuard.request[].(1)bedrockGuardrails.policies.mcpAuthorization.rules`||
-|`policies[].policy.ai.promptGuard.request[].(1)bedrockGuardrails.policies.a2a`|Mark this traffic as A2A to enable A2A processing and telemetry.|
-|`policies[].policy.ai.promptGuard.request[].(1)bedrockGuardrails.policies.ai`|Mark this as LLM traffic to enable LLM processing.|
 |`policies[].policy.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendTLS`|Send TLS to the backend.|
 |`policies[].policy.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendTLS.cert`||
 |`policies[].policy.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendTLS.key`||
@@ -1920,10 +3163,6 @@
 |`policies[].policy.ai.promptGuard.request[].(1)googleModelArmor.policies.requestRedirect.path.(any)(1)full`||
 |`policies[].policy.ai.promptGuard.request[].(1)googleModelArmor.policies.requestRedirect.path.(any)(1)prefix`||
 |`policies[].policy.ai.promptGuard.request[].(1)googleModelArmor.policies.requestRedirect.status`||
-|`policies[].policy.ai.promptGuard.request[].(1)googleModelArmor.policies.mcpAuthorization`|Authorization policies for MCP access.|
-|`policies[].policy.ai.promptGuard.request[].(1)googleModelArmor.policies.mcpAuthorization.rules`||
-|`policies[].policy.ai.promptGuard.request[].(1)googleModelArmor.policies.a2a`|Mark this traffic as A2A to enable A2A processing and telemetry.|
-|`policies[].policy.ai.promptGuard.request[].(1)googleModelArmor.policies.ai`|Mark this as LLM traffic to enable LLM processing.|
 |`policies[].policy.ai.promptGuard.request[].(1)googleModelArmor.policies.backendTLS`|Send TLS to the backend.|
 |`policies[].policy.ai.promptGuard.request[].(1)googleModelArmor.policies.backendTLS.cert`||
 |`policies[].policy.ai.promptGuard.request[].(1)googleModelArmor.policies.backendTLS.key`||
@@ -2021,10 +3260,6 @@
 |`policies[].policy.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestRedirect.path.(any)(1)full`||
 |`policies[].policy.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestRedirect.path.(any)(1)prefix`||
 |`policies[].policy.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestRedirect.status`||
-|`policies[].policy.ai.promptGuard.response[].(1)bedrockGuardrails.policies.mcpAuthorization`|Authorization policies for MCP access.|
-|`policies[].policy.ai.promptGuard.response[].(1)bedrockGuardrails.policies.mcpAuthorization.rules`||
-|`policies[].policy.ai.promptGuard.response[].(1)bedrockGuardrails.policies.a2a`|Mark this traffic as A2A to enable A2A processing and telemetry.|
-|`policies[].policy.ai.promptGuard.response[].(1)bedrockGuardrails.policies.ai`|Mark this as LLM traffic to enable LLM processing.|
 |`policies[].policy.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendTLS`|Send TLS to the backend.|
 |`policies[].policy.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendTLS.cert`||
 |`policies[].policy.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendTLS.key`||
@@ -2095,10 +3330,6 @@
 |`policies[].policy.ai.promptGuard.response[].(1)googleModelArmor.policies.requestRedirect.path.(any)(1)full`||
 |`policies[].policy.ai.promptGuard.response[].(1)googleModelArmor.policies.requestRedirect.path.(any)(1)prefix`||
 |`policies[].policy.ai.promptGuard.response[].(1)googleModelArmor.policies.requestRedirect.status`||
-|`policies[].policy.ai.promptGuard.response[].(1)googleModelArmor.policies.mcpAuthorization`|Authorization policies for MCP access.|
-|`policies[].policy.ai.promptGuard.response[].(1)googleModelArmor.policies.mcpAuthorization.rules`||
-|`policies[].policy.ai.promptGuard.response[].(1)googleModelArmor.policies.a2a`|Mark this traffic as A2A to enable A2A processing and telemetry.|
-|`policies[].policy.ai.promptGuard.response[].(1)googleModelArmor.policies.ai`|Mark this as LLM traffic to enable LLM processing.|
 |`policies[].policy.ai.promptGuard.response[].(1)googleModelArmor.policies.backendTLS`|Send TLS to the backend.|
 |`policies[].policy.ai.promptGuard.response[].(1)googleModelArmor.policies.backendTLS.cert`||
 |`policies[].policy.ai.promptGuard.response[].(1)googleModelArmor.policies.backendTLS.key`||
@@ -2219,12 +3450,77 @@
 |`policies[].policy.remoteRateLimit.(any)(1)host`|Hostname or IP address|
 |`policies[].policy.remoteRateLimit.(any)(1)backend`|Explicit backend reference. Backend must be defined in the top level backends list|
 |`policies[].policy.remoteRateLimit.(any)domain`||
+|`policies[].policy.remoteRateLimit.(any)policies`|Policies to connect to the backend|
+|`policies[].policy.remoteRateLimit.(any)policies.requestHeaderModifier`|Headers to be modified in the request.|
+|`policies[].policy.remoteRateLimit.(any)policies.requestHeaderModifier.add`||
+|`policies[].policy.remoteRateLimit.(any)policies.requestHeaderModifier.set`||
+|`policies[].policy.remoteRateLimit.(any)policies.requestHeaderModifier.remove`||
+|`policies[].policy.remoteRateLimit.(any)policies.responseHeaderModifier`|Headers to be modified in the response.|
+|`policies[].policy.remoteRateLimit.(any)policies.responseHeaderModifier.add`||
+|`policies[].policy.remoteRateLimit.(any)policies.responseHeaderModifier.set`||
+|`policies[].policy.remoteRateLimit.(any)policies.responseHeaderModifier.remove`||
+|`policies[].policy.remoteRateLimit.(any)policies.requestRedirect`|Directly respond to the request with a redirect.|
+|`policies[].policy.remoteRateLimit.(any)policies.requestRedirect.scheme`||
+|`policies[].policy.remoteRateLimit.(any)policies.requestRedirect.authority`||
+|`policies[].policy.remoteRateLimit.(any)policies.requestRedirect.authority.(any)(1)full`||
+|`policies[].policy.remoteRateLimit.(any)policies.requestRedirect.authority.(any)(1)host`||
+|`policies[].policy.remoteRateLimit.(any)policies.requestRedirect.authority.(any)(1)port`||
+|`policies[].policy.remoteRateLimit.(any)policies.requestRedirect.path`||
+|`policies[].policy.remoteRateLimit.(any)policies.requestRedirect.path.(any)(1)full`||
+|`policies[].policy.remoteRateLimit.(any)policies.requestRedirect.path.(any)(1)prefix`||
+|`policies[].policy.remoteRateLimit.(any)policies.requestRedirect.status`||
+|`policies[].policy.remoteRateLimit.(any)policies.backendTLS`|Send TLS to the backend.|
+|`policies[].policy.remoteRateLimit.(any)policies.backendTLS.cert`||
+|`policies[].policy.remoteRateLimit.(any)policies.backendTLS.key`||
+|`policies[].policy.remoteRateLimit.(any)policies.backendTLS.root`||
+|`policies[].policy.remoteRateLimit.(any)policies.backendTLS.hostname`||
+|`policies[].policy.remoteRateLimit.(any)policies.backendTLS.insecure`||
+|`policies[].policy.remoteRateLimit.(any)policies.backendTLS.insecureHost`||
+|`policies[].policy.remoteRateLimit.(any)policies.backendTLS.alpn`||
+|`policies[].policy.remoteRateLimit.(any)policies.backendTLS.subjectAltNames`||
+|`policies[].policy.remoteRateLimit.(any)policies.backendAuth`|Authenticate to the backend.|
+|`policies[].policy.remoteRateLimit.(any)policies.backendAuth.(any)(1)passthrough`||
+|`policies[].policy.remoteRateLimit.(any)policies.backendAuth.(any)(1)key`||
+|`policies[].policy.remoteRateLimit.(any)policies.backendAuth.(any)(1)key.(any)file`||
+|`policies[].policy.remoteRateLimit.(any)policies.backendAuth.(any)(1)gcp`||
+|`policies[].policy.remoteRateLimit.(any)policies.backendAuth.(any)(1)gcp.(any)type`||
+|`policies[].policy.remoteRateLimit.(any)policies.backendAuth.(any)(1)gcp.(any)audience`|Audience for the token. If not set, the destination host will be used.|
+|`policies[].policy.remoteRateLimit.(any)policies.backendAuth.(any)(1)gcp.(any)type`||
+|`policies[].policy.remoteRateLimit.(any)policies.backendAuth.(any)(1)aws`||
+|`policies[].policy.remoteRateLimit.(any)policies.backendAuth.(any)(1)aws.(any)accessKeyId`||
+|`policies[].policy.remoteRateLimit.(any)policies.backendAuth.(any)(1)aws.(any)secretAccessKey`||
+|`policies[].policy.remoteRateLimit.(any)policies.backendAuth.(any)(1)aws.(any)region`||
+|`policies[].policy.remoteRateLimit.(any)policies.backendAuth.(any)(1)aws.(any)sessionToken`||
+|`policies[].policy.remoteRateLimit.(any)policies.backendAuth.(any)(1)azure`||
+|`policies[].policy.remoteRateLimit.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig`||
+|`policies[].policy.remoteRateLimit.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret`||
+|`policies[].policy.remoteRateLimit.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.tenant_id`||
+|`policies[].policy.remoteRateLimit.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_id`||
+|`policies[].policy.remoteRateLimit.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_secret`||
+|`policies[].policy.remoteRateLimit.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity`||
+|`policies[].policy.remoteRateLimit.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity`||
+|`policies[].policy.remoteRateLimit.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)clientId`||
+|`policies[].policy.remoteRateLimit.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)objectId`||
+|`policies[].policy.remoteRateLimit.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)resourceId`||
+|`policies[].policy.remoteRateLimit.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)workloadIdentity`||
+|`policies[].policy.remoteRateLimit.(any)policies.backendAuth.(any)(1)azure.(1)developerImplicit`||
+|`policies[].policy.remoteRateLimit.(any)policies.http`|Specify HTTP settings for the backend|
+|`policies[].policy.remoteRateLimit.(any)policies.http.version`||
+|`policies[].policy.remoteRateLimit.(any)policies.http.requestTimeout`||
+|`policies[].policy.remoteRateLimit.(any)policies.tcp`|Specify TCP settings for the backend|
+|`policies[].policy.remoteRateLimit.(any)policies.tcp.keepalives`||
+|`policies[].policy.remoteRateLimit.(any)policies.tcp.keepalives.enabled`||
+|`policies[].policy.remoteRateLimit.(any)policies.tcp.keepalives.time`||
+|`policies[].policy.remoteRateLimit.(any)policies.tcp.keepalives.interval`||
+|`policies[].policy.remoteRateLimit.(any)policies.tcp.keepalives.retries`||
+|`policies[].policy.remoteRateLimit.(any)policies.tcp.connectTimeout`||
+|`policies[].policy.remoteRateLimit.(any)policies.tcp.connectTimeout.secs`||
+|`policies[].policy.remoteRateLimit.(any)policies.tcp.connectTimeout.nanos`||
 |`policies[].policy.remoteRateLimit.(any)descriptors`||
 |`policies[].policy.remoteRateLimit.(any)descriptors[].entries`||
 |`policies[].policy.remoteRateLimit.(any)descriptors[].entries[].key`||
 |`policies[].policy.remoteRateLimit.(any)descriptors[].entries[].value`||
 |`policies[].policy.remoteRateLimit.(any)descriptors[].type`||
-|`policies[].policy.remoteRateLimit.(any)timeout`|Timeout for the request|
 |`policies[].policy.remoteRateLimit.(any)failureMode`|Behavior when the remote rate limit service is unavailable or returns an error.<br>Defaults to failClosed, denying requests with a 500 status on service failure.|
 |`policies[].policy.jwtAuth`|Authenticate incoming JWT requests.|
 |`policies[].policy.jwtAuth.(any)(any)mode`||
@@ -2262,6 +3558,72 @@
 |`policies[].policy.extAuthz.(any)(1)service.port`||
 |`policies[].policy.extAuthz.(any)(1)host`|Hostname or IP address|
 |`policies[].policy.extAuthz.(any)(1)backend`|Explicit backend reference. Backend must be defined in the top level backends list|
+|`policies[].policy.extAuthz.(any)policies`|Policies to connect to the backend|
+|`policies[].policy.extAuthz.(any)policies.requestHeaderModifier`|Headers to be modified in the request.|
+|`policies[].policy.extAuthz.(any)policies.requestHeaderModifier.add`||
+|`policies[].policy.extAuthz.(any)policies.requestHeaderModifier.set`||
+|`policies[].policy.extAuthz.(any)policies.requestHeaderModifier.remove`||
+|`policies[].policy.extAuthz.(any)policies.responseHeaderModifier`|Headers to be modified in the response.|
+|`policies[].policy.extAuthz.(any)policies.responseHeaderModifier.add`||
+|`policies[].policy.extAuthz.(any)policies.responseHeaderModifier.set`||
+|`policies[].policy.extAuthz.(any)policies.responseHeaderModifier.remove`||
+|`policies[].policy.extAuthz.(any)policies.requestRedirect`|Directly respond to the request with a redirect.|
+|`policies[].policy.extAuthz.(any)policies.requestRedirect.scheme`||
+|`policies[].policy.extAuthz.(any)policies.requestRedirect.authority`||
+|`policies[].policy.extAuthz.(any)policies.requestRedirect.authority.(any)(1)full`||
+|`policies[].policy.extAuthz.(any)policies.requestRedirect.authority.(any)(1)host`||
+|`policies[].policy.extAuthz.(any)policies.requestRedirect.authority.(any)(1)port`||
+|`policies[].policy.extAuthz.(any)policies.requestRedirect.path`||
+|`policies[].policy.extAuthz.(any)policies.requestRedirect.path.(any)(1)full`||
+|`policies[].policy.extAuthz.(any)policies.requestRedirect.path.(any)(1)prefix`||
+|`policies[].policy.extAuthz.(any)policies.requestRedirect.status`||
+|`policies[].policy.extAuthz.(any)policies.backendTLS`|Send TLS to the backend.|
+|`policies[].policy.extAuthz.(any)policies.backendTLS.cert`||
+|`policies[].policy.extAuthz.(any)policies.backendTLS.key`||
+|`policies[].policy.extAuthz.(any)policies.backendTLS.root`||
+|`policies[].policy.extAuthz.(any)policies.backendTLS.hostname`||
+|`policies[].policy.extAuthz.(any)policies.backendTLS.insecure`||
+|`policies[].policy.extAuthz.(any)policies.backendTLS.insecureHost`||
+|`policies[].policy.extAuthz.(any)policies.backendTLS.alpn`||
+|`policies[].policy.extAuthz.(any)policies.backendTLS.subjectAltNames`||
+|`policies[].policy.extAuthz.(any)policies.backendAuth`|Authenticate to the backend.|
+|`policies[].policy.extAuthz.(any)policies.backendAuth.(any)(1)passthrough`||
+|`policies[].policy.extAuthz.(any)policies.backendAuth.(any)(1)key`||
+|`policies[].policy.extAuthz.(any)policies.backendAuth.(any)(1)key.(any)file`||
+|`policies[].policy.extAuthz.(any)policies.backendAuth.(any)(1)gcp`||
+|`policies[].policy.extAuthz.(any)policies.backendAuth.(any)(1)gcp.(any)type`||
+|`policies[].policy.extAuthz.(any)policies.backendAuth.(any)(1)gcp.(any)audience`|Audience for the token. If not set, the destination host will be used.|
+|`policies[].policy.extAuthz.(any)policies.backendAuth.(any)(1)gcp.(any)type`||
+|`policies[].policy.extAuthz.(any)policies.backendAuth.(any)(1)aws`||
+|`policies[].policy.extAuthz.(any)policies.backendAuth.(any)(1)aws.(any)accessKeyId`||
+|`policies[].policy.extAuthz.(any)policies.backendAuth.(any)(1)aws.(any)secretAccessKey`||
+|`policies[].policy.extAuthz.(any)policies.backendAuth.(any)(1)aws.(any)region`||
+|`policies[].policy.extAuthz.(any)policies.backendAuth.(any)(1)aws.(any)sessionToken`||
+|`policies[].policy.extAuthz.(any)policies.backendAuth.(any)(1)azure`||
+|`policies[].policy.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig`||
+|`policies[].policy.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret`||
+|`policies[].policy.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.tenant_id`||
+|`policies[].policy.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_id`||
+|`policies[].policy.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_secret`||
+|`policies[].policy.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity`||
+|`policies[].policy.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity`||
+|`policies[].policy.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)clientId`||
+|`policies[].policy.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)objectId`||
+|`policies[].policy.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)resourceId`||
+|`policies[].policy.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)workloadIdentity`||
+|`policies[].policy.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)developerImplicit`||
+|`policies[].policy.extAuthz.(any)policies.http`|Specify HTTP settings for the backend|
+|`policies[].policy.extAuthz.(any)policies.http.version`||
+|`policies[].policy.extAuthz.(any)policies.http.requestTimeout`||
+|`policies[].policy.extAuthz.(any)policies.tcp`|Specify TCP settings for the backend|
+|`policies[].policy.extAuthz.(any)policies.tcp.keepalives`||
+|`policies[].policy.extAuthz.(any)policies.tcp.keepalives.enabled`||
+|`policies[].policy.extAuthz.(any)policies.tcp.keepalives.time`||
+|`policies[].policy.extAuthz.(any)policies.tcp.keepalives.interval`||
+|`policies[].policy.extAuthz.(any)policies.tcp.keepalives.retries`||
+|`policies[].policy.extAuthz.(any)policies.tcp.connectTimeout`||
+|`policies[].policy.extAuthz.(any)policies.tcp.connectTimeout.secs`||
+|`policies[].policy.extAuthz.(any)policies.tcp.connectTimeout.nanos`||
 |`policies[].policy.extAuthz.(any)protocol`|The ext_authz protocol to use. Unless you need to integrate with an HTTP-only server, gRPC is recommended.|
 |`policies[].policy.extAuthz.(any)protocol.(1)grpc`||
 |`policies[].policy.extAuthz.(any)protocol.(1)grpc.context`|Additional context to send to the authorization service.<br>This maps to the `context_extensions` field of the request, and only allows static values.|
@@ -2279,7 +3641,6 @@
 |`policies[].policy.extAuthz.(any)includeRequestBody.maxRequestBytes`|Maximum size of request body to buffer (default: 8192)|
 |`policies[].policy.extAuthz.(any)includeRequestBody.allowPartialMessage`|If true, send partial body when max_request_bytes is reached|
 |`policies[].policy.extAuthz.(any)includeRequestBody.packAsBytes`|If true, pack body as raw bytes in gRPC|
-|`policies[].policy.extAuthz.(any)timeout`|Timeout for the authorization request (default: 200ms)|
 |`policies[].policy.extProc`|Extend agentgateway with an external processor|
 |`policies[].policy.extProc.(any)(1)service`||
 |`policies[].policy.extProc.(any)(1)service.name`||
@@ -2288,6 +3649,72 @@
 |`policies[].policy.extProc.(any)(1)service.port`||
 |`policies[].policy.extProc.(any)(1)host`|Hostname or IP address|
 |`policies[].policy.extProc.(any)(1)backend`|Explicit backend reference. Backend must be defined in the top level backends list|
+|`policies[].policy.extProc.(any)policies`|Policies to connect to the backend|
+|`policies[].policy.extProc.(any)policies.requestHeaderModifier`|Headers to be modified in the request.|
+|`policies[].policy.extProc.(any)policies.requestHeaderModifier.add`||
+|`policies[].policy.extProc.(any)policies.requestHeaderModifier.set`||
+|`policies[].policy.extProc.(any)policies.requestHeaderModifier.remove`||
+|`policies[].policy.extProc.(any)policies.responseHeaderModifier`|Headers to be modified in the response.|
+|`policies[].policy.extProc.(any)policies.responseHeaderModifier.add`||
+|`policies[].policy.extProc.(any)policies.responseHeaderModifier.set`||
+|`policies[].policy.extProc.(any)policies.responseHeaderModifier.remove`||
+|`policies[].policy.extProc.(any)policies.requestRedirect`|Directly respond to the request with a redirect.|
+|`policies[].policy.extProc.(any)policies.requestRedirect.scheme`||
+|`policies[].policy.extProc.(any)policies.requestRedirect.authority`||
+|`policies[].policy.extProc.(any)policies.requestRedirect.authority.(any)(1)full`||
+|`policies[].policy.extProc.(any)policies.requestRedirect.authority.(any)(1)host`||
+|`policies[].policy.extProc.(any)policies.requestRedirect.authority.(any)(1)port`||
+|`policies[].policy.extProc.(any)policies.requestRedirect.path`||
+|`policies[].policy.extProc.(any)policies.requestRedirect.path.(any)(1)full`||
+|`policies[].policy.extProc.(any)policies.requestRedirect.path.(any)(1)prefix`||
+|`policies[].policy.extProc.(any)policies.requestRedirect.status`||
+|`policies[].policy.extProc.(any)policies.backendTLS`|Send TLS to the backend.|
+|`policies[].policy.extProc.(any)policies.backendTLS.cert`||
+|`policies[].policy.extProc.(any)policies.backendTLS.key`||
+|`policies[].policy.extProc.(any)policies.backendTLS.root`||
+|`policies[].policy.extProc.(any)policies.backendTLS.hostname`||
+|`policies[].policy.extProc.(any)policies.backendTLS.insecure`||
+|`policies[].policy.extProc.(any)policies.backendTLS.insecureHost`||
+|`policies[].policy.extProc.(any)policies.backendTLS.alpn`||
+|`policies[].policy.extProc.(any)policies.backendTLS.subjectAltNames`||
+|`policies[].policy.extProc.(any)policies.backendAuth`|Authenticate to the backend.|
+|`policies[].policy.extProc.(any)policies.backendAuth.(any)(1)passthrough`||
+|`policies[].policy.extProc.(any)policies.backendAuth.(any)(1)key`||
+|`policies[].policy.extProc.(any)policies.backendAuth.(any)(1)key.(any)file`||
+|`policies[].policy.extProc.(any)policies.backendAuth.(any)(1)gcp`||
+|`policies[].policy.extProc.(any)policies.backendAuth.(any)(1)gcp.(any)type`||
+|`policies[].policy.extProc.(any)policies.backendAuth.(any)(1)gcp.(any)audience`|Audience for the token. If not set, the destination host will be used.|
+|`policies[].policy.extProc.(any)policies.backendAuth.(any)(1)gcp.(any)type`||
+|`policies[].policy.extProc.(any)policies.backendAuth.(any)(1)aws`||
+|`policies[].policy.extProc.(any)policies.backendAuth.(any)(1)aws.(any)accessKeyId`||
+|`policies[].policy.extProc.(any)policies.backendAuth.(any)(1)aws.(any)secretAccessKey`||
+|`policies[].policy.extProc.(any)policies.backendAuth.(any)(1)aws.(any)region`||
+|`policies[].policy.extProc.(any)policies.backendAuth.(any)(1)aws.(any)sessionToken`||
+|`policies[].policy.extProc.(any)policies.backendAuth.(any)(1)azure`||
+|`policies[].policy.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig`||
+|`policies[].policy.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret`||
+|`policies[].policy.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.tenant_id`||
+|`policies[].policy.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_id`||
+|`policies[].policy.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_secret`||
+|`policies[].policy.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity`||
+|`policies[].policy.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity`||
+|`policies[].policy.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)clientId`||
+|`policies[].policy.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)objectId`||
+|`policies[].policy.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)resourceId`||
+|`policies[].policy.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)workloadIdentity`||
+|`policies[].policy.extProc.(any)policies.backendAuth.(any)(1)azure.(1)developerImplicit`||
+|`policies[].policy.extProc.(any)policies.http`|Specify HTTP settings for the backend|
+|`policies[].policy.extProc.(any)policies.http.version`||
+|`policies[].policy.extProc.(any)policies.http.requestTimeout`||
+|`policies[].policy.extProc.(any)policies.tcp`|Specify TCP settings for the backend|
+|`policies[].policy.extProc.(any)policies.tcp.keepalives`||
+|`policies[].policy.extProc.(any)policies.tcp.keepalives.enabled`||
+|`policies[].policy.extProc.(any)policies.tcp.keepalives.time`||
+|`policies[].policy.extProc.(any)policies.tcp.keepalives.interval`||
+|`policies[].policy.extProc.(any)policies.tcp.keepalives.retries`||
+|`policies[].policy.extProc.(any)policies.tcp.connectTimeout`||
+|`policies[].policy.extProc.(any)policies.tcp.connectTimeout.secs`||
+|`policies[].policy.extProc.(any)policies.tcp.connectTimeout.nanos`||
 |`policies[].policy.extProc.(any)failureMode`|Behavior when the ext_proc service is unavailable or returns an error|
 |`policies[].policy.extProc.(any)metadataContext`|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
 |`policies[].policy.extProc.(any)requestAttributes`|Maps to the request `attributes` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -2336,105 +3763,6 @@
 |`backends[].policies.requestRedirect.path.(any)(1)full`||
 |`backends[].policies.requestRedirect.path.(any)(1)prefix`||
 |`backends[].policies.requestRedirect.status`||
-|`backends[].policies.mcpAuthorization`|Authorization policies for MCP access.|
-|`backends[].policies.mcpAuthorization.rules`||
-|`backends[].policies.a2a`|Mark this traffic as A2A to enable A2A processing and telemetry.|
-|`backends[].policies.ai`|Mark this as LLM traffic to enable LLM processing.|
-|`backends[].policies.ai.promptGuard`||
-|`backends[].policies.ai.promptGuard.request`||
-|`backends[].policies.ai.promptGuard.request[].(1)regex`||
-|`backends[].policies.ai.promptGuard.request[].(1)regex.action`||
-|`backends[].policies.ai.promptGuard.request[].(1)regex.rules`||
-|`backends[].policies.ai.promptGuard.request[].(1)regex.rules[].(any)builtin`||
-|`backends[].policies.ai.promptGuard.request[].(1)regex.rules[].(any)pattern`||
-|`backends[].policies.ai.promptGuard.request[].(1)webhook`||
-|`backends[].policies.ai.promptGuard.request[].(1)webhook.target`||
-|`backends[].policies.ai.promptGuard.request[].(1)webhook.target.(1)service`||
-|`backends[].policies.ai.promptGuard.request[].(1)webhook.target.(1)service.name`||
-|`backends[].policies.ai.promptGuard.request[].(1)webhook.target.(1)service.name.namespace`||
-|`backends[].policies.ai.promptGuard.request[].(1)webhook.target.(1)service.name.hostname`||
-|`backends[].policies.ai.promptGuard.request[].(1)webhook.target.(1)service.port`||
-|`backends[].policies.ai.promptGuard.request[].(1)webhook.target.(1)host`|Hostname or IP address|
-|`backends[].policies.ai.promptGuard.request[].(1)webhook.target.(1)backend`|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].policies.ai.promptGuard.request[].(1)webhook.forwardHeaderMatches`||
-|`backends[].policies.ai.promptGuard.request[].(1)webhook.forwardHeaderMatches[].name`||
-|`backends[].policies.ai.promptGuard.request[].(1)webhook.forwardHeaderMatches[].value`||
-|`backends[].policies.ai.promptGuard.request[].(1)webhook.forwardHeaderMatches[].value.(1)exact`||
-|`backends[].policies.ai.promptGuard.request[].(1)webhook.forwardHeaderMatches[].value.(1)regex`||
-|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration`||
-|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.model`|Model to use. Defaults to `omni-moderation-latest`|
-|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies`||
-|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails`|Configuration for AWS Bedrock Guardrails integration.|
-|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.guardrailIdentifier`|The unique identifier of the guardrail|
-|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.guardrailVersion`|The version of the guardrail|
-|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.region`|AWS region where the guardrail is deployed|
-|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies`|Backend policies for AWS authentication (optional, defaults to implicit AWS auth)|
-|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor`|Configuration for Google Cloud Model Armor integration.|
-|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.templateId`|The template ID for the Model Armor configuration|
-|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.projectId`|The GCP project ID|
-|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.location`|The GCP region (default: us-central1)|
-|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies`|Backend policies for GCP authentication (optional, defaults to implicit GCP auth)|
-|`backends[].policies.ai.promptGuard.request[].rejection`||
-|`backends[].policies.ai.promptGuard.request[].rejection.body`||
-|`backends[].policies.ai.promptGuard.request[].rejection.status`||
-|`backends[].policies.ai.promptGuard.request[].rejection.headers`|Optional headers to add, set, or remove from the rejection response|
-|`backends[].policies.ai.promptGuard.request[].rejection.headers.add`||
-|`backends[].policies.ai.promptGuard.request[].rejection.headers.set`||
-|`backends[].policies.ai.promptGuard.request[].rejection.headers.remove`||
-|`backends[].policies.ai.promptGuard.response`||
-|`backends[].policies.ai.promptGuard.response[].(1)regex`||
-|`backends[].policies.ai.promptGuard.response[].(1)regex.action`||
-|`backends[].policies.ai.promptGuard.response[].(1)regex.rules`||
-|`backends[].policies.ai.promptGuard.response[].(1)regex.rules[].(any)builtin`||
-|`backends[].policies.ai.promptGuard.response[].(1)regex.rules[].(any)pattern`||
-|`backends[].policies.ai.promptGuard.response[].(1)webhook`||
-|`backends[].policies.ai.promptGuard.response[].(1)webhook.target`||
-|`backends[].policies.ai.promptGuard.response[].(1)webhook.target.(1)service`||
-|`backends[].policies.ai.promptGuard.response[].(1)webhook.target.(1)service.name`||
-|`backends[].policies.ai.promptGuard.response[].(1)webhook.target.(1)service.name.namespace`||
-|`backends[].policies.ai.promptGuard.response[].(1)webhook.target.(1)service.name.hostname`||
-|`backends[].policies.ai.promptGuard.response[].(1)webhook.target.(1)service.port`||
-|`backends[].policies.ai.promptGuard.response[].(1)webhook.target.(1)host`|Hostname or IP address|
-|`backends[].policies.ai.promptGuard.response[].(1)webhook.target.(1)backend`|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].policies.ai.promptGuard.response[].(1)webhook.forwardHeaderMatches`||
-|`backends[].policies.ai.promptGuard.response[].(1)webhook.forwardHeaderMatches[].name`||
-|`backends[].policies.ai.promptGuard.response[].(1)webhook.forwardHeaderMatches[].value`||
-|`backends[].policies.ai.promptGuard.response[].(1)webhook.forwardHeaderMatches[].value.(1)exact`||
-|`backends[].policies.ai.promptGuard.response[].(1)webhook.forwardHeaderMatches[].value.(1)regex`||
-|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails`|Configuration for AWS Bedrock Guardrails integration.|
-|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.guardrailIdentifier`|The unique identifier of the guardrail|
-|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.guardrailVersion`|The version of the guardrail|
-|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.region`|AWS region where the guardrail is deployed|
-|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies`|Backend policies for AWS authentication (optional, defaults to implicit AWS auth)|
-|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor`|Configuration for Google Cloud Model Armor integration.|
-|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.templateId`|The template ID for the Model Armor configuration|
-|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.projectId`|The GCP project ID|
-|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.location`|The GCP region (default: us-central1)|
-|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies`|Backend policies for GCP authentication (optional, defaults to implicit GCP auth)|
-|`backends[].policies.ai.promptGuard.response[].rejection`||
-|`backends[].policies.ai.promptGuard.response[].rejection.body`||
-|`backends[].policies.ai.promptGuard.response[].rejection.status`||
-|`backends[].policies.ai.promptGuard.response[].rejection.headers`|Optional headers to add, set, or remove from the rejection response|
-|`backends[].policies.ai.promptGuard.response[].rejection.headers.add`||
-|`backends[].policies.ai.promptGuard.response[].rejection.headers.set`||
-|`backends[].policies.ai.promptGuard.response[].rejection.headers.remove`||
-|`backends[].policies.ai.defaults`||
-|`backends[].policies.ai.overrides`||
-|`backends[].policies.ai.transformations`||
-|`backends[].policies.ai.prompts`||
-|`backends[].policies.ai.prompts.append`||
-|`backends[].policies.ai.prompts.append[].role`||
-|`backends[].policies.ai.prompts.append[].content`||
-|`backends[].policies.ai.prompts.prepend`||
-|`backends[].policies.ai.prompts.prepend[].role`||
-|`backends[].policies.ai.prompts.prepend[].content`||
-|`backends[].policies.ai.modelAliases`||
-|`backends[].policies.ai.promptCaching`||
-|`backends[].policies.ai.promptCaching.cacheSystem`||
-|`backends[].policies.ai.promptCaching.cacheMessages`||
-|`backends[].policies.ai.promptCaching.cacheTools`||
-|`backends[].policies.ai.promptCaching.minTokens`||
-|`backends[].policies.ai.routes`||
 |`backends[].policies.backendTLS`|Send TLS to the backend.|
 |`backends[].policies.backendTLS.cert`||
 |`backends[].policies.backendTLS.key`||
@@ -2482,6 +3810,430 @@
 |`backends[].policies.tcp.connectTimeout`||
 |`backends[].policies.tcp.connectTimeout.secs`||
 |`backends[].policies.tcp.connectTimeout.nanos`||
+|`backends[].policies.mcpAuthorization`|Authorization policies for MCP access.|
+|`backends[].policies.mcpAuthorization.rules`||
+|`backends[].policies.a2a`|Mark this traffic as A2A to enable A2A processing and telemetry.|
+|`backends[].policies.ai`|Mark this as LLM traffic to enable LLM processing.|
+|`backends[].policies.ai.promptGuard`||
+|`backends[].policies.ai.promptGuard.request`||
+|`backends[].policies.ai.promptGuard.request[].(1)regex`||
+|`backends[].policies.ai.promptGuard.request[].(1)regex.action`||
+|`backends[].policies.ai.promptGuard.request[].(1)regex.rules`||
+|`backends[].policies.ai.promptGuard.request[].(1)regex.rules[].(any)builtin`||
+|`backends[].policies.ai.promptGuard.request[].(1)regex.rules[].(any)pattern`||
+|`backends[].policies.ai.promptGuard.request[].(1)webhook`||
+|`backends[].policies.ai.promptGuard.request[].(1)webhook.target`||
+|`backends[].policies.ai.promptGuard.request[].(1)webhook.target.(1)service`||
+|`backends[].policies.ai.promptGuard.request[].(1)webhook.target.(1)service.name`||
+|`backends[].policies.ai.promptGuard.request[].(1)webhook.target.(1)service.name.namespace`||
+|`backends[].policies.ai.promptGuard.request[].(1)webhook.target.(1)service.name.hostname`||
+|`backends[].policies.ai.promptGuard.request[].(1)webhook.target.(1)service.port`||
+|`backends[].policies.ai.promptGuard.request[].(1)webhook.target.(1)host`|Hostname or IP address|
+|`backends[].policies.ai.promptGuard.request[].(1)webhook.target.(1)backend`|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].policies.ai.promptGuard.request[].(1)webhook.forwardHeaderMatches`||
+|`backends[].policies.ai.promptGuard.request[].(1)webhook.forwardHeaderMatches[].name`||
+|`backends[].policies.ai.promptGuard.request[].(1)webhook.forwardHeaderMatches[].value`||
+|`backends[].policies.ai.promptGuard.request[].(1)webhook.forwardHeaderMatches[].value.(1)exact`||
+|`backends[].policies.ai.promptGuard.request[].(1)webhook.forwardHeaderMatches[].value.(1)regex`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.model`|Model to use. Defaults to `omni-moderation-latest`|
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestHeaderModifier`|Headers to be modified in the request.|
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestHeaderModifier.add`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestHeaderModifier.set`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestHeaderModifier.remove`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.responseHeaderModifier`|Headers to be modified in the response.|
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.responseHeaderModifier.add`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.responseHeaderModifier.set`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.responseHeaderModifier.remove`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestRedirect`|Directly respond to the request with a redirect.|
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestRedirect.scheme`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestRedirect.authority`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestRedirect.authority.(any)(1)full`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestRedirect.authority.(any)(1)host`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestRedirect.authority.(any)(1)port`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestRedirect.path`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestRedirect.path.(any)(1)full`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestRedirect.path.(any)(1)prefix`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestRedirect.status`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendTLS`|Send TLS to the backend.|
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendTLS.cert`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendTLS.key`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendTLS.root`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendTLS.hostname`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendTLS.insecure`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendTLS.insecureHost`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendTLS.alpn`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendTLS.subjectAltNames`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth`|Authenticate to the backend.|
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)passthrough`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)key`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)key.(any)file`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)gcp`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)gcp.(any)type`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)gcp.(any)audience`|Audience for the token. If not set, the destination host will be used.|
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)gcp.(any)type`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)aws`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)aws.(any)accessKeyId`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)aws.(any)secretAccessKey`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)aws.(any)region`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)aws.(any)sessionToken`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)azure`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)azure.(1)explicitConfig`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.tenant_id`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_id`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_secret`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)clientId`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)objectId`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)resourceId`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)workloadIdentity`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendAuth.(any)(1)azure.(1)developerImplicit`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.http`|Specify HTTP settings for the backend|
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.http.version`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.http.requestTimeout`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.tcp`|Specify TCP settings for the backend|
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.tcp.keepalives`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.tcp.keepalives.enabled`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.tcp.keepalives.time`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.tcp.keepalives.interval`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.tcp.keepalives.retries`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.tcp.connectTimeout`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.tcp.connectTimeout.secs`||
+|`backends[].policies.ai.promptGuard.request[].(1)openAIModeration.policies.tcp.connectTimeout.nanos`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails`|Configuration for AWS Bedrock Guardrails integration.|
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.guardrailIdentifier`|The unique identifier of the guardrail|
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.guardrailVersion`|The version of the guardrail|
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.region`|AWS region where the guardrail is deployed|
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies`|Backend policies for AWS authentication (optional, defaults to implicit AWS auth)|
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestHeaderModifier`|Headers to be modified in the request.|
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestHeaderModifier.add`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestHeaderModifier.set`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestHeaderModifier.remove`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.responseHeaderModifier`|Headers to be modified in the response.|
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.responseHeaderModifier.add`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.responseHeaderModifier.set`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.responseHeaderModifier.remove`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestRedirect`|Directly respond to the request with a redirect.|
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestRedirect.scheme`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestRedirect.authority`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestRedirect.authority.(any)(1)full`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestRedirect.authority.(any)(1)host`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestRedirect.authority.(any)(1)port`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestRedirect.path`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestRedirect.path.(any)(1)full`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestRedirect.path.(any)(1)prefix`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestRedirect.status`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendTLS`|Send TLS to the backend.|
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendTLS.cert`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendTLS.key`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendTLS.root`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendTLS.hostname`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendTLS.insecure`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendTLS.insecureHost`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendTLS.alpn`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendTLS.subjectAltNames`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth`|Authenticate to the backend.|
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)passthrough`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)key`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)key.(any)file`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)gcp`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)gcp.(any)type`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)gcp.(any)audience`|Audience for the token. If not set, the destination host will be used.|
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)gcp.(any)type`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)aws`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)aws.(any)accessKeyId`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)aws.(any)secretAccessKey`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)aws.(any)region`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)aws.(any)sessionToken`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.tenant_id`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_id`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_secret`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)clientId`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)objectId`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)resourceId`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)workloadIdentity`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)developerImplicit`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.http`|Specify HTTP settings for the backend|
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.http.version`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.http.requestTimeout`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.tcp`|Specify TCP settings for the backend|
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.tcp.keepalives`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.tcp.keepalives.enabled`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.tcp.keepalives.time`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.tcp.keepalives.interval`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.tcp.keepalives.retries`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.tcp.connectTimeout`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.tcp.connectTimeout.secs`||
+|`backends[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.tcp.connectTimeout.nanos`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor`|Configuration for Google Cloud Model Armor integration.|
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.templateId`|The template ID for the Model Armor configuration|
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.projectId`|The GCP project ID|
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.location`|The GCP region (default: us-central1)|
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies`|Backend policies for GCP authentication (optional, defaults to implicit GCP auth)|
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestHeaderModifier`|Headers to be modified in the request.|
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestHeaderModifier.add`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestHeaderModifier.set`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestHeaderModifier.remove`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.responseHeaderModifier`|Headers to be modified in the response.|
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.responseHeaderModifier.add`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.responseHeaderModifier.set`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.responseHeaderModifier.remove`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestRedirect`|Directly respond to the request with a redirect.|
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestRedirect.scheme`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestRedirect.authority`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestRedirect.authority.(any)(1)full`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestRedirect.authority.(any)(1)host`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestRedirect.authority.(any)(1)port`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestRedirect.path`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestRedirect.path.(any)(1)full`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestRedirect.path.(any)(1)prefix`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestRedirect.status`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendTLS`|Send TLS to the backend.|
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendTLS.cert`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendTLS.key`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendTLS.root`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendTLS.hostname`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendTLS.insecure`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendTLS.insecureHost`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendTLS.alpn`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendTLS.subjectAltNames`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth`|Authenticate to the backend.|
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)passthrough`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)key`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)key.(any)file`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)gcp`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)gcp.(any)type`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)gcp.(any)audience`|Audience for the token. If not set, the destination host will be used.|
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)gcp.(any)type`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)aws`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)aws.(any)accessKeyId`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)aws.(any)secretAccessKey`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)aws.(any)region`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)aws.(any)sessionToken`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.tenant_id`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_id`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_secret`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)clientId`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)objectId`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)resourceId`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)workloadIdentity`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)developerImplicit`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.http`|Specify HTTP settings for the backend|
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.http.version`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.http.requestTimeout`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.tcp`|Specify TCP settings for the backend|
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.tcp.keepalives`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.tcp.keepalives.enabled`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.tcp.keepalives.time`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.tcp.keepalives.interval`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.tcp.keepalives.retries`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.tcp.connectTimeout`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.tcp.connectTimeout.secs`||
+|`backends[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies.tcp.connectTimeout.nanos`||
+|`backends[].policies.ai.promptGuard.request[].rejection`||
+|`backends[].policies.ai.promptGuard.request[].rejection.body`||
+|`backends[].policies.ai.promptGuard.request[].rejection.status`||
+|`backends[].policies.ai.promptGuard.request[].rejection.headers`|Optional headers to add, set, or remove from the rejection response|
+|`backends[].policies.ai.promptGuard.request[].rejection.headers.add`||
+|`backends[].policies.ai.promptGuard.request[].rejection.headers.set`||
+|`backends[].policies.ai.promptGuard.request[].rejection.headers.remove`||
+|`backends[].policies.ai.promptGuard.response`||
+|`backends[].policies.ai.promptGuard.response[].(1)regex`||
+|`backends[].policies.ai.promptGuard.response[].(1)regex.action`||
+|`backends[].policies.ai.promptGuard.response[].(1)regex.rules`||
+|`backends[].policies.ai.promptGuard.response[].(1)regex.rules[].(any)builtin`||
+|`backends[].policies.ai.promptGuard.response[].(1)regex.rules[].(any)pattern`||
+|`backends[].policies.ai.promptGuard.response[].(1)webhook`||
+|`backends[].policies.ai.promptGuard.response[].(1)webhook.target`||
+|`backends[].policies.ai.promptGuard.response[].(1)webhook.target.(1)service`||
+|`backends[].policies.ai.promptGuard.response[].(1)webhook.target.(1)service.name`||
+|`backends[].policies.ai.promptGuard.response[].(1)webhook.target.(1)service.name.namespace`||
+|`backends[].policies.ai.promptGuard.response[].(1)webhook.target.(1)service.name.hostname`||
+|`backends[].policies.ai.promptGuard.response[].(1)webhook.target.(1)service.port`||
+|`backends[].policies.ai.promptGuard.response[].(1)webhook.target.(1)host`|Hostname or IP address|
+|`backends[].policies.ai.promptGuard.response[].(1)webhook.target.(1)backend`|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].policies.ai.promptGuard.response[].(1)webhook.forwardHeaderMatches`||
+|`backends[].policies.ai.promptGuard.response[].(1)webhook.forwardHeaderMatches[].name`||
+|`backends[].policies.ai.promptGuard.response[].(1)webhook.forwardHeaderMatches[].value`||
+|`backends[].policies.ai.promptGuard.response[].(1)webhook.forwardHeaderMatches[].value.(1)exact`||
+|`backends[].policies.ai.promptGuard.response[].(1)webhook.forwardHeaderMatches[].value.(1)regex`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails`|Configuration for AWS Bedrock Guardrails integration.|
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.guardrailIdentifier`|The unique identifier of the guardrail|
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.guardrailVersion`|The version of the guardrail|
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.region`|AWS region where the guardrail is deployed|
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies`|Backend policies for AWS authentication (optional, defaults to implicit AWS auth)|
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestHeaderModifier`|Headers to be modified in the request.|
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestHeaderModifier.add`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestHeaderModifier.set`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestHeaderModifier.remove`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.responseHeaderModifier`|Headers to be modified in the response.|
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.responseHeaderModifier.add`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.responseHeaderModifier.set`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.responseHeaderModifier.remove`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestRedirect`|Directly respond to the request with a redirect.|
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestRedirect.scheme`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestRedirect.authority`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestRedirect.authority.(any)(1)full`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestRedirect.authority.(any)(1)host`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestRedirect.authority.(any)(1)port`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestRedirect.path`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestRedirect.path.(any)(1)full`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestRedirect.path.(any)(1)prefix`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestRedirect.status`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendTLS`|Send TLS to the backend.|
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendTLS.cert`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendTLS.key`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendTLS.root`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendTLS.hostname`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendTLS.insecure`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendTLS.insecureHost`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendTLS.alpn`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendTLS.subjectAltNames`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth`|Authenticate to the backend.|
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)passthrough`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)key`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)key.(any)file`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)gcp`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)gcp.(any)type`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)gcp.(any)audience`|Audience for the token. If not set, the destination host will be used.|
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)gcp.(any)type`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)aws`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)aws.(any)accessKeyId`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)aws.(any)secretAccessKey`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)aws.(any)region`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)aws.(any)sessionToken`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.tenant_id`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_id`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_secret`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)clientId`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)objectId`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)resourceId`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)workloadIdentity`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendAuth.(any)(1)azure.(1)developerImplicit`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.http`|Specify HTTP settings for the backend|
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.http.version`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.http.requestTimeout`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.tcp`|Specify TCP settings for the backend|
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.tcp.keepalives`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.tcp.keepalives.enabled`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.tcp.keepalives.time`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.tcp.keepalives.interval`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.tcp.keepalives.retries`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.tcp.connectTimeout`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.tcp.connectTimeout.secs`||
+|`backends[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.tcp.connectTimeout.nanos`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor`|Configuration for Google Cloud Model Armor integration.|
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.templateId`|The template ID for the Model Armor configuration|
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.projectId`|The GCP project ID|
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.location`|The GCP region (default: us-central1)|
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies`|Backend policies for GCP authentication (optional, defaults to implicit GCP auth)|
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestHeaderModifier`|Headers to be modified in the request.|
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestHeaderModifier.add`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestHeaderModifier.set`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestHeaderModifier.remove`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.responseHeaderModifier`|Headers to be modified in the response.|
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.responseHeaderModifier.add`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.responseHeaderModifier.set`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.responseHeaderModifier.remove`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestRedirect`|Directly respond to the request with a redirect.|
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestRedirect.scheme`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestRedirect.authority`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestRedirect.authority.(any)(1)full`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestRedirect.authority.(any)(1)host`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestRedirect.authority.(any)(1)port`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestRedirect.path`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestRedirect.path.(any)(1)full`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestRedirect.path.(any)(1)prefix`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestRedirect.status`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendTLS`|Send TLS to the backend.|
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendTLS.cert`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendTLS.key`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendTLS.root`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendTLS.hostname`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendTLS.insecure`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendTLS.insecureHost`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendTLS.alpn`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendTLS.subjectAltNames`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth`|Authenticate to the backend.|
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)passthrough`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)key`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)key.(any)file`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)gcp`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)gcp.(any)type`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)gcp.(any)audience`|Audience for the token. If not set, the destination host will be used.|
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)gcp.(any)type`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)aws`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)aws.(any)accessKeyId`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)aws.(any)secretAccessKey`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)aws.(any)region`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)aws.(any)sessionToken`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.tenant_id`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_id`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_secret`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)clientId`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)objectId`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)resourceId`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)workloadIdentity`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendAuth.(any)(1)azure.(1)developerImplicit`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.http`|Specify HTTP settings for the backend|
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.http.version`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.http.requestTimeout`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.tcp`|Specify TCP settings for the backend|
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.tcp.keepalives`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.tcp.keepalives.enabled`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.tcp.keepalives.time`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.tcp.keepalives.interval`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.tcp.keepalives.retries`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.tcp.connectTimeout`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.tcp.connectTimeout.secs`||
+|`backends[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies.tcp.connectTimeout.nanos`||
+|`backends[].policies.ai.promptGuard.response[].rejection`||
+|`backends[].policies.ai.promptGuard.response[].rejection.body`||
+|`backends[].policies.ai.promptGuard.response[].rejection.status`||
+|`backends[].policies.ai.promptGuard.response[].rejection.headers`|Optional headers to add, set, or remove from the rejection response|
+|`backends[].policies.ai.promptGuard.response[].rejection.headers.add`||
+|`backends[].policies.ai.promptGuard.response[].rejection.headers.set`||
+|`backends[].policies.ai.promptGuard.response[].rejection.headers.remove`||
+|`backends[].policies.ai.defaults`||
+|`backends[].policies.ai.overrides`||
+|`backends[].policies.ai.transformations`||
+|`backends[].policies.ai.prompts`||
+|`backends[].policies.ai.prompts.append`||
+|`backends[].policies.ai.prompts.append[].role`||
+|`backends[].policies.ai.prompts.append[].content`||
+|`backends[].policies.ai.prompts.prepend`||
+|`backends[].policies.ai.prompts.prepend[].role`||
+|`backends[].policies.ai.prompts.prepend[].content`||
+|`backends[].policies.ai.modelAliases`||
+|`backends[].policies.ai.promptCaching`||
+|`backends[].policies.ai.promptCaching.cacheSystem`||
+|`backends[].policies.ai.promptCaching.cacheMessages`||
+|`backends[].policies.ai.promptCaching.cacheTools`||
+|`backends[].policies.ai.promptCaching.minTokens`||
+|`backends[].policies.ai.routes`||
 |`llm`||
 |`llm.port`||
 |`llm.models`|models defines the set of models that can be served by this gateway. The model name refers to the<br>model in the users request that is matched; the model sent to the actual LLM can be overridden<br>on a per-model basis.|
@@ -2544,28 +4296,6 @@
 |`llm.models[].guardrails.request[].(1)openAIModeration.policies.requestRedirect.path.(any)(1)full`||
 |`llm.models[].guardrails.request[].(1)openAIModeration.policies.requestRedirect.path.(any)(1)prefix`||
 |`llm.models[].guardrails.request[].(1)openAIModeration.policies.requestRedirect.status`||
-|`llm.models[].guardrails.request[].(1)openAIModeration.policies.mcpAuthorization`|Authorization policies for MCP access.|
-|`llm.models[].guardrails.request[].(1)openAIModeration.policies.mcpAuthorization.rules`||
-|`llm.models[].guardrails.request[].(1)openAIModeration.policies.a2a`|Mark this traffic as A2A to enable A2A processing and telemetry.|
-|`llm.models[].guardrails.request[].(1)openAIModeration.policies.ai`|Mark this as LLM traffic to enable LLM processing.|
-|`llm.models[].guardrails.request[].(1)openAIModeration.policies.ai.promptGuard`||
-|`llm.models[].guardrails.request[].(1)openAIModeration.policies.ai.defaults`||
-|`llm.models[].guardrails.request[].(1)openAIModeration.policies.ai.overrides`||
-|`llm.models[].guardrails.request[].(1)openAIModeration.policies.ai.transformations`||
-|`llm.models[].guardrails.request[].(1)openAIModeration.policies.ai.prompts`||
-|`llm.models[].guardrails.request[].(1)openAIModeration.policies.ai.prompts.append`||
-|`llm.models[].guardrails.request[].(1)openAIModeration.policies.ai.prompts.append[].role`||
-|`llm.models[].guardrails.request[].(1)openAIModeration.policies.ai.prompts.append[].content`||
-|`llm.models[].guardrails.request[].(1)openAIModeration.policies.ai.prompts.prepend`||
-|`llm.models[].guardrails.request[].(1)openAIModeration.policies.ai.prompts.prepend[].role`||
-|`llm.models[].guardrails.request[].(1)openAIModeration.policies.ai.prompts.prepend[].content`||
-|`llm.models[].guardrails.request[].(1)openAIModeration.policies.ai.modelAliases`||
-|`llm.models[].guardrails.request[].(1)openAIModeration.policies.ai.promptCaching`||
-|`llm.models[].guardrails.request[].(1)openAIModeration.policies.ai.promptCaching.cacheSystem`||
-|`llm.models[].guardrails.request[].(1)openAIModeration.policies.ai.promptCaching.cacheMessages`||
-|`llm.models[].guardrails.request[].(1)openAIModeration.policies.ai.promptCaching.cacheTools`||
-|`llm.models[].guardrails.request[].(1)openAIModeration.policies.ai.promptCaching.minTokens`||
-|`llm.models[].guardrails.request[].(1)openAIModeration.policies.ai.routes`||
 |`llm.models[].guardrails.request[].(1)openAIModeration.policies.backendTLS`|Send TLS to the backend.|
 |`llm.models[].guardrails.request[].(1)openAIModeration.policies.backendTLS.cert`||
 |`llm.models[].guardrails.request[].(1)openAIModeration.policies.backendTLS.key`||
@@ -2636,28 +4366,6 @@
 |`llm.models[].guardrails.request[].(1)bedrockGuardrails.policies.requestRedirect.path.(any)(1)full`||
 |`llm.models[].guardrails.request[].(1)bedrockGuardrails.policies.requestRedirect.path.(any)(1)prefix`||
 |`llm.models[].guardrails.request[].(1)bedrockGuardrails.policies.requestRedirect.status`||
-|`llm.models[].guardrails.request[].(1)bedrockGuardrails.policies.mcpAuthorization`|Authorization policies for MCP access.|
-|`llm.models[].guardrails.request[].(1)bedrockGuardrails.policies.mcpAuthorization.rules`||
-|`llm.models[].guardrails.request[].(1)bedrockGuardrails.policies.a2a`|Mark this traffic as A2A to enable A2A processing and telemetry.|
-|`llm.models[].guardrails.request[].(1)bedrockGuardrails.policies.ai`|Mark this as LLM traffic to enable LLM processing.|
-|`llm.models[].guardrails.request[].(1)bedrockGuardrails.policies.ai.promptGuard`||
-|`llm.models[].guardrails.request[].(1)bedrockGuardrails.policies.ai.defaults`||
-|`llm.models[].guardrails.request[].(1)bedrockGuardrails.policies.ai.overrides`||
-|`llm.models[].guardrails.request[].(1)bedrockGuardrails.policies.ai.transformations`||
-|`llm.models[].guardrails.request[].(1)bedrockGuardrails.policies.ai.prompts`||
-|`llm.models[].guardrails.request[].(1)bedrockGuardrails.policies.ai.prompts.append`||
-|`llm.models[].guardrails.request[].(1)bedrockGuardrails.policies.ai.prompts.append[].role`||
-|`llm.models[].guardrails.request[].(1)bedrockGuardrails.policies.ai.prompts.append[].content`||
-|`llm.models[].guardrails.request[].(1)bedrockGuardrails.policies.ai.prompts.prepend`||
-|`llm.models[].guardrails.request[].(1)bedrockGuardrails.policies.ai.prompts.prepend[].role`||
-|`llm.models[].guardrails.request[].(1)bedrockGuardrails.policies.ai.prompts.prepend[].content`||
-|`llm.models[].guardrails.request[].(1)bedrockGuardrails.policies.ai.modelAliases`||
-|`llm.models[].guardrails.request[].(1)bedrockGuardrails.policies.ai.promptCaching`||
-|`llm.models[].guardrails.request[].(1)bedrockGuardrails.policies.ai.promptCaching.cacheSystem`||
-|`llm.models[].guardrails.request[].(1)bedrockGuardrails.policies.ai.promptCaching.cacheMessages`||
-|`llm.models[].guardrails.request[].(1)bedrockGuardrails.policies.ai.promptCaching.cacheTools`||
-|`llm.models[].guardrails.request[].(1)bedrockGuardrails.policies.ai.promptCaching.minTokens`||
-|`llm.models[].guardrails.request[].(1)bedrockGuardrails.policies.ai.routes`||
 |`llm.models[].guardrails.request[].(1)bedrockGuardrails.policies.backendTLS`|Send TLS to the backend.|
 |`llm.models[].guardrails.request[].(1)bedrockGuardrails.policies.backendTLS.cert`||
 |`llm.models[].guardrails.request[].(1)bedrockGuardrails.policies.backendTLS.key`||
@@ -2728,28 +4436,6 @@
 |`llm.models[].guardrails.request[].(1)googleModelArmor.policies.requestRedirect.path.(any)(1)full`||
 |`llm.models[].guardrails.request[].(1)googleModelArmor.policies.requestRedirect.path.(any)(1)prefix`||
 |`llm.models[].guardrails.request[].(1)googleModelArmor.policies.requestRedirect.status`||
-|`llm.models[].guardrails.request[].(1)googleModelArmor.policies.mcpAuthorization`|Authorization policies for MCP access.|
-|`llm.models[].guardrails.request[].(1)googleModelArmor.policies.mcpAuthorization.rules`||
-|`llm.models[].guardrails.request[].(1)googleModelArmor.policies.a2a`|Mark this traffic as A2A to enable A2A processing and telemetry.|
-|`llm.models[].guardrails.request[].(1)googleModelArmor.policies.ai`|Mark this as LLM traffic to enable LLM processing.|
-|`llm.models[].guardrails.request[].(1)googleModelArmor.policies.ai.promptGuard`||
-|`llm.models[].guardrails.request[].(1)googleModelArmor.policies.ai.defaults`||
-|`llm.models[].guardrails.request[].(1)googleModelArmor.policies.ai.overrides`||
-|`llm.models[].guardrails.request[].(1)googleModelArmor.policies.ai.transformations`||
-|`llm.models[].guardrails.request[].(1)googleModelArmor.policies.ai.prompts`||
-|`llm.models[].guardrails.request[].(1)googleModelArmor.policies.ai.prompts.append`||
-|`llm.models[].guardrails.request[].(1)googleModelArmor.policies.ai.prompts.append[].role`||
-|`llm.models[].guardrails.request[].(1)googleModelArmor.policies.ai.prompts.append[].content`||
-|`llm.models[].guardrails.request[].(1)googleModelArmor.policies.ai.prompts.prepend`||
-|`llm.models[].guardrails.request[].(1)googleModelArmor.policies.ai.prompts.prepend[].role`||
-|`llm.models[].guardrails.request[].(1)googleModelArmor.policies.ai.prompts.prepend[].content`||
-|`llm.models[].guardrails.request[].(1)googleModelArmor.policies.ai.modelAliases`||
-|`llm.models[].guardrails.request[].(1)googleModelArmor.policies.ai.promptCaching`||
-|`llm.models[].guardrails.request[].(1)googleModelArmor.policies.ai.promptCaching.cacheSystem`||
-|`llm.models[].guardrails.request[].(1)googleModelArmor.policies.ai.promptCaching.cacheMessages`||
-|`llm.models[].guardrails.request[].(1)googleModelArmor.policies.ai.promptCaching.cacheTools`||
-|`llm.models[].guardrails.request[].(1)googleModelArmor.policies.ai.promptCaching.minTokens`||
-|`llm.models[].guardrails.request[].(1)googleModelArmor.policies.ai.routes`||
 |`llm.models[].guardrails.request[].(1)googleModelArmor.policies.backendTLS`|Send TLS to the backend.|
 |`llm.models[].guardrails.request[].(1)googleModelArmor.policies.backendTLS.cert`||
 |`llm.models[].guardrails.request[].(1)googleModelArmor.policies.backendTLS.key`||
@@ -2847,28 +4533,6 @@
 |`llm.models[].guardrails.response[].(1)bedrockGuardrails.policies.requestRedirect.path.(any)(1)full`||
 |`llm.models[].guardrails.response[].(1)bedrockGuardrails.policies.requestRedirect.path.(any)(1)prefix`||
 |`llm.models[].guardrails.response[].(1)bedrockGuardrails.policies.requestRedirect.status`||
-|`llm.models[].guardrails.response[].(1)bedrockGuardrails.policies.mcpAuthorization`|Authorization policies for MCP access.|
-|`llm.models[].guardrails.response[].(1)bedrockGuardrails.policies.mcpAuthorization.rules`||
-|`llm.models[].guardrails.response[].(1)bedrockGuardrails.policies.a2a`|Mark this traffic as A2A to enable A2A processing and telemetry.|
-|`llm.models[].guardrails.response[].(1)bedrockGuardrails.policies.ai`|Mark this as LLM traffic to enable LLM processing.|
-|`llm.models[].guardrails.response[].(1)bedrockGuardrails.policies.ai.promptGuard`||
-|`llm.models[].guardrails.response[].(1)bedrockGuardrails.policies.ai.defaults`||
-|`llm.models[].guardrails.response[].(1)bedrockGuardrails.policies.ai.overrides`||
-|`llm.models[].guardrails.response[].(1)bedrockGuardrails.policies.ai.transformations`||
-|`llm.models[].guardrails.response[].(1)bedrockGuardrails.policies.ai.prompts`||
-|`llm.models[].guardrails.response[].(1)bedrockGuardrails.policies.ai.prompts.append`||
-|`llm.models[].guardrails.response[].(1)bedrockGuardrails.policies.ai.prompts.append[].role`||
-|`llm.models[].guardrails.response[].(1)bedrockGuardrails.policies.ai.prompts.append[].content`||
-|`llm.models[].guardrails.response[].(1)bedrockGuardrails.policies.ai.prompts.prepend`||
-|`llm.models[].guardrails.response[].(1)bedrockGuardrails.policies.ai.prompts.prepend[].role`||
-|`llm.models[].guardrails.response[].(1)bedrockGuardrails.policies.ai.prompts.prepend[].content`||
-|`llm.models[].guardrails.response[].(1)bedrockGuardrails.policies.ai.modelAliases`||
-|`llm.models[].guardrails.response[].(1)bedrockGuardrails.policies.ai.promptCaching`||
-|`llm.models[].guardrails.response[].(1)bedrockGuardrails.policies.ai.promptCaching.cacheSystem`||
-|`llm.models[].guardrails.response[].(1)bedrockGuardrails.policies.ai.promptCaching.cacheMessages`||
-|`llm.models[].guardrails.response[].(1)bedrockGuardrails.policies.ai.promptCaching.cacheTools`||
-|`llm.models[].guardrails.response[].(1)bedrockGuardrails.policies.ai.promptCaching.minTokens`||
-|`llm.models[].guardrails.response[].(1)bedrockGuardrails.policies.ai.routes`||
 |`llm.models[].guardrails.response[].(1)bedrockGuardrails.policies.backendTLS`|Send TLS to the backend.|
 |`llm.models[].guardrails.response[].(1)bedrockGuardrails.policies.backendTLS.cert`||
 |`llm.models[].guardrails.response[].(1)bedrockGuardrails.policies.backendTLS.key`||
@@ -2939,28 +4603,6 @@
 |`llm.models[].guardrails.response[].(1)googleModelArmor.policies.requestRedirect.path.(any)(1)full`||
 |`llm.models[].guardrails.response[].(1)googleModelArmor.policies.requestRedirect.path.(any)(1)prefix`||
 |`llm.models[].guardrails.response[].(1)googleModelArmor.policies.requestRedirect.status`||
-|`llm.models[].guardrails.response[].(1)googleModelArmor.policies.mcpAuthorization`|Authorization policies for MCP access.|
-|`llm.models[].guardrails.response[].(1)googleModelArmor.policies.mcpAuthorization.rules`||
-|`llm.models[].guardrails.response[].(1)googleModelArmor.policies.a2a`|Mark this traffic as A2A to enable A2A processing and telemetry.|
-|`llm.models[].guardrails.response[].(1)googleModelArmor.policies.ai`|Mark this as LLM traffic to enable LLM processing.|
-|`llm.models[].guardrails.response[].(1)googleModelArmor.policies.ai.promptGuard`||
-|`llm.models[].guardrails.response[].(1)googleModelArmor.policies.ai.defaults`||
-|`llm.models[].guardrails.response[].(1)googleModelArmor.policies.ai.overrides`||
-|`llm.models[].guardrails.response[].(1)googleModelArmor.policies.ai.transformations`||
-|`llm.models[].guardrails.response[].(1)googleModelArmor.policies.ai.prompts`||
-|`llm.models[].guardrails.response[].(1)googleModelArmor.policies.ai.prompts.append`||
-|`llm.models[].guardrails.response[].(1)googleModelArmor.policies.ai.prompts.append[].role`||
-|`llm.models[].guardrails.response[].(1)googleModelArmor.policies.ai.prompts.append[].content`||
-|`llm.models[].guardrails.response[].(1)googleModelArmor.policies.ai.prompts.prepend`||
-|`llm.models[].guardrails.response[].(1)googleModelArmor.policies.ai.prompts.prepend[].role`||
-|`llm.models[].guardrails.response[].(1)googleModelArmor.policies.ai.prompts.prepend[].content`||
-|`llm.models[].guardrails.response[].(1)googleModelArmor.policies.ai.modelAliases`||
-|`llm.models[].guardrails.response[].(1)googleModelArmor.policies.ai.promptCaching`||
-|`llm.models[].guardrails.response[].(1)googleModelArmor.policies.ai.promptCaching.cacheSystem`||
-|`llm.models[].guardrails.response[].(1)googleModelArmor.policies.ai.promptCaching.cacheMessages`||
-|`llm.models[].guardrails.response[].(1)googleModelArmor.policies.ai.promptCaching.cacheTools`||
-|`llm.models[].guardrails.response[].(1)googleModelArmor.policies.ai.promptCaching.minTokens`||
-|`llm.models[].guardrails.response[].(1)googleModelArmor.policies.ai.routes`||
 |`llm.models[].guardrails.response[].(1)googleModelArmor.policies.backendTLS`|Send TLS to the backend.|
 |`llm.models[].guardrails.response[].(1)googleModelArmor.policies.backendTLS.cert`||
 |`llm.models[].guardrails.response[].(1)googleModelArmor.policies.backendTLS.key`||
@@ -3048,6 +4690,72 @@
 |`llm.policies.extAuthz.(any)(1)service.port`||
 |`llm.policies.extAuthz.(any)(1)host`|Hostname or IP address|
 |`llm.policies.extAuthz.(any)(1)backend`|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.policies.extAuthz.(any)policies`|Policies to connect to the backend|
+|`llm.policies.extAuthz.(any)policies.requestHeaderModifier`|Headers to be modified in the request.|
+|`llm.policies.extAuthz.(any)policies.requestHeaderModifier.add`||
+|`llm.policies.extAuthz.(any)policies.requestHeaderModifier.set`||
+|`llm.policies.extAuthz.(any)policies.requestHeaderModifier.remove`||
+|`llm.policies.extAuthz.(any)policies.responseHeaderModifier`|Headers to be modified in the response.|
+|`llm.policies.extAuthz.(any)policies.responseHeaderModifier.add`||
+|`llm.policies.extAuthz.(any)policies.responseHeaderModifier.set`||
+|`llm.policies.extAuthz.(any)policies.responseHeaderModifier.remove`||
+|`llm.policies.extAuthz.(any)policies.requestRedirect`|Directly respond to the request with a redirect.|
+|`llm.policies.extAuthz.(any)policies.requestRedirect.scheme`||
+|`llm.policies.extAuthz.(any)policies.requestRedirect.authority`||
+|`llm.policies.extAuthz.(any)policies.requestRedirect.authority.(any)(1)full`||
+|`llm.policies.extAuthz.(any)policies.requestRedirect.authority.(any)(1)host`||
+|`llm.policies.extAuthz.(any)policies.requestRedirect.authority.(any)(1)port`||
+|`llm.policies.extAuthz.(any)policies.requestRedirect.path`||
+|`llm.policies.extAuthz.(any)policies.requestRedirect.path.(any)(1)full`||
+|`llm.policies.extAuthz.(any)policies.requestRedirect.path.(any)(1)prefix`||
+|`llm.policies.extAuthz.(any)policies.requestRedirect.status`||
+|`llm.policies.extAuthz.(any)policies.backendTLS`|Send TLS to the backend.|
+|`llm.policies.extAuthz.(any)policies.backendTLS.cert`||
+|`llm.policies.extAuthz.(any)policies.backendTLS.key`||
+|`llm.policies.extAuthz.(any)policies.backendTLS.root`||
+|`llm.policies.extAuthz.(any)policies.backendTLS.hostname`||
+|`llm.policies.extAuthz.(any)policies.backendTLS.insecure`||
+|`llm.policies.extAuthz.(any)policies.backendTLS.insecureHost`||
+|`llm.policies.extAuthz.(any)policies.backendTLS.alpn`||
+|`llm.policies.extAuthz.(any)policies.backendTLS.subjectAltNames`||
+|`llm.policies.extAuthz.(any)policies.backendAuth`|Authenticate to the backend.|
+|`llm.policies.extAuthz.(any)policies.backendAuth.(any)(1)passthrough`||
+|`llm.policies.extAuthz.(any)policies.backendAuth.(any)(1)key`||
+|`llm.policies.extAuthz.(any)policies.backendAuth.(any)(1)key.(any)file`||
+|`llm.policies.extAuthz.(any)policies.backendAuth.(any)(1)gcp`||
+|`llm.policies.extAuthz.(any)policies.backendAuth.(any)(1)gcp.(any)type`||
+|`llm.policies.extAuthz.(any)policies.backendAuth.(any)(1)gcp.(any)audience`|Audience for the token. If not set, the destination host will be used.|
+|`llm.policies.extAuthz.(any)policies.backendAuth.(any)(1)gcp.(any)type`||
+|`llm.policies.extAuthz.(any)policies.backendAuth.(any)(1)aws`||
+|`llm.policies.extAuthz.(any)policies.backendAuth.(any)(1)aws.(any)accessKeyId`||
+|`llm.policies.extAuthz.(any)policies.backendAuth.(any)(1)aws.(any)secretAccessKey`||
+|`llm.policies.extAuthz.(any)policies.backendAuth.(any)(1)aws.(any)region`||
+|`llm.policies.extAuthz.(any)policies.backendAuth.(any)(1)aws.(any)sessionToken`||
+|`llm.policies.extAuthz.(any)policies.backendAuth.(any)(1)azure`||
+|`llm.policies.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig`||
+|`llm.policies.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret`||
+|`llm.policies.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.tenant_id`||
+|`llm.policies.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_id`||
+|`llm.policies.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_secret`||
+|`llm.policies.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity`||
+|`llm.policies.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity`||
+|`llm.policies.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)clientId`||
+|`llm.policies.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)objectId`||
+|`llm.policies.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)resourceId`||
+|`llm.policies.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)workloadIdentity`||
+|`llm.policies.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)developerImplicit`||
+|`llm.policies.extAuthz.(any)policies.http`|Specify HTTP settings for the backend|
+|`llm.policies.extAuthz.(any)policies.http.version`||
+|`llm.policies.extAuthz.(any)policies.http.requestTimeout`||
+|`llm.policies.extAuthz.(any)policies.tcp`|Specify TCP settings for the backend|
+|`llm.policies.extAuthz.(any)policies.tcp.keepalives`||
+|`llm.policies.extAuthz.(any)policies.tcp.keepalives.enabled`||
+|`llm.policies.extAuthz.(any)policies.tcp.keepalives.time`||
+|`llm.policies.extAuthz.(any)policies.tcp.keepalives.interval`||
+|`llm.policies.extAuthz.(any)policies.tcp.keepalives.retries`||
+|`llm.policies.extAuthz.(any)policies.tcp.connectTimeout`||
+|`llm.policies.extAuthz.(any)policies.tcp.connectTimeout.secs`||
+|`llm.policies.extAuthz.(any)policies.tcp.connectTimeout.nanos`||
 |`llm.policies.extAuthz.(any)protocol`|The ext_authz protocol to use. Unless you need to integrate with an HTTP-only server, gRPC is recommended.|
 |`llm.policies.extAuthz.(any)protocol.(1)grpc`||
 |`llm.policies.extAuthz.(any)protocol.(1)grpc.context`|Additional context to send to the authorization service.<br>This maps to the `context_extensions` field of the request, and only allows static values.|
@@ -3065,7 +4773,6 @@
 |`llm.policies.extAuthz.(any)includeRequestBody.maxRequestBytes`|Maximum size of request body to buffer (default: 8192)|
 |`llm.policies.extAuthz.(any)includeRequestBody.allowPartialMessage`|If true, send partial body when max_request_bytes is reached|
 |`llm.policies.extAuthz.(any)includeRequestBody.packAsBytes`|If true, pack body as raw bytes in gRPC|
-|`llm.policies.extAuthz.(any)timeout`|Timeout for the authorization request (default: 200ms)|
 |`llm.policies.extProc`|Extend agentgateway with an external processor|
 |`llm.policies.extProc.(any)(1)service`||
 |`llm.policies.extProc.(any)(1)service.name`||
@@ -3074,6 +4781,72 @@
 |`llm.policies.extProc.(any)(1)service.port`||
 |`llm.policies.extProc.(any)(1)host`|Hostname or IP address|
 |`llm.policies.extProc.(any)(1)backend`|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.policies.extProc.(any)policies`|Policies to connect to the backend|
+|`llm.policies.extProc.(any)policies.requestHeaderModifier`|Headers to be modified in the request.|
+|`llm.policies.extProc.(any)policies.requestHeaderModifier.add`||
+|`llm.policies.extProc.(any)policies.requestHeaderModifier.set`||
+|`llm.policies.extProc.(any)policies.requestHeaderModifier.remove`||
+|`llm.policies.extProc.(any)policies.responseHeaderModifier`|Headers to be modified in the response.|
+|`llm.policies.extProc.(any)policies.responseHeaderModifier.add`||
+|`llm.policies.extProc.(any)policies.responseHeaderModifier.set`||
+|`llm.policies.extProc.(any)policies.responseHeaderModifier.remove`||
+|`llm.policies.extProc.(any)policies.requestRedirect`|Directly respond to the request with a redirect.|
+|`llm.policies.extProc.(any)policies.requestRedirect.scheme`||
+|`llm.policies.extProc.(any)policies.requestRedirect.authority`||
+|`llm.policies.extProc.(any)policies.requestRedirect.authority.(any)(1)full`||
+|`llm.policies.extProc.(any)policies.requestRedirect.authority.(any)(1)host`||
+|`llm.policies.extProc.(any)policies.requestRedirect.authority.(any)(1)port`||
+|`llm.policies.extProc.(any)policies.requestRedirect.path`||
+|`llm.policies.extProc.(any)policies.requestRedirect.path.(any)(1)full`||
+|`llm.policies.extProc.(any)policies.requestRedirect.path.(any)(1)prefix`||
+|`llm.policies.extProc.(any)policies.requestRedirect.status`||
+|`llm.policies.extProc.(any)policies.backendTLS`|Send TLS to the backend.|
+|`llm.policies.extProc.(any)policies.backendTLS.cert`||
+|`llm.policies.extProc.(any)policies.backendTLS.key`||
+|`llm.policies.extProc.(any)policies.backendTLS.root`||
+|`llm.policies.extProc.(any)policies.backendTLS.hostname`||
+|`llm.policies.extProc.(any)policies.backendTLS.insecure`||
+|`llm.policies.extProc.(any)policies.backendTLS.insecureHost`||
+|`llm.policies.extProc.(any)policies.backendTLS.alpn`||
+|`llm.policies.extProc.(any)policies.backendTLS.subjectAltNames`||
+|`llm.policies.extProc.(any)policies.backendAuth`|Authenticate to the backend.|
+|`llm.policies.extProc.(any)policies.backendAuth.(any)(1)passthrough`||
+|`llm.policies.extProc.(any)policies.backendAuth.(any)(1)key`||
+|`llm.policies.extProc.(any)policies.backendAuth.(any)(1)key.(any)file`||
+|`llm.policies.extProc.(any)policies.backendAuth.(any)(1)gcp`||
+|`llm.policies.extProc.(any)policies.backendAuth.(any)(1)gcp.(any)type`||
+|`llm.policies.extProc.(any)policies.backendAuth.(any)(1)gcp.(any)audience`|Audience for the token. If not set, the destination host will be used.|
+|`llm.policies.extProc.(any)policies.backendAuth.(any)(1)gcp.(any)type`||
+|`llm.policies.extProc.(any)policies.backendAuth.(any)(1)aws`||
+|`llm.policies.extProc.(any)policies.backendAuth.(any)(1)aws.(any)accessKeyId`||
+|`llm.policies.extProc.(any)policies.backendAuth.(any)(1)aws.(any)secretAccessKey`||
+|`llm.policies.extProc.(any)policies.backendAuth.(any)(1)aws.(any)region`||
+|`llm.policies.extProc.(any)policies.backendAuth.(any)(1)aws.(any)sessionToken`||
+|`llm.policies.extProc.(any)policies.backendAuth.(any)(1)azure`||
+|`llm.policies.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig`||
+|`llm.policies.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret`||
+|`llm.policies.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.tenant_id`||
+|`llm.policies.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_id`||
+|`llm.policies.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_secret`||
+|`llm.policies.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity`||
+|`llm.policies.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity`||
+|`llm.policies.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)clientId`||
+|`llm.policies.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)objectId`||
+|`llm.policies.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)resourceId`||
+|`llm.policies.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)workloadIdentity`||
+|`llm.policies.extProc.(any)policies.backendAuth.(any)(1)azure.(1)developerImplicit`||
+|`llm.policies.extProc.(any)policies.http`|Specify HTTP settings for the backend|
+|`llm.policies.extProc.(any)policies.http.version`||
+|`llm.policies.extProc.(any)policies.http.requestTimeout`||
+|`llm.policies.extProc.(any)policies.tcp`|Specify TCP settings for the backend|
+|`llm.policies.extProc.(any)policies.tcp.keepalives`||
+|`llm.policies.extProc.(any)policies.tcp.keepalives.enabled`||
+|`llm.policies.extProc.(any)policies.tcp.keepalives.time`||
+|`llm.policies.extProc.(any)policies.tcp.keepalives.interval`||
+|`llm.policies.extProc.(any)policies.tcp.keepalives.retries`||
+|`llm.policies.extProc.(any)policies.tcp.connectTimeout`||
+|`llm.policies.extProc.(any)policies.tcp.connectTimeout.secs`||
+|`llm.policies.extProc.(any)policies.tcp.connectTimeout.nanos`||
 |`llm.policies.extProc.(any)failureMode`|Behavior when the ext_proc service is unavailable or returns an error|
 |`llm.policies.extProc.(any)metadataContext`|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
 |`llm.policies.extProc.(any)requestAttributes`|Maps to the request `attributes` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -3143,105 +4916,6 @@
 |`mcp.targets[].policies.requestRedirect.path.(any)(1)full`||
 |`mcp.targets[].policies.requestRedirect.path.(any)(1)prefix`||
 |`mcp.targets[].policies.requestRedirect.status`||
-|`mcp.targets[].policies.mcpAuthorization`|Authorization policies for MCP access.|
-|`mcp.targets[].policies.mcpAuthorization.rules`||
-|`mcp.targets[].policies.a2a`|Mark this traffic as A2A to enable A2A processing and telemetry.|
-|`mcp.targets[].policies.ai`|Mark this as LLM traffic to enable LLM processing.|
-|`mcp.targets[].policies.ai.promptGuard`||
-|`mcp.targets[].policies.ai.promptGuard.request`||
-|`mcp.targets[].policies.ai.promptGuard.request[].(1)regex`||
-|`mcp.targets[].policies.ai.promptGuard.request[].(1)regex.action`||
-|`mcp.targets[].policies.ai.promptGuard.request[].(1)regex.rules`||
-|`mcp.targets[].policies.ai.promptGuard.request[].(1)regex.rules[].(any)builtin`||
-|`mcp.targets[].policies.ai.promptGuard.request[].(1)regex.rules[].(any)pattern`||
-|`mcp.targets[].policies.ai.promptGuard.request[].(1)webhook`||
-|`mcp.targets[].policies.ai.promptGuard.request[].(1)webhook.target`||
-|`mcp.targets[].policies.ai.promptGuard.request[].(1)webhook.target.(1)service`||
-|`mcp.targets[].policies.ai.promptGuard.request[].(1)webhook.target.(1)service.name`||
-|`mcp.targets[].policies.ai.promptGuard.request[].(1)webhook.target.(1)service.name.namespace`||
-|`mcp.targets[].policies.ai.promptGuard.request[].(1)webhook.target.(1)service.name.hostname`||
-|`mcp.targets[].policies.ai.promptGuard.request[].(1)webhook.target.(1)service.port`||
-|`mcp.targets[].policies.ai.promptGuard.request[].(1)webhook.target.(1)host`|Hostname or IP address|
-|`mcp.targets[].policies.ai.promptGuard.request[].(1)webhook.target.(1)backend`|Explicit backend reference. Backend must be defined in the top level backends list|
-|`mcp.targets[].policies.ai.promptGuard.request[].(1)webhook.forwardHeaderMatches`||
-|`mcp.targets[].policies.ai.promptGuard.request[].(1)webhook.forwardHeaderMatches[].name`||
-|`mcp.targets[].policies.ai.promptGuard.request[].(1)webhook.forwardHeaderMatches[].value`||
-|`mcp.targets[].policies.ai.promptGuard.request[].(1)webhook.forwardHeaderMatches[].value.(1)exact`||
-|`mcp.targets[].policies.ai.promptGuard.request[].(1)webhook.forwardHeaderMatches[].value.(1)regex`||
-|`mcp.targets[].policies.ai.promptGuard.request[].(1)openAIModeration`||
-|`mcp.targets[].policies.ai.promptGuard.request[].(1)openAIModeration.model`|Model to use. Defaults to `omni-moderation-latest`|
-|`mcp.targets[].policies.ai.promptGuard.request[].(1)openAIModeration.policies`||
-|`mcp.targets[].policies.ai.promptGuard.request[].(1)bedrockGuardrails`|Configuration for AWS Bedrock Guardrails integration.|
-|`mcp.targets[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.guardrailIdentifier`|The unique identifier of the guardrail|
-|`mcp.targets[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.guardrailVersion`|The version of the guardrail|
-|`mcp.targets[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.region`|AWS region where the guardrail is deployed|
-|`mcp.targets[].policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies`|Backend policies for AWS authentication (optional, defaults to implicit AWS auth)|
-|`mcp.targets[].policies.ai.promptGuard.request[].(1)googleModelArmor`|Configuration for Google Cloud Model Armor integration.|
-|`mcp.targets[].policies.ai.promptGuard.request[].(1)googleModelArmor.templateId`|The template ID for the Model Armor configuration|
-|`mcp.targets[].policies.ai.promptGuard.request[].(1)googleModelArmor.projectId`|The GCP project ID|
-|`mcp.targets[].policies.ai.promptGuard.request[].(1)googleModelArmor.location`|The GCP region (default: us-central1)|
-|`mcp.targets[].policies.ai.promptGuard.request[].(1)googleModelArmor.policies`|Backend policies for GCP authentication (optional, defaults to implicit GCP auth)|
-|`mcp.targets[].policies.ai.promptGuard.request[].rejection`||
-|`mcp.targets[].policies.ai.promptGuard.request[].rejection.body`||
-|`mcp.targets[].policies.ai.promptGuard.request[].rejection.status`||
-|`mcp.targets[].policies.ai.promptGuard.request[].rejection.headers`|Optional headers to add, set, or remove from the rejection response|
-|`mcp.targets[].policies.ai.promptGuard.request[].rejection.headers.add`||
-|`mcp.targets[].policies.ai.promptGuard.request[].rejection.headers.set`||
-|`mcp.targets[].policies.ai.promptGuard.request[].rejection.headers.remove`||
-|`mcp.targets[].policies.ai.promptGuard.response`||
-|`mcp.targets[].policies.ai.promptGuard.response[].(1)regex`||
-|`mcp.targets[].policies.ai.promptGuard.response[].(1)regex.action`||
-|`mcp.targets[].policies.ai.promptGuard.response[].(1)regex.rules`||
-|`mcp.targets[].policies.ai.promptGuard.response[].(1)regex.rules[].(any)builtin`||
-|`mcp.targets[].policies.ai.promptGuard.response[].(1)regex.rules[].(any)pattern`||
-|`mcp.targets[].policies.ai.promptGuard.response[].(1)webhook`||
-|`mcp.targets[].policies.ai.promptGuard.response[].(1)webhook.target`||
-|`mcp.targets[].policies.ai.promptGuard.response[].(1)webhook.target.(1)service`||
-|`mcp.targets[].policies.ai.promptGuard.response[].(1)webhook.target.(1)service.name`||
-|`mcp.targets[].policies.ai.promptGuard.response[].(1)webhook.target.(1)service.name.namespace`||
-|`mcp.targets[].policies.ai.promptGuard.response[].(1)webhook.target.(1)service.name.hostname`||
-|`mcp.targets[].policies.ai.promptGuard.response[].(1)webhook.target.(1)service.port`||
-|`mcp.targets[].policies.ai.promptGuard.response[].(1)webhook.target.(1)host`|Hostname or IP address|
-|`mcp.targets[].policies.ai.promptGuard.response[].(1)webhook.target.(1)backend`|Explicit backend reference. Backend must be defined in the top level backends list|
-|`mcp.targets[].policies.ai.promptGuard.response[].(1)webhook.forwardHeaderMatches`||
-|`mcp.targets[].policies.ai.promptGuard.response[].(1)webhook.forwardHeaderMatches[].name`||
-|`mcp.targets[].policies.ai.promptGuard.response[].(1)webhook.forwardHeaderMatches[].value`||
-|`mcp.targets[].policies.ai.promptGuard.response[].(1)webhook.forwardHeaderMatches[].value.(1)exact`||
-|`mcp.targets[].policies.ai.promptGuard.response[].(1)webhook.forwardHeaderMatches[].value.(1)regex`||
-|`mcp.targets[].policies.ai.promptGuard.response[].(1)bedrockGuardrails`|Configuration for AWS Bedrock Guardrails integration.|
-|`mcp.targets[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.guardrailIdentifier`|The unique identifier of the guardrail|
-|`mcp.targets[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.guardrailVersion`|The version of the guardrail|
-|`mcp.targets[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.region`|AWS region where the guardrail is deployed|
-|`mcp.targets[].policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies`|Backend policies for AWS authentication (optional, defaults to implicit AWS auth)|
-|`mcp.targets[].policies.ai.promptGuard.response[].(1)googleModelArmor`|Configuration for Google Cloud Model Armor integration.|
-|`mcp.targets[].policies.ai.promptGuard.response[].(1)googleModelArmor.templateId`|The template ID for the Model Armor configuration|
-|`mcp.targets[].policies.ai.promptGuard.response[].(1)googleModelArmor.projectId`|The GCP project ID|
-|`mcp.targets[].policies.ai.promptGuard.response[].(1)googleModelArmor.location`|The GCP region (default: us-central1)|
-|`mcp.targets[].policies.ai.promptGuard.response[].(1)googleModelArmor.policies`|Backend policies for GCP authentication (optional, defaults to implicit GCP auth)|
-|`mcp.targets[].policies.ai.promptGuard.response[].rejection`||
-|`mcp.targets[].policies.ai.promptGuard.response[].rejection.body`||
-|`mcp.targets[].policies.ai.promptGuard.response[].rejection.status`||
-|`mcp.targets[].policies.ai.promptGuard.response[].rejection.headers`|Optional headers to add, set, or remove from the rejection response|
-|`mcp.targets[].policies.ai.promptGuard.response[].rejection.headers.add`||
-|`mcp.targets[].policies.ai.promptGuard.response[].rejection.headers.set`||
-|`mcp.targets[].policies.ai.promptGuard.response[].rejection.headers.remove`||
-|`mcp.targets[].policies.ai.defaults`||
-|`mcp.targets[].policies.ai.overrides`||
-|`mcp.targets[].policies.ai.transformations`||
-|`mcp.targets[].policies.ai.prompts`||
-|`mcp.targets[].policies.ai.prompts.append`||
-|`mcp.targets[].policies.ai.prompts.append[].role`||
-|`mcp.targets[].policies.ai.prompts.append[].content`||
-|`mcp.targets[].policies.ai.prompts.prepend`||
-|`mcp.targets[].policies.ai.prompts.prepend[].role`||
-|`mcp.targets[].policies.ai.prompts.prepend[].content`||
-|`mcp.targets[].policies.ai.modelAliases`||
-|`mcp.targets[].policies.ai.promptCaching`||
-|`mcp.targets[].policies.ai.promptCaching.cacheSystem`||
-|`mcp.targets[].policies.ai.promptCaching.cacheMessages`||
-|`mcp.targets[].policies.ai.promptCaching.cacheTools`||
-|`mcp.targets[].policies.ai.promptCaching.minTokens`||
-|`mcp.targets[].policies.ai.routes`||
 |`mcp.targets[].policies.backendTLS`|Send TLS to the backend.|
 |`mcp.targets[].policies.backendTLS.cert`||
 |`mcp.targets[].policies.backendTLS.key`||
@@ -3289,6 +4963,8 @@
 |`mcp.targets[].policies.tcp.connectTimeout`||
 |`mcp.targets[].policies.tcp.connectTimeout.secs`||
 |`mcp.targets[].policies.tcp.connectTimeout.nanos`||
+|`mcp.targets[].policies.mcpAuthorization`|Authorization policies for MCP access.|
+|`mcp.targets[].policies.mcpAuthorization.rules`||
 |`mcp.statefulMode`||
 |`mcp.prefixMode`||
 |`mcp.policies`||
@@ -3399,10 +5075,6 @@
 |`mcp.policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestRedirect.path.(any)(1)full`||
 |`mcp.policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestRedirect.path.(any)(1)prefix`||
 |`mcp.policies.ai.promptGuard.request[].(1)openAIModeration.policies.requestRedirect.status`||
-|`mcp.policies.ai.promptGuard.request[].(1)openAIModeration.policies.mcpAuthorization`|Authorization policies for MCP access.|
-|`mcp.policies.ai.promptGuard.request[].(1)openAIModeration.policies.mcpAuthorization.rules`||
-|`mcp.policies.ai.promptGuard.request[].(1)openAIModeration.policies.a2a`|Mark this traffic as A2A to enable A2A processing and telemetry.|
-|`mcp.policies.ai.promptGuard.request[].(1)openAIModeration.policies.ai`|Mark this as LLM traffic to enable LLM processing.|
 |`mcp.policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendTLS`|Send TLS to the backend.|
 |`mcp.policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendTLS.cert`||
 |`mcp.policies.ai.promptGuard.request[].(1)openAIModeration.policies.backendTLS.key`||
@@ -3473,10 +5145,6 @@
 |`mcp.policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestRedirect.path.(any)(1)full`||
 |`mcp.policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestRedirect.path.(any)(1)prefix`||
 |`mcp.policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.requestRedirect.status`||
-|`mcp.policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.mcpAuthorization`|Authorization policies for MCP access.|
-|`mcp.policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.mcpAuthorization.rules`||
-|`mcp.policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.a2a`|Mark this traffic as A2A to enable A2A processing and telemetry.|
-|`mcp.policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.ai`|Mark this as LLM traffic to enable LLM processing.|
 |`mcp.policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendTLS`|Send TLS to the backend.|
 |`mcp.policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendTLS.cert`||
 |`mcp.policies.ai.promptGuard.request[].(1)bedrockGuardrails.policies.backendTLS.key`||
@@ -3547,10 +5215,6 @@
 |`mcp.policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestRedirect.path.(any)(1)full`||
 |`mcp.policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestRedirect.path.(any)(1)prefix`||
 |`mcp.policies.ai.promptGuard.request[].(1)googleModelArmor.policies.requestRedirect.status`||
-|`mcp.policies.ai.promptGuard.request[].(1)googleModelArmor.policies.mcpAuthorization`|Authorization policies for MCP access.|
-|`mcp.policies.ai.promptGuard.request[].(1)googleModelArmor.policies.mcpAuthorization.rules`||
-|`mcp.policies.ai.promptGuard.request[].(1)googleModelArmor.policies.a2a`|Mark this traffic as A2A to enable A2A processing and telemetry.|
-|`mcp.policies.ai.promptGuard.request[].(1)googleModelArmor.policies.ai`|Mark this as LLM traffic to enable LLM processing.|
 |`mcp.policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendTLS`|Send TLS to the backend.|
 |`mcp.policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendTLS.cert`||
 |`mcp.policies.ai.promptGuard.request[].(1)googleModelArmor.policies.backendTLS.key`||
@@ -3648,10 +5312,6 @@
 |`mcp.policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestRedirect.path.(any)(1)full`||
 |`mcp.policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestRedirect.path.(any)(1)prefix`||
 |`mcp.policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.requestRedirect.status`||
-|`mcp.policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.mcpAuthorization`|Authorization policies for MCP access.|
-|`mcp.policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.mcpAuthorization.rules`||
-|`mcp.policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.a2a`|Mark this traffic as A2A to enable A2A processing and telemetry.|
-|`mcp.policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.ai`|Mark this as LLM traffic to enable LLM processing.|
 |`mcp.policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendTLS`|Send TLS to the backend.|
 |`mcp.policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendTLS.cert`||
 |`mcp.policies.ai.promptGuard.response[].(1)bedrockGuardrails.policies.backendTLS.key`||
@@ -3722,10 +5382,6 @@
 |`mcp.policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestRedirect.path.(any)(1)full`||
 |`mcp.policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestRedirect.path.(any)(1)prefix`||
 |`mcp.policies.ai.promptGuard.response[].(1)googleModelArmor.policies.requestRedirect.status`||
-|`mcp.policies.ai.promptGuard.response[].(1)googleModelArmor.policies.mcpAuthorization`|Authorization policies for MCP access.|
-|`mcp.policies.ai.promptGuard.response[].(1)googleModelArmor.policies.mcpAuthorization.rules`||
-|`mcp.policies.ai.promptGuard.response[].(1)googleModelArmor.policies.a2a`|Mark this traffic as A2A to enable A2A processing and telemetry.|
-|`mcp.policies.ai.promptGuard.response[].(1)googleModelArmor.policies.ai`|Mark this as LLM traffic to enable LLM processing.|
 |`mcp.policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendTLS`|Send TLS to the backend.|
 |`mcp.policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendTLS.cert`||
 |`mcp.policies.ai.promptGuard.response[].(1)googleModelArmor.policies.backendTLS.key`||
@@ -3846,12 +5502,77 @@
 |`mcp.policies.remoteRateLimit.(any)(1)host`|Hostname or IP address|
 |`mcp.policies.remoteRateLimit.(any)(1)backend`|Explicit backend reference. Backend must be defined in the top level backends list|
 |`mcp.policies.remoteRateLimit.(any)domain`||
+|`mcp.policies.remoteRateLimit.(any)policies`|Policies to connect to the backend|
+|`mcp.policies.remoteRateLimit.(any)policies.requestHeaderModifier`|Headers to be modified in the request.|
+|`mcp.policies.remoteRateLimit.(any)policies.requestHeaderModifier.add`||
+|`mcp.policies.remoteRateLimit.(any)policies.requestHeaderModifier.set`||
+|`mcp.policies.remoteRateLimit.(any)policies.requestHeaderModifier.remove`||
+|`mcp.policies.remoteRateLimit.(any)policies.responseHeaderModifier`|Headers to be modified in the response.|
+|`mcp.policies.remoteRateLimit.(any)policies.responseHeaderModifier.add`||
+|`mcp.policies.remoteRateLimit.(any)policies.responseHeaderModifier.set`||
+|`mcp.policies.remoteRateLimit.(any)policies.responseHeaderModifier.remove`||
+|`mcp.policies.remoteRateLimit.(any)policies.requestRedirect`|Directly respond to the request with a redirect.|
+|`mcp.policies.remoteRateLimit.(any)policies.requestRedirect.scheme`||
+|`mcp.policies.remoteRateLimit.(any)policies.requestRedirect.authority`||
+|`mcp.policies.remoteRateLimit.(any)policies.requestRedirect.authority.(any)(1)full`||
+|`mcp.policies.remoteRateLimit.(any)policies.requestRedirect.authority.(any)(1)host`||
+|`mcp.policies.remoteRateLimit.(any)policies.requestRedirect.authority.(any)(1)port`||
+|`mcp.policies.remoteRateLimit.(any)policies.requestRedirect.path`||
+|`mcp.policies.remoteRateLimit.(any)policies.requestRedirect.path.(any)(1)full`||
+|`mcp.policies.remoteRateLimit.(any)policies.requestRedirect.path.(any)(1)prefix`||
+|`mcp.policies.remoteRateLimit.(any)policies.requestRedirect.status`||
+|`mcp.policies.remoteRateLimit.(any)policies.backendTLS`|Send TLS to the backend.|
+|`mcp.policies.remoteRateLimit.(any)policies.backendTLS.cert`||
+|`mcp.policies.remoteRateLimit.(any)policies.backendTLS.key`||
+|`mcp.policies.remoteRateLimit.(any)policies.backendTLS.root`||
+|`mcp.policies.remoteRateLimit.(any)policies.backendTLS.hostname`||
+|`mcp.policies.remoteRateLimit.(any)policies.backendTLS.insecure`||
+|`mcp.policies.remoteRateLimit.(any)policies.backendTLS.insecureHost`||
+|`mcp.policies.remoteRateLimit.(any)policies.backendTLS.alpn`||
+|`mcp.policies.remoteRateLimit.(any)policies.backendTLS.subjectAltNames`||
+|`mcp.policies.remoteRateLimit.(any)policies.backendAuth`|Authenticate to the backend.|
+|`mcp.policies.remoteRateLimit.(any)policies.backendAuth.(any)(1)passthrough`||
+|`mcp.policies.remoteRateLimit.(any)policies.backendAuth.(any)(1)key`||
+|`mcp.policies.remoteRateLimit.(any)policies.backendAuth.(any)(1)key.(any)file`||
+|`mcp.policies.remoteRateLimit.(any)policies.backendAuth.(any)(1)gcp`||
+|`mcp.policies.remoteRateLimit.(any)policies.backendAuth.(any)(1)gcp.(any)type`||
+|`mcp.policies.remoteRateLimit.(any)policies.backendAuth.(any)(1)gcp.(any)audience`|Audience for the token. If not set, the destination host will be used.|
+|`mcp.policies.remoteRateLimit.(any)policies.backendAuth.(any)(1)gcp.(any)type`||
+|`mcp.policies.remoteRateLimit.(any)policies.backendAuth.(any)(1)aws`||
+|`mcp.policies.remoteRateLimit.(any)policies.backendAuth.(any)(1)aws.(any)accessKeyId`||
+|`mcp.policies.remoteRateLimit.(any)policies.backendAuth.(any)(1)aws.(any)secretAccessKey`||
+|`mcp.policies.remoteRateLimit.(any)policies.backendAuth.(any)(1)aws.(any)region`||
+|`mcp.policies.remoteRateLimit.(any)policies.backendAuth.(any)(1)aws.(any)sessionToken`||
+|`mcp.policies.remoteRateLimit.(any)policies.backendAuth.(any)(1)azure`||
+|`mcp.policies.remoteRateLimit.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig`||
+|`mcp.policies.remoteRateLimit.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret`||
+|`mcp.policies.remoteRateLimit.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.tenant_id`||
+|`mcp.policies.remoteRateLimit.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_id`||
+|`mcp.policies.remoteRateLimit.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_secret`||
+|`mcp.policies.remoteRateLimit.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity`||
+|`mcp.policies.remoteRateLimit.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity`||
+|`mcp.policies.remoteRateLimit.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)clientId`||
+|`mcp.policies.remoteRateLimit.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)objectId`||
+|`mcp.policies.remoteRateLimit.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)resourceId`||
+|`mcp.policies.remoteRateLimit.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)workloadIdentity`||
+|`mcp.policies.remoteRateLimit.(any)policies.backendAuth.(any)(1)azure.(1)developerImplicit`||
+|`mcp.policies.remoteRateLimit.(any)policies.http`|Specify HTTP settings for the backend|
+|`mcp.policies.remoteRateLimit.(any)policies.http.version`||
+|`mcp.policies.remoteRateLimit.(any)policies.http.requestTimeout`||
+|`mcp.policies.remoteRateLimit.(any)policies.tcp`|Specify TCP settings for the backend|
+|`mcp.policies.remoteRateLimit.(any)policies.tcp.keepalives`||
+|`mcp.policies.remoteRateLimit.(any)policies.tcp.keepalives.enabled`||
+|`mcp.policies.remoteRateLimit.(any)policies.tcp.keepalives.time`||
+|`mcp.policies.remoteRateLimit.(any)policies.tcp.keepalives.interval`||
+|`mcp.policies.remoteRateLimit.(any)policies.tcp.keepalives.retries`||
+|`mcp.policies.remoteRateLimit.(any)policies.tcp.connectTimeout`||
+|`mcp.policies.remoteRateLimit.(any)policies.tcp.connectTimeout.secs`||
+|`mcp.policies.remoteRateLimit.(any)policies.tcp.connectTimeout.nanos`||
 |`mcp.policies.remoteRateLimit.(any)descriptors`||
 |`mcp.policies.remoteRateLimit.(any)descriptors[].entries`||
 |`mcp.policies.remoteRateLimit.(any)descriptors[].entries[].key`||
 |`mcp.policies.remoteRateLimit.(any)descriptors[].entries[].value`||
 |`mcp.policies.remoteRateLimit.(any)descriptors[].type`||
-|`mcp.policies.remoteRateLimit.(any)timeout`|Timeout for the request|
 |`mcp.policies.remoteRateLimit.(any)failureMode`|Behavior when the remote rate limit service is unavailable or returns an error.<br>Defaults to failClosed, denying requests with a 500 status on service failure.|
 |`mcp.policies.jwtAuth`|Authenticate incoming JWT requests.|
 |`mcp.policies.jwtAuth.(any)(any)mode`||
@@ -3889,6 +5610,72 @@
 |`mcp.policies.extAuthz.(any)(1)service.port`||
 |`mcp.policies.extAuthz.(any)(1)host`|Hostname or IP address|
 |`mcp.policies.extAuthz.(any)(1)backend`|Explicit backend reference. Backend must be defined in the top level backends list|
+|`mcp.policies.extAuthz.(any)policies`|Policies to connect to the backend|
+|`mcp.policies.extAuthz.(any)policies.requestHeaderModifier`|Headers to be modified in the request.|
+|`mcp.policies.extAuthz.(any)policies.requestHeaderModifier.add`||
+|`mcp.policies.extAuthz.(any)policies.requestHeaderModifier.set`||
+|`mcp.policies.extAuthz.(any)policies.requestHeaderModifier.remove`||
+|`mcp.policies.extAuthz.(any)policies.responseHeaderModifier`|Headers to be modified in the response.|
+|`mcp.policies.extAuthz.(any)policies.responseHeaderModifier.add`||
+|`mcp.policies.extAuthz.(any)policies.responseHeaderModifier.set`||
+|`mcp.policies.extAuthz.(any)policies.responseHeaderModifier.remove`||
+|`mcp.policies.extAuthz.(any)policies.requestRedirect`|Directly respond to the request with a redirect.|
+|`mcp.policies.extAuthz.(any)policies.requestRedirect.scheme`||
+|`mcp.policies.extAuthz.(any)policies.requestRedirect.authority`||
+|`mcp.policies.extAuthz.(any)policies.requestRedirect.authority.(any)(1)full`||
+|`mcp.policies.extAuthz.(any)policies.requestRedirect.authority.(any)(1)host`||
+|`mcp.policies.extAuthz.(any)policies.requestRedirect.authority.(any)(1)port`||
+|`mcp.policies.extAuthz.(any)policies.requestRedirect.path`||
+|`mcp.policies.extAuthz.(any)policies.requestRedirect.path.(any)(1)full`||
+|`mcp.policies.extAuthz.(any)policies.requestRedirect.path.(any)(1)prefix`||
+|`mcp.policies.extAuthz.(any)policies.requestRedirect.status`||
+|`mcp.policies.extAuthz.(any)policies.backendTLS`|Send TLS to the backend.|
+|`mcp.policies.extAuthz.(any)policies.backendTLS.cert`||
+|`mcp.policies.extAuthz.(any)policies.backendTLS.key`||
+|`mcp.policies.extAuthz.(any)policies.backendTLS.root`||
+|`mcp.policies.extAuthz.(any)policies.backendTLS.hostname`||
+|`mcp.policies.extAuthz.(any)policies.backendTLS.insecure`||
+|`mcp.policies.extAuthz.(any)policies.backendTLS.insecureHost`||
+|`mcp.policies.extAuthz.(any)policies.backendTLS.alpn`||
+|`mcp.policies.extAuthz.(any)policies.backendTLS.subjectAltNames`||
+|`mcp.policies.extAuthz.(any)policies.backendAuth`|Authenticate to the backend.|
+|`mcp.policies.extAuthz.(any)policies.backendAuth.(any)(1)passthrough`||
+|`mcp.policies.extAuthz.(any)policies.backendAuth.(any)(1)key`||
+|`mcp.policies.extAuthz.(any)policies.backendAuth.(any)(1)key.(any)file`||
+|`mcp.policies.extAuthz.(any)policies.backendAuth.(any)(1)gcp`||
+|`mcp.policies.extAuthz.(any)policies.backendAuth.(any)(1)gcp.(any)type`||
+|`mcp.policies.extAuthz.(any)policies.backendAuth.(any)(1)gcp.(any)audience`|Audience for the token. If not set, the destination host will be used.|
+|`mcp.policies.extAuthz.(any)policies.backendAuth.(any)(1)gcp.(any)type`||
+|`mcp.policies.extAuthz.(any)policies.backendAuth.(any)(1)aws`||
+|`mcp.policies.extAuthz.(any)policies.backendAuth.(any)(1)aws.(any)accessKeyId`||
+|`mcp.policies.extAuthz.(any)policies.backendAuth.(any)(1)aws.(any)secretAccessKey`||
+|`mcp.policies.extAuthz.(any)policies.backendAuth.(any)(1)aws.(any)region`||
+|`mcp.policies.extAuthz.(any)policies.backendAuth.(any)(1)aws.(any)sessionToken`||
+|`mcp.policies.extAuthz.(any)policies.backendAuth.(any)(1)azure`||
+|`mcp.policies.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig`||
+|`mcp.policies.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret`||
+|`mcp.policies.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.tenant_id`||
+|`mcp.policies.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_id`||
+|`mcp.policies.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_secret`||
+|`mcp.policies.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity`||
+|`mcp.policies.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity`||
+|`mcp.policies.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)clientId`||
+|`mcp.policies.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)objectId`||
+|`mcp.policies.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)resourceId`||
+|`mcp.policies.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)workloadIdentity`||
+|`mcp.policies.extAuthz.(any)policies.backendAuth.(any)(1)azure.(1)developerImplicit`||
+|`mcp.policies.extAuthz.(any)policies.http`|Specify HTTP settings for the backend|
+|`mcp.policies.extAuthz.(any)policies.http.version`||
+|`mcp.policies.extAuthz.(any)policies.http.requestTimeout`||
+|`mcp.policies.extAuthz.(any)policies.tcp`|Specify TCP settings for the backend|
+|`mcp.policies.extAuthz.(any)policies.tcp.keepalives`||
+|`mcp.policies.extAuthz.(any)policies.tcp.keepalives.enabled`||
+|`mcp.policies.extAuthz.(any)policies.tcp.keepalives.time`||
+|`mcp.policies.extAuthz.(any)policies.tcp.keepalives.interval`||
+|`mcp.policies.extAuthz.(any)policies.tcp.keepalives.retries`||
+|`mcp.policies.extAuthz.(any)policies.tcp.connectTimeout`||
+|`mcp.policies.extAuthz.(any)policies.tcp.connectTimeout.secs`||
+|`mcp.policies.extAuthz.(any)policies.tcp.connectTimeout.nanos`||
 |`mcp.policies.extAuthz.(any)protocol`|The ext_authz protocol to use. Unless you need to integrate with an HTTP-only server, gRPC is recommended.|
 |`mcp.policies.extAuthz.(any)protocol.(1)grpc`||
 |`mcp.policies.extAuthz.(any)protocol.(1)grpc.context`|Additional context to send to the authorization service.<br>This maps to the `context_extensions` field of the request, and only allows static values.|
@@ -3906,7 +5693,6 @@
 |`mcp.policies.extAuthz.(any)includeRequestBody.maxRequestBytes`|Maximum size of request body to buffer (default: 8192)|
 |`mcp.policies.extAuthz.(any)includeRequestBody.allowPartialMessage`|If true, send partial body when max_request_bytes is reached|
 |`mcp.policies.extAuthz.(any)includeRequestBody.packAsBytes`|If true, pack body as raw bytes in gRPC|
-|`mcp.policies.extAuthz.(any)timeout`|Timeout for the authorization request (default: 200ms)|
 |`mcp.policies.extProc`|Extend agentgateway with an external processor|
 |`mcp.policies.extProc.(any)(1)service`||
 |`mcp.policies.extProc.(any)(1)service.name`||
@@ -3915,6 +5701,72 @@
 |`mcp.policies.extProc.(any)(1)service.port`||
 |`mcp.policies.extProc.(any)(1)host`|Hostname or IP address|
 |`mcp.policies.extProc.(any)(1)backend`|Explicit backend reference. Backend must be defined in the top level backends list|
+|`mcp.policies.extProc.(any)policies`|Policies to connect to the backend|
+|`mcp.policies.extProc.(any)policies.requestHeaderModifier`|Headers to be modified in the request.|
+|`mcp.policies.extProc.(any)policies.requestHeaderModifier.add`||
+|`mcp.policies.extProc.(any)policies.requestHeaderModifier.set`||
+|`mcp.policies.extProc.(any)policies.requestHeaderModifier.remove`||
+|`mcp.policies.extProc.(any)policies.responseHeaderModifier`|Headers to be modified in the response.|
+|`mcp.policies.extProc.(any)policies.responseHeaderModifier.add`||
+|`mcp.policies.extProc.(any)policies.responseHeaderModifier.set`||
+|`mcp.policies.extProc.(any)policies.responseHeaderModifier.remove`||
+|`mcp.policies.extProc.(any)policies.requestRedirect`|Directly respond to the request with a redirect.|
+|`mcp.policies.extProc.(any)policies.requestRedirect.scheme`||
+|`mcp.policies.extProc.(any)policies.requestRedirect.authority`||
+|`mcp.policies.extProc.(any)policies.requestRedirect.authority.(any)(1)full`||
+|`mcp.policies.extProc.(any)policies.requestRedirect.authority.(any)(1)host`||
+|`mcp.policies.extProc.(any)policies.requestRedirect.authority.(any)(1)port`||
+|`mcp.policies.extProc.(any)policies.requestRedirect.path`||
+|`mcp.policies.extProc.(any)policies.requestRedirect.path.(any)(1)full`||
+|`mcp.policies.extProc.(any)policies.requestRedirect.path.(any)(1)prefix`||
+|`mcp.policies.extProc.(any)policies.requestRedirect.status`||
+|`mcp.policies.extProc.(any)policies.backendTLS`|Send TLS to the backend.|
+|`mcp.policies.extProc.(any)policies.backendTLS.cert`||
+|`mcp.policies.extProc.(any)policies.backendTLS.key`||
+|`mcp.policies.extProc.(any)policies.backendTLS.root`||
+|`mcp.policies.extProc.(any)policies.backendTLS.hostname`||
+|`mcp.policies.extProc.(any)policies.backendTLS.insecure`||
+|`mcp.policies.extProc.(any)policies.backendTLS.insecureHost`||
+|`mcp.policies.extProc.(any)policies.backendTLS.alpn`||
+|`mcp.policies.extProc.(any)policies.backendTLS.subjectAltNames`||
+|`mcp.policies.extProc.(any)policies.backendAuth`|Authenticate to the backend.|
+|`mcp.policies.extProc.(any)policies.backendAuth.(any)(1)passthrough`||
+|`mcp.policies.extProc.(any)policies.backendAuth.(any)(1)key`||
+|`mcp.policies.extProc.(any)policies.backendAuth.(any)(1)key.(any)file`||
+|`mcp.policies.extProc.(any)policies.backendAuth.(any)(1)gcp`||
+|`mcp.policies.extProc.(any)policies.backendAuth.(any)(1)gcp.(any)type`||
+|`mcp.policies.extProc.(any)policies.backendAuth.(any)(1)gcp.(any)audience`|Audience for the token. If not set, the destination host will be used.|
+|`mcp.policies.extProc.(any)policies.backendAuth.(any)(1)gcp.(any)type`||
+|`mcp.policies.extProc.(any)policies.backendAuth.(any)(1)aws`||
+|`mcp.policies.extProc.(any)policies.backendAuth.(any)(1)aws.(any)accessKeyId`||
+|`mcp.policies.extProc.(any)policies.backendAuth.(any)(1)aws.(any)secretAccessKey`||
+|`mcp.policies.extProc.(any)policies.backendAuth.(any)(1)aws.(any)region`||
+|`mcp.policies.extProc.(any)policies.backendAuth.(any)(1)aws.(any)sessionToken`||
+|`mcp.policies.extProc.(any)policies.backendAuth.(any)(1)azure`||
+|`mcp.policies.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig`||
+|`mcp.policies.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret`||
+|`mcp.policies.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.tenant_id`||
+|`mcp.policies.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_id`||
+|`mcp.policies.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)clientSecret.client_secret`||
+|`mcp.policies.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity`||
+|`mcp.policies.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity`||
+|`mcp.policies.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)clientId`||
+|`mcp.policies.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)objectId`||
+|`mcp.policies.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)managedIdentity.userAssignedIdentity.(any)(1)resourceId`||
+|`mcp.policies.extProc.(any)policies.backendAuth.(any)(1)azure.(1)explicitConfig.(1)workloadIdentity`||
+|`mcp.policies.extProc.(any)policies.backendAuth.(any)(1)azure.(1)developerImplicit`||
+|`mcp.policies.extProc.(any)policies.http`|Specify HTTP settings for the backend|
+|`mcp.policies.extProc.(any)policies.http.version`||
+|`mcp.policies.extProc.(any)policies.http.requestTimeout`||
+|`mcp.policies.extProc.(any)policies.tcp`|Specify TCP settings for the backend|
+|`mcp.policies.extProc.(any)policies.tcp.keepalives`||
+|`mcp.policies.extProc.(any)policies.tcp.keepalives.enabled`||
+|`mcp.policies.extProc.(any)policies.tcp.keepalives.time`||
+|`mcp.policies.extProc.(any)policies.tcp.keepalives.interval`||
+|`mcp.policies.extProc.(any)policies.tcp.keepalives.retries`||
+|`mcp.policies.extProc.(any)policies.tcp.connectTimeout`||
+|`mcp.policies.extProc.(any)policies.tcp.connectTimeout.secs`||
+|`mcp.policies.extProc.(any)policies.tcp.connectTimeout.nanos`||
 |`mcp.policies.extProc.(any)failureMode`|Behavior when the ext_proc service is unavailable or returns an error|
 |`mcp.policies.extProc.(any)metadataContext`|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
 |`mcp.policies.extProc.(any)requestAttributes`|Maps to the request `attributes` field in ProcessingRequest, and allows dynamic CEL expressions.|


### PR DESCRIPTION
Users can now specify (in standalone) policies to connect to backends
that are made in policies.

Remove deprecated extauthz explicit timeout which is obsolete by this.

Additionally, do not allow 'ai' policies where they don't make sense.
