### PR TITLE
Fix AgentgatewayPolicy CRD HostRewrite property

### DIFF
--- a/controller/api/tests/testdata/agentgateway_policy_invalid.yaml
+++ b/controller/api/tests/testdata/agentgateway_policy_invalid.yaml
@@ -302,14 +302,15 @@ spec:
       protocol: GRPC
       path: /v1/traces
 ---
-_err: 'hostRewrite: Unsupported value'
+_err: 'spec.traffic.hostRewrite.mode: Unsupported value'
 apiVersion: agentgateway.dev/v1alpha1
 kind: AgentgatewayPolicy
 metadata:
   name: traffic-hostrewrite-invalid
 spec:
   traffic:
-    hostRewrite: Custom
+    hostRewrite:
+      mode: Custom
 ---
 _err: ' exactly one of the fields in [targetRefs targetSelectors] must be set'
 apiVersion: agentgateway.dev/v1alpha1

--- a/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
+++ b/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
@@ -506,7 +506,6 @@ type Traffic struct {
 	// hostRewrite specifies how to rewrite the Host header for requests.
 	//
 	// If the HTTPRoute `urlRewrite` filter already specifies a host rewrite, this setting is ignored.
-	// +kubebuilder:validation:Enum=Auto;None
 	// +optional
 	HostnameRewrite *HostnameRewrite `json:"hostRewrite,omitempty"`
 
@@ -1348,6 +1347,7 @@ type HostnameRewrite struct {
 	//
 	// This setting defaults to Auto when connecting to hostname-based Backend types, and None otherwise (for Service or
 	// IP-based Backends).
+	// +kubebuilder:validation:Enum=Auto;None
 	// +required
 	Mode HostnameRewriteMode `json:"mode"`
 }

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
@@ -6583,9 +6583,6 @@ spec:
                       hostRewrite specifies how to rewrite the Host header for requests.
 
                       If the HTTPRoute `urlRewrite` filter already specifies a host rewrite, this setting is ignored.
-                    enum:
-                    - Auto
-                    - None
                     properties:
                       mode:
                         description: |-
@@ -6597,6 +6594,9 @@ spec:
 
                           This setting defaults to Auto when connecting to hostname-based Backend types, and None otherwise (for Service or
                           IP-based Backends).
+                        enum:
+                        - Auto
+                        - None
                         type: string
                     required:
                     - mode

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
@@ -6583,9 +6583,6 @@ spec:
                       hostRewrite specifies how to rewrite the Host header for requests.
 
                       If the HTTPRoute `urlRewrite` filter already specifies a host rewrite, this setting is ignored.
-                    enum:
-                    - Auto
-                    - None
                     properties:
                       mode:
                         description: |-
@@ -6597,6 +6594,9 @@ spec:
 
                           This setting defaults to Auto when connecting to hostname-based Backend types, and None otherwise (for Service or
                           IP-based Backends).
+                        enum:
+                          - Auto
+                          - None
                         type: string
                     required:
                     - mode

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
@@ -6583,6 +6583,9 @@ spec:
                       hostRewrite specifies how to rewrite the Host header for requests.
 
                       If the HTTPRoute `urlRewrite` filter already specifies a host rewrite, this setting is ignored.
+                    enum:
+                    - Auto
+                    - None
                     properties:
                       mode:
                         description: |-
@@ -6594,9 +6597,6 @@ spec:
 
                           This setting defaults to Auto when connecting to hostname-based Backend types, and None otherwise (for Service or
                           IP-based Backends).
-                        enum:
-                          - Auto
-                          - None
                         type: string
                     required:
                     - mode


### PR DESCRIPTION
Within the AgentgatewayPolicy CRD there is a bug with the HostRewrite optional property.

It is simultaneously an `enum` for `Auto`/`None` and of type `object` with a `mode` property, which are not simultaneously satisfiable.

I believe an adequate fix would be to just move the `enum` into the `mode`, as it was probably just an indentation bug to begin with.

I'm not sure if there are any considerations to be had about backwards-compability since, in this case, it goes from not working (unsatisfiable constraints) to functional (at least on the CRD side).