### PR TITLE
tracing: use a stable scope name

### DIFF
--- a/crates/agentgateway/src/telemetry/trc.rs
+++ b/crates/agentgateway/src/telemetry/trc.rs
@@ -150,7 +150,7 @@ impl Tracer {
 				)
 				.build()
 		};
-		let tracer = provider.tracer(tracer_name);
+		let tracer = provider.tracer("agentgateway");
 		Ok(Tracer {
 			tracer: Arc::new(tracer),
 			provider,


### PR DESCRIPTION
serviec.name is intended to change while scope name is more like the
library or SDK emitting it

Originally changed in https://github.com/agentgateway/agentgateway/pull/712, this reverts back