### PR TITLE
telemetry: make spans hierarchical and refine MCP telemetry

### DIFF
--- a/crates/agentgateway/src/mcp/session.rs
+++ b/crates/agentgateway/src/mcp/session.rs
@@ -197,12 +197,12 @@ impl Session {
 		// It's very common to not have any notifications, though.
 		match message {
 			ClientJsonRpcMessage::Request(mut r) => {
-				let method = r.request.method();
+				let method = r.request.method().to_string();
 				let ctx = IncomingRequestContext::new(&parts);
-				let (_span, log, cel) = mcp::handler::setup_request_log(parts, method);
+				let (mut span, log, cel) = mcp::handler::setup_request_log(parts, &method);
 				let session_id = self.id.to_string();
 				log.non_atomic_mutate(|l| {
-					l.method_name = Some(method.to_string());
+					l.method_name = Some(method.clone());
 					l.session_id = Some(session_id);
 				});
 				match &mut r.request {
@@ -296,6 +296,7 @@ impl Session {
 					ClientRequest::CallToolRequest(ctr) => {
 						let name = ctr.params.name.clone();
 						let (service_name, tool) = self.relay.parse_resource_name(&name)?;
+						span.rename_span(format!("{method} {service_name}"));
 						log.non_atomic_mutate(|l| {
 							l.resource_name = Some(tool.to_string());
 							l.target_name = Some(service_name.to_string());
@@ -321,6 +322,7 @@ impl Session {
 					ClientRequest::GetPromptRequest(gpr) => {
 						let name = gpr.params.name.clone();
 						let (service_name, prompt) = self.relay.parse_resource_name(&name)?;
+						span.rename_span(format!("{method} {service_name}"));
 						log.non_atomic_mutate(|l| {
 							l.target_name = Some(service_name.to_string());
 							l.resource_name = Some(prompt.to_string());
@@ -344,6 +346,7 @@ impl Session {
 					ClientRequest::ReadResourceRequest(rrr) => {
 						if let Some(service_name) = self.relay.default_target_name() {
 							let uri = rrr.params.uri.clone();
+							span.rename_span(format!("{method} {service_name}"));
 							log.non_atomic_mutate(|l| {
 								l.target_name = Some(service_name.to_string());
 								l.resource_name = Some(uri.to_string());

--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -1005,10 +1005,6 @@ impl Drop for DropOnLog {
 				log.llm_request.as_ref().map(|l| display(&l.provider)),
 			),
 			(
-				"gen_ai.system", // Kept for compatibility with v1.37
-				log.llm_request.as_ref().map(|l| display(&l.provider)),
-			),
-			(
 				"gen_ai.request.model",
 				log.llm_request.as_ref().map(|l| display(&l.request_model)),
 			),

--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -17,7 +17,9 @@ use http_body::{Body, Frame, SizeHint};
 use indexmap::IndexMap;
 use itertools::Itertools;
 use opentelemetry::TraceFlags;
-use opentelemetry::trace::{Span, SpanBuilder, SpanContext, SpanKind, TraceState, Tracer};
+use opentelemetry::trace::{
+	Span, SpanBuilder, SpanContext, SpanKind, TraceContextExt as _, TraceState, Tracer,
+};
 use serde::de::DeserializeOwned;
 use serde::ser::SerializeMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -41,7 +43,7 @@ use crate::types::loadbalancer::ActiveHandle;
 use crate::{cel, llm, mcp};
 
 use opentelemetry::logs::{AnyValue, LogRecord as _, Logger, LoggerProvider as _, Severity};
-use opentelemetry::{Key, KeyValue};
+use opentelemetry::{Context as OtelContext, Key, KeyValue};
 use opentelemetry_otlp::{WithExportConfig, WithHttpConfig};
 use opentelemetry_sdk::Resource;
 use opentelemetry_sdk::logs::SdkLoggerProvider;
@@ -634,12 +636,10 @@ impl RequestLog {
 	fn span_writer_inner(&self) -> Option<SpanWriterInner> {
 		let tp = self.outgoing_span.clone()?;
 		let tc = self.tracer.clone()?;
-		let current = tp.new_span();
 
 		Some(SpanWriterInner {
 			tracer: tc,
 			parent: tp,
-			current,
 			inner: self.trace_spans.clone(),
 		})
 	}
@@ -659,7 +659,7 @@ pub struct RequestLog {
 	pub tracer: Option<std::sync::Arc<trc::Tracer>>,
 	/// Additional spans created during the request (e.g. upstream call spans).
 	/// These are flushed on drop when tracing is enabled.
-	pub trace_spans: Arc<Mutex<Vec<SpanBuilder>>>,
+	pub trace_spans: Arc<Mutex<Vec<(SpanBuilder, OtelContext)>>>,
 
 	// Set only if OTLP logging is configured
 	pub otel_logger: Option<std::sync::Arc<OtelAccessLogger>>,
@@ -941,11 +941,50 @@ impl Drop for DropOnLog {
 			("protocol", log.backend_protocol.as_ref().map(debug)),
 			("a2a.method", log.a2a_method.display()),
 			(
-				"mcp.method",
+				"mcp.method.name",
 				mcp
 					.as_ref()
 					.and_then(|m| m.method_name.as_ref())
 					.map(display),
+			),
+			(
+				"mcp.method", // Kept for compatibility with v1.37
+				mcp
+					.as_ref()
+					.and_then(|m| m.method_name.as_ref())
+					.map(display),
+			),
+			(
+				"gen_ai.operation.name",
+				mcp.as_ref().and_then(|m| {
+					if matches!(m.resource, Some(MCPOperation::Tool))
+						&& m.method_name.as_deref() == Some("tools/call")
+					{
+						Some("execute_tool".into())
+					} else {
+						None
+					}
+				}),
+			),
+			(
+				"gen_ai.tool.name",
+				mcp.as_ref().and_then(|m| {
+					if matches!(m.resource, Some(MCPOperation::Tool)) {
+						m.resource_name.as_ref().map(display)
+					} else {
+						None
+					}
+				}),
+			),
+			(
+				"gen_ai.prompt.name",
+				mcp.as_ref().and_then(|m| {
+					if matches!(m.resource, Some(MCPOperation::Prompt)) {
+						m.resource_name.as_ref().map(display)
+					} else {
+						None
+					}
+				}),
 			),
 			(
 				"mcp.target",
@@ -959,7 +998,17 @@ impl Drop for DropOnLog {
 				mcp.as_ref().and_then(|m| m.resource.as_ref()).map(display),
 			),
 			(
-				"mcp.resource.name",
+				"mcp.resource.uri",
+				mcp.as_ref().and_then(|m| {
+					if matches!(m.resource, Some(MCPOperation::Resource)) {
+						m.resource_name.as_ref().map(display)
+					} else {
+						None
+					}
+				}),
+			),
+			(
+				"mcp.resource.name", // Kept for compatibility with v1.37
 				mcp
 					.as_ref()
 					.and_then(|m| m.resource_name.as_ref())
@@ -976,7 +1025,7 @@ impl Drop for DropOnLog {
 				"inferencepool.selected_endpoint",
 				log.inference_pool.display(),
 			),
-			// OpenTelemetry Gen AI Semantic Conventions v1.37.0
+			// OpenTelemetry Gen AI Semantic Conventions v1.40.0
 			(
 				"gen_ai.operation.name",
 				log.llm_request.as_ref().map(|r| {
@@ -989,6 +1038,10 @@ impl Drop for DropOnLog {
 			),
 			(
 				"gen_ai.provider.name",
+				log.llm_request.as_ref().map(|l| display(&l.provider)),
+			),
+			(
+				"gen_ai.system", // Kept for compatibility with v1.37
 				log.llm_request.as_ref().map(|l| display(&l.provider)),
 			),
 			(
@@ -1077,13 +1130,14 @@ impl Drop for DropOnLog {
 			("reason", reason.display()),
 			("duration", Some(dur.as_str().into())),
 		];
+
 		if enable_trace && let Some(t) = &log.tracer {
 			t.send(&log, &cel_exec, kv.as_slice());
 			// Flush any buffered spans created during request processing.
 			// Does best effort, if the lock is poisoned, skip flushing.
 			if let Ok(mut spans) = log.trace_spans.lock() {
-				for sb in spans.drain(..) {
-					sb.start(t.tracer.as_ref()).end();
+				for (sb, context) in spans.drain(..) {
+					sb.start_with_context(t.tracer.as_ref(), &context).end();
 				}
 			}
 		};
@@ -1446,15 +1500,20 @@ impl SpanWriter {
 #[derive(Debug, Clone)]
 pub struct SpanWriterInner {
 	parent: trc::TraceParent,
-	current: trc::TraceParent,
 	tracer: Arc<trc::Tracer>,
-	inner: Arc<Mutex<Vec<SpanBuilder>>>,
+	inner: Arc<Mutex<Vec<(SpanBuilder, OtelContext)>>>,
 }
 
 impl SpanWriterInner {
-	#[allow(unused)]
-	pub fn traceparent(&self) -> &trc::TraceParent {
-		&self.current
+	fn parent_context(&self) -> OtelContext {
+		let parent = SpanContext::new(
+			self.parent.trace_id.into(),
+			self.parent.span_id.into(),
+			TraceFlags::new(self.parent.flags),
+			true,
+			TraceState::default(),
+		);
+		OtelContext::new().with_remote_span_context(parent)
 	}
 
 	#[allow(unused)]
@@ -1477,18 +1536,9 @@ impl SpanWriterInner {
 		// Capture end time at write time so it measures the intended operation duration.
 		sb = sb.with_end_time(SystemTime::now());
 
-		let parent = SpanContext::new(
-			self.parent.trace_id.into(),
-			self.parent.span_id.into(),
-			TraceFlags::new(self.parent.flags),
-			true,
-			TraceState::default(),
-		);
-		sb = sb.with_links(vec![opentelemetry::trace::Link::new(parent, vec![], 0)]);
-
 		// Store for later flush when the request log is finalized.
 		if let Ok(mut spans) = self.inner.lock() {
-			spans.push(sb);
+			spans.push((sb, self.parent_context()));
 		}
 	}
 
@@ -1506,7 +1556,7 @@ impl SpanWriterInner {
 
 		SpanWriteOnDrop {
 			sb: Some(sb),
-			parent: self.parent.clone(),
+			context: self.parent_context(),
 			inner: self.inner.clone(),
 		}
 	}
@@ -1515,26 +1565,131 @@ impl SpanWriterInner {
 #[derive(Default)]
 pub struct SpanWriteOnDrop {
 	sb: Option<SpanBuilder>,
-	parent: trc::TraceParent,
-	inner: Arc<Mutex<Vec<SpanBuilder>>>,
+	context: OtelContext,
+	inner: Arc<Mutex<Vec<(SpanBuilder, OtelContext)>>>,
+}
+impl SpanWriteOnDrop {
+	pub fn rename_span(&mut self, name: impl Into<Cow<'static, str>>) {
+		if let Some(sb) = self.sb.as_mut() {
+			sb.name = name.into();
+		}
+	}
 }
 impl Drop for SpanWriteOnDrop {
 	fn drop(&mut self) {
 		let Some(mut sb) = self.sb.take() else { return };
 		sb = sb.with_end_time(SystemTime::now());
 
-		let parent = SpanContext::new(
-			self.parent.trace_id.into(),
-			self.parent.span_id.into(),
-			TraceFlags::new(self.parent.flags),
-			true,
-			TraceState::default(),
-		);
-		sb = sb.with_links(vec![opentelemetry::trace::Link::new(parent, vec![], 0)]);
-
 		// Store for later flush when the request log is finalized.
 		if let Ok(mut spans) = self.inner.lock() {
-			spans.push(sb);
+			spans.push((sb, self.context.clone()));
 		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::future::ready;
+	use std::net::SocketAddr;
+	use std::sync::{Arc, Mutex};
+	use std::time::Instant;
+
+	use opentelemetry::trace::{SpanKind, TracerProvider};
+	use opentelemetry_sdk::error::OTelSdkResult;
+	use opentelemetry_sdk::trace::{SimpleSpanProcessor, SpanData, SpanExporter};
+	use prometheus_client::registry::Registry;
+
+	use super::*;
+	use crate::telemetry::metrics::Metrics;
+	use crate::telemetry::trc;
+	use crate::transport::stream::TCPConnectionInfo;
+
+	#[derive(Clone, Debug, Default)]
+	struct RecordingSpanExporter {
+		spans: Arc<Mutex<Vec<SpanData>>>,
+	}
+
+	impl RecordingSpanExporter {
+		fn finished_spans(&self) -> Vec<SpanData> {
+			self.spans.lock().unwrap().clone()
+		}
+	}
+
+	impl SpanExporter for RecordingSpanExporter {
+		fn export(
+			&self,
+			batch: Vec<SpanData>,
+		) -> impl std::future::Future<Output = OTelSdkResult> + Send {
+			self.spans.lock().unwrap().extend(batch);
+			ready(Ok(()))
+		}
+	}
+
+	fn test_tracer() -> (Arc<trc::Tracer>, RecordingSpanExporter) {
+		let exporter = RecordingSpanExporter::default();
+		let provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
+			.with_span_processor(SimpleSpanProcessor::new(exporter.clone()))
+			.build();
+		let tracer = provider.tracer("test-tracer");
+		(
+			Arc::new(trc::Tracer {
+				tracer: Arc::new(tracer),
+				provider,
+				fields: Arc::new(LoggingFields::default()),
+			}),
+			exporter,
+		)
+	}
+
+	fn test_request_log() -> RequestLog {
+		let cel = CelLogging {
+			cel_context: crate::cel::ContextBuilder::new(),
+			filter: None,
+			fields: LoggingFields::default(),
+			metric_fields: Arc::new(MetricFields::default()),
+		};
+		let mut registry = Registry::default();
+		let metrics = Arc::new(Metrics::new(&mut registry, Default::default()));
+		RequestLog::new(
+			cel,
+			metrics,
+			Instant::now(),
+			TCPConnectionInfo {
+				peer_addr: "127.0.0.1:12345".parse::<SocketAddr>().unwrap(),
+				local_addr: "127.0.0.1:8080".parse::<SocketAddr>().unwrap(),
+				start: Instant::now(),
+				raw_peer_addr: None,
+			},
+		)
+	}
+
+	#[test]
+	fn span_writer_flushes_recorded_spans_as_children_of_request_span() {
+		let (tracer, exporter) = test_tracer();
+		let mut request = test_request_log();
+		request.tracer = Some(tracer.clone());
+
+		let mut outgoing = trc::TraceParent::new();
+		outgoing.flags = 1;
+		request.outgoing_span = Some(outgoing.clone());
+
+		{
+			let _span = request.span_writer().start("buffered child span");
+		}
+
+		drop(DropOnLog::from(request));
+		let _ = tracer.provider.force_flush();
+
+		let spans = exporter.finished_spans();
+		assert_eq!(spans.len(), 2);
+
+		let child = spans
+			.iter()
+			.find(|span| span.name.as_ref() == "buffered child span")
+			.expect("buffered span should be exported");
+		assert_eq!(child.span_kind, SpanKind::Server);
+		assert_eq!(child.parent_span_id, outgoing.span_id.into());
+		assert_eq!(child.span_context.trace_id(), outgoing.trace_id.into());
+		assert!(child.parent_span_is_remote);
 	}
 }

--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -948,38 +948,9 @@ impl Drop for DropOnLog {
 					.map(display),
 			),
 			(
-				"mcp.method", // Kept for compatibility with v1.37
-				mcp
-					.as_ref()
-					.and_then(|m| m.method_name.as_ref())
-					.map(display),
-			),
-			(
-				"gen_ai.operation.name",
-				mcp.as_ref().and_then(|m| {
-					if matches!(m.resource, Some(MCPOperation::Tool))
-						&& m.method_name.as_deref() == Some("tools/call")
-					{
-						Some("execute_tool".into())
-					} else {
-						None
-					}
-				}),
-			),
-			(
 				"gen_ai.tool.name",
 				mcp.as_ref().and_then(|m| {
 					if matches!(m.resource, Some(MCPOperation::Tool)) {
-						m.resource_name.as_ref().map(display)
-					} else {
-						None
-					}
-				}),
-			),
-			(
-				"gen_ai.prompt.name",
-				mcp.as_ref().and_then(|m| {
-					if matches!(m.resource, Some(MCPOperation::Prompt)) {
 						m.resource_name.as_ref().map(display)
 					} else {
 						None
@@ -1006,13 +977,6 @@ impl Drop for DropOnLog {
 						None
 					}
 				}),
-			),
-			(
-				"mcp.resource.name", // Kept for compatibility with v1.37
-				mcp
-					.as_ref()
-					.and_then(|m| m.resource_name.as_ref())
-					.map(display),
 			),
 			(
 				"mcp.session.id",

--- a/crates/agentgateway/src/telemetry/trc.rs
+++ b/crates/agentgateway/src/telemetry/trc.rs
@@ -7,8 +7,10 @@ use agent_core::telemetry::ValueBag;
 use http::Version;
 use itertools::Itertools;
 use once_cell::sync::OnceCell;
-use opentelemetry::trace::{Span, SpanContext, SpanKind, TraceState, Tracer as _, TracerProvider};
-use opentelemetry::{Key, KeyValue, TraceFlags};
+use opentelemetry::trace::{
+	Span, SpanContext, SpanKind, TraceContextExt as _, TraceState, Tracer as _, TracerProvider,
+};
+use opentelemetry::{Context, Key, KeyValue, TraceFlags};
 use opentelemetry_otlp::{WithExportConfig, WithHttpConfig};
 use opentelemetry_sdk::Resource;
 use opentelemetry_sdk::trace::SdkTracerProvider;
@@ -218,7 +220,7 @@ impl Tracer {
 		});
 
 		let out_span = request.outgoing_span.as_ref().unwrap();
-		let mut sb = self
+		let sb = self
 			.tracer
 			.span_builder(span_name)
 			.with_start_time(end.sub(elapsed))
@@ -228,6 +230,7 @@ impl Tracer {
 			.with_trace_id(out_span.trace_id.into())
 			.with_span_id(out_span.span_id.into());
 
+		let mut context = Context::new();
 		if let Some(in_span) = &request.incoming_span {
 			let parent = SpanContext::new(
 				in_span.trace_id.into(),
@@ -236,13 +239,9 @@ impl Tracer {
 				true,
 				TraceState::default(),
 			);
-			sb = sb.with_links(vec![opentelemetry::trace::Link::new(
-				parent.clone(),
-				vec![],
-				0,
-			)]);
+			context = context.with_remote_span_context(parent);
 		}
-		sb.start(self.tracer.as_ref()).end()
+		sb.start_with_context(self.tracer.as_ref(), &context).end()
 	}
 }
 
@@ -582,5 +581,123 @@ mod traceparent {
 				flags: u8::from_str_radix(segs[3], 16)?,
 			})
 		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::future::ready;
+	use std::net::SocketAddr;
+	use std::sync::{Arc, Mutex};
+	use std::time::Instant;
+
+	use agent_core::strng;
+	use opentelemetry::trace::SpanKind;
+	use opentelemetry_sdk::error::OTelSdkResult;
+	use opentelemetry_sdk::trace::{SimpleSpanProcessor, SpanData, SpanExporter};
+	use prometheus_client::registry::Registry;
+
+	use super::*;
+	use crate::telemetry::log::{
+		CelLogging, CelLoggingExecutor, LoggingFields, MetricFields, RequestLog,
+	};
+	use crate::telemetry::metrics::Metrics;
+	use crate::transport::stream::TCPConnectionInfo;
+
+	#[derive(Clone, Debug, Default)]
+	struct RecordingSpanExporter {
+		spans: Arc<Mutex<Vec<SpanData>>>,
+	}
+
+	impl RecordingSpanExporter {
+		fn finished_spans(&self) -> Vec<SpanData> {
+			self.spans.lock().unwrap().clone()
+		}
+	}
+
+	impl SpanExporter for RecordingSpanExporter {
+		fn export(
+			&self,
+			batch: Vec<SpanData>,
+		) -> impl std::future::Future<Output = OTelSdkResult> + Send {
+			self.spans.lock().unwrap().extend(batch);
+			ready(Ok(()))
+		}
+	}
+
+	fn test_tracer() -> (Tracer, RecordingSpanExporter) {
+		let exporter = RecordingSpanExporter::default();
+		let provider = SdkTracerProvider::builder()
+			.with_span_processor(SimpleSpanProcessor::new(exporter.clone()))
+			.build();
+		let tracer = provider.tracer("test-tracer");
+		(
+			Tracer {
+				tracer: Arc::new(tracer),
+				provider,
+				fields: Arc::new(LoggingFields::default()),
+			},
+			exporter,
+		)
+	}
+
+	fn test_request_log() -> RequestLog {
+		let cel = CelLogging {
+			cel_context: crate::cel::ContextBuilder::new(),
+			filter: None,
+			fields: LoggingFields::default(),
+			metric_fields: Arc::new(MetricFields::default()),
+		};
+		let mut registry = Registry::default();
+		let metrics = Arc::new(Metrics::new(&mut registry, Default::default()));
+		RequestLog::new(
+			cel,
+			metrics,
+			Instant::now(),
+			TCPConnectionInfo {
+				peer_addr: "127.0.0.1:12345".parse::<SocketAddr>().unwrap(),
+				local_addr: "127.0.0.1:8080".parse::<SocketAddr>().unwrap(),
+				start: Instant::now(),
+				raw_peer_addr: None,
+			},
+		)
+	}
+
+	#[test]
+	fn send_uses_incoming_span_as_parent_and_preserves_manual_ids() {
+		let (tracer, exporter) = test_tracer();
+		let mut request = test_request_log();
+		request.method = Some(http::Method::GET);
+		request.path_match = Some(strng::new("/trace"));
+
+		let mut incoming = TraceParent::new();
+		incoming.flags = 1;
+		let mut outgoing = incoming.new_span();
+		outgoing.flags = 1;
+		request.incoming_span = Some(incoming.clone());
+		request.outgoing_span = Some(outgoing.clone());
+
+		let filter = None;
+		let fields = LoggingFields::default();
+		let metric_fields = Arc::new(MetricFields::default());
+		let cel_exec = CelLoggingExecutor {
+			executor: crate::cel::Executor::new_empty(),
+			filter: &filter,
+			fields: &fields,
+			metric_fields: &metric_fields,
+		};
+
+		tracer.send(&request, &cel_exec, &[]);
+		let _ = tracer.provider.force_flush();
+
+		let spans = exporter.finished_spans();
+		assert_eq!(spans.len(), 1);
+		let span = &spans[0];
+		assert_eq!(span.span_kind, SpanKind::Server);
+		assert_eq!(span.span_context.trace_id(), outgoing.trace_id.into());
+		assert_eq!(span.span_context.span_id(), outgoing.span_id.into());
+		assert_eq!(span.parent_span_id, incoming.span_id.into());
+		assert!(span.parent_span_is_remote);
+		assert!(span.links.iter().next().is_none());
 	}
 }


### PR DESCRIPTION
## Summary

This PR changes agentgateway tracing from link-based upstream relationships to explicit parent/child relationships when an incoming `traceparent` is present.

It also:
- parents buffered `SpanWriter` spans under the request span
- switches to fresh explicit OTEL contexts (`Context::new()`) so parenting is deterministic
- updates MCP telemetry mapping/naming to align with OTel GenAI/MCP semantic conventions v1.40
- adds focused tests for request-span and `SpanWriter` topology

## Why

The current behavior shares the caller's `trace_id`, but uses span links rather than `parent_span_id`, so the gateway span usually renders as a sibling root instead of a child of the caller.

Before:

```text
trace abc
- caller-span
- gateway-span   (linked to caller-span)
```

After:

```text
trace abc
- caller-span
  - gateway-span
```

This same hierarchical model is now applied to buffered spans emitted through `SpanWriter`.

This is an intentional observability behavior change:
- waterfalls become hierarchical instead of link-based
- parent/child queries in tracing backends will behave differently
- app/runtime behavior should remain the same

On the MCP side, this also aligns the emitted fields with the v1.40 conventions:
- `gen_ai.operation.name=execute_tool` only for `tools/call`
- resource reads emit `mcp.resource.uri`
- span names stay low-cardinality via `{method} {service_name}`