### PR TITLE
Drop more 'kgateway' names

### DIFF
--- a/controller/pkg/kgateway/agentgatewaysyncer/krtxds/xds.go
+++ b/controller/pkg/kgateway/agentgatewaysyncer/krtxds/xds.go
@@ -47,7 +47,7 @@ import (
 
 var (
 	log                 = logging.New("krtxds")
-	agentGwXdsSubsystem = "agentgateway_xds"
+	agentGwXdsSubsystem = "xds"
 	xdsRejectsTotal     = metrics.NewCounter(
 		metrics.CounterOpts{
 			Subsystem: agentGwXdsSubsystem,

--- a/controller/pkg/kgateway/helm/agentgateway/templates/_helpers.tpl
+++ b/controller/pkg/kgateway/helm/agentgateway/templates/_helpers.tpl
@@ -51,8 +51,7 @@ All labels including selector labels, standard labels, and custom gateway labels
 {{- define "kgateway.gateway.allLabels" -}}
 {{- $gateway := .Values.agentgateway -}}
 {{- $labels := merge (dict
-  "kgateway" "kube-gateway"
-  "app.kubernetes.io/managed-by" "kgateway"
+  "app.kubernetes.io/managed-by" "agentgateway"
   "gateway.networking.k8s.io/gateway-class-name" .Values.agentgateway.gatewayClassName
   )
   (include "kgateway.gateway.selectorLabels" . | fromYaml)

--- a/controller/pkg/kgateway/helm/agentgateway/templates/deployment.yaml
+++ b/controller/pkg/kgateway/helm/agentgateway/templates/deployment.yaml
@@ -208,7 +208,7 @@ spec:
           projected:
             sources:
             - serviceAccountToken:
-                audience: kgateway
+                audience: agentgateway
                 expirationSeconds: 43200
                 path: xds-token
         - name: tmp

--- a/controller/pkg/kgateway/setup/authn.go
+++ b/controller/pkg/kgateway/setup/authn.go
@@ -20,7 +20,7 @@ const (
 	bearerTokenPrefix = "Bearer "
 )
 
-var xdsTokenAudiences = []string{"kgateway"}
+var xdsTokenAudiences = []string{"kgateway", "agentgateway"}
 
 // KubeJWTAuthenticator authenticates K8s JWTs.
 type KubeJWTAuthenticator struct {

--- a/controller/pkg/metrics/cmd/findmetrics/main.go
+++ b/controller/pkg/metrics/cmd/findmetrics/main.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 )
 
-const defaultNamespace = "kgateway"
+const defaultNamespace = "agentgateway"
 
 type metricInfo struct {
 	File      string

--- a/controller/pkg/metrics/metrics.go
+++ b/controller/pkg/metrics/metrics.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	// DefaultNamespace is the default namespace used for all metrics.
-	DefaultNamespace = "kgateway"
+	DefaultNamespace = "agentgateway"
 )
 
 var (

--- a/controller/pkg/metrics/metrics_test.go
+++ b/controller/pkg/metrics/metrics_test.go
@@ -28,7 +28,7 @@ func TestCounterInterface(t *testing.T) {
 	counter.Inc(Label{Name: "label1", Value: "value1"}, Label{Name: "label2", Value: "value2"})
 
 	gathered := metricstest.MustGatherMetrics(t)
-	gathered.AssertMetric("kgateway_test_total", &metricstest.ExpectedMetric{
+	gathered.AssertMetric("agentgateway_test_total", &metricstest.ExpectedMetric{
 		Labels: []Label{
 			{Name: "label1", Value: "value1"},
 			{Name: "label2", Value: "value2"},
@@ -38,7 +38,7 @@ func TestCounterInterface(t *testing.T) {
 
 	counter.Add(5.0, Label{Name: "label1", Value: "value1"}, Label{Name: "label2", Value: "value2"})
 	gathered = metricstest.MustGatherMetrics(t)
-	gathered.AssertMetric("kgateway_test_total", &metricstest.ExpectedMetric{
+	gathered.AssertMetric("agentgateway_test_total", &metricstest.ExpectedMetric{
 		Labels: []Label{
 			{Name: "label1", Value: "value1"},
 			{Name: "label2", Value: "value2"},
@@ -49,7 +49,7 @@ func TestCounterInterface(t *testing.T) {
 	counter.Reset()
 	gathered = metricstest.MustGatherMetrics(t)
 	// After reset, counter exists with value 0 and empty label values
-	gathered.AssertMetric("kgateway_test_total", &metricstest.ExpectedMetric{
+	gathered.AssertMetric("agentgateway_test_total", &metricstest.ExpectedMetric{
 		Labels: []Label{
 			{Name: "label1", Value: ""},
 			{Name: "label2", Value: ""},
@@ -72,7 +72,7 @@ func TestCounterPartialLabels(t *testing.T) {
 	counter.Inc(Label{Name: "label3", Value: "value3"}, Label{Name: "label1", Value: "value1"})
 
 	gathered := metricstest.MustGatherMetrics(t)
-	gathered.AssertMetric("kgateway_test_total", &metricstest.ExpectedMetric{
+	gathered.AssertMetric("agentgateway_test_total", &metricstest.ExpectedMetric{
 		Labels: []Label{
 			{Name: "label1", Value: "value1"},
 			{Name: "label2", Value: ""},
@@ -96,7 +96,7 @@ func TestCounterNoLabels(t *testing.T) {
 	counter.Add(2.5)
 
 	gathered := metricstest.MustGatherMetrics(t)
-	gathered.AssertMetric("kgateway_test_total", &metricstest.ExpectedMetric{
+	gathered.AssertMetric("agentgateway_test_total", &metricstest.ExpectedMetric{
 		Labels: []Label{},
 		Value:  3.5,
 	})
@@ -132,19 +132,19 @@ func TestHistogramInterface(t *testing.T) {
 	histogram.Observe(2.5, Label{Name: "label1", Value: "value1"}, Label{Name: "label2", Value: "value2"})
 
 	gathered := metricstest.MustGatherMetrics(t)
-	gathered.AssertMetricHistogramValue("kgateway_test_duration_seconds", metricstest.HistogramMetricOutput{
+	gathered.AssertMetricHistogramValue("agentgateway_test_duration_seconds", metricstest.HistogramMetricOutput{
 		SampleCount: 2,
 		SampleSum:   4.0,
 	})
-	gathered.AssertMetricLabels("kgateway_test_duration_seconds", []Label{
+	gathered.AssertMetricLabels("agentgateway_test_duration_seconds", []Label{
 		{Name: "label1", Value: "value1"},
 		{Name: "label2", Value: "value2"},
 	})
-	gathered.AssertHistogramBuckets("kgateway_test_duration_seconds", DefaultBuckets)
+	gathered.AssertHistogramBuckets("agentgateway_test_duration_seconds", DefaultBuckets)
 
 	histogram.Reset()
 	gathered = metricstest.MustGatherMetrics(t)
-	gathered.AssertMetricNotExists("kgateway_test_duration_seconds")
+	gathered.AssertMetricNotExists("agentgateway_test_duration_seconds")
 }
 
 func TestHistogramBuckets(t *testing.T) {
@@ -163,15 +163,15 @@ func TestHistogramBuckets(t *testing.T) {
 	histogram.Observe(1.5, Label{Name: "label1", Value: "value1"}, Label{Name: "label2", Value: "value2"})
 
 	gathered := metricstest.MustGatherMetrics(t)
-	gathered.AssertMetricHistogramValue("kgateway_test_duration_seconds", metricstest.HistogramMetricOutput{
+	gathered.AssertMetricHistogramValue("agentgateway_test_duration_seconds", metricstest.HistogramMetricOutput{
 		SampleCount: 1,
 		SampleSum:   1.5,
 	})
-	gathered.AssertMetricLabels("kgateway_test_duration_seconds", []Label{
+	gathered.AssertMetricLabels("agentgateway_test_duration_seconds", []Label{
 		{Name: "label1", Value: "value1"},
 		{Name: "label2", Value: "value2"},
 	})
-	gathered.AssertHistogramBuckets("kgateway_test_duration_seconds", testBuckets)
+	gathered.AssertHistogramBuckets("agentgateway_test_duration_seconds", testBuckets)
 }
 
 func TestHistogramPartialLabels(t *testing.T) {
@@ -188,11 +188,11 @@ func TestHistogramPartialLabels(t *testing.T) {
 	histogram.Observe(3.14, Label{Name: "label1", Value: "value1"}, Label{Name: "label3", Value: "value3"})
 
 	gathered := metricstest.MustGatherMetrics(t)
-	gathered.AssertMetricHistogramValue("kgateway_test_duration_seconds_partial", metricstest.HistogramMetricOutput{
+	gathered.AssertMetricHistogramValue("agentgateway_test_duration_seconds_partial", metricstest.HistogramMetricOutput{
 		SampleCount: 1,
 		SampleSum:   3.14,
 	})
-	gathered.AssertMetricLabels("kgateway_test_duration_seconds_partial", []Label{
+	gathered.AssertMetricLabels("agentgateway_test_duration_seconds_partial", []Label{
 		{Name: "label1", Value: "value1"},
 		{Name: "label2", Value: ""},
 		{Name: "label3", Value: "value3"},
@@ -214,7 +214,7 @@ func TestHistogramNoLabels(t *testing.T) {
 	histogram.Observe(7.0)
 
 	gathered := metricstest.MustGatherMetrics(t)
-	gathered.AssertMetricHistogramValue("kgateway_test_duration_seconds_no_labels", metricstest.HistogramMetricOutput{
+	gathered.AssertMetricHistogramValue("agentgateway_test_duration_seconds_no_labels", metricstest.HistogramMetricOutput{
 		SampleCount: 3,
 		SampleSum:   9.0,
 	})
@@ -254,28 +254,28 @@ func TestGaugeInterface(t *testing.T) {
 	gauge.Set(10.0, labels...)
 
 	gathered := metricstest.MustGatherMetrics(t)
-	gathered.AssertMetric("kgateway_tests", &metricstest.ExpectedMetric{
+	gathered.AssertMetric("agentgateway_tests", &metricstest.ExpectedMetric{
 		Labels: labels,
 		Value:  10.0,
 	})
 
 	gauge.Add(5.0, labels...)
 	gathered = metricstest.MustGatherMetrics(t)
-	gathered.AssertMetric("kgateway_tests", &metricstest.ExpectedMetric{
+	gathered.AssertMetric("agentgateway_tests", &metricstest.ExpectedMetric{
 		Labels: labels,
 		Value:  15.0,
 	})
 
 	gauge.Sub(3.0, labels...)
 	gathered = metricstest.MustGatherMetrics(t)
-	gathered.AssertMetric("kgateway_tests", &metricstest.ExpectedMetric{
+	gathered.AssertMetric("agentgateway_tests", &metricstest.ExpectedMetric{
 		Labels: labels,
 		Value:  12.0,
 	})
 
 	gauge.Reset()
 	gathered = metricstest.MustGatherMetrics(t)
-	gathered.AssertMetricNotExists("kgateway_tests")
+	gathered.AssertMetricNotExists("agentgateway_tests")
 }
 
 func TestGaugePartialLabels(t *testing.T) {
@@ -292,7 +292,7 @@ func TestGaugePartialLabels(t *testing.T) {
 	gauge.Set(42.0, Label{Name: "label3", Value: "value3"}, Label{Name: "label1", Value: "value1"})
 
 	gathered := metricstest.MustGatherMetrics(t)
-	gathered.AssertMetric("kgateway_tests_partial", &metricstest.ExpectedMetric{
+	gathered.AssertMetric("agentgateway_tests_partial", &metricstest.ExpectedMetric{
 		Labels: []Label{
 			{Name: "label1", Value: "value1"},
 			{Name: "label2", Value: ""},
@@ -317,7 +317,7 @@ func TestGaugeNoLabels(t *testing.T) {
 	gauge.Sub(25.0)
 
 	gathered := metricstest.MustGatherMetrics(t)
-	gathered.AssertMetric("kgateway_tests_no_labels", &metricstest.ExpectedMetric{
+	gathered.AssertMetric("agentgateway_tests_no_labels", &metricstest.ExpectedMetric{
 		Labels: []Label{},
 		Value:  125.0,
 	})
@@ -392,7 +392,7 @@ func TestValidateLabelsOrder(t *testing.T) {
 
 	gathered := metricstest.MustGatherMetrics(t)
 	// Labels are provided to the metric in the order they are defined, and gathered in alphabetical order.
-	gathered.AssertMetric("kgateway_test_label_order_total", &metricstest.ExpectedMetric{
+	gathered.AssertMetric("agentgateway_test_label_order_total", &metricstest.ExpectedMetric{
 		Labels: []Label{
 			{Name: "a_label", Value: "a_value"},
 			{Name: "m_label", Value: "m_value"},
@@ -419,7 +419,7 @@ func TestLabelsWithEmptyValues(t *testing.T) {
 	)
 
 	gathered := metricstest.MustGatherMetrics(t)
-	gathered.AssertMetric("kgateway_test_empty_labels_total", &metricstest.ExpectedMetric{
+	gathered.AssertMetric("agentgateway_test_empty_labels_total", &metricstest.ExpectedMetric{
 		Labels: []Label{
 			{Name: "label1", Value: ""},
 			{Name: "label2", Value: "non_empty"},

--- a/controller/test/deployer/testdata/agentgateway-agwp-pod-scheduling-out.yaml
+++ b/controller/test/deployer/testdata/agentgateway-agwp-pod-scheduling-out.yaml
@@ -4,12 +4,11 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -20,12 +19,11 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -33,12 +31,11 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   ports:
@@ -59,12 +56,11 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   selector:
@@ -76,7 +72,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bb8bdc8cacbd1ae4af6e9f72baafbd5859e9422ade140b725464c0ec0d7fee9d
+        checksum/config: 864542ed2e0b0de7cfd066cda1995c0816d7b62bfd2ec96fd7eaa6f50f2624aa
         checksum/session-key: 2a8abfa8cb9906290437854193ca6bca41d4d4e26d1d454bd66a35158095e737
         gateway.kgateway.dev/gateway-full-name: gw
         prometheus.io/path: /metrics
@@ -215,7 +211,7 @@ spec:
         projected:
           sources:
           - serviceAccountToken:
-              audience: kgateway
+              audience: agentgateway
               expirationSeconds: 43200
               path: xds-token
       - emptyDir: {}

--- a/controller/test/deployer/testdata/agentgateway-aws-annotations-out.yaml
+++ b/controller/test/deployer/testdata/agentgateway-aws-annotations-out.yaml
@@ -4,12 +4,11 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -20,12 +19,11 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -38,12 +36,11 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-type: nlb
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   ports:
@@ -64,12 +61,11 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   selector:
@@ -81,7 +77,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bb8bdc8cacbd1ae4af6e9f72baafbd5859e9422ade140b725464c0ec0d7fee9d
+        checksum/config: 864542ed2e0b0de7cfd066cda1995c0816d7b62bfd2ec96fd7eaa6f50f2624aa
         checksum/session-key: 2a8abfa8cb9906290437854193ca6bca41d4d4e26d1d454bd66a35158095e737
         gateway.kgateway.dev/gateway-full-name: gw
         prometheus.io/path: /metrics
@@ -194,7 +190,7 @@ spec:
         projected:
           sources:
           - serviceAccountToken:
-              audience: kgateway
+              audience: agentgateway
               expirationSeconds: 43200
               path: xds-token
       - emptyDir: {}

--- a/controller/test/deployer/testdata/agentgateway-aws-nlb-dummy-port-out.yaml
+++ b/controller/test/deployer/testdata/agentgateway-aws-nlb-dummy-port-out.yaml
@@ -4,12 +4,11 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -20,12 +19,11 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -37,12 +35,11 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-type: external
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   loadBalancerClass: service.k8s.aws/nlb
@@ -64,12 +61,11 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   selector:
@@ -81,7 +77,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bb8bdc8cacbd1ae4af6e9f72baafbd5859e9422ade140b725464c0ec0d7fee9d
+        checksum/config: 864542ed2e0b0de7cfd066cda1995c0816d7b62bfd2ec96fd7eaa6f50f2624aa
         checksum/session-key: 2a8abfa8cb9906290437854193ca6bca41d4d4e26d1d454bd66a35158095e737
         gateway.kgateway.dev/gateway-full-name: gw
         prometheus.io/path: /metrics
@@ -194,7 +190,7 @@ spec:
         projected:
           sources:
           - serviceAccountToken:
-              audience: kgateway
+              audience: agentgateway
               expirationSeconds: 43200
               path: xds-token
       - emptyDir: {}

--- a/controller/test/deployer/testdata/agentgateway-azure-annotations-out.yaml
+++ b/controller/test/deployer/testdata/agentgateway-azure-annotations-out.yaml
@@ -4,12 +4,11 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -20,12 +19,11 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -36,12 +34,11 @@ metadata:
     service.beta.kubernetes.io/azure-load-balancer-resource-group: my-resource-group
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   ports:
@@ -62,12 +59,11 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   selector:
@@ -79,7 +75,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bb8bdc8cacbd1ae4af6e9f72baafbd5859e9422ade140b725464c0ec0d7fee9d
+        checksum/config: 864542ed2e0b0de7cfd066cda1995c0816d7b62bfd2ec96fd7eaa6f50f2624aa
         checksum/session-key: 2a8abfa8cb9906290437854193ca6bca41d4d4e26d1d454bd66a35158095e737
         gateway.kgateway.dev/gateway-full-name: gw
         prometheus.io/path: /metrics
@@ -192,7 +188,7 @@ spec:
         projected:
           sources:
           - serviceAccountToken:
-              audience: kgateway
+              audience: agentgateway
               expirationSeconds: 43200
               path: xds-token
       - emptyDir: {}

--- a/controller/test/deployer/testdata/agentgateway-both-gwc-and-gw-have-params-out.yaml
+++ b/controller/test/deployer/testdata/agentgateway-both-gwc-and-gw-have-params-out.yaml
@@ -4,12 +4,11 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: gw-using-gw-params
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw-using-gw-params
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw-using-gw-params
-    kgateway: kube-gateway
   name: gw-using-gw-params
 ---
 apiVersion: v1
@@ -20,12 +19,11 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: gw-using-gw-params
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw-using-gw-params
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw-using-gw-params
-    kgateway: kube-gateway
   name: gw-using-gw-params
 ---
 apiVersion: v1
@@ -33,12 +31,11 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: gw-using-gw-params
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw-using-gw-params
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw-using-gw-params
-    kgateway: kube-gateway
   name: gw-using-gw-params
 spec:
   ports:
@@ -59,12 +56,11 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: gw-using-gw-params
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw-using-gw-params
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw-using-gw-params
-    kgateway: kube-gateway
   name: gw-using-gw-params
 spec:
   replicas: 3
@@ -77,7 +73,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9fbb8893347ff0b7be4bf329b3534c0da22ae769bd6547471f071a1980dffd20
+        checksum/config: 426fb2c1a0ae3ebe84ee75bc413f97a5336c8aae36a37fcc583036985e2ab83a
         checksum/session-key: 2a8abfa8cb9906290437854193ca6bca41d4d4e26d1d454bd66a35158095e737
         gateway.kgateway.dev/gateway-full-name: gw-using-gw-params
         prometheus.io/path: /metrics
@@ -190,7 +186,7 @@ spec:
         projected:
           sources:
           - serviceAccountToken:
-              audience: kgateway
+              audience: agentgateway
               expirationSeconds: 43200
               path: xds-token
       - emptyDir: {}

--- a/controller/test/deployer/testdata/agentgateway-controller-but-custom-gatewayclass-out.yaml
+++ b/controller/test/deployer/testdata/agentgateway-controller-but-custom-gatewayclass-out.yaml
@@ -4,12 +4,11 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: a-lot-like-agentgateway-but-not-named-agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -20,12 +19,11 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: a-lot-like-agentgateway-but-not-named-agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -33,12 +31,11 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: a-lot-like-agentgateway-but-not-named-agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   ports:
@@ -59,12 +56,11 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: a-lot-like-agentgateway-but-not-named-agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   selector:
@@ -76,7 +72,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: fe1cb40e04ec34ac00a439d4b02f061f7b7217ee3a312cda8c5e1fddf51c8112
+        checksum/config: 7e79fd6596c1da330ef08ae4b1dca51cb738c968c4ce05bfae61d08b5d320a1a
         checksum/session-key: 2a8abfa8cb9906290437854193ca6bca41d4d4e26d1d454bd66a35158095e737
         gateway.kgateway.dev/gateway-full-name: gw
         prometheus.io/path: /metrics
@@ -189,7 +185,7 @@ spec:
         projected:
           sources:
           - serviceAccountToken:
-              audience: kgateway
+              audience: agentgateway
               expirationSeconds: 43200
               path: xds-token
       - emptyDir: {}

--- a/controller/test/deployer/testdata/agentgateway-custom-configmap-out.yaml
+++ b/controller/test/deployer/testdata/agentgateway-custom-configmap-out.yaml
@@ -4,12 +4,11 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: agentgateway
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: agentgateway
-    kgateway: kube-gateway
   name: agentgateway
 ---
 apiVersion: v1
@@ -20,12 +19,11 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: agentgateway
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: agentgateway
-    kgateway: kube-gateway
   name: agentgateway
 ---
 apiVersion: v1
@@ -33,12 +31,11 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: agentgateway
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: agentgateway
-    kgateway: kube-gateway
   name: agentgateway
 spec:
   ports:
@@ -59,12 +56,11 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: agentgateway
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: agentgateway
-    kgateway: kube-gateway
   name: agentgateway
 spec:
   selector:
@@ -76,7 +72,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 63173967f10317253d918f3354b522fc6d25c8f116d0201f34cc3bd72be3d496
+        checksum/config: ec135fae21e21f5a5230963218b244d7bd004d0d21da900292b3f317e4545a22
         checksum/session-key: 2a8abfa8cb9906290437854193ca6bca41d4d4e26d1d454bd66a35158095e737
         gateway.kgateway.dev/gateway-full-name: agentgateway
         prometheus.io/path: /metrics
@@ -189,7 +185,7 @@ spec:
         projected:
           sources:
           - serviceAccountToken:
-              audience: kgateway
+              audience: agentgateway
               expirationSeconds: 43200
               path: xds-token
       - emptyDir: {}

--- a/controller/test/deployer/testdata/agentgateway-deep-merging-out.yaml
+++ b/controller/test/deployer/testdata/agentgateway-deep-merging-out.yaml
@@ -4,12 +4,11 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -20,12 +19,11 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -33,12 +31,11 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   ports:
@@ -59,12 +56,11 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   selector:
@@ -76,7 +72,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bb8bdc8cacbd1ae4af6e9f72baafbd5859e9422ade140b725464c0ec0d7fee9d
+        checksum/config: 864542ed2e0b0de7cfd066cda1995c0816d7b62bfd2ec96fd7eaa6f50f2624aa
         checksum/session-key: 2a8abfa8cb9906290437854193ca6bca41d4d4e26d1d454bd66a35158095e737
         gateway.kgateway.dev/gateway-full-name: gw
         prometheus.io/path: /metrics
@@ -205,7 +201,7 @@ spec:
         projected:
           sources:
           - serviceAccountToken:
-              audience: kgateway
+              audience: agentgateway
               expirationSeconds: 43200
               path: xds-token
       - emptyDir: {}

--- a/controller/test/deployer/testdata/agentgateway-env-out.yaml
+++ b/controller/test/deployer/testdata/agentgateway-env-out.yaml
@@ -4,12 +4,11 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -20,12 +19,11 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -33,12 +31,11 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   ports:
@@ -59,12 +56,11 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   selector:
@@ -76,7 +72,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bb8bdc8cacbd1ae4af6e9f72baafbd5859e9422ade140b725464c0ec0d7fee9d
+        checksum/config: 864542ed2e0b0de7cfd066cda1995c0816d7b62bfd2ec96fd7eaa6f50f2624aa
         checksum/session-key: 2a8abfa8cb9906290437854193ca6bca41d4d4e26d1d454bd66a35158095e737
         gateway.kgateway.dev/gateway-full-name: gw
         prometheus.io/path: /metrics
@@ -193,7 +189,7 @@ spec:
         projected:
           sources:
           - serviceAccountToken:
-              audience: kgateway
+              audience: agentgateway
               expirationSeconds: 43200
               path: xds-token
       - emptyDir: {}

--- a/controller/test/deployer/testdata/agentgateway-gateway-addresses-out.yaml
+++ b/controller/test/deployer/testdata/agentgateway-gateway-addresses-out.yaml
@@ -4,12 +4,11 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -20,12 +19,11 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -33,12 +31,11 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   loadBalancerIP: 203.0.113.11
@@ -60,12 +57,11 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   selector:
@@ -77,7 +73,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bb8bdc8cacbd1ae4af6e9f72baafbd5859e9422ade140b725464c0ec0d7fee9d
+        checksum/config: 864542ed2e0b0de7cfd066cda1995c0816d7b62bfd2ec96fd7eaa6f50f2624aa
         checksum/session-key: 2a8abfa8cb9906290437854193ca6bca41d4d4e26d1d454bd66a35158095e737
         gateway.kgateway.dev/gateway-full-name: gw
         prometheus.io/path: /metrics
@@ -190,7 +186,7 @@ spec:
         projected:
           sources:
           - serviceAccountToken:
-              audience: kgateway
+              audience: agentgateway
               expirationSeconds: 43200
               path: xds-token
       - emptyDir: {}

--- a/controller/test/deployer/testdata/agentgateway-gke-subsetting-static-ip-out.yaml
+++ b/controller/test/deployer/testdata/agentgateway-gke-subsetting-static-ip-out.yaml
@@ -4,12 +4,11 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -20,12 +19,11 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -37,12 +35,11 @@ metadata:
     networking.gke.io/load-balancer-subnet: YOUR_SUBNET_NAME
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   ports:
@@ -63,12 +60,11 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   selector:
@@ -80,7 +76,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bb8bdc8cacbd1ae4af6e9f72baafbd5859e9422ade140b725464c0ec0d7fee9d
+        checksum/config: 864542ed2e0b0de7cfd066cda1995c0816d7b62bfd2ec96fd7eaa6f50f2624aa
         checksum/session-key: 2a8abfa8cb9906290437854193ca6bca41d4d4e26d1d454bd66a35158095e737
         gateway.kgateway.dev/gateway-full-name: gw
         prometheus.io/path: /metrics
@@ -193,7 +189,7 @@ spec:
         projected:
           sources:
           - serviceAccountToken:
-              audience: kgateway
+              audience: agentgateway
               expirationSeconds: 43200
               path: xds-token
       - emptyDir: {}

--- a/controller/test/deployer/testdata/agentgateway-hpa-overlay-out.yaml
+++ b/controller/test/deployer/testdata/agentgateway-hpa-overlay-out.yaml
@@ -4,12 +4,11 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -20,12 +19,11 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -33,12 +31,11 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   ports:
@@ -59,12 +56,11 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   selector:
@@ -76,7 +72,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bb8bdc8cacbd1ae4af6e9f72baafbd5859e9422ade140b725464c0ec0d7fee9d
+        checksum/config: 864542ed2e0b0de7cfd066cda1995c0816d7b62bfd2ec96fd7eaa6f50f2624aa
         checksum/session-key: 2a8abfa8cb9906290437854193ca6bca41d4d4e26d1d454bd66a35158095e737
         gateway.kgateway.dev/gateway-full-name: gw
         prometheus.io/path: /metrics
@@ -189,7 +185,7 @@ spec:
         projected:
           sources:
           - serviceAccountToken:
-              audience: kgateway
+              audience: agentgateway
               expirationSeconds: 43200
               path: xds-token
       - emptyDir: {}

--- a/controller/test/deployer/testdata/agentgateway-image-override-out.yaml
+++ b/controller/test/deployer/testdata/agentgateway-image-override-out.yaml
@@ -4,12 +4,11 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -20,12 +19,11 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -33,12 +31,11 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   ports:
@@ -59,12 +56,11 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   selector:
@@ -76,7 +72,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bb8bdc8cacbd1ae4af6e9f72baafbd5859e9422ade140b725464c0ec0d7fee9d
+        checksum/config: 864542ed2e0b0de7cfd066cda1995c0816d7b62bfd2ec96fd7eaa6f50f2624aa
         checksum/session-key: 2a8abfa8cb9906290437854193ca6bca41d4d4e26d1d454bd66a35158095e737
         gateway.kgateway.dev/gateway-full-name: gw
         prometheus.io/path: /metrics
@@ -190,7 +186,7 @@ spec:
         projected:
           sources:
           - serviceAccountToken:
-              audience: kgateway
+              audience: agentgateway
               expirationSeconds: 43200
               path: xds-token
       - emptyDir: {}

--- a/controller/test/deployer/testdata/agentgateway-image-pull-secrets-out.yaml
+++ b/controller/test/deployer/testdata/agentgateway-image-pull-secrets-out.yaml
@@ -4,12 +4,11 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -20,12 +19,11 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -33,12 +31,11 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   ports:
@@ -59,12 +56,11 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   selector:
@@ -76,7 +72,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bb8bdc8cacbd1ae4af6e9f72baafbd5859e9422ade140b725464c0ec0d7fee9d
+        checksum/config: 864542ed2e0b0de7cfd066cda1995c0816d7b62bfd2ec96fd7eaa6f50f2624aa
         checksum/session-key: 2a8abfa8cb9906290437854193ca6bca41d4d4e26d1d454bd66a35158095e737
         gateway.kgateway.dev/gateway-full-name: gw
         prometheus.io/path: /metrics
@@ -192,7 +188,7 @@ spec:
         projected:
           sources:
           - serviceAccountToken:
-              audience: kgateway
+              audience: agentgateway
               expirationSeconds: 43200
               path: xds-token
       - emptyDir: {}

--- a/controller/test/deployer/testdata/agentgateway-image-repo-only-out.yaml
+++ b/controller/test/deployer/testdata/agentgateway-image-repo-only-out.yaml
@@ -4,12 +4,11 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -20,12 +19,11 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -33,12 +31,11 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   ports:
@@ -59,12 +56,11 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   selector:
@@ -76,7 +72,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bb8bdc8cacbd1ae4af6e9f72baafbd5859e9422ade140b725464c0ec0d7fee9d
+        checksum/config: 864542ed2e0b0de7cfd066cda1995c0816d7b62bfd2ec96fd7eaa6f50f2624aa
         checksum/session-key: 2a8abfa8cb9906290437854193ca6bca41d4d4e26d1d454bd66a35158095e737
         gateway.kgateway.dev/gateway-full-name: gw
         prometheus.io/path: /metrics
@@ -189,7 +185,7 @@ spec:
         projected:
           sources:
           - serviceAccountToken:
-              audience: kgateway
+              audience: agentgateway
               expirationSeconds: 43200
               path: xds-token
       - emptyDir: {}

--- a/controller/test/deployer/testdata/agentgateway-infrastructure-out.yaml
+++ b/controller/test/deployer/testdata/agentgateway-infrastructure-out.yaml
@@ -8,13 +8,12 @@ metadata:
     prometheus.io/path: /something/else
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
     infra-and-params: infra
-    kgateway: kube-gateway
     my-label: my-value
   name: gw
 ---
@@ -30,13 +29,12 @@ metadata:
     prometheus.io/path: /something/else
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
     infra-and-params: infra
-    kgateway: kube-gateway
     my-label: my-value
   name: gw
 ---
@@ -49,13 +47,12 @@ metadata:
     prometheus.io/path: /something/else
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
     infra-and-params: infra
-    kgateway: kube-gateway
     my-label: my-value
   name: gw
 spec:
@@ -82,14 +79,13 @@ metadata:
     prometheus.io/path: /something/else
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     extra-label: v1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
     infra-and-params: params-but-only-because-overlays-happen-last
-    kgateway: kube-gateway
     my-label: my-value
   name: gw
 spec:
@@ -102,7 +98,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a1c83112dda602acaac811fc898dd49fe4c4736a4e4c7d895019293dc7ab1726
+        checksum/config: eecf8edcf37f75935e67bb280c4158573434f258386cad8ed2dc680782155efb
         checksum/session-key: 2a8abfa8cb9906290437854193ca6bca41d4d4e26d1d454bd66a35158095e737
         extra-annotation: v1
         gateway.kgateway.dev/gateway-full-name: gw
@@ -221,7 +217,7 @@ spec:
         projected:
           sources:
           - serviceAccountToken:
-              audience: kgateway
+              audience: agentgateway
               expirationSeconds: 43200
               path: xds-token
       - emptyDir: {}

--- a/controller/test/deployer/testdata/agentgateway-init-containers-out.yaml
+++ b/controller/test/deployer/testdata/agentgateway-init-containers-out.yaml
@@ -4,12 +4,11 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -20,12 +19,11 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -33,12 +31,11 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   ports:
@@ -59,12 +56,11 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   selector:
@@ -76,7 +72,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bb8bdc8cacbd1ae4af6e9f72baafbd5859e9422ade140b725464c0ec0d7fee9d
+        checksum/config: 864542ed2e0b0de7cfd066cda1995c0816d7b62bfd2ec96fd7eaa6f50f2624aa
         checksum/session-key: 2a8abfa8cb9906290437854193ca6bca41d4d4e26d1d454bd66a35158095e737
         gateway.kgateway.dev/gateway-full-name: gw
         prometheus.io/path: /metrics
@@ -197,7 +193,7 @@ spec:
         projected:
           sources:
           - serviceAccountToken:
-              audience: kgateway
+              audience: agentgateway
               expirationSeconds: 43200
               path: xds-token
       - emptyDir: {}

--- a/controller/test/deployer/testdata/agentgateway-istio-out.yaml
+++ b/controller/test/deployer/testdata/agentgateway-istio-out.yaml
@@ -4,12 +4,11 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -20,12 +19,11 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -33,12 +31,11 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   ports:
@@ -59,12 +56,11 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   selector:
@@ -76,7 +72,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bb8bdc8cacbd1ae4af6e9f72baafbd5859e9422ade140b725464c0ec0d7fee9d
+        checksum/config: 864542ed2e0b0de7cfd066cda1995c0816d7b62bfd2ec96fd7eaa6f50f2624aa
         checksum/session-key: 2a8abfa8cb9906290437854193ca6bca41d4d4e26d1d454bd66a35158095e737
         gateway.kgateway.dev/gateway-full-name: gw
         prometheus.io/path: /metrics
@@ -199,7 +195,7 @@ spec:
         projected:
           sources:
           - serviceAccountToken:
-              audience: kgateway
+              audience: agentgateway
               expirationSeconds: 43200
               path: xds-token
       - emptyDir: {}

--- a/controller/test/deployer/testdata/agentgateway-loadbalancer-static-ip-out.yaml
+++ b/controller/test/deployer/testdata/agentgateway-loadbalancer-static-ip-out.yaml
@@ -4,12 +4,11 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -20,12 +19,11 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -33,12 +31,11 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   loadBalancerIP: 2.2.2.2
@@ -60,12 +57,11 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   selector:
@@ -77,7 +73,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bb8bdc8cacbd1ae4af6e9f72baafbd5859e9422ade140b725464c0ec0d7fee9d
+        checksum/config: 864542ed2e0b0de7cfd066cda1995c0816d7b62bfd2ec96fd7eaa6f50f2624aa
         checksum/session-key: 2a8abfa8cb9906290437854193ca6bca41d4d4e26d1d454bd66a35158095e737
         gateway.kgateway.dev/gateway-full-name: gw
         prometheus.io/path: /metrics
@@ -190,7 +186,7 @@ spec:
         projected:
           sources:
           - serviceAccountToken:
-              audience: kgateway
+              audience: agentgateway
               expirationSeconds: 43200
               path: xds-token
       - emptyDir: {}

--- a/controller/test/deployer/testdata/agentgateway-logging-format-out.yaml
+++ b/controller/test/deployer/testdata/agentgateway-logging-format-out.yaml
@@ -4,12 +4,11 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -22,12 +21,11 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -35,12 +33,11 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   ports:
@@ -61,12 +58,11 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   selector:
@@ -78,7 +74,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 3b43d7224a1e97d7d32221cfa2bbcfae83e747b809dc8b5ca1357d0f3ecf20c8
+        checksum/config: b860a5f2ba1e1fc5aef2a9c73ae2ccc3c663a0fd4da4030e82a63cff7fb1eee1
         checksum/session-key: 2a8abfa8cb9906290437854193ca6bca41d4d4e26d1d454bd66a35158095e737
         gateway.kgateway.dev/gateway-full-name: gw
         prometheus.io/path: /metrics
@@ -191,7 +187,7 @@ spec:
         projected:
           sources:
           - serviceAccountToken:
-              audience: kgateway
+              audience: agentgateway
               expirationSeconds: 43200
               path: xds-token
       - emptyDir: {}

--- a/controller/test/deployer/testdata/agentgateway-long-gateway-name-exactly-63-chars-out.yaml
+++ b/controller/test/deployer/testdata/agentgateway-long-gateway-name-exactly-63-chars-out.yaml
@@ -4,12 +4,11 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: very-long-gateway-name-that-is-exactly-sixty-three-characterslo
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: very-long-gateway-name-that-is-exactly-sixty-three-characterslo
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: very-long-gateway-name-that-is-exactly-sixty-three-characterslo
-    kgateway: kube-gateway
   name: very-long-gateway-name-that-is-exactly-sixty-three-characterslo
 ---
 apiVersion: v1
@@ -20,12 +19,11 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: very-long-gateway-name-that-is-exactly-sixty-three-characterslo
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: very-long-gateway-name-that-is-exactly-sixty-three-characterslo
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: very-long-gateway-name-that-is-exactly-sixty-three-characterslo
-    kgateway: kube-gateway
   name: very-long-gateway-name-that-is-exactly-sixty-three-characterslo
 ---
 apiVersion: v1
@@ -33,12 +31,11 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: very-long-gateway-name-that-is-exactly-sixty-three-characterslo
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: very-long-gateway-name-that-is-exactly-sixty-three-characterslo
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: very-long-gateway-name-that-is-exactly-sixty-three-characterslo
-    kgateway: kube-gateway
   name: very-long-gateway-name-that-is-exactly-sixty-three-characterslo
 spec:
   ports:
@@ -59,12 +56,11 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: very-long-gateway-name-that-is-exactly-sixty-three-characterslo
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: very-long-gateway-name-that-is-exactly-sixty-three-characterslo
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: very-long-gateway-name-that-is-exactly-sixty-three-characterslo
-    kgateway: kube-gateway
   name: very-long-gateway-name-that-is-exactly-sixty-three-characterslo
 spec:
   selector:
@@ -76,7 +72,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bd5a792abb7811a8cd7c81d8acfed9ae4be83332ee2972d4df458f37c4912c01
+        checksum/config: fc5678ba92359577972aaaa85efec2259cd1aa1e474fcbada2d474bfcb9a6512
         checksum/session-key: 2a8abfa8cb9906290437854193ca6bca41d4d4e26d1d454bd66a35158095e737
         gateway.kgateway.dev/gateway-full-name: very-long-gateway-name-that-is-exactly-sixty-three-characterslo
         prometheus.io/path: /metrics
@@ -189,7 +185,7 @@ spec:
         projected:
           sources:
           - serviceAccountToken:
-              audience: kgateway
+              audience: agentgateway
               expirationSeconds: 43200
               path: xds-token
       - emptyDir: {}

--- a/controller/test/deployer/testdata/agentgateway-long-gateway-name-over-63-chars-out.yaml
+++ b/controller/test/deployer/testdata/agentgateway-long-gateway-name-over-63-chars-out.yaml
@@ -4,12 +4,11 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: extremely-long-gateway-name-that-exceeds-the-sixty-ff41b39ff097
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: extremely-long-gateway-name-that-exceeds-the-sixty-ff41b39ff097
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: extremely-long-gateway-name-that-exceeds-the-sixty-ff41b39ff097
-    kgateway: kube-gateway
   name: extremely-long-gateway-name-that-exceeds-the-sixty-ff41b39ff097
 ---
 apiVersion: v1
@@ -20,12 +19,11 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: extremely-long-gateway-name-that-exceeds-the-sixty-ff41b39ff097
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: extremely-long-gateway-name-that-exceeds-the-sixty-ff41b39ff097
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: extremely-long-gateway-name-that-exceeds-the-sixty-ff41b39ff097
-    kgateway: kube-gateway
   name: extremely-long-gateway-name-that-exceeds-the-sixty-ff41b39ff097
 ---
 apiVersion: v1
@@ -33,12 +31,11 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: extremely-long-gateway-name-that-exceeds-the-sixty-ff41b39ff097
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: extremely-long-gateway-name-that-exceeds-the-sixty-ff41b39ff097
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: extremely-long-gateway-name-that-exceeds-the-sixty-ff41b39ff097
-    kgateway: kube-gateway
   name: extremely-long-gateway-name-that-exceeds-the-sixty-ff41b39ff097
 spec:
   ports:
@@ -59,12 +56,11 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: extremely-long-gateway-name-that-exceeds-the-sixty-ff41b39ff097
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: extremely-long-gateway-name-that-exceeds-the-sixty-ff41b39ff097
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: extremely-long-gateway-name-that-exceeds-the-sixty-ff41b39ff097
-    kgateway: kube-gateway
   name: extremely-long-gateway-name-that-exceeds-the-sixty-ff41b39ff097
 spec:
   selector:
@@ -76,7 +72,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: aaf5e2738c763c66015fbfc634d35ab6ccf946d18956c1ad787c730ba03aa5d4
+        checksum/config: 20e03375ff2a736462894456b982110ca3e7b8ba58eab83c6f2e936be3e714ba
         checksum/session-key: 2a8abfa8cb9906290437854193ca6bca41d4d4e26d1d454bd66a35158095e737
         gateway.kgateway.dev/gateway-full-name: extremely-long-gateway-name-that-exceeds-the-sixty-three-character-limit-imposed-by-kubernetes-dns-naming-requirements
         prometheus.io/path: /metrics
@@ -189,7 +185,7 @@ spec:
         projected:
           sources:
           - serviceAccountToken:
-              audience: kgateway
+              audience: agentgateway
               expirationSeconds: 43200
               path: xds-token
       - emptyDir: {}

--- a/controller/test/deployer/testdata/agentgateway-omitdefaultsecuritycontext-out.yaml
+++ b/controller/test/deployer/testdata/agentgateway-omitdefaultsecuritycontext-out.yaml
@@ -4,12 +4,11 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -20,12 +19,11 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -33,12 +31,11 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   ports:
@@ -59,12 +56,11 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   selector:
@@ -76,7 +72,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bb8bdc8cacbd1ae4af6e9f72baafbd5859e9422ade140b725464c0ec0d7fee9d
+        checksum/config: 864542ed2e0b0de7cfd066cda1995c0816d7b62bfd2ec96fd7eaa6f50f2624aa
         checksum/session-key: 2a8abfa8cb9906290437854193ca6bca41d4d4e26d1d454bd66a35158095e737
         gateway.kgateway.dev/gateway-full-name: gw
         prometheus.io/path: /metrics
@@ -178,7 +174,7 @@ spec:
         projected:
           sources:
           - serviceAccountToken:
-              audience: kgateway
+              audience: agentgateway
               expirationSeconds: 43200
               path: xds-token
       - emptyDir: {}

--- a/controller/test/deployer/testdata/agentgateway-omitdefaultsecuritycontext-ref-gwp-on-gw-out.yaml
+++ b/controller/test/deployer/testdata/agentgateway-omitdefaultsecuritycontext-ref-gwp-on-gw-out.yaml
@@ -4,12 +4,11 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -20,12 +19,11 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -33,12 +31,11 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   ports:
@@ -59,12 +56,11 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   selector:
@@ -76,7 +72,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bb8bdc8cacbd1ae4af6e9f72baafbd5859e9422ade140b725464c0ec0d7fee9d
+        checksum/config: 864542ed2e0b0de7cfd066cda1995c0816d7b62bfd2ec96fd7eaa6f50f2624aa
         checksum/session-key: 2a8abfa8cb9906290437854193ca6bca41d4d4e26d1d454bd66a35158095e737
         gateway.kgateway.dev/gateway-full-name: gw
         prometheus.io/path: /metrics
@@ -178,7 +174,7 @@ spec:
         projected:
           sources:
           - serviceAccountToken:
-              audience: kgateway
+              audience: agentgateway
               expirationSeconds: 43200
               path: xds-token
       - emptyDir: {}

--- a/controller/test/deployer/testdata/agentgateway-out.yaml
+++ b/controller/test/deployer/testdata/agentgateway-out.yaml
@@ -4,12 +4,11 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -20,12 +19,11 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -33,12 +31,11 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   ports:
@@ -59,12 +56,11 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   selector:
@@ -76,7 +72,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bb8bdc8cacbd1ae4af6e9f72baafbd5859e9422ade140b725464c0ec0d7fee9d
+        checksum/config: 864542ed2e0b0de7cfd066cda1995c0816d7b62bfd2ec96fd7eaa6f50f2624aa
         checksum/session-key: 2a8abfa8cb9906290437854193ca6bca41d4d4e26d1d454bd66a35158095e737
         gateway.kgateway.dev/gateway-full-name: gw
         prometheus.io/path: /metrics
@@ -189,7 +185,7 @@ spec:
         projected:
           sources:
           - serviceAccountToken:
-              audience: kgateway
+              audience: agentgateway
               expirationSeconds: 43200
               path: xds-token
       - emptyDir: {}

--- a/controller/test/deployer/testdata/agentgateway-params-primary-out.yaml
+++ b/controller/test/deployer/testdata/agentgateway-params-primary-out.yaml
@@ -4,12 +4,11 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -20,12 +19,11 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -35,12 +33,11 @@ metadata:
     service-overlay-annotation: from-overlay
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   ports:
@@ -67,12 +64,11 @@ metadata:
     deployment-overlay-annotation: from-overlay
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   selector:
@@ -84,7 +80,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bb8bdc8cacbd1ae4af6e9f72baafbd5859e9422ade140b725464c0ec0d7fee9d
+        checksum/config: 864542ed2e0b0de7cfd066cda1995c0816d7b62bfd2ec96fd7eaa6f50f2624aa
         checksum/session-key: 2a8abfa8cb9906290437854193ca6bca41d4d4e26d1d454bd66a35158095e737
         deployment-overlay-annotation: from-overlay
         gateway.kgateway.dev/gateway-full-name: gw
@@ -205,7 +201,7 @@ spec:
         projected:
           sources:
           - serviceAccountToken:
-              audience: kgateway
+              audience: agentgateway
               expirationSeconds: 43200
               path: xds-token
       - emptyDir: {}

--- a/controller/test/deployer/testdata/agentgateway-pdb-overlay-out.yaml
+++ b/controller/test/deployer/testdata/agentgateway-pdb-overlay-out.yaml
@@ -4,12 +4,11 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -20,12 +19,11 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -33,12 +31,11 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   ports:
@@ -59,12 +56,11 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   selector:
@@ -76,7 +72,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bb8bdc8cacbd1ae4af6e9f72baafbd5859e9422ade140b725464c0ec0d7fee9d
+        checksum/config: 864542ed2e0b0de7cfd066cda1995c0816d7b62bfd2ec96fd7eaa6f50f2624aa
         checksum/session-key: 2a8abfa8cb9906290437854193ca6bca41d4d4e26d1d454bd66a35158095e737
         gateway.kgateway.dev/gateway-full-name: gw
         prometheus.io/path: /metrics
@@ -189,7 +185,7 @@ spec:
         projected:
           sources:
           - serviceAccountToken:
-              audience: kgateway
+              audience: agentgateway
               expirationSeconds: 43200
               path: xds-token
       - emptyDir: {}

--- a/controller/test/deployer/testdata/agentgateway-rawconfig-binds-out.yaml
+++ b/controller/test/deployer/testdata/agentgateway-rawconfig-binds-out.yaml
@@ -4,12 +4,11 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -32,12 +31,11 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -45,12 +43,11 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   ports:
@@ -71,12 +68,11 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   selector:
@@ -88,7 +84,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 407c0f4790d6c546dcd3f6e25d851393551583ac234d4effaf03520f6a53e2c8
+        checksum/config: c8dd0eededbc1e356c9c03047ef174e0e43b23917db0164e3aa32b571a78e9fd
         checksum/session-key: 2a8abfa8cb9906290437854193ca6bca41d4d4e26d1d454bd66a35158095e737
         gateway.kgateway.dev/gateway-full-name: gw
         prometheus.io/path: /metrics
@@ -201,7 +197,7 @@ spec:
         projected:
           sources:
           - serviceAccountToken:
-              audience: kgateway
+              audience: agentgateway
               expirationSeconds: 43200
               path: xds-token
       - emptyDir: {}

--- a/controller/test/deployer/testdata/agentgateway-rawconfig-typed-conflict-out.yaml
+++ b/controller/test/deployer/testdata/agentgateway-rawconfig-typed-conflict-out.yaml
@@ -4,12 +4,11 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -24,12 +23,11 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -37,12 +35,11 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   ports:
@@ -63,12 +60,11 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   selector:
@@ -80,7 +76,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: cbf0b8cbd77bdcbda8bab51122412ace9f28b61e8dd3c8a2680b7a3d19d7b19e
+        checksum/config: 0e387a33b1316b17067364d03b2be59a8eafe945a7d908c7eb46038d4a64886a
         checksum/session-key: 2a8abfa8cb9906290437854193ca6bca41d4d4e26d1d454bd66a35158095e737
         gateway.kgateway.dev/gateway-full-name: gw
         prometheus.io/path: /metrics
@@ -193,7 +189,7 @@ spec:
         projected:
           sources:
           - serviceAccountToken:
-              audience: kgateway
+              audience: agentgateway
               expirationSeconds: 43200
               path: xds-token
       - emptyDir: {}

--- a/controller/test/deployer/testdata/agentgateway-replicas-out.yaml
+++ b/controller/test/deployer/testdata/agentgateway-replicas-out.yaml
@@ -4,12 +4,11 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -20,12 +19,11 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -33,12 +31,11 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   ports:
@@ -59,12 +56,11 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   replicas: 3
@@ -77,7 +73,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bb8bdc8cacbd1ae4af6e9f72baafbd5859e9422ade140b725464c0ec0d7fee9d
+        checksum/config: 864542ed2e0b0de7cfd066cda1995c0816d7b62bfd2ec96fd7eaa6f50f2624aa
         checksum/session-key: 2a8abfa8cb9906290437854193ca6bca41d4d4e26d1d454bd66a35158095e737
         gateway.kgateway.dev/gateway-full-name: gw
         prometheus.io/path: /metrics
@@ -190,7 +186,7 @@ spec:
         projected:
           sources:
           - serviceAccountToken:
-              audience: kgateway
+              audience: agentgateway
               expirationSeconds: 43200
               path: xds-token
       - emptyDir: {}

--- a/controller/test/deployer/testdata/agentgateway-sa-iam-annotations-out.yaml
+++ b/controller/test/deployer/testdata/agentgateway-sa-iam-annotations-out.yaml
@@ -6,12 +6,11 @@ metadata:
     eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/agentgateway-role
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -22,12 +21,11 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -35,12 +33,11 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   ports:
@@ -61,12 +58,11 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: ""
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   selector:
@@ -78,7 +74,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bb8bdc8cacbd1ae4af6e9f72baafbd5859e9422ade140b725464c0ec0d7fee9d
+        checksum/config: 864542ed2e0b0de7cfd066cda1995c0816d7b62bfd2ec96fd7eaa6f50f2624aa
         checksum/session-key: 2a8abfa8cb9906290437854193ca6bca41d4d4e26d1d454bd66a35158095e737
         gateway.kgateway.dev/gateway-full-name: gw
         prometheus.io/path: /metrics
@@ -191,7 +187,7 @@ spec:
         projected:
           sources:
           - serviceAccountToken:
-              audience: kgateway
+              audience: agentgateway
               expirationSeconds: 43200
               path: xds-token
       - emptyDir: {}

--- a/controller/test/deployer/testdata/agentgateway-security-context-out.yaml
+++ b/controller/test/deployer/testdata/agentgateway-security-context-out.yaml
@@ -4,12 +4,11 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -20,12 +19,11 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -33,12 +31,11 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   ports:
@@ -59,12 +56,11 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   selector:
@@ -76,7 +72,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bb8bdc8cacbd1ae4af6e9f72baafbd5859e9422ade140b725464c0ec0d7fee9d
+        checksum/config: 864542ed2e0b0de7cfd066cda1995c0816d7b62bfd2ec96fd7eaa6f50f2624aa
         checksum/session-key: 2a8abfa8cb9906290437854193ca6bca41d4d4e26d1d454bd66a35158095e737
         gateway.kgateway.dev/gateway-full-name: gw
         prometheus.io/path: /metrics
@@ -192,7 +188,7 @@ spec:
         projected:
           sources:
           - serviceAccountToken:
-              audience: kgateway
+              audience: agentgateway
               expirationSeconds: 43200
               path: xds-token
       - emptyDir: {}

--- a/controller/test/deployer/testdata/agentgateway-shutdown-out.yaml
+++ b/controller/test/deployer/testdata/agentgateway-shutdown-out.yaml
@@ -4,12 +4,11 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -20,12 +19,11 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -33,12 +31,11 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   ports:
@@ -59,12 +56,11 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   selector:
@@ -76,7 +72,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bb8bdc8cacbd1ae4af6e9f72baafbd5859e9422ade140b725464c0ec0d7fee9d
+        checksum/config: 864542ed2e0b0de7cfd066cda1995c0816d7b62bfd2ec96fd7eaa6f50f2624aa
         checksum/session-key: 2a8abfa8cb9906290437854193ca6bca41d4d4e26d1d454bd66a35158095e737
         gateway.kgateway.dev/gateway-full-name: gw
         prometheus.io/path: /metrics
@@ -189,7 +185,7 @@ spec:
         projected:
           sources:
           - serviceAccountToken:
-              audience: kgateway
+              audience: agentgateway
               expirationSeconds: 43200
               path: xds-token
       - emptyDir: {}

--- a/controller/test/deployer/testdata/agentgateway-sidecar-containers-out.yaml
+++ b/controller/test/deployer/testdata/agentgateway-sidecar-containers-out.yaml
@@ -4,12 +4,11 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -20,12 +19,11 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -33,12 +31,11 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   ports:
@@ -59,12 +56,11 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   selector:
@@ -76,7 +72,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bb8bdc8cacbd1ae4af6e9f72baafbd5859e9422ade140b725464c0ec0d7fee9d
+        checksum/config: 864542ed2e0b0de7cfd066cda1995c0816d7b62bfd2ec96fd7eaa6f50f2624aa
         checksum/session-key: 2a8abfa8cb9906290437854193ca6bca41d4d4e26d1d454bd66a35158095e737
         gateway.kgateway.dev/gateway-full-name: gw
         prometheus.io/path: /metrics
@@ -196,7 +192,7 @@ spec:
         projected:
           sources:
           - serviceAccountToken:
-              audience: kgateway
+              audience: agentgateway
               expirationSeconds: 43200
               path: xds-token
       - emptyDir: {}

--- a/controller/test/deployer/testdata/agentgateway-strategic-merge-patch-out.yaml
+++ b/controller/test/deployer/testdata/agentgateway-strategic-merge-patch-out.yaml
@@ -4,12 +4,11 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -20,12 +19,11 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -35,12 +33,11 @@ metadata:
     service-overlay-annotation: from-overlay
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   ports:
@@ -74,7 +71,6 @@ metadata:
     deployment-overlay-label2: from-overlay
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   selector:
@@ -86,7 +82,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bb8bdc8cacbd1ae4af6e9f72baafbd5859e9422ade140b725464c0ec0d7fee9d
+        checksum/config: 864542ed2e0b0de7cfd066cda1995c0816d7b62bfd2ec96fd7eaa6f50f2624aa
         checksum/session-key: 2a8abfa8cb9906290437854193ca6bca41d4d4e26d1d454bd66a35158095e737
         gateway.kgateway.dev/gateway-full-name: gw
         prometheus.io/path: /metrics

--- a/controller/test/deployer/testdata/agentgateway-tls-out.yaml
+++ b/controller/test/deployer/testdata/agentgateway-tls-out.yaml
@@ -4,12 +4,11 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -20,12 +19,11 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -49,12 +47,11 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw-xds-ca
 ---
 apiVersion: v1
@@ -62,12 +59,11 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   ports:
@@ -88,12 +84,11 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   selector:
@@ -105,7 +100,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bb8bdc8cacbd1ae4af6e9f72baafbd5859e9422ade140b725464c0ec0d7fee9d
+        checksum/config: 864542ed2e0b0de7cfd066cda1995c0816d7b62bfd2ec96fd7eaa6f50f2624aa
         checksum/session-key: 2a8abfa8cb9906290437854193ca6bca41d4d4e26d1d454bd66a35158095e737
         gateway.kgateway.dev/gateway-full-name: gw
         prometheus.io/path: /metrics
@@ -223,7 +218,7 @@ spec:
         projected:
           sources:
           - serviceAccountToken:
-              audience: kgateway
+              audience: agentgateway
               expirationSeconds: 43200
               path: xds-token
       - emptyDir: {}

--- a/controller/test/deployer/testdata/agentgateway-yaml-injection-out.yaml
+++ b/controller/test/deployer/testdata/agentgateway-yaml-injection-out.yaml
@@ -8,12 +8,11 @@ metadata:
       attack
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway-v2
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -30,12 +29,11 @@ metadata:
       attack
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway-v2
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 ---
 apiVersion: v1
@@ -47,12 +45,11 @@ metadata:
       attack
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway-v2
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   ports:
@@ -77,12 +74,11 @@ metadata:
       attack
   labels:
     app.kubernetes.io/instance: gw
-    app.kubernetes.io/managed-by: kgateway
+    app.kubernetes.io/managed-by: agentgateway
     app.kubernetes.io/name: gw
     app.kubernetes.io/version: 1.0.0-ci1
     gateway.networking.k8s.io/gateway-class-name: agentgateway-v2
     gateway.networking.k8s.io/gateway-name: gw
-    kgateway: kube-gateway
   name: gw
 spec:
   selector:
@@ -94,7 +90,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: b90a8eb34d3d5082498d2226b619beea258e6753371b9970790b026550cd2ec5
+        checksum/config: dd166b926ffac8d8a222e8cd90428a60e9ac01eff806f6aa3cb5b28ed9b54ac6
         checksum/session-key: 2a8abfa8cb9906290437854193ca6bca41d4d4e26d1d454bd66a35158095e737
         foo: |-
           bar
@@ -215,7 +211,7 @@ spec:
         projected:
           sources:
           - serviceAccountToken:
-              audience: kgateway
+              audience: agentgateway
               expirationSeconds: 43200
               path: xds-token
       - emptyDir: {}


### PR DESCRIPTION
* Drop a 'kgateway' label that had no use
* Change metrics to agentgateway_ prefix instead of kgateway_
* Use agentgateway as aud in xds token but support the old one in the
  control plane for compat
