### PR TITLE
cel: add back serializing null values

### DIFF
--- a/crates/agentgateway/src/cel/tests.rs
+++ b/crates/agentgateway/src/cel/tests.rs
@@ -354,3 +354,26 @@ fn dynamic_index_key() {
 fn has_on_dynamic_map() {
 	assert_eq!(json!(true), eval(r#"has(request.headers.foo)"#).unwrap());
 }
+
+#[test]
+fn unset_values() {
+	let req = || {
+		::http::Request::builder()
+			.method(Method::GET)
+			.uri("http://example.com")
+			.header("x-example", "value")
+			.body(Body::empty())
+			.unwrap()
+	};
+	assert_eq!(Value::Null, eval_request("jwt", req()).unwrap());
+	assert_eq!(
+		Value::Bool(true),
+		eval_request("jwt == null", req()).unwrap()
+	);
+	// This is just invalid syntax
+	assert!(eval_request("has(jwt)", req()).is_err());
+	assert_eq!(
+		Value::Bool(false),
+		eval_request("has(jwt.sub)", req()).unwrap()
+	);
+}

--- a/crates/agentgateway/src/cel/types.rs
+++ b/crates/agentgateway/src/cel/types.rs
@@ -35,48 +35,35 @@ use serde_json::json;
 #[derive(Debug, Default, cel::DynamicType)]
 #[dynamic(rename_all = "camelCase")]
 pub struct Executor<'a> {
-	#[dynamic(skip_serializing_if = "Option::is_none")]
 	pub request: Option<RequestRef<'a>>,
 
-	#[dynamic(skip_serializing_if = "Option::is_none")]
 	pub response: Option<ResponseRef<'a>>,
 
 	pub env: EnvContext,
 
-	#[dynamic(skip_serializing_if = "is_extension_or_direct_none")]
 	pub source: ExtensionOrDirect<'a, SourceContext>,
 
-	#[dynamic(skip_serializing_if = "is_extension_or_direct_none")]
 	pub jwt: ExtensionOrDirect<'a, jwt::Claims>,
 
-	#[dynamic(rename = "apiKey", skip_serializing_if = "is_extension_or_direct_none")]
+	#[dynamic(rename = "apiKey")]
 	pub api_key: ExtensionOrDirect<'a, apikey::Claims>,
 
-	#[dynamic(
-		rename = "basicAuth",
-		skip_serializing_if = "is_extension_or_direct_none"
-	)]
+	#[dynamic(rename = "basicAuth")]
 	pub basic_auth: ExtensionOrDirect<'a, basicauth::Claims>,
 
-	#[dynamic(skip_serializing_if = "is_extension_or_direct_none")]
 	pub llm: ExtensionOrDirect<'a, LLMContext>,
 
-	#[dynamic(rename = "llmRequest", skip_serializing_if = "Option::is_none")]
+	#[dynamic(rename = "llmRequest")]
 	pub llm_request: Option<&'a serde_json::Value>,
 
-	#[dynamic(skip_serializing_if = "Option::is_none")]
 	pub mcp: Option<&'a ResourceType>,
 
-	#[dynamic(skip_serializing_if = "is_extension_or_direct_none")]
 	pub backend: ExtensionOrDirect<'a, BackendContext>,
 
-	#[dynamic(skip_serializing_if = "is_extension_or_direct_none")]
 	pub extauthz: ExtensionOrDirect<'a, ExtAuthzDynamicMetadata>,
 
-	#[dynamic(skip_serializing_if = "is_extension_or_direct_none")]
 	pub extproc: ExtensionOrDirect<'a, ExtProcDynamicMetadata>,
 
-	#[dynamic(skip_serializing_if = "is_extension_or_direct_none")]
 	pub metadata: ExtensionOrDirect<'a, TransformationMetadata>,
 }
 


### PR DESCRIPTION
See https://github.com/agentgateway/agentgateway/issues/1262

In https://github.com/agentgateway/agentgateway/pull/877 we changed the top level vars to be conditionally available. I think this was a mistake, as can be seen in the issue.

One of things I had hoped this enabled was `has(jwt)` which doesn't work anyways; has MUST have at least one field selection like `x.b`.

