### PR TITLE
local: set default path match

### DIFF
--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -775,11 +775,16 @@ pub struct TCPRouteBackend {
 pub struct RouteMatch {
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub headers: Vec<HeaderMatch>,
+	#[serde(default = "default_route_match_path")]
 	pub path: PathMatch,
 	#[serde(default, flatten, skip_serializing_if = "Option::is_none")]
 	pub method: Option<MethodMatch>,
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub query: Vec<QueryMatch>,
+}
+
+fn default_route_match_path() -> PathMatch {
+	PathMatch::PathPrefix("/".into())
 }
 
 #[apply(schema!)]

--- a/schema/config.json
+++ b/schema/config.json
@@ -793,7 +793,10 @@
           }
         },
         "path": {
-          "$ref": "#/$defs/PathMatch"
+          "$ref": "#/$defs/PathMatch",
+          "default": {
+            "pathPrefix": "/"
+          }
         },
         "method": {
           "type": "string"
@@ -805,10 +808,7 @@
           }
         }
       },
-      "additionalProperties": false,
-      "required": [
-        "path"
-      ]
+      "additionalProperties": false
     },
     "HeaderMatch": {
       "type": "object",


### PR DESCRIPTION
Makes no sense that to set a header match, I need to also set a path
match
