### PR TITLE
Enhance waypoint support in proxy

### DIFF
--- a/crates/agentgateway/src/app.rs
+++ b/crates/agentgateway/src/app.rs
@@ -172,19 +172,7 @@ impl Bound {
 			b.all_shutdown_policies()
 		};
 		for p in sdp {
-			if let Some(t) = p.tracer.get() {
-				t.shutdown()
-			}
-		}
-
-		let access_log_policies = {
-			let b = self.stores.binds.read();
-			b.all_access_log_policies()
-		};
-		for p in access_log_policies {
-			if let Some(logger) = p.logger.get() {
-				logger.shutdown()
-			}
+			p();
 		}
 
 		// Start a drain; this will attempt to end all connections

--- a/crates/agentgateway/src/control/caclient.rs
+++ b/crates/agentgateway/src/control/caclient.rs
@@ -184,7 +184,7 @@ impl WorkloadCertificate {
 	pub fn hbone_termination(&self) -> Result<ServerConfig, Error> {
 		let Identity::Spiffe { trust_domain, .. } = &self.identity;
 
-		// TODO: this istoo expensive to build per request
+		// TODO: this is too expensive to build per request
 		let roots = self.roots.clone();
 		let raw_client_cert_verifier = rustls::server::WebPkiClientVerifier::builder_with_provider(
 			roots.clone(),
@@ -195,7 +195,7 @@ impl WorkloadCertificate {
 			raw_client_cert_verifier,
 			Some(trust_domain.clone()),
 		);
-		let sc = ServerConfig::builder_with_provider(transport::tls::provider())
+		let mut sc = ServerConfig::builder_with_provider(transport::tls::provider())
 			.with_protocol_versions(transport::tls::ALL_TLS_VERSIONS)
 			.expect("server config must be valid")
 			.with_client_cert_verifier(client_cert_verifier)
@@ -203,6 +203,7 @@ impl WorkloadCertificate {
 				self.chain.iter().map(|c| c.der.clone()).collect(),
 				self.private_key.clone_key(),
 			)?;
+		sc.alpn_protocols = vec![b"h2".into()];
 		Ok(sc)
 	}
 }

--- a/crates/agentgateway/src/http/authorization.rs
+++ b/crates/agentgateway/src/http/authorization.rs
@@ -2,6 +2,7 @@ use serde::ser::SerializeMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::cel::{ContextBuilder, Executor};
+use crate::proxy::ProxyError;
 use crate::*;
 
 #[derive(Clone, Debug)]
@@ -34,13 +35,14 @@ impl NetworkAuthorizationSet {
 		Self(rs)
 	}
 
-	pub fn apply(&self, source: &crate::cel::SourceContext) -> anyhow::Result<()> {
+	pub fn apply(&self, source: &crate::cel::SourceContext) -> Result<(), ProxyError> {
 		let exec = Executor::new_source(source);
 		let allowed = self.0.validate(&exec);
 		if !allowed {
-			anyhow::bail!("network authorization denied");
+			Err(ProxyError::AuthorizationFailed)
+		} else {
+			Ok(())
 		}
-		Ok(())
 	}
 
 	pub fn register(&self, cel: &mut ContextBuilder) {

--- a/crates/agentgateway/src/http/route.rs
+++ b/crates/agentgateway/src/http/route.rs
@@ -8,11 +8,9 @@ use agent_core::strng;
 use crate::http::Request;
 use crate::types::agent;
 use crate::types::agent::{
-	BackendReference, HeaderMatch, HeaderValueMatch, Listener, ListenerProtocol, PathMatch,
-	QueryValueMatch, Route, RouteBackendReference, RouteMatch, RouteName,
+	BackendReference, HeaderMatch, HeaderValueMatch, Listener, PathMatch, QueryValueMatch, Route,
+	RouteBackendReference, RouteMatch, RouteName,
 };
-use crate::types::discovery::gatewayaddress::Destination;
-use crate::types::discovery::{NetworkAddress, WaypointIdentity};
 use crate::*;
 
 #[cfg(any(test, feature = "internal_benches"))]
@@ -101,8 +99,6 @@ fn matches_request(m: &RouteMatch, request: &Request) -> bool {
 
 pub fn select_best_route(
 	stores: Stores,
-	network: Strng,
-	self_addr: Option<&WaypointIdentity>,
 	dst: SocketAddr,
 	listener: &Listener,
 	request: &Request,
@@ -125,106 +121,71 @@ pub fn select_best_route(
 	// criteria.
 
 	let host = http::get_host(request).ok()?;
-	let (default_response, host) = if matches!(listener.protocol, ListenerProtocol::HBONE) {
-		let Some(self_id) = self_addr else {
-			warn!("waypoint requires self address");
-			return None;
-		};
-		// We are going to get a VIP request. Look up the Service
-		let svc = stores
-			.read_discovery()
-			.services
-			.get_by_vip(&NetworkAddress {
-				network,
-				address: dst.ip(),
-			})?;
-		let wp = svc.waypoint.as_ref()?;
-		// Make sure the service is actually bound to us
-		let is_ours = match &wp.destination {
-			Destination::Address(addr) => {
-				let stores_ref = stores.clone();
-				self_id.matches_address(addr, |ns, hostname| {
-					let discovery = stores_ref.read_discovery();
-					let self_svc = discovery.services.get_by_namespaced_host(
-						&crate::types::discovery::NamespacedHostname {
-							namespace: ns.clone(),
-							hostname: hostname.clone(),
-						},
-					)?;
-					Some(self_svc.vips.clone())
-				})
-			},
-			Destination::Hostname(n) => self_id.matches_hostname(n),
-		};
-		if !is_ours {
-			warn!(
-				"service {} is meant for waypoint {:?}, but we are {}.{}",
-				svc.hostname, wp.destination, self_id.gateway, self_id.namespace
-			);
-			return None;
-		}
 
-		// When routes are attached to a Service via parentRef, they take priority
-		// over listener-attached routes. If service routes exist but none match,
-		// the request is rejected (per GAMMA spec).
-		let svc_nh = svc.namespaced_hostname();
-		let (has_svc_routes, svc_route_match) = {
-			let binds = stores.read_binds();
-			match binds.get_service_routes(&svc_nh) {
-				Some(svc_routes) => {
-					let mut result = None;
-					for hnm in agent::HostnameMatch::all_matches(&svc.hostname) {
-						result = svc_routes
-							.get_hostname(&hnm)
-							.find(|(_, m)| matches_request(m, request))
-							.map(|(route, matcher)| (route, matcher.path.clone()));
-						if result.is_some() {
-							break;
+	let (default_response, host) =
+		if let Some(wps) = request.extensions().get::<crate::proxy::WaypointService>() {
+			// When routes are attached to a Service via parentRef, they take priority
+			// over listener-attached routes. If service routes exist but none match,
+			// the request is rejected (per GAMMA spec).
+			let svc = wps.as_ref();
+			let svc_nh = svc.namespaced_hostname();
+			let (has_svc_routes, svc_route_match) = {
+				let binds = stores.read_binds();
+				match binds.get_service_routes(&svc_nh) {
+					Some(svc_routes) => {
+						let mut result = None;
+						for hnm in agent::HostnameMatch::all_matches(&svc.hostname) {
+							result = svc_routes
+								.get_hostname(&hnm)
+								.find(|(_, m)| matches_request(m, request))
+								.map(|(route, matcher)| (route, matcher.path.clone()));
+							if result.is_some() {
+								break;
+							}
 						}
-					}
-					(true, result)
-				},
-				None => (false, None),
+						(true, result)
+					},
+					None => (false, None),
+				}
+			};
+			if let Some(result) = svc_route_match {
+				return Some(result);
 			}
-		};
-		if let Some(result) = svc_route_match {
-			return Some(result);
-		}
-		if has_svc_routes {
-			// GAMMA: service routes exist but none matched -> reject
-			return None;
-		}
+			if has_svc_routes {
+				// GAMMA: service routes exist but none matched -> reject
+				return None;
+			}
 
-		// No service-keyed routes: fall through to hostname matching with default route
-		let default_route = Route {
-			key: strng::literal!("_waypoint-default"),
-			service_key: None,
-			name: RouteName {
-				name: strng::literal!("_waypoint-default"),
-				namespace: svc.namespace.clone(),
-				rule_name: None,
-				kind: None,
-			},
-			hostnames: vec![],
-			matches: vec![],
-			inline_policies: vec![],
-			backends: vec![RouteBackendReference {
-				weight: 1,
-				backend: BackendReference::Service {
-					name: svc.namespaced_hostname(),
-					port: dst.port(), // TODO: get from req
+			// No service-keyed routes: fall through to hostname matching with default route
+			let default_route = Route {
+				key: strng::literal!("_waypoint-default"),
+				service_key: None,
+				name: RouteName {
+					name: strng::literal!("_waypoint-default"),
+					namespace: svc.namespace.clone(),
+					rule_name: None,
+					kind: None,
 				},
-				inline_policies: Vec::new(),
-			}],
+				hostnames: vec![],
+				matches: vec![],
+				inline_policies: vec![],
+				backends: vec![RouteBackendReference {
+					weight: 1,
+					backend: BackendReference::Service {
+						name: svc.namespaced_hostname(),
+						port: dst.port(), // TODO: get from req
+					},
+					inline_policies: Vec::new(),
+				}],
+			};
+			let def = Some((
+				Arc::new(default_route),
+				PathMatch::PathPrefix(strng::new("/")),
+			));
+			(def, Cow::Owned(svc.hostname.to_string()))
+		} else {
+			(None, Cow::Borrowed(host))
 		};
-		let def = Some((
-			Arc::new(default_route),
-			PathMatch::PathPrefix(strng::new("/")),
-		));
-		(def, Cow::Owned(svc.hostname.to_string()))
-	} else {
-		(None, Cow::Borrowed(host))
-	};
 	for hnm in agent::HostnameMatch::all_matches(&host) {
 		let mut candidates = listener.routes.get_hostname(&hnm);
 		let best_match = candidates.find(|(_, m)| matches_request(m, request));

--- a/crates/agentgateway/src/http/route_test.rs
+++ b/crates/agentgateway/src/http/route_test.rs
@@ -15,26 +15,17 @@ use crate::types::agent::{
 	QueryValueMatch, Route, RouteMatch, RouteSet,
 };
 use crate::types::discovery::{
-	GatewayAddress, NamespacedHostname, NetworkAddress, Service, WaypointIdentity,
-	gatewayaddress::Destination,
+	GatewayAddress, NamespacedHostname, NetworkAddress, Service, gatewayaddress::Destination,
 };
 use crate::*;
 
 fn run_test(req: &Request, routes: &[(&str, Vec<&str>, Vec<RouteMatch>)]) -> Option<String> {
 	let stores = Stores::with_ipv6_enabled(true);
-	let network = strng::literal!("network");
 	let dummy_dest = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 1000);
 
 	let listener = setup_listener(routes);
 
-	let result = super::select_best_route(
-		stores.clone(),
-		network.clone(),
-		None,
-		dummy_dest,
-		&listener,
-		req,
-	);
+	let result = super::select_best_route(stores.clone(), dummy_dest, &listener, req);
 	result.map(|(r, _)| r.key.to_string())
 }
 
@@ -65,6 +56,15 @@ fn setup_listener(routes: &[(&str, Vec<&str>, Vec<RouteMatch>)]) -> Arc<Listener
 				.collect(),
 		),
 	})
+}
+
+fn attach_waypoint_service(req: &mut Request, stores: &Stores, service_key: &NamespacedHostname) {
+	let svc = stores
+		.read_discovery()
+		.services
+		.get_by_namespaced_host(service_key)
+		.expect("test service must exist in discovery store");
+	req.extensions_mut().insert(proxy::WaypointService(svc));
 }
 
 #[test]
@@ -892,26 +892,16 @@ async fn test_waypoint_hostname_match() {
 		}),
 	);
 	let stores = stores_with_services(vec![svc]);
-	let self_id = WaypointIdentity {
-		gateway: strng::new("my-waypoint"),
-		namespace: strng::new("istio-system"),
-	};
 	let dst = SocketAddr::new("10.0.0.100".parse().unwrap(), 80);
-	let req = request(
+	let mut req = request(
 		"http://my-app.default.svc.cluster.local/",
 		http::Method::GET,
 		&[],
 	);
 	let listener = hbone_listener();
+	attach_waypoint_service(&mut req, &stores, &svc_nh());
 
-	let result = super::select_best_route(
-		stores,
-		strng::literal!("network"),
-		Some(&self_id),
-		dst,
-		&listener,
-		&req,
-	);
+	let result = super::select_best_route(stores, dst, &listener, &req);
 	assert!(result.is_some(), "should return default waypoint route");
 	let (route, _) = result.unwrap();
 	assert_eq!(route.key.as_str(), "_waypoint-default");
@@ -935,10 +925,6 @@ async fn test_waypoint_hostname_mismatch() {
 		}),
 	);
 	let stores = stores_with_services(vec![svc]);
-	let self_id = WaypointIdentity {
-		gateway: strng::new("my-waypoint"),
-		namespace: strng::new("istio-system"),
-	};
 	let dst = SocketAddr::new("10.0.0.100".parse().unwrap(), 80);
 	let req = request(
 		"http://my-app.default.svc.cluster.local/",
@@ -947,14 +933,7 @@ async fn test_waypoint_hostname_mismatch() {
 	);
 	let listener = hbone_listener();
 
-	let result = super::select_best_route(
-		stores,
-		strng::literal!("network"),
-		Some(&self_id),
-		dst,
-		&listener,
-		&req,
-	);
+	let result = super::select_best_route(stores, dst, &listener, &req);
 	assert!(
 		result.is_none(),
 		"should reject service bound to a different waypoint"
@@ -979,26 +958,16 @@ async fn test_waypoint_hostname_fqdn_match() {
 		}),
 	);
 	let stores = stores_with_services(vec![svc]);
-	let self_id = WaypointIdentity {
-		gateway: strng::new("my-waypoint"),
-		namespace: strng::new("istio-system"),
-	};
 	let dst = SocketAddr::new("10.0.0.100".parse().unwrap(), 80);
-	let req = request(
+	let mut req = request(
 		"http://my-app.default.svc.cluster.local/",
 		http::Method::GET,
 		&[],
 	);
 	let listener = hbone_listener();
+	attach_waypoint_service(&mut req, &stores, &svc_nh());
 
-	let result = super::select_best_route(
-		stores,
-		strng::literal!("network"),
-		Some(&self_id),
-		dst,
-		&listener,
-		&req,
-	);
+	let result = super::select_best_route(stores, dst, &listener, &req);
 	assert!(result.is_some(), "should match waypoint with FQDN hostname");
 }
 
@@ -1030,26 +999,16 @@ async fn test_waypoint_address_match() {
 		None,
 	);
 	let stores = stores_with_services(vec![svc, waypoint_svc]);
-	let self_id = WaypointIdentity {
-		gateway: strng::new("my-waypoint"),
-		namespace: strng::new("istio-system"),
-	};
 	let dst = SocketAddr::new("10.0.0.100".parse().unwrap(), 80);
-	let req = request(
+	let mut req = request(
 		"http://my-app.default.svc.cluster.local/",
 		http::Method::GET,
 		&[],
 	);
 	let listener = hbone_listener();
+	attach_waypoint_service(&mut req, &stores, &svc_nh());
 
-	let result = super::select_best_route(
-		stores,
-		strng::literal!("network"),
-		Some(&self_id),
-		dst,
-		&listener,
-		&req,
-	);
+	let result = super::select_best_route(stores, dst, &listener, &req);
 	assert!(result.is_some(), "should match waypoint by address VIP");
 	let (route, _) = result.unwrap();
 	assert_eq!(route.key.as_str(), "_waypoint-default");
@@ -1082,10 +1041,6 @@ async fn test_waypoint_address_mismatch() {
 		None,
 	);
 	let stores = stores_with_services(vec![svc, waypoint_svc]);
-	let self_id = WaypointIdentity {
-		gateway: strng::new("my-waypoint"),
-		namespace: strng::new("istio-system"),
-	};
 	let dst = SocketAddr::new("10.0.0.100".parse().unwrap(), 80);
 	let req = request(
 		"http://my-app.default.svc.cluster.local/",
@@ -1094,14 +1049,7 @@ async fn test_waypoint_address_mismatch() {
 	);
 	let listener = hbone_listener();
 
-	let result = super::select_best_route(
-		stores,
-		strng::literal!("network"),
-		Some(&self_id),
-		dst,
-		&listener,
-		&req,
-	);
+	let result = super::select_best_route(stores, dst, &listener, &req);
 	assert!(
 		result.is_none(),
 		"should reject service bound to a different waypoint address"
@@ -1120,10 +1068,6 @@ async fn test_waypoint_no_waypoint_on_service() {
 		None, // no waypoint
 	);
 	let stores = stores_with_services(vec![svc]);
-	let self_id = WaypointIdentity {
-		gateway: strng::new("my-waypoint"),
-		namespace: strng::new("istio-system"),
-	};
 	let dst = SocketAddr::new("10.0.0.100".parse().unwrap(), 80);
 	let req = request(
 		"http://my-app.default.svc.cluster.local/",
@@ -1132,14 +1076,7 @@ async fn test_waypoint_no_waypoint_on_service() {
 	);
 	let listener = hbone_listener();
 
-	let result = super::select_best_route(
-		stores,
-		strng::literal!("network"),
-		Some(&self_id),
-		dst,
-		&listener,
-		&req,
-	);
+	let result = super::select_best_route(stores, dst, &listener, &req);
 	assert!(
 		result.is_none(),
 		"should return None for service without waypoint"
@@ -1172,14 +1109,7 @@ async fn test_waypoint_no_self_addr() {
 	);
 	let listener = hbone_listener();
 
-	let result = super::select_best_route(
-		stores,
-		strng::literal!("network"),
-		None, // no self_addr
-		dst,
-		&listener,
-		&req,
-	);
+	let result = super::select_best_route(stores, dst, &listener, &req);
 	assert!(
 		result.is_none(),
 		"should return None when self_addr is not configured"
@@ -1190,22 +1120,11 @@ async fn test_waypoint_no_self_addr() {
 async fn test_waypoint_unknown_vip() {
 	// Request to a VIP that doesn't match any known service
 	let stores = stores_with_services(vec![]);
-	let self_id = WaypointIdentity {
-		gateway: strng::new("my-waypoint"),
-		namespace: strng::new("istio-system"),
-	};
 	let dst = SocketAddr::new("10.0.0.200".parse().unwrap(), 80);
 	let req = request("http://unknown.svc.cluster.local/", http::Method::GET, &[]);
 	let listener = hbone_listener();
 
-	let result = super::select_best_route(
-		stores,
-		strng::literal!("network"),
-		Some(&self_id),
-		dst,
-		&listener,
-		&req,
-	);
+	let result = super::select_best_route(stores, dst, &listener, &req);
 	assert!(result.is_none(), "should return None for unknown VIP");
 }
 
@@ -1261,13 +1180,6 @@ fn waypoint_svc() -> Service {
 	)
 }
 
-fn waypoint_self_id() -> WaypointIdentity {
-	WaypointIdentity {
-		gateway: strng::new("my-waypoint"),
-		namespace: strng::new("istio-system"),
-	}
-}
-
 #[tokio::test]
 async fn test_service_route_path_match() {
 	let stores = stores_with_service_routes(
@@ -1295,40 +1207,27 @@ async fn test_service_route_path_match() {
 			),
 		],
 	);
-	let self_id = waypoint_self_id();
 	let listener = hbone_listener();
 	let dst = SocketAddr::new("10.0.0.100".parse().unwrap(), 80);
 
 	// /api/v1 matches the prefix route
-	let req = request(
+	let mut req = request(
 		"http://my-app.default.svc.cluster.local/api/v1",
 		http::Method::GET,
 		&[],
 	);
-	let result = super::select_best_route(
-		stores.clone(),
-		strng::literal!("network"),
-		Some(&self_id),
-		dst,
-		&listener,
-		&req,
-	);
+	attach_waypoint_service(&mut req, &stores, &svc_nh());
+	let result = super::select_best_route(stores.clone(), dst, &listener, &req);
 	assert_eq!(result.unwrap().0.key.as_str(), "api-route");
 
 	// /healthz matches the exact route (higher priority than prefix)
-	let req = request(
+	let mut req = request(
 		"http://my-app.default.svc.cluster.local/healthz",
 		http::Method::GET,
 		&[],
 	);
-	let result = super::select_best_route(
-		stores.clone(),
-		strng::literal!("network"),
-		Some(&self_id),
-		dst,
-		&listener,
-		&req,
-	);
+	attach_waypoint_service(&mut req, &stores, &svc_nh());
+	let result = super::select_best_route(stores.clone(), dst, &listener, &req);
 	assert_eq!(result.unwrap().0.key.as_str(), "health-route");
 }
 
@@ -1363,23 +1262,16 @@ async fn test_service_route_method_match() {
 			),
 		],
 	);
-	let self_id = waypoint_self_id();
 	let listener = hbone_listener();
 	let dst = SocketAddr::new("10.0.0.100".parse().unwrap(), 80);
 
-	let req = request(
+	let mut req = request(
 		"http://my-app.default.svc.cluster.local/",
 		http::Method::POST,
 		&[],
 	);
-	let result = super::select_best_route(
-		stores.clone(),
-		strng::literal!("network"),
-		Some(&self_id),
-		dst,
-		&listener,
-		&req,
-	);
+	attach_waypoint_service(&mut req, &stores, &svc_nh());
+	let result = super::select_best_route(stores.clone(), dst, &listener, &req);
 	assert_eq!(result.unwrap().0.key.as_str(), "post-route");
 }
 
@@ -1401,40 +1293,27 @@ async fn test_service_route_header_match() {
 			}],
 		)],
 	);
-	let self_id = waypoint_self_id();
 	let listener = hbone_listener();
 	let dst = SocketAddr::new("10.0.0.100".parse().unwrap(), 80);
 
 	// With matching header -> matches
-	let req = request(
+	let mut req = request(
 		"http://my-app.default.svc.cluster.local/",
 		http::Method::GET,
 		&[("x-custom", "special")],
 	);
-	let result = super::select_best_route(
-		stores.clone(),
-		strng::literal!("network"),
-		Some(&self_id),
-		dst,
-		&listener,
-		&req,
-	);
+	attach_waypoint_service(&mut req, &stores, &svc_nh());
+	let result = super::select_best_route(stores.clone(), dst, &listener, &req);
 	assert_eq!(result.unwrap().0.key.as_str(), "header-route");
 
 	// Without matching header -> GAMMA reject (service routes exist, none match)
-	let req = request(
+	let mut req = request(
 		"http://my-app.default.svc.cluster.local/",
 		http::Method::GET,
 		&[],
 	);
-	let result = super::select_best_route(
-		stores.clone(),
-		strng::literal!("network"),
-		Some(&self_id),
-		dst,
-		&listener,
-		&req,
-	);
+	attach_waypoint_service(&mut req, &stores, &svc_nh());
+	let result = super::select_best_route(stores.clone(), dst, &listener, &req);
 	assert!(
 		result.is_none(),
 		"should reject when service routes exist but none match"
@@ -1457,23 +1336,16 @@ async fn test_service_route_rejects_unmatched() {
 			}],
 		)],
 	);
-	let self_id = waypoint_self_id();
 	let listener = hbone_listener();
 	let dst = SocketAddr::new("10.0.0.100".parse().unwrap(), 80);
 
-	let req = request(
+	let mut req = request(
 		"http://my-app.default.svc.cluster.local/other",
 		http::Method::GET,
 		&[],
 	);
-	let result = super::select_best_route(
-		stores.clone(),
-		strng::literal!("network"),
-		Some(&self_id),
-		dst,
-		&listener,
-		&req,
-	);
+	attach_waypoint_service(&mut req, &stores, &svc_nh());
+	let result = super::select_best_route(stores.clone(), dst, &listener, &req);
 	assert!(
 		result.is_none(),
 		"GAMMA: should reject when service routes exist but none match"
@@ -1484,23 +1356,16 @@ async fn test_service_route_rejects_unmatched() {
 async fn test_no_service_routes_falls_through_to_default() {
 	// No service-keyed routes -> default passthrough route
 	let stores = stores_with_services(vec![waypoint_svc()]);
-	let self_id = waypoint_self_id();
 	let listener = hbone_listener();
 	let dst = SocketAddr::new("10.0.0.100".parse().unwrap(), 80);
 
-	let req = request(
+	let mut req = request(
 		"http://my-app.default.svc.cluster.local/anything",
 		http::Method::GET,
 		&[],
 	);
-	let result = super::select_best_route(
-		stores,
-		strng::literal!("network"),
-		Some(&self_id),
-		dst,
-		&listener,
-		&req,
-	);
+	attach_waypoint_service(&mut req, &stores, &svc_nh());
+	let result = super::select_best_route(stores, dst, &listener, &req);
 	assert!(
 		result.is_some(),
 		"should fall through to default route when no service routes"
@@ -1549,15 +1414,12 @@ fn bench(b: Bencher, (host, route): (u64, u64)) {
 		),
 	});
 	let stores = Stores::with_ipv6_enabled(true);
-	let network = strng::literal!("network");
 	let dummy_dest = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 1000);
 	let req = request("http://example.com", http::Method::GET, &[]);
 
 	b.bench_local(|| {
 		divan::black_box(super::select_best_route(
 			stores.clone(),
-			network.clone(),
-			None,
 			dummy_dest,
 			&listener,
 			divan::black_box(&req),

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -616,7 +616,7 @@ async fn setup_access_log_mcp_proxy(mock: &MockServer) -> (TestBind, SocketAddr)
 		t.pi
 			.stores
 			.read_binds()
-			.listener_frontend_policies(&listener_name)
+			.listener_frontend_policies(&listener_name, None)
 			.access_log
 			.is_some()
 	);

--- a/crates/agentgateway/src/proxy/gateway.rs
+++ b/crates/agentgateway/src/proxy/gateway.rs
@@ -20,7 +20,7 @@ use tokio::task::{AbortHandle, JoinSet};
 use tokio_stream::StreamExt;
 use tracing::{Instrument, debug, error, event, info, info_span, warn};
 
-use crate::proxy::ProxyError;
+use crate::proxy::{ProxyError, WaypointService};
 use crate::store::{BindEvent, BindListeners, FrontendPolices};
 use crate::telemetry::metrics::TCPLabels;
 use crate::transport::BufferLimit;
@@ -30,9 +30,12 @@ use crate::transport::stream::{
 use crate::types::agent::{
 	BindKey, BindProtocol, Listener, ListenerProtocol, TransportProtocol, TunnelProtocol,
 };
+use crate::types::discovery::Service;
+use crate::types::discovery::gatewayaddress::Destination;
 use crate::types::frontend;
 use crate::{ProxyInputs, client};
 use agent_core::strng;
+use agent_hbone::server::H2Request;
 
 #[cfg(test)]
 #[path = "gateway_test.rs"]
@@ -422,17 +425,7 @@ impl Gateway {
 					warn!(src.addr = %peer_addr, "proxy error: {e}");
 				}
 			},
-			BindProtocol::tcp => {
-				Self::proxy_tcp(
-					bind_name,
-					inputs,
-					None,
-					raw_stream,
-					Arc::new(policies),
-					drain,
-				)
-				.await
-			},
+			BindProtocol::tcp => Self::proxy_tcp(bind_name, inputs, None, raw_stream, drain).await,
 			BindProtocol::tls => {
 				match Self::maybe_terminate_tls(
 					inputs.clone(),
@@ -456,15 +449,7 @@ impl Gateway {
 							.await;
 						},
 						ListenerProtocol::TLS(_) => {
-							Self::proxy_tcp(
-								bind_name,
-								inputs,
-								Some(selected_listener),
-								stream,
-								Arc::new(policies),
-								drain,
-							)
-							.await
+							Self::proxy_tcp(bind_name, inputs, Some(selected_listener), stream, drain).await
 						},
 						_ => {
 							error!(
@@ -528,7 +513,6 @@ impl Gateway {
 											inputs,
 											Some(selected_listener),
 											tls_stream,
-											Arc::new(policies),
 											drain,
 										)
 										.await
@@ -601,8 +585,11 @@ impl Gateway {
 				Self::proxy_bind(bind_name, bind_protocol, raw_stream, inputs, drain).await
 			},
 			TunnelProtocol::HboneWaypoint => {
-				let _ =
+				let err =
 					Self::terminate_waypoint_hbone(bind_name, inputs, raw_stream, policies, drain).await;
+				if let Err(e) = err {
+					warn!(src.addr = %peer_addr, "hbone error: {e}");
+				}
 			},
 			TunnelProtocol::HboneGateway => {
 				let _ = Self::terminate_gateway_hbone(inputs, raw_stream, policies, drain).await;
@@ -717,7 +704,6 @@ impl Gateway {
 		inputs: Arc<ProxyInputs>,
 		selected_listener: Option<Arc<Listener>>,
 		stream: Socket,
-		policies: Arc<FrontendPolices>,
 		_drain: DrainWatcher,
 	) {
 		let selected_listener = match selected_listener {
@@ -740,7 +726,7 @@ impl Gateway {
 			selected_listener,
 			target_address,
 		};
-		proxy.proxy(stream, policies).await
+		proxy.proxy(stream).await
 	}
 
 	// maybe_terminate_tls will observe the TLS handshake, and once the client hello has been received, select
@@ -924,17 +910,9 @@ impl Gateway {
 
 		debug!("accepted connection");
 		let cfg = inp.cfg.clone();
-		let pols = Arc::new(policies);
 		let request_handler = move |req, ext, graceful| {
-			Self::serve_waypoint_connect(
-				bind_name.clone(),
-				inp.clone(),
-				pols.clone(),
-				req,
-				ext,
-				graceful,
-			)
-			.instrument(info_span!("inbound"))
+			Self::serve_waypoint_connect(bind_name.clone(), inp.clone(), req, ext, graceful)
+				.instrument(info_span!("inbound"))
 		};
 
 		let (_, force_shutdown) = watch::channel(());
@@ -991,20 +969,14 @@ impl Gateway {
 	async fn serve_waypoint_connect(
 		bind_name: BindKey,
 		pi: Arc<ProxyInputs>,
-		policies: Arc<FrontendPolices>,
 		req: agent_hbone::server::H2Request,
 		ext: Arc<Extension>,
 		drain: DrainWatcher,
 	) {
-		let uri = req.uri();
-		let parsed_addr = match HboneAddress::try_from(uri) {
-			Ok(addr) => addr,
-			Err(_) => {
-				warn!(
-					bind=?bind_name,
-					uri=%uri,
-					"serve_waypoint_connect: invalid URI format"
-				);
+		let (socket_addr, svc) = match Self::setup_hbone_info(&pi, &req).await {
+			Ok(i) => i,
+			Err(e) => {
+				warn!("hbone failed: {e}");
 				let _ = req
 					.send_response(build_response(StatusCode::BAD_REQUEST))
 					.await;
@@ -1012,62 +984,11 @@ impl Gateway {
 			},
 		};
 
-		// Resolve the HBONE address to a socket address and detect the service protocol
-		// in a single discovery store lookup to avoid redundant read locks.
-		let (socket_addr, is_http) = {
-			let discovery = pi.stores.read_discovery();
-			let network = &pi.cfg.network;
-
-			let resolved_addr = match parsed_addr {
-				HboneAddress::SocketAddr(addr) => addr,
-				HboneAddress::SvcHostname(hostname, port) => {
-					let hostname_str = hostname.to_string();
-					let svc = find_service_by_hostname(&discovery, &hostname_str);
-
-					let vip = if let Some(svc) = svc {
-						if let Some(vip) = svc
-							.vips
-							.iter()
-							.find(|vip| vip.network == *network)
-							.or_else(|| svc.vips.first())
-						{
-							vip.address
-						} else {
-							warn!(
-								bind=?bind_name,
-								hostname=%hostname_str,
-								"serve_waypoint_connect: no VIP found for service"
-							);
-							return;
-						}
-					} else {
-						warn!(
-							bind=?bind_name,
-							hostname=%hostname_str,
-							"serve_waypoint_connect: no service found for hostname"
-						);
-						return;
-					};
-					SocketAddr::from((vip, port))
-				},
-			};
-
-			// Determine protocol from service discovery. Default to HTTP since the vast
-			// majority of waypoint traffic is HTTP; only use TCP when there is a positive
-			// signal via explicit AppProtocol::Tcp/Tls (from istio/istio#59259).
-			let svc = discovery
-				.services
-				.get_by_vip(&crate::types::discovery::NetworkAddress {
-					network: network.clone(),
-					address: resolved_addr.ip(),
-				});
-			let is_http = match svc {
-				Some(svc) => !svc.port_is_tcp(resolved_addr.port()),
-				None => true,
-			};
-
-			(resolved_addr, is_http)
-		};
+		// Determine protocol from service discovery. Default to HTTP since the vast
+		// majority of waypoint traffic is HTTP; only use TCP when there is a positive
+		// signal via explicit AppProtocol::Tcp/Tls (from istio/istio#59259).
+		let should_sniff_tls = svc.port_is_tls(socket_addr.port());
+		let is_http = !svc.port_is_tcp(socket_addr.port());
 
 		let Ok(resp) = req.send_response(build_response(StatusCode::OK)).await else {
 			warn!("failed to send response");
@@ -1092,10 +1013,10 @@ impl Gateway {
 					.find(|l| matches!(l.protocol, ListenerProtocol::HBONE))
 					.cloned()
 			})
-			.or_else(|| {
+			.unwrap_or_else(|| {
 				// Synthetic fallback so route selection works via VIP lookup.
 				// We may eventually elide the need to generate an HBONE listener at all.
-				Some(Arc::new(Listener {
+				Arc::new(Listener {
 					key: Default::default(),
 					name: crate::types::agent::ListenerName {
 						gateway_name: pi.cfg.xds.gateway.clone(),
@@ -1107,15 +1028,120 @@ impl Gateway {
 					protocol: ListenerProtocol::HBONE,
 					tcp_routes: Default::default(),
 					routes: Default::default(),
-				}))
+				})
 			});
 
-		let socket = Socket::from_hbone(ext, socket_addr, con);
+		let wps = WaypointService(svc);
+		// Ensure we load policies per-stream so we don't cache stale policies on long-lived HBONE connections.
+		let policies = pi
+			.stores
+			.read_binds()
+			.listener_frontend_policies(&listener.name, Some(wps.as_policy_ref()));
+		let mut socket = Socket::from_hbone(ext, socket_addr, con);
+		socket.ext_mut().insert(wps);
 		if is_http {
-			let _ = Self::proxy(bind_name, pi, listener, socket, policies.clone(), drain).await;
+			let _ = Self::proxy(
+				bind_name,
+				pi,
+				Some(listener),
+				socket,
+				Arc::new(policies),
+				drain,
+			)
+			.await;
 		} else {
-			Self::proxy_tcp(bind_name, pi, listener, socket, policies.clone(), drain).await;
+			// For waypoint TCP traffic, only sniff TLS if the service port's appProtocol is TLS
+			socket
+				.ext_mut()
+				.insert(crate::transport::stream::WaypointTLSInfo { should_sniff_tls });
+
+			Self::proxy_tcp(bind_name, pi, Some(listener), socket, drain).await;
 		}
+	}
+
+	async fn setup_hbone_info(
+		pi: &Arc<ProxyInputs>,
+		req: &H2Request,
+	) -> anyhow::Result<(SocketAddr, Arc<Service>)> {
+		let uri = req.uri();
+		let parsed_addr = match HboneAddress::try_from(uri) {
+			Ok(addr) => addr,
+			Err(err) => {
+				anyhow::bail!("invalid URI format: {uri} {err}");
+			},
+		};
+
+		// Resolve the HBONE address to a socket address and detect the service protocol
+		// in a single discovery store lookup to avoid redundant read locks.
+		let discovery = pi.stores.read_discovery();
+		let network = &pi.cfg.network;
+
+		let (addr, svc) = match parsed_addr {
+			HboneAddress::SocketAddr(addr) => {
+				let Some(svc) = discovery
+					.services
+					.get_by_vip(&crate::types::discovery::NetworkAddress {
+						network: network.clone(),
+						address: addr.ip(),
+					})
+				else {
+					anyhow::bail!("no service found for address {addr}");
+				};
+				(addr, svc)
+			},
+			HboneAddress::SvcHostname(hostname, port) => {
+				let hostname_str = hostname.to_string();
+				let Some(svc) = find_service_by_hostname(&discovery, &hostname_str) else {
+					anyhow::bail!("no service found for hostname {hostname_str}");
+				};
+
+				let Some(vip) = svc
+					.vips
+					.iter()
+					.find(|vip| vip.network == *network)
+					.or_else(|| svc.vips.first())
+					.map(|v| v.address)
+				else {
+					anyhow::bail!("serve_waypoint_connect: no VIP found for service {hostname_str}");
+				};
+				(SocketAddr::from((vip, port)), svc)
+			},
+		};
+
+		// Make sure the service is actually bound to us
+		let Some(wp) = svc.waypoint.as_ref() else {
+			anyhow::bail!(
+				"service {}.{} is not bound to a waypoint",
+				svc.hostname,
+				svc.namespace
+			);
+		};
+		let Some(self_id) = pi.cfg.self_addr.as_ref() else {
+			anyhow::bail!("self_id required for waypoint");
+		};
+		let is_ours = match &wp.destination {
+			Destination::Address(addr) => self_id.matches_address(addr, |ns, hostname| {
+				let self_svc = discovery.services.get_by_namespaced_host(
+					&crate::types::discovery::NamespacedHostname {
+						namespace: ns.clone(),
+						hostname: hostname.clone(),
+					},
+				)?;
+				Some(self_svc.vips.clone())
+			}),
+			Destination::Hostname(n) => self_id.matches_hostname(n),
+		};
+		if !is_ours {
+			anyhow::bail!(
+				"service {} is meant for waypoint {:?}, but we are {}.{}",
+				svc.hostname,
+				wp.destination,
+				self_id.gateway,
+				self_id.namespace
+			);
+		}
+
+		Ok((addr, svc))
 	}
 
 	/// serve_gateway_connect handles a single connection from a client.

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -29,7 +29,9 @@ use crate::http::{
 };
 use crate::llm::{InputFormat, LLMInfo, LLMRequest, LLMResponse, RequestResult, RouteType};
 use crate::proxy::tcpproxy::TCPProxy;
-use crate::proxy::{ProxyError, ProxyResponse, ProxyResponseReason, resolve_simple_backend};
+use crate::proxy::{
+	ProxyError, ProxyResponse, ProxyResponseReason, WaypointService, resolve_simple_backend,
+};
 use crate::store::{
 	BackendPolicies, FrontendPolices, GatewayPolicies, LLMRequestPolicies, LLMResponsePolicies,
 	RoutePath,
@@ -410,6 +412,7 @@ impl HTTPProxy {
 			.clone();
 		connection.copy::<TLSConnectionInfo>(req.extensions_mut());
 		connection.copy::<cel::SourceContext>(req.extensions_mut());
+		connection.copy::<WaypointService>(req.extensions_mut());
 		req
 			.extensions_mut()
 			.insert(RequestTime(start.as_datetime()));
@@ -428,12 +431,7 @@ impl HTTPProxy {
 		// or direct responses
 		let mut response_policies = ResponsePolicies::default();
 		let ret = self
-			.proxy_internal(
-				connection,
-				req,
-				log.as_mut().unwrap(),
-				&mut response_policies,
-			)
+			.proxy_internal(req, log.as_mut().unwrap(), &mut response_policies)
 			.await
 			.map_err(|e| e.0);
 
@@ -497,12 +495,11 @@ impl HTTPProxy {
 
 	async fn proxy_internal(
 		&self,
-		connection: Arc<Extension>,
 		req: ::http::Request<Incoming>,
 		log: &mut RequestLog,
 		response_policies: &mut ResponsePolicies,
 	) -> Result<Response, SnapshottedProxyResponse> {
-		log.tls_info = connection.get::<TLSConnectionInfo>().cloned();
+		log.tls_info = req.extensions().get::<TLSConnectionInfo>().cloned();
 		log.backend_protocol = Some(cel::BackendProtocol::http);
 
 		let selected_listener = self.selected_listener.clone();
@@ -516,7 +513,7 @@ impl HTTPProxy {
 		};
 
 		sensitive_headers(&mut req);
-		normalize_uri(&connection, &mut req)
+		normalize_uri(log.tls_info.as_ref(), &mut req)
 			.map_err(ProxyError::Processing)
 			.snapshot_on_err(log, &mut req)?;
 		let mut req_upgrade = hop_by_hop_headers(&mut req);
@@ -542,10 +539,13 @@ impl HTTPProxy {
 		let selected_listener = match selected_listener {
 			Ok(l) => {
 				debug!(bind=%bind_name, listener=%l.key, "selected listener");
-				let frontend_policies = inputs
-					.stores
-					.read_binds()
-					.listener_frontend_policies(&l.name);
+				let frontend_policies = inputs.stores.read_binds().listener_frontend_policies(
+					&l.name,
+					req
+						.extensions()
+						.get::<WaypointService>()
+						.map(WaypointService::as_policy_ref),
+				);
 
 				self
 					.handle_frontend_policies(&frontend_policies, log, &mut req)
@@ -595,8 +595,6 @@ impl HTTPProxy {
 
 		let (selected_route, path_match) = http::route::select_best_route(
 			inputs.stores.clone(),
-			inputs.cfg.network.clone(),
-			inputs.cfg.self_addr.as_ref(),
 			self.target_address,
 			&selected_listener,
 			&req,
@@ -1103,7 +1101,7 @@ pub async fn build_transport(
 	if let Some(tun) = backend_tunnel {
 		let backend = super::resolve_simple_backend_with_policies(&tun.proxy, inputs)?;
 		let pols = crate::proxy::tcpproxy::get_backend_policies(inputs, &backend, &[], None);
-		let call = TCPProxy::build_backend_call(&mut None, inputs, &backend.backend, pols)?;
+		let call = TCPProxy::build_backend_call(&mut None, None, inputs, &backend.backend, pols)?;
 		let tunnel_backend_tls = call.backend_policies.backend_tls.clone();
 		let tunnel_auth = call.backend_policies.backend_auth.clone();
 		// This is a bounded recursion; this code is only called when backend_tunnel is set, and in this call
@@ -1365,9 +1363,15 @@ async fn make_backend_call(
 				network_gateway: None,
 			}
 		},
-		Backend::Service(svc, port) => {
-			build_service_call(&inputs, policies, &mut log, override_dest, svc, port)?
-		},
+		Backend::Service(svc, port) => build_service_call(
+			&inputs,
+			policies,
+			&mut log,
+			override_dest,
+			svc,
+			port,
+			req.uri().host(),
+		)?,
 		Backend::Opaque(_, target) => BackendCall {
 			target: target.clone(),
 			http_version_override: None,
@@ -1717,6 +1721,7 @@ pub fn build_service_call(
 	override_dest: Option<SocketAddr>,
 	svc: &Arc<Service>,
 	port: &u16,
+	request_host: Option<&str>,
 ) -> Result<BackendCall, ProxyError> {
 	let port = *port;
 	let workloads = &inputs.stores.read_discovery().workloads;
@@ -1801,14 +1806,19 @@ pub fn build_service_call(
 		);
 		Target::Hostname(svc.hostname.clone(), port)
 	} else {
-		// TODO: support a mode like ServiceEntry DYNAMIC_DNS. Need a way to signal this, though; perhaps:
-		// wl.workload_ips.is_empty() && wl.hostname.starts_with("*.")
-		// For direct connections, we need the workload IP
-		let Some(ip) = wl.workload_ips.first() else {
-			return Err(ProxyError::NoHealthyEndpoints);
-		};
-		let dest = SocketAddr::from((*ip, target_port));
-		Target::Address(dest)
+		// TODO: this should only be used with DNS resolution type! maybe?
+		if wl.workload_ips.is_empty()
+			&& let Some(hostname) = resolved_workload_target_hostname(&wl.hostname, request_host)
+		{
+			Target::Hostname(hostname.into(), port)
+		} else {
+			// For direct connections, we need the workload IP
+			let Some(ip) = wl.workload_ips.first() else {
+				return Err(ProxyError::NoHealthyEndpoints);
+			};
+			let dest = SocketAddr::from((*ip, target_port));
+			Target::Address(dest)
+		}
 	};
 
 	Ok(BackendCall {
@@ -1833,11 +1843,72 @@ fn workload_and_service_sans(wl: &Workload, svc: &Service) -> Vec<Identity> {
 	ids
 }
 
+fn resolved_workload_target_hostname<'a>(
+	workload_hostname: &'a str,
+	request_host: Option<&'a str>,
+) -> Option<&'a str> {
+	if workload_hostname.is_empty() {
+		return None;
+	}
+
+	if let Some(wildcard_suffix) = workload_hostname.strip_prefix("*.") {
+		let suffix = format!(".{wildcard_suffix}");
+		request_host.filter(|host| host.ends_with(&suffix))
+	} else {
+		Some(workload_hostname)
+	}
+}
+
 fn should_retry(res: &Result<Response, SnapshottedProxyResponse>, pol: &retry::Policy) -> bool {
 	match res {
 		Ok(resp) => pol.codes.contains(&resp.status()),
 		Err(SnapshottedProxyResponse(ProxyResponse::Error(e))) => e.is_retryable(),
 		Err(SnapshottedProxyResponse(ProxyResponse::DirectResponse(_))) => false,
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::resolved_workload_target_hostname;
+
+	#[test]
+	fn resolved_workload_target_hostname_uses_explicit_workload_hostname() {
+		assert_eq!(
+			resolved_workload_target_hostname("api.example.com", Some("caller.example.com")),
+			Some("api.example.com")
+		);
+		assert_eq!(
+			resolved_workload_target_hostname("api.example.com", None),
+			Some("api.example.com")
+		);
+	}
+
+	#[test]
+	fn resolved_workload_target_hostname_uses_request_host_for_matching_wildcard() {
+		assert_eq!(
+			resolved_workload_target_hostname("*.example.com", Some("api.example.com")),
+			Some("api.example.com")
+		);
+		assert_eq!(
+			resolved_workload_target_hostname("*.example.com", Some("deep.api.example.com")),
+			Some("deep.api.example.com")
+		);
+	}
+
+	#[test]
+	fn resolved_workload_target_hostname_rejects_non_matching_wildcard() {
+		assert_eq!(
+			resolved_workload_target_hostname("*.example.com", Some("example.com")),
+			None
+		);
+		assert_eq!(
+			resolved_workload_target_hostname("*.example.com", Some("api.other.com")),
+			None
+		);
+		assert_eq!(
+			resolved_workload_target_hostname("*.example.com", None),
+			None
+		);
 	}
 }
 
@@ -1944,7 +2015,7 @@ fn sensitive_headers(req: &mut Request) {
 
 // The http library will not put the authority into req.uri().authority for HTTP/1. Normalize so
 // the rest of the code doesn't need to worry about it
-fn normalize_uri(connection: &Extension, req: &mut Request) -> anyhow::Result<()> {
+fn normalize_uri(tls: Option<&TLSConnectionInfo>, req: &mut Request) -> anyhow::Result<()> {
 	debug!("request before normalization: {req:?}");
 	if let ::http::Version::HTTP_10 | ::http::Version::HTTP_11 = req.version()
 		&& req.uri().authority().is_none()
@@ -1961,7 +2032,7 @@ fn normalize_uri(connection: &Extension, req: &mut Request) -> anyhow::Result<()
 		parts.authority = Some(host);
 		if parts.path_and_query.is_some() {
 			// TODO: or always do this?
-			if connection.get::<TLSConnectionInfo>().is_some() {
+			if tls.is_some() {
 				parts.scheme = Some(Scheme::HTTPS);
 			} else {
 				parts.scheme = Some(Scheme::HTTP);

--- a/crates/agentgateway/src/proxy/mod.rs
+++ b/crates/agentgateway/src/proxy/mod.rs
@@ -11,9 +11,10 @@ use rmcp::model::{ErrorCode, JsonRpcError};
 
 use crate::http::{HeaderValue, Response, StatusCode, ext_proc};
 use crate::types::agent::{
-	Backend, BackendReference, BackendWithPolicies, ResourceName, SimpleBackend,
+	Backend, BackendReference, BackendTargetRef, BackendWithPolicies, ResourceName, SimpleBackend,
 	SimpleBackendReference, SimpleBackendWithPolicies,
 };
+use crate::types::discovery::Service;
 use crate::*;
 
 #[derive(thiserror::Error, Debug)]
@@ -385,6 +386,24 @@ impl ProxyError {
 	}
 }
 
+#[derive(Clone, Debug)]
+pub struct WaypointService(pub Arc<Service>);
+
+impl AsRef<Service> for WaypointService {
+	fn as_ref(&self) -> &Service {
+		self.0.as_ref()
+	}
+}
+
+impl WaypointService {
+	pub fn as_policy_ref(&self) -> PolicyTargetRef {
+		PolicyTargetRef::Backend(BackendTargetRef::Service {
+			hostname: self.0.hostname.as_str(),
+			namespace: self.0.namespace.as_str(),
+			port: None,
+		})
+	}
+}
 pub fn resolve_backend(
 	b: &BackendReference,
 	pi: &ProxyInputs,

--- a/crates/agentgateway/src/proxy/tcpproxy.rs
+++ b/crates/agentgateway/src/proxy/tcpproxy.rs
@@ -1,22 +1,23 @@
 use crate::cel::SourceContext;
+use futures::pin_mut;
 use rand::prelude::IndexedRandom;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
 use crate::proxy::httpproxy::BackendCall;
-use crate::proxy::{ProxyError, httpproxy};
+use crate::proxy::{ProxyError, WaypointService, httpproxy};
 use crate::store::{BackendPolicies, FrontendPolices, RoutePath};
 use crate::telemetry::log;
 use crate::telemetry::log::{DropOnLog, RequestLog};
 use crate::telemetry::metrics::TCPLabels;
-use crate::transport::stream::{Socket, TCPConnectionInfo, TLSConnectionInfo};
-use crate::types::agent;
+use crate::transport::stream::{Socket, TCPConnectionInfo, TLSConnectionInfo, WaypointTLSInfo};
 use crate::types::agent::{
 	BackendPolicy, BindKey, Listener, ListenerProtocol, SimpleBackend, SimpleBackendReference,
 	SimpleBackendWithPolicies, TCPRoute, TCPRouteBackend, TCPRouteBackendReference,
 	TransportProtocol,
 };
 use crate::types::discovery::{NetworkAddress, WaypointIdentity, gatewayaddress::Destination};
+use crate::types::{agent, frontend};
 use crate::{ProxyInputs, Stores, *};
 
 #[derive(Clone)]
@@ -29,7 +30,7 @@ pub struct TCPProxy {
 }
 
 impl TCPProxy {
-	pub async fn proxy(&self, connection: Socket, policies: Arc<FrontendPolices>) {
+	pub async fn proxy(&self, connection: Socket) {
 		let start = agent_core::Timestamp::now();
 
 		let tcp = connection
@@ -52,15 +53,7 @@ impl TCPProxy {
 		)
 		.into();
 		// Set source context for TCP logging
-		let authz_error = policies
-			.network_authorization
-			.as_ref()
-			.map(|p| p.apply(&src));
 		log.with(|l| l.source_context = Some(src));
-		if let Some(Err(e)) = authz_error {
-			log.with(|l| l.error = Some(e.to_string()));
-			return;
-		}
 		let ret = self.proxy_internal(connection, log.as_mut().unwrap()).await;
 		if let Err(e) = ret {
 			log.with(|l| l.error = Some(e.to_string()));
@@ -72,11 +65,12 @@ impl TCPProxy {
 		connection: Socket,
 		log: &mut RequestLog,
 	) -> Result<(), ProxyError> {
-		let frontend_policies = self
-			.inputs
-			.stores
-			.read_binds()
-			.frontend_policies(self.inputs.cfg.gateway_ref());
+		let frontend_policies = self.inputs.stores.read_binds().listener_frontend_policies(
+			&self.selected_listener.name,
+			connection
+				.ext::<WaypointService>()
+				.map(WaypointService::as_policy_ref),
+		);
 
 		// Apply frontend policies for access logging (skip tracing for TCP)
 		frontend_policies.register_cel_expressions(log.cel.ctx());
@@ -84,6 +78,27 @@ impl TCPProxy {
 			httpproxy::apply_logging_policy_to_log(log, lp);
 		}
 
+		// Only sniff TLS if: From waypoint AND service port's appProtocol is TLS
+		let should_sniff = connection
+			.ext::<WaypointTLSInfo>()
+			.map(|info| info.should_sniff_tls)
+			.unwrap_or(false);
+
+		let connection = if should_sniff {
+			Self::sniff_tls_sni(connection, &frontend_policies)
+				.await
+				.map_err(ProxyError::Processing)?
+		} else {
+			connection
+		};
+		if let Some(authz) = frontend_policies.network_authorization.as_ref() {
+			authz.apply(
+				log
+					.source_context
+					.as_ref()
+					.expect("expected source context"),
+			)?;
+		}
 		log.tls_info = connection.ext::<TLSConnectionInfo>().cloned();
 		log.backend_protocol = Some(cel::BackendProtocol::tcp);
 		let tcp_labels = TCPLabels {
@@ -105,7 +120,8 @@ impl TCPProxy {
 		let sni = log
 			.tls_info
 			.as_ref()
-			.and_then(|tls| tls.server_name.as_deref());
+			.and_then(|tls| tls.server_name.as_deref())
+			.map(|s| s.to_string());
 
 		let selected_listener = self.selected_listener.clone();
 		let inputs = self.inputs.clone();
@@ -116,7 +132,7 @@ impl TCPProxy {
 		debug!(bind=%bind_name, listener=%selected_listener.key, "selected listener");
 
 		let selected_route = select_best_route(
-			sni,
+			sni.as_deref(),
 			selected_listener.clone(),
 			&self.inputs.stores,
 			&self.inputs.cfg.network,
@@ -144,6 +160,7 @@ impl TCPProxy {
 
 		let backend_call = Self::build_backend_call(
 			&mut Some(log),
+			sni,
 			&inputs,
 			&selected_backend.backend.backend,
 			backend_policies,
@@ -180,14 +197,21 @@ impl TCPProxy {
 
 	pub fn build_backend_call(
 		log: &mut Option<&mut RequestLog>,
+		sni: Option<String>,
 		inputs: &ProxyInputs,
 		selected_backend: &SimpleBackend,
 		backend_policies: BackendPolicies,
 	) -> Result<BackendCall, ProxyError> {
 		let backend_call = match &selected_backend {
-			SimpleBackend::Service(svc, port) => {
-				httpproxy::build_service_call(inputs, backend_policies, log, None, svc, port)?
-			},
+			SimpleBackend::Service(svc, port) => httpproxy::build_service_call(
+				inputs,
+				backend_policies,
+				log,
+				None,
+				svc,
+				port,
+				sni.as_deref(),
+			)?,
 			SimpleBackend::Opaque(_, target) => BackendCall {
 				target: target.clone(),
 				http_version_override: None,
@@ -198,6 +222,30 @@ impl TCPProxy {
 			SimpleBackend::Invalid => return Err(ProxyError::BackendDoesNotExist),
 		};
 		Ok(backend_call)
+	}
+
+	async fn sniff_tls_sni(raw_stream: Socket, policies: &FrontendPolices) -> anyhow::Result<Socket> {
+		let def = frontend::TLS::default();
+		let tls_pol = policies.tls.as_ref();
+		let to = tls_pol.unwrap_or(&def).handshake_timeout;
+		let handshake = async move {
+			let (mut ext, counter, inner) = raw_stream.into_parts();
+			let inner = Socket::new_rewind(inner);
+			let acceptor =
+				tokio_rustls::LazyConfigAcceptor::new(rustls::server::Acceptor::default(), inner);
+			pin_mut!(acceptor);
+			let mut start = acceptor.as_mut().await?;
+			let ch = start.client_hello();
+			let sni = ch.server_name().unwrap_or_default().to_string();
+			start.io.rewind();
+			let existing = ext.remove().unwrap_or_default();
+			ext.insert(TLSConnectionInfo {
+				server_name: Some(sni),
+				..existing
+			});
+			Ok(Socket::from_rewind(ext, counter, start.io))
+		};
+		tokio::time::timeout(to, handshake).await?
 	}
 }
 

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -2,12 +2,6 @@ use std::collections::{HashMap, HashSet};
 use std::net::TcpListener as StdTcpListener;
 use std::sync::Arc;
 
-use agent_xds::{RejectedConfig, XdsUpdate};
-use anyhow::Context;
-use futures_core::Stream;
-use itertools::Itertools;
-use tracing::{Level, instrument, warn};
-
 use crate::cel::ContextBuilder;
 use crate::http::auth::BackendAuth;
 use crate::http::authorization::{HTTPAuthorizationSet, NetworkAuthorizationSet};
@@ -22,7 +16,7 @@ use crate::types::agent::{
 	A2aPolicy, Backend, BackendKey, BackendPolicy, BackendTargetRef, BackendWithPolicies, Bind,
 	BindKey, FrontendPolicy, JwtAuthentication, Listener, ListenerKey, ListenerName,
 	McpAuthentication, PolicyKey, PolicyTarget, Route, RouteKey, RouteName, RouteSet, TCPRoute,
-	TCPRouteSet, TargetedPolicy, TracingPolicy, TrafficPolicy,
+	TCPRouteSet, TargetedPolicy, TrafficPolicy,
 };
 use crate::types::discovery::NamespacedHostname;
 use crate::types::proto::agent::resource::Kind as XdsKind;
@@ -32,6 +26,11 @@ use crate::types::proto::agent::{
 };
 use crate::types::{agent, frontend};
 use crate::*;
+use agent_xds::{RejectedConfig, XdsUpdate};
+use anyhow::Context;
+use futures_core::Stream;
+use itertools::Itertools;
+use tracing::{Level, instrument, warn};
 
 #[derive(Debug)]
 enum ResourceKind {
@@ -796,31 +795,35 @@ impl Store {
 		pol
 	}
 
-	pub fn all_shutdown_policies(&self) -> Vec<Arc<TracingPolicy>> {
+	pub fn all_shutdown_policies(&self) -> Vec<Box<dyn FnOnce() + Send + Sync + 'static>> {
+		type ShutdownPolicy = Box<dyn FnOnce() + Send + Sync + 'static>;
+
 		self
 			.policies_by_key
-			.iter()
-			.filter_map(|(_, v)| v.policy.as_frontend())
+			.values()
+			.filter_map(|v| v.policy.as_frontend())
 			.filter_map(|v| match v {
-				FrontendPolicy::Tracing(t) => Some(t.clone()),
+				FrontendPolicy::Tracing(t) => {
+					let tracer_policy = Arc::clone(t);
+					Some(Box::new(move || {
+						if let Some(t) = tracer_policy.tracer.get() {
+							t.shutdown()
+						}
+					}) as ShutdownPolicy)
+				},
+				FrontendPolicy::AccessLog(t) => {
+					let access_log_policy = t.access_log_policy.clone();
+					Some(Box::new(move || {
+						if let Some(t) = access_log_policy.as_ref().and_then(|l| l.logger.get()) {
+							t.shutdown()
+						}
+					}) as ShutdownPolicy)
+				},
 				_ => None,
 			})
 			.collect_vec()
 	}
-	pub fn all_access_log_policies(&self) -> Vec<Arc<crate::types::agent::AccessLogPolicy>> {
-		self
-			.binds
-			.values()
-			.flat_map(|bind| {
-				bind
-					.listeners
-					.iter()
-					.map(|listener| self.listener_frontend_policies(&listener.name))
-			})
-			.filter_map(|fp| fp.access_log_otlp)
-			.unique_by(|p| Arc::as_ptr(p) as usize)
-			.collect_vec()
-	}
+
 	pub fn frontend_policies(&self, gateway: PolicyTargetRef) -> FrontendPolices {
 		let gw_rules = self.policies_by_target.get(&gateway);
 		let rules = gw_rules
@@ -834,14 +837,19 @@ impl Store {
 		rules.for_each(|r| pol.set_if_empty(r));
 		pol
 	}
-
-	pub fn listener_frontend_policies(&self, name: &ListenerName) -> FrontendPolices {
+	pub fn listener_frontend_policies(
+		&self,
+		name: &ListenerName,
+		service: Option<PolicyTargetRef>,
+	) -> FrontendPolices {
 		let gateway = self.policies_by_target.get(&name.as_gateway_target_ref());
 		let listener = self.policies_by_target.get(&name.as_listener_target_ref());
-		let rules = listener
+		let svc = service.and_then(|s| self.policies_by_target.get(&s));
+		let rules = svc
 			.iter()
 			.copied()
 			.flatten()
+			.chain(listener.iter().copied().flatten())
 			.chain(gateway.iter().copied().flatten())
 			.filter_map(|n| self.policies_by_key.get(n))
 			.filter_map(|p| p.policy.as_frontend());
@@ -1308,10 +1316,16 @@ impl Store {
 pub struct StoreUpdater {
 	state: Arc<RwLock<Store>>,
 }
-
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RoutesDump {
+	http_mesh: HashMap<NamespacedHostname, RouteSet>,
+	tcp_mesh: HashMap<NamespacedHostname, TCPRouteSet>,
+}
 #[derive(serde::Serialize)]
 pub struct Dump {
 	binds: Vec<Arc<Bind>>,
+	routes: RoutesDump,
 	policies: Vec<Arc<TargetedPolicy>>,
 	backends: Vec<Arc<BackendWithPolicies>>,
 }
@@ -1328,6 +1342,7 @@ impl StoreUpdater {
 	}
 	pub fn dump(&self) -> Dump {
 		let store = self.state.read().expect("mutex");
+
 		// Services all have hostname, so use that as the key
 		let binds: Vec<_> = store
 			.binds
@@ -1351,6 +1366,10 @@ impl StoreUpdater {
 			binds,
 			policies,
 			backends,
+			routes: RoutesDump {
+				http_mesh: store.service_routes.clone(),
+				tcp_mesh: store.service_tcp_routes.clone(),
+			},
 		}
 	}
 	pub fn sync_local(
@@ -1636,7 +1655,7 @@ mod tests {
 		insert_gateway_level_frontend_policy(&mut store, &listener, "gw_remove");
 		insert_listener_level_frontend_policy(&mut store, &listener, "listener_remove");
 
-		let merged_pols = store.listener_frontend_policies(&listener);
+		let merged_pols = store.listener_frontend_policies(&listener, None);
 		// Verify that listener policy takes precedence over gateway policy
 		assert!(
 			merged_pols.access_log.is_some(),

--- a/crates/agentgateway/src/transport/stream.rs
+++ b/crates/agentgateway/src/transport/stream.rs
@@ -63,6 +63,13 @@ pub struct HBONEConnectionInfo {
 	pub hbone_address: SocketAddr,
 }
 
+/// WaypointTLSInfo indicates if TLS sniffing should be performed
+/// for waypoint traffic based on the service port's appProtocol.
+#[derive(Debug, Clone)]
+pub struct WaypointTLSInfo {
+	pub should_sniff_tls: bool,
+}
+
 #[derive(Debug, Default)]
 pub struct Metrics {
 	counter: Option<BytesCounter>,
@@ -531,6 +538,13 @@ impl Extension {
 	}
 	fn wrap(ext: Arc<Extension>) -> Self {
 		Extension::Wrapped(http::Extensions::new(), ext)
+	}
+
+	pub fn remove<T: Clone + Send + Sync + 'static>(&mut self) -> Option<T> {
+		match self {
+			Extension::Single(extensions) => extensions.remove(),
+			Extension::Wrapped(extensions, _) => extensions.remove(),
+		}
 	}
 
 	pub fn insert<T: Clone + Send + Sync + 'static>(&mut self, val: T) -> Option<T> {


### PR DESCRIPTION
This is like setting HTTP_PROXY=xyz but done with explicit policies not implicit.

We support a subset of policies only on the tunnel connection: HTTP/1.1 only, authentication, and TLS.

TODO before merging: auth is hardcoded in a weird way right now pending the backend auth customization