### PR TITLE
Feature/Add IP access control policy with xDS support

### DIFF
--- a/api/resource.pb.go
+++ b/api/resource.pb.go
@@ -4810,6 +4810,7 @@ type TrafficPolicySpec struct {
 	//	*TrafficPolicySpec_BasicAuth
 	//	*TrafficPolicySpec_ApiKeyAuth
 	//	*TrafficPolicySpec_HostRewrite_
+	//	*TrafficPolicySpec_IpAccessControl_
 	Kind          isTrafficPolicySpec_Kind `protobuf_oneof:"kind"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -5039,6 +5040,15 @@ func (x *TrafficPolicySpec) GetHostRewrite() *TrafficPolicySpec_HostRewrite {
 	return nil
 }
 
+func (x *TrafficPolicySpec) GetIpAccessControl() *TrafficPolicySpec_IpAccessControl {
+	if x != nil {
+		if x, ok := x.Kind.(*TrafficPolicySpec_IpAccessControl_); ok {
+			return x.IpAccessControl
+		}
+	}
+	return nil
+}
+
 type isTrafficPolicySpec_Kind interface {
 	isTrafficPolicySpec_Kind()
 }
@@ -5123,6 +5133,10 @@ type TrafficPolicySpec_HostRewrite_ struct {
 	HostRewrite *TrafficPolicySpec_HostRewrite `protobuf:"bytes,21,opt,name=host_rewrite,json=hostRewrite,proto3,oneof"`
 }
 
+type TrafficPolicySpec_IpAccessControl_ struct {
+	IpAccessControl *TrafficPolicySpec_IpAccessControl `protobuf:"bytes,22,opt,name=ip_access_control,json=ipAccessControl,proto3,oneof"`
+}
+
 func (*TrafficPolicySpec_Timeout) isTrafficPolicySpec_Kind() {}
 
 func (*TrafficPolicySpec_Retry) isTrafficPolicySpec_Kind() {}
@@ -5162,6 +5176,8 @@ func (*TrafficPolicySpec_BasicAuth) isTrafficPolicySpec_Kind() {}
 func (*TrafficPolicySpec_ApiKeyAuth) isTrafficPolicySpec_Kind() {}
 
 func (*TrafficPolicySpec_HostRewrite_) isTrafficPolicySpec_Kind() {}
+
+func (*TrafficPolicySpec_IpAccessControl_) isTrafficPolicySpec_Kind() {}
 
 type BackendPolicySpec struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -7754,6 +7770,98 @@ func (x *TrafficPolicySpec_HostRewrite) GetMode() TrafficPolicySpec_HostRewrite_
 	return TrafficPolicySpec_HostRewrite_NONE
 }
 
+// IP-based access control supporting CIDR allow and deny lists.
+type TrafficPolicySpec_IpAccessControl struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// CIDR ranges that are allowed. When non-empty, only IPs matching at least
+	// one entry are permitted (after deny check).
+	Allow []string `protobuf:"bytes,1,rep,name=allow,proto3" json:"allow,omitempty"`
+	// CIDR ranges that are denied. Deny rules are evaluated before allow rules.
+	Deny []string `protobuf:"bytes,2,rep,name=deny,proto3" json:"deny,omitempty"`
+	// Number of trusted proxy hops for X-Forwarded-For client IP resolution.
+	XffNumTrustedHops *uint32 `protobuf:"varint,3,opt,name=xff_num_trusted_hops,json=xffNumTrustedHops,proto3,oneof" json:"xff_num_trusted_hops,omitempty"`
+	// When true, private/loopback IPs bypass allow and deny checks.
+	SkipPrivateIps bool `protobuf:"varint,4,opt,name=skip_private_ips,json=skipPrivateIps,proto3" json:"skip_private_ips,omitempty"`
+	// When true, every IP in the XFF chain plus the connection IP is checked.
+	EnforceFullChain bool `protobuf:"varint,5,opt,name=enforce_full_chain,json=enforceFullChain,proto3" json:"enforce_full_chain,omitempty"`
+	// Maximum number of IPs allowed in the X-Forwarded-For chain.
+	MaxXffLength  *uint32 `protobuf:"varint,6,opt,name=max_xff_length,json=maxXffLength,proto3,oneof" json:"max_xff_length,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TrafficPolicySpec_IpAccessControl) Reset() {
+	*x = TrafficPolicySpec_IpAccessControl{}
+	mi := &file_resource_proto_msgTypes[83]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TrafficPolicySpec_IpAccessControl) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TrafficPolicySpec_IpAccessControl) ProtoMessage() {}
+
+func (x *TrafficPolicySpec_IpAccessControl) ProtoReflect() protoreflect.Message {
+	mi := &file_resource_proto_msgTypes[83]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TrafficPolicySpec_IpAccessControl.ProtoReflect.Descriptor instead.
+func (*TrafficPolicySpec_IpAccessControl) Descriptor() ([]byte, []int) {
+	return file_resource_proto_rawDescGZIP(), []int{44, 14}
+}
+
+func (x *TrafficPolicySpec_IpAccessControl) GetAllow() []string {
+	if x != nil {
+		return x.Allow
+	}
+	return nil
+}
+
+func (x *TrafficPolicySpec_IpAccessControl) GetDeny() []string {
+	if x != nil {
+		return x.Deny
+	}
+	return nil
+}
+
+func (x *TrafficPolicySpec_IpAccessControl) GetXffNumTrustedHops() uint32 {
+	if x != nil && x.XffNumTrustedHops != nil {
+		return *x.XffNumTrustedHops
+	}
+	return 0
+}
+
+func (x *TrafficPolicySpec_IpAccessControl) GetSkipPrivateIps() bool {
+	if x != nil {
+		return x.SkipPrivateIps
+	}
+	return false
+}
+
+func (x *TrafficPolicySpec_IpAccessControl) GetEnforceFullChain() bool {
+	if x != nil {
+		return x.EnforceFullChain
+	}
+	return false
+}
+
+func (x *TrafficPolicySpec_IpAccessControl) GetMaxXffLength() uint32 {
+	if x != nil && x.MaxXffLength != nil {
+		return *x.MaxXffLength
+	}
+	return 0
+}
+
 type TrafficPolicySpec_RemoteRateLimit_Descriptor struct {
 	state         protoimpl.MessageState                     `protogen:"open.v1"`
 	Entries       []*TrafficPolicySpec_RemoteRateLimit_Entry `protobuf:"bytes,1,rep,name=entries,proto3" json:"entries,omitempty"`
@@ -7764,7 +7872,7 @@ type TrafficPolicySpec_RemoteRateLimit_Descriptor struct {
 
 func (x *TrafficPolicySpec_RemoteRateLimit_Descriptor) Reset() {
 	*x = TrafficPolicySpec_RemoteRateLimit_Descriptor{}
-	mi := &file_resource_proto_msgTypes[83]
+	mi := &file_resource_proto_msgTypes[84]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7776,7 +7884,7 @@ func (x *TrafficPolicySpec_RemoteRateLimit_Descriptor) String() string {
 func (*TrafficPolicySpec_RemoteRateLimit_Descriptor) ProtoMessage() {}
 
 func (x *TrafficPolicySpec_RemoteRateLimit_Descriptor) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[83]
+	mi := &file_resource_proto_msgTypes[84]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7816,7 +7924,7 @@ type TrafficPolicySpec_RemoteRateLimit_Entry struct {
 
 func (x *TrafficPolicySpec_RemoteRateLimit_Entry) Reset() {
 	*x = TrafficPolicySpec_RemoteRateLimit_Entry{}
-	mi := &file_resource_proto_msgTypes[84]
+	mi := &file_resource_proto_msgTypes[85]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7828,7 +7936,7 @@ func (x *TrafficPolicySpec_RemoteRateLimit_Entry) String() string {
 func (*TrafficPolicySpec_RemoteRateLimit_Entry) ProtoMessage() {}
 
 func (x *TrafficPolicySpec_RemoteRateLimit_Entry) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[84]
+	mi := &file_resource_proto_msgTypes[85]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7869,7 +7977,7 @@ type TrafficPolicySpec_ExternalAuth_BodyOptions struct {
 
 func (x *TrafficPolicySpec_ExternalAuth_BodyOptions) Reset() {
 	*x = TrafficPolicySpec_ExternalAuth_BodyOptions{}
-	mi := &file_resource_proto_msgTypes[85]
+	mi := &file_resource_proto_msgTypes[86]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7881,7 +7989,7 @@ func (x *TrafficPolicySpec_ExternalAuth_BodyOptions) String() string {
 func (*TrafficPolicySpec_ExternalAuth_BodyOptions) ProtoMessage() {}
 
 func (x *TrafficPolicySpec_ExternalAuth_BodyOptions) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[85]
+	mi := &file_resource_proto_msgTypes[86]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7928,7 +8036,7 @@ type TrafficPolicySpec_ExternalAuth_GRPCProtocol struct {
 
 func (x *TrafficPolicySpec_ExternalAuth_GRPCProtocol) Reset() {
 	*x = TrafficPolicySpec_ExternalAuth_GRPCProtocol{}
-	mi := &file_resource_proto_msgTypes[86]
+	mi := &file_resource_proto_msgTypes[87]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7940,7 +8048,7 @@ func (x *TrafficPolicySpec_ExternalAuth_GRPCProtocol) String() string {
 func (*TrafficPolicySpec_ExternalAuth_GRPCProtocol) ProtoMessage() {}
 
 func (x *TrafficPolicySpec_ExternalAuth_GRPCProtocol) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[86]
+	mi := &file_resource_proto_msgTypes[87]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7983,7 +8091,7 @@ type TrafficPolicySpec_ExternalAuth_HTTPProtocol struct {
 
 func (x *TrafficPolicySpec_ExternalAuth_HTTPProtocol) Reset() {
 	*x = TrafficPolicySpec_ExternalAuth_HTTPProtocol{}
-	mi := &file_resource_proto_msgTypes[87]
+	mi := &file_resource_proto_msgTypes[88]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7995,7 +8103,7 @@ func (x *TrafficPolicySpec_ExternalAuth_HTTPProtocol) String() string {
 func (*TrafficPolicySpec_ExternalAuth_HTTPProtocol) ProtoMessage() {}
 
 func (x *TrafficPolicySpec_ExternalAuth_HTTPProtocol) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[87]
+	mi := &file_resource_proto_msgTypes[88]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8056,7 +8164,7 @@ type TrafficPolicySpec_APIKey_User struct {
 
 func (x *TrafficPolicySpec_APIKey_User) Reset() {
 	*x = TrafficPolicySpec_APIKey_User{}
-	mi := &file_resource_proto_msgTypes[92]
+	mi := &file_resource_proto_msgTypes[93]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8068,7 +8176,7 @@ func (x *TrafficPolicySpec_APIKey_User) String() string {
 func (*TrafficPolicySpec_APIKey_User) ProtoMessage() {}
 
 func (x *TrafficPolicySpec_APIKey_User) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[92]
+	mi := &file_resource_proto_msgTypes[93]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8110,7 +8218,7 @@ type TrafficPolicySpec_TransformationPolicy_Transform struct {
 
 func (x *TrafficPolicySpec_TransformationPolicy_Transform) Reset() {
 	*x = TrafficPolicySpec_TransformationPolicy_Transform{}
-	mi := &file_resource_proto_msgTypes[93]
+	mi := &file_resource_proto_msgTypes[94]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8122,7 +8230,7 @@ func (x *TrafficPolicySpec_TransformationPolicy_Transform) String() string {
 func (*TrafficPolicySpec_TransformationPolicy_Transform) ProtoMessage() {}
 
 func (x *TrafficPolicySpec_TransformationPolicy_Transform) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[93]
+	mi := &file_resource_proto_msgTypes[94]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8175,7 +8283,7 @@ type TrafficPolicySpec_ExtProc_NamespacedMetadataContext struct {
 
 func (x *TrafficPolicySpec_ExtProc_NamespacedMetadataContext) Reset() {
 	*x = TrafficPolicySpec_ExtProc_NamespacedMetadataContext{}
-	mi := &file_resource_proto_msgTypes[96]
+	mi := &file_resource_proto_msgTypes[97]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8187,7 +8295,7 @@ func (x *TrafficPolicySpec_ExtProc_NamespacedMetadataContext) String() string {
 func (*TrafficPolicySpec_ExtProc_NamespacedMetadataContext) ProtoMessage() {}
 
 func (x *TrafficPolicySpec_ExtProc_NamespacedMetadataContext) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[96]
+	mi := &file_resource_proto_msgTypes[97]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8234,7 +8342,7 @@ type BackendPolicySpec_Ai struct {
 
 func (x *BackendPolicySpec_Ai) Reset() {
 	*x = BackendPolicySpec_Ai{}
-	mi := &file_resource_proto_msgTypes[99]
+	mi := &file_resource_proto_msgTypes[100]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8246,7 +8354,7 @@ func (x *BackendPolicySpec_Ai) String() string {
 func (*BackendPolicySpec_Ai) ProtoMessage() {}
 
 func (x *BackendPolicySpec_Ai) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[99]
+	mi := &file_resource_proto_msgTypes[100]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8326,7 +8434,7 @@ type BackendPolicySpec_A2A struct {
 
 func (x *BackendPolicySpec_A2A) Reset() {
 	*x = BackendPolicySpec_A2A{}
-	mi := &file_resource_proto_msgTypes[100]
+	mi := &file_resource_proto_msgTypes[101]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8338,7 +8446,7 @@ func (x *BackendPolicySpec_A2A) String() string {
 func (*BackendPolicySpec_A2A) ProtoMessage() {}
 
 func (x *BackendPolicySpec_A2A) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[100]
+	mi := &file_resource_proto_msgTypes[101]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8364,7 +8472,7 @@ type BackendPolicySpec_InferenceRouting struct {
 
 func (x *BackendPolicySpec_InferenceRouting) Reset() {
 	*x = BackendPolicySpec_InferenceRouting{}
-	mi := &file_resource_proto_msgTypes[101]
+	mi := &file_resource_proto_msgTypes[102]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8376,7 +8484,7 @@ func (x *BackendPolicySpec_InferenceRouting) String() string {
 func (*BackendPolicySpec_InferenceRouting) ProtoMessage() {}
 
 func (x *BackendPolicySpec_InferenceRouting) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[101]
+	mi := &file_resource_proto_msgTypes[102]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8429,7 +8537,7 @@ type BackendPolicySpec_BackendTLS struct {
 
 func (x *BackendPolicySpec_BackendTLS) Reset() {
 	*x = BackendPolicySpec_BackendTLS{}
-	mi := &file_resource_proto_msgTypes[102]
+	mi := &file_resource_proto_msgTypes[103]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8441,7 +8549,7 @@ func (x *BackendPolicySpec_BackendTLS) String() string {
 func (*BackendPolicySpec_BackendTLS) ProtoMessage() {}
 
 func (x *BackendPolicySpec_BackendTLS) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[102]
+	mi := &file_resource_proto_msgTypes[103]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8516,7 +8624,7 @@ type BackendPolicySpec_BackendHTTP struct {
 
 func (x *BackendPolicySpec_BackendHTTP) Reset() {
 	*x = BackendPolicySpec_BackendHTTP{}
-	mi := &file_resource_proto_msgTypes[103]
+	mi := &file_resource_proto_msgTypes[104]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8528,7 +8636,7 @@ func (x *BackendPolicySpec_BackendHTTP) String() string {
 func (*BackendPolicySpec_BackendHTTP) ProtoMessage() {}
 
 func (x *BackendPolicySpec_BackendHTTP) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[103]
+	mi := &file_resource_proto_msgTypes[104]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8568,7 +8676,7 @@ type BackendPolicySpec_BackendTCP struct {
 
 func (x *BackendPolicySpec_BackendTCP) Reset() {
 	*x = BackendPolicySpec_BackendTCP{}
-	mi := &file_resource_proto_msgTypes[104]
+	mi := &file_resource_proto_msgTypes[105]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8580,7 +8688,7 @@ func (x *BackendPolicySpec_BackendTCP) String() string {
 func (*BackendPolicySpec_BackendTCP) ProtoMessage() {}
 
 func (x *BackendPolicySpec_BackendTCP) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[104]
+	mi := &file_resource_proto_msgTypes[105]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8620,7 +8728,7 @@ type BackendPolicySpec_McpAuthorization struct {
 
 func (x *BackendPolicySpec_McpAuthorization) Reset() {
 	*x = BackendPolicySpec_McpAuthorization{}
-	mi := &file_resource_proto_msgTypes[105]
+	mi := &file_resource_proto_msgTypes[106]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8632,7 +8740,7 @@ func (x *BackendPolicySpec_McpAuthorization) String() string {
 func (*BackendPolicySpec_McpAuthorization) ProtoMessage() {}
 
 func (x *BackendPolicySpec_McpAuthorization) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[105]
+	mi := &file_resource_proto_msgTypes[106]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8679,7 +8787,7 @@ type BackendPolicySpec_McpAuthentication struct {
 
 func (x *BackendPolicySpec_McpAuthentication) Reset() {
 	*x = BackendPolicySpec_McpAuthentication{}
-	mi := &file_resource_proto_msgTypes[106]
+	mi := &file_resource_proto_msgTypes[107]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8691,7 +8799,7 @@ func (x *BackendPolicySpec_McpAuthentication) String() string {
 func (*BackendPolicySpec_McpAuthentication) ProtoMessage() {}
 
 func (x *BackendPolicySpec_McpAuthentication) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[106]
+	mi := &file_resource_proto_msgTypes[107]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8766,7 +8874,7 @@ type BackendPolicySpec_Ai_Message struct {
 
 func (x *BackendPolicySpec_Ai_Message) Reset() {
 	*x = BackendPolicySpec_Ai_Message{}
-	mi := &file_resource_proto_msgTypes[107]
+	mi := &file_resource_proto_msgTypes[108]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8778,7 +8886,7 @@ func (x *BackendPolicySpec_Ai_Message) String() string {
 func (*BackendPolicySpec_Ai_Message) ProtoMessage() {}
 
 func (x *BackendPolicySpec_Ai_Message) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[107]
+	mi := &file_resource_proto_msgTypes[108]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8818,7 +8926,7 @@ type BackendPolicySpec_Ai_PromptEnrichment struct {
 
 func (x *BackendPolicySpec_Ai_PromptEnrichment) Reset() {
 	*x = BackendPolicySpec_Ai_PromptEnrichment{}
-	mi := &file_resource_proto_msgTypes[108]
+	mi := &file_resource_proto_msgTypes[109]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8830,7 +8938,7 @@ func (x *BackendPolicySpec_Ai_PromptEnrichment) String() string {
 func (*BackendPolicySpec_Ai_PromptEnrichment) ProtoMessage() {}
 
 func (x *BackendPolicySpec_Ai_PromptEnrichment) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[108]
+	mi := &file_resource_proto_msgTypes[109]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8873,7 +8981,7 @@ type BackendPolicySpec_Ai_RegexRule struct {
 
 func (x *BackendPolicySpec_Ai_RegexRule) Reset() {
 	*x = BackendPolicySpec_Ai_RegexRule{}
-	mi := &file_resource_proto_msgTypes[109]
+	mi := &file_resource_proto_msgTypes[110]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8885,7 +8993,7 @@ func (x *BackendPolicySpec_Ai_RegexRule) String() string {
 func (*BackendPolicySpec_Ai_RegexRule) ProtoMessage() {}
 
 func (x *BackendPolicySpec_Ai_RegexRule) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[109]
+	mi := &file_resource_proto_msgTypes[110]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8952,7 +9060,7 @@ type BackendPolicySpec_Ai_RegexRules struct {
 
 func (x *BackendPolicySpec_Ai_RegexRules) Reset() {
 	*x = BackendPolicySpec_Ai_RegexRules{}
-	mi := &file_resource_proto_msgTypes[110]
+	mi := &file_resource_proto_msgTypes[111]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8964,7 +9072,7 @@ func (x *BackendPolicySpec_Ai_RegexRules) String() string {
 func (*BackendPolicySpec_Ai_RegexRules) ProtoMessage() {}
 
 func (x *BackendPolicySpec_Ai_RegexRules) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[110]
+	mi := &file_resource_proto_msgTypes[111]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9004,7 +9112,7 @@ type BackendPolicySpec_Ai_Webhook struct {
 
 func (x *BackendPolicySpec_Ai_Webhook) Reset() {
 	*x = BackendPolicySpec_Ai_Webhook{}
-	mi := &file_resource_proto_msgTypes[111]
+	mi := &file_resource_proto_msgTypes[112]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9016,7 +9124,7 @@ func (x *BackendPolicySpec_Ai_Webhook) String() string {
 func (*BackendPolicySpec_Ai_Webhook) ProtoMessage() {}
 
 func (x *BackendPolicySpec_Ai_Webhook) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[111]
+	mi := &file_resource_proto_msgTypes[112]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9057,7 +9165,7 @@ type BackendPolicySpec_Ai_Moderation struct {
 
 func (x *BackendPolicySpec_Ai_Moderation) Reset() {
 	*x = BackendPolicySpec_Ai_Moderation{}
-	mi := &file_resource_proto_msgTypes[112]
+	mi := &file_resource_proto_msgTypes[113]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9069,7 +9177,7 @@ func (x *BackendPolicySpec_Ai_Moderation) String() string {
 func (*BackendPolicySpec_Ai_Moderation) ProtoMessage() {}
 
 func (x *BackendPolicySpec_Ai_Moderation) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[112]
+	mi := &file_resource_proto_msgTypes[113]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9112,7 +9220,7 @@ type BackendPolicySpec_Ai_BedrockGuardrails struct {
 
 func (x *BackendPolicySpec_Ai_BedrockGuardrails) Reset() {
 	*x = BackendPolicySpec_Ai_BedrockGuardrails{}
-	mi := &file_resource_proto_msgTypes[113]
+	mi := &file_resource_proto_msgTypes[114]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9124,7 +9232,7 @@ func (x *BackendPolicySpec_Ai_BedrockGuardrails) String() string {
 func (*BackendPolicySpec_Ai_BedrockGuardrails) ProtoMessage() {}
 
 func (x *BackendPolicySpec_Ai_BedrockGuardrails) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[113]
+	mi := &file_resource_proto_msgTypes[114]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9181,7 +9289,7 @@ type BackendPolicySpec_Ai_GoogleModelArmor struct {
 
 func (x *BackendPolicySpec_Ai_GoogleModelArmor) Reset() {
 	*x = BackendPolicySpec_Ai_GoogleModelArmor{}
-	mi := &file_resource_proto_msgTypes[114]
+	mi := &file_resource_proto_msgTypes[115]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9193,7 +9301,7 @@ func (x *BackendPolicySpec_Ai_GoogleModelArmor) String() string {
 func (*BackendPolicySpec_Ai_GoogleModelArmor) ProtoMessage() {}
 
 func (x *BackendPolicySpec_Ai_GoogleModelArmor) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[114]
+	mi := &file_resource_proto_msgTypes[115]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9248,7 +9356,7 @@ type BackendPolicySpec_Ai_RequestRejection struct {
 
 func (x *BackendPolicySpec_Ai_RequestRejection) Reset() {
 	*x = BackendPolicySpec_Ai_RequestRejection{}
-	mi := &file_resource_proto_msgTypes[115]
+	mi := &file_resource_proto_msgTypes[116]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9260,7 +9368,7 @@ func (x *BackendPolicySpec_Ai_RequestRejection) String() string {
 func (*BackendPolicySpec_Ai_RequestRejection) ProtoMessage() {}
 
 func (x *BackendPolicySpec_Ai_RequestRejection) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[115]
+	mi := &file_resource_proto_msgTypes[116]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9308,7 +9416,7 @@ type BackendPolicySpec_Ai_ResponseGuard struct {
 
 func (x *BackendPolicySpec_Ai_ResponseGuard) Reset() {
 	*x = BackendPolicySpec_Ai_ResponseGuard{}
-	mi := &file_resource_proto_msgTypes[116]
+	mi := &file_resource_proto_msgTypes[117]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9320,7 +9428,7 @@ func (x *BackendPolicySpec_Ai_ResponseGuard) String() string {
 func (*BackendPolicySpec_Ai_ResponseGuard) ProtoMessage() {}
 
 func (x *BackendPolicySpec_Ai_ResponseGuard) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[116]
+	mi := &file_resource_proto_msgTypes[117]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9435,7 +9543,7 @@ type BackendPolicySpec_Ai_RequestGuard struct {
 
 func (x *BackendPolicySpec_Ai_RequestGuard) Reset() {
 	*x = BackendPolicySpec_Ai_RequestGuard{}
-	mi := &file_resource_proto_msgTypes[117]
+	mi := &file_resource_proto_msgTypes[118]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9447,7 +9555,7 @@ func (x *BackendPolicySpec_Ai_RequestGuard) String() string {
 func (*BackendPolicySpec_Ai_RequestGuard) ProtoMessage() {}
 
 func (x *BackendPolicySpec_Ai_RequestGuard) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[117]
+	mi := &file_resource_proto_msgTypes[118]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9571,7 +9679,7 @@ type BackendPolicySpec_Ai_PromptGuard struct {
 
 func (x *BackendPolicySpec_Ai_PromptGuard) Reset() {
 	*x = BackendPolicySpec_Ai_PromptGuard{}
-	mi := &file_resource_proto_msgTypes[118]
+	mi := &file_resource_proto_msgTypes[119]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9583,7 +9691,7 @@ func (x *BackendPolicySpec_Ai_PromptGuard) String() string {
 func (*BackendPolicySpec_Ai_PromptGuard) ProtoMessage() {}
 
 func (x *BackendPolicySpec_Ai_PromptGuard) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[118]
+	mi := &file_resource_proto_msgTypes[119]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9626,7 +9734,7 @@ type BackendPolicySpec_Ai_PromptCaching struct {
 
 func (x *BackendPolicySpec_Ai_PromptCaching) Reset() {
 	*x = BackendPolicySpec_Ai_PromptCaching{}
-	mi := &file_resource_proto_msgTypes[119]
+	mi := &file_resource_proto_msgTypes[120]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9638,7 +9746,7 @@ func (x *BackendPolicySpec_Ai_PromptCaching) String() string {
 func (*BackendPolicySpec_Ai_PromptCaching) ProtoMessage() {}
 
 func (x *BackendPolicySpec_Ai_PromptCaching) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[119]
+	mi := &file_resource_proto_msgTypes[120]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9691,7 +9799,7 @@ type BackendPolicySpec_McpAuthentication_ResourceMetadata struct {
 
 func (x *BackendPolicySpec_McpAuthentication_ResourceMetadata) Reset() {
 	*x = BackendPolicySpec_McpAuthentication_ResourceMetadata{}
-	mi := &file_resource_proto_msgTypes[125]
+	mi := &file_resource_proto_msgTypes[126]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9703,7 +9811,7 @@ func (x *BackendPolicySpec_McpAuthentication_ResourceMetadata) String() string {
 func (*BackendPolicySpec_McpAuthentication_ResourceMetadata) ProtoMessage() {}
 
 func (x *BackendPolicySpec_McpAuthentication_ResourceMetadata) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[125]
+	mi := &file_resource_proto_msgTypes[126]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9736,7 +9844,7 @@ type AIBackend_HostOverride struct {
 
 func (x *AIBackend_HostOverride) Reset() {
 	*x = AIBackend_HostOverride{}
-	mi := &file_resource_proto_msgTypes[127]
+	mi := &file_resource_proto_msgTypes[128]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9748,7 +9856,7 @@ func (x *AIBackend_HostOverride) String() string {
 func (*AIBackend_HostOverride) ProtoMessage() {}
 
 func (x *AIBackend_HostOverride) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[127]
+	mi := &file_resource_proto_msgTypes[128]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9787,7 +9895,7 @@ type AIBackend_OpenAI struct {
 
 func (x *AIBackend_OpenAI) Reset() {
 	*x = AIBackend_OpenAI{}
-	mi := &file_resource_proto_msgTypes[128]
+	mi := &file_resource_proto_msgTypes[129]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9799,7 +9907,7 @@ func (x *AIBackend_OpenAI) String() string {
 func (*AIBackend_OpenAI) ProtoMessage() {}
 
 func (x *AIBackend_OpenAI) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[128]
+	mi := &file_resource_proto_msgTypes[129]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9831,7 +9939,7 @@ type AIBackend_Gemini struct {
 
 func (x *AIBackend_Gemini) Reset() {
 	*x = AIBackend_Gemini{}
-	mi := &file_resource_proto_msgTypes[129]
+	mi := &file_resource_proto_msgTypes[130]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9843,7 +9951,7 @@ func (x *AIBackend_Gemini) String() string {
 func (*AIBackend_Gemini) ProtoMessage() {}
 
 func (x *AIBackend_Gemini) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[129]
+	mi := &file_resource_proto_msgTypes[130]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9877,7 +9985,7 @@ type AIBackend_Vertex struct {
 
 func (x *AIBackend_Vertex) Reset() {
 	*x = AIBackend_Vertex{}
-	mi := &file_resource_proto_msgTypes[130]
+	mi := &file_resource_proto_msgTypes[131]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9889,7 +9997,7 @@ func (x *AIBackend_Vertex) String() string {
 func (*AIBackend_Vertex) ProtoMessage() {}
 
 func (x *AIBackend_Vertex) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[130]
+	mi := &file_resource_proto_msgTypes[131]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9935,7 +10043,7 @@ type AIBackend_Anthropic struct {
 
 func (x *AIBackend_Anthropic) Reset() {
 	*x = AIBackend_Anthropic{}
-	mi := &file_resource_proto_msgTypes[131]
+	mi := &file_resource_proto_msgTypes[132]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9947,7 +10055,7 @@ func (x *AIBackend_Anthropic) String() string {
 func (*AIBackend_Anthropic) ProtoMessage() {}
 
 func (x *AIBackend_Anthropic) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[131]
+	mi := &file_resource_proto_msgTypes[132]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9982,7 +10090,7 @@ type AIBackend_Bedrock struct {
 
 func (x *AIBackend_Bedrock) Reset() {
 	*x = AIBackend_Bedrock{}
-	mi := &file_resource_proto_msgTypes[132]
+	mi := &file_resource_proto_msgTypes[133]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9994,7 +10102,7 @@ func (x *AIBackend_Bedrock) String() string {
 func (*AIBackend_Bedrock) ProtoMessage() {}
 
 func (x *AIBackend_Bedrock) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[132]
+	mi := &file_resource_proto_msgTypes[133]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10049,7 +10157,7 @@ type AIBackend_AzureOpenAI struct {
 
 func (x *AIBackend_AzureOpenAI) Reset() {
 	*x = AIBackend_AzureOpenAI{}
-	mi := &file_resource_proto_msgTypes[133]
+	mi := &file_resource_proto_msgTypes[134]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10061,7 +10169,7 @@ func (x *AIBackend_AzureOpenAI) String() string {
 func (*AIBackend_AzureOpenAI) ProtoMessage() {}
 
 func (x *AIBackend_AzureOpenAI) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[133]
+	mi := &file_resource_proto_msgTypes[134]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10119,7 +10227,7 @@ type AIBackend_Provider struct {
 
 func (x *AIBackend_Provider) Reset() {
 	*x = AIBackend_Provider{}
-	mi := &file_resource_proto_msgTypes[134]
+	mi := &file_resource_proto_msgTypes[135]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10131,7 +10239,7 @@ func (x *AIBackend_Provider) String() string {
 func (*AIBackend_Provider) ProtoMessage() {}
 
 func (x *AIBackend_Provider) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[134]
+	mi := &file_resource_proto_msgTypes[135]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10285,7 +10393,7 @@ type AIBackend_ProviderGroup struct {
 
 func (x *AIBackend_ProviderGroup) Reset() {
 	*x = AIBackend_ProviderGroup{}
-	mi := &file_resource_proto_msgTypes[135]
+	mi := &file_resource_proto_msgTypes[136]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10297,7 +10405,7 @@ func (x *AIBackend_ProviderGroup) String() string {
 func (*AIBackend_ProviderGroup) ProtoMessage() {}
 
 func (x *AIBackend_ProviderGroup) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[135]
+	mi := &file_resource_proto_msgTypes[136]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10330,7 +10438,7 @@ type BackendReference_Service struct {
 
 func (x *BackendReference_Service) Reset() {
 	*x = BackendReference_Service{}
-	mi := &file_resource_proto_msgTypes[136]
+	mi := &file_resource_proto_msgTypes[137]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10342,7 +10450,7 @@ func (x *BackendReference_Service) String() string {
 func (*BackendReference_Service) ProtoMessage() {}
 
 func (x *BackendReference_Service) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[136]
+	mi := &file_resource_proto_msgTypes[137]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10719,7 +10827,7 @@ const file_resource_proto_rawDesc = "" +
 	"\x05value\x18\x02 \x01(\tR\x05valueB\x06\n" +
 	"\x04kind\"?\n" +
 	"\x14JWTValidationOptions\x12'\n" +
-	"\x0frequired_claims\x18\x01 \x03(\tR\x0erequiredClaims\"\xc8:\n" +
+	"\x0frequired_claims\x18\x01 \x03(\tR\x0erequiredClaims\"\xd7=\n" +
 	"\x11TrafficPolicySpec\x12N\n" +
 	"\x05phase\x18\x01 \x01(\x0e28.agentgateway.dev.resource.TrafficPolicySpec.PolicyPhaseR\x05phase\x12>\n" +
 	"\atimeout\x18\x02 \x01(\v2\".agentgateway.dev.resource.TimeoutH\x00R\atimeout\x128\n" +
@@ -10745,7 +10853,8 @@ const file_resource_proto_rawDesc = "" +
 	"basic_auth\x18\x13 \x01(\v2@.agentgateway.dev.resource.TrafficPolicySpec.BasicAuthenticationH\x00R\tbasicAuth\x12W\n" +
 	"\fapi_key_auth\x18\x14 \x01(\v23.agentgateway.dev.resource.TrafficPolicySpec.APIKeyH\x00R\n" +
 	"apiKeyAuth\x12]\n" +
-	"\fhost_rewrite\x18\x15 \x01(\v28.agentgateway.dev.resource.TrafficPolicySpec.HostRewriteH\x00R\vhostRewrite\x1a\x8c\x05\n" +
+	"\fhost_rewrite\x18\x15 \x01(\v28.agentgateway.dev.resource.TrafficPolicySpec.HostRewriteH\x00R\vhostRewrite\x12j\n" +
+	"\x11ip_access_control\x18\x16 \x01(\v2<.agentgateway.dev.resource.TrafficPolicySpec.IpAccessControlH\x00R\x0fipAccessControl\x1a\x8c\x05\n" +
 	"\x0fRemoteRateLimit\x12\x16\n" +
 	"\x06domain\x18\x01 \x01(\tR\x06domain\x12i\n" +
 	"\vdescriptors\x18\x02 \x03(\v2G.agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.DescriptorR\vdescriptors\x12C\n" +
@@ -10899,7 +11008,16 @@ const file_resource_proto_rawDesc = "" +
 	"\x04mode\x18\x01 \x01(\x0e2=.agentgateway.dev.resource.TrafficPolicySpec.HostRewrite.ModeR\x04mode\"\x1a\n" +
 	"\x04Mode\x12\b\n" +
 	"\x04NONE\x10\x00\x12\b\n" +
-	"\x04AUTO\x10\x01\"%\n" +
+	"\x04AUTO\x10\x01\x1a\xa0\x02\n" +
+	"\x0fIpAccessControl\x12\x14\n" +
+	"\x05allow\x18\x01 \x03(\tR\x05allow\x12\x12\n" +
+	"\x04deny\x18\x02 \x03(\tR\x04deny\x124\n" +
+	"\x14xff_num_trusted_hops\x18\x03 \x01(\rH\x00R\x11xffNumTrustedHops\x88\x01\x01\x12(\n" +
+	"\x10skip_private_ips\x18\x04 \x01(\bR\x0eskipPrivateIps\x12,\n" +
+	"\x12enforce_full_chain\x18\x05 \x01(\bR\x10enforceFullChain\x12)\n" +
+	"\x0emax_xff_length\x18\x06 \x01(\rH\x01R\fmaxXffLength\x88\x01\x01B\x17\n" +
+	"\x15_xff_num_trusted_hopsB\x11\n" +
+	"\x0f_max_xff_length\"%\n" +
 	"\vPolicyPhase\x12\t\n" +
 	"\x05ROUTE\x10\x00\x12\v\n" +
 	"\aGATEWAY\x10\x01B\x06\n" +
@@ -11213,7 +11331,7 @@ func file_resource_proto_rawDescGZIP() []byte {
 }
 
 var file_resource_proto_enumTypes = make([]protoimpl.EnumInfo, 27)
-var file_resource_proto_msgTypes = make([]protoimpl.MessageInfo, 137)
+var file_resource_proto_msgTypes = make([]protoimpl.MessageInfo, 138)
 var file_resource_proto_goTypes = []any{
 	(Protocol)(0),                                       // 0: agentgateway.dev.resource.Protocol
 	(Bind_Protocol)(0),                                  // 1: agentgateway.dev.resource.Bind.Protocol
@@ -11325,65 +11443,66 @@ var file_resource_proto_goTypes = []any{
 	(*TrafficPolicySpec_CSRF)(nil),                              // 107: agentgateway.dev.resource.TrafficPolicySpec.CSRF
 	(*TrafficPolicySpec_ExtProc)(nil),                           // 108: agentgateway.dev.resource.TrafficPolicySpec.ExtProc
 	(*TrafficPolicySpec_HostRewrite)(nil),                       // 109: agentgateway.dev.resource.TrafficPolicySpec.HostRewrite
-	(*TrafficPolicySpec_RemoteRateLimit_Descriptor)(nil),        // 110: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor
-	(*TrafficPolicySpec_RemoteRateLimit_Entry)(nil),             // 111: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Entry
-	(*TrafficPolicySpec_ExternalAuth_BodyOptions)(nil),          // 112: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.BodyOptions
-	(*TrafficPolicySpec_ExternalAuth_GRPCProtocol)(nil),         // 113: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol
-	(*TrafficPolicySpec_ExternalAuth_HTTPProtocol)(nil),         // 114: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol
-	nil,                                   // 115: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.ContextEntry
-	nil,                                   // 116: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.MetadataEntry
-	nil,                                   // 117: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.AddRequestHeadersEntry
-	nil,                                   // 118: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.MetadataEntry
-	(*TrafficPolicySpec_APIKey_User)(nil), // 119: agentgateway.dev.resource.TrafficPolicySpec.APIKey.User
-	(*TrafficPolicySpec_TransformationPolicy_Transform)(nil), // 120: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform
-	nil, // 121: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.RequestAttributesEntry
-	nil, // 122: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ResponseAttributesEntry
-	(*TrafficPolicySpec_ExtProc_NamespacedMetadataContext)(nil), // 123: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext
-	nil,                           // 124: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.MetadataContextEntry
-	nil,                           // 125: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext.ContextEntry
-	(*BackendPolicySpec_Ai)(nil),  // 126: agentgateway.dev.resource.BackendPolicySpec.Ai
-	(*BackendPolicySpec_A2A)(nil), // 127: agentgateway.dev.resource.BackendPolicySpec.A2a
-	(*BackendPolicySpec_InferenceRouting)(nil),     // 128: agentgateway.dev.resource.BackendPolicySpec.InferenceRouting
-	(*BackendPolicySpec_BackendTLS)(nil),           // 129: agentgateway.dev.resource.BackendPolicySpec.BackendTLS
-	(*BackendPolicySpec_BackendHTTP)(nil),          // 130: agentgateway.dev.resource.BackendPolicySpec.BackendHTTP
-	(*BackendPolicySpec_BackendTCP)(nil),           // 131: agentgateway.dev.resource.BackendPolicySpec.BackendTCP
-	(*BackendPolicySpec_McpAuthorization)(nil),     // 132: agentgateway.dev.resource.BackendPolicySpec.McpAuthorization
-	(*BackendPolicySpec_McpAuthentication)(nil),    // 133: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication
-	(*BackendPolicySpec_Ai_Message)(nil),           // 134: agentgateway.dev.resource.BackendPolicySpec.Ai.Message
-	(*BackendPolicySpec_Ai_PromptEnrichment)(nil),  // 135: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment
-	(*BackendPolicySpec_Ai_RegexRule)(nil),         // 136: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRule
-	(*BackendPolicySpec_Ai_RegexRules)(nil),        // 137: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules
-	(*BackendPolicySpec_Ai_Webhook)(nil),           // 138: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook
-	(*BackendPolicySpec_Ai_Moderation)(nil),        // 139: agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation
-	(*BackendPolicySpec_Ai_BedrockGuardrails)(nil), // 140: agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails
-	(*BackendPolicySpec_Ai_GoogleModelArmor)(nil),  // 141: agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor
-	(*BackendPolicySpec_Ai_RequestRejection)(nil),  // 142: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestRejection
-	(*BackendPolicySpec_Ai_ResponseGuard)(nil),     // 143: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard
-	(*BackendPolicySpec_Ai_RequestGuard)(nil),      // 144: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard
-	(*BackendPolicySpec_Ai_PromptGuard)(nil),       // 145: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard
-	(*BackendPolicySpec_Ai_PromptCaching)(nil),     // 146: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptCaching
-	nil, // 147: agentgateway.dev.resource.BackendPolicySpec.Ai.DefaultsEntry
-	nil, // 148: agentgateway.dev.resource.BackendPolicySpec.Ai.OverridesEntry
-	nil, // 149: agentgateway.dev.resource.BackendPolicySpec.Ai.TransformationsEntry
-	nil, // 150: agentgateway.dev.resource.BackendPolicySpec.Ai.ModelAliasesEntry
-	nil, // 151: agentgateway.dev.resource.BackendPolicySpec.Ai.RoutesEntry
-	(*BackendPolicySpec_McpAuthentication_ResourceMetadata)(nil), // 152: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata
-	nil,                              // 153: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntry
-	(*AIBackend_HostOverride)(nil),   // 154: agentgateway.dev.resource.AIBackend.HostOverride
-	(*AIBackend_OpenAI)(nil),         // 155: agentgateway.dev.resource.AIBackend.OpenAI
-	(*AIBackend_Gemini)(nil),         // 156: agentgateway.dev.resource.AIBackend.Gemini
-	(*AIBackend_Vertex)(nil),         // 157: agentgateway.dev.resource.AIBackend.Vertex
-	(*AIBackend_Anthropic)(nil),      // 158: agentgateway.dev.resource.AIBackend.Anthropic
-	(*AIBackend_Bedrock)(nil),        // 159: agentgateway.dev.resource.AIBackend.Bedrock
-	(*AIBackend_AzureOpenAI)(nil),    // 160: agentgateway.dev.resource.AIBackend.AzureOpenAI
-	(*AIBackend_Provider)(nil),       // 161: agentgateway.dev.resource.AIBackend.Provider
-	(*AIBackend_ProviderGroup)(nil),  // 162: agentgateway.dev.resource.AIBackend.ProviderGroup
-	(*BackendReference_Service)(nil), // 163: agentgateway.dev.resource.BackendReference.Service
-	(*workloadapi.Workload)(nil),     // 164: istio.workload.Workload
-	(*workloadapi.Service)(nil),      // 165: istio.workload.Service
-	(*durationpb.Duration)(nil),      // 166: google.protobuf.Duration
-	(*structpb.Struct)(nil),          // 167: google.protobuf.Struct
-	(*structpb.Value)(nil),           // 168: google.protobuf.Value
+	(*TrafficPolicySpec_IpAccessControl)(nil),                   // 110: agentgateway.dev.resource.TrafficPolicySpec.IpAccessControl
+	(*TrafficPolicySpec_RemoteRateLimit_Descriptor)(nil),        // 111: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor
+	(*TrafficPolicySpec_RemoteRateLimit_Entry)(nil),             // 112: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Entry
+	(*TrafficPolicySpec_ExternalAuth_BodyOptions)(nil),          // 113: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.BodyOptions
+	(*TrafficPolicySpec_ExternalAuth_GRPCProtocol)(nil),         // 114: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol
+	(*TrafficPolicySpec_ExternalAuth_HTTPProtocol)(nil),         // 115: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol
+	nil,                                   // 116: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.ContextEntry
+	nil,                                   // 117: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.MetadataEntry
+	nil,                                   // 118: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.AddRequestHeadersEntry
+	nil,                                   // 119: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.MetadataEntry
+	(*TrafficPolicySpec_APIKey_User)(nil), // 120: agentgateway.dev.resource.TrafficPolicySpec.APIKey.User
+	(*TrafficPolicySpec_TransformationPolicy_Transform)(nil), // 121: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform
+	nil, // 122: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.RequestAttributesEntry
+	nil, // 123: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ResponseAttributesEntry
+	(*TrafficPolicySpec_ExtProc_NamespacedMetadataContext)(nil), // 124: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext
+	nil,                           // 125: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.MetadataContextEntry
+	nil,                           // 126: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext.ContextEntry
+	(*BackendPolicySpec_Ai)(nil),  // 127: agentgateway.dev.resource.BackendPolicySpec.Ai
+	(*BackendPolicySpec_A2A)(nil), // 128: agentgateway.dev.resource.BackendPolicySpec.A2a
+	(*BackendPolicySpec_InferenceRouting)(nil),     // 129: agentgateway.dev.resource.BackendPolicySpec.InferenceRouting
+	(*BackendPolicySpec_BackendTLS)(nil),           // 130: agentgateway.dev.resource.BackendPolicySpec.BackendTLS
+	(*BackendPolicySpec_BackendHTTP)(nil),          // 131: agentgateway.dev.resource.BackendPolicySpec.BackendHTTP
+	(*BackendPolicySpec_BackendTCP)(nil),           // 132: agentgateway.dev.resource.BackendPolicySpec.BackendTCP
+	(*BackendPolicySpec_McpAuthorization)(nil),     // 133: agentgateway.dev.resource.BackendPolicySpec.McpAuthorization
+	(*BackendPolicySpec_McpAuthentication)(nil),    // 134: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication
+	(*BackendPolicySpec_Ai_Message)(nil),           // 135: agentgateway.dev.resource.BackendPolicySpec.Ai.Message
+	(*BackendPolicySpec_Ai_PromptEnrichment)(nil),  // 136: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment
+	(*BackendPolicySpec_Ai_RegexRule)(nil),         // 137: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRule
+	(*BackendPolicySpec_Ai_RegexRules)(nil),        // 138: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules
+	(*BackendPolicySpec_Ai_Webhook)(nil),           // 139: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook
+	(*BackendPolicySpec_Ai_Moderation)(nil),        // 140: agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation
+	(*BackendPolicySpec_Ai_BedrockGuardrails)(nil), // 141: agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails
+	(*BackendPolicySpec_Ai_GoogleModelArmor)(nil),  // 142: agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor
+	(*BackendPolicySpec_Ai_RequestRejection)(nil),  // 143: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestRejection
+	(*BackendPolicySpec_Ai_ResponseGuard)(nil),     // 144: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard
+	(*BackendPolicySpec_Ai_RequestGuard)(nil),      // 145: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard
+	(*BackendPolicySpec_Ai_PromptGuard)(nil),       // 146: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard
+	(*BackendPolicySpec_Ai_PromptCaching)(nil),     // 147: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptCaching
+	nil, // 148: agentgateway.dev.resource.BackendPolicySpec.Ai.DefaultsEntry
+	nil, // 149: agentgateway.dev.resource.BackendPolicySpec.Ai.OverridesEntry
+	nil, // 150: agentgateway.dev.resource.BackendPolicySpec.Ai.TransformationsEntry
+	nil, // 151: agentgateway.dev.resource.BackendPolicySpec.Ai.ModelAliasesEntry
+	nil, // 152: agentgateway.dev.resource.BackendPolicySpec.Ai.RoutesEntry
+	(*BackendPolicySpec_McpAuthentication_ResourceMetadata)(nil), // 153: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata
+	nil,                              // 154: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntry
+	(*AIBackend_HostOverride)(nil),   // 155: agentgateway.dev.resource.AIBackend.HostOverride
+	(*AIBackend_OpenAI)(nil),         // 156: agentgateway.dev.resource.AIBackend.OpenAI
+	(*AIBackend_Gemini)(nil),         // 157: agentgateway.dev.resource.AIBackend.Gemini
+	(*AIBackend_Vertex)(nil),         // 158: agentgateway.dev.resource.AIBackend.Vertex
+	(*AIBackend_Anthropic)(nil),      // 159: agentgateway.dev.resource.AIBackend.Anthropic
+	(*AIBackend_Bedrock)(nil),        // 160: agentgateway.dev.resource.AIBackend.Bedrock
+	(*AIBackend_AzureOpenAI)(nil),    // 161: agentgateway.dev.resource.AIBackend.AzureOpenAI
+	(*AIBackend_Provider)(nil),       // 162: agentgateway.dev.resource.AIBackend.Provider
+	(*AIBackend_ProviderGroup)(nil),  // 163: agentgateway.dev.resource.AIBackend.ProviderGroup
+	(*BackendReference_Service)(nil), // 164: agentgateway.dev.resource.BackendReference.Service
+	(*workloadapi.Workload)(nil),     // 165: istio.workload.Workload
+	(*workloadapi.Service)(nil),      // 166: istio.workload.Service
+	(*durationpb.Duration)(nil),      // 167: google.protobuf.Duration
+	(*structpb.Struct)(nil),          // 168: google.protobuf.Struct
+	(*structpb.Value)(nil),           // 169: google.protobuf.Value
 }
 var file_resource_proto_depIdxs = []int32{
 	28,  // 0: agentgateway.dev.resource.Resource.bind:type_name -> agentgateway.dev.resource.Bind
@@ -11392,8 +11511,8 @@ var file_resource_proto_depIdxs = []int32{
 	37,  // 3: agentgateway.dev.resource.Resource.backend:type_name -> agentgateway.dev.resource.Backend
 	36,  // 4: agentgateway.dev.resource.Resource.policy:type_name -> agentgateway.dev.resource.Policy
 	35,  // 5: agentgateway.dev.resource.Resource.tcp_route:type_name -> agentgateway.dev.resource.TCPRoute
-	164, // 6: agentgateway.dev.resource.Resource.workload:type_name -> istio.workload.Workload
-	165, // 7: agentgateway.dev.resource.Resource.service:type_name -> istio.workload.Service
+	165, // 6: agentgateway.dev.resource.Resource.workload:type_name -> istio.workload.Workload
+	166, // 7: agentgateway.dev.resource.Resource.service:type_name -> istio.workload.Service
 	1,   // 8: agentgateway.dev.resource.Bind.protocol:type_name -> agentgateway.dev.resource.Bind.Protocol
 	2,   // 9: agentgateway.dev.resource.Bind.tunnel_protocol:type_name -> agentgateway.dev.resource.Bind.TunnelProtocol
 	31,  // 10: agentgateway.dev.resource.ListenerName.listener_set:type_name -> agentgateway.dev.resource.ResourceName
@@ -11420,9 +11539,9 @@ var file_resource_proto_depIdxs = []int32{
 	4,   // 31: agentgateway.dev.resource.TLSConfig.cipher_suites:type_name -> agentgateway.dev.resource.TLSConfig.CipherSuite
 	3,   // 32: agentgateway.dev.resource.TLSConfig.min_version:type_name -> agentgateway.dev.resource.TLSConfig.TLSVersion
 	3,   // 33: agentgateway.dev.resource.TLSConfig.max_version:type_name -> agentgateway.dev.resource.TLSConfig.TLSVersion
-	166, // 34: agentgateway.dev.resource.Timeout.request:type_name -> google.protobuf.Duration
-	166, // 35: agentgateway.dev.resource.Timeout.backend_request:type_name -> google.protobuf.Duration
-	166, // 36: agentgateway.dev.resource.Retry.backoff:type_name -> google.protobuf.Duration
+	167, // 34: agentgateway.dev.resource.Timeout.request:type_name -> google.protobuf.Duration
+	167, // 35: agentgateway.dev.resource.Timeout.backend_request:type_name -> google.protobuf.Duration
+	167, // 36: agentgateway.dev.resource.Retry.backoff:type_name -> google.protobuf.Duration
 	42,  // 37: agentgateway.dev.resource.BackendAuthPolicy.passthrough:type_name -> agentgateway.dev.resource.Passthrough
 	43,  // 38: agentgateway.dev.resource.BackendAuthPolicy.key:type_name -> agentgateway.dev.resource.Key
 	44,  // 39: agentgateway.dev.resource.BackendAuthPolicy.gcp:type_name -> agentgateway.dev.resource.Gcp
@@ -11442,7 +11561,7 @@ var file_resource_proto_depIdxs = []int32{
 	58,  // 53: agentgateway.dev.resource.RouteMatch.headers:type_name -> agentgateway.dev.resource.HeaderMatch
 	57,  // 54: agentgateway.dev.resource.RouteMatch.method:type_name -> agentgateway.dev.resource.MethodMatch
 	56,  // 55: agentgateway.dev.resource.RouteMatch.query_params:type_name -> agentgateway.dev.resource.QueryMatch
-	166, // 56: agentgateway.dev.resource.CORS.max_age:type_name -> google.protobuf.Duration
+	167, // 56: agentgateway.dev.resource.CORS.max_age:type_name -> google.protobuf.Duration
 	65,  // 57: agentgateway.dev.resource.HeaderModifier.add:type_name -> agentgateway.dev.resource.Header
 	65,  // 58: agentgateway.dev.resource.HeaderModifier.set:type_name -> agentgateway.dev.resource.Header
 	83,  // 59: agentgateway.dev.resource.RequestMirrors.mirrors:type_name -> agentgateway.dev.resource.RequestMirrors.Mirror
@@ -11452,8 +11571,8 @@ var file_resource_proto_depIdxs = []int32{
 	87,  // 63: agentgateway.dev.resource.PolicyTarget.route:type_name -> agentgateway.dev.resource.PolicyTarget.RouteTarget
 	85,  // 64: agentgateway.dev.resource.PolicyTarget.backend:type_name -> agentgateway.dev.resource.PolicyTarget.BackendTarget
 	84,  // 65: agentgateway.dev.resource.PolicyTarget.service:type_name -> agentgateway.dev.resource.PolicyTarget.ServiceTarget
-	166, // 66: agentgateway.dev.resource.KeepaliveConfig.time:type_name -> google.protobuf.Duration
-	166, // 67: agentgateway.dev.resource.KeepaliveConfig.interval:type_name -> google.protobuf.Duration
+	167, // 66: agentgateway.dev.resource.KeepaliveConfig.time:type_name -> google.protobuf.Duration
+	167, // 67: agentgateway.dev.resource.KeepaliveConfig.interval:type_name -> google.protobuf.Duration
 	90,  // 68: agentgateway.dev.resource.FrontendPolicySpec.tcp:type_name -> agentgateway.dev.resource.FrontendPolicySpec.TCP
 	89,  // 69: agentgateway.dev.resource.FrontendPolicySpec.tls:type_name -> agentgateway.dev.resource.FrontendPolicySpec.TLS
 	88,  // 70: agentgateway.dev.resource.FrontendPolicySpec.http:type_name -> agentgateway.dev.resource.FrontendPolicySpec.HTTP
@@ -11480,138 +11599,139 @@ var file_resource_proto_depIdxs = []int32{
 	102, // 91: agentgateway.dev.resource.TrafficPolicySpec.basic_auth:type_name -> agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication
 	103, // 92: agentgateway.dev.resource.TrafficPolicySpec.api_key_auth:type_name -> agentgateway.dev.resource.TrafficPolicySpec.APIKey
 	109, // 93: agentgateway.dev.resource.TrafficPolicySpec.host_rewrite:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HostRewrite
-	127, // 94: agentgateway.dev.resource.BackendPolicySpec.a2a:type_name -> agentgateway.dev.resource.BackendPolicySpec.A2a
-	128, // 95: agentgateway.dev.resource.BackendPolicySpec.inference_routing:type_name -> agentgateway.dev.resource.BackendPolicySpec.InferenceRouting
-	129, // 96: agentgateway.dev.resource.BackendPolicySpec.backend_tls:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTLS
-	41,  // 97: agentgateway.dev.resource.BackendPolicySpec.auth:type_name -> agentgateway.dev.resource.BackendAuthPolicy
-	132, // 98: agentgateway.dev.resource.BackendPolicySpec.mcp_authorization:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthorization
-	133, // 99: agentgateway.dev.resource.BackendPolicySpec.mcp_authentication:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication
-	126, // 100: agentgateway.dev.resource.BackendPolicySpec.ai:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai
-	61,  // 101: agentgateway.dev.resource.BackendPolicySpec.request_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
-	61,  // 102: agentgateway.dev.resource.BackendPolicySpec.response_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
-	63,  // 103: agentgateway.dev.resource.BackendPolicySpec.request_redirect:type_name -> agentgateway.dev.resource.RequestRedirect
-	62,  // 104: agentgateway.dev.resource.BackendPolicySpec.request_mirror:type_name -> agentgateway.dev.resource.RequestMirrors
-	130, // 105: agentgateway.dev.resource.BackendPolicySpec.backend_http:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendHTTP
-	131, // 106: agentgateway.dev.resource.BackendPolicySpec.backend_tcp:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTCP
-	162, // 107: agentgateway.dev.resource.AIBackend.provider_groups:type_name -> agentgateway.dev.resource.AIBackend.ProviderGroup
-	77,  // 108: agentgateway.dev.resource.MCPBackend.targets:type_name -> agentgateway.dev.resource.MCPTarget
-	24,  // 109: agentgateway.dev.resource.MCPBackend.stateful_mode:type_name -> agentgateway.dev.resource.MCPBackend.StatefulMode
-	25,  // 110: agentgateway.dev.resource.MCPBackend.prefix_mode:type_name -> agentgateway.dev.resource.MCPBackend.PrefixMode
-	78,  // 111: agentgateway.dev.resource.MCPTarget.backend:type_name -> agentgateway.dev.resource.BackendReference
-	26,  // 112: agentgateway.dev.resource.MCPTarget.protocol:type_name -> agentgateway.dev.resource.MCPTarget.Protocol
-	163, // 113: agentgateway.dev.resource.BackendReference.service:type_name -> agentgateway.dev.resource.BackendReference.Service
-	78,  // 114: agentgateway.dev.resource.RequestMirrors.Mirror.backend:type_name -> agentgateway.dev.resource.BackendReference
-	166, // 115: agentgateway.dev.resource.FrontendPolicySpec.HTTP.http1_idle_timeout:type_name -> google.protobuf.Duration
-	166, // 116: agentgateway.dev.resource.FrontendPolicySpec.HTTP.http2_keepalive_interval:type_name -> google.protobuf.Duration
-	166, // 117: agentgateway.dev.resource.FrontendPolicySpec.HTTP.http2_keepalive_timeout:type_name -> google.protobuf.Duration
-	166, // 118: agentgateway.dev.resource.FrontendPolicySpec.TLS.handshake_timeout:type_name -> google.protobuf.Duration
-	79,  // 119: agentgateway.dev.resource.FrontendPolicySpec.TLS.alpn:type_name -> agentgateway.dev.resource.Alpn
-	4,   // 120: agentgateway.dev.resource.FrontendPolicySpec.TLS.cipher_suites:type_name -> agentgateway.dev.resource.TLSConfig.CipherSuite
-	3,   // 121: agentgateway.dev.resource.FrontendPolicySpec.TLS.min_version:type_name -> agentgateway.dev.resource.TLSConfig.TLSVersion
-	3,   // 122: agentgateway.dev.resource.FrontendPolicySpec.TLS.max_version:type_name -> agentgateway.dev.resource.TLSConfig.TLSVersion
-	68,  // 123: agentgateway.dev.resource.FrontendPolicySpec.TCP.keepalives:type_name -> agentgateway.dev.resource.KeepaliveConfig
-	95,  // 124: agentgateway.dev.resource.FrontendPolicySpec.Logging.fields:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging.Fields
-	78,  // 125: agentgateway.dev.resource.FrontendPolicySpec.Tracing.provider_backend:type_name -> agentgateway.dev.resource.BackendReference
-	93,  // 126: agentgateway.dev.resource.FrontendPolicySpec.Tracing.attributes:type_name -> agentgateway.dev.resource.FrontendPolicySpec.TracingAttribute
-	93,  // 127: agentgateway.dev.resource.FrontendPolicySpec.Tracing.resources:type_name -> agentgateway.dev.resource.FrontendPolicySpec.TracingAttribute
-	5,   // 128: agentgateway.dev.resource.FrontendPolicySpec.Tracing.protocol:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Tracing.Protocol
-	94,  // 129: agentgateway.dev.resource.FrontendPolicySpec.Logging.Fields.add:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging.Field
-	110, // 130: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.descriptors:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor
-	78,  // 131: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.target:type_name -> agentgateway.dev.resource.BackendReference
-	8,   // 132: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.failure_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.FailureMode
-	166, // 133: agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit.fill_interval:type_name -> google.protobuf.Duration
-	9,   // 134: agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit.type:type_name -> agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit.Type
-	78,  // 135: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.target:type_name -> agentgateway.dev.resource.BackendReference
-	113, // 136: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.grpc:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol
-	114, // 137: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.http:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol
-	10,  // 138: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.failure_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.FailureMode
-	112, // 139: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.include_request_body:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.BodyOptions
-	70,  // 140: agentgateway.dev.resource.TrafficPolicySpec.JWTProvider.jwt_validation_options:type_name -> agentgateway.dev.resource.JWTValidationOptions
-	11,  // 141: agentgateway.dev.resource.TrafficPolicySpec.JWT.mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.JWT.Mode
-	100, // 142: agentgateway.dev.resource.TrafficPolicySpec.JWT.providers:type_name -> agentgateway.dev.resource.TrafficPolicySpec.JWTProvider
-	12,  // 143: agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication.mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication.Mode
-	119, // 144: agentgateway.dev.resource.TrafficPolicySpec.APIKey.api_keys:type_name -> agentgateway.dev.resource.TrafficPolicySpec.APIKey.User
-	13,  // 145: agentgateway.dev.resource.TrafficPolicySpec.APIKey.mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.APIKey.Mode
-	120, // 146: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.request:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform
-	120, // 147: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.response:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform
-	78,  // 148: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.target:type_name -> agentgateway.dev.resource.BackendReference
-	14,  // 149: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.failure_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.FailureMode
-	121, // 150: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.request_attributes:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.RequestAttributesEntry
-	122, // 151: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.response_attributes:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ResponseAttributesEntry
-	124, // 152: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.metadata_context:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.MetadataContextEntry
-	15,  // 153: agentgateway.dev.resource.TrafficPolicySpec.HostRewrite.mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HostRewrite.Mode
-	111, // 154: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor.entries:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Entry
-	7,   // 155: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor.type:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Type
-	115, // 156: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.context:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.ContextEntry
-	116, // 157: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.metadata:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.MetadataEntry
-	117, // 158: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.add_request_headers:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.AddRequestHeadersEntry
-	118, // 159: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.metadata:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.MetadataEntry
-	167, // 160: agentgateway.dev.resource.TrafficPolicySpec.APIKey.User.metadata:type_name -> google.protobuf.Struct
-	105, // 161: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.set:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HeaderTransformation
-	105, // 162: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.add:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HeaderTransformation
-	106, // 163: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.body:type_name -> agentgateway.dev.resource.TrafficPolicySpec.BodyTransformation
-	125, // 164: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext.context:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext.ContextEntry
-	123, // 165: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.MetadataContextEntry.value:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext
-	145, // 166: agentgateway.dev.resource.BackendPolicySpec.Ai.prompt_guard:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard
-	147, // 167: agentgateway.dev.resource.BackendPolicySpec.Ai.defaults:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.DefaultsEntry
-	148, // 168: agentgateway.dev.resource.BackendPolicySpec.Ai.overrides:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.OverridesEntry
-	149, // 169: agentgateway.dev.resource.BackendPolicySpec.Ai.transformations:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.TransformationsEntry
-	135, // 170: agentgateway.dev.resource.BackendPolicySpec.Ai.prompts:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment
-	150, // 171: agentgateway.dev.resource.BackendPolicySpec.Ai.model_aliases:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ModelAliasesEntry
-	146, // 172: agentgateway.dev.resource.BackendPolicySpec.Ai.prompt_caching:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptCaching
-	151, // 173: agentgateway.dev.resource.BackendPolicySpec.Ai.routes:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RoutesEntry
-	78,  // 174: agentgateway.dev.resource.BackendPolicySpec.InferenceRouting.endpoint_picker:type_name -> agentgateway.dev.resource.BackendReference
-	19,  // 175: agentgateway.dev.resource.BackendPolicySpec.InferenceRouting.failure_mode:type_name -> agentgateway.dev.resource.BackendPolicySpec.InferenceRouting.FailureMode
-	20,  // 176: agentgateway.dev.resource.BackendPolicySpec.BackendTLS.verification:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTLS.VerificationMode
-	79,  // 177: agentgateway.dev.resource.BackendPolicySpec.BackendTLS.alpn:type_name -> agentgateway.dev.resource.Alpn
-	21,  // 178: agentgateway.dev.resource.BackendPolicySpec.BackendHTTP.version:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendHTTP.HttpVersion
-	166, // 179: agentgateway.dev.resource.BackendPolicySpec.BackendHTTP.request_timeout:type_name -> google.protobuf.Duration
-	68,  // 180: agentgateway.dev.resource.BackendPolicySpec.BackendTCP.keepalive:type_name -> agentgateway.dev.resource.KeepaliveConfig
-	166, // 181: agentgateway.dev.resource.BackendPolicySpec.BackendTCP.connect_timeout:type_name -> google.protobuf.Duration
-	22,  // 182: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.provider:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.McpIDP
-	152, // 183: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.resource_metadata:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata
-	23,  // 184: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.mode:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.Mode
-	70,  // 185: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.jwt_validation_options:type_name -> agentgateway.dev.resource.JWTValidationOptions
-	134, // 186: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment.append:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Message
-	134, // 187: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment.prepend:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Message
-	16,  // 188: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRule.builtin:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.BuiltinRegexRule
-	17,  // 189: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules.action:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ActionKind
-	136, // 190: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules.rules:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRule
-	78,  // 191: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.backend:type_name -> agentgateway.dev.resource.BackendReference
-	58,  // 192: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.forward_header_matches:type_name -> agentgateway.dev.resource.HeaderMatch
-	72,  // 193: agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	72,  // 194: agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	72,  // 195: agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	142, // 196: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.rejection:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestRejection
-	137, // 197: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.regex:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules
-	138, // 198: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.webhook:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook
-	141, // 199: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.google_model_armor:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor
-	140, // 200: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.bedrock_guardrails:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails
-	142, // 201: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.rejection:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestRejection
-	137, // 202: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.regex:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules
-	138, // 203: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.webhook:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook
-	139, // 204: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.openai_moderation:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation
-	141, // 205: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.google_model_armor:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor
-	140, // 206: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.bedrock_guardrails:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails
-	144, // 207: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.request:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard
-	143, // 208: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.response:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard
-	18,  // 209: agentgateway.dev.resource.BackendPolicySpec.Ai.RoutesEntry.value:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RouteType
-	153, // 210: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.extra:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntry
-	168, // 211: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntry.value:type_name -> google.protobuf.Value
-	154, // 212: agentgateway.dev.resource.AIBackend.Provider.host_override:type_name -> agentgateway.dev.resource.AIBackend.HostOverride
-	155, // 213: agentgateway.dev.resource.AIBackend.Provider.openai:type_name -> agentgateway.dev.resource.AIBackend.OpenAI
-	156, // 214: agentgateway.dev.resource.AIBackend.Provider.gemini:type_name -> agentgateway.dev.resource.AIBackend.Gemini
-	157, // 215: agentgateway.dev.resource.AIBackend.Provider.vertex:type_name -> agentgateway.dev.resource.AIBackend.Vertex
-	158, // 216: agentgateway.dev.resource.AIBackend.Provider.anthropic:type_name -> agentgateway.dev.resource.AIBackend.Anthropic
-	159, // 217: agentgateway.dev.resource.AIBackend.Provider.bedrock:type_name -> agentgateway.dev.resource.AIBackend.Bedrock
-	160, // 218: agentgateway.dev.resource.AIBackend.Provider.azureopenai:type_name -> agentgateway.dev.resource.AIBackend.AzureOpenAI
-	72,  // 219: agentgateway.dev.resource.AIBackend.Provider.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	161, // 220: agentgateway.dev.resource.AIBackend.ProviderGroup.providers:type_name -> agentgateway.dev.resource.AIBackend.Provider
-	221, // [221:221] is the sub-list for method output_type
-	221, // [221:221] is the sub-list for method input_type
-	221, // [221:221] is the sub-list for extension type_name
-	221, // [221:221] is the sub-list for extension extendee
-	0,   // [0:221] is the sub-list for field type_name
+	110, // 94: agentgateway.dev.resource.TrafficPolicySpec.ip_access_control:type_name -> agentgateway.dev.resource.TrafficPolicySpec.IpAccessControl
+	128, // 95: agentgateway.dev.resource.BackendPolicySpec.a2a:type_name -> agentgateway.dev.resource.BackendPolicySpec.A2a
+	129, // 96: agentgateway.dev.resource.BackendPolicySpec.inference_routing:type_name -> agentgateway.dev.resource.BackendPolicySpec.InferenceRouting
+	130, // 97: agentgateway.dev.resource.BackendPolicySpec.backend_tls:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTLS
+	41,  // 98: agentgateway.dev.resource.BackendPolicySpec.auth:type_name -> agentgateway.dev.resource.BackendAuthPolicy
+	133, // 99: agentgateway.dev.resource.BackendPolicySpec.mcp_authorization:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthorization
+	134, // 100: agentgateway.dev.resource.BackendPolicySpec.mcp_authentication:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication
+	127, // 101: agentgateway.dev.resource.BackendPolicySpec.ai:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai
+	61,  // 102: agentgateway.dev.resource.BackendPolicySpec.request_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
+	61,  // 103: agentgateway.dev.resource.BackendPolicySpec.response_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
+	63,  // 104: agentgateway.dev.resource.BackendPolicySpec.request_redirect:type_name -> agentgateway.dev.resource.RequestRedirect
+	62,  // 105: agentgateway.dev.resource.BackendPolicySpec.request_mirror:type_name -> agentgateway.dev.resource.RequestMirrors
+	131, // 106: agentgateway.dev.resource.BackendPolicySpec.backend_http:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendHTTP
+	132, // 107: agentgateway.dev.resource.BackendPolicySpec.backend_tcp:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTCP
+	163, // 108: agentgateway.dev.resource.AIBackend.provider_groups:type_name -> agentgateway.dev.resource.AIBackend.ProviderGroup
+	77,  // 109: agentgateway.dev.resource.MCPBackend.targets:type_name -> agentgateway.dev.resource.MCPTarget
+	24,  // 110: agentgateway.dev.resource.MCPBackend.stateful_mode:type_name -> agentgateway.dev.resource.MCPBackend.StatefulMode
+	25,  // 111: agentgateway.dev.resource.MCPBackend.prefix_mode:type_name -> agentgateway.dev.resource.MCPBackend.PrefixMode
+	78,  // 112: agentgateway.dev.resource.MCPTarget.backend:type_name -> agentgateway.dev.resource.BackendReference
+	26,  // 113: agentgateway.dev.resource.MCPTarget.protocol:type_name -> agentgateway.dev.resource.MCPTarget.Protocol
+	164, // 114: agentgateway.dev.resource.BackendReference.service:type_name -> agentgateway.dev.resource.BackendReference.Service
+	78,  // 115: agentgateway.dev.resource.RequestMirrors.Mirror.backend:type_name -> agentgateway.dev.resource.BackendReference
+	167, // 116: agentgateway.dev.resource.FrontendPolicySpec.HTTP.http1_idle_timeout:type_name -> google.protobuf.Duration
+	167, // 117: agentgateway.dev.resource.FrontendPolicySpec.HTTP.http2_keepalive_interval:type_name -> google.protobuf.Duration
+	167, // 118: agentgateway.dev.resource.FrontendPolicySpec.HTTP.http2_keepalive_timeout:type_name -> google.protobuf.Duration
+	167, // 119: agentgateway.dev.resource.FrontendPolicySpec.TLS.handshake_timeout:type_name -> google.protobuf.Duration
+	79,  // 120: agentgateway.dev.resource.FrontendPolicySpec.TLS.alpn:type_name -> agentgateway.dev.resource.Alpn
+	4,   // 121: agentgateway.dev.resource.FrontendPolicySpec.TLS.cipher_suites:type_name -> agentgateway.dev.resource.TLSConfig.CipherSuite
+	3,   // 122: agentgateway.dev.resource.FrontendPolicySpec.TLS.min_version:type_name -> agentgateway.dev.resource.TLSConfig.TLSVersion
+	3,   // 123: agentgateway.dev.resource.FrontendPolicySpec.TLS.max_version:type_name -> agentgateway.dev.resource.TLSConfig.TLSVersion
+	68,  // 124: agentgateway.dev.resource.FrontendPolicySpec.TCP.keepalives:type_name -> agentgateway.dev.resource.KeepaliveConfig
+	95,  // 125: agentgateway.dev.resource.FrontendPolicySpec.Logging.fields:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging.Fields
+	78,  // 126: agentgateway.dev.resource.FrontendPolicySpec.Tracing.provider_backend:type_name -> agentgateway.dev.resource.BackendReference
+	93,  // 127: agentgateway.dev.resource.FrontendPolicySpec.Tracing.attributes:type_name -> agentgateway.dev.resource.FrontendPolicySpec.TracingAttribute
+	93,  // 128: agentgateway.dev.resource.FrontendPolicySpec.Tracing.resources:type_name -> agentgateway.dev.resource.FrontendPolicySpec.TracingAttribute
+	5,   // 129: agentgateway.dev.resource.FrontendPolicySpec.Tracing.protocol:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Tracing.Protocol
+	94,  // 130: agentgateway.dev.resource.FrontendPolicySpec.Logging.Fields.add:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging.Field
+	111, // 131: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.descriptors:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor
+	78,  // 132: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.target:type_name -> agentgateway.dev.resource.BackendReference
+	8,   // 133: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.failure_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.FailureMode
+	167, // 134: agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit.fill_interval:type_name -> google.protobuf.Duration
+	9,   // 135: agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit.type:type_name -> agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit.Type
+	78,  // 136: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.target:type_name -> agentgateway.dev.resource.BackendReference
+	114, // 137: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.grpc:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol
+	115, // 138: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.http:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol
+	10,  // 139: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.failure_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.FailureMode
+	113, // 140: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.include_request_body:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.BodyOptions
+	70,  // 141: agentgateway.dev.resource.TrafficPolicySpec.JWTProvider.jwt_validation_options:type_name -> agentgateway.dev.resource.JWTValidationOptions
+	11,  // 142: agentgateway.dev.resource.TrafficPolicySpec.JWT.mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.JWT.Mode
+	100, // 143: agentgateway.dev.resource.TrafficPolicySpec.JWT.providers:type_name -> agentgateway.dev.resource.TrafficPolicySpec.JWTProvider
+	12,  // 144: agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication.mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication.Mode
+	120, // 145: agentgateway.dev.resource.TrafficPolicySpec.APIKey.api_keys:type_name -> agentgateway.dev.resource.TrafficPolicySpec.APIKey.User
+	13,  // 146: agentgateway.dev.resource.TrafficPolicySpec.APIKey.mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.APIKey.Mode
+	121, // 147: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.request:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform
+	121, // 148: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.response:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform
+	78,  // 149: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.target:type_name -> agentgateway.dev.resource.BackendReference
+	14,  // 150: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.failure_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.FailureMode
+	122, // 151: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.request_attributes:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.RequestAttributesEntry
+	123, // 152: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.response_attributes:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ResponseAttributesEntry
+	125, // 153: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.metadata_context:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.MetadataContextEntry
+	15,  // 154: agentgateway.dev.resource.TrafficPolicySpec.HostRewrite.mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HostRewrite.Mode
+	112, // 155: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor.entries:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Entry
+	7,   // 156: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor.type:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Type
+	116, // 157: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.context:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.ContextEntry
+	117, // 158: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.metadata:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.MetadataEntry
+	118, // 159: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.add_request_headers:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.AddRequestHeadersEntry
+	119, // 160: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.metadata:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.MetadataEntry
+	168, // 161: agentgateway.dev.resource.TrafficPolicySpec.APIKey.User.metadata:type_name -> google.protobuf.Struct
+	105, // 162: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.set:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HeaderTransformation
+	105, // 163: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.add:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HeaderTransformation
+	106, // 164: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.body:type_name -> agentgateway.dev.resource.TrafficPolicySpec.BodyTransformation
+	126, // 165: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext.context:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext.ContextEntry
+	124, // 166: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.MetadataContextEntry.value:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext
+	146, // 167: agentgateway.dev.resource.BackendPolicySpec.Ai.prompt_guard:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard
+	148, // 168: agentgateway.dev.resource.BackendPolicySpec.Ai.defaults:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.DefaultsEntry
+	149, // 169: agentgateway.dev.resource.BackendPolicySpec.Ai.overrides:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.OverridesEntry
+	150, // 170: agentgateway.dev.resource.BackendPolicySpec.Ai.transformations:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.TransformationsEntry
+	136, // 171: agentgateway.dev.resource.BackendPolicySpec.Ai.prompts:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment
+	151, // 172: agentgateway.dev.resource.BackendPolicySpec.Ai.model_aliases:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ModelAliasesEntry
+	147, // 173: agentgateway.dev.resource.BackendPolicySpec.Ai.prompt_caching:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptCaching
+	152, // 174: agentgateway.dev.resource.BackendPolicySpec.Ai.routes:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RoutesEntry
+	78,  // 175: agentgateway.dev.resource.BackendPolicySpec.InferenceRouting.endpoint_picker:type_name -> agentgateway.dev.resource.BackendReference
+	19,  // 176: agentgateway.dev.resource.BackendPolicySpec.InferenceRouting.failure_mode:type_name -> agentgateway.dev.resource.BackendPolicySpec.InferenceRouting.FailureMode
+	20,  // 177: agentgateway.dev.resource.BackendPolicySpec.BackendTLS.verification:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTLS.VerificationMode
+	79,  // 178: agentgateway.dev.resource.BackendPolicySpec.BackendTLS.alpn:type_name -> agentgateway.dev.resource.Alpn
+	21,  // 179: agentgateway.dev.resource.BackendPolicySpec.BackendHTTP.version:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendHTTP.HttpVersion
+	167, // 180: agentgateway.dev.resource.BackendPolicySpec.BackendHTTP.request_timeout:type_name -> google.protobuf.Duration
+	68,  // 181: agentgateway.dev.resource.BackendPolicySpec.BackendTCP.keepalive:type_name -> agentgateway.dev.resource.KeepaliveConfig
+	167, // 182: agentgateway.dev.resource.BackendPolicySpec.BackendTCP.connect_timeout:type_name -> google.protobuf.Duration
+	22,  // 183: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.provider:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.McpIDP
+	153, // 184: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.resource_metadata:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata
+	23,  // 185: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.mode:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.Mode
+	70,  // 186: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.jwt_validation_options:type_name -> agentgateway.dev.resource.JWTValidationOptions
+	135, // 187: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment.append:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Message
+	135, // 188: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment.prepend:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Message
+	16,  // 189: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRule.builtin:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.BuiltinRegexRule
+	17,  // 190: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules.action:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ActionKind
+	137, // 191: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules.rules:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRule
+	78,  // 192: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.backend:type_name -> agentgateway.dev.resource.BackendReference
+	58,  // 193: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.forward_header_matches:type_name -> agentgateway.dev.resource.HeaderMatch
+	72,  // 194: agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	72,  // 195: agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	72,  // 196: agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	143, // 197: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.rejection:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestRejection
+	138, // 198: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.regex:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules
+	139, // 199: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.webhook:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook
+	142, // 200: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.google_model_armor:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor
+	141, // 201: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.bedrock_guardrails:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails
+	143, // 202: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.rejection:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestRejection
+	138, // 203: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.regex:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules
+	139, // 204: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.webhook:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook
+	140, // 205: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.openai_moderation:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation
+	142, // 206: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.google_model_armor:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor
+	141, // 207: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.bedrock_guardrails:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails
+	145, // 208: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.request:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard
+	144, // 209: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.response:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard
+	18,  // 210: agentgateway.dev.resource.BackendPolicySpec.Ai.RoutesEntry.value:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RouteType
+	154, // 211: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.extra:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntry
+	169, // 212: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntry.value:type_name -> google.protobuf.Value
+	155, // 213: agentgateway.dev.resource.AIBackend.Provider.host_override:type_name -> agentgateway.dev.resource.AIBackend.HostOverride
+	156, // 214: agentgateway.dev.resource.AIBackend.Provider.openai:type_name -> agentgateway.dev.resource.AIBackend.OpenAI
+	157, // 215: agentgateway.dev.resource.AIBackend.Provider.gemini:type_name -> agentgateway.dev.resource.AIBackend.Gemini
+	158, // 216: agentgateway.dev.resource.AIBackend.Provider.vertex:type_name -> agentgateway.dev.resource.AIBackend.Vertex
+	159, // 217: agentgateway.dev.resource.AIBackend.Provider.anthropic:type_name -> agentgateway.dev.resource.AIBackend.Anthropic
+	160, // 218: agentgateway.dev.resource.AIBackend.Provider.bedrock:type_name -> agentgateway.dev.resource.AIBackend.Bedrock
+	161, // 219: agentgateway.dev.resource.AIBackend.Provider.azureopenai:type_name -> agentgateway.dev.resource.AIBackend.AzureOpenAI
+	72,  // 220: agentgateway.dev.resource.AIBackend.Provider.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	162, // 221: agentgateway.dev.resource.AIBackend.ProviderGroup.providers:type_name -> agentgateway.dev.resource.AIBackend.Provider
+	222, // [222:222] is the sub-list for method output_type
+	222, // [222:222] is the sub-list for method input_type
+	222, // [222:222] is the sub-list for extension type_name
+	222, // [222:222] is the sub-list for extension extendee
+	0,   // [0:222] is the sub-list for field type_name
 }
 
 func init() { file_resource_proto_init() }
@@ -11724,6 +11844,7 @@ func file_resource_proto_init() {
 		(*TrafficPolicySpec_BasicAuth)(nil),
 		(*TrafficPolicySpec_ApiKeyAuth)(nil),
 		(*TrafficPolicySpec_HostRewrite_)(nil),
+		(*TrafficPolicySpec_IpAccessControl_)(nil),
 	}
 	file_resource_proto_msgTypes[45].OneofWrappers = []any{
 		(*BackendPolicySpec_A2A_)(nil),
@@ -11766,35 +11887,36 @@ func file_resource_proto_init() {
 		(*TrafficPolicySpec_JWTProvider_Inline)(nil),
 	}
 	file_resource_proto_msgTypes[75].OneofWrappers = []any{}
-	file_resource_proto_msgTypes[87].OneofWrappers = []any{}
-	file_resource_proto_msgTypes[102].OneofWrappers = []any{}
-	file_resource_proto_msgTypes[109].OneofWrappers = []any{
+	file_resource_proto_msgTypes[83].OneofWrappers = []any{}
+	file_resource_proto_msgTypes[88].OneofWrappers = []any{}
+	file_resource_proto_msgTypes[103].OneofWrappers = []any{}
+	file_resource_proto_msgTypes[110].OneofWrappers = []any{
 		(*BackendPolicySpec_Ai_RegexRule_Builtin)(nil),
 		(*BackendPolicySpec_Ai_RegexRule_Regex)(nil),
 	}
-	file_resource_proto_msgTypes[112].OneofWrappers = []any{}
-	file_resource_proto_msgTypes[114].OneofWrappers = []any{}
-	file_resource_proto_msgTypes[116].OneofWrappers = []any{
+	file_resource_proto_msgTypes[113].OneofWrappers = []any{}
+	file_resource_proto_msgTypes[115].OneofWrappers = []any{}
+	file_resource_proto_msgTypes[117].OneofWrappers = []any{
 		(*BackendPolicySpec_Ai_ResponseGuard_Regex)(nil),
 		(*BackendPolicySpec_Ai_ResponseGuard_Webhook)(nil),
 		(*BackendPolicySpec_Ai_ResponseGuard_GoogleModelArmor)(nil),
 		(*BackendPolicySpec_Ai_ResponseGuard_BedrockGuardrails)(nil),
 	}
-	file_resource_proto_msgTypes[117].OneofWrappers = []any{
+	file_resource_proto_msgTypes[118].OneofWrappers = []any{
 		(*BackendPolicySpec_Ai_RequestGuard_Regex)(nil),
 		(*BackendPolicySpec_Ai_RequestGuard_Webhook)(nil),
 		(*BackendPolicySpec_Ai_RequestGuard_OpenaiModeration)(nil),
 		(*BackendPolicySpec_Ai_RequestGuard_GoogleModelArmor)(nil),
 		(*BackendPolicySpec_Ai_RequestGuard_BedrockGuardrails)(nil),
 	}
-	file_resource_proto_msgTypes[119].OneofWrappers = []any{}
-	file_resource_proto_msgTypes[128].OneofWrappers = []any{}
+	file_resource_proto_msgTypes[120].OneofWrappers = []any{}
 	file_resource_proto_msgTypes[129].OneofWrappers = []any{}
 	file_resource_proto_msgTypes[130].OneofWrappers = []any{}
 	file_resource_proto_msgTypes[131].OneofWrappers = []any{}
 	file_resource_proto_msgTypes[132].OneofWrappers = []any{}
 	file_resource_proto_msgTypes[133].OneofWrappers = []any{}
-	file_resource_proto_msgTypes[134].OneofWrappers = []any{
+	file_resource_proto_msgTypes[134].OneofWrappers = []any{}
+	file_resource_proto_msgTypes[135].OneofWrappers = []any{
 		(*AIBackend_Provider_Openai)(nil),
 		(*AIBackend_Provider_Gemini)(nil),
 		(*AIBackend_Provider_Vertex)(nil),
@@ -11808,7 +11930,7 @@ func file_resource_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_resource_proto_rawDesc), len(file_resource_proto_rawDesc)),
 			NumEnums:      27,
-			NumMessages:   137,
+			NumMessages:   138,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/resource_json.gen.go
+++ b/api/resource_json.gen.go
@@ -919,6 +919,17 @@ func (this *TrafficPolicySpec_HostRewrite) UnmarshalJSON(b []byte) error {
 	return ResourceUnmarshaler.Unmarshal(bytes.NewReader(b), this)
 }
 
+// MarshalJSON is a custom marshaler for TrafficPolicySpec_IpAccessControl
+func (this *TrafficPolicySpec_IpAccessControl) MarshalJSON() ([]byte, error) {
+	str, err := ResourceMarshaler.MarshalToString(this)
+	return []byte(str), err
+}
+
+// UnmarshalJSON is a custom unmarshaler for TrafficPolicySpec_IpAccessControl
+func (this *TrafficPolicySpec_IpAccessControl) UnmarshalJSON(b []byte) error {
+	return ResourceUnmarshaler.Unmarshal(bytes.NewReader(b), this)
+}
+
 // MarshalJSON is a custom marshaler for BackendPolicySpec
 func (this *BackendPolicySpec) MarshalJSON() ([]byte, error) {
 	str, err := ResourceMarshaler.MarshalToString(this)

--- a/crates/agentgateway/proto/resource.proto
+++ b/crates/agentgateway/proto/resource.proto
@@ -761,6 +761,23 @@ message TrafficPolicySpec {
     Mode mode = 1;
   }
 
+  // IP-based access control supporting CIDR allow and deny lists.
+  message IpAccessControl {
+    // CIDR ranges that are allowed. When non-empty, only IPs matching at least
+    // one entry are permitted (after deny check).
+    repeated string allow = 1;
+    // CIDR ranges that are denied. Deny rules are evaluated before allow rules.
+    repeated string deny = 2;
+    // Number of trusted proxy hops for X-Forwarded-For client IP resolution.
+    optional uint32 xff_num_trusted_hops = 3;
+    // When true, private/loopback IPs bypass allow and deny checks.
+    bool skip_private_ips = 4;
+    // When true, every IP in the XFF chain plus the connection IP is checked.
+    bool enforce_full_chain = 5;
+    // Maximum number of IPs allowed in the X-Forwarded-For chain.
+    optional uint32 max_xff_length = 6;
+  }
+
   PolicyPhase phase = 1;
   oneof kind {
     Timeout timeout = 2;
@@ -783,6 +800,7 @@ message TrafficPolicySpec {
     BasicAuthentication basic_auth = 19;
     APIKey api_key_auth = 20;
     HostRewrite host_rewrite = 21;
+    IpAccessControl ip_access_control = 22;
   }
 }
 

--- a/crates/agentgateway/src/http/ipallowlist.rs
+++ b/crates/agentgateway/src/http/ipallowlist.rs
@@ -1,0 +1,251 @@
+use std::net::IpAddr;
+
+use ipnet::IpNet;
+use macro_rules_attribute::apply;
+use once_cell::sync::Lazy;
+use tracing::debug;
+
+use crate::cel::SourceContext;
+use crate::http::Request;
+use crate::proxy::ProxyError;
+use crate::*;
+
+#[cfg(test)]
+#[path = "ipallowlist_tests.rs"]
+mod tests;
+
+const DEFAULT_MAX_XFF_IPS: usize = 30;
+
+static PRIVATE_RANGES: Lazy<Vec<IpNet>> = Lazy::new(|| {
+	[
+		"10.0.0.0/8",
+		"172.16.0.0/12",
+		"192.168.0.0/16",
+		"127.0.0.0/8",
+		"::1/128",
+		"fc00::/7",
+		"fe80::/10",
+	]
+	.iter()
+	.map(|s| s.parse().unwrap())
+	.collect()
+});
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+	#[error("ip address {0} is not allowed")]
+	Denied(IpAddr),
+	#[error("missing source context")]
+	MissingSourceContext,
+	#[error("X-Forwarded-For chain length {actual} exceeds maximum {max}")]
+	XffTooLong { actual: usize, max: usize },
+}
+
+/// IP access control policy supporting allow and deny lists with CIDR ranges.
+///
+/// Evaluation order:
+/// 1. If the IP matches any deny entry, reject (403).
+/// 2. If an allow list is configured and the IP does not match, reject (403).
+/// 3. Otherwise, allow.
+///
+/// When `xff_num_trusted_hops` is set, the client IP is extracted from the
+/// X-Forwarded-For header (counting from the right) instead of the direct
+/// connection IP.
+#[apply(schema!)]
+#[derive(PartialEq, Eq)]
+pub struct IpAccessControl {
+	/// CIDR ranges that are allowed. When non-empty, only IPs matching at least
+	/// one entry are permitted (after deny check).
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	#[cfg_attr(feature = "schema", schemars(with = "Vec<String>"))]
+	pub allow: Vec<IpNet>,
+
+	/// CIDR ranges that are denied. Deny rules are evaluated before allow rules.
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	#[cfg_attr(feature = "schema", schemars(with = "Vec<String>"))]
+	pub deny: Vec<IpNet>,
+
+	/// Number of trusted proxy hops. When set, the client IP is taken from the
+	/// X-Forwarded-For header, counting backwards from the rightmost entry.
+	/// For example, 1 means the last entry is the client IP (one trusted proxy).
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub xff_num_trusted_hops: Option<usize>,
+
+	/// When true, private/loopback IPs (RFC 1918, RFC 4193, link-local) bypass
+	/// both allow and deny checks. Defaults to false.
+	#[serde(default, skip_serializing_if = "is_false")]
+	pub skip_private_ips: bool,
+
+	/// When true, every IP in the X-Forwarded-For chain (plus the connection IP)
+	/// is checked against allow/deny rules. A deny match on any hop rejects the
+	/// request, and every non-private hop must satisfy the allow list.
+	/// When false, only the resolved client IP is checked.
+	#[serde(default, skip_serializing_if = "is_false")]
+	pub enforce_full_chain: bool,
+
+	/// Maximum number of IPs allowed in the X-Forwarded-For chain. Requests
+	/// exceeding this limit are rejected with 403. Guards against forwarding
+	/// loops and header abuse. Defaults to 30 when unset.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub max_xff_length: Option<usize>,
+}
+
+fn is_false(v: &bool) -> bool {
+	!v
+}
+
+fn is_private(ip: &IpAddr) -> bool {
+	PRIVATE_RANGES.iter().any(|net| net.contains(ip))
+}
+
+impl IpAccessControl {
+	/// Merge multiple `IpAccessControl` policies into one. This is used when
+	/// policies are attached at different levels (e.g., gateway-wide by the
+	/// operator and listener-level by a client). The semantics are:
+	///
+	/// - **allow**: union -- an IP matching any source's allow list is permitted.
+	/// - **deny**: union -- a deny entry from any source blocks.
+	/// - **Behavioral flags** (`xff_num_trusted_hops`, `skip_private_ips`,
+	///   `enforce_full_chain`, `max_xff_length`): the first (most specific)
+	///   non-default value wins.
+	///
+	/// Policies earlier in the iterator are considered more specific (listener
+	/// before gateway).
+	pub fn merge(policies: impl IntoIterator<Item = IpAccessControl>) -> Option<Self> {
+		let mut allow = Vec::new();
+		let mut deny = Vec::new();
+		let mut xff_num_trusted_hops: Option<usize> = None;
+		let mut skip_private_ips: Option<bool> = None;
+		let mut enforce_full_chain: Option<bool> = None;
+		let mut max_xff_length: Option<usize> = None;
+		let mut count = 0;
+
+		for p in policies {
+			count += 1;
+			allow.extend(p.allow);
+			deny.extend(p.deny);
+			if xff_num_trusted_hops.is_none() && p.xff_num_trusted_hops.is_some() {
+				xff_num_trusted_hops = p.xff_num_trusted_hops;
+			}
+			if skip_private_ips.is_none() && p.skip_private_ips {
+				skip_private_ips = Some(true);
+			}
+			if enforce_full_chain.is_none() && p.enforce_full_chain {
+				enforce_full_chain = Some(true);
+			}
+			if max_xff_length.is_none() && p.max_xff_length.is_some() {
+				max_xff_length = p.max_xff_length;
+			}
+		}
+
+		if count == 0 {
+			return None;
+		}
+
+		allow.sort_by_key(|a| a.to_string());
+		allow.dedup();
+		deny.sort_by_key(|a| a.to_string());
+		deny.dedup();
+
+		Some(IpAccessControl {
+			allow,
+			deny,
+			xff_num_trusted_hops,
+			skip_private_ips: skip_private_ips.unwrap_or(false),
+			enforce_full_chain: enforce_full_chain.unwrap_or(false),
+			max_xff_length,
+		})
+	}
+
+	pub fn apply(&self, req: &Request) -> Result<(), ProxyError> {
+		let xff_parts = self.parse_xff(req);
+
+		self
+			.validate_xff_length(&xff_parts)
+			.map_err(ProxyError::IpAccessDenied)?;
+
+		if self.enforce_full_chain {
+			self.apply_full_chain(req, &xff_parts)
+		} else {
+			let ip = self.resolve_client_ip(req, &xff_parts)?;
+			self.check(ip).map_err(ProxyError::IpAccessDenied)
+		}
+	}
+
+	fn parse_xff<'a>(&self, req: &'a Request) -> Vec<&'a str> {
+		req
+			.headers()
+			.get("x-forwarded-for")
+			.and_then(|v| v.to_str().ok())
+			.map(|s| s.split(',').map(|part| part.trim()).collect())
+			.unwrap_or_default()
+	}
+
+	fn validate_xff_length(&self, xff_parts: &[&str]) -> Result<(), Error> {
+		let max = self.max_xff_length.unwrap_or(DEFAULT_MAX_XFF_IPS);
+		if xff_parts.len() > max {
+			return Err(Error::XffTooLong {
+				actual: xff_parts.len(),
+				max,
+			});
+		}
+		Ok(())
+	}
+
+	fn resolve_client_ip(&self, req: &Request, xff_parts: &[&str]) -> Result<IpAddr, ProxyError> {
+		if let Some(hops) = self.xff_num_trusted_hops
+			&& !xff_parts.is_empty()
+		{
+			let idx = xff_parts.len().saturating_sub(hops);
+			if let Some(ip_str) = xff_parts.get(idx) {
+				if let Ok(ip) = ip_str.parse::<IpAddr>() {
+					return Ok(ip);
+				}
+				debug!(
+					hop_index = idx,
+					entry = ip_str,
+					"failed to parse XFF IP entry"
+				);
+			}
+		}
+
+		req
+			.extensions()
+			.get::<SourceContext>()
+			.map(|src| src.address)
+			.ok_or(ProxyError::IpAccessDenied(Error::MissingSourceContext))
+	}
+
+	fn apply_full_chain(&self, req: &Request, xff_parts: &[&str]) -> Result<(), ProxyError> {
+		let conn_ip = req
+			.extensions()
+			.get::<SourceContext>()
+			.map(|src| src.address);
+
+		let xff_ips = xff_parts.iter().filter_map(|s| s.parse::<IpAddr>().ok());
+
+		let all_ips: Vec<IpAddr> = xff_ips.chain(conn_ip).collect();
+
+		for ip in all_ips {
+			self.check(ip).map_err(ProxyError::IpAccessDenied)?;
+		}
+
+		Ok(())
+	}
+
+	fn check(&self, ip: IpAddr) -> Result<(), Error> {
+		if self.skip_private_ips && is_private(&ip) {
+			return Ok(());
+		}
+
+		if self.deny.iter().any(|net| net.contains(&ip)) {
+			return Err(Error::Denied(ip));
+		}
+
+		if !self.allow.is_empty() && !self.allow.iter().any(|net| net.contains(&ip)) {
+			return Err(Error::Denied(ip));
+		}
+
+		Ok(())
+	}
+}

--- a/crates/agentgateway/src/http/ipallowlist_tests.rs
+++ b/crates/agentgateway/src/http/ipallowlist_tests.rs
@@ -1,0 +1,1083 @@
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+use ipnet::IpNet;
+
+use super::*;
+use crate::cel::SourceContext;
+use crate::types::agent::TrafficPolicy;
+
+fn make_request_with_ip(ip: IpAddr) -> Request {
+	let mut req = ::http::Request::builder()
+		.uri("http://example.com/")
+		.body(crate::http::Body::empty())
+		.unwrap();
+	req.extensions_mut().insert(SourceContext {
+		address: ip,
+		port: 12345,
+		tls: None,
+	});
+	req
+}
+
+fn make_request_with_ip_and_xff(ip: IpAddr, xff: &str) -> Request {
+	let mut req = make_request_with_ip(ip);
+	req.headers_mut().insert(
+		"x-forwarded-for",
+		::http::HeaderValue::from_str(xff).unwrap(),
+	);
+	req
+}
+
+fn cidr(s: &str) -> IpNet {
+	s.parse().unwrap()
+}
+
+fn default_policy() -> IpAccessControl {
+	IpAccessControl {
+		allow: vec![],
+		deny: vec![],
+		xff_num_trusted_hops: None,
+		skip_private_ips: false,
+		enforce_full_chain: false,
+		max_xff_length: None,
+	}
+}
+
+// ── Basic allow / deny ──
+
+#[test]
+fn allow_all_when_empty() {
+	let policy = default_policy();
+	let req = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)));
+	assert!(policy.apply(&req).is_ok());
+}
+
+#[test]
+fn allow_list_permits_matching_ip() {
+	let policy = IpAccessControl {
+		allow: vec![cidr("10.0.0.0/8")],
+		..default_policy()
+	};
+	let req = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(10, 1, 2, 3)));
+	assert!(policy.apply(&req).is_ok());
+}
+
+#[test]
+fn allow_list_rejects_non_matching_ip() {
+	let policy = IpAccessControl {
+		allow: vec![cidr("10.0.0.0/8")],
+		..default_policy()
+	};
+	let req = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)));
+	assert!(policy.apply(&req).is_err());
+}
+
+#[test]
+fn deny_list_rejects_matching_ip() {
+	let policy = IpAccessControl {
+		deny: vec![cidr("192.168.0.0/16")],
+		..default_policy()
+	};
+	let req = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)));
+	assert!(policy.apply(&req).is_err());
+}
+
+#[test]
+fn deny_list_allows_non_matching_ip() {
+	let policy = IpAccessControl {
+		deny: vec![cidr("192.168.0.0/16")],
+		..default_policy()
+	};
+	let req = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)));
+	assert!(policy.apply(&req).is_ok());
+}
+
+#[test]
+fn deny_takes_precedence_over_allow() {
+	let policy = IpAccessControl {
+		allow: vec![cidr("10.0.0.0/8")],
+		deny: vec![cidr("10.0.1.0/24")],
+		..default_policy()
+	};
+	let req = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(10, 0, 1, 5)));
+	assert!(policy.apply(&req).is_err());
+
+	let req = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(10, 0, 2, 5)));
+	assert!(policy.apply(&req).is_ok());
+}
+
+#[test]
+fn ipv6_support() {
+	let policy = IpAccessControl {
+		allow: vec![cidr("fd00::/8")],
+		..default_policy()
+	};
+	let req = make_request_with_ip(IpAddr::V6("fd00::1".parse().unwrap()));
+	assert!(policy.apply(&req).is_ok());
+
+	let req = make_request_with_ip(IpAddr::V6("2001:db8::1".parse().unwrap()));
+	assert!(policy.apply(&req).is_err());
+}
+
+#[test]
+fn single_ip_cidr() {
+	let policy = IpAccessControl {
+		allow: vec![cidr("10.0.0.1/32")],
+		..default_policy()
+	};
+	let req = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)));
+	assert!(policy.apply(&req).is_ok());
+
+	let req = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)));
+	assert!(policy.apply(&req).is_err());
+}
+
+// ── XFF hops ──
+
+#[test]
+fn xff_single_trusted_hop() {
+	let policy = IpAccessControl {
+		allow: vec![cidr("10.0.0.0/8")],
+		xff_num_trusted_hops: Some(1),
+		..default_policy()
+	};
+	// XFF: "10.0.0.5, 172.16.0.1"
+	// With 1 trusted hop: idx = 2 - 1 = 1, parts[1] = "172.16.0.1" not in 10/8
+	let req = make_request_with_ip_and_xff(
+		IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)),
+		"10.0.0.5, 172.16.0.1",
+	);
+	assert!(policy.apply(&req).is_err());
+}
+
+#[test]
+fn xff_two_trusted_hops() {
+	let policy = IpAccessControl {
+		allow: vec![cidr("10.0.0.0/8")],
+		xff_num_trusted_hops: Some(2),
+		..default_policy()
+	};
+	// idx = 3 - 2 = 1, parts[1] = "172.16.0.1" not in 10/8
+	let req = make_request_with_ip_and_xff(
+		IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)),
+		"10.0.0.5, 172.16.0.1, 172.16.0.2",
+	);
+	assert!(policy.apply(&req).is_err());
+
+	// idx = 3 - 2 = 1, parts[1] = "10.0.0.6" IS in 10/8
+	let req = make_request_with_ip_and_xff(
+		IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)),
+		"10.0.0.5, 10.0.0.6, 172.16.0.2",
+	);
+	assert!(policy.apply(&req).is_ok());
+}
+
+#[test]
+fn xff_falls_back_to_connection_ip_when_no_header() {
+	let policy = IpAccessControl {
+		allow: vec![cidr("10.0.0.0/8")],
+		xff_num_trusted_hops: Some(1),
+		..default_policy()
+	};
+	let req = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)));
+	assert!(policy.apply(&req).is_ok());
+}
+
+#[test]
+fn xff_disabled_ignores_header() {
+	let policy = IpAccessControl {
+		allow: vec![cidr("10.0.0.0/8")],
+		..default_policy()
+	};
+	let req = make_request_with_ip_and_xff(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), "192.168.1.1");
+	assert!(policy.apply(&req).is_ok());
+}
+
+#[test]
+fn multiple_allow_ranges() {
+	let policy = IpAccessControl {
+		allow: vec![cidr("10.0.0.0/8"), cidr("172.16.0.0/12")],
+		..default_policy()
+	};
+	let req = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(10, 1, 2, 3)));
+	assert!(policy.apply(&req).is_ok());
+
+	let req = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(172, 20, 0, 1)));
+	assert!(policy.apply(&req).is_ok());
+
+	let req = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)));
+	assert!(policy.apply(&req).is_err());
+}
+
+#[test]
+fn check_method_directly() {
+	let policy = IpAccessControl {
+		allow: vec![cidr("10.0.0.0/8")],
+		deny: vec![cidr("10.0.1.0/24")],
+		..default_policy()
+	};
+
+	assert!(policy.check(IpAddr::V4(Ipv4Addr::new(10, 0, 2, 1))).is_ok());
+	assert!(
+		policy
+			.check(IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1)))
+			.is_err()
+	);
+	assert!(
+		policy
+			.check(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)))
+			.is_err()
+	);
+}
+
+// ── Private IP bypass ──
+
+#[test]
+fn skip_private_ips_bypasses_allow_list() {
+	let policy = IpAccessControl {
+		allow: vec![cidr("203.0.113.0/24")],
+		skip_private_ips: true,
+		..default_policy()
+	};
+	// 10.0.0.1 is private -> should bypass the allowlist and pass
+	let req = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)));
+	assert!(policy.apply(&req).is_ok());
+
+	// 203.0.113.5 is in the allowlist -> passes
+	let req = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 5)));
+	assert!(policy.apply(&req).is_ok());
+
+	// 8.8.8.8 is public and not in the allowlist -> rejected
+	let req = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)));
+	assert!(policy.apply(&req).is_err());
+}
+
+#[test]
+fn skip_private_ips_bypasses_deny_list() {
+	let policy = IpAccessControl {
+		deny: vec![cidr("10.0.0.0/8")],
+		skip_private_ips: true,
+		..default_policy()
+	};
+	// 10.0.0.1 matches deny but is private -> bypassed
+	let req = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)));
+	assert!(policy.apply(&req).is_ok());
+
+	// 192.168.1.1 is private -> bypassed even though not in any list
+	let req = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)));
+	assert!(policy.apply(&req).is_ok());
+}
+
+#[test]
+fn skip_private_ips_still_denies_public_ips() {
+	let policy = IpAccessControl {
+		deny: vec![cidr("8.8.8.0/24")],
+		skip_private_ips: true,
+		..default_policy()
+	};
+	// 8.8.8.8 is public and in deny -> rejected
+	let req = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)));
+	assert!(policy.apply(&req).is_err());
+
+	// 1.1.1.1 is public and not in deny -> allowed
+	let req = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1)));
+	assert!(policy.apply(&req).is_ok());
+}
+
+#[test]
+fn skip_private_ips_loopback_v4() {
+	let policy = IpAccessControl {
+		allow: vec![cidr("203.0.113.0/24")],
+		skip_private_ips: true,
+		..default_policy()
+	};
+	// 127.0.0.1 is loopback -> bypassed
+	let req = make_request_with_ip(IpAddr::V4(Ipv4Addr::LOCALHOST));
+	assert!(policy.apply(&req).is_ok());
+}
+
+#[test]
+fn skip_private_ips_loopback_v6() {
+	let policy = IpAccessControl {
+		allow: vec![cidr("2001:db8::/32")],
+		skip_private_ips: true,
+		..default_policy()
+	};
+	// ::1 is IPv6 loopback -> bypassed
+	let req = make_request_with_ip(IpAddr::V6(Ipv6Addr::LOCALHOST));
+	assert!(policy.apply(&req).is_ok());
+}
+
+#[test]
+fn skip_private_ips_ula_v6() {
+	let policy = IpAccessControl {
+		allow: vec![cidr("2001:db8::/32")],
+		skip_private_ips: true,
+		..default_policy()
+	};
+	// fc00::1 is ULA (private IPv6) -> bypassed
+	let req = make_request_with_ip(IpAddr::V6("fc00::1".parse().unwrap()));
+	assert!(policy.apply(&req).is_ok());
+}
+
+#[test]
+fn skip_private_ips_link_local_v6() {
+	let policy = IpAccessControl {
+		allow: vec![cidr("2001:db8::/32")],
+		skip_private_ips: true,
+		..default_policy()
+	};
+	// fe80::1 is link-local -> bypassed
+	let req = make_request_with_ip(IpAddr::V6("fe80::1".parse().unwrap()));
+	assert!(policy.apply(&req).is_ok());
+}
+
+#[test]
+fn skip_private_ips_disabled_does_not_bypass() {
+	let policy = IpAccessControl {
+		allow: vec![cidr("203.0.113.0/24")],
+		skip_private_ips: false,
+		..default_policy()
+	};
+	// 10.0.0.1 is private but bypass is disabled -> rejected by allowlist
+	let req = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)));
+	assert!(policy.apply(&req).is_err());
+}
+
+// ── XFF length limit ──
+
+#[test]
+fn xff_length_limit_rejects_oversized_chain() {
+	let policy = IpAccessControl {
+		max_xff_length: Some(3),
+		..default_policy()
+	};
+	let req = make_request_with_ip_and_xff(
+		IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)),
+		"10.0.0.1, 10.0.0.2, 10.0.0.3, 10.0.0.4",
+	);
+	assert!(policy.apply(&req).is_err());
+}
+
+#[test]
+fn xff_length_limit_allows_within_limit() {
+	let policy = IpAccessControl {
+		max_xff_length: Some(3),
+		..default_policy()
+	};
+	let req = make_request_with_ip_and_xff(
+		IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)),
+		"10.0.0.1, 10.0.0.2, 10.0.0.3",
+	);
+	assert!(policy.apply(&req).is_ok());
+}
+
+#[test]
+fn xff_length_limit_allows_exact_boundary() {
+	let policy = IpAccessControl {
+		max_xff_length: Some(2),
+		..default_policy()
+	};
+	// Exactly 2 entries -> allowed
+	let req =
+		make_request_with_ip_and_xff(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), "10.0.0.1, 10.0.0.2");
+	assert!(policy.apply(&req).is_ok());
+
+	// 3 entries -> rejected
+	let req = make_request_with_ip_and_xff(
+		IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)),
+		"10.0.0.1, 10.0.0.2, 10.0.0.3",
+	);
+	assert!(policy.apply(&req).is_err());
+}
+
+#[test]
+fn xff_length_default_limit_allows_30() {
+	let policy = default_policy();
+	let ips: Vec<String> = (1..=30).map(|i| format!("10.0.0.{i}")).collect();
+	let xff = ips.join(", ");
+	let req = make_request_with_ip_and_xff(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), &xff);
+	assert!(policy.apply(&req).is_ok());
+}
+
+#[test]
+fn xff_length_default_limit_rejects_31() {
+	let policy = default_policy();
+	let ips: Vec<String> = (1..=31).map(|i| format!("10.0.{}", i % 256)).collect();
+	let xff = ips.join(", ");
+	let req = make_request_with_ip_and_xff(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), &xff);
+	assert!(policy.apply(&req).is_err());
+}
+
+#[test]
+fn xff_length_no_xff_header_always_passes() {
+	let policy = IpAccessControl {
+		max_xff_length: Some(1),
+		..default_policy()
+	};
+	let req = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)));
+	assert!(policy.apply(&req).is_ok());
+}
+
+// ── Enforce full chain ──
+
+#[test]
+fn full_chain_rejects_if_any_hop_denied() {
+	let policy = IpAccessControl {
+		deny: vec![cidr("172.16.0.0/12")],
+		enforce_full_chain: true,
+		..default_policy()
+	};
+	// Connection IP is fine, but one XFF hop matches deny
+	let req = make_request_with_ip_and_xff(
+		IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+		"10.0.0.2, 172.16.0.5, 10.0.0.3",
+	);
+	assert!(policy.apply(&req).is_err());
+}
+
+#[test]
+fn full_chain_allows_when_all_hops_clean() {
+	let policy = IpAccessControl {
+		deny: vec![cidr("172.16.0.0/12")],
+		enforce_full_chain: true,
+		..default_policy()
+	};
+	let req =
+		make_request_with_ip_and_xff(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), "10.0.0.2, 10.0.0.3");
+	assert!(policy.apply(&req).is_ok());
+}
+
+#[test]
+fn full_chain_rejects_connection_ip_too() {
+	let policy = IpAccessControl {
+		deny: vec![cidr("192.168.0.0/16")],
+		enforce_full_chain: true,
+		..default_policy()
+	};
+	// All XFF hops are fine but the connection IP itself is denied
+	let req = make_request_with_ip_and_xff(
+		IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)),
+		"10.0.0.1, 10.0.0.2",
+	);
+	assert!(policy.apply(&req).is_err());
+}
+
+#[test]
+fn full_chain_allowlist_every_hop_must_pass() {
+	let policy = IpAccessControl {
+		allow: vec![cidr("10.0.0.0/8")],
+		enforce_full_chain: true,
+		..default_policy()
+	};
+	// One XFF hop outside the allowlist
+	let req = make_request_with_ip_and_xff(
+		IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+		"10.0.0.2, 8.8.8.8, 10.0.0.3",
+	);
+	assert!(policy.apply(&req).is_err());
+
+	// All hops within the allowlist
+	let req = make_request_with_ip_and_xff(
+		IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+		"10.0.0.2, 10.0.0.3, 10.0.0.4",
+	);
+	assert!(policy.apply(&req).is_ok());
+}
+
+#[test]
+fn full_chain_with_private_bypass() {
+	let policy = IpAccessControl {
+		allow: vec![cidr("203.0.113.0/24")],
+		enforce_full_chain: true,
+		skip_private_ips: true,
+		..default_policy()
+	};
+	// XFF contains private 10.x and allowed 203.0.113.x, connection is private 192.168.x
+	let req = make_request_with_ip_and_xff(
+		IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)),
+		"10.0.0.1, 203.0.113.5",
+	);
+	assert!(policy.apply(&req).is_ok());
+
+	// Public IP not in allow list -> rejected
+	let req = make_request_with_ip_and_xff(
+		IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)),
+		"10.0.0.1, 8.8.8.8",
+	);
+	assert!(policy.apply(&req).is_err());
+}
+
+#[test]
+fn full_chain_skips_unparseable_xff_entries() {
+	let policy = IpAccessControl {
+		deny: vec![cidr("172.16.0.0/12")],
+		enforce_full_chain: true,
+		..default_policy()
+	};
+	// "garbage" entry is silently skipped; remaining IPs are clean
+	let req = make_request_with_ip_and_xff(
+		IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+		"10.0.0.2, garbage, 10.0.0.3",
+	);
+	assert!(policy.apply(&req).is_ok());
+}
+
+#[test]
+fn full_chain_no_xff_header_checks_connection_only() {
+	let policy = IpAccessControl {
+		allow: vec![cidr("10.0.0.0/8")],
+		enforce_full_chain: true,
+		..default_policy()
+	};
+	let req = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)));
+	assert!(policy.apply(&req).is_ok());
+
+	let req = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)));
+	assert!(policy.apply(&req).is_err());
+}
+
+// ── Combined features ──
+
+#[test]
+fn xff_limit_checked_before_full_chain() {
+	let policy = IpAccessControl {
+		max_xff_length: Some(2),
+		enforce_full_chain: true,
+		..default_policy()
+	};
+	// 3 XFF entries exceed limit=2 -> rejected even though IPs are all fine
+	let req = make_request_with_ip_and_xff(
+		IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+		"10.0.0.2, 10.0.0.3, 10.0.0.4",
+	);
+	assert!(policy.apply(&req).is_err());
+}
+
+// ── Edge cases ──
+
+#[test]
+fn missing_source_context_returns_error() {
+	let policy = IpAccessControl {
+		allow: vec![cidr("10.0.0.0/8")],
+		..default_policy()
+	};
+	let req = ::http::Request::builder()
+		.uri("http://example.com/")
+		.body(crate::http::Body::empty())
+		.unwrap();
+	// No SourceContext inserted -> should error
+	assert!(policy.apply(&req).is_err());
+}
+
+#[test]
+fn missing_source_context_full_chain_still_checks_xff() {
+	let policy = IpAccessControl {
+		allow: vec![cidr("10.0.0.0/8")],
+		enforce_full_chain: true,
+		..default_policy()
+	};
+	let mut req = ::http::Request::builder()
+		.uri("http://example.com/")
+		.body(crate::http::Body::empty())
+		.unwrap();
+	// No SourceContext, but XFF has allowed IPs
+	req.headers_mut().insert(
+		"x-forwarded-for",
+		::http::HeaderValue::from_static("10.0.0.1, 10.0.0.2"),
+	);
+	// No conn_ip in chain -> only XFF IPs checked, all allowed -> ok
+	assert!(policy.apply(&req).is_ok());
+}
+
+#[test]
+fn xff_hops_exceeds_chain_length_uses_first_entry() {
+	let policy = IpAccessControl {
+		allow: vec![cidr("10.0.0.0/8")],
+		xff_num_trusted_hops: Some(10),
+		..default_policy()
+	};
+	// Only 2 entries, hops=10 -> saturating_sub gives idx=0 -> uses first entry
+	let req = make_request_with_ip_and_xff(
+		IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)),
+		"10.0.0.5, 172.16.0.1",
+	);
+	// idx=0, parts[0]="10.0.0.5" which IS in 10/8 -> allowed
+	assert!(policy.apply(&req).is_ok());
+}
+
+#[test]
+fn xff_unparseable_entry_falls_back_to_connection_ip() {
+	let policy = IpAccessControl {
+		allow: vec![cidr("10.0.0.0/8")],
+		xff_num_trusted_hops: Some(1),
+		..default_policy()
+	};
+	// XFF has one entry but it's garbage -> falls back to connection IP
+	let req = make_request_with_ip_and_xff(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), "not-an-ip");
+	// Connection IP is 10.0.0.1 which is in allow -> ok
+	assert!(policy.apply(&req).is_ok());
+}
+
+#[test]
+fn ipv6_deny() {
+	let policy = IpAccessControl {
+		deny: vec![cidr("2001:db8::/32")],
+		..default_policy()
+	};
+	let req = make_request_with_ip(IpAddr::V6("2001:db8::1".parse().unwrap()));
+	assert!(policy.apply(&req).is_err());
+
+	let req = make_request_with_ip(IpAddr::V6("fd00::1".parse().unwrap()));
+	assert!(policy.apply(&req).is_ok());
+}
+
+#[test]
+fn ipv6_single_host_cidr() {
+	let policy = IpAccessControl {
+		allow: vec![cidr("2001:db8::1/128")],
+		..default_policy()
+	};
+	let req = make_request_with_ip(IpAddr::V6("2001:db8::1".parse().unwrap()));
+	assert!(policy.apply(&req).is_ok());
+
+	let req = make_request_with_ip(IpAddr::V6("2001:db8::2".parse().unwrap()));
+	assert!(policy.apply(&req).is_err());
+}
+
+#[test]
+fn multiple_deny_ranges() {
+	let policy = IpAccessControl {
+		deny: vec![
+			cidr("192.168.0.0/16"),
+			cidr("172.16.0.0/12"),
+			cidr("10.0.1.0/24"),
+		],
+		..default_policy()
+	};
+	let req = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)));
+	assert!(policy.apply(&req).is_err());
+
+	let req = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(172, 20, 0, 1)));
+	assert!(policy.apply(&req).is_err());
+
+	let req = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(10, 0, 1, 5)));
+	assert!(policy.apply(&req).is_err());
+
+	// Not in any deny range -> allowed
+	let req = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)));
+	assert!(policy.apply(&req).is_ok());
+}
+
+#[test]
+fn xff_whitespace_handling() {
+	let policy = IpAccessControl {
+		allow: vec![cidr("10.0.0.0/8")],
+		xff_num_trusted_hops: Some(1),
+		..default_policy()
+	};
+	// Extra whitespace around the IP entries
+	let req = make_request_with_ip_and_xff(
+		IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)),
+		"  10.0.0.5  ,  10.0.0.6  ",
+	);
+	// idx = 2 - 1 = 1, parts[1] = "10.0.0.6" (trimmed) which IS in 10/8
+	assert!(policy.apply(&req).is_ok());
+}
+
+#[test]
+fn xff_limit_rejects_before_single_ip_check() {
+	let policy = IpAccessControl {
+		allow: vec![cidr("10.0.0.0/8")],
+		max_xff_length: Some(1),
+		xff_num_trusted_hops: Some(1),
+		..default_policy()
+	};
+	// 2 XFF entries > limit of 1 -> rejected before any IP check
+	let req =
+		make_request_with_ip_and_xff(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), "10.0.0.2, 10.0.0.3");
+	assert!(policy.apply(&req).is_err());
+}
+
+// ── Merge ──
+
+#[test]
+fn merge_empty_returns_none() {
+	assert!(IpAccessControl::merge(vec![]).is_none());
+}
+
+#[test]
+fn merge_single_policy_is_identity() {
+	let p = IpAccessControl {
+		allow: vec![cidr("10.0.0.0/8")],
+		deny: vec![cidr("192.168.0.0/16")],
+		xff_num_trusted_hops: Some(2),
+		skip_private_ips: true,
+		enforce_full_chain: true,
+		max_xff_length: Some(10),
+	};
+	let merged = IpAccessControl::merge(vec![p.clone()]).unwrap();
+	assert_eq!(merged.allow, vec![cidr("10.0.0.0/8")]);
+	assert_eq!(merged.deny, vec![cidr("192.168.0.0/16")]);
+	assert_eq!(merged.xff_num_trusted_hops, Some(2));
+	assert!(merged.skip_private_ips);
+	assert!(merged.enforce_full_chain);
+	assert_eq!(merged.max_xff_length, Some(10));
+}
+
+#[test]
+fn merge_unions_allow_lists() {
+	let operator = IpAccessControl {
+		allow: vec![cidr("10.0.0.0/8")],
+		..default_policy()
+	};
+	let client = IpAccessControl {
+		allow: vec![cidr("172.16.0.0/12")],
+		..default_policy()
+	};
+	let merged = IpAccessControl::merge(vec![operator, client]).unwrap();
+	assert_eq!(
+		merged.allow,
+		vec![cidr("10.0.0.0/8"), cidr("172.16.0.0/12")]
+	);
+}
+
+#[test]
+fn merge_unions_deny_lists() {
+	let operator = IpAccessControl {
+		deny: vec![cidr("192.168.0.0/16")],
+		..default_policy()
+	};
+	let client = IpAccessControl {
+		deny: vec![cidr("10.0.1.0/24")],
+		..default_policy()
+	};
+	let merged = IpAccessControl::merge(vec![operator, client]).unwrap();
+	assert_eq!(merged.deny.len(), 2);
+	assert!(merged.deny.contains(&cidr("192.168.0.0/16")));
+	assert!(merged.deny.contains(&cidr("10.0.1.0/24")));
+}
+
+#[test]
+fn merge_unions_both_allow_and_deny() {
+	let operator = IpAccessControl {
+		allow: vec![cidr("10.0.0.0/8")],
+		deny: vec![cidr("10.0.1.0/24")],
+		..default_policy()
+	};
+	let client = IpAccessControl {
+		allow: vec![cidr("203.0.113.0/24")],
+		deny: vec![cidr("10.0.2.0/24")],
+		..default_policy()
+	};
+	let merged = IpAccessControl::merge(vec![operator, client]).unwrap();
+
+	// IP in operator's allow range but not in operator's deny -> allowed
+	let req = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)));
+	assert!(merged.apply(&req).is_ok());
+
+	// IP in client's allow range -> allowed
+	let req = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 5)));
+	assert!(merged.apply(&req).is_ok());
+
+	// IP in operator's deny range -> denied even though in operator's allow range
+	let req = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(10, 0, 1, 5)));
+	assert!(merged.apply(&req).is_err());
+
+	// IP in client's deny range -> denied
+	let req = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(10, 0, 2, 5)));
+	assert!(merged.apply(&req).is_err());
+
+	// IP not in any allow range -> denied
+	let req = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)));
+	assert!(merged.apply(&req).is_err());
+}
+
+#[test]
+fn merge_first_policy_flags_win() {
+	// Listener-level (more specific, comes first) sets flags
+	let listener = IpAccessControl {
+		xff_num_trusted_hops: Some(3),
+		skip_private_ips: true,
+		enforce_full_chain: true,
+		max_xff_length: Some(5),
+		..default_policy()
+	};
+	// Gateway-level (less specific, comes second) also sets flags
+	let gateway = IpAccessControl {
+		xff_num_trusted_hops: Some(1),
+		skip_private_ips: false,
+		enforce_full_chain: false,
+		max_xff_length: Some(50),
+		..default_policy()
+	};
+	let merged = IpAccessControl::merge(vec![listener, gateway]).unwrap();
+	assert_eq!(
+		merged.xff_num_trusted_hops,
+		Some(3),
+		"listener's value wins"
+	);
+	assert!(merged.skip_private_ips, "listener's true wins");
+	assert!(merged.enforce_full_chain, "listener's true wins");
+	assert_eq!(merged.max_xff_length, Some(5), "listener's value wins");
+}
+
+#[test]
+fn merge_falls_back_to_second_policy_flags_when_first_is_default() {
+	let listener = default_policy(); // all flags are default
+	let gateway = IpAccessControl {
+		xff_num_trusted_hops: Some(2),
+		skip_private_ips: true,
+		enforce_full_chain: true,
+		max_xff_length: Some(20),
+		..default_policy()
+	};
+	let merged = IpAccessControl::merge(vec![listener, gateway]).unwrap();
+	assert_eq!(merged.xff_num_trusted_hops, Some(2), "gateway's value used");
+	assert!(merged.skip_private_ips, "gateway's true used");
+	assert!(merged.enforce_full_chain, "gateway's true used");
+	assert_eq!(merged.max_xff_length, Some(20), "gateway's value used");
+}
+
+#[test]
+fn merge_deduplicates_identical_ranges() {
+	let a = IpAccessControl {
+		allow: vec![cidr("10.0.0.0/8"), cidr("172.16.0.0/12")],
+		deny: vec![cidr("192.168.0.0/16")],
+		..default_policy()
+	};
+	let b = IpAccessControl {
+		allow: vec![cidr("10.0.0.0/8")],
+		deny: vec![cidr("192.168.0.0/16"), cidr("10.0.1.0/24")],
+		..default_policy()
+	};
+	let merged = IpAccessControl::merge(vec![a, b]).unwrap();
+	assert_eq!(merged.allow.len(), 2, "duplicates removed from allow");
+	assert!(merged.allow.contains(&cidr("10.0.0.0/8")));
+	assert!(merged.allow.contains(&cidr("172.16.0.0/12")));
+	assert_eq!(merged.deny.len(), 2, "duplicates removed from deny");
+	assert!(merged.deny.contains(&cidr("192.168.0.0/16")));
+	assert!(merged.deny.contains(&cidr("10.0.1.0/24")));
+}
+
+#[test]
+fn merge_operator_deny_client_allow_interaction() {
+	// Operator denies a subnet; client allows a broader range
+	let operator = IpAccessControl {
+		deny: vec![cidr("10.0.1.0/24")],
+		..default_policy()
+	};
+	let client = IpAccessControl {
+		allow: vec![cidr("10.0.0.0/8")],
+		..default_policy()
+	};
+	let merged = IpAccessControl::merge(vec![operator, client]).unwrap();
+
+	// 10.0.2.1 is in client's allow and not in operator's deny -> allowed
+	let req = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(10, 0, 2, 1)));
+	assert!(merged.apply(&req).is_ok());
+
+	// 10.0.1.5 is in client's allow BUT in operator's deny -> denied
+	let req = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(10, 0, 1, 5)));
+	assert!(merged.apply(&req).is_err());
+
+	// 8.8.8.8 is not in client's allow -> denied
+	let req = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)));
+	assert!(merged.apply(&req).is_err());
+}
+
+#[test]
+fn merge_three_sources() {
+	let infra = IpAccessControl {
+		deny: vec![cidr("198.51.100.0/24")],
+		skip_private_ips: true,
+		..default_policy()
+	};
+	let operator = IpAccessControl {
+		allow: vec![cidr("203.0.113.0/24")],
+		deny: vec![cidr("203.0.113.128/25")],
+		..default_policy()
+	};
+	let client = IpAccessControl {
+		allow: vec![cidr("100.64.0.0/10")],
+		..default_policy()
+	};
+	let merged = IpAccessControl::merge(vec![infra, operator, client]).unwrap();
+
+	assert!(merged.skip_private_ips, "infra's true wins");
+
+	// 203.0.113.5 in operator's allow, not in operator's deny -> ok
+	let req = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 5)));
+	assert!(merged.apply(&req).is_ok());
+
+	// 100.64.0.1 in client's allow -> ok
+	let req = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(100, 64, 0, 1)));
+	assert!(merged.apply(&req).is_ok());
+
+	// 203.0.113.200 in operator's deny (128/25 covers .128-.255) -> denied
+	let req = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 200)));
+	assert!(merged.apply(&req).is_err());
+
+	// 198.51.100.1 in infra's deny -> denied
+	let req = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(198, 51, 100, 1)));
+	assert!(merged.apply(&req).is_err());
+
+	// 192.168.1.1 is private and skip_private_ips is on -> ok (bypassed)
+	let req = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)));
+	assert!(merged.apply(&req).is_ok());
+
+	// 8.8.8.8 is public, not in any allow list -> denied
+	let req = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)));
+	assert!(merged.apply(&req).is_err());
+}
+
+// MARK: xDS proto conversion tests
+
+fn make_proto_ip_access_control(
+	allow: Vec<&str>,
+	deny: Vec<&str>,
+	xff_hops: Option<u32>,
+	skip_private: bool,
+	full_chain: bool,
+	max_xff: Option<u32>,
+) -> crate::types::proto::agent::TrafficPolicySpec {
+	use crate::types::proto::agent::traffic_policy_spec;
+	crate::types::proto::agent::TrafficPolicySpec {
+		phase: traffic_policy_spec::PolicyPhase::Gateway as i32,
+		kind: Some(traffic_policy_spec::Kind::IpAccessControl(
+			traffic_policy_spec::IpAccessControl {
+				allow: allow.into_iter().map(String::from).collect(),
+				deny: deny.into_iter().map(String::from).collect(),
+				xff_num_trusted_hops: xff_hops,
+				skip_private_ips: skip_private,
+				enforce_full_chain: full_chain,
+				max_xff_length: max_xff,
+			},
+		)),
+	}
+}
+
+#[test]
+fn xds_roundtrip_basic_allow_deny() {
+	let proto = make_proto_ip_access_control(
+		vec!["10.0.0.0/8", "172.16.0.0/12"],
+		vec!["10.0.1.0/24"],
+		None,
+		false,
+		false,
+		None,
+	);
+	let tp = TrafficPolicy::try_from(&proto).expect("conversion should succeed");
+	match tp {
+		TrafficPolicy::IpAccessControl(iac) => {
+			assert_eq!(iac.allow.len(), 2);
+			assert_eq!(iac.deny.len(), 1);
+			assert_eq!(iac.allow[0], "10.0.0.0/8".parse::<IpNet>().unwrap());
+			assert_eq!(iac.allow[1], "172.16.0.0/12".parse::<IpNet>().unwrap());
+			assert_eq!(iac.deny[0], "10.0.1.0/24".parse::<IpNet>().unwrap());
+			assert!(iac.xff_num_trusted_hops.is_none());
+			assert!(!iac.skip_private_ips);
+			assert!(!iac.enforce_full_chain);
+			assert!(iac.max_xff_length.is_none());
+		},
+		other => panic!("expected IpAccessControl, got {other:?}"),
+	}
+}
+
+#[test]
+fn xds_roundtrip_all_flags() {
+	let proto = make_proto_ip_access_control(
+		vec!["192.168.0.0/16"],
+		vec![],
+		Some(2),
+		true,
+		true,
+		Some(50),
+	);
+	let tp = TrafficPolicy::try_from(&proto).expect("conversion should succeed");
+	match tp {
+		TrafficPolicy::IpAccessControl(iac) => {
+			assert_eq!(iac.allow.len(), 1);
+			assert!(iac.deny.is_empty());
+			assert_eq!(iac.xff_num_trusted_hops, Some(2));
+			assert!(iac.skip_private_ips);
+			assert!(iac.enforce_full_chain);
+			assert_eq!(iac.max_xff_length, Some(50));
+		},
+		other => panic!("expected IpAccessControl, got {other:?}"),
+	}
+}
+
+#[test]
+fn xds_roundtrip_empty_lists() {
+	let proto = make_proto_ip_access_control(vec![], vec![], None, false, false, None);
+	let tp = TrafficPolicy::try_from(&proto).expect("conversion should succeed");
+	match tp {
+		TrafficPolicy::IpAccessControl(iac) => {
+			assert!(iac.allow.is_empty());
+			assert!(iac.deny.is_empty());
+		},
+		other => panic!("expected IpAccessControl, got {other:?}"),
+	}
+}
+
+#[test]
+fn xds_roundtrip_invalid_cidr_rejected() {
+	let proto = make_proto_ip_access_control(vec!["not-a-cidr"], vec![], None, false, false, None);
+	let result = TrafficPolicy::try_from(&proto);
+	assert!(
+		result.is_err(),
+		"invalid CIDR should cause conversion error"
+	);
+}
+
+#[test]
+fn xds_roundtrip_ipv6_cidrs() {
+	let proto = make_proto_ip_access_control(
+		vec!["fd00::/8", "2001:db8::/32"],
+		vec!["::1/128"],
+		Some(1),
+		false,
+		false,
+		None,
+	);
+	let tp = TrafficPolicy::try_from(&proto).expect("conversion should succeed");
+	match tp {
+		TrafficPolicy::IpAccessControl(iac) => {
+			assert_eq!(iac.allow.len(), 2);
+			assert_eq!(iac.deny.len(), 1);
+			assert_eq!(iac.xff_num_trusted_hops, Some(1));
+		},
+		other => panic!("expected IpAccessControl, got {other:?}"),
+	}
+}
+
+#[test]
+fn xds_roundtrip_functional_apply() {
+	let proto = make_proto_ip_access_control(
+		vec!["10.0.0.0/8"],
+		vec!["10.0.1.0/24"],
+		None,
+		false,
+		false,
+		None,
+	);
+	let tp = TrafficPolicy::try_from(&proto).expect("conversion should succeed");
+	let iac = match tp {
+		TrafficPolicy::IpAccessControl(iac) => iac,
+		other => panic!("expected IpAccessControl, got {other:?}"),
+	};
+
+	let ok_req = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)));
+	assert!(iac.apply(&ok_req).is_ok(), "10.0.0.1 should be allowed");
+
+	let deny_req = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(10, 0, 1, 5)));
+	assert!(iac.apply(&deny_req).is_err(), "10.0.1.5 should be denied");
+
+	let no_match_req = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)));
+	assert!(no_match_req.extensions().get::<SourceContext>().is_some());
+	assert!(
+		iac.apply(&no_match_req).is_err(),
+		"192.168.1.1 not in allow list"
+	);
+}

--- a/crates/agentgateway/src/http/ipallowlist_tests.rs
+++ b/crates/agentgateway/src/http/ipallowlist_tests.rs
@@ -1086,21 +1086,21 @@ fn xds_roundtrip_functional_apply() {
 fn xds_roundtrip_invalid_deny_cidr_rejected() {
 	let proto = make_proto_ip_access_control(vec![], vec!["bad-deny"], None, false, false, None);
 	let result = TrafficPolicy::try_from(&proto);
-	assert!(result.is_err(), "invalid deny CIDR should cause conversion error");
+	assert!(
+		result.is_err(),
+		"invalid deny CIDR should cause conversion error"
+	);
 	let err_msg = format!("{:?}", result.unwrap_err());
-	assert!(err_msg.contains("deny"), "error should mention deny: {err_msg}");
+	assert!(
+		err_msg.contains("deny"),
+		"error should mention deny: {err_msg}"
+	);
 }
 
 #[test]
 fn xds_roundtrip_deny_only_functional() {
-	let proto = make_proto_ip_access_control(
-		vec![],
-		vec!["203.0.113.0/24"],
-		None,
-		false,
-		false,
-		None,
-	);
+	let proto =
+		make_proto_ip_access_control(vec![], vec!["203.0.113.0/24"], None, false, false, None);
 	let tp = TrafficPolicy::try_from(&proto).expect("conversion should succeed");
 	let iac = match tp {
 		TrafficPolicy::IpAccessControl(iac) => iac,
@@ -1111,7 +1111,10 @@ fn xds_roundtrip_deny_only_functional() {
 	assert!(iac.apply(&denied).is_err(), "203.0.113.50 should be denied");
 
 	let allowed = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)));
-	assert!(iac.apply(&allowed).is_ok(), "8.8.8.8 should be allowed (no allow list)");
+	assert!(
+		iac.apply(&allowed).is_ok(),
+		"8.8.8.8 should be allowed (no allow list)"
+	);
 }
 
 #[test]
@@ -1172,14 +1175,7 @@ fn xds_roundtrip_mixed_ipv4_ipv6() {
 
 #[test]
 fn xds_roundtrip_xff_trusted_hops_functional() {
-	let proto = make_proto_ip_access_control(
-		vec!["10.0.0.0/8"],
-		vec![],
-		Some(1),
-		false,
-		false,
-		None,
-	);
+	let proto = make_proto_ip_access_control(vec!["10.0.0.0/8"], vec![], Some(1), false, false, None);
 	let tp = TrafficPolicy::try_from(&proto).expect("conversion should succeed");
 	let iac = match tp {
 		TrafficPolicy::IpAccessControl(iac) => iac,
@@ -1194,7 +1190,10 @@ fn xds_roundtrip_xff_trusted_hops_functional() {
 		IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)),
 		"10.0.0.5, 172.16.0.1",
 	);
-	assert!(iac.apply(&denied).is_err(), "client IP 172.16.0.1 not in 10.0.0.0/8");
+	assert!(
+		iac.apply(&denied).is_err(),
+		"client IP 172.16.0.1 not in 10.0.0.0/8"
+	);
 
 	// xff="172.16.0.1, 10.0.0.5", hops=1 -> idx = 2 - 1 = 1 -> client = 10.0.0.5
 	// 10.0.0.5 is in 10.0.0.0/8 -> allowed
@@ -1202,19 +1201,15 @@ fn xds_roundtrip_xff_trusted_hops_functional() {
 		IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)),
 		"172.16.0.1, 10.0.0.5",
 	);
-	assert!(iac.apply(&allowed).is_ok(), "client IP 10.0.0.5 is in 10.0.0.0/8");
+	assert!(
+		iac.apply(&allowed).is_ok(),
+		"client IP 10.0.0.5 is in 10.0.0.0/8"
+	);
 }
 
 #[test]
 fn xds_roundtrip_skip_private_ips_functional() {
-	let proto = make_proto_ip_access_control(
-		vec!["203.0.113.0/24"],
-		vec![],
-		None,
-		true,
-		false,
-		None,
-	);
+	let proto = make_proto_ip_access_control(vec!["203.0.113.0/24"], vec![], None, true, false, None);
 	let tp = TrafficPolicy::try_from(&proto).expect("conversion should succeed");
 	let iac = match tp {
 		TrafficPolicy::IpAccessControl(iac) => iac,
@@ -1224,13 +1219,22 @@ fn xds_roundtrip_skip_private_ips_functional() {
 	assert!(iac.skip_private_ips);
 
 	let private = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)));
-	assert!(iac.apply(&private).is_ok(), "private IP should bypass allow check");
+	assert!(
+		iac.apply(&private).is_ok(),
+		"private IP should bypass allow check"
+	);
 
 	let public_ok = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 1)));
-	assert!(iac.apply(&public_ok).is_ok(), "203.0.113.1 is in allow list");
+	assert!(
+		iac.apply(&public_ok).is_ok(),
+		"203.0.113.1 is in allow list"
+	);
 
 	let public_no = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)));
-	assert!(iac.apply(&public_no).is_err(), "8.8.8.8 not in allow list, not private");
+	assert!(
+		iac.apply(&public_no).is_err(),
+		"8.8.8.8 not in allow list, not private"
+	);
 }
 
 #[test]
@@ -1255,25 +1259,22 @@ fn xds_roundtrip_enforce_full_chain_functional() {
 		IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
 		"10.0.0.5, 10.0.1.50",
 	);
-	assert!(iac.apply(&req).is_err(), "10.0.1.50 in XFF chain hits deny list");
-
-	let ok_req = make_request_with_ip_and_xff(
-		IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
-		"10.0.0.5, 10.0.2.1",
+	assert!(
+		iac.apply(&req).is_err(),
+		"10.0.1.50 in XFF chain hits deny list"
 	);
-	assert!(iac.apply(&ok_req).is_ok(), "all IPs in 10.0.0.0/8 and none in deny");
+
+	let ok_req =
+		make_request_with_ip_and_xff(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), "10.0.0.5, 10.0.2.1");
+	assert!(
+		iac.apply(&ok_req).is_ok(),
+		"all IPs in 10.0.0.0/8 and none in deny"
+	);
 }
 
 #[test]
 fn xds_roundtrip_max_xff_length_functional() {
-	let proto = make_proto_ip_access_control(
-		vec![],
-		vec![],
-		Some(1),
-		false,
-		false,
-		Some(2),
-	);
+	let proto = make_proto_ip_access_control(vec![], vec![], Some(1), false, false, Some(2));
 	let tp = TrafficPolicy::try_from(&proto).expect("conversion should succeed");
 	let iac = match tp {
 		TrafficPolicy::IpAccessControl(iac) => iac,
@@ -1282,32 +1283,29 @@ fn xds_roundtrip_max_xff_length_functional() {
 
 	assert_eq!(iac.max_xff_length, Some(2));
 
-	let ok = make_request_with_ip_and_xff(
-		IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
-		"1.1.1.1, 2.2.2.2",
-	);
+	let ok = make_request_with_ip_and_xff(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), "1.1.1.1, 2.2.2.2");
 	assert!(iac.apply(&ok).is_ok(), "2 entries within limit of 2");
 
 	let too_long = make_request_with_ip_and_xff(
 		IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
 		"1.1.1.1, 2.2.2.2, 3.3.3.3",
 	);
-	assert!(iac.apply(&too_long).is_err(), "3 entries exceeds limit of 2");
+	assert!(
+		iac.apply(&too_long).is_err(),
+		"3 entries exceeds limit of 2"
+	);
 }
 
 #[test]
 fn xds_roundtrip_phased_traffic_policy() {
 	use crate::types::agent::{PhasedTrafficPolicy, PolicyPhase};
-	let proto = make_proto_ip_access_control(
-		vec!["10.0.0.0/8"],
-		vec![],
-		None,
-		false,
-		false,
-		None,
-	);
+	let proto = make_proto_ip_access_control(vec!["10.0.0.0/8"], vec![], None, false, false, None);
 	let phased = PhasedTrafficPolicy::try_from(&proto).expect("conversion should succeed");
-	assert_eq!(phased.phase, PolicyPhase::Gateway, "IP access control should be gateway phase");
+	assert_eq!(
+		phased.phase,
+		PolicyPhase::Gateway,
+		"IP access control should be gateway phase"
+	);
 	match phased.policy {
 		TrafficPolicy::IpAccessControl(iac) => {
 			assert_eq!(iac.allow.len(), 1);

--- a/crates/agentgateway/src/http/ipallowlist_tests.rs
+++ b/crates/agentgateway/src/http/ipallowlist_tests.rs
@@ -1081,3 +1081,237 @@ fn xds_roundtrip_functional_apply() {
 		"192.168.1.1 not in allow list"
 	);
 }
+
+#[test]
+fn xds_roundtrip_invalid_deny_cidr_rejected() {
+	let proto = make_proto_ip_access_control(vec![], vec!["bad-deny"], None, false, false, None);
+	let result = TrafficPolicy::try_from(&proto);
+	assert!(result.is_err(), "invalid deny CIDR should cause conversion error");
+	let err_msg = format!("{:?}", result.unwrap_err());
+	assert!(err_msg.contains("deny"), "error should mention deny: {err_msg}");
+}
+
+#[test]
+fn xds_roundtrip_deny_only_functional() {
+	let proto = make_proto_ip_access_control(
+		vec![],
+		vec!["203.0.113.0/24"],
+		None,
+		false,
+		false,
+		None,
+	);
+	let tp = TrafficPolicy::try_from(&proto).expect("conversion should succeed");
+	let iac = match tp {
+		TrafficPolicy::IpAccessControl(iac) => iac,
+		other => panic!("expected IpAccessControl, got {other:?}"),
+	};
+
+	let denied = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 50)));
+	assert!(iac.apply(&denied).is_err(), "203.0.113.50 should be denied");
+
+	let allowed = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)));
+	assert!(iac.apply(&allowed).is_ok(), "8.8.8.8 should be allowed (no allow list)");
+}
+
+#[test]
+fn xds_roundtrip_single_host_cidrs() {
+	let proto = make_proto_ip_access_control(
+		vec!["10.0.0.1/32", "::1/128"],
+		vec![],
+		None,
+		false,
+		false,
+		None,
+	);
+	let tp = TrafficPolicy::try_from(&proto).expect("conversion should succeed");
+	let iac = match tp {
+		TrafficPolicy::IpAccessControl(iac) => iac,
+		other => panic!("expected IpAccessControl, got {other:?}"),
+	};
+
+	assert_eq!(iac.allow.len(), 2);
+	let ok = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)));
+	assert!(iac.apply(&ok).is_ok());
+
+	let not_ok = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)));
+	assert!(iac.apply(&not_ok).is_err(), "10.0.0.2 is not 10.0.0.1/32");
+}
+
+#[test]
+fn xds_roundtrip_mixed_ipv4_ipv6() {
+	let proto = make_proto_ip_access_control(
+		vec!["10.0.0.0/8", "fd00::/8"],
+		vec!["10.0.1.0/24", "fd00:dead::/32"],
+		None,
+		false,
+		false,
+		None,
+	);
+	let tp = TrafficPolicy::try_from(&proto).expect("conversion should succeed");
+	let iac = match tp {
+		TrafficPolicy::IpAccessControl(iac) => iac,
+		other => panic!("expected IpAccessControl, got {other:?}"),
+	};
+
+	assert_eq!(iac.allow.len(), 2);
+	assert_eq!(iac.deny.len(), 2);
+
+	let v4_ok = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)));
+	assert!(iac.apply(&v4_ok).is_ok());
+
+	let v4_deny = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1)));
+	assert!(iac.apply(&v4_deny).is_err());
+
+	let v6_ok = make_request_with_ip(IpAddr::V6("fd00::1".parse().unwrap()));
+	assert!(iac.apply(&v6_ok).is_ok());
+
+	let v6_deny = make_request_with_ip(IpAddr::V6("fd00:dead::1".parse().unwrap()));
+	assert!(iac.apply(&v6_deny).is_err());
+}
+
+#[test]
+fn xds_roundtrip_xff_trusted_hops_functional() {
+	let proto = make_proto_ip_access_control(
+		vec!["10.0.0.0/8"],
+		vec![],
+		Some(1),
+		false,
+		false,
+		None,
+	);
+	let tp = TrafficPolicy::try_from(&proto).expect("conversion should succeed");
+	let iac = match tp {
+		TrafficPolicy::IpAccessControl(iac) => iac,
+		other => panic!("expected IpAccessControl, got {other:?}"),
+	};
+
+	assert_eq!(iac.xff_num_trusted_hops, Some(1));
+
+	// xff="10.0.0.5, 172.16.0.1", hops=1 -> idx = len(2) - 1 = 1 -> client = 172.16.0.1
+	// 172.16.0.1 is NOT in 10.0.0.0/8 -> denied
+	let denied = make_request_with_ip_and_xff(
+		IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)),
+		"10.0.0.5, 172.16.0.1",
+	);
+	assert!(iac.apply(&denied).is_err(), "client IP 172.16.0.1 not in 10.0.0.0/8");
+
+	// xff="172.16.0.1, 10.0.0.5", hops=1 -> idx = 2 - 1 = 1 -> client = 10.0.0.5
+	// 10.0.0.5 is in 10.0.0.0/8 -> allowed
+	let allowed = make_request_with_ip_and_xff(
+		IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)),
+		"172.16.0.1, 10.0.0.5",
+	);
+	assert!(iac.apply(&allowed).is_ok(), "client IP 10.0.0.5 is in 10.0.0.0/8");
+}
+
+#[test]
+fn xds_roundtrip_skip_private_ips_functional() {
+	let proto = make_proto_ip_access_control(
+		vec!["203.0.113.0/24"],
+		vec![],
+		None,
+		true,
+		false,
+		None,
+	);
+	let tp = TrafficPolicy::try_from(&proto).expect("conversion should succeed");
+	let iac = match tp {
+		TrafficPolicy::IpAccessControl(iac) => iac,
+		other => panic!("expected IpAccessControl, got {other:?}"),
+	};
+
+	assert!(iac.skip_private_ips);
+
+	let private = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)));
+	assert!(iac.apply(&private).is_ok(), "private IP should bypass allow check");
+
+	let public_ok = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 1)));
+	assert!(iac.apply(&public_ok).is_ok(), "203.0.113.1 is in allow list");
+
+	let public_no = make_request_with_ip(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)));
+	assert!(iac.apply(&public_no).is_err(), "8.8.8.8 not in allow list, not private");
+}
+
+#[test]
+fn xds_roundtrip_enforce_full_chain_functional() {
+	let proto = make_proto_ip_access_control(
+		vec!["10.0.0.0/8"],
+		vec!["10.0.1.0/24"],
+		Some(1),
+		false,
+		true,
+		None,
+	);
+	let tp = TrafficPolicy::try_from(&proto).expect("conversion should succeed");
+	let iac = match tp {
+		TrafficPolicy::IpAccessControl(iac) => iac,
+		other => panic!("expected IpAccessControl, got {other:?}"),
+	};
+
+	assert!(iac.enforce_full_chain);
+
+	let req = make_request_with_ip_and_xff(
+		IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+		"10.0.0.5, 10.0.1.50",
+	);
+	assert!(iac.apply(&req).is_err(), "10.0.1.50 in XFF chain hits deny list");
+
+	let ok_req = make_request_with_ip_and_xff(
+		IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+		"10.0.0.5, 10.0.2.1",
+	);
+	assert!(iac.apply(&ok_req).is_ok(), "all IPs in 10.0.0.0/8 and none in deny");
+}
+
+#[test]
+fn xds_roundtrip_max_xff_length_functional() {
+	let proto = make_proto_ip_access_control(
+		vec![],
+		vec![],
+		Some(1),
+		false,
+		false,
+		Some(2),
+	);
+	let tp = TrafficPolicy::try_from(&proto).expect("conversion should succeed");
+	let iac = match tp {
+		TrafficPolicy::IpAccessControl(iac) => iac,
+		other => panic!("expected IpAccessControl, got {other:?}"),
+	};
+
+	assert_eq!(iac.max_xff_length, Some(2));
+
+	let ok = make_request_with_ip_and_xff(
+		IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+		"1.1.1.1, 2.2.2.2",
+	);
+	assert!(iac.apply(&ok).is_ok(), "2 entries within limit of 2");
+
+	let too_long = make_request_with_ip_and_xff(
+		IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+		"1.1.1.1, 2.2.2.2, 3.3.3.3",
+	);
+	assert!(iac.apply(&too_long).is_err(), "3 entries exceeds limit of 2");
+}
+
+#[test]
+fn xds_roundtrip_phased_traffic_policy() {
+	use crate::types::agent::{PhasedTrafficPolicy, PolicyPhase};
+	let proto = make_proto_ip_access_control(
+		vec!["10.0.0.0/8"],
+		vec![],
+		None,
+		false,
+		false,
+		None,
+	);
+	let phased = PhasedTrafficPolicy::try_from(&proto).expect("conversion should succeed");
+	assert_eq!(phased.phase, PolicyPhase::Gateway, "IP access control should be gateway phase");
+	match phased.policy {
+		TrafficPolicy::IpAccessControl(iac) => {
+			assert_eq!(iac.allow.len(), 1);
+		},
+		other => panic!("expected IpAccessControl, got {other:?}"),
+	}
+}

--- a/crates/agentgateway/src/http/mod.rs
+++ b/crates/agentgateway/src/http/mod.rs
@@ -17,6 +17,7 @@ pub mod compression;
 pub mod csrf;
 pub mod ext_authz;
 pub mod ext_proc;
+pub mod ipallowlist;
 pub mod outlierdetection;
 mod peekbody;
 pub mod remoteratelimit;

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -246,6 +246,9 @@ async fn apply_gateway_policies(
 	ext_proc: Option<&mut ExtProcRequest>,
 	response_headers: &mut HeaderMap,
 ) -> Result<(), ProxyResponse> {
+	if let Some(ip) = &policies.ip_access_control {
+		ip.apply(req).map_err(ProxyResponse::from)?;
+	}
 	if let Some(j) = &policies.jwt {
 		j.apply(Some(log), req)
 			.await

--- a/crates/agentgateway/src/proxy/mod.rs
+++ b/crates/agentgateway/src/proxy/mod.rs
@@ -54,9 +54,9 @@ impl ProxyResponse {
 			ProxyError::APIKeyAuthenticationFailure(_) => ProxyResponseReason::APIKeyAuth,
 			ProxyError::ExternalAuthorizationFailed(_) => ProxyResponseReason::ExtAuth,
 			ProxyError::MCP(_) => ProxyResponseReason::MCP,
-			ProxyError::AuthorizationFailed | ProxyError::CsrfValidationFailed => {
-				ProxyResponseReason::Authorization
-			},
+			ProxyError::AuthorizationFailed
+			| ProxyError::CsrfValidationFailed
+			| ProxyError::IpAccessDenied(_) => ProxyResponseReason::Authorization,
 			ProxyError::UpstreamCallFailed(_)
 			| ProxyError::UpstreamTCPCallFailed(_)
 			| ProxyError::BackendAuthenticationFailed(_)
@@ -148,6 +148,8 @@ pub enum ProxyError {
 	APIKeyAuthenticationFailure(http::apikey::Error),
 	#[error("CSRF validation failed")]
 	CsrfValidationFailed,
+	#[error("ip access denied: {0}")]
+	IpAccessDenied(http::ipallowlist::Error),
 	#[error("service not found")]
 	ServiceNotFound,
 	#[error("invalid backend type")]
@@ -232,6 +234,7 @@ impl ProxyError {
 			ProxyError::APIKeyAuthenticationFailure(_) => StatusCode::UNAUTHORIZED,
 			ProxyError::McpJwtAuthenticationFailure(_, _) => StatusCode::UNAUTHORIZED,
 			ProxyError::AuthorizationFailed => StatusCode::FORBIDDEN,
+			ProxyError::IpAccessDenied(_) => StatusCode::FORBIDDEN,
 			ProxyError::ExternalAuthorizationFailed(status) => status.unwrap_or(StatusCode::FORBIDDEN),
 
 			ProxyError::DnsResolution => StatusCode::SERVICE_UNAVAILABLE,

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -202,6 +202,7 @@ pub struct RoutePolicies {
 
 #[derive(Debug, Default)]
 pub struct GatewayPolicies {
+	pub ip_access_control: Option<http::ipallowlist::IpAccessControl>,
 	pub ext_proc: Option<ext_proc::ExtProc>,
 	pub jwt: Option<http::jwt::Jwt>,
 	pub ext_authz: Option<ext_authz::ExtAuthz>,
@@ -467,6 +468,9 @@ impl Store {
 				TrafficPolicy::CORS(p) => {
 					pol.cors.get_or_insert_with(|| p.clone());
 				},
+				TrafficPolicy::IpAccessControl(_) => {
+					// IP access control is handled at the gateway phase
+				},
 			}
 		}
 		if !authz.is_empty() {
@@ -487,9 +491,13 @@ impl Store {
 			.filter_map(|n| self.policies_by_key.get(n))
 			.filter_map(|p| p.policy.as_traffic_gateway_phase());
 
+		let mut ip_access_controls = Vec::new();
 		let mut pol = GatewayPolicies::default();
 		for rule in rules {
 			match &rule {
+				TrafficPolicy::IpAccessControl(p) => {
+					ip_access_controls.push(p.clone());
+				},
 				TrafficPolicy::JwtAuth(p) => {
 					pol.jwt.get_or_insert_with(|| p.clone());
 				},
@@ -513,6 +521,7 @@ impl Store {
 				},
 			}
 		}
+		pol.ip_access_control = http::ipallowlist::IpAccessControl::merge(ip_access_controls);
 
 		pol
 	}

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -1866,6 +1866,7 @@ pub enum TrafficPolicy {
 	JwtAuth(crate::http::jwt::Jwt),
 	BasicAuth(crate::http::basicauth::BasicAuthentication),
 	APIKey(crate::http::apikey::APIKeyAuthentication),
+	IpAccessControl(crate::http::ipallowlist::IpAccessControl),
 	Transformation(crate::http::transformation_cel::Transformation),
 	Csrf(crate::http::csrf::Csrf),
 

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -1598,6 +1598,32 @@ impl TryFrom<&proto::agent::TrafficPolicySpec> for TrafficPolicy {
 					Mode::Auto => agent::HostRedirectOverride::Auto,
 				})
 			},
+			Some(tps::Kind::IpAccessControl(iac)) => {
+				let allow = iac
+					.allow
+					.iter()
+					.map(|s| {
+						s.parse::<ipnet::IpNet>()
+							.map_err(|e| ProtoError::Generic(format!("invalid allow CIDR '{s}': {e}")))
+					})
+					.collect::<Result<Vec<_>, _>>()?;
+				let deny = iac
+					.deny
+					.iter()
+					.map(|s| {
+						s.parse::<ipnet::IpNet>()
+							.map_err(|e| ProtoError::Generic(format!("invalid deny CIDR '{s}': {e}")))
+					})
+					.collect::<Result<Vec<_>, _>>()?;
+				TrafficPolicy::IpAccessControl(http::ipallowlist::IpAccessControl {
+					allow,
+					deny,
+					xff_num_trusted_hops: iac.xff_num_trusted_hops.map(|v| v as usize),
+					skip_private_ips: iac.skip_private_ips,
+					enforce_full_chain: iac.enforce_full_chain,
+					max_xff_length: iac.max_xff_length.map(|v| v as usize),
+				})
+			},
 			None => return Err(ProtoError::MissingRequiredField),
 		})
 	}

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -749,6 +749,9 @@ struct LocalLLMPolicy {
 #[apply(schema_de!)]
 #[derive(Default)]
 struct LocalGatewayPolicy {
+	/// Control access based on client IP address using allow/deny CIDR lists.
+	#[serde(default)]
+	ip_access_control: Option<crate::http::ipallowlist::IpAccessControl>,
 	/// Authenticate incoming JWT requests.
 	#[serde(default)]
 	jwt_auth: Option<crate::http::jwt::LocalJwtConfig>,
@@ -777,6 +780,7 @@ struct LocalGatewayPolicy {
 impl From<LocalGatewayPolicy> for FilterOrPolicy {
 	fn from(val: LocalGatewayPolicy) -> Self {
 		let LocalGatewayPolicy {
+			ip_access_control,
 			jwt_auth,
 			ext_authz,
 			ext_proc,
@@ -785,6 +789,7 @@ impl From<LocalGatewayPolicy> for FilterOrPolicy {
 			api_key,
 		} = val;
 		FilterOrPolicy {
+			ip_access_control,
 			jwt_auth,
 			ext_authz,
 			ext_proc,
@@ -978,6 +983,9 @@ struct FilterOrPolicy {
 	cors: Option<http::cors::Cors>,
 
 	// Policy
+	/// Control access based on client IP address using allow/deny CIDR lists.
+	#[serde(default)]
+	ip_access_control: Option<crate::http::ipallowlist::IpAccessControl>,
 	/// Authorization policies for MCP access.
 	#[serde(default)]
 	mcp_authorization: Option<McpAuthorization>,
@@ -1898,6 +1906,7 @@ async fn split_policies(client: Client, pol: FilterOrPolicy) -> Result<ResolvedP
 		request_mirror,
 		direct_response,
 		cors,
+		ip_access_control,
 		mcp_authorization,
 		mcp_authentication,
 		a2a,
@@ -1962,6 +1971,9 @@ async fn split_policies(client: Client, pol: FilterOrPolicy) -> Result<ResolvedP
 	}
 
 	// Route policies
+	if let Some(p) = ip_access_control {
+		route_policies.push(TrafficPolicy::IpAccessControl(p));
+	}
 	if let Some(mut p) = ai {
 		p.compile_model_alias_patterns();
 		route_policies.push(TrafficPolicy::AI(Arc::new(p)))

--- a/examples/README.md
+++ b/examples/README.md
@@ -34,3 +34,7 @@ The `http` example shows how to use agentgateway to serve generic HTTP traffic.
 ### [Prompt Enrichment](prompt-enrichment/README.md)
 
 The `prompt-enrichment` example shows how to append or preprend prompts to agentgateway AI requests.
+
+### [IP Access Control](ip-access-control/README.md)
+
+The `ip-access-control` examples show how to control access based on client IP addresses using allow/deny CIDR lists, X-Forwarded-For support, private IP bypass, full chain enforcement, and multi-source policy merge.

--- a/examples/ip-access-control/README.md
+++ b/examples/ip-access-control/README.md
@@ -1,0 +1,151 @@
+## IP Access Control Examples
+
+This directory contains examples for the `ipAccessControl` policy, which controls access to agentgateway based on client IP addresses using CIDR allow and deny lists.
+
+The policy runs at the **gateway phase** (before authentication and routing), so disallowed IPs are rejected immediately with minimal overhead.
+
+### Running an example
+
+```bash
+cargo run -- -f examples/ip-access-control/<example>.yaml
+```
+
+### Examples
+
+#### [Allowlist only](allowlist-only.yaml)
+
+Only permit requests from specific CIDR ranges. All other IPs receive a 403.
+
+```yaml
+policies:
+  ipAccessControl:
+    allow:
+    - "10.0.0.0/8"
+    - "172.16.0.0/12"
+    - "192.168.0.0/16"
+```
+
+#### [Denylist only](denylist-only.yaml)
+
+Block requests from specific CIDR ranges (embargoed countries, known bad actors). All other IPs are allowed through.
+
+```yaml
+policies:
+  ipAccessControl:
+    deny:
+    - "198.51.100.0/24"
+    - "203.0.113.0/24"
+```
+
+#### [Allow with deny override](allow-with-deny-override.yaml)
+
+Allow a broad range but carve out a specific subnet to deny. Deny rules are always evaluated before allow rules, so an IP matching both lists is rejected.
+
+```yaml
+policies:
+  ipAccessControl:
+    allow:
+    - "10.0.0.0/8"
+    deny:
+    - "10.0.1.0/24"
+```
+
+#### [XFF trusted hops](xff-trusted-hops.yaml)
+
+When running behind load balancers or proxies, extract the real client IP from the `X-Forwarded-For` header. Set `xffNumTrustedHops` to the number of trusted proxies between the client and agentgateway.
+
+```yaml
+policies:
+  ipAccessControl:
+    allow:
+    - "203.0.113.0/24"
+    xffNumTrustedHops: 2
+```
+
+#### [Private IP bypass](private-ip-bypass.yaml)
+
+Allow only specific public IP ranges but let internal traffic (RFC 1918, loopback, link-local) through unconditionally. Useful for environments where pod-to-pod or health-check traffic should never be blocked.
+
+```yaml
+policies:
+  ipAccessControl:
+    allow:
+    - "203.0.113.0/24"
+    skipPrivateIps: true
+```
+
+#### [Full chain enforcement](full-chain-enforcement.yaml)
+
+Check every IP in the X-Forwarded-For chain, not just the resolved client IP. If any hop matches a deny rule or fails the allowlist, the request is rejected. Combined with `skipPrivateIps` to avoid blocking internal proxy hops and `maxXffLength` to guard against header abuse.
+
+```yaml
+policies:
+  ipAccessControl:
+    allow:
+    - "203.0.113.0/24"
+    deny:
+    - "203.0.113.128/25"
+    enforceFullChain: true
+    skipPrivateIps: true
+    maxXffLength: 10
+```
+
+#### [Multi-source merge](multi-source-merge.yaml)
+
+When `ipAccessControl` policies are attached at multiple levels (listener and route), they are **merged** rather than overridden:
+
+- **Allow lists** are unioned: an IP matching any source's allow list passes.
+- **Deny lists** are unioned: a deny from any source blocks.
+- **Behavioral flags** use the most-specific (listener-level) value.
+
+This enables an operator to define infrastructure-wide deny rules at the listener level while letting individual routes add their own allowlists.
+
+```yaml
+listeners:
+- policies:
+    ipAccessControl:
+      deny:
+      - "198.51.100.0/24"
+      skipPrivateIps: true
+  routes:
+  - policies:
+      ipAccessControl:
+        allow:
+        - "10.0.0.0/8"
+```
+
+#### [IPv6](ipv6.yaml)
+
+IPv4 and IPv6 CIDR ranges can be mixed freely in allow and deny lists.
+
+```yaml
+policies:
+  ipAccessControl:
+    allow:
+    - "10.0.0.0/8"
+    - "2001:db8::/32"
+    deny:
+    - "2001:db8:bad::/48"
+```
+
+### Configuration reference
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `allow` | list of CIDR strings | `[]` | When non-empty, only IPs matching at least one entry are permitted |
+| `deny` | list of CIDR strings | `[]` | IPs matching any entry are rejected. Evaluated before allow |
+| `xffNumTrustedHops` | integer | unset | Extract client IP from X-Forwarded-For, counting from the right |
+| `skipPrivateIps` | boolean | `false` | Bypass allow/deny checks for RFC 1918, loopback, and link-local IPs |
+| `enforceFullChain` | boolean | `false` | Check every IP in the XFF chain, not just the resolved client |
+| `maxXffLength` | integer | `30` | Maximum number of IPs in the XFF chain before rejecting |
+
+### Evaluation order
+
+1. Validate XFF chain length (reject if exceeds `maxXffLength`)
+2. If `enforceFullChain`: check every IP in XFF + connection IP
+3. Otherwise: resolve single client IP (from XFF or connection)
+4. For each checked IP:
+   - If `skipPrivateIps` and IP is private -> skip
+   - If IP matches any deny entry -> reject (403)
+   - If allow list is non-empty and IP doesn't match -> reject (403)
+   - Otherwise -> allow

--- a/examples/ip-access-control/allow-with-deny-override.yaml
+++ b/examples/ip-access-control/allow-with-deny-override.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://agentgateway.dev/schema/config
+#
+# Scenario: Allow a broad corporate range but explicitly deny a
+# specific subnet within it. Deny rules always take precedence.
+#
+# Given IP 10.0.1.5:
+#   - Matches allow 10.0.0.0/8? Yes
+#   - Matches deny 10.0.1.0/24? Yes -> DENIED (deny wins)
+#
+# Given IP 10.0.2.5:
+#   - Matches deny 10.0.1.0/24? No
+#   - Matches allow 10.0.0.0/8? Yes -> ALLOWED
+#
+binds:
+- port: 3000
+  listeners:
+  - policies:
+      ipAccessControl:
+        allow:
+        - "10.0.0.0/8"
+        deny:
+        - "10.0.1.0/24"
+    routes:
+    - backends:
+      - mcp:
+          targets:
+          - name: everything
+            stdio:
+              cmd: npx
+              args: ["@modelcontextprotocol/server-everything"]

--- a/examples/ip-access-control/allowlist-only.yaml
+++ b/examples/ip-access-control/allowlist-only.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://agentgateway.dev/schema/config
+#
+# Scenario: Only allow requests from specific CIDR ranges.
+# All other IPs are rejected with 403.
+#
+binds:
+- port: 3000
+  listeners:
+  - policies:
+      ipAccessControl:
+        allow:
+        - "10.0.0.0/8"
+        - "172.16.0.0/12"
+        - "192.168.0.0/16"
+    routes:
+    - backends:
+      - mcp:
+          targets:
+          - name: everything
+            stdio:
+              cmd: npx
+              args: ["@modelcontextprotocol/server-everything"]

--- a/examples/ip-access-control/denylist-only.yaml
+++ b/examples/ip-access-control/denylist-only.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://agentgateway.dev/schema/config
+#
+# Scenario: Block requests from specific CIDR ranges (embargoed countries,
+# known bad actors, etc.). All other IPs are allowed.
+#
+binds:
+- port: 3000
+  listeners:
+  - policies:
+      ipAccessControl:
+        deny:
+        - "198.51.100.0/24"
+        - "203.0.113.0/24"
+    routes:
+    - backends:
+      - mcp:
+          targets:
+          - name: everything
+            stdio:
+              cmd: npx
+              args: ["@modelcontextprotocol/server-everything"]

--- a/examples/ip-access-control/full-chain-enforcement.yaml
+++ b/examples/ip-access-control/full-chain-enforcement.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://agentgateway.dev/schema/config
+#
+# Scenario: Paranoid mode - check every IP in the X-Forwarded-For
+# chain, not just the resolved client IP. If any hop in the chain
+# matches a deny rule (or fails the allowlist), the request is
+# rejected.
+#
+# Combined with skipPrivateIps to avoid rejecting internal proxy
+# hops and maxXffLength to guard against header abuse.
+#
+binds:
+- port: 3000
+  listeners:
+  - policies:
+      ipAccessControl:
+        allow:
+        - "203.0.113.0/24"
+        - "198.51.100.0/24"
+        deny:
+        - "203.0.113.128/25"
+        enforceFullChain: true
+        skipPrivateIps: true
+        maxXffLength: 10
+    routes:
+    - backends:
+      - mcp:
+          targets:
+          - name: everything
+            stdio:
+              cmd: npx
+              args: ["@modelcontextprotocol/server-everything"]

--- a/examples/ip-access-control/ipv6.yaml
+++ b/examples/ip-access-control/ipv6.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://agentgateway.dev/schema/config
+#
+# Scenario: IPv6 access control. Both IPv4 and IPv6 CIDR ranges
+# can be mixed freely in allow and deny lists.
+#
+binds:
+- port: 3000
+  listeners:
+  - policies:
+      ipAccessControl:
+        allow:
+        - "10.0.0.0/8"
+        - "2001:db8::/32"
+        - "fd00::/8"
+        deny:
+        - "2001:db8:bad::/48"
+    routes:
+    - backends:
+      - mcp:
+          targets:
+          - name: everything
+            stdio:
+              cmd: npx
+              args: ["@modelcontextprotocol/server-everything"]

--- a/examples/ip-access-control/multi-source-merge.yaml
+++ b/examples/ip-access-control/multi-source-merge.yaml
@@ -1,0 +1,56 @@
+# yaml-language-server: $schema=https://agentgateway.dev/schema/config
+#
+# Scenario: Multi-source policy merge. An operator defines
+# infrastructure-wide deny rules and private IP bypass at the
+# listener level, while each route adds its own allowlist.
+#
+# Because ipAccessControl policies merge across attachment levels:
+#   - Allow lists are unioned (IP in *any* allow list passes)
+#   - Deny lists are unioned (IP in *any* deny list is blocked)
+#   - Behavioral flags use the most-specific (listener) value
+#
+# In this example:
+#   Listener-level: deny embargoed ranges, skip private IPs
+#   Route "internal": allow corporate 10.0.0.0/8
+#   Route "partners": allow partner range 203.0.113.0/24
+#
+binds:
+- port: 3000
+  listeners:
+  - policies:
+      ipAccessControl:
+        deny:
+        - "198.51.100.0/24"
+        skipPrivateIps: true
+        maxXffLength: 20
+    routes:
+    - name: internal-tools
+      matches:
+      - path:
+          pathPrefix: /internal
+      policies:
+        ipAccessControl:
+          allow:
+          - "10.0.0.0/8"
+      backends:
+      - mcp:
+          targets:
+          - name: internal
+            stdio:
+              cmd: npx
+              args: ["@modelcontextprotocol/server-everything"]
+    - name: partner-api
+      matches:
+      - path:
+          pathPrefix: /partners
+      policies:
+        ipAccessControl:
+          allow:
+          - "203.0.113.0/24"
+      backends:
+      - mcp:
+          targets:
+          - name: partners
+            stdio:
+              cmd: npx
+              args: ["@modelcontextprotocol/server-everything"]

--- a/examples/ip-access-control/private-ip-bypass.yaml
+++ b/examples/ip-access-control/private-ip-bypass.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://agentgateway.dev/schema/config
+#
+# Scenario: Allow only specific public IP ranges but let internal
+# (RFC 1918, loopback, link-local) traffic through unconditionally.
+# Useful in environments where pod-to-pod or health-check traffic
+# should never be blocked.
+#
+# Private ranges bypassed automatically:
+#   IPv4: 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 127.0.0.0/8
+#   IPv6: ::1/128, fc00::/7, fe80::/10
+#
+binds:
+- port: 3000
+  listeners:
+  - policies:
+      ipAccessControl:
+        allow:
+        - "203.0.113.0/24"
+        - "198.51.100.0/24"
+        skipPrivateIps: true
+    routes:
+    - backends:
+      - mcp:
+          targets:
+          - name: everything
+            stdio:
+              cmd: npx
+              args: ["@modelcontextprotocol/server-everything"]

--- a/examples/ip-access-control/xff-trusted-hops.yaml
+++ b/examples/ip-access-control/xff-trusted-hops.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://agentgateway.dev/schema/config
+#
+# Scenario: Running behind a load balancer. The real client IP is
+# in the X-Forwarded-For header. Set xffNumTrustedHops to the number
+# of trusted proxies between the client and agentgateway.
+#
+# Example: client -> CDN -> LB -> agentgateway
+# X-Forwarded-For: <client>, <CDN>, <LB>
+#
+# With xffNumTrustedHops: 2, agentgateway picks the IP at
+# position len(XFF) - 2, which is the client IP.
+#
+# If the XFF header is missing or unparseable, agentgateway falls
+# back to the direct TCP connection IP.
+#
+binds:
+- port: 3000
+  listeners:
+  - policies:
+      ipAccessControl:
+        allow:
+        - "203.0.113.0/24"
+        xffNumTrustedHops: 2
+    routes:
+    - backends:
+      - mcp:
+          targets:
+          - name: everything
+            stdio:
+              cmd: npx
+              args: ["@modelcontextprotocol/server-everything"]

--- a/schema/config.json
+++ b/schema/config.json
@@ -1037,6 +1037,18 @@
           ],
           "default": null
         },
+        "ipAccessControl": {
+          "description": "Control access based on client IP address using allow/deny CIDR lists.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/IpAccessControl"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "mcpAuthorization": {
           "description": "Authorization policies for MCP access.",
           "anyOf": [
@@ -1586,6 +1598,53 @@
             "null"
           ],
           "default": null
+        }
+      },
+      "additionalProperties": false
+    },
+    "IpAccessControl": {
+      "description": "IP access control policy supporting allow and deny lists with CIDR ranges.\n\nEvaluation order:\n1. If the IP matches any deny entry, reject (403).\n2. If an allow list is configured and the IP does not match, reject (403).\n3. Otherwise, allow.\n\nWhen `xff_num_trusted_hops` is set, the client IP is extracted from the\nX-Forwarded-For header (counting from the right) instead of the direct\nconnection IP.",
+      "type": "object",
+      "properties": {
+        "allow": {
+          "description": "CIDR ranges that are allowed. When non-empty, only IPs matching at least\none entry are permitted (after deny check).",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "deny": {
+          "description": "CIDR ranges that are denied. Deny rules are evaluated before allow rules.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "xffNumTrustedHops": {
+          "description": "Number of trusted proxy hops. When set, the client IP is taken from the\nX-Forwarded-For header, counting backwards from the rightmost entry.\nFor example, 1 means the last entry is the client IP (one trusted proxy).",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 0
+        },
+        "skipPrivateIps": {
+          "description": "When true, private/loopback IPs (RFC 1918, RFC 4193, link-local) bypass\nboth allow and deny checks. Defaults to false.",
+          "type": "boolean"
+        },
+        "enforceFullChain": {
+          "description": "When true, every IP in the X-Forwarded-For chain (plus the connection IP)\nis checked against allow/deny rules. A deny match on any hop rejects the\nrequest, and every non-private hop must satisfy the allow list.\nWhen false, only the resolved client IP is checked.",
+          "type": "boolean"
+        },
+        "maxXffLength": {
+          "description": "Maximum number of IPs allowed in the X-Forwarded-For chain. Requests\nexceeding this limit are rejected with 403. Guards against forwarding\nloops and header abuse. Defaults to 30 when unset.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 0
         }
       },
       "additionalProperties": false
@@ -4671,6 +4730,18 @@
     "LocalGatewayPolicy": {
       "type": "object",
       "properties": {
+        "ipAccessControl": {
+          "description": "Control access based on client IP address using allow/deny CIDR lists.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/IpAccessControl"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "jwtAuth": {
           "description": "Authenticate incoming JWT requests.",
           "anyOf": [
@@ -5555,6 +5626,18 @@
     "LocalLLMPolicy": {
       "type": "object",
       "properties": {
+        "ipAccessControl": {
+          "description": "Control access based on client IP address using allow/deny CIDR lists.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/IpAccessControl"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "jwtAuth": {
           "description": "Authenticate incoming JWT requests.",
           "anyOf": [

--- a/schema/config.md
+++ b/schema/config.md
@@ -141,6 +141,13 @@
 |`binds[].listeners[].routes[].policies.cors.allowOrigins`||
 |`binds[].listeners[].routes[].policies.cors.exposeHeaders`||
 |`binds[].listeners[].routes[].policies.cors.maxAge`||
+|`binds[].listeners[].routes[].policies.ipAccessControl`|Control access based on client IP address using allow/deny CIDR lists.|
+|`binds[].listeners[].routes[].policies.ipAccessControl.allow`|CIDR ranges that are allowed. When non-empty, only IPs matching at least<br>one entry are permitted (after deny check).|
+|`binds[].listeners[].routes[].policies.ipAccessControl.deny`|CIDR ranges that are denied. Deny rules are evaluated before allow rules.|
+|`binds[].listeners[].routes[].policies.ipAccessControl.xffNumTrustedHops`|Number of trusted proxy hops. When set, the client IP is taken from the<br>X-Forwarded-For header, counting backwards from the rightmost entry.<br>For example, 1 means the last entry is the client IP (one trusted proxy).|
+|`binds[].listeners[].routes[].policies.ipAccessControl.skipPrivateIps`|When true, private/loopback IPs (RFC 1918, RFC 4193, link-local) bypass<br>both allow and deny checks. Defaults to false.|
+|`binds[].listeners[].routes[].policies.ipAccessControl.enforceFullChain`|When true, every IP in the X-Forwarded-For chain (plus the connection IP)<br>is checked against allow/deny rules. A deny match on any hop rejects the<br>request, and every non-private hop must satisfy the allow list.<br>When false, only the resolved client IP is checked.|
+|`binds[].listeners[].routes[].policies.ipAccessControl.maxXffLength`|Maximum number of IPs allowed in the X-Forwarded-For chain. Requests<br>exceeding this limit are rejected with 403. Guards against forwarding<br>loops and header abuse. Defaults to 30 when unset.|
 |`binds[].listeners[].routes[].policies.mcpAuthorization`|Authorization policies for MCP access.|
 |`binds[].listeners[].routes[].policies.mcpAuthorization.rules`||
 |`binds[].listeners[].routes[].policies.authorization`|Authorization policies for HTTP access.|
@@ -2575,6 +2582,13 @@
 |`binds[].listeners[].tcpRoutes[].backends[].policies.backendTLS.alpn`||
 |`binds[].listeners[].tcpRoutes[].backends[].policies.backendTLS.subjectAltNames`||
 |`binds[].listeners[].policies`||
+|`binds[].listeners[].policies.ipAccessControl`|Control access based on client IP address using allow/deny CIDR lists.|
+|`binds[].listeners[].policies.ipAccessControl.allow`|CIDR ranges that are allowed. When non-empty, only IPs matching at least<br>one entry are permitted (after deny check).|
+|`binds[].listeners[].policies.ipAccessControl.deny`|CIDR ranges that are denied. Deny rules are evaluated before allow rules.|
+|`binds[].listeners[].policies.ipAccessControl.xffNumTrustedHops`|Number of trusted proxy hops. When set, the client IP is taken from the<br>X-Forwarded-For header, counting backwards from the rightmost entry.<br>For example, 1 means the last entry is the client IP (one trusted proxy).|
+|`binds[].listeners[].policies.ipAccessControl.skipPrivateIps`|When true, private/loopback IPs (RFC 1918, RFC 4193, link-local) bypass<br>both allow and deny checks. Defaults to false.|
+|`binds[].listeners[].policies.ipAccessControl.enforceFullChain`|When true, every IP in the X-Forwarded-For chain (plus the connection IP)<br>is checked against allow/deny rules. A deny match on any hop rejects the<br>request, and every non-private hop must satisfy the allow list.<br>When false, only the resolved client IP is checked.|
+|`binds[].listeners[].policies.ipAccessControl.maxXffLength`|Maximum number of IPs allowed in the X-Forwarded-For chain. Requests<br>exceeding this limit are rejected with 403. Guards against forwarding<br>loops and header abuse. Defaults to 30 when unset.|
 |`binds[].listeners[].policies.jwtAuth`|Authenticate incoming JWT requests.|
 |`binds[].listeners[].policies.jwtAuth.(any)(any)mode`||
 |`binds[].listeners[].policies.jwtAuth.(any)(any)providers`||
@@ -2962,6 +2976,13 @@
 |`policies[].policy.cors.allowOrigins`||
 |`policies[].policy.cors.exposeHeaders`||
 |`policies[].policy.cors.maxAge`||
+|`policies[].policy.ipAccessControl`|Control access based on client IP address using allow/deny CIDR lists.|
+|`policies[].policy.ipAccessControl.allow`|CIDR ranges that are allowed. When non-empty, only IPs matching at least<br>one entry are permitted (after deny check).|
+|`policies[].policy.ipAccessControl.deny`|CIDR ranges that are denied. Deny rules are evaluated before allow rules.|
+|`policies[].policy.ipAccessControl.xffNumTrustedHops`|Number of trusted proxy hops. When set, the client IP is taken from the<br>X-Forwarded-For header, counting backwards from the rightmost entry.<br>For example, 1 means the last entry is the client IP (one trusted proxy).|
+|`policies[].policy.ipAccessControl.skipPrivateIps`|When true, private/loopback IPs (RFC 1918, RFC 4193, link-local) bypass<br>both allow and deny checks. Defaults to false.|
+|`policies[].policy.ipAccessControl.enforceFullChain`|When true, every IP in the X-Forwarded-For chain (plus the connection IP)<br>is checked against allow/deny rules. A deny match on any hop rejects the<br>request, and every non-private hop must satisfy the allow list.<br>When false, only the resolved client IP is checked.|
+|`policies[].policy.ipAccessControl.maxXffLength`|Maximum number of IPs allowed in the X-Forwarded-For chain. Requests<br>exceeding this limit are rejected with 403. Guards against forwarding<br>loops and header abuse. Defaults to 30 when unset.|
 |`policies[].policy.mcpAuthorization`|Authorization policies for MCP access.|
 |`policies[].policy.mcpAuthorization.rules`||
 |`policies[].policy.authorization`|Authorization policies for HTTP access.|
@@ -4664,6 +4685,13 @@
 |`llm.models[].matches[].headers[].value.(1)exact`||
 |`llm.models[].matches[].headers[].value.(1)regex`||
 |`llm.policies`|policies defines policies for handling incoming requests, before a model is selected|
+|`llm.policies.ipAccessControl`|Control access based on client IP address using allow/deny CIDR lists.|
+|`llm.policies.ipAccessControl.allow`|CIDR ranges that are allowed. When non-empty, only IPs matching at least<br>one entry are permitted (after deny check).|
+|`llm.policies.ipAccessControl.deny`|CIDR ranges that are denied. Deny rules are evaluated before allow rules.|
+|`llm.policies.ipAccessControl.xffNumTrustedHops`|Number of trusted proxy hops. When set, the client IP is taken from the<br>X-Forwarded-For header, counting backwards from the rightmost entry.<br>For example, 1 means the last entry is the client IP (one trusted proxy).|
+|`llm.policies.ipAccessControl.skipPrivateIps`|When true, private/loopback IPs (RFC 1918, RFC 4193, link-local) bypass<br>both allow and deny checks. Defaults to false.|
+|`llm.policies.ipAccessControl.enforceFullChain`|When true, every IP in the X-Forwarded-For chain (plus the connection IP)<br>is checked against allow/deny rules. A deny match on any hop rejects the<br>request, and every non-private hop must satisfy the allow list.<br>When false, only the resolved client IP is checked.|
+|`llm.policies.ipAccessControl.maxXffLength`|Maximum number of IPs allowed in the X-Forwarded-For chain. Requests<br>exceeding this limit are rejected with 403. Guards against forwarding<br>loops and header abuse. Defaults to 30 when unset.|
 |`llm.policies.jwtAuth`|Authenticate incoming JWT requests.|
 |`llm.policies.jwtAuth.(any)(any)mode`||
 |`llm.policies.jwtAuth.(any)(any)providers`||
@@ -5014,6 +5042,13 @@
 |`mcp.policies.cors.allowOrigins`||
 |`mcp.policies.cors.exposeHeaders`||
 |`mcp.policies.cors.maxAge`||
+|`mcp.policies.ipAccessControl`|Control access based on client IP address using allow/deny CIDR lists.|
+|`mcp.policies.ipAccessControl.allow`|CIDR ranges that are allowed. When non-empty, only IPs matching at least<br>one entry are permitted (after deny check).|
+|`mcp.policies.ipAccessControl.deny`|CIDR ranges that are denied. Deny rules are evaluated before allow rules.|
+|`mcp.policies.ipAccessControl.xffNumTrustedHops`|Number of trusted proxy hops. When set, the client IP is taken from the<br>X-Forwarded-For header, counting backwards from the rightmost entry.<br>For example, 1 means the last entry is the client IP (one trusted proxy).|
+|`mcp.policies.ipAccessControl.skipPrivateIps`|When true, private/loopback IPs (RFC 1918, RFC 4193, link-local) bypass<br>both allow and deny checks. Defaults to false.|
+|`mcp.policies.ipAccessControl.enforceFullChain`|When true, every IP in the X-Forwarded-For chain (plus the connection IP)<br>is checked against allow/deny rules. A deny match on any hop rejects the<br>request, and every non-private hop must satisfy the allow list.<br>When false, only the resolved client IP is checked.|
+|`mcp.policies.ipAccessControl.maxXffLength`|Maximum number of IPs allowed in the X-Forwarded-For chain. Requests<br>exceeding this limit are rejected with 403. Guards against forwarding<br>loops and header abuse. Defaults to 30 when unset.|
 |`mcp.policies.mcpAuthorization`|Authorization policies for MCP access.|
 |`mcp.policies.mcpAuthorization.rules`||
 |`mcp.policies.authorization`|Authorization policies for HTTP access.|


### PR DESCRIPTION
Introduce CIDR-based allow/deny IP filtering as a gateway-phase traffic policy. Includes XFF client IP resolution, private IP bypass, full-chain enforcement, policy merging across attachment levels, proto definition and xDS conversion

Implements https://github.com/agentgateway/agentgateway/issues/1103 