### PR TITLE
Add cache token usage to metrics

### DIFF
--- a/crates/agentgateway/src/llm/conversion/messages.rs
+++ b/crates/agentgateway/src/llm/conversion/messages.rs
@@ -641,9 +641,12 @@ pub mod from_completions {
 					messages::MessagesStreamEvent::MessageDelta { usage, delta } => {
 						let finish_reason = delta.stop_reason.as_ref().map(super::translate_stop_reason);
 						log.non_atomic_mutate(|r| {
-							r.response.cached_input_tokens = usage.cache_read_input_tokens.map(|i| i as u64);
-							r.response.cache_creation_input_tokens =
-								usage.cache_creation_input_tokens.map(|i| i as u64);
+							if let Some(crt) = usage.cache_read_input_tokens {
+								r.response.cached_input_tokens = Some(crt as u64);
+							}
+							if let Some(cwt) = usage.cache_creation_input_tokens {
+								r.response.cache_creation_input_tokens = Some(cwt as u64);
+							}
 							if let Some(o) = usage.output_tokens {
 								r.response.output_tokens = Some(o as u64);
 							}
@@ -736,9 +739,12 @@ pub fn passthrough_stream(b: Body, buffer_limit: usize, log: AmendOnDrop) -> Bod
 					if let Some(o) = usage.output_tokens {
 						r.response.output_tokens = Some(o as u64);
 					}
-					r.response.cached_input_tokens = usage.cache_read_input_tokens.map(|i| i as u64);
-					r.response.cache_creation_input_tokens =
-						usage.cache_creation_input_tokens.map(|i| i as u64);
+					if let Some(crt) = usage.cache_read_input_tokens {
+						r.response.cached_input_tokens = Some(crt as u64);
+					}
+					if let Some(cwt) = usage.cache_creation_input_tokens {
+						r.response.cache_creation_input_tokens = Some(cwt as u64);
+					}
 					if let Some(inp) = r.response.input_tokens
 						&& let Some(o) = r.response.output_tokens
 					{

--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -481,6 +481,26 @@ impl DropOnLog {
 					})
 					.observe(ot as f64)
 			}
+			if let Some(crt) = llm_response.cached_input_tokens {
+				log
+					.metrics
+					.gen_ai_token_usage
+					.get_or_create(&GenAILabelsTokenUsage {
+						gen_ai_token_type: strng::literal!("input_cache_read").into(),
+						common: gen_ai_labels.clone().into(),
+					})
+					.observe(crt as f64)
+			}
+			if let Some(cwt) = llm_response.cache_creation_input_tokens {
+				log
+					.metrics
+					.gen_ai_token_usage
+					.get_or_create(&GenAILabelsTokenUsage {
+						gen_ai_token_type: strng::literal!("input_cache_write").into(),
+						common: gen_ai_labels.clone().into(),
+					})
+					.observe(cwt as f64)
+			}
 			log
 				.metrics
 				.gen_ai_request_duration


### PR DESCRIPTION
Adds input_cache_read and input_cache_write token types to the existing list of input/output.

Fixes https://github.com/agentgateway/agentgateway/issues/1121

Tested by running locally, triggering cache reads and writes with claude sonnet via vertex via agentgateway via claude code. Both reads and writes present in the /metrics dump and match the numbers reported by claude code's `/cost` function.