### PR TITLE
fix(telemetry): logged error when otlpEndpoint has connectivity issues

### DIFF
--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -1267,7 +1267,8 @@ impl opentelemetry_sdk::logs::LogExporter for PolicyGrpcLogExporter {
 				.await
 				.map_err(|e| OTelSdkError::InternalFailure(e.to_string()))?
 				.map(|_| ())
-				.map_err(|e| OTelSdkError::InternalFailure(e.to_string())) as OTelSdkResult
+				.map_err(|e: tonic::Status| OTelSdkError::InternalFailure(e.message().to_string()))
+				as OTelSdkResult
 		}
 	}
 

--- a/crates/agentgateway/src/telemetry/trc.rs
+++ b/crates/agentgateway/src/telemetry/trc.rs
@@ -317,7 +317,8 @@ impl opentelemetry_sdk::trace::SpanExporter for PolicyGrpcSpanExporter {
 				.await
 				.map_err(|e| OTelSdkError::InternalFailure(e.to_string()))?
 				.map(|_| ())
-				.map_err(|e| OTelSdkError::InternalFailure(e.to_string())) as OTelSdkResult
+				.map_err(|e: tonic::Status| OTelSdkError::InternalFailure(e.message().to_string()))
+				as OTelSdkResult
 		}
 	}
 


### PR DESCRIPTION
When setting a tracing `otlpEndpoint` if there are connectivity issues agentgateway currently 

Example config:
```yaml
config:
  tracing:
    otlpEndpoint: http://invalid-host:4317
    randomSampling: true
...
```

**Before:**
```
error opentelemetry_sdk  name="BatchSpanProcessor.ExportError"  error="Operation failed: code: 'Unknown error', message: \"upstream call failed: Connect: Connection refused (os error 61)\", source: upstream call failed: Connect: Connection refused (os error 61)"
```

With `RUST_BACKTRACE=1` enabled
```
error opentelemetry_sdk  name="BatchSpanProcessor.ExportError" error="Operation failed: code: 'Unknown error', message: \"upstream call failed: Connect: Connection refused (os error 61)\", source: upstream call failed: Connect: Connection refused (os error 61)\n\nStack backtrace:\n   0: std::backtrace_rs::backtrace::libunwind::trace\n  ......... lib/rustlib/src/rust/library/std/src/rt.rs:205:5\n  63: _main"
```

**After:**
```
error opentelemetry_sdk  name="BatchSpanProcessor.ExportError" error="Operation failed: upstream call failed: Connect: Connection refused (os error 61)"
```
