### PR TITLE
Bind Policies to specific Gateways

### DIFF
--- a/controller/hack/utils/oss_compliance/osa_provided.md
+++ b/controller/hack/utils/oss_compliance/osa_provided.md
@@ -4,7 +4,7 @@ Name|Version|License
 [anthropics/anthropic-sdk-go](https://github.com/anthropics/anthropic-sdk-go)|v1.26.0|MIT License
 [retry-go/v4](https://github.com/avast/retry-go)|v4.7.0|MIT License
 [xds/go](https://github.com/cncf/xds)|v0.0.0-20260202195803-dba9d589def2|Apache License 2.0
-[go-control-plane/envoy](https://github.com/envoyproxy/go-control-plane)|v1.37.1-0.20260227072845-439e4fd5530c|Apache License 2.0
+[go-control-plane/envoy](https://github.com/envoyproxy/go-control-plane)|v1.37.1-0.20260308004542-b60714bc2ea3|Apache License 2.0
 [ghodss/yaml](https://github.com/ghodss/yaml)|v1.0.1-0.20190212211648-25d852aebe32|MIT License
 [go-jose/v4](https://github.com/go-jose/go-jose)|v4.1.3|Apache License 2.0
 [go-logr/logr](https://github.com/go-logr/logr)|v1.4.3|Apache License 2.0
@@ -35,9 +35,9 @@ Name|Version|License
 [google.golang.org/grpc](https://google.golang.org/grpc)|v1.79.1|Apache License 2.0
 [google.golang.org/protobuf](https://google.golang.org/protobuf)|v1.36.11|BSD 3-clause "New" or "Revised" License
 [helm/v3](https://helm.sh/helm/v3)|v3.20.0|Apache License 2.0
-[istio.io/api](https://istio.io/api)|v1.29.0-alpha.0.0.20260302212057-b10ab91e9ded|Apache License 2.0
-[istio.io/client-go](https://istio.io/client-go)|v1.29.0-alpha.0.0.20260302212359-b21b30ec7057|Apache License 2.0
-[istio.io/istio](https://istio.io/istio)|v0.0.0-20260304223159-1086b9070383|Apache License 2.0
+[istio.io/api](https://istio.io/api)|v1.29.0-alpha.0.0.20260310163805-1e4fee88597d|Apache License 2.0
+[istio.io/client-go](https://istio.io/client-go)|v1.29.0-alpha.0.0.20260310170739-44d7c6ab3a5b|Apache License 2.0
+[istio.io/istio](https://istio.io/istio)|v0.0.0-20260311173339-67ad6fb5ba6a|Apache License 2.0
 [k8s.io/api](https://k8s.io/api)|v0.35.2|Apache License 2.0
 [k8s.io/apiextensions-apiserver](https://k8s.io/apiextensions-apiserver)|v0.35.2|Apache License 2.0
 [k8s.io/apimachinery](https://k8s.io/apimachinery)|v0.35.2|Apache License 2.0

--- a/controller/pkg/agentgateway/plugins/a2a_plugin.go
+++ b/controller/pkg/agentgateway/plugins/a2a_plugin.go
@@ -8,8 +8,10 @@ import (
 	"istio.io/istio/pkg/ptr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/agentgateway/agentgateway/api"
+	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/utils"
 	"github.com/agentgateway/agentgateway/controller/pkg/kgateway/wellknown"
 	"github.com/agentgateway/agentgateway/controller/pkg/utils/kubeutils"
 )
@@ -20,13 +22,13 @@ const (
 
 // NewA2APlugin creates a new A2A policy plugin
 func NewA2APlugin(agw *AgwCollections) AgwPlugin {
-	policyCol := krt.NewManyCollection(agw.Services, func(krtctx krt.HandlerContext, svc *corev1.Service) []AgwPolicy {
-		return translatePoliciesForService(svc, kubeutils.GetClusterDomainName())
-	})
 	return AgwPlugin{
 		ContributesPolicies: map[schema.GroupKind]PolicyPlugin{
 			wellknown.ServiceGVK.GroupKind(): {
 				Build: func(input PolicyPluginInput) (krt.StatusCollection[controllers.Object, any], krt.Collection[AgwPolicy]) {
+					policyCol := krt.NewManyCollection(agw.Services, func(krtctx krt.HandlerContext, svc *corev1.Service) []AgwPolicy {
+						return translatePoliciesForService(krtctx, svc, kubeutils.GetClusterDomainName(), input.References)
+					})
 					return nil, policyCol
 				},
 			},
@@ -35,8 +37,15 @@ func NewA2APlugin(agw *AgwCollections) AgwPlugin {
 }
 
 // translatePoliciesForService generates A2A policies for a single service
-func translatePoliciesForService(svc *corev1.Service, clusterDomain string) []AgwPolicy {
+func translatePoliciesForService(krtctx krt.HandlerContext, svc *corev1.Service, clusterDomain string, references ReferenceIndex) []AgwPolicy {
 	var a2aPolicies []AgwPolicy
+	gatewayTargets := references.LookupGatewaysForBackend(krtctx, utils.TypedNamespacedName{
+		Kind: wellknown.ServiceKind,
+		NamespacedName: types.NamespacedName{
+			Namespace: svc.Namespace,
+			Name:      svc.Name,
+		},
+	}).UnsortedList()
 
 	for _, port := range svc.Spec.Ports {
 		if port.AppProtocol != nil && *port.AppProtocol == a2aProtocol {
@@ -60,7 +69,7 @@ func translatePoliciesForService(svc *corev1.Service, clusterDomain string) []Ag
 				},
 			}
 
-			a2aPolicies = append(a2aPolicies, AgwPolicy{Policy: policy})
+			a2aPolicies = appendPolicyForGateways(a2aPolicies, gatewayTargets, policy)
 		}
 	}
 

--- a/controller/pkg/agentgateway/plugins/backend_policies.go
+++ b/controller/pkg/agentgateway/plugins/backend_policies.go
@@ -50,8 +50,8 @@ func TranslateInlineBackendPolicy(
 		Spec: agentgateway.AgentgatewayPolicySpec{Backend: policy},
 	}
 	res, err := translateBackendPolicyToAgw(ctx, dummy, nil)
-	return slices.MapFilter(res, func(e AgwPolicy) **api.BackendPolicySpec {
-		return ptr.Of(e.Policy.GetBackend())
+	return slices.MapFilter(res, func(e *api.Policy) **api.BackendPolicySpec {
+		return ptr.Of(e.GetBackend())
 	}), err
 }
 
@@ -59,19 +59,19 @@ func translateBackendPolicyToAgw(
 	ctx PolicyCtx,
 	policy *agentgateway.AgentgatewayPolicy,
 	policyTarget *api.PolicyTarget,
-) ([]AgwPolicy, error) {
+) ([]*api.Policy, error) {
 	backend := policy.Spec.Backend
 	if backend == nil {
 		return nil, nil
 	}
-	agwPolicies := make([]AgwPolicy, 0)
+	agwPolicies := make([]*api.Policy, 0)
 	var errs []error
 
 	policyName := getBackendPolicyName(policy.Namespace, policy.Name)
 
 	if s := backend.HTTP; s != nil {
 		pol := translateBackendHTTP(policy, policyTarget)
-		agwPolicies = append(agwPolicies, pol...)
+		agwPolicies = append(agwPolicies, pol)
 	}
 
 	if s := backend.Tunnel; s != nil {
@@ -80,7 +80,9 @@ func translateBackendPolicyToAgw(
 			logger.Error("error processing backend tunnel", "err", err)
 			errs = append(errs, err)
 		}
-		agwPolicies = append(agwPolicies, pol...)
+		if pol != nil {
+			agwPolicies = append(agwPolicies, pol)
+		}
 	}
 
 	if s := backend.TLS; s != nil {
@@ -89,7 +91,9 @@ func translateBackendPolicyToAgw(
 			logger.Error("error processing backend TLS", "err", err)
 			errs = append(errs, err)
 		}
-		agwPolicies = append(agwPolicies, pol...)
+		if pol != nil {
+			agwPolicies = append(agwPolicies, pol)
+		}
 	}
 
 	if s := backend.TCP; s != nil {
@@ -98,7 +102,9 @@ func translateBackendPolicyToAgw(
 			logger.Error("error processing backend TCP", "err", err)
 			errs = append(errs, err)
 		}
-		agwPolicies = append(agwPolicies, pol...)
+		if pol != nil {
+			agwPolicies = append(agwPolicies, pol)
+		}
 	}
 
 	if s := backend.Health; s != nil {
@@ -107,7 +113,9 @@ func translateBackendPolicyToAgw(
 			logger.Error("error processing backend health policy", "err", err)
 			errs = append(errs, err)
 		}
-		agwPolicies = append(agwPolicies, pol...)
+		if pol != nil {
+			agwPolicies = append(agwPolicies, pol)
+		}
 	}
 
 	if s := backend.Transformation; s != nil {
@@ -116,13 +124,17 @@ func translateBackendPolicyToAgw(
 			logger.Error("error processing backend transformation", "err", err)
 			errs = append(errs, err)
 		}
-		agwPolicies = append(agwPolicies, pol...)
+		if pol != nil {
+			agwPolicies = append(agwPolicies, pol)
+		}
 	}
 
 	if s := backend.MCP; s != nil {
 		if backend.MCP.Authorization != nil {
 			pol := translateBackendMCPAuthorization(policy, policyTarget)
-			agwPolicies = append(agwPolicies, pol...)
+			if pol != nil {
+				agwPolicies = append(agwPolicies, pol)
+			}
 		}
 
 		if backend.MCP.Authentication != nil {
@@ -131,7 +143,9 @@ func translateBackendPolicyToAgw(
 				logger.Error("error processing backend mcp auth", "err", err)
 				errs = append(errs, err)
 			}
-			agwPolicies = append(agwPolicies, pol...)
+			if pol != nil {
+				agwPolicies = append(agwPolicies, pol)
+			}
 		}
 	}
 
@@ -141,7 +155,9 @@ func translateBackendPolicyToAgw(
 			logger.Error("error processing backend AI", "err", err)
 			errs = append(errs, err)
 		}
-		agwPolicies = append(agwPolicies, pol...)
+		if pol != nil {
+			agwPolicies = append(agwPolicies, pol)
+		}
 	}
 
 	if s := backend.Auth; s != nil {
@@ -150,13 +166,15 @@ func translateBackendPolicyToAgw(
 			logger.Error("error processing backend Auth", "err", err)
 			errs = append(errs, err)
 		}
-		agwPolicies = append(agwPolicies, pol...)
+		if pol != nil {
+			agwPolicies = append(agwPolicies, pol)
+		}
 	}
 
 	return agwPolicies, errors.Join(errs...)
 }
 
-func translateBackendHealthPolicy(policy *agentgateway.AgentgatewayPolicy, target *api.PolicyTarget) ([]AgwPolicy, error) {
+func translateBackendHealthPolicy(policy *agentgateway.AgentgatewayPolicy, target *api.PolicyTarget) (*api.Policy, error) {
 	var errs []error
 
 	healthPolicy := policy.Spec.Backend.Health
@@ -210,10 +228,10 @@ func translateBackendHealthPolicy(policy *agentgateway.AgentgatewayPolicy, targe
 		},
 	}
 
-	return []AgwPolicy{{Policy: evictPolicy}}, errors.Join(errs...)
+	return evictPolicy, errors.Join(errs...)
 }
 
-func translateBackendTCP(ctx PolicyCtx, policy *agentgateway.AgentgatewayPolicy, name string, target *api.PolicyTarget) ([]AgwPolicy, error) {
+func translateBackendTCP(ctx PolicyCtx, policy *agentgateway.AgentgatewayPolicy, name string, target *api.PolicyTarget) (*api.Policy, error) {
 	// TODO
 	return nil, nil
 }
@@ -221,7 +239,7 @@ func translateBackendTCP(ctx PolicyCtx, policy *agentgateway.AgentgatewayPolicy,
 func translateBackendTransformation(
 	policy *agentgateway.AgentgatewayPolicy,
 	target *api.PolicyTarget,
-) ([]AgwPolicy, error) {
+) (*api.Policy, error) {
 	var errs []error
 	transformation := policy.Spec.Backend.Transformation
 
@@ -252,10 +270,10 @@ func translateBackendTransformation(
 	logger.Debug("generated backend transformation policy",
 		"policy", policy.Name,
 		"agentgateway_policy", tp.Name)
-	return []AgwPolicy{{Policy: tp}}, errors.Join(errs...)
+	return tp, errors.Join(errs...)
 }
 
-func translateBackendTLS(ctx PolicyCtx, policy *agentgateway.AgentgatewayPolicy, target *api.PolicyTarget) ([]AgwPolicy, error) {
+func translateBackendTLS(ctx PolicyCtx, policy *agentgateway.AgentgatewayPolicy, target *api.PolicyTarget) (*api.Policy, error) {
 	var errs []error
 	tls := policy.Spec.Backend.TLS
 
@@ -345,10 +363,10 @@ func translateBackendTLS(ctx PolicyCtx, policy *agentgateway.AgentgatewayPolicy,
 		"policy", policy.Name,
 		"agentgateway_policy", tlsPolicy.Name)
 
-	return []AgwPolicy{{Policy: tlsPolicy}}, errors.Join(errs...)
+	return tlsPolicy, errors.Join(errs...)
 }
 
-func translateBackendHTTP(policy *agentgateway.AgentgatewayPolicy, target *api.PolicyTarget) []AgwPolicy {
+func translateBackendHTTP(policy *agentgateway.AgentgatewayPolicy, target *api.PolicyTarget) *api.Policy {
 	http := policy.Spec.Backend.HTTP
 	p := &api.BackendPolicySpec_BackendHTTP{}
 	if v := http.Version; v != nil {
@@ -378,10 +396,10 @@ func translateBackendHTTP(policy *agentgateway.AgentgatewayPolicy, target *api.P
 		"policy", policy.Name,
 		"agentgateway_policy", tp.Name)
 
-	return []AgwPolicy{{Policy: tp}}
+	return tp
 }
 
-func translateBackendTunnel(ctx PolicyCtx, policy *agentgateway.AgentgatewayPolicy, target *api.PolicyTarget) ([]AgwPolicy, error) {
+func translateBackendTunnel(ctx PolicyCtx, policy *agentgateway.AgentgatewayPolicy, target *api.PolicyTarget) (*api.Policy, error) {
 	tunnel := policy.Spec.Backend.Tunnel
 
 	proxy, err := buildBackendRef(ctx, tunnel.BackendRef, policy.Namespace)
@@ -408,10 +426,10 @@ func translateBackendTunnel(ctx PolicyCtx, policy *agentgateway.AgentgatewayPoli
 		"policy", policy.Name,
 		"agentgateway_policy", tunnelPolicy.Name)
 
-	return []AgwPolicy{{Policy: tunnelPolicy}}, nil
+	return tunnelPolicy, nil
 }
 
-func translateBackendMCPAuthorization(policy *agentgateway.AgentgatewayPolicy, target *api.PolicyTarget) []AgwPolicy {
+func translateBackendMCPAuthorization(policy *agentgateway.AgentgatewayPolicy, target *api.PolicyTarget) *api.Policy {
 	backend := policy.Spec.Backend
 	if backend == nil || backend.MCP == nil || backend.MCP.Authorization == nil {
 		return nil
@@ -444,10 +462,10 @@ func translateBackendMCPAuthorization(policy *agentgateway.AgentgatewayPolicy, t
 		"policy", policy.Name,
 		"agentgateway_policy", mcpPolicy.Name)
 
-	return []AgwPolicy{{Policy: mcpPolicy}}
+	return mcpPolicy
 }
 
-func translateBackendMCPAuthentication(ctx PolicyCtx, policy *agentgateway.AgentgatewayPolicy, target *api.PolicyTarget) ([]AgwPolicy, error) {
+func translateBackendMCPAuthentication(ctx PolicyCtx, policy *agentgateway.AgentgatewayPolicy, target *api.PolicyTarget) (*api.Policy, error) {
 	backend := policy.Spec.Backend
 	if backend == nil || backend.MCP == nil || backend.MCP.Authentication == nil {
 		return nil, nil
@@ -532,11 +550,11 @@ func translateBackendMCPAuthentication(ctx PolicyCtx, policy *agentgateway.Agent
 		"policy", policy.Name,
 		"agentgateway_policy", mcpAuthnPolicy.Name)
 
-	return []AgwPolicy{{Policy: mcpAuthnPolicy}}, errors.Join(errs...)
+	return mcpAuthnPolicy, errors.Join(errs...)
 }
 
 // translateBackendAI processes AI configuration and creates corresponding Agw policies
-func translateBackendAI(ctx PolicyCtx, agwPolicy *agentgateway.AgentgatewayPolicy, name string, policyTarget *api.PolicyTarget) ([]AgwPolicy, error) {
+func translateBackendAI(ctx PolicyCtx, agwPolicy *agentgateway.AgentgatewayPolicy, name string, policyTarget *api.PolicyTarget) (*api.Policy, error) {
 	var errs []error
 	aiSpec := agwPolicy.Spec.Backend.AI
 
@@ -646,10 +664,10 @@ func translateBackendAI(ctx PolicyCtx, agwPolicy *agentgateway.AgentgatewayPolic
 		"policy", agwPolicy.Name,
 		"agentgateway_policy", aiPolicy.Name)
 
-	return []AgwPolicy{{Policy: aiPolicy}}, errors.Join(errs...)
+	return aiPolicy, errors.Join(errs...)
 }
 
-func translateBackendAuth(ctx PolicyCtx, policy *agentgateway.AgentgatewayPolicy, name string, target *api.PolicyTarget) ([]AgwPolicy, error) {
+func translateBackendAuth(ctx PolicyCtx, policy *agentgateway.AgentgatewayPolicy, name string, target *api.PolicyTarget) (*api.Policy, error) {
 	var errs []error
 	auth := policy.Spec.Backend.Auth
 
@@ -719,7 +737,7 @@ func translateBackendAuth(ctx PolicyCtx, policy *agentgateway.AgentgatewayPolicy
 		"policy", policy.Name,
 		"agentgateway_policy", authPolicy.Name)
 
-	return []AgwPolicy{{Policy: authPolicy}}, errors.Join(errs...)
+	return authPolicy, errors.Join(errs...)
 }
 
 // translateRouteType converts kgateway RouteType to agentgateway proto RouteType

--- a/controller/pkg/agentgateway/plugins/backend_tls_plugin.go
+++ b/controller/pkg/agentgateway/plugins/backend_tls_plugin.go
@@ -233,7 +233,7 @@ func translatePoliciesForBackendTLS(
 				},
 			},
 		}
-		policies = append(policies, AgwPolicy{policy})
+		policies = appendPolicyForGateways(policies, gatewayTargets, policy)
 	}
 	ancestorStatus := make([]gwv1.PolicyAncestorStatus, 0, len(btls.Spec.TargetRefs))
 	for g := range uniqueGateways {

--- a/controller/pkg/agentgateway/plugins/frontend_policies.go
+++ b/controller/pkg/agentgateway/plugins/frontend_policies.go
@@ -25,34 +25,34 @@ func translateFrontendPolicyToAgw(
 	policyCtx PolicyCtx,
 	policy *agentgateway.AgentgatewayPolicy,
 	policyTarget *api.PolicyTarget,
-) ([]AgwPolicy, error) {
+) ([]*api.Policy, error) {
 	frontend := policy.Spec.Frontend
 	if frontend == nil {
 		return nil, nil
 	}
-	agwPolicies := make([]AgwPolicy, 0)
+	agwPolicies := make([]*api.Policy, 0)
 	var errs []error
 
 	policyName := getFrontendPolicyName(policy.Namespace, policy.Name)
 
 	if s := frontend.HTTP; s != nil {
 		pol := translateFrontendHTTP(policy, policyName, policyTarget)
-		agwPolicies = append(agwPolicies, pol...)
+		agwPolicies = append(agwPolicies, pol)
 	}
 
 	if s := frontend.TLS; s != nil {
 		pol := translateFrontendTLS(policy, policyName, policyTarget)
-		agwPolicies = append(agwPolicies, pol...)
+		agwPolicies = append(agwPolicies, pol)
 	}
 
 	if s := frontend.TCP; s != nil {
 		pol := translateFrontendTCP(policy, policyName, policyTarget)
-		agwPolicies = append(agwPolicies, pol...)
+		agwPolicies = append(agwPolicies, pol)
 	}
 
 	if s := frontend.AccessLog; s != nil {
 		pol := translateFrontendAccessLog(policy, policyName, policyTarget)
-		agwPolicies = append(agwPolicies, pol...)
+		agwPolicies = append(agwPolicies, pol)
 	}
 
 	if s := frontend.Tracing; s != nil {
@@ -61,13 +61,15 @@ func translateFrontendPolicyToAgw(
 			logger.Error("error processing tracing", "err", err)
 			errs = append(errs, err)
 		}
-		agwPolicies = append(agwPolicies, pol...)
+		if pol != nil {
+			agwPolicies = append(agwPolicies, pol)
+		}
 	}
 
 	return agwPolicies, errors.Join(errs...)
 }
 
-func translateFrontendTracing(ctx PolicyCtx, policy *agentgateway.AgentgatewayPolicy, name string, target *api.PolicyTarget) ([]AgwPolicy, error) {
+func translateFrontendTracing(ctx PolicyCtx, policy *agentgateway.AgentgatewayPolicy, name string, target *api.PolicyTarget) (*api.Policy, error) {
 	tracing := policy.Spec.Frontend.Tracing
 	if tracing == nil {
 		return nil, nil
@@ -153,10 +155,10 @@ func translateFrontendTracing(ctx PolicyCtx, policy *agentgateway.AgentgatewayPo
 		"agentgateway_policy", tracingPolicy.Name,
 		"target", target)
 
-	return []AgwPolicy{{Policy: tracingPolicy}}, nil
+	return tracingPolicy, nil
 }
 
-func translateFrontendAccessLog(policy *agentgateway.AgentgatewayPolicy, name string, target *api.PolicyTarget) []AgwPolicy {
+func translateFrontendAccessLog(policy *agentgateway.AgentgatewayPolicy, name string, target *api.PolicyTarget) *api.Policy {
 	logging := policy.Spec.Frontend.AccessLog
 	spec := &api.FrontendPolicySpec_Logging{}
 	if f := logging.Filter; f != nil {
@@ -193,10 +195,10 @@ func translateFrontendAccessLog(policy *agentgateway.AgentgatewayPolicy, name st
 		"agentgateway_policy", loggingPolicy.Name,
 		"target", target)
 
-	return []AgwPolicy{{Policy: loggingPolicy}}
+	return loggingPolicy
 }
 
-func translateFrontendTCP(policy *agentgateway.AgentgatewayPolicy, name string, target *api.PolicyTarget) []AgwPolicy {
+func translateFrontendTCP(policy *agentgateway.AgentgatewayPolicy, name string, target *api.PolicyTarget) *api.Policy {
 	tcp := policy.Spec.Frontend.TCP
 	spec := &api.FrontendPolicySpec_TCP{}
 	if ka := tcp.KeepAlive; ka != nil {
@@ -230,14 +232,14 @@ func translateFrontendTCP(policy *agentgateway.AgentgatewayPolicy, name string, 
 		"agentgateway_policy", tcpPolicy.Name,
 		"target", target)
 
-	return []AgwPolicy{{Policy: tcpPolicy}}
+	return tcpPolicy
 }
 
 func castUint32[T ~int32](ka *T) *uint32 {
 	return ptr.Of((uint32)(*ka))
 }
 
-func translateFrontendTLS(policy *agentgateway.AgentgatewayPolicy, name string, target *api.PolicyTarget) []AgwPolicy {
+func translateFrontendTLS(policy *agentgateway.AgentgatewayPolicy, name string, target *api.PolicyTarget) *api.Policy {
 	tls := policy.Spec.Frontend.TLS
 	spec := &api.FrontendPolicySpec_TLS{}
 	if ka := tls.HandshakeTimeout; ka != nil {
@@ -320,10 +322,10 @@ func translateFrontendTLS(policy *agentgateway.AgentgatewayPolicy, name string, 
 		"agentgateway_policy", tlsPolicy.Name,
 		"target", target)
 
-	return []AgwPolicy{{Policy: tlsPolicy}}
+	return tlsPolicy
 }
 
-func translateFrontendHTTP(policy *agentgateway.AgentgatewayPolicy, name string, target *api.PolicyTarget) []AgwPolicy {
+func translateFrontendHTTP(policy *agentgateway.AgentgatewayPolicy, name string, target *api.PolicyTarget) *api.Policy {
 	http := policy.Spec.Frontend.HTTP
 	spec := &api.FrontendPolicySpec_HTTP{}
 	if v := http.MaxBufferSize; v != nil {
@@ -369,5 +371,5 @@ func translateFrontendHTTP(policy *agentgateway.AgentgatewayPolicy, name string,
 		"agentgateway_policy", httpPolicy.Name,
 		"target", target)
 
-	return []AgwPolicy{{Policy: httpPolicy}}
+	return httpPolicy
 }

--- a/controller/pkg/agentgateway/plugins/inference_plugin.go
+++ b/controller/pkg/agentgateway/plugins/inference_plugin.go
@@ -91,7 +91,11 @@ func translatePoliciesForInferencePool(
 			},
 		},
 	}
-	infPolicies = append(infPolicies, AgwPolicy{Policy: inferencePolicy})
+	gatewayTargets := make([]types.NamespacedName, 0, len(attachedGateways))
+	for gatewayTarget := range attachedGateways {
+		gatewayTargets = append(gatewayTargets, gatewayTarget)
+	}
+	infPolicies = appendPolicyForGateways(infPolicies, gatewayTargets, inferencePolicy)
 
 	// Create the TLS policy for the endpoint picker
 	// TODO: we would want some way if they explicitly set a BackendTLSPolicy for the EPP to respect that
@@ -110,7 +114,7 @@ func translatePoliciesForInferencePool(
 			},
 		},
 	}
-	infPolicies = append(infPolicies, AgwPolicy{Policy: inferencePolicyTLS})
+	infPolicies = appendPolicyForGateways(infPolicies, gatewayTargets, inferencePolicyTLS)
 
 	logger.Debug("generated inference pool policies",
 		"pool", pool.Name,

--- a/controller/pkg/agentgateway/plugins/interfaces.go
+++ b/controller/pkg/agentgateway/plugins/interfaces.go
@@ -2,11 +2,13 @@ package plugins
 
 import (
 	"context"
+	"sort"
 
 	"istio.io/istio/pilot/pkg/util/protoconv"
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/kube/krt"
+	"istio.io/istio/pkg/ptr"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/agentgateway/agentgateway/api"
@@ -33,16 +35,17 @@ func (p *PolicyPlugin) ApplyPolicies(inputs PolicyPluginInput) (krt.Collection[A
 
 // AgwPolicy wraps an Agw policy for collection handling
 type AgwPolicy struct {
-	Policy *api.Policy
+	Gateway *types.NamespacedName
+	Policy  *api.Policy
 	// TODO: track errors per policy
 }
 
 func (p AgwPolicy) Equals(in AgwPolicy) bool {
-	return protoconv.Equals(p.Policy, in.Policy)
+	return ptr.Equal(p.Gateway, in.Gateway) && protoconv.Equals(p.Policy, in.Policy)
 }
 
 func (p AgwPolicy) ResourceName() string {
-	return p.Policy.Key
+	return p.Gateway.String() + "/" + p.Policy.Key
 }
 
 type AddResourcesPlugin struct {
@@ -87,4 +90,17 @@ func TypedResourceFromName(typ string, o types.NamespacedName) *api.TypedResourc
 		Namespace: o.Namespace,
 		Name:      o.Name,
 	}
+}
+
+func appendPolicyForGateways(policies []AgwPolicy, gatewayTargets []types.NamespacedName, policy *api.Policy) []AgwPolicy {
+	sort.Slice(gatewayTargets, func(i, j int) bool {
+		return gatewayTargets[i].String() < gatewayTargets[j].String()
+	})
+	for _, gatewayTarget := range gatewayTargets {
+		policies = append(policies, AgwPolicy{
+			Gateway: ptr.Of(gatewayTarget),
+			Policy:  policy,
+		})
+	}
+	return policies
 }

--- a/controller/pkg/agentgateway/plugins/testdata/backendpolicy/_defaults.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/backendpolicy/_defaults.yaml
@@ -1,4 +1,11 @@
 apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: agentgateway
+spec:
+  controllerName: agentgateway.dev/agentgateway
+---
+apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: test
@@ -24,6 +31,9 @@ spec:
     - backendRefs:
         - name: reviews
           port: 8080
+        - name: be
+          group: agentgateway.dev
+          kind: AgentgatewayBackend
 ---
 apiVersion: v1
 kind: Secret

--- a/controller/pkg/agentgateway/plugins/testdata/backendpolicy/ai.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/backendpolicy/ai.yaml
@@ -114,7 +114,10 @@ spec:
 ---
 # Output
 output:
-- resource:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
     policy:
       backend:
         ai:
@@ -177,7 +180,10 @@ output:
           kind: HTTPRoute
           name: test
           namespace: default
-- resource:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
     policy:
       key: traffic/default/agw:rbac:default/test
       name:

--- a/controller/pkg/agentgateway/plugins/testdata/backendpolicy/awsauth.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/backendpolicy/awsauth.yaml
@@ -27,7 +27,10 @@ data:
 ---
 # Output
 output:
-- resource:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
     policy:
       backend:
         auth:

--- a/controller/pkg/agentgateway/plugins/testdata/backendpolicy/azureauth.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/backendpolicy/azureauth.yaml
@@ -18,7 +18,10 @@ spec:
 ---
 # Output
 output:
-- resource:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
     policy:
       backend:
         auth:

--- a/controller/pkg/agentgateway/plugins/testdata/backendpolicy/backend-ancestor-backend.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/backendpolicy/backend-ancestor-backend.yaml
@@ -25,7 +25,10 @@ spec:
 ---
 # Output
 output:
-- resource:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
     policy:
       backend:
         backendTls: {}

--- a/controller/pkg/agentgateway/plugins/testdata/backendpolicy/backend-missing-not-attached.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/backendpolicy/backend-missing-not-attached.yaml
@@ -1,3 +1,4 @@
+# Intentionally no output. There is no backend, so nothing to attach to.
 apiVersion: agentgateway.dev/v1alpha1
 kind: AgentgatewayPolicy
 metadata:
@@ -14,20 +15,7 @@ spec:
         - name: mtls
 ---
 # Output
-output:
-- resource:
-    policy:
-      backend:
-        backendTls: {}
-      key: default/agw:tls:default/missing
-      name:
-        kind: AgentgatewayPolicy
-        name: agw
-        namespace: default
-      target:
-        backend:
-          name: missing
-          namespace: default
+output: []
 status:
   ancestors:
   - ancestorRef:

--- a/controller/pkg/agentgateway/plugins/testdata/backendpolicy/eviction.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/backendpolicy/eviction.yaml
@@ -28,7 +28,10 @@ spec:
 ---
 # Output
 output:
-- resource:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
     policy:
       backend:
         health:

--- a/controller/pkg/agentgateway/plugins/testdata/backendpolicy/gcpauth.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/backendpolicy/gcpauth.yaml
@@ -16,7 +16,10 @@ spec:
 ---
 # Output
 output:
-- resource:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
     policy:
       backend:
         auth:

--- a/controller/pkg/agentgateway/plugins/testdata/backendpolicy/httproute-missing-not-attached.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/backendpolicy/httproute-missing-not-attached.yaml
@@ -15,7 +15,7 @@ spec:
           name: aws-auth-secret
 ---
 # Output
-output: null
+output: []
 status:
   ancestors:
   - ancestorRef:

--- a/controller/pkg/agentgateway/plugins/testdata/backendpolicy/mcp-authz-gateway.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/backendpolicy/mcp-authz-gateway.yaml
@@ -24,7 +24,10 @@ spec:
 ---
 # Output
 output:
-- resource:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
     policy:
       backend:
         mcpAuthorization:
@@ -40,7 +43,10 @@ output:
         gateway:
           name: test
           namespace: default
-- resource:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
     policy:
       key: traffic/default/agw:rbac:default/test
       name:

--- a/controller/pkg/agentgateway/plugins/testdata/backendpolicy/mcp-authz-route.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/backendpolicy/mcp-authz-route.yaml
@@ -24,7 +24,10 @@ spec:
 ---
 # Output
 output:
-- resource:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
     policy:
       backend:
         mcpAuthorization:
@@ -41,7 +44,10 @@ output:
           kind: HTTPRoute
           name: test
           namespace: default
-- resource:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
     policy:
       key: traffic/default/agw:rbac:default/test
       name:

--- a/controller/pkg/agentgateway/plugins/testdata/backendpolicy/multi-target-ref-backend-policy.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/backendpolicy/multi-target-ref-backend-policy.yaml
@@ -5,13 +5,22 @@ metadata:
   namespace: default
 spec:
   parentRefs:
-    - name: mcp
+    - name: test
       namespace: default
   rules:
     - backendRefs:
-        - name: agentgateway
-          namespace: agentgateway-system
-          port: 7777
+      - group: agentgateway.dev
+        kind: AgentgatewayBackend
+        name: test1
+      - group: agentgateway.dev
+        kind: AgentgatewayBackend
+        name: test2
+      - group: agentgateway.dev
+        kind: AgentgatewayBackend
+        name: test3
+      - group: agentgateway.dev
+        kind: AgentgatewayBackend
+        name: dummy-oauth
       matches:
         - path:
             type: PathPrefix
@@ -136,7 +145,10 @@ metadata:
 ---
 # Output
 output:
-- resource:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
     policy:
       backend:
         mcpAuthentication:
@@ -161,7 +173,10 @@ output:
         backend:
           name: dummy-oauth
           namespace: default
-- resource:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
     policy:
       backend:
         mcpAuthentication:
@@ -186,7 +201,10 @@ output:
         backend:
           name: test1
           namespace: default
-- resource:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
     policy:
       backend:
         mcpAuthentication:
@@ -211,7 +229,10 @@ output:
         backend:
           name: test2
           namespace: default
-- resource:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
     policy:
       backend:
         mcpAuthentication:

--- a/controller/pkg/agentgateway/plugins/testdata/backendpolicy/simple.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/backendpolicy/simple.yaml
@@ -46,7 +46,10 @@ data:
 ---
 # Output
 output:
-- resource:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
     policy:
       backend:
         backendHttp:
@@ -62,7 +65,10 @@ output:
           kind: HTTPRoute
           name: test
           namespace: default
-- resource:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
     policy:
       backend:
         backendTls:

--- a/controller/pkg/agentgateway/plugins/testdata/backendpolicy/transformation.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/backendpolicy/transformation.yaml
@@ -21,7 +21,10 @@ spec:
 ---
 # Output
 output:
-- resource:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
     policy:
       backend:
         transformation:

--- a/controller/pkg/agentgateway/plugins/testdata/backendpolicy/tunnel.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/backendpolicy/tunnel.yaml
@@ -25,7 +25,10 @@ spec:
 ---
 # Output
 output:
-- resource:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
     policy:
       backend:
         backendTunnel:

--- a/controller/pkg/agentgateway/plugins/testdata/frontendpolicy/_defaults.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/frontendpolicy/_defaults.yaml
@@ -1,4 +1,11 @@
 apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: agentgateway
+spec:
+  controllerName: agentgateway.dev/agentgateway
+---
+apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: test

--- a/controller/pkg/agentgateway/plugins/testdata/frontendpolicy/accesslog.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/frontendpolicy/accesslog.yaml
@@ -20,7 +20,10 @@ spec:
 ---
 # Output
 output:
-- resource:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
     policy:
       frontend:
         logging:

--- a/controller/pkg/agentgateway/plugins/testdata/frontendpolicy/full.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/frontendpolicy/full.yaml
@@ -62,7 +62,10 @@ spec:
 ---
 # Output
 output:
-- resource:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
     policy:
       frontend:
         http:
@@ -77,7 +80,10 @@ output:
         gateway:
           name: test
           namespace: default
-- resource:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
     policy:
       frontend:
         logging:
@@ -97,7 +103,10 @@ output:
         gateway:
           name: test
           namespace: default
-- resource:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
     policy:
       frontend:
         tcp:
@@ -114,7 +123,10 @@ output:
         gateway:
           name: test
           namespace: default
-- resource:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
     policy:
       frontend:
         tls:

--- a/controller/pkg/agentgateway/plugins/testdata/frontendpolicy/http.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/frontendpolicy/http.yaml
@@ -27,7 +27,10 @@ spec:
 ---
 # Output
 output:
-- resource:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
     policy:
       frontend:
         http:

--- a/controller/pkg/agentgateway/plugins/testdata/frontendpolicy/tcp-keepalive.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/frontendpolicy/tcp-keepalive.yaml
@@ -29,7 +29,10 @@ spec:
 ---
 # Output
 output:
-- resource:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
     policy:
       frontend:
         tcp:

--- a/controller/pkg/agentgateway/plugins/testdata/frontendpolicy/tls-listener-no-gw.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/frontendpolicy/tls-listener-no-gw.yaml
@@ -14,7 +14,10 @@ spec:
 ---
 # Output
 output:
-- resource:
+- gateway:
+    Name: fake-gw
+    Namespace: default
+  resource:
     policy:
       frontend:
         tls:

--- a/controller/pkg/agentgateway/plugins/testdata/frontendpolicy/tls.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/frontendpolicy/tls.yaml
@@ -34,7 +34,10 @@ spec:
 ---
 # Output
 output:
-- resource:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
     policy:
       frontend:
         tls:

--- a/controller/pkg/agentgateway/plugins/testdata/frontendpolicy/tracing.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/frontendpolicy/tracing.yaml
@@ -28,7 +28,10 @@ spec:
 ---
 # Output
 output:
-- resource:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
     policy:
       frontend:
         tracing:

--- a/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/_defaults.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/_defaults.yaml
@@ -1,4 +1,11 @@
 apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: agentgateway
+spec:
+  controllerName: agentgateway.dev/agentgateway
+---
+apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: test
@@ -24,3 +31,6 @@ spec:
     - backendRefs:
         - name: reviews
           port: 8080
+        - name: be
+          group: agentgateway.dev
+          kind: AgentgatewayBackend

--- a/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/apikey-pre-routing.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/apikey-pre-routing.yaml
@@ -27,7 +27,10 @@ data:
 ---
 # Output
 output:
-- resource:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
     policy:
       key: traffic/default/apikey-pre-routing:apikeyauth:default/test
       name:

--- a/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/basic-auth-pre-routing.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/basic-auth-pre-routing.yaml
@@ -18,7 +18,10 @@ spec:
 ---
 # Output
 output:
-- resource:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
     policy:
       key: traffic/default/basic-auth-pre-routing:basicauth:default/test
       name:

--- a/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/cel-invalid.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/cel-invalid.yaml
@@ -20,7 +20,10 @@ spec:
 ---
 # Output
 output:
-- resource:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
     policy:
       key: traffic/default/agw:transformation:default/test
       name:

--- a/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/cel.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/cel.yaml
@@ -28,7 +28,10 @@ spec:
 ---
 # Output
 output:
-- resource:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
     policy:
       key: traffic/default/agw:transformation:default/test
       name:

--- a/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/cors.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/cors.yaml
@@ -30,7 +30,10 @@ spec:
 ---
 # Output
 output:
-- resource:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
     policy:
       key: traffic/default/agw:cors:default/test
       name:

--- a/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/csrf.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/csrf.yaml
@@ -17,7 +17,10 @@ spec:
 ---
 # Output
 output:
-- resource:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
     policy:
       key: traffic/default/agw:csrf:default/test
       name:

--- a/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/extauthz-grpc.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/extauthz-grpc.yaml
@@ -32,7 +32,10 @@ spec:
 ---
 # Output
 output:
-- resource:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
     policy:
       key: traffic/default/grpc:extauth:default/test
       name:

--- a/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/extauthz-http.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/extauthz-http.yaml
@@ -40,7 +40,10 @@ spec:
 ---
 # Output
 output:
-- resource:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
     policy:
       key: traffic/default/http:extauth:default/test
       name:

--- a/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/extauthz-missing-backend.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/extauthz-missing-backend.yaml
@@ -23,7 +23,10 @@ spec:
 ---
 # Output
 output:
-- resource:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
     policy:
       key: traffic/default/grpc:extauth:default/test
       name:

--- a/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/extproc.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/extproc.yaml
@@ -25,7 +25,10 @@ spec:
 ---
 # Output
 output:
-- resource:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
     policy:
       key: traffic/default/http:extproc:default/test
       name:

--- a/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/gateway-missing-not-attached.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/gateway-missing-not-attached.yaml
@@ -14,7 +14,10 @@ spec:
 ---
 # Output
 output:
-- resource:
+- gateway:
+    Name: fake-gw
+    Namespace: default
+  resource:
     policy:
       key: traffic/default/agw:timeout:default/fake-gw
       name:

--- a/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/global-rl.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/global-rl.yaml
@@ -31,7 +31,10 @@ spec:
 ---
 # Output
 output:
-- resource:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
     policy:
       key: traffic/default/http:rl-global:default/test
       name:

--- a/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/header-modifier.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/header-modifier.yaml
@@ -31,7 +31,10 @@ spec:
 ---
 # Output
 output:
-- resource:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
     policy:
       key: traffic/default/agw:header-modifier:default/test
       name:
@@ -52,7 +55,10 @@ output:
           set:
           - name: set-req-header
             value: foo
-- resource:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
     policy:
       key: traffic/default/agw:resp-header-modifier:default/test
       name:

--- a/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/http-route-ancestor-gateway.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/http-route-ancestor-gateway.yaml
@@ -1,39 +1,3 @@
-apiVersion: gateway.networking.k8s.io/v1
-kind: Gateway
-metadata:
-  name: gw
-  namespace: default
-spec:
-  gatewayClassName: agentgateway
-  listeners:
-    - protocol: HTTP
-      port: 8080
-      name: http
----
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: r
-  namespace: default
-spec:
-  parentRefs:
-  - name: gw
-  rules:
-  - backendRefs:
-    - name: example-svc
-      port: 8080
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: example-svc
-  namespace: default
-spec:
-  ports:
-  - name: http
-    port: 8080
-    targetPort: 8080
----
 apiVersion: agentgateway.dev/v1alpha1
 kind: AgentgatewayPolicy
 metadata:
@@ -42,7 +6,7 @@ metadata:
 spec:
   targetRefs:
   - kind: HTTPRoute
-    name: r
+    name: test
     group: gateway.networking.k8s.io
   traffic:
     timeouts:
@@ -50,9 +14,12 @@ spec:
 ---
 # Output
 output:
-- resource:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
     policy:
-      key: traffic/default/agw:timeout:default/r
+      key: traffic/default/agw:timeout:default/test
       name:
         kind: AgentgatewayPolicy
         name: agw
@@ -60,7 +27,7 @@ output:
       target:
         route:
           kind: HTTPRoute
-          name: r
+          name: test
           namespace: default
       traffic:
         timeout:
@@ -70,7 +37,7 @@ status:
   - ancestorRef:
       group: gateway.networking.k8s.io
       kind: Gateway
-      name: gw
+      name: test
       namespace: default
     conditions:
     - lastTransitionTime: fake

--- a/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/http-route-missing-not-attached.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/http-route-missing-not-attached.yaml
@@ -13,22 +13,7 @@ spec:
       request: 5s
 ---
 # Output
-output:
-- resource:
-    policy:
-      key: traffic/default/agw:timeout:default/missing
-      name:
-        kind: AgentgatewayPolicy
-        name: agw
-        namespace: default
-      target:
-        route:
-          kind: HTTPRoute
-          name: missing
-          namespace: default
-      traffic:
-        timeout:
-          request: 5s
+output: []
 status:
   ancestors:
   - ancestorRef:

--- a/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/jwt-pre-routing.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/jwt-pre-routing.yaml
@@ -33,7 +33,10 @@ spec:
 ---
 # Output
 output:
-- resource:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
     policy:
       key: traffic/default/jwt-pre-routing:jwt:default/test
       name:

--- a/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/mcp-auth-multi-target.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/mcp-auth-multi-target.yaml
@@ -5,13 +5,22 @@ metadata:
   namespace: default
 spec:
   parentRefs:
-    - name: mcp
+    - name: test
       namespace: default
   rules:
     - backendRefs:
-        - name: agentgateway
-          namespace: agentgateway-system
-          port: 7777
+      - group: agentgateway.dev
+        kind: AgentgatewayBackend
+        name: test1
+      - group: agentgateway.dev
+        kind: AgentgatewayBackend
+        name: test2
+      - group: agentgateway.dev
+        kind: AgentgatewayBackend
+        name: test3
+      - group: agentgateway.dev
+        kind: AgentgatewayBackend
+        name: dummy-oauth
       matches:
         - path:
             type: PathPrefix
@@ -136,7 +145,10 @@ metadata:
 ---
 # Output
 output:
-- resource:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
     policy:
       backend:
         mcpAuthentication:
@@ -161,7 +173,10 @@ output:
         backend:
           name: dummy-oauth
           namespace: default
-- resource:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
     policy:
       backend:
         mcpAuthentication:
@@ -186,7 +201,10 @@ output:
         backend:
           name: test1
           namespace: default
-- resource:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
     policy:
       backend:
         mcpAuthentication:
@@ -211,7 +229,10 @@ output:
         backend:
           name: test2
           namespace: default
-- resource:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
     policy:
       backend:
         mcpAuthentication:

--- a/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/mcp-auth.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/mcp-auth.yaml
@@ -1,7 +1,7 @@
 apiVersion: agentgateway.dev/v1alpha1
 kind: AgentgatewayBackend
 metadata:
-  name: mcp-backend-static
+  name: be
   namespace: default
 spec:
   mcp:
@@ -20,7 +20,7 @@ metadata:
   namespace: default
 spec:
   targetRefs:
-    - name: mcp-backend-static
+    - name: be
       kind: AgentgatewayBackend
       group: agentgateway.dev
   backend:
@@ -56,7 +56,10 @@ metadata:
 ---
 # Output
 output:
-- resource:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
     policy:
       backend:
         mcpAuthentication:
@@ -73,21 +76,21 @@ output:
               resourceDocumentation: http://mcp-website-fetcher.default.svc.cluster.local/docs
               resourcePolicyUri: http://mcp-website-fetcher.default.svc.cluster.local/policies
               scopesSupported: '["tools/call/fetch"]'
-      key: default/keycloak-mcp-authn-policy:mcp-authentication:default/mcp-backend-static
+      key: default/keycloak-mcp-authn-policy:mcp-authentication:default/be
       name:
         kind: AgentgatewayPolicy
         name: keycloak-mcp-authn-policy
         namespace: default
       target:
         backend:
-          name: mcp-backend-static
+          name: be
           namespace: default
 status:
   ancestors:
   - ancestorRef:
       group: agentgateway.dev
       kind: AgentgatewayBackend
-      name: mcp-backend-static
+      name: be
       namespace: default
     conditions:
     - lastTransitionTime: fake

--- a/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/retry-invalid-attempts-exceeds-i32.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/retry-invalid-attempts-exceeds-i32.yaml
@@ -13,7 +13,7 @@ spec:
       attempts: 2147483648
 ---
 # Output
-output: null
+output: []
 status:
   ancestors:
   - ancestorRef:

--- a/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/retry-invalid-attempts-negative.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/retry-invalid-attempts-negative.yaml
@@ -13,7 +13,7 @@ spec:
       attempts: -4
 ---
 # Output
-output: null
+output: []
 status:
   ancestors:
   - ancestorRef:

--- a/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/retry.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/retry.yaml
@@ -20,7 +20,10 @@ spec:
 ---
 # Output
 output:
-- resource:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
     policy:
       key: traffic/default/agw:retry:default/test
       name:

--- a/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/timeout.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/timeout.yaml
@@ -14,7 +14,10 @@ spec:
 ---
 # Output
 output:
-- resource:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
     policy:
       key: traffic/default/agw:timeout:default/test
       name:

--- a/controller/pkg/agentgateway/plugins/traffic_plugin.go
+++ b/controller/pkg/agentgateway/plugins/traffic_plugin.go
@@ -88,17 +88,16 @@ func convertStatusCollection[T controllers.Object, S any](col krt.Collection[krt
 
 // NewAgentPlugin creates a new AgentgatewayPolicy plugin
 func NewAgentPlugin(agw *AgwCollections) AgwPlugin {
-	policyStatusCol, policyCol := krt.NewStatusManyCollection(agw.AgentgatewayPolicies, func(krtctx krt.HandlerContext, policyCR *agentgateway.AgentgatewayPolicy) (
-		*gwv1.PolicyStatus,
-		[]AgwPolicy,
-	) {
-		return TranslateAgentgatewayPolicy(krtctx, policyCR, agw)
-	}, agw.KrtOpts.ToOptions("AgentgatewayPolicy")...)
-
 	return AgwPlugin{
 		ContributesPolicies: map[schema.GroupKind]PolicyPlugin{
 			wellknown.AgentgatewayPolicyGVK.GroupKind(): {
 				Build: func(input PolicyPluginInput) (krt.StatusCollection[controllers.Object, any], krt.Collection[AgwPolicy]) {
+					policyStatusCol, policyCol := krt.NewStatusManyCollection(agw.AgentgatewayPolicies, func(krtctx krt.HandlerContext, policyCR *agentgateway.AgentgatewayPolicy) (
+						*gwv1.PolicyStatus,
+						[]AgwPolicy,
+					) {
+						return TranslateAgentgatewayPolicy(krtctx, policyCR, agw, input.References)
+					}, agw.KrtOpts.ToOptions("AgentgatewayPolicy")...)
 					return convertStatusCollection(policyStatusCol), policyCol
 				},
 			},
@@ -113,26 +112,27 @@ type PolicyCtx struct {
 
 type ResolvedTarget struct {
 	AgentgatewayTarget *api.PolicyTarget
+	GatewayTargets     []types.NamespacedName
 	AncestorRefs       []gwv1.ParentReference
 	AttachmentError    string
 }
 
 // TranslateAgentgatewayPolicy generates policies for a single traffic policy
-func TranslateAgentgatewayPolicy(
-	ctx krt.HandlerContext,
-	policy *agentgateway.AgentgatewayPolicy,
-	agw *AgwCollections,
-) (*gwv1.PolicyStatus, []AgwPolicy) {
+func TranslateAgentgatewayPolicy(ctx krt.HandlerContext, policy *agentgateway.AgentgatewayPolicy, agw *AgwCollections, references ReferenceIndex) (*gwv1.PolicyStatus, []AgwPolicy) {
 	var agwPolicies []AgwPolicy
 
 	pctx := PolicyCtx{Krt: ctx, Collections: agw}
-
 	var policyTargets []ResolvedTarget
 	// TODO: add selectors
 	for _, target := range policy.Spec.TargetRefs {
 		var policyTarget *api.PolicyTarget
-
 		gk := schema.GroupKind{Group: string(target.Group), Kind: string(target.Kind)}
+
+		gatewayTargets := references.LookupGatewaysForTarget(ctx, utils.TypedNamespacedName{
+			NamespacedName: types.NamespacedName{Namespace: policy.Namespace, Name: string(target.Name)},
+			Kind:           gk.Kind,
+		}).UnsortedList()
+
 		switch gk {
 		case wellknown.GatewayGVK.GroupKind():
 			policyTarget = &api.PolicyTarget{
@@ -156,6 +156,7 @@ func TranslateAgentgatewayPolicy(
 			}
 			// TODO: add support for inferencepool https://github.com/kgateway-dev/kgateway/issues/13295
 			// TODO: add support for ListenerSet https://github.com/kgateway-dev/kgateway/issues/13296
+			// If we add ListenerSet, we MUST update ReferenceIndex
 
 		default:
 			// TODO(npolshak): support attaching policies to k8s services, serviceentries, and other backends
@@ -167,6 +168,7 @@ func TranslateAgentgatewayPolicy(
 
 		policyTargets = append(policyTargets, ResolvedTarget{
 			AgentgatewayTarget: policyTarget,
+			GatewayTargets:     gatewayTargets,
 			AncestorRefs:       ancestorRefs,
 			AttachmentError:    attachmentErr,
 		})
@@ -175,7 +177,14 @@ func TranslateAgentgatewayPolicy(
 	var ancestors []gwv1.PolicyAncestorStatus
 	for _, policyTarget := range policyTargets {
 		translatedPolicies, err := translatePolicyToAgw(pctx, policy, policyTarget.AgentgatewayTarget)
-		agwPolicies = append(agwPolicies, translatedPolicies...)
+		for _, translatedPolicy := range translatedPolicies {
+			for _, gatewayTarget := range policyTarget.GatewayTargets {
+				agwPolicies = append(agwPolicies, AgwPolicy{
+					Gateway: ptr.Of(gatewayTarget),
+					Policy:  translatedPolicy,
+				})
+			}
+		}
 		var conds []metav1.Condition
 		if err != nil {
 			// If we produced some policies alongside errors, treat as partial validity
@@ -392,8 +401,8 @@ func translatePolicyToAgw(
 	ctx PolicyCtx,
 	policy *agentgateway.AgentgatewayPolicy,
 	policyTarget *api.PolicyTarget,
-) ([]AgwPolicy, error) {
-	agwPolicies := make([]AgwPolicy, 0)
+) ([]*api.Policy, error) {
+	agwPolicies := make([]*api.Policy, 0)
 	var errs []error
 
 	frontend, err := translateFrontendPolicyToAgw(ctx, policy, policyTarget)
@@ -421,13 +430,13 @@ func translateTrafficPolicyToAgw(
 	ctx PolicyCtx,
 	policy *agentgateway.AgentgatewayPolicy,
 	policyTarget *api.PolicyTarget,
-) ([]AgwPolicy, error) {
+) ([]*api.Policy, error) {
 	traffic := policy.Spec.Traffic
 	if traffic == nil {
 		return nil, nil
 	}
 
-	agwPolicies := make([]AgwPolicy, 0)
+	agwPolicies := make([]*api.Policy, 0)
 	var errs []error
 
 	// Generate a base policy name from the TrafficPolicy reference
@@ -436,28 +445,33 @@ func translateTrafficPolicyToAgw(
 
 	// Convert ExtAuth policy if present
 	if traffic.ExtAuth != nil {
-		extAuthPolicies, err := processExtAuthPolicy(ctx, traffic.ExtAuth, traffic.Phase, basePolicyName, policyName, policyTarget)
+		extAuthPolicy, err := processExtAuthPolicy(ctx, traffic.ExtAuth, traffic.Phase, basePolicyName, policyName, policyTarget)
 		if err != nil {
 			logger.Error("error processing ExtAuth policy", "error", err)
 			errs = append(errs, err)
 		}
-		agwPolicies = append(agwPolicies, extAuthPolicies...)
+		if extAuthPolicy != nil {
+			agwPolicies = append(agwPolicies, extAuthPolicy)
+		}
 	}
 
 	// Convert ExtProc policy if present
 	if traffic.ExtProc != nil {
-		extProcPolicies, err := processExtProcPolicy(ctx, traffic.ExtProc, traffic.Phase, basePolicyName, policyName, policyTarget)
+		extProcPolicy, err := processExtProcPolicy(ctx, traffic.ExtProc, traffic.Phase, basePolicyName, policyName, policyTarget)
 		if err != nil {
 			logger.Error("error processing ExtProc policy", "error", err)
 			errs = append(errs, err)
 		}
-		agwPolicies = append(agwPolicies, extProcPolicies...)
+		if extProcPolicy != nil {
+			agwPolicies = append(agwPolicies, extProcPolicy)
+		}
 	}
 
 	// Convert Authorization policy if present
 	if traffic.Authorization != nil {
-		rbacPolicies := processAuthorizationPolicy(traffic.Authorization, basePolicyName, policyName, policyTarget)
-		agwPolicies = append(agwPolicies, rbacPolicies...)
+		if rbacPolicy := processAuthorizationPolicy(traffic.Authorization, basePolicyName, policyName, policyTarget); rbacPolicy != nil {
+			agwPolicies = append(agwPolicies, rbacPolicy)
+		}
 	}
 
 	// Process RateLimit policies if present
@@ -472,23 +486,27 @@ func translateTrafficPolicyToAgw(
 
 	// Process transformation policies if present
 	if traffic.Transformation != nil {
-		transformationPolicies, err := processTransformationPolicy(traffic.Transformation, traffic.Phase, basePolicyName, policyName, policyTarget)
+		transformationPolicy, err := processTransformationPolicy(traffic.Transformation, traffic.Phase, basePolicyName, policyName, policyTarget)
 		if err != nil {
 			logger.Error("error processing transformation policy", "error", err)
 			errs = append(errs, err)
 		}
-		agwPolicies = append(agwPolicies, transformationPolicies...)
+		if transformationPolicy != nil {
+			agwPolicies = append(agwPolicies, transformationPolicy)
+		}
 	}
 
 	// Process CSRF policies if present
 	if traffic.Csrf != nil {
-		csrfPolicies := processCSRFPolicy(traffic.Csrf, basePolicyName, policyName, policyTarget)
-		agwPolicies = append(agwPolicies, csrfPolicies...)
+		if csrfPolicy := processCSRFPolicy(traffic.Csrf, basePolicyName, policyName, policyTarget); csrfPolicy != nil {
+			agwPolicies = append(agwPolicies, csrfPolicy)
+		}
 	}
 
 	if traffic.Cors != nil {
-		corsPolicies := processCorsPolicy(traffic.Cors, basePolicyName, policyName, policyTarget)
-		agwPolicies = append(agwPolicies, corsPolicies...)
+		if corsPolicy := processCorsPolicy(traffic.Cors, basePolicyName, policyName, policyTarget); corsPolicy != nil {
+			agwPolicies = append(agwPolicies, corsPolicy)
+		}
 	}
 
 	if traffic.HeaderModifiers != nil {
@@ -497,59 +515,70 @@ func translateTrafficPolicyToAgw(
 	}
 
 	if traffic.HostnameRewrite != nil {
-		hostnameRewritePolicies := processHostnameRewritePolicy(traffic.HostnameRewrite, basePolicyName, policyName, policyTarget)
-		agwPolicies = append(agwPolicies, hostnameRewritePolicies...)
+		if hostnameRewritePolicy := processHostnameRewritePolicy(traffic.HostnameRewrite, basePolicyName, policyName, policyTarget); hostnameRewritePolicy != nil {
+			agwPolicies = append(agwPolicies, hostnameRewritePolicy)
+		}
 	}
 
 	if traffic.Timeouts != nil {
-		timeoutsPolicies := processTimeoutPolicy(traffic.Timeouts, basePolicyName, policyName, policyTarget)
-		agwPolicies = append(agwPolicies, timeoutsPolicies...)
+		if timeoutPolicy := processTimeoutPolicy(traffic.Timeouts, basePolicyName, policyName, policyTarget); timeoutPolicy != nil {
+			agwPolicies = append(agwPolicies, timeoutPolicy)
+		}
 	}
 
 	if traffic.Retry != nil {
-		retriesPolicies, err := processRetriesPolicy(traffic.Retry, basePolicyName, policyName, policyTarget)
+		retryPolicy, err := processRetriesPolicy(traffic.Retry, basePolicyName, policyName, policyTarget)
 		if err != nil {
 			logger.Error("error processing retries policy", "error", err)
 			errs = append(errs, err)
 		}
-		agwPolicies = append(agwPolicies, retriesPolicies...)
+		if retryPolicy != nil {
+			agwPolicies = append(agwPolicies, retryPolicy)
+		}
 	}
 
 	if traffic.DirectResponse != nil {
-		directRespPolicies := processDirectResponse(traffic.DirectResponse, basePolicyName, policyName, policyTarget)
-		agwPolicies = append(agwPolicies, directRespPolicies...)
+		if directRespPolicy := processDirectResponse(traffic.DirectResponse, basePolicyName, policyName, policyTarget); directRespPolicy != nil {
+			agwPolicies = append(agwPolicies, directRespPolicy)
+		}
 	}
 
 	if traffic.JWTAuthentication != nil {
-		jwtAuthenticationPolicies, err := processJWTAuthenticationPolicy(ctx, traffic.JWTAuthentication, traffic.Phase, basePolicyName, policyName, policyTarget)
+		jwtAuthenticationPolicy, err := processJWTAuthenticationPolicy(ctx, traffic.JWTAuthentication, traffic.Phase, basePolicyName, policyName, policyTarget)
 		if err != nil {
 			logger.Error("error processing jwtAuthentication policy", "error", err)
 			errs = append(errs, err)
 		}
-		agwPolicies = append(agwPolicies, jwtAuthenticationPolicies...)
+		if jwtAuthenticationPolicy != nil {
+			agwPolicies = append(agwPolicies, jwtAuthenticationPolicy)
+		}
 	}
 
 	if traffic.APIKeyAuthentication != nil {
-		apiKeyAuthenticationPolicies, err := processAPIKeyAuthenticationPolicy(ctx, traffic.APIKeyAuthentication, traffic.Phase, basePolicyName, policyName, policyTarget)
+		apiKeyAuthenticationPolicy, err := processAPIKeyAuthenticationPolicy(ctx, traffic.APIKeyAuthentication, traffic.Phase, basePolicyName, policyName, policyTarget)
 		if err != nil {
 			logger.Error("error processing apiKeyAuthentication policy", "error", err)
 			errs = append(errs, err)
 		}
-		agwPolicies = append(agwPolicies, apiKeyAuthenticationPolicies...)
+		if apiKeyAuthenticationPolicy != nil {
+			agwPolicies = append(agwPolicies, apiKeyAuthenticationPolicy)
+		}
 	}
 
 	if traffic.BasicAuthentication != nil {
-		basicAuthenticationPolicies, err := processBasicAuthenticationPolicy(ctx, traffic.BasicAuthentication, traffic.Phase, basePolicyName, policyName, policyTarget)
+		basicAuthenticationPolicy, err := processBasicAuthenticationPolicy(ctx, traffic.BasicAuthentication, traffic.Phase, basePolicyName, policyName, policyTarget)
 		if err != nil {
 			logger.Error("error processing basicAuthentication policy", "error", err)
 			errs = append(errs, err)
 		}
-		agwPolicies = append(agwPolicies, basicAuthenticationPolicies...)
+		if basicAuthenticationPolicy != nil {
+			agwPolicies = append(agwPolicies, basicAuthenticationPolicy)
+		}
 	}
 	return agwPolicies, errors.Join(errs...)
 }
 
-func processRetriesPolicy(retry *agentgateway.Retry, basePolicyName string, policy types.NamespacedName, target *api.PolicyTarget) ([]AgwPolicy, error) {
+func processRetriesPolicy(retry *agentgateway.Retry, basePolicyName string, policy types.NamespacedName, target *api.PolicyTarget) (*api.Policy, error) {
 	translatedRetry := &api.Retry{}
 
 	if retry.Codes != nil {
@@ -590,10 +619,10 @@ func processRetriesPolicy(retry *agentgateway.Retry, basePolicyName string, poli
 		"agentgateway_policy", retryPolicy.Name,
 		"target", target)
 
-	return []AgwPolicy{{Policy: retryPolicy}}, nil
+	return retryPolicy, nil
 }
 
-func processDirectResponse(directResponse *agentgateway.DirectResponse, basePolicyName string, policy types.NamespacedName, target *api.PolicyTarget) []AgwPolicy {
+func processDirectResponse(directResponse *agentgateway.DirectResponse, basePolicyName string, policy types.NamespacedName, target *api.PolicyTarget) *api.Policy {
 	tp := &api.TrafficPolicySpec{
 		Kind: &api.TrafficPolicySpec_DirectResponse{
 			DirectResponse: &api.DirectResponse{
@@ -621,10 +650,10 @@ func processDirectResponse(directResponse *agentgateway.DirectResponse, basePoli
 		"agentgateway_policy", directRespPolicy.Name,
 		"target", target)
 
-	return []AgwPolicy{{Policy: directRespPolicy}}
+	return directRespPolicy
 }
 
-func processJWTAuthenticationPolicy(ctx PolicyCtx, jwt *agentgateway.JWTAuthentication, policyPhase *agentgateway.PolicyPhase, basePolicyName string, policy types.NamespacedName, target *api.PolicyTarget) ([]AgwPolicy, error) {
+func processJWTAuthenticationPolicy(ctx PolicyCtx, jwt *agentgateway.JWTAuthentication, policyPhase *agentgateway.PolicyPhase, basePolicyName string, policy types.NamespacedName, target *api.PolicyTarget) (*api.Policy, error) {
 	p := &api.TrafficPolicySpec_JWT{}
 
 	switch jwt.Mode {
@@ -680,10 +709,10 @@ func processJWTAuthenticationPolicy(ctx PolicyCtx, jwt *agentgateway.JWTAuthenti
 		"agentgateway_policy", jwtPolicy.Name,
 		"target", target)
 
-	return []AgwPolicy{{Policy: jwtPolicy}}, errors.Join(errs...)
+	return jwtPolicy, errors.Join(errs...)
 }
 
-func processBasicAuthenticationPolicy(ctx PolicyCtx, ba *agentgateway.BasicAuthentication, policyPhase *agentgateway.PolicyPhase, basePolicyName string, policy types.NamespacedName, target *api.PolicyTarget) ([]AgwPolicy, error) {
+func processBasicAuthenticationPolicy(ctx PolicyCtx, ba *agentgateway.BasicAuthentication, policyPhase *agentgateway.PolicyPhase, basePolicyName string, policy types.NamespacedName, target *api.PolicyTarget) (*api.Policy, error) {
 	p := &api.TrafficPolicySpec_BasicAuthentication{}
 	p.Realm = ba.Realm
 
@@ -725,7 +754,7 @@ func processBasicAuthenticationPolicy(ctx PolicyCtx, ba *agentgateway.BasicAuthe
 		"agentgateway_policy", basicAuthPolicy.Name,
 		"target", target)
 
-	return []AgwPolicy{{Policy: basicAuthPolicy}}, nil
+	return basicAuthPolicy, nil
 }
 
 type APIKeyEntry struct {
@@ -740,7 +769,7 @@ func processAPIKeyAuthenticationPolicy(
 	basePolicyName string,
 	policy types.NamespacedName,
 	target *api.PolicyTarget,
-) ([]AgwPolicy, error) {
+) (*api.Policy, error) {
 	p := &api.TrafficPolicySpec_APIKey{}
 
 	switch ak.Mode {
@@ -808,10 +837,10 @@ func processAPIKeyAuthenticationPolicy(
 		"agentgateway_policy", apiKeyPolicy.Name,
 		"target", target)
 
-	return []AgwPolicy{{Policy: apiKeyPolicy}}, errors.Join(errs...)
+	return apiKeyPolicy, errors.Join(errs...)
 }
 
-func processTimeoutPolicy(timeout *agentgateway.Timeouts, basePolicyName string, policy types.NamespacedName, target *api.PolicyTarget) []AgwPolicy {
+func processTimeoutPolicy(timeout *agentgateway.Timeouts, basePolicyName string, policy types.NamespacedName, target *api.PolicyTarget) *api.Policy {
 	timeoutPolicy := &api.Policy{
 		Key:    basePolicyName + timeoutPolicySuffix + attachmentName(target),
 		Name:   TypedResourceFromName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
@@ -830,10 +859,10 @@ func processTimeoutPolicy(timeout *agentgateway.Timeouts, basePolicyName string,
 		"agentgateway_policy", timeoutPolicy.Name,
 		"target", target)
 
-	return []AgwPolicy{{Policy: timeoutPolicy}}
+	return timeoutPolicy
 }
 
-func processHostnameRewritePolicy(hnrw *agentgateway.HostnameRewrite, basePolicyName string, policy types.NamespacedName, target *api.PolicyTarget) []AgwPolicy {
+func processHostnameRewritePolicy(hnrw *agentgateway.HostnameRewrite, basePolicyName string, policy types.NamespacedName, target *api.PolicyTarget) *api.Policy {
 	r := &api.TrafficPolicySpec_HostRewrite{}
 	switch hnrw.Mode {
 	case agentgateway.HostnameRewriteModeAuto:
@@ -858,11 +887,11 @@ func processHostnameRewritePolicy(hnrw *agentgateway.HostnameRewrite, basePolicy
 		"agentgateway_policy", p.Name,
 		"target", target)
 
-	return []AgwPolicy{{Policy: p}}
+	return p
 }
 
-func processHeaderModifierPolicy(headerModifier *shared.HeaderModifiers, basePolicyName string, policy types.NamespacedName, target *api.PolicyTarget) []AgwPolicy {
-	var policies []AgwPolicy
+func processHeaderModifierPolicy(headerModifier *shared.HeaderModifiers, basePolicyName string, policy types.NamespacedName, target *api.PolicyTarget) []*api.Policy {
+	var policies []*api.Policy
 
 	var headerModifierPolicyRequest, headerModifierPolicyResponse *api.Policy
 	if headerModifier.Request != nil {
@@ -884,7 +913,7 @@ func processHeaderModifierPolicy(headerModifier *shared.HeaderModifiers, basePol
 			"policy", basePolicyName,
 			"agentgateway_policy", headerModifierPolicyRequest.Name,
 			"target", target)
-		policies = append(policies, AgwPolicy{Policy: headerModifierPolicyRequest})
+		policies = append(policies, headerModifierPolicyRequest)
 	}
 
 	if headerModifier.Response != nil {
@@ -906,13 +935,13 @@ func processHeaderModifierPolicy(headerModifier *shared.HeaderModifiers, basePol
 			"policy", basePolicyName,
 			"agentgateway_policy", headerModifierPolicyResponse.Name,
 			"target", target)
-		policies = append(policies, AgwPolicy{Policy: headerModifierPolicyResponse})
+		policies = append(policies, headerModifierPolicyResponse)
 	}
 
 	return policies
 }
 
-func processCorsPolicy(cors *agentgateway.CORS, basePolicyName string, policy types.NamespacedName, target *api.PolicyTarget) []AgwPolicy {
+func processCorsPolicy(cors *agentgateway.CORS, basePolicyName string, policy types.NamespacedName, target *api.PolicyTarget) *api.Policy {
 	corsPolicy := &api.Policy{
 		Key:    basePolicyName + corsPolicySuffix + attachmentName(target),
 		Name:   TypedResourceFromName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
@@ -938,7 +967,7 @@ func processCorsPolicy(cors *agentgateway.CORS, basePolicyName string, policy ty
 		"agentgateway_policy", corsPolicy.Name,
 		"target", target)
 
-	return []AgwPolicy{{Policy: corsPolicy}}
+	return corsPolicy
 }
 
 // processExtAuthPolicy processes ExtAuth configuration and creates corresponding agentgateway policies
@@ -949,7 +978,7 @@ func processExtAuthPolicy(
 	basePolicyName string,
 	policy types.NamespacedName,
 	policyTarget *api.PolicyTarget,
-) ([]AgwPolicy, error) {
+) (*api.Policy, error) {
 	var backendErr error
 	be, err := buildBackendRef(ctx, extAuth.BackendRef, policy.Namespace)
 	if err != nil {
@@ -1011,7 +1040,7 @@ func processExtAuthPolicy(
 		"agentgateway_policy", extauthPolicy.Name,
 		"target", policyTarget)
 
-	return []AgwPolicy{{Policy: extauthPolicy}}, backendErr
+	return extauthPolicy, backendErr
 }
 
 // processExtProcPolicy processes ExtProc configuration and creates corresponding agentgateway policies
@@ -1022,7 +1051,7 @@ func processExtProcPolicy(
 	basePolicyName string,
 	policy types.NamespacedName,
 	policyTarget *api.PolicyTarget,
-) ([]AgwPolicy, error) {
+) (*api.Policy, error) {
 	be, err := buildBackendRef(ctx, extProc.BackendRef, policy.Namespace)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build extProc: %v", err)
@@ -1053,7 +1082,7 @@ func processExtProcPolicy(
 		"agentgateway_policy", extprocPolicy.Name,
 		"target", policyTarget)
 
-	return []AgwPolicy{{Policy: extprocPolicy}}, nil
+	return extprocPolicy, nil
 }
 
 func phase(policyPhase *agentgateway.PolicyPhase) api.TrafficPolicySpec_PolicyPhase {
@@ -1099,7 +1128,7 @@ func processAuthorizationPolicy(
 	basePolicyName string,
 	policy types.NamespacedName,
 	policyTarget *api.PolicyTarget,
-) []AgwPolicy {
+) *api.Policy {
 	var allowPolicies, denyPolicies []string
 	if auth.Action == shared.AuthorizationPolicyActionDeny {
 		denyPolicies = append(denyPolicies, cast(auth.Policy.MatchExpressions)...)
@@ -1128,7 +1157,7 @@ func processAuthorizationPolicy(
 		"agentgateway_policy", pol.Name,
 		"target", policyTarget)
 
-	return []AgwPolicy{{Policy: pol}}
+	return pol
 }
 
 func getFrontendPolicyName(trafficPolicyNs, trafficPolicyName string) string {
@@ -1144,15 +1173,15 @@ func getTrafficPolicyName(trafficPolicyNs, trafficPolicyName string) string {
 }
 
 // processRateLimitPolicy processes RateLimit configuration and creates corresponding agentgateway policies
-func processRateLimitPolicy(ctx PolicyCtx, rl *agentgateway.RateLimits, basePolicyName string, policy types.NamespacedName, policyTarget *api.PolicyTarget) ([]AgwPolicy, error) {
-	var agwPolicies []AgwPolicy
+func processRateLimitPolicy(ctx PolicyCtx, rl *agentgateway.RateLimits, basePolicyName string, policy types.NamespacedName, policyTarget *api.PolicyTarget) ([]*api.Policy, error) {
+	var agwPolicies []*api.Policy
 	var errs []error
 
 	// Process local rate limiting if present
 	if rl.Local != nil {
 		localPolicy := processLocalRateLimitPolicy(rl.Local, basePolicyName, policy, policyTarget)
 		if localPolicy != nil {
-			agwPolicies = append(agwPolicies, *localPolicy)
+			agwPolicies = append(agwPolicies, localPolicy)
 		}
 	}
 
@@ -1160,7 +1189,7 @@ func processRateLimitPolicy(ctx PolicyCtx, rl *agentgateway.RateLimits, basePoli
 	if rl.Global != nil {
 		globalPolicy, err := processGlobalRateLimitPolicy(ctx, *rl.Global, basePolicyName, policy, policyTarget)
 		if globalPolicy != nil && err == nil {
-			agwPolicies = append(agwPolicies, *globalPolicy)
+			agwPolicies = append(agwPolicies, globalPolicy)
 		} else {
 			errs = append(errs, err)
 		}
@@ -1170,7 +1199,7 @@ func processRateLimitPolicy(ctx PolicyCtx, rl *agentgateway.RateLimits, basePoli
 }
 
 // processLocalRateLimitPolicy processes local rate limiting configuration
-func processLocalRateLimitPolicy(limits []agentgateway.LocalRateLimit, basePolicyName string, policy types.NamespacedName, policyTarget *api.PolicyTarget) *AgwPolicy {
+func processLocalRateLimitPolicy(limits []agentgateway.LocalRateLimit, basePolicyName string, policy types.NamespacedName, policyTarget *api.PolicyTarget) *api.Policy {
 	// TODO: support multiple
 	limit := limits[0]
 
@@ -1209,7 +1238,7 @@ func processLocalRateLimitPolicy(limits []agentgateway.LocalRateLimit, basePolic
 		},
 	}
 
-	return &AgwPolicy{Policy: localRateLimitPolicy}
+	return localRateLimitPolicy
 }
 
 func processGlobalRateLimitPolicy(
@@ -1218,7 +1247,7 @@ func processGlobalRateLimitPolicy(
 	basePolicyName string,
 	policy types.NamespacedName,
 	policyTarget *api.PolicyTarget,
-) (*AgwPolicy, error) {
+) (*api.Policy, error) {
 	be, err := buildBackendRef(ctx, grl.BackendRef, policy.Namespace)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build global rate limit: %v", err)
@@ -1249,7 +1278,7 @@ func processGlobalRateLimitPolicy(
 		},
 	}
 
-	return &AgwPolicy{Policy: p}, nil
+	return p, nil
 }
 
 func processRateLimitDescriptor(descriptor agentgateway.RateLimitDescriptor) *api.TrafficPolicySpec_RemoteRateLimit_Descriptor {
@@ -1364,7 +1393,7 @@ func toJSONValue(j apiextensionsv1.JSON) (string, error) {
 	return string(marshaled), nil
 }
 
-func processCSRFPolicy(csrf *agentgateway.CSRF, basePolicyName string, policy types.NamespacedName, policyTarget *api.PolicyTarget) []AgwPolicy {
+func processCSRFPolicy(csrf *agentgateway.CSRF, basePolicyName string, policy types.NamespacedName, policyTarget *api.PolicyTarget) *api.Policy {
 	csrfPolicy := &api.Policy{
 		Key:    basePolicyName + csrfPolicySuffix + attachmentName(policyTarget),
 		Name:   TypedResourceFromName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
@@ -1380,7 +1409,7 @@ func processCSRFPolicy(csrf *agentgateway.CSRF, basePolicyName string, policy ty
 		},
 	}
 
-	return []AgwPolicy{{Policy: csrfPolicy}}
+	return csrfPolicy
 }
 
 // processTransformationPolicy processes transformation configuration and creates corresponding Agw policies
@@ -1390,7 +1419,7 @@ func processTransformationPolicy(
 	basePolicyName string,
 	policy types.NamespacedName,
 	policyTarget *api.PolicyTarget,
-) ([]AgwPolicy, error) {
+) (*api.Policy, error) {
 	var errs []error
 	convertedReq, err := convertTransformSpec(transformation.Request)
 	if err != nil {
@@ -1423,7 +1452,7 @@ func processTransformationPolicy(
 			"policy", basePolicyName,
 			"agentgateway_policy", transformationPolicy.Name,
 			"target", policyTarget)
-		return []AgwPolicy{{Policy: transformationPolicy}}, errors.Join(errs...)
+		return transformationPolicy, errors.Join(errs...)
 	}
 	return nil, errors.Join(errs...)
 }

--- a/controller/pkg/agentgateway/translator/gateway_collection.go
+++ b/controller/pkg/agentgateway/translator/gateway_collection.go
@@ -60,12 +60,6 @@ func ToResourceForGateway(gw types.NamespacedName, resource any) ir.AgwResource 
 	}
 }
 
-func ToResourceGlobal(resource any) ir.AgwResource {
-	return ir.AgwResource{
-		Resource: ToAgwResource(resource),
-	}
-}
-
 // AgwBind is a wrapper type that contains the bind on the gateway, as well as the status for the bind.
 type AgwBind struct {
 	*api.Bind

--- a/controller/pkg/agentgateway/translator/model.go
+++ b/controller/pkg/agentgateway/translator/model.go
@@ -109,11 +109,6 @@ type Config struct {
 	Status Status
 }
 
-type TypedResource struct {
-	Kind schema.GroupVersionKind
-	Name types.NamespacedName
-}
-
 // Spec defines the spec for the  In order to use below helper methods,
 // this must be one of:
 // * golang/protobuf Message

--- a/controller/pkg/agentgateway/translator/testdata/backends/a2a.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/backends/a2a.yaml
@@ -15,7 +15,10 @@ spec:
 ---
 # Output
 output:
-- resource:
+- gateway:
+    Name: basic
+    Namespace: default
+  resource:
     policy:
       backend:
         a2a: {}

--- a/controller/pkg/agentgateway/translator/testdata/backends/backendtlspolicy.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/backends/backendtlspolicy.yaml
@@ -66,7 +66,10 @@ data:
 ---
 # Output
 output:
-- resource:
+- gateway:
+    Name: basic
+    Namespace: default
+  resource:
     policy:
       backend:
         backendTls:
@@ -81,7 +84,10 @@ output:
         service:
           hostname: infra-backend-v2.default.svc.cluster.local
           namespace: default
-- resource:
+- gateway:
+    Name: basic
+    Namespace: default
+  resource:
     policy:
       backend:
         backendTls:

--- a/controller/pkg/agentgateway/translator/testdata/backends/inferencepool.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/backends/inferencepool.yaml
@@ -45,7 +45,10 @@ spec:
 ---
 # Output
 output:
-- resource:
+- gateway:
+    Name: basic
+    Namespace: default
+  resource:
     policy:
       backend:
         inferenceRouting:
@@ -64,7 +67,10 @@ output:
         service:
           hostname: gateway-pool.default.inference.cluster.local
           namespace: default
-- resource:
+- gateway:
+    Name: basic
+    Namespace: default
+  resource:
     policy:
       backend:
         backendTls:
@@ -79,7 +85,10 @@ output:
           hostname: gateway-pool-endpoint-picker.default.svc.cluster.local
           namespace: default
           port: 9002
-- resource:
+- gateway:
+    Name: basic
+    Namespace: default
+  resource:
     policy:
       backend:
         backendTls:

--- a/controller/pkg/agentgateway/translator/testdata/backends/tls.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/backends/tls.yaml
@@ -322,7 +322,10 @@ output:
       name:
         name: openai-single
         namespace: default
-- resource:
+- gateway:
+    Name: basic
+    Namespace: default
+  resource:
     policy:
       backend:
         backendTls:
@@ -336,7 +339,10 @@ output:
         backend:
           name: ai-groups
           namespace: default
-- resource:
+- gateway:
+    Name: basic
+    Namespace: default
+  resource:
     policy:
       backend:
         backendTls:
@@ -351,7 +357,10 @@ output:
           name: ai-groups
           namespace: default
           section: anthropic
-- resource:
+- gateway:
+    Name: basic
+    Namespace: default
+  resource:
     policy:
       backend:
         backendTls:
@@ -365,7 +374,10 @@ output:
         backend:
           name: openai-single
           namespace: default
-- resource:
+- gateway:
+    Name: basic
+    Namespace: default
+  resource:
     policy:
       backend:
         backendTls:
@@ -380,7 +392,10 @@ output:
         service:
           hostname: mcp-svc.default.svc.cluster.local
           namespace: default
-- resource:
+- gateway:
+    Name: basic
+    Namespace: default
+  resource:
     policy:
       backend:
         backendTls:
@@ -395,7 +410,10 @@ output:
           name: mcp-backend
           namespace: default
           section: mcp-static
-- resource:
+- gateway:
+    Name: basic
+    Namespace: default
+  resource:
     policy:
       backend:
         backendTls:

--- a/controller/pkg/agentgateway/translator/testdata/routes/inferencepool.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/routes/inferencepool.yaml
@@ -50,21 +50,6 @@ output:
     Name: test-gateway
     Namespace: default
   resource:
-    route:
-      backends:
-      - backend:
-          port: 8080
-          service:
-            hostname: gateway-pool.default.inference.cluster.local
-            namespace: default
-        weight: 1
-      key: default/gateway-route.0.http
-      listenerKey: default/test-gateway.http
-      name:
-        kind: HTTPRoute
-        name: gateway-route
-        namespace: default
-- resource:
     policy:
       backend:
         inferenceRouting:
@@ -83,7 +68,10 @@ output:
         service:
           hostname: gateway-pool.default.inference.cluster.local
           namespace: default
-- resource:
+- gateway:
+    Name: test-gateway
+    Namespace: default
+  resource:
     policy:
       backend:
         backendTls:
@@ -98,6 +86,24 @@ output:
           hostname: gateway-pool-endpoint-picker.default.svc.cluster.local
           namespace: default
           port: 9002
+- gateway:
+    Name: test-gateway
+    Namespace: default
+  resource:
+    route:
+      backends:
+      - backend:
+          port: 8080
+          service:
+            hostname: gateway-pool.default.inference.cluster.local
+            namespace: default
+        weight: 1
+      key: default/gateway-route.0.http
+      listenerKey: default/test-gateway.http
+      name:
+        kind: HTTPRoute
+        name: gateway-route
+        namespace: default
 status:
 - apiVersion: inference.networking.k8s.io/v1
   kind: InferencePool

--- a/controller/pkg/kgateway/agentgatewaysyncer/policy_collections.go
+++ b/controller/pkg/kgateway/agentgatewaysyncer/policy_collections.go
@@ -31,7 +31,7 @@ func AgwPolicyCollection(agwPlugins plugins.AgwPlugin, references plugins.Refere
 	joinPolicies := krt.JoinCollection(allPolicies, krtopts.ToOptions("JoinPolicies")...)
 
 	allPoliciesCol := krt.NewCollection(joinPolicies, func(ctx krt.HandlerContext, i plugins.AgwPolicy) *ir.AgwResource {
-		return ptr.Of(translator.ToResourceGlobal(i))
+		return ptr.Of(translator.ToResourceForGateway(*i.Gateway, i))
 	}, krtopts.ToOptions("AllPolicies")...)
 
 	return allPoliciesCol, policyStatusMap


### PR DESCRIPTION
~Draft pending https://github.com/istio/istio/pull/59342~

Like https://github.com/agentgateway/agentgateway/pull/1147 but for policies. Original work in https://github.com/kgateway-dev/kgateway/pull/13247 but changed a lot since then.

Lots of changes... to facilitate this.
* merge redundant types: TypedResource, ParentKey, utils.typednamespacename since we need to use them as a consistent thing (https://github.com/agentgateway/agentgateway/issues/1161)
* Instead of just 'ancestors', which is a Backend --> Gateway index, build a new "References" index that can take any type (gateway, listenerset, route, backend) and reverse it to the Gateway(s) its a part of.
* Add a test for ancestors to make sure all combinations of {ListenerSet,RouteTYpe,BackendType} works. I didn't think ListenerSet would pass but it did which is great, so no change needed there.
* Extend the 'route attachment' object to include the Gateway. Before, we have Route --> Gateway OR ListenerSet. Its trivial to add a new Gateway field that always has the Gateway in the case of a ListenerSet, which gives us our Route --> ListenerSet mapping.
* We do NOT have a ListenerSet --> Gateway mapping. its trivial to add,  but not needed until we actually support ListenerSet in AGWPolicy.
* Change all the golden tests to consistently use the full TestSyncer flow, which allows them to get ReferenceIndex.
  * As a side effect, the YAML changes a bit. I ran each one through Codex and it found many real issues which I have no fixed and it gives a clean bill of 'these changes are formatting only'.
  * Real bug found unrelated to this change: response and request header modifiers used the same key, so you could only set one and the other was dropped.
