### PR TITLE
Fix e2e test setup on mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,14 @@ else
 	$(DOCKER_BUILDER) build $(DOCKER_BUILD_ARGS) -t $(IMAGE_FULL_NAME) . --progress=plain
 endif
 
+.PHONY: docker-ci
+docker-ci:
+ifeq ($(OS),Windows_NT)
+	$(DOCKER_BUILDER) build $(DOCKER_BUILD_ARGS) --build-arg PROFILE=ci -f Dockerfile.windows -t $(IMAGE_FULL_NAME) .
+else
+	$(DOCKER_BUILDER) build $(DOCKER_BUILD_ARGS) --build-arg PROFILE=ci -t $(IMAGE_FULL_NAME) . --progress=plain
+endif
+
 .PHONY: docker-musl
 docker-musl:
 	$(DOCKER_BUILDER) build $(DOCKER_BUILD_ARGS) -t $(IMAGE_FULL_NAME)-musl --build-arg=BUILDER=musl . --progress=plain

--- a/controller/Makefile
+++ b/controller/Makefile
@@ -564,9 +564,11 @@ else
 	kubectl apply --kustomize "https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd?ref=$(GIE_CRD_VERSION)"
 endif
 
-.PHONY: kind-metallb
+.PHONY: metallb
 metallb: ## Install the MetalLB load balancer
-	./hack/kind/setup-metalllb-on-kind.sh
+	kubectl apply -f ./test/setup/metallb.yaml
+	kubectl rollout status -n metallb-system deployment/controller --timeout=120s
+	kubectl rollout status -n metallb-system daemonset/speaker --timeout=120s
 
 .PHONY: deploy-agentgateway
 deploy-agentgateway: package-agentgateway-charts deploy-agentgateway-crd-chart deploy-agentgateway-chart ## Deploy the agentgateway chart and CRDs

--- a/controller/Makefile
+++ b/controller/Makefile
@@ -579,7 +579,7 @@ setup-base: kind-create gw-api-crds gie-crds metallb ## Setup the base infrastru
 # Creates a functional kind cluster, builds and loads all images, and packages charts
 # Does NOT deploy anything to the cluster
 .PHONY: setup
-setup: setup-base kind-build-and-load package-agentgateway-charts  ## Setup the complete infrastructure (base setup plus images and charts)
+setup: setup-base kind-build-and-load package-agentgateway-charts  ## Setup base infra, build/load images, and package charts (without deployment)
 
 .PHONY: run
 run: setup deploy-agentgateway ## Set up complete development environment

--- a/controller/test/e2e/common/base.go
+++ b/controller/test/e2e/common/base.go
@@ -5,14 +5,22 @@ package common
 import (
 	"context"
 	"fmt"
+	"log"
+	"net"
 	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"istio.io/istio/pkg/test/util/assert"
 	"istio.io/istio/pkg/test/util/retry"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/agentgateway/agentgateway/controller/pkg/utils/kubeutils/portforward"
 	"github.com/agentgateway/agentgateway/controller/pkg/utils/requestutils/curl"
 	"github.com/agentgateway/agentgateway/controller/test/e2e"
 	"github.com/agentgateway/agentgateway/controller/test/gomega/matchers"
@@ -24,15 +32,97 @@ func SetupBaseConfig(ctx context.Context, t *testing.T, installation *e2e.TestIn
 }
 
 func SetupBaseGateway(ctx context.Context, installation *e2e.TestInstallation, name types.NamespacedName) {
-	address := installation.Assertions.EventuallyGatewayAddress(
-		ctx,
-		name.Name,
-		name.Namespace,
-	)
+	baseInstallation = installation
 	BaseGateway = Gateway{
 		NamespacedName: name,
-		Address:        address,
+		Address:        ResolveGatewayAddress(ctx, installation, name),
 	}
+}
+
+var (
+	gatewayAddressMu sync.Mutex
+	gatewayAddresses = map[types.NamespacedName]string{}
+	baseInstallation *e2e.TestInstallation
+)
+
+// ResolveGatewayAddress returns a reachable gateway address for e2e traffic.
+// If USE_PORTFORWARD is set, tests use a local port-forward; otherwise, they use the LoadBalancer address.
+func ResolveGatewayAddress(ctx context.Context, installation *e2e.TestInstallation, name types.NamespacedName) string {
+	if !shouldUsePortForward() {
+		return installation.Assertions.EventuallyGatewayAddress(ctx, name.Name, name.Namespace)
+	}
+
+	gatewayAddressMu.Lock()
+	defer gatewayAddressMu.Unlock()
+	if addr, ok := gatewayAddresses[name]; ok {
+		return addr
+	}
+
+	addr, err := setupGatewayPortForwards(ctx, installation, name)
+	if err != nil {
+		log.Printf(
+			"WARN: USE_PORTFORWARD is set but port-forward setup failed for Gateway %s/%s: %v; falling back to LoadBalancer address",
+			name.Namespace,
+			name.Name,
+			err,
+		)
+		// Do not cache the fallback LB address. Keep retrying port-forward resolution on subsequent calls.
+		return installation.Assertions.EventuallyGatewayAddress(ctx, name.Name, name.Namespace)
+	}
+	gatewayAddresses[name] = addr
+	return addr
+}
+
+func shouldUsePortForward() bool {
+	_, set := os.LookupEnv("USE_PORTFORWARD")
+	return set
+}
+
+func setupGatewayPortForwards(ctx context.Context, installation *e2e.TestInstallation, name types.NamespacedName) (string, error) {
+	svc := &corev1.Service{}
+	if err := installation.ClusterContext.Client.Get(ctx, name, svc); err != nil {
+		return "", fmt.Errorf("failed to get gateway service %s/%s: %w", name.Namespace, name.Name, err)
+	}
+	if len(svc.Spec.Ports) == 0 {
+		return "", fmt.Errorf("gateway service %s/%s has no ports", name.Namespace, name.Name)
+	}
+
+	forwarders := make([]portforward.PortForwarder, 0, len(svc.Spec.Ports))
+	defaultAddress := ""
+	for _, port := range svc.Spec.Ports {
+		remotePort := int(port.Port)
+		options := []portforward.Option{
+			portforward.WithService(name.Name, name.Namespace),
+		}
+		// Privileged ports like 80 cannot be bound locally without elevation.
+		if remotePort < 1024 {
+			options = append(options, portforward.WithRemotePort(remotePort))
+		} else {
+			options = append(options, portforward.WithPorts(remotePort, remotePort))
+		}
+
+		forwarder, err := installation.Actions.Kubectl().StartPortForward(ctx, options...)
+		if err != nil {
+			for _, started := range forwarders {
+				started.Close()
+			}
+			return "", fmt.Errorf("failed to port-forward service %s/%s on port %d: %w", name.Namespace, name.Name, remotePort, err)
+		}
+		forwarders = append(forwarders, forwarder)
+
+		if defaultAddress == "" || port.Port == 80 || strings.EqualFold(port.Name, "http") {
+			defaultAddress = forwarder.Address()
+		}
+	}
+
+	go func() {
+		<-ctx.Done()
+		for _, forwarder := range forwarders {
+			forwarder.Close()
+		}
+	}()
+
+	return defaultAddress, nil
 }
 
 type Gateway struct {
@@ -48,7 +138,8 @@ func (g *Gateway) Send(t *testing.T, match *matchers.HttpResponse, opts ...curl.
 }
 
 func (g *Gateway) SendWithResponse(t *testing.T, match *matchers.HttpResponse, opts ...curl.Option) http.Response {
-	fullOpts := append([]curl.Option{curl.WithHost(g.Address)}, opts...)
+	address := g.ResolvedAddress()
+	fullOpts := append(GatewayAddressOptions(address), opts...)
 	var passedRes http.Response
 	retry.UntilSuccessOrFail(t, func() error {
 		r, err := curl.ExecuteRequest(fullOpts...)
@@ -69,4 +160,32 @@ func (g *Gateway) SendWithResponse(t *testing.T, match *matchers.HttpResponse, o
 		return nil
 	}, retry.Timeout(time.Second*300))
 	return passedRes
+}
+
+func (g *Gateway) ResolvedAddress() string {
+	address := g.Address
+	if shouldUsePortForward() && g.NamespacedName.Name != "" && !addressHasPort(address) && baseInstallation != nil {
+		return ResolveGatewayAddress(context.Background(), baseInstallation, g.NamespacedName)
+	}
+	return address
+}
+
+func GatewayAddressOptions(address string) []curl.Option {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return []curl.Option{curl.WithHost(address)}
+	}
+	if strings.EqualFold(host, "localhost") {
+		host = "127.0.0.1"
+	}
+	parsedPort, err := strconv.Atoi(port)
+	if err != nil {
+		return []curl.Option{curl.WithHost(address)}
+	}
+	return []curl.Option{curl.WithHost(host), curl.WithPort(parsedPort)}
+}
+
+func addressHasPort(address string) bool {
+	_, _, err := net.SplitHostPort(address)
+	return err == nil
 }

--- a/controller/test/e2e/common/base.go
+++ b/controller/test/e2e/common/base.go
@@ -33,6 +33,7 @@ func SetupBaseConfig(ctx context.Context, t *testing.T, installation *e2e.TestIn
 
 func SetupBaseGateway(ctx context.Context, installation *e2e.TestInstallation, name types.NamespacedName) {
 	baseInstallation = installation
+	baseContext = ctx
 	BaseGateway = Gateway{
 		NamespacedName: name,
 		Address:        ResolveGatewayAddress(ctx, installation, name),
@@ -42,7 +43,9 @@ func SetupBaseGateway(ctx context.Context, installation *e2e.TestInstallation, n
 var (
 	gatewayAddressMu sync.Mutex
 	gatewayAddresses = map[types.NamespacedName]string{}
+	gatewayPorts     = map[types.NamespacedName]map[int]int{}
 	baseInstallation *e2e.TestInstallation
+	baseContext      context.Context
 )
 
 // ResolveGatewayAddress returns a reachable gateway address for e2e traffic.
@@ -58,7 +61,7 @@ func ResolveGatewayAddress(ctx context.Context, installation *e2e.TestInstallati
 		return addr
 	}
 
-	addr, err := setupGatewayPortForwards(ctx, installation, name)
+	addr, portMap, err := setupGatewayPortForwards(ctx, installation, name)
 	if err != nil {
 		log.Printf(
 			"WARN: USE_PORTFORWARD is set but port-forward setup failed for Gateway %s/%s: %v; falling back to LoadBalancer address",
@@ -70,7 +73,47 @@ func ResolveGatewayAddress(ctx context.Context, installation *e2e.TestInstallati
 		return installation.Assertions.EventuallyGatewayAddress(ctx, name.Name, name.Namespace)
 	}
 	gatewayAddresses[name] = addr
+	gatewayPorts[name] = portMap
 	return addr
+}
+
+// ResolveGatewayPort resolves the local forwarded port for a remote gateway service port.
+// If USE_PORTFORWARD is not set, it returns remotePort unchanged.
+func ResolveGatewayPort(ctx context.Context, installation *e2e.TestInstallation, name types.NamespacedName, remotePort int) int {
+	if !shouldUsePortForward() {
+		return remotePort
+	}
+
+	gatewayAddressMu.Lock()
+	defer gatewayAddressMu.Unlock()
+
+	if ports, ok := gatewayPorts[name]; ok {
+		if localPort, ok := ports[remotePort]; ok {
+			return localPort
+		}
+	}
+	// Ensure cached port-forwards are initialized for this gateway.
+	if _, ok := gatewayAddresses[name]; !ok {
+		addr, portMap, err := setupGatewayPortForwards(ctx, installation, name)
+		if err != nil {
+			log.Printf(
+				"WARN: USE_PORTFORWARD is set but port-forward setup failed for Gateway %s/%s: %v; using remote port %d",
+				name.Namespace,
+				name.Name,
+				err,
+				remotePort,
+			)
+			return remotePort
+		}
+		gatewayAddresses[name] = addr
+		gatewayPorts[name] = portMap
+	}
+	if ports, ok := gatewayPorts[name]; ok {
+		if localPort, ok := ports[remotePort]; ok {
+			return localPort
+		}
+	}
+	return remotePort
 }
 
 func shouldUsePortForward() bool {
@@ -78,27 +121,23 @@ func shouldUsePortForward() bool {
 	return set
 }
 
-func setupGatewayPortForwards(ctx context.Context, installation *e2e.TestInstallation, name types.NamespacedName) (string, error) {
+func setupGatewayPortForwards(ctx context.Context, installation *e2e.TestInstallation, name types.NamespacedName) (string, map[int]int, error) {
 	svc := &corev1.Service{}
 	if err := installation.ClusterContext.Client.Get(ctx, name, svc); err != nil {
-		return "", fmt.Errorf("failed to get gateway service %s/%s: %w", name.Namespace, name.Name, err)
+		return "", nil, fmt.Errorf("failed to get gateway service %s/%s: %w", name.Namespace, name.Name, err)
 	}
 	if len(svc.Spec.Ports) == 0 {
-		return "", fmt.Errorf("gateway service %s/%s has no ports", name.Namespace, name.Name)
+		return "", nil, fmt.Errorf("gateway service %s/%s has no ports", name.Namespace, name.Name)
 	}
 
 	forwarders := make([]portforward.PortForwarder, 0, len(svc.Spec.Ports))
+	portMap := make(map[int]int, len(svc.Spec.Ports))
 	defaultAddress := ""
 	for _, port := range svc.Spec.Ports {
 		remotePort := int(port.Port)
 		options := []portforward.Option{
 			portforward.WithService(name.Name, name.Namespace),
-		}
-		// Privileged ports like 80 cannot be bound locally without elevation.
-		if remotePort < 1024 {
-			options = append(options, portforward.WithRemotePort(remotePort))
-		} else {
-			options = append(options, portforward.WithPorts(remotePort, remotePort))
+			portforward.WithRemotePort(remotePort),
 		}
 
 		forwarder, err := installation.Actions.Kubectl().StartPortForward(ctx, options...)
@@ -106,9 +145,24 @@ func setupGatewayPortForwards(ctx context.Context, installation *e2e.TestInstall
 			for _, started := range forwarders {
 				started.Close()
 			}
-			return "", fmt.Errorf("failed to port-forward service %s/%s on port %d: %w", name.Namespace, name.Name, remotePort, err)
+			return "", nil, fmt.Errorf("failed to port-forward service %s/%s on port %d: %w", name.Namespace, name.Name, remotePort, err)
+		}
+		_, localPort, err := net.SplitHostPort(forwarder.Address())
+		if err != nil {
+			for _, started := range forwarders {
+				started.Close()
+			}
+			return "", nil, fmt.Errorf("failed to parse local port-forward address %q for service %s/%s port %d: %w", forwarder.Address(), name.Namespace, name.Name, remotePort, err)
+		}
+		parsedLocalPort, err := strconv.Atoi(localPort)
+		if err != nil {
+			for _, started := range forwarders {
+				started.Close()
+			}
+			return "", nil, fmt.Errorf("failed to parse local port-forward port %q for service %s/%s port %d: %w", localPort, name.Namespace, name.Name, remotePort, err)
 		}
 		forwarders = append(forwarders, forwarder)
+		portMap[remotePort] = parsedLocalPort
 
 		if defaultAddress == "" || port.Port == 80 || strings.EqualFold(port.Name, "http") {
 			defaultAddress = forwarder.Address()
@@ -122,7 +176,7 @@ func setupGatewayPortForwards(ctx context.Context, installation *e2e.TestInstall
 		}
 	}()
 
-	return defaultAddress, nil
+	return defaultAddress, portMap, nil
 }
 
 type Gateway struct {
@@ -165,9 +219,23 @@ func (g *Gateway) SendWithResponse(t *testing.T, match *matchers.HttpResponse, o
 func (g *Gateway) ResolvedAddress() string {
 	address := g.Address
 	if shouldUsePortForward() && g.NamespacedName.Name != "" && !addressHasPort(address) && baseInstallation != nil {
-		return ResolveGatewayAddress(context.Background(), baseInstallation, g.NamespacedName)
+		return ResolveGatewayAddress(resolveBaseGatewayContext(), baseInstallation, g.NamespacedName)
 	}
 	return address
+}
+
+func (g *Gateway) PortForRemote(remotePort int) int {
+	if shouldUsePortForward() && g.NamespacedName.Name != "" && baseInstallation != nil {
+		return ResolveGatewayPort(resolveBaseGatewayContext(), baseInstallation, g.NamespacedName, remotePort)
+	}
+	return remotePort
+}
+
+func resolveBaseGatewayContext() context.Context {
+	if baseContext != nil {
+		return baseContext
+	}
+	return context.Background()
 }
 
 func GatewayAddressOptions(address string) []curl.Option {

--- a/controller/test/e2e/features/agentgateway/mcp/helpers.go
+++ b/controller/test/e2e/features/agentgateway/mcp/helpers.go
@@ -194,13 +194,10 @@ func (s *testingSuite) mcpCurlOptions(headers map[string]string, body string, ex
 }
 
 func mcpCurlOptionsWithPort(port int, headers map[string]string, body string, extraArgs ...string) []curl.Option {
+	_ = port
 	timeoutSec := parseMaxTimeSeconds(extraArgs, 10)
-	if port == 8080 {
-		port = 80
-	}
 
 	opts := []curl.Option{
-		curl.WithPort(port),
 		curl.WithPath("/mcp"),
 		curl.WithMethod(http.MethodPost),
 		curl.WithConnectionTimeout(timeoutSec),
@@ -217,13 +214,11 @@ func mcpCurlOptionsWithPort(port int, headers map[string]string, body string, ex
 // helper to run a request to a given path and return response and body text.
 func (s *testingSuite) execCurl(path string, headers map[string]string, body string, extraArgs ...string) (*http.Response, string, error) {
 	timeoutSec := parseMaxTimeSeconds(extraArgs, 10)
-	opts := []curl.Option{
-		curl.WithHost(common.BaseGateway.Address),
-		curl.WithPort(80),
+	opts := append(common.GatewayAddressOptions(common.BaseGateway.ResolvedAddress()),
 		curl.WithPath(path),
 		curl.WithMethod(http.MethodPost),
 		curl.WithConnectionTimeout(timeoutSec),
-	}
+	)
 	for k, v := range headers {
 		opts = append(opts, curl.WithHeader(k, v))
 	}
@@ -431,7 +426,7 @@ func (s *testingSuite) waitForMCP200(
 ) {
 	_ = backoffs
 	opts := append(
-		[]curl.Option{curl.WithHost(common.BaseGateway.Address)},
+		common.GatewayAddressOptions(common.BaseGateway.ResolvedAddress()),
 		mcpCurlOptionsWithPort(port, headers, body, "--max-time", "10")...,
 	)
 	common.BaseGateway.Send(s.T(), &testmatchers.HttpResponse{StatusCode: httpOKCode}, opts...)

--- a/controller/test/e2e/features/agentgateway/remotejwtauth/suite.go
+++ b/controller/test/e2e/features/agentgateway/remotejwtauth/suite.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/agentgateway/agentgateway/controller/pkg/utils/fsutils"
@@ -237,7 +238,8 @@ func (s *testingSuite) TestGatewayPolicyWithRbac() {
 }
 
 func (s *testingSuite) assertResponse(hostHeader, authHeader string, expectedStatus int) {
-	common.BaseGateway.Send(
+	gw := s.gateway()
+	gw.Send(
 		s.T(),
 		&testmatchers.HttpResponse{
 			StatusCode: expectedStatus,
@@ -248,13 +250,25 @@ func (s *testingSuite) assertResponse(hostHeader, authHeader string, expectedSta
 }
 
 func (s *testingSuite) assertResponseWithoutAuth(hostHeader string, expectedStatus int) {
-	common.BaseGateway.Send(
+	gw := s.gateway()
+	gw.Send(
 		s.T(),
 		&testmatchers.HttpResponse{
 			StatusCode: expectedStatus,
 		},
 		curl.WithHostHeader(hostHeader),
 	)
+}
+
+func (s *testingSuite) gateway() common.Gateway {
+	name := types.NamespacedName{
+		Namespace: namespace,
+		Name:      "gateway",
+	}
+	return common.Gateway{
+		NamespacedName: name,
+		Address:        common.ResolveGatewayAddress(s.Ctx, s.TestInstallation, name),
+	}
 }
 
 func getTestFile(filename string) string {

--- a/controller/test/e2e/features/agentgateway/suite.go
+++ b/controller/test/e2e/features/agentgateway/suite.go
@@ -53,6 +53,10 @@ func (s *testingSuite) TestAgentgatewayTCPRoute() {
 	)
 
 	gateway := common.Gateway{
+		NamespacedName: types.NamespacedName{
+			Name:      sharedGatewayObjectMeta.Name,
+			Namespace: sharedGatewayObjectMeta.Namespace,
+		},
 		Address: common.ResolveGatewayAddress(
 			s.Ctx,
 			s.TestInstallation,
@@ -67,7 +71,7 @@ func (s *testingSuite) TestAgentgatewayTCPRoute() {
 		&matchers.HttpResponse{
 			StatusCode: http.StatusOK,
 		},
-		curl.WithPort(9090),
+		curl.WithPort(gateway.PortForRemote(9090)),
 	)
 }
 
@@ -95,6 +99,10 @@ func (s *testingSuite) TestAgentgatewayHTTPRoute() {
 	)
 
 	gateway := common.Gateway{
+		NamespacedName: types.NamespacedName{
+			Name:      sharedGatewayObjectMeta.Name,
+			Namespace: sharedGatewayObjectMeta.Namespace,
+		},
 		Address: common.ResolveGatewayAddress(
 			s.Ctx,
 			s.TestInstallation,

--- a/controller/test/e2e/features/agentgateway/suite.go
+++ b/controller/test/e2e/features/agentgateway/suite.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/agentgateway/agentgateway/controller/pkg/utils/requestutils/curl"
@@ -52,10 +53,13 @@ func (s *testingSuite) TestAgentgatewayTCPRoute() {
 	)
 
 	gateway := common.Gateway{
-		Address: s.TestInstallation.AssertionsT(s.T()).EventuallyGatewayAddress(
+		Address: common.ResolveGatewayAddress(
 			s.Ctx,
-			sharedGatewayObjectMeta.Name,
-			sharedGatewayObjectMeta.Namespace,
+			s.TestInstallation,
+			types.NamespacedName{
+				Name:      sharedGatewayObjectMeta.Name,
+				Namespace: sharedGatewayObjectMeta.Namespace,
+			},
 		),
 	}
 	gateway.Send(
@@ -91,10 +95,13 @@ func (s *testingSuite) TestAgentgatewayHTTPRoute() {
 	)
 
 	gateway := common.Gateway{
-		Address: s.TestInstallation.AssertionsT(s.T()).EventuallyGatewayAddress(
+		Address: common.ResolveGatewayAddress(
 			s.Ctx,
-			sharedGatewayObjectMeta.Name,
-			sharedGatewayObjectMeta.Namespace,
+			s.TestInstallation,
+			types.NamespacedName{
+				Name:      sharedGatewayObjectMeta.Name,
+				Namespace: sharedGatewayObjectMeta.Namespace,
+			},
 		),
 	}
 	gateway.Send(

--- a/controller/test/e2e/features/agentgateway/transformation/suite.go
+++ b/controller/test/e2e/features/agentgateway/transformation/suite.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/stretchr/testify/suite"
@@ -244,7 +245,11 @@ func sendH2CGrpcRequest(address, authority, methodPath string, protobufPayload [
 	binary.BigEndian.PutUint32(grpcFrame[1:5], uint32(len(protobufPayload)))
 	copy(grpcFrame[5:], protobufPayload)
 
-	url := fmt.Sprintf("http://%s:80%s", address, methodPath)
+	targetAddress := address
+	if !strings.Contains(address, ":") {
+		targetAddress = fmt.Sprintf("%s:80", address)
+	}
+	url := fmt.Sprintf("http://%s%s", targetAddress, methodPath)
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(grpcFrame))
 	if err != nil {
 		return nil, nil, err

--- a/controller/test/e2e/test.go
+++ b/controller/test/e2e/test.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/agentgateway/agentgateway/controller/pkg/utils/fsutils"
 	"github.com/agentgateway/agentgateway/controller/pkg/utils/helmutils"
 	"github.com/agentgateway/agentgateway/controller/test/e2e/testutils/actions"
 	"github.com/agentgateway/agentgateway/controller/test/e2e/testutils/assertions"
@@ -157,6 +158,8 @@ func (i *TestInstallation) InstallAgentgatewayCRDsFromLocalChart(ctx context.Con
 		}
 	}
 
+	// Use absolute chart paths so tests work regardless of current working directory.
+	crdChartPath := filepath.Join(fsutils.GetModuleRoot(), "controller", "install", "helm", "agentgateway-crds")
 	// install the CRD chart first
 	err := i.Actions.Helm().WithReceiver(os.Stdout).Upgrade(
 		ctx,
@@ -164,7 +167,7 @@ func (i *TestInstallation) InstallAgentgatewayCRDsFromLocalChart(ctx context.Con
 			CreateNamespace: true,
 			ReleaseName:     helmutils.AgentgatewayCRDChartName,
 			Namespace:       i.Metadata.InstallNamespace,
-			Chart:           "install/helm/agentgateway-crds",
+			Chart:           crdChartPath,
 		})
 	i.AssertionsT(t).Require.NoError(err)
 }
@@ -182,6 +185,8 @@ func (i *TestInstallation) InstallAgentgatewayCoreFromLocalChart(ctx context.Con
 		}
 	}
 
+	// Use absolute chart paths so tests work regardless of current working directory.
+	coreChartPath := filepath.Join(fsutils.GetModuleRoot(), "controller", "install", "helm", "agentgateway")
 	// and then install the main chart
 	err := i.Actions.Helm().WithReceiver(os.Stdout).Upgrade(
 		ctx,
@@ -194,7 +199,7 @@ func (i *TestInstallation) InstallAgentgatewayCoreFromLocalChart(ctx context.Con
 				ManifestPath("agent-gateway-integration.yaml"),
 			},
 			ReleaseName: helmutils.AgentgatewayChartName,
-			Chart:       "install/helm/agentgateway",
+			Chart:       coreChartPath,
 			ExtraArgs:   i.Metadata.ExtraHelmArgs,
 		})
 	i.AssertionsT(t).Require.NoError(err)

--- a/controller/test/setup/setup-kind-ci.sh
+++ b/controller/test/setup/setup-kind-ci.sh
@@ -212,7 +212,7 @@ function step_push_go_controller_to_local_registry() {
 
 function step_build_proxy_binary() {
    if [[ "$(uname -s)" == "Darwin" ]]; then
-      make -C "${REPO_ROOT}" docker IMAGE_TAG="${TAG}"
+      make -C "${REPO_ROOT}" docker-ci IMAGE_TAG="${TAG}"
    else
       (cd "${REPO_ROOT}" && TIMINGS=true DRY_RUN=true ./tools/proxy-dev-build ci)
    fi
@@ -265,6 +265,12 @@ function step_warm_test() {
 
 function await() {
   for pid in "$@"; do
+    if [[ "$(uname -s)" != "Darwin" ]]; then
+      # GNU tail can block on an arbitrary pid without polling.
+      tail --pid="$pid" -f /dev/null
+      continue
+    fi
+
     while true; do
       if ! state="$(ps -o stat= -p "$pid" 2>/dev/null)"; then
         break

--- a/controller/test/setup/setup-kind-ci.sh
+++ b/controller/test/setup/setup-kind-ci.sh
@@ -72,6 +72,11 @@ run_step() {
 }
 
 step_create_kind_cluster() {
+  if kind get clusters 2>/dev/null | grep -Fxq "${CLUSTER_NAME}"; then
+    echo "kind cluster '${CLUSTER_NAME}' already exists; skipping create" >&2
+    return 0
+  fi
+
   cat <<EOF | kind create cluster --name "${CLUSTER_NAME}" --image "${KIND_NODE_IMAGE}" --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
@@ -206,11 +211,20 @@ function step_push_go_controller_to_local_registry() {
 }
 
 function step_build_proxy_binary() {
-   (cd "${REPO_ROOT}" && TIMINGS=true DRY_RUN=true ./tools/proxy-dev-build ci)
+   if [[ "$(uname -s)" == "Darwin" ]]; then
+      make -C "${REPO_ROOT}" docker IMAGE_TAG="${TAG}"
+   else
+      (cd "${REPO_ROOT}" && TIMINGS=true DRY_RUN=true ./tools/proxy-dev-build ci)
+   fi
 }
 
 function step_push_proxy_to_local_registry() {
-   (cd "${REPO_ROOT}" && ./tools/proxy-dev-build ci)
+   if [[ "$(uname -s)" == "Darwin" ]]; then
+      docker tag "ghcr.io/agentgateway/agentgateway:${TAG}" "${LOCAL_REGISTRY}/agentgateway:${TAG}"
+      docker push "${LOCAL_REGISTRY}/agentgateway:${TAG}"
+   else
+      (cd "${REPO_ROOT}" && ./tools/proxy-dev-build ci)
+   fi
 }
 
 function step_deploy_helm() {
@@ -250,9 +264,21 @@ function step_warm_test() {
 }
 
 function await() {
-    for pid in "$@"; do
-        tail --pid="$pid" -f /dev/null
+  for pid in "$@"; do
+    while true; do
+      if ! state="$(ps -o stat= -p "$pid" 2>/dev/null)"; then
+        break
+      fi
+
+      # `wait` cannot be used on sibling pids from subshells.
+      # Treat zombie processes as completed to avoid hanging forever.
+      if [[ "$state" == Z* ]]; then
+        break
+      fi
+
+      sleep 0.2
     done
+  done
 }
 function main() {
   echo "Timings will be written to: ${TIMINGS_FILE}"

--- a/tools/proxy-dev-build
+++ b/tools/proxy-dev-build
@@ -18,25 +18,25 @@ if [[ $tgt == "dev" ]]; then
   tgt=debug
 fi
 
+if [[ "$(uname -s)" != "Linux" ]]; then
+  echo "Error: proxy-dev-build only supports Linux. Use 'make docker-ci' on Mac." >&2
+  exit 1
+fi
+
 cargo build --profile "${profile}" ${platform:+--target $platform} ${TIMINGS+--timings} || exit 1
-if [[ "${DRY_RUN}" == "" ]]; then
+if [[ -n "${DRY_RUN:-}" ]]; then
   exit 0
 fi
 tag="$(get-tag)"
 dest="localhost:5000/agentgateway:${tag}"
 
-if [[ "$(uname -s)" != "Linux" ]]; then
-  # On non-Linux (e.g., Mac), use docker build to produce a linux/amd64 image
-  # instead of crane append which would bundle the native (ARM64) binary.
-  docker build --platform linux/amd64 --build-arg PROFILE="${profile}" -t "${dest}" .
-  docker push "${dest}"
-else
+{
   crane mutate --platform linux/amd64 $(
     crane append --platform linux/amd64 \
-      -f <(tar -f - -c -s "|./target/${platform:+$platform/}${tgt}/|/usr/bin/|" ./target/${platform:+$platform/}${tgt}/agentgateway) \
+      -f <(tar -f - -c --transform "s|./target/${platform:+$platform/}${tgt}/|/usr/bin/|" ./target/${platform:+$platform/}${tgt}/agentgateway) \
       -t ${dest} \
       -b istio/base
   ) --entrypoint /usr/bin/agentgateway -t ${dest} 1>&2
-fi
+}
 echo ${tag}
 echo ${dest} 1>&2

--- a/tools/proxy-dev-build
+++ b/tools/proxy-dev-build
@@ -24,11 +24,19 @@ if [[ "${DRY_RUN}" == "" ]]; then
 fi
 tag="$(get-tag)"
 dest="localhost:5000/agentgateway:${tag}"
-crane mutate --platform linux/amd64 $(
-  crane append --platform linux/amd64 \
-    -f <(tar -f - -c ./target/${platform:+$platform/}${tgt}/agentgateway --transform "s|./target/${platform:+$platform/}${tgt}/|/usr/bin/|") \
-    -t ${dest} \
-    -b istio/base
-) --entrypoint /usr/bin/agentgateway -t ${dest} 1>&2
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+  # On non-Linux (e.g., Mac), use docker build to produce a linux/amd64 image
+  # instead of crane append which would bundle the native (ARM64) binary.
+  docker build --platform linux/amd64 --build-arg PROFILE="${profile}" -t "${dest}" .
+  docker push "${dest}"
+else
+  crane mutate --platform linux/amd64 $(
+    crane append --platform linux/amd64 \
+      -f <(tar -f - -c -s "|./target/${platform:+$platform/}${tgt}/|/usr/bin/|" ./target/${platform:+$platform/}${tgt}/agentgateway) \
+      -t ${dest} \
+      -b istio/base
+  ) --entrypoint /usr/bin/agentgateway -t ${dest} 1>&2
+fi
 echo ${tag}
 echo ${dest} 1>&2


### PR DESCRIPTION
To test e2e tests locally on a mac you can run the setup with:
```
TEST_MODE=e2e ./controller/test/setup/setup-kind-ci.sh
```

Then run the tests with:
```
 USE_PORTFORWARD=true PERSIST_INSTALL=true CGO_ENABLED=0 go test -vet=off -ldflags='-s -w' --failfast -tags=e2e -v ./controller/test/e2e/tests -run 'TestAgentgatewayIntegration'
```
(Where the regex can select a specific test or run the full suite)

```
--- PASS: TestAgentgatewayIntegration (49.60s)
    --- PASS: TestAgentgatewayIntegration/LocalRateLimit (0.24s)
        --- SKIP: TestAgentgatewayIntegration/LocalRateLimit/TestLocalRateLimitDisabledForRoute (0.00s)
        --- PASS: TestAgentgatewayIntegration/LocalRateLimit/TestLocalRateLimitForGateway (0.05s)
        --- PASS: TestAgentgatewayIntegration/LocalRateLimit/TestLocalRateLimitForRoute (0.07s)
        --- SKIP: TestAgentgatewayIntegration/LocalRateLimit/TestLocalRateLimitForRouteUsingExtensionRef (0.00s)
    --- PASS: TestAgentgatewayIntegration/RBAC (0.13s)
        --- PASS: TestAgentgatewayIntegration/RBAC/TestRBACHeaderAuthorization (0.03s)
    --- PASS: TestAgentgatewayIntegration/MCP (12.19s)
        --- PASS: TestAgentgatewayIntegration/MCP/TestDynamicMCPAdminRouting (0.43s)
        --- PASS: TestAgentgatewayIntegration/MCP/TestDynamicMCPAdminVsUserTools (0.37s)
        --- PASS: TestAgentgatewayIntegration/MCP/TestDynamicMCPDefaultRouting (0.18s)
        --- PASS: TestAgentgatewayIntegration/MCP/TestDynamicMCPUserRouting (0.20s)
        --- PASS: TestAgentgatewayIntegration/MCP/TestMCPAuthn (3.01s)
        --- PASS: TestAgentgatewayIntegration/MCP/TestMCPWorkflow (0.21s)
        --- PASS: TestAgentgatewayIntegration/MCP/TestSSEEndpoint (0.09s)
    --- PASS: TestAgentgatewayIntegration/AIBackend (1.20s)
        --- PASS: TestAgentgatewayIntegration/AIBackend/TestPromptGuard (0.02s)
        --- PASS: TestAgentgatewayIntegration/AIBackend/TestRouting (0.01s)
        --- SKIP: TestAgentgatewayIntegration/AIBackend/TestWebhook (0.00s)
    --- PASS: TestAgentgatewayIntegration/PolicyStatus (0.17s)
        --- PASS: TestAgentgatewayIntegration/PolicyStatus/TestAgwPolicyClearStaleStatus (0.09s)
    --- PASS: TestAgentgatewayIntegration/A2A (1.18s)
        --- PASS: TestAgentgatewayIntegration/A2A/TestA2AAgentCard (0.03s)
        --- PASS: TestAgentgatewayIntegration/A2A/TestA2AHelloWorld (0.03s)
        --- PASS: TestAgentgatewayIntegration/A2A/TestA2AMessageSend (0.01s)
    --- PASS: TestAgentgatewayIntegration/BasicRouting (0.13s)
        --- PASS: TestAgentgatewayIntegration/BasicRouting/TestAgentgatewayHTTPRoute (0.04s)
        --- PASS: TestAgentgatewayIntegration/BasicRouting/TestAgentgatewayTCPRoute (0.02s)
    --- PASS: TestAgentgatewayIntegration/BackendTLSPolicy (0.34s)
        --- PASS: TestAgentgatewayIntegration/BackendTLSPolicy/TestBackendTLSPolicyAndStatus (0.20s)
    --- PASS: TestAgentgatewayIntegration/BasicAuth (0.22s)
        --- PASS: TestAgentgatewayIntegration/BasicAuth/TestGatewayPolicy (0.05s)
        --- PASS: TestAgentgatewayIntegration/BasicAuth/TestRoutePolicy (0.08s)
    --- PASS: TestAgentgatewayIntegration/JwtAuth (0.27s)
        --- PASS: TestAgentgatewayIntegration/JwtAuth/TestGatewayPolicy (0.05s)
        --- PASS: TestAgentgatewayIntegration/JwtAuth/TestGatewayPolicyWithRbac (0.04s)
        --- PASS: TestAgentgatewayIntegration/JwtAuth/TestRoutePolicy (0.06s)
        --- PASS: TestAgentgatewayIntegration/JwtAuth/TestRoutePolicyWithRbac (0.04s)
    --- PASS: TestAgentgatewayIntegration/RemoteJwtAuth (8.89s)
        --- PASS: TestAgentgatewayIntegration/RemoteJwtAuth/TestGatewayPolicyBackend (0.40s)
        --- PASS: TestAgentgatewayIntegration/RemoteJwtAuth/TestGatewayPolicyBackendWithTlsPolicy (0.92s)
        --- PASS: TestAgentgatewayIntegration/RemoteJwtAuth/TestGatewayPolicySvc (0.04s)
        --- PASS: TestAgentgatewayIntegration/RemoteJwtAuth/TestGatewayPolicySvcCaCert (1.06s)
        --- PASS: TestAgentgatewayIntegration/RemoteJwtAuth/TestGatewayPolicyWithRbac (0.88s)
        --- PASS: TestAgentgatewayIntegration/RemoteJwtAuth/TestRoutePolicyBackend (1.08s)
        --- PASS: TestAgentgatewayIntegration/RemoteJwtAuth/TestRoutePolicyBackendAndTlsPolicy (0.04s)
        --- PASS: TestAgentgatewayIntegration/RemoteJwtAuth/TestRoutePolicySvc (0.90s)
        --- PASS: TestAgentgatewayIntegration/RemoteJwtAuth/TestRoutePolicySvcCaCert (1.06s)
        --- PASS: TestAgentgatewayIntegration/RemoteJwtAuth/TestRoutePolicyWithRbac (0.89s)
    --- PASS: TestAgentgatewayIntegration/Tracing (16.41s)
        --- PASS: TestAgentgatewayIntegration/Tracing/TestOTelTracing (15.29s)
    --- PASS: TestAgentgatewayIntegration/ApiKeyAuth (0.21s)
        --- PASS: TestAgentgatewayIntegration/ApiKeyAuth/TestGatewayPolicy (0.06s)
        --- PASS: TestAgentgatewayIntegration/ApiKeyAuth/TestRoutePolicy (0.08s)
    --- PASS: TestAgentgatewayIntegration/Extauth (1.26s)
        --- PASS: TestAgentgatewayIntegration/Extauth/TestExtAuthPolicy (0.05s)
            --- PASS: TestAgentgatewayIntegration/Extauth/TestExtAuthPolicy/request_allowed_with_allow_header (0.02s)
            --- PASS: TestAgentgatewayIntegration/Extauth/TestExtAuthPolicy/request_denied_without_allow_header (0.00s)
            --- PASS: TestAgentgatewayIntegration/Extauth/TestExtAuthPolicy/request_denied_with_deny_header (0.00s)
        --- PASS: TestAgentgatewayIntegration/Extauth/TestExtAuthPolicyMissingBackendRef (0.04s)
            --- PASS: TestAgentgatewayIntegration/Extauth/TestExtAuthPolicyMissingBackendRef/request_denied_for_invalid_extauth_policy_due_to_missing_backendRef (0.02s)
        --- PASS: TestAgentgatewayIntegration/Extauth/TestRouteTargetedExtAuthPolicy (0.05s)
            --- PASS: TestAgentgatewayIntegration/Extauth/TestRouteTargetedExtAuthPolicy/request_allowed_by_default (0.00s)
            --- PASS: TestAgentgatewayIntegration/Extauth/TestRouteTargetedExtAuthPolicy/request_allowed_with_allow_header_on_secured_route (0.02s)
            --- PASS: TestAgentgatewayIntegration/Extauth/TestRouteTargetedExtAuthPolicy/request_denied_without_header_on_secured_route (0.01s)
    --- PASS: TestAgentgatewayIntegration/GlobalRateLimit (4.42s)
        --- PASS: TestAgentgatewayIntegration/GlobalRateLimit/TestCombinedLocalAndGlobalRateLimit (0.07s)
        --- PASS: TestAgentgatewayIntegration/GlobalRateLimit/TestGlobalRateLimitByPath (0.07s)
        --- PASS: TestAgentgatewayIntegration/GlobalRateLimit/TestGlobalRateLimitByRemoteAddress (0.06s)
        --- PASS: TestAgentgatewayIntegration/GlobalRateLimit/TestGlobalRateLimitByUserID (0.04s)
    --- PASS: TestAgentgatewayIntegration/Transformation (0.19s)
        --- PASS: TestAgentgatewayIntegration/Transformation/TestGatewayWithTransformedGRPCRoute (0.06s)
        --- PASS: TestAgentgatewayIntegration/Transformation/TestGatewayWithTransformedHTTPRoute (0.05s)
    --- PASS: TestAgentgatewayIntegration/CSRF (0.13s)
        --- PASS: TestAgentgatewayIntegration/CSRF/TestGatewayLevelCSRF (0.06s)
    --- PASS: TestAgentgatewayIntegration/Extproc (1.71s)
        --- PASS: TestAgentgatewayIntegration/Extproc/TestExtProcWithGatewayTargetRef (0.06s)
            --- PASS: TestAgentgatewayIntegration/Extproc/TestExtProcWithGatewayTargetRef/first_route_should_have_ExtProc_applied_via_Gateway_policy (0.01s)
            --- PASS: TestAgentgatewayIntegration/Extproc/TestExtProcWithGatewayTargetRef/second_route_also_has_ExtProc_applied_via_Gateway_policy (0.00s)
        --- PASS: TestAgentgatewayIntegration/Extproc/TestExtProcWithHTTPRouteTargetRef (0.03s)
            --- PASS: TestAgentgatewayIntegration/Extproc/TestExtProcWithHTTPRouteTargetRef/route_with_ExtProc_applied_should_have_header_modified (0.00s)
            --- PASS: TestAgentgatewayIntegration/Extproc/TestExtProcWithHTTPRouteTargetRef/route_without_ExtProc_should_not_have_header_modified (0.00s)
PASS
ok      github.com/agentgateway/agentgateway/controller/test/e2e/tests  50.401s

```

Changes made:
- `USE_PORTFORWARD` will run the tests with the gateway port-forwarded, removing the dependency of having to set up  the cloud provider kind workaround https://github.com/kubernetes-sigs/cloud-provider-kind 
- Small fixes to makefile to reflect new agentgateway repo paths 
- Fixes setup script to work with mac commands (`wait` fix for sibling pids, fix proxy build) 
- Introduce `docker-ci` to have a fast version of building locally 