### PR TITLE
Setup nightly releases

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch: {}
 
 permissions:
-  contents: read
+  contents: write
   packages: write
   id-token: write
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,53 @@
+name: Nightly Release
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+jobs:
+  prepare:
+    runs-on: ubuntu-24.04
+    outputs:
+      has_commits: ${{ steps.check.outputs.has_commits }}
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Check for commits in the last 24 hours
+        id: check
+        run: |
+          LAST_COMMIT=$(git log -1 --format="%ct")
+          NOW=$(date +%s)
+          DIFF=$((NOW - LAST_COMMIT))
+          # 86400 = seconds in one day
+          if [ "$DIFF" -lt 86400 ]; then
+            echo "has_commits=true" >> $GITHUB_OUTPUT
+            echo "Recent commit found (${DIFF}s ago)"
+          else
+            echo "has_commits=false" >> $GITHUB_OUTPUT
+            echo "No recent commits (last commit was ${DIFF}s ago), skipping nightly release"
+          fi
+
+      - name: Compute nightly version
+        id: version
+        run: |
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          echo "version=0.0.0-alpha.${SHORT_SHA}" >> $GITHUB_OUTPUT
+          echo "Nightly version: 0.0.0-alpha.${SHORT_SHA}"
+
+  release:
+    needs: prepare
+    if: ${{ needs.prepare.outputs.has_commits == 'true' || github.event_name == 'workflow_dispatch' }}
+    uses: ./.github/workflows/release.yml
+    with:
+      version: ${{ needs.prepare.outputs.version }}
+      extra_tag: latest-dev
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -482,8 +482,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Helm login to ${{ env.CHART_REGISTRY_IMAGE_BASE }}
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.repository_owner }} --password-stdin
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push helm charts
         run: make -C controller release-charts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -483,7 +483,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Helm login to ${{ env.CHART_REGISTRY_IMAGE_BASE }}
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | ./tools/helm registry login ghcr.io -u ${{ github.repository_owner }} --password-stdin
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.repository_owner }} --password-stdin
 
       - name: Push helm charts
         run: make -C controller release-charts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,17 @@ on:
         required: false
         default: false
         type: boolean
+  workflow_call:
+    inputs:
+      version:
+        description: 'Version number (without v prefix)'
+        required: true
+        type: string
+      extra_tag:
+        description: 'Additional Docker image tag to push (e.g. latest-dev)'
+        required: false
+        default: ''
+        type: string
 
 env:
   CARGO_TERM_COLOR: always
@@ -37,8 +48,8 @@ jobs:
         id: version
         run: |
           # Determine version source
-          if [ "${{ github.event_name }}" == "workflow_dispatch" ] && [ -n "${{ github.event.inputs.version }}" ]; then
-            VERSION="${{ github.event.inputs.version }}"
+          if [ -n "${{ inputs.version }}" ]; then
+            VERSION="${{ inputs.version }}"
           else
             VERSION="${{ github.ref_name }}"
           fi
@@ -153,6 +164,7 @@ jobs:
           images: ${{ env.REGISTRY_IMAGE }}
           tags: |
             type=raw,value=v${{ env.VERSION }}
+            type=raw,value=${{ inputs.extra_tag }},enable=${{ inputs.extra_tag != '' }}
 
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests
@@ -162,6 +174,10 @@ jobs:
 
       - name: Sign the container image
         run: cosign sign --yes ${{ env.REGISTRY_IMAGE }}:v${{ env.VERSION }}
+
+      - name: Sign the extra tag
+        if: ${{ inputs.extra_tag != '' }}
+        run: cosign sign --yes ${{ env.REGISTRY_IMAGE }}:${{ inputs.extra_tag }}
 
       - name: Inspect image
         run: |
@@ -275,6 +291,7 @@ jobs:
           images: ${{ env.REGISTRY_IMAGE }}
           tags: |
             type=raw,value=v${{ env.VERSION }}
+            type=raw,value=${{ inputs.extra_tag }},enable=${{ inputs.extra_tag != '' }}
 
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests-musl
@@ -284,6 +301,10 @@ jobs:
 
       - name: Sign the container image
         run: cosign sign --yes ${{ env.REGISTRY_IMAGE }}:v${{ env.VERSION }}-musl
+
+      - name: Sign the extra tag
+        if: ${{ inputs.extra_tag != '' }}
+        run: cosign sign --yes ${{ env.REGISTRY_IMAGE }}:${{ inputs.extra_tag }}-musl
 
       - name: Inspect image
         run: |
@@ -428,6 +449,7 @@ jobs:
           images: ${{ env.CONTROLLER_REGISTRY_IMAGE }}
           tags: |
             type=raw,value=v${{ env.VERSION }}
+            type=raw,value=${{ inputs.extra_tag }},enable=${{ inputs.extra_tag != '' }}
 
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/controller-digests
@@ -437,6 +459,10 @@ jobs:
 
       - name: Sign the container image
         run: cosign sign --yes ${{ env.CONTROLLER_REGISTRY_IMAGE }}:v${{ env.VERSION }}
+
+      - name: Sign the extra tag
+        if: ${{ inputs.extra_tag != '' }}
+        run: cosign sign --yes ${{ env.CONTROLLER_REGISTRY_IMAGE }}:${{ inputs.extra_tag }}
 
       - name: Inspect image
         run: |
@@ -465,10 +491,12 @@ jobs:
           IMAGE_REGISTRY: ${{ env.CHART_REGISTRY_IMAGE_BASE }}
 
   build:
-    if: ${{ github.event_name == 'push' || ! github.event.inputs.skip_gh_release }}
+    if: ${{ github.event_name != 'workflow_call' && (github.event_name == 'push' || ! github.event.inputs.skip_gh_release) }}
     needs:
       - setup
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     env:
       VERSION: ${{ needs.setup.outputs.version }}
     strategy:
@@ -527,7 +555,7 @@ jobs:
           target/${{ matrix.target }}/release/agentgateway.exe
 
   release:
-    if: ${{ github.event_name == 'push' || ! github.event.inputs.skip_gh_release }}
+    if: ${{ github.event_name != 'workflow_call' && (github.event_name == 'push' || ! github.event.inputs.skip_gh_release) }}
     needs:
     - setup
     - push-image

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ env:
   REGISTRY_IMAGE: ghcr.io/${{ github.repository_owner }}/agentgateway
   CONTROLLER_REGISTRY_IMAGE: ghcr.io/${{ github.repository_owner }}/controller
   # Note: /charts is added to this
-  CHART_REGISTRY_IMAGE_BASE: ghcr.io/${{ github.repository_owner }}
+  CHART_REGISTRY_IMAGE_BASE: ghcr.io/${{ github.repository }}
 
 jobs:
   setup:
@@ -482,12 +482,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Helm login to ${{ env.CHART_REGISTRY_IMAGE_BASE }}
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | ./tools/helm registry login ghcr.io -u ${{ github.repository_owner }} --password-stdin
 
       - name: Push helm charts
         run: make -C controller release-charts


### PR DESCRIPTION
Based on https://github.com/agentgateway/agentgateway/pull/1213

Tested on fork: https://github.com/npolshakova/agentgateway/actions/workflows/nightly.yml 

See sample published nightly build here: https://github.com/npolshakova?tab=packages&repo_name=agentgateway 

It currently uses this format as the version with the short sha `0.0.0-alpha.7238053`. Let me know if we want to change this format to something else!  
<img width="657" height="75" alt="image" src="https://github.com/user-attachments/assets/aeb3c017-8d5b-439f-89b1-7760f592fd25" />


```
docker pull ghcr.io/npolshakova/agentgateway/charts/agentgateway:v0.0.0-alpha.a7af494
```