### PR TITLE
read oas doc servers and pick out the path prefixes, not the full ser…

### DIFF
--- a/crates/agentgateway/src/mcp/upstream/openapi/mod.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/mod.rs
@@ -49,8 +49,21 @@ pub enum ParseError {
 
 pub(crate) fn get_server_prefix(server: &OpenAPI) -> Result<String, ParseError> {
 	match server.servers.len() {
-		0 => Ok("".to_string()), // Return empty string instead of "/" to avoid double slash
-		1 => Ok(server.servers[0].url.clone()),
+		0 => Ok("".to_string()),
+		1 => {
+			let raw = &server.servers[0].url;
+			if let Ok(parsed) = url::Url::parse(raw) {
+				let path = parsed.path().trim_end_matches('/').to_string();
+				if path.is_empty() || path == "/" {
+					Ok("".to_string())
+				} else {
+					Ok(path)
+				}
+			} else {
+				// Not a full URL -- treat as a relative path prefix (existing behavior)
+				Ok(raw.clone())
+			}
+		},
 		_ => Err(ParseError::UnsupportedReference(format!(
 			"multiple servers are not supported: {:?}",
 			server.servers

--- a/crates/agentgateway/src/mcp/upstream/openapi/mod.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/mod.rs
@@ -52,16 +52,39 @@ pub(crate) fn get_server_prefix(server: &OpenAPI) -> Result<String, ParseError> 
 		0 => Ok("".to_string()),
 		1 => {
 			let raw = &server.servers[0].url;
-			if let Ok(parsed) = url::Url::parse(raw) {
-				let path = parsed.path().trim_end_matches('/').to_string();
-				if path.is_empty() || path == "/" {
-					Ok("".to_string())
+			
+			let extract_path = |after_scheme: &str| -> String {
+				if let Some(path_idx) = after_scheme.find('/') {
+					let path = &after_scheme[path_idx..];
+					let path = path.split('?').next().unwrap_or(path);
+					let path = path.split('#').next().unwrap_or(path);
+					let path = path.trim_end_matches('/');
+					if path.is_empty() || path == "/" {
+						"".to_string()
+					} else {
+						path.to_string()
+					}
 				} else {
-					Ok(path)
+					"".to_string()
 				}
+			};
+
+			if let Some(idx) = raw.find("://") {
+				Ok(extract_path(&raw[idx + 3..]))
+			} else if raw.starts_with("//") {
+				Ok(extract_path(&raw[2..]))
 			} else {
-				// Not a full URL -- treat as a relative path prefix (existing behavior)
-				Ok(raw.clone())
+				// Not an absolute URL -- treat as a relative path prefix (existing behavior)
+				if let Ok(parsed) = url::Url::parse(raw) {
+					let path = parsed.path().trim_end_matches('/').to_string();
+					if path.is_empty() || path == "/" {
+						Ok("".to_string())
+					} else {
+						Ok(path)
+					}
+				} else {
+					Ok(raw.clone())
+				}
 			}
 		},
 		_ => Err(ParseError::UnsupportedReference(format!(

--- a/crates/agentgateway/src/mcp/upstream/openapi/mod.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/mod.rs
@@ -52,7 +52,7 @@ pub(crate) fn get_server_prefix(server: &OpenAPI) -> Result<String, ParseError> 
 		0 => Ok("".to_string()),
 		1 => {
 			let raw = &server.servers[0].url;
-			
+
 			let extract_path = |after_scheme: &str| -> String {
 				if let Some(path_idx) = after_scheme.find('/') {
 					let path = &after_scheme[path_idx..];
@@ -71,8 +71,8 @@ pub(crate) fn get_server_prefix(server: &OpenAPI) -> Result<String, ParseError> 
 
 			if let Some(idx) = raw.find("://") {
 				Ok(extract_path(&raw[idx + 3..]))
-			} else if raw.starts_with("//") {
-				Ok(extract_path(&raw[2..]))
+			} else if let Some(stripped) = raw.strip_prefix("//") {
+				Ok(extract_path(stripped))
 			} else {
 				// Not an absolute URL -- treat as a relative path prefix (existing behavior)
 				if let Ok(parsed) = url::Url::parse(raw) {

--- a/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
@@ -689,6 +689,10 @@ fn openapi_with_servers(servers: serde_json::Value) -> OpenAPI {
 #[case::full_url_no_trailing_slash("https://api.example.com", "")]
 #[case::full_url_with_path("https://api.example.com/v2", "/v2")]
 #[case::full_url_with_path_trailing_slash("https://api.example.com/v2/", "/v2")]
+#[case::full_url_with_host_variable("https://{tenant}.example.com/v1", "/v1")]
+#[case::full_url_with_host_variable_no_path("https://{tenant}.example.com", "")]
+#[case::full_url_with_host_variable_root("https://{tenant}.example.com/", "")]
+#[case::full_url_with_path_variable("https://api.example.com/v1/{version}", "/v1/{version}")]
 #[case::relative_path("/api/v1", "/api/v1")]
 #[case::empty_string("", "")]
 fn test_get_server_prefix(#[case] server_url: &str, #[case] expected: &str) {

--- a/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use agent_core::{metrics, strng};
 use hickory_resolver::config::{ResolverConfig, ResolverOpts};
-use openapiv3::ReferenceOr;
+use openapiv3::{OpenAPI, ReferenceOr};
 use prometheus_client::registry::Registry;
 use rmcp::model::Tool;
 use rstest::rstest;
@@ -23,8 +23,9 @@ use crate::types::local::{
 };
 use crate::{BackendConfig, ProxyInputs, client, mcp};
 
-// Helper to create a handler and mock server for tests
-async fn setup() -> (MockServer, Handler) {
+// Helper to create a handler and mock server for tests.
+// Use prefix "" for no path prefix, or e.g. "/v2" for a path prefix.
+async fn setup_with_prefix(prefix: &str) -> (MockServer, Handler) {
 	let server = MockServer::start().await;
 	let host = server.uri();
 	let parsed = reqwest::Url::parse(&host).unwrap();
@@ -168,10 +169,68 @@ async fn setup() -> (MockServer, Handler) {
 			(test_tool_get, upstream_call_get),
 			(test_tool_post, upstream_call_post),
 		],
-		"".to_string(),
+		prefix.to_string(),
 	);
 
 	(server, handler)
+}
+
+async fn setup() -> (MockServer, Handler) {
+	setup_with_prefix("").await
+}
+
+#[tokio::test]
+async fn test_call_tool_full_url_server_prefix() {
+	// When OpenAPI spec has servers: [{ url: "https://api.example.com/" }],
+	// get_server_prefix returns "" so the request goes to /users/{id} (no double host).
+	let prefix = super::get_server_prefix(&openapi_with_servers(json!([{ "url": "https://api.example.com/" }])))
+		.expect("should parse");
+	assert_eq!(prefix, "", "full URL with root path should yield empty prefix");
+
+	let (server, handler) = setup_with_prefix(&prefix).await;
+	let user_id = "123";
+	let expected_response = json!({ "id": user_id, "name": "Test User" });
+
+	Mock::given(method("GET"))
+		.and(path(format!("/users/{user_id}")))
+		.respond_with(ResponseTemplate::new(200).set_body_json(&expected_response))
+		.mount(&server)
+		.await;
+
+	let args = json!({ "path": { "user_id": user_id } });
+	let result = handler
+		.call_tool("get_user", Some(args.as_object().unwrap().clone()), &IncomingRequestContext::empty())
+		.await;
+
+	assert!(result.is_ok(), "full-URL server prefix should not cause invalid authority");
+	assert_eq!(result.unwrap(), expected_response);
+}
+
+#[tokio::test]
+async fn test_call_tool_path_prefix_server() {
+	// When OpenAPI spec has servers: [{ url: "https://api.example.com/v2" }],
+	// get_server_prefix returns "/v2" and requests go to /v2/users/{id}.
+	let prefix = super::get_server_prefix(&openapi_with_servers(json!([{ "url": "https://api.example.com/v2" }])))
+		.expect("should parse");
+	assert_eq!(prefix, "/v2", "full URL with path should yield path prefix");
+
+	let (server, handler) = setup_with_prefix(&prefix).await;
+	let user_id = "456";
+	let expected_response = json!({ "id": user_id, "name": "Versioned User" });
+
+	Mock::given(method("GET"))
+		.and(path(format!("/v2/users/{user_id}")))
+		.respond_with(ResponseTemplate::new(200).set_body_json(&expected_response))
+		.mount(&server)
+		.await;
+
+	let args = json!({ "path": { "user_id": user_id } });
+	let result = handler
+		.call_tool("get_user", Some(args.as_object().unwrap().clone()), &IncomingRequestContext::empty())
+		.await;
+
+	assert!(result.is_ok());
+	assert_eq!(result.unwrap(), expected_response);
 }
 
 #[tokio::test]
@@ -595,6 +654,46 @@ async fn test_normalize_url_path_path_without_leading_slash() {
 fn test_normalize_url_path(#[case] prefix: &str, #[case] path: &str, #[case] expected: &str) {
 	let result = super::normalize_url_path(prefix, path);
 	assert_eq!(result, expected);
+}
+
+fn openapi_with_servers(servers: serde_json::Value) -> OpenAPI {
+	let spec = json!({
+		"openapi": "3.0.0",
+		"info": { "title": "Test", "version": "1.0.0" },
+		"servers": servers,
+		"paths": { "/x": { "get": { "operationId": "getX", "responses": { "200": { "description": "ok" } } } } }
+	});
+	serde_json::from_value(spec).expect("valid OpenAPI spec")
+}
+
+#[rstest]
+#[case::full_url_root("https://api.example.com/", "")]
+#[case::full_url_no_trailing_slash("https://api.example.com", "")]
+#[case::full_url_with_path("https://api.example.com/v2", "/v2")]
+#[case::full_url_with_path_trailing_slash("https://api.example.com/v2/", "/v2")]
+#[case::relative_path("/api/v1", "/api/v1")]
+#[case::empty_string("", "")]
+fn test_get_server_prefix(#[case] server_url: &str, #[case] expected: &str) {
+	let spec = openapi_with_servers(json!([{ "url": server_url }]));
+	let result = super::get_server_prefix(&spec).expect("should succeed");
+	assert_eq!(result, expected, "server_url={server_url}");
+}
+
+#[tokio::test]
+async fn test_get_server_prefix_empty_servers() {
+	let spec = openapi_with_servers(json!([]));
+	let result = super::get_server_prefix(&spec).expect("should succeed");
+	assert_eq!(result, "");
+}
+
+#[tokio::test]
+async fn test_get_server_prefix_multiple_servers_err() {
+	let spec = openapi_with_servers(json!([
+		{ "url": "https://api.example.com/" },
+		{ "url": "https://api2.example.com/" }
+	]));
+	let result = super::get_server_prefix(&spec);
+	assert!(result.is_err(), "multiple servers should yield error");
 }
 
 #[rstest]

--- a/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
@@ -183,9 +183,14 @@ async fn setup() -> (MockServer, Handler) {
 async fn test_call_tool_full_url_server_prefix() {
 	// When OpenAPI spec has servers: [{ url: "https://api.example.com/" }],
 	// get_server_prefix returns "" so the request goes to /users/{id} (no double host).
-	let prefix = super::get_server_prefix(&openapi_with_servers(json!([{ "url": "https://api.example.com/" }])))
-		.expect("should parse");
-	assert_eq!(prefix, "", "full URL with root path should yield empty prefix");
+	let prefix = super::get_server_prefix(&openapi_with_servers(
+		json!([{ "url": "https://api.example.com/" }]),
+	))
+	.expect("should parse");
+	assert_eq!(
+		prefix, "",
+		"full URL with root path should yield empty prefix"
+	);
 
 	let (server, handler) = setup_with_prefix(&prefix).await;
 	let user_id = "123";
@@ -199,10 +204,17 @@ async fn test_call_tool_full_url_server_prefix() {
 
 	let args = json!({ "path": { "user_id": user_id } });
 	let result = handler
-		.call_tool("get_user", Some(args.as_object().unwrap().clone()), &IncomingRequestContext::empty())
+		.call_tool(
+			"get_user",
+			Some(args.as_object().unwrap().clone()),
+			&IncomingRequestContext::empty(),
+		)
 		.await;
 
-	assert!(result.is_ok(), "full-URL server prefix should not cause invalid authority");
+	assert!(
+		result.is_ok(),
+		"full-URL server prefix should not cause invalid authority"
+	);
 	assert_eq!(result.unwrap(), expected_response);
 }
 
@@ -210,8 +222,10 @@ async fn test_call_tool_full_url_server_prefix() {
 async fn test_call_tool_path_prefix_server() {
 	// When OpenAPI spec has servers: [{ url: "https://api.example.com/v2" }],
 	// get_server_prefix returns "/v2" and requests go to /v2/users/{id}.
-	let prefix = super::get_server_prefix(&openapi_with_servers(json!([{ "url": "https://api.example.com/v2" }])))
-		.expect("should parse");
+	let prefix = super::get_server_prefix(&openapi_with_servers(
+		json!([{ "url": "https://api.example.com/v2" }]),
+	))
+	.expect("should parse");
 	assert_eq!(prefix, "/v2", "full URL with path should yield path prefix");
 
 	let (server, handler) = setup_with_prefix(&prefix).await;
@@ -226,7 +240,11 @@ async fn test_call_tool_path_prefix_server() {
 
 	let args = json!({ "path": { "user_id": user_id } });
 	let result = handler
-		.call_tool("get_user", Some(args.as_object().unwrap().clone()), &IncomingRequestContext::empty())
+		.call_tool(
+			"get_user",
+			Some(args.as_object().unwrap().clone()),
+			&IncomingRequestContext::empty(),
+		)
 		.await;
 
 	assert!(result.is_ok());


### PR DESCRIPTION
…ver since that is specified in the agentgateway backend