### PR TITLE
cel: add support for header modifier

### DIFF
--- a/crates/agentgateway/src/cel/tests.rs
+++ b/crates/agentgateway/src/cel/tests.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use super::*;
 use crate::http::Body;
-use http::Method;
+use http::{HeaderValue, Method};
 use serde_json::json;
 
 fn eval(expr: &str) -> Result<serde_json::Value, Error> {
@@ -43,6 +43,125 @@ fn expression() {
 		.body(Body::empty())
 		.unwrap();
 	assert_eq!(Value::Bool(true), eval_request(expr, req).unwrap());
+}
+
+fn request_with_header_modes() -> crate::http::Request {
+	let mut req = ::http::Request::builder()
+		.method(Method::GET)
+		.uri("http://example.com")
+		.header("single", "z")
+		.header("multi", "a,b")
+		.body(Body::empty())
+		.unwrap();
+	req.headers_mut().append("multi", "c".parse().unwrap());
+	let mut authorization = HeaderValue::from_static("Bearer token");
+	authorization.set_sensitive(true);
+	req.headers_mut().insert("authorization", authorization);
+	req
+}
+
+mod headers {
+	use crate::cel::tests::{eval_request, request_with_header_modes};
+	use cel::Value;
+
+	#[test]
+	fn lookup_default() {
+		assert_eq!(
+			Value::Bool(true),
+			eval_request(
+				r#"request.headers.multi == ['a,b', 'c']"#,
+				request_with_header_modes()
+			)
+			.unwrap()
+		);
+		assert_eq!(
+			Value::Bool(true),
+			eval_request(
+				r#"request.headers.single == 'z'"#,
+				request_with_header_modes()
+			)
+			.unwrap()
+		);
+	}
+
+	#[test]
+	fn redacted() {
+		assert_eq!(
+			"Bearer token",
+			eval_request(
+				r#"request.headers.authorization"#,
+				request_with_header_modes()
+			)
+			.unwrap()
+			.as_str()
+			.unwrap()
+			.as_ref()
+		);
+		assert_eq!(
+			"<redacted>",
+			eval_request(
+				r#"request.headers.redacted().authorization"#,
+				request_with_header_modes()
+			)
+			.unwrap()
+			.as_str()
+			.unwrap()
+			.as_ref()
+		);
+	}
+
+	#[test]
+	fn join() {
+		let req = request_with_header_modes();
+		assert_eq!(
+			Value::Bool(true),
+			eval_request(r#"request.headers.join().multi == "a,b,c""#, req).unwrap()
+		);
+	}
+
+	#[test]
+	fn raw() {
+		let req = request_with_header_modes();
+		assert_eq!(
+			Value::Bool(true),
+			eval_request(r#"request.headers.raw().multi == ['a,b','c']"#, req,).unwrap()
+		);
+	}
+
+	#[test]
+	fn split() {
+		let req = request_with_header_modes();
+		assert_eq!(
+			Value::Bool(true),
+			eval_request(r#"request.headers.split().multi == ['a','b','c']"#, req,).unwrap()
+		);
+	}
+
+	#[test]
+	fn chained() {
+		let req = request_with_header_modes();
+		assert_eq!(
+				Value::Bool(true),
+				eval_request(
+					r#"size(request.headers.redacted().raw()["authorization"]) == 1 && request.headers.redacted().raw()["authorization"][0] == "<redacted>""#,
+					req,
+				)
+				.unwrap()
+			);
+	}
+
+	#[test]
+	fn last_mode_wins() {
+		let req = request_with_header_modes();
+		assert_eq!(
+				Value::Bool(true),
+				eval_request(
+					r#"request.headers.raw().join().multi == "a,b,c" && request.headers.join().split().multi == ['a','b','c']"#,
+					req,
+				)
+				.unwrap()
+			);
+	}
 }
 
 #[test]

--- a/crates/agentgateway/src/cel/types.rs
+++ b/crates/agentgateway/src/cel/types.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::fmt::Debug;
 use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
@@ -8,8 +9,9 @@ use bytes::Bytes;
 use cel::Value;
 use cel::common::ast::OptimizedExpr;
 use cel::context::VariableResolver;
-use cel::objects::BytesValue;
-use cel::types::dynamic::DynamicType;
+use cel::objects::{BytesValue, ListValue};
+use cel::types::dynamic::{DynamicType, DynamicValue};
+use cel::{ExecutionError, FunctionContext};
 use chrono::{DateTime, FixedOffset};
 use http::{Extensions, HeaderMap, Method, Uri, Version};
 use prometheus_client::encoding::EncodeLabelValue;
@@ -472,8 +474,7 @@ pub struct RequestRef<'a> {
 	pub version: http::Version,
 
 	/// The request's headers
-	#[serde(with = "http_serde::header_map")]
-	pub headers: &'a http::HeaderMap,
+	pub headers: Headers<'a>,
 
 	#[serde(skip_serializing_if = "is_extension_or_direct_none")]
 	pub body: ExtensionOrDirect<'a, BufferedBody>,
@@ -501,8 +502,7 @@ pub struct ResponseRef<'a> {
 	pub code: u16,
 
 	/// The headers of the response.
-	#[serde(with = "http_serde::header_map")]
-	pub headers: &'a http::HeaderMap,
+	pub headers: Headers<'a>,
 
 	#[serde(skip_serializing_if = "is_extension_or_direct_none")]
 	pub body: ExtensionOrDirect<'a, BufferedBody>,
@@ -512,7 +512,7 @@ impl<'a> From<&'a ResponseSnapshot> for ResponseRef<'a> {
 	fn from(value: &'a ResponseSnapshot) -> Self {
 		Self {
 			code: value.code.as_u16(),
-			headers: &value.headers,
+			headers: Headers::new(&value.headers),
 			body: value.body.as_ref().into(),
 		}
 	}
@@ -598,7 +598,7 @@ impl<'a> From<&'a RequestSnapshot> for RequestRef<'a> {
 			host: value.host.as_ref(),
 			scheme: value.scheme.as_ref(),
 			version: value.version,
-			headers: &value.headers,
+			headers: Headers::new(&value.headers),
 			body: value.body.as_ref().into(),
 			start_time: value.start_time.as_ref().into(),
 			end_time: None,
@@ -614,7 +614,7 @@ impl<'a, B> From<&'a ::http::Request<B>> for RequestRef<'a> {
 			host: req.uri().authority(),
 			scheme: req.uri().scheme(),
 			version: req.version(),
-			headers: req.headers(),
+			headers: Headers::new(req.headers()),
 			body: req.extensions().into(),
 			start_time: req.extensions().into(),
 			// Only known in snapshot phase...
@@ -627,7 +627,7 @@ impl<'a> From<&'a crate::http::Response> for ResponseRef<'a> {
 	fn from(resp: &'a crate::http::Response) -> Self {
 		Self {
 			code: resp.status().as_u16(),
-			headers: resp.headers(),
+			headers: Headers::new(resp.headers()),
 			body: resp.extensions().into(),
 		}
 	}
@@ -848,6 +848,201 @@ fn to_value_owned_string<'a, T: ToString>(c: &'a &'a T) -> Value<'a> {
 	Value::String(c.to_string().into())
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HeadersMode {
+	First,
+	Join,
+	Raw,
+	Split,
+}
+
+#[derive(Debug, Clone)]
+pub struct Headers<'a> {
+	headers: &'a http::HeaderMap,
+	redact_sensitive: bool,
+	mode: HeadersMode,
+}
+
+impl<'a> Headers<'a> {
+	const REDACTED: &'static str = "<redacted>";
+
+	pub fn new(headers: &'a http::HeaderMap) -> Self {
+		Self {
+			headers,
+			redact_sensitive: false,
+			mode: HeadersMode::First,
+		}
+	}
+
+	fn as_ref(&self) -> &http::HeaderMap {
+		self.headers
+	}
+
+	fn get<K>(&self, name: K) -> Option<&http::HeaderValue>
+	where
+		K: http::header::AsHeaderName,
+	{
+		self.as_ref().get(name)
+	}
+
+	fn redacted(mut self) -> Self {
+		self.redact_sensitive = true;
+		self
+	}
+
+	fn join(mut self) -> Self {
+		self.mode = HeadersMode::Join;
+		self
+	}
+
+	fn raw(mut self) -> Self {
+		self.mode = HeadersMode::Raw;
+		self
+	}
+
+	fn split(mut self) -> Self {
+		self.mode = HeadersMode::Split;
+		self
+	}
+
+	fn raw_values(&self, name: &str) -> Option<Vec<Cow<'_, str>>> {
+		let values = self
+			.as_ref()
+			.get_all(name)
+			.iter()
+			.map(|value| {
+				if self.redact_sensitive && value.is_sensitive() {
+					Some(Cow::Borrowed(Self::REDACTED))
+				} else {
+					Some(Cow::Borrowed(std::str::from_utf8(value.as_bytes()).ok()?))
+				}
+			})
+			.collect::<Option<Vec<_>>>()?;
+		if values.is_empty() {
+			None
+		} else {
+			Some(values)
+		}
+	}
+
+	fn cow_to_value(value: Cow<'_, str>) -> Value<'_> {
+		match value {
+			Cow::Borrowed(value) => Value::from(value),
+			Cow::Owned(value) => Value::from(value),
+		}
+	}
+
+	fn joined_value(values: Vec<Cow<'_, str>>) -> Value<'_> {
+		if values.len() == 1 {
+			return Self::cow_to_value(values.into_iter().next().unwrap());
+		}
+		let joined = values
+			.into_iter()
+			.map(Cow::into_owned)
+			.collect::<Vec<_>>()
+			.join(",");
+		Value::from(joined)
+	}
+
+	fn split_header_values(values: Vec<Cow<'_, str>>) -> Vec<Cow<'_, str>> {
+		values
+			.into_iter()
+			.flat_map(|value| {
+				value
+					.split(',')
+					.map(|part| Cow::Owned(part.trim().to_string()))
+					.collect::<Vec<_>>()
+			})
+			.collect()
+	}
+
+	fn raw_list_value(values: Vec<Cow<'_, str>>) -> Value<'_> {
+		let items = values
+			.into_iter()
+			.map(Self::cow_to_value)
+			.collect::<Vec<_>>();
+		Value::List(ListValue::PartiallyOwned(items.into()))
+	}
+
+	fn default_value(values: Vec<Cow<'_, str>>) -> Value<'_> {
+		if values.len() == 1 {
+			return Self::cow_to_value(values.into_iter().next().unwrap());
+		}
+		Self::raw_list_value(values)
+	}
+
+	fn split_list_value(values: Vec<Cow<'_, str>>) -> Value<'_> {
+		let items = Self::split_header_values(values)
+			.into_iter()
+			.map(Self::cow_to_value)
+			.collect::<Vec<_>>();
+		Value::List(ListValue::PartiallyOwned(items.into()))
+	}
+
+	fn lookup_value(&self, name: &str) -> Option<Value<'_>> {
+		let values = self.raw_values(name)?;
+		match self.mode {
+			HeadersMode::First => Some(Self::default_value(values)),
+			HeadersMode::Join => Some(Self::joined_value(values)),
+			HeadersMode::Raw => Some(Self::raw_list_value(values)),
+			HeadersMode::Split => Some(Self::split_list_value(values)),
+		}
+	}
+}
+
+impl Serialize for Headers<'_> {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: Serializer,
+	{
+		http_serde::header_map::serialize(self.as_ref(), serializer)
+	}
+}
+
+impl DynamicType for Headers<'_> {
+	fn materialize(&self) -> Value<'_> {
+		let mut map = vector_map::VecMap::with_capacity(self.as_ref().len());
+		for name in self.as_ref().keys() {
+			let key = cel::objects::KeyRef::from(name.as_str());
+			if map.contains_key(&key) {
+				continue;
+			}
+			if let Some(value) = self.lookup_value(name.as_str()) {
+				map.insert(key, value);
+			}
+		}
+		Value::Map(cel::objects::MapValue::Borrow(map))
+	}
+
+	fn field(&self, field: &str) -> Option<Value<'_>> {
+		self.lookup_value(field)
+	}
+
+	fn call_function<'a, 'rf>(
+		&self,
+		name: &str,
+		ftx: &mut FunctionContext<'a, 'rf>,
+	) -> Option<cel::ResolveResult<'a>>
+	where
+		Self: 'a,
+	{
+		if !ftx.args.is_empty() {
+			return Some(Err(ExecutionError::invalid_argument_count(
+				0,
+				ftx.args.len(),
+			)));
+		}
+		let next = match name {
+			"redacted" => self.clone().redacted(),
+			"join" => self.clone().join(),
+			"raw" => self.clone().raw(),
+			"split" => self.clone().split(),
+			_ => return None,
+		};
+		Some(Ok(Value::Dynamic(DynamicValue::new_owned(next))))
+	}
+}
+
 /// Wrapper for values that can come from HTTP Extensions or direct references.
 ///
 /// This enum is used in `Executor` to support two patterns:
@@ -1046,7 +1241,7 @@ impl ExecutorSerde {
 				host: req.host.as_ref(),
 				scheme: req.scheme.as_ref(),
 				version: req.version,
-				headers: &req.headers,
+				headers: Headers::new(&req.headers),
 				body: ExtensionOrDirect::Direct(req.body.as_ref()),
 				start_time: ExtensionOrDirect::Direct(req.start_time.as_ref()),
 				end_time: req.end_time.as_ref(),
@@ -1057,7 +1252,7 @@ impl ExecutorSerde {
 		if let Some(resp) = &self.response {
 			exec.response = Some(ResponseRef {
 				code: resp.code,
-				headers: &resp.headers,
+				headers: Headers::new(&resp.headers),
 				body: ExtensionOrDirect::Direct(resp.body.as_ref()),
 			});
 		}

--- a/crates/cel-fork/cel/src/objects.rs
+++ b/crates/cel-fork/cel/src/objects.rs
@@ -870,11 +870,17 @@ impl<'a> Value<'a> {
 						}
 						let tgt = Some(resolve(target)?);
 
-						// Try call_function first for opaque objects
+						// Try call_function first for opaque and dynamic objects.
 						if let Some(Value::Object(ob)) = &tgt {
 							let ob = ob.clone();
 							let mut fctx = FunctionContext::new(&call.func_name, None, ctx, &call.args, resolver);
 							if let Some(result) = ob.call_function(call.func_name.as_str(), &mut fctx) {
+								return result;
+							}
+						}
+						if let Some(Value::Dynamic(dynamic)) = &tgt {
+							let mut fctx = FunctionContext::new(&call.func_name, None, ctx, &call.args, resolver);
+							if let Some(result) = dynamic.call_function(call.func_name.as_str(), &mut fctx) {
 								return result;
 							}
 						}
@@ -1586,6 +1592,72 @@ mod tests {
 		let result = p.execute_with(&ctx, &vars);
 
 		assert!(result.is_err(), "Should error on missing map key");
+	}
+
+	mod dynamic {
+		use std::sync::Arc;
+
+		use crate::context::MapResolver;
+		use crate::objects::StringValue;
+		use crate::types::dynamic::{DynamicType, DynamicValue};
+		use crate::{Context, ExecutionError, FunctionContext, Program, Value};
+
+		#[derive(Debug)]
+		struct MyDynamic {
+			field: &'static str,
+		}
+
+		impl DynamicType for MyDynamic {
+			fn materialize(&self) -> Value<'_> {
+				let mut map = vector_map::VecMap::with_capacity(1);
+				map.insert(
+					crate::objects::KeyRef::from("field"),
+					Value::from(self.field),
+				);
+				Value::Map(crate::objects::MapValue::Borrow(map))
+			}
+
+			fn field(&self, field: &str) -> Option<Value<'_>> {
+				match field {
+					"field" => Some(Value::from(self.field)),
+					_ => None,
+				}
+			}
+
+			fn call_function<'a, 'rf>(
+				&self,
+				name: &str,
+				ftx: &mut FunctionContext<'a, 'rf>,
+			) -> Option<crate::ResolveResult<'a>>
+			where
+				Self: 'a,
+			{
+				match name {
+					"next" => Some(if ftx.args.is_empty() {
+						Ok(Value::Dynamic(DynamicValue::new_owned(MyDynamic {
+							field: "next",
+						})))
+					} else {
+						Err(ExecutionError::invalid_argument_count(0, ftx.args.len()))
+					}),
+					_ => None,
+				}
+			}
+		}
+
+		#[test]
+		fn test_dynamic_fn() {
+			let value = MyDynamic { field: "value" };
+
+			let mut vars = MapResolver::new();
+			vars.add_variable_from_value("mine", Value::Dynamic(DynamicValue::new(&value)));
+			let ctx = Context::default();
+			let prog = Program::compile("mine.next().field").unwrap();
+			assert_eq!(
+				Ok(Value::String(StringValue::Owned(Arc::from("next")))),
+				prog.execute_with(&ctx, &vars)
+			);
+		}
 	}
 
 	mod opaque {

--- a/crates/cel-fork/cel/src/types/dynamic.rs
+++ b/crates/cel-fork/cel/src/types/dynamic.rs
@@ -3,6 +3,7 @@ use std::net::IpAddr;
 use std::sync::Arc;
 
 use crate::Value;
+use crate::functions::FunctionContext;
 use crate::objects::StringValue;
 use cel::objects::KeyRef;
 use cel::{to_value, types};
@@ -36,6 +37,19 @@ pub trait DynamicType: std::fmt::Debug + Send + Sync {
 	fn field(&self, field: &str) -> Option<Value<'_>> {
 		None
 	}
+
+	/// Resolves a method function by name.
+	#[allow(unused_variables)]
+	fn call_function<'a, 'rf>(
+		&self,
+		name: &str,
+		ftx: &mut FunctionContext<'a, 'rf>,
+	) -> Option<crate::ResolveResult<'a>>
+	where
+		Self: 'a,
+	{
+		None
+	}
 }
 
 /// Trait for types that can be flattened into a parent struct's map.
@@ -49,37 +63,73 @@ pub trait DynamicFlatten: DynamicType {
 	);
 }
 
+#[derive(Clone)]
+enum DynamicRef<'a> {
+	Borrowed(&'a dyn DynamicType),
+	Owned(Arc<dyn DynamicType + 'a>),
+}
+
 pub struct DynamicValue<'a> {
-	dyn_ref: &'a dyn DynamicType,
+	dyn_ref: DynamicRef<'a>,
 }
 
 impl<'a> DynamicValue<'a> {
 	pub fn new<T: DynamicType>(t: &'a T) -> Self {
 		Self {
-			dyn_ref: t as &dyn DynamicType,
+			dyn_ref: DynamicRef::Borrowed(t as &dyn DynamicType),
+		}
+	}
+
+	pub fn new_owned<T: DynamicType + 'a>(t: T) -> Self {
+		Self {
+			dyn_ref: DynamicRef::Owned(Arc::new(t)),
+		}
+	}
+
+	fn as_ref(&self) -> &(dyn DynamicType + 'a) {
+		match &self.dyn_ref {
+			DynamicRef::Borrowed(dyn_ref) => *dyn_ref,
+			DynamicRef::Owned(dyn_ref) => dyn_ref.as_ref(),
 		}
 	}
 
 	pub fn materialize(&self) -> Value<'a> {
-		self.dyn_ref.materialize()
+		match &self.dyn_ref {
+			DynamicRef::Borrowed(dyn_ref) => dyn_ref.materialize(),
+			DynamicRef::Owned(dyn_ref) => dyn_ref.materialize().as_static(),
+		}
 	}
 
 	pub fn field(&self, field: &str) -> Option<Value<'a>> {
-		self.dyn_ref.field(field)
+		match &self.dyn_ref {
+			DynamicRef::Borrowed(dyn_ref) => dyn_ref.field(field),
+			DynamicRef::Owned(dyn_ref) => dyn_ref.field(field).map(|value| value.as_static()),
+		}
+	}
+
+	pub fn call_function<'rf>(
+		&self,
+		name: &str,
+		ftx: &mut FunctionContext<'a, 'rf>,
+	) -> Option<crate::ResolveResult<'a>> {
+		match &self.dyn_ref {
+			DynamicRef::Borrowed(dyn_ref) => dyn_ref.call_function(name, ftx),
+			DynamicRef::Owned(dyn_ref) => dyn_ref.call_function(name, ftx),
+		}
 	}
 }
 
 impl<'a> Clone for DynamicValue<'a> {
 	fn clone(&self) -> Self {
 		Self {
-			dyn_ref: self.dyn_ref,
+			dyn_ref: self.dyn_ref.clone(),
 		}
 	}
 }
 
 impl<'a> std::fmt::Debug for DynamicValue<'a> {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		self.dyn_ref.fmt(f)
+		self.as_ref().fmt(f)
 	}
 }
 
@@ -266,37 +316,16 @@ impl<T: DynamicType> DynamicType for &T {
 	fn field(&self, field: &str) -> Option<Value<'_>> {
 		(*self).field(field)
 	}
-}
 
-impl DynamicType for http::HeaderMap {
-	fn materialize(&self) -> Value<'_> {
-		let mut map = vector_map::VecMap::with_capacity(self.len());
-		for (k, v) in self.iter() {
-			if let Ok(s) = str::from_utf8(v.as_bytes()) {
-				map.insert(crate::objects::KeyRef::from(k.as_str()), Value::from(s));
-			}
-		}
-		Value::Map(crate::objects::MapValue::Borrow(map))
-	}
-
-	fn field(&self, field: &str) -> Option<Value<'_>> {
-		// TODO: do not implicitly drop invalid utf8
-		self
-			.get(field)
-			.and_then(|v| Some(Value::from(str::from_utf8(v.as_bytes()).ok()?)))
-	}
-}
-
-impl DynamicFlatten for http::HeaderMap {
-	fn materialize_into<'a>(
-		&'a self,
-		map: &mut vector_map::VecMap<crate::objects::KeyRef<'a>, Value<'a>>,
-	) {
-		for (k, v) in self.iter() {
-			if let Ok(s) = str::from_utf8(v.as_bytes()) {
-				map.insert(crate::objects::KeyRef::from(k.as_str()), Value::from(s));
-			}
-		}
+	fn call_function<'a, 'rf>(
+		&self,
+		name: &str,
+		ftx: &mut FunctionContext<'a, 'rf>,
+	) -> Option<crate::ResolveResult<'a>>
+	where
+		Self: 'a,
+	{
+		(*self).call_function(name, ftx)
 	}
 }
 
@@ -323,6 +352,16 @@ where
 	fn field(&self, field: &str) -> Option<Value<'_>> {
 		self.as_ref().field(field)
 	}
+	fn call_function<'a, 'rf>(
+		&self,
+		name: &str,
+		ftx: &mut FunctionContext<'a, 'rf>,
+	) -> Option<crate::ResolveResult<'a>>
+	where
+		Self: 'a,
+	{
+		self.as_ref().call_function(name, ftx)
+	}
 }
 impl<T> DynamicType for Option<T>
 where
@@ -343,6 +382,19 @@ where
 	fn field(&self, field: &str) -> Option<Value<'_>> {
 		match self {
 			Some(v) => v.field(field),
+			None => None,
+		}
+	}
+	fn call_function<'a, 'rf>(
+		&self,
+		name: &str,
+		ftx: &mut FunctionContext<'a, 'rf>,
+	) -> Option<crate::ResolveResult<'a>>
+	where
+		Self: 'a,
+	{
+		match self {
+			Some(v) => v.call_function(name, ftx),
 			None => None,
 		}
 	}

--- a/schema/cel-functions.md
+++ b/schema/cel-functions.md
@@ -33,3 +33,26 @@ The following standard functions are available:
 * From the [strings extension](https://pkg.go.dev/github.com/google/cel-go/ext#Strings): `charAt`, `indexOf`, `join`, `lastIndexOf`, `lowerAscii`, `upperAscii`, `trim`, `replace`, `split`, `substring`, `stripPrefix`, `stripSuffix`.
 * From the [Kubernetes IP extension](https://kubernetes.io/docs/reference/using-api/cel/#kubernetes-ip-address-library): `isIP("...")`, `ip("...")`, `ip("...").family()`, `ip("...").isUnspecified()`, `ip("...").isLoopback()`, `ip("...").isLinkLocalMulticast()`, `ip("...").isLinkLocalUnicast()`, `ip("...").isGlobalUnicast()`.
 * From the [Kubernetes CIDR extension](https://kubernetes.io/docs/reference/using-api/cel/#kubernetes-cidr-library): `cidr("...").containsIP("...")`, `cidr("...").containsIP(ip("..."))`, `cidr("...").containsCIDR(cidr("..."))`, `cidr("...").ip()`, `cidr("...").masked()`, `cidr("...").prefixLength()`.
+
+## Header Views
+
+`request.headers` and `response.headers` expose a header-view object with chainable methods.
+
+Available methods:
+
+| Method       | Purpose                                                                                                                                                                                         |
+|--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| default      | A direct header lookup returns a string when there is one header entry, or a list of raw values when there are multiple entries. Example: `["a,b", "c"] -> ["a,b", "c"]`, while `["z"] -> "z"`. |
+| `redacted()` | Replaces sensitive header values with `"<redacted>"`. Useful for usage within logs.                                                                                                             |
+| `join()`     | Joins all header entries with `,`. Example: `["a,b", "c"] -> "a,b,c"`.                                                                                                                          |
+| `raw()`      | Returns the raw header entries as a list. Example: `["a,b", "c"] -> ["a,b", "c"]`.                                                                                                              |
+| `split()`    | Returns all header entries split on `,` as a list. Example: `["a,b", "c"] -> ["a", "b", "c"]`.                                                                                                  |
+
+Examples:
+
+* `request.headers.redacted().authorization`
+* `request.headers.join()["x-forwarded-for"]`
+* `request.headers.raw()["set-cookie"]`
+* `request.headers.redacted().split()["authorization"]`
+
+`redacted()` can be combined with any of the other methods. `join()`, `raw()`, and `split()` are mutually exclusive; if multiple are chained, the last one wins.


### PR DESCRIPTION
Fixes https://github.com/agentgateway/agentgateway/issues/828

See the cel-functions.md update for info.

Example

```json
{
  "default": {
    "foo": [
      "a,b",
      "c"
    ],
    "user-agent": "curl/8.18.0",
    "accept": "*/*",
    "cookie": "USER_TOKEN=Yes; BAR_TOKEN=Yes",
    "authorization": "foo"
  },
  "join": {
    "authorization": "foo",
    "accept": "*/*",
    "user-agent": "curl/8.18.0",
    "foo": "a,b,c",
    "cookie": "USER_TOKEN=Yes; BAR_TOKEN=Yes"
  },
  "split": {
    "cookie": [
      "USER_TOKEN=Yes; BAR_TOKEN=Yes"
    ],
    "authorization": [
      "foo"
    ],
    "user-agent": [
      "curl/8.18.0"
    ],
    "accept": [
      "*/*"
    ],
    "foo": [
      "a",
      "b",
      "c"
    ]
  },
  "raw": {
    "cookie": [
      "USER_TOKEN=Yes; BAR_TOKEN=Yes"
    ],
    "authorization": [
      "foo"
    ],
    "user-agent": [
      "curl/8.18.0"
    ],
    "foo": [
      "a,b",
      "c"
    ],
    "accept": [
      "*/*"
    ]
  },
  "redacted": {
    "user-agent": "curl/8.18.0",
    "accept": "*/*",
    "foo": [
      "a,b",
      "c"
    ],
    "cookie": "USER_TOKEN=Yes; BAR_TOKEN=Yes",
    "authorization": "<redacted>"
  }
}
```
