### PR TITLE
Add support for extending network gateways computation

### DIFF
--- a/controller/pkg/kgateway/agentgatewaysyncer/option.go
+++ b/controller/pkg/kgateway/agentgatewaysyncer/option.go
@@ -2,7 +2,11 @@ package agentgatewaysyncer
 
 import (
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/serviceregistry/kube/controller/ambient"
+	"istio.io/istio/pkg/cluster"
+	"istio.io/istio/pkg/kube/krt"
 	"istio.io/istio/pkg/workloadapi"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/translator"
 )
@@ -12,6 +16,7 @@ type agentgatewaySyncerConfig struct {
 	CustomResourceCollections   func(cfg CustomResourceCollectionsConfig)
 	WorkloadAddressProviderFunc func(model.WorkloadInfo) *workloadapi.Address
 	ServiceAddressProviderFunc  func(model.ServiceInfo) *workloadapi.Address
+	ExtraNetworkGatewaysFunc    func(clusterID cluster.ID, gateways krt.Collection[*gwv1.Gateway], opts krt.OptionsBuilder) krt.Collection[ambient.NetworkGateway]
 }
 
 type AgentgatewaySyncerOption func(*agentgatewaySyncerConfig)
@@ -64,6 +69,17 @@ func WithServiceAddressProviderFunc(f func(model.ServiceInfo) *workloadapi.Addre
 	return func(o *agentgatewaySyncerConfig) {
 		if f != nil {
 			o.ServiceAddressProviderFunc = f
+		}
+	}
+}
+
+// WithExtraNetworkGatewaysFunc provides a function that produces additional NetworkGateway entries
+// to be merged with those derived by the Istio ambient.BuildNetworkCollections call in syncer.
+// This allows downstream implementations to extend the network gateway computation for workloads.
+func WithExtraNetworkGatewaysFunc(f func(clusterID cluster.ID, gateways krt.Collection[*gwv1.Gateway], opts krt.OptionsBuilder) krt.Collection[ambient.NetworkGateway]) AgentgatewaySyncerOption {
+	return func(o *agentgatewaySyncerConfig) {
+		if f != nil {
+			o.ExtraNetworkGatewaysFunc = f
 		}
 	}
 }

--- a/controller/pkg/kgateway/agentgatewaysyncer/syncer.go
+++ b/controller/pkg/kgateway/agentgatewaysyncer/syncer.go
@@ -81,6 +81,7 @@ type Syncer struct {
 	customResourceCollections   func(cfg CustomResourceCollectionsConfig)
 	workloadAddressProviderFunc func(model.WorkloadInfo) *workloadapi.Address
 	serviceAddressProviderFunc  func(model.ServiceInfo) *workloadapi.Address
+	extraNetworkGatewaysFunc    func(clusterID cluster.ID, gateways krt.Collection[*gwv1.Gateway], opts krt.OptionsBuilder) krt.Collection[ambient.NetworkGateway]
 }
 
 func NewAgwSyncer(
@@ -108,6 +109,7 @@ func NewAgwSyncer(
 		customResourceCollections:   cfg.CustomResourceCollections,
 		workloadAddressProviderFunc: cfg.WorkloadAddressProviderFunc,
 		serviceAddressProviderFunc:  cfg.ServiceAddressProviderFunc,
+		extraNetworkGatewaysFunc:    cfg.ExtraNetworkGatewaysFunc,
 	}
 	logger.Debug("init agentgateway Syncer", "controllername", controllerName)
 
@@ -613,6 +615,16 @@ func (s *Syncer) buildAddressCollections(krtopts krtutil.KrtOptions) krt.Collect
 		SystemNamespace: cols.IstioNamespace,
 		ClusterID:       clusterId,
 	}, opts)
+	if s.extraNetworkGatewaysFunc != nil {
+		extra := s.extraNetworkGatewaysFunc(clusterId, cols.Gateways, opts)
+		Networks.NetworkGateways = krt.JoinCollection(
+			[]krt.Collection[ambient.NetworkGateway]{Networks.NetworkGateways, extra},
+			opts.WithName("MergedNetworkGateways")...,
+		)
+		Networks.GatewaysByNetwork = krt.NewIndex(Networks.NetworkGateways, "network", func(o ambient.NetworkGateway) []network.ID {
+			return []network.ID{o.Network}
+		})
+	}
 	builder := ambient.Builder{
 		DomainSuffix:      kubeutils.GetClusterDomainName(),
 		ClusterID:         clusterId,

--- a/controller/pkg/kgateway/agentgatewaysyncer/syncer.go
+++ b/controller/pkg/kgateway/agentgatewaysyncer/syncer.go
@@ -621,7 +621,7 @@ func (s *Syncer) buildAddressCollections(krtopts krtutil.KrtOptions) krt.Collect
 			[]krt.Collection[ambient.NetworkGateway]{Networks.NetworkGateways, extra},
 			opts.WithName("MergedNetworkGateways")...,
 		)
-		Networks.GatewaysByNetwork = krt.NewIndex(Networks.NetworkGateways, "network", func(o ambient.NetworkGateway) []network.ID {
+		Networks.GatewaysByNetwork = krt.NewIndex(Networks.NetworkGateways, "mergedNetwork", func(o ambient.NetworkGateway) []network.ID {
 			return []network.ID{o.Network}
 		})
 	}


### PR DESCRIPTION
Adds a new `WithExtraNetworkGatewaysFunc` syncer option that allows downstream implementations to inject additional NetworkGateway entries into the ambient network collections.

Previously, the set of NetworkGateway objects was determined solely by the Istio ambient.BuildNetworkCollections code. This change makes that extensible by accepting an optional function that produces a supplementary `krt.Collection[ambient.NetworkGateway]`. When provided, the syncer merges the extra entries with the Istio-derived ones.