### PR TITLE
chore: bump inference extension to v1.4.0-rc.2

### DIFF
--- a/controller/hack/utils/oss_compliance/osa_provided.md
+++ b/controller/hack/utils/oss_compliance/osa_provided.md
@@ -47,8 +47,8 @@ Name|Version|License
 [sigs.k8s.io/controller-runtime](https://sigs.k8s.io/controller-runtime)|v0.23.1|Apache License 2.0
 [sigs.k8s.io/controller-tools](https://sigs.k8s.io/controller-tools)|v0.20.1|Apache License 2.0
 [sigs.k8s.io/gateway-api](https://sigs.k8s.io/gateway-api)|v1.5.0|Apache License 2.0
-[sigs.k8s.io/gateway-api-inference-extension](https://sigs.k8s.io/gateway-api-inference-extension)|v1.4.0-rc.1|Apache License 2.0
-[gateway-api-inference-extension/conformance](https://sigs.k8s.io/gateway-api-inference-extension/conformance)|v0.0.0-20260303210102-8f057d769fa6|Apache License 2.0
+[sigs.k8s.io/gateway-api-inference-extension](https://sigs.k8s.io/gateway-api-inference-extension)|v1.4.0-rc.2|Apache License 2.0
+[gateway-api-inference-extension/conformance](https://sigs.k8s.io/gateway-api-inference-extension/conformance)|v0.0.0-20260310170806-b32dfd041324|Apache License 2.0
 [gateway-api/conformance](https://sigs.k8s.io/gateway-api/conformance)|v1.5.1-0.20260302214453-c33c5449a202|Apache License 2.0
 [sigs.k8s.io/yaml](https://sigs.k8s.io/yaml)|v1.6.0|MIT License
 [cmd/goimports](https://golang.org/x/tools/cmd/goimports)|latest|MIT License

--- a/controller/pkg/kgateway/crds/inference-crds.yaml
+++ b/controller/pkg/kgateway/crds/inference-crds.yaml
@@ -1,10 +1,10 @@
-# Source: https://raw.githubusercontent.com/kubernetes-sigs/gateway-api-inference-extension/v1.1.0/config/crd/bases/inference.networking.k8s.io_inferencepools.yaml
+# Source: https://raw.githubusercontent.com/kubernetes-sigs/gateway-api-inference-extension/v1.4.0-rc.2/config/crd/bases/inference.networking.k8s.io_inferencepools.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/1173
-    inference.networking.k8s.io/bundle-version: v1.1.0
+    inference.networking.k8s.io/bundle-version: v1.4.0-rc.2
   name: inferencepools.inference.networking.k8s.io
 spec:
   group: inference.networking.k8s.io
@@ -43,6 +43,20 @@ spec:
           spec:
             description: Spec defines the desired state of the InferencePool.
             properties:
+              appProtocol:
+                default: http
+                description: |-
+                  AppProtocol describes the application protocol for all the target ports.
+
+                  If unspecified, the protocol defaults to HTTP/1.1.
+
+                  Supported values include:
+                  * "http": HTTP/1.1. This is the default.
+                  * "kubernetes.io/h2c": HTTP/2 over cleartext.
+                enum:
+                - http
+                - kubernetes.io/h2c
+                type: string
               endpointPickerRef:
                 description: |-
                   EndpointPickerRef is a reference to the Endpoint Picker extension and its
@@ -359,12 +373,12 @@ status:
   conditions: null
   storedVersions: null
 ---
-# Source: https://raw.githubusercontent.com/kubernetes-sigs/gateway-api-inference-extension/v1.1.0/config/crd/bases/inference.networking.x-k8s.io_inferenceobjectives.yaml
+# Source: https://raw.githubusercontent.com/kubernetes-sigs/gateway-api-inference-extension/v1.4.0-rc.2/config/crd/bases/inference.networking.x-k8s.io_inferenceobjectives.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    inference.networking.k8s.io/bundle-version: v1.1.0
+    inference.networking.k8s.io/bundle-version: v1.4.0-rc.2
   name: inferenceobjectives.inference.networking.x-k8s.io
 spec:
   group: inference.networking.x-k8s.io

--- a/go.mod
+++ b/go.mod
@@ -46,8 +46,8 @@ require (
 	sigs.k8s.io/controller-runtime v0.23.1
 	sigs.k8s.io/controller-tools v0.20.1
 	sigs.k8s.io/gateway-api v1.5.0
-	sigs.k8s.io/gateway-api-inference-extension v1.4.0-rc.1
-	sigs.k8s.io/gateway-api-inference-extension/conformance v0.0.0-20260303210102-8f057d769fa6
+	sigs.k8s.io/gateway-api-inference-extension v1.4.0-rc.2
+	sigs.k8s.io/gateway-api-inference-extension/conformance v0.0.0-20260310170806-b32dfd041324
 	sigs.k8s.io/gateway-api/conformance v1.5.1-0.20260302214453-c33c5449a202
 	sigs.k8s.io/yaml v1.6.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1225,10 +1225,10 @@ sigs.k8s.io/controller-tools v0.20.1 h1:gkfMt9YodI0K85oT8rVi80NTXO/kDmabKR5Ajn5G
 sigs.k8s.io/controller-tools v0.20.1/go.mod h1:b4qPmjGU3iZwqn34alUU5tILhNa9+VXK+J3QV0fT/uU=
 sigs.k8s.io/gateway-api v1.5.0 h1:duoo14Ky/fJXpjpmyMISE2RTBGnfCg8zICfTYLTnBJA=
 sigs.k8s.io/gateway-api v1.5.0/go.mod h1:GvCETiaMAlLym5CovLxGjS0NysqFk3+Yuq3/rh6QL2o=
-sigs.k8s.io/gateway-api-inference-extension v1.4.0-rc.1 h1:j0mbz140/+rLWLTgNQBKMu12CyXwKJ8CPXiGrAK9As4=
-sigs.k8s.io/gateway-api-inference-extension v1.4.0-rc.1/go.mod h1:Z9MZpf6wdjn9iCT5Xu6Ugqh88zSa0zuDra0VqJXT7eM=
-sigs.k8s.io/gateway-api-inference-extension/conformance v0.0.0-20260303210102-8f057d769fa6 h1:XTVeNHMsq8SE+qyH/yacB2aFigwCCc645/YOje5rx50=
-sigs.k8s.io/gateway-api-inference-extension/conformance v0.0.0-20260303210102-8f057d769fa6/go.mod h1:n+dkKGgLEdvx6W08kTQKPMbQDW5AtlayFAipEIgv4RA=
+sigs.k8s.io/gateway-api-inference-extension v1.4.0-rc.2 h1:M0EniqRq7wE8dVl6AHsQ6nr7iwHzoa8R8u2HyCkL1t8=
+sigs.k8s.io/gateway-api-inference-extension v1.4.0-rc.2/go.mod h1:Z9MZpf6wdjn9iCT5Xu6Ugqh88zSa0zuDra0VqJXT7eM=
+sigs.k8s.io/gateway-api-inference-extension/conformance v0.0.0-20260310170806-b32dfd041324 h1:ZuPG2eR+Dkw+P0lBhFtObneHltX1XyLemIcaM9YvasU=
+sigs.k8s.io/gateway-api-inference-extension/conformance v0.0.0-20260310170806-b32dfd041324/go.mod h1:ql30Yb8tsl1tE3VOvPcLda5DXxAJS3Z3LjAyDbCBV0c=
 sigs.k8s.io/gateway-api/conformance v1.5.1-0.20260302214453-c33c5449a202 h1:h+CiyT4ClVNky6kqqU8L6dy+VZ48JoVlviSkeV1KQK0=
 sigs.k8s.io/gateway-api/conformance v1.5.1-0.20260302214453-c33c5449a202/go.mod h1:mcvYR0Zll1i5hmcKn+jNbWdZTBls6s5GU+FPUFIceXw=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=


### PR DESCRIPTION
bump gateway-api-inference-extension to v1.4.0-rc.2

GIE conformance passed:

```sh
GatewayAPIInferenceExtensionVersion: v1.4.0-rc.2
apiVersion: gateway.networking.k8s.io/v1
date: "2026-03-11T14:47:17-07:00"
gatewayAPIChannel: experimental
gatewayAPIVersion: v1.5.0
implementation:
  contact:
  - github.com/agentgateway/agentgateway/issues/new/choose
  organization: agentgateway
  project: agentgateway
  url: github.com/agentgateway/agentgateway
  version: v0.0.2-rc.2
kind: ConformanceReport
mode: default
profiles:
- core:
    result: success
    statistics:
      Failed: 0
      Passed: 12
      Skipped: 0
  name: Gateway
  summary: Core tests succeeded.

```

xref https://github.com/agentgateway/agentgateway/issues/1195 to run GIE conformance from a local test harness.