### PR TITLE
feat: remove ring & rustls-pemfile dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,6 @@ dependencies = [
  "rstest",
  "rustls",
  "rustls-native-certs",
- "rustls-pemfile",
  "rustls-pki-types",
  "schemars 1.0.4",
  "secrecy",
@@ -616,8 +615,6 @@ checksum = "11493b0bad143270fb8ad284a096dd529ba91924c5409adeac856cc1bf047dbc"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
- "aws-sdk-sso",
- "aws-sdk-ssooidc",
  "aws-sdk-sts",
  "aws-smithy-async",
  "aws-smithy-http",
@@ -628,14 +625,11 @@ dependencies = [
  "aws-types",
  "bytes",
  "fastrand",
- "hex",
  "http 1.4.0",
- "sha1",
  "time",
  "tokio",
  "tracing",
  "url",
- "zeroize",
 ]
 
 [[package]]
@@ -696,54 +690,6 @@ dependencies = [
  "pin-project-lite",
  "tracing",
  "uuid",
-]
-
-[[package]]
-name = "aws-sdk-sso"
-version = "1.96.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f64a6eded248c6b453966e915d32aeddb48ea63ad17932682774eb026fbef5b1"
-dependencies = [
- "aws-credential-types",
- "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-observability",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "fastrand",
- "http 0.2.12",
- "http 1.4.0",
- "regex-lite",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-ssooidc"
-version = "1.98.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db96d720d3c622fcbe08bae1c4b04a72ce6257d8b0584cb5418da00ae20a344f"
-dependencies = [
- "aws-credential-types",
- "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-observability",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "fastrand",
- "http 0.2.12",
- "http 1.4.0",
- "regex-lite",
- "tracing",
 ]
 
 [[package]]
@@ -5039,8 +4985,8 @@ version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10b99e0098aa4082912d4c649628623db6aba77335e4f4569ff5083a6448b32e"
 dependencies = [
+ "aws-lc-rs",
  "pem",
- "ring",
  "rustls-pki-types",
  "time",
  "x509-parser",
@@ -7896,7 +7842,6 @@ dependencies = [
  "lazy_static",
  "nom",
  "oid-registry",
- "ring",
  "rusticata-macros",
  "thiserror 2.0.18",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ assert_matches = "1.5.0"
 async-openai = { version = "0.33.0", default-features = false, features = ["chat-completion-types", "moderation-types", "response-types", "realtime-types"] }
 async-stream = "0.3"
 async-trait = "0.1"
-aws-config = "1.8"
+aws-config = { version = "1.8.5", default-features = false, features = ["default-https-client", "rt-tokio"] }
 aws-credential-types = "1.2"
 aws-sigv4 = "1.3"
 aws-smithy-eventstream = "0.60"
@@ -142,7 +142,7 @@ prost-wkt-types = { version = "0.7.0", features = ["vendored-protox"] }
 prost-wkt-build = "0.7.0"
 pwhash = "1"
 rand = "0.10"
-rcgen = { version = "0.14", features = ["pem", "x509-parser"] }
+rcgen = { version = "0.14", default-features = false, features = ["pem", "x509-parser", "aws_lc_rs"] }
 regex = "1.11"
 reqwest = { version = "0.13", default-features = false, features = [
     "http2",
@@ -151,9 +151,8 @@ reqwest = { version = "0.13", default-features = false, features = [
 ] }
 rstest = "0.26"
 rustc_version = "0.4"
-rustls = { version = "0.23", features = ["tls12", "ring"] }
+rustls = { version = "0.23", default-features = false, features = ["tls12", "aws_lc_rs"] }
 rustls-native-certs = "0.8"
-rustls-pemfile = "2.2"
 rustls-pki-types = "1.12"
 schemars = { version = "=1.0.4", git = "https://github.com/howardjohn/schemars", rev = "4364354fa41897a0c2001d891c0a9a38eafedb82", features = [
     #schemars = { version = "1.0", features = [
@@ -180,7 +179,7 @@ tempfile = "3.20"
 thiserror = "2.0"
 tiktoken-rs = "0.9"
 tokio = { version = "1.48", features = ["full", "macros", "sync"] }
-tokio-rustls = { version = "0.26", default-features = false }
+tokio-rustls = { version = "0.26", default-features = false, features = ["aws_lc_rs"] }
 tokio-stream = { version = "0.1", features = ["net", "sync"] }
 tokio-test = "0.4"
 tokio-util = { version = "0.7", features = ["codec", "io"] }

--- a/crates/agentgateway/Cargo.toml
+++ b/crates/agentgateway/Cargo.toml
@@ -9,11 +9,10 @@ publish = { workspace = true }
 path = "src/lib.rs"
 
 [features]
-default = ["tls-ring"]
+default = []
 jemalloc = ["dep:tikv-jemallocator", "dep:jemalloc_pprof"]
 ui = []
 schema = ["schemars"]
-tls-ring = ["rustls/ring", "tokio-rustls/ring"]
 internal_benches = ["divan"]
 
 [dependencies]
@@ -105,7 +104,6 @@ rmcp = { version = "0.16", features = [
     "transport-child-process",
 ] }
 rustls-native-certs.workspace = true
-rustls-pemfile.workspace = true
 rustls-pki-types.workspace = true
 rustls.workspace = true
 schemars = { workspace = true, optional = true }

--- a/crates/agentgateway/src/http/backendtls.rs
+++ b/crates/agentgateway/src/http/backendtls.rs
@@ -1,10 +1,9 @@
-use std::io::Cursor;
 use std::path::PathBuf;
 use std::sync::Arc;
 
 use once_cell::sync::Lazy;
 use rustls::ClientConfig;
-use rustls_pki_types::ServerName;
+use rustls_pki_types::{CertificateDer, ServerName, pem::PemObject};
 use serde::Serializer;
 
 use crate::transport;
@@ -159,8 +158,7 @@ impl ResolvedBackendTLS {
 	pub fn try_into(self) -> anyhow::Result<BackendTLS> {
 		let mut roots = rustls::RootCertStore::empty();
 		if let Some(root) = self.root {
-			let mut reader = std::io::BufReader::new(Cursor::new(root));
-			let certs = rustls_pemfile::certs(&mut reader).collect::<Result<Vec<_>, _>>()?;
+			let certs = CertificateDer::pem_slice_iter(&root).collect::<Result<Vec<_>, _>>()?;
 			roots.add_parsable_certificates(certs);
 		} else {
 			// TODO: we probably should do this once globally!

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -2,7 +2,6 @@ use std::cmp;
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap};
 use std::fmt::{Display, Formatter};
-use std::io::Cursor;
 use std::net::{IpAddr, SocketAddr};
 use std::num::NonZeroU16;
 use std::sync::{Arc, RwLock};
@@ -18,7 +17,7 @@ use prometheus_client::encoding::EncodeLabelValue;
 use rustls::ServerConfig;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};
 use rustls::server::danger::ClientCertVerifier;
-use rustls_pemfile::Item;
+use rustls_pki_types::pem::{PemObject, SectionKind};
 use serde::{Serialize, Serializer};
 use serde_json::Value;
 
@@ -322,8 +321,7 @@ impl ServerTLSConfig {
 
 		let scb = if let Some(root) = &inputs.root_pem {
 			let mut roots_store = rustls::RootCertStore::empty();
-			let mut reader = std::io::BufReader::new(Cursor::new(root.as_slice()));
-			let certs = rustls_pemfile::certs(&mut reader).collect::<Result<Vec<_>, _>>()?;
+			let certs = CertificateDer::pem_slice_iter(root).collect::<Result<Vec<_>, _>>()?;
 			roots_store.add_parsable_certificates(certs);
 			let verify = rustls::server::WebPkiClientVerifier::builder_with_provider(
 				Arc::new(roots_store),
@@ -399,28 +397,32 @@ impl serde::Serialize for ServerTLSConfig {
 	}
 }
 
-pub fn parse_cert(mut cert: &[u8]) -> Result<Vec<CertificateDer<'static>>, anyhow::Error> {
-	let mut reader = std::io::BufReader::new(Cursor::new(&mut cert));
-	let parsed: Result<Vec<_>, _> = rustls_pemfile::read_all(&mut reader).collect();
-	parsed?
+pub fn parse_cert(cert: &[u8]) -> Result<Vec<CertificateDer<'static>>, anyhow::Error> {
+	let parsed = <(SectionKind, Vec<u8>)>::pem_slice_iter(cert).collect::<Result<Vec<_>, _>>()?;
+	if parsed.is_empty() {
+		return Err(anyhow!("no certificate"));
+	}
+
+	parsed
 		.into_iter()
-		.map(|p| {
-			let Item::X509Certificate(der) = p else {
+		.map(|(kind, der)| {
+			if kind != SectionKind::Certificate {
 				return Err(anyhow!("no certificate"));
-			};
-			Ok(der)
+			}
+			Ok(CertificateDer::from(der))
 		})
-		.collect::<Result<Vec<_>, _>>()
+		.collect()
 }
 
-pub fn parse_key(mut key: &[u8]) -> Result<PrivateKeyDer<'static>, anyhow::Error> {
-	let mut reader = std::io::BufReader::new(Cursor::new(&mut key));
-	let parsed = rustls_pemfile::read_one(&mut reader)?;
-	let parsed = parsed.ok_or_else(|| anyhow!("no key"))?;
-	match parsed {
-		Item::Pkcs8Key(c) => Ok(PrivateKeyDer::Pkcs8(c)),
-		Item::Pkcs1Key(c) => Ok(PrivateKeyDer::Pkcs1(c)),
-		Item::Sec1Key(c) => Ok(PrivateKeyDer::Sec1(c)),
+pub fn parse_key(key: &[u8]) -> Result<PrivateKeyDer<'static>, anyhow::Error> {
+	let (kind, der) = <(SectionKind, Vec<u8>)>::from_pem_slice(key).map_err(|e| match e {
+		rustls_pki_types::pem::Error::NoItemsFound => anyhow!("no key"),
+		_ => anyhow!(e),
+	})?;
+	match kind {
+		SectionKind::PrivateKey => Ok(PrivateKeyDer::Pkcs8(der.into())),
+		SectionKind::RsaPrivateKey => Ok(PrivateKeyDer::Pkcs1(der.into())),
+		SectionKind::EcPrivateKey => Ok(PrivateKeyDer::Sec1(der.into())),
 		_ => Err(anyhow!("unsupported key")),
 	}
 }
@@ -2417,13 +2419,8 @@ InvalidKeyData
 
 		let result = parse_key(invalid_key);
 		assert!(result.is_err());
-		// Check for actual error message that rustls_pemfile returns
 		let error_msg = result.unwrap_err().to_string();
-		assert!(
-			error_msg.contains("failed to fill whole buffer")
-				|| error_msg.contains("no key")
-				|| error_msg.contains("unsupported key")
-		);
+		assert!(error_msg.contains("base64 decode error") || error_msg.contains("no key"));
 	}
 
 	#[test]

--- a/crates/agentgateway/tests/common/hbone_server.rs
+++ b/crates/agentgateway/tests/common/hbone_server.rs
@@ -184,7 +184,8 @@ fn generate_test_certs(name: &str) -> rustls::ServerConfig {
 		CertificateParams, DistinguishedName, DnType, ExtendedKeyUsagePurpose, Issuer, KeyPair,
 		KeyUsagePurpose, SanType, SerialNumber,
 	};
-	use rustls::pki_types::CertificateDer;
+	use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+	use rustls_pki_types::pem::PemObject;
 
 	// Generate random serial number (159 bits)
 	let serial_number = {
@@ -231,16 +232,10 @@ fn generate_test_certs(name: &str) -> rustls::ServerConfig {
 
 	// Convert to DER for rustls
 	let cert_der = CertificateDer::from(server_cert.der().to_vec());
-	let key_der = rustls_pemfile::private_key(&mut key_pem.as_bytes())
-		.unwrap()
-		.unwrap();
+	let key_der = PrivateKeyDer::from_pem_slice(key_pem.as_bytes()).unwrap();
 
 	// Load CA cert for trust store
-	let mut root_cursor = std::io::Cursor::new(super::shared_ca::TEST_ROOT);
-	let ca_der = rustls_pemfile::certs(&mut root_cursor)
-		.next()
-		.unwrap()
-		.unwrap();
+	let ca_der = CertificateDer::from_pem_slice(super::shared_ca::TEST_ROOT).unwrap();
 
 	let mut root_store = rustls::RootCertStore::empty();
 	root_store.add(ca_der).unwrap();

--- a/deny.toml
+++ b/deny.toml
@@ -46,15 +46,6 @@ exceptions = [
     { allow = ["CDLA-Permissive-2.0"], crate = "webpki-roots" },
 ]
 
-# Deny cannot detect ring properly. Directly assign
-[[licenses.clarify]]
-name = "ring"
-version = "*"
-expression = "MIT AND ISC AND OpenSSL"
-license-files = [
-    { path = "LICENSE", hash = 0xbd0eed23 },
-]
-
 [bans]
 skip = [
     { crate = "regex-syntax", version = "0.6.29", reason = "acceptable duplicate" },


### PR DESCRIPTION
We already make extensive use of `aws-lc-rs` instead of `ring`. This removes the need for `ring` in the agentgateway binaries. Which should also speed up compilation a bit.