### PR TITLE
Misc refactoring of routes

### DIFF
--- a/controller/pkg/agentgateway/translator/conversion.go
+++ b/controller/pkg/agentgateway/translator/conversion.go
@@ -1,6 +1,7 @@
 package translator
 
 import (
+	"cmp"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -977,7 +978,7 @@ func extractParentReferenceInfo(ctx RouteContext, parents RouteParents, obj cont
 
 			rpi := RouteParentReference{
 				ParentGateway:     pr.ParentGateway,
-				InternalName:      pr.InternalName,
+				ListenerKey:       pr.ListenerKey,
 				InternalKind:      ir.Kind,
 				Hostname:          pr.OriginalHostname,
 				DeniedReason:      deniedReason,
@@ -1022,11 +1023,10 @@ func (p ParentReference) String() string {
 // ParentInfo holds info about a "Parent" - something that can be referenced as a ParentRef in the API.
 // Today, this is just Gateway
 type ParentInfo struct {
-	ParentGateway types.NamespacedName
-	// +krtEqualsTodo ensure gateway class changes trigger equality differences
+	ParentGateway          types.NamespacedName
 	ParentGatewayClassName string
-	// InternalName refers to the internal name we can reference it by. For example "my-ns/my-gateway"
-	InternalName string
+	// ListenerKey is the internal key of the listener resource created for this parent.
+	ListenerKey string
 	// AllowedKinds indicates which kinds can be admitted by this Parent
 	AllowedKinds []gwv1.RouteGroupKind
 	// Hostnames is the hostnames that must be match to reference to the Parent. For gateway this is listener hostname
@@ -1045,8 +1045,8 @@ type ParentInfo struct {
 
 // RouteParentReference holds information about a route's parent reference
 type RouteParentReference struct {
-	// InternalName refers to the internal name of the parent we can reference it by. For example "my-ns/my-gateway"
-	InternalName string
+	// ListenerKey is the internal key of the listener resource created for this parent.
+	ListenerKey string
 	// InternalKind is the Kind of the Parent
 	InternalKind string
 	// DeniedReason, if present, indicates why the reference was not valid
@@ -1073,10 +1073,15 @@ func FilteredReferences(parents []RouteParentReference) []RouteParentReference {
 		ret = append(ret, p)
 	}
 	// To ensure deterministic order, sort them
-	sort.Slice(ret, func(i, j int) bool {
-		return ret[i].InternalName < ret[j].InternalName
+	return slices.SortFunc(ret, func(a, b RouteParentReference) int {
+		if r := cmp.Compare(a.ListenerKey, b.ListenerKey); r != 0 {
+			return r
+		}
+		if r := cmp.Compare(a.ParentGateway.Namespace, b.ParentGateway.Namespace); r != 0 {
+			return r
+		}
+		return cmp.Compare(a.ParentGateway.Name, b.ParentGateway.Name)
 	})
-	return ret
 }
 
 // IsManaged checks if a Gateway is managed (ie we create the Deployment and Service) or unmanaged.

--- a/controller/pkg/agentgateway/translator/gateway_collection.go
+++ b/controller/pkg/agentgateway/translator/gateway_collection.go
@@ -197,7 +197,8 @@ func (g GatewayListener) Equals(other GatewayListener) bool {
 
 func (g ParentInfo) Equals(other ParentInfo) bool {
 	return g.ParentGateway == other.ParentGateway &&
-		g.InternalName == other.InternalName &&
+		g.ParentGatewayClassName == other.ParentGatewayClassName &&
+		g.ListenerKey == other.ListenerKey &&
 		g.OriginalHostname == other.OriginalHostname &&
 		g.SectionName == other.SectionName &&
 		g.Port == other.Port &&
@@ -301,7 +302,7 @@ func GatewayTransformationFunc(cfg GatewayCollectionConfig) func(ctx krt.Handler
 			pri := ParentInfo{
 				ParentGateway:          config.NamespacedName(obj),
 				ParentGatewayClassName: string(obj.Spec.GatewayClassName),
-				InternalName:           utils.InternalGatewayName(obj.Namespace, name, ""),
+				ListenerKey:            name,
 				AllowedKinds:           allowed,
 				Hostnames:              hostnames,
 				OriginalHostname:       string(ptr.OrEmpty(l.Hostname)),
@@ -505,7 +506,7 @@ func ListenerSetBuilder(
 		allowed, _ := GenerateSupportedKinds(standardListener)
 		pri := ParentInfo{
 			ParentGateway:    config.NamespacedName(parentGwObj),
-			InternalName:     obj.Namespace + "/" + name,
+			ListenerKey:      name,
 			AllowedKinds:     allowed,
 			Hostnames:        hostnames,
 			OriginalHostname: string(ptr.OrEmpty(l.Hostname)),

--- a/controller/pkg/agentgateway/translator/route_collections.go
+++ b/controller/pkg/agentgateway/translator/route_collections.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"iter"
-	"strings"
 
 	networkingclient "istio.io/client-go/pkg/apis/networking/v1"
 	"istio.io/istio/pkg/config"
@@ -45,7 +44,7 @@ func AgwRouteCollection(
 	inputs RouteContextInputs,
 	krtopts krtutil.KrtOptions,
 ) (krt.Collection[agwir.AgwResource], krt.Collection[*plugins.RouteAttachment], krt.Collection[*utils.AncestorBackend]) {
-	httpRouteStatus, httpRoutes := createRouteCollection(httpRouteCol, inputs, krtopts, "HTTPRoutes",
+	httpRouteStatus, httpRoutes := createRouteCollectionGeneric(httpRouteCol, inputs, krtopts, "HTTPRoutes",
 		func(ctx RouteContext, obj *gwv1.HTTPRoute) (RouteContext, iter.Seq2[AgwRoute, *reporter.RouteCondition]) {
 			route := obj.Spec
 			return ctx, func(yield func(AgwRoute, *reporter.RouteCondition) bool) {
@@ -61,7 +60,7 @@ func AgwRouteCollection(
 		})
 	status.RegisterStatus(queue, httpRouteStatus, GetStatus)
 
-	grpcRouteStatus, grpcRoutes := createRouteCollection(grpcRouteCol, inputs, krtopts, "GRPCRoutes",
+	grpcRouteStatus, grpcRoutes := createRouteCollectionGeneric(grpcRouteCol, inputs, krtopts, "GRPCRoutes",
 		func(ctx RouteContext, obj *gwv1.GRPCRoute) (RouteContext, iter.Seq2[AgwRoute, *reporter.RouteCondition]) {
 			route := obj.Spec
 			return ctx, func(yield func(AgwRoute, *reporter.RouteCondition) bool) {
@@ -78,7 +77,7 @@ func AgwRouteCollection(
 		})
 	status.RegisterStatus(queue, grpcRouteStatus, GetStatus)
 
-	tcpRouteStatus, tcpRoutes := createTCPRouteCollection(tcpRouteCol, inputs, krtopts, "TCPRoutes",
+	tcpRouteStatus, tcpRoutes := createRouteCollectionGeneric(tcpRouteCol, inputs, krtopts, "TCPRoutes",
 		func(ctx RouteContext, obj *gwv1a2.TCPRoute) (RouteContext, iter.Seq2[AgwTCPRoute, *reporter.RouteCondition]) {
 			route := obj.Spec
 			return ctx, func(yield func(AgwTCPRoute, *reporter.RouteCondition) bool) {
@@ -95,7 +94,7 @@ func AgwRouteCollection(
 		})
 	status.RegisterStatus(queue, tcpRouteStatus, GetStatus)
 
-	tlsRouteStatus, tlsRoutes := createTCPRouteCollection(tlsRouteCol, inputs, krtopts, "TLSRoutes",
+	tlsRouteStatus, tlsRoutes := createRouteCollectionGeneric(tlsRouteCol, inputs, krtopts, "TLSRoutes",
 		func(ctx RouteContext, obj *gwv1.TLSRoute) (RouteContext, iter.Seq2[AgwTCPRoute, *reporter.RouteCondition]) {
 			route := obj.Spec
 			return ctx, func(yield func(AgwTCPRoute, *reporter.RouteCondition) bool) {
@@ -161,7 +160,6 @@ func ProcessParentReferences[T any](
 	gwResult ConversionResult[T],
 	routeNN types.NamespacedName, // <-- route namespace/name so we can detect cross-NS parents
 	routeReporter reporter.RouteReporter,
-	resourceMapper func(T, RouteParentReference) *api.Resource,
 ) []agwir.AgwResource {
 	resources := make([]agwir.AgwResource, 0, len(parentRefs))
 
@@ -294,6 +292,30 @@ func ProcessParentReferences[T any](
 	return resources
 }
 
+func resourceMapper(t any, parent RouteParentReference) *api.Resource {
+	switch tt := t.(type) {
+	case AgwTCPRoute:
+		// safety: a shallow clone is ok because we only modify a top level field (Key)
+		inner := protomarshal.ShallowClone(tt.TCPRoute)
+		inner.ListenerKey = parent.ListenerKey
+		if sec := string(parent.ParentSection); sec != "" {
+			inner.Key += "." + sec
+		}
+		return ToAgwResource(AgwTCPRoute{TCPRoute: inner})
+	case AgwRoute:
+		// safety: a shallow clone is ok because we only modify a top level field (Key)
+		inner := protomarshal.ShallowClone(tt.Route)
+		inner.ListenerKey = parent.ListenerKey
+		if sec := string(parent.ParentSection); sec != "" {
+			inner.Key += "." + sec
+		}
+		return ToAgwResource(AgwRoute{Route: inner})
+	default:
+		log.Fatalf("unknown route kind %T", t)
+		return nil
+	}
+}
+
 // reasonResolvedRefs picks a ResolvedRefs reason from a conversion failure condition.
 // Falls back to "ResolvedRefs" (when ok) or "Invalid" (when not ok and no specific reason).
 func reasonResolvedRefs(cond *reporter.RouteCondition, ok bool) gwv1.RouteConditionReason {
@@ -348,7 +370,6 @@ func createRouteCollectionGeneric[T controllers.Object, R comparable, ST any](
 	krtopts krtutil.KrtOptions,
 	collectionName string,
 	translator func(ctx RouteContext, obj T) (RouteContext, iter.Seq2[R, *reporter.RouteCondition]),
-	resourceTransformer func(route R, parent RouteParentReference) *api.Resource,
 	buildStatus func(status gwv1.RouteStatus) ST,
 ) (
 	krt.StatusCollection[T, ST],
@@ -381,78 +402,10 @@ func createRouteCollectionGeneric[T controllers.Object, R comparable, ST any](
 			gwResult,
 			routeNN,
 			routeReporter,
-			resourceTransformer,
 		)
 		status := rm.BuildRouteStatusWithParentRefDefaulting(context.Background(), obj, inputs.ControllerName, true)
 		return ptr.Of(buildStatus(*status)), resources
 	}, krtopts.ToOptions(collectionName)...)
-}
-
-// Simplified HTTP route collection function
-func createRouteCollection[T controllers.Object, ST any](
-	routeCol krt.Collection[T],
-	inputs RouteContextInputs,
-	krtopts krtutil.KrtOptions,
-	collectionName string,
-	translator func(ctx RouteContext, obj T) (RouteContext, iter.Seq2[AgwRoute, *reporter.RouteCondition]),
-	buildStatus func(status gwv1.RouteStatus) ST,
-) (
-	krt.StatusCollection[T, ST],
-	krt.Collection[agwir.AgwResource],
-) {
-	return createRouteCollectionGeneric(
-		routeCol,
-		inputs,
-		krtopts,
-		collectionName,
-		translator,
-		func(e AgwRoute, parent RouteParentReference) *api.Resource {
-			// safety: a shallow clone is ok because we only modify a top level field (Key)
-			inner := protomarshal.ShallowClone(e.Route)
-			_, name, _ := strings.Cut(parent.InternalName, "/")
-			inner.ListenerKey = name
-			if sec := string(parent.ParentSection); sec != "" {
-				inner.Key = inner.GetKey() + "." + sec
-			} else {
-				inner.Key = inner.GetKey()
-			}
-			return ToAgwResource(AgwRoute{Route: inner})
-		},
-		buildStatus,
-	)
-}
-
-// Simplified TCP route collection function (plugins parameter removed)
-func createTCPRouteCollection[T controllers.Object, ST any](
-	routeCol krt.Collection[T],
-	inputs RouteContextInputs,
-	krtopts krtutil.KrtOptions,
-	collectionName string,
-	translator func(ctx RouteContext, obj T) (RouteContext, iter.Seq2[AgwTCPRoute, *reporter.RouteCondition]),
-	buildStatus func(status gwv1.RouteStatus) ST,
-) (
-	krt.StatusCollection[T, ST],
-	krt.Collection[agwir.AgwResource],
-) {
-	return createRouteCollectionGeneric(
-		routeCol,
-		inputs,
-		krtopts,
-		collectionName,
-		translator,
-		func(e AgwTCPRoute, parent RouteParentReference) *api.Resource {
-			inner := protomarshal.Clone(e.TCPRoute)
-			_, name, _ := strings.Cut(parent.InternalName, "/")
-			inner.ListenerKey = name
-			if sec := string(parent.ParentSection); sec != "" {
-				inner.Key = inner.GetKey() + "." + sec
-			} else {
-				inner.Key = inner.GetKey()
-			}
-			return ToAgwResource(AgwTCPRoute{TCPRoute: inner})
-		},
-		buildStatus,
-	)
 }
 
 // ListenersPerGateway returns the set of listener sectionNames referenced for each parent Gateway,


### PR DESCRIPTION
1. Avoid special handling of InternalName where we need to cut it and
   assume knowledge. Instead just pass what we need
2. Avoid excessive nesting of functions for route generation.
