### PR TITLE
Fix local regex path match and prefix rewrite

### DIFF
--- a/crates/agentgateway/src/http/filters.rs
+++ b/crates/agentgateway/src/http/filters.rs
@@ -244,7 +244,8 @@ fn rewrite_path(
 				));
 			};
 			let mut new_path = r.to_string();
-			let (_, rest) = orig.path().split_at(match_pfx.len());
+			// path prefix ignores trailing / so trim those out
+			let (_, rest) = orig.path().split_at(match_pfx.trim_end_matches("/").len());
 			if !new_path.ends_with('/') && !rest.is_empty() && !rest.starts_with('/') {
 				new_path.push('/');
 			}

--- a/crates/agentgateway/src/http/filters_test.rs
+++ b/crates/agentgateway/src/http/filters_test.rs
@@ -912,9 +912,6 @@ fn rewrite_test() {
 		),
 	];
 	for (name, inp, want) in cases {
-		if name != "path_prefix_trailing_slash_full" {
-			continue;
-		}
 		let mut req = request_for_uri(inp.uri);
 		req.extensions_mut().insert(inp.path.clone());
 

--- a/crates/agentgateway/src/http/filters_test.rs
+++ b/crates/agentgateway/src/http/filters_test.rs
@@ -160,7 +160,7 @@ fn redirection_test() {
 		status: None,
 	};
 
-	let match_regex = PathMatch::Regex(regex::Regex::new(r"^/regex/(\d+)$").unwrap(), 1);
+	let match_regex = PathMatch::Regex(regex::Regex::new(r"^/regex/(\d+)$").unwrap());
 	let regex_path = RequestRedirect {
 		scheme: None,
 		authority: None,
@@ -764,6 +764,18 @@ fn rewrite_test() {
 				uri: "http://test.com/v1/users".to_string(),
 			}),
 		),
+		// Test path prefix edge case - with trailing slash matching the url
+		(
+			"path_prefix_trailing_slash_full",
+			Input {
+				path: &match_api_slash,
+				rewrite: &prefix_path_v1_slash_rewrite,
+				uri: "http://test.com/api",
+			},
+			Some(Want {
+				uri: "http://test.com/v1/".to_string(),
+			}),
+		),
 		// Test path prefix edge case - replace prefix_without_trailing_slash with /
 		(
 			"path_prefix_trailing_slash",
@@ -900,6 +912,9 @@ fn rewrite_test() {
 		),
 	];
 	for (name, inp, want) in cases {
+		if name != "path_prefix_trailing_slash_full" {
+			continue;
+		}
 		let mut req = request_for_uri(inp.uri);
 		req.extensions_mut().insert(inp.path.clone());
 

--- a/crates/agentgateway/src/http/route.rs
+++ b/crates/agentgateway/src/http/route.rs
@@ -118,7 +118,7 @@ pub fn select_best_route(
 		let best_match = candidates.find(|(_, m)| {
 			let path_matches = match &m.path {
 				PathMatch::Exact(p) => request.uri().path() == p.as_str(),
-				PathMatch::Regex(r, _) => {
+				PathMatch::Regex(r) => {
 					// Regex has no defined ordering. We will order by the length of the regex expression.
 					let path = request.uri().path();
 					r.find(path)

--- a/crates/agentgateway/src/http/route_test.rs
+++ b/crates/agentgateway/src/http/route_test.rs
@@ -160,7 +160,7 @@ fn test_path_matching() {
 		("prefix-path", PathMatch::PathPrefix("/api/".into())),
 		(
 			"regex-path",
-			PathMatch::Regex(Regex::new(r"^/api/v\d+/users$").unwrap(), 18),
+			PathMatch::Regex(Regex::new(r"^/api/v\d+/users$").unwrap()),
 		),
 		("root-prefix", PathMatch::PathPrefix("/".into())),
 	];

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -608,7 +608,7 @@ impl HTTPProxy {
 					strng::format!("{}/*", p)
 				}
 			},
-			PathMatch::Regex(r, _) => r.as_str().into(),
+			PathMatch::Regex(r) => r.as_str().into(),
 		});
 		req.extensions_mut().insert(path_match);
 

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -839,7 +839,6 @@ pub enum PathMatch {
 		#[serde(with = "serde_regex")]
 		#[cfg_attr(feature = "schema", schemars(with = "String"))]
 		regex::Regex,
-		usize,
 	),
 }
 
@@ -1683,7 +1682,7 @@ fn get_path_rank(path: &PathMatch) -> i32 {
 		PathMatch::Exact(_) => 3,
 		// Prefix/Regex -- we will defer to the length
 		PathMatch::PathPrefix(_) => 2,
-		PathMatch::Regex(_, _) => 2,
+		PathMatch::Regex(_) => 2,
 	}
 }
 
@@ -1691,7 +1690,7 @@ fn get_path_length(path: &PathMatch) -> usize {
 	match path {
 		PathMatch::Exact(s) => s.len(),
 		PathMatch::PathPrefix(s) => s.len(),
-		PathMatch::Regex(_, l) => *l,
+		PathMatch::Regex(r) => r.as_str().len(),
 	}
 }
 

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -909,7 +909,7 @@ impl TryFrom<&proto::agent::RouteMatch> for RouteMatch {
 			}) => PathMatch::Exact(strng::new(prefix)),
 			Some(proto::agent::PathMatch {
 				kind: Some(Kind::Regex(r)),
-			}) => PathMatch::Regex(regex::Regex::new(r)?, r.len()),
+			}) => PathMatch::Regex(regex::Regex::new(r)?),
 			Some(proto::agent::PathMatch { kind: None }) => {
 				return Err(ProtoError::Generic("invalid path match".to_string()));
 			},

--- a/schema/config.json
+++ b/schema/config.json
@@ -884,19 +884,7 @@
           "type": "object",
           "properties": {
             "regex": {
-              "type": "array",
-              "prefixItems": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "integer",
-                  "format": "uint",
-                  "minimum": 0
-                }
-              ],
-              "minItems": 2,
-              "maxItems": 2
+              "type": "string"
             }
           },
           "required": [

--- a/ui/src/components/policy-config.tsx
+++ b/ui/src/components/policy-config.tsx
@@ -109,7 +109,7 @@ export function PolicyConfig() {
             const routePath = route.matches?.[0]?.path
               ? route.matches[0].path.exact ||
                 route.matches[0].path.pathPrefix ||
-                route.matches[0].path.regex?.[0] ||
+                route.matches[0].path.regex ||
                 "/*"
               : "/*";
 

--- a/ui/src/components/setup-wizard/RouteStep.tsx
+++ b/ui/src/components/setup-wizard/RouteStep.tsx
@@ -79,7 +79,7 @@ export function RouteStep({ onNext, onPrevious, config, onConfigChange }: RouteS
           ? { exact: pathValue }
           : pathType === "prefix"
             ? { pathPrefix: pathValue }
-            : { regex: [pathValue, 0] as [string, number] };
+            : { regex: pathValue };
 
       const newRoute: Route = {
         name: routeName,

--- a/ui/src/lib/configMapper.ts
+++ b/ui/src/lib/configMapper.ts
@@ -221,7 +221,7 @@ function mapToMatches(matchesData: any): Match[] {
       } else if (matchData.path.prefix) {
         match.path.pathPrefix = matchData.path.prefix;
       } else if (matchData.path.regex) {
-        match.path.regex = [matchData.path.regex, 0];
+        match.path.regex = matchData.path.regex;
       }
     }
 

--- a/ui/src/lib/route-utils.ts
+++ b/ui/src/lib/route-utils.ts
@@ -25,7 +25,7 @@ export const buildMatch = (routeForm: typeof DEFAULT_HTTP_ROUTE_FORM): Match => 
   const match: Match = {
     path:
       routeForm.pathType === "regex"
-        ? { regex: [routeForm.pathPrefix, 0] }
+        ? { regex: routeForm.pathPrefix }
         : { [routeForm.pathType]: routeForm.pathPrefix },
   };
 
@@ -70,7 +70,7 @@ export const populateEditForm = (route: RouteType): typeof DEFAULT_HTTP_ROUTE_FO
     ruleName: route.ruleName || "",
     hostnames: route.hostnames?.join(", ") || "",
     pathPrefix:
-      firstMatch?.path.pathPrefix || firstMatch?.path.exact || firstMatch?.path.regex?.[0] || "/",
+      firstMatch?.path.pathPrefix || firstMatch?.path.exact || firstMatch?.path.regex || "/",
     pathType: firstMatch?.path.pathPrefix
       ? "pathPrefix"
       : firstMatch?.path.exact
@@ -97,7 +97,7 @@ export const populateTcpEditForm = (tcpRoute: TcpRoute): typeof DEFAULT_TCP_ROUT
 export const getPathDisplayString = (match: Match): string => {
   if (match.path.exact) return `= ${match.path.exact}`;
   if (match.path.pathPrefix) return `${match.path.pathPrefix}*`;
-  if (match.path.regex) return `~ ${match.path.regex[0]}`;
+  if (match.path.regex) return `~ ${match.path.regex}`;
   return "/";
 };
 

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -79,7 +79,7 @@ export interface HeaderMatch {
 export interface PathMatch {
   exact?: string;
   pathPrefix?: string;
-  regex?: [string, number]; // [pattern, flags]
+  regex?: string;
 }
 
 export interface MethodMatch {


### PR DESCRIPTION
Before you had to set the length of the regex which was obviously wrong.

For prefix, we didn't properly handle trailing / in the matcher
