### PR TITLE
fix keycloak mcp auth

### DIFF
--- a/crates/agentgateway/src/mcp/auth.rs
+++ b/crates/agentgateway/src/mcp/auth.rs
@@ -189,11 +189,12 @@ pub(super) async fn authorization_server_metadata(
 	auth: &McpAuthentication,
 	client: PolicyClient,
 ) -> Result<Response, ProxyError> {
-	// Construct the metadata URL per RFC 8414 Section 3:
-	// For path-based issuers, the well-known suffix is inserted between the origin and path.
-	// e.g. issuer "https://idp.example.com/app/myapp/" becomes
-	//      "https://idp.example.com/.well-known/oauth-authorization-server/app/myapp/"
-	let metadata_uri = rfc8414_metadata_url(&auth.issuer);
+	// RFC 8414 URL for standard AS metadata. Keycloak does not implement RFC 8414; it only
+	// exposes OpenID Provider Metadata at {issuer}/.well-known/openid-configuration (OIDC Discovery).
+	let metadata_uri = match &auth.provider {
+		Some(McpIDP::Keycloak { .. }) => openid_configuration_metadata_url(&auth.issuer),
+		_ => rfc8414_metadata_url(&auth.issuer),
+	};
 	let ureq = ::http::Request::builder()
 		.uri(metadata_uri)
 		.body(Body::empty())?;
@@ -297,6 +298,14 @@ pub(super) async fn client_registration(
 /// For root issuers (no path), this produces the same result as before:
 ///   issuer: https://idp.example.com
 ///   result: https://idp.example.com/.well-known/oauth-authorization-server
+/// OpenID Connect Discovery 1.0 metadata document URL.
+fn openid_configuration_metadata_url(issuer: &str) -> String {
+	format!(
+		"{}/.well-known/openid-configuration",
+		issuer.trim_end_matches('/')
+	)
+}
+
 fn rfc8414_metadata_url(issuer: &str) -> String {
 	match url::Url::parse(issuer) {
 		Ok(parsed) => {
@@ -319,6 +328,22 @@ fn rfc8414_metadata_url(issuer: &str) -> String {
 #[cfg(test)]
 mod tests {
 	use super::*;
+
+	#[test]
+	fn test_openid_configuration_metadata_url_keycloak_realm() {
+		assert_eq!(
+			openid_configuration_metadata_url("http://keycloak:8080/realms/test"),
+			"http://keycloak:8080/realms/test/.well-known/openid-configuration"
+		);
+	}
+
+	#[test]
+	fn test_openid_configuration_metadata_url_trailing_slash() {
+		assert_eq!(
+			openid_configuration_metadata_url("http://keycloak:8080/realms/mcp/"),
+			"http://keycloak:8080/realms/mcp/.well-known/openid-configuration"
+		);
+	}
 
 	#[test]
 	fn test_rfc8414_metadata_url_path_based() {


### PR DESCRIPTION
Tested locally with config + mcp inspector + keycloak running locally in kind:
```
# yaml-language-server: $schema=https://agentgateway.dev/schema/config
binds:
- listeners:
  - routes:
    - backends:
      - mcp:
          targets:
          - name: everything
            stdio:
              args:
              - '@modelcontextprotocol/server-everything'
              cmd: npx
      matches:
      - path:
          exact: /keycloak/mcp
      - path:
          exact: /.well-known/oauth-protected-resource/keycloak/mcp
      - path:
          exact: /.well-known/oauth-authorization-server/keycloak/mcp
      - path:
          exact: /.well-known/oauth-authorization-server/keycloak/mcp/client-registration
      policies:
        cors:
          allowHeaders:
          - mcp-protocol-version
          - content-type
          allowOrigins:
          - '*'
          exposeHeaders:
          - Mcp-Session-Id
        mcpAuthentication:
          issuer: http://keycloak.kind.cluster:8080/realms/master
          audiences:
          - mcp_proxy
          jwks:
            url: http://localhost:7080/realms/master/protocol/openid-connect/certs
          provider:
            keycloak: {}
          resourceMetadata:
            resource: http://localhost:3000/keycloak/mcp
            scopesSupported:
            - email
            - openid
            bearerMethodsSupported:
            - header
            - body
            - query
            resourceDocumentation: http://localhost:3000/keycloak/docs
            resourcePolicyUri: http://localhost:3000/keycloak/policies
  port: 3000

```
<img width="1354" height="746" alt="Screenshot 2026-03-20 at 2 42 31 PM" src="https://github.com/user-attachments/assets/f97edff8-5fe9-46df-ae48-6f760be44d2d" />



Fixes: https://github.com/agentgateway/agentgateway/issues/1294 
