### PR TITLE
fix oauth bug for anthropic subscription

### DIFF
--- a/crates/agentgateway/src/llm/anthropic.rs
+++ b/crates/agentgateway/src/llm/anthropic.rs
@@ -16,9 +16,47 @@ impl super::Provider for Provider {
 pub const DEFAULT_HOST_STR: &str = "api.anthropic.com";
 pub const DEFAULT_HOST: Strng = strng::literal!(DEFAULT_HOST_STR);
 
+pub const OAUTH_TOKEN_PREFIX: &str = "sk-ant-oat";
+pub const BETA_HEADER: &str = "anthropic-beta";
+pub const OAUTH_BETA_FLAG: &str = "oauth-2025-04-20";
+
 pub fn path(route: RouteType) -> &'static str {
 	match route {
 		RouteType::AnthropicTokenCount => "/v1/messages/count_tokens",
 		_ => "/v1/messages",
 	}
 }
+
+/// Ensures `flag` is present in the `anthropic-beta` CSV header.
+/// Uses `get_all` to handle multiple header instances correctly; merges
+/// them all into one consolidated value with the flag appended if absent.
+pub fn ensure_beta_flag(headers: &mut ::http::HeaderMap, flag: &str) -> anyhow::Result<()> {
+	use ::http::HeaderValue;
+
+	let already_present = headers.get_all(BETA_HEADER).iter().any(|v| {
+		v.to_str()
+			.is_ok_and(|s| s.split(',').any(|f| f.trim() == flag))
+	});
+
+	if !already_present {
+		let existing: Vec<String> = headers
+			.get_all(BETA_HEADER)
+			.iter()
+			.filter_map(|v| v.to_str().ok())
+			.map(str::to_owned)
+			.collect();
+
+		let new_val = if existing.is_empty() {
+			flag.to_owned()
+		} else {
+			format!("{},{flag}", existing.join(","))
+		};
+
+		headers.insert(BETA_HEADER, HeaderValue::from_str(&new_val)?);
+	}
+	Ok(())
+}
+
+#[cfg(test)]
+#[path = "anthropic_tests.rs"]
+mod tests;

--- a/crates/agentgateway/src/llm/anthropic.rs
+++ b/crates/agentgateway/src/llm/anthropic.rs
@@ -17,44 +17,12 @@ pub const DEFAULT_HOST_STR: &str = "api.anthropic.com";
 pub const DEFAULT_HOST: Strng = strng::literal!(DEFAULT_HOST_STR);
 
 pub const OAUTH_TOKEN_PREFIX: &str = "sk-ant-oat";
-pub const BETA_HEADER: &str = "anthropic-beta";
-pub const OAUTH_BETA_FLAG: &str = "oauth-2025-04-20";
 
 pub fn path(route: RouteType) -> &'static str {
 	match route {
 		RouteType::AnthropicTokenCount => "/v1/messages/count_tokens",
 		_ => "/v1/messages",
 	}
-}
-
-/// Ensures `flag` is present in the `anthropic-beta` CSV header.
-/// Uses `get_all` to handle multiple header instances correctly; merges
-/// them all into one consolidated value with the flag appended if absent.
-pub fn ensure_beta_flag(headers: &mut ::http::HeaderMap, flag: &str) -> anyhow::Result<()> {
-	use ::http::HeaderValue;
-
-	let already_present = headers.get_all(BETA_HEADER).iter().any(|v| {
-		v.to_str()
-			.is_ok_and(|s| s.split(',').any(|f| f.trim() == flag))
-	});
-
-	if !already_present {
-		let existing: Vec<String> = headers
-			.get_all(BETA_HEADER)
-			.iter()
-			.filter_map(|v| v.to_str().ok())
-			.map(str::to_owned)
-			.collect();
-
-		let new_val = if existing.is_empty() {
-			flag.to_owned()
-		} else {
-			format!("{},{flag}", existing.join(","))
-		};
-
-		headers.insert(BETA_HEADER, HeaderValue::from_str(&new_val)?);
-	}
-	Ok(())
 }
 
 #[cfg(test)]

--- a/crates/agentgateway/src/llm/anthropic_tests.rs
+++ b/crates/agentgateway/src/llm/anthropic_tests.rs
@@ -1,3 +1,5 @@
+use crate::llm::AIProvider;
+
 use super::OAUTH_TOKEN_PREFIX;
 
 // ── set_required_fields integration tests ───────────────────────────────────
@@ -11,10 +13,18 @@ fn make_bearer_request(token: &str) -> crate::http::Request {
 		.unwrap()
 }
 
+fn make_bearer_request_with_api_key(token: &str, api_key: &str) -> crate::http::Request {
+	::http::Request::builder()
+		.method("POST")
+		.uri("https://api.anthropic.com/v1/messages")
+		.header(::http::header::AUTHORIZATION, format!("Bearer {token}"))
+		.header("x-api-key", api_key)
+		.body(crate::http::Body::empty())
+		.unwrap()
+}
+
 #[test]
 fn set_required_fields_oauth_token() {
-	use crate::llm::AIProvider;
-
 	let provider = AIProvider::Anthropic(super::Provider { model: None });
 	let mut req = make_bearer_request(&format!("{OAUTH_TOKEN_PREFIX}01234567890abcdef"));
 
@@ -29,10 +39,23 @@ fn set_required_fields_oauth_token() {
 }
 
 #[test]
-fn set_required_fields_api_key_token() {
-	use crate::llm::AIProvider;
-	use ::http::HeaderValue;
+fn set_required_fields_oauth_token_strips_api_key() {
+	let provider = AIProvider::Anthropic(super::Provider { model: None });
+	let mut req = make_bearer_request_with_api_key(
+		&format!("{OAUTH_TOKEN_PREFIX}01234567890abcdef"),
+		"some-stale-key",
+	);
 
+	provider.set_required_fields(&mut req).unwrap();
+
+	// Authorization header must still be present.
+	assert!(req.headers().contains_key(::http::header::AUTHORIZATION));
+	// x-api-key must be removed.
+	assert!(!req.headers().contains_key("x-api-key"));
+}
+
+#[test]
+fn set_required_fields_api_key_token() {
 	let provider = AIProvider::Anthropic(super::Provider { model: None });
 	let mut req = make_bearer_request("sk-ant-api01234567890abcdef");
 
@@ -42,14 +65,6 @@ fn set_required_fields_api_key_token() {
 	assert!(!req.headers().contains_key(::http::header::AUTHORIZATION));
 	// Token moved to x-api-key.
 	assert!(req.headers().contains_key("x-api-key"));
-	// oauth beta flag must NOT have been added.
-	assert!(
-		!req
-			.headers()
-			.get("anthropic-beta")
-			.map(|v: &HeaderValue| v.to_str().unwrap_or("").contains("oauth-2025-04-20"))
-			.unwrap_or(false)
-	);
 	// anthropic-version must be set.
 	assert!(req.headers().contains_key("anthropic-version"));
 }

--- a/crates/agentgateway/src/llm/anthropic_tests.rs
+++ b/crates/agentgateway/src/llm/anthropic_tests.rs
@@ -1,0 +1,126 @@
+use ::http::{HeaderMap, HeaderValue};
+
+use super::{BETA_HEADER, OAUTH_BETA_FLAG, OAUTH_TOKEN_PREFIX, ensure_beta_flag};
+
+// ── ensure_beta_flag unit tests ──────────────────────────────────────────────
+
+#[test]
+fn ensure_beta_flag_no_existing_header() {
+	let mut headers = HeaderMap::new();
+	ensure_beta_flag(&mut headers, OAUTH_BETA_FLAG).unwrap();
+	assert_eq!(headers.get(BETA_HEADER).unwrap(), OAUTH_BETA_FLAG);
+}
+
+#[test]
+fn ensure_beta_flag_existing_other_value() {
+	let mut headers = HeaderMap::new();
+	headers.insert(BETA_HEADER, HeaderValue::from_static("other-flag"));
+	ensure_beta_flag(&mut headers, OAUTH_BETA_FLAG).unwrap();
+	let val = headers.get(BETA_HEADER).unwrap().to_str().unwrap();
+	assert_eq!(val, "other-flag,oauth-2025-04-20");
+}
+
+#[test]
+fn ensure_beta_flag_already_present() {
+	let mut headers = HeaderMap::new();
+	headers.insert(BETA_HEADER, HeaderValue::from_static("oauth-2025-04-20"));
+	ensure_beta_flag(&mut headers, OAUTH_BETA_FLAG).unwrap();
+	// Should be no-op – still exactly one entry with the original value.
+	let values: Vec<&str> = headers
+		.get_all(BETA_HEADER)
+		.iter()
+		.map(|v| v.to_str().unwrap())
+		.collect();
+	assert_eq!(values, vec!["oauth-2025-04-20"]);
+}
+
+#[test]
+fn ensure_beta_flag_already_present_with_spaces() {
+	let mut headers = HeaderMap::new();
+	headers.insert(BETA_HEADER, HeaderValue::from_static(" oauth-2025-04-20 "));
+	ensure_beta_flag(&mut headers, OAUTH_BETA_FLAG).unwrap();
+	// Trimmed match → no duplicate appended.
+	let val = headers.get(BETA_HEADER).unwrap().to_str().unwrap();
+	assert!(!val.contains("oauth-2025-04-20,oauth-2025-04-20"));
+}
+
+#[test]
+fn ensure_beta_flag_multiple_headers() {
+	let mut headers = HeaderMap::new();
+	// HTTP allows multiple headers with the same name.
+	headers.insert(BETA_HEADER, HeaderValue::from_static("flag-a"));
+	headers.append(BETA_HEADER, HeaderValue::from_static("flag-b"));
+	ensure_beta_flag(&mut headers, OAUTH_BETA_FLAG).unwrap();
+	let val = headers.get(BETA_HEADER).unwrap().to_str().unwrap();
+	// All prior values merged, flag appended.
+	assert!(val.contains("flag-a"));
+	assert!(val.contains("flag-b"));
+	assert!(val.contains(OAUTH_BETA_FLAG));
+}
+
+#[test]
+fn ensure_beta_flag_csv_in_header() {
+	let mut headers = HeaderMap::new();
+	headers.insert(BETA_HEADER, HeaderValue::from_static("flag-a,flag-b"));
+	ensure_beta_flag(&mut headers, OAUTH_BETA_FLAG).unwrap();
+	let val = headers.get(BETA_HEADER).unwrap().to_str().unwrap();
+	assert!(val.contains("flag-a"));
+	assert!(val.contains("flag-b"));
+	assert!(val.contains(OAUTH_BETA_FLAG));
+}
+
+// ── set_required_fields integration tests ───────────────────────────────────
+
+fn make_bearer_request(token: &str) -> crate::http::Request {
+	::http::Request::builder()
+		.method("POST")
+		.uri("https://api.anthropic.com/v1/messages")
+		.header(::http::header::AUTHORIZATION, format!("Bearer {token}"))
+		.body(crate::http::Body::empty())
+		.unwrap()
+}
+
+#[test]
+fn set_required_fields_oauth_token() {
+	use crate::llm::AIProvider;
+
+	let provider = AIProvider::Anthropic(super::Provider { model: None });
+	let mut req = make_bearer_request(&format!("{OAUTH_TOKEN_PREFIX}01234567890abcdef"));
+
+	provider.set_required_fields(&mut req).unwrap();
+
+	// Authorization header must still be present (OAuth keeps Bearer).
+	assert!(req.headers().contains_key(::http::header::AUTHORIZATION));
+	// x-api-key must NOT be set.
+	assert!(!req.headers().contains_key("x-api-key"));
+	// oauth beta flag must be present.
+	let beta = req.headers().get(BETA_HEADER).unwrap().to_str().unwrap();
+	assert!(beta.split(',').any(|f| f.trim() == OAUTH_BETA_FLAG));
+	// anthropic-version must be set.
+	assert!(req.headers().contains_key("anthropic-version"));
+}
+
+#[test]
+fn set_required_fields_api_key_token() {
+	use crate::llm::AIProvider;
+
+	let provider = AIProvider::Anthropic(super::Provider { model: None });
+	let mut req = make_bearer_request("sk-ant-api01234567890abcdef");
+
+	provider.set_required_fields(&mut req).unwrap();
+
+	// Authorization header must be removed.
+	assert!(!req.headers().contains_key(::http::header::AUTHORIZATION));
+	// Token moved to x-api-key.
+	assert!(req.headers().contains_key("x-api-key"));
+	// oauth beta flag must NOT have been added.
+	assert!(
+		!req
+			.headers()
+			.get(BETA_HEADER)
+			.map(|v: &HeaderValue| v.to_str().unwrap_or("").contains(OAUTH_BETA_FLAG))
+			.unwrap_or(false)
+	);
+	// anthropic-version must be set.
+	assert!(req.headers().contains_key("anthropic-version"));
+}

--- a/crates/agentgateway/src/llm/anthropic_tests.rs
+++ b/crates/agentgateway/src/llm/anthropic_tests.rs
@@ -1,73 +1,4 @@
-use ::http::{HeaderMap, HeaderValue};
-
-use super::{BETA_HEADER, OAUTH_BETA_FLAG, OAUTH_TOKEN_PREFIX, ensure_beta_flag};
-
-// ── ensure_beta_flag unit tests ──────────────────────────────────────────────
-
-#[test]
-fn ensure_beta_flag_no_existing_header() {
-	let mut headers = HeaderMap::new();
-	ensure_beta_flag(&mut headers, OAUTH_BETA_FLAG).unwrap();
-	assert_eq!(headers.get(BETA_HEADER).unwrap(), OAUTH_BETA_FLAG);
-}
-
-#[test]
-fn ensure_beta_flag_existing_other_value() {
-	let mut headers = HeaderMap::new();
-	headers.insert(BETA_HEADER, HeaderValue::from_static("other-flag"));
-	ensure_beta_flag(&mut headers, OAUTH_BETA_FLAG).unwrap();
-	let val = headers.get(BETA_HEADER).unwrap().to_str().unwrap();
-	assert_eq!(val, "other-flag,oauth-2025-04-20");
-}
-
-#[test]
-fn ensure_beta_flag_already_present() {
-	let mut headers = HeaderMap::new();
-	headers.insert(BETA_HEADER, HeaderValue::from_static("oauth-2025-04-20"));
-	ensure_beta_flag(&mut headers, OAUTH_BETA_FLAG).unwrap();
-	// Should be no-op – still exactly one entry with the original value.
-	let values: Vec<&str> = headers
-		.get_all(BETA_HEADER)
-		.iter()
-		.map(|v| v.to_str().unwrap())
-		.collect();
-	assert_eq!(values, vec!["oauth-2025-04-20"]);
-}
-
-#[test]
-fn ensure_beta_flag_already_present_with_spaces() {
-	let mut headers = HeaderMap::new();
-	headers.insert(BETA_HEADER, HeaderValue::from_static(" oauth-2025-04-20 "));
-	ensure_beta_flag(&mut headers, OAUTH_BETA_FLAG).unwrap();
-	// Trimmed match → no duplicate appended.
-	let val = headers.get(BETA_HEADER).unwrap().to_str().unwrap();
-	assert!(!val.contains("oauth-2025-04-20,oauth-2025-04-20"));
-}
-
-#[test]
-fn ensure_beta_flag_multiple_headers() {
-	let mut headers = HeaderMap::new();
-	// HTTP allows multiple headers with the same name.
-	headers.insert(BETA_HEADER, HeaderValue::from_static("flag-a"));
-	headers.append(BETA_HEADER, HeaderValue::from_static("flag-b"));
-	ensure_beta_flag(&mut headers, OAUTH_BETA_FLAG).unwrap();
-	let val = headers.get(BETA_HEADER).unwrap().to_str().unwrap();
-	// All prior values merged, flag appended.
-	assert!(val.contains("flag-a"));
-	assert!(val.contains("flag-b"));
-	assert!(val.contains(OAUTH_BETA_FLAG));
-}
-
-#[test]
-fn ensure_beta_flag_csv_in_header() {
-	let mut headers = HeaderMap::new();
-	headers.insert(BETA_HEADER, HeaderValue::from_static("flag-a,flag-b"));
-	ensure_beta_flag(&mut headers, OAUTH_BETA_FLAG).unwrap();
-	let val = headers.get(BETA_HEADER).unwrap().to_str().unwrap();
-	assert!(val.contains("flag-a"));
-	assert!(val.contains("flag-b"));
-	assert!(val.contains(OAUTH_BETA_FLAG));
-}
+use super::OAUTH_TOKEN_PREFIX;
 
 // ── set_required_fields integration tests ───────────────────────────────────
 
@@ -93,9 +24,6 @@ fn set_required_fields_oauth_token() {
 	assert!(req.headers().contains_key(::http::header::AUTHORIZATION));
 	// x-api-key must NOT be set.
 	assert!(!req.headers().contains_key("x-api-key"));
-	// oauth beta flag must be present.
-	let beta = req.headers().get(BETA_HEADER).unwrap().to_str().unwrap();
-	assert!(beta.split(',').any(|f| f.trim() == OAUTH_BETA_FLAG));
 	// anthropic-version must be set.
 	assert!(req.headers().contains_key("anthropic-version"));
 }
@@ -103,6 +31,7 @@ fn set_required_fields_oauth_token() {
 #[test]
 fn set_required_fields_api_key_token() {
 	use crate::llm::AIProvider;
+	use ::http::HeaderValue;
 
 	let provider = AIProvider::Anthropic(super::Provider { model: None });
 	let mut req = make_bearer_request("sk-ant-api01234567890abcdef");
@@ -117,8 +46,8 @@ fn set_required_fields_api_key_token() {
 	assert!(
 		!req
 			.headers()
-			.get(BETA_HEADER)
-			.map(|v: &HeaderValue| v.to_str().unwrap_or("").contains(OAUTH_BETA_FLAG))
+			.get("anthropic-beta")
+			.map(|v: &HeaderValue| v.to_str().unwrap_or("").contains("oauth-2025-04-20"))
 			.unwrap_or(false)
 	);
 	// anthropic-version must be set.

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -430,9 +430,11 @@ impl AIProvider {
 			AIProvider::Anthropic(_) => {
 				http::modify_req(req, |req| {
 					if let Some(authz) = req.headers.typed_get::<headers::Authorization<Bearer>>() {
-						// OAuth tokens ("sk-ant-oat*") keep Authorization: Bearer as-is.
+						// OAuth tokens ("sk-ant-oat*") keep Authorization: Bearer; drop any x-api-key.
 						// All other tokens are moved to x-api-key (standard API key auth).
-						if !authz.token().starts_with(anthropic::OAUTH_TOKEN_PREFIX) {
+						if authz.token().starts_with(anthropic::OAUTH_TOKEN_PREFIX) {
+							req.headers.remove("x-api-key");
+						} else {
 							req.headers.remove(http::header::AUTHORIZATION);
 							let mut api_key = HeaderValue::from_str(authz.token())?;
 							api_key.set_sensitive(true);

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -430,14 +430,9 @@ impl AIProvider {
 			AIProvider::Anthropic(_) => {
 				http::modify_req(req, |req| {
 					if let Some(authz) = req.headers.typed_get::<headers::Authorization<Bearer>>() {
-						// Anthropic OAuth tokens are identified by the "sk-ant-oat" prefix.
-						// When detected: keep Authorization: Bearer as-is and ensure the
-						// oauth-2025-04-20 beta flag is present (required for OAuth auth).
-						// Otherwise: move the Bearer token to x-api-key (standard API key auth).
-						if authz.token().starts_with(anthropic::OAUTH_TOKEN_PREFIX) {
-							anthropic::ensure_beta_flag(&mut req.headers, anthropic::OAUTH_BETA_FLAG)?;
-						} else {
-							// Move bearer token to x-api-key for standard API-key auth
+						// OAuth tokens ("sk-ant-oat*") keep Authorization: Bearer as-is.
+						// All other tokens are moved to x-api-key (standard API key auth).
+						if !authz.token().starts_with(anthropic::OAUTH_TOKEN_PREFIX) {
 							req.headers.remove(http::header::AUTHORIZATION);
 							let mut api_key = HeaderValue::from_str(authz.token())?;
 							api_key.set_sensitive(true);

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -430,11 +430,37 @@ impl AIProvider {
 			AIProvider::Anthropic(_) => {
 				http::modify_req(req, |req| {
 					if let Some(authz) = req.headers.typed_get::<headers::Authorization<Bearer>>() {
-						// Move bearer token in anthropic header
-						req.headers.remove(http::header::AUTHORIZATION);
-						let mut api_key = HeaderValue::from_str(authz.token())?;
-						api_key.set_sensitive(true);
-						req.headers.insert("x-api-key", api_key);
+						// Anthropic OAuth tokens are identified by the "sk-ant-oat" prefix.
+						// When detected: keep Authorization: Bearer as-is and ensure the
+						// oauth-2025-04-20 beta flag is present (required for OAuth auth).
+						// Otherwise: move the Bearer token to x-api-key (standard API key auth).
+						if authz.token().starts_with("sk-ant-oat") {
+							// Ensure oauth-2025-04-20 is in anthropic-beta
+							let has_oauth_flag = req
+								.headers
+								.get("anthropic-beta")
+								.and_then(|v| v.to_str().ok())
+								.is_some_and(|v| v.split(',').any(|f| f.trim() == "oauth-2025-04-20"));
+							if !has_oauth_flag {
+								let new_val = match req
+									.headers
+									.get("anthropic-beta")
+									.and_then(|v| v.to_str().ok())
+								{
+									Some(existing) => format!("{existing},oauth-2025-04-20"),
+									None => "oauth-2025-04-20".to_string(),
+								};
+								req
+									.headers
+									.insert("anthropic-beta", HeaderValue::from_str(&new_val)?);
+							}
+						} else {
+							// Move bearer token to x-api-key for standard API-key auth
+							req.headers.remove(http::header::AUTHORIZATION);
+							let mut api_key = HeaderValue::from_str(authz.token())?;
+							api_key.set_sensitive(true);
+							req.headers.insert("x-api-key", api_key);
+						}
 						// https://docs.anthropic.com/en/api/versioning
 						req
 							.headers

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -434,26 +434,8 @@ impl AIProvider {
 						// When detected: keep Authorization: Bearer as-is and ensure the
 						// oauth-2025-04-20 beta flag is present (required for OAuth auth).
 						// Otherwise: move the Bearer token to x-api-key (standard API key auth).
-						if authz.token().starts_with("sk-ant-oat") {
-							// Ensure oauth-2025-04-20 is in anthropic-beta
-							let has_oauth_flag = req
-								.headers
-								.get("anthropic-beta")
-								.and_then(|v| v.to_str().ok())
-								.is_some_and(|v| v.split(',').any(|f| f.trim() == "oauth-2025-04-20"));
-							if !has_oauth_flag {
-								let new_val = match req
-									.headers
-									.get("anthropic-beta")
-									.and_then(|v| v.to_str().ok())
-								{
-									Some(existing) => format!("{existing},oauth-2025-04-20"),
-									None => "oauth-2025-04-20".to_string(),
-								};
-								req
-									.headers
-									.insert("anthropic-beta", HeaderValue::from_str(&new_val)?);
-							}
+						if authz.token().starts_with(anthropic::OAUTH_TOKEN_PREFIX) {
+							anthropic::ensure_beta_flag(&mut req.headers, anthropic::OAUTH_BETA_FLAG)?;
 						} else {
 							// Move bearer token to x-api-key for standard API-key auth
 							req.headers.remove(http::header::AUTHORIZATION);


### PR DESCRIPTION
when using anthropic via a subscription (not api key, like claude pro/max), claude code for example would send the bearer token in the Authorize header, but currently we have it configured that it would remove it and move the value to x-api-key, but this returns an error like:

```
2026-03-12T22:04:30.790807Z     debug   upstream response       upstream response received      status=401 body="{\"type\":\"error\",\"error\":{\"type\":\"authentication_error\",\"message\":\"invalid x-api-key\"},\"request_id\":\"req_011CYywgNgQ1jgkLwvFsyo2X\"}"
```

This probably was a somewhat recent change when anthropic disallow 3rd party coding tools using the subscription tokens.  

litellm has a similar utility in https://github.com/BerriAI/litellm/blob/92d39c308cd6426943ad7a0a83569cc9647815fb/litellm/llms/anthropic/common_utils.py#L44.  

Our change is simpler than litellm, we expect claude code or any other anthropic client to send the correct beta headers. We can add the beta header injection later if needed.