### PR TITLE
fix: omit null cached_tokens in ai response for better compatibility

### DIFF
--- a/crates/agentgateway/src/llm/types/completions.rs
+++ b/crates/agentgateway/src/llm/types/completions.rs
@@ -95,6 +95,7 @@ pub struct UsageCompletionDetails {
 
 #[derive(Debug, Deserialize, Clone, Serialize)]
 pub struct UsagePromptDetails {
+	#[serde(skip_serializing_if = "Option::is_none")]
 	pub cached_tokens: Option<u64>,
 	#[serde(flatten, default)]
 	pub rest: serde_json::Value,


### PR DESCRIPTION
agentgateway currently sets cached_tokens to null when absent, breaking clients that expect the field to be either a number or omitted. This PR skips serialization when None to prevent unexpected null values in the response.