### PR TITLE
make EINVAL not fatal on mac

### DIFF
--- a/crates/agentgateway/src/proxy/gateway.rs
+++ b/crates/agentgateway/src/proxy/gateway.rs
@@ -1115,10 +1115,16 @@ pub fn auto_server(c: Option<&frontend::HTTP>) -> auto::Builder<::hyper_util::rt
 	b
 }
 
-/// The listening socket itself is broken (EBADF, EINVAL, ENOTSOCK); retrying won't help.
+/// The listening socket itself is broken; retrying won't help.
+/// EBADF/ENOTSOCK: fd is dead on all platforms.
+/// EINVAL: permanent on Linux (socket not listening), transient on macOS (can recover).
 fn is_accept_error_permanent(e: &std::io::Error) -> bool {
-	matches!(e.kind(), std::io::ErrorKind::InvalidInput)
-		|| matches!(e.raw_os_error(), Some(libc::EBADF | libc::ENOTSOCK))
+	match e.raw_os_error() {
+		Some(libc::EBADF | libc::ENOTSOCK) => true,
+		#[cfg(target_os = "linux")]
+		Some(libc::EINVAL) => true,
+		_ => false,
+	}
 }
 
 /// Per-connection failure (client gone during handshake); harmless, no backoff needed.

--- a/crates/agentgateway/src/proxy/gateway_test.rs
+++ b/crates/agentgateway/src/proxy/gateway_test.rs
@@ -1424,9 +1424,14 @@ fn accept_error_classification() {
 	assert!(is_accept_error_permanent(&Error::from_raw_os_error(
 		libc::ENOTSOCK
 	)));
-	assert!(is_accept_error_permanent(&Error::new(
-		ErrorKind::InvalidInput,
-		"bad"
+	// EINVAL is permanent on Linux (socket not listening), but transient on macOS
+	#[cfg(target_os = "linux")]
+	assert!(is_accept_error_permanent(&Error::from_raw_os_error(
+		libc::EINVAL
+	)));
+	#[cfg(not(target_os = "linux"))]
+	assert!(!is_accept_error_permanent(&Error::from_raw_os_error(
+		libc::EINVAL
 	)));
 
 	// Per-connection errors: harmless, no backoff needed


### PR DESCRIPTION
looks like EINVAL behaves differently on Mac, so making it a permanent error would block the agent to work properly.
We could also just have all these fatal to go and be retried in case there are unknown, but from what I have read the other two are more consistent fatal, and also running locally the agent did not block