### PR TITLE
release: do not put both versions in the notes, and use v prefix consistently

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,7 +152,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY_IMAGE }}
           tags: |
-            type=semver,pattern=v{{version}},value=${{ env.VERSION }}
+            type=semver,pattern={{version}},value=${{ env.VERSION }}
 
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests
@@ -274,7 +274,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY_IMAGE }}
           tags: |
-            type=semver,pattern=v{{version}},value=${{ env.VERSION }}
+            type=semver,pattern={{version}},value=${{ env.VERSION }}
 
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests-musl
@@ -427,7 +427,7 @@ jobs:
         with:
           images: ${{ env.CONTROLLER_REGISTRY_IMAGE }}
           tags: |
-            type=semver,pattern=v{{version}},value=${{ env.VERSION }}
+            type=semver,pattern={{version}},value=${{ env.VERSION }}
 
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/controller-digests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -574,9 +574,7 @@ jobs:
           * `cr.agentgateway.dev/controller:v${{ env.VERSION }}`
 
           **Helm charts** are available:
-          * `cr.agentgateway.dev/charts/agentgateway:${{ env.VERSION }}`
           * `cr.agentgateway.dev/charts/agentgateway:v${{ env.VERSION }}`
-          * `cr.agentgateway.dev/charts/agentgateway-crds:${{ env.VERSION }}`
           * `cr.agentgateway.dev/charts/agentgateway-crds:v${{ env.VERSION }}`
 
           **Binaries** are available below.


### PR DESCRIPTION
we do both just to satisfy internals of helm, no need to put both in the notes

Helm: both
Images: v
Git: v