### PR TITLE
garbage collection for unneeded pdb/hpa/vpa

### DIFF
--- a/controller/pkg/deployer/deployer.go
+++ b/controller/pkg/deployer/deployer.go
@@ -258,15 +258,6 @@ func (d *Deployer) SetNamespaceAndOwnerWithGVK(owner client.Object, ownerGVK sch
 	return objs
 }
 
-func isOwnedByController(obj metav1.Object, ownerUID types.UID) bool {
-	for _, ref := range obj.GetOwnerReferences() {
-		if ref.UID == ownerUID && ref.Controller != nil && *ref.Controller {
-			return true
-		}
-	}
-	return false
-}
-
 func (d *Deployer) DeployObjs(ctx context.Context, objs []client.Object) error {
 	return d.DeployObjsWithSource(ctx, objs, nil)
 }
@@ -344,8 +335,8 @@ func (d *Deployer) DeployObjsWithSource(ctx context.Context, objs []client.Objec
 // but are no longer in the desired set of objects. This prevents stale autoscaling
 // resources from persisting when configuration changes.
 func (d *Deployer) PruneRemovedResources(ctx context.Context, owner client.Object, desiredObjs []client.Object) error {
-	ownerUID := owner.GetUID()
 	ownerNamespace := owner.GetNamespace()
+	labelSelector := fmt.Sprintf("%s=%s", wellknown.GatewayNameLabel, owner.GetName())
 
 	// Build map of desired resources by GVK
 	desiredByGVK := make(map[schema.GroupVersionKind]map[string]bool)
@@ -374,9 +365,9 @@ func (d *Deployer) PruneRemovedResources(ctx context.Context, owner client.Objec
 			continue
 		}
 
-		// List all resources of this type in the namespace
+		// List resources of this type in the namespace owned by this gateway
 		client := d.client.Dynamic().Resource(gvr).Namespace(ownerNamespace)
-		list, err := client.List(ctx, metav1.ListOptions{})
+		list, err := client.List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				// Resource type doesn't exist (e.g., VPA CRD not installed)
@@ -388,11 +379,6 @@ func (d *Deployer) PruneRemovedResources(ctx context.Context, owner client.Objec
 
 		// Check each resource for pruning
 		for _, item := range list.Items {
-			// Only process resources owned by this controller
-			if !isOwnedByController(&item, ownerUID) {
-				continue
-			}
-
 			// Check if resource is in desired set
 			resourceName := item.GetName()
 			if desiredSet, exists := desiredByGVK[gvk]; exists && desiredSet[resourceName] {

--- a/controller/pkg/deployer/deployer.go
+++ b/controller/pkg/deployer/deployer.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"slices"
+	"errors"
 
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
@@ -363,6 +364,8 @@ func (d *Deployer) PruneRemovedResources(ctx context.Context, owner client.Objec
 		wellknown.VerticalPodAutoscalerGVK,
 	}
 
+	var pruningErrors []error
+
 	for _, gvk := range targetGVKs {
 		// Convert GVK to GVR
 		gvr, err := d.gvkToGVR(gvk)
@@ -406,9 +409,20 @@ func (d *Deployer) PruneRemovedResources(ctx context.Context, owner client.Objec
 
 			err := client.Delete(ctx, resourceName, metav1.DeleteOptions{})
 			if err != nil && !apierrors.IsNotFound(err) {
-				return fmt.Errorf("failed to delete resource %s/%s: %w", gvk.String(), resourceName, err)
+				pruningErrors = append(pruningErrors, fmt.Errorf("failed to delete resource %s/%s: %w", gvk.String(), resourceName, err))
+				logger.Debug("error pruning removed resource", 
+					"gvk", gvk.String(),
+					"namespace", ownerNamespace,
+					"name", resourceName,
+					"owner", owner.GetName(), 
+				  "error", err.Error(),
+				)
 			}
 		}
+	}
+
+	if len(pruningErrors) > 0 {
+		return errors.Join(pruningErrors...)
 	}
 
 	return nil

--- a/controller/pkg/deployer/deployer.go
+++ b/controller/pkg/deployer/deployer.go
@@ -257,6 +257,15 @@ func (d *Deployer) SetNamespaceAndOwnerWithGVK(owner client.Object, ownerGVK sch
 	return objs
 }
 
+func isOwnedByController(obj metav1.Object, ownerUID types.UID) bool {
+	for _, ref := range obj.GetOwnerReferences() {
+		if ref.UID == ownerUID && ref.Controller != nil && *ref.Controller {
+			return true
+		}
+	}
+	return false
+}
+
 func (d *Deployer) DeployObjs(ctx context.Context, objs []client.Object) error {
 	return d.DeployObjsWithSource(ctx, objs, nil)
 }
@@ -327,6 +336,81 @@ func (d *Deployer) DeployObjsWithSource(ctx context.Context, objs []client.Objec
 			return fmt.Errorf("failed to apply object %s %s/%s: %w", u.GetObjectKind().GroupVersionKind().String(), u.GetNamespace(), u.GetName(), err)
 		}
 	}
+	return nil
+}
+
+// PruneRemovedResources deletes PDB/HPA/VPA resources that are owned by the owner
+// but are no longer in the desired set of objects. This prevents stale autoscaling
+// resources from persisting when configuration changes.
+func (d *Deployer) PruneRemovedResources(ctx context.Context, owner client.Object, desiredObjs []client.Object) error {
+	ownerUID := owner.GetUID()
+	ownerNamespace := owner.GetNamespace()
+
+	// Build map of desired resources by GVK
+	desiredByGVK := make(map[schema.GroupVersionKind]map[string]bool)
+	for _, obj := range desiredObjs {
+		gvk := obj.GetObjectKind().GroupVersionKind()
+		if _, exists := desiredByGVK[gvk]; !exists {
+			desiredByGVK[gvk] = make(map[string]bool)
+		}
+		desiredByGVK[gvk][obj.GetName()] = true
+	}
+
+	// Check each target GVK for resources to prune
+	targetGVKs := []schema.GroupVersionKind{
+		wellknown.PodDisruptionBudgetGVK,
+		wellknown.HorizontalPodAutoscalerGVK,
+		wellknown.VerticalPodAutoscalerGVK,
+	}
+
+	for _, gvk := range targetGVKs {
+		// Convert GVK to GVR
+		gvr, err := d.gvkToGVR(gvk)
+		if err != nil {
+			logger.Debug("skipping pruning for unknown GVK", "gvk", gvk.String(), "error", err)
+			continue
+		}
+
+		// List all resources of this type in the namespace
+		client := d.client.Dynamic().Resource(gvr).Namespace(ownerNamespace)
+		list, err := client.List(ctx, metav1.ListOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				// Resource type doesn't exist (e.g., VPA CRD not installed)
+				logger.Debug("resource type not found, skipping pruning", "gvk", gvk.String())
+				continue
+			}
+			return fmt.Errorf("failed to list resources for pruning %s: %w", gvk.String(), err)
+		}
+
+		// Check each resource for pruning
+		for _, item := range list.Items {
+			// Only process resources owned by this controller
+			if !isOwnedByController(&item, ownerUID) {
+				continue
+			}
+
+			// Check if resource is in desired set
+			resourceName := item.GetName()
+			if desiredSet, exists := desiredByGVK[gvk]; exists && desiredSet[resourceName] {
+				// Resource is desired, keep it
+				continue
+			}
+
+			// Resource is not desired, delete it
+			logger.Info("pruning removed resource",
+				"gvk", gvk.String(),
+				"namespace", ownerNamespace,
+				"name", resourceName,
+				"owner", owner.GetName())
+
+			err := client.Delete(ctx, resourceName, metav1.DeleteOptions{})
+			if err != nil && !apierrors.IsNotFound(err) {
+				return fmt.Errorf("failed to delete resource %s/%s: %w", gvk.String(), resourceName, err)
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/controller/pkg/deployer/deployer.go
+++ b/controller/pkg/deployer/deployer.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"slices"
-	"errors"
 
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
@@ -410,12 +410,12 @@ func (d *Deployer) PruneRemovedResources(ctx context.Context, owner client.Objec
 			err := client.Delete(ctx, resourceName, metav1.DeleteOptions{})
 			if err != nil && !apierrors.IsNotFound(err) {
 				pruningErrors = append(pruningErrors, fmt.Errorf("failed to delete resource %s/%s: %w", gvk.String(), resourceName, err))
-				logger.Debug("error pruning removed resource", 
+				logger.Debug("error pruning removed resource",
 					"gvk", gvk.String(),
 					"namespace", ownerNamespace,
 					"name", resourceName,
-					"owner", owner.GetName(), 
-				  "error", err.Error(),
+					"owner", owner.GetName(),
+					"error", err.Error(),
 				)
 			}
 		}

--- a/controller/pkg/deployer/deployer_test.go
+++ b/controller/pkg/deployer/deployer_test.go
@@ -12,7 +12,6 @@ import (
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -191,8 +190,6 @@ func TestPruneRemovedResources(t *testing.T) {
 	var (
 		ns         = "test-ns"
 		gwName     = "test-gateway"
-		gwUID      = types.UID("gateway-uid-123")
-		otherUID   = types.UID("other-uid-456")
 		ctx        = context.Background()
 		deployName = "test-deploy"
 		pdbName    = "test-pdb"
@@ -212,12 +209,11 @@ func TestPruneRemovedResources(t *testing.T) {
 		return d
 	}
 
-	createGateway := func(uid types.UID) *gwv1.Gateway {
+	createGateway := func() *gwv1.Gateway {
 		gw := &gwv1.Gateway{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      gwName,
 				Namespace: ns,
-				UID:       uid,
 			},
 			Spec: gwv1.GatewaySpec{
 				GatewayClassName: wellknown.DefaultAgwClassName,
@@ -227,7 +223,7 @@ func TestPruneRemovedResources(t *testing.T) {
 		return gw
 	}
 
-	createPDB := func(name string, ownerUID types.UID, controller bool) *policyv1.PodDisruptionBudget {
+	createPDB := func(name string, gatewayName string) *policyv1.PodDisruptionBudget {
 		pdb := &policyv1.PodDisruptionBudget{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       wellknown.PodDisruptionBudgetGVK.Kind,
@@ -236,13 +232,9 @@ func TestPruneRemovedResources(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: ns,
-				OwnerReferences: []metav1.OwnerReference{{
-					APIVersion: wellknown.GatewayGVK.GroupVersion().String(),
-					Kind:       wellknown.GatewayGVK.Kind,
-					Name:       gwName,
-					UID:        ownerUID,
-					Controller: ptr.To(controller),
-				}},
+				Labels: map[string]string{
+					wellknown.GatewayNameLabel: gatewayName,
+				},
 			},
 			Spec: policyv1.PodDisruptionBudgetSpec{
 				Selector: &metav1.LabelSelector{
@@ -253,7 +245,7 @@ func TestPruneRemovedResources(t *testing.T) {
 		return pdb
 	}
 
-	createHPA := func(name string, ownerUID types.UID, controller bool) *autoscalingv2.HorizontalPodAutoscaler {
+	createHPA := func(name string, gatewayName string) *autoscalingv2.HorizontalPodAutoscaler {
 		hpa := &autoscalingv2.HorizontalPodAutoscaler{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       wellknown.HorizontalPodAutoscalerGVK.Kind,
@@ -262,13 +254,9 @@ func TestPruneRemovedResources(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: ns,
-				OwnerReferences: []metav1.OwnerReference{{
-					APIVersion: wellknown.GatewayGVK.GroupVersion().String(),
-					Kind:       wellknown.GatewayGVK.Kind,
-					Name:       gwName,
-					UID:        ownerUID,
-					Controller: ptr.To(controller),
-				}},
+				Labels: map[string]string{
+					wellknown.GatewayNameLabel: gatewayName,
+				},
 			},
 			Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
@@ -283,8 +271,8 @@ func TestPruneRemovedResources(t *testing.T) {
 	}
 
 	t.Run("prunes PDB when not in desired set", func(t *testing.T) {
-		gw := createGateway(gwUID)
-		pdb := createPDB(pdbName, gwUID, true)
+		gw := createGateway()
+		pdb := createPDB(pdbName, gwName)
 
 		fc := fake.NewClient(t, gw, pdb)
 		d := getDeployer(t, fc)
@@ -303,15 +291,15 @@ func TestPruneRemovedResources(t *testing.T) {
 	})
 
 	t.Run("keeps PDB when in desired set", func(t *testing.T) {
-		gw := createGateway(gwUID)
-		pdb := createPDB(pdbName, gwUID, true)
+		gw := createGateway()
+		pdb := createPDB(pdbName, gwName)
 
 		fc := fake.NewClient(t, gw, pdb)
 		d := getDeployer(t, fc)
 		fc.RunAndWait(ctx.Done())
 
 		// PDB is in desired set - should be kept
-		desiredPDB := createPDB(pdbName, gwUID, true)
+		desiredPDB := createPDB(pdbName, gwName)
 		err := d.PruneRemovedResources(ctx, gw, []client.Object{desiredPDB})
 		assert.NoError(t, err)
 
@@ -324,41 +312,20 @@ func TestPruneRemovedResources(t *testing.T) {
 		assert.Equal(t, pdbName, list.Items[0].GetName())
 	})
 
-	t.Run("skips resources not owned by this Gateway", func(t *testing.T) {
-		gw := createGateway(gwUID)
-		// PDB owned by a different Gateway
-		pdb := createPDB(pdbName, otherUID, true)
+	t.Run("skips resources belonging to a different Gateway", func(t *testing.T) {
+		gw := createGateway()
+		// PDB labeled for a different Gateway
+		pdb := createPDB(pdbName, "other-gateway")
 
 		fc := fake.NewClient(t, gw, pdb)
 		d := getDeployer(t, fc)
 		fc.RunAndWait(ctx.Done())
 
-		// Empty desired set, but PDB owned by different Gateway
+		// Empty desired set, but PDB belongs to a different Gateway
 		err := d.PruneRemovedResources(ctx, gw, []client.Object{})
 		assert.NoError(t, err)
 
-		// Verify PDB was NOT deleted (different owner)
-		gvr, err := wellknown.GVKToGVR(wellknown.PodDisruptionBudgetGVK)
-		assert.NoError(t, err)
-		list, err := fc.Dynamic().Resource(gvr).Namespace(ns).List(ctx, metav1.ListOptions{})
-		assert.NoError(t, err)
-		assert.Equal(t, 1, len(list.Items))
-	})
-
-	t.Run("skips resources owned but not controller", func(t *testing.T) {
-		gw := createGateway(gwUID)
-		// PDB owned by Gateway but controller=false
-		pdb := createPDB(pdbName, gwUID, false)
-
-		fc := fake.NewClient(t, gw, pdb)
-		d := getDeployer(t, fc)
-		fc.RunAndWait(ctx.Done())
-
-		// Empty desired set
-		err := d.PruneRemovedResources(ctx, gw, []client.Object{})
-		assert.NoError(t, err)
-
-		// Verify PDB was NOT deleted (not controller)
+		// Verify PDB was NOT deleted (different gateway label)
 		gvr, err := wellknown.GVKToGVR(wellknown.PodDisruptionBudgetGVK)
 		assert.NoError(t, err)
 		list, err := fc.Dynamic().Resource(gvr).Namespace(ns).List(ctx, metav1.ListOptions{})
@@ -367,9 +334,9 @@ func TestPruneRemovedResources(t *testing.T) {
 	})
 
 	t.Run("prunes multiple resources in one call", func(t *testing.T) {
-		gw := createGateway(gwUID)
-		pdb := createPDB(pdbName, gwUID, true)
-		hpa := createHPA(hpaName, gwUID, true)
+		gw := createGateway()
+		pdb := createPDB(pdbName, gwName)
+		hpa := createHPA(hpaName, gwName)
 
 		fc := fake.NewClient(t, gw, pdb, hpa)
 		d := getDeployer(t, fc)
@@ -394,16 +361,16 @@ func TestPruneRemovedResources(t *testing.T) {
 	})
 
 	t.Run("prunes some resources while keeping others", func(t *testing.T) {
-		gw := createGateway(gwUID)
-		pdb := createPDB(pdbName, gwUID, true)
-		hpa := createHPA(hpaName, gwUID, true)
+		gw := createGateway()
+		pdb := createPDB(pdbName, gwName)
+		hpa := createHPA(hpaName, gwName)
 
 		fc := fake.NewClient(t, gw, pdb, hpa)
 		d := getDeployer(t, fc)
 		fc.RunAndWait(ctx.Done())
 
 		// Only PDB in desired set - HPA should be pruned
-		desiredPDB := createPDB(pdbName, gwUID, true)
+		desiredPDB := createPDB(pdbName, gwName)
 		err := d.PruneRemovedResources(ctx, gw, []client.Object{desiredPDB})
 		assert.NoError(t, err)
 
@@ -423,7 +390,7 @@ func TestPruneRemovedResources(t *testing.T) {
 	})
 
 	t.Run("handles no existing resources gracefully", func(t *testing.T) {
-		gw := createGateway(gwUID)
+		gw := createGateway()
 
 		fc := fake.NewClient(t, gw)
 		d := getDeployer(t, fc)
@@ -435,9 +402,9 @@ func TestPruneRemovedResources(t *testing.T) {
 	})
 
 	t.Run("handles empty desired set", func(t *testing.T) {
-		gw := createGateway(gwUID)
-		pdb := createPDB(pdbName, gwUID, true)
-		hpa := createHPA(hpaName, gwUID, true)
+		gw := createGateway()
+		pdb := createPDB(pdbName, gwName)
+		hpa := createHPA(hpaName, gwName)
 
 		fc := fake.NewClient(t, gw, pdb, hpa)
 		d := getDeployer(t, fc)

--- a/controller/pkg/deployer/deployer_test.go
+++ b/controller/pkg/deployer/deployer_test.go
@@ -7,9 +7,13 @@ import (
 
 	"istio.io/istio/pkg/config/schema/gvk"
 	"istio.io/istio/pkg/test/util/assert"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -180,5 +184,280 @@ func TestDeployObjs(t *testing.T) {
 		err := d.DeployObjsWithSource(ctx, []client.Object{cm}, gw)
 		assert.NoError(t, err)
 		assert.Equal(t, wellknown.DefaultAgwControllerName, usedFieldManager)
+	})
+}
+
+func TestPruneRemovedResources(t *testing.T) {
+	var (
+		ns         = "test-ns"
+		gwName     = "test-gateway"
+		gwUID      = types.UID("gateway-uid-123")
+		otherUID   = types.UID("other-uid-456")
+		ctx        = context.Background()
+		deployName = "test-deploy"
+		pdbName    = "test-pdb"
+		hpaName    = "test-hpa"
+	)
+
+	getDeployer := func(t *testing.T, fc apiclient.Client) *deployer.Deployer {
+		t.Helper()
+		d, err := deployerinternal.NewGatewayDeployer(
+			wellknown.DefaultAgwControllerName,
+			wellknown.DefaultAgwClassName,
+			scheme,
+			fc,
+			nil,
+		)
+		assert.NoError(t, err)
+		return d
+	}
+
+	createGateway := func(uid types.UID) *gwv1.Gateway {
+		gw := &gwv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      gwName,
+				Namespace: ns,
+				UID:       uid,
+			},
+			Spec: gwv1.GatewaySpec{
+				GatewayClassName: wellknown.DefaultAgwClassName,
+			},
+		}
+		gw.SetGroupVersionKind(wellknown.GatewayGVK)
+		return gw
+	}
+
+	createPDB := func(name string, ownerUID types.UID, controller bool) *policyv1.PodDisruptionBudget {
+		pdb := &policyv1.PodDisruptionBudget{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       wellknown.PodDisruptionBudgetGVK.Kind,
+				APIVersion: wellknown.PodDisruptionBudgetGVK.GroupVersion().String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: ns,
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: wellknown.GatewayGVK.GroupVersion().String(),
+					Kind:       wellknown.GatewayGVK.Kind,
+					Name:       gwName,
+					UID:        ownerUID,
+					Controller: ptr.To(controller),
+				}},
+			},
+			Spec: policyv1.PodDisruptionBudgetSpec{
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": "test"},
+				},
+			},
+		}
+		return pdb
+	}
+
+	createHPA := func(name string, ownerUID types.UID, controller bool) *autoscalingv2.HorizontalPodAutoscaler {
+		hpa := &autoscalingv2.HorizontalPodAutoscaler{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       wellknown.HorizontalPodAutoscalerGVK.Kind,
+				APIVersion: wellknown.HorizontalPodAutoscalerGVK.GroupVersion().String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: ns,
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: wellknown.GatewayGVK.GroupVersion().String(),
+					Kind:       wellknown.GatewayGVK.Kind,
+					Name:       gwName,
+					UID:        ownerUID,
+					Controller: ptr.To(controller),
+				}},
+			},
+			Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+				ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+					Kind: "Deployment",
+					Name: deployName,
+				},
+				MinReplicas: ptr.To(int32(1)),
+				MaxReplicas: 10,
+			},
+		}
+		return hpa
+	}
+
+	t.Run("prunes PDB when not in desired set", func(t *testing.T) {
+		gw := createGateway(gwUID)
+		pdb := createPDB(pdbName, gwUID, true)
+
+		fc := fake.NewClient(t, gw, pdb)
+		d := getDeployer(t, fc)
+		fc.RunAndWait(ctx.Done())
+
+		// Desired set is empty - PDB should be pruned
+		err := d.PruneRemovedResources(ctx, gw, []client.Object{})
+		assert.NoError(t, err)
+
+		// Verify PDB was deleted using dynamic client
+		gvr, err := wellknown.GVKToGVR(wellknown.PodDisruptionBudgetGVK)
+		assert.NoError(t, err)
+		list, err := fc.Dynamic().Resource(gvr).Namespace(ns).List(ctx, metav1.ListOptions{})
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(list.Items))
+	})
+
+	t.Run("keeps PDB when in desired set", func(t *testing.T) {
+		gw := createGateway(gwUID)
+		pdb := createPDB(pdbName, gwUID, true)
+
+		fc := fake.NewClient(t, gw, pdb)
+		d := getDeployer(t, fc)
+		fc.RunAndWait(ctx.Done())
+
+		// PDB is in desired set - should be kept
+		desiredPDB := createPDB(pdbName, gwUID, true)
+		err := d.PruneRemovedResources(ctx, gw, []client.Object{desiredPDB})
+		assert.NoError(t, err)
+
+		// Verify PDB still exists using dynamic client
+		gvr, err := wellknown.GVKToGVR(wellknown.PodDisruptionBudgetGVK)
+		assert.NoError(t, err)
+		list, err := fc.Dynamic().Resource(gvr).Namespace(ns).List(ctx, metav1.ListOptions{})
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(list.Items))
+		assert.Equal(t, pdbName, list.Items[0].GetName())
+	})
+
+	t.Run("skips resources not owned by this Gateway", func(t *testing.T) {
+		gw := createGateway(gwUID)
+		// PDB owned by a different Gateway
+		pdb := createPDB(pdbName, otherUID, true)
+
+		fc := fake.NewClient(t, gw, pdb)
+		d := getDeployer(t, fc)
+		fc.RunAndWait(ctx.Done())
+
+		// Empty desired set, but PDB owned by different Gateway
+		err := d.PruneRemovedResources(ctx, gw, []client.Object{})
+		assert.NoError(t, err)
+
+		// Verify PDB was NOT deleted (different owner)
+		gvr, err := wellknown.GVKToGVR(wellknown.PodDisruptionBudgetGVK)
+		assert.NoError(t, err)
+		list, err := fc.Dynamic().Resource(gvr).Namespace(ns).List(ctx, metav1.ListOptions{})
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(list.Items))
+	})
+
+	t.Run("skips resources owned but not controller", func(t *testing.T) {
+		gw := createGateway(gwUID)
+		// PDB owned by Gateway but controller=false
+		pdb := createPDB(pdbName, gwUID, false)
+
+		fc := fake.NewClient(t, gw, pdb)
+		d := getDeployer(t, fc)
+		fc.RunAndWait(ctx.Done())
+
+		// Empty desired set
+		err := d.PruneRemovedResources(ctx, gw, []client.Object{})
+		assert.NoError(t, err)
+
+		// Verify PDB was NOT deleted (not controller)
+		gvr, err := wellknown.GVKToGVR(wellknown.PodDisruptionBudgetGVK)
+		assert.NoError(t, err)
+		list, err := fc.Dynamic().Resource(gvr).Namespace(ns).List(ctx, metav1.ListOptions{})
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(list.Items))
+	})
+
+	t.Run("prunes multiple resources in one call", func(t *testing.T) {
+		gw := createGateway(gwUID)
+		pdb := createPDB(pdbName, gwUID, true)
+		hpa := createHPA(hpaName, gwUID, true)
+
+		fc := fake.NewClient(t, gw, pdb, hpa)
+		d := getDeployer(t, fc)
+		fc.RunAndWait(ctx.Done())
+
+		// Empty desired set - both should be pruned
+		err := d.PruneRemovedResources(ctx, gw, []client.Object{})
+		assert.NoError(t, err)
+
+		// Verify both were deleted
+		pdbGVR, err := wellknown.GVKToGVR(wellknown.PodDisruptionBudgetGVK)
+		assert.NoError(t, err)
+		pdbList, err := fc.Dynamic().Resource(pdbGVR).Namespace(ns).List(ctx, metav1.ListOptions{})
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(pdbList.Items))
+
+		hpaGVR, err := wellknown.GVKToGVR(wellknown.HorizontalPodAutoscalerGVK)
+		assert.NoError(t, err)
+		hpaList, err := fc.Dynamic().Resource(hpaGVR).Namespace(ns).List(ctx, metav1.ListOptions{})
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(hpaList.Items))
+	})
+
+	t.Run("prunes some resources while keeping others", func(t *testing.T) {
+		gw := createGateway(gwUID)
+		pdb := createPDB(pdbName, gwUID, true)
+		hpa := createHPA(hpaName, gwUID, true)
+
+		fc := fake.NewClient(t, gw, pdb, hpa)
+		d := getDeployer(t, fc)
+		fc.RunAndWait(ctx.Done())
+
+		// Only PDB in desired set - HPA should be pruned
+		desiredPDB := createPDB(pdbName, gwUID, true)
+		err := d.PruneRemovedResources(ctx, gw, []client.Object{desiredPDB})
+		assert.NoError(t, err)
+
+		// Verify PDB still exists
+		pdbGVR, err := wellknown.GVKToGVR(wellknown.PodDisruptionBudgetGVK)
+		assert.NoError(t, err)
+		pdbList, err := fc.Dynamic().Resource(pdbGVR).Namespace(ns).List(ctx, metav1.ListOptions{})
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(pdbList.Items))
+
+		// Verify HPA was deleted
+		hpaGVR, err := wellknown.GVKToGVR(wellknown.HorizontalPodAutoscalerGVK)
+		assert.NoError(t, err)
+		hpaList, err := fc.Dynamic().Resource(hpaGVR).Namespace(ns).List(ctx, metav1.ListOptions{})
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(hpaList.Items))
+	})
+
+	t.Run("handles no existing resources gracefully", func(t *testing.T) {
+		gw := createGateway(gwUID)
+
+		fc := fake.NewClient(t, gw)
+		d := getDeployer(t, fc)
+		fc.RunAndWait(ctx.Done())
+
+		// No resources exist, empty desired set
+		err := d.PruneRemovedResources(ctx, gw, []client.Object{})
+		assert.NoError(t, err)
+	})
+
+	t.Run("handles empty desired set", func(t *testing.T) {
+		gw := createGateway(gwUID)
+		pdb := createPDB(pdbName, gwUID, true)
+		hpa := createHPA(hpaName, gwUID, true)
+
+		fc := fake.NewClient(t, gw, pdb, hpa)
+		d := getDeployer(t, fc)
+		fc.RunAndWait(ctx.Done())
+
+		// All resources should be pruned with empty desired set
+		err := d.PruneRemovedResources(ctx, gw, []client.Object{})
+		assert.NoError(t, err)
+
+		// Verify all were deleted
+		pdbGVR, err := wellknown.GVKToGVR(wellknown.PodDisruptionBudgetGVK)
+		assert.NoError(t, err)
+		pdbList, err := fc.Dynamic().Resource(pdbGVR).Namespace(ns).List(ctx, metav1.ListOptions{})
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(pdbList.Items))
+
+		hpaGVR, err := wellknown.GVKToGVR(wellknown.HorizontalPodAutoscalerGVK)
+		assert.NoError(t, err)
+		hpaList, err := fc.Dynamic().Resource(hpaGVR).Namespace(ns).List(ctx, metav1.ListOptions{})
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(hpaList.Items))
 	})
 }

--- a/controller/pkg/deployer/strategicpatch/strategicpatch.go
+++ b/controller/pkg/deployer/strategicpatch/strategicpatch.go
@@ -265,6 +265,7 @@ func createPodDisruptionBudget(deployment *appsv1.Deployment, overlay *shared.Ku
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      deployment.Name,
 			Namespace: deployment.Namespace,
+			Labels:    maps.Clone(deployment.GetLabels()),
 		},
 		Spec: policyv1.PodDisruptionBudgetSpec{
 			Selector: deployment.Spec.Selector,
@@ -292,6 +293,7 @@ func createHorizontalPodAutoscaler(deployment *appsv1.Deployment, overlay *share
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      deployment.Name,
 			Namespace: deployment.Namespace,
+			Labels:    maps.Clone(deployment.GetLabels()),
 		},
 		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
 			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
@@ -334,6 +336,7 @@ func createVerticalPodAutoscaler(deployment *appsv1.Deployment, overlay *shared.
 		},
 	}
 	vpa.SetGroupVersionKind(wellknown.VerticalPodAutoscalerGVK)
+	vpa.SetLabels(maps.Clone(deployment.GetLabels()))
 
 	// Apply the overlay - for VPA we need to handle it specially since it's unstructured
 	if overlay.Metadata != nil {

--- a/controller/pkg/deployer/strategicpatch/strategicpatch_test.go
+++ b/controller/pkg/deployer/strategicpatch/strategicpatch_test.go
@@ -335,11 +335,11 @@ func TestOverlayApplier_ApplyOverlays_MultipleObjects(t *testing.T) {
 // deploymentWithLabels returns a Deployment carrying the given labels and a
 // matching label selector, suitable for use as the base object when testing
 // PDB / HPA / VPA creation.
-func deploymentWithLabels(name string, labels map[string]string) *appsv1.Deployment {
+func deploymentWithLabels(labels map[string]string) *appsv1.Deployment {
 	return &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{APIVersion: "apps/v1", Kind: "Deployment"},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
+			Name:      "gw",
 			Namespace: "default",
 			Labels:    labels,
 		},
@@ -360,7 +360,7 @@ var gatewayLabels = map[string]string{
 }
 
 func TestCreatePodDisruptionBudget_InheritsDeploymentLabels(t *testing.T) {
-	dep := deploymentWithLabels("gw", gatewayLabels)
+	dep := deploymentWithLabels(gatewayLabels)
 	overlay := &shared.KubernetesResourceOverlay{}
 
 	obj, err := createPodDisruptionBudget(dep, overlay)
@@ -371,7 +371,7 @@ func TestCreatePodDisruptionBudget_InheritsDeploymentLabels(t *testing.T) {
 }
 
 func TestCreatePodDisruptionBudget_OverlayLabelsMergeOnTop(t *testing.T) {
-	dep := deploymentWithLabels("gw", gatewayLabels)
+	dep := deploymentWithLabels(gatewayLabels)
 	overlay := &shared.KubernetesResourceOverlay{
 		Metadata: &shared.ObjectMetadata{
 			Labels: map[string]string{"extra": "label"},
@@ -389,7 +389,7 @@ func TestCreatePodDisruptionBudget_OverlayLabelsMergeOnTop(t *testing.T) {
 }
 
 func TestCreateHorizontalPodAutoscaler_InheritsDeploymentLabels(t *testing.T) {
-	dep := deploymentWithLabels("gw", gatewayLabels)
+	dep := deploymentWithLabels(gatewayLabels)
 	overlay := &shared.KubernetesResourceOverlay{}
 
 	obj, err := createHorizontalPodAutoscaler(dep, overlay)
@@ -400,7 +400,7 @@ func TestCreateHorizontalPodAutoscaler_InheritsDeploymentLabels(t *testing.T) {
 }
 
 func TestCreateHorizontalPodAutoscaler_OverlayLabelsMergeOnTop(t *testing.T) {
-	dep := deploymentWithLabels("gw", gatewayLabels)
+	dep := deploymentWithLabels(gatewayLabels)
 	overlay := &shared.KubernetesResourceOverlay{
 		Metadata: &shared.ObjectMetadata{
 			Labels: map[string]string{"extra": "label"},
@@ -418,7 +418,7 @@ func TestCreateHorizontalPodAutoscaler_OverlayLabelsMergeOnTop(t *testing.T) {
 }
 
 func TestCreateVerticalPodAutoscaler_InheritsDeploymentLabels(t *testing.T) {
-	dep := deploymentWithLabels("gw", gatewayLabels)
+	dep := deploymentWithLabels(gatewayLabels)
 	overlay := &shared.KubernetesResourceOverlay{}
 
 	obj, err := createVerticalPodAutoscaler(dep, overlay)
@@ -429,7 +429,7 @@ func TestCreateVerticalPodAutoscaler_InheritsDeploymentLabels(t *testing.T) {
 }
 
 func TestCreateVerticalPodAutoscaler_OverlayLabelsMergeOnTop(t *testing.T) {
-	dep := deploymentWithLabels("gw", gatewayLabels)
+	dep := deploymentWithLabels(gatewayLabels)
 	overlay := &shared.KubernetesResourceOverlay{
 		Metadata: &shared.ObjectMetadata{
 			Labels: map[string]string{"extra": "label"},
@@ -447,7 +447,7 @@ func TestCreateVerticalPodAutoscaler_OverlayLabelsMergeOnTop(t *testing.T) {
 }
 
 func TestCreatePodDisruptionBudget_DeploymentLabelsNotMutated(t *testing.T) {
-	dep := deploymentWithLabels("gw", gatewayLabels)
+	dep := deploymentWithLabels(gatewayLabels)
 	overlay := &shared.KubernetesResourceOverlay{
 		Metadata: &shared.ObjectMetadata{
 			Labels: map[string]string{"extra": "label"},

--- a/controller/pkg/deployer/strategicpatch/strategicpatch_test.go
+++ b/controller/pkg/deployer/strategicpatch/strategicpatch_test.go
@@ -6,9 +6,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -327,4 +330,133 @@ func TestOverlayApplier_ApplyOverlays_MultipleObjects(t *testing.T) {
 	// Check configmap (should be unchanged, no overlay for it)
 	cm := objs[3].(*corev1.ConfigMap)
 	assert.Empty(t, cm.Labels)
+}
+
+// deploymentWithLabels returns a Deployment carrying the given labels and a
+// matching label selector, suitable for use as the base object when testing
+// PDB / HPA / VPA creation.
+func deploymentWithLabels(name string, labels map[string]string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{APIVersion: "apps/v1", Kind: "Deployment"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			Labels:    labels,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: labels},
+		},
+	}
+}
+
+var gatewayLabels = map[string]string{
+	"app.kubernetes.io/instance":                   "gw",
+	"app.kubernetes.io/managed-by":                 "kgateway",
+	"app.kubernetes.io/name":                       "gw",
+	"app.kubernetes.io/version":                    "1.0.0-dev",
+	"gateway.networking.k8s.io/gateway-class-name": "agentgateway",
+	"gateway.networking.k8s.io/gateway-name":       "gw",
+	"kgateway":                                     "kube-gateway",
+}
+
+func TestCreatePodDisruptionBudget_InheritsDeploymentLabels(t *testing.T) {
+	dep := deploymentWithLabels("gw", gatewayLabels)
+	overlay := &shared.KubernetesResourceOverlay{}
+
+	obj, err := createPodDisruptionBudget(dep, overlay)
+	require.NoError(t, err)
+
+	pdb := obj.(*policyv1.PodDisruptionBudget)
+	assert.Equal(t, gatewayLabels, pdb.GetLabels())
+}
+
+func TestCreatePodDisruptionBudget_OverlayLabelsMergeOnTop(t *testing.T) {
+	dep := deploymentWithLabels("gw", gatewayLabels)
+	overlay := &shared.KubernetesResourceOverlay{
+		Metadata: &shared.ObjectMetadata{
+			Labels: map[string]string{"extra": "label"},
+		},
+	}
+
+	obj, err := createPodDisruptionBudget(dep, overlay)
+	require.NoError(t, err)
+
+	pdb := obj.(*policyv1.PodDisruptionBudget)
+	assert.Equal(t, "label", pdb.GetLabels()["extra"])
+	for k, v := range gatewayLabels {
+		assert.Equal(t, v, pdb.GetLabels()[k])
+	}
+}
+
+func TestCreateHorizontalPodAutoscaler_InheritsDeploymentLabels(t *testing.T) {
+	dep := deploymentWithLabels("gw", gatewayLabels)
+	overlay := &shared.KubernetesResourceOverlay{}
+
+	obj, err := createHorizontalPodAutoscaler(dep, overlay)
+	require.NoError(t, err)
+
+	hpa := obj.(*autoscalingv2.HorizontalPodAutoscaler)
+	assert.Equal(t, gatewayLabels, hpa.GetLabels())
+}
+
+func TestCreateHorizontalPodAutoscaler_OverlayLabelsMergeOnTop(t *testing.T) {
+	dep := deploymentWithLabels("gw", gatewayLabels)
+	overlay := &shared.KubernetesResourceOverlay{
+		Metadata: &shared.ObjectMetadata{
+			Labels: map[string]string{"extra": "label"},
+		},
+	}
+
+	obj, err := createHorizontalPodAutoscaler(dep, overlay)
+	require.NoError(t, err)
+
+	hpa := obj.(*autoscalingv2.HorizontalPodAutoscaler)
+	assert.Equal(t, "label", hpa.GetLabels()["extra"])
+	for k, v := range gatewayLabels {
+		assert.Equal(t, v, hpa.GetLabels()[k])
+	}
+}
+
+func TestCreateVerticalPodAutoscaler_InheritsDeploymentLabels(t *testing.T) {
+	dep := deploymentWithLabels("gw", gatewayLabels)
+	overlay := &shared.KubernetesResourceOverlay{}
+
+	obj, err := createVerticalPodAutoscaler(dep, overlay)
+	require.NoError(t, err)
+
+	vpa := obj.(*unstructured.Unstructured)
+	assert.Equal(t, gatewayLabels, vpa.GetLabels())
+}
+
+func TestCreateVerticalPodAutoscaler_OverlayLabelsMergeOnTop(t *testing.T) {
+	dep := deploymentWithLabels("gw", gatewayLabels)
+	overlay := &shared.KubernetesResourceOverlay{
+		Metadata: &shared.ObjectMetadata{
+			Labels: map[string]string{"extra": "label"},
+		},
+	}
+
+	obj, err := createVerticalPodAutoscaler(dep, overlay)
+	require.NoError(t, err)
+
+	vpa := obj.(*unstructured.Unstructured)
+	assert.Equal(t, "label", vpa.GetLabels()["extra"])
+	for k, v := range gatewayLabels {
+		assert.Equal(t, v, vpa.GetLabels()[k])
+	}
+}
+
+func TestCreatePodDisruptionBudget_DeploymentLabelsNotMutated(t *testing.T) {
+	dep := deploymentWithLabels("gw", gatewayLabels)
+	overlay := &shared.KubernetesResourceOverlay{
+		Metadata: &shared.ObjectMetadata{
+			Labels: map[string]string{"extra": "label"},
+		},
+	}
+
+	_, err := createPodDisruptionBudget(dep, overlay)
+	require.NoError(t, err)
+
+	// The original deployment labels must not have been mutated.
+	assert.NotContains(t, dep.GetLabels(), "extra")
 }

--- a/controller/pkg/kgateway/controller/gw_controller.go
+++ b/controller/pkg/kgateway/controller/gw_controller.go
@@ -342,6 +342,12 @@ func (r *gatewayReconciler) Reconcile(req types.NamespacedName) (rErr error) {
 		return err
 	}
 
+	// Prune any PDB/HPA/VPA resources that are no longer desired
+	err = r.deployer.PruneRemovedResources(ctx, gw, objs)
+	if err != nil {
+		return fmt.Errorf("error pruning removed resources for Gateway %s: %w", req, err)
+	}
+
 	// find the name/ns of the service we own so we can grab addresses
 	// from it for status
 	var generatedSvc *metav1.ObjectMeta

--- a/controller/test/deployer/testdata/agentgateway-hpa-overlay-out.yaml
+++ b/controller/test/deployer/testdata/agentgateway-hpa-overlay-out.yaml
@@ -199,13 +199,12 @@ metadata:
     hpa-annotation: from-overlay
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
     hpa-label: from-overlay
-    kgateway: kube-gateway
   name: gw
 spec:
   maxReplicas: 10

--- a/controller/test/deployer/testdata/agentgateway-hpa-overlay-out.yaml
+++ b/controller/test/deployer/testdata/agentgateway-hpa-overlay-out.yaml
@@ -198,7 +198,14 @@ metadata:
   annotations:
     hpa-annotation: from-overlay
   labels:
+    app.kubernetes.io/instance: gw
+    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/name: gw
+    app.kubernetes.io/version: 1.0.0-ci1
+    gateway.networking.k8s.io/gateway-class-name: agentgateway
+    gateway.networking.k8s.io/gateway-name: gw
     hpa-label: from-overlay
+    kgateway: kube-gateway
   name: gw
 spec:
   maxReplicas: 10

--- a/controller/test/deployer/testdata/agentgateway-pdb-overlay-out.yaml
+++ b/controller/test/deployer/testdata/agentgateway-pdb-overlay-out.yaml
@@ -198,6 +198,13 @@ metadata:
   annotations:
     pdb-annotation: from-overlay
   labels:
+    app.kubernetes.io/instance: gw
+    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/name: gw
+    app.kubernetes.io/version: 1.0.0-ci1
+    gateway.networking.k8s.io/gateway-class-name: agentgateway
+    gateway.networking.k8s.io/gateway-name: gw
+    kgateway: kube-gateway
     pdb-label: from-overlay
   name: gw
 spec:

--- a/controller/test/deployer/testdata/agentgateway-pdb-overlay-out.yaml
+++ b/controller/test/deployer/testdata/agentgateway-pdb-overlay-out.yaml
@@ -199,12 +199,11 @@ metadata:
     pdb-annotation: from-overlay
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
     pdb-label: from-overlay
   name: gw
 spec:


### PR DESCRIPTION
When a Gateway or GatewayParameters is updated or deleted such that a previously-created PodDisruptionBudget, HorizontalPodAutoscaler, or VerticalPodAutoscaler is no longer required, the controller does not currently remove those resources. This is a resource leak.

ownerReferences-based garbage collection is insufficient here because it only fires when the owner is deleted — if the owner (e.g. the Gateway) still exists but has been updated to no longer require a PDB/HPA/VPA, Kubernetes will not clean up the now-orphaned resource.

The `PruneRemovedResources` method on the `Deployer` collects pdb/hpa/vpa resources owned by the reconciling gateway and checks them against the list of desired objects and prunes those which are undesired. 
