### PR TITLE
authorization: add new Require mode

### DIFF
--- a/api/resource.pb.go
+++ b/api/resource.pb.go
@@ -7620,6 +7620,7 @@ type TrafficPolicySpec_RBAC struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Allow         []string               `protobuf:"bytes,1,rep,name=allow,proto3" json:"allow,omitempty"`
 	Deny          []string               `protobuf:"bytes,2,rep,name=deny,proto3" json:"deny,omitempty"`
+	Require       []string               `protobuf:"bytes,3,rep,name=require,proto3" json:"require,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -7664,6 +7665,13 @@ func (x *TrafficPolicySpec_RBAC) GetAllow() []string {
 func (x *TrafficPolicySpec_RBAC) GetDeny() []string {
 	if x != nil {
 		return x.Deny
+	}
+	return nil
+}
+
+func (x *TrafficPolicySpec_RBAC) GetRequire() []string {
+	if x != nil {
+		return x.Require
 	}
 	return nil
 }
@@ -9308,6 +9316,7 @@ type BackendPolicySpec_McpAuthorization struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Allow         []string               `protobuf:"bytes,1,rep,name=allow,proto3" json:"allow,omitempty"`
 	Deny          []string               `protobuf:"bytes,2,rep,name=deny,proto3" json:"deny,omitempty"`
+	Require       []string               `protobuf:"bytes,3,rep,name=require,proto3" json:"require,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -9352,6 +9361,13 @@ func (x *BackendPolicySpec_McpAuthorization) GetAllow() []string {
 func (x *BackendPolicySpec_McpAuthorization) GetDeny() []string {
 	if x != nil {
 		return x.Deny
+	}
+	return nil
+}
+
+func (x *BackendPolicySpec_McpAuthorization) GetRequire() []string {
+	if x != nil {
+		return x.Require
 	}
 	return nil
 }
@@ -11435,7 +11451,7 @@ const file_resource_proto_rawDesc = "" +
 	"\x05value\x18\x02 \x01(\tR\x05valueB\x06\n" +
 	"\x04kind\"?\n" +
 	"\x14JWTValidationOptions\x12'\n" +
-	"\x0frequired_claims\x18\x01 \x03(\tR\x0erequiredClaims\"\xfc;\n" +
+	"\x0frequired_claims\x18\x01 \x03(\tR\x0erequiredClaims\"\x96<\n" +
 	"\x11TrafficPolicySpec\x12N\n" +
 	"\x05phase\x18\x01 \x01(\x0e28.agentgateway.dev.resource.TrafficPolicySpec.PolicyPhaseR\x05phase\x12>\n" +
 	"\atimeout\x18\x02 \x01(\v2\".agentgateway.dev.resource.TimeoutH\x00R\atimeout\x128\n" +
@@ -11531,10 +11547,11 @@ const file_resource_proto_rawDesc = "" +
 	"\x10DENY_WITH_STATUS\x10\x02B\n" +
 	"\n" +
 	"\bprotocolB\x12\n" +
-	"\x10_status_on_errorJ\x04\b\b\x10\tR\atimeout\x1a0\n" +
+	"\x10_status_on_errorJ\x04\b\b\x10\tR\atimeout\x1aJ\n" +
 	"\x04RBAC\x12\x14\n" +
 	"\x05allow\x18\x01 \x03(\tR\x05allow\x12\x12\n" +
-	"\x04deny\x18\x02 \x03(\tR\x04deny\x1a\xd3\x01\n" +
+	"\x04deny\x18\x02 \x03(\tR\x04deny\x12\x18\n" +
+	"\arequire\x18\x03 \x03(\tR\arequire\x1a\xd3\x01\n" +
 	"\vJWTProvider\x12\x16\n" +
 	"\x06issuer\x18\x01 \x01(\tR\x06issuer\x12\x1c\n" +
 	"\taudiences\x18\x02 \x03(\tR\taudiences\x12\x18\n" +
@@ -11623,7 +11640,7 @@ const file_resource_proto_rawDesc = "" +
 	"\vPolicyPhase\x12\t\n" +
 	"\x05ROUTE\x10\x00\x12\v\n" +
 	"\aGATEWAY\x10\x01B\x06\n" +
-	"\x04kind\"\x9cB\n" +
+	"\x04kind\"\xb6B\n" +
 	"\x11BackendPolicySpec\x12D\n" +
 	"\x03a2a\x18\x01 \x01(\v20.agentgateway.dev.resource.BackendPolicySpec.A2aH\x00R\x03a2a\x12l\n" +
 	"\x11inference_routing\x18\x02 \x01(\v2=.agentgateway.dev.resource.BackendPolicySpec.InferenceRoutingH\x00R\x10inferenceRouting\x12Z\n" +
@@ -11811,10 +11828,11 @@ const file_resource_proto_rawDesc = "" +
 	"\n" +
 	"BackendTCP\x12H\n" +
 	"\tkeepalive\x18\x01 \x01(\v2*.agentgateway.dev.resource.KeepaliveConfigR\tkeepalive\x12B\n" +
-	"\x0fconnect_timeout\x18\x02 \x01(\v2\x19.google.protobuf.DurationR\x0econnectTimeout\x1a<\n" +
+	"\x0fconnect_timeout\x18\x02 \x01(\v2\x19.google.protobuf.DurationR\x0econnectTimeout\x1aV\n" +
 	"\x10McpAuthorization\x12\x14\n" +
 	"\x05allow\x18\x01 \x03(\tR\x05allow\x12\x12\n" +
-	"\x04deny\x18\x02 \x03(\tR\x04deny\x1a\xca\x06\n" +
+	"\x04deny\x18\x02 \x03(\tR\x04deny\x12\x18\n" +
+	"\arequire\x18\x03 \x03(\tR\arequire\x1a\xca\x06\n" +
 	"\x11McpAuthentication\x12\x16\n" +
 	"\x06issuer\x18\x01 \x01(\tR\x06issuer\x12\x1c\n" +
 	"\taudiences\x18\x02 \x03(\tR\taudiences\x12\x1f\n" +

--- a/controller/api/tests/testdata/agentgateway_backend_valid.yaml
+++ b/controller/api/tests/testdata/agentgateway_backend_valid.yaml
@@ -125,3 +125,22 @@ spec:
         host: localhost
         port: 8443
         path: /custom
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayBackend
+metadata:
+  name: mcp-require
+spec:
+  mcp:
+    targets:
+    - name: everything
+      static:
+        host: example.com
+        port: 443
+        policies:
+          mcp:
+            authorization:
+              action: Require
+              policy:
+                matchExpressions:
+                - 'mcp.tool.name == "hello"'

--- a/controller/api/v1alpha1/shared/rbac.go
+++ b/controller/api/v1alpha1/shared/rbac.go
@@ -7,9 +7,10 @@ type Authorization struct {
 	// +required
 	Policy AuthorizationPolicy `json:"policy"`
 
-	// `action` defines whether the rule allows or denies the request if
+	// `action` defines whether the rule allows, denies, or requires the request if
 	// matched. If unspecified, the default is `Allow`.
-	// +kubebuilder:validation:Enum=Allow;Deny
+	// Require policies are conjunctive across merged policies: all require policies must match.
+	// +kubebuilder:validation:Enum=Allow;Deny;Require
 	// +kubebuilder:default=Allow
 	// +optional
 	Action AuthorizationPolicyAction `json:"action,omitempty"`
@@ -44,4 +45,6 @@ const (
 	// AuthorizationPolicyActionDeny denies the action to take when the
 	// `RBACPolicies` matches.
 	AuthorizationPolicyActionDeny AuthorizationPolicyAction = "Deny"
+	// AuthorizationPolicyActionRequire requires the action to take when the RBACPolicies matches.
+	AuthorizationPolicyActionRequire AuthorizationPolicyAction = "Require"
 )

--- a/controller/api/v1alpha1/shared/rbac.go
+++ b/controller/api/v1alpha1/shared/rbac.go
@@ -3,8 +3,14 @@ package shared
 // Authorization defines the configuration for role-based access control.
 type Authorization struct {
 	// `policy` specifies the authorization rule to evaluate.
-	// A policy matches when **any** of the conditions evaluates to true.
-	// +required
+	//
+	// * For `Allow` rules: any policy allows the request.
+	// * For `Require` rules: all policies must match for the request to be allowed.
+	// * For `Deny` rules: any matching policy denies the request. Note: a CEL expression that fails to evaluate is not
+	// considered to match, making this a risky policy; prefer to use `Require`.
+	//
+	// The presence of at least one `Allow` rule triggers a deny-by-default policy, requiring at least 1 match to allow.
+	// With no rules, all requires are allowed.
 	Policy AuthorizationPolicy `json:"policy"`
 
 	// `action` defines whether the rule allows, denies, or requires the request if

--- a/controller/api/v1alpha1/shared/rbac.go
+++ b/controller/api/v1alpha1/shared/rbac.go
@@ -11,6 +11,7 @@ type Authorization struct {
 	//
 	// The presence of at least one `Allow` rule triggers a deny-by-default policy, requiring at least 1 match to allow.
 	// With no rules, all requires are allowed.
+	// +required
 	Policy AuthorizationPolicy `json:"policy"`
 
 	// `action` defines whether the rule allows, denies, or requires the request if

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
@@ -7169,11 +7169,13 @@ spec:
                                         action:
                                           default: Allow
                                           description: |-
-                                            `action` defines whether the rule allows or denies the request if
+                                            `action` defines whether the rule allows, denies, or requires the request if
                                             matched. If unspecified, the default is `Allow`.
+                                            Require policies are conjunctive across merged policies: all require policies must match.
                                           enum:
                                           - Allow
                                           - Deny
+                                          - Require
                                           type: string
                                         policy:
                                           description: |-
@@ -12884,11 +12886,13 @@ spec:
                           action:
                             default: Allow
                             description: |-
-                              `action` defines whether the rule allows or denies the request if
+                              `action` defines whether the rule allows, denies, or requires the request if
                               matched. If unspecified, the default is `Allow`.
+                              Require policies are conjunctive across merged policies: all require policies must match.
                             enum:
                             - Allow
                             - Deny
+                            - Require
                             type: string
                           policy:
                             description: |-

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
@@ -7180,7 +7180,14 @@ spec:
                                         policy:
                                           description: |-
                                             `policy` specifies the authorization rule to evaluate.
-                                            A policy matches when **any** of the conditions evaluates to true.
+
+                                            * For `Allow` rules: any policy allows the request.
+                                            * For `Require` rules: all policies must match for the request to be allowed.
+                                            * For `Deny` rules: any matching policy denies the request. Note: a CEL expression that fails to evaluate is not
+                                            considered to match, making this a risky policy; prefer to use `Require`.
+
+                                            The presence of at least one `Allow` rule triggers a deny-by-default policy, requiring at least 1 match to allow.
+                                            With no rules, all requires are allowed.
                                           properties:
                                             matchExpressions:
                                               description: |-
@@ -12897,7 +12904,14 @@ spec:
                           policy:
                             description: |-
                               `policy` specifies the authorization rule to evaluate.
-                              A policy matches when **any** of the conditions evaluates to true.
+
+                              * For `Allow` rules: any policy allows the request.
+                              * For `Require` rules: all policies must match for the request to be allowed.
+                              * For `Deny` rules: any matching policy denies the request. Note: a CEL expression that fails to evaluate is not
+                              considered to match, making this a risky policy; prefer to use `Require`.
+
+                              The presence of at least one `Allow` rule triggers a deny-by-default policy, requiring at least 1 match to allow.
+                              With no rules, all requires are allowed.
                             properties:
                               matchExpressions:
                                 description: |-

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
@@ -5191,11 +5191,13 @@ spec:
                           action:
                             default: Allow
                             description: |-
-                              `action` defines whether the rule allows or denies the request if
+                              `action` defines whether the rule allows, denies, or requires the request if
                               matched. If unspecified, the default is `Allow`.
+                              Require policies are conjunctive across merged policies: all require policies must match.
                             enum:
                             - Allow
                             - Deny
+                            - Require
                             type: string
                           policy:
                             description: |-
@@ -6479,11 +6481,13 @@ spec:
                       action:
                         default: Allow
                         description: |-
-                          `action` defines whether the rule allows or denies the request if
+                          `action` defines whether the rule allows, denies, or requires the request if
                           matched. If unspecified, the default is `Allow`.
+                          Require policies are conjunctive across merged policies: all require policies must match.
                         enum:
                         - Allow
                         - Deny
+                        - Require
                         type: string
                       policy:
                         description: |-

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
@@ -5202,7 +5202,14 @@ spec:
                           policy:
                             description: |-
                               `policy` specifies the authorization rule to evaluate.
-                              A policy matches when **any** of the conditions evaluates to true.
+
+                              * For `Allow` rules: any policy allows the request.
+                              * For `Require` rules: all policies must match for the request to be allowed.
+                              * For `Deny` rules: any matching policy denies the request. Note: a CEL expression that fails to evaluate is not
+                              considered to match, making this a risky policy; prefer to use `Require`.
+
+                              The presence of at least one `Allow` rule triggers a deny-by-default policy, requiring at least 1 match to allow.
+                              With no rules, all requires are allowed.
                             properties:
                               matchExpressions:
                                 description: |-
@@ -6492,7 +6499,14 @@ spec:
                       policy:
                         description: |-
                           `policy` specifies the authorization rule to evaluate.
-                          A policy matches when **any** of the conditions evaluates to true.
+
+                          * For `Allow` rules: any policy allows the request.
+                          * For `Require` rules: all policies must match for the request to be allowed.
+                          * For `Deny` rules: any matching policy denies the request. Note: a CEL expression that fails to evaluate is not
+                          considered to match, making this a risky policy; prefer to use `Require`.
+
+                          The presence of at least one `Allow` rule triggers a deny-by-default policy, requiring at least 1 match to allow.
+                          With no rules, all requires are allowed.
                         properties:
                           matchExpressions:
                             description: |-

--- a/controller/pkg/agentgateway/plugins/backend_policies.go
+++ b/controller/pkg/agentgateway/plugins/backend_policies.go
@@ -376,9 +376,11 @@ func translateBackendMCPAuthorization(policy *agentgateway.AgentgatewayPolicy) *
 		return nil
 	}
 	auth := backend.MCP.Authorization
-	var allowPolicies, denyPolicies []string
+	var allowPolicies, denyPolicies, requirePolicies []string
 	if auth.Action == shared.AuthorizationPolicyActionDeny {
 		denyPolicies = append(denyPolicies, cast(auth.Policy.MatchExpressions)...)
+	} else if auth.Action == shared.AuthorizationPolicyActionRequire {
+		requirePolicies = append(requirePolicies, cast(auth.Policy.MatchExpressions)...)
 	} else {
 		allowPolicies = append(allowPolicies, cast(auth.Policy.MatchExpressions)...)
 	}
@@ -390,8 +392,9 @@ func translateBackendMCPAuthorization(policy *agentgateway.AgentgatewayPolicy) *
 			Backend: &api.BackendPolicySpec{
 				Kind: &api.BackendPolicySpec_McpAuthorization_{
 					McpAuthorization: &api.BackendPolicySpec_McpAuthorization{
-						Allow: allowPolicies,
-						Deny:  denyPolicies,
+						Allow:   allowPolicies,
+						Deny:    denyPolicies,
+						Require: requirePolicies,
 					},
 				},
 			},

--- a/controller/pkg/agentgateway/plugins/testdata/backendpolicy/mcp-authz-require.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/backendpolicy/mcp-authz-require.yaml
@@ -65,21 +65,28 @@ output:
           require:
           - request.path == "/mcp"
 status:
-  ancestors:
-  - ancestorRef:
-      group: gateway.networking.k8s.io
-      kind: Gateway
-      name: test
-      namespace: default
-    conditions:
-    - lastTransitionTime: fake
-      message: Policy accepted
-      reason: Valid
-      status: "True"
-      type: Accepted
-    - lastTransitionTime: fake
-      message: Attached to all targets
-      reason: Attached
-      status: "True"
-      type: Attached
-    controllerName: agentgateway.dev/agentgateway
+- apiVersion: agentgateway.dev/v1alpha1
+  kind: AgentgatewayPolicy
+  metadata:
+    name: agw
+    namespace: default
+  spec: null
+  status:
+    ancestors:
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: test
+        namespace: default
+      conditions:
+      - lastTransitionTime: fake
+        message: Policy accepted
+        reason: Valid
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: Attached to all targets
+        reason: Attached
+        status: "True"
+        type: Attached
+      controllerName: agentgateway.dev/agentgateway

--- a/controller/pkg/agentgateway/plugins/testdata/backendpolicy/mcp-authz-require.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/backendpolicy/mcp-authz-require.yaml
@@ -1,0 +1,85 @@
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: agw
+  namespace: default
+spec:
+  targetRefs:
+    - kind: HTTPRoute
+      name: test
+      group: gateway.networking.k8s.io
+  traffic:
+    authorization:
+      action: Require
+      policy:
+        matchExpressions:
+          - 'request.path == "/mcp"'
+  backend:
+    mcp:
+      authorization:
+        action: Require
+        policy:
+          matchExpressions:
+            - 'mcp.tool.name == "echo"'
+            - 'jwt.sub == "test-user" && mcp.tool.name == "add"'
+---
+# Output
+output:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
+    policy:
+      backend:
+        mcpAuthorization:
+          require:
+          - mcp.tool.name == "echo"
+          - jwt.sub == "test-user" && mcp.tool.name == "add"
+      key: default/agw:mcp-authorization:default/test
+      name:
+        kind: AgentgatewayPolicy
+        name: agw
+        namespace: default
+      target:
+        route:
+          kind: HTTPRoute
+          name: test
+          namespace: default
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
+    policy:
+      key: traffic/default/agw:rbac:default/test
+      name:
+        kind: AgentgatewayPolicy
+        name: agw
+        namespace: default
+      target:
+        route:
+          kind: HTTPRoute
+          name: test
+          namespace: default
+      traffic:
+        authorization:
+          require:
+          - request.path == "/mcp"
+status:
+  ancestors:
+  - ancestorRef:
+      group: gateway.networking.k8s.io
+      kind: Gateway
+      name: test
+      namespace: default
+    conditions:
+    - lastTransitionTime: fake
+      message: Policy accepted
+      reason: Valid
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: fake
+      message: Attached to all targets
+      reason: Attached
+      status: "True"
+      type: Attached
+    controllerName: agentgateway.dev/agentgateway

--- a/controller/pkg/agentgateway/plugins/traffic_plugin.go
+++ b/controller/pkg/agentgateway/plugins/traffic_plugin.go
@@ -1016,9 +1016,11 @@ func processAuthorizationPolicy(
 	basePolicyName string,
 	policy types.NamespacedName,
 ) *api.Policy {
-	var allowPolicies, denyPolicies []string
+	var allowPolicies, denyPolicies, requirePolicies []string
 	if auth.Action == shared.AuthorizationPolicyActionDeny {
 		denyPolicies = append(denyPolicies, cast(auth.Policy.MatchExpressions)...)
+	} else if auth.Action == shared.AuthorizationPolicyActionRequire {
+		requirePolicies = append(requirePolicies, cast(auth.Policy.MatchExpressions)...)
 	} else {
 		allowPolicies = append(allowPolicies, cast(auth.Policy.MatchExpressions)...)
 	}
@@ -1030,8 +1032,9 @@ func processAuthorizationPolicy(
 			Traffic: &api.TrafficPolicySpec{
 				Kind: &api.TrafficPolicySpec_Authorization{
 					Authorization: &api.TrafficPolicySpec_RBAC{
-						Allow: allowPolicies,
-						Deny:  denyPolicies,
+						Allow:   allowPolicies,
+						Deny:    denyPolicies,
+						Require: requirePolicies,
 					},
 				},
 			},

--- a/crates/agentgateway/src/http/authorization.rs
+++ b/crates/agentgateway/src/http/authorization.rs
@@ -41,6 +41,9 @@ impl RuleSet {
 		for rule in &self.rules.deny {
 			cel.register_expression(rule.as_ref());
 		}
+		for rule in &self.rules.require {
+			cel.register_expression(rule.as_ref());
+		}
 	}
 }
 
@@ -48,12 +51,14 @@ impl RuleSet {
 pub struct PolicySet {
 	allow: Vec<Arc<cel::Expression>>,
 	deny: Vec<Arc<cel::Expression>>,
+	require: Vec<Arc<cel::Expression>>,
 }
 
 #[derive(Clone, Debug)]
 pub enum Policy {
 	Allow(Arc<cel::Expression>),
 	Deny(Arc<cel::Expression>),
+	Require(Arc<cel::Expression>),
 }
 
 #[apply(schema!)]
@@ -70,18 +75,37 @@ enum RuleSerde {
 enum RuleTypeSerde {
 	Allow(String),
 	Deny(String),
+	Require(String),
 }
 
 impl PolicySet {
-	pub fn new(allow: Vec<Arc<cel::Expression>>, deny: Vec<Arc<cel::Expression>>) -> Self {
-		Self { allow, deny }
+	pub fn new(
+		allow: Vec<Arc<cel::Expression>>,
+		deny: Vec<Arc<cel::Expression>>,
+		require: Vec<Arc<cel::Expression>>,
+	) -> Self {
+		Self {
+			allow,
+			deny,
+			require,
+		}
 	}
 }
 
 pub fn se_policies<S: Serializer>(t: &PolicySet, serializer: S) -> Result<S::Ok, S::Error> {
-	let mut m = serializer.serialize_map(Some(2))?;
-	m.serialize_entry("allow", &t.allow)?;
-	m.serialize_entry("deny", &t.deny)?;
+	let len = usize::from(!t.allow.is_empty())
+		+ usize::from(!t.deny.is_empty())
+		+ usize::from(!t.require.is_empty());
+	let mut m = serializer.serialize_map(Some(len))?;
+	if !t.allow.is_empty() {
+		m.serialize_entry("allow", &t.allow)?;
+	}
+	if !t.deny.is_empty() {
+		m.serialize_entry("deny", &t.deny)?;
+	}
+	if !t.require.is_empty() {
+		m.serialize_entry("require", &t.require)?;
+	}
 	m.end()
 }
 
@@ -93,6 +117,7 @@ where
 	let mut res = PolicySet {
 		allow: vec![],
 		deny: vec![],
+		require: vec![],
 	};
 	for r in raw {
 		match r {
@@ -108,6 +133,13 @@ where
 				rule: RuleTypeSerde::Deny(deny),
 			} => res.deny.push(
 				cel::Expression::new_strict(deny)
+					.map(Arc::new)
+					.map_err(|e| serde::de::Error::custom(e.to_string()))?,
+			),
+			RuleSerde::Object {
+				rule: RuleTypeSerde::Require(require),
+			} => res.require.push(
+				cel::Expression::new_strict(require)
 					.map(Arc::new)
 					.map_err(|e| serde::de::Error::custom(e.to_string()))?,
 			),
@@ -144,6 +176,10 @@ impl RuleSets {
 		if rule_sets.iter().any(|r| r.denies(exec)) {
 			return false;
 		}
+		// All REQUIRE policies must match when present.
+		if rule_sets.iter().any(|r| !r.all_requires_match(exec)) {
+			return false;
+		}
 		// If there are any ALLOW, allow
 		if rule_sets.iter().any(|r| r.allows(exec)) {
 			return true;
@@ -164,11 +200,14 @@ impl RuleSet {
 	}
 
 	pub fn has_rules(&self) -> bool {
-		!self.rules.allow.is_empty() || !self.rules.deny.is_empty()
+		!self.rules.allow.is_empty() || !self.rules.deny.is_empty() || !self.rules.require.is_empty()
 	}
 
 	pub fn has_allow_rules(&self) -> bool {
 		!self.rules.allow.is_empty()
+	}
+	pub fn has_require_rules(&self) -> bool {
+		!self.rules.require.is_empty()
 	}
 	pub fn denies(&self, exec: &cel::Executor) -> bool {
 		if self.rules.deny.is_empty() {
@@ -192,6 +231,14 @@ impl RuleSet {
 				.iter()
 				.any(|rule| exec.eval_bool(rule.as_ref()))
 		}
+	}
+
+	pub fn all_requires_match(&self, exec: &cel::Executor) -> bool {
+		self
+			.rules
+			.require
+			.iter()
+			.all(|rule| exec.eval_bool(rule.as_ref()))
 	}
 }
 

--- a/crates/agentgateway/src/http/authorization_tests.rs
+++ b/crates/agentgateway/src/http/authorization_tests.rs
@@ -36,6 +36,16 @@ fn tool_context(target: &str, name: &str) -> MCPInfo {
 	)))
 }
 
+fn create_require_policy_set(policies: Vec<&str>) -> PolicySet {
+	let mut policy_set = PolicySet::default();
+	for p in policies.into_iter() {
+		policy_set
+			.require
+			.push(Arc::new(cel::Expression::new_strict(p).unwrap()));
+	}
+	policy_set
+}
+
 #[test]
 fn test_rbac_reject_exact_match() {
 	let policies = vec![r#"mcp.tool.name == "increment" && jwt.user == "admin""#];
@@ -206,6 +216,7 @@ fn test_mixed_allow_deny_default_deny() {
 		vec![Arc::new(
 			cel::Expression::new_strict(r#"mcp.tool.name == "denied_tool""#).unwrap(),
 		)],
+		vec![],
 	);
 	let rbac = RuleSet::new(policy_set);
 	let mut ctx = ContextBuilder::new();
@@ -241,6 +252,78 @@ fn test_rbac_mcp_context_is_identity_only() {
 	.unwrap();
 
 	assert!(exec.eval_bool(&expr));
+}
+
+#[test]
+fn test_require_only_matching_allows() {
+	let require_policies = vec![r#"mcp.tool.name == "increment""#];
+	let rbac = RuleSet::new(create_require_policy_set(require_policies));
+	let mut ctx = ContextBuilder::new();
+	let rs = RuleSets::from(vec![rbac]);
+	rs.register(&mut ctx);
+
+	let req = req(json!({"sub": "1234567890"}));
+	let mcp = tool_context("server", "increment");
+	let exec = cel::Executor::new_mcp(req.as_ref(), &mcp);
+
+	assert_matches!(rs.validate(&exec), true);
+}
+
+#[test]
+fn test_require_only_non_matching_denies() {
+	let require_policies = vec![r#"mcp.tool.name == "increment""#];
+	let rbac = RuleSet::new(create_require_policy_set(require_policies));
+	let mut ctx = ContextBuilder::new();
+	let rs = RuleSets::from(vec![rbac]);
+	rs.register(&mut ctx);
+
+	let req = req(json!({"sub": "1234567890"}));
+	let mcp = tool_context("server", "decrement");
+	let exec = cel::Executor::new_mcp(req.as_ref(), &mcp);
+
+	assert_matches!(rs.validate(&exec), false);
+}
+
+#[test]
+fn test_all_require_rule_sets_must_pass() {
+	let require_increment = RuleSet::new(create_require_policy_set(vec![
+		r#"mcp.tool.name == "increment""#,
+	]));
+	let require_admin = RuleSet::new(create_require_policy_set(vec![r#"jwt.role == "admin""#]));
+	let mut ctx = ContextBuilder::new();
+	let rs = RuleSets::from(vec![require_increment, require_admin]);
+	rs.register(&mut ctx);
+
+	let admin_req = req(json!({"role": "admin"}));
+	let mcp = tool_context("server", "increment");
+	let exec = cel::Executor::new_mcp(admin_req.as_ref(), &mcp);
+	assert_matches!(rs.validate(&exec), true);
+
+	let user_req = req(json!({"role": "user"}));
+	let mcp = tool_context("server", "increment");
+	let exec = cel::Executor::new_mcp(user_req.as_ref(), &mcp);
+	assert_matches!(rs.validate(&exec), false);
+}
+
+#[test]
+fn test_require_is_not_sufficient_when_allow_rules_exist() {
+	let require_increment = RuleSet::new(create_require_policy_set(vec![
+		r#"mcp.tool.name == "increment""#,
+	]));
+	let allow_admin = RuleSet::new(create_policy_set(vec![r#"jwt.role == "admin""#]));
+	let mut ctx = ContextBuilder::new();
+	let rs = RuleSets::from(vec![require_increment, allow_admin]);
+	rs.register(&mut ctx);
+
+	let user_req = req(json!({"role": "user"}));
+	let mcp = tool_context("server", "increment");
+	let exec = cel::Executor::new_mcp(user_req.as_ref(), &mcp);
+	assert_matches!(rs.validate(&exec), false);
+
+	let admin_req = req(json!({"role": "admin"}));
+	let mcp = tool_context("server", "increment");
+	let exec = cel::Executor::new_mcp(admin_req.as_ref(), &mcp);
+	assert_matches!(rs.validate(&exec), true);
 }
 
 #[divan::bench]

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -187,6 +187,7 @@ async fn authorization_denied_returns_unknown_tool_error() {
 	let deny_all_policy = McpAuthorization::new(RuleSet::new(PolicySet::new(
 		vec![],                                                       // no allow rules
 		vec![Arc::new(cel::Expression::new_strict("true").unwrap())], // deny all
+		vec![],
 	)));
 
 	let (_bind, io) = setup_proxy_policies(
@@ -246,6 +247,7 @@ async fn authorization_denied_returns_unknown_prompt_error() {
 	let deny_all_policy = McpAuthorization::new(RuleSet::new(PolicySet::new(
 		vec![],                                                       // no allow rules
 		vec![Arc::new(cel::Expression::new_strict("true").unwrap())], // deny all
+		vec![],
 	)));
 
 	let (_bind, io) = setup_proxy_policies(
@@ -304,6 +306,7 @@ async fn authorization_denied_returns_unknown_resource_error() {
 	let deny_all_policy = McpAuthorization::new(RuleSet::new(PolicySet::new(
 		vec![],                                                       // no allow rules
 		vec![Arc::new(cel::Expression::new_strict("true").unwrap())], // deny all
+		vec![],
 	)));
 
 	let (_bind, io) = setup_proxy_policies(
@@ -363,6 +366,7 @@ async fn authorization_deny_specific_tool_filters_only_that_tool() {
 		vec![Arc::new(
 			cel::Expression::new_strict(r#"mcp.tool.name == "echo""#).unwrap(),
 		)],
+		vec![],
 	)));
 
 	let (_bind, io) = setup_proxy_policies(
@@ -433,6 +437,7 @@ async fn authorization_deny_with_request_header_filters_per_agent() {
 			)
 			.unwrap(),
 		)],
+		vec![],
 	)));
 
 	let (_bind, io) = setup_proxy_policies(

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -171,7 +171,13 @@ impl TryFrom<&proto::agent::backend_policy_spec::McpAuthorization> for McpAuthor
 			deny_exprs.push(Arc::new(expr));
 		}
 
-		let policy_set = authorization::PolicySet::new(allow_exprs, deny_exprs);
+		let mut require_exprs = Vec::new();
+		for require_rule in &rbac.require {
+			let expr = cel::Expression::new_permissive(require_rule);
+			require_exprs.push(Arc::new(expr));
+		}
+
+		let policy_set = authorization::PolicySet::new(allow_exprs, deny_exprs, require_exprs);
 		Ok(McpAuthorization::new(authorization::RuleSet::new(
 			policy_set,
 		)))
@@ -991,8 +997,14 @@ impl TryFrom<&proto::agent::traffic_policy_spec::Rbac> for Authorization {
 			deny_exprs.push(Arc::new(expr));
 		}
 
+		let mut require_exprs = Vec::new();
+		for require_rule in &rbac.require {
+			let expr = cel::Expression::new_permissive(require_rule);
+			require_exprs.push(Arc::new(expr));
+		}
+
 		// Create PolicySet using the same pattern as in de_policies function
-		let policy_set = authorization::PolicySet::new(allow_exprs, deny_exprs);
+		let policy_set = authorization::PolicySet::new(allow_exprs, deny_exprs, require_exprs);
 		Ok(Authorization(authorization::RuleSet::new(policy_set)))
 	}
 }

--- a/crates/agentgateway/src/types/local_tests/llm_simple_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/llm_simple_normalized.snap
@@ -165,7 +165,6 @@ policies:
           rules:
             allow:
               - "jwt.email.endsWith(\"@example.com\")"
-            deny: []
         phase: route
   - key: "llm:transformation"
     name:

--- a/crates/agentgateway/src/types/local_tests/mcp_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/mcp_normalized.snap
@@ -26,7 +26,6 @@ binds:
                           - "mcp.tool.name == \"echo\""
                           - "jwt.sub == \"test-user\" && mcp.tool.name == \"add\""
                           - "mcp.tool.name == \"printEnv\" && jwt.nested.key == \"value\""
-                        deny: []
                 weight: 1
             inlinePolicies:
               - cors:

--- a/crates/protos/proto/resource.proto
+++ b/crates/protos/proto/resource.proto
@@ -668,6 +668,7 @@ message TrafficPolicySpec {
   message RBAC {
     repeated string allow = 1;
     repeated string deny = 2;
+    repeated string require = 3;
   }
   message JWTProvider {
     // JWT issuer that must match the 'iss' claim
@@ -1078,6 +1079,7 @@ message BackendPolicySpec {
   message McpAuthorization {
     repeated string allow = 1;
     repeated string deny = 2;
+    repeated string require = 3;
   }
 
   message McpAuthentication {


### PR DESCRIPTION
`Deny` mode is a bad API with a useful goal: to ensure that policies
MUST match the rule, essentialy adding AND semantics on top of the ALLOW
policies OR semantics.

Deny is trick, because you often end up having double negatives.

For example `deny: !(port in [443, 8443])`. Or worse, somethign like
`deny: jwt.group != 'eng'`; if the jwt doesn't have a `group` this rule
will not deny.

Instead, this proposes adding a new Require mode which is like deny but
inverted.

The above rules would be `require: port in [443, 8443]` or `require: jwt.group == 'eng'`.

These are useful for admin level rules that apply on top of user level
rules like `require: source.address not in [banned country cidr ranges]`
etc
