### PR TITLE
Fix responses api for missing type

### DIFF
--- a/crates/agentgateway/src/llm/conversion/bedrock.rs
+++ b/crates/agentgateway/src/llm/conversion/bedrock.rs
@@ -1893,7 +1893,11 @@ pub mod from_responses {
 	fn responses_text_format_to_bedrock_output_config(
 		text: &responses::ResponseTextParam,
 	) -> Option<bedrock::OutputConfig> {
-		let (name, description, schema) = match &text.format {
+		let (name, description, schema): (
+			Option<String>,
+			Option<String>,
+			std::borrow::Cow<'_, serde_json::Value>,
+		) = match &text.format {
 			responses::TextResponseFormatConfiguration::Text => return None,
 			responses::TextResponseFormatConfiguration::JsonObject => (
 				None,

--- a/crates/agentgateway/src/llm/conversion/bedrock.rs
+++ b/crates/agentgateway/src/llm/conversion/bedrock.rs
@@ -1893,11 +1893,7 @@ pub mod from_responses {
 	fn responses_text_format_to_bedrock_output_config(
 		text: &responses::ResponseTextParam,
 	) -> Option<bedrock::OutputConfig> {
-		let (name, description, schema): (
-			Option<String>,
-			Option<String>,
-			std::borrow::Cow<'_, serde_json::Value>,
-		) = match &text.format {
+		let (name, description, schema) = match &text.format {
 			responses::TextResponseFormatConfiguration::Text => return None,
 			responses::TextResponseFormatConfiguration::JsonObject => (
 				None,

--- a/crates/agentgateway/src/llm/types/responses.rs
+++ b/crates/agentgateway/src/llm/types/responses.rs
@@ -12,75 +12,54 @@ use crate::llm::{
 	conversion,
 };
 
-/// Normalize input array elements so they match async-openai's InputItem: the crate's
-/// untagged enum tries `Item` (which requires `"type"`) before `EasyMessage`. SDKs often
-/// send `{"role":"user","content":"hi"}` without `"type"`. Convert those to the
-/// structured form Item::Message expects: `"type":"message"` and content as
-/// `[{"type":"input_text","text":"..."}]`.
-fn normalize_input_items(v: serde_json::Value) -> serde_json::Value {
-	let arr = match v {
-		serde_json::Value::Array(a) => a,
-		_ => return v,
-	};
-	let normalized: Vec<serde_json::Value> = arr
-		.into_iter()
-		.map(|elem| {
-			let mut obj = match elem {
-				serde_json::Value::Object(o) => o,
-				_ => return elem,
-			};
-			if obj.contains_key("type") {
-				return serde_json::Value::Object(obj);
-			}
-			let Some(content_val) = obj.get("content").cloned() else {
-				return serde_json::Value::Object(obj);
-			};
-			// String content -> structured form so Item::Message(Input(InputMessage)) parses
-			let content = match content_val {
-				serde_json::Value::String(s) => serde_json::Value::Array(vec![
-					serde_json::json!({"type": "input_text", "text": s}),
-				]),
-				other => other,
-			};
-			obj.insert("type".to_string(), serde_json::Value::String("message".to_string()));
-			obj.insert("content".to_string(), content);
-			serde_json::Value::Object(obj)
-		})
-		.collect();
-	serde_json::Value::Array(normalized)
+// Responses API can accept messages without the type specified but rust sdk requires it
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum LenientInput {
+	StrictSdk(Input),
+	MessagesWithoutType(Vec<MessageWithoutType>),
+	SingleMessageWithoutType(MessageWithoutType),
 }
 
-/// Deserializes `input` leniently: (1) single object -> one-element array; (2) array of
-/// simple messages without `"type"` (e.g. `{"role":"user","content":"hi"}`) are normalized
-/// so they parse as Item::Message.
+#[derive(Debug, Deserialize)]
+struct MessageWithoutType {
+	role: Strng,
+	content: Strng,
+}
+
+impl From<MessageWithoutType> for InputItem {
+	fn from(msg: MessageWithoutType) -> Self {
+		InputItem::from(SimpleChatCompletionMessage {
+			role: msg.role,
+			content: msg.content,
+		})
+	}
+}
+
+impl TryFrom<LenientInput> for Input {
+	type Error = String;
+
+	fn try_from(value: LenientInput) -> Result<Self, Self::Error> {
+		match value {
+			LenientInput::StrictSdk(input) => Ok(input),
+			LenientInput::MessagesWithoutType(messages) => {
+				Ok(Input::Items(messages.into_iter().map(Into::into).collect()))
+			},
+			LenientInput::SingleMessageWithoutType(message) => Ok(Input::Items(vec![message.into()])),
+		}
+	}
+}
+
 fn deserialize_input_lenient<'de, D>(d: D) -> Result<Input, D::Error>
 where
 	D: Deserializer<'de>,
 {
-	let v = serde_json::Value::deserialize(d)?;
-	match v {
-		// Fast path: plain text input is valid Responses API input.
-		serde_json::Value::String(text) => Ok(Input::Text(text)),
-		// Accept historical single-message object form by coercing to an array.
-		serde_json::Value::Object(_) => {
-			let normalized = normalize_input_items(serde_json::Value::Array(vec![v]));
-			serde_json::from_value(normalized).map_err(|e| serde::de::Error::custom(e.to_string()))
-		},
-		// Standard items form.
-		serde_json::Value::Array(_) => {
-			let normalized = normalize_input_items(v);
-			serde_json::from_value(normalized).map_err(|e| serde::de::Error::custom(e.to_string()))
-		},
-		other => Err(serde::de::Error::custom(format!(
-			"invalid `input`: expected string, object, or array; got {}",
-			other
-		))),
-	}
+	crate::serdes::de_as::<LenientInput, Input, _>(d)
 }
 
 #[derive(Debug, Deserialize, Clone, Serialize)]
 pub struct Request {
-	/// Input to the model: string or array of items. Deserialized so a single object is accepted as one item.
+	/// Input to the model: string or array of items.
 	#[serde(deserialize_with = "deserialize_input_lenient")]
 	pub input: Input,
 
@@ -578,9 +557,9 @@ pub mod typed {
 		ReasoningEffort, Response, ResponseCompletedEvent, ResponseContentPartAddedEvent,
 		ResponseContentPartDoneEvent, ResponseCreatedEvent, ResponseErrorEvent, ResponseFailedEvent,
 		ResponseFunctionCallArgumentsDeltaEvent, ResponseFunctionCallArgumentsDoneEvent,
-		ResponseIncompleteEvent, ResponseOutputItemAddedEvent, ResponseOutputItemDoneEvent, ResponseTextParam,
-		ResponseTextDeltaEvent, ResponseUsage, Role, Status, TextResponseFormatConfiguration, Tool,
-		ToolChoiceFunction, ToolChoiceOptions, ToolChoiceParam,
+		ResponseIncompleteEvent, ResponseOutputItemAddedEvent, ResponseOutputItemDoneEvent,
+		ResponseTextDeltaEvent, ResponseTextParam, ResponseUsage, Role, Status,
+		TextResponseFormatConfiguration, Tool, ToolChoiceFunction, ToolChoiceOptions, ToolChoiceParam,
 	};
 	use serde::{Deserialize, Serialize};
 
@@ -631,6 +610,7 @@ pub mod typed {
 #[cfg(test)]
 mod tests {
 	use super::{Input, Request};
+	use crate::llm::RequestType;
 
 	#[test]
 	fn request_input_accepts_string() {
@@ -661,6 +641,29 @@ mod tests {
 	}
 
 	#[test]
+	fn request_input_accepts_array_without_type() {
+		let req: Request = serde_json::from_value(serde_json::json!({
+			"input": [
+				{
+					"role": "system",
+					"content": "test1"
+				},
+				{
+					"role": "system",
+					"content": "test2"
+				},
+				{
+					"role": "user",
+					"content": "test3"
+				}
+			]
+		}))
+		.expect("array input without type should deserialize");
+
+		assert!(matches!(req.input, Input::Items(_)));
+	}
+
+	#[test]
 	fn request_input_accepts_single_object_message() {
 		let req: Request = serde_json::from_value(serde_json::json!({
 			"input": {
@@ -671,5 +674,30 @@ mod tests {
 		.expect("single object message should deserialize");
 
 		assert!(matches!(req.input, Input::Items(_)));
+	}
+
+	#[test]
+	fn canonical_and_fallback_message_inputs_produce_same_messages() {
+		let canonical: Request = serde_json::from_value(serde_json::json!({
+			"model": "llama3.1",
+			"input": [
+				{ "type": "message", "role": "system", "content": "test1" },
+				{ "type": "message", "role": "system", "content": "test2" },
+				{ "type": "message", "role": "user", "content": "test3" }
+			]
+		}))
+		.expect("canonical message input should deserialize");
+
+		let fallback: Request = serde_json::from_value(serde_json::json!({
+			"model": "llama3.1",
+			"input": [
+				{ "role": "system", "content": "test1" },
+				{ "role": "system", "content": "test2" },
+				{ "role": "user", "content": "test3" }
+			]
+		}))
+		.expect("fallback message input should deserialize");
+
+		assert_eq!(canonical.get_messages(), fallback.get_messages());
 	}
 }

--- a/crates/agentgateway/src/llm/types/responses.rs
+++ b/crates/agentgateway/src/llm/types/responses.rs
@@ -1,3 +1,4 @@
+use serde::de::Deserializer;
 use serde::{Deserialize, Serialize};
 
 use self::typed::{
@@ -11,9 +12,76 @@ use crate::llm::{
 	conversion,
 };
 
+/// Normalize input array elements so they match async-openai's InputItem: the crate's
+/// untagged enum tries `Item` (which requires `"type"`) before `EasyMessage`. SDKs often
+/// send `{"role":"user","content":"hi"}` without `"type"`. Convert those to the
+/// structured form Item::Message expects: `"type":"message"` and content as
+/// `[{"type":"input_text","text":"..."}]`.
+fn normalize_input_items(v: serde_json::Value) -> serde_json::Value {
+	let arr = match v {
+		serde_json::Value::Array(a) => a,
+		_ => return v,
+	};
+	let normalized: Vec<serde_json::Value> = arr
+		.into_iter()
+		.map(|elem| {
+			let mut obj = match elem {
+				serde_json::Value::Object(o) => o,
+				_ => return elem,
+			};
+			if obj.contains_key("type") {
+				return serde_json::Value::Object(obj);
+			}
+			let Some(content_val) = obj.get("content").cloned() else {
+				return serde_json::Value::Object(obj);
+			};
+			// String content -> structured form so Item::Message(Input(InputMessage)) parses
+			let content = match content_val {
+				serde_json::Value::String(s) => serde_json::Value::Array(vec![
+					serde_json::json!({"type": "input_text", "text": s}),
+				]),
+				other => other,
+			};
+			obj.insert("type".to_string(), serde_json::Value::String("message".to_string()));
+			obj.insert("content".to_string(), content);
+			serde_json::Value::Object(obj)
+		})
+		.collect();
+	serde_json::Value::Array(normalized)
+}
+
+/// Deserializes `input` leniently: (1) single object -> one-element array; (2) array of
+/// simple messages without `"type"` (e.g. `{"role":"user","content":"hi"}`) are normalized
+/// so they parse as Item::Message.
+fn deserialize_input_lenient<'de, D>(d: D) -> Result<Input, D::Error>
+where
+	D: Deserializer<'de>,
+{
+	let v = serde_json::Value::deserialize(d)?;
+	match v {
+		// Fast path: plain text input is valid Responses API input.
+		serde_json::Value::String(text) => Ok(Input::Text(text)),
+		// Accept historical single-message object form by coercing to an array.
+		serde_json::Value::Object(_) => {
+			let normalized = normalize_input_items(serde_json::Value::Array(vec![v]));
+			serde_json::from_value(normalized).map_err(|e| serde::de::Error::custom(e.to_string()))
+		},
+		// Standard items form.
+		serde_json::Value::Array(_) => {
+			let normalized = normalize_input_items(v);
+			serde_json::from_value(normalized).map_err(|e| serde::de::Error::custom(e.to_string()))
+		},
+		other => Err(serde::de::Error::custom(format!(
+			"invalid `input`: expected string, object, or array; got {}",
+			other
+		))),
+	}
+}
+
 #[derive(Debug, Deserialize, Clone, Serialize)]
 pub struct Request {
-	// Required field for prompt enrichment/guards
+	/// Input to the model: string or array of items. Deserialized so a single object is accepted as one item.
+	#[serde(deserialize_with = "deserialize_input_lenient")]
 	pub input: Input,
 
 	// Fields we actually read for routing/telemetry
@@ -510,9 +578,9 @@ pub mod typed {
 		ReasoningEffort, Response, ResponseCompletedEvent, ResponseContentPartAddedEvent,
 		ResponseContentPartDoneEvent, ResponseCreatedEvent, ResponseErrorEvent, ResponseFailedEvent,
 		ResponseFunctionCallArgumentsDeltaEvent, ResponseFunctionCallArgumentsDoneEvent,
-		ResponseIncompleteEvent, ResponseOutputItemAddedEvent, ResponseOutputItemDoneEvent,
-		ResponseTextDeltaEvent, ResponseTextParam, ResponseUsage, Role, Status,
-		TextResponseFormatConfiguration, Tool, ToolChoiceFunction, ToolChoiceOptions, ToolChoiceParam,
+		ResponseIncompleteEvent, ResponseOutputItemAddedEvent, ResponseOutputItemDoneEvent, ResponseTextParam,
+		ResponseTextDeltaEvent, ResponseUsage, Role, Status, TextResponseFormatConfiguration, Tool,
+		ToolChoiceFunction, ToolChoiceOptions, ToolChoiceParam,
 	};
 	use serde::{Deserialize, Serialize};
 
@@ -557,5 +625,51 @@ pub mod typed {
 		/// Emitted when an error occurs.
 		#[serde(rename = "error")]
 		ResponseError(openai_responses::ResponseErrorEvent),
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::{Input, Request};
+
+	#[test]
+	fn request_input_accepts_string() {
+		let req: Request = serde_json::from_value(serde_json::json!({
+			"input": "hello"
+		}))
+		.expect("string input should deserialize");
+
+		assert!(matches!(req.input, Input::Text(ref s) if s == "hello"));
+	}
+
+	#[test]
+	fn request_input_accepts_array() {
+		let req: Request = serde_json::from_value(serde_json::json!({
+			"input": [
+				{
+					"type": "message",
+					"role": "user",
+					"content": [
+						{ "type": "input_text", "text": "hi" }
+					]
+				}
+			]
+		}))
+		.expect("array input should deserialize");
+
+		assert!(matches!(req.input, Input::Items(_)));
+	}
+
+	#[test]
+	fn request_input_accepts_single_object_message() {
+		let req: Request = serde_json::from_value(serde_json::json!({
+			"input": {
+				"role": "user",
+				"content": "hi"
+			}
+		}))
+		.expect("single object message should deserialize");
+
+		assert!(matches!(req.input, Input::Items(_)));
 	}
 }


### PR DESCRIPTION
The responses api seems to take in as input: optional string or array of [ResponseInputItem](https://developers.openai.com/api/reference/resources/responses#(resource)%20responses%20%3E%20(model)%20response_input_item%20%3E%20(schema)): https://developers.openai.com/api/reference/resources/responses/methods/create where the type is optional in the array.

This breaks on main with test-req.json:
```
{
  "input": [
    {
      "role": "system",
      "content": "test1"
    },
    {
      "role": "system",
      "content": "test2"
    },
    {
      "role": "user",
      "content": "test3"
    }
  ],
  "parallel_tool_calls": false,
  "temperature": 0.2,
  "text": {
    "format": {
      "type": "text"
    }
  },
  "model": "llama3.1"
}
```

When the type is included, the request succeeds as expected. We should make the `type` optional to follow the open ai api behavior. 

Tested with config.yaml:
```
binds:
- port: 3000
  listeners:
  - name: llm-responses
    protocol: HTTP
    routes:
    - backends:
      - ai:
          groups:
          - providers:
            - name: llama3.1
              hostOverride: "localhost:11434"
              pathOverride: /v1/responses
              provider:
                openAI:
                  model: llama3.1
      policies:
        ai:
          routes:
            "/v1/chat/completions": completions
            "/v1/responses": responses
            "*": passthrough
```

```
❯ curl -v -X POST http://localhost:3000/v1/responses \
  -H "Content-Type: application/json" \
  --data-binary @test-req.json
Note: Unnecessary use of -X or --request, POST is already inferred.
* Host localhost:3000 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:3000...
* Connected to localhost (::1) port 3000
* using HTTP/1.x
> POST /v1/responses HTTP/1.1
> Host: localhost:3000
> User-Agent: curl/8.13.0
> Accept: */*
> Content-Type: application/json
> Content-Length: 566
>
* upload completely sent off: 566 bytes
< HTTP/1.1 503 Service Unavailable
< content-type: text/plain
< content-length: 122
< date: Tue, 03 Mar 2026 02:29:54 GMT
<
* Connection #0 to host localhost left intact
processing failed: failed to parse request: data did not match any variant of untagged enum InputParam at line 31 column 3

```

But works directly with model:
```
❯ curl -v -X POST http://localhost:11434/v1/responses \
  -H "Content-Type: application/json" \
  --data-binary @test-req.json
Note: Unnecessary use of -X or --request, POST is already inferred.
* Host localhost:11434 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:11434...
* connect to ::1 port 11434 from ::1 port 60762 failed: Connection refused
*   Trying 127.0.0.1:11434...
* Connected to localhost (127.0.0.1) port 11434
* using HTTP/1.x
> POST /v1/responses HTTP/1.1
> Host: localhost:11434
> User-Agent: curl/8.13.0
> Accept: */*
> Content-Type: application/json
> Content-Length: 589
>
* upload completely sent off: 589 bytes
< HTTP/1.1 200 OK
< Content-Type: application/json
< Date: Tue, 03 Mar 2026 02:31:48 GMT
< Content-Length: 1044
<
{"id":"resp_898859","object":"response","created_at":1772505108,"completed_at":1772505108,"status":"completed","incomplete_details":null,"model":"llama3.1","previous_response_id":null,"instructions":null,"output":[{"id":"msg_788627","type":"message","status":"completed","role":"assistant","content":[{"type":"output_text","text":"You're adding to the list. Here's the updated version:\n\ntest1\n\ntest2\n\ntest3\n\ntest4\n\ntest5\n\ntest6\n\ntest7","annotations":[],"logprobs":[]}]}],"error":null,"tools":[],"tool_choice":"auto","truncation":"disabled","parallel_tool_calls":true,"text":{"format":{"type":"text"}},"top_p":1,"presence_penalty":0,"frequency_penalty":0,"top_logprobs":0,"temperature":0.2,"reasoning":null,"usage":{"input_tokens":34,"output_tokens":34,"total_tokens":68,"input_tokens_details":{"cached_tokens":0},"output_tokens_details":{"reasoning_tokens":0}},"max_output_tokens":null,"max_tool_calls":null,"store":false,"background":false,"service_tier":"default","metadata":{},"safety_identifier":null,"prompt_cache_key":null}
* Connection #0 to host localhost left intact
```

Fixed here:
```
❯ curl -v -X POST http://localhost:3000/v1/responses \
  -H "Content-Type: application/json" \
  --data-binary @test-req.json
Note: Unnecessary use of -X or --request, POST is already inferred.
* Host localhost:3000 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:3000...
* Connected to localhost (::1) port 3000
* using HTTP/1.x
> POST /v1/responses HTTP/1.1
> Host: localhost:3000
> User-Agent: curl/8.13.0
> Accept: */*
> Content-Type: application/json
> Content-Length: 566
>
* upload completely sent off: 566 bytes
< HTTP/1.1 200 OK
< content-type: application/json
< date: Tue, 03 Mar 2026 02:25:46 GMT
< content-length: 928
<
* Connection #0 to host localhost left intact
{"id":"resp_7263","status":"completed","output":[{"type":"message","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"test8"}],"id":"msg_920096","role":"assistant","status":"completed"}],"model":"llama3.1","usage":{"input_tokens":34,"output_tokens":3,"input_tokens_details":{"cached_tokens":0},"output_tokens_details":{"reasoning_tokens":0},"total_tokens":37},"object":"response","created_at":1772504746,"completed_at":1772504746,"incomplete_details":null,"previous_response_id":null,"instructions":null,"error":null,"tools":[],"tool_choice":"auto","truncation":"disabled","parallel_tool_calls":true,"text":{"format":{"type":"text"}},"top_p":1,"presence_penalty":0,"frequency_penalty":0,"top_logprobs":0,"temperature":0.2,"reasoning":null,"max_output_tokens":null,"max_tool_calls":null,"store":false,"background":false,"service_tier":"default","metadata":{},"safety_identifier":null,"prompt_cache_key":null}%
```