### PR TITLE
perf: optimize timecaching and client string allocation

### DIFF
--- a/crates/hyper-util-fork/src/client/legacy/client.rs
+++ b/crates/hyper-util-fork/src/client/legacy/client.rs
@@ -274,7 +274,7 @@ where
 						s.push_str(hostname);
 						s.push(':');
 						s.push_str(port.as_str());
-						HeaderValue::from_str(&s)
+						HeaderValue::from_maybe_shared(hyper::body::Bytes::from(s))
 					} else {
 						HeaderValue::from_str(hostname)
 					}

--- a/crates/hyper-util-fork/src/client/legacy/pool.rs
+++ b/crates/hyper-util-fork/src/client/legacy/pool.rs
@@ -804,7 +804,7 @@ impl<T> WeakOpt<T> {
 	}
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(miri)))]
 mod tests {
 	use std::fmt::Debug;
 	use std::future::Future;

--- a/crates/hyper-util-fork/src/client/legacy/pool.rs
+++ b/crates/hyper-util-fork/src/client/legacy/pool.rs
@@ -272,7 +272,7 @@ struct IdlePopper<'a, T, K> {
 }
 
 impl<'a, T: Poolable + 'a, K: Debug> IdlePopper<'a, T, K> {
-	fn pop(self, expiration: &Expiration) -> Option<Idle<T>> {
+	fn pop(self, expiration: &Expiration, now: Instant) -> Option<Idle<T>> {
 		while let Some(entry) = self.list.pop() {
 			// If the connection has been closed, or is older than our idle
 			// timeout, simply drop it and keep looking...
@@ -286,7 +286,7 @@ impl<'a, T: Poolable + 'a, K: Debug> IdlePopper<'a, T, K> {
 			//
 			// In that case, we could just break out of the loop and drop the
 			// whole list...
-			if expiration.expires(entry.idle_at) {
+			if expiration.expires(entry.idle_at, now) {
 				trace!("removing expired connection for {:?}", self.key);
 				continue;
 			}
@@ -294,7 +294,7 @@ impl<'a, T: Poolable + 'a, K: Debug> IdlePopper<'a, T, K> {
 			let value = match entry.value.reserve() {
 				Reservation::Shared(to_reinsert, to_checkout) => {
 					self.list.push(Idle {
-						idle_at: Instant::now(),
+						idle_at: now,
 						value: to_reinsert,
 					});
 					to_checkout
@@ -313,7 +313,14 @@ impl<'a, T: Poolable + 'a, K: Debug> IdlePopper<'a, T, K> {
 }
 
 impl<T: Poolable, K: Key> PoolInner<T, K> {
+	fn now(&self) -> Instant {
+		self.timer
+			.as_ref()
+			.map_or_else(|| Instant::now(), |t| t.now())
+	}
+
 	fn put(&mut self, key: K, value: T, __pool_ref: &Arc<Mutex<PoolInner<T, K>>>) {
+		let now = self.now();
 		if value.can_share() && self.idle.contains_key(&key) {
 			trace!("put; existing idle HTTP/2 connection for {:?}", key);
 			return;
@@ -367,7 +374,7 @@ impl<T: Poolable, K: Key> PoolInner<T, K> {
 					debug!("pooling idle connection for {:?}", key);
 					idle_list.push(Idle {
 						value,
-						idle_at: Instant::now(),
+						idle_at: now,
 					});
 				}
 
@@ -440,7 +447,7 @@ impl<T: Poolable, K: Key> PoolInner<T, K> {
 	fn clear_expired(&mut self) {
 		let dur = self.timeout.expect("interval assumes timeout");
 
-		let now = Instant::now();
+		let now = self.now();
 		// self.last_idle_check_at = now;
 
 		self.idle.retain(|key, values| {
@@ -610,6 +617,7 @@ impl<T: Poolable, K: Key> Checkout<T, K> {
 		let entry = {
 			let mut inner = self.pool.inner.as_ref()?.lock().unwrap();
 			let expiration = Expiration::new(inner.timeout);
+			let now = inner.now();
 			let maybe_entry = inner.idle.get_mut(&self.key).and_then(|list| {
 				trace!("take? {:?}: expiration = {:?}", self.key, expiration.0);
 				// A block to end the mutable borrow on list,
@@ -619,7 +627,7 @@ impl<T: Poolable, K: Key> Checkout<T, K> {
 						key: &self.key,
 						list,
 					};
-					popper.pop(&expiration)
+					popper.pop(&expiration, now)
 				}
 				.map(|e| (e, list.is_empty()))
 			});
@@ -723,10 +731,10 @@ impl Expiration {
 		Expiration(dur)
 	}
 
-	fn expires(&self, instant: Instant) -> bool {
+	fn expires(&self, instant: Instant, now: Instant) -> bool {
 		match self.0 {
 			// Avoid `Instant::elapsed` to avoid issues like rust-lang/rust#86470.
-			Some(timeout) => Instant::now().saturating_duration_since(instant) > timeout,
+			Some(timeout) => now.saturating_duration_since(instant) > timeout,
 			None => false,
 		}
 	}
@@ -798,7 +806,7 @@ impl<T> WeakOpt<T> {
 	}
 }
 
-#[cfg(all(test, not(miri)))]
+#[cfg(test)]
 mod tests {
 	use std::fmt::Debug;
 	use std::future::Future;

--- a/crates/hyper-util-fork/src/client/legacy/pool.rs
+++ b/crates/hyper-util-fork/src/client/legacy/pool.rs
@@ -314,9 +314,7 @@ impl<'a, T: Poolable + 'a, K: Debug> IdlePopper<'a, T, K> {
 
 impl<T: Poolable, K: Key> PoolInner<T, K> {
 	fn now(&self) -> Instant {
-		self.timer
-			.as_ref()
-			.map_or_else(|| Instant::now(), |t| t.now())
+		self.timer.as_ref().map_or_else(Instant::now, |t| t.now())
 	}
 
 	fn put(&mut self, key: K, value: T, __pool_ref: &Arc<Mutex<PoolInner<T, K>>>) {

--- a/crates/hyper-util-fork/src/common/timer.rs
+++ b/crates/hyper-util-fork/src/common/timer.rs
@@ -34,4 +34,8 @@ impl hyper::rt::Timer for Timer {
 	fn sleep_until(&self, deadline: Instant) -> Pin<Box<dyn Sleep>> {
 		self.0.sleep_until(deadline)
 	}
+
+	fn now(&self) -> Instant {
+		self.0.now()
+	}
 }


### PR DESCRIPTION
This PR attempts to perform a couple of optimizations wrt connection pooling.

Relates to #1155

Optimizations:

1. Handed now() down through the Timer trait to cache the current time during intensive pool iterations, minimizing system calls. The current setup calls Instant::now() for each connection in the pool to expire existing connections and grab a valid one. This PR optimizes this by caching the time at the start of the loop, so all expiration checks in the request flow use the cached timestamp instead of making repeated syscalls.
2. Converted the HOST header generation to use zero-copy Bytes, avoiding extra string allocations. (Minor optimization)
