### PR TITLE
DNS lookup family

### DIFF
--- a/crates/agentgateway/src/config.rs
+++ b/crates/agentgateway/src/config.rs
@@ -15,8 +15,8 @@ use crate::telemetry::log::{LoggingFields, MetricFields};
 use crate::telemetry::trc;
 use crate::types::discovery::{Identity, WaypointIdentity};
 use crate::{
-	Address, Config, ConfigSource, NestedRawConfig, RawLoggingLevel, StringOrInt, ThreadingMode,
-	XDSConfig, cel, client, serdes, telemetry,
+	Address, Config, ConfigSource, DnsLookupFamily, NestedRawConfig, RawLoggingLevel, StringOrInt,
+	ThreadingMode, XDSConfig, cel, client, serdes, telemetry,
 };
 
 pub fn parse_config(contents: String, filename: Option<PathBuf>) -> anyhow::Result<Config> {
@@ -45,6 +45,9 @@ pub fn parse_config(contents: String, filename: Option<PathBuf>) -> anyhow::Resu
 		.or(filename)
 		.map(ConfigSource::File);
 
+	let dns_lookup_family = parse::<DnsLookupFamily>("DNS_LOOKUP_FAMILY")?
+		.or(raw.dns_lookup_family)
+		.unwrap_or_default();
 	let (resolver_cfg, resolver_opts) = {
 		let (cfg, opts) = hickory_resolver::system_conf::read_system_conf().unwrap_or_else(|e| {
 			warn!(err=?e, "failed to read system DNS config, using defaults");
@@ -53,7 +56,7 @@ pub fn parse_config(contents: String, filename: Option<PathBuf>) -> anyhow::Resu
 				hickory_resolver::config::ResolverOpts::default(),
 			)
 		});
-		resolve_dns_config(cfg, opts)
+		resolve_dns_config(cfg, opts, dns_lookup_family, ipv6_enabled)
 	};
 	let cluster: String = parse("CLUSTER_ID")?
 		.or(raw.cluster_id.clone())
@@ -548,10 +551,13 @@ fn parse_otlp_headers(
 }
 
 /// If the resolved config has no nameservers, fall back to defaults while
-/// preserving the original resolver options.
+/// preserving the original resolver options. Applies the configured
+/// `DnsLookupFamily` as the IP lookup strategy.
 fn resolve_dns_config(
 	cfg: hickory_resolver::config::ResolverConfig,
-	opts: hickory_resolver::config::ResolverOpts,
+	mut opts: hickory_resolver::config::ResolverOpts,
+	dns_lookup_family: DnsLookupFamily,
+	ipv6_enabled: bool,
 ) -> (
 	hickory_resolver::config::ResolverConfig,
 	hickory_resolver::config::ResolverOpts,
@@ -569,7 +575,16 @@ fn resolve_dns_config(
 		.iter()
 		.map(|ns| ns.to_string())
 		.collect();
-	info!(nameservers = ?nameservers, "using DNS nameservers");
+
+	let ip_strategy = dns_lookup_family.to_lookup_strategy(ipv6_enabled);
+	opts.ip_strategy = ip_strategy;
+	opts.edns0 = true;
+	info!(
+		nameservers = ?nameservers,
+		dns_lookup_family = ?dns_lookup_family,
+		ip_strategy = ?ip_strategy,
+		"using DNS nameservers"
+	);
 	(resolved_cfg, opts)
 }
 
@@ -704,7 +719,8 @@ config:
 		let mut custom_opts = hickory_resolver::config::ResolverOpts::default();
 		custom_opts.ndots = 42;
 
-		let (resolved_cfg, resolved_opts) = resolve_dns_config(empty_cfg, custom_opts);
+		let (resolved_cfg, resolved_opts) =
+			resolve_dns_config(empty_cfg, custom_opts, DnsLookupFamily::default(), true);
 
 		assert!(
 			!resolved_cfg.name_servers().is_empty(),
@@ -720,7 +736,8 @@ config:
 		custom_opts.ndots = 7;
 
 		let original_count = valid_cfg.name_servers().len();
-		let (resolved_cfg, resolved_opts) = resolve_dns_config(valid_cfg, custom_opts);
+		let (resolved_cfg, resolved_opts) =
+			resolve_dns_config(valid_cfg, custom_opts, DnsLookupFamily::default(), true);
 
 		assert_eq!(
 			resolved_cfg.name_servers().len(),
@@ -728,6 +745,62 @@ config:
 			"should keep original nameservers"
 		);
 		assert_eq!(resolved_opts.ndots, 7, "should preserve original opts");
+	}
+
+	#[test]
+	fn resolve_dns_config_applies_v4_only() {
+		let cfg = hickory_resolver::config::ResolverConfig::default();
+		let opts = hickory_resolver::config::ResolverOpts::default();
+
+		let (_, resolved_opts) = resolve_dns_config(cfg, opts, crate::DnsLookupFamily::V4Only, true);
+
+		assert_eq!(
+			resolved_opts.ip_strategy,
+			hickory_resolver::config::LookupIpStrategy::Ipv4Only,
+			"V4_ONLY should map to Ipv4Only"
+		);
+	}
+
+	#[test]
+	fn resolve_dns_config_applies_v6_only() {
+		let cfg = hickory_resolver::config::ResolverConfig::default();
+		let opts = hickory_resolver::config::ResolverOpts::default();
+
+		let (_, resolved_opts) = resolve_dns_config(cfg, opts, crate::DnsLookupFamily::V6Only, false);
+
+		assert_eq!(
+			resolved_opts.ip_strategy,
+			hickory_resolver::config::LookupIpStrategy::Ipv6Only,
+			"V6_ONLY should map to Ipv6Only"
+		);
+	}
+
+	#[test]
+	fn resolve_dns_config_auto_with_ipv6_disabled() {
+		let cfg = hickory_resolver::config::ResolverConfig::default();
+		let opts = hickory_resolver::config::ResolverOpts::default();
+
+		let (_, resolved_opts) = resolve_dns_config(cfg, opts, crate::DnsLookupFamily::Auto, false);
+
+		assert_eq!(
+			resolved_opts.ip_strategy,
+			hickory_resolver::config::LookupIpStrategy::Ipv4Only,
+			"AUTO with ipv6 disabled should map to Ipv4Only"
+		);
+	}
+
+	#[test]
+	fn resolve_dns_config_auto_with_ipv6_enabled() {
+		let cfg = hickory_resolver::config::ResolverConfig::default();
+		let opts = hickory_resolver::config::ResolverOpts::default();
+
+		let (_, resolved_opts) = resolve_dns_config(cfg, opts, crate::DnsLookupFamily::Auto, true);
+
+		assert_eq!(
+			resolved_opts.ip_strategy,
+			hickory_resolver::config::LookupIpStrategy::Ipv4AndIpv6,
+			"AUTO with ipv6 enabled should map to Ipv4AndIpv6"
+		);
 	}
 
 	#[test]

--- a/crates/agentgateway/src/config.rs
+++ b/crates/agentgateway/src/config.rs
@@ -45,9 +45,13 @@ pub fn parse_config(contents: String, filename: Option<PathBuf>) -> anyhow::Resu
 		.or(filename)
 		.map(ConfigSource::File);
 
-	let dns_lookup_family = parse::<DnsLookupFamily>("DNS_LOOKUP_FAMILY")?
-		.or(raw.dns_lookup_family)
-		.unwrap_or_default();
+	let dns_lookup_family = match env::var("DNS_LOOKUP_FAMILY") {
+		Ok(val) => Some(DnsLookupFamily::from_env_str(&val)?),
+		Err(_) => None,
+	}
+	.or(raw.dns_lookup_family)
+	.unwrap_or_default();
+	let dns_edns0: Option<bool> = parse("DNS_EDNS0")?.or(raw.dns_edns0);
 	let (resolver_cfg, resolver_opts) = {
 		let (cfg, opts) = hickory_resolver::system_conf::read_system_conf().unwrap_or_else(|e| {
 			warn!(err=?e, "failed to read system DNS config, using defaults");
@@ -56,7 +60,7 @@ pub fn parse_config(contents: String, filename: Option<PathBuf>) -> anyhow::Resu
 				hickory_resolver::config::ResolverOpts::default(),
 			)
 		});
-		resolve_dns_config(cfg, opts, dns_lookup_family, ipv6_enabled)
+		resolve_dns_config(cfg, opts, dns_lookup_family, ipv6_enabled, dns_edns0)
 	};
 	let cluster: String = parse("CLUSTER_ID")?
 		.or(raw.cluster_id.clone())
@@ -552,12 +556,15 @@ fn parse_otlp_headers(
 
 /// If the resolved config has no nameservers, fall back to defaults while
 /// preserving the original resolver options. Applies the configured
-/// `DnsLookupFamily` as the IP lookup strategy.
+/// `DnsLookupFamily` as the IP lookup strategy. When `edns0` is `Some`, it
+/// overrides the resolver's EDNS0 setting; when `None`, the system-provided
+/// (or default) value is preserved.
 fn resolve_dns_config(
 	cfg: hickory_resolver::config::ResolverConfig,
 	mut opts: hickory_resolver::config::ResolverOpts,
 	dns_lookup_family: DnsLookupFamily,
 	ipv6_enabled: bool,
+	edns0: Option<bool>,
 ) -> (
 	hickory_resolver::config::ResolverConfig,
 	hickory_resolver::config::ResolverOpts,
@@ -578,11 +585,14 @@ fn resolve_dns_config(
 
 	let ip_strategy = dns_lookup_family.to_lookup_strategy(ipv6_enabled);
 	opts.ip_strategy = ip_strategy;
-	opts.edns0 = true;
+	if let Some(edns0) = edns0 {
+		opts.edns0 = edns0;
+	}
 	info!(
 		nameservers = ?nameservers,
 		dns_lookup_family = ?dns_lookup_family,
 		ip_strategy = ?ip_strategy,
+		edns0 = opts.edns0,
 		"using DNS nameservers"
 	);
 	(resolved_cfg, opts)
@@ -720,7 +730,7 @@ config:
 		custom_opts.ndots = 42;
 
 		let (resolved_cfg, resolved_opts) =
-			resolve_dns_config(empty_cfg, custom_opts, DnsLookupFamily::default(), true);
+			resolve_dns_config(empty_cfg, custom_opts, DnsLookupFamily::default(), true, None);
 
 		assert!(
 			!resolved_cfg.name_servers().is_empty(),
@@ -737,7 +747,7 @@ config:
 
 		let original_count = valid_cfg.name_servers().len();
 		let (resolved_cfg, resolved_opts) =
-			resolve_dns_config(valid_cfg, custom_opts, DnsLookupFamily::default(), true);
+			resolve_dns_config(valid_cfg, custom_opts, DnsLookupFamily::default(), true, None);
 
 		assert_eq!(
 			resolved_cfg.name_servers().len(),
@@ -752,12 +762,13 @@ config:
 		let cfg = hickory_resolver::config::ResolverConfig::default();
 		let opts = hickory_resolver::config::ResolverOpts::default();
 
-		let (_, resolved_opts) = resolve_dns_config(cfg, opts, crate::DnsLookupFamily::V4Only, true);
+		let (_, resolved_opts) =
+			resolve_dns_config(cfg, opts, crate::DnsLookupFamily::V4Only, true, None);
 
 		assert_eq!(
 			resolved_opts.ip_strategy,
 			hickory_resolver::config::LookupIpStrategy::Ipv4Only,
-			"V4_ONLY should map to Ipv4Only"
+			"V4Only should map to Ipv4Only"
 		);
 	}
 
@@ -766,12 +777,13 @@ config:
 		let cfg = hickory_resolver::config::ResolverConfig::default();
 		let opts = hickory_resolver::config::ResolverOpts::default();
 
-		let (_, resolved_opts) = resolve_dns_config(cfg, opts, crate::DnsLookupFamily::V6Only, false);
+		let (_, resolved_opts) =
+			resolve_dns_config(cfg, opts, crate::DnsLookupFamily::V6Only, false, None);
 
 		assert_eq!(
 			resolved_opts.ip_strategy,
 			hickory_resolver::config::LookupIpStrategy::Ipv6Only,
-			"V6_ONLY should map to Ipv6Only"
+			"V6Only should map to Ipv6Only"
 		);
 	}
 
@@ -780,12 +792,13 @@ config:
 		let cfg = hickory_resolver::config::ResolverConfig::default();
 		let opts = hickory_resolver::config::ResolverOpts::default();
 
-		let (_, resolved_opts) = resolve_dns_config(cfg, opts, crate::DnsLookupFamily::Auto, false);
+		let (_, resolved_opts) =
+			resolve_dns_config(cfg, opts, crate::DnsLookupFamily::Auto, false, None);
 
 		assert_eq!(
 			resolved_opts.ip_strategy,
 			hickory_resolver::config::LookupIpStrategy::Ipv4Only,
-			"AUTO with ipv6 disabled should map to Ipv4Only"
+			"Auto with ipv6 disabled should map to Ipv4Only"
 		);
 	}
 
@@ -794,13 +807,50 @@ config:
 		let cfg = hickory_resolver::config::ResolverConfig::default();
 		let opts = hickory_resolver::config::ResolverOpts::default();
 
-		let (_, resolved_opts) = resolve_dns_config(cfg, opts, crate::DnsLookupFamily::Auto, true);
+		let (_, resolved_opts) =
+			resolve_dns_config(cfg, opts, crate::DnsLookupFamily::Auto, true, None);
 
 		assert_eq!(
 			resolved_opts.ip_strategy,
-			hickory_resolver::config::LookupIpStrategy::Ipv4AndIpv6,
-			"AUTO with ipv6 enabled should map to Ipv4AndIpv6"
+			hickory_resolver::config::LookupIpStrategy::Ipv4thenIpv6,
+			"Auto with ipv6 enabled should behave like V4Preferred (Ipv4thenIpv6)"
 		);
+	}
+
+	#[test]
+	fn resolve_dns_config_edns0_none_preserves_system_value() {
+		let cfg = hickory_resolver::config::ResolverConfig::default();
+		let mut opts = hickory_resolver::config::ResolverOpts::default();
+		opts.edns0 = false;
+
+		let (_, resolved_opts) =
+			resolve_dns_config(cfg, opts, DnsLookupFamily::default(), true, None);
+
+		assert!(!resolved_opts.edns0, "None should preserve the original edns0 value");
+	}
+
+	#[test]
+	fn resolve_dns_config_edns0_explicit_true() {
+		let cfg = hickory_resolver::config::ResolverConfig::default();
+		let mut opts = hickory_resolver::config::ResolverOpts::default();
+		opts.edns0 = false;
+
+		let (_, resolved_opts) =
+			resolve_dns_config(cfg, opts, DnsLookupFamily::default(), true, Some(true));
+
+		assert!(resolved_opts.edns0, "Some(true) should enable edns0");
+	}
+
+	#[test]
+	fn resolve_dns_config_edns0_explicit_false() {
+		let cfg = hickory_resolver::config::ResolverConfig::default();
+		let mut opts = hickory_resolver::config::ResolverOpts::default();
+		opts.edns0 = true;
+
+		let (_, resolved_opts) =
+			resolve_dns_config(cfg, opts, DnsLookupFamily::default(), true, Some(false));
+
+		assert!(!resolved_opts.edns0, "Some(false) should disable edns0");
 	}
 
 	#[test]

--- a/crates/agentgateway/src/config.rs
+++ b/crates/agentgateway/src/config.rs
@@ -767,102 +767,57 @@ config:
 		assert_eq!(resolved_opts.ndots, 7, "should preserve original opts");
 	}
 
-	#[test]
-	fn resolve_dns_config_applies_v4_only() {
+	#[rstest::rstest]
+	#[case(
+		DnsLookupFamily::V4Only,
+		true,
+		hickory_resolver::config::LookupIpStrategy::Ipv4Only
+	)]
+	#[case(
+		DnsLookupFamily::V6Only,
+		false,
+		hickory_resolver::config::LookupIpStrategy::Ipv6Only
+	)]
+	#[case(
+		DnsLookupFamily::Auto,
+		false,
+		hickory_resolver::config::LookupIpStrategy::Ipv4Only
+	)]
+	#[case(
+		DnsLookupFamily::Auto,
+		true,
+		hickory_resolver::config::LookupIpStrategy::Ipv4thenIpv6
+	)]
+	fn resolve_dns_config_ip_strategy(
+		#[case] family: DnsLookupFamily,
+		#[case] ipv6_enabled: bool,
+		#[case] expected: hickory_resolver::config::LookupIpStrategy,
+	) {
 		let cfg = hickory_resolver::config::ResolverConfig::default();
 		let opts = hickory_resolver::config::ResolverOpts::default();
 
-		let (_, resolved_opts) =
-			resolve_dns_config(cfg, opts, crate::DnsLookupFamily::V4Only, true, None);
+		let (_, resolved_opts) = resolve_dns_config(cfg, opts, family, ipv6_enabled, None);
 
-		assert_eq!(
-			resolved_opts.ip_strategy,
-			hickory_resolver::config::LookupIpStrategy::Ipv4Only,
-			"V4Only should map to Ipv4Only"
-		);
+		assert_eq!(resolved_opts.ip_strategy, expected);
 	}
 
-	#[test]
-	fn resolve_dns_config_applies_v6_only() {
-		let cfg = hickory_resolver::config::ResolverConfig::default();
-		let opts = hickory_resolver::config::ResolverOpts::default();
-
-		let (_, resolved_opts) =
-			resolve_dns_config(cfg, opts, crate::DnsLookupFamily::V6Only, false, None);
-
-		assert_eq!(
-			resolved_opts.ip_strategy,
-			hickory_resolver::config::LookupIpStrategy::Ipv6Only,
-			"V6Only should map to Ipv6Only"
-		);
-	}
-
-	#[test]
-	fn resolve_dns_config_auto_with_ipv6_disabled() {
-		let cfg = hickory_resolver::config::ResolverConfig::default();
-		let opts = hickory_resolver::config::ResolverOpts::default();
-
-		let (_, resolved_opts) =
-			resolve_dns_config(cfg, opts, crate::DnsLookupFamily::Auto, false, None);
-
-		assert_eq!(
-			resolved_opts.ip_strategy,
-			hickory_resolver::config::LookupIpStrategy::Ipv4Only,
-			"Auto with ipv6 disabled should map to Ipv4Only"
-		);
-	}
-
-	#[test]
-	fn resolve_dns_config_auto_with_ipv6_enabled() {
-		let cfg = hickory_resolver::config::ResolverConfig::default();
-		let opts = hickory_resolver::config::ResolverOpts::default();
-
-		let (_, resolved_opts) =
-			resolve_dns_config(cfg, opts, crate::DnsLookupFamily::Auto, true, None);
-
-		assert_eq!(
-			resolved_opts.ip_strategy,
-			hickory_resolver::config::LookupIpStrategy::Ipv4thenIpv6,
-			"Auto with ipv6 enabled should behave like V4Preferred (Ipv4thenIpv6)"
-		);
-	}
-
-	#[test]
-	fn resolve_dns_config_edns0_none_preserves_system_value() {
+	#[rstest::rstest]
+	#[case(false, None, false)]
+	#[case(false, Some(true), true)]
+	#[case(true, Some(false), false)]
+	fn resolve_dns_config_edns0(
+		#[case] initial_edns0: bool,
+		#[case] edns0_param: Option<bool>,
+		#[case] expected: bool,
+	) {
 		let cfg = hickory_resolver::config::ResolverConfig::default();
 		let mut opts = hickory_resolver::config::ResolverOpts::default();
-		opts.edns0 = false;
-
-		let (_, resolved_opts) = resolve_dns_config(cfg, opts, DnsLookupFamily::default(), true, None);
-
-		assert!(
-			!resolved_opts.edns0,
-			"None should preserve the original edns0 value"
-		);
-	}
-
-	#[test]
-	fn resolve_dns_config_edns0_explicit_true() {
-		let cfg = hickory_resolver::config::ResolverConfig::default();
-		let mut opts = hickory_resolver::config::ResolverOpts::default();
-		opts.edns0 = false;
+		opts.edns0 = initial_edns0;
 
 		let (_, resolved_opts) =
-			resolve_dns_config(cfg, opts, DnsLookupFamily::default(), true, Some(true));
+			resolve_dns_config(cfg, opts, DnsLookupFamily::default(), true, edns0_param);
 
-		assert!(resolved_opts.edns0, "Some(true) should enable edns0");
-	}
-
-	#[test]
-	fn resolve_dns_config_edns0_explicit_false() {
-		let cfg = hickory_resolver::config::ResolverConfig::default();
-		let mut opts = hickory_resolver::config::ResolverOpts::default();
-		opts.edns0 = true;
-
-		let (_, resolved_opts) =
-			resolve_dns_config(cfg, opts, DnsLookupFamily::default(), true, Some(false));
-
-		assert!(!resolved_opts.edns0, "Some(false) should disable edns0");
+		assert_eq!(resolved_opts.edns0, expected);
 	}
 
 	#[test]

--- a/crates/agentgateway/src/config.rs
+++ b/crates/agentgateway/src/config.rs
@@ -45,13 +45,14 @@ pub fn parse_config(contents: String, filename: Option<PathBuf>) -> anyhow::Resu
 		.or(filename)
 		.map(ConfigSource::File);
 
+	let dns = raw.dns.unwrap_or_default();
 	let dns_lookup_family = match env::var("DNS_LOOKUP_FAMILY") {
 		Ok(val) => Some(DnsLookupFamily::from_env_str(&val)?),
 		Err(_) => None,
 	}
-	.or(raw.dns_lookup_family)
+	.or(dns.lookup_family)
 	.unwrap_or_default();
-	let dns_edns0: Option<bool> = parse("DNS_EDNS0")?.or(raw.dns_edns0);
+	let dns_edns0: Option<bool> = parse("DNS_EDNS0")?.or(dns.edns0);
 	let (resolver_cfg, resolver_opts) = {
 		let (cfg, opts) = hickory_resolver::system_conf::read_system_conf().unwrap_or_else(|e| {
 			warn!(err=?e, "failed to read system DNS config, using defaults");

--- a/crates/agentgateway/src/config.rs
+++ b/crates/agentgateway/src/config.rs
@@ -729,8 +729,13 @@ config:
 		let mut custom_opts = hickory_resolver::config::ResolverOpts::default();
 		custom_opts.ndots = 42;
 
-		let (resolved_cfg, resolved_opts) =
-			resolve_dns_config(empty_cfg, custom_opts, DnsLookupFamily::default(), true, None);
+		let (resolved_cfg, resolved_opts) = resolve_dns_config(
+			empty_cfg,
+			custom_opts,
+			DnsLookupFamily::default(),
+			true,
+			None,
+		);
 
 		assert!(
 			!resolved_cfg.name_servers().is_empty(),
@@ -746,8 +751,13 @@ config:
 		custom_opts.ndots = 7;
 
 		let original_count = valid_cfg.name_servers().len();
-		let (resolved_cfg, resolved_opts) =
-			resolve_dns_config(valid_cfg, custom_opts, DnsLookupFamily::default(), true, None);
+		let (resolved_cfg, resolved_opts) = resolve_dns_config(
+			valid_cfg,
+			custom_opts,
+			DnsLookupFamily::default(),
+			true,
+			None,
+		);
 
 		assert_eq!(
 			resolved_cfg.name_servers().len(),
@@ -823,10 +833,12 @@ config:
 		let mut opts = hickory_resolver::config::ResolverOpts::default();
 		opts.edns0 = false;
 
-		let (_, resolved_opts) =
-			resolve_dns_config(cfg, opts, DnsLookupFamily::default(), true, None);
+		let (_, resolved_opts) = resolve_dns_config(cfg, opts, DnsLookupFamily::default(), true, None);
 
-		assert!(!resolved_opts.edns0, "None should preserve the original edns0 value");
+		assert!(
+			!resolved_opts.edns0,
+			"None should preserve the original edns0 value"
+		);
 	}
 
 	#[test]

--- a/crates/agentgateway/src/lib.rs
+++ b/crates/agentgateway/src/lib.rs
@@ -64,8 +64,7 @@ pub struct NestedRawConfig {
 /// Controls which IP address families the DNS resolver will query for
 /// upstream (backend) connections.
 ///
-/// Mirrors Envoy's `DnsLookupFamily` semantics. Maps to hickory_resolver's
-/// `LookupIpStrategy` under the hood.
+///  Maps to hickory_resolver's `LookupIpStrategy` under the hood.
 ///
 /// Can be set via the `DNS_LOOKUP_FAMILY` environment variable or the
 /// `dnsLookupFamily` field in the config file.
@@ -94,35 +93,23 @@ impl Default for DnsLookupFamily {
 	}
 }
 
-impl std::str::FromStr for DnsLookupFamily {
-	type Err = String;
-
-	fn from_str(s: &str) -> Result<Self, Self::Err> {
-		match s {
-			"All" | "ALL" | "all" => Ok(Self::All),
-			"Auto" | "AUTO" | "auto" => Ok(Self::Auto),
-			"V4Preferred" | "V4_PREFERRED" | "v4_preferred" => Ok(Self::V4Preferred),
-			"V4Only" | "V4_ONLY" | "v4_only" => Ok(Self::V4Only),
-			"V6Only" | "V6_ONLY" | "v6_only" => Ok(Self::V6Only),
-			_ => Err(format!(
-				"unknown DNS lookup family '{s}': expected one of \
-				 All, Auto, V4Preferred, V4Only, V6Only"
-			)),
-		}
-	}
-}
-
 impl DnsLookupFamily {
+	pub fn from_env_str(s: &str) -> anyhow::Result<Self> {
+		serde_json::from_value(serde_json::Value::String(s.to_owned()))
+			.map_err(|e| anyhow::anyhow!("invalid DNS lookup family '{s}': {e}"))
+	}
+
 	/// Convert to hickory_resolver's `LookupIpStrategy`, using the
 	/// `ipv6_enabled` flag to resolve the `Auto` case.
 	pub fn to_lookup_strategy(self, ipv6_enabled: bool) -> LookupIpStrategy {
 		match self {
-			Self::All | Self::V4Preferred => LookupIpStrategy::Ipv4AndIpv6,
+			Self::All => LookupIpStrategy::Ipv4AndIpv6,
+			Self::V4Preferred => LookupIpStrategy::Ipv4thenIpv6,
 			Self::V4Only => LookupIpStrategy::Ipv4Only,
 			Self::V6Only => LookupIpStrategy::Ipv6Only,
 			Self::Auto => {
 				if ipv6_enabled {
-					LookupIpStrategy::Ipv4AndIpv6
+					LookupIpStrategy::Ipv4thenIpv6
 				} else {
 					LookupIpStrategy::Ipv4Only
 				}
@@ -139,11 +126,15 @@ pub struct RawConfig {
 	enable_ipv6: Option<bool>,
 
 	/// Controls which IP address families the DNS resolver will query for
-	/// upstream connections. Mirrors Envoy's DnsLookupFamily.
+	/// upstream connections.
 	/// Accepted values: All, Auto, V4Preferred, V4Only, V6Only.
-	/// Can also be set via the DNS_LOOKUP_FAMILY environment variable.
 	/// Defaults to Auto (IPv4-only when enableIpv6 is false, both when true).
 	dns_lookup_family: Option<DnsLookupFamily>,
+
+	/// Whether to enable EDNS0 (Extension Mechanisms for DNS) in the resolver.
+	/// When `None`, the system-provided resolver setting is preserved.
+	/// Can also be set via the `DNS_EDNS0` environment variable.
+	dns_edns0: Option<bool>,
 
 	/// Local XDS path. If not specified, the current configuration file will be used.
 	local_xds_path: Option<PathBuf>,

--- a/crates/agentgateway/src/lib.rs
+++ b/crates/agentgateway/src/lib.rs
@@ -67,7 +67,7 @@ pub struct NestedRawConfig {
 ///  Maps to hickory_resolver's `LookupIpStrategy` under the hood.
 ///
 /// Can be set via the `DNS_LOOKUP_FAMILY` environment variable or the
-/// `dnsLookupFamily` field in the config file.
+/// `dns.lookupFamily` field in the config file.
 ///
 /// See: <https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#enum-config-cluster-v3-cluster-dnslookupfamily>
 #[derive(serde::Deserialize, serde::Serialize, Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -116,20 +116,28 @@ impl DnsLookupFamily {
 #[derive(serde::Deserialize, Default, Clone, Debug)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
-// RawConfig represents the inputs a user can pass in. Config represents the internal representation of this.
-pub struct RawConfig {
-	enable_ipv6: Option<bool>,
-
+pub struct RawDnsConfig {
 	/// Controls which IP address families the DNS resolver will query for
 	/// upstream connections.
 	/// Accepted values: All, Auto, V4Preferred, V4Only, V6Only.
 	/// Defaults to Auto (IPv4-only when enableIpv6 is false, both when true).
-	dns_lookup_family: Option<DnsLookupFamily>,
+	lookup_family: Option<DnsLookupFamily>,
 
 	/// Whether to enable EDNS0 (Extension Mechanisms for DNS) in the resolver.
 	/// When `None`, the system-provided resolver setting is preserved.
 	/// Can also be set via the `DNS_EDNS0` environment variable.
-	dns_edns0: Option<bool>,
+	edns0: Option<bool>,
+}
+
+#[derive(serde::Deserialize, Default, Clone, Debug)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+// RawConfig represents the inputs a user can pass in. Config represents the internal representation of this.
+pub struct RawConfig {
+	enable_ipv6: Option<bool>,
+
+	/// DNS resolver settings.
+	dns: Option<RawDnsConfig>,
 
 	/// Local XDS path. If not specified, the current configuration file will be used.
 	local_xds_path: Option<PathBuf>,

--- a/crates/agentgateway/src/lib.rs
+++ b/crates/agentgateway/src/lib.rs
@@ -70,13 +70,14 @@ pub struct NestedRawConfig {
 /// `dnsLookupFamily` field in the config file.
 ///
 /// See: <https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#enum-config-cluster-v3-cluster-dnslookupfamily>
-#[derive(serde::Deserialize, serde::Serialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(serde::Deserialize, serde::Serialize, Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 pub enum DnsLookupFamily {
 	/// Query for both A and AAAA records in parallel and use all results.
 	All,
 	/// Automatically choose based on the `enable_ipv6` setting. When IPv6 is
 	/// enabled this behaves like `V4Preferred`; otherwise `V4Only`.
+	#[default]
 	Auto,
 	/// Query for both A and AAAA, but prefer IPv4 addresses when both are
 	/// available.
@@ -85,12 +86,6 @@ pub enum DnsLookupFamily {
 	V4Only,
 	/// Only query for AAAA (IPv6) records.
 	V6Only,
-}
-
-impl Default for DnsLookupFamily {
-	fn default() -> Self {
-		Self::Auto
-	}
 }
 
 impl DnsLookupFamily {

--- a/crates/agentgateway/src/lib.rs
+++ b/crates/agentgateway/src/lib.rs
@@ -8,7 +8,7 @@ use std::{fmt, io};
 
 use agent_core::prelude::*;
 use control::caclient::CaClient;
-use hickory_resolver::config::{ResolverConfig, ResolverOpts};
+use hickory_resolver::config::{LookupIpStrategy, ResolverConfig, ResolverOpts};
 use indexmap::IndexMap;
 #[cfg(feature = "schema")]
 pub use schemars::JsonSchema;
@@ -61,12 +61,89 @@ pub struct NestedRawConfig {
 	config: Option<RawConfig>,
 }
 
+/// Controls which IP address families the DNS resolver will query for
+/// upstream (backend) connections.
+///
+/// Mirrors Envoy's `DnsLookupFamily` semantics. Maps to hickory_resolver's
+/// `LookupIpStrategy` under the hood.
+///
+/// Can be set via the `DNS_LOOKUP_FAMILY` environment variable or the
+/// `dnsLookupFamily` field in the config file.
+///
+/// See: <https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#enum-config-cluster-v3-cluster-dnslookupfamily>
+#[derive(serde::Deserialize, serde::Serialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+pub enum DnsLookupFamily {
+	/// Query for both A and AAAA records in parallel and use all results.
+	All,
+	/// Automatically choose based on the `enable_ipv6` setting. When IPv6 is
+	/// enabled this behaves like `V4Preferred`; otherwise `V4Only`.
+	Auto,
+	/// Query for both A and AAAA, but prefer IPv4 addresses when both are
+	/// available.
+	V4Preferred,
+	/// Only query for A (IPv4) records.
+	V4Only,
+	/// Only query for AAAA (IPv6) records.
+	V6Only,
+}
+
+impl Default for DnsLookupFamily {
+	fn default() -> Self {
+		Self::Auto
+	}
+}
+
+impl std::str::FromStr for DnsLookupFamily {
+	type Err = String;
+
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		match s {
+			"All" | "ALL" | "all" => Ok(Self::All),
+			"Auto" | "AUTO" | "auto" => Ok(Self::Auto),
+			"V4Preferred" | "V4_PREFERRED" | "v4_preferred" => Ok(Self::V4Preferred),
+			"V4Only" | "V4_ONLY" | "v4_only" => Ok(Self::V4Only),
+			"V6Only" | "V6_ONLY" | "v6_only" => Ok(Self::V6Only),
+			_ => Err(format!(
+				"unknown DNS lookup family '{s}': expected one of \
+				 All, Auto, V4Preferred, V4Only, V6Only"
+			)),
+		}
+	}
+}
+
+impl DnsLookupFamily {
+	/// Convert to hickory_resolver's `LookupIpStrategy`, using the
+	/// `ipv6_enabled` flag to resolve the `Auto` case.
+	pub fn to_lookup_strategy(self, ipv6_enabled: bool) -> LookupIpStrategy {
+		match self {
+			Self::All | Self::V4Preferred => LookupIpStrategy::Ipv4AndIpv6,
+			Self::V4Only => LookupIpStrategy::Ipv4Only,
+			Self::V6Only => LookupIpStrategy::Ipv6Only,
+			Self::Auto => {
+				if ipv6_enabled {
+					LookupIpStrategy::Ipv4AndIpv6
+				} else {
+					LookupIpStrategy::Ipv4Only
+				}
+			},
+		}
+	}
+}
+
 #[derive(serde::Deserialize, Default, Clone, Debug)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 // RawConfig represents the inputs a user can pass in. Config represents the internal representation of this.
 pub struct RawConfig {
 	enable_ipv6: Option<bool>,
+
+	/// Controls which IP address families the DNS resolver will query for
+	/// upstream connections. Mirrors Envoy's DnsLookupFamily.
+	/// Accepted values: All, Auto, V4Preferred, V4Only, V6Only.
+	/// Can also be set via the DNS_LOOKUP_FAMILY environment variable.
+	/// Defaults to Auto (IPv4-only when enableIpv6 is false, both when true).
+	dns_lookup_family: Option<DnsLookupFamily>,
 
 	/// Local XDS path. If not specified, the current configuration file will be used.
 	local_xds_path: Option<PathBuf>,

--- a/crates/agentgateway/tests/tests/llm.rs
+++ b/crates/agentgateway/tests/tests/llm.rs
@@ -29,6 +29,11 @@ use crate::common::gateway::AgentGateway;
 // 3. Run a specific targeted test case (e.g., Bedrock messages):
 //    AGENTGATEWAY_E2E=true cargo test --test integration tests::llm::bedrock::messages
 //
+// DNS configuration can be overridden via environment variables, for example:
+//    IPV6_ENABLED=false DNS_LOOKUP_FAMILY=V4Only DNS_EDNS0=true \
+//    AGENTGATEWAY_E2E=true cargo test --test integration tests::llm::gemini::
+// This will disable IPv6 and enable EDNS0 for the Gemini tests.
+//
 // Note: Some providers (Bedrock, Vertex) use implicit environment auth (AWS/GCP) instead of explicit keys.
 
 macro_rules! send_completions_tests {

--- a/schema/config.json
+++ b/schema/config.json
@@ -78,6 +78,13 @@
             }
           ]
         },
+        "dnsEdns0": {
+          "description": "Whether to enable EDNS0 (Extension Mechanisms for DNS) in the resolver.\nWhen `None`, the system-provided resolver setting is preserved.\nCan also be set via the `DNS_EDNS0` environment variable.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "localXdsPath": {
           "description": "Local XDS path. If not specified, the current configuration file will be used.",
           "type": [

--- a/schema/config.json
+++ b/schema/config.json
@@ -67,6 +67,17 @@
             "null"
           ]
         },
+        "dnsLookupFamily": {
+          "description": "Controls which IP address families the DNS resolver will query for\nupstream connections. Mirrors Envoy's DnsLookupFamily.\nAccepted values: All, Auto, V4Preferred, V4Only, V6Only.\nCan also be set via the DNS_LOOKUP_FAMILY environment variable.\nDefaults to Auto (IPv4-only when enableIpv6 is false, both when true).",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DnsLookupFamily"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "localXdsPath": {
           "description": "Local XDS path. If not specified, the current configuration file will be used.",
           "type": [
@@ -242,6 +253,36 @@
         }
       },
       "additionalProperties": false
+    },
+    "DnsLookupFamily": {
+      "description": "Controls which IP address families the DNS resolver will query for\nupstream (backend) connections.\n\nMirrors Envoy's `DnsLookupFamily` semantics. Maps to hickory_resolver's\n`LookupIpStrategy` under the hood.\n\nCan be set via the `DNS_LOOKUP_FAMILY` environment variable or the\n`dnsLookupFamily` field in the config file.\n\nSee: <https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#enum-config-cluster-v3-cluster-dnslookupfamily>",
+      "oneOf": [
+        {
+          "description": "Query for both A and AAAA records in parallel and use all results.",
+          "type": "string",
+          "const": "All"
+        },
+        {
+          "description": "Automatically choose based on the `enable_ipv6` setting. When IPv6 is\nenabled this behaves like `V4Preferred`; otherwise `V4Only`.",
+          "type": "string",
+          "const": "Auto"
+        },
+        {
+          "description": "Query for both A and AAAA, but prefer IPv4 addresses when both are\navailable.",
+          "type": "string",
+          "const": "V4Preferred"
+        },
+        {
+          "description": "Only query for A (IPv4) records.",
+          "type": "string",
+          "const": "V4Only"
+        },
+        {
+          "description": "Only query for AAAA (IPv6) records.",
+          "type": "string",
+          "const": "V6Only"
+        }
+      ]
     },
     "RawSession": {
       "type": "object",

--- a/schema/config.json
+++ b/schema/config.json
@@ -67,22 +67,15 @@
             "null"
           ]
         },
-        "dnsLookupFamily": {
-          "description": "Controls which IP address families the DNS resolver will query for\nupstream connections.\nAccepted values: All, Auto, V4Preferred, V4Only, V6Only.\nDefaults to Auto (IPv4-only when enableIpv6 is false, both when true).",
+        "dns": {
+          "description": "DNS resolver settings.",
           "anyOf": [
             {
-              "$ref": "#/$defs/DnsLookupFamily"
+              "$ref": "#/$defs/RawDnsConfig"
             },
             {
               "type": "null"
             }
-          ]
-        },
-        "dnsEdns0": {
-          "description": "Whether to enable EDNS0 (Extension Mechanisms for DNS) in the resolver.\nWhen `None`, the system-provided resolver setting is preserved.\nCan also be set via the `DNS_EDNS0` environment variable.",
-          "type": [
-            "boolean",
-            "null"
           ]
         },
         "localXdsPath": {
@@ -261,8 +254,32 @@
       },
       "additionalProperties": false
     },
+    "RawDnsConfig": {
+      "type": "object",
+      "properties": {
+        "lookupFamily": {
+          "description": "Controls which IP address families the DNS resolver will query for\nupstream connections.\nAccepted values: All, Auto, V4Preferred, V4Only, V6Only.\nDefaults to Auto (IPv4-only when enableIpv6 is false, both when true).",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DnsLookupFamily"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "edns0": {
+          "description": "Whether to enable EDNS0 (Extension Mechanisms for DNS) in the resolver.\nWhen `None`, the system-provided resolver setting is preserved.\nCan also be set via the `DNS_EDNS0` environment variable.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
     "DnsLookupFamily": {
-      "description": "Controls which IP address families the DNS resolver will query for\nupstream (backend) connections.\n\n Maps to hickory_resolver's `LookupIpStrategy` under the hood.\n\nCan be set via the `DNS_LOOKUP_FAMILY` environment variable or the\n`dnsLookupFamily` field in the config file.\n\nSee: <https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#enum-config-cluster-v3-cluster-dnslookupfamily>",
+      "description": "Controls which IP address families the DNS resolver will query for\nupstream (backend) connections.\n\n Maps to hickory_resolver's `LookupIpStrategy` under the hood.\n\nCan be set via the `DNS_LOOKUP_FAMILY` environment variable or the\n`dns.lookupFamily` field in the config file.\n\nSee: <https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#enum-config-cluster-v3-cluster-dnslookupfamily>",
       "oneOf": [
         {
           "description": "Query for both A and AAAA records in parallel and use all results.",

--- a/schema/config.json
+++ b/schema/config.json
@@ -68,7 +68,7 @@
           ]
         },
         "dnsLookupFamily": {
-          "description": "Controls which IP address families the DNS resolver will query for\nupstream connections. Mirrors Envoy's DnsLookupFamily.\nAccepted values: All, Auto, V4Preferred, V4Only, V6Only.\nCan also be set via the DNS_LOOKUP_FAMILY environment variable.\nDefaults to Auto (IPv4-only when enableIpv6 is false, both when true).",
+          "description": "Controls which IP address families the DNS resolver will query for\nupstream connections.\nAccepted values: All, Auto, V4Preferred, V4Only, V6Only.\nDefaults to Auto (IPv4-only when enableIpv6 is false, both when true).",
           "anyOf": [
             {
               "$ref": "#/$defs/DnsLookupFamily"
@@ -255,7 +255,7 @@
       "additionalProperties": false
     },
     "DnsLookupFamily": {
-      "description": "Controls which IP address families the DNS resolver will query for\nupstream (backend) connections.\n\nMirrors Envoy's `DnsLookupFamily` semantics. Maps to hickory_resolver's\n`LookupIpStrategy` under the hood.\n\nCan be set via the `DNS_LOOKUP_FAMILY` environment variable or the\n`dnsLookupFamily` field in the config file.\n\nSee: <https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#enum-config-cluster-v3-cluster-dnslookupfamily>",
+      "description": "Controls which IP address families the DNS resolver will query for\nupstream (backend) connections.\n\n Maps to hickory_resolver's `LookupIpStrategy` under the hood.\n\nCan be set via the `DNS_LOOKUP_FAMILY` environment variable or the\n`dnsLookupFamily` field in the config file.\n\nSee: <https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#enum-config-cluster-v3-cluster-dnslookupfamily>",
       "oneOf": [
         {
           "description": "Query for both A and AAAA records in parallel and use all results.",

--- a/schema/config.md
+++ b/schema/config.md
@@ -5,6 +5,7 @@
 |`config`||
 |`config.enableIpv6`||
 |`config.dnsLookupFamily`|Controls which IP address families the DNS resolver will query for<br>upstream connections.<br>Accepted values: All, Auto, V4Preferred, V4Only, V6Only.<br>Defaults to Auto (IPv4-only when enableIpv6 is false, both when true).|
+|`config.dnsEdns0`|Whether to enable EDNS0 (Extension Mechanisms for DNS) in the resolver.<br>When `None`, the system-provided resolver setting is preserved.<br>Can also be set via the `DNS_EDNS0` environment variable.|
 |`config.localXdsPath`|Local XDS path. If not specified, the current configuration file will be used.|
 |`config.caAddress`||
 |`config.caAuthToken`||

--- a/schema/config.md
+++ b/schema/config.md
@@ -4,7 +4,7 @@
 |-|-|
 |`config`||
 |`config.enableIpv6`||
-|`config.dnsLookupFamily`|Controls which IP address families the DNS resolver will query for<br>upstream connections. Mirrors Envoy's DnsLookupFamily.<br>Accepted values: All, Auto, V4Preferred, V4Only, V6Only.<br>Can also be set via the DNS_LOOKUP_FAMILY environment variable.<br>Defaults to Auto (IPv4-only when enableIpv6 is false, both when true).|
+|`config.dnsLookupFamily`|Controls which IP address families the DNS resolver will query for<br>upstream connections.<br>Accepted values: All, Auto, V4Preferred, V4Only, V6Only.<br>Defaults to Auto (IPv4-only when enableIpv6 is false, both when true).|
 |`config.localXdsPath`|Local XDS path. If not specified, the current configuration file will be used.|
 |`config.caAddress`||
 |`config.caAuthToken`||

--- a/schema/config.md
+++ b/schema/config.md
@@ -4,8 +4,9 @@
 |-|-|
 |`config`||
 |`config.enableIpv6`||
-|`config.dnsLookupFamily`|Controls which IP address families the DNS resolver will query for<br>upstream connections.<br>Accepted values: All, Auto, V4Preferred, V4Only, V6Only.<br>Defaults to Auto (IPv4-only when enableIpv6 is false, both when true).|
-|`config.dnsEdns0`|Whether to enable EDNS0 (Extension Mechanisms for DNS) in the resolver.<br>When `None`, the system-provided resolver setting is preserved.<br>Can also be set via the `DNS_EDNS0` environment variable.|
+|`config.dns`|DNS resolver settings.|
+|`config.dns.lookupFamily`|Controls which IP address families the DNS resolver will query for<br>upstream connections.<br>Accepted values: All, Auto, V4Preferred, V4Only, V6Only.<br>Defaults to Auto (IPv4-only when enableIpv6 is false, both when true).|
+|`config.dns.edns0`|Whether to enable EDNS0 (Extension Mechanisms for DNS) in the resolver.<br>When `None`, the system-provided resolver setting is preserved.<br>Can also be set via the `DNS_EDNS0` environment variable.|
 |`config.localXdsPath`|Local XDS path. If not specified, the current configuration file will be used.|
 |`config.caAddress`||
 |`config.caAuthToken`||

--- a/schema/config.md
+++ b/schema/config.md
@@ -4,6 +4,7 @@
 |-|-|
 |`config`||
 |`config.enableIpv6`||
+|`config.dnsLookupFamily`|Controls which IP address families the DNS resolver will query for<br>upstream connections. Mirrors Envoy's DnsLookupFamily.<br>Accepted values: All, Auto, V4Preferred, V4Only, V6Only.<br>Can also be set via the DNS_LOOKUP_FAMILY environment variable.<br>Defaults to Auto (IPv4-only when enableIpv6 is false, both when true).|
 |`config.localXdsPath`|Local XDS path. If not specified, the current configuration file will be used.|
 |`config.caAddress`||
 |`config.caAuthToken`||


### PR DESCRIPTION
You can use this either as an env:
```
DNS_LOOKUP_FAMILY=V4Only agentgateway -f config.yaml
```

Or with the config:
```
config:
  enableIpv6: false # restrict to only ipv4
  dns:
     lookupFamily: V4Only # Controls which DNS address families are queried. V4Only means only A records (IPv4), skipping AAAA (IPv6) lookups
     edns0: true #  Enables EDNS0 (Extension Mechanisms for DNS), which allows larger DNS responses and supports features like DNSSEC.
```