### PR TITLE
fix: set HTTP Host header from TLS SNI when fetching JWKS

### DIFF
--- a/controller/pkg/agentgateway/jwks/jwks_fetcher.go
+++ b/controller/pkg/agentgateway/jwks/jwks_fetcher.go
@@ -220,20 +220,38 @@ func (f *JwksFetcher) RemoveKeyset(source JwksSource) {
 }
 
 func (f *JwksFetcher) fetchJwks(ctx context.Context, jwksURL string, tlsConfig *tls.Config) (jose.JSONWebKeySet, error) {
+	// When TLS is configured with an SNI ServerName, use it as the HTTP Host
+	// header override. This is needed for ExternalName services behind CDN
+	// proxies (e.g. Cloudflare), which validate the Host header and reject
+	// requests with Kubernetes internal service hostnames.
+	var hostOverride string
 	if tlsConfig != nil {
+		hostOverride = tlsConfig.ServerName
 		c := &jwksHttpClientImpl{Client: makeClient(tlsConfig)}
-		return c.FetchJwks(ctx, jwksURL)
+		return c.fetchJwksWithHostOverride(ctx, jwksURL, hostOverride)
 	}
 	return f.defaultJwksClient.FetchJwks(ctx, jwksURL)
 }
 
 func (c *jwksHttpClientImpl) FetchJwks(ctx context.Context, jwksURL string) (jose.JSONWebKeySet, error) {
+	return c.fetchJwksWithHostOverride(ctx, jwksURL, "")
+}
+
+func (c *jwksHttpClientImpl) fetchJwksWithHostOverride(ctx context.Context, jwksURL string, hostOverride string) (jose.JSONWebKeySet, error) {
 	log := log.FromContext(ctx)
-	log.Info("fetching jwks", "url", jwksURL)
+	log.Info("fetching jwks", "url", jwksURL, "hostOverride", hostOverride)
 
 	request, err := http.NewRequest(http.MethodGet, jwksURL, nil)
 	if err != nil {
 		return jose.JSONWebKeySet{}, fmt.Errorf("could not build request to get JWKS: %w", err)
+	}
+
+	// Override Host header with the TLS SNI value if provided.
+	// This ensures CDN proxies (e.g. Cloudflare) and host-based load balancers
+	// receive the correct Host header when the JWKS URL uses a Kubernetes
+	// internal service hostname (e.g. from an ExternalName service).
+	if hostOverride != "" {
+		request.Host = hostOverride
 	}
 
 	// TODO (dmitri-d) control the size here maybe?


### PR DESCRIPTION
## Description

When the JWKS fetcher resolves a `backendRef` pointing to a Kubernetes `ExternalName` Service behind a CDN proxy (e.g. Cloudflare), the HTTP `Host` header is set to the internal service hostname (e.g. `idp-service.agentgateway-stage.svc.cluster.local`). CDN proxies validate the `Host` header and reject requests with unrecognized hostnames, causing JWKS fetching to fail with `403`.

## Changes

In `jwks_fetcher.go`:
- Extract `ServerName` from the `tls.Config` (set via the `AgentgatewayPolicy` `sni` field)
- Use it as the HTTP `Host` header override via `request.Host`
- No interface changes — `FetchJwks` delegates to a new internal `fetchJwksWithHostOverride` method

## Testing

- When `tlsConfig` is `nil` (no TLS) — behavior unchanged, no Host override
- When `tlsConfig.ServerName` is empty — behavior unchanged, no Host override
- When `tlsConfig.ServerName` is set — `request.Host` is overridden with the SNI value

Fixes #1235