### PR TITLE
tests: use JSON for construction instead of non-ergonomic types

### DIFF
--- a/crates/agentgateway/src/http/ext_proc_tests.rs
+++ b/crates/agentgateway/src/http/ext_proc_tests.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use ::http::{HeaderMap, Method, Request};
 use hyper_util::client::legacy::Client;
+use serde_json::json;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::Sender;
 use tonic::Status;
@@ -21,9 +22,6 @@ use crate::test_helpers::extprocmock::{
 	request_header_response, response_body_response, response_header_response,
 };
 use crate::test_helpers::proxymock::*;
-use crate::types::agent::{
-	PolicyTarget, RouteTarget, SimpleBackendReference, TargetedPolicy, TrafficPolicy,
-};
 use crate::*;
 
 #[tokio::test]
@@ -206,28 +204,16 @@ pub async fn setup_ext_proc_mock_with_meta<T: Handler + Send + Sync + 'static>(
 		.with_backend(*mock.address())
 		.with_backend(ext_proc.address)
 		.with_bind(simple_bind(basic_route(*mock.address())))
-		.with_policy(TargetedPolicy {
-			key: strng::new("ext_proc"),
-			name: None,
-			target: PolicyTarget::Route(RouteTarget {
-				name: "route".into(),
-				namespace: Default::default(),
-				rule_name: None,
-				kind: None,
-			}),
-			policy: TrafficPolicy::ExtProc(ext_proc::ExtProc {
-				policies: Default::default(),
-				target: Arc::new(SimpleBackendReference::Backend(strng::format!(
-					"/{}",
-					ext_proc.address
-				))),
-				failure_mode,
-				metadata_context,
-				request_attributes,
-				response_attributes,
-			})
-			.into(),
-		});
+		.attach_route_policy_builder(json!({
+			"extProc": {
+				"host": ext_proc.address,
+				"failureMode": failure_mode,
+				"metadataContext": metadata_context,
+				"requestAttributes": request_attributes,
+				"responseAttributes": response_attributes,
+			}
+		}))
+		.await;
 	let io = t.serve_http(strng::new("bind"));
 	(mock, ext_proc, t, io)
 }

--- a/crates/agentgateway/src/http/tests_common.rs
+++ b/crates/agentgateway/src/http/tests_common.rs
@@ -1,6 +1,8 @@
+use bytes::Bytes;
 use http::{HeaderName, HeaderValue, Uri};
 
 use crate::http::{Body, Request, Response};
+use crate::test_helpers::proxymock::read_body_raw;
 
 pub fn request_for_uri(uri: &str) -> Request {
 	request(uri, http::Method::GET, &[])
@@ -34,4 +36,49 @@ impl ResponseExt for Response {
 			.and_then(|s| s.to_str().ok())
 			.unwrap_or_default()
 	}
+}
+
+pub fn assert_status(res: &Response, want: u16) {
+	assert_eq!(res.status().as_u16(), want);
+}
+
+pub fn assert_header(res: &Response, h: impl TryInto<HeaderName>, want: &str) {
+	let Ok(h) = h.try_into() else {
+		panic!("invalid header key")
+	};
+	assert_eq!(res.hdr(h), want);
+}
+
+pub async fn assert_body(res: Response, want: impl AsRef<[u8]>) {
+	let body = read_body_raw(res.into_body()).await;
+	assert_eq!(body.as_ref(), want.as_ref());
+}
+
+pub trait IntoTestBody {
+	fn into_test_body(self) -> Body;
+}
+
+impl IntoTestBody for Body {
+	fn into_test_body(self) -> Body {
+		self
+	}
+}
+
+impl IntoTestBody for Response {
+	fn into_test_body(self) -> Body {
+		self.into_body()
+	}
+}
+
+pub async fn read_body_for_test(body: impl IntoTestBody) -> Bytes {
+	crate::http::read_body_with_limit(body.into_test_body(), 100)
+		.await
+		.unwrap()
+}
+
+#[macro_export]
+macro_rules! read_body {
+	($body:expr) => {
+		$crate::http::tests_common::read_body_for_test($body).await
+	};
 }

--- a/crates/agentgateway/src/proxy/gateway_test.rs
+++ b/crates/agentgateway/src/proxy/gateway_test.rs
@@ -1,25 +1,21 @@
-use ::http::{Method, StatusCode, Version};
+use ::http::{Method, Version};
 use agent_core::strng;
 use assert_matches::assert_matches;
-use bytes::Bytes;
 use http_body_util::BodyExt;
 use hyper_util::client::legacy::Client;
 use rand::RngExt;
-use serde::de::DeserializeOwned;
 use serde_json::{Value, json};
 use x509_parser::nom::AsBytes;
 
-use crate::http::cors;
 use crate::http::tests_common::*;
-use crate::http::transformation_cel::Transformation;
-use crate::http::{Body, Response, transformation_cel};
+use crate::http::{Body, Response};
 use crate::llm::{AIProvider, openai};
 use crate::proxy::request_builder::RequestBuilder;
+use crate::read_body;
 use crate::test_helpers::proxymock::*;
 use crate::types::agent::{
-	Backend, BackendPolicy, BackendReference, BackendWithPolicies, Bind, BindProtocol, Listener,
-	ListenerProtocol, ListenerSet, PathMatch, PolicyTarget, ResourceName, Route,
-	RouteBackendReference, RouteMatch, RouteName, RouteSet, Target, TargetedPolicy, TrafficPolicy,
+	Backend, BackendPolicy, BackendWithPolicies, Bind, BindProtocol, Listener, ListenerProtocol,
+	ListenerSet, ResourceName, RouteSet, Target,
 };
 use crate::types::backend;
 use crate::*;
@@ -62,28 +58,16 @@ async fn basic_http2() {
 
 #[tokio::test]
 async fn local_ratelimit() {
-	let (_mock, bind, io) = basic_setup().await;
-	let _bind = bind.with_policy(TargetedPolicy {
-		key: strng::new("rl"),
-		name: None,
-		target: PolicyTarget::Route(RouteName {
-			name: "route".into(),
-			namespace: "".into(),
-			rule_name: None,
-			kind: None,
-		}),
-		policy: TrafficPolicy::LocalRateLimit(vec![
-			http::localratelimit::RateLimitSpec {
-				max_tokens: 1,
-				tokens_per_fill: 1,
-				fill_interval: Duration::from_secs(1),
-				limit_type: Default::default(),
-			}
-			.try_into()
-			.unwrap(),
-		])
-		.into(),
-	});
+	let (_mock, mut bind, io) = basic_setup().await;
+	bind
+		.attach_route_policy(json!({
+			"localRateLimit": [{
+				"maxTokens": 1,
+				"tokensPerFill": 1,
+				"fillInterval": "1s",
+			}],
+		}))
+		.await;
 
 	let res = send_request(io.clone(), Method::GET, "http://lo").await;
 	assert_eq!(res.status(), 200);
@@ -91,56 +75,29 @@ async fn local_ratelimit() {
 	assert_eq!(res.status(), 429);
 }
 
-/// Helper to build a CORS policy for tests.
-fn cors_policy(allow_origins: Vec<&str>, allow_methods: Vec<&str>) -> cors::Cors {
-	cors::Cors::try_from(cors::CorsSerde {
-		allow_credentials: false,
-		allow_headers: vec!["*".to_string()],
-		allow_methods: allow_methods.into_iter().map(String::from).collect(),
-		allow_origins: allow_origins.into_iter().map(String::from).collect(),
-		expose_headers: vec![],
-		max_age: None,
-	})
-	.unwrap()
-}
-
 /// Verifies that a CORS preflight (OPTIONS) request returns 200 even when
 /// the rate limit is exhausted, because CORS runs before authentication and rate limiting.
 #[tokio::test]
 async fn cors_preflight_bypasses_ratelimit() {
-	let (_mock, bind, io) = basic_setup().await;
-	let route_target = PolicyTarget::Route(RouteName {
-		name: "route".into(),
-		namespace: "".into(),
-		rule_name: None,
-		kind: None,
-	});
+	let (_mock, mut bind, io) = basic_setup().await;
 
 	// Attach CORS + rate limit (1 token, essentially immediately exhausted after first real request)
-	let _bind = bind
-		.with_policy(TargetedPolicy {
-			key: strng::new("cors"),
-			name: None,
-			target: route_target.clone(),
-			policy: TrafficPolicy::CORS(cors_policy(vec!["http://example.com"], vec!["GET", "POST"]))
-				.into(),
-		})
-		.with_policy(TargetedPolicy {
-			key: strng::new("rl"),
-			name: None,
-			target: route_target,
-			policy: TrafficPolicy::LocalRateLimit(vec![
-				http::localratelimit::RateLimitSpec {
-					max_tokens: 1,
-					tokens_per_fill: 1,
-					fill_interval: Duration::from_secs(100),
-					limit_type: Default::default(),
-				}
-				.try_into()
-				.unwrap(),
-			])
-			.into(),
-		});
+	bind
+		.attach_route_policy(json!({
+			"cors": {
+				"allowCredentials": false,
+				"allowHeaders": ["*"],
+				"allowMethods": ["GET", "POST"],
+				"allowOrigins": ["http://example.com"],
+				"exposeHeaders": [],
+			},
+			"localRateLimit": [{
+				"maxTokens": 1,
+				"tokensPerFill": 1,
+				"fillInterval": "100s",
+			}],
+		}))
+		.await;
 
 	// First real request exhausts the single token
 	let res = send_request(io.clone(), Method::GET, "http://lo").await;
@@ -169,38 +126,23 @@ async fn cors_preflight_bypasses_ratelimit() {
 /// still carries the CORS headers so browsers can read the error.
 #[tokio::test]
 async fn cors_headers_present_on_ratelimited_response() {
-	let (_mock, bind, io) = basic_setup().await;
-	let route_target = PolicyTarget::Route(RouteName {
-		name: "route".into(),
-		namespace: "".into(),
-		rule_name: None,
-		kind: None,
-	});
-
-	let _bind = bind
-		.with_policy(TargetedPolicy {
-			key: strng::new("cors"),
-			name: None,
-			target: route_target.clone(),
-			policy: TrafficPolicy::CORS(cors_policy(vec!["http://example.com"], vec!["GET", "POST"]))
-				.into(),
-		})
-		.with_policy(TargetedPolicy {
-			key: strng::new("rl"),
-			name: None,
-			target: route_target,
-			policy: TrafficPolicy::LocalRateLimit(vec![
-				http::localratelimit::RateLimitSpec {
-					max_tokens: 1,
-					tokens_per_fill: 1,
-					fill_interval: Duration::from_secs(100),
-					limit_type: Default::default(),
-				}
-				.try_into()
-				.unwrap(),
-			])
-			.into(),
-		});
+	let (_mock, mut bind, io) = basic_setup().await;
+	bind
+		.attach_route_policy(json!({
+			"cors": {
+				"allowCredentials": false,
+				"allowHeaders": ["*"],
+				"allowMethods": ["GET", "POST"],
+				"allowOrigins": ["http://example.com"],
+				"exposeHeaders": [],
+			},
+			"localRateLimit": [{
+				"maxTokens": 1,
+				"tokensPerFill": 1,
+				"fillInterval": "100s",
+			}],
+		}))
+		.await;
 
 	// Exhaust rate limit with a normal cross-origin GET
 	let res = send_request_headers(
@@ -234,38 +176,24 @@ async fn cors_headers_present_on_ratelimited_response() {
 /// and authorization.
 #[tokio::test]
 async fn cors_preflight_bypasses_api_key_auth() {
-	let (_mock, bind, io) = basic_setup().await;
-	let route_target = PolicyTarget::Route(RouteName {
-		name: "route".into(),
-		namespace: "".into(),
-		rule_name: None,
-		kind: None,
-	});
-
-	let _bind = bind
-		.with_policy(TargetedPolicy {
-			key: strng::new("cors"),
-			name: None,
-			target: route_target.clone(),
-			policy: TrafficPolicy::CORS(cors_policy(vec!["http://example.com"], vec!["GET", "POST"]))
-				.into(),
-		})
-		.with_policy(TargetedPolicy {
-			key: strng::new("apikey"),
-			name: None,
-			target: route_target,
-			policy: TrafficPolicy::APIKey(
-				http::apikey::LocalAPIKeys {
-					keys: vec![http::apikey::LocalAPIKey {
-						key: http::apikey::APIKey::new("sk-123"),
-						metadata: None,
-					}],
-					mode: http::apikey::Mode::Strict,
-				}
-				.into(),
-			)
-			.into(),
-		});
+	let (_mock, mut bind, io) = basic_setup().await;
+	bind
+		.attach_route_policy(json!({
+			"cors": {
+				"allowCredentials": false,
+				"allowHeaders": ["*"],
+				"allowMethods": ["GET", "POST"],
+				"allowOrigins": ["http://example.com"],
+				"exposeHeaders": [],
+			},
+			"apiKey": {
+				"keys": [{
+					"key": "sk-123",
+				}],
+				"mode": "strict",
+			},
+		}))
+		.await;
 
 	// Request without credentials should be rejected
 	let res = send_request(io.clone(), Method::GET, "http://lo").await;
@@ -291,37 +219,23 @@ async fn cors_preflight_bypasses_api_key_auth() {
 /// and authorization.
 #[tokio::test]
 async fn cors_preflight_bypasses_basic_auth() {
-	let (_mock, bind, io) = basic_setup().await;
-	let route_target = PolicyTarget::Route(RouteName {
-		name: "route".into(),
-		namespace: "".into(),
-		rule_name: None,
-		kind: None,
-	});
-
-	let _bind = bind
-		.with_policy(TargetedPolicy {
-			key: strng::new("cors"),
-			name: None,
-			target: route_target.clone(),
-			policy: TrafficPolicy::CORS(cors_policy(vec!["http://example.com"], vec!["GET", "POST"]))
-				.into(),
-		})
-		.with_policy(TargetedPolicy {
-			key: strng::new("basic"),
-			name: None,
-			target: route_target,
-			policy: TrafficPolicy::BasicAuth(
-				http::basicauth::LocalBasicAuth {
-					htpasswd: FileOrInline::Inline("user:$apr1$lZL6V/ci$eIMz/iKDkbtys/uU7LEK00".to_string()),
-					realm: Some("my-realm".into()),
-					mode: http::basicauth::Mode::Strict,
-				}
-				.try_into()
-				.unwrap(),
-			)
-			.into(),
-		});
+	let (_mock, mut bind, io) = basic_setup().await;
+	bind
+		.attach_route_policy(json!({
+			"cors": {
+				"allowCredentials": false,
+				"allowHeaders": ["*"],
+				"allowMethods": ["GET", "POST"],
+				"allowOrigins": ["http://example.com"],
+				"exposeHeaders": [],
+			},
+			"basicAuth": {
+				"htpasswd": "user:$apr1$lZL6V/ci$eIMz/iKDkbtys/uU7LEK00",
+				"realm": "my-realm",
+				"mode": "strict",
+			},
+		}))
+		.await;
 
 	// Request without credentials should be rejected
 	let res = send_request(io.clone(), Method::GET, "http://lo").await;
@@ -347,47 +261,28 @@ async fn cors_preflight_bypasses_basic_auth() {
 /// authorization.
 #[tokio::test]
 async fn cors_preflight_bypasses_authorization() {
-	let (_mock, bind, io) = basic_setup().await;
-	let route_target = PolicyTarget::Route(RouteName {
-		name: "route".into(),
-		namespace: "".into(),
-		rule_name: None,
-		kind: None,
-	});
-
-	let _bind = bind
-		.with_policy(TargetedPolicy {
-			key: strng::new("cors"),
-			name: None,
-			target: route_target.clone(),
-			policy: TrafficPolicy::CORS(cors_policy(vec!["http://example.com"], vec!["GET", "POST"]))
-				.into(),
-		})
-		.with_policy(TargetedPolicy {
-			key: strng::new("apikey"),
-			name: None,
-			target: route_target.clone(),
-			policy: TrafficPolicy::APIKey(
-				http::apikey::LocalAPIKeys {
-					keys: vec![http::apikey::LocalAPIKey {
-						key: http::apikey::APIKey::new("sk-123"),
-						metadata: Some(json!({"group": "eng"})),
-					}],
-					mode: http::apikey::Mode::Strict,
-				}
-				.into(),
-			)
-			.into(),
-		})
-		.with_policy(TargetedPolicy {
-			key: strng::new("auth"),
-			name: None,
-			target: route_target,
-			policy: TrafficPolicy::Authorization(deser(json!({
-				"rules": ["apiKey.group == 'admin'"]
-			})))
-			.into(),
-		});
+	let (_mock, mut bind, io) = basic_setup().await;
+	bind
+		.attach_route_policy(json!({
+			"cors": {
+				"allowCredentials": false,
+				"allowHeaders": ["*"],
+				"allowMethods": ["GET", "POST"],
+				"allowOrigins": ["http://example.com"],
+				"exposeHeaders": [],
+			},
+			"apiKey": {
+				"keys": [{
+					"key": "sk-123",
+					"metadata": {"group": "eng"},
+				}],
+				"mode": "strict",
+			},
+			"authorization": {
+				"rules": ["apiKey.group == 'admin'"],
+			},
+		}))
+		.await;
 
 	// Authenticated request should be rejected by authorization (403)
 	let res = send_request_headers(
@@ -419,47 +314,28 @@ async fn cors_preflight_bypasses_authorization() {
 /// error body.
 #[tokio::test]
 async fn cors_headers_present_on_auth_rejected_response() {
-	let (_mock, bind, io) = basic_setup().await;
-	let route_target = PolicyTarget::Route(RouteName {
-		name: "route".into(),
-		namespace: "".into(),
-		rule_name: None,
-		kind: None,
-	});
-
-	let _bind = bind
-		.with_policy(TargetedPolicy {
-			key: strng::new("cors"),
-			name: None,
-			target: route_target.clone(),
-			policy: TrafficPolicy::CORS(cors_policy(vec!["http://example.com"], vec!["GET", "POST"]))
-				.into(),
-		})
-		.with_policy(TargetedPolicy {
-			key: strng::new("apikey"),
-			name: None,
-			target: route_target.clone(),
-			policy: TrafficPolicy::APIKey(
-				http::apikey::LocalAPIKeys {
-					keys: vec![http::apikey::LocalAPIKey {
-						key: http::apikey::APIKey::new("sk-123"),
-						metadata: Some(json!({"group": "eng"})),
-					}],
-					mode: http::apikey::Mode::Strict,
-				}
-				.into(),
-			)
-			.into(),
-		})
-		.with_policy(TargetedPolicy {
-			key: strng::new("auth"),
-			name: None,
-			target: route_target,
-			policy: TrafficPolicy::Authorization(deser(json!({
-				"rules": ["apiKey.group == 'admin'"]
-			})))
-			.into(),
-		});
+	let (_mock, mut bind, io) = basic_setup().await;
+	bind
+		.attach_route_policy(json!({
+			"cors": {
+				"allowCredentials": false,
+				"allowHeaders": ["*"],
+				"allowMethods": ["GET", "POST"],
+				"allowOrigins": ["http://example.com"],
+				"exposeHeaders": [],
+			},
+			"apiKey": {
+				"keys": [{
+					"key": "sk-123",
+					"metadata": {"group": "eng"},
+				}],
+				"mode": "strict",
+			},
+			"authorization": {
+				"rules": ["apiKey.group == 'admin'"],
+			},
+		}))
+		.await;
 
 	// 401: missing credentials, CORS headers should still be present
 	let res = send_request_headers(
@@ -612,58 +488,36 @@ async fn basic_tcp() {
 
 #[tokio::test]
 async fn direct_response() {
-	let mock = simple_mock().await;
-	let xfm = transformation_cel::LocalTransformationConfig {
-		response: Some(transformation_cel::LocalTransform {
-			add: vec![("x-xfm".into(), "\"x-xfm-val\"".into())],
-			..Default::default()
-		}),
-		request: None,
-	};
-	let xfm = Transformation::try_from_local_config(xfm, true).unwrap();
-	let bind = base_gateway(&mock).with_route(Route {
-		key: "route2".into(),
-		name: RouteName {
-			name: "route2".into(),
-			namespace: Default::default(),
-			rule_name: None,
-			kind: None,
-		},
-		hostnames: Default::default(),
-		matches: vec![RouteMatch {
-			headers: vec![],
-			path: PathMatch::PathPrefix("/p".into()),
-			method: None,
-			query: vec![],
-		}],
-		inline_policies: vec![
-			TrafficPolicy::ResponseHeaderModifier(http::filters::HeaderModifier {
-				add: vec![("x-filter".into(), "x-filter-val".into())],
-				set: vec![],
-				remove: vec![],
-			}),
-			TrafficPolicy::DirectResponse(crate::http::filters::DirectResponse {
-				body: Bytes::from_static(b"hello"),
-				status: StatusCode::UNPROCESSABLE_ENTITY,
-			}),
-			TrafficPolicy::Transformation(xfm),
-		],
-		backends: vec![],
-	});
-	let io = bind.serve_http(BIND_KEY);
+	let (_mock, mut bind, io) = basic_setup().await;
+	bind
+		.attach_route(json!({
+			"policies": {
+				"responseHeaderModifier": {
+					"add": {
+						"x-filter": "x-filter-val"
+					},
+				},
+				"directResponse": {
+					"body": "hello",
+					"status": 422,
+				},
+				"transformations": {
+					"response": {
+						"add": {
+							"x-xfm": "'x-xfm-val'",
+						},
+					},
+				},
+			},
+		}))
+		.await;
 
 	let res = send_request(io.clone(), Method::GET, "http://lo/p").await;
 	assert_eq!(res.status(), 422);
 	// Each type of response modifier should still run even though its a direct response
 	assert_eq!(res.hdr("x-filter"), "x-filter-val");
 	assert_eq!(res.hdr("x-xfm"), "x-xfm-val");
-	assert_eq!(
-		http::read_body_with_limit(res.into_body(), 100)
-			.await
-			.unwrap()
-			.as_bytes(),
-		b"hello"
-	);
+	assert_eq!(read_body!(res).as_bytes(), b"hello");
 }
 
 #[tokio::test]
@@ -922,63 +776,50 @@ async fn send_http_version(t: &TestBind, v: Version) -> Response {
 
 #[tokio::test]
 async fn header_manipulation() {
-	let mock = simple_mock().await;
-	let backend_xfm = transformation_cel::LocalTransformationConfig {
-		request: Some(transformation_cel::LocalTransform {
-			set: vec![("x-backend-xfm-req".into(), "\"backend-xfm-req\"".into())],
-			..Default::default()
-		}),
-		response: Some(transformation_cel::LocalTransform {
-			add: vec![("x-backend-xfm-resp".into(), "\"backend-xfm-resp\"".into())],
-			..Default::default()
-		}),
-	};
-	let backend_xfm = Transformation::try_from_local_config(backend_xfm, true).unwrap();
-	let bind = base_gateway(&mock).with_route(Route {
-		key: "route2".into(),
-		name: RouteName {
-			name: "route2".into(),
-			namespace: Default::default(),
-			rule_name: None,
-			kind: None,
-		},
-		hostnames: Default::default(),
-		matches: vec![RouteMatch {
-			headers: vec![],
-			path: PathMatch::PathPrefix("/p".into()),
-			method: None,
-			query: vec![],
-		}],
-		inline_policies: vec![
-			TrafficPolicy::RequestHeaderModifier(http::filters::HeaderModifier {
-				add: vec![("x-route-req".into(), "route-req".into())],
-				set: vec![],
-				remove: vec![],
-			}),
-			TrafficPolicy::ResponseHeaderModifier(http::filters::HeaderModifier {
-				add: vec![("x-route-resp".into(), "route-resp".into())],
-				set: vec![],
-				remove: vec![],
-			}),
-		],
-		backends: vec![RouteBackendReference {
-			weight: 1,
-			backend: BackendReference::Backend(strng::format!("/{}", mock.address())),
-			inline_policies: vec![
-				BackendPolicy::RequestHeaderModifier(http::filters::HeaderModifier {
-					add: vec![("x-backend-req".into(), "backend-req".into())],
-					set: vec![],
-					remove: vec![],
-				}),
-				BackendPolicy::ResponseHeaderModifier(http::filters::HeaderModifier {
-					add: vec![("x-backend-resp".into(), "backend-resp".into())],
-					set: vec![],
-					remove: vec![],
-				}),
-				BackendPolicy::Transformation(backend_xfm),
-			],
-		}],
-	});
+	let (mock, mut bind, _io) = basic_setup().await;
+	bind
+		.attach_route(json!({
+			"policies": {
+				"requestHeaderModifier": {
+					"add": {
+						"x-route-req": "route-req",
+					},
+				},
+				"responseHeaderModifier": {
+					"add": {
+						"x-route-resp": "route-resp",
+					},
+				},
+			},
+			"backends": [{
+				"host": mock.address().to_string(),
+				"policies": {
+					"requestHeaderModifier": {
+						"add": {
+							"x-backend-req": "backend-req",
+						},
+					},
+					"responseHeaderModifier": {
+						"add": {
+							"x-backend-resp": "backend-resp",
+						},
+					},
+					"transformations": {
+						"request": {
+							"set": {
+								"x-backend-xfm-req": "'backend-xfm-req'",
+							},
+						},
+						"response": {
+							"add": {
+								"x-backend-xfm-resp": "'backend-xfm-resp'",
+							},
+						},
+					},
+				},
+			}],
+		}))
+		.await;
 	let io = bind.serve_http(BIND_KEY);
 
 	let res = send_request(io.clone(), Method::GET, "http://lo/p").await;
@@ -1003,71 +844,56 @@ async fn header_manipulation() {
 
 #[tokio::test]
 async fn inline_backend_policies() {
-	let mock = simple_mock().await;
-	let bind = base_gateway(&mock)
-		.with_route(Route {
-			key: "route2".into(),
-			name: RouteName {
-				name: "route2".into(),
-				namespace: Default::default(),
-				rule_name: None,
-				kind: None,
+	let (mock, mut bind, io) = basic_setup().await;
+	bind
+		.attach_backend(json!({
+			"name": "backend1",
+			"host": mock.address(),
+			"policies": {
+				"requestHeaderModifier": {
+					"add": {
+						"x-backend-req": "backend-req",
+					}
+				},
+				"responseHeaderModifier": {
+					"add": {
+						"x-backend-resp": "backend-resp",
+					}
+				}
+			}
+		}))
+		.await;
+	bind
+		.attach_route(json!({
+			"policies": {
+				"requestHeaderModifier": {
+					"add": {
+						"x-route-req": "route-req",
+					},
+				},
+				"responseHeaderModifier": {
+					"add": {
+						"x-route-resp": "route-resp",
+					},
+				},
 			},
-			hostnames: Default::default(),
-			matches: vec![RouteMatch {
-				headers: vec![],
-				path: PathMatch::PathPrefix("/p".into()),
-				method: None,
-				query: vec![],
+			"backends": [{
+				"backend": "/backend1",
+				"policies": {
+					"requestHeaderModifier": {
+						"add": {
+							"x-backend-route-req": "backend-route-req",
+						},
+					},
+					"responseHeaderModifier": {
+						"add": {
+							"x-backend-route-resp": "backend-route-resp",
+						},
+					},
+				},
 			}],
-			inline_policies: vec![
-				TrafficPolicy::RequestHeaderModifier(http::filters::HeaderModifier {
-					add: vec![("x-route-req".into(), "route-req".into())],
-					set: vec![],
-					remove: vec![],
-				}),
-				TrafficPolicy::ResponseHeaderModifier(http::filters::HeaderModifier {
-					add: vec![("x-route-resp".into(), "route-resp".into())],
-					set: vec![],
-					remove: vec![],
-				}),
-			],
-			backends: vec![RouteBackendReference {
-				weight: 1,
-				backend: BackendReference::Backend(strng::format!("/{}", mock.address())),
-				inline_policies: vec![
-					BackendPolicy::RequestHeaderModifier(http::filters::HeaderModifier {
-						add: vec![("x-backend-route-req".into(), "backend-route-req".into())],
-						set: vec![],
-						remove: vec![],
-					}),
-					BackendPolicy::ResponseHeaderModifier(http::filters::HeaderModifier {
-						add: vec![("x-backend-route-resp".into(), "backend-route-resp".into())],
-						set: vec![],
-						remove: vec![],
-					}),
-				],
-			}],
-		})
-		.with_raw_backend(BackendWithPolicies {
-			backend: Backend::Opaque(
-				ResourceName::new(strng::format!("{}", mock.address()), "".into()),
-				Target::Address(*mock.address()),
-			),
-			inline_policies: vec![
-				BackendPolicy::RequestHeaderModifier(http::filters::HeaderModifier {
-					add: vec![("x-backend-req".into(), "backend-req".into())],
-					set: vec![],
-					remove: vec![],
-				}),
-				BackendPolicy::ResponseHeaderModifier(http::filters::HeaderModifier {
-					add: vec![("x-backend-resp".into(), "backend-resp".into())],
-					set: vec![],
-					remove: vec![],
-				}),
-			],
-		});
-	let io = bind.serve_http(BIND_KEY);
+		}))
+		.await;
 
 	let res = send_request(io.clone(), Method::GET, "http://lo/p").await;
 	assert_eq!(res.status(), 200);
@@ -1090,49 +916,27 @@ async fn inline_backend_policies() {
 
 #[tokio::test]
 async fn api_key() {
-	let (_mock, bind, io) = basic_setup().await;
-	let _bind = bind
-		.with_policy(TargetedPolicy {
-			key: strng::new("apikey"),
-			name: Default::default(),
-			target: PolicyTarget::Route(RouteName {
-				name: "route".into(),
-				namespace: "".into(),
-				rule_name: None,
-				kind: None,
-			}),
-			policy: TrafficPolicy::APIKey(
-				http::apikey::LocalAPIKeys {
-					keys: vec![
-						http::apikey::LocalAPIKey {
-							key: http::apikey::APIKey::new("sk-123"),
-							metadata: Some(json!({"group": "eng"})),
-						},
-						http::apikey::LocalAPIKey {
-							key: http::apikey::APIKey::new("sk-456"),
-							metadata: Some(json!({"group": "sales"})),
-						},
-					],
-					mode: http::apikey::Mode::Strict,
-				}
-				.into(),
-			)
-			.into(),
-		})
-		.with_policy(TargetedPolicy {
-			key: strng::new("auth"),
-			name: Default::default(),
-			target: PolicyTarget::Route(RouteName {
-				name: "route".into(),
-				namespace: "".into(),
-				rule_name: None,
-				kind: None,
-			}),
-			policy: TrafficPolicy::Authorization(deser(json!({
-				"rules": ["apiKey.group == 'eng'"]
-			})))
-			.into(),
-		});
+	let (_mock, mut bind, io) = basic_setup().await;
+	bind
+		.attach_route_policy(json!({
+			"apiKey": {
+				"keys": [
+					{
+						"key": "sk-123",
+						"metadata": {"group": "eng"},
+					},
+					{
+						"key": "sk-456",
+						"metadata": {"group": "sales"},
+					}
+				],
+				"mode": "strict",
+			},
+			"authorization": {
+				"rules": ["apiKey.group == 'eng'"],
+			},
+		}))
+		.await;
 
 	let res = send_request_headers(
 		io.clone(),
@@ -1167,48 +971,19 @@ async fn api_key() {
 
 #[tokio::test]
 async fn basic_auth() {
-	let (_mock, bind, io) = basic_setup().await;
-	let _bind = bind
-		.with_policy(TargetedPolicy {
-			key: strng::new("basic"),
-			name: None,
-			target: PolicyTarget::Route(RouteName {
-				name: "route".into(),
-				namespace: "".into(),
-				rule_name: None,
-				kind: None,
-			}),
-			policy: TrafficPolicy::BasicAuth(
-				http::basicauth::LocalBasicAuth {
-					htpasswd: FileOrInline::Inline(
-						"user:$apr1$lZL6V/ci$eIMz/iKDkbtys/uU7LEK00
-bcrypt_test:$2y$05$nC6nErr9XZJuMJ57WyCob.EuZEjylDt2KaHfbfOtyb.EgL1I2jCVa
-sha1_test:{SHA}W6ph5Mm5Pz8GgiULbPgzG37mj9g=
-crypt_test:bGVh02xkuGli2"
-							.to_string(),
-					),
-					realm: Some("my-realm".into()),
-					mode: http::basicauth::Mode::Strict,
-				}
-				.try_into()
-				.unwrap(),
-			)
-			.into(),
-		})
-		.with_policy(TargetedPolicy {
-			key: strng::new("auth"),
-			name: Default::default(),
-			target: PolicyTarget::Route(RouteName {
-				name: "route".into(),
-				namespace: "".into(),
-				rule_name: None,
-				kind: None,
-			}),
-			policy: TrafficPolicy::Authorization(deser(json!({
-				"rules": ["basicAuth.username == 'user'"]
-			})))
-			.into(),
-		});
+	let (_mock, mut bind, io) = basic_setup().await;
+	bind
+      .attach_route_policy(json!({
+			"basicAuth": {
+				"htpasswd": "user:$apr1$lZL6V/ci$eIMz/iKDkbtys/uU7LEK00\nbcrypt_test:$2y$05$nC6nErr9XZJuMJ57WyCob.EuZEjylDt2KaHfbfOtyb.EgL1I2jCVa\nsha1_test:{SHA}W6ph5Mm5Pz8GgiULbPgzG37mj9g=\ncrypt_test:bGVh02xkuGli2",
+				"realm": "my-realm",
+				"mode": "strict",
+			},
+			"authorization": {
+				"rules": ["basicAuth.username == 'user'"],
+			},
+		}))
+      .await;
 
 	use base64::Engine;
 	let md5 = base64::prelude::BASE64_STANDARD.encode(b"user:password");
@@ -1390,10 +1165,6 @@ async fn assert_llm(io: Client<MemoryConnector, Body>, body: &[u8], want: Value)
 	.unwrap();
 	let valid = is_json_subset(&want, &log);
 	assert!(valid, "want={want:#?} got={log:#?}");
-}
-
-fn deser<T: DeserializeOwned>(v: serde_json::Value) -> T {
-	serde_json::from_value(v).unwrap()
 }
 
 // --- Dynamic Forward Proxy (DFP) tests ---

--- a/crates/agentgateway/src/serdes.rs
+++ b/crates/agentgateway/src/serdes.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::fmt::{Debug, Display};
 use std::io;
 use std::path::PathBuf;
@@ -246,28 +247,28 @@ pub fn ser_bytes<S: Serializer, T: AsRef<[u8]>>(t: &T, serializer: S) -> Result<
 	}
 }
 
-pub fn de_parse<'de: 'a, 'a, D, T>(deserializer: D) -> Result<T, D::Error>
+pub fn de_parse<'de, D, T>(deserializer: D) -> Result<T, D::Error>
 where
 	D: Deserializer<'de>,
-	T: TryFrom<&'a str>,
-	<T as TryFrom<&'a str>>::Error: Display,
+	for<'a> T: TryFrom<&'a str>,
+	for<'a> <T as TryFrom<&'a str>>::Error: Display,
 {
-	let s: &'a str = <&str>::deserialize(deserializer)?;
-	match T::try_from(s) {
+	let s: Cow<'de, str> = Cow::<str>::deserialize(deserializer)?;
+	match T::try_from(s.as_ref()) {
 		Ok(t) => Ok(t),
 		Err(e) => Err(serde::de::Error::custom(e)),
 	}
 }
 
-pub fn de_parse_option<'de: 'a, 'a, D, T>(deserializer: D) -> Result<Option<T>, D::Error>
+pub fn de_parse_option<'de, D, T>(deserializer: D) -> Result<Option<T>, D::Error>
 where
 	D: Deserializer<'de>,
-	T: TryFrom<&'a str>,
-	<T as TryFrom<&'a str>>::Error: Display,
+	for<'a> T: TryFrom<&'a str>,
+	for<'a> <T as TryFrom<&'a str>>::Error: Display,
 {
-	let s: Option<&'a str> = Option::deserialize(deserializer)?;
+	let s: Option<Cow<'de, str>> = Option::deserialize(deserializer)?;
 	let Some(s) = s else { return Ok(None) };
-	match T::try_from(s) {
+	match T::try_from(s.as_ref()) {
 		Ok(t) => Ok(Some(t)),
 		Err(e) => Err(serde::de::Error::custom(e)),
 	}

--- a/crates/agentgateway/src/test_helpers/proxymock.rs
+++ b/crates/agentgateway/src/test_helpers/proxymock.rs
@@ -528,7 +528,7 @@ impl TestBind {
 				.stores
 				.binds
 				.write()
-				.insert_backend(b.backend.name(), b.into());
+				.insert_backend(b.backend.name(), b);
 		}
 		self
 			.pi

--- a/crates/agentgateway/src/test_helpers/proxymock.rs
+++ b/crates/agentgateway/src/test_helpers/proxymock.rs
@@ -35,10 +35,11 @@ use crate::transport::tls;
 use crate::types::agent::{
 	Backend, BackendPolicy, BackendReference, BackendWithPolicies, Bind, BindKey, BindProtocol,
 	Listener, ListenerProtocol, ListenerSet, McpBackend, McpTarget, McpTargetSpec, PathMatch,
-	ResourceName, Route, RouteBackendReference, RouteMatch, RouteName, RouteSet,
+	PolicyTarget, ResourceName, Route, RouteBackendReference, RouteMatch, RouteName, RouteSet,
 	SimpleBackendReference, SseTargetSpec, StreamableHTTPTargetSpec, TCPRoute,
 	TCPRouteBackendReference, TCPRouteSet, Target, TargetedPolicy,
 };
+use crate::types::local;
 use crate::types::local::LocalNamedAIProvider;
 use crate::{ProxyInputs, client, mcp};
 
@@ -299,6 +300,10 @@ pub struct TestBind {
 	pi: Arc<ProxyInputs>,
 	drain_rx: DrainWatcher,
 	_drain_tx: DrainTrigger,
+
+	// Counters to help make unique items
+	routes: usize,
+	policies: usize,
 }
 
 #[derive(Debug, Clone)]
@@ -486,9 +491,75 @@ impl TestBind {
 		self
 	}
 
-	pub fn with_policy(self, p: TargetedPolicy) -> TestBind {
-		self.pi.stores.binds.write().insert_policy(p);
+	pub async fn attach_route_policy_builder(mut self, p: serde_json::Value) -> Self {
+		self.attach_route_policy(p).await;
 		self
+	}
+	pub async fn attach_backend(&mut self, p: serde_json::Value) {
+		let b: local::FullLocalBackend = serde_json::from_value(p).unwrap();
+
+		let policies = b
+			.policies
+			.map(|p| p.translate())
+			.transpose()
+			.unwrap()
+			.unwrap_or_default();
+		let bps = BackendWithPolicies {
+			backend: Backend::Opaque(crate::types::local::local_name(b.name), b.host),
+			inline_policies: policies,
+		};
+		self
+			.pi
+			.stores
+			.binds
+			.write()
+			.insert_backend(bps.backend.name(), bps)
+	}
+	pub async fn attach_route(&mut self, p: serde_json::Value) {
+		let pol: local::LocalRoute = serde_json::from_value(p).unwrap();
+		self.routes += 1;
+		let (route, backends) =
+			local::convert_route(self.pi.upstream.clone(), pol, self.routes, LISTENER_KEY)
+				.await
+				.unwrap();
+		for b in backends {
+			self
+				.pi
+				.stores
+				.binds
+				.write()
+				.insert_backend(b.backend.name(), b.into());
+		}
+		self
+			.pi
+			.stores
+			.binds
+			.write()
+			.insert_route(route, LISTENER_KEY);
+	}
+	pub async fn attach_route_policy(&mut self, p: serde_json::Value) {
+		let pol: local::FilterOrPolicy = serde_json::from_value(p).unwrap();
+		let pols = local::split_policies(self.pi.upstream.clone(), pol)
+			.await
+			.unwrap();
+		for v in pols.route_policies.into_iter() {
+			self.policies += 1;
+			self.with_policy(TargetedPolicy {
+				key: strng::format!("pol-{}", self.policies),
+				name: None,
+				target: PolicyTarget::Route(RouteName {
+					name: "route".into(),
+					namespace: "".into(),
+					rule_name: None,
+					kind: None,
+				}),
+				policy: v.into(),
+			});
+		}
+	}
+
+	pub fn with_policy(&mut self, p: TargetedPolicy) {
+		self.pi.stores.binds.write().insert_policy(p);
 	}
 	pub fn serve_http(&self, bind_name: BindKey) -> Client<MemoryConnector, Body> {
 		let io = self.serve(bind_name);
@@ -621,6 +692,9 @@ pub fn setup_proxy_test(cfg: &str) -> anyhow::Result<TestBind> {
 		pi,
 		drain_rx,
 		_drain_tx: drain_tx,
+
+		routes: 0,
+		policies: 0,
 	})
 }
 

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -2477,6 +2477,12 @@ InvalidKeyData
 	}
 
 	#[test]
+	fn test_target_deserializes_from_json_value() {
+		let target: Target = serde_json::from_value(serde_json::json!("127.0.0.1:8080")).unwrap();
+		assert!(matches!(target, Target::Address(addr) if addr.to_string() == "127.0.0.1:8080"));
+	}
+
+	#[test]
 	fn test_all_matches_subdomain() {
 		let matches: Vec<_> = HostnameMatch::all_matches("api.example.com").collect();
 

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -443,7 +443,7 @@ pub struct LocalRouteName {
 }
 
 #[apply(schema_de!)]
-struct LocalRoute {
+pub struct LocalRoute {
 	#[serde(flatten)]
 	name: LocalRouteName,
 	/// Can be a wildcard
@@ -473,10 +473,10 @@ fn default_weight() -> usize {
 
 #[apply(schema_de!)]
 pub struct FullLocalBackend {
-	name: BackendKey,
-	host: Target,
+	pub name: BackendKey,
+	pub host: Target,
 	#[serde(default, skip_serializing_if = "Option::is_none")]
-	policies: Option<LocalBackendPolicies>,
+	pub policies: Option<LocalBackendPolicies>,
 }
 
 #[apply(schema_de!)]
@@ -506,6 +506,7 @@ pub enum LocalBackend {
 		name: NamespacedHostname,
 		port: u16,
 	},
+	Backend(BackendKey),
 	// Rest are inlined
 	#[serde(rename = "host")]
 	Opaque(Target), // Hostname or IP
@@ -645,6 +646,7 @@ impl LocalBackend {
 	) -> anyhow::Result<Vec<BackendWithPolicies>> {
 		Ok(match self {
 			LocalBackend::Service { .. } => vec![], // These stay as references
+			LocalBackend::Backend(_) => vec![],     // These stay as references
 			LocalBackend::Opaque(tgt) => vec![Backend::Opaque(name, tgt.clone()).into()],
 			LocalBackend::Dynamic { .. } => vec![Backend::Dynamic(name, ()).into()],
 			LocalBackend::MCP(tgt) => {
@@ -1178,7 +1180,7 @@ struct LocalFrontendPolicies {
 
 #[apply(schema_de!)]
 #[derive(Default)]
-struct FilterOrPolicy {
+pub struct FilterOrPolicy {
 	// Filters. Keep in sync with RouteFilter
 	/// Headers to be modified in the request.
 	#[serde(default)]
@@ -1940,8 +1942,7 @@ async fn convert_listener(
 
 	let mut rs = RouteSet::default();
 	for (idx, l) in routes.into_iter().flatten().enumerate() {
-		let (route, policies, backends) = convert_route(client.clone(), l, idx, key.clone()).await?;
-		all_policies.extend_from_slice(&policies);
+		let (route, backends) = convert_route(client.clone(), l, idx, key.clone()).await?;
 		all_backends.extend_from_slice(&backends);
 		rs.insert(route)
 	}
@@ -1985,12 +1986,12 @@ async fn convert_listener(
 	Ok((l, all_policies, all_backends))
 }
 
-async fn convert_route(
+pub async fn convert_route(
 	client: client::Client,
 	lr: LocalRoute,
 	idx: usize,
 	listener_key: ListenerKey,
-) -> anyhow::Result<(Route, Vec<TargetedPolicy>, Vec<BackendWithPolicies>)> {
+) -> anyhow::Result<(Route, Vec<BackendWithPolicies>)> {
 	let LocalRoute {
 		name,
 		hostnames,
@@ -2019,6 +2020,7 @@ async fn convert_route(
 				name: name.clone(),
 				port: *port,
 			},
+			LocalBackend::Backend(n) => BackendReference::Backend(n.clone()),
 			LocalBackend::Invalid => BackendReference::Invalid,
 			LocalBackend::Dynamic {} => BackendReference::Backend("dynamic".into()),
 			_ => BackendReference::Backend(strng::format!("/{}", backend_key)),
@@ -2057,13 +2059,13 @@ async fn convert_route(
 		backends: backend_refs,
 		inline_policies: resolved.route_policies,
 	};
-	Ok((route, vec![], external_backends))
+	Ok((route, external_backends))
 }
 
 #[derive(Default)]
-struct ResolvedPolicies {
+pub struct ResolvedPolicies {
 	backend_policies: Vec<BackendPolicy>,
-	route_policies: Vec<TrafficPolicy>,
+	pub route_policies: Vec<TrafficPolicy>,
 }
 
 async fn split_frontend_policies(
@@ -2118,7 +2120,10 @@ async fn split_frontend_policies(
 	}
 	Ok(pols)
 }
-async fn split_policies(client: Client, pol: FilterOrPolicy) -> Result<ResolvedPolicies, Error> {
+pub async fn split_policies(
+	client: Client,
+	pol: FilterOrPolicy,
+) -> Result<ResolvedPolicies, Error> {
 	let mut resolved = ResolvedPolicies::default();
 	let ResolvedPolicies {
 		backend_policies,
@@ -2346,7 +2351,7 @@ impl TryInto<ServerTLSConfig> for LocalTLSServerConfig {
 	}
 }
 
-fn local_name(name: Strng) -> ResourceName {
+pub fn local_name(name: Strng) -> ResourceName {
 	ResourceName::new(name, "".into())
 }
 

--- a/schema/config.json
+++ b/schema/config.json
@@ -3839,6 +3839,17 @@
         {
           "type": "object",
           "properties": {
+            "backend": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "backend"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
             "host": {
               "type": "string"
             }

--- a/schema/config.md
+++ b/schema/config.md
@@ -1078,6 +1078,7 @@
 |`binds[].listeners[].routes[].backends[].(1)service.name.namespace`||
 |`binds[].listeners[].routes[].backends[].(1)service.name.hostname`||
 |`binds[].listeners[].routes[].backends[].(1)service.port`||
+|`binds[].listeners[].routes[].backends[].(1)backend`||
 |`binds[].listeners[].routes[].backends[].(1)host`||
 |`binds[].listeners[].routes[].backends[].(1)dynamic`||
 |`binds[].listeners[].routes[].backends[].(1)mcp`||


### PR DESCRIPTION
not 100% sure this is better but I think it is,... we trade off type safety for testing more user-facing flows, and for more concise inputs