### PR TITLE
cel: fix LLM RL by avoiding using removed req extensions

### DIFF
--- a/crates/agentgateway/src/cel/benches.rs
+++ b/crates/agentgateway/src/cel/benches.rs
@@ -176,7 +176,7 @@ fn test_benchmark_cases_snapshot() {
 		let expr = Expression::new_strict(tc.expression)
 			.unwrap_or_else(|e| panic!("Failed to compile expression '{}': {}", tc.expression, e));
 		let mut req = (tc.request_builder)();
-		let ss = crate::cel::snapshot_request(&mut req);
+		let ss = crate::cel::snapshot_request(&mut req, true);
 		let exec = crate::cel::Executor::new_logger(Some(&ss), None, None, None, None);
 		let result = exec
 			.eval(&expr)
@@ -219,7 +219,7 @@ fn bench_execute_snapshot(b: Bencher, case_name: &str) {
 	// Pre-compile and build context
 	let expr = Expression::new_strict(tc.expression).unwrap();
 	let mut req = (tc.request_builder)();
-	let ss = crate::cel::snapshot_request(&mut req);
+	let ss = crate::cel::snapshot_request(&mut req, true);
 	let exec = crate::cel::Executor::new_logger(Some(&ss), None, None, None, None);
 
 	b.bench(|| {

--- a/crates/agentgateway/src/cel/mod.rs
+++ b/crates/agentgateway/src/cel/mod.rs
@@ -162,7 +162,11 @@ impl ContextBuilder {
 			None
 		}
 	}
-	pub fn maybe_snapshot_request(&self, res: &mut crate::http::Request) -> Option<RequestSnapshot> {
+	pub fn maybe_snapshot_request(
+		&self,
+		res: &mut crate::http::Request,
+		clear: bool,
+	) -> Option<RequestSnapshot> {
 		if self.any_has(Attributes::Source)
 			|| self.any_has(Attributes::Request)
 			|| self.any_has(Attributes::Llm)
@@ -175,7 +179,7 @@ impl ContextBuilder {
 			|| self.any_has(Attributes::Metadata)
 		{
 			// TODO: support partial snapshots based on what is requested
-			Some(types::snapshot_request(res))
+			Some(types::snapshot_request(res, clear))
 		} else {
 			None
 		}

--- a/crates/agentgateway/src/cel/types.rs
+++ b/crates/agentgateway/src/cel/types.rs
@@ -411,7 +411,7 @@ pub fn snapshot_request(req: &mut crate::http::Request, clear: bool) -> RequestS
 		scheme: req.uri().scheme().cloned(),
 		version: req.version(),
 		headers: req.headers().clone(),
-		body: req.extensions_mut().remove::<BufferedBody>(),
+		body: ext::<BufferedBody>(req, clear),
 
 		jwt: ext::<jwt::Claims>(req, clear),
 		api_key: ext::<apikey::Claims>(req, clear),

--- a/crates/agentgateway/src/cel/types.rs
+++ b/crates/agentgateway/src/cel/types.rs
@@ -31,6 +31,7 @@ pub use schemars::JsonSchema;
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize, Serializer};
 use serde_json::json;
+use tracing::event;
 
 #[derive(Debug, Default, cel::DynamicType)]
 #[dynamic(rename_all = "camelCase")]
@@ -274,6 +275,12 @@ impl<'a> Executor<'a> {
 		this.mcp = Some(mcp);
 		this
 	}
+	pub fn new_mcp_request<B>(req: &'a ::http::Request<B>, mcp: &'a ResourceType) -> Self {
+		let mut this = Self::new_empty();
+		this.set_request(req);
+		this.mcp = Some(mcp);
+		this
+	}
 	pub fn new_llm(req: Option<&'a RequestSnapshot>, llm_body: &'a serde_json::Value) -> Self {
 		let mut this = Self::new_empty();
 		if let Some(req) = req {
@@ -350,7 +357,12 @@ impl<'a> Executor<'a> {
 		) {
 			Ok(v) => Ok(v),
 			Err(e) => {
-				tracing::trace!("failed to evaluate expression: {}", e);
+				event!(
+					target: "cel",
+					tracing::Level::TRACE,
+					"failed to evaluate expression: {}",
+					e,
+				);
 				Err(e.into())
 			},
 		}
@@ -382,9 +394,16 @@ impl<'a> Executor<'a> {
 	}
 }
 
+fn ext<T: Clone + Send + Sync + 'static>(req: &mut crate::http::Request, clear: bool) -> Option<T> {
+	if clear {
+		req.extensions_mut().remove()
+	} else {
+		req.extensions_mut().get().cloned()
+	}
+}
 /// snapshot_request takes a request and returns a snapshot of its attributes.
-/// EXTENSIONS ARE CLEARED. Do not use this if you still need the extensions later.
-pub fn snapshot_request(req: &mut crate::http::Request) -> RequestSnapshot {
+/// Conditionally, EXTENSIONS ARE CLEARED. Do not use this if you still need the extensions later.
+pub fn snapshot_request(req: &mut crate::http::Request, clear: bool) -> RequestSnapshot {
 	RequestSnapshot {
 		method: req.method().clone(),
 		path: req.uri().clone(),
@@ -393,18 +412,17 @@ pub fn snapshot_request(req: &mut crate::http::Request) -> RequestSnapshot {
 		version: req.version(),
 		headers: req.headers().clone(),
 		body: req.extensions_mut().remove::<BufferedBody>(),
-		// This one we do not remove, as it's used downstream of the snapshot for auth in MCP case
-		// TODO: structure this better
-		jwt: req.extensions_mut().get::<jwt::Claims>().cloned(),
-		api_key: req.extensions_mut().remove::<apikey::Claims>(),
-		basic_auth: req.extensions_mut().remove::<basicauth::Claims>(),
-		backend: req.extensions_mut().remove::<BackendContext>(),
-		source: req.extensions_mut().remove::<SourceContext>(),
-		extauthz: req.extensions_mut().remove::<ExtAuthzDynamicMetadata>(),
-		extproc: req.extensions_mut().remove::<ExtProcDynamicMetadata>(),
-		metadata: req.extensions_mut().remove::<TransformationMetadata>(),
-		llm: req.extensions_mut().remove::<LLMContext>(),
-		start_time: req.extensions_mut().remove::<RequestTime>(),
+
+		jwt: ext::<jwt::Claims>(req, clear),
+		api_key: ext::<apikey::Claims>(req, clear),
+		basic_auth: ext::<basicauth::Claims>(req, clear),
+		backend: ext::<BackendContext>(req, clear),
+		source: ext::<SourceContext>(req, clear),
+		extauthz: ext::<ExtAuthzDynamicMetadata>(req, clear),
+		extproc: ext::<ExtProcDynamicMetadata>(req, clear),
+		metadata: ext::<TransformationMetadata>(req, clear),
+		llm: ext::<LLMContext>(req, clear),
+		start_time: ext::<RequestTime>(req, clear),
 	}
 }
 

--- a/crates/agentgateway/src/cel/types_test.rs
+++ b/crates/agentgateway/src/cel/types_test.rs
@@ -71,7 +71,7 @@ fn build_test_request() -> crate::http::Request {
 #[test]
 fn test_snapshot_matches_ref() {
 	let mut req = build_test_request();
-	let snapshot = snapshot_request(&mut req);
+	let snapshot = snapshot_request(&mut req, true);
 	let req = build_test_request();
 	let snapshot_exec =
 		Executor::new_logger(Some(&snapshot), None, snapshot.llm.as_ref(), None, None);
@@ -92,7 +92,7 @@ fn test_request_start_time_is_native_timestamp() {
 #[test]
 fn test_executor_snapshot_round_trip() {
 	let mut req = build_test_request();
-	let req_snapshot = snapshot_request(&mut req);
+	let req_snapshot = snapshot_request(&mut req, true);
 
 	// Create executor from snapshot
 	let executor1 = Executor::new_logger(Some(&req_snapshot), None, None, None, None);

--- a/crates/agentgateway/src/http/authorization_tests.rs
+++ b/crates/agentgateway/src/http/authorization_tests.rs
@@ -297,5 +297,5 @@ fn req(claims: serde_json::Value) -> Option<RequestSnapshot> {
 		jwt: Default::default(),
 	});
 
-	Some(cel::snapshot_request(&mut req))
+	Some(cel::snapshot_request(&mut req, true))
 }

--- a/crates/agentgateway/src/http/remoteratelimit.rs
+++ b/crates/agentgateway/src/http/remoteratelimit.rs
@@ -1,5 +1,3 @@
-use ::http::{HeaderMap, StatusCode};
-
 use crate::cel::Expression;
 use crate::http::envoy_proto_common;
 use crate::http::ext_proc::GrpcReferenceChannel;
@@ -12,6 +10,7 @@ use crate::proxy::ProxyError;
 use crate::proxy::httpproxy::PolicyClient;
 use crate::types::agent::{BackendPolicy, SimpleBackendReference};
 use crate::*;
+use ::http::{HeaderMap, StatusCode};
 
 #[cfg(test)]
 #[path = "remoteratelimit_tests.rs"]

--- a/crates/agentgateway/src/http/transformation_cel_tests.rs
+++ b/crates/agentgateway/src/http/transformation_cel_tests.rs
@@ -50,7 +50,7 @@ async fn test_transformation_body() {
 		.status(200)
 		.body(crate::http::Body::empty())
 		.unwrap();
-	let snap = cel::snapshot_request(&mut req);
+	let snap = cel::snapshot_request(&mut req, true);
 	xfm.apply_response(&mut resp, Some(&snap));
 	let b = http::read_body_with_limit(resp.into_body(), 1000)
 		.await

--- a/crates/agentgateway/src/mcp/handler.rs
+++ b/crates/agentgateway/src/mcp/handler.rs
@@ -2,7 +2,6 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use crate::cel::RequestSnapshot;
 use crate::http::Response;
 use crate::http::sessionpersistence::MCPSession;
 use crate::mcp;
@@ -529,19 +528,12 @@ pub fn setup_request_log(
 		.cloned()
 		.unwrap_or_default();
 
-	let snap = http
-		.extensions
-		.get::<Arc<Option<RequestSnapshot>>>()
-		.cloned()
-		.unwrap_or_else(|| Arc::new(None));
-
-	let cel = CelExecWrapper::new(snap);
-
 	let tracer = http
 		.extensions
 		.get::<SpanWriter>()
 		.cloned()
 		.unwrap_or_default();
+	let cel = CelExecWrapper::new(::http::Request::from_parts(http, ()));
 	let _span = tracer.start(span_name.to_string());
 	(_span, log, cel)
 }

--- a/crates/agentgateway/src/mcp/rbac.rs
+++ b/crates/agentgateway/src/mcp/rbac.rs
@@ -3,7 +3,7 @@ use ::cel::objects::{KeyRef, MapValue};
 use serde::{Deserialize, Serialize};
 use vector_map::VecMap;
 
-use crate::cel::{ContextBuilder, RequestSnapshot};
+use crate::cel::ContextBuilder;
 use crate::http::authorization::{RuleSet, RuleSets};
 use crate::*;
 
@@ -20,11 +20,11 @@ impl McpAuthorization {
 	}
 }
 
-pub struct CelExecWrapper(Arc<Option<RequestSnapshot>>);
+pub struct CelExecWrapper(::http::Request<()>);
 
 impl CelExecWrapper {
-	pub fn new(snap: Arc<Option<RequestSnapshot>>) -> CelExecWrapper {
-		CelExecWrapper(snap)
+	pub fn new(req: ::http::Request<()>) -> CelExecWrapper {
+		CelExecWrapper(req)
 	}
 }
 #[derive(Clone, Debug)]
@@ -36,7 +36,7 @@ impl McpAuthorizationSet {
 	}
 	pub fn validate(&self, res: &ResourceType, cel: &CelExecWrapper) -> bool {
 		tracing::debug!("Checking RBAC for resource: {:?}", res);
-		let exec = crate::cel::Executor::new_mcp(cel.0.as_ref().as_ref(), res);
+		let exec = crate::cel::Executor::new_mcp_request(&cel.0, res);
 		self.0.validate(&exec)
 	}
 

--- a/crates/agentgateway/src/mcp/router.rs
+++ b/crates/agentgateway/src/mcp/router.rs
@@ -130,12 +130,8 @@ impl App {
 			return Ok(resp);
 		}
 
-		let mut req = req.take_and_snapshot(Some(&mut log))?;
-		// This is an unfortunate clone. The request snapshot is intended to be done at the end of the request,
-		// so it strips all of the extensions. However, in MCP land its much trickier for us to do this so
-		// we snapshot early... but then we lose the extensions. So we do a clone here.
-		let snapshot = log.request_snapshot.clone();
-		req.extensions_mut().insert(Arc::new(snapshot));
+		// MCP requires CEL execution after the snapshot so we do not clear extensions
+		let req = req.take_and_snapshot_without_clearing_extensions(Some(&mut log))?;
 		if req.uri().path() == "/sse" {
 			// Legacy handling
 			// Assume this is streamable HTTP otherwise

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -361,7 +361,7 @@ where
 		req: &mut Request,
 	) -> Result<T, SnapshottedProxyResponse> {
 		self.map_err(|e| {
-			log.request_snapshot = log.cel.cel_context.maybe_snapshot_request(req);
+			log.request_snapshot = log.cel.cel_context.maybe_snapshot_request(req, true);
 			SnapshottedProxyResponse(e.into())
 		})
 	}
@@ -372,7 +372,7 @@ where
 	) -> Result<T, SnapshottedProxyResponse> {
 		self.map_err(|e| {
 			if let Some(req) = req.as_mut() {
-				log.request_snapshot = log.cel.cel_context.maybe_snapshot_request(req);
+				log.request_snapshot = log.cel.cel_context.maybe_snapshot_request(req, true);
 			}
 			SnapshottedProxyResponse(e.into())
 		})
@@ -649,7 +649,6 @@ impl HTTPProxy {
 		)
 		.await
 		.snapshot_on_err(log, &mut req)?;
-
 		let selected_backend = select_backend(selected_route.as_ref(), &req)
 			.ok_or(ProxyError::NoValidBackends)
 			.snapshot_on_err(log, &mut req)?;
@@ -1214,13 +1213,27 @@ impl<'a> MustSnapshot<'a> {
 	pub fn new(req: &'a mut Option<Request>) -> Self {
 		Self(req)
 	}
-	pub fn take_and_snapshot(
+	pub fn take_and_snapshot_clearing_extensions(
+		self,
+		log: Option<&mut &mut RequestLog>,
+	) -> Result<Request, ProxyError> {
+		self.take_and_snapshot(log, true)
+	}
+	pub fn take_and_snapshot_without_clearing_extensions(
+		self,
+		log: Option<&mut &mut RequestLog>,
+	) -> Result<Request, ProxyError> {
+		self.take_and_snapshot(log, false)
+	}
+	fn take_and_snapshot(
 		self,
 		mut log: Option<&mut &mut RequestLog>,
+		clear: bool,
 	) -> Result<Request, ProxyError> {
 		if let Some(mut req) = self.0.take() {
 			if let Some(l) = log.take() {
-				l.request_snapshot = l.cel.cel_context.maybe_snapshot_request(&mut req);
+				// Do not clear extensions
+				l.request_snapshot = l.cel.cel_context.maybe_snapshot_request(&mut req, clear);
 			};
 			Ok(req)
 		} else {
@@ -1453,7 +1466,8 @@ async fn make_backend_call(
 
 	let (mut req, llm_response_policies, llm_request) =
 		if let Some(llm) = &backend_call.backend_policies.llm_provider {
-			let mut req = req.take_and_snapshot(log.as_mut())?;
+			// LLM requires CEL execution after the snapshot so we do not clear extensions
+			let mut req = req.take_and_snapshot_without_clearing_extensions(log.as_mut())?;
 			let route_type = llm_request_policies
 				.llm
 				.as_ref()
@@ -1601,7 +1615,8 @@ async fn make_backend_call(
 			}
 		} else {
 			(
-				req.take_and_snapshot(log.as_mut())?,
+				// Clearing extensions is fine; the HTTP codepath doesn't require usage after this point.
+				req.take_and_snapshot_clearing_extensions(log.as_mut())?,
 				LLMResponsePolicies::default(),
 				None,
 			)


### PR DESCRIPTION
This was a bug we worked around in MCP but not in LLM; I think the MCP
fix was not ideal so changed it to use this approach consistently which
should be a lot harder to mess up
