### PR TITLE
proxy: respect Service SANs field

### DIFF
--- a/crates/agentgateway/src/client/hbone_tunnel.rs
+++ b/crates/agentgateway/src/client/hbone_tunnel.rs
@@ -14,7 +14,7 @@ use crate::types::discovery::Identity;
 pub async fn handshake(
 	mut hbone_pool: agent_hbone::pool::WorkloadHBONEPool<hbone::WorkloadKey>,
 	ep: SocketAddr,
-	identity: Identity,
+	identities: Vec<Identity>,
 ) -> Result<Socket, Error> {
 	let uri = Uri::builder()
 		.scheme(Scheme::HTTPS)
@@ -31,7 +31,7 @@ pub async fn handshake(
 		.expect("builder with known status code should not fail");
 
 	let pool_key = Box::new(WorkloadKey {
-		dst_id: vec![identity],
+		dst_id: identities,
 		dst: SocketAddr::from((ep.ip(), 15008)),
 	});
 
@@ -56,7 +56,7 @@ pub async fn handshake_double(
 	ep: SocketAddr,
 	gateway_address: SocketAddr,
 	gateway_identity: Identity,
-	waypoint_identity: Identity,
+	waypoint_identities: Vec<Identity>,
 ) -> Result<Socket, Error> {
 	tracing::debug!(
 		"will use DOUBLE HBONE: gateway {} -> workload {}",
@@ -109,14 +109,14 @@ pub async fn handshake_double(
 	// Otherwise, we would only ever reach one workload in the remote cluster.
 	// We also need to abort tasks the right way to get graceful terminations.
 	let wl_key = WorkloadKey {
-		dst_id: vec![waypoint_identity.clone()],
+		dst_id: waypoint_identities.clone(),
 		dst: ep,
 	};
 
 	// Use the pool's certificate fetcher to get TLS config for the waypoint
 	let tls_config = pool
 		.fetch_certificate(WorkloadKey {
-			dst_id: vec![waypoint_identity.clone()],
+			dst_id: waypoint_identities,
 			dst: ep,
 		})
 		.await

--- a/crates/agentgateway/src/client/mod.rs
+++ b/crates/agentgateway/src/client/mod.rs
@@ -82,11 +82,11 @@ pub struct TunnelConfig {
 pub enum Transport {
 	Plain(ApplicationTransport),
 	Tunnel(ApplicationTransport, TunnelConfig),
-	Hbone(ApplicationTransport, Identity),
+	Hbone(ApplicationTransport, Vec<Identity>),
 	DoubleHbone {
 		gateway_address: SocketAddr, // Address of network gateway to connect to
 		gateway_identity: Identity,  // Identity of network gateway
-		waypoint_identity: Identity, // Identity of waypoint/workload
+		waypoint_identities: Vec<Identity>, // Identities of waypoint/workload (workload + service SANs)
 		inner: ApplicationTransport,
 	},
 }
@@ -241,18 +241,18 @@ impl Connector {
 				socket.ext_mut().insert(stream::HttpProxy);
 				socket
 			},
-			Transport::Hbone(_, identity) => {
+			Transport::Hbone(_, identities) => {
 				let pool = self
 					.hbone_pool
 					.clone()
 					.ok_or_else(|| crate::http::Error::new(anyhow::anyhow!("hbone pool disabled")))?;
-				hbone_tunnel::handshake(pool, ep, identity).await?
+				hbone_tunnel::handshake(pool, ep, identities).await?
 			},
 
 			Transport::DoubleHbone {
 				gateway_address,
 				gateway_identity,
-				waypoint_identity,
+				waypoint_identities,
 				inner: _,
 			} => {
 				let pool = self
@@ -265,7 +265,7 @@ impl Connector {
 					ep,
 					gateway_address,
 					gateway_identity,
-					waypoint_identity,
+					waypoint_identities,
 				)
 				.await?
 			},

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -1124,7 +1124,7 @@ pub async fn build_transport(
 	// Check if we need double hbone
 	if let (
 		Some((gw_addr, gw_identity)),
-		Some((InboundProtocol::HBONE, waypoint_identity)),
+		Some((InboundProtocol::HBONE, waypoint_identities)),
 		Some(ca),
 	) = (
 		&backend_call.network_gateway,
@@ -1151,7 +1151,7 @@ pub async fn build_transport(
 			return Ok(Transport::DoubleHbone {
 				gateway_address: gateway_socket_addr,
 				gateway_identity: gw_identity.clone(),
-				waypoint_identity: waypoint_identity.clone(),
+				waypoint_identities: waypoint_identities.clone(),
 				inner: app_transport,
 			});
 		} else {
@@ -1163,12 +1163,12 @@ pub async fn build_transport(
 	Ok(match (&backend_call.transport_override, &inputs.ca) {
 		// Use legacy mTLS if they did not define a TLS policy. We could do double TLS but Istio doesn't,
 		// so maintain bug-for-bug parity
-		(Some((InboundProtocol::LegacyIstioMtls, ident)), Some(ca))
+		(Some((InboundProtocol::LegacyIstioMtls, idents)), Some(ca))
 			if matches!(app_transport, ApplicationTransport::Plaintext) =>
 		{
 			if let Ok(id) = ca.get_identity().await {
 				Some(
-					id.legacy_mtls(vec![ident.clone()])
+					id.legacy_mtls(idents.clone())
 						.map_err(|e| ProxyError::Processing(anyhow!("{e}")))?,
 				)
 				.into()
@@ -1177,9 +1177,9 @@ pub async fn build_transport(
 				app_transport.into()
 			}
 		},
-		(Some((InboundProtocol::HBONE, ident)), Some(ca)) => {
+		(Some((InboundProtocol::HBONE, idents)), Some(ca)) => {
 			if ca.get_identity().await.is_ok() {
-				Transport::Hbone(app_transport, ident.clone())
+				Transport::Hbone(app_transport, idents.clone())
 			} else {
 				warn!("wanted TLS but CA is not available");
 				app_transport.into()
@@ -1786,10 +1786,23 @@ pub fn build_service_call(
 	Ok(BackendCall {
 		target,
 		http_version_override,
-		transport_override: Some((wl.protocol, wl.identity())),
+		transport_override: Some((wl.protocol, workload_and_service_sans(&wl, svc))),
 		network_gateway,
 		backend_policies,
 	})
+}
+
+/// Combines workload identity with service SANs.
+fn workload_and_service_sans(wl: &Workload, svc: &Service) -> Vec<Identity> {
+	let wl_id = wl.identity();
+	let mut ids = Vec::with_capacity(1 + svc.subject_alt_names.len());
+	ids.push(wl_id.clone());
+	for id in &svc.subject_alt_names {
+		if *id != wl_id {
+			ids.push(id.clone());
+		}
+	}
+	ids
 }
 
 fn should_retry(res: &Result<Response, SnapshottedProxyResponse>, pol: &retry::Policy) -> bool {
@@ -1935,7 +1948,7 @@ fn normalize_uri(connection: &Extension, req: &mut Request) -> anyhow::Result<()
 pub struct BackendCall {
 	pub target: Target,
 	pub http_version_override: Option<::http::Version>,
-	pub transport_override: Option<(InboundProtocol, Identity)>,
+	pub transport_override: Option<(InboundProtocol, Vec<Identity>)>,
 	pub network_gateway: Option<(GatewayAddress, Identity)>, /* For double hbone: (gateway_address, gateway_identity) */
 	pub backend_policies: BackendPolicies,
 }

--- a/crates/agentgateway/src/types/discovery.rs
+++ b/crates/agentgateway/src/types/discovery.rs
@@ -288,6 +288,16 @@ impl serde::Serialize for Identity {
 	}
 }
 
+impl<'de> serde::Deserialize<'de> for Identity {
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: serde::Deserializer<'de>,
+	{
+		let s = String::deserialize(deserializer)?;
+		Identity::from_str(&s).map_err(serde::de::Error::custom)
+	}
+}
+
 impl FromStr for Identity {
 	type Err = anyhow::Error;
 	fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -461,7 +471,7 @@ pub struct Service {
 	#[serde(default, skip_deserializing)]
 	pub endpoints: loadbalancer::EndpointSet<Endpoint>,
 	#[serde(default)]
-	pub subject_alt_names: Vec<Strng>,
+	pub subject_alt_names: Vec<Identity>,
 
 	#[serde(default, skip_serializing_if = "is_default")]
 	pub waypoint: Option<GatewayAddress>,
@@ -850,7 +860,20 @@ impl TryFrom<&XdsService> for Service {
 			}),
 			app_protocols,
 			endpoints: Default::default(), // Will be populated once inserted into the store.
-			subject_alt_names: s.subject_alt_names.iter().map(strng::new).collect(),
+			subject_alt_names: s
+				.subject_alt_names
+				.iter()
+				.filter_map(|san| match Identity::from_str(san) {
+					Ok(id) => Some(id),
+					Err(err) => {
+						warn!(
+							"service {}/{} SAN {:?} could not be parsed: {err}",
+							s.namespace, s.hostname, san
+						);
+						None
+					},
+				})
+				.collect(),
 			waypoint,
 			load_balancer: lb,
 			ip_families,


### PR DESCRIPTION
We were ignoring this WDS field, control planes can set a list of SANs on a Service and we should allow them when creating the mesh TLS.

