### PR TITLE
mcp: harden fail-open degraded mode

### DIFF
--- a/api/resource.pb.go
+++ b/api/resource.pb.go
@@ -1457,6 +1457,54 @@ func (MCPBackend_PrefixMode) EnumDescriptor() ([]byte, []int) {
 	return file_resource_proto_rawDescGZIP(), []int{51, 1}
 }
 
+// failure_mode controls behavior when MCP targets fail to initialize or
+// become unavailable at runtime. Defaults to FAIL_CLOSED.
+type MCPBackend_FailureMode int32
+
+const (
+	MCPBackend_FAIL_CLOSED MCPBackend_FailureMode = 0
+	MCPBackend_FAIL_OPEN   MCPBackend_FailureMode = 1
+)
+
+// Enum value maps for MCPBackend_FailureMode.
+var (
+	MCPBackend_FailureMode_name = map[int32]string{
+		0: "FAIL_CLOSED",
+		1: "FAIL_OPEN",
+	}
+	MCPBackend_FailureMode_value = map[string]int32{
+		"FAIL_CLOSED": 0,
+		"FAIL_OPEN":   1,
+	}
+)
+
+func (x MCPBackend_FailureMode) Enum() *MCPBackend_FailureMode {
+	p := new(MCPBackend_FailureMode)
+	*p = x
+	return p
+}
+
+func (x MCPBackend_FailureMode) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (MCPBackend_FailureMode) Descriptor() protoreflect.EnumDescriptor {
+	return file_resource_proto_enumTypes[28].Descriptor()
+}
+
+func (MCPBackend_FailureMode) Type() protoreflect.EnumType {
+	return &file_resource_proto_enumTypes[28]
+}
+
+func (x MCPBackend_FailureMode) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use MCPBackend_FailureMode.Descriptor instead.
+func (MCPBackend_FailureMode) EnumDescriptor() ([]byte, []int) {
+	return file_resource_proto_rawDescGZIP(), []int{51, 2}
+}
+
 type MCPTarget_Protocol int32
 
 const (
@@ -1490,11 +1538,11 @@ func (x MCPTarget_Protocol) String() string {
 }
 
 func (MCPTarget_Protocol) Descriptor() protoreflect.EnumDescriptor {
-	return file_resource_proto_enumTypes[28].Descriptor()
+	return file_resource_proto_enumTypes[29].Descriptor()
 }
 
 func (MCPTarget_Protocol) Type() protoreflect.EnumType {
-	return &file_resource_proto_enumTypes[28]
+	return &file_resource_proto_enumTypes[29]
 }
 
 func (x MCPTarget_Protocol) Number() protoreflect.EnumNumber {
@@ -5848,7 +5896,8 @@ type MCPBackend struct {
 	// to mix stateful and stateless targets in the same backend.
 	StatefulMode MCPBackend_StatefulMode `protobuf:"varint,3,opt,name=stateful_mode,json=statefulMode,proto3,enum=agentgateway.dev.resource.MCPBackend_StatefulMode" json:"stateful_mode,omitempty"`
 	// Whether to always prefix the tool name using the target name
-	PrefixMode    MCPBackend_PrefixMode `protobuf:"varint,4,opt,name=prefix_mode,json=prefixMode,proto3,enum=agentgateway.dev.resource.MCPBackend_PrefixMode" json:"prefix_mode,omitempty"`
+	PrefixMode    MCPBackend_PrefixMode  `protobuf:"varint,4,opt,name=prefix_mode,json=prefixMode,proto3,enum=agentgateway.dev.resource.MCPBackend_PrefixMode" json:"prefix_mode,omitempty"`
+	FailureMode   MCPBackend_FailureMode `protobuf:"varint,5,opt,name=failure_mode,json=failureMode,proto3,enum=agentgateway.dev.resource.MCPBackend_FailureMode" json:"failure_mode,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -5902,6 +5951,13 @@ func (x *MCPBackend) GetPrefixMode() MCPBackend_PrefixMode {
 		return x.PrefixMode
 	}
 	return MCPBackend_CONDITIONAL
+}
+
+func (x *MCPBackend) GetFailureMode() MCPBackend_FailureMode {
+	if x != nil {
+		return x.FailureMode
+	}
+	return MCPBackend_FAIL_CLOSED
 }
 
 type MCPTarget struct {
@@ -11772,13 +11828,14 @@ const file_resource_proto_rawDesc = "" +
 	"\bproviderB\x10\n" +
 	"\x0e_path_override\x1a\\\n" +
 	"\rProviderGroup\x12K\n" +
-	"\tproviders\x18\x01 \x03(\v2-.agentgateway.dev.resource.AIBackend.ProviderR\tproviders\"\xd0\x02\n" +
+	"\tproviders\x18\x01 \x03(\v2-.agentgateway.dev.resource.AIBackend.ProviderR\tproviders\"\xd5\x03\n" +
 	"\n" +
 	"MCPBackend\x12>\n" +
 	"\atargets\x18\x02 \x03(\v2$.agentgateway.dev.resource.MCPTargetR\atargets\x12W\n" +
 	"\rstateful_mode\x18\x03 \x01(\x0e22.agentgateway.dev.resource.MCPBackend.StatefulModeR\fstatefulMode\x12Q\n" +
 	"\vprefix_mode\x18\x04 \x01(\x0e20.agentgateway.dev.resource.MCPBackend.PrefixModeR\n" +
-	"prefixMode\"+\n" +
+	"prefixMode\x12T\n" +
+	"\ffailure_mode\x18\x05 \x01(\x0e21.agentgateway.dev.resource.MCPBackend.FailureModeR\vfailureMode\"+\n" +
 	"\fStatefulMode\x12\f\n" +
 	"\bSTATEFUL\x10\x00\x12\r\n" +
 	"\tSTATELESS\x10\x01\")\n" +
@@ -11786,7 +11843,10 @@ const file_resource_proto_rawDesc = "" +
 	"PrefixMode\x12\x0f\n" +
 	"\vCONDITIONAL\x10\x00\x12\n" +
 	"\n" +
-	"\x06ALWAYS\x10\x01\"\xfe\x01\n" +
+	"\x06ALWAYS\x10\x01\"-\n" +
+	"\vFailureMode\x12\x0f\n" +
+	"\vFAIL_CLOSED\x10\x00\x12\r\n" +
+	"\tFAIL_OPEN\x10\x01\"\xfe\x01\n" +
 	"\tMCPTarget\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12E\n" +
 	"\abackend\x18\x02 \x01(\v2+.agentgateway.dev.resource.BackendReferenceR\abackend\x12\x12\n" +
@@ -11826,7 +11886,7 @@ func file_resource_proto_rawDescGZIP() []byte {
 	return file_resource_proto_rawDescData
 }
 
-var file_resource_proto_enumTypes = make([]protoimpl.EnumInfo, 29)
+var file_resource_proto_enumTypes = make([]protoimpl.EnumInfo, 30)
 var file_resource_proto_msgTypes = make([]protoimpl.MessageInfo, 144)
 var file_resource_proto_goTypes = []any{
 	(Protocol)(0),              // 0: agentgateway.dev.resource.Protocol
@@ -11857,398 +11917,400 @@ var file_resource_proto_goTypes = []any{
 	(BackendPolicySpec_McpAuthentication_Mode)(0),          // 25: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.Mode
 	(MCPBackend_StatefulMode)(0),                           // 26: agentgateway.dev.resource.MCPBackend.StatefulMode
 	(MCPBackend_PrefixMode)(0),                             // 27: agentgateway.dev.resource.MCPBackend.PrefixMode
-	(MCPTarget_Protocol)(0),                                // 28: agentgateway.dev.resource.MCPTarget.Protocol
-	(*Resource)(nil),                                       // 29: agentgateway.dev.resource.Resource
-	(*Bind)(nil),                                           // 30: agentgateway.dev.resource.Bind
-	(*RouteName)(nil),                                      // 31: agentgateway.dev.resource.RouteName
-	(*ListenerName)(nil),                                   // 32: agentgateway.dev.resource.ListenerName
-	(*ResourceName)(nil),                                   // 33: agentgateway.dev.resource.ResourceName
-	(*TypedResourceName)(nil),                              // 34: agentgateway.dev.resource.TypedResourceName
-	(*Listener)(nil),                                       // 35: agentgateway.dev.resource.Listener
-	(*Route)(nil),                                          // 36: agentgateway.dev.resource.Route
-	(*TCPRoute)(nil),                                       // 37: agentgateway.dev.resource.TCPRoute
-	(*Policy)(nil),                                         // 38: agentgateway.dev.resource.Policy
-	(*Backend)(nil),                                        // 39: agentgateway.dev.resource.Backend
-	(*TLSConfig)(nil),                                      // 40: agentgateway.dev.resource.TLSConfig
-	(*Timeout)(nil),                                        // 41: agentgateway.dev.resource.Timeout
-	(*Retry)(nil),                                          // 42: agentgateway.dev.resource.Retry
-	(*BackendAuthPolicy)(nil),                              // 43: agentgateway.dev.resource.BackendAuthPolicy
-	(*Passthrough)(nil),                                    // 44: agentgateway.dev.resource.Passthrough
-	(*Key)(nil),                                            // 45: agentgateway.dev.resource.Key
-	(*Gcp)(nil),                                            // 46: agentgateway.dev.resource.Gcp
-	(*Aws)(nil),                                            // 47: agentgateway.dev.resource.Aws
-	(*Azure)(nil),                                          // 48: agentgateway.dev.resource.Azure
-	(*AwsExplicitConfig)(nil),                              // 49: agentgateway.dev.resource.AwsExplicitConfig
-	(*AwsImplicit)(nil),                                    // 50: agentgateway.dev.resource.AwsImplicit
-	(*AzureExplicitConfig)(nil),                            // 51: agentgateway.dev.resource.AzureExplicitConfig
-	(*AzureClientSecret)(nil),                              // 52: agentgateway.dev.resource.AzureClientSecret
-	(*AzureManagedIdentityCredential)(nil),                 // 53: agentgateway.dev.resource.AzureManagedIdentityCredential
-	(*AzureWorkloadIdentityCredential)(nil),                // 54: agentgateway.dev.resource.AzureWorkloadIdentityCredential
-	(*AzureDeveloperImplicit)(nil),                         // 55: agentgateway.dev.resource.AzureDeveloperImplicit
-	(*RouteMatch)(nil),                                     // 56: agentgateway.dev.resource.RouteMatch
-	(*PathMatch)(nil),                                      // 57: agentgateway.dev.resource.PathMatch
-	(*QueryMatch)(nil),                                     // 58: agentgateway.dev.resource.QueryMatch
-	(*MethodMatch)(nil),                                    // 59: agentgateway.dev.resource.MethodMatch
-	(*HeaderMatch)(nil),                                    // 60: agentgateway.dev.resource.HeaderMatch
-	(*CORS)(nil),                                           // 61: agentgateway.dev.resource.CORS
-	(*DirectResponse)(nil),                                 // 62: agentgateway.dev.resource.DirectResponse
-	(*HeaderModifier)(nil),                                 // 63: agentgateway.dev.resource.HeaderModifier
-	(*RequestMirrors)(nil),                                 // 64: agentgateway.dev.resource.RequestMirrors
-	(*RequestRedirect)(nil),                                // 65: agentgateway.dev.resource.RequestRedirect
-	(*UrlRewrite)(nil),                                     // 66: agentgateway.dev.resource.UrlRewrite
-	(*Header)(nil),                                         // 67: agentgateway.dev.resource.Header
-	(*RouteBackend)(nil),                                   // 68: agentgateway.dev.resource.RouteBackend
-	(*PolicyTarget)(nil),                                   // 69: agentgateway.dev.resource.PolicyTarget
-	(*KeepaliveConfig)(nil),                                // 70: agentgateway.dev.resource.KeepaliveConfig
-	(*FrontendPolicySpec)(nil),                             // 71: agentgateway.dev.resource.FrontendPolicySpec
-	(*JWTValidationOptions)(nil),                           // 72: agentgateway.dev.resource.JWTValidationOptions
-	(*TrafficPolicySpec)(nil),                              // 73: agentgateway.dev.resource.TrafficPolicySpec
-	(*BackendPolicySpec)(nil),                              // 74: agentgateway.dev.resource.BackendPolicySpec
-	(*StaticBackend)(nil),                                  // 75: agentgateway.dev.resource.StaticBackend
-	(*DynamicForwardProxy)(nil),                            // 76: agentgateway.dev.resource.DynamicForwardProxy
-	(*AwsBackend)(nil),                                     // 77: agentgateway.dev.resource.AwsBackend
-	(*AwsAgentCoreBackend)(nil),                            // 78: agentgateway.dev.resource.AwsAgentCoreBackend
-	(*AIBackend)(nil),                                      // 79: agentgateway.dev.resource.AIBackend
-	(*MCPBackend)(nil),                                     // 80: agentgateway.dev.resource.MCPBackend
-	(*MCPTarget)(nil),                                      // 81: agentgateway.dev.resource.MCPTarget
-	(*BackendReference)(nil),                               // 82: agentgateway.dev.resource.BackendReference
-	(*Alpn)(nil),                                           // 83: agentgateway.dev.resource.Alpn
-	(*Gcp_AccessToken)(nil),                                // 84: agentgateway.dev.resource.Gcp.AccessToken
-	(*Gcp_IdToken)(nil),                                    // 85: agentgateway.dev.resource.Gcp.IdToken
-	(*AzureManagedIdentityCredential_UserAssignedIdentity)(nil), // 86: agentgateway.dev.resource.AzureManagedIdentityCredential.UserAssignedIdentity
-	(*RequestMirrors_Mirror)(nil),                               // 87: agentgateway.dev.resource.RequestMirrors.Mirror
-	(*PolicyTarget_ServiceTarget)(nil),                          // 88: agentgateway.dev.resource.PolicyTarget.ServiceTarget
-	(*PolicyTarget_BackendTarget)(nil),                          // 89: agentgateway.dev.resource.PolicyTarget.BackendTarget
-	(*PolicyTarget_GatewayTarget)(nil),                          // 90: agentgateway.dev.resource.PolicyTarget.GatewayTarget
-	(*PolicyTarget_RouteTarget)(nil),                            // 91: agentgateway.dev.resource.PolicyTarget.RouteTarget
-	(*FrontendPolicySpec_HTTP)(nil),                             // 92: agentgateway.dev.resource.FrontendPolicySpec.HTTP
-	(*FrontendPolicySpec_TLS)(nil),                              // 93: agentgateway.dev.resource.FrontendPolicySpec.TLS
-	(*FrontendPolicySpec_TCP)(nil),                              // 94: agentgateway.dev.resource.FrontendPolicySpec.TCP
-	(*FrontendPolicySpec_Logging)(nil),                          // 95: agentgateway.dev.resource.FrontendPolicySpec.Logging
-	(*FrontendPolicySpec_Tracing)(nil),                          // 96: agentgateway.dev.resource.FrontendPolicySpec.Tracing
-	(*FrontendPolicySpec_TracingAttribute)(nil),                 // 97: agentgateway.dev.resource.FrontendPolicySpec.TracingAttribute
-	(*FrontendPolicySpec_Logging_Field)(nil),                    // 98: agentgateway.dev.resource.FrontendPolicySpec.Logging.Field
-	(*FrontendPolicySpec_Logging_Fields)(nil),                   // 99: agentgateway.dev.resource.FrontendPolicySpec.Logging.Fields
-	(*FrontendPolicySpec_Logging_OtlpAccessLog)(nil),            // 100: agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog
-	(*TrafficPolicySpec_RemoteRateLimit)(nil),                   // 101: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit
-	(*TrafficPolicySpec_LocalRateLimit)(nil),                    // 102: agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit
-	(*TrafficPolicySpec_ExternalAuth)(nil),                      // 103: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth
-	(*TrafficPolicySpec_RBAC)(nil),                              // 104: agentgateway.dev.resource.TrafficPolicySpec.RBAC
-	(*TrafficPolicySpec_JWTProvider)(nil),                       // 105: agentgateway.dev.resource.TrafficPolicySpec.JWTProvider
-	(*TrafficPolicySpec_JWT)(nil),                               // 106: agentgateway.dev.resource.TrafficPolicySpec.JWT
-	(*TrafficPolicySpec_BasicAuthentication)(nil),               // 107: agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication
-	(*TrafficPolicySpec_APIKey)(nil),                            // 108: agentgateway.dev.resource.TrafficPolicySpec.APIKey
-	(*TrafficPolicySpec_TransformationPolicy)(nil),              // 109: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy
-	(*TrafficPolicySpec_HeaderTransformation)(nil),              // 110: agentgateway.dev.resource.TrafficPolicySpec.HeaderTransformation
-	(*TrafficPolicySpec_BodyTransformation)(nil),                // 111: agentgateway.dev.resource.TrafficPolicySpec.BodyTransformation
-	(*TrafficPolicySpec_CSRF)(nil),                              // 112: agentgateway.dev.resource.TrafficPolicySpec.CSRF
-	(*TrafficPolicySpec_ExtProc)(nil),                           // 113: agentgateway.dev.resource.TrafficPolicySpec.ExtProc
-	(*TrafficPolicySpec_HostRewrite)(nil),                       // 114: agentgateway.dev.resource.TrafficPolicySpec.HostRewrite
-	(*TrafficPolicySpec_RemoteRateLimit_Descriptor)(nil),        // 115: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor
-	(*TrafficPolicySpec_RemoteRateLimit_Entry)(nil),             // 116: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Entry
-	(*TrafficPolicySpec_ExternalAuth_BodyOptions)(nil),          // 117: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.BodyOptions
-	(*TrafficPolicySpec_ExternalAuth_GRPCProtocol)(nil),         // 118: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol
-	(*TrafficPolicySpec_ExternalAuth_HTTPProtocol)(nil),         // 119: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol
-	nil,                                   // 120: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.ContextEntry
-	nil,                                   // 121: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.MetadataEntry
-	nil,                                   // 122: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.AddRequestHeadersEntry
-	nil,                                   // 123: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.MetadataEntry
-	(*TrafficPolicySpec_APIKey_User)(nil), // 124: agentgateway.dev.resource.TrafficPolicySpec.APIKey.User
-	(*TrafficPolicySpec_TransformationPolicy_Transform)(nil), // 125: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform
-	nil, // 126: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.MetadataEntry
-	nil, // 127: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.RequestAttributesEntry
-	nil, // 128: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ResponseAttributesEntry
-	(*TrafficPolicySpec_ExtProc_NamespacedMetadataContext)(nil), // 129: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext
-	nil,                           // 130: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.MetadataContextEntry
-	nil,                           // 131: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext.ContextEntry
-	(*BackendPolicySpec_Ai)(nil),  // 132: agentgateway.dev.resource.BackendPolicySpec.Ai
-	(*BackendPolicySpec_A2A)(nil), // 133: agentgateway.dev.resource.BackendPolicySpec.A2a
-	(*BackendPolicySpec_InferenceRouting)(nil),     // 134: agentgateway.dev.resource.BackendPolicySpec.InferenceRouting
-	(*BackendPolicySpec_Eviction)(nil),             // 135: agentgateway.dev.resource.BackendPolicySpec.Eviction
-	(*BackendPolicySpec_Health)(nil),               // 136: agentgateway.dev.resource.BackendPolicySpec.Health
-	(*BackendPolicySpec_BackendTLS)(nil),           // 137: agentgateway.dev.resource.BackendPolicySpec.BackendTLS
-	(*BackendPolicySpec_BackendHTTP)(nil),          // 138: agentgateway.dev.resource.BackendPolicySpec.BackendHTTP
-	(*BackendPolicySpec_BackendTunnel)(nil),        // 139: agentgateway.dev.resource.BackendPolicySpec.BackendTunnel
-	(*BackendPolicySpec_BackendTCP)(nil),           // 140: agentgateway.dev.resource.BackendPolicySpec.BackendTCP
-	(*BackendPolicySpec_McpAuthorization)(nil),     // 141: agentgateway.dev.resource.BackendPolicySpec.McpAuthorization
-	(*BackendPolicySpec_McpAuthentication)(nil),    // 142: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication
-	(*BackendPolicySpec_Ai_Message)(nil),           // 143: agentgateway.dev.resource.BackendPolicySpec.Ai.Message
-	(*BackendPolicySpec_Ai_PromptEnrichment)(nil),  // 144: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment
-	(*BackendPolicySpec_Ai_RegexRule)(nil),         // 145: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRule
-	(*BackendPolicySpec_Ai_RegexRules)(nil),        // 146: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules
-	(*BackendPolicySpec_Ai_Webhook)(nil),           // 147: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook
-	(*BackendPolicySpec_Ai_Moderation)(nil),        // 148: agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation
-	(*BackendPolicySpec_Ai_BedrockGuardrails)(nil), // 149: agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails
-	(*BackendPolicySpec_Ai_GoogleModelArmor)(nil),  // 150: agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor
-	(*BackendPolicySpec_Ai_RequestRejection)(nil),  // 151: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestRejection
-	(*BackendPolicySpec_Ai_ResponseGuard)(nil),     // 152: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard
-	(*BackendPolicySpec_Ai_RequestGuard)(nil),      // 153: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard
-	(*BackendPolicySpec_Ai_PromptGuard)(nil),       // 154: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard
-	(*BackendPolicySpec_Ai_PromptCaching)(nil),     // 155: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptCaching
-	nil, // 156: agentgateway.dev.resource.BackendPolicySpec.Ai.DefaultsEntry
-	nil, // 157: agentgateway.dev.resource.BackendPolicySpec.Ai.OverridesEntry
-	nil, // 158: agentgateway.dev.resource.BackendPolicySpec.Ai.TransformationsEntry
-	nil, // 159: agentgateway.dev.resource.BackendPolicySpec.Ai.ModelAliasesEntry
-	nil, // 160: agentgateway.dev.resource.BackendPolicySpec.Ai.RoutesEntry
-	(*BackendPolicySpec_McpAuthentication_ResourceMetadata)(nil), // 161: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata
-	nil,                              // 162: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntry
-	(*AIBackend_HostOverride)(nil),   // 163: agentgateway.dev.resource.AIBackend.HostOverride
-	(*AIBackend_OpenAI)(nil),         // 164: agentgateway.dev.resource.AIBackend.OpenAI
-	(*AIBackend_Gemini)(nil),         // 165: agentgateway.dev.resource.AIBackend.Gemini
-	(*AIBackend_Vertex)(nil),         // 166: agentgateway.dev.resource.AIBackend.Vertex
-	(*AIBackend_Anthropic)(nil),      // 167: agentgateway.dev.resource.AIBackend.Anthropic
-	(*AIBackend_Bedrock)(nil),        // 168: agentgateway.dev.resource.AIBackend.Bedrock
-	(*AIBackend_AzureOpenAI)(nil),    // 169: agentgateway.dev.resource.AIBackend.AzureOpenAI
-	(*AIBackend_Provider)(nil),       // 170: agentgateway.dev.resource.AIBackend.Provider
-	(*AIBackend_ProviderGroup)(nil),  // 171: agentgateway.dev.resource.AIBackend.ProviderGroup
-	(*BackendReference_Service)(nil), // 172: agentgateway.dev.resource.BackendReference.Service
-	(*workloadapi.Workload)(nil),     // 173: istio.workload.Workload
-	(*workloadapi.Service)(nil),      // 174: istio.workload.Service
-	(*durationpb.Duration)(nil),      // 175: google.protobuf.Duration
-	(*structpb.Struct)(nil),          // 176: google.protobuf.Struct
-	(*structpb.Value)(nil),           // 177: google.protobuf.Value
+	(MCPBackend_FailureMode)(0),                            // 28: agentgateway.dev.resource.MCPBackend.FailureMode
+	(MCPTarget_Protocol)(0),                                // 29: agentgateway.dev.resource.MCPTarget.Protocol
+	(*Resource)(nil),                                       // 30: agentgateway.dev.resource.Resource
+	(*Bind)(nil),                                           // 31: agentgateway.dev.resource.Bind
+	(*RouteName)(nil),                                      // 32: agentgateway.dev.resource.RouteName
+	(*ListenerName)(nil),                                   // 33: agentgateway.dev.resource.ListenerName
+	(*ResourceName)(nil),                                   // 34: agentgateway.dev.resource.ResourceName
+	(*TypedResourceName)(nil),                              // 35: agentgateway.dev.resource.TypedResourceName
+	(*Listener)(nil),                                       // 36: agentgateway.dev.resource.Listener
+	(*Route)(nil),                                          // 37: agentgateway.dev.resource.Route
+	(*TCPRoute)(nil),                                       // 38: agentgateway.dev.resource.TCPRoute
+	(*Policy)(nil),                                         // 39: agentgateway.dev.resource.Policy
+	(*Backend)(nil),                                        // 40: agentgateway.dev.resource.Backend
+	(*TLSConfig)(nil),                                      // 41: agentgateway.dev.resource.TLSConfig
+	(*Timeout)(nil),                                        // 42: agentgateway.dev.resource.Timeout
+	(*Retry)(nil),                                          // 43: agentgateway.dev.resource.Retry
+	(*BackendAuthPolicy)(nil),                              // 44: agentgateway.dev.resource.BackendAuthPolicy
+	(*Passthrough)(nil),                                    // 45: agentgateway.dev.resource.Passthrough
+	(*Key)(nil),                                            // 46: agentgateway.dev.resource.Key
+	(*Gcp)(nil),                                            // 47: agentgateway.dev.resource.Gcp
+	(*Aws)(nil),                                            // 48: agentgateway.dev.resource.Aws
+	(*Azure)(nil),                                          // 49: agentgateway.dev.resource.Azure
+	(*AwsExplicitConfig)(nil),                              // 50: agentgateway.dev.resource.AwsExplicitConfig
+	(*AwsImplicit)(nil),                                    // 51: agentgateway.dev.resource.AwsImplicit
+	(*AzureExplicitConfig)(nil),                            // 52: agentgateway.dev.resource.AzureExplicitConfig
+	(*AzureClientSecret)(nil),                              // 53: agentgateway.dev.resource.AzureClientSecret
+	(*AzureManagedIdentityCredential)(nil),                 // 54: agentgateway.dev.resource.AzureManagedIdentityCredential
+	(*AzureWorkloadIdentityCredential)(nil),                // 55: agentgateway.dev.resource.AzureWorkloadIdentityCredential
+	(*AzureDeveloperImplicit)(nil),                         // 56: agentgateway.dev.resource.AzureDeveloperImplicit
+	(*RouteMatch)(nil),                                     // 57: agentgateway.dev.resource.RouteMatch
+	(*PathMatch)(nil),                                      // 58: agentgateway.dev.resource.PathMatch
+	(*QueryMatch)(nil),                                     // 59: agentgateway.dev.resource.QueryMatch
+	(*MethodMatch)(nil),                                    // 60: agentgateway.dev.resource.MethodMatch
+	(*HeaderMatch)(nil),                                    // 61: agentgateway.dev.resource.HeaderMatch
+	(*CORS)(nil),                                           // 62: agentgateway.dev.resource.CORS
+	(*DirectResponse)(nil),                                 // 63: agentgateway.dev.resource.DirectResponse
+	(*HeaderModifier)(nil),                                 // 64: agentgateway.dev.resource.HeaderModifier
+	(*RequestMirrors)(nil),                                 // 65: agentgateway.dev.resource.RequestMirrors
+	(*RequestRedirect)(nil),                                // 66: agentgateway.dev.resource.RequestRedirect
+	(*UrlRewrite)(nil),                                     // 67: agentgateway.dev.resource.UrlRewrite
+	(*Header)(nil),                                         // 68: agentgateway.dev.resource.Header
+	(*RouteBackend)(nil),                                   // 69: agentgateway.dev.resource.RouteBackend
+	(*PolicyTarget)(nil),                                   // 70: agentgateway.dev.resource.PolicyTarget
+	(*KeepaliveConfig)(nil),                                // 71: agentgateway.dev.resource.KeepaliveConfig
+	(*FrontendPolicySpec)(nil),                             // 72: agentgateway.dev.resource.FrontendPolicySpec
+	(*JWTValidationOptions)(nil),                           // 73: agentgateway.dev.resource.JWTValidationOptions
+	(*TrafficPolicySpec)(nil),                              // 74: agentgateway.dev.resource.TrafficPolicySpec
+	(*BackendPolicySpec)(nil),                              // 75: agentgateway.dev.resource.BackendPolicySpec
+	(*StaticBackend)(nil),                                  // 76: agentgateway.dev.resource.StaticBackend
+	(*DynamicForwardProxy)(nil),                            // 77: agentgateway.dev.resource.DynamicForwardProxy
+	(*AwsBackend)(nil),                                     // 78: agentgateway.dev.resource.AwsBackend
+	(*AwsAgentCoreBackend)(nil),                            // 79: agentgateway.dev.resource.AwsAgentCoreBackend
+	(*AIBackend)(nil),                                      // 80: agentgateway.dev.resource.AIBackend
+	(*MCPBackend)(nil),                                     // 81: agentgateway.dev.resource.MCPBackend
+	(*MCPTarget)(nil),                                      // 82: agentgateway.dev.resource.MCPTarget
+	(*BackendReference)(nil),                               // 83: agentgateway.dev.resource.BackendReference
+	(*Alpn)(nil),                                           // 84: agentgateway.dev.resource.Alpn
+	(*Gcp_AccessToken)(nil),                                // 85: agentgateway.dev.resource.Gcp.AccessToken
+	(*Gcp_IdToken)(nil),                                    // 86: agentgateway.dev.resource.Gcp.IdToken
+	(*AzureManagedIdentityCredential_UserAssignedIdentity)(nil), // 87: agentgateway.dev.resource.AzureManagedIdentityCredential.UserAssignedIdentity
+	(*RequestMirrors_Mirror)(nil),                               // 88: agentgateway.dev.resource.RequestMirrors.Mirror
+	(*PolicyTarget_ServiceTarget)(nil),                          // 89: agentgateway.dev.resource.PolicyTarget.ServiceTarget
+	(*PolicyTarget_BackendTarget)(nil),                          // 90: agentgateway.dev.resource.PolicyTarget.BackendTarget
+	(*PolicyTarget_GatewayTarget)(nil),                          // 91: agentgateway.dev.resource.PolicyTarget.GatewayTarget
+	(*PolicyTarget_RouteTarget)(nil),                            // 92: agentgateway.dev.resource.PolicyTarget.RouteTarget
+	(*FrontendPolicySpec_HTTP)(nil),                             // 93: agentgateway.dev.resource.FrontendPolicySpec.HTTP
+	(*FrontendPolicySpec_TLS)(nil),                              // 94: agentgateway.dev.resource.FrontendPolicySpec.TLS
+	(*FrontendPolicySpec_TCP)(nil),                              // 95: agentgateway.dev.resource.FrontendPolicySpec.TCP
+	(*FrontendPolicySpec_Logging)(nil),                          // 96: agentgateway.dev.resource.FrontendPolicySpec.Logging
+	(*FrontendPolicySpec_Tracing)(nil),                          // 97: agentgateway.dev.resource.FrontendPolicySpec.Tracing
+	(*FrontendPolicySpec_TracingAttribute)(nil),                 // 98: agentgateway.dev.resource.FrontendPolicySpec.TracingAttribute
+	(*FrontendPolicySpec_Logging_Field)(nil),                    // 99: agentgateway.dev.resource.FrontendPolicySpec.Logging.Field
+	(*FrontendPolicySpec_Logging_Fields)(nil),                   // 100: agentgateway.dev.resource.FrontendPolicySpec.Logging.Fields
+	(*FrontendPolicySpec_Logging_OtlpAccessLog)(nil),            // 101: agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog
+	(*TrafficPolicySpec_RemoteRateLimit)(nil),                   // 102: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit
+	(*TrafficPolicySpec_LocalRateLimit)(nil),                    // 103: agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit
+	(*TrafficPolicySpec_ExternalAuth)(nil),                      // 104: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth
+	(*TrafficPolicySpec_RBAC)(nil),                              // 105: agentgateway.dev.resource.TrafficPolicySpec.RBAC
+	(*TrafficPolicySpec_JWTProvider)(nil),                       // 106: agentgateway.dev.resource.TrafficPolicySpec.JWTProvider
+	(*TrafficPolicySpec_JWT)(nil),                               // 107: agentgateway.dev.resource.TrafficPolicySpec.JWT
+	(*TrafficPolicySpec_BasicAuthentication)(nil),               // 108: agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication
+	(*TrafficPolicySpec_APIKey)(nil),                            // 109: agentgateway.dev.resource.TrafficPolicySpec.APIKey
+	(*TrafficPolicySpec_TransformationPolicy)(nil),              // 110: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy
+	(*TrafficPolicySpec_HeaderTransformation)(nil),              // 111: agentgateway.dev.resource.TrafficPolicySpec.HeaderTransformation
+	(*TrafficPolicySpec_BodyTransformation)(nil),                // 112: agentgateway.dev.resource.TrafficPolicySpec.BodyTransformation
+	(*TrafficPolicySpec_CSRF)(nil),                              // 113: agentgateway.dev.resource.TrafficPolicySpec.CSRF
+	(*TrafficPolicySpec_ExtProc)(nil),                           // 114: agentgateway.dev.resource.TrafficPolicySpec.ExtProc
+	(*TrafficPolicySpec_HostRewrite)(nil),                       // 115: agentgateway.dev.resource.TrafficPolicySpec.HostRewrite
+	(*TrafficPolicySpec_RemoteRateLimit_Descriptor)(nil),        // 116: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor
+	(*TrafficPolicySpec_RemoteRateLimit_Entry)(nil),             // 117: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Entry
+	(*TrafficPolicySpec_ExternalAuth_BodyOptions)(nil),          // 118: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.BodyOptions
+	(*TrafficPolicySpec_ExternalAuth_GRPCProtocol)(nil),         // 119: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol
+	(*TrafficPolicySpec_ExternalAuth_HTTPProtocol)(nil),         // 120: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol
+	nil,                                   // 121: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.ContextEntry
+	nil,                                   // 122: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.MetadataEntry
+	nil,                                   // 123: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.AddRequestHeadersEntry
+	nil,                                   // 124: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.MetadataEntry
+	(*TrafficPolicySpec_APIKey_User)(nil), // 125: agentgateway.dev.resource.TrafficPolicySpec.APIKey.User
+	(*TrafficPolicySpec_TransformationPolicy_Transform)(nil), // 126: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform
+	nil, // 127: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.MetadataEntry
+	nil, // 128: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.RequestAttributesEntry
+	nil, // 129: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ResponseAttributesEntry
+	(*TrafficPolicySpec_ExtProc_NamespacedMetadataContext)(nil), // 130: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext
+	nil,                           // 131: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.MetadataContextEntry
+	nil,                           // 132: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext.ContextEntry
+	(*BackendPolicySpec_Ai)(nil),  // 133: agentgateway.dev.resource.BackendPolicySpec.Ai
+	(*BackendPolicySpec_A2A)(nil), // 134: agentgateway.dev.resource.BackendPolicySpec.A2a
+	(*BackendPolicySpec_InferenceRouting)(nil),     // 135: agentgateway.dev.resource.BackendPolicySpec.InferenceRouting
+	(*BackendPolicySpec_Eviction)(nil),             // 136: agentgateway.dev.resource.BackendPolicySpec.Eviction
+	(*BackendPolicySpec_Health)(nil),               // 137: agentgateway.dev.resource.BackendPolicySpec.Health
+	(*BackendPolicySpec_BackendTLS)(nil),           // 138: agentgateway.dev.resource.BackendPolicySpec.BackendTLS
+	(*BackendPolicySpec_BackendHTTP)(nil),          // 139: agentgateway.dev.resource.BackendPolicySpec.BackendHTTP
+	(*BackendPolicySpec_BackendTunnel)(nil),        // 140: agentgateway.dev.resource.BackendPolicySpec.BackendTunnel
+	(*BackendPolicySpec_BackendTCP)(nil),           // 141: agentgateway.dev.resource.BackendPolicySpec.BackendTCP
+	(*BackendPolicySpec_McpAuthorization)(nil),     // 142: agentgateway.dev.resource.BackendPolicySpec.McpAuthorization
+	(*BackendPolicySpec_McpAuthentication)(nil),    // 143: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication
+	(*BackendPolicySpec_Ai_Message)(nil),           // 144: agentgateway.dev.resource.BackendPolicySpec.Ai.Message
+	(*BackendPolicySpec_Ai_PromptEnrichment)(nil),  // 145: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment
+	(*BackendPolicySpec_Ai_RegexRule)(nil),         // 146: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRule
+	(*BackendPolicySpec_Ai_RegexRules)(nil),        // 147: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules
+	(*BackendPolicySpec_Ai_Webhook)(nil),           // 148: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook
+	(*BackendPolicySpec_Ai_Moderation)(nil),        // 149: agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation
+	(*BackendPolicySpec_Ai_BedrockGuardrails)(nil), // 150: agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails
+	(*BackendPolicySpec_Ai_GoogleModelArmor)(nil),  // 151: agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor
+	(*BackendPolicySpec_Ai_RequestRejection)(nil),  // 152: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestRejection
+	(*BackendPolicySpec_Ai_ResponseGuard)(nil),     // 153: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard
+	(*BackendPolicySpec_Ai_RequestGuard)(nil),      // 154: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard
+	(*BackendPolicySpec_Ai_PromptGuard)(nil),       // 155: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard
+	(*BackendPolicySpec_Ai_PromptCaching)(nil),     // 156: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptCaching
+	nil, // 157: agentgateway.dev.resource.BackendPolicySpec.Ai.DefaultsEntry
+	nil, // 158: agentgateway.dev.resource.BackendPolicySpec.Ai.OverridesEntry
+	nil, // 159: agentgateway.dev.resource.BackendPolicySpec.Ai.TransformationsEntry
+	nil, // 160: agentgateway.dev.resource.BackendPolicySpec.Ai.ModelAliasesEntry
+	nil, // 161: agentgateway.dev.resource.BackendPolicySpec.Ai.RoutesEntry
+	(*BackendPolicySpec_McpAuthentication_ResourceMetadata)(nil), // 162: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata
+	nil,                              // 163: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntry
+	(*AIBackend_HostOverride)(nil),   // 164: agentgateway.dev.resource.AIBackend.HostOverride
+	(*AIBackend_OpenAI)(nil),         // 165: agentgateway.dev.resource.AIBackend.OpenAI
+	(*AIBackend_Gemini)(nil),         // 166: agentgateway.dev.resource.AIBackend.Gemini
+	(*AIBackend_Vertex)(nil),         // 167: agentgateway.dev.resource.AIBackend.Vertex
+	(*AIBackend_Anthropic)(nil),      // 168: agentgateway.dev.resource.AIBackend.Anthropic
+	(*AIBackend_Bedrock)(nil),        // 169: agentgateway.dev.resource.AIBackend.Bedrock
+	(*AIBackend_AzureOpenAI)(nil),    // 170: agentgateway.dev.resource.AIBackend.AzureOpenAI
+	(*AIBackend_Provider)(nil),       // 171: agentgateway.dev.resource.AIBackend.Provider
+	(*AIBackend_ProviderGroup)(nil),  // 172: agentgateway.dev.resource.AIBackend.ProviderGroup
+	(*BackendReference_Service)(nil), // 173: agentgateway.dev.resource.BackendReference.Service
+	(*workloadapi.Workload)(nil),     // 174: istio.workload.Workload
+	(*workloadapi.Service)(nil),      // 175: istio.workload.Service
+	(*durationpb.Duration)(nil),      // 176: google.protobuf.Duration
+	(*structpb.Struct)(nil),          // 177: google.protobuf.Struct
+	(*structpb.Value)(nil),           // 178: google.protobuf.Value
 }
 var file_resource_proto_depIdxs = []int32{
-	30,  // 0: agentgateway.dev.resource.Resource.bind:type_name -> agentgateway.dev.resource.Bind
-	35,  // 1: agentgateway.dev.resource.Resource.listener:type_name -> agentgateway.dev.resource.Listener
-	36,  // 2: agentgateway.dev.resource.Resource.route:type_name -> agentgateway.dev.resource.Route
-	39,  // 3: agentgateway.dev.resource.Resource.backend:type_name -> agentgateway.dev.resource.Backend
-	38,  // 4: agentgateway.dev.resource.Resource.policy:type_name -> agentgateway.dev.resource.Policy
-	37,  // 5: agentgateway.dev.resource.Resource.tcp_route:type_name -> agentgateway.dev.resource.TCPRoute
-	173, // 6: agentgateway.dev.resource.Resource.workload:type_name -> istio.workload.Workload
-	174, // 7: agentgateway.dev.resource.Resource.service:type_name -> istio.workload.Service
+	31,  // 0: agentgateway.dev.resource.Resource.bind:type_name -> agentgateway.dev.resource.Bind
+	36,  // 1: agentgateway.dev.resource.Resource.listener:type_name -> agentgateway.dev.resource.Listener
+	37,  // 2: agentgateway.dev.resource.Resource.route:type_name -> agentgateway.dev.resource.Route
+	40,  // 3: agentgateway.dev.resource.Resource.backend:type_name -> agentgateway.dev.resource.Backend
+	39,  // 4: agentgateway.dev.resource.Resource.policy:type_name -> agentgateway.dev.resource.Policy
+	38,  // 5: agentgateway.dev.resource.Resource.tcp_route:type_name -> agentgateway.dev.resource.TCPRoute
+	174, // 6: agentgateway.dev.resource.Resource.workload:type_name -> istio.workload.Workload
+	175, // 7: agentgateway.dev.resource.Resource.service:type_name -> istio.workload.Service
 	1,   // 8: agentgateway.dev.resource.Bind.protocol:type_name -> agentgateway.dev.resource.Bind.Protocol
 	2,   // 9: agentgateway.dev.resource.Bind.tunnel_protocol:type_name -> agentgateway.dev.resource.Bind.TunnelProtocol
-	33,  // 10: agentgateway.dev.resource.ListenerName.listener_set:type_name -> agentgateway.dev.resource.ResourceName
-	32,  // 11: agentgateway.dev.resource.Listener.name:type_name -> agentgateway.dev.resource.ListenerName
+	34,  // 10: agentgateway.dev.resource.ListenerName.listener_set:type_name -> agentgateway.dev.resource.ResourceName
+	33,  // 11: agentgateway.dev.resource.Listener.name:type_name -> agentgateway.dev.resource.ListenerName
 	0,   // 12: agentgateway.dev.resource.Listener.protocol:type_name -> agentgateway.dev.resource.Protocol
-	40,  // 13: agentgateway.dev.resource.Listener.tls:type_name -> agentgateway.dev.resource.TLSConfig
-	31,  // 14: agentgateway.dev.resource.Route.name:type_name -> agentgateway.dev.resource.RouteName
-	56,  // 15: agentgateway.dev.resource.Route.matches:type_name -> agentgateway.dev.resource.RouteMatch
-	68,  // 16: agentgateway.dev.resource.Route.backends:type_name -> agentgateway.dev.resource.RouteBackend
-	73,  // 17: agentgateway.dev.resource.Route.traffic_policies:type_name -> agentgateway.dev.resource.TrafficPolicySpec
-	31,  // 18: agentgateway.dev.resource.TCPRoute.name:type_name -> agentgateway.dev.resource.RouteName
-	68,  // 19: agentgateway.dev.resource.TCPRoute.backends:type_name -> agentgateway.dev.resource.RouteBackend
-	34,  // 20: agentgateway.dev.resource.Policy.name:type_name -> agentgateway.dev.resource.TypedResourceName
-	69,  // 21: agentgateway.dev.resource.Policy.target:type_name -> agentgateway.dev.resource.PolicyTarget
-	73,  // 22: agentgateway.dev.resource.Policy.traffic:type_name -> agentgateway.dev.resource.TrafficPolicySpec
-	74,  // 23: agentgateway.dev.resource.Policy.backend:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	71,  // 24: agentgateway.dev.resource.Policy.frontend:type_name -> agentgateway.dev.resource.FrontendPolicySpec
-	33,  // 25: agentgateway.dev.resource.Backend.name:type_name -> agentgateway.dev.resource.ResourceName
-	75,  // 26: agentgateway.dev.resource.Backend.static:type_name -> agentgateway.dev.resource.StaticBackend
-	79,  // 27: agentgateway.dev.resource.Backend.ai:type_name -> agentgateway.dev.resource.AIBackend
-	80,  // 28: agentgateway.dev.resource.Backend.mcp:type_name -> agentgateway.dev.resource.MCPBackend
-	76,  // 29: agentgateway.dev.resource.Backend.dynamic:type_name -> agentgateway.dev.resource.DynamicForwardProxy
-	77,  // 30: agentgateway.dev.resource.Backend.aws:type_name -> agentgateway.dev.resource.AwsBackend
-	74,  // 31: agentgateway.dev.resource.Backend.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	41,  // 13: agentgateway.dev.resource.Listener.tls:type_name -> agentgateway.dev.resource.TLSConfig
+	32,  // 14: agentgateway.dev.resource.Route.name:type_name -> agentgateway.dev.resource.RouteName
+	57,  // 15: agentgateway.dev.resource.Route.matches:type_name -> agentgateway.dev.resource.RouteMatch
+	69,  // 16: agentgateway.dev.resource.Route.backends:type_name -> agentgateway.dev.resource.RouteBackend
+	74,  // 17: agentgateway.dev.resource.Route.traffic_policies:type_name -> agentgateway.dev.resource.TrafficPolicySpec
+	32,  // 18: agentgateway.dev.resource.TCPRoute.name:type_name -> agentgateway.dev.resource.RouteName
+	69,  // 19: agentgateway.dev.resource.TCPRoute.backends:type_name -> agentgateway.dev.resource.RouteBackend
+	35,  // 20: agentgateway.dev.resource.Policy.name:type_name -> agentgateway.dev.resource.TypedResourceName
+	70,  // 21: agentgateway.dev.resource.Policy.target:type_name -> agentgateway.dev.resource.PolicyTarget
+	74,  // 22: agentgateway.dev.resource.Policy.traffic:type_name -> agentgateway.dev.resource.TrafficPolicySpec
+	75,  // 23: agentgateway.dev.resource.Policy.backend:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	72,  // 24: agentgateway.dev.resource.Policy.frontend:type_name -> agentgateway.dev.resource.FrontendPolicySpec
+	34,  // 25: agentgateway.dev.resource.Backend.name:type_name -> agentgateway.dev.resource.ResourceName
+	76,  // 26: agentgateway.dev.resource.Backend.static:type_name -> agentgateway.dev.resource.StaticBackend
+	80,  // 27: agentgateway.dev.resource.Backend.ai:type_name -> agentgateway.dev.resource.AIBackend
+	81,  // 28: agentgateway.dev.resource.Backend.mcp:type_name -> agentgateway.dev.resource.MCPBackend
+	77,  // 29: agentgateway.dev.resource.Backend.dynamic:type_name -> agentgateway.dev.resource.DynamicForwardProxy
+	78,  // 30: agentgateway.dev.resource.Backend.aws:type_name -> agentgateway.dev.resource.AwsBackend
+	75,  // 31: agentgateway.dev.resource.Backend.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
 	5,   // 32: agentgateway.dev.resource.TLSConfig.cipher_suites:type_name -> agentgateway.dev.resource.TLSConfig.CipherSuite
 	3,   // 33: agentgateway.dev.resource.TLSConfig.min_version:type_name -> agentgateway.dev.resource.TLSConfig.TLSVersion
 	3,   // 34: agentgateway.dev.resource.TLSConfig.max_version:type_name -> agentgateway.dev.resource.TLSConfig.TLSVersion
 	4,   // 35: agentgateway.dev.resource.TLSConfig.mtls_mode:type_name -> agentgateway.dev.resource.TLSConfig.MTLSMode
-	175, // 36: agentgateway.dev.resource.Timeout.request:type_name -> google.protobuf.Duration
-	175, // 37: agentgateway.dev.resource.Timeout.backend_request:type_name -> google.protobuf.Duration
-	175, // 38: agentgateway.dev.resource.Retry.backoff:type_name -> google.protobuf.Duration
-	44,  // 39: agentgateway.dev.resource.BackendAuthPolicy.passthrough:type_name -> agentgateway.dev.resource.Passthrough
-	45,  // 40: agentgateway.dev.resource.BackendAuthPolicy.key:type_name -> agentgateway.dev.resource.Key
-	46,  // 41: agentgateway.dev.resource.BackendAuthPolicy.gcp:type_name -> agentgateway.dev.resource.Gcp
-	47,  // 42: agentgateway.dev.resource.BackendAuthPolicy.aws:type_name -> agentgateway.dev.resource.Aws
-	48,  // 43: agentgateway.dev.resource.BackendAuthPolicy.azure:type_name -> agentgateway.dev.resource.Azure
-	84,  // 44: agentgateway.dev.resource.Gcp.access_token:type_name -> agentgateway.dev.resource.Gcp.AccessToken
-	85,  // 45: agentgateway.dev.resource.Gcp.id_token:type_name -> agentgateway.dev.resource.Gcp.IdToken
-	49,  // 46: agentgateway.dev.resource.Aws.explicit_config:type_name -> agentgateway.dev.resource.AwsExplicitConfig
-	50,  // 47: agentgateway.dev.resource.Aws.implicit:type_name -> agentgateway.dev.resource.AwsImplicit
-	51,  // 48: agentgateway.dev.resource.Azure.explicit_config:type_name -> agentgateway.dev.resource.AzureExplicitConfig
-	55,  // 49: agentgateway.dev.resource.Azure.developer_implicit:type_name -> agentgateway.dev.resource.AzureDeveloperImplicit
-	52,  // 50: agentgateway.dev.resource.AzureExplicitConfig.client_secret:type_name -> agentgateway.dev.resource.AzureClientSecret
-	53,  // 51: agentgateway.dev.resource.AzureExplicitConfig.managed_identity_credential:type_name -> agentgateway.dev.resource.AzureManagedIdentityCredential
-	54,  // 52: agentgateway.dev.resource.AzureExplicitConfig.workload_identity_credential:type_name -> agentgateway.dev.resource.AzureWorkloadIdentityCredential
-	86,  // 53: agentgateway.dev.resource.AzureManagedIdentityCredential.user_assigned_identity:type_name -> agentgateway.dev.resource.AzureManagedIdentityCredential.UserAssignedIdentity
-	57,  // 54: agentgateway.dev.resource.RouteMatch.path:type_name -> agentgateway.dev.resource.PathMatch
-	60,  // 55: agentgateway.dev.resource.RouteMatch.headers:type_name -> agentgateway.dev.resource.HeaderMatch
-	59,  // 56: agentgateway.dev.resource.RouteMatch.method:type_name -> agentgateway.dev.resource.MethodMatch
-	58,  // 57: agentgateway.dev.resource.RouteMatch.query_params:type_name -> agentgateway.dev.resource.QueryMatch
-	175, // 58: agentgateway.dev.resource.CORS.max_age:type_name -> google.protobuf.Duration
-	67,  // 59: agentgateway.dev.resource.HeaderModifier.add:type_name -> agentgateway.dev.resource.Header
-	67,  // 60: agentgateway.dev.resource.HeaderModifier.set:type_name -> agentgateway.dev.resource.Header
-	87,  // 61: agentgateway.dev.resource.RequestMirrors.mirrors:type_name -> agentgateway.dev.resource.RequestMirrors.Mirror
-	82,  // 62: agentgateway.dev.resource.RouteBackend.backend:type_name -> agentgateway.dev.resource.BackendReference
-	74,  // 63: agentgateway.dev.resource.RouteBackend.backend_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	90,  // 64: agentgateway.dev.resource.PolicyTarget.gateway:type_name -> agentgateway.dev.resource.PolicyTarget.GatewayTarget
-	91,  // 65: agentgateway.dev.resource.PolicyTarget.route:type_name -> agentgateway.dev.resource.PolicyTarget.RouteTarget
-	89,  // 66: agentgateway.dev.resource.PolicyTarget.backend:type_name -> agentgateway.dev.resource.PolicyTarget.BackendTarget
-	88,  // 67: agentgateway.dev.resource.PolicyTarget.service:type_name -> agentgateway.dev.resource.PolicyTarget.ServiceTarget
-	175, // 68: agentgateway.dev.resource.KeepaliveConfig.time:type_name -> google.protobuf.Duration
-	175, // 69: agentgateway.dev.resource.KeepaliveConfig.interval:type_name -> google.protobuf.Duration
-	94,  // 70: agentgateway.dev.resource.FrontendPolicySpec.tcp:type_name -> agentgateway.dev.resource.FrontendPolicySpec.TCP
-	93,  // 71: agentgateway.dev.resource.FrontendPolicySpec.tls:type_name -> agentgateway.dev.resource.FrontendPolicySpec.TLS
-	92,  // 72: agentgateway.dev.resource.FrontendPolicySpec.http:type_name -> agentgateway.dev.resource.FrontendPolicySpec.HTTP
-	95,  // 73: agentgateway.dev.resource.FrontendPolicySpec.logging:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging
-	96,  // 74: agentgateway.dev.resource.FrontendPolicySpec.tracing:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Tracing
+	176, // 36: agentgateway.dev.resource.Timeout.request:type_name -> google.protobuf.Duration
+	176, // 37: agentgateway.dev.resource.Timeout.backend_request:type_name -> google.protobuf.Duration
+	176, // 38: agentgateway.dev.resource.Retry.backoff:type_name -> google.protobuf.Duration
+	45,  // 39: agentgateway.dev.resource.BackendAuthPolicy.passthrough:type_name -> agentgateway.dev.resource.Passthrough
+	46,  // 40: agentgateway.dev.resource.BackendAuthPolicy.key:type_name -> agentgateway.dev.resource.Key
+	47,  // 41: agentgateway.dev.resource.BackendAuthPolicy.gcp:type_name -> agentgateway.dev.resource.Gcp
+	48,  // 42: agentgateway.dev.resource.BackendAuthPolicy.aws:type_name -> agentgateway.dev.resource.Aws
+	49,  // 43: agentgateway.dev.resource.BackendAuthPolicy.azure:type_name -> agentgateway.dev.resource.Azure
+	85,  // 44: agentgateway.dev.resource.Gcp.access_token:type_name -> agentgateway.dev.resource.Gcp.AccessToken
+	86,  // 45: agentgateway.dev.resource.Gcp.id_token:type_name -> agentgateway.dev.resource.Gcp.IdToken
+	50,  // 46: agentgateway.dev.resource.Aws.explicit_config:type_name -> agentgateway.dev.resource.AwsExplicitConfig
+	51,  // 47: agentgateway.dev.resource.Aws.implicit:type_name -> agentgateway.dev.resource.AwsImplicit
+	52,  // 48: agentgateway.dev.resource.Azure.explicit_config:type_name -> agentgateway.dev.resource.AzureExplicitConfig
+	56,  // 49: agentgateway.dev.resource.Azure.developer_implicit:type_name -> agentgateway.dev.resource.AzureDeveloperImplicit
+	53,  // 50: agentgateway.dev.resource.AzureExplicitConfig.client_secret:type_name -> agentgateway.dev.resource.AzureClientSecret
+	54,  // 51: agentgateway.dev.resource.AzureExplicitConfig.managed_identity_credential:type_name -> agentgateway.dev.resource.AzureManagedIdentityCredential
+	55,  // 52: agentgateway.dev.resource.AzureExplicitConfig.workload_identity_credential:type_name -> agentgateway.dev.resource.AzureWorkloadIdentityCredential
+	87,  // 53: agentgateway.dev.resource.AzureManagedIdentityCredential.user_assigned_identity:type_name -> agentgateway.dev.resource.AzureManagedIdentityCredential.UserAssignedIdentity
+	58,  // 54: agentgateway.dev.resource.RouteMatch.path:type_name -> agentgateway.dev.resource.PathMatch
+	61,  // 55: agentgateway.dev.resource.RouteMatch.headers:type_name -> agentgateway.dev.resource.HeaderMatch
+	60,  // 56: agentgateway.dev.resource.RouteMatch.method:type_name -> agentgateway.dev.resource.MethodMatch
+	59,  // 57: agentgateway.dev.resource.RouteMatch.query_params:type_name -> agentgateway.dev.resource.QueryMatch
+	176, // 58: agentgateway.dev.resource.CORS.max_age:type_name -> google.protobuf.Duration
+	68,  // 59: agentgateway.dev.resource.HeaderModifier.add:type_name -> agentgateway.dev.resource.Header
+	68,  // 60: agentgateway.dev.resource.HeaderModifier.set:type_name -> agentgateway.dev.resource.Header
+	88,  // 61: agentgateway.dev.resource.RequestMirrors.mirrors:type_name -> agentgateway.dev.resource.RequestMirrors.Mirror
+	83,  // 62: agentgateway.dev.resource.RouteBackend.backend:type_name -> agentgateway.dev.resource.BackendReference
+	75,  // 63: agentgateway.dev.resource.RouteBackend.backend_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	91,  // 64: agentgateway.dev.resource.PolicyTarget.gateway:type_name -> agentgateway.dev.resource.PolicyTarget.GatewayTarget
+	92,  // 65: agentgateway.dev.resource.PolicyTarget.route:type_name -> agentgateway.dev.resource.PolicyTarget.RouteTarget
+	90,  // 66: agentgateway.dev.resource.PolicyTarget.backend:type_name -> agentgateway.dev.resource.PolicyTarget.BackendTarget
+	89,  // 67: agentgateway.dev.resource.PolicyTarget.service:type_name -> agentgateway.dev.resource.PolicyTarget.ServiceTarget
+	176, // 68: agentgateway.dev.resource.KeepaliveConfig.time:type_name -> google.protobuf.Duration
+	176, // 69: agentgateway.dev.resource.KeepaliveConfig.interval:type_name -> google.protobuf.Duration
+	95,  // 70: agentgateway.dev.resource.FrontendPolicySpec.tcp:type_name -> agentgateway.dev.resource.FrontendPolicySpec.TCP
+	94,  // 71: agentgateway.dev.resource.FrontendPolicySpec.tls:type_name -> agentgateway.dev.resource.FrontendPolicySpec.TLS
+	93,  // 72: agentgateway.dev.resource.FrontendPolicySpec.http:type_name -> agentgateway.dev.resource.FrontendPolicySpec.HTTP
+	96,  // 73: agentgateway.dev.resource.FrontendPolicySpec.logging:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging
+	97,  // 74: agentgateway.dev.resource.FrontendPolicySpec.tracing:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Tracing
 	8,   // 75: agentgateway.dev.resource.TrafficPolicySpec.phase:type_name -> agentgateway.dev.resource.TrafficPolicySpec.PolicyPhase
-	41,  // 76: agentgateway.dev.resource.TrafficPolicySpec.timeout:type_name -> agentgateway.dev.resource.Timeout
-	42,  // 77: agentgateway.dev.resource.TrafficPolicySpec.retry:type_name -> agentgateway.dev.resource.Retry
-	102, // 78: agentgateway.dev.resource.TrafficPolicySpec.local_rate_limit:type_name -> agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit
-	103, // 79: agentgateway.dev.resource.TrafficPolicySpec.ext_authz:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth
-	104, // 80: agentgateway.dev.resource.TrafficPolicySpec.authorization:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RBAC
-	106, // 81: agentgateway.dev.resource.TrafficPolicySpec.jwt:type_name -> agentgateway.dev.resource.TrafficPolicySpec.JWT
-	109, // 82: agentgateway.dev.resource.TrafficPolicySpec.transformation:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy
-	101, // 83: agentgateway.dev.resource.TrafficPolicySpec.remote_rate_limit:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit
-	112, // 84: agentgateway.dev.resource.TrafficPolicySpec.csrf:type_name -> agentgateway.dev.resource.TrafficPolicySpec.CSRF
-	113, // 85: agentgateway.dev.resource.TrafficPolicySpec.ext_proc:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc
-	63,  // 86: agentgateway.dev.resource.TrafficPolicySpec.request_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
-	63,  // 87: agentgateway.dev.resource.TrafficPolicySpec.response_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
-	65,  // 88: agentgateway.dev.resource.TrafficPolicySpec.request_redirect:type_name -> agentgateway.dev.resource.RequestRedirect
-	66,  // 89: agentgateway.dev.resource.TrafficPolicySpec.url_rewrite:type_name -> agentgateway.dev.resource.UrlRewrite
-	64,  // 90: agentgateway.dev.resource.TrafficPolicySpec.request_mirror:type_name -> agentgateway.dev.resource.RequestMirrors
-	62,  // 91: agentgateway.dev.resource.TrafficPolicySpec.direct_response:type_name -> agentgateway.dev.resource.DirectResponse
-	61,  // 92: agentgateway.dev.resource.TrafficPolicySpec.cors:type_name -> agentgateway.dev.resource.CORS
-	107, // 93: agentgateway.dev.resource.TrafficPolicySpec.basic_auth:type_name -> agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication
-	108, // 94: agentgateway.dev.resource.TrafficPolicySpec.api_key_auth:type_name -> agentgateway.dev.resource.TrafficPolicySpec.APIKey
-	114, // 95: agentgateway.dev.resource.TrafficPolicySpec.host_rewrite:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HostRewrite
-	133, // 96: agentgateway.dev.resource.BackendPolicySpec.a2a:type_name -> agentgateway.dev.resource.BackendPolicySpec.A2a
-	134, // 97: agentgateway.dev.resource.BackendPolicySpec.inference_routing:type_name -> agentgateway.dev.resource.BackendPolicySpec.InferenceRouting
-	137, // 98: agentgateway.dev.resource.BackendPolicySpec.backend_tls:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTLS
-	43,  // 99: agentgateway.dev.resource.BackendPolicySpec.auth:type_name -> agentgateway.dev.resource.BackendAuthPolicy
-	141, // 100: agentgateway.dev.resource.BackendPolicySpec.mcp_authorization:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthorization
-	142, // 101: agentgateway.dev.resource.BackendPolicySpec.mcp_authentication:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication
-	132, // 102: agentgateway.dev.resource.BackendPolicySpec.ai:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai
-	63,  // 103: agentgateway.dev.resource.BackendPolicySpec.request_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
-	63,  // 104: agentgateway.dev.resource.BackendPolicySpec.response_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
-	65,  // 105: agentgateway.dev.resource.BackendPolicySpec.request_redirect:type_name -> agentgateway.dev.resource.RequestRedirect
-	64,  // 106: agentgateway.dev.resource.BackendPolicySpec.request_mirror:type_name -> agentgateway.dev.resource.RequestMirrors
-	138, // 107: agentgateway.dev.resource.BackendPolicySpec.backend_http:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendHTTP
-	140, // 108: agentgateway.dev.resource.BackendPolicySpec.backend_tcp:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTCP
-	109, // 109: agentgateway.dev.resource.BackendPolicySpec.transformation:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy
-	136, // 110: agentgateway.dev.resource.BackendPolicySpec.health:type_name -> agentgateway.dev.resource.BackendPolicySpec.Health
-	139, // 111: agentgateway.dev.resource.BackendPolicySpec.backend_tunnel:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTunnel
-	78,  // 112: agentgateway.dev.resource.AwsBackend.agent_core:type_name -> agentgateway.dev.resource.AwsAgentCoreBackend
-	171, // 113: agentgateway.dev.resource.AIBackend.provider_groups:type_name -> agentgateway.dev.resource.AIBackend.ProviderGroup
-	81,  // 114: agentgateway.dev.resource.MCPBackend.targets:type_name -> agentgateway.dev.resource.MCPTarget
+	42,  // 76: agentgateway.dev.resource.TrafficPolicySpec.timeout:type_name -> agentgateway.dev.resource.Timeout
+	43,  // 77: agentgateway.dev.resource.TrafficPolicySpec.retry:type_name -> agentgateway.dev.resource.Retry
+	103, // 78: agentgateway.dev.resource.TrafficPolicySpec.local_rate_limit:type_name -> agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit
+	104, // 79: agentgateway.dev.resource.TrafficPolicySpec.ext_authz:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth
+	105, // 80: agentgateway.dev.resource.TrafficPolicySpec.authorization:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RBAC
+	107, // 81: agentgateway.dev.resource.TrafficPolicySpec.jwt:type_name -> agentgateway.dev.resource.TrafficPolicySpec.JWT
+	110, // 82: agentgateway.dev.resource.TrafficPolicySpec.transformation:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy
+	102, // 83: agentgateway.dev.resource.TrafficPolicySpec.remote_rate_limit:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit
+	113, // 84: agentgateway.dev.resource.TrafficPolicySpec.csrf:type_name -> agentgateway.dev.resource.TrafficPolicySpec.CSRF
+	114, // 85: agentgateway.dev.resource.TrafficPolicySpec.ext_proc:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc
+	64,  // 86: agentgateway.dev.resource.TrafficPolicySpec.request_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
+	64,  // 87: agentgateway.dev.resource.TrafficPolicySpec.response_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
+	66,  // 88: agentgateway.dev.resource.TrafficPolicySpec.request_redirect:type_name -> agentgateway.dev.resource.RequestRedirect
+	67,  // 89: agentgateway.dev.resource.TrafficPolicySpec.url_rewrite:type_name -> agentgateway.dev.resource.UrlRewrite
+	65,  // 90: agentgateway.dev.resource.TrafficPolicySpec.request_mirror:type_name -> agentgateway.dev.resource.RequestMirrors
+	63,  // 91: agentgateway.dev.resource.TrafficPolicySpec.direct_response:type_name -> agentgateway.dev.resource.DirectResponse
+	62,  // 92: agentgateway.dev.resource.TrafficPolicySpec.cors:type_name -> agentgateway.dev.resource.CORS
+	108, // 93: agentgateway.dev.resource.TrafficPolicySpec.basic_auth:type_name -> agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication
+	109, // 94: agentgateway.dev.resource.TrafficPolicySpec.api_key_auth:type_name -> agentgateway.dev.resource.TrafficPolicySpec.APIKey
+	115, // 95: agentgateway.dev.resource.TrafficPolicySpec.host_rewrite:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HostRewrite
+	134, // 96: agentgateway.dev.resource.BackendPolicySpec.a2a:type_name -> agentgateway.dev.resource.BackendPolicySpec.A2a
+	135, // 97: agentgateway.dev.resource.BackendPolicySpec.inference_routing:type_name -> agentgateway.dev.resource.BackendPolicySpec.InferenceRouting
+	138, // 98: agentgateway.dev.resource.BackendPolicySpec.backend_tls:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTLS
+	44,  // 99: agentgateway.dev.resource.BackendPolicySpec.auth:type_name -> agentgateway.dev.resource.BackendAuthPolicy
+	142, // 100: agentgateway.dev.resource.BackendPolicySpec.mcp_authorization:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthorization
+	143, // 101: agentgateway.dev.resource.BackendPolicySpec.mcp_authentication:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication
+	133, // 102: agentgateway.dev.resource.BackendPolicySpec.ai:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai
+	64,  // 103: agentgateway.dev.resource.BackendPolicySpec.request_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
+	64,  // 104: agentgateway.dev.resource.BackendPolicySpec.response_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
+	66,  // 105: agentgateway.dev.resource.BackendPolicySpec.request_redirect:type_name -> agentgateway.dev.resource.RequestRedirect
+	65,  // 106: agentgateway.dev.resource.BackendPolicySpec.request_mirror:type_name -> agentgateway.dev.resource.RequestMirrors
+	139, // 107: agentgateway.dev.resource.BackendPolicySpec.backend_http:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendHTTP
+	141, // 108: agentgateway.dev.resource.BackendPolicySpec.backend_tcp:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTCP
+	110, // 109: agentgateway.dev.resource.BackendPolicySpec.transformation:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy
+	137, // 110: agentgateway.dev.resource.BackendPolicySpec.health:type_name -> agentgateway.dev.resource.BackendPolicySpec.Health
+	140, // 111: agentgateway.dev.resource.BackendPolicySpec.backend_tunnel:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTunnel
+	79,  // 112: agentgateway.dev.resource.AwsBackend.agent_core:type_name -> agentgateway.dev.resource.AwsAgentCoreBackend
+	172, // 113: agentgateway.dev.resource.AIBackend.provider_groups:type_name -> agentgateway.dev.resource.AIBackend.ProviderGroup
+	82,  // 114: agentgateway.dev.resource.MCPBackend.targets:type_name -> agentgateway.dev.resource.MCPTarget
 	26,  // 115: agentgateway.dev.resource.MCPBackend.stateful_mode:type_name -> agentgateway.dev.resource.MCPBackend.StatefulMode
 	27,  // 116: agentgateway.dev.resource.MCPBackend.prefix_mode:type_name -> agentgateway.dev.resource.MCPBackend.PrefixMode
-	82,  // 117: agentgateway.dev.resource.MCPTarget.backend:type_name -> agentgateway.dev.resource.BackendReference
-	28,  // 118: agentgateway.dev.resource.MCPTarget.protocol:type_name -> agentgateway.dev.resource.MCPTarget.Protocol
-	172, // 119: agentgateway.dev.resource.BackendReference.service:type_name -> agentgateway.dev.resource.BackendReference.Service
-	82,  // 120: agentgateway.dev.resource.RequestMirrors.Mirror.backend:type_name -> agentgateway.dev.resource.BackendReference
-	175, // 121: agentgateway.dev.resource.FrontendPolicySpec.HTTP.http1_idle_timeout:type_name -> google.protobuf.Duration
-	175, // 122: agentgateway.dev.resource.FrontendPolicySpec.HTTP.http2_keepalive_interval:type_name -> google.protobuf.Duration
-	175, // 123: agentgateway.dev.resource.FrontendPolicySpec.HTTP.http2_keepalive_timeout:type_name -> google.protobuf.Duration
-	175, // 124: agentgateway.dev.resource.FrontendPolicySpec.TLS.handshake_timeout:type_name -> google.protobuf.Duration
-	83,  // 125: agentgateway.dev.resource.FrontendPolicySpec.TLS.alpn:type_name -> agentgateway.dev.resource.Alpn
-	5,   // 126: agentgateway.dev.resource.FrontendPolicySpec.TLS.cipher_suites:type_name -> agentgateway.dev.resource.TLSConfig.CipherSuite
-	3,   // 127: agentgateway.dev.resource.FrontendPolicySpec.TLS.min_version:type_name -> agentgateway.dev.resource.TLSConfig.TLSVersion
-	3,   // 128: agentgateway.dev.resource.FrontendPolicySpec.TLS.max_version:type_name -> agentgateway.dev.resource.TLSConfig.TLSVersion
-	70,  // 129: agentgateway.dev.resource.FrontendPolicySpec.TCP.keepalives:type_name -> agentgateway.dev.resource.KeepaliveConfig
-	99,  // 130: agentgateway.dev.resource.FrontendPolicySpec.Logging.fields:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging.Fields
-	100, // 131: agentgateway.dev.resource.FrontendPolicySpec.Logging.otlp_access_log:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog
-	82,  // 132: agentgateway.dev.resource.FrontendPolicySpec.Tracing.provider_backend:type_name -> agentgateway.dev.resource.BackendReference
-	97,  // 133: agentgateway.dev.resource.FrontendPolicySpec.Tracing.attributes:type_name -> agentgateway.dev.resource.FrontendPolicySpec.TracingAttribute
-	97,  // 134: agentgateway.dev.resource.FrontendPolicySpec.Tracing.resources:type_name -> agentgateway.dev.resource.FrontendPolicySpec.TracingAttribute
-	7,   // 135: agentgateway.dev.resource.FrontendPolicySpec.Tracing.protocol:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Tracing.Protocol
-	98,  // 136: agentgateway.dev.resource.FrontendPolicySpec.Logging.Fields.add:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging.Field
-	82,  // 137: agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog.provider_backend:type_name -> agentgateway.dev.resource.BackendReference
-	74,  // 138: agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	6,   // 139: agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog.protocol:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog.Protocol
-	115, // 140: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.descriptors:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor
-	82,  // 141: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.target:type_name -> agentgateway.dev.resource.BackendReference
-	10,  // 142: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.failure_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.FailureMode
-	175, // 143: agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit.fill_interval:type_name -> google.protobuf.Duration
-	11,  // 144: agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit.type:type_name -> agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit.Type
-	82,  // 145: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.target:type_name -> agentgateway.dev.resource.BackendReference
-	118, // 146: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.grpc:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol
-	119, // 147: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.http:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol
-	12,  // 148: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.failure_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.FailureMode
-	117, // 149: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.include_request_body:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.BodyOptions
-	72,  // 150: agentgateway.dev.resource.TrafficPolicySpec.JWTProvider.jwt_validation_options:type_name -> agentgateway.dev.resource.JWTValidationOptions
-	13,  // 151: agentgateway.dev.resource.TrafficPolicySpec.JWT.mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.JWT.Mode
-	105, // 152: agentgateway.dev.resource.TrafficPolicySpec.JWT.providers:type_name -> agentgateway.dev.resource.TrafficPolicySpec.JWTProvider
-	14,  // 153: agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication.mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication.Mode
-	124, // 154: agentgateway.dev.resource.TrafficPolicySpec.APIKey.api_keys:type_name -> agentgateway.dev.resource.TrafficPolicySpec.APIKey.User
-	15,  // 155: agentgateway.dev.resource.TrafficPolicySpec.APIKey.mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.APIKey.Mode
-	125, // 156: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.request:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform
-	125, // 157: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.response:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform
-	82,  // 158: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.target:type_name -> agentgateway.dev.resource.BackendReference
-	16,  // 159: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.failure_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.FailureMode
-	127, // 160: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.request_attributes:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.RequestAttributesEntry
-	128, // 161: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.response_attributes:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ResponseAttributesEntry
-	130, // 162: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.metadata_context:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.MetadataContextEntry
-	17,  // 163: agentgateway.dev.resource.TrafficPolicySpec.HostRewrite.mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HostRewrite.Mode
-	116, // 164: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor.entries:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Entry
-	9,   // 165: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor.type:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Type
-	120, // 166: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.context:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.ContextEntry
-	121, // 167: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.metadata:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.MetadataEntry
-	122, // 168: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.add_request_headers:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.AddRequestHeadersEntry
-	123, // 169: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.metadata:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.MetadataEntry
-	176, // 170: agentgateway.dev.resource.TrafficPolicySpec.APIKey.User.metadata:type_name -> google.protobuf.Struct
-	110, // 171: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.set:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HeaderTransformation
-	110, // 172: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.add:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HeaderTransformation
-	111, // 173: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.body:type_name -> agentgateway.dev.resource.TrafficPolicySpec.BodyTransformation
-	126, // 174: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.metadata:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.MetadataEntry
-	131, // 175: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext.context:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext.ContextEntry
-	129, // 176: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.MetadataContextEntry.value:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext
-	154, // 177: agentgateway.dev.resource.BackendPolicySpec.Ai.prompt_guard:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard
-	156, // 178: agentgateway.dev.resource.BackendPolicySpec.Ai.defaults:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.DefaultsEntry
-	157, // 179: agentgateway.dev.resource.BackendPolicySpec.Ai.overrides:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.OverridesEntry
-	158, // 180: agentgateway.dev.resource.BackendPolicySpec.Ai.transformations:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.TransformationsEntry
-	144, // 181: agentgateway.dev.resource.BackendPolicySpec.Ai.prompts:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment
-	159, // 182: agentgateway.dev.resource.BackendPolicySpec.Ai.model_aliases:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ModelAliasesEntry
-	155, // 183: agentgateway.dev.resource.BackendPolicySpec.Ai.prompt_caching:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptCaching
-	160, // 184: agentgateway.dev.resource.BackendPolicySpec.Ai.routes:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RoutesEntry
-	82,  // 185: agentgateway.dev.resource.BackendPolicySpec.InferenceRouting.endpoint_picker:type_name -> agentgateway.dev.resource.BackendReference
-	21,  // 186: agentgateway.dev.resource.BackendPolicySpec.InferenceRouting.failure_mode:type_name -> agentgateway.dev.resource.BackendPolicySpec.InferenceRouting.FailureMode
-	175, // 187: agentgateway.dev.resource.BackendPolicySpec.Eviction.duration:type_name -> google.protobuf.Duration
-	135, // 188: agentgateway.dev.resource.BackendPolicySpec.Health.eviction:type_name -> agentgateway.dev.resource.BackendPolicySpec.Eviction
-	22,  // 189: agentgateway.dev.resource.BackendPolicySpec.BackendTLS.verification:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTLS.VerificationMode
-	83,  // 190: agentgateway.dev.resource.BackendPolicySpec.BackendTLS.alpn:type_name -> agentgateway.dev.resource.Alpn
-	23,  // 191: agentgateway.dev.resource.BackendPolicySpec.BackendHTTP.version:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendHTTP.HttpVersion
-	175, // 192: agentgateway.dev.resource.BackendPolicySpec.BackendHTTP.request_timeout:type_name -> google.protobuf.Duration
-	82,  // 193: agentgateway.dev.resource.BackendPolicySpec.BackendTunnel.proxy:type_name -> agentgateway.dev.resource.BackendReference
-	70,  // 194: agentgateway.dev.resource.BackendPolicySpec.BackendTCP.keepalive:type_name -> agentgateway.dev.resource.KeepaliveConfig
-	175, // 195: agentgateway.dev.resource.BackendPolicySpec.BackendTCP.connect_timeout:type_name -> google.protobuf.Duration
-	24,  // 196: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.provider:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.McpIDP
-	161, // 197: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.resource_metadata:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata
-	25,  // 198: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.mode:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.Mode
-	72,  // 199: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.jwt_validation_options:type_name -> agentgateway.dev.resource.JWTValidationOptions
-	143, // 200: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment.append:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Message
-	143, // 201: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment.prepend:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Message
-	18,  // 202: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRule.builtin:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.BuiltinRegexRule
-	19,  // 203: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules.action:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ActionKind
-	145, // 204: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules.rules:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRule
-	82,  // 205: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.backend:type_name -> agentgateway.dev.resource.BackendReference
-	60,  // 206: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.forward_header_matches:type_name -> agentgateway.dev.resource.HeaderMatch
-	74,  // 207: agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	74,  // 208: agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	74,  // 209: agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	151, // 210: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.rejection:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestRejection
-	146, // 211: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.regex:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules
-	147, // 212: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.webhook:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook
-	150, // 213: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.google_model_armor:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor
-	149, // 214: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.bedrock_guardrails:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails
-	151, // 215: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.rejection:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestRejection
-	146, // 216: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.regex:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules
-	147, // 217: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.webhook:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook
-	148, // 218: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.openai_moderation:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation
-	150, // 219: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.google_model_armor:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor
-	149, // 220: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.bedrock_guardrails:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails
-	153, // 221: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.request:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard
-	152, // 222: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.response:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard
-	20,  // 223: agentgateway.dev.resource.BackendPolicySpec.Ai.RoutesEntry.value:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RouteType
-	162, // 224: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.extra:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntry
-	177, // 225: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntry.value:type_name -> google.protobuf.Value
-	163, // 226: agentgateway.dev.resource.AIBackend.Provider.host_override:type_name -> agentgateway.dev.resource.AIBackend.HostOverride
-	164, // 227: agentgateway.dev.resource.AIBackend.Provider.openai:type_name -> agentgateway.dev.resource.AIBackend.OpenAI
-	165, // 228: agentgateway.dev.resource.AIBackend.Provider.gemini:type_name -> agentgateway.dev.resource.AIBackend.Gemini
-	166, // 229: agentgateway.dev.resource.AIBackend.Provider.vertex:type_name -> agentgateway.dev.resource.AIBackend.Vertex
-	167, // 230: agentgateway.dev.resource.AIBackend.Provider.anthropic:type_name -> agentgateway.dev.resource.AIBackend.Anthropic
-	168, // 231: agentgateway.dev.resource.AIBackend.Provider.bedrock:type_name -> agentgateway.dev.resource.AIBackend.Bedrock
-	169, // 232: agentgateway.dev.resource.AIBackend.Provider.azureopenai:type_name -> agentgateway.dev.resource.AIBackend.AzureOpenAI
-	74,  // 233: agentgateway.dev.resource.AIBackend.Provider.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	170, // 234: agentgateway.dev.resource.AIBackend.ProviderGroup.providers:type_name -> agentgateway.dev.resource.AIBackend.Provider
-	235, // [235:235] is the sub-list for method output_type
-	235, // [235:235] is the sub-list for method input_type
-	235, // [235:235] is the sub-list for extension type_name
-	235, // [235:235] is the sub-list for extension extendee
-	0,   // [0:235] is the sub-list for field type_name
+	28,  // 117: agentgateway.dev.resource.MCPBackend.failure_mode:type_name -> agentgateway.dev.resource.MCPBackend.FailureMode
+	83,  // 118: agentgateway.dev.resource.MCPTarget.backend:type_name -> agentgateway.dev.resource.BackendReference
+	29,  // 119: agentgateway.dev.resource.MCPTarget.protocol:type_name -> agentgateway.dev.resource.MCPTarget.Protocol
+	173, // 120: agentgateway.dev.resource.BackendReference.service:type_name -> agentgateway.dev.resource.BackendReference.Service
+	83,  // 121: agentgateway.dev.resource.RequestMirrors.Mirror.backend:type_name -> agentgateway.dev.resource.BackendReference
+	176, // 122: agentgateway.dev.resource.FrontendPolicySpec.HTTP.http1_idle_timeout:type_name -> google.protobuf.Duration
+	176, // 123: agentgateway.dev.resource.FrontendPolicySpec.HTTP.http2_keepalive_interval:type_name -> google.protobuf.Duration
+	176, // 124: agentgateway.dev.resource.FrontendPolicySpec.HTTP.http2_keepalive_timeout:type_name -> google.protobuf.Duration
+	176, // 125: agentgateway.dev.resource.FrontendPolicySpec.TLS.handshake_timeout:type_name -> google.protobuf.Duration
+	84,  // 126: agentgateway.dev.resource.FrontendPolicySpec.TLS.alpn:type_name -> agentgateway.dev.resource.Alpn
+	5,   // 127: agentgateway.dev.resource.FrontendPolicySpec.TLS.cipher_suites:type_name -> agentgateway.dev.resource.TLSConfig.CipherSuite
+	3,   // 128: agentgateway.dev.resource.FrontendPolicySpec.TLS.min_version:type_name -> agentgateway.dev.resource.TLSConfig.TLSVersion
+	3,   // 129: agentgateway.dev.resource.FrontendPolicySpec.TLS.max_version:type_name -> agentgateway.dev.resource.TLSConfig.TLSVersion
+	71,  // 130: agentgateway.dev.resource.FrontendPolicySpec.TCP.keepalives:type_name -> agentgateway.dev.resource.KeepaliveConfig
+	100, // 131: agentgateway.dev.resource.FrontendPolicySpec.Logging.fields:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging.Fields
+	101, // 132: agentgateway.dev.resource.FrontendPolicySpec.Logging.otlp_access_log:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog
+	83,  // 133: agentgateway.dev.resource.FrontendPolicySpec.Tracing.provider_backend:type_name -> agentgateway.dev.resource.BackendReference
+	98,  // 134: agentgateway.dev.resource.FrontendPolicySpec.Tracing.attributes:type_name -> agentgateway.dev.resource.FrontendPolicySpec.TracingAttribute
+	98,  // 135: agentgateway.dev.resource.FrontendPolicySpec.Tracing.resources:type_name -> agentgateway.dev.resource.FrontendPolicySpec.TracingAttribute
+	7,   // 136: agentgateway.dev.resource.FrontendPolicySpec.Tracing.protocol:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Tracing.Protocol
+	99,  // 137: agentgateway.dev.resource.FrontendPolicySpec.Logging.Fields.add:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging.Field
+	83,  // 138: agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog.provider_backend:type_name -> agentgateway.dev.resource.BackendReference
+	75,  // 139: agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	6,   // 140: agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog.protocol:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog.Protocol
+	116, // 141: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.descriptors:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor
+	83,  // 142: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.target:type_name -> agentgateway.dev.resource.BackendReference
+	10,  // 143: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.failure_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.FailureMode
+	176, // 144: agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit.fill_interval:type_name -> google.protobuf.Duration
+	11,  // 145: agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit.type:type_name -> agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit.Type
+	83,  // 146: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.target:type_name -> agentgateway.dev.resource.BackendReference
+	119, // 147: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.grpc:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol
+	120, // 148: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.http:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol
+	12,  // 149: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.failure_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.FailureMode
+	118, // 150: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.include_request_body:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.BodyOptions
+	73,  // 151: agentgateway.dev.resource.TrafficPolicySpec.JWTProvider.jwt_validation_options:type_name -> agentgateway.dev.resource.JWTValidationOptions
+	13,  // 152: agentgateway.dev.resource.TrafficPolicySpec.JWT.mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.JWT.Mode
+	106, // 153: agentgateway.dev.resource.TrafficPolicySpec.JWT.providers:type_name -> agentgateway.dev.resource.TrafficPolicySpec.JWTProvider
+	14,  // 154: agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication.mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication.Mode
+	125, // 155: agentgateway.dev.resource.TrafficPolicySpec.APIKey.api_keys:type_name -> agentgateway.dev.resource.TrafficPolicySpec.APIKey.User
+	15,  // 156: agentgateway.dev.resource.TrafficPolicySpec.APIKey.mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.APIKey.Mode
+	126, // 157: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.request:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform
+	126, // 158: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.response:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform
+	83,  // 159: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.target:type_name -> agentgateway.dev.resource.BackendReference
+	16,  // 160: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.failure_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.FailureMode
+	128, // 161: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.request_attributes:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.RequestAttributesEntry
+	129, // 162: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.response_attributes:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ResponseAttributesEntry
+	131, // 163: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.metadata_context:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.MetadataContextEntry
+	17,  // 164: agentgateway.dev.resource.TrafficPolicySpec.HostRewrite.mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HostRewrite.Mode
+	117, // 165: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor.entries:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Entry
+	9,   // 166: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor.type:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Type
+	121, // 167: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.context:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.ContextEntry
+	122, // 168: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.metadata:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.MetadataEntry
+	123, // 169: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.add_request_headers:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.AddRequestHeadersEntry
+	124, // 170: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.metadata:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.MetadataEntry
+	177, // 171: agentgateway.dev.resource.TrafficPolicySpec.APIKey.User.metadata:type_name -> google.protobuf.Struct
+	111, // 172: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.set:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HeaderTransformation
+	111, // 173: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.add:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HeaderTransformation
+	112, // 174: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.body:type_name -> agentgateway.dev.resource.TrafficPolicySpec.BodyTransformation
+	127, // 175: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.metadata:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.MetadataEntry
+	132, // 176: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext.context:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext.ContextEntry
+	130, // 177: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.MetadataContextEntry.value:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext
+	155, // 178: agentgateway.dev.resource.BackendPolicySpec.Ai.prompt_guard:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard
+	157, // 179: agentgateway.dev.resource.BackendPolicySpec.Ai.defaults:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.DefaultsEntry
+	158, // 180: agentgateway.dev.resource.BackendPolicySpec.Ai.overrides:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.OverridesEntry
+	159, // 181: agentgateway.dev.resource.BackendPolicySpec.Ai.transformations:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.TransformationsEntry
+	145, // 182: agentgateway.dev.resource.BackendPolicySpec.Ai.prompts:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment
+	160, // 183: agentgateway.dev.resource.BackendPolicySpec.Ai.model_aliases:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ModelAliasesEntry
+	156, // 184: agentgateway.dev.resource.BackendPolicySpec.Ai.prompt_caching:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptCaching
+	161, // 185: agentgateway.dev.resource.BackendPolicySpec.Ai.routes:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RoutesEntry
+	83,  // 186: agentgateway.dev.resource.BackendPolicySpec.InferenceRouting.endpoint_picker:type_name -> agentgateway.dev.resource.BackendReference
+	21,  // 187: agentgateway.dev.resource.BackendPolicySpec.InferenceRouting.failure_mode:type_name -> agentgateway.dev.resource.BackendPolicySpec.InferenceRouting.FailureMode
+	176, // 188: agentgateway.dev.resource.BackendPolicySpec.Eviction.duration:type_name -> google.protobuf.Duration
+	136, // 189: agentgateway.dev.resource.BackendPolicySpec.Health.eviction:type_name -> agentgateway.dev.resource.BackendPolicySpec.Eviction
+	22,  // 190: agentgateway.dev.resource.BackendPolicySpec.BackendTLS.verification:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTLS.VerificationMode
+	84,  // 191: agentgateway.dev.resource.BackendPolicySpec.BackendTLS.alpn:type_name -> agentgateway.dev.resource.Alpn
+	23,  // 192: agentgateway.dev.resource.BackendPolicySpec.BackendHTTP.version:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendHTTP.HttpVersion
+	176, // 193: agentgateway.dev.resource.BackendPolicySpec.BackendHTTP.request_timeout:type_name -> google.protobuf.Duration
+	83,  // 194: agentgateway.dev.resource.BackendPolicySpec.BackendTunnel.proxy:type_name -> agentgateway.dev.resource.BackendReference
+	71,  // 195: agentgateway.dev.resource.BackendPolicySpec.BackendTCP.keepalive:type_name -> agentgateway.dev.resource.KeepaliveConfig
+	176, // 196: agentgateway.dev.resource.BackendPolicySpec.BackendTCP.connect_timeout:type_name -> google.protobuf.Duration
+	24,  // 197: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.provider:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.McpIDP
+	162, // 198: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.resource_metadata:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata
+	25,  // 199: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.mode:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.Mode
+	73,  // 200: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.jwt_validation_options:type_name -> agentgateway.dev.resource.JWTValidationOptions
+	144, // 201: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment.append:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Message
+	144, // 202: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment.prepend:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Message
+	18,  // 203: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRule.builtin:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.BuiltinRegexRule
+	19,  // 204: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules.action:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ActionKind
+	146, // 205: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules.rules:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRule
+	83,  // 206: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.backend:type_name -> agentgateway.dev.resource.BackendReference
+	61,  // 207: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.forward_header_matches:type_name -> agentgateway.dev.resource.HeaderMatch
+	75,  // 208: agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	75,  // 209: agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	75,  // 210: agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	152, // 211: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.rejection:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestRejection
+	147, // 212: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.regex:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules
+	148, // 213: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.webhook:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook
+	151, // 214: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.google_model_armor:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor
+	150, // 215: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.bedrock_guardrails:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails
+	152, // 216: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.rejection:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestRejection
+	147, // 217: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.regex:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules
+	148, // 218: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.webhook:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook
+	149, // 219: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.openai_moderation:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation
+	151, // 220: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.google_model_armor:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor
+	150, // 221: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.bedrock_guardrails:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails
+	154, // 222: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.request:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard
+	153, // 223: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.response:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard
+	20,  // 224: agentgateway.dev.resource.BackendPolicySpec.Ai.RoutesEntry.value:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RouteType
+	163, // 225: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.extra:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntry
+	178, // 226: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntry.value:type_name -> google.protobuf.Value
+	164, // 227: agentgateway.dev.resource.AIBackend.Provider.host_override:type_name -> agentgateway.dev.resource.AIBackend.HostOverride
+	165, // 228: agentgateway.dev.resource.AIBackend.Provider.openai:type_name -> agentgateway.dev.resource.AIBackend.OpenAI
+	166, // 229: agentgateway.dev.resource.AIBackend.Provider.gemini:type_name -> agentgateway.dev.resource.AIBackend.Gemini
+	167, // 230: agentgateway.dev.resource.AIBackend.Provider.vertex:type_name -> agentgateway.dev.resource.AIBackend.Vertex
+	168, // 231: agentgateway.dev.resource.AIBackend.Provider.anthropic:type_name -> agentgateway.dev.resource.AIBackend.Anthropic
+	169, // 232: agentgateway.dev.resource.AIBackend.Provider.bedrock:type_name -> agentgateway.dev.resource.AIBackend.Bedrock
+	170, // 233: agentgateway.dev.resource.AIBackend.Provider.azureopenai:type_name -> agentgateway.dev.resource.AIBackend.AzureOpenAI
+	75,  // 234: agentgateway.dev.resource.AIBackend.Provider.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	171, // 235: agentgateway.dev.resource.AIBackend.ProviderGroup.providers:type_name -> agentgateway.dev.resource.AIBackend.Provider
+	236, // [236:236] is the sub-list for method output_type
+	236, // [236:236] is the sub-list for method input_type
+	236, // [236:236] is the sub-list for extension type_name
+	236, // [236:236] is the sub-list for extension extendee
+	0,   // [0:236] is the sub-list for field type_name
 }
 
 func init() { file_resource_proto_init() }
@@ -12454,7 +12516,7 @@ func file_resource_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_resource_proto_rawDesc), len(file_resource_proto_rawDesc)),
-			NumEnums:      29,
+			NumEnums:      30,
 			NumMessages:   144,
 			NumExtensions: 0,
 			NumServices:   0,

--- a/controller/api/v1alpha1/agentgateway/agentgateway_backend_types.go
+++ b/controller/api/v1alpha1/agentgateway/agentgateway_backend_types.go
@@ -337,8 +337,8 @@ type MCPBackend struct {
 	SessionRouting SessionRouting `json:"sessionRouting,omitempty"`
 
 	// FailureMode controls behavior when MCP targets fail to initialize or
-	// become unavailable at runtime. "failOpen" skips failed targets and
-	// continues serving from healthy ones. "failClosed" (default) fails the
+	// become unavailable at runtime. "FailOpen" skips failed targets and
+	// continues serving from healthy ones. "FailClosed" (default) fails the
 	// entire session if any target fails.
 	// +optional
 	FailureMode FailureMode `json:"failureMode,omitempty"`
@@ -346,12 +346,12 @@ type MCPBackend struct {
 
 const (
 	// FailClosed fails the entire MCP session if any target fails.
-	FailClosed FailureMode = "failClosed"
+	FailClosed FailureMode = "FailClosed"
 	// FailOpen skips failed targets and continues serving from healthy ones.
-	FailOpen FailureMode = "failOpen"
+	FailOpen FailureMode = "FailOpen"
 )
 
-// +kubebuilder:validation:Enum=failOpen;failClosed
+// +kubebuilder:validation:Enum=FailOpen;FailClosed
 type FailureMode string
 
 // McpTargetSelector defines the MCPBackend target to use for this backend.

--- a/controller/api/v1alpha1/agentgateway/agentgateway_backend_types.go
+++ b/controller/api/v1alpha1/agentgateway/agentgateway_backend_types.go
@@ -335,7 +335,24 @@ type MCPBackend struct {
 	// Defaults to Stateful if not set.
 	// +optional
 	SessionRouting SessionRouting `json:"sessionRouting,omitempty"`
+
+	// FailureMode controls behavior when MCP targets fail to initialize or
+	// become unavailable at runtime. "failOpen" skips failed targets and
+	// continues serving from healthy ones. "failClosed" (default) fails the
+	// entire session if any target fails.
+	// +optional
+	FailureMode FailureMode `json:"failureMode,omitempty"`
 }
+
+const (
+	// FailClosed fails the entire MCP session if any target fails.
+	FailClosed FailureMode = "failClosed"
+	// FailOpen skips failed targets and continues serving from healthy ones.
+	FailOpen FailureMode = "failOpen"
+)
+
+// +kubebuilder:validation:Enum=failOpen;failClosed
+type FailureMode string
 
 // McpTargetSelector defines the MCPBackend target to use for this backend.
 // +kubebuilder:validation:ExactlyOneOf=selector;static

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
@@ -6604,6 +6604,16 @@ spec:
               mcp:
                 description: mcp represents an MCP backend
                 properties:
+                  failureMode:
+                    description: |-
+                      FailureMode controls behavior when MCP targets fail to initialize or
+                      become unavailable at runtime. "FailOpen" skips failed targets and
+                      continues serving from healthy ones. "FailClosed" (default) fails the
+                      entire session if any target fails.
+                    enum:
+                    - FailOpen
+                    - FailClosed
+                    type: string
                   sessionRouting:
                     description: |-
                       SessionRouting configures MCP session behavior for requests.

--- a/controller/pkg/kgateway/agentgatewaysyncer/backend/translate.go
+++ b/controller/pkg/kgateway/agentgatewaysyncer/backend/translate.go
@@ -324,6 +324,10 @@ func translateMCPBackends(ctx plugins.PolicyCtx, be *agentgateway.AgentgatewayBa
 	if mcp.SessionRouting == agentgateway.Stateless {
 		sessionRouting = api.MCPBackend_STATELESS
 	}
+	failureMode := api.MCPBackend_FAIL_CLOSED
+	if mcp.FailureMode == "failOpen" {
+		failureMode = api.MCPBackend_FAIL_OPEN
+	}
 	mcpBackend := &api.Backend{
 		Key:  be.Namespace + "/" + be.Name,
 		Name: plugins.ResourceName(be),
@@ -331,6 +335,7 @@ func translateMCPBackends(ctx plugins.PolicyCtx, be *agentgateway.AgentgatewayBa
 			Mcp: &api.MCPBackend{
 				Targets:      mcpTargets,
 				StatefulMode: sessionRouting,
+				FailureMode:  failureMode,
 			},
 		},
 		InlinePolicies: inlinePolicies,

--- a/crates/agentgateway/proto/resource.proto
+++ b/crates/agentgateway/proto/resource.proto
@@ -1210,6 +1210,14 @@ message MCPBackend {
   StatefulMode stateful_mode = 3;
   // Whether to always prefix the tool name using the target name
   PrefixMode prefix_mode = 4;
+
+  // failure_mode controls behavior when MCP targets fail to initialize or
+  // become unavailable at runtime. Defaults to FAIL_CLOSED.
+  enum FailureMode {
+    FAIL_CLOSED = 0;
+    FAIL_OPEN = 1;
+  }
+  FailureMode failure_mode = 5;
 }
 
 message MCPTarget {

--- a/crates/agentgateway/src/http/sessionpersistence.rs
+++ b/crates/agentgateway/src/http/sessionpersistence.rs
@@ -60,6 +60,8 @@ impl MCPSessionState {
 
 #[apply(schema!)]
 pub struct MCPSession {
+	#[serde(default, rename = "t", skip_serializing_if = "Option::is_none")]
+	pub target_name: Option<String>,
 	#[serde(default, rename = "s", skip_serializing_if = "Option::is_none")]
 	pub session: Option<String>,
 	#[serde(default, rename = "b", skip_serializing_if = "Option::is_none")]

--- a/crates/agentgateway/src/mcp/handler.rs
+++ b/crates/agentgateway/src/mcp/handler.rs
@@ -1,11 +1,13 @@
 use std::borrow::Cow;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::cel::RequestSnapshot;
 use crate::http::Response;
 use crate::http::sessionpersistence::MCPSession;
 use crate::mcp;
-use crate::mcp::mergestream::MergeFn;
+use crate::mcp::FailureMode;
+use crate::mcp::mergestream::{MergeFn, Messages};
 use crate::mcp::rbac::{CelExecWrapper, McpAuthorizationSet};
 use crate::mcp::router::McpBackendGroup;
 use crate::mcp::streamablehttp::ServerSseMessage;
@@ -24,6 +26,7 @@ use rmcp::model::{
 	PromptsCapability, ProtocolVersion, RequestId, ResourcesCapability, ServerCapabilities,
 	ServerInfo, ServerJsonRpcMessage, ServerResult, Tool, ToolsCapability,
 };
+use tracing::warn;
 
 const DELIMITER: &str = "_";
 
@@ -94,15 +97,54 @@ impl Relay {
 		Some(sessions)
 	}
 
-	pub fn set_sessions(&self, sessions: Vec<MCPSession>) {
-		for ((_, us), session) in self.upstreams.iter_named().zip(sessions) {
+	pub fn set_sessions(&self, sessions: Vec<MCPSession>) -> anyhow::Result<()> {
+		if sessions.iter().all(|session| session.target_name.is_none()) {
+			if sessions.len() != self.upstreams.size() {
+				anyhow::bail!(
+					"session count {} did not match initialized upstreams {}",
+					sessions.len(),
+					self.upstreams.size()
+				);
+			}
+			for ((_, us), session) in self.upstreams.iter_named().zip(sessions) {
+				us.set_session_id(session.session.as_deref(), session.backend);
+			}
+			return Ok(());
+		}
+
+		if sessions.iter().any(|session| session.target_name.is_none()) {
+			anyhow::bail!("mixed keyed and unkeyed MCP session state is unsupported");
+		}
+
+		// Target-keyed resume is intentionally strict: if the initialized target set changed,
+		// failing the resume is safer than binding persisted session state to the wrong target.
+		let mut by_target = HashMap::with_capacity(sessions.len());
+		for session in sessions {
+			let target_name = session
+				.target_name
+				.clone()
+				.expect("checked all sessions are target-keyed above");
+			if by_target.insert(target_name.clone(), session).is_some() {
+				anyhow::bail!("duplicate persisted session for target {target_name}");
+			}
+		}
+
+		if by_target.len() != self.upstreams.size() {
+			anyhow::bail!(
+				"persisted target count {} did not match initialized upstreams {}",
+				by_target.len(),
+				self.upstreams.size()
+			);
+		}
+
+		for (target_name, us) in self.upstreams.iter_named() {
+			let session = by_target
+				.remove(target_name.as_str())
+				.ok_or_else(|| anyhow::anyhow!("missing persisted session for target {target_name}"))?;
 			us.set_session_id(session.session.as_deref(), session.backend);
 		}
+		Ok(())
 	}
-	pub fn count(&self) -> usize {
-		self.upstreams.size()
-	}
-
 	pub fn is_multiplexing(&self) -> bool {
 		self.upstreams.is_multiplexing
 	}
@@ -160,10 +202,16 @@ impl Relay {
 		Box::new(move |s| {
 			if !multiplexing {
 				// Happy case: we can forward everything
-				let (_, ServerResult::InitializeResult(ir)) = s.into_iter().next().unwrap() else {
-					return Ok(Self::get_info(pv, multiplexing).into());
-				};
-				return Ok(ir.clone().into());
+				let res = s.into_iter().next().and_then(|(_, r)| match r {
+					ServerResult::InitializeResult(ir) => Some(ir),
+					_ => None,
+				});
+				if let Some(ir) = res {
+					return Ok(ir.into());
+				}
+				// If we got here in FailOpen mode, it means the only target failed.
+				// Return a default info response to keep the client session alive.
+				return Ok(Self::get_info(pv, multiplexing).into());
 			}
 
 			// Multiplexing is more complex. We need to find the lowest protocol version that all servers support.
@@ -326,8 +374,20 @@ impl Relay {
 		&self,
 		ctx: IncomingRequestContext,
 	) -> Result<Response, UpstreamError> {
-		for (_, con) in self.upstreams.iter_named() {
-			con.delete(&ctx).await?;
+		for (name, con) in self.upstreams.iter_named() {
+			match con.delete(&ctx).await {
+				Ok(_) => {},
+				Err(e) => {
+					if self.upstreams.failure_mode == FailureMode::FailOpen {
+						warn!(
+							"upstream '{}' failed during deletion, skipping: {}",
+							name, e
+						);
+					} else {
+						return Err(e);
+					}
+				},
+			}
 		}
 		Ok(accepted_response())
 	}
@@ -337,10 +397,26 @@ impl Relay {
 	) -> Result<Response, UpstreamError> {
 		let mut streams = Vec::new();
 		for (name, con) in self.upstreams.iter_named() {
-			streams.push((name, con.get_event_stream(&ctx).await?));
+			match con.get_event_stream(&ctx).await {
+				Ok(s) => streams.push((name, s)),
+				Err(e) => {
+					if self.upstreams.failure_mode == FailureMode::FailOpen {
+						warn!("upstream '{}' failed for GET stream, skipping: {}", name, e);
+					} else {
+						return Err(e);
+					}
+				},
+			}
 		}
 
-		let ms = mergestream::MergeStream::new_without_merge(streams);
+		if streams.is_empty() {
+			// FailClosed: unreachable — InitializeRequest would have failed with NoBackends.
+			// FailOpen: keep the SSE connection open so legacy SSE clients do not immediately
+			// reconnect in a tight loop after all upstream GET streams disappear.
+			return messages_to_response(RequestId::Number(0), Messages::pending());
+		}
+
+		let ms = mergestream::MergeStream::new_without_merge(streams, self.upstreams.failure_mode);
 		messages_to_response(RequestId::Number(0), ms)
 	}
 	pub async fn send_fanout(
@@ -352,10 +428,30 @@ impl Relay {
 		let id = r.id.clone();
 		let mut streams = Vec::new();
 		for (name, con) in self.upstreams.iter_named() {
-			streams.push((name, con.generic_stream(r.clone(), &ctx).await?));
+			match con.generic_stream(r.clone(), &ctx).await {
+				Ok(s) => streams.push((name, s)),
+				Err(e) => {
+					if self.upstreams.failure_mode == FailureMode::FailOpen {
+						warn!("upstream '{}' failed during fanout, skipping: {}", name, e);
+					} else {
+						return Err(e);
+					}
+				},
+			}
 		}
 
-		let ms = mergestream::MergeStream::new(streams, id.clone(), merge);
+		if streams.is_empty() {
+			// Unlike GET fanout, ordinary request fanout does not have a transport-level
+			// "stay connected" fallback, and most MCP methods do not have a safe generic
+			// synthetic success response. By the time we get here, every initialized
+			// upstream has failed this request, so we surface that as an error even in
+			// FailOpen rather than inventing a method-specific response.
+			return Err(UpstreamError::InvalidRequest(
+				"no upstreams available".to_string(),
+			));
+		}
+
+		let ms = mergestream::MergeStream::new(streams, id.clone(), merge, self.upstreams.failure_mode);
 		messages_to_response(id, ms)
 	}
 	pub async fn send_notification(
@@ -363,14 +459,20 @@ impl Relay {
 		r: JsonRpcNotification<ClientNotification>,
 		ctx: IncomingRequestContext,
 	) -> Result<Response, UpstreamError> {
-		let mut streams = Vec::new();
 		for (name, con) in self.upstreams.iter_named() {
-			streams.push((
-				name,
-				con
-					.generic_notification(r.notification.clone(), &ctx)
-					.await?,
-			));
+			match con.generic_notification(r.notification.clone(), &ctx).await {
+				Ok(_) => {},
+				Err(e) => {
+					if self.upstreams.failure_mode == FailureMode::FailOpen {
+						warn!(
+							"upstream '{}' failed during notification, skipping: {}",
+							name, e
+						);
+					} else {
+						return Err(e);
+					}
+				},
+			}
 		}
 
 		Ok(accepted_response())

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -10,7 +10,11 @@ use secrecy::SecretString;
 
 use crate::http::auth::BackendAuth;
 use crate::http::authorization::{PolicySet, RuleSet};
+use crate::mcp::FailureMode;
 use crate::mcp::McpAuthorization;
+use crate::mcp::handler::Relay;
+use crate::mcp::router::{McpBackendGroup, McpTarget};
+use crate::proxy::httpproxy::PolicyClient;
 use crate::test_helpers::proxymock::{
 	BIND_KEY, TestBind, basic_named_route, basic_route, setup_proxy_test, simple_bind,
 };
@@ -1215,4 +1219,338 @@ mod legacymockserver {
 			Ok(self.get_info())
 		}
 	}
+}
+
+#[tokio::test]
+async fn test_zero_targets_fail_closed() {
+	let backend = McpBackendGroup {
+		targets: vec![],
+		stateful: true,
+		failure_mode: FailureMode::FailClosed,
+	};
+	let client = PolicyClient {
+		inputs: setup_proxy_test("{}").unwrap().pi,
+	};
+	let err = crate::mcp::upstream::UpstreamGroup::new(client, backend).unwrap_err();
+	assert!(matches!(err, crate::mcp::Error::NoBackends));
+}
+
+#[tokio::test]
+async fn test_zero_targets_fail_open() {
+	let backend = McpBackendGroup {
+		targets: vec![],
+		stateful: true,
+		failure_mode: FailureMode::FailOpen,
+	};
+	let client = PolicyClient {
+		inputs: setup_proxy_test("{}").unwrap().pi,
+	};
+	crate::mcp::upstream::UpstreamGroup::new(client, backend).unwrap();
+}
+
+#[tokio::test]
+async fn test_setup_partial_success_fail_open() {
+	// Test skipping failed stdio targets
+	let backend = McpBackendGroup {
+		targets: vec![
+			Arc::new(McpTarget {
+				name: "bad".into(),
+				spec: crate::types::agent::McpTargetSpec::Stdio {
+					cmd: "this-binary-does-not-exist-agentgateway-test".into(),
+					args: vec![],
+					env: Default::default(),
+				},
+				backend_policies: Default::default(),
+				backend: None,
+				always_use_prefix: false,
+			}),
+			Arc::new(McpTarget {
+				name: "ok".into(),
+				spec: crate::types::agent::McpTargetSpec::Stdio {
+					cmd: "cat".into(),
+					args: vec![],
+					env: Default::default(),
+				},
+				backend_policies: Default::default(),
+				backend: None,
+				always_use_prefix: false,
+			}),
+		],
+		stateful: false,
+		failure_mode: FailureMode::FailOpen,
+	};
+	let client = PolicyClient {
+		inputs: setup_proxy_test("{}").unwrap().pi,
+	};
+	let group = crate::mcp::upstream::UpstreamGroup::new(client, backend).unwrap();
+	assert_eq!(group.size(), 1);
+}
+
+#[tokio::test]
+async fn test_all_targets_fail_open_still_errors() {
+	let backend = McpBackendGroup {
+		targets: vec![
+			Arc::new(McpTarget {
+				name: "bad-1".into(),
+				spec: crate::types::agent::McpTargetSpec::Stdio {
+					cmd: "this-binary-does-not-exist-agentgateway-test-1".into(),
+					args: vec![],
+					env: Default::default(),
+				},
+				backend_policies: Default::default(),
+				backend: None,
+				always_use_prefix: false,
+			}),
+			Arc::new(McpTarget {
+				name: "bad-2".into(),
+				spec: crate::types::agent::McpTargetSpec::Stdio {
+					cmd: "this-binary-does-not-exist-agentgateway-test-2".into(),
+					args: vec![],
+					env: Default::default(),
+				},
+				backend_policies: Default::default(),
+				backend: None,
+				always_use_prefix: false,
+			}),
+		],
+		stateful: false,
+		failure_mode: FailureMode::FailOpen,
+	};
+	let client = PolicyClient {
+		inputs: setup_proxy_test("{}").unwrap().pi,
+	};
+	let err = crate::mcp::upstream::UpstreamGroup::new(client, backend).unwrap_err();
+	assert!(matches!(err, crate::mcp::Error::NoBackends));
+}
+
+fn fake_streamable_target(name: &str, addr: SocketAddr) -> Arc<McpTarget> {
+	Arc::new(McpTarget {
+		name: name.into(),
+		spec: crate::types::agent::McpTargetSpec::Mcp(crate::types::agent::StreamableHTTPTargetSpec {
+			backend: crate::types::agent::SimpleBackendReference::Backend(strng::format!(
+				"/unused-{name}"
+			)),
+			path: "/mcp".to_string(),
+		}),
+		backend_policies: Default::default(),
+		backend: Some(crate::types::agent::SimpleBackend::Opaque(
+			crate::types::agent::ResourceName::new(strng::format!("backend-{name}"), "".into()),
+			crate::types::agent::Target::Address(addr),
+		)),
+		always_use_prefix: false,
+	})
+}
+
+fn empty_mcp_policies() -> crate::mcp::McpAuthorizationSet {
+	crate::mcp::McpAuthorizationSet::new(crate::http::authorization::RuleSets::from(Vec::new()))
+}
+
+fn persisted_session(
+	target_name: &str,
+	session: &str,
+	backend: SocketAddr,
+) -> http::sessionpersistence::MCPSession {
+	http::sessionpersistence::MCPSession {
+		target_name: Some(target_name.to_string()),
+		session: Some(session.to_string()),
+		backend: Some(backend),
+	}
+}
+
+#[tokio::test]
+async fn test_fanout_deletion_fail_open_skips_failed_upstreams() {
+	let good = mock_streamable_http_server(true).await;
+	let bad_addr = SocketAddr::from(([127, 0, 0, 1], 31999));
+	let relay = Relay::new(
+		McpBackendGroup {
+			targets: vec![
+				fake_streamable_target("good", good.addr),
+				fake_streamable_target("bad", bad_addr),
+			],
+			stateful: true,
+			failure_mode: FailureMode::FailOpen,
+		},
+		empty_mcp_policies(),
+		PolicyClient {
+			inputs: setup_proxy_test("{}").unwrap().pi,
+		},
+	)
+	.unwrap();
+
+	relay
+		.set_sessions(vec![
+			persisted_session("good", "session-good", good.addr),
+			persisted_session("bad", "session-bad", bad_addr),
+		])
+		.unwrap();
+
+	let response = relay
+		.send_fanout_deletion(crate::mcp::upstream::IncomingRequestContext::empty())
+		.await
+		.unwrap();
+
+	assert_eq!(response.status(), http::StatusCode::ACCEPTED);
+}
+
+#[test]
+fn test_set_sessions_matches_by_target_name() {
+	let relay = Relay::new(
+		McpBackendGroup {
+			targets: vec![
+				fake_streamable_target("alpha", SocketAddr::from(([127, 0, 0, 1], 30001))),
+				fake_streamable_target("beta", SocketAddr::from(([127, 0, 0, 1], 30002))),
+			],
+			stateful: true,
+			failure_mode: FailureMode::FailClosed,
+		},
+		empty_mcp_policies(),
+		PolicyClient {
+			inputs: setup_proxy_test("{}").unwrap().pi,
+		},
+	)
+	.unwrap();
+
+	relay
+		.set_sessions(vec![
+			persisted_session(
+				"beta",
+				"session-beta",
+				SocketAddr::from(([127, 0, 0, 1], 31002)),
+			),
+			persisted_session(
+				"alpha",
+				"session-alpha",
+				SocketAddr::from(([127, 0, 0, 1], 31001)),
+			),
+		])
+		.unwrap();
+
+	let sessions = relay.get_sessions().unwrap();
+	assert_eq!(sessions.len(), 2);
+	assert_eq!(sessions[0].target_name.as_deref(), Some("alpha"));
+	assert_eq!(sessions[0].session.as_deref(), Some("session-alpha"));
+	assert_eq!(
+		sessions[0].backend,
+		Some(SocketAddr::from(([127, 0, 0, 1], 31001)))
+	);
+	assert_eq!(sessions[1].target_name.as_deref(), Some("beta"));
+	assert_eq!(sessions[1].session.as_deref(), Some("session-beta"));
+	assert_eq!(
+		sessions[1].backend,
+		Some(SocketAddr::from(([127, 0, 0, 1], 31002)))
+	);
+}
+
+#[test]
+fn test_set_sessions_rejects_mismatched_target_set() {
+	let relay = Relay::new(
+		McpBackendGroup {
+			targets: vec![
+				fake_streamable_target("alpha", SocketAddr::from(([127, 0, 0, 1], 30011))),
+				fake_streamable_target("beta", SocketAddr::from(([127, 0, 0, 1], 30012))),
+			],
+			stateful: true,
+			failure_mode: FailureMode::FailClosed,
+		},
+		empty_mcp_policies(),
+		PolicyClient {
+			inputs: setup_proxy_test("{}").unwrap().pi,
+		},
+	)
+	.unwrap();
+
+	let err = relay
+		.set_sessions(vec![
+			persisted_session(
+				"beta",
+				"session-beta",
+				SocketAddr::from(([127, 0, 0, 1], 32012)),
+			),
+			persisted_session(
+				"gamma",
+				"session-gamma",
+				SocketAddr::from(([127, 0, 0, 1], 32013)),
+			),
+		])
+		.unwrap_err();
+
+	assert!(
+		err
+			.to_string()
+			.contains("missing persisted session for target alpha")
+	);
+}
+
+#[tokio::test]
+async fn test_runtime_fanout_fail_open() {
+	use crate::mcp::mergestream::{MergeStream, Messages};
+	use futures_util::StreamExt;
+	use rmcp::model::{ListToolsResult, RequestId, ServerJsonRpcMessage};
+
+	let ok_msg = ServerJsonRpcMessage::response(
+		rmcp::model::ServerResult::ListToolsResult(ListToolsResult {
+			tools: vec![],
+			next_cursor: None,
+			meta: None,
+		}),
+		RequestId::Number(1),
+	);
+	let ok_stream = Messages::from(ok_msg);
+	let err_stream = Messages::from(Err(crate::mcp::ClientError::new(anyhow::anyhow!(
+		"bad upstream"
+	))));
+
+	let streams = vec![("ok".into(), ok_stream), ("bad".into(), err_stream)];
+
+	let merge = Box::new(|results: Vec<(Strng, rmcp::model::ServerResult)>| {
+		// Just return the first one for simplicity in this test
+		Ok(results.into_iter().next().unwrap().1)
+	});
+
+	let mut ms = MergeStream::new(streams, RequestId::Number(1), merge, FailureMode::FailOpen);
+
+	let res = ms.next().await;
+	assert!(res.is_some());
+	let res = res.unwrap();
+	assert!(
+		res.is_ok(),
+		"expected success with FailOpen even if one upstream errors: {:?}",
+		res.err()
+	);
+}
+
+#[tokio::test]
+async fn test_runtime_fanout_fail_open_all_fail() {
+	use crate::mcp::mergestream::{MergeStream, Messages};
+	use futures_util::StreamExt;
+	use rmcp::model::{ListToolsResult, RequestId};
+
+	let err_stream1 = Messages::from(Err(crate::mcp::ClientError::new(anyhow::anyhow!("bad 1"))));
+	let err_stream2 = Messages::from(Err(crate::mcp::ClientError::new(anyhow::anyhow!("bad 2"))));
+
+	let streams = vec![("bad1".into(), err_stream1), ("bad2".into(), err_stream2)];
+
+	let merge = Box::new(|results: Vec<(Strng, rmcp::model::ServerResult)>| {
+		// All failed, so results should be empty.
+		// Return an empty success result (idiomatic for FailOpen).
+		assert!(results.is_empty());
+		Ok(rmcp::model::ServerResult::ListToolsResult(
+			ListToolsResult {
+				tools: vec![],
+				next_cursor: None,
+				meta: None,
+			},
+		))
+	});
+
+	let mut ms = MergeStream::new(streams, RequestId::Number(1), merge, FailureMode::FailOpen);
+
+	let res = ms.next().await;
+	assert!(res.is_some());
+	let res = res.unwrap();
+	assert!(
+		res.is_ok(),
+		"expected success with FailOpen even if ALL upstreams error mid-request: {:?}",
+		res.err()
+	);
 }

--- a/crates/agentgateway/src/mcp/mergestream.rs
+++ b/crates/agentgateway/src/mcp/mergestream.rs
@@ -4,8 +4,10 @@ use futures_core::stream::BoxStream;
 use futures_util::StreamExt;
 use itertools::Itertools;
 use rmcp::model::{RequestId, ServerJsonRpcMessage, ServerResult};
+use tracing::warn;
 
 use crate::mcp::ClientError;
+use crate::mcp::FailureMode;
 use crate::mcp::streamablehttp::StreamableHttpPostResponse;
 use crate::*;
 
@@ -36,6 +38,12 @@ impl Stream for Messages {
 impl From<ServerJsonRpcMessage> for Messages {
 	fn from(value: ServerJsonRpcMessage) -> Self {
 		Messages(futures::stream::once(async { Ok(value) }).boxed())
+	}
+}
+
+impl From<Result<ServerJsonRpcMessage, ClientError>> for Messages {
+	fn from(value: Result<ServerJsonRpcMessage, ClientError>) -> Self {
+		Messages(futures::stream::once(async { value }).boxed())
 	}
 }
 
@@ -91,19 +99,26 @@ pub struct MergeStream {
 	complete: bool,
 	req_id: RequestId,
 	merge: Option<Box<MergeFn>>,
+	failure_mode: FailureMode,
 }
 
 impl MergeStream {
-	pub fn new_without_merge(streams: Vec<(Strng, Messages)>) -> Self {
-		Self::new_internal(streams, RequestId::Number(0), None)
+	pub fn new_without_merge(streams: Vec<(Strng, Messages)>, failure_mode: FailureMode) -> Self {
+		Self::new_internal(streams, RequestId::Number(0), None, failure_mode)
 	}
-	pub fn new(streams: Vec<(Strng, Messages)>, req_id: RequestId, merge: Box<MergeFn>) -> Self {
-		Self::new_internal(streams, req_id, Some(merge))
+	pub fn new(
+		streams: Vec<(Strng, Messages)>,
+		req_id: RequestId,
+		merge: Box<MergeFn>,
+		failure_mode: FailureMode,
+	) -> Self {
+		Self::new_internal(streams, req_id, Some(merge), failure_mode)
 	}
 	fn new_internal(
 		streams: Vec<(Strng, Messages)>,
 		req_id: RequestId,
 		merge: Option<Box<MergeFn>>,
+		failure_mode: FailureMode,
 	) -> Self {
 		let terminal_messages = streams.iter().map(|_| None).collect::<Vec<_>>();
 		Self {
@@ -112,6 +127,7 @@ impl MergeStream {
 			req_id,
 			complete: false,
 			merge,
+			failure_mode,
 		}
 	}
 
@@ -123,6 +139,7 @@ impl MergeStream {
 			.iter_mut()
 			.filter_map(Option::take)
 			.collect_vec();
+
 		let res = self
 			.merge
 			.take()
@@ -160,17 +177,33 @@ impl Stream for MergeStream {
 							// This stream is done, never look at it again
 						},
 						Err(e) => {
-							self.complete = true;
-							return Poll::Ready(Some(Err(e)));
+							if self.failure_mode == FailureMode::FailOpen {
+								warn!(
+									"upstream stream error, skipping (failure_mode=FailOpen): {}",
+									e
+								);
+								drop = true;
+							} else {
+								self.complete = true;
+								return Poll::Ready(Some(Err(e)));
+							}
 						},
 						_ => return Poll::Ready(Some(msg)),
 					}
 				},
 				Poll::Ready(None) => {
 					// Stream ended without terminal message (shouldn't happen in this design)
-					// Not much we can do here I guess.
-					drop = true;
+					if self.failure_mode == FailureMode::FailOpen {
+						warn!("upstream stream ended unexpectedly, skipping (failure_mode=FailOpen)");
+						drop = true;
+					} else {
+						self.complete = true;
+						return Poll::Ready(Some(Err(ClientError::new(anyhow::anyhow!(
+							"upstream stream ended unexpectedly"
+						)))));
+					}
 				},
+
 				Poll::Pending => {
 					any_pending = true;
 				},

--- a/crates/agentgateway/src/mcp/mod.rs
+++ b/crates/agentgateway/src/mcp/mod.rs
@@ -12,6 +12,8 @@ use std::fmt::{Display, Write};
 use std::io;
 use std::sync::Arc;
 
+#[cfg(feature = "schema")]
+use crate::JsonSchema;
 use crate::http::SendDirectResponse;
 use crate::proxy::ProxyError;
 use axum_core::BoxError;
@@ -20,6 +22,20 @@ pub use rbac::{McpAuthorization, McpAuthorizationSet, ResourceId, ResourceType};
 use rmcp::model::RequestId;
 pub use router::App;
 use thiserror::Error;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "camelCase")]
+pub enum FailureMode {
+	/// Fail the entire session if any target fails to initialize or any
+	/// upstream fails during a fanout. This is the default and matches
+	/// current behavior.
+	#[default]
+	FailClosed,
+	/// Skip failed targets/upstreams and continue serving from healthy ones.
+	/// If ALL targets fail, still return an error.
+	FailOpen,
+}
 
 #[cfg(test)]
 #[path = "mcp_tests.rs"]
@@ -64,6 +80,8 @@ pub enum Error {
 	CreateSseUrl(String),
 	#[error("failed to parse openapi: {0}")]
 	OpenAPI(upstream::OpenAPIParseError),
+	#[error("no backends configured")]
+	NoBackends,
 }
 
 impl From<Error> for ProxyError {

--- a/crates/agentgateway/src/mcp/router.rs
+++ b/crates/agentgateway/src/mcp/router.rs
@@ -7,6 +7,7 @@ use crate::ProxyInputs;
 use crate::http::authorization::RuleSets;
 use crate::http::sessionpersistence::Encoder;
 use crate::http::*;
+use crate::mcp::FailureMode;
 use crate::mcp::auth;
 use crate::mcp::handler::RelayInputs;
 use crate::mcp::session::SessionManager;
@@ -99,6 +100,7 @@ impl App {
 			McpBackendGroup {
 				targets: nt,
 				stateful: backend.stateful,
+				failure_mode: backend.failure_mode,
 			}
 		};
 		let sm = self.session.clone();
@@ -171,6 +173,7 @@ impl App {
 pub struct McpBackendGroup {
 	pub targets: Vec<Arc<McpTarget>>,
 	pub stateful: bool,
+	pub failure_mode: FailureMode,
 }
 
 #[derive(Debug)]

--- a/crates/agentgateway/src/mcp/session.rs
+++ b/crates/agentgateway/src/mcp/session.rs
@@ -459,16 +459,10 @@ impl SessionManager {
 			return Ok(None);
 		};
 		let relay = builder.build_new_connections()?;
-		let n = relay.count();
-		if state.sessions.len() != n {
-			warn!(
-				"failed to resume session: sessions {} did not match config {}",
-				state.sessions.len(),
-				n
-			);
+		if let Err(err) = relay.set_sessions(state.sessions) {
+			warn!("failed to resume session: {err}");
 			return Ok(None);
 		}
-		relay.set_sessions(state.sessions);
 
 		let sess = Session {
 			id: id.into(),

--- a/crates/agentgateway/src/mcp/upstream/client.rs
+++ b/crates/agentgateway/src/mcp/upstream/client.rs
@@ -93,6 +93,10 @@ impl McpHttpClient {
 		Some((*self.pinned_dest.lock().unwrap())?.0)
 	}
 
+	pub fn target_name(&self) -> &str {
+		&self.target_name
+	}
+
 	pub fn backend(&self) -> &SimpleBackend {
 		&self.backend
 	}

--- a/crates/agentgateway/src/mcp/upstream/mod.rs
+++ b/crates/agentgateway/src/mcp/upstream/mod.rs
@@ -14,6 +14,7 @@ use thiserror::Error;
 use tokio::process::Command;
 
 use crate::http::jwt::Claims;
+use crate::mcp::FailureMode;
 use crate::mcp::mergestream::Messages;
 use crate::mcp::router::{McpBackendGroup, McpTarget};
 use crate::mcp::streamablehttp::StreamableHttpPostResponse;
@@ -137,7 +138,7 @@ impl Upstream {
 		ctx: &IncomingRequestContext,
 	) -> Result<mergestream::Messages, UpstreamError> {
 		match &self {
-			Upstream::McpStdio(c) => Ok(c.get_event_stream().await),
+			Upstream::McpStdio(c) => Ok(c.get_event_stream().await?),
 			Upstream::McpSSE(c) => c.connect_to_event_stream(ctx).await,
 			Upstream::McpStreamable(c) => c
 				.get_event_stream(ctx)
@@ -207,11 +208,12 @@ pub(crate) struct UpstreamGroup {
 	// Else this is empty
 	pub default_target_name: Option<String>,
 	pub is_multiplexing: bool,
+	pub failure_mode: FailureMode,
 }
 
 impl UpstreamGroup {
 	pub fn size(&self) -> usize {
-		self.backend.targets.len()
+		self.by_name.len()
 	}
 
 	pub(crate) fn new(client: PolicyClient, backend: McpBackendGroup) -> Result<Self, mcp::Error> {
@@ -225,6 +227,7 @@ impl UpstreamGroup {
 			Some(backend.targets[0].name.to_string())
 		};
 		let mut s = Self {
+			failure_mode: backend.failure_mode,
 			backend,
 			client,
 			by_name: IndexMap::new(),
@@ -232,14 +235,36 @@ impl UpstreamGroup {
 			is_multiplexing,
 		};
 		s.setup_connections()?;
+		if s.by_name.is_empty() {
+			if s.backend.targets.is_empty() && s.failure_mode == FailureMode::FailOpen {
+				warn!(
+					"MCP backend configured with zero targets and failure_mode=failOpen; allowing startup to avoid downstream retry loops"
+				);
+				return Ok(s);
+			}
+			return Err(mcp::Error::NoBackends);
+		}
 		Ok(s)
 	}
 
 	pub(crate) fn setup_connections(&mut self) -> Result<(), mcp::Error> {
 		for tgt in &self.backend.targets {
 			debug!("initializing target: {}", tgt.name);
-			let transport = self.setup_upstream(tgt.as_ref())?;
-			self.by_name.insert(tgt.name.clone(), Arc::new(transport));
+			match self.setup_upstream(tgt.as_ref()) {
+				Ok(transport) => {
+					self.by_name.insert(tgt.name.clone(), Arc::new(transport));
+				},
+				Err(e) => {
+					if self.failure_mode == FailureMode::FailOpen {
+						warn!(
+							"failed to initialize target '{}', skipping (failure_mode=FailOpen): {}",
+							tgt.name, e
+						);
+					} else {
+						return Err(e);
+					}
+				},
+			}
 		}
 		Ok(())
 	}

--- a/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
@@ -1064,6 +1064,7 @@ async fn test_openapi_from_url() {
 		})],
 		stateful_mode: McpStatefulMode::Stateful,
 		prefix_mode: None,
+		failure_mode: None,
 	});
 
 	// Convert to runtime backends

--- a/crates/agentgateway/src/mcp/upstream/sse.rs
+++ b/crates/agentgateway/src/mcp/upstream/sse.rs
@@ -163,21 +163,21 @@ impl Client {
 	async fn get_stream(&self, ctx: &IncomingRequestContext) -> Result<Arc<Process>, UpstreamError> {
 		let mut stream = self.active_stream.lock().await;
 		if let Some(s) = stream.clone() {
-			Ok(s)
-		} else {
-			let (post_uri, sse) = self.establish_sse(ctx).await?;
-			let transport = SseClient {
-				client: ClientCore {
-					uri: post_uri,
-					..self.client.clone()
-				},
-				events: sse,
-			};
-
-			let proc = Arc::new(Process::new(transport));
-			*stream = Some(proc.clone());
-			Ok(proc)
+			return Ok(s);
 		}
+
+		let (post_uri, sse) = self.establish_sse(ctx).await?;
+		let transport = SseClient {
+			client: ClientCore {
+				uri: post_uri,
+				..self.client.clone()
+			},
+			events: sse,
+		};
+
+		let proc = Arc::new(Process::new(transport));
+		*stream = Some(proc.clone());
+		Ok(proc)
 	}
 	async fn establish_sse(
 		&self,
@@ -207,7 +207,7 @@ impl Client {
 		ctx: &IncomingRequestContext,
 	) -> Result<Messages, UpstreamError> {
 		let stream = self.get_stream(ctx).await?;
-		Ok(stream.get_event_stream().await)
+		stream.get_event_stream().await
 	}
 	pub async fn send_message(
 		&self,

--- a/crates/agentgateway/src/mcp/upstream/stdio.rs
+++ b/crates/agentgateway/src/mcp/upstream/stdio.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::fmt;
 use std::fmt::{Debug, Formatter};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use agent_core::prelude::*;
@@ -22,10 +23,18 @@ pub struct Process {
 	shutdown_tx: agent_core::responsechannel::Sender<(), Option<UpstreamError>>,
 	event_stream: AtomicOption<mpsc::Sender<ServerJsonRpcMessage>>,
 	pending_requests: Arc<Mutex<HashMap<RequestId, oneshot::Sender<ServerJsonRpcMessage>>>>,
+	alive: Arc<AtomicBool>,
 }
 
 impl Process {
+	pub fn is_alive(&self) -> bool {
+		self.alive.load(Ordering::Acquire)
+	}
+
 	pub async fn stop(&self) -> Result<(), UpstreamError> {
+		if !self.is_alive() {
+			return Ok(());
+		}
 		let res = self
 			.shutdown_tx
 			.send_and_wait(())
@@ -42,30 +51,51 @@ impl Process {
 		req: JsonRpcRequest<ClientRequest>,
 		ctx: &IncomingRequestContext,
 	) -> Result<ServerJsonRpcMessage, UpstreamError> {
+		if !self.is_alive() {
+			return Err(UpstreamError::Recv);
+		}
 		let req_id = req.id.clone();
 		let (sender, receiver) = oneshot::channel();
 
-		self.pending_requests.lock().unwrap().insert(req_id, sender);
-
 		self
+			.pending_requests
+			.lock()
+			.unwrap()
+			.insert(req_id.clone(), sender);
+
+		if self
 			.sender
 			.send((JsonRpcMessage::Request(req), ctx.clone()))
 			.await
-			.map_err(|_| UpstreamError::Send)?;
+			.is_err()
+		{
+			self.pending_requests.lock().unwrap().remove(&req_id);
+			return Err(UpstreamError::Send);
+		}
 
 		let response = receiver.await.map_err(|_| UpstreamError::Recv)?;
 		Ok(response)
 	}
-	pub async fn get_event_stream(&self) -> Messages {
+	pub async fn get_event_stream(&self) -> Result<Messages, UpstreamError> {
+		if !self.is_alive() {
+			return Err(UpstreamError::Recv);
+		}
 		let (tx, rx) = tokio::sync::mpsc::channel(10);
+		// This transport assumes a single active downstream event-stream consumer per
+		// upstream session. Replacing the sender is acceptable for current MCP usage,
+		// where one session owns one active GET/SSE stream, but it is not a general
+		// multi-subscriber broadcast mechanism.
 		self.event_stream.store(Some(Arc::new(tx)));
-		Messages::from(rx)
+		Ok(Messages::from(rx))
 	}
 	pub async fn send_notification(
 		&self,
 		req: ClientNotification,
 		ctx: &IncomingRequestContext,
 	) -> Result<(), UpstreamError> {
+		if !self.is_alive() {
+			return Err(UpstreamError::Send);
+		}
 		self
 			.sender
 			.send((JsonRpcMessage::notification(req), ctx.clone()))
@@ -88,13 +118,18 @@ impl Process {
 		let pending_requests_clone = pending_requests.clone();
 		let event_stream: AtomicOption<Sender<ServerJsonRpcMessage>> = Default::default();
 		let event_stream_send: AtomicOption<Sender<ServerJsonRpcMessage>> = event_stream.clone();
+		let alive = Arc::new(AtomicBool::new(true));
+		let alive_task = alive.clone();
 
 		tokio::spawn(async move {
+			let mut terminal_err = None;
+			let mut shutdown_resp = None;
 			loop {
 				tokio::select! {
 					Some((msg, ctx)) = sender_rx.recv() => {
 						if let Err(e) = proc.send(msg, &ctx).await {
 							error!("Error sending message to stdio process: {:?}", e);
+							terminal_err = Some(e);
 							break;
 						}
 					},
@@ -114,21 +149,25 @@ impl Process {
 						}
 					},
 					Some((_, resp)) = shutdown_rx.recv() => {
-						let err = proc.close().await;
-						if let Err(e) = &err {
-							warn!("Error shutting down stdio process: {:?}", e);
-						}
-						let _ = resp.send(err.err());
-						return;
+						shutdown_resp = Some(resp);
+						break;
 					},
 					else => {
-						let err = proc.close().await;
-						if let Err(e) = err {
-							warn!("Error shutting down stdio process: {:?}", e);
-						}
-						return;
+						break;
 					},
 				}
+			}
+
+			alive_task.store(false, Ordering::Release);
+			event_stream_send.store(None);
+			pending_requests_clone.lock().unwrap().clear();
+
+			let close_err = proc.close().await.err();
+			if let Some(e) = close_err.as_ref() {
+				warn!("Error shutting down stdio process: {:?}", e);
+			}
+			if let Some(resp) = shutdown_resp {
+				let _ = resp.send(terminal_err.or(close_err));
 			}
 		});
 
@@ -137,6 +176,7 @@ impl Process {
 			shutdown_tx,
 			event_stream,
 			pending_requests,
+			alive,
 		}
 	}
 }
@@ -180,5 +220,92 @@ impl MCPTransport for TokioChildProcess {
 
 	fn close(&mut self) -> impl Future<Output = Result<(), UpstreamError>> + Send {
 		Transport::close(self).map_err(Into::into)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use futures_util::StreamExt;
+	use rmcp::model::{ClientRequest, JsonRpcRequest, RequestId};
+	use tokio::time::{Duration, timeout};
+
+	use super::*;
+
+	struct FailOnSendTransport;
+
+	impl MCPTransport for FailOnSendTransport {
+		fn send(
+			&mut self,
+			_: ClientJsonRpcMessage,
+			_: &IncomingRequestContext,
+		) -> impl Future<Output = Result<(), UpstreamError>> + Send + 'static {
+			std::future::ready(Err(UpstreamError::InvalidRequest("boom".to_string())))
+		}
+
+		fn receive(&mut self) -> impl Future<Output = Option<ServerJsonRpcMessage>> + Send {
+			std::future::pending()
+		}
+
+		fn close(&mut self) -> impl Future<Output = Result<(), UpstreamError>> + Send {
+			std::future::ready(Ok(()))
+		}
+	}
+
+	#[tokio::test]
+	async fn test_process_fails_pending_requests_when_transport_dies() {
+		let proc = Process::new(FailOnSendTransport);
+		let req = JsonRpcRequest {
+			jsonrpc: Default::default(),
+			id: RequestId::Number(1),
+			request: ClientRequest::PingRequest(Default::default()),
+		};
+
+		let err = proc
+			.send_message(req, &IncomingRequestContext::empty())
+			.await
+			.unwrap_err();
+
+		assert!(matches!(err, UpstreamError::Recv));
+		assert!(!proc.is_alive());
+	}
+
+	#[tokio::test]
+	async fn test_process_closes_event_stream_when_transport_dies() {
+		let proc = Process::new(FailOnSendTransport);
+		let mut events = proc.get_event_stream().await.unwrap();
+		let req = JsonRpcRequest {
+			jsonrpc: Default::default(),
+			id: RequestId::Number(1),
+			request: ClientRequest::PingRequest(Default::default()),
+		};
+
+		let _ = proc
+			.send_message(req, &IncomingRequestContext::empty())
+			.await;
+
+		let next = timeout(Duration::from_secs(1), events.next())
+			.await
+			.unwrap();
+		assert!(next.is_none());
+	}
+
+	#[tokio::test]
+	async fn test_process_rejects_new_event_stream_when_dead() {
+		let proc = Process::new(FailOnSendTransport);
+		let req = JsonRpcRequest {
+			jsonrpc: Default::default(),
+			id: RequestId::Number(1),
+			request: ClientRequest::PingRequest(Default::default()),
+		};
+
+		let _ = proc
+			.send_message(req, &IncomingRequestContext::empty())
+			.await;
+
+		let err = match proc.get_event_stream().await {
+			Ok(_) => panic!("expected dead process to reject new event stream"),
+			Err(err) => err,
+		};
+		assert!(matches!(err, UpstreamError::Recv));
 	}
 }

--- a/crates/agentgateway/src/mcp/upstream/streamablehttp.rs
+++ b/crates/agentgateway/src/mcp/upstream/streamablehttp.rs
@@ -39,6 +39,7 @@ impl Client {
 		let session_id = self.session_id.load().clone();
 		let backend = self.http_client.pinned_backend();
 		http::sessionpersistence::MCPSession {
+			target_name: Some(self.http_client.target_name().to_string()),
 			session: session_id.map(|s| s.to_string()),
 			backend,
 		}

--- a/crates/agentgateway/src/proxy/mod.rs
+++ b/crates/agentgateway/src/proxy/mod.rs
@@ -267,6 +267,7 @@ impl ProxyError {
 			ProxyError::MCP(mcp::Error::ForwardLegacySse(_)) => StatusCode::INTERNAL_SERVER_ERROR,
 			ProxyError::MCP(mcp::Error::Stdio(_)) => StatusCode::INTERNAL_SERVER_ERROR,
 			ProxyError::MCP(mcp::Error::OpenAPI(_)) => StatusCode::INTERNAL_SERVER_ERROR,
+			ProxyError::MCP(mcp::Error::NoBackends) => StatusCode::SERVICE_UNAVAILABLE,
 			ProxyError::MCP(mcp::Error::UpstreamError(e)) => return e.0.map(http::Body::from),
 			ProxyError::MCP(mcp::Error::SendError(_, _)) => StatusCode::INTERNAL_SERVER_ERROR,
 			// Note: we do not return a 401/403 here, as the obscure that it was rejected due to auth

--- a/crates/agentgateway/src/test_helpers/proxymock.rs
+++ b/crates/agentgateway/src/test_helpers/proxymock.rs
@@ -27,6 +27,7 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 use crate::http::backendtls::BackendTLS;
 use crate::http::{Body, Response};
 use crate::llm::AIProvider;
+use crate::mcp::FailureMode;
 use crate::proxy::Gateway;
 use crate::proxy::request_builder::RequestBuilder;
 use crate::store::Stores;
@@ -297,7 +298,7 @@ pub async fn tls_mock() -> (MockServer, MockTlsCertificates) {
 }
 
 pub struct TestBind {
-	pi: Arc<ProxyInputs>,
+	pub pi: Arc<ProxyInputs>,
 	drain_rx: DrainWatcher,
 	_drain_tx: DrainTrigger,
 
@@ -428,6 +429,7 @@ impl TestBind {
 				})],
 				stateful,
 				always_use_prefix: false,
+				failure_mode: FailureMode::FailClosed,
 			},
 		);
 		{
@@ -475,6 +477,7 @@ impl TestBind {
 					.collect_vec(),
 				stateful,
 				always_use_prefix: false,
+				failure_mode: FailureMode::FailClosed,
 			},
 		);
 		{

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -27,6 +27,7 @@ use crate::http::{
 	HeaderOrPseudo, HeaderValue, ext_authz, ext_proc, filters, health, remoteratelimit, retry,
 	timeout,
 };
+use crate::mcp::FailureMode;
 use crate::mcp::McpAuthorization;
 use crate::telemetry::log::OrderedStringMap;
 use crate::transport::tls;
@@ -1186,6 +1187,9 @@ pub struct McpBackend {
 	pub targets: Vec<Arc<McpTarget>>,
 	pub stateful: bool,
 	pub always_use_prefix: bool,
+	/// Behavior when one or more MCP targets fail to initialize or fail during fanout.
+	/// Defaults to `failClosed`.
+	pub failure_mode: FailureMode,
 }
 
 impl McpBackend {

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -12,6 +12,7 @@ use super::agent::*;
 use crate::http::auth::{AwsAuth, BackendAuth, GcpAuth};
 use crate::http::transformation_cel::{LocalTransform, LocalTransformationConfig, Transformation};
 use crate::http::{HeaderOrPseudo, Scheme, auth, authorization, health};
+use crate::mcp::FailureMode;
 use crate::mcp::McpAuthorization;
 use crate::telemetry::log::OrderedStringMap;
 use crate::types::discovery::NamespacedHostname;
@@ -848,6 +849,10 @@ impl TryFrom<&proto::agent::Backend> for BackendWithPolicies {
 					always_use_prefix: match m.prefix_mode() {
 						proto::agent::mcp_backend::PrefixMode::Always => true,
 						proto::agent::mcp_backend::PrefixMode::Conditional => false,
+					},
+					failure_mode: match m.failure_mode() {
+						proto::agent::mcp_backend::FailureMode::FailOpen => FailureMode::FailOpen,
+						proto::agent::mcp_backend::FailureMode::FailClosed => FailureMode::FailClosed,
 					},
 				},
 			),

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -16,6 +16,7 @@ use crate::http::{
 use crate::llm::policy::PromptGuard;
 use crate::llm::{AIBackend, AIProvider, LocalModelAIProvider, NamedAIProvider};
 use crate::llm::{anthropic, openai};
+use crate::mcp::FailureMode;
 use crate::mcp::McpAuthorization;
 use crate::store::LocalWorkload;
 use crate::types::agent::{
@@ -730,6 +731,7 @@ impl LocalBackend {
 						McpPrefixMode::Always => true,
 						McpPrefixMode::Conditional => false,
 					}),
+					failure_mode: tgt.failure_mode.unwrap_or_default(),
 				};
 				backends.push(Backend::MCP(name, m).into());
 				backends
@@ -796,6 +798,10 @@ pub struct LocalMcpBackend {
 	pub stateful_mode: McpStatefulMode,
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub prefix_mode: Option<McpPrefixMode>,
+	/// Behavior when one or more MCP targets fail to initialize or fail during fanout.
+	/// Defaults to `failClosed`.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub failure_mode: Option<FailureMode>,
 }
 
 #[apply(schema_de!)]

--- a/crates/agentgateway/src/types/local_tests/basic_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/basic_normalized.snap
@@ -64,5 +64,6 @@ backends:
                   - "@modelcontextprotocol/server-everything"
           stateful: true
           alwaysUsePrefix: false
+          failureMode: failClosed
 workloads: []
 services: []

--- a/crates/agentgateway/src/types/local_tests/health_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/health_normalized.snap
@@ -48,5 +48,6 @@ backends:
                   - "@modelcontextprotocol/server-everything"
           stateful: true
           alwaysUsePrefix: false
+          failureMode: failClosed
 workloads: []
 services: []

--- a/crates/agentgateway/src/types/local_tests/mcp_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/mcp_normalized.snap
@@ -70,5 +70,6 @@ backends:
               name: remote
           stateful: true
           alwaysUsePrefix: false
+          failureMode: failClosed
 workloads: []
 services: []

--- a/crates/agentgateway/src/types/local_tests/mcp_simple_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/mcp_simple_normalized.snap
@@ -47,5 +47,6 @@ backends:
                   - "@modelcontextprotocol/server-everything"
           stateful: true
           alwaysUsePrefix: false
+          failureMode: failClosed
 workloads: []
 services: []

--- a/schema/config.json
+++ b/schema/config.json
@@ -3975,6 +3975,17 @@
               "type": "null"
             }
           ]
+        },
+        "failureMode": {
+          "description": "Behavior when one or more MCP targets fail to initialize or fail during fanout.\nDefaults to `failClosed`.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FailureMode4"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "additionalProperties": false,
@@ -4296,6 +4307,20 @@
       "enum": [
         "always",
         "conditional"
+      ]
+    },
+    "FailureMode4": {
+      "oneOf": [
+        {
+          "description": "Fail the entire session if any target fails to initialize or any\nupstream fails during a fanout. This is the default and matches\ncurrent behavior.",
+          "type": "string",
+          "const": "failClosed"
+        },
+        {
+          "description": "Skip failed targets/upstreams and continue serving from healthy ones.\nIf ALL targets fail, still return an error.",
+          "type": "string",
+          "const": "failOpen"
+        }
       ]
     },
     "LocalAIBackend": {
@@ -6098,6 +6123,17 @@
           "anyOf": [
             {
               "$ref": "#/$defs/McpPrefixMode"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "failureMode": {
+          "description": "Behavior when one or more MCP targets fail to initialize or fail during fanout.\nDefaults to `failClosed`.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FailureMode4"
             },
             {
               "type": "null"

--- a/schema/config.md
+++ b/schema/config.md
@@ -1291,6 +1291,7 @@
 |`binds[].listeners[].routes[].backends[].(1)mcp.targets[].policies.mcpAuthorization.rules`||
 |`binds[].listeners[].routes[].backends[].(1)mcp.statefulMode`||
 |`binds[].listeners[].routes[].backends[].(1)mcp.prefixMode`||
+|`binds[].listeners[].routes[].backends[].(1)mcp.failureMode`|Behavior when one or more MCP targets fail to initialize or fail during fanout.<br>Defaults to `failClosed`.|
 |`binds[].listeners[].routes[].backends[].(1)ai`||
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)name`||
 |`binds[].listeners[].routes[].backends[].(1)ai.(any)provider`||
@@ -6652,6 +6653,7 @@
 |`mcp.targets[].policies.mcpAuthorization.rules`||
 |`mcp.statefulMode`||
 |`mcp.prefixMode`||
+|`mcp.failureMode`|Behavior when one or more MCP targets fail to initialize or fail during fanout.<br>Defaults to `failClosed`.|
 |`mcp.policies`||
 |`mcp.policies.requestHeaderModifier`|Headers to be modified in the request.|
 |`mcp.policies.requestHeaderModifier.add`||


### PR DESCRIPTION
This hardens MCP degraded-mode behavior so multiplexed backends can keep serving healthy targets without hanging, looping, or corrupting resumable session state.

The original `failureMode` work was meant to cover three concrete failure cases:
- `#1162`: zero-target MCP backends should not trap clients in a reconnect loop
- `#1029`: `failOpen` should skip bad targets, but still fail if every configured target is unusable
- `#962`: one bad upstream should not take down the rest of a multiplexed MCP session

This change makes that behavior consistent across init, runtime fanout, and session resume.

At init time, `failOpen` now allows partial success but still returns `NoBackends` when all configured targets fail. Zero configured targets remain a special case so we do not regress the zero-target handling behind `#1162`. The `failureMode` setting is also threaded through the controller, local config, schema, and MCP runtime so the configured behavior is preserved end to end.

At runtime, multiplexed fanout now degrades correctly when individual upstreams fail. That includes the legacy SSE path, which was the sharp edge here: a dead legacy SSE transport could leave pending requests orphaned and hang the whole downstream request. This change makes wrapped transports fail pending work, fail fast once dead, and treat dead legacy SSE upstreams as unavailable for the rest of that downstream session instead of trying to silently rejoin mid-session. That keeps healthy stdio, SSE, and streamable HTTP targets serving without introducing questionable session semantics for non-resumable transports.

For resumable streamable HTTP MCP sessions, persisted upstream session state is now keyed by target name. New session handles include an optional target field, and resume restores by target identity instead of positional zip. Old handles without target names still use the legacy positional path, so existing session IDs remain readable. This avoids misbinding persisted sessions when `failOpen` changes the initialized target set.

Most of the diff is test coverage plus generated/schema updates from wiring the config surface through. The behavior changes themselves are concentrated in the MCP relay, upstream transport wrappers, and resume logic.

Fixes #1162
Fixes #1029
Fixes #962