### PR TITLE
Fix transitive dependencies from Gateway <---> Backend

### DIFF
--- a/controller/pkg/agentgateway/plugins/interfaces.go
+++ b/controller/pkg/agentgateway/plugins/interfaces.go
@@ -24,13 +24,18 @@ type PolicyPluginInput struct {
 }
 
 type PolicyPlugin struct {
-	Build func(PolicyPluginInput) (krt.StatusCollection[controllers.Object, any], krt.Collection[AgwPolicy])
+	Build           func(PolicyPluginInput) (krt.StatusCollection[controllers.Object, any], krt.Collection[AgwPolicy])
+	BuildReferences func(input PolicyPluginInput) krt.Collection[*PolicyAttachment]
 }
 
 // ApplyPolicies extracts all policies from the collection
-func (p *PolicyPlugin) ApplyPolicies(inputs PolicyPluginInput) (krt.Collection[AgwPolicy], krt.StatusCollection[controllers.Object, any]) {
+func (p *PolicyPlugin) ApplyPolicies(inputs PolicyPluginInput) (krt.Collection[AgwPolicy], krt.StatusCollection[controllers.Object, any], krt.Collection[*PolicyAttachment]) {
 	status, col := p.Build(inputs)
-	return col, status
+	var refs krt.Collection[*PolicyAttachment]
+	if p.BuildReferences != nil {
+		refs = p.BuildReferences(inputs)
+	}
+	return col, status, refs
 }
 
 // AgwPolicy wraps an Agw policy for collection handling

--- a/controller/pkg/agentgateway/plugins/reference_indexes.go
+++ b/controller/pkg/agentgateway/plugins/reference_indexes.go
@@ -2,6 +2,7 @@ package plugins
 
 import (
 	"istio.io/istio/pkg/kube/krt"
+	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -43,9 +44,25 @@ func BuildReferenceIndex(
 	}
 }
 
+type PolicyAttachment struct {
+	Target  utils.TypedNamespacedName
+	Backend utils.TypedNamespacedName
+	Source  utils.TypedNamespacedName
+}
+
+func (a PolicyAttachment) Equals(other PolicyAttachment) bool {
+	return a.Target == other.Target && a.Backend == other.Backend && a.Source == other.Source
+}
+
+func (a PolicyAttachment) ResourceName() string {
+	return a.Source.String() + "/" + a.Target.String() + "/" + a.Backend.String()
+}
+
 type ReferenceIndex struct {
-	// Backend --> Gateway
+	// Backend --> Gateway via Route
 	Ancestors krt.IndexCollection[utils.TypedNamespacedName, *utils.AncestorBackend]
+	// Backend --> Target via Policy
+	PolicyAttachments krt.IndexCollection[utils.TypedNamespacedName, *PolicyAttachment]
 	// Route --> Gateway
 	attachments krt.IndexCollection[utils.TypedNamespacedName, *RouteAttachment]
 	// Gateway --> Gateway: trivial, no collection needed
@@ -73,5 +90,19 @@ func (p ReferenceIndex) LookupGatewaysForTarget(ctx krt.HandlerContext, object u
 }
 
 func (p ReferenceIndex) LookupGatewaysForBackend(ctx krt.HandlerContext, object utils.TypedNamespacedName) sets.Set[types.NamespacedName] {
-	return p.LookupGatewaysForTarget(ctx, object)
+	base := p.LookupGatewaysForTarget(ctx, object)
+	log.Errorf("howardjohn: LOOKup %+v", object)
+	if p.PolicyAttachments != nil {
+		log.Errorf("howardjohn: LOOKup more %+v %v", object, p.PolicyAttachments.List())
+		for _, pref := range krt.FetchOne(ctx, p.PolicyAttachments, krt.FilterKey(object.String())).Objects {
+			log.Errorf("howardjohn: pref.. %+v", object)
+			base = base.Union(p.LookupGatewaysForTarget(ctx, pref.Target))
+		}
+	}
+	return base
+}
+
+func (p ReferenceIndex) WithPolicyAttachments(references krt.IndexCollection[utils.TypedNamespacedName, *PolicyAttachment]) ReferenceIndex {
+	p.PolicyAttachments = references
+	return p
 }

--- a/controller/pkg/agentgateway/plugins/reference_indexes.go
+++ b/controller/pkg/agentgateway/plugins/reference_indexes.go
@@ -2,7 +2,6 @@ package plugins
 
 import (
 	"istio.io/istio/pkg/kube/krt"
-	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -90,14 +89,22 @@ func (p ReferenceIndex) LookupGatewaysForTarget(ctx krt.HandlerContext, object u
 }
 
 func (p ReferenceIndex) LookupGatewaysForBackend(ctx krt.HandlerContext, object utils.TypedNamespacedName) sets.Set[types.NamespacedName] {
+	return p.lookupGatewaysForBackend(ctx, object, map[string]struct{}{})
+}
+
+func (p ReferenceIndex) lookupGatewaysForBackend(ctx krt.HandlerContext, object utils.TypedNamespacedName, seen map[string]struct{}) sets.Set[types.NamespacedName] {
+	key := object.String()
+	if _, ok := seen[key]; ok {
+		return sets.New[types.NamespacedName]()
+	}
+	seen[key] = struct{}{}
+
 	base := p.LookupGatewaysForTarget(ctx, object)
-	log.Errorf("howardjohn: LOOKup %+v", object)
-	if p.PolicyAttachments != nil {
-		log.Errorf("howardjohn: LOOKup more %+v %v", object, p.PolicyAttachments.List())
-		for _, pref := range krt.FetchOne(ctx, p.PolicyAttachments, krt.FilterKey(object.String())).Objects {
-			log.Errorf("howardjohn: pref.. %+v", object)
-			base = base.Union(p.LookupGatewaysForTarget(ctx, pref.Target))
-		}
+	if p.PolicyAttachments == nil {
+		return base
+	}
+	for _, pref := range krt.FetchOne(ctx, p.PolicyAttachments, krt.FilterKey(key)).Objects {
+		base = base.Union(p.lookupGatewaysForBackend(ctx, pref.Target, seen))
 	}
 	return base
 }

--- a/controller/pkg/agentgateway/plugins/traffic_plugin.go
+++ b/controller/pkg/agentgateway/plugins/traffic_plugin.go
@@ -88,93 +88,8 @@ func convertStatusCollection[T controllers.Object, S any](col krt.Collection[krt
 
 // NewAgentPlugin creates a new AgentgatewayPolicy plugin
 func NewAgentPlugin(agw *AgwCollections) AgwPlugin {
-	backendReferences := krt.NewManyCollection(agw.AgentgatewayPolicies, func(krtctx krt.HandlerContext, policy *agentgateway.AgentgatewayPolicy) []*PolicyAttachment {
-		var attachments []*PolicyAttachment
-		s := policy.Spec
-		self := utils.TypedNamespacedName{
-			NamespacedName: types.NamespacedName{Namespace: policy.Namespace, Name: policy.Name},
-			Kind:           wellknown.AgentgatewayPolicyGVK.Kind,
-		}
-		app := func(ref gwv1.BackendObjectReference) {
-			for _, tgt := range s.TargetRefs {
-				attachments = append(attachments, &PolicyAttachment{
-					Target: utils.TypedNamespacedName{
-						NamespacedName: types.NamespacedName{Namespace: policy.Namespace, Name: string(tgt.Name)},
-						Kind:           string(tgt.Kind),
-					},
-					Backend: utils.TypedNamespacedName{
-						NamespacedName: types.NamespacedName{Namespace: defaultString(ref.Namespace, policy.Namespace), Name: string(ref.Name)},
-						Kind:           defaultString(ref.Kind, wellknown.ServiceKind),
-					},
-					Source: self,
-				})
-			}
-		}
-		appTunnel := func(backend *agentgateway.BackendSimple) {
-			if backend != nil && backend.Tunnel != nil {
-				app(backend.Tunnel.BackendRef)
-			}
-		}
-		if s.Traffic != nil {
-			if s.Traffic.ExtAuth != nil {
-				app(s.Traffic.ExtAuth.BackendRef)
-			}
-			if s.Traffic.ExtProc != nil {
-				app(s.Traffic.ExtProc.BackendRef)
-			}
-			if s.Traffic.RateLimit != nil && s.Traffic.RateLimit.Global != nil {
-				app(s.Traffic.RateLimit.Global.BackendRef)
-			}
-			if s.Traffic.JWTAuthentication != nil {
-				for _, p := range s.Traffic.JWTAuthentication.Providers {
-					if p.JWKS.Remote != nil {
-						app(p.JWKS.Remote.BackendRef)
-					}
-				}
-			}
-		}
-		if s.Frontend != nil {
-			if s.Frontend.Tracing != nil {
-				app(s.Frontend.Tracing.BackendRef)
-			}
-			if s.Frontend.AccessLog != nil && s.Frontend.AccessLog.Otlp != nil {
-				app(s.Frontend.AccessLog.Otlp.BackendRef)
-			}
-		}
-		if s.Backend != nil {
-			appTunnel(&s.Backend.BackendSimple)
-			if s.Backend.MCP != nil && s.Backend.MCP.Authentication != nil {
-				app(s.Backend.MCP.Authentication.JWKS.BackendRef)
-			}
-			if s.Backend.AI != nil && s.Backend.AI.PromptGuard != nil {
-				for _, p := range s.Backend.AI.PromptGuard.Request {
-					if p.Webhook != nil {
-						app(p.Webhook.BackendRef)
-					}
-					if p.OpenAIModeration != nil {
-						appTunnel(p.OpenAIModeration.Policies)
-					}
-					if p.GoogleModelArmor != nil {
-						appTunnel(p.GoogleModelArmor.Policies)
-					}
-					if p.BedrockGuardrails != nil {
-						appTunnel(p.BedrockGuardrails.Policies)
-					}
-				}
-				for _, p := range s.Backend.AI.PromptGuard.Response {
-					if p.Webhook != nil {
-						app(p.Webhook.BackendRef)
-					}
-					if p.GoogleModelArmor != nil {
-						appTunnel(p.GoogleModelArmor.Policies)
-					}
-					if p.BedrockGuardrails != nil {
-						appTunnel(p.BedrockGuardrails.Policies)
-					}
-				}
-			}
-		}
-		return attachments
+	backendReferences := krt.NewManyCollection(agw.AgentgatewayPolicies, func(ctx krt.HandlerContext, policy *agentgateway.AgentgatewayPolicy) []*PolicyAttachment {
+		return BackendReferencesFromPolicy(policy)
 	})
 	return AgwPlugin{
 		ContributesPolicies: map[schema.GroupKind]PolicyPlugin{
@@ -1688,9 +1603,101 @@ func toStruct(rm json.RawMessage) (*structpb.Struct, error) {
 	return pbs, nil
 }
 
-func defaultString[T ~string](s *T, def string) string {
+func DefaultString[T ~string](s *T, def string) string {
 	if s == nil {
 		return def
 	}
 	return string(*s)
+}
+func BackendReferencesFromPolicy(policy *agentgateway.AgentgatewayPolicy) []*PolicyAttachment {
+	var attachments []*PolicyAttachment
+	s := policy.Spec
+	self := utils.TypedNamespacedName{
+		NamespacedName: types.NamespacedName{Namespace: policy.Namespace, Name: policy.Name},
+		Kind:           wellknown.AgentgatewayPolicyGVK.Kind,
+	}
+	app := func(ref gwv1.BackendObjectReference) {
+		for _, tgt := range s.TargetRefs {
+			attachments = append(attachments, &PolicyAttachment{
+				Target: utils.TypedNamespacedName{
+					NamespacedName: types.NamespacedName{Namespace: policy.Namespace, Name: string(tgt.Name)},
+					Kind:           string(tgt.Kind),
+				},
+				Backend: utils.TypedNamespacedName{
+					NamespacedName: types.NamespacedName{Namespace: DefaultString(ref.Namespace, policy.Namespace), Name: string(ref.Name)},
+					Kind:           DefaultString(ref.Kind, wellknown.ServiceKind),
+				},
+				Source: self,
+			})
+		}
+	}
+	if s.Traffic != nil {
+		if s.Traffic.ExtAuth != nil {
+			app(s.Traffic.ExtAuth.BackendRef)
+		}
+		if s.Traffic.ExtProc != nil {
+			app(s.Traffic.ExtProc.BackendRef)
+		}
+		if s.Traffic.RateLimit != nil && s.Traffic.RateLimit.Global != nil {
+			app(s.Traffic.RateLimit.Global.BackendRef)
+		}
+		if s.Traffic.JWTAuthentication != nil {
+			for _, p := range s.Traffic.JWTAuthentication.Providers {
+				if p.JWKS.Remote != nil {
+					app(p.JWKS.Remote.BackendRef)
+				}
+			}
+		}
+	}
+	if s.Frontend != nil {
+		if s.Frontend.Tracing != nil {
+			app(s.Frontend.Tracing.BackendRef)
+		}
+		if s.Frontend.AccessLog != nil && s.Frontend.AccessLog.Otlp != nil {
+			app(s.Frontend.AccessLog.Otlp.BackendRef)
+		}
+	}
+	if s.Backend != nil {
+		BackendReferencesFromBackendPolicy(s.Backend, app)
+	}
+	return attachments
+}
+
+func BackendReferencesFromBackendPolicy(s *agentgateway.BackendFull, app func(ref gwv1.BackendObjectReference)) {
+	appTunnel := func(backend *agentgateway.BackendSimple) {
+		if backend != nil && backend.Tunnel != nil {
+			app(backend.Tunnel.BackendRef)
+		}
+	}
+	appTunnel(&s.BackendSimple)
+	if s.MCP != nil && s.MCP.Authentication != nil {
+		app(s.MCP.Authentication.JWKS.BackendRef)
+	}
+	if s.AI != nil && s.AI.PromptGuard != nil {
+		for _, p := range s.AI.PromptGuard.Request {
+			if p.Webhook != nil {
+				app(p.Webhook.BackendRef)
+			}
+			if p.OpenAIModeration != nil {
+				appTunnel(p.OpenAIModeration.Policies)
+			}
+			if p.GoogleModelArmor != nil {
+				appTunnel(p.GoogleModelArmor.Policies)
+			}
+			if p.BedrockGuardrails != nil {
+				appTunnel(p.BedrockGuardrails.Policies)
+			}
+		}
+		for _, p := range s.AI.PromptGuard.Response {
+			if p.Webhook != nil {
+				app(p.Webhook.BackendRef)
+			}
+			if p.GoogleModelArmor != nil {
+				appTunnel(p.GoogleModelArmor.Policies)
+			}
+			if p.BedrockGuardrails != nil {
+				appTunnel(p.BedrockGuardrails.Policies)
+			}
+		}
+	}
 }

--- a/controller/pkg/agentgateway/plugins/traffic_plugin.go
+++ b/controller/pkg/agentgateway/plugins/traffic_plugin.go
@@ -88,6 +88,94 @@ func convertStatusCollection[T controllers.Object, S any](col krt.Collection[krt
 
 // NewAgentPlugin creates a new AgentgatewayPolicy plugin
 func NewAgentPlugin(agw *AgwCollections) AgwPlugin {
+	backendReferences := krt.NewManyCollection(agw.AgentgatewayPolicies, func(krtctx krt.HandlerContext, policy *agentgateway.AgentgatewayPolicy) []*PolicyAttachment {
+		var attachments []*PolicyAttachment
+		s := policy.Spec
+		self := utils.TypedNamespacedName{
+			NamespacedName: types.NamespacedName{Namespace: policy.Namespace, Name: policy.Name},
+			Kind:           wellknown.AgentgatewayPolicyGVK.Kind,
+		}
+		app := func(ref gwv1.BackendObjectReference) {
+			for _, tgt := range s.TargetRefs {
+				attachments = append(attachments, &PolicyAttachment{
+					Target: utils.TypedNamespacedName{
+						NamespacedName: types.NamespacedName{Namespace: policy.Namespace, Name: string(tgt.Name)},
+						Kind:           string(tgt.Kind),
+					},
+					Backend: utils.TypedNamespacedName{
+						NamespacedName: types.NamespacedName{Namespace: defaultString(ref.Namespace, policy.Namespace), Name: string(ref.Name)},
+						Kind:           defaultString(ref.Kind, wellknown.ServiceKind),
+					},
+					Source: self,
+				})
+			}
+		}
+		appTunnel := func(backend *agentgateway.BackendSimple) {
+			if backend != nil && backend.Tunnel != nil {
+				app(backend.Tunnel.BackendRef)
+			}
+		}
+		if s.Traffic != nil {
+			if s.Traffic.ExtAuth != nil {
+				app(s.Traffic.ExtAuth.BackendRef)
+			}
+			if s.Traffic.ExtProc != nil {
+				app(s.Traffic.ExtProc.BackendRef)
+			}
+			if s.Traffic.RateLimit != nil && s.Traffic.RateLimit.Global != nil {
+				app(s.Traffic.RateLimit.Global.BackendRef)
+			}
+			if s.Traffic.JWTAuthentication != nil {
+				for _, p := range s.Traffic.JWTAuthentication.Providers {
+					if p.JWKS.Remote != nil {
+						app(p.JWKS.Remote.BackendRef)
+					}
+				}
+			}
+		}
+		if s.Frontend != nil {
+			if s.Frontend.Tracing != nil {
+				app(s.Frontend.Tracing.BackendRef)
+			}
+			if s.Frontend.AccessLog != nil && s.Frontend.AccessLog.Otlp != nil {
+				app(s.Frontend.AccessLog.Otlp.BackendRef)
+			}
+		}
+		if s.Backend != nil {
+			appTunnel(&s.Backend.BackendSimple)
+			if s.Backend.MCP != nil && s.Backend.MCP.Authentication != nil {
+				app(s.Backend.MCP.Authentication.JWKS.BackendRef)
+			}
+			if s.Backend.AI != nil && s.Backend.AI.PromptGuard != nil {
+				for _, p := range s.Backend.AI.PromptGuard.Request {
+					if p.Webhook != nil {
+						app(p.Webhook.BackendRef)
+					}
+					if p.OpenAIModeration != nil {
+						appTunnel(p.OpenAIModeration.Policies)
+					}
+					if p.GoogleModelArmor != nil {
+						appTunnel(p.GoogleModelArmor.Policies)
+					}
+					if p.BedrockGuardrails != nil {
+						appTunnel(p.BedrockGuardrails.Policies)
+					}
+				}
+				for _, p := range s.Backend.AI.PromptGuard.Response {
+					if p.Webhook != nil {
+						app(p.Webhook.BackendRef)
+					}
+					if p.GoogleModelArmor != nil {
+						appTunnel(p.GoogleModelArmor.Policies)
+					}
+					if p.BedrockGuardrails != nil {
+						appTunnel(p.BedrockGuardrails.Policies)
+					}
+				}
+			}
+		}
+		return attachments
+	})
 	return AgwPlugin{
 		ContributesPolicies: map[schema.GroupKind]PolicyPlugin{
 			wellknown.AgentgatewayPolicyGVK.GroupKind(): {
@@ -99,6 +187,9 @@ func NewAgentPlugin(agw *AgwCollections) AgwPlugin {
 						return TranslateAgentgatewayPolicy(krtctx, policyCR, agw, input.References)
 					}, agw.KrtOpts.ToOptions("AgentgatewayPolicy")...)
 					return convertStatusCollection(policyStatusCol), policyCol
+				},
+				BuildReferences: func(input PolicyPluginInput) krt.Collection[*PolicyAttachment] {
+					return backendReferences
 				},
 			},
 		},
@@ -1595,4 +1686,11 @@ func toStruct(rm json.RawMessage) (*structpb.Struct, error) {
 	}
 
 	return pbs, nil
+}
+
+func defaultString[T ~string](s *T, def string) string {
+	if s == nil {
+		return def
+	}
+	return string(*s)
 }

--- a/controller/pkg/agentgateway/translator/golden_test.go
+++ b/controller/pkg/agentgateway/translator/golden_test.go
@@ -18,6 +18,20 @@ import (
 	"github.com/agentgateway/agentgateway/controller/pkg/kgateway/agentgatewaysyncer"
 )
 
+func TestReferences(t *testing.T) {
+	testutils.RunForDirectory(t, "testdata/references", func(t *testing.T, ctx plugins.PolicyCtx) (any, []ir.AgwResource) {
+		sq, ri := testutils.Syncer(t, ctx, "")
+		r := ri.Outputs.Resources.List()
+		r = slices.FilterInPlace(r, func(resource ir.AgwResource) bool {
+			x := ir.GetAgwResourceName(resource.Resource)
+			return strings.HasPrefix(x, "policy/") || strings.HasPrefix(x, "backend/")
+		})
+		return sq.Dump(), slices.SortBy(r, func(a ir.AgwResource) string {
+			return a.ResourceName()
+		})
+	})
+}
+
 func TestRouteCollection(t *testing.T) {
 	testutils.RunForDirectory(t, "testdata/routes", func(t *testing.T, ctx plugins.PolicyCtx) (any, []ir.AgwResource) {
 		sq, ri := testutils.Syncer(t, ctx, "HTTPRoute", "GRPCRoute", "TCPRoute", "TLSRoute", "InferencePool")

--- a/controller/pkg/agentgateway/translator/testdata/references/_defaults.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/references/_defaults.yaml
@@ -1,0 +1,54 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: agentgateway
+spec:
+  controllerName: agentgateway.dev/agentgateway
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: test
+  namespace: default
+spec:
+  gatewayClassName: agentgateway
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: test
+  namespace: default
+spec:
+  parentRefs:
+    - name: test
+  hostnames:
+    - "www.example.com"
+  rules:
+    - backendRefs:
+        - name: reviews
+          port: 8080
+        - name: be
+          group: agentgateway.dev
+          kind: AgentgatewayBackend
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aws-secret
+  namespace: default
+type: Opaque
+data:
+  test: test
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hello
+  namespace: default
+type: Opaque
+data:
+  test: test

--- a/controller/pkg/agentgateway/translator/testdata/references/backend-policy-to-backend-ref-cyclic.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/references/backend-policy-to-backend-ref-cyclic.yaml
@@ -1,0 +1,67 @@
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayBackend
+metadata:
+  name: be
+  namespace: default
+spec:
+  static:
+    host: primary.example.com
+    port: 80
+  policies:
+    tunnel:
+      backendRef:
+        name: be-b
+        group: agentgateway.dev
+        kind: AgentgatewayBackend
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayBackend
+metadata:
+  name: be-b
+  namespace: default
+spec:
+  static:
+    host: secondary.example.com
+    port: 80
+  policies:
+    tunnel:
+      backendRef:
+        name: be
+        group: agentgateway.dev
+        kind: AgentgatewayBackend
+---
+# Output
+output:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
+    backend:
+      inlinePolicies:
+      - backendTunnel:
+          proxy:
+            backend: default/be-b
+      key: default/be
+      name:
+        name: be
+        namespace: default
+      static:
+        host: primary.example.com
+        port: 80
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
+    backend:
+      inlinePolicies:
+      - backendTunnel:
+          proxy:
+            backend: default/be
+      key: default/be-b
+      name:
+        name: be-b
+        namespace: default
+      static:
+        host: secondary.example.com
+        port: 80
+status: []

--- a/controller/pkg/agentgateway/translator/testdata/references/backend-policy-to-backend-ref-transitive.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/references/backend-policy-to-backend-ref-transitive.yaml
@@ -1,0 +1,89 @@
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayBackend
+metadata:
+  name: be
+  namespace: default
+spec:
+  static:
+    host: primary.example.com
+    port: 80
+  policies:
+    tunnel:
+      backendRef:
+        name: be-b
+        group: agentgateway.dev
+        kind: AgentgatewayBackend
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayBackend
+metadata:
+  name: be-b
+  namespace: default
+spec:
+  static:
+    host: secondary.example.com
+    port: 80
+  policies:
+    tunnel:
+      backendRef:
+        name: be-c
+        group: agentgateway.dev
+        kind: AgentgatewayBackend
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayBackend
+metadata:
+  name: be-c
+  namespace: default
+spec:
+  static:
+    host: tertiary.example.com
+    port: 80
+---
+# Output
+output:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
+    backend:
+      inlinePolicies:
+      - backendTunnel:
+          proxy:
+            backend: default/be-b
+      key: default/be
+      name:
+        name: be
+        namespace: default
+      static:
+        host: primary.example.com
+        port: 80
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
+    backend:
+      inlinePolicies:
+      - backendTunnel:
+          proxy:
+            backend: default/be-c
+      key: default/be-b
+      name:
+        name: be-b
+        namespace: default
+      static:
+        host: secondary.example.com
+        port: 80
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
+    backend:
+      key: default/be-c
+      name:
+        name: be-c
+        namespace: default
+      static:
+        host: tertiary.example.com
+        port: 80
+status: []

--- a/controller/pkg/agentgateway/translator/testdata/references/backend-policy-to-backend-ref.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/references/backend-policy-to-backend-ref.yaml
@@ -45,4 +45,16 @@ output:
       static:
         host: primary.example.com
         port: 80
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
+    backend:
+      key: default/policy-be
+      name:
+        name: policy-be
+        namespace: default
+      static:
+        host: policy.example.com
+        port: 80
 status: []

--- a/controller/pkg/agentgateway/translator/testdata/references/backend-policy-to-backend-ref.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/references/backend-policy-to-backend-ref.yaml
@@ -1,0 +1,48 @@
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayBackend
+metadata:
+  name: policy-be
+  namespace: default
+spec:
+  static:
+    host: policy.example.com
+    port: 80
+---
+# Policy is attached to gateway via HTTPRoute
+# policy-be should be attached via BE -> Policy -> Route -> Gateway
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayBackend
+metadata:
+  name: be
+  namespace: default
+spec:
+  static:
+    host: primary.example.com
+    port: 80
+  policies:
+    tunnel:
+      backendRef:
+        name: policy-be
+        group: agentgateway.dev
+        kind: AgentgatewayBackend
+---
+---
+# Output
+output:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
+    backend:
+      inlinePolicies:
+      - backendTunnel:
+          proxy:
+            backend: default/policy-be
+      key: default/be
+      name:
+        name: be
+        namespace: default
+      static:
+        host: primary.example.com
+        port: 80
+status: []

--- a/controller/pkg/agentgateway/translator/testdata/references/policy-to-backend-ref.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/references/policy-to-backend-ref.yaml
@@ -1,0 +1,65 @@
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayBackend
+metadata:
+  name: policy-be
+  namespace: default
+spec:
+  static:
+    host: example.com
+    port: 80
+---
+# Policy is attached to gateway via HTTPRoute
+# policy-be should be attached via BE -> Policy -> Route -> Gateway
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: agw
+  namespace: default
+spec:
+  targetRefs:
+    - kind: HTTPRoute
+      name: test
+      group: gateway.networking.k8s.io
+  traffic:
+    extAuth:
+      grpc: {}
+      backendRef:
+        name: policy-be
+        group: agentgateway.dev
+        kind: AgentgatewayBackend
+---
+# Output
+output:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
+    backend:
+      key: default/policy-be
+      name:
+        name: policy-be
+        namespace: default
+      static:
+        host: example.com
+        port: 80
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
+    policy:
+      key: traffic/default/agw:extauth:default/test
+      name:
+        kind: AgentgatewayPolicy
+        name: agw
+        namespace: default
+      target:
+        route:
+          kind: HTTPRoute
+          name: test
+          namespace: default
+      traffic:
+        extAuthz:
+          grpc: {}
+          target:
+            backend: default/policy-be
+status: []

--- a/controller/pkg/kgateway/agentgatewaysyncer/backend/translate.go
+++ b/controller/pkg/kgateway/agentgatewaysyncer/backend/translate.go
@@ -84,7 +84,7 @@ func BuildAgwBackend(
 func TranslateAgwBackend(
 	ctx plugins.PolicyCtx,
 	backend *agentgateway.AgentgatewayBackend,
-	ancestors krt.IndexCollection[utils.TypedNamespacedName, *utils.AncestorBackend],
+	references plugins.ReferenceIndex,
 ) (*agentgateway.AgentgatewayBackendStatus, []agwir.AgwResource) {
 	var results []agwir.AgwResource
 	backends, err := BuildAgwBackend(ctx, backend)
@@ -102,15 +102,15 @@ func TranslateAgwBackend(
 		}, results
 	}
 
-	gtws := krt.FetchOne(ctx.Krt, ancestors, krt.FilterKey(utils.TypedNamespacedName{
+	gtws := references.LookupGatewaysForBackend(ctx.Krt, utils.TypedNamespacedName{
 		NamespacedName: config.NamespacedName(backend),
 		Kind:           wellknown.AgentgatewayBackendGVK.Kind,
-	}.String()))
+	})
 	// handle all backends created as an MCPBackend backend may create multiple backends
-	for _, gateways := range gtws.Objects {
+	for gateway := range gtws {
 		for _, backend := range backends {
 			logger.Debug("creating backend", "backend", backend.Name)
-			resourceWrapper := translator.ToResourceForGateway(gateways.Gateway, &api.Resource{
+			resourceWrapper := translator.ToResourceForGateway(gateway, &api.Resource{
 				Kind: &api.Resource_Backend{
 					Backend: backend,
 				},

--- a/controller/pkg/kgateway/agentgatewaysyncer/backend/translate.go
+++ b/controller/pkg/kgateway/agentgatewaysyncer/backend/translate.go
@@ -11,6 +11,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/agentgateway/agentgateway/api"
 	apiannotations "github.com/agentgateway/agentgateway/controller/api/annotations"
@@ -25,6 +27,55 @@ import (
 )
 
 var logger = logging.New("agentgateway/backend")
+
+func BuildAgwBackendReferences(
+	backend *agentgateway.AgentgatewayBackend,
+) []*plugins.PolicyAttachment {
+	var attachments []*plugins.PolicyAttachment
+	self := utils.TypedNamespacedName{
+		NamespacedName: types.NamespacedName{Namespace: backend.Namespace, Name: backend.Name},
+		Kind:           wellknown.AgentgatewayBackendGVK.Kind,
+	}
+	app := func(ref gwv1.BackendObjectReference) {
+		attachments = append(attachments, &plugins.PolicyAttachment{
+			Target: self,
+			Backend: utils.TypedNamespacedName{
+				NamespacedName: types.NamespacedName{Namespace: plugins.DefaultString(ref.Namespace, backend.Namespace), Name: string(ref.Name)},
+				Kind:           plugins.DefaultString(ref.Kind, wellknown.ServiceKind),
+			},
+			Source: self,
+		})
+	}
+	if backend.Spec.Policies != nil {
+		plugins.BackendReferencesFromBackendPolicy(backend.Spec.Policies, app)
+	}
+	if ai := backend.Spec.AI; ai != nil {
+		for _, r := range ai.PriorityGroups {
+			for _, p := range r.Providers {
+				if p.Policies != nil {
+					plugins.BackendReferencesFromBackendPolicy(&agentgateway.BackendFull{
+						BackendSimple: p.Policies.BackendSimple,
+						AI:            p.Policies.AI,
+						MCP:           nil,
+					}, app)
+				}
+			}
+		}
+	}
+	if mcp := backend.Spec.MCP; mcp != nil {
+		for _, r := range mcp.Targets {
+			if r.Static != nil && r.Static.Policies != nil {
+				p := r.Static.Policies
+				plugins.BackendReferencesFromBackendPolicy(&agentgateway.BackendFull{
+					BackendSimple: p.BackendSimple,
+					MCP:           p.MCP,
+					AI:            nil,
+				}, app)
+			}
+		}
+	}
+	return attachments
+}
 
 // BuildAgwBackend translates a Backend to an AgwBackend
 func BuildAgwBackend(

--- a/controller/pkg/kgateway/agentgatewaysyncer/policy_collections.go
+++ b/controller/pkg/kgateway/agentgatewaysyncer/policy_collections.go
@@ -14,14 +14,18 @@ import (
 
 type PolicyStatusCollections = map[schema.GroupKind]krt.StatusCollection[controllers.Object, any]
 
-func AgwPolicyCollection(agwPlugins plugins.AgwPlugin, references plugins.ReferenceIndex, krtopts krtutil.KrtOptions) (krt.Collection[ir.AgwResource], PolicyStatusCollections) {
+func AgwPolicyCollection(agwPlugins plugins.AgwPlugin, references plugins.ReferenceIndex, krtopts krtutil.KrtOptions) (krt.Collection[ir.AgwResource], krt.Collection[*plugins.PolicyAttachment], PolicyStatusCollections) {
 	var allPolicies []krt.Collection[plugins.AgwPolicy]
+	var allReferences []krt.Collection[*plugins.PolicyAttachment]
 	policyStatusMap := PolicyStatusCollections{}
 	// Collect all policies from registered plugins.
 	// Note: Only one plugin should be used per source GVK.
 	// Avoid joining collections per-GVK before passing them to a plugin.
 	for gvk, plugin := range agwPlugins.ContributesPolicies {
-		policy, policyStatus := plugin.ApplyPolicies(plugins.PolicyPluginInput{References: references})
+		policy, policyStatus, refs := plugin.ApplyPolicies(plugins.PolicyPluginInput{References: references})
+		if refs != nil {
+			allReferences = append(allReferences, refs)
+		}
 		allPolicies = append(allPolicies, policy)
 		if policyStatus != nil {
 			// some plugins may not have a status collection (a2a services, etc.)
@@ -34,5 +38,7 @@ func AgwPolicyCollection(agwPlugins plugins.AgwPlugin, references plugins.Refere
 		return ptr.Of(translator.ToResourceForGateway(*i.Gateway, i))
 	}, krtopts.ToOptions("AllPolicies")...)
 
-	return allPoliciesCol, policyStatusMap
+	allRefsCol := krt.JoinCollection(allReferences, krtopts.ToOptions("PolicyReferences")...)
+
+	return allPoliciesCol, allRefsCol, policyStatusMap
 }

--- a/controller/pkg/kgateway/agentgatewaysyncer/syncer.go
+++ b/controller/pkg/kgateway/agentgatewaysyncer/syncer.go
@@ -471,10 +471,15 @@ func (s *Syncer) buildAgwResources(gateways krt.Collection[*translator.GatewayLi
 	})
 	ancestorCollection := ancestorsIndex.AsCollection(append(krtopts.ToOptions("AncestorBackend"), utils.TypedNamespacedNameIndexCollectionFunc)...)
 	referenceIndex := plugins.BuildReferenceIndex(ancestorCollection, routeAttachmentsIndex)
-	agwPolicies, policyStatuses := AgwPolicyCollection(s.agwPlugins, referenceIndex, krtopts)
+	agwPolicies, policyReferences, policyStatuses := AgwPolicyCollection(s.agwPlugins, referenceIndex, krtopts)
+	policyReferencesIndex := krt.NewIndex(policyReferences, "policyReferences", func(o *plugins.PolicyAttachment) []utils.TypedNamespacedName {
+		return []utils.TypedNamespacedName{o.Backend}
+	})
+	policyReferencesIndexCollection := policyReferencesIndex.AsCollection(append(krtopts.ToOptions("PolicyReferencesIndex"), utils.TypedNamespacedNameIndexCollectionFunc)...)
+	referenceIndex = referenceIndex.WithPolicyAttachments(policyReferencesIndexCollection)
 
 	// Create an agentgateway backend collection from the kgateway backend resources
-	agwBackendStatus, agwBackends := s.newAgwBackendCollection(s.agwCollections.Backends, ancestorCollection, krtopts)
+	agwBackendStatus, agwBackends := s.newAgwBackendCollection(s.agwCollections.Backends, referenceIndex, krtopts)
 
 	// Join all Agw resources
 	allAgwResources := krt.JoinCollection([]krt.Collection[agwir.AgwResource]{binds, listeners, agwRoutes, agwPolicies, agwBackends}, krtopts.ToOptions("Resources")...)
@@ -509,7 +514,7 @@ func (s *Syncer) buildListenerFromGateway(obj *translator.GatewayListener) *agwi
 // newAgwBackendCollection creates the ADP backend collection for agent gateway resources
 func (s *Syncer) newAgwBackendCollection(
 	finalBackends krt.Collection[*agentgateway.AgentgatewayBackend],
-	ancestors krt.IndexCollection[utils.TypedNamespacedName, *utils.AncestorBackend],
+	references plugins.ReferenceIndex,
 	krtopts krtutil.KrtOptions,
 ) (
 	krt.StatusCollection[*agentgateway.AgentgatewayBackend, agentgateway.AgentgatewayBackendStatus],
@@ -523,7 +528,7 @@ func (s *Syncer) newAgwBackendCollection(
 			Krt:         ctx,
 			Collections: s.agwCollections,
 		}
-		return agentgatewaybackend.TranslateAgwBackend(pc, backend, ancestors)
+		return agentgatewaybackend.TranslateAgwBackend(pc, backend, references)
 	}, krtopts.ToOptions("Backends")...)
 }
 

--- a/controller/pkg/kgateway/agentgatewaysyncer/syncer.go
+++ b/controller/pkg/kgateway/agentgatewaysyncer/syncer.go
@@ -472,7 +472,9 @@ func (s *Syncer) buildAgwResources(gateways krt.Collection[*translator.GatewayLi
 	ancestorCollection := ancestorsIndex.AsCollection(append(krtopts.ToOptions("AncestorBackend"), utils.TypedNamespacedNameIndexCollectionFunc)...)
 	referenceIndex := plugins.BuildReferenceIndex(ancestorCollection, routeAttachmentsIndex)
 	agwPolicies, policyReferences, policyStatuses := AgwPolicyCollection(s.agwPlugins, referenceIndex, krtopts)
-	policyReferencesIndex := krt.NewIndex(policyReferences, "policyReferences", func(o *plugins.PolicyAttachment) []utils.TypedNamespacedName {
+	backendPolicyReferences := s.newAgwBackendPolicyReferences(s.agwCollections.Backends, krtopts)
+	joinedPolicyReferences := krt.JoinCollection([]krt.Collection[*plugins.PolicyAttachment]{policyReferences, backendPolicyReferences}, krtopts.ToOptions("JoinPolicyAttachment")...)
+	policyReferencesIndex := krt.NewIndex(joinedPolicyReferences, "policyReferences", func(o *plugins.PolicyAttachment) []utils.TypedNamespacedName {
 		return []utils.TypedNamespacedName{o.Backend}
 	})
 	policyReferencesIndexCollection := policyReferencesIndex.AsCollection(append(krtopts.ToOptions("PolicyReferencesIndex"), utils.TypedNamespacedNameIndexCollectionFunc)...)
@@ -509,6 +511,17 @@ func (s *Syncer) buildListenerFromGateway(obj *translator.GatewayListener) *agwi
 		Namespace: obj.ParentGateway.Namespace,
 		Name:      obj.ParentGateway.Name,
 	}, translator.AgwListener{l}))
+}
+
+// newAgwBackendPolicyReferences creates the ADP backend collection for agent gateway resources
+func (s *Syncer) newAgwBackendPolicyReferences(
+	finalBackends krt.Collection[*agentgateway.AgentgatewayBackend],
+	krtopts krtutil.KrtOptions,
+) krt.Collection[*plugins.PolicyAttachment] {
+	policyReferences := krt.NewManyCollection(finalBackends, func(ctx krt.HandlerContext, backend *agentgateway.AgentgatewayBackend) []*plugins.PolicyAttachment {
+		return agentgatewaybackend.BuildAgwBackendReferences(backend)
+	}, krtopts.ToOptions("BackendPolicyAttachments")...)
+	return policyReferences
 }
 
 // newAgwBackendCollection creates the ADP backend collection for agent gateway resources

--- a/crates/agentgateway/src/http/ext_authz.rs
+++ b/crates/agentgateway/src/http/ext_authz.rs
@@ -407,7 +407,7 @@ impl ExtAuthz {
 		let cr = match resp {
 			Ok(response) => response,
 			Err(e) => {
-				warn!("ext_authz request failed: {}", e.message());
+				warn!("ext_authz request failed: {}", e);
 				return self.handle_auth_failure("Authorization service unavailable");
 			},
 		};

--- a/crates/agentgateway/src/http/ext_authz.rs
+++ b/crates/agentgateway/src/http/ext_authz.rs
@@ -407,7 +407,7 @@ impl ExtAuthz {
 		let cr = match resp {
 			Ok(response) => response,
 			Err(e) => {
-				warn!("ext_authz request failed: {}", e);
+				warn!("ext_authz request failed: {}", e.message());
 				return self.handle_auth_failure("Authorization service unavailable");
 			},
 		};

--- a/crates/agentgateway/src/http/ext_proc.rs
+++ b/crates/agentgateway/src/http/ext_proc.rs
@@ -1126,11 +1126,9 @@ impl tower::Service<::http::Request<tonic::body::Body>> for GrpcReferenceChannel
 		let policies = self.policies.clone();
 		let req = req.map(http::Body::new);
 		Box::pin(async move {
-			Ok(
-				client
-					.call_reference_with_policies(req, &target, policies.as_slice())
-					.await?,
-			)
+			client
+				.call_reference_with_policies(req, &target, policies.as_slice())
+				.await
 		})
 	}
 }

--- a/crates/agentgateway/src/http/ext_proc.rs
+++ b/crates/agentgateway/src/http/ext_proc.rs
@@ -1113,7 +1113,7 @@ pub struct GrpcReferenceChannel {
 
 impl tower::Service<::http::Request<tonic::body::Body>> for GrpcReferenceChannel {
 	type Response = http::Response;
-	type Error = anyhow::Error;
+	type Error = ProxyError;
 	type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
 
 	fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {


### PR DESCRIPTION
We associate Backends with Gateways to avoid sending Backends that are not relevant. To do this, we need to know all relevant backends.

This was working only for backends from routes, not policies. This adds policies.

A tricky thing is policies can be inline on backend, and in a few places. You can also have cycles and chains (!) of backend --> backend --> backend, etc.