### PR TITLE
Add application/json Content-Type header to /v1/models response

### DIFF
--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -1587,7 +1587,7 @@ json(request.body).model
 			},
 		],
 		backends: vec![],
-		inline_policies: vec![TrafficPolicy::DirectResponse(filters::DirectResponse {
+		inline_policies: vec![TrafficPolicy::ResponseHeaderModifier(crate::http::filters::HeaderModifier { set: vec![(strng::new("Content-Type"), strng::new("application/json"))], add: vec![], remove: vec![] }), TrafficPolicy::DirectResponse(filters::DirectResponse {
 			body: Bytes::copy_from_slice(model_list_body.as_bytes()),
 			status: ::http::StatusCode::OK,
 		})],

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -1587,10 +1587,17 @@ json(request.body).model
 			},
 		],
 		backends: vec![],
-		inline_policies: vec![TrafficPolicy::ResponseHeaderModifier(crate::http::filters::HeaderModifier { set: vec![(strng::new("Content-Type"), strng::new("application/json"))], add: vec![], remove: vec![] }), TrafficPolicy::DirectResponse(filters::DirectResponse {
-			body: Bytes::copy_from_slice(model_list_body.as_bytes()),
-			status: ::http::StatusCode::OK,
-		})],
+		inline_policies: vec![
+			TrafficPolicy::ResponseHeaderModifier(crate::http::filters::HeaderModifier {
+				set: vec![(strng::new("Content-Type"), strng::new("application/json"))],
+				add: vec![],
+				remove: vec![],
+			}),
+			TrafficPolicy::DirectResponse(filters::DirectResponse {
+				body: Bytes::copy_from_slice(model_list_body.as_bytes()),
+				status: ::http::StatusCode::OK,
+			}),
+		],
 	};
 	routes.insert(model_list_route);
 

--- a/crates/agentgateway/src/types/local_tests/llm_simple_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/llm_simple_normalized.snap
@@ -18,6 +18,9 @@ binds:
         routes:
           "llm:admin:model-list":
             inlinePolicies:
+              - responseHeaderModifier:
+                  set:
+                    Content-Type: application/json
               - directResponse:
                   body: eyJkYXRhIjpbeyJpZCI6ImNsYXVkZS0zLWhhaWt1Iiwib2JqZWN0IjoibW9kZWwiLCJjcmVhdGVkIjowLCJvd25lZF9ieSI6Im9wZW5haSJ9LHsiaWQiOiJnZW1pbmktMC41LXBybyIsIm9iamVjdCI6Im1vZGVsIiwiY3JlYXRlZCI6MCwib3duZWRfYnkiOiJvcGVuYWkifSx7ImlkIjoiZ3B0LTctbWF4Iiwib2JqZWN0IjoibW9kZWwiLCJjcmVhdGVkIjowLCJvd25lZF9ieSI6Im9wZW5haSJ9LHsiaWQiOiJncHQtMy41LXR1cmJvIiwib2JqZWN0IjoibW9kZWwiLCJjcmVhdGVkIjowLCJvd25lZF9ieSI6Im9wZW5haSJ9XSwib2JqZWN0IjoibGlzdCJ9
                   status: 200


### PR DESCRIPTION
# What does this PR do?

When using the top-level llm configuration block, Agentgateway synthesizes a default route for /v1/models and returns a hardcoded JSON payload via the DirectResponse policy. However, this response was missing the Content-Type: application/json header.
Without this header, strict OpenAI-compatible clients (like PyCharm's LLM plugin, curl defaults, or strict HTTP clients) fail to parse the response, throwing content-type or transformation errors.
This PR fixes the issue by injecting a ResponseHeaderModifier policy directly into the synthesized model_list_route's inline_policies array, ensuring the Content-Type: application/json header is properly attached to the response before the DirectResponse short-circuits.

# Why is this important?

Ensures 100% compatibility with strict HTTP clients expecting standard OpenAPI/OpenAI headers.
Allows developer tools like JetBrains IDEs to successfully fetch and parse the available proxy models without resorting to manual bind workarounds or intercepting external mock servers.

# Testing:

Compiled and tested locally using cargo check & cargo run.
Sent a GET /v1/models request against the llm listener port and verified the Content-Type: application/json header is now present in the HTTP response.