### PR TITLE
Draft: benchmarking framework for agentgateway inference routing

### DIFF
--- a/benchmarking/README.md
+++ b/benchmarking/README.md
@@ -1,0 +1,89 @@
+# Benchmarking
+
+The inference-perf Helm chart is adapted from the GIE benchmarking framework. See inference-perf/README.md for details.
+
+More generally, the agentgateway benchmarking framework mirror the GIE benchmarking framework.
+
+## Directory structure
+
+```
+benchmarking/
+  run-benchmark.sh          # Orchestrates agentgateway + baseline runs
+  download-results.sh       # Downloads results locally
+  values.yaml               # Base inference-perf config
+  inference-perf/           # Helm chart
+  single-workload/          # Per-target overrides
+    agentgateway-values.yaml
+    baseline-values.yaml
+```
+
+## Prerequisites
+
+- A running Kubernetes cluster with agentgateway deployed
+- Following resources must exist in `NAMESPACE`:
+  - `Gateway` resource (default: `inference-gateway`) exposing agentgateway on port 8080
+  - `Service` named `llm-d-baseline` (override via `BASELINE_SVC`) exposing the baseline model server on port 80
+- `helm` and `kubectl` available locally + configured against the cluster
+- A GCS bucket for storing results (todo S3)
+
+## Running a benchmark
+
+```bash
+WORKLOAD=single-workload \
+NAMESPACE=<your-namespace> \
+GCS_BUCKET=<your-bucket> \
+./run-benchmark.sh
+```
+
+Auto-discovery work thanks to `kubectl get gateway` and `kubectl get svc` (can be overriden)
+
+```bash
+GW_URL=http://<ip>:8080 BASELINE_URL=http://<ip>:80 ... ./run-benchmark.sh
+```
+
+### GCS credentials
+
+`KSA_NAME` on GKE (todo AWS):
+
+```bash
+KSA_NAME=my-ksa ... ./run-benchmark.sh
+```
+
+Create a GCP secret if outside GKE (todo AWS):
+
+```bash
+GCS_CREDENTIALS_SECRET=gcs-key GCS_PROJECT=<project-id> ... ./run-benchmark.sh
+```
+
+### Environment variables
+
+| Variable | Description | Default |
+|---|---|---|
+| `NAMESPACE` | Kubernetes namespace | mandatory |
+| `WORKLOAD` | Workload subdirectory (e.g. `single-workload`) | mandatory |
+| `GW_NAME` | Gateway resource name | `inference-gateway` |
+| `BASELINE_SVC` | Baseline service name | `llm-d-baseline` |
+| `GW_URL` | Override gateway URL (skips discovery) | auto-discovered |
+| `BASELINE_URL` | Override baseline URL (skips discovery) | auto-discovered |
+| `GCS_BUCKET` | GCS bucket for results | optional |
+| `GCS_CREDENTIALS_SECRET` | k8s secret name containing `key.json` | optional |
+| `GCS_PROJECT` | GCP project ID (`GOOGLE_CLOUD_PROJECT` in pod) | optional |
+| `KSA_NAME` | Kubernetes service account for Workload Identity | optional |
+| `HF_TOKEN` | Hugging Face token | optional |
+| `BENCHMARK_TIMEOUT` | kubectl wait timeout for the job | `3600s` |
+
+## Downloading results
+
+```bash
+./download-results.sh <bucket> <timestamp> [workload]
+```
+
+Results are saved to `output/<timestamp>/agentgateway/` and `output/<timestamp>/baseline/`.
+
+## Adding workload scenarios
+
+Add a new subdirectory (e.g. `prefix-cache/`) with `agentgateway-values.yaml` and `baseline-values.yaml`, then run:
+
+```bash
+WORKLOAD=prefix-cache ... ./run-benchmark.sh
+```

--- a/benchmarking/download-results.sh
+++ b/benchmarking/download-results.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# downloads a full benchmark (agentgateway + baseline) from GCS (for now)
+# ./download-results.sh <BUCKET> <TIMESTAMP> [WORKLOAD]
+
+set -euo pipefail
+
+: "${1:?Usage: $0 <BUCKET> <TIMESTAMP> [WORKLOAD]}"
+: "${2:?Usage: $0 <BUCKET> <TIMESTAMP> [WORKLOAD]}"
+
+BUCKET="$1"
+TIMESTAMP="$2"
+WORKLOAD="${3:-single-workload}"
+output_dir="${OUTPUT_DIR:-output}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOCAL_DIR="${SCRIPT_DIR}/${output_dir}/${TIMESTAMP}"
+
+echo "Downloading run ${TIMESTAMP} (${WORKLOAD})..."
+
+for target in agentgateway baseline; do
+  gcs_path="gs://${BUCKET}/${target}/${WORKLOAD}/${TIMESTAMP}"
+  local_path="${LOCAL_DIR}/${target}"
+  echo "${target}: ${gcs_path} to ${local_path}"
+  mkdir -p "${local_path}"
+  gsutil cp -r "${gcs_path}/*" "${local_path}/"
+done
+
+echo ""
+echo "Run downloaded to: ${LOCAL_DIR}"
+echo "${LOCAL_DIR}/agentgateway/"
+echo "${LOCAL_DIR}/baseline/"

--- a/benchmarking/inference-perf/.helmignore
+++ b/benchmarking/inference-perf/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/benchmarking/inference-perf/Chart.yaml
+++ b/benchmarking/inference-perf/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: inference-perf
+description: A Helm chart for running inference-perf benchmarking tool
+type: application
+version: 0.2.0
+appVersion: "v0.2.0"

--- a/benchmarking/inference-perf/README.md
+++ b/benchmarking/inference-perf/README.md
@@ -1,0 +1,120 @@
+*This Helm chart is adapted from the Gateway API Inference Extension benchmarking tooling, licensed under Apache 2.0. You can find it [here](https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/benchmarking/inference-perf)*
+
+## 🚀 Deploying `inference-perf` via Helm Chart
+
+This guide explains how to deploy `inference-perf` to a Kubernetes cluster with Helm.
+
+Note: This is a temporary chart added until remote chart is available.
+
+---
+
+### 1. Prerequisites
+
+Make sure you have the following tools installed and configured:
+
+* **Kubernetes Cluster:** Access to a functional cluster (e.g., GKE).
+* **Helm:** The Helm CLI installed locally.
+
+---
+
+### 2. Configuration (`values.yaml`)
+
+Before deployment, navigate to the **`benchmarking/inference-perf`** directory and edit the **`values.yaml`** file to customize your deployment and the benchmark parameters.
+
+#### Optional Token Parameters
+Hugging Face token can be provided either by providing a value (`hfToken`) or by referencing an existing Kubernetes Secret (`hfSecret.Name` and `hfSecret.Key`).
+
+> If both `hfToken` and the `hfSecret` parameters are provided, the chart logic is configured to prioritize the `hfSecret` reference.
+
+| Key | Description | Default |
+| :--- | :--- | :--- |
+| `hfToken` | Hugging Face API token. If provided, a Kubernetes `Secret` named `hf-token-secret` will be created for authentication. | `""` |
+| `hfSecret.name` | The name of a pre-existing Kubernetes Secret that contains a Hugging Face API token. | `""` |
+| `hfSecret.key` | The key within the pre-existing Kubernetes Secret that holds the token value. | `""` |
+---
+
+#### Optional Job Parameters
+
+| Key | Description | Default |
+| :--- | :--- | :--- |
+| `serviceAccountName` | Standard Kubernetes `serviceAccountName`. If not provided, default service account is used. | `""` |
+| `nodeSelector` |  Standard Kubernetes `nodeSelector` map to constrain pod placement to nodes with matching labels. | `{}` |
+| `resources` | Standard Kubernetes resource requests and limits for the main `inference-perf` container. | `{}` |
+---
+
+> **Example Resource Block:**
+> ```yaml
+> # resources:
+> #   requests:
+> #     cpu: "1"
+> #     memory: "4Gi"
+> #   limits:
+> #     cpu: "2"
+> #     memory: "8Gi"
+> ```
+
+#### Cloud Storage Parameters
+
+This section details the necessary configuration and permissions for using a Google Cloud Storage (GCS) path to manage your dataset, typical for deployments on GKE.
+
+##### Required IAM Permissions
+
+The identity executing the workload (e.g., the associated Kubernetes Service Account, often configured via **Workload Identity**) must possess the following IAM roles on the target GCS bucket for data transfer:
+
+* **`roles/storage.objectViewer`** (Required to read/download the input dataset from GCS).
+* **`roles/storage.objectCreator`** (Required to write/push benchmark results back to GCS).
+
+
+| Key | Description | Default |
+| :--- | :--- | :--- |
+| `gcsPath` | A GCS bucket name pointing to the dataset file (e.g., `<my-bucket-path-to-file>/dataset.json`). The file will be automatically copied to the running pod during initialization. The file will be copied to `gcsDataset/dataset.json` | `""` |
+
+---
+
+#### AWS Specific Parameters
+
+This section details the necessary configuration and permissions for using an S3 path to manage your dataset, typical for deployments on AWS EKS.
+
+##### Required IAM Permissions
+
+The identity executing the workload (e.g., the associated Kubernetes Service Account, often configured via IRSA - IAM Roles for Service Accounts) must possess an associated AWS IAM Policy that grants the following S3 Actions on the target S3 bucket for data transfer:
+
+* **S3 Read/Download (Object Access)**
+    * Action: `s3:GetObject` (Required to download the input dataset from S3).
+    * Action: `s3:ListBucket` (Often required to check for the file's existence and list bucket contents).
+
+* **S3 Write/Upload (Object Creation)**
+    * Action: `s3:PutObject` (Required to upload benchmark results back to S3).
+
+
+| Key | Description | Default |
+| :--- | :--- | :--- |
+| `s3Path` | An S3 bucket name pointing to the dataset file (e.g., `<my-bucket-path-to-file>/dataset.json`). The file will be automatically copied to the running pod during initialization. The file will be copied to `s3Dataset/dataset.json` | `""` |
+
+---
+
+### 3. Run Deployment
+
+Use the **`helm install`** command from the **`benchmarking/inference-perf`** directory to deploy the chart.
+
+* **Standard Install:** Deploy using the default `values.yaml`.
+    ```bash
+    helm install agentgateway-benchmark .
+    ```
+
+* **Set `hfToken` Override:** Pass the Hugging Face token directly.
+    ```bash
+    helm install agentgateway-benchmark . --set hfToken="<TOKEN>"
+    ```
+
+* **Custom Config Override:** Make changes to the values file for custom settings.
+    ```bash
+    helm install agentgateway-benchmark . -f values.yaml
+    ```
+
+### 4. Cleanup
+
+To remove the benchmark deployment.
+```bash
+    helm uninstall test
+```

--- a/benchmarking/inference-perf/templates/_helpers.tpl
+++ b/benchmarking/inference-perf/templates/_helpers.tpl
@@ -1,0 +1,72 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "inference-perf.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "inference-perf.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "inference-perf.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "inference-perf.labels" -}}
+helm.sh/chart: {{ include "inference-perf.chart" . }}
+{{ include "inference-perf.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "inference-perf.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "inference-perf.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Common Secret Name for HuggingFace credentials
+*/}}
+{{- define "inference-perf.hfSecret" -}}
+{{ include "inference-perf.fullname" . }}-hf-secret
+{{- end -}}
+
+{{/*
+Common Secret Key for HuggingFace credentials
+*/}}
+{{- define "inference-perf.hfKey" -}}
+{{ include "inference-perf.fullname" . }}-hf-key
+{{- end -}}
+
+{{/*
+Mount path for config map
+*/}}
+{{- define "inference-perf.configMount" -}}
+/cfg
+{{- end -}}

--- a/benchmarking/inference-perf/templates/configmap.yaml
+++ b/benchmarking/inference-perf/templates/configmap.yaml
@@ -1,0 +1,10 @@
+# inference-perf/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "inference-perf.fullname" . }}-config
+  labels:
+    {{- include "inference-perf.labels" . | nindent 4 }}
+data:
+  config.yml: |
+    {{- toYaml .Values.config | nindent 4 }}

--- a/benchmarking/inference-perf/templates/job.yaml
+++ b/benchmarking/inference-perf/templates/job.yaml
@@ -1,0 +1,106 @@
+# inference-perf/templates/job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "inference-perf.fullname" . }}-job
+  labels:
+    {{- include "inference-perf.labels" . | nindent 4 }}
+    app: inference-perf
+spec:
+  template:
+    metadata:
+      labels:
+        {{- include "inference-perf.selectorLabels" . | nindent 8 }}
+        app: inference-perf
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ .Values.job.serviceAccountName }}
+      {{- with .Values.job.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- if .Values.gcsPath}}
+      initContainers:
+        - name: fetch-gcs-dataset
+          image: google/cloud-sdk:latest
+          command: ["sh", "-c", "gsutil cp gs://{{ .Values.gcsPath }} /gcsDataset/gcs-dataset.json"]
+          volumeMounts:
+            - name: gcs-dataset-volume
+              mountPath: /gcsDataset
+{{- end }}
+{{- if .Values.s3Path}}
+      initContainers:
+        - name: fetch-s3-dataset
+          image: google/cloud-sdk:latest
+          command: ["sh", "-c", "aws s3 cp s3://{{ .Values.s3Path }} /s3Dataset/s3-dataset.json"]
+          volumeMounts:
+            - name: s3-dataset-volume
+              mountPath: /s3Dataset
+{{- end }}
+      containers:
+        - name: inference-perf-container
+          image: "{{ .Values.job.image.repository }}:{{ .Values.job.image.tag | default .Chart.AppVersion }}"
+          command: ["inference-perf"]
+          args:
+            - "--config_file"
+            - "{{ include "inference-perf.configMount" . }}/config.yml"
+            - "--log-level"
+            - {{ .Values.logLevel }}
+          env:
+{{- if and .Values.token.hfSecret.name .Values.token.hfSecret.key }}
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.token.hfSecret.name }}
+                  key: {{ .Values.token.hfSecret.key }}
+{{- else if .Values.token.hfToken }}
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "inference-perf.hfSecret" . }}
+                  key: {{ include "inference-perf.hfKey" . }}
+{{- end }}
+{{- if .Values.gcsCredentials.secretName }}
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: /etc/gcs/key.json
+{{- end }}
+{{- if .Values.gcsProject }}
+            - name: GOOGLE_CLOUD_PROJECT
+              value: {{ .Values.gcsProject }}
+{{- end }}
+          volumeMounts:
+            - name: config-volume
+              mountPath: {{ include "inference-perf.configMount" . }}
+              readOnly: true
+{{- if .Values.gcsPath}}
+            - name: gcs-dataset-volume
+              mountPath: /gcsDataset
+{{- end }}
+{{- if .Values.s3Path}}
+            - name: s3-dataset-volume
+              mountPath: /s3Dataset
+{{- end }}
+{{- if .Values.gcsCredentials.secretName }}
+            - name: gcs-credentials-volume
+              mountPath: /etc/gcs
+              readOnly: true
+{{- end }}
+          resources:
+            {{- toYaml .Values.job.resources | nindent 12 }}
+      volumes:
+        - name: config-volume
+          configMap:
+            name: {{ include "inference-perf.fullname" . }}-config
+{{- if .Values.gcsPath}}
+        - name: gcs-dataset-volume
+          emptyDir: {}
+{{- end }}
+{{- if .Values.s3Path}}
+        - name: s3-dataset-volume
+          emptyDir: {}
+{{- end }}
+{{- if .Values.gcsCredentials.secretName }}
+        - name: gcs-credentials-volume
+          secret:
+            secretName: {{ .Values.gcsCredentials.secretName }}
+{{- end }}

--- a/benchmarking/inference-perf/templates/secret.yaml
+++ b/benchmarking/inference-perf/templates/secret.yaml
@@ -1,0 +1,12 @@
+# inference-perf/templates/secret.yaml
+{{- if .Values.token.hfToken }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "inference-perf.hfSecret" . }}
+  labels:
+    {{- include "inference-perf.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{ include "inference-perf.hfKey" . }}: {{ .Values.token.hfToken | quote }}
+{{- end }}

--- a/benchmarking/run-benchmark.sh
+++ b/benchmarking/run-benchmark.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+
+# environment variables:
+#   NAMESPACE               namespace Kubernetes target (mandatory)
+#   GCS_BUCKET              bucket GCS for results (optional)
+#   WORKLOAD                workload subdir, e.g. single-workload (mandatory)
+#
+#   GW_NAME                 gateway resource name (default: inference-gateway)
+#   BASELINE_SVC            baseline service name (default: llm-d-baseline)
+#   GW_URL                  override gateway url (optional, discovered by default)
+#   BASELINE_URL            override baseline url (optional, discovered by default)
+#   HF_TOKEN                token hugging face (optional)
+#   GCS_CREDENTIALS_SECRET  k8s secret name containing key.json (optional)
+#   GCS_PROJECT             GCP project ID, sets GOOGLE_CLOUD_PROJECT in the pod (optional)
+#   KSA_NAME                KSA kubernetes for workloqd identity (optional)
+#   BENCHMARK_TIMEOUT       timeout for the job (default: 3600s)
+
+set -euo pipefail
+
+: "${NAMESPACE:?NAMESPACE is mandatory}"
+: "${WORKLOAD:?WORKLOAD is mandatory (ex: single-workload)}"
+
+GCS_BUCKET="${GCS_BUCKET:-}"
+GCS_CREDENTIALS_SECRET="${GCS_CREDENTIALS_SECRET:-}"
+GCS_PROJECT="${GCS_PROJECT:-}"
+HF_TOKEN="${HF_TOKEN:-}"
+KSA_NAME="${KSA_NAME:-}"
+BENCHMARK_TIMEOUT="${BENCHMARK_TIMEOUT:-3600s}"
+TIMESTAMP=$(date +"%Y-%m-%d-%H-%M-%S")
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART_DIR="${SCRIPT_DIR}/inference-perf"
+VALUES_DIR="${SCRIPT_DIR}/${WORKLOAD}"
+
+GW_NAME="${GW_NAME:-inference-gateway}"
+BASELINE_SVC="${BASELINE_SVC:-llm-d-baseline}"
+
+# auto discovery (override GW_URL/BASELINE_URL to skip)
+GW_URL="${GW_URL:-http://$(kubectl get gateway "${GW_NAME}" \
+  -n "${NAMESPACE}" \
+  -o jsonpath='{.status.addresses[0].value}'):8080}"
+
+BASELINE_URL="${BASELINE_URL:-http://$(kubectl get svc "${BASELINE_SVC}" \
+  -n "${NAMESPACE}" \
+  -o jsonpath='{.spec.clusterIP}'):80}"
+
+echo "Gateway URL: ${GW_URL}"
+echo "Baseline URL: ${BASELINE_URL}"
+
+# run benchmark then cleanup
+run_benchmark() {
+  local target="$1"   # agentgateway | baseline
+  local base_url="$2"
+  local release_name="${target}-benchmark"
+  local job_name="${release_name}-inference-perf-job"
+  local gcs_path="${target}/${WORKLOAD}/${TIMESTAMP}"
+
+  echo "Benchmark: ${target}"
+  echo "URL: ${base_url}"
+  [[ -n "${GCS_BUCKET}" ]] && echo "GCS path: gs://${GCS_BUCKET}/${gcs_path}"
+
+  local helm_args=(
+    install "${release_name}" "${CHART_DIR}"
+    -f "${SCRIPT_DIR}/values.yaml"
+    -f "${VALUES_DIR}/${target}-values.yaml"
+    --namespace "${NAMESPACE}"
+    --set "config.server.base_url=${base_url}"
+  )
+
+  if [[ -n "${GCS_BUCKET}" ]]; then
+    helm_args+=(
+      --set "config.storage.google_cloud_storage.bucket_name=${GCS_BUCKET}"
+      --set "config.storage.google_cloud_storage.path=${gcs_path}"
+    )
+  fi
+
+  if [[ -n "${GCS_CREDENTIALS_SECRET}" ]]; then
+    helm_args+=(--set "gcsCredentials.secretName=${GCS_CREDENTIALS_SECRET}")
+  fi
+
+  if [[ -n "${GCS_PROJECT}" ]]; then
+    helm_args+=(--set "gcsProject=${GCS_PROJECT}")
+  fi
+
+  if [[ -n "${HF_TOKEN}" ]]; then
+    helm_args+=(--set "token.hfToken=${HF_TOKEN}")
+  fi
+
+  if [[ -n "${KSA_NAME}" ]]; then
+    helm_args+=(--set "job.serviceAccountName=${KSA_NAME}")
+  fi
+
+  helm "${helm_args[@]}"
+
+  echo "Waiting for job ${job_name} to complete (timeout: ${BENCHMARK_TIMEOUT})..."
+  if ! kubectl wait --for=condition=complete "job/${job_name}" \
+       -n "${NAMESPACE}" \
+       --timeout="${BENCHMARK_TIMEOUT}"; then
+    echo "ERROR: job ${job_name} did not complete within the timeout." >&2
+    kubectl describe job "${job_name}" -n "${NAMESPACE}" >&2
+    kubectl logs -l "job-name=${job_name}" -n "${NAMESPACE}" --tail=50 >&2
+    helm uninstall "${release_name}" -n "${NAMESPACE}" --ignore-not-found || true
+    return 1
+  fi
+
+  echo "Job ${job_name} completed successfully."
+  [[ -n "${GCS_BUCKET}" ]] && echo "Results : gs://${GCS_BUCKET}/${gcs_path}"
+
+  helm uninstall "${release_name}" -n "${NAMESPACE}" --ignore-not-found
+}
+
+# sequential run: agentgateway then baseline
+run_benchmark "agentgateway" "${GW_URL}"
+run_benchmark "baseline"     "${BASELINE_URL}"
+
+echo ""
+echo "All benchmarks completed."
+echo "Timestamp : ${TIMESTAMP}"

--- a/benchmarking/single-workload/agentgateway-values.yaml
+++ b/benchmarking/single-workload/agentgateway-values.yaml
@@ -1,0 +1,8 @@
+# Overrides for the agentgateway benchmark target.
+# Base values are defined in benchmarking/values.yaml.
+config:
+  server:
+    base_url: ""
+    model_name: meta-llama/Llama-3.1-8B-Instruct
+  tokenizer:
+    pretrained_model_name_or_path: gpt2

--- a/benchmarking/single-workload/baseline-values.yaml
+++ b/benchmarking/single-workload/baseline-values.yaml
@@ -1,0 +1,8 @@
+# Overrides for the baseline benchmark target (direct k8s service, no gateway).
+# Base values are defined in benchmarking/values.yaml.
+config:
+  server:
+    base_url: ""
+    model_name: meta-llama/Llama-3.1-8B-Instruct
+  tokenizer:
+    pretrained_model_name_or_path: gpt2

--- a/benchmarking/values.yaml
+++ b/benchmarking/values.yaml
@@ -19,12 +19,6 @@ token:
     key: ""
   hfToken: ""
 
-token:
-  hfSecret:
-    name: ""
-    key: ""
-  hfToken: ""
-
 gcsCredentials:
   secretName: "" # secret containing GCP key (key.json)
 gcsProject: ""  # GCP project ID (sets GOOGLE_CLOUD_PROJECT in the pod)

--- a/benchmarking/values.yaml
+++ b/benchmarking/values.yaml
@@ -1,0 +1,59 @@
+# override per-benchmark via -f single-workload/<target>-values.yaml
+
+job:
+  image:
+    repository: quay.io/inference-perf/inference-perf
+    tag: "" # defaults to .Chart.AppVersion
+  nodeSelector: {}
+  serviceAccountName: ""
+  resources: {}
+
+
+logLevel: INFO
+gcsPath: ""
+s3Path: ""
+
+token:
+  hfSecret:
+    name: ""
+    key: ""
+  hfToken: ""
+
+token:
+  hfSecret:
+    name: ""
+    key: ""
+  hfToken: ""
+
+gcsCredentials:
+  secretName: "" # secret containing GCP key (key.json)
+gcsProject: ""  # GCP project ID (sets GOOGLE_CLOUD_PROJECT in the pod)
+
+config:
+  load:
+    type: constant
+    interval: 5
+    stages:
+      - rate: 2
+        duration: 30
+      - rate: 5
+        duration: 30
+      - rate: 10
+        duration: 30
+  api:
+    type: completion
+    streaming: true
+  server:
+    type: vllm # agentgateway is wire compatible with vllm /v1/completions
+    base_url: ""
+    model_name: ""
+    ignore_eos: true
+  tokenizer:
+    pretrained_model_name_or_path: ""
+  data:
+    type: shareGPT
+  report:
+    request_lifecycle:
+      summary: true
+      per_stage: true
+      per_request: true


### PR DESCRIPTION
Related to kgateway-dev/kgateway#12289

This is a draft PR as part of my GSoC 2026 application for the 
benchmarking project. Feedback welcome before the proposal deadline.

## What this does

Adds a reproducible benchmarking framework for agentgateway inference 
routing, mirroring GIE.

See [benchmarking/README.md](benchmarking/README.md) for usage and config.

## Results (local, llm-d-inference-sim)

> Results obtained with llm-d-inference-sim on a local Kind cluster.
> GPU-based results pending infrastructure confirmation.

| Metric | agentgateway | baseline |
|--------|-------------|----------|
| Requests succeeded | 455 / 510 | 455 / 510 |
| Mean latency | 6.30 ms | 3.20 ms |
| TTFT (mean) | 3.00 ms | 0.95 ms |
| ITL (mean) | 5.67 µs | 3.38 µs |

_Table manually extracted from `summary_lifecycle_metrics.json`_  

Results stored at `gs://agentgateway-benchmark-test/` (in my case).

## Questions for maintainers

1. Is llm-d-inference-sim in CI acceptable for the periodic job? with GPU runs reserved for release benchmarks?
2. Should the CI interval be nightly or weekly for the periodic job?
3. I used GCS to mirror GIE, should I add S3 support in parallel, or keep it as it is?
4. Do you want to use Looker studio like GIE, or github pages to publish results?
5. Should the inference-perf Helm chart adaptations be contributed back to GIE, or kept agentgateway-specific?

## TODO

- [ ] CI GitHub Actions workflow
- [ ] Looker Studio / notebook for results visualization  
- [ ] Additional scenarios (decode-heavy, prefill-heavy, streaming, ...)
- [ ] S3 support
- [ ] Regression detection

cc @danehans @npolshakova 