### PR TITLE
controller: consistently use Gateway as policy parent

### DIFF
--- a/controller/pkg/agentgateway/plugins/backend_policies.go
+++ b/controller/pkg/agentgateway/plugins/backend_policies.go
@@ -49,7 +49,7 @@ func TranslateInlineBackendPolicy(
 		},
 		Spec: agentgateway.AgentgatewayPolicySpec{Backend: policy},
 	}
-	res, err := translateBackendPolicyToAgw(ctx, dummy, nil)
+	res, err := translateBackendPolicyToAgw(ctx, dummy)
 	return slices.MapFilter(res, func(e *api.Policy) **api.BackendPolicySpec {
 		return ptr.Of(e.GetBackend())
 	}), err
@@ -58,7 +58,6 @@ func TranslateInlineBackendPolicy(
 func translateBackendPolicyToAgw(
 	ctx PolicyCtx,
 	policy *agentgateway.AgentgatewayPolicy,
-	policyTarget *api.PolicyTarget,
 ) ([]*api.Policy, error) {
 	backend := policy.Spec.Backend
 	if backend == nil {
@@ -82,51 +81,51 @@ func translateBackendPolicyToAgw(
 	}
 
 	if s := backend.HTTP; s != nil {
-		appendPolicy("backendHTTP")(translateBackendHTTP(policy, policyTarget), nil)
+		appendPolicy("backendHTTP")(translateBackendHTTP(policy), nil)
 	}
 
 	if s := backend.Tunnel; s != nil {
-		appendPolicy("backendTunnel")(translateBackendTunnel(ctx, policy, policyTarget))
+		appendPolicy("backendTunnel")(translateBackendTunnel(ctx, policy))
 	}
 
 	if s := backend.TLS; s != nil {
-		appendPolicy("backendTLS")(translateBackendTLS(ctx, policy, policyTarget))
+		appendPolicy("backendTLS")(translateBackendTLS(ctx, policy))
 	}
 
 	if s := backend.TCP; s != nil {
-		appendPolicy("backendTCP")(translateBackendTCP(ctx, policy, policyName, policyTarget))
+		appendPolicy("backendTCP")(translateBackendTCP(ctx, policy, policyName))
 	}
 
 	if s := backend.Health; s != nil {
-		appendPolicy("backendHealth")(translateBackendHealthPolicy(policy, policyTarget))
+		appendPolicy("backendHealth")(translateBackendHealthPolicy(policy))
 	}
 
 	if s := backend.Transformation; s != nil {
-		appendPolicy("backendTransformation")(translateBackendTransformation(policy, policyTarget))
+		appendPolicy("backendTransformation")(translateBackendTransformation(policy))
 	}
 
 	if s := backend.MCP; s != nil {
 		if backend.MCP.Authorization != nil {
-			appendPolicy("backendMCPAuthorization")(translateBackendMCPAuthorization(policy, policyTarget), nil)
+			appendPolicy("backendMCPAuthorization")(translateBackendMCPAuthorization(policy), nil)
 		}
 
 		if backend.MCP.Authentication != nil {
-			appendPolicy("backendMCPAuthentication")(translateBackendMCPAuthentication(ctx, policy, policyTarget))
+			appendPolicy("backendMCPAuthentication")(translateBackendMCPAuthentication(ctx, policy))
 		}
 	}
 
 	if s := backend.AI; s != nil {
-		appendPolicy("backendAI")(translateBackendAI(ctx, policy, policyName, policyTarget))
+		appendPolicy("backendAI")(translateBackendAI(ctx, policy, policyName))
 	}
 
 	if s := backend.Auth; s != nil {
-		appendPolicy("backendAuth")(translateBackendAuth(ctx, policy, policyName, policyTarget))
+		appendPolicy("backendAuth")(translateBackendAuth(ctx, policy, policyName))
 	}
 
 	return agwPolicies, errors.Join(errs...)
 }
 
-func translateBackendHealthPolicy(policy *agentgateway.AgentgatewayPolicy, target *api.PolicyTarget) (*api.Policy, error) {
+func translateBackendHealthPolicy(policy *agentgateway.AgentgatewayPolicy) (*api.Policy, error) {
 	var errs []error
 
 	healthPolicy := policy.Spec.Backend.Health
@@ -168,9 +167,8 @@ func translateBackendHealthPolicy(policy *agentgateway.AgentgatewayPolicy, targe
 		Eviction:           evictionProto,
 	}
 	evictPolicy := &api.Policy{
-		Key:    policy.Namespace + "/" + policy.Name + healthPolicySuffix + attachmentName(target),
-		Name:   TypedResourceName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
-		Target: target,
+		Key:  policy.Namespace + "/" + policy.Name + healthPolicySuffix,
+		Name: TypedResourceName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
 		Kind: &api.Policy_Backend{
 			Backend: &api.BackendPolicySpec{
 				Kind: &api.BackendPolicySpec_Health_{
@@ -183,14 +181,13 @@ func translateBackendHealthPolicy(policy *agentgateway.AgentgatewayPolicy, targe
 	return evictPolicy, errors.Join(errs...)
 }
 
-func translateBackendTCP(ctx PolicyCtx, policy *agentgateway.AgentgatewayPolicy, name string, target *api.PolicyTarget) (*api.Policy, error) {
+func translateBackendTCP(ctx PolicyCtx, policy *agentgateway.AgentgatewayPolicy, name string) (*api.Policy, error) {
 	// TODO
 	return nil, nil
 }
 
 func translateBackendTransformation(
 	policy *agentgateway.AgentgatewayPolicy,
-	target *api.PolicyTarget,
 ) (*api.Policy, error) {
 	var errs []error
 	transformation := policy.Spec.Backend.Transformation
@@ -205,9 +202,8 @@ func translateBackendTransformation(
 	}
 
 	tp := &api.Policy{
-		Key:    policy.Namespace + "/" + policy.Name + backendTransformationSuffix + attachmentName(target),
-		Name:   TypedResourceName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
-		Target: target,
+		Key:  policy.Namespace + "/" + policy.Name + backendTransformationSuffix,
+		Name: TypedResourceName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
 		Kind: &api.Policy_Backend{
 			Backend: &api.BackendPolicySpec{
 				Kind: &api.BackendPolicySpec_Transformation{
@@ -225,7 +221,7 @@ func translateBackendTransformation(
 	return tp, errors.Join(errs...)
 }
 
-func translateBackendTLS(ctx PolicyCtx, policy *agentgateway.AgentgatewayPolicy, target *api.PolicyTarget) (*api.Policy, error) {
+func translateBackendTLS(ctx PolicyCtx, policy *agentgateway.AgentgatewayPolicy) (*api.Policy, error) {
 	var errs []error
 	tls := policy.Spec.Backend.TLS
 
@@ -298,9 +294,8 @@ func translateBackendTLS(ctx PolicyCtx, policy *agentgateway.AgentgatewayPolicy,
 	}
 
 	tlsPolicy := &api.Policy{
-		Key:    policy.Namespace + "/" + policy.Name + tlsPolicySuffix + attachmentName(target),
-		Name:   TypedResourceName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
-		Target: target,
+		Key:  policy.Namespace + "/" + policy.Name + tlsPolicySuffix,
+		Name: TypedResourceName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
 		Kind: &api.Policy_Backend{
 			Backend: &api.BackendPolicySpec{
 				Kind: &api.BackendPolicySpec_BackendTls{
@@ -317,7 +312,7 @@ func translateBackendTLS(ctx PolicyCtx, policy *agentgateway.AgentgatewayPolicy,
 	return tlsPolicy, errors.Join(errs...)
 }
 
-func translateBackendHTTP(policy *agentgateway.AgentgatewayPolicy, target *api.PolicyTarget) *api.Policy {
+func translateBackendHTTP(policy *agentgateway.AgentgatewayPolicy) *api.Policy {
 	http := policy.Spec.Backend.HTTP
 	p := &api.BackendPolicySpec_BackendHTTP{}
 	if v := http.Version; v != nil {
@@ -332,9 +327,8 @@ func translateBackendHTTP(policy *agentgateway.AgentgatewayPolicy, target *api.P
 		p.RequestTimeout = durationpb.New(rt.Duration)
 	}
 	tp := &api.Policy{
-		Key:    policy.Namespace + "/" + policy.Name + backendHttpPolicySuffix + attachmentName(target),
-		Name:   TypedResourceName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
-		Target: target,
+		Key:  policy.Namespace + "/" + policy.Name + backendHttpPolicySuffix,
+		Name: TypedResourceName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
 		Kind: &api.Policy_Backend{
 			Backend: &api.BackendPolicySpec{
 				Kind: &api.BackendPolicySpec_BackendHttp{
@@ -350,15 +344,14 @@ func translateBackendHTTP(policy *agentgateway.AgentgatewayPolicy, target *api.P
 	return tp
 }
 
-func translateBackendTunnel(ctx PolicyCtx, policy *agentgateway.AgentgatewayPolicy, target *api.PolicyTarget) (*api.Policy, error) {
+func translateBackendTunnel(ctx PolicyCtx, policy *agentgateway.AgentgatewayPolicy) (*api.Policy, error) {
 	tunnel := policy.Spec.Backend.Tunnel
 
 	proxy, err := buildBackendRef(ctx, tunnel.BackendRef, policy.Namespace)
 
 	tunnelPolicy := &api.Policy{
-		Key:    policy.Namespace + "/" + policy.Name + backendTunnelPolicySuffix + attachmentName(target),
-		Name:   TypedResourceName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
-		Target: target,
+		Key:  policy.Namespace + "/" + policy.Name + backendTunnelPolicySuffix,
+		Name: TypedResourceName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
 		Kind: &api.Policy_Backend{
 			Backend: &api.BackendPolicySpec{
 				Kind: &api.BackendPolicySpec_BackendTunnel_{
@@ -377,7 +370,7 @@ func translateBackendTunnel(ctx PolicyCtx, policy *agentgateway.AgentgatewayPoli
 	return tunnelPolicy, err
 }
 
-func translateBackendMCPAuthorization(policy *agentgateway.AgentgatewayPolicy, target *api.PolicyTarget) *api.Policy {
+func translateBackendMCPAuthorization(policy *agentgateway.AgentgatewayPolicy) *api.Policy {
 	backend := policy.Spec.Backend
 	if backend == nil || backend.MCP == nil || backend.MCP.Authorization == nil {
 		return nil
@@ -391,9 +384,8 @@ func translateBackendMCPAuthorization(policy *agentgateway.AgentgatewayPolicy, t
 	}
 
 	mcpPolicy := &api.Policy{
-		Key:    policy.Namespace + "/" + policy.Name + mcpAuthorizationPolicySuffix + attachmentName(target),
-		Name:   TypedResourceName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
-		Target: target,
+		Key:  policy.Namespace + "/" + policy.Name + mcpAuthorizationPolicySuffix,
+		Name: TypedResourceName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
 		Kind: &api.Policy_Backend{
 			Backend: &api.BackendPolicySpec{
 				Kind: &api.BackendPolicySpec_McpAuthorization_{
@@ -413,7 +405,7 @@ func translateBackendMCPAuthorization(policy *agentgateway.AgentgatewayPolicy, t
 	return mcpPolicy
 }
 
-func translateBackendMCPAuthentication(ctx PolicyCtx, policy *agentgateway.AgentgatewayPolicy, target *api.PolicyTarget) (*api.Policy, error) {
+func translateBackendMCPAuthentication(ctx PolicyCtx, policy *agentgateway.AgentgatewayPolicy) (*api.Policy, error) {
 	authnPolicy := policy.Spec.Backend.MCP.Authentication
 
 	idp := api.BackendPolicySpec_McpAuthentication_UNSPECIFIED
@@ -478,9 +470,8 @@ func translateBackendMCPAuthentication(ctx PolicyCtx, policy *agentgateway.Agent
 		Mode:       mode,
 	}
 	mcpAuthnPolicy := &api.Policy{
-		Key:    policy.Namespace + "/" + policy.Name + mcpAuthenticationPolicySuffix + attachmentName(target),
-		Name:   TypedResourceName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
-		Target: target,
+		Key:  policy.Namespace + "/" + policy.Name + mcpAuthenticationPolicySuffix,
+		Name: TypedResourceName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
 		Kind: &api.Policy_Backend{
 			Backend: &api.BackendPolicySpec{
 				Kind: &api.BackendPolicySpec_McpAuthentication_{
@@ -498,7 +489,7 @@ func translateBackendMCPAuthentication(ctx PolicyCtx, policy *agentgateway.Agent
 }
 
 // translateBackendAI processes AI configuration and creates corresponding Agw policies
-func translateBackendAI(ctx PolicyCtx, agwPolicy *agentgateway.AgentgatewayPolicy, name string, policyTarget *api.PolicyTarget) (*api.Policy, error) {
+func translateBackendAI(ctx PolicyCtx, agwPolicy *agentgateway.AgentgatewayPolicy, name string) (*api.Policy, error) {
 	var errs []error
 	aiSpec := agwPolicy.Spec.Backend.AI
 
@@ -592,9 +583,8 @@ func translateBackendAI(ctx PolicyCtx, agwPolicy *agentgateway.AgentgatewayPolic
 	}
 
 	aiPolicy := &api.Policy{
-		Key:    name + aiPolicySuffix + attachmentName(policyTarget),
-		Name:   TypedResourceName(wellknown.AgentgatewayPolicyGVK.Kind, agwPolicy),
-		Target: policyTarget,
+		Key:  name + aiPolicySuffix,
+		Name: TypedResourceName(wellknown.AgentgatewayPolicyGVK.Kind, agwPolicy),
 		Kind: &api.Policy_Backend{
 			Backend: &api.BackendPolicySpec{
 				Kind: &api.BackendPolicySpec_Ai_{
@@ -611,7 +601,7 @@ func translateBackendAI(ctx PolicyCtx, agwPolicy *agentgateway.AgentgatewayPolic
 	return aiPolicy, errors.Join(errs...)
 }
 
-func translateBackendAuth(ctx PolicyCtx, policy *agentgateway.AgentgatewayPolicy, name string, target *api.PolicyTarget) (*api.Policy, error) {
+func translateBackendAuth(ctx PolicyCtx, policy *agentgateway.AgentgatewayPolicy, name string) (*api.Policy, error) {
 	var errs []error
 	auth := policy.Spec.Backend.Auth
 
@@ -673,9 +663,8 @@ func translateBackendAuth(ctx PolicyCtx, policy *agentgateway.AgentgatewayPolicy
 	}
 
 	authPolicy := &api.Policy{
-		Key:    name + backendauthPolicySuffix + attachmentName(target),
-		Name:   TypedResourceName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
-		Target: target,
+		Key:  name + backendauthPolicySuffix,
+		Name: TypedResourceName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
 		Kind: &api.Policy_Backend{
 			Backend: &api.BackendPolicySpec{
 				Kind: &api.BackendPolicySpec_Auth{

--- a/controller/pkg/agentgateway/plugins/frontend_policies.go
+++ b/controller/pkg/agentgateway/plugins/frontend_policies.go
@@ -24,7 +24,6 @@ const (
 func translateFrontendPolicyToAgw(
 	policyCtx PolicyCtx,
 	policy *agentgateway.AgentgatewayPolicy,
-	policyTarget *api.PolicyTarget,
 ) ([]*api.Policy, error) {
 	frontend := policy.Spec.Frontend
 	if frontend == nil {
@@ -48,29 +47,29 @@ func translateFrontendPolicyToAgw(
 	}
 
 	if s := frontend.HTTP; s != nil {
-		appendPolicy("http")(translateFrontendHTTP(policy, policyName, policyTarget), nil)
+		appendPolicy("http")(translateFrontendHTTP(policy, policyName), nil)
 	}
 
 	if s := frontend.TLS; s != nil {
-		appendPolicy("tls")(translateFrontendTLS(policy, policyName, policyTarget), nil)
+		appendPolicy("tls")(translateFrontendTLS(policy, policyName), nil)
 	}
 
 	if s := frontend.TCP; s != nil {
-		appendPolicy("tcp")(translateFrontendTCP(policy, policyName, policyTarget), nil)
+		appendPolicy("tcp")(translateFrontendTCP(policy, policyName), nil)
 	}
 
 	if s := frontend.AccessLog; s != nil {
-		appendPolicy("accessLog")(translateFrontendAccessLog(policyCtx, policy, policyName, policyTarget))
+		appendPolicy("accessLog")(translateFrontendAccessLog(policyCtx, policy, policyName))
 	}
 
 	if s := frontend.Tracing; s != nil {
-		appendPolicy("tracing")(translateFrontendTracing(policyCtx, policy, policyName, policyTarget))
+		appendPolicy("tracing")(translateFrontendTracing(policyCtx, policy, policyName))
 	}
 
 	return agwPolicies, errors.Join(errs...)
 }
 
-func translateFrontendTracing(ctx PolicyCtx, policy *agentgateway.AgentgatewayPolicy, name string, target *api.PolicyTarget) (*api.Policy, error) {
+func translateFrontendTracing(ctx PolicyCtx, policy *agentgateway.AgentgatewayPolicy, name string) (*api.Policy, error) {
 	tracing := policy.Spec.Frontend.Tracing
 
 	var backendErr error
@@ -130,9 +129,8 @@ func translateFrontendTracing(ctx PolicyCtx, policy *agentgateway.AgentgatewayPo
 	}
 
 	tracingPolicy := &api.Policy{
-		Key:    name + frontendTracingPolicySuffix + attachmentName(target),
-		Name:   TypedResourceName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
-		Target: target,
+		Key:  name + frontendTracingPolicySuffix,
+		Name: TypedResourceName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
 		Kind: &api.Policy_Frontend{
 			Frontend: &api.FrontendPolicySpec{
 				Kind: &api.FrontendPolicySpec_Tracing_{Tracing: &api.FrontendPolicySpec_Tracing{
@@ -151,13 +149,12 @@ func translateFrontendTracing(ctx PolicyCtx, policy *agentgateway.AgentgatewayPo
 
 	logger.Debug("generated tracing policy",
 		"policy", policy.Name,
-		"agentgateway_policy", tracingPolicy.Name,
-		"target", target)
+		"agentgateway_policy", tracingPolicy.Name)
 
 	return tracingPolicy, backendErr
 }
 
-func translateFrontendAccessLog(ctx PolicyCtx, policy *agentgateway.AgentgatewayPolicy, name string, target *api.PolicyTarget) (*api.Policy, error) {
+func translateFrontendAccessLog(ctx PolicyCtx, policy *agentgateway.AgentgatewayPolicy, name string) (*api.Policy, error) {
 	logging := policy.Spec.Frontend.AccessLog
 	spec := &api.FrontendPolicySpec_Logging{}
 	var backendErr error
@@ -205,9 +202,8 @@ func translateFrontendAccessLog(ctx PolicyCtx, policy *agentgateway.Agentgateway
 	}
 
 	loggingPolicy := &api.Policy{
-		Key:    name + frontendLoggingPolicySuffix + attachmentName(target),
-		Name:   TypedResourceName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
-		Target: target,
+		Key:  name + frontendLoggingPolicySuffix,
+		Name: TypedResourceName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
 		Kind: &api.Policy_Frontend{
 			Frontend: &api.FrontendPolicySpec{
 				Kind: &api.FrontendPolicySpec_Logging_{
@@ -219,13 +215,12 @@ func translateFrontendAccessLog(ctx PolicyCtx, policy *agentgateway.Agentgateway
 
 	logger.Debug("generated logging policy",
 		"policy", policy.Name,
-		"agentgateway_policy", loggingPolicy.Name,
-		"target", target)
+		"agentgateway_policy", loggingPolicy.Name)
 
 	return loggingPolicy, backendErr
 }
 
-func translateFrontendTCP(policy *agentgateway.AgentgatewayPolicy, name string, target *api.PolicyTarget) *api.Policy {
+func translateFrontendTCP(policy *agentgateway.AgentgatewayPolicy, name string) *api.Policy {
 	tcp := policy.Spec.Frontend.TCP
 	spec := &api.FrontendPolicySpec_TCP{}
 	if ka := tcp.KeepAlive; ka != nil {
@@ -242,9 +237,8 @@ func translateFrontendTCP(policy *agentgateway.AgentgatewayPolicy, name string, 
 	}
 
 	tcpPolicy := &api.Policy{
-		Key:    name + frontendTcpPolicySuffix + attachmentName(target),
-		Name:   TypedResourceName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
-		Target: target,
+		Key:  name + frontendTcpPolicySuffix,
+		Name: TypedResourceName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
 		Kind: &api.Policy_Frontend{
 			Frontend: &api.FrontendPolicySpec{
 				Kind: &api.FrontendPolicySpec_Tcp{
@@ -256,8 +250,7 @@ func translateFrontendTCP(policy *agentgateway.AgentgatewayPolicy, name string, 
 
 	logger.Debug("generated tcp policy",
 		"policy", policy.Name,
-		"agentgateway_policy", tcpPolicy.Name,
-		"target", target)
+		"agentgateway_policy", tcpPolicy.Name)
 
 	return tcpPolicy
 }
@@ -266,7 +259,7 @@ func castUint32[T ~int32](ka *T) *uint32 {
 	return ptr.Of((uint32)(*ka))
 }
 
-func translateFrontendTLS(policy *agentgateway.AgentgatewayPolicy, name string, target *api.PolicyTarget) *api.Policy {
+func translateFrontendTLS(policy *agentgateway.AgentgatewayPolicy, name string) *api.Policy {
 	tls := policy.Spec.Frontend.TLS
 	spec := &api.FrontendPolicySpec_TLS{}
 	if ka := tls.HandshakeTimeout; ka != nil {
@@ -332,9 +325,8 @@ func translateFrontendTLS(policy *agentgateway.AgentgatewayPolicy, name string, 
 	}
 
 	tlsPolicy := &api.Policy{
-		Key:    name + frontendTlsPolicySuffix + attachmentName(target),
-		Name:   TypedResourceName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
-		Target: target,
+		Key:  name + frontendTlsPolicySuffix,
+		Name: TypedResourceName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
 		Kind: &api.Policy_Frontend{
 			Frontend: &api.FrontendPolicySpec{
 				Kind: &api.FrontendPolicySpec_Tls{
@@ -346,13 +338,12 @@ func translateFrontendTLS(policy *agentgateway.AgentgatewayPolicy, name string, 
 
 	logger.Debug("generated tls policy",
 		"policy", policy.Name,
-		"agentgateway_policy", tlsPolicy.Name,
-		"target", target)
+		"agentgateway_policy", tlsPolicy.Name)
 
 	return tlsPolicy
 }
 
-func translateFrontendHTTP(policy *agentgateway.AgentgatewayPolicy, name string, target *api.PolicyTarget) *api.Policy {
+func translateFrontendHTTP(policy *agentgateway.AgentgatewayPolicy, name string) *api.Policy {
 	http := policy.Spec.Frontend.HTTP
 	spec := &api.FrontendPolicySpec_HTTP{}
 	if v := http.MaxBufferSize; v != nil {
@@ -381,9 +372,8 @@ func translateFrontendHTTP(policy *agentgateway.AgentgatewayPolicy, name string,
 	}
 
 	httpPolicy := &api.Policy{
-		Key:    name + frontendHttpPolicySuffix + attachmentName(target),
-		Name:   TypedResourceName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
-		Target: target,
+		Key:  name + frontendHttpPolicySuffix,
+		Name: TypedResourceName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
 		Kind: &api.Policy_Frontend{
 			Frontend: &api.FrontendPolicySpec{
 				Kind: &api.FrontendPolicySpec_Http{
@@ -395,8 +385,7 @@ func translateFrontendHTTP(policy *agentgateway.AgentgatewayPolicy, name string,
 
 	logger.Debug("generated http policy",
 		"policy", policy.Name,
-		"agentgateway_policy", httpPolicy.Name,
-		"target", target)
+		"agentgateway_policy", httpPolicy.Name)
 
 	return httpPolicy
 }

--- a/controller/pkg/agentgateway/plugins/testdata/backendpolicy/backend-ancestor-backend.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/backendpolicy/backend-ancestor-backend.yaml
@@ -51,9 +51,9 @@ status:
   status:
     ancestors:
     - ancestorRef:
-        group: agentgateway.dev
-        kind: AgentgatewayBackend
-        name: be
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: test
         namespace: default
       conditions:
       - lastTransitionTime: fake

--- a/controller/pkg/agentgateway/plugins/testdata/backendpolicy/backend-missing-not-attached.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/backendpolicy/backend-missing-not-attached.yaml
@@ -30,8 +30,8 @@ status:
         name: StatusSummary
       conditions:
       - lastTransitionTime: fake
-        message: Policy accepted
-        reason: Valid
+        message: secret default/mtls not found
+        reason: PartiallyValid
         status: "True"
         type: Accepted
       - lastTransitionTime: fake

--- a/controller/pkg/agentgateway/plugins/testdata/backendpolicy/httproute-missing-not-attached.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/backendpolicy/httproute-missing-not-attached.yaml
@@ -30,8 +30,8 @@ status:
         name: StatusSummary
       conditions:
       - lastTransitionTime: fake
-        message: Policy accepted
-        reason: Valid
+        message: secret default/aws-auth-secret not found
+        reason: PartiallyValid
         status: "True"
         type: Accepted
       - lastTransitionTime: fake

--- a/controller/pkg/agentgateway/plugins/testdata/backendpolicy/multi-target-ref-backend-policy.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/backendpolicy/multi-target-ref-backend-policy.yaml
@@ -267,60 +267,9 @@ status:
   status:
     ancestors:
     - ancestorRef:
-        group: agentgateway.dev
-        kind: AgentgatewayBackend
-        name: dummy-oauth
-        namespace: default
-      conditions:
-      - lastTransitionTime: fake
-        message: Policy accepted
-        reason: Valid
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: fake
-        message: Attached to all targets
-        reason: Attached
-        status: "True"
-        type: Attached
-      controllerName: agentgateway.dev/agentgateway
-    - ancestorRef:
-        group: agentgateway.dev
-        kind: AgentgatewayBackend
-        name: test1
-        namespace: default
-      conditions:
-      - lastTransitionTime: fake
-        message: Policy accepted
-        reason: Valid
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: fake
-        message: Attached to all targets
-        reason: Attached
-        status: "True"
-        type: Attached
-      controllerName: agentgateway.dev/agentgateway
-    - ancestorRef:
-        group: agentgateway.dev
-        kind: AgentgatewayBackend
-        name: test2
-        namespace: default
-      conditions:
-      - lastTransitionTime: fake
-        message: Policy accepted
-        reason: Valid
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: fake
-        message: Attached to all targets
-        reason: Attached
-        status: "True"
-        type: Attached
-      controllerName: agentgateway.dev/agentgateway
-    - ancestorRef:
-        group: agentgateway.dev
-        kind: AgentgatewayBackend
-        name: test3
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: test
         namespace: default
       conditions:
       - lastTransitionTime: fake

--- a/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/http-route-ancestor-listenerset.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/http-route-ancestor-listenerset.yaml
@@ -1,0 +1,109 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: listenerset-gw
+  namespace: default
+spec:
+  gatewayClassName: agentgateway
+  allowedListeners:
+    namespaces:
+      from: All
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 8081
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: listenerset
+  namespace: default
+spec:
+  parentRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: listenerset-gw
+  listeners:
+  - name: http-9090
+    protocol: HTTP
+    port: 9090
+    allowedRoutes:
+      namespaces:
+        from: All
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: listenerset-route
+  namespace: default
+spec:
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: ListenerSet
+    name: listenerset
+  rules:
+  - backendRefs:
+    - name: reviews
+      port: 8080
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: listenerset-route-policy
+  namespace: default
+spec:
+  targetRefs:
+  - kind: HTTPRoute
+    name: listenerset-route
+    group: gateway.networking.k8s.io
+  traffic:
+    timeouts:
+      request: 5s
+
+---
+# Output
+output:
+- gateway:
+    Name: listenerset-gw
+    Namespace: default
+  resource:
+    policy:
+      key: traffic/default/listenerset-route-policy:timeout:default/listenerset-route
+      name:
+        kind: AgentgatewayPolicy
+        name: listenerset-route-policy
+        namespace: default
+      target:
+        route:
+          kind: HTTPRoute
+          name: listenerset-route
+          namespace: default
+      traffic:
+        timeout:
+          request: 5s
+status:
+- apiVersion: agentgateway.dev/v1alpha1
+  kind: AgentgatewayPolicy
+  metadata:
+    name: listenerset-route-policy
+    namespace: default
+  spec: null
+  status:
+    ancestors:
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: listenerset-gw
+        namespace: default
+      conditions:
+      - lastTransitionTime: fake
+        message: Policy accepted
+        reason: Valid
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: Attached to all targets
+        reason: Attached
+        status: "True"
+        type: Attached
+      controllerName: agentgateway.dev/agentgateway

--- a/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/mcp-auth-multi-target.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/mcp-auth-multi-target.yaml
@@ -267,60 +267,9 @@ status:
   status:
     ancestors:
     - ancestorRef:
-        group: agentgateway.dev
-        kind: AgentgatewayBackend
-        name: dummy-oauth
-        namespace: default
-      conditions:
-      - lastTransitionTime: fake
-        message: Policy accepted
-        reason: Valid
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: fake
-        message: Attached to all targets
-        reason: Attached
-        status: "True"
-        type: Attached
-      controllerName: agentgateway.dev/agentgateway
-    - ancestorRef:
-        group: agentgateway.dev
-        kind: AgentgatewayBackend
-        name: test1
-        namespace: default
-      conditions:
-      - lastTransitionTime: fake
-        message: Policy accepted
-        reason: Valid
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: fake
-        message: Attached to all targets
-        reason: Attached
-        status: "True"
-        type: Attached
-      controllerName: agentgateway.dev/agentgateway
-    - ancestorRef:
-        group: agentgateway.dev
-        kind: AgentgatewayBackend
-        name: test2
-        namespace: default
-      conditions:
-      - lastTransitionTime: fake
-        message: Policy accepted
-        reason: Valid
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: fake
-        message: Attached to all targets
-        reason: Attached
-        status: "True"
-        type: Attached
-      controllerName: agentgateway.dev/agentgateway
-    - ancestorRef:
-        group: agentgateway.dev
-        kind: AgentgatewayBackend
-        name: test3
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: test
         namespace: default
       conditions:
       - lastTransitionTime: fake

--- a/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/mcp-auth.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/mcp-auth.yaml
@@ -95,9 +95,9 @@ status:
   status:
     ancestors:
     - ancestorRef:
-        group: agentgateway.dev
-        kind: AgentgatewayBackend
-        name: be
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: test
         namespace: default
       conditions:
       - lastTransitionTime: fake

--- a/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/multi-target-missing.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/multi-target-missing.yaml
@@ -1,0 +1,116 @@
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: agw
+  namespace: default
+spec:
+  targetRefs:
+    - kind: Gateway
+      name: test
+      group: gateway.networking.k8s.io
+    - kind: Gateway
+      name: not-test
+      group: gateway.networking.k8s.io
+    - kind: Gateway
+      name: not-test2
+      group: gateway.networking.k8s.io
+  traffic:
+    retry:
+      attempts: 2
+---
+# Output
+output:
+- gateway:
+    Name: not-test
+    Namespace: default
+  resource:
+    policy:
+      key: traffic/default/agw:retry:default/not-test
+      name:
+        kind: AgentgatewayPolicy
+        name: agw
+        namespace: default
+      target:
+        gateway:
+          name: not-test
+          namespace: default
+      traffic:
+        retry:
+          attempts: 2
+- gateway:
+    Name: not-test2
+    Namespace: default
+  resource:
+    policy:
+      key: traffic/default/agw:retry:default/not-test2
+      name:
+        kind: AgentgatewayPolicy
+        name: agw
+        namespace: default
+      target:
+        gateway:
+          name: not-test2
+          namespace: default
+      traffic:
+        retry:
+          attempts: 2
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
+    policy:
+      key: traffic/default/agw:retry:default/test
+      name:
+        kind: AgentgatewayPolicy
+        name: agw
+        namespace: default
+      target:
+        gateway:
+          name: test
+          namespace: default
+      traffic:
+        retry:
+          attempts: 2
+status:
+- apiVersion: agentgateway.dev/v1alpha1
+  kind: AgentgatewayPolicy
+  metadata:
+    name: agw
+    namespace: default
+  spec: null
+  status:
+    ancestors:
+    - ancestorRef:
+        group: agentgateway.dev
+        name: StatusSummary
+      conditions:
+      - lastTransitionTime: fake
+        message: Policy accepted
+        reason: Valid
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: |-
+          Policy is not attached: Gateway default/not-test not found
+          Policy is not attached: Gateway default/not-test2 not found
+        reason: Pending
+        status: "False"
+        type: Attached
+      controllerName: agentgateway.dev/agentgateway
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: test
+        namespace: default
+      conditions:
+      - lastTransitionTime: fake
+        message: Policy accepted
+        reason: Valid
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: Attached to all targets
+        reason: Attached
+        status: "True"
+        type: Attached
+      controllerName: agentgateway.dev/agentgateway

--- a/controller/pkg/agentgateway/plugins/traffic_plugin.go
+++ b/controller/pkg/agentgateway/plugins/traffic_plugin.go
@@ -169,7 +169,7 @@ func TranslateAgentgatewayPolicy(ctx krt.HandlerContext, policy *agentgateway.Ag
 			continue
 		}
 
-		ancestorRefs, attachmentErr := resolvePolicyAncestorRefs(ctx, policy.Namespace, gk, target.Name, agw)
+		ancestorRefs, attachmentErr := resolvePolicyAncestorRefs(ctx, policy.Namespace, gk, target.Name, agw, references)
 
 		policyTargets = append(policyTargets, ResolvedTarget{
 			AgentgatewayTarget: policyTarget,
@@ -259,14 +259,18 @@ func TranslateAgentgatewayPolicy(ctx krt.HandlerContext, policy *agentgateway.Ag
 		// Policy status SHOULD be reported per Gateway
 		// If we couldn't resolve a Gateway ancestor, report status against a summary ref.
 		appendAncestor := func(ar gwv1.ParentReference) {
-			// Only append valid ancestors: require non-empty controllerName and parentRef name
-			if agw.ControllerName != "" && string(ar.Name) != "" {
-				ancestors = append(ancestors, gwv1.PolicyAncestorStatus{
-					AncestorRef:    ar,
-					ControllerName: v1alpha2.GatewayController(agw.ControllerName),
-					Conditions:     conds,
-				})
+			// A policy should report at most one status per Gateway parent, even if multiple
+			// targetRefs resolve to the same Gateway.
+			if slices.IndexFunc(ancestors, func(existing gwv1.PolicyAncestorStatus) bool {
+				return existing.ControllerName == v1alpha2.GatewayController(agw.ControllerName) && parentRefEqual(existing.AncestorRef, ar)
+			}) != -1 {
+				return
 			}
+			ancestors = append(ancestors, gwv1.PolicyAncestorStatus{
+				AncestorRef:    ar,
+				ControllerName: v1alpha2.GatewayController(agw.ControllerName),
+				Conditions:     conds,
+			})
 		}
 		if len(policyTarget.AncestorRefs) > 0 {
 			for _, ar := range policyTarget.AncestorRefs {
@@ -321,84 +325,52 @@ func resolvePolicyAncestorRefs(
 	targetGK schema.GroupKind,
 	targetName gwv1.ObjectName,
 	agw *AgwCollections,
+	references ReferenceIndex,
 ) ([]gwv1.ParentReference, string) {
-	// Default: fall back to the original targetRef (for non-route targets)
-	fallback := []gwv1.ParentReference{{
-		Name:      targetName,
-		Namespace: ptr.Of(gwv1.Namespace(policyNamespace)),
-		Group:     ptr.Of(gwv1.Group(targetGK.Group)),
-		Kind:      ptr.Of(gwv1.Kind(targetGK.Kind)),
-	}}
-
-	// If the policy is attached directly to a Gateway, that Gateway is the ancestor.
-	if targetGK == wellknown.GatewayGVK.GroupKind() {
-		key := policyNamespace + "/" + string(targetName)
-		gw := ptr.Flatten(krt.FetchOne(ctx, agw.Gateways, krt.FilterKey(key)))
-		if gw == nil {
-			return nil, fmt.Sprintf("Policy is not attached: Gateway %s/%s not found", policyNamespace, targetName)
-		}
-		// TODO: Validate the listener exists to avoid reporting attached for a non-existent sectionName
-		// Requires listeners attachment to be supported: https://github.com/agentgateway/agentgateway/issues/825
-		return fallback, ""
+	object := utils.TypedNamespacedName{
+		NamespacedName: types.NamespacedName{Namespace: policyNamespace, Name: string(targetName)},
+		Kind:           targetGK.Kind,
+	}
+	if !policyTargetExists(ctx, agw, object) {
+		return nil, fmt.Sprintf("Policy is not attached: %s %s/%s not found", targetGK.Kind, policyNamespace, targetName)
 	}
 
-	// If attached to an AgentgatewayBackend, the backend itself is the ancestor.
-	if targetGK == wellknown.AgentgatewayBackendGVK.GroupKind() {
-		key := policyNamespace + "/" + string(targetName)
-		be := ptr.Flatten(krt.FetchOne(ctx, agw.Backends, krt.FilterKey(key)))
-		if be == nil {
-			return nil, fmt.Sprintf("Policy is not attached: AgentgatewayBackend %s/%s not found", policyNamespace, targetName)
-		}
-		return []gwv1.ParentReference{{
-			Name:      targetName,
-			Namespace: ptr.Of(gwv1.Namespace(policyNamespace)),
-			Group:     ptr.Of(gwv1.Group(wellknown.AgentgatewayBackendGVK.Group)),
-			Kind:      ptr.Of(gwv1.Kind(wellknown.AgentgatewayBackendGVK.Kind)),
-		}}, ""
+	gatewayTargets := references.LookupGatewaysForTarget(ctx, object).UnsortedList()
+	if len(gatewayTargets) == 0 {
+		return nil, fmt.Sprintf("Policy is not attached: %s %s/%s is not attached to any Gateway", targetGK.Kind, policyNamespace, targetName)
 	}
 
-	// If attached to an HTTPRoute, prefer the Gateway(s) the route attaches to.
-	// This follows Gateway API guidance to use Gateway as the PolicyAncestorStatus when possible.
-	if targetGK == wellknown.HTTPRouteGVK.GroupKind() {
-		key := policyNamespace + "/" + string(targetName)
-		route := ptr.Flatten(krt.FetchOne(ctx, agw.HTTPRoutes, krt.FilterKey(key)))
-		if route == nil {
-			return nil, fmt.Sprintf("Policy is not attached: HTTPRoute %s/%s not found", policyNamespace, targetName)
-		}
-
-		seen := make(map[types.NamespacedName]struct{})
-		var refs []gwv1.ParentReference
-		for _, pr := range route.Spec.ParentRefs {
-			kind := ptr.OrDefault(pr.Kind, gwv1.Kind(wellknown.GatewayKind))
-			group := ptr.OrDefault(pr.Group, gwv1.Group(wellknown.GatewayGVK.Group))
-			if string(kind) != wellknown.GatewayKind || string(group) != wellknown.GatewayGVK.Group {
-				continue
-			}
-			ns := string(ptr.OrDefault(pr.Namespace, gwv1.Namespace(route.Namespace)))
-			nn := types.NamespacedName{Namespace: ns, Name: string(pr.Name)}
-			if _, ok := seen[nn]; ok {
-				continue
-			}
-			seen[nn] = struct{}{}
-			refs = append(refs, gwv1.ParentReference{
-				Name:      pr.Name,
-				Namespace: ptr.Of(gwv1.Namespace(ns)),
-				Group:     ptr.Of(gwv1.Group(wellknown.GatewayGVK.Group)),
-				Kind:      ptr.Of(gwv1.Kind(wellknown.GatewayKind)),
-				// NOTE: Intentionally omit SectionName; we report per Gateway, not per listener.
-			})
-		}
-
-		if len(refs) == 0 {
-			return nil, fmt.Sprintf("Policy is not attached: HTTPRoute %s/%s has no Gateway parentRefs", policyNamespace, targetName)
-		}
-		slices.SortStableFunc(refs, func(a, b gwv1.ParentReference) int {
-			return strings.Compare(reports.ParentString(a), reports.ParentString(b))
+	refs := make([]gwv1.ParentReference, 0, len(gatewayTargets))
+	for _, gatewayTarget := range gatewayTargets {
+		refs = append(refs, gwv1.ParentReference{
+			Name:      gwv1.ObjectName(gatewayTarget.Name),
+			Namespace: ptr.Of(gwv1.Namespace(gatewayTarget.Namespace)),
+			Group:     ptr.Of(gwv1.Group(wellknown.GatewayGVK.Group)),
+			Kind:      ptr.Of(gwv1.Kind(wellknown.GatewayGVK.Kind)),
 		})
-		return refs, ""
 	}
+	slices.SortStableFunc(refs, func(a, b gwv1.ParentReference) int {
+		return strings.Compare(reports.ParentString(a), reports.ParentString(b))
+	})
+	return refs, ""
+}
 
-	return fallback, ""
+func policyTargetExists(ctx krt.HandlerContext, agw *AgwCollections, target utils.TypedNamespacedName) bool {
+	key := target.Namespace + "/" + target.Name
+	switch target.Kind {
+	case wellknown.GatewayGVK.Kind:
+		return ptr.Flatten(krt.FetchOne(ctx, agw.Gateways, krt.FilterKey(key))) != nil
+	case wellknown.HTTPRouteGVK.Kind:
+		return ptr.Flatten(krt.FetchOne(ctx, agw.HTTPRoutes, krt.FilterKey(key))) != nil
+	case wellknown.GRPCRouteGVK.Kind:
+		return ptr.Flatten(krt.FetchOne(ctx, agw.GRPCRoutes, krt.FilterKey(key))) != nil
+	case wellknown.AgentgatewayBackendGVK.Kind:
+		return ptr.Flatten(krt.FetchOne(ctx, agw.Backends, krt.FilterKey(key))) != nil
+	case wellknown.ServiceGVK.Kind:
+		return ptr.Flatten(krt.FetchOne(ctx, agw.Services, krt.FilterKey(key))) != nil
+	default:
+		return false
+	}
 }
 
 // translateTrafficPolicyToAgw converts a TrafficPolicy to agentgateway Policy resources
@@ -410,22 +382,26 @@ func translatePolicyToAgw(
 	agwPolicies := make([]*api.Policy, 0)
 	var errs []error
 
-	frontend, err := translateFrontendPolicyToAgw(ctx, policy, policyTarget)
+	frontend, err := translateFrontendPolicyToAgw(ctx, policy)
 	agwPolicies = append(agwPolicies, frontend...)
 	if err != nil {
 		errs = append(errs, err)
 	}
 
-	traffic, err := translateTrafficPolicyToAgw(ctx, policy, policyTarget)
+	traffic, err := translateTrafficPolicyToAgw(ctx, policy)
 	agwPolicies = append(agwPolicies, traffic...)
 	if err != nil {
 		errs = append(errs, err)
 	}
 
-	backend, err := translateBackendPolicyToAgw(ctx, policy, policyTarget)
+	backend, err := translateBackendPolicyToAgw(ctx, policy)
 	agwPolicies = append(agwPolicies, backend...)
 	if err != nil {
 		errs = append(errs, err)
+	}
+	for _, p := range agwPolicies {
+		p.Key += attachmentName(policyTarget)
+		p.Target = policyTarget
 	}
 
 	return agwPolicies, errors.Join(errs...)
@@ -434,7 +410,6 @@ func translatePolicyToAgw(
 func translateTrafficPolicyToAgw(
 	ctx PolicyCtx,
 	policy *agentgateway.AgentgatewayPolicy,
-	policyTarget *api.PolicyTarget,
 ) ([]*api.Policy, error) {
 	traffic := policy.Spec.Traffic
 	if traffic == nil {
@@ -474,73 +449,73 @@ func translateTrafficPolicyToAgw(
 
 	// Convert ExtAuth policy if present
 	if traffic.ExtAuth != nil {
-		appendPolicy("extAuth")(processExtAuthPolicy(ctx, traffic.ExtAuth, traffic.Phase, basePolicyName, policyName, policyTarget))
+		appendPolicy("extAuth")(processExtAuthPolicy(ctx, traffic.ExtAuth, traffic.Phase, basePolicyName, policyName))
 	}
 
 	// Convert ExtProc policy if present
 	if traffic.ExtProc != nil {
-		appendPolicy("extProc")(processExtProcPolicy(ctx, traffic.ExtProc, traffic.Phase, basePolicyName, policyName, policyTarget))
+		appendPolicy("extProc")(processExtProcPolicy(ctx, traffic.ExtProc, traffic.Phase, basePolicyName, policyName))
 	}
 
 	// Convert Authorization policy if present
 	if traffic.Authorization != nil {
-		appendPolicy("authorization")(processAuthorizationPolicy(traffic.Authorization, basePolicyName, policyName, policyTarget), nil)
+		appendPolicy("authorization")(processAuthorizationPolicy(traffic.Authorization, basePolicyName, policyName))
 	}
 
 	// Process RateLimit policies if present
 	if traffic.RateLimit != nil {
-		appendPolicies("rateLimit")(processRateLimitPolicy(ctx, traffic.RateLimit, basePolicyName, policyName, policyTarget))
+		appendPolicies("rateLimit")(processRateLimitPolicy(ctx, traffic.RateLimit, basePolicyName, policyName))
 	}
 
 	// Process transformation policies if present
 	if traffic.Transformation != nil {
-		appendPolicy("transformation")(processTransformationPolicy(traffic.Transformation, traffic.Phase, basePolicyName, policyName, policyTarget))
+		appendPolicy("transformation")(processTransformationPolicy(traffic.Transformation, traffic.Phase, basePolicyName, policyName))
 	}
 
 	// Process CSRF policies if present
 	if traffic.Csrf != nil {
-		appendPolicy("csrf")(processCSRFPolicy(traffic.Csrf, basePolicyName, policyName, policyTarget), nil)
+		appendPolicy("csrf")(processCSRFPolicy(traffic.Csrf, basePolicyName, policyName), nil)
 	}
 
 	if traffic.Cors != nil {
-		appendPolicy("cors")(processCorsPolicy(traffic.Cors, basePolicyName, policyName, policyTarget), nil)
+		appendPolicy("cors")(processCorsPolicy(traffic.Cors, basePolicyName, policyName), nil)
 	}
 
 	if traffic.HeaderModifiers != nil {
-		appendPolicies("headerModifiers")(processHeaderModifierPolicy(traffic.HeaderModifiers, basePolicyName, policyName, policyTarget), nil)
+		appendPolicies("headerModifiers")(processHeaderModifierPolicy(traffic.HeaderModifiers, basePolicyName, policyName), nil)
 	}
 
 	if traffic.HostnameRewrite != nil {
-		appendPolicy("hostnameRewrite")(processHostnameRewritePolicy(traffic.HostnameRewrite, basePolicyName, policyName, policyTarget), nil)
+		appendPolicy("hostnameRewrite")(processHostnameRewritePolicy(traffic.HostnameRewrite, basePolicyName, policyName), nil)
 	}
 
 	if traffic.Timeouts != nil {
-		appendPolicy("timeouts")(processTimeoutPolicy(traffic.Timeouts, basePolicyName, policyName, policyTarget), nil)
+		appendPolicy("timeouts")(processTimeoutPolicy(traffic.Timeouts, basePolicyName, policyName), nil)
 	}
 
 	if traffic.Retry != nil {
-		appendPolicy("retry")(processRetriesPolicy(traffic.Retry, basePolicyName, policyName, policyTarget))
+		appendPolicy("retry")(processRetriesPolicy(traffic.Retry, basePolicyName, policyName))
 	}
 
 	if traffic.DirectResponse != nil {
-		appendPolicy("directResponse")(processDirectResponse(traffic.DirectResponse, basePolicyName, policyName, policyTarget), nil)
+		appendPolicy("directResponse")(processDirectResponse(traffic.DirectResponse, basePolicyName, policyName), nil)
 	}
 
 	if traffic.JWTAuthentication != nil {
-		appendPolicy("jwtAuthentication")(processJWTAuthenticationPolicy(ctx, traffic.JWTAuthentication, traffic.Phase, basePolicyName, policyName, policyTarget))
+		appendPolicy("jwtAuthentication")(processJWTAuthenticationPolicy(ctx, traffic.JWTAuthentication, traffic.Phase, basePolicyName, policyName))
 	}
 
 	if traffic.APIKeyAuthentication != nil {
-		appendPolicy("apiKeyAuthentication")(processAPIKeyAuthenticationPolicy(ctx, traffic.APIKeyAuthentication, traffic.Phase, basePolicyName, policyName, policyTarget))
+		appendPolicy("apiKeyAuthentication")(processAPIKeyAuthenticationPolicy(ctx, traffic.APIKeyAuthentication, traffic.Phase, basePolicyName, policyName))
 	}
 
 	if traffic.BasicAuthentication != nil {
-		appendPolicy("basicAuthentication")(processBasicAuthenticationPolicy(ctx, traffic.BasicAuthentication, traffic.Phase, basePolicyName, policyName, policyTarget))
+		appendPolicy("basicAuthentication")(processBasicAuthenticationPolicy(ctx, traffic.BasicAuthentication, traffic.Phase, basePolicyName, policyName))
 	}
 	return agwPolicies, errors.Join(errs...)
 }
 
-func processRetriesPolicy(retry *agentgateway.Retry, basePolicyName string, policy types.NamespacedName, target *api.PolicyTarget) (*api.Policy, error) {
+func processRetriesPolicy(retry *agentgateway.Retry, basePolicyName string, policy types.NamespacedName) (*api.Policy, error) {
 	translatedRetry := &api.Retry{}
 	var errs []error
 
@@ -571,9 +546,8 @@ func processRetriesPolicy(retry *agentgateway.Retry, basePolicyName string, poli
 	}
 
 	retryPolicy := &api.Policy{
-		Key:    basePolicyName + retryPolicySuffix + attachmentName(target),
-		Name:   TypedResourceFromName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
-		Target: target,
+		Key:  basePolicyName + retryPolicySuffix,
+		Name: TypedResourceFromName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
 		Kind: &api.Policy_Traffic{
 			Traffic: &api.TrafficPolicySpec{
 				Kind: &api.TrafficPolicySpec_Retry{Retry: translatedRetry},
@@ -583,13 +557,12 @@ func processRetriesPolicy(retry *agentgateway.Retry, basePolicyName string, poli
 
 	logger.Debug("generated Retry policy",
 		"policy", basePolicyName,
-		"agentgateway_policy", retryPolicy.Name,
-		"target", target)
+		"agentgateway_policy", retryPolicy.Name)
 
 	return retryPolicy, errors.Join(errs...)
 }
 
-func processDirectResponse(directResponse *agentgateway.DirectResponse, basePolicyName string, policy types.NamespacedName, target *api.PolicyTarget) *api.Policy {
+func processDirectResponse(directResponse *agentgateway.DirectResponse, basePolicyName string, policy types.NamespacedName) *api.Policy {
 	tp := &api.TrafficPolicySpec{
 		Kind: &api.TrafficPolicySpec_DirectResponse{
 			DirectResponse: &api.DirectResponse{
@@ -604,9 +577,8 @@ func processDirectResponse(directResponse *agentgateway.DirectResponse, basePoli
 	}
 
 	directRespPolicy := &api.Policy{
-		Key:    basePolicyName + directResponseSuffix + attachmentName(target),
-		Name:   TypedResourceFromName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
-		Target: target,
+		Key:  basePolicyName + directResponseSuffix,
+		Name: TypedResourceFromName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
 		Kind: &api.Policy_Traffic{
 			Traffic: tp,
 		},
@@ -614,13 +586,12 @@ func processDirectResponse(directResponse *agentgateway.DirectResponse, basePoli
 
 	logger.Debug("generated DirectResponse policy",
 		"policy", basePolicyName,
-		"agentgateway_policy", directRespPolicy.Name,
-		"target", target)
+		"agentgateway_policy", directRespPolicy.Name)
 
 	return directRespPolicy
 }
 
-func processJWTAuthenticationPolicy(ctx PolicyCtx, jwt *agentgateway.JWTAuthentication, policyPhase *agentgateway.PolicyPhase, basePolicyName string, policy types.NamespacedName, target *api.PolicyTarget) (*api.Policy, error) {
+func processJWTAuthenticationPolicy(ctx PolicyCtx, jwt *agentgateway.JWTAuthentication, policyPhase *agentgateway.PolicyPhase, basePolicyName string, policy types.NamespacedName) (*api.Policy, error) {
 	p := &api.TrafficPolicySpec_JWT{}
 
 	switch jwt.Mode {
@@ -660,9 +631,8 @@ func processJWTAuthenticationPolicy(ctx PolicyCtx, jwt *agentgateway.JWTAuthenti
 	}
 
 	jwtPolicy := &api.Policy{
-		Key:    basePolicyName + jwtPolicySuffix + attachmentName(target),
-		Name:   TypedResourceFromName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
-		Target: target,
+		Key:  basePolicyName + jwtPolicySuffix,
+		Name: TypedResourceFromName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
 		Kind: &api.Policy_Traffic{
 			Traffic: &api.TrafficPolicySpec{
 				Phase: phase(policyPhase),
@@ -673,8 +643,7 @@ func processJWTAuthenticationPolicy(ctx PolicyCtx, jwt *agentgateway.JWTAuthenti
 
 	logger.Debug("generated jwt policy",
 		"policy", basePolicyName,
-		"agentgateway_policy", jwtPolicy.Name,
-		"target", target)
+		"agentgateway_policy", jwtPolicy.Name)
 
 	return jwtPolicy, errors.Join(errs...)
 }
@@ -685,7 +654,6 @@ func processBasicAuthenticationPolicy(
 	policyPhase *agentgateway.PolicyPhase,
 	basePolicyName string,
 	policy types.NamespacedName,
-	target *api.PolicyTarget,
 ) (*api.Policy, error) {
 	p := &api.TrafficPolicySpec_BasicAuthentication{}
 	p.Realm = ba.Realm
@@ -715,9 +683,8 @@ func processBasicAuthenticationPolicy(
 		p.HtpasswdContent = strings.Join(ba.Users, "\n")
 	}
 	basicAuthPolicy := &api.Policy{
-		Key:    basePolicyName + basicAuthPolicySuffix + attachmentName(target),
-		Name:   TypedResourceFromName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
-		Target: target,
+		Key:  basePolicyName + basicAuthPolicySuffix,
+		Name: TypedResourceFromName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
 		Kind: &api.Policy_Traffic{
 			Traffic: &api.TrafficPolicySpec{
 				Phase: phase(policyPhase),
@@ -728,8 +695,7 @@ func processBasicAuthenticationPolicy(
 
 	logger.Debug("generated basic auth policy",
 		"policy", basePolicyName,
-		"agentgateway_policy", basicAuthPolicy.Name,
-		"target", target)
+		"agentgateway_policy", basicAuthPolicy.Name)
 
 	return basicAuthPolicy, err
 }
@@ -745,7 +711,6 @@ func processAPIKeyAuthenticationPolicy(
 	policyPhase *agentgateway.PolicyPhase,
 	basePolicyName string,
 	policy types.NamespacedName,
-	target *api.PolicyTarget,
 ) (*api.Policy, error) {
 	p := &api.TrafficPolicySpec_APIKey{}
 
@@ -804,9 +769,8 @@ func processAPIKeyAuthenticationPolicy(
 		return a.Key
 	})
 	apiKeyPolicy := &api.Policy{
-		Key:    basePolicyName + apiKeyPolicySuffix + attachmentName(target),
-		Name:   TypedResourceFromName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
-		Target: target,
+		Key:  basePolicyName + apiKeyPolicySuffix,
+		Name: TypedResourceFromName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
 		Kind: &api.Policy_Traffic{
 			Traffic: &api.TrafficPolicySpec{
 				Phase: phase(policyPhase),
@@ -817,17 +781,15 @@ func processAPIKeyAuthenticationPolicy(
 
 	logger.Debug("generated api key auth policy",
 		"policy", basePolicyName,
-		"agentgateway_policy", apiKeyPolicy.Name,
-		"target", target)
+		"agentgateway_policy", apiKeyPolicy.Name)
 
 	return apiKeyPolicy, errors.Join(errs...)
 }
 
-func processTimeoutPolicy(timeout *agentgateway.Timeouts, basePolicyName string, policy types.NamespacedName, target *api.PolicyTarget) *api.Policy {
+func processTimeoutPolicy(timeout *agentgateway.Timeouts, basePolicyName string, policy types.NamespacedName) *api.Policy {
 	timeoutPolicy := &api.Policy{
-		Key:    basePolicyName + timeoutPolicySuffix + attachmentName(target),
-		Name:   TypedResourceFromName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
-		Target: target,
+		Key:  basePolicyName + timeoutPolicySuffix,
+		Name: TypedResourceFromName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
 		Kind: &api.Policy_Traffic{
 			Traffic: &api.TrafficPolicySpec{
 				Kind: &api.TrafficPolicySpec_Timeout{Timeout: &api.Timeout{
@@ -839,13 +801,12 @@ func processTimeoutPolicy(timeout *agentgateway.Timeouts, basePolicyName string,
 
 	logger.Debug("generated Timeout policy",
 		"policy", basePolicyName,
-		"agentgateway_policy", timeoutPolicy.Name,
-		"target", target)
+		"agentgateway_policy", timeoutPolicy.Name)
 
 	return timeoutPolicy
 }
 
-func processHostnameRewritePolicy(hnrw *agentgateway.HostnameRewrite, basePolicyName string, policy types.NamespacedName, target *api.PolicyTarget) *api.Policy {
+func processHostnameRewritePolicy(hnrw *agentgateway.HostnameRewrite, basePolicyName string, policy types.NamespacedName) *api.Policy {
 	r := &api.TrafficPolicySpec_HostRewrite{}
 	switch hnrw.Mode {
 	case agentgateway.HostnameRewriteModeAuto:
@@ -855,9 +816,8 @@ func processHostnameRewritePolicy(hnrw *agentgateway.HostnameRewrite, basePolicy
 	}
 
 	p := &api.Policy{
-		Key:    basePolicyName + hostnameRewritePolicySuffix + attachmentName(target),
-		Name:   TypedResourceFromName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
-		Target: target,
+		Key:  basePolicyName + hostnameRewritePolicySuffix,
+		Name: TypedResourceFromName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
 		Kind: &api.Policy_Traffic{
 			Traffic: &api.TrafficPolicySpec{
 				Kind: &api.TrafficPolicySpec_HostRewrite_{HostRewrite: r},
@@ -867,21 +827,19 @@ func processHostnameRewritePolicy(hnrw *agentgateway.HostnameRewrite, basePolicy
 
 	logger.Debug("generated HostnameRewrite policy",
 		"policy", basePolicyName,
-		"agentgateway_policy", p.Name,
-		"target", target)
+		"agentgateway_policy", p.Name)
 
 	return p
 }
 
-func processHeaderModifierPolicy(headerModifier *shared.HeaderModifiers, basePolicyName string, policy types.NamespacedName, target *api.PolicyTarget) []*api.Policy {
+func processHeaderModifierPolicy(headerModifier *shared.HeaderModifiers, basePolicyName string, policy types.NamespacedName) []*api.Policy {
 	var policies []*api.Policy
 
 	var headerModifierPolicyRequest, headerModifierPolicyResponse *api.Policy
 	if headerModifier.Request != nil {
 		headerModifierPolicyRequest = &api.Policy{
-			Key:    basePolicyName + headerModifierPolicySuffix + attachmentName(target),
-			Name:   TypedResourceFromName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
-			Target: target,
+			Key:  basePolicyName + headerModifierPolicySuffix,
+			Name: TypedResourceFromName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
 			Kind: &api.Policy_Traffic{
 				Traffic: &api.TrafficPolicySpec{
 					Kind: &api.TrafficPolicySpec_RequestHeaderModifier{RequestHeaderModifier: &api.HeaderModifier{
@@ -894,16 +852,14 @@ func processHeaderModifierPolicy(headerModifier *shared.HeaderModifiers, basePol
 		}
 		logger.Debug("generated HeaderModifier policy",
 			"policy", basePolicyName,
-			"agentgateway_policy", headerModifierPolicyRequest.Name,
-			"target", target)
+			"agentgateway_policy", headerModifierPolicyRequest.Name)
 		policies = append(policies, headerModifierPolicyRequest)
 	}
 
 	if headerModifier.Response != nil {
 		headerModifierPolicyResponse = &api.Policy{
-			Key:    basePolicyName + respHeaderModifierPolicySuffix + attachmentName(target),
-			Name:   TypedResourceFromName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
-			Target: target,
+			Key:  basePolicyName + respHeaderModifierPolicySuffix,
+			Name: TypedResourceFromName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
 			Kind: &api.Policy_Traffic{
 				Traffic: &api.TrafficPolicySpec{
 					Kind: &api.TrafficPolicySpec_ResponseHeaderModifier{ResponseHeaderModifier: &api.HeaderModifier{
@@ -916,19 +872,17 @@ func processHeaderModifierPolicy(headerModifier *shared.HeaderModifiers, basePol
 		}
 		logger.Debug("generated HeaderModifier policy",
 			"policy", basePolicyName,
-			"agentgateway_policy", headerModifierPolicyResponse.Name,
-			"target", target)
+			"agentgateway_policy", headerModifierPolicyResponse.Name)
 		policies = append(policies, headerModifierPolicyResponse)
 	}
 
 	return policies
 }
 
-func processCorsPolicy(cors *agentgateway.CORS, basePolicyName string, policy types.NamespacedName, target *api.PolicyTarget) *api.Policy {
+func processCorsPolicy(cors *agentgateway.CORS, basePolicyName string, policy types.NamespacedName) *api.Policy {
 	corsPolicy := &api.Policy{
-		Key:    basePolicyName + corsPolicySuffix + attachmentName(target),
-		Name:   TypedResourceFromName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
-		Target: target,
+		Key:  basePolicyName + corsPolicySuffix,
+		Name: TypedResourceFromName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
 		Kind: &api.Policy_Traffic{
 			Traffic: &api.TrafficPolicySpec{
 				Kind: &api.TrafficPolicySpec_Cors{Cors: &api.CORS{
@@ -947,8 +901,7 @@ func processCorsPolicy(cors *agentgateway.CORS, basePolicyName string, policy ty
 
 	logger.Debug("generated Cors policy",
 		"policy", basePolicyName,
-		"agentgateway_policy", corsPolicy.Name,
-		"target", target)
+		"agentgateway_policy", corsPolicy.Name)
 
 	return corsPolicy
 }
@@ -960,12 +913,11 @@ func processExtAuthPolicy(
 	policyPhase *agentgateway.PolicyPhase,
 	basePolicyName string,
 	policy types.NamespacedName,
-	policyTarget *api.PolicyTarget,
 ) (*api.Policy, error) {
-	var backendErr error
+	var errs []error
 	be, err := buildBackendRef(ctx, extAuth.BackendRef, policy.Namespace)
 	if err != nil {
-		backendErr = fmt.Errorf("failed to build extAuth: %v", err)
+		errs = append(errs, fmt.Errorf("failed to build extAuth: %v", err))
 	}
 
 	spec := &api.TrafficPolicySpec_ExternalAuth{
@@ -973,20 +925,35 @@ func processExtAuthPolicy(
 		FailureMode: api.TrafficPolicySpec_ExternalAuth_DENY,
 	}
 	if g := extAuth.GRPC; g != nil {
+		metadata := castCELMap(g.RequestMetadata, func(key string, expr shared.CELExpression) {
+			errs = append(errs, fmt.Errorf("extAuth grpc requestMetadata %q is not a valid CEL expression: %s", key, expr))
+		})
 		p := &api.TrafficPolicySpec_ExternalAuth_GRPCProtocol{
 			Context:  g.ContextExtensions,
-			Metadata: castMap(g.RequestMetadata),
+			Metadata: metadata,
 		}
 		spec.Protocol = &api.TrafficPolicySpec_ExternalAuth_Grpc{
 			Grpc: p,
 		}
 	} else if h := extAuth.HTTP; h != nil {
+		path := castCELPtr(h.Path, func(expr shared.CELExpression) {
+			errs = append(errs, fmt.Errorf("extAuth http path is not a valid CEL expression: %s", expr))
+		})
+		redirect := castCELPtr(h.Redirect, func(expr shared.CELExpression) {
+			errs = append(errs, fmt.Errorf("extAuth http redirect is not a valid CEL expression: %s", expr))
+		})
+		addRequestHeaders := castCELMap(h.AddRequestHeaders, func(key string, expr shared.CELExpression) {
+			errs = append(errs, fmt.Errorf("extAuth http addRequestHeaders %q is not a valid CEL expression: %s", key, expr))
+		})
+		metadata := castCELMap(h.ResponseMetadata, func(key string, expr shared.CELExpression) {
+			errs = append(errs, fmt.Errorf("extAuth http responseMetadata %q is not a valid CEL expression: %s", key, expr))
+		})
 		p := &api.TrafficPolicySpec_ExternalAuth_HTTPProtocol{
-			Path:                   castPtr(h.Path),
-			Redirect:               castPtr(h.Redirect),
+			Path:                   path,
+			Redirect:               redirect,
 			IncludeResponseHeaders: h.AllowedResponseHeaders,
-			AddRequestHeaders:      castMap(h.AddRequestHeaders),
-			Metadata:               castMap(h.ResponseMetadata),
+			AddRequestHeaders:      addRequestHeaders,
+			Metadata:               metadata,
 		}
 		spec.IncludeRequestHeaders = h.AllowedRequestHeaders
 		spec.Protocol = &api.TrafficPolicySpec_ExternalAuth_Http{
@@ -1005,9 +972,8 @@ func processExtAuthPolicy(
 	}
 
 	extauthPolicy := &api.Policy{
-		Key:    basePolicyName + extauthPolicySuffix + attachmentName(policyTarget),
-		Name:   TypedResourceFromName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
-		Target: policyTarget,
+		Key:  basePolicyName + extauthPolicySuffix,
+		Name: TypedResourceFromName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
 		Kind: &api.Policy_Traffic{
 			Traffic: &api.TrafficPolicySpec{
 				Phase: phase(policyPhase),
@@ -1020,10 +986,9 @@ func processExtAuthPolicy(
 
 	logger.Debug("generated ExtAuth policy",
 		"policy", basePolicyName,
-		"agentgateway_policy", extauthPolicy.Name,
-		"target", policyTarget)
+		"agentgateway_policy", extauthPolicy.Name)
 
-	return extauthPolicy, backendErr
+	return extauthPolicy, errors.Join(errs...)
 }
 
 // processExtProcPolicy processes ExtProc configuration and creates corresponding agentgateway policies
@@ -1033,7 +998,6 @@ func processExtProcPolicy(
 	policyPhase *agentgateway.PolicyPhase,
 	basePolicyName string,
 	policy types.NamespacedName,
-	policyTarget *api.PolicyTarget,
 ) (*api.Policy, error) {
 	var backendErr error
 	be, err := buildBackendRef(ctx, extProc.BackendRef, policy.Namespace)
@@ -1048,9 +1012,8 @@ func processExtProcPolicy(
 	}
 
 	extprocPolicy := &api.Policy{
-		Key:    basePolicyName + extprocPolicySuffix + attachmentName(policyTarget),
-		Name:   TypedResourceFromName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
-		Target: policyTarget,
+		Key:  basePolicyName + extprocPolicySuffix,
+		Name: TypedResourceFromName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
 		Kind: &api.Policy_Traffic{
 			Traffic: &api.TrafficPolicySpec{
 				Phase: phase(policyPhase),
@@ -1063,8 +1026,7 @@ func processExtProcPolicy(
 
 	logger.Info("generated ExtProc policy",
 		"policy", basePolicyName,
-		"agentgateway_policy", extprocPolicy.Name,
-		"target", policyTarget)
+		"agentgateway_policy", extprocPolicy.Name)
 
 	return extprocPolicy, backendErr
 }
@@ -1088,6 +1050,20 @@ func cast[T ~string](items []T) []string {
 	})
 }
 
+func castCELSlice(items []shared.CELExpression, invalid func(shared.CELExpression)) []string {
+	if items == nil {
+		return nil
+	}
+	res := make([]string, 0, len(items))
+	for _, item := range items {
+		res = append(res, string(item))
+		if !isCEL(item) {
+			invalid(item)
+		}
+	}
+	return res
+}
+
 func castMap[T ~string](items map[string]T) map[string]string {
 	if items == nil {
 		return nil
@@ -1099,6 +1075,20 @@ func castMap[T ~string](items map[string]T) map[string]string {
 	return res
 }
 
+func castCELMap(items map[string]shared.CELExpression, invalid func(string, shared.CELExpression)) map[string]string {
+	if items == nil {
+		return nil
+	}
+	res := make(map[string]string, len(items))
+	for k, v := range items {
+		res[k] = string(v)
+		if !isCEL(v) {
+			invalid(k, v)
+		}
+	}
+	return res
+}
+
 func castPtr[T ~string](item *T) *string {
 	if item == nil {
 		return nil
@@ -1106,24 +1096,37 @@ func castPtr[T ~string](item *T) *string {
 	return ptr.Of(string(*item))
 }
 
+func castCELPtr(item *shared.CELExpression, invalid func(shared.CELExpression)) *string {
+	if item == nil {
+		return nil
+	}
+	res := ptr.Of(string(*item))
+	if !isCEL(*item) {
+		invalid(*item)
+	}
+	return res
+}
+
 // processAuthorizationPolicy processes Authorization configuration and creates corresponding Agw policies
 func processAuthorizationPolicy(
 	auth *shared.Authorization,
 	basePolicyName string,
 	policy types.NamespacedName,
-	policyTarget *api.PolicyTarget,
-) *api.Policy {
+) (*api.Policy, error) {
+	var errs []error
 	var allowPolicies, denyPolicies []string
+	policies := castCELSlice(auth.Policy.MatchExpressions, func(expr shared.CELExpression) {
+		errs = append(errs, fmt.Errorf("authorization matchExpression is not a valid CEL expression: %s", expr))
+	})
 	if auth.Action == shared.AuthorizationPolicyActionDeny {
-		denyPolicies = append(denyPolicies, cast(auth.Policy.MatchExpressions)...)
+		denyPolicies = append(denyPolicies, policies...)
 	} else {
-		allowPolicies = append(allowPolicies, cast(auth.Policy.MatchExpressions)...)
+		allowPolicies = append(allowPolicies, policies...)
 	}
 
 	pol := &api.Policy{
-		Key:    basePolicyName + rbacPolicySuffix + attachmentName(policyTarget),
-		Name:   TypedResourceFromName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
-		Target: policyTarget,
+		Key:  basePolicyName + rbacPolicySuffix,
+		Name: TypedResourceFromName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
 		Kind: &api.Policy_Traffic{
 			Traffic: &api.TrafficPolicySpec{
 				Kind: &api.TrafficPolicySpec_Authorization{
@@ -1138,10 +1141,9 @@ func processAuthorizationPolicy(
 
 	logger.Debug("generated Authorization policy",
 		"policy", basePolicyName,
-		"agentgateway_policy", pol.Name,
-		"target", policyTarget)
+		"agentgateway_policy", pol.Name)
 
-	return pol
+	return pol, errors.Join(errs...)
 }
 
 func getFrontendPolicyName(trafficPolicyNs, trafficPolicyName string) string {
@@ -1157,13 +1159,13 @@ func getTrafficPolicyName(trafficPolicyNs, trafficPolicyName string) string {
 }
 
 // processRateLimitPolicy processes RateLimit configuration and creates corresponding agentgateway policies
-func processRateLimitPolicy(ctx PolicyCtx, rl *agentgateway.RateLimits, basePolicyName string, policy types.NamespacedName, policyTarget *api.PolicyTarget) ([]*api.Policy, error) {
+func processRateLimitPolicy(ctx PolicyCtx, rl *agentgateway.RateLimits, basePolicyName string, policy types.NamespacedName) ([]*api.Policy, error) {
 	var agwPolicies []*api.Policy
 	var errs []error
 
 	// Process local rate limiting if present
 	if rl.Local != nil {
-		localPolicy := processLocalRateLimitPolicy(rl.Local, basePolicyName, policy, policyTarget)
+		localPolicy := processLocalRateLimitPolicy(rl.Local, basePolicyName, policy)
 		if localPolicy != nil {
 			agwPolicies = append(agwPolicies, localPolicy)
 		}
@@ -1171,11 +1173,12 @@ func processRateLimitPolicy(ctx PolicyCtx, rl *agentgateway.RateLimits, basePoli
 
 	// Process global rate limiting if present
 	if rl.Global != nil {
-		globalPolicy, err := processGlobalRateLimitPolicy(ctx, *rl.Global, basePolicyName, policy, policyTarget)
-		if globalPolicy != nil && err == nil {
-			agwPolicies = append(agwPolicies, globalPolicy)
-		} else {
+		globalPolicy, err := processGlobalRateLimitPolicy(ctx, *rl.Global, basePolicyName, policy)
+		if err != nil {
 			errs = append(errs, err)
+		}
+		if globalPolicy != nil {
+			agwPolicies = append(agwPolicies, globalPolicy)
 		}
 	}
 
@@ -1183,7 +1186,7 @@ func processRateLimitPolicy(ctx PolicyCtx, rl *agentgateway.RateLimits, basePoli
 }
 
 // processLocalRateLimitPolicy processes local rate limiting configuration
-func processLocalRateLimitPolicy(limits []agentgateway.LocalRateLimit, basePolicyName string, policy types.NamespacedName, policyTarget *api.PolicyTarget) *api.Policy {
+func processLocalRateLimitPolicy(limits []agentgateway.LocalRateLimit, basePolicyName string, policy types.NamespacedName) *api.Policy {
 	// TODO: support multiple
 	limit := limits[0]
 
@@ -1210,9 +1213,8 @@ func processLocalRateLimitPolicy(limits []agentgateway.LocalRateLimit, basePolic
 	}
 
 	localRateLimitPolicy := &api.Policy{
-		Key:    basePolicyName + localRateLimitPolicySuffix + attachmentName(policyTarget),
-		Name:   TypedResourceFromName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
-		Target: policyTarget,
+		Key:  basePolicyName + localRateLimitPolicySuffix,
+		Name: TypedResourceFromName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
 		Kind: &api.Policy_Traffic{
 			Traffic: &api.TrafficPolicySpec{
 				Kind: &api.TrafficPolicySpec_LocalRateLimit_{
@@ -1230,26 +1232,28 @@ func processGlobalRateLimitPolicy(
 	grl agentgateway.GlobalRateLimit,
 	basePolicyName string,
 	policy types.NamespacedName,
-	policyTarget *api.PolicyTarget,
 ) (*api.Policy, error) {
-	var backendErr error
+	var errs []error
 	be, err := buildBackendRef(ctx, grl.BackendRef, policy.Namespace)
 	if err != nil {
-		backendErr = fmt.Errorf("failed to build global rate limit: %v", err)
+		errs = append(errs, fmt.Errorf("failed to build global rate limit: %v", err))
 	}
 	// Translate descriptors
 	descriptors := make([]*api.TrafficPolicySpec_RemoteRateLimit_Descriptor, 0, len(grl.Descriptors))
 	for _, d := range grl.Descriptors {
-		if agw := processRateLimitDescriptor(d); agw != nil {
+		agw, err := processRateLimitDescriptor(d)
+		if err != nil {
+			errs = append(errs, err)
+		}
+		if agw != nil {
 			descriptors = append(descriptors, agw)
 		}
 	}
 
 	// Build the RemoteRateLimit policy that agentgateway expects
 	p := &api.Policy{
-		Key:    basePolicyName + globalRateLimitPolicySuffix + attachmentName(policyTarget),
-		Name:   TypedResourceFromName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
-		Target: policyTarget,
+		Key:  basePolicyName + globalRateLimitPolicySuffix,
+		Name: TypedResourceFromName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
 		Kind: &api.Policy_Traffic{
 			Traffic: &api.TrafficPolicySpec{
 				Kind: &api.TrafficPolicySpec_RemoteRateLimit_{
@@ -1263,13 +1267,17 @@ func processGlobalRateLimitPolicy(
 		},
 	}
 
-	return p, backendErr
+	return p, errors.Join(errs...)
 }
 
-func processRateLimitDescriptor(descriptor agentgateway.RateLimitDescriptor) *api.TrafficPolicySpec_RemoteRateLimit_Descriptor {
+func processRateLimitDescriptor(descriptor agentgateway.RateLimitDescriptor) (*api.TrafficPolicySpec_RemoteRateLimit_Descriptor, error) {
 	entries := make([]*api.TrafficPolicySpec_RemoteRateLimit_Entry, 0, len(descriptor.Entries))
+	var errs []error
 
 	for _, entry := range descriptor.Entries {
+		if !isCEL(entry.Expression) {
+			errs = append(errs, fmt.Errorf("rate limit descriptor entry %q is not a valid CEL expression: %s", entry.Name, entry.Expression))
+		}
 		entries = append(entries, &api.TrafficPolicySpec_RemoteRateLimit_Entry{
 			Key:   entry.Name,
 			Value: string(entry.Expression),
@@ -1284,7 +1292,7 @@ func processRateLimitDescriptor(descriptor agentgateway.RateLimitDescriptor) *ap
 	return &api.TrafficPolicySpec_RemoteRateLimit_Descriptor{
 		Entries: entries,
 		Type:    rlType,
-	}
+	}, errors.Join(errs...)
 }
 
 func buildBackendRef(ctx PolicyCtx, ref gwv1.BackendObjectReference, defaultNS string) (*api.BackendReference, error) {
@@ -1296,6 +1304,28 @@ func buildBackendRef(ctx PolicyCtx, ref gwv1.BackendObjectReference, defaultNS s
 	}
 	namespace := string(ptr.OrDefault(ref.Namespace, gwv1.Namespace(defaultNS)))
 	switch gk {
+	case wellknown.InferencePoolGVK.GroupKind():
+		if strings.Contains(string(ref.Name), ".") {
+			return nil, errors.New("service name invalid; the name of the InferencePool, not the hostname")
+		}
+		hostname := kubeutils.GetInferenceServiceHostname(string(ref.Name), namespace)
+		key := namespace + "/" + string(ref.Name)
+		svc := ptr.Flatten(krt.FetchOne(ctx.Krt, ctx.Collections.InferencePools, krt.FilterKey(key)))
+		logger.Debug("found pull pool for service", "svc", svc, "key", key)
+		if svc == nil {
+			return nil, fmt.Errorf("unable to find the InferencePool %v", key)
+		} else {
+			return &api.BackendReference{
+				Kind: &api.BackendReference_Service_{
+					Service: &api.BackendReference_Service{
+						Hostname:  hostname,
+						Namespace: namespace,
+					},
+				},
+				// InferencePool only supports single port
+				Port: uint32(svc.Spec.TargetPorts[0].Number), //nolint:gosec // G115: InferencePool TargetPort is int32 with validation 1-65535, always safe
+			}, nil
+		}
 	case wellknown.ServiceGVK.GroupKind():
 		port := ref.Port
 		if strings.Contains(string(ref.Name), ".") {
@@ -1356,11 +1386,10 @@ func toJSONValue(j apiextensionsv1.JSON) (string, error) {
 	return string(marshaled), nil
 }
 
-func processCSRFPolicy(csrf *agentgateway.CSRF, basePolicyName string, policy types.NamespacedName, policyTarget *api.PolicyTarget) *api.Policy {
+func processCSRFPolicy(csrf *agentgateway.CSRF, basePolicyName string, policy types.NamespacedName) *api.Policy {
 	csrfPolicy := &api.Policy{
-		Key:    basePolicyName + csrfPolicySuffix + attachmentName(policyTarget),
-		Name:   TypedResourceFromName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
-		Target: policyTarget,
+		Key:  basePolicyName + csrfPolicySuffix,
+		Name: TypedResourceFromName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
 		Kind: &api.Policy_Traffic{
 			Traffic: &api.TrafficPolicySpec{
 				Kind: &api.TrafficPolicySpec_Csrf{
@@ -1381,7 +1410,6 @@ func processTransformationPolicy(
 	policyPhase *agentgateway.PolicyPhase,
 	basePolicyName string,
 	policy types.NamespacedName,
-	policyTarget *api.PolicyTarget,
 ) (*api.Policy, error) {
 	var errs []error
 	convertedReq, err := convertTransformSpec(transformation.Request)
@@ -1395,9 +1423,8 @@ func processTransformationPolicy(
 
 	if convertedResp != nil || convertedReq != nil {
 		transformationPolicy := &api.Policy{
-			Key:    basePolicyName + transformationPolicySuffix + attachmentName(policyTarget),
-			Name:   TypedResourceFromName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
-			Target: policyTarget,
+			Key:  basePolicyName + transformationPolicySuffix,
+			Name: TypedResourceFromName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
 			Kind: &api.Policy_Traffic{
 				Traffic: &api.TrafficPolicySpec{
 					Phase: phase(policyPhase),
@@ -1413,8 +1440,7 @@ func processTransformationPolicy(
 
 		logger.Debug("generated transformation policy",
 			"policy", basePolicyName,
-			"agentgateway_policy", transformationPolicy.Name,
-			"target", policyTarget)
+			"agentgateway_policy", transformationPolicy.Name)
 		return transformationPolicy, errors.Join(errs...)
 	}
 	return nil, errors.Join(errs...)

--- a/controller/pkg/agentgateway/plugins/traffic_plugin.go
+++ b/controller/pkg/agentgateway/plugins/traffic_plugin.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
-	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"github.com/agentgateway/agentgateway/api"
 	"github.com/agentgateway/agentgateway/controller/api/v1alpha1/agentgateway"
@@ -191,13 +190,13 @@ func TranslateAgentgatewayPolicy(ctx krt.HandlerContext, policy *agentgateway.Ag
 			// A policy should report at most one status per Gateway parent, even if multiple
 			// targetRefs resolve to the same Gateway.
 			if slices.IndexFunc(ancestors, func(existing gwv1.PolicyAncestorStatus) bool {
-				return existing.ControllerName == v1alpha2.GatewayController(agw.ControllerName) && parentRefEqual(existing.AncestorRef, ar)
+				return existing.ControllerName == gwv1.GatewayController(agw.ControllerName) && parentRefEqual(existing.AncestorRef, ar)
 			}) != -1 {
 				continue
 			}
 			ancestors = append(ancestors, gwv1.PolicyAncestorStatus{
 				AncestorRef:    ar,
-				ControllerName: v1alpha2.GatewayController(agw.ControllerName),
+				ControllerName: gwv1.GatewayController(agw.ControllerName),
 				Conditions:     baseConds,
 			})
 		}
@@ -460,7 +459,7 @@ func translateTrafficPolicyToAgw(
 
 	// Convert Authorization policy if present
 	if traffic.Authorization != nil {
-		appendPolicy("authorization")(processAuthorizationPolicy(traffic.Authorization, basePolicyName, policyName))
+		appendPolicy("authorization")(processAuthorizationPolicy(traffic.Authorization, basePolicyName, policyName), nil)
 	}
 
 	// Process RateLimit policies if present
@@ -926,35 +925,20 @@ func processExtAuthPolicy(
 		FailureMode: api.TrafficPolicySpec_ExternalAuth_DENY,
 	}
 	if g := extAuth.GRPC; g != nil {
-		metadata := castCELMap(g.RequestMetadata, func(key string, expr shared.CELExpression) {
-			errs = append(errs, fmt.Errorf("extAuth grpc requestMetadata %q is not a valid CEL expression: %s", key, expr))
-		})
 		p := &api.TrafficPolicySpec_ExternalAuth_GRPCProtocol{
 			Context:  g.ContextExtensions,
-			Metadata: metadata,
+			Metadata: castMap(g.RequestMetadata),
 		}
 		spec.Protocol = &api.TrafficPolicySpec_ExternalAuth_Grpc{
 			Grpc: p,
 		}
 	} else if h := extAuth.HTTP; h != nil {
-		path := castCELPtr(h.Path, func(expr shared.CELExpression) {
-			errs = append(errs, fmt.Errorf("extAuth http path is not a valid CEL expression: %s", expr))
-		})
-		redirect := castCELPtr(h.Redirect, func(expr shared.CELExpression) {
-			errs = append(errs, fmt.Errorf("extAuth http redirect is not a valid CEL expression: %s", expr))
-		})
-		addRequestHeaders := castCELMap(h.AddRequestHeaders, func(key string, expr shared.CELExpression) {
-			errs = append(errs, fmt.Errorf("extAuth http addRequestHeaders %q is not a valid CEL expression: %s", key, expr))
-		})
-		metadata := castCELMap(h.ResponseMetadata, func(key string, expr shared.CELExpression) {
-			errs = append(errs, fmt.Errorf("extAuth http responseMetadata %q is not a valid CEL expression: %s", key, expr))
-		})
 		p := &api.TrafficPolicySpec_ExternalAuth_HTTPProtocol{
-			Path:                   path,
-			Redirect:               redirect,
+			Path:                   castPtr(h.Path),
+			Redirect:               castPtr(h.Redirect),
 			IncludeResponseHeaders: h.AllowedResponseHeaders,
-			AddRequestHeaders:      addRequestHeaders,
-			Metadata:               metadata,
+			AddRequestHeaders:      castMap(h.AddRequestHeaders),
+			Metadata:               castMap(h.ResponseMetadata),
 		}
 		spec.IncludeRequestHeaders = h.AllowedRequestHeaders
 		spec.Protocol = &api.TrafficPolicySpec_ExternalAuth_Http{
@@ -1051,20 +1035,6 @@ func cast[T ~string](items []T) []string {
 	})
 }
 
-func castCELSlice(items []shared.CELExpression, invalid func(shared.CELExpression)) []string {
-	if items == nil {
-		return nil
-	}
-	res := make([]string, 0, len(items))
-	for _, item := range items {
-		res = append(res, string(item))
-		if !isCEL(item) {
-			invalid(item)
-		}
-	}
-	return res
-}
-
 func castMap[T ~string](items map[string]T) map[string]string {
 	if items == nil {
 		return nil
@@ -1076,20 +1046,6 @@ func castMap[T ~string](items map[string]T) map[string]string {
 	return res
 }
 
-func castCELMap(items map[string]shared.CELExpression, invalid func(string, shared.CELExpression)) map[string]string {
-	if items == nil {
-		return nil
-	}
-	res := make(map[string]string, len(items))
-	for k, v := range items {
-		res[k] = string(v)
-		if !isCEL(v) {
-			invalid(k, v)
-		}
-	}
-	return res
-}
-
 func castPtr[T ~string](item *T) *string {
 	if item == nil {
 		return nil
@@ -1097,32 +1053,17 @@ func castPtr[T ~string](item *T) *string {
 	return ptr.Of(string(*item))
 }
 
-func castCELPtr(item *shared.CELExpression, invalid func(shared.CELExpression)) *string {
-	if item == nil {
-		return nil
-	}
-	res := ptr.Of(string(*item))
-	if !isCEL(*item) {
-		invalid(*item)
-	}
-	return res
-}
-
 // processAuthorizationPolicy processes Authorization configuration and creates corresponding Agw policies
 func processAuthorizationPolicy(
 	auth *shared.Authorization,
 	basePolicyName string,
 	policy types.NamespacedName,
-) (*api.Policy, error) {
-	var errs []error
+) *api.Policy {
 	var allowPolicies, denyPolicies []string
-	policies := castCELSlice(auth.Policy.MatchExpressions, func(expr shared.CELExpression) {
-		errs = append(errs, fmt.Errorf("authorization matchExpression is not a valid CEL expression: %s", expr))
-	})
 	if auth.Action == shared.AuthorizationPolicyActionDeny {
-		denyPolicies = append(denyPolicies, policies...)
+		denyPolicies = append(denyPolicies, cast(auth.Policy.MatchExpressions)...)
 	} else {
-		allowPolicies = append(allowPolicies, policies...)
+		allowPolicies = append(allowPolicies, cast(auth.Policy.MatchExpressions)...)
 	}
 
 	pol := &api.Policy{
@@ -1144,7 +1085,7 @@ func processAuthorizationPolicy(
 		"policy", basePolicyName,
 		"agentgateway_policy", pol.Name)
 
-	return pol, errors.Join(errs...)
+	return pol
 }
 
 func getFrontendPolicyName(trafficPolicyNs, trafficPolicyName string) string {
@@ -1234,19 +1175,15 @@ func processGlobalRateLimitPolicy(
 	basePolicyName string,
 	policy types.NamespacedName,
 ) (*api.Policy, error) {
-	var errs []error
+	var backendErr error
 	be, err := buildBackendRef(ctx, grl.BackendRef, policy.Namespace)
 	if err != nil {
-		errs = append(errs, fmt.Errorf("failed to build global rate limit: %v", err))
+		backendErr = fmt.Errorf("failed to build global rate limit: %v", err)
 	}
 	// Translate descriptors
 	descriptors := make([]*api.TrafficPolicySpec_RemoteRateLimit_Descriptor, 0, len(grl.Descriptors))
 	for _, d := range grl.Descriptors {
-		agw, err := processRateLimitDescriptor(d)
-		if err != nil {
-			errs = append(errs, err)
-		}
-		if agw != nil {
+		if agw := processRateLimitDescriptor(d); agw != nil {
 			descriptors = append(descriptors, agw)
 		}
 	}
@@ -1268,17 +1205,13 @@ func processGlobalRateLimitPolicy(
 		},
 	}
 
-	return p, errors.Join(errs...)
+	return p, backendErr
 }
 
-func processRateLimitDescriptor(descriptor agentgateway.RateLimitDescriptor) (*api.TrafficPolicySpec_RemoteRateLimit_Descriptor, error) {
+func processRateLimitDescriptor(descriptor agentgateway.RateLimitDescriptor) *api.TrafficPolicySpec_RemoteRateLimit_Descriptor {
 	entries := make([]*api.TrafficPolicySpec_RemoteRateLimit_Entry, 0, len(descriptor.Entries))
-	var errs []error
 
 	for _, entry := range descriptor.Entries {
-		if !isCEL(entry.Expression) {
-			errs = append(errs, fmt.Errorf("rate limit descriptor entry %q is not a valid CEL expression: %s", entry.Name, entry.Expression))
-		}
 		entries = append(entries, &api.TrafficPolicySpec_RemoteRateLimit_Entry{
 			Key:   entry.Name,
 			Value: string(entry.Expression),
@@ -1293,7 +1226,7 @@ func processRateLimitDescriptor(descriptor agentgateway.RateLimitDescriptor) (*a
 	return &api.TrafficPolicySpec_RemoteRateLimit_Descriptor{
 		Entries: entries,
 		Type:    rlType,
-	}, errors.Join(errs...)
+	}
 }
 
 func buildBackendRef(ctx PolicyCtx, ref gwv1.BackendObjectReference, defaultNS string) (*api.BackendReference, error) {
@@ -1305,28 +1238,6 @@ func buildBackendRef(ctx PolicyCtx, ref gwv1.BackendObjectReference, defaultNS s
 	}
 	namespace := string(ptr.OrDefault(ref.Namespace, gwv1.Namespace(defaultNS)))
 	switch gk {
-	case wellknown.InferencePoolGVK.GroupKind():
-		if strings.Contains(string(ref.Name), ".") {
-			return nil, errors.New("service name invalid; the name of the InferencePool, not the hostname")
-		}
-		hostname := kubeutils.GetInferenceServiceHostname(string(ref.Name), namespace)
-		key := namespace + "/" + string(ref.Name)
-		svc := ptr.Flatten(krt.FetchOne(ctx.Krt, ctx.Collections.InferencePools, krt.FilterKey(key)))
-		logger.Debug("found pull pool for service", "svc", svc, "key", key)
-		if svc == nil {
-			return nil, fmt.Errorf("unable to find the InferencePool %v", key)
-		} else {
-			return &api.BackendReference{
-				Kind: &api.BackendReference_Service_{
-					Service: &api.BackendReference_Service{
-						Hostname:  hostname,
-						Namespace: namespace,
-					},
-				},
-				// InferencePool only supports single port
-				Port: uint32(svc.Spec.TargetPorts[0].Number), //nolint:gosec // G115: InferencePool TargetPort is int32 with validation 1-65535, always safe
-			}, nil
-		}
 	case wellknown.ServiceGVK.GroupKind():
 		port := ref.Port
 		if strings.Contains(string(ref.Name), ".") {

--- a/controller/pkg/agentgateway/plugins/traffic_plugin.go
+++ b/controller/pkg/agentgateway/plugins/traffic_plugin.go
@@ -127,10 +127,12 @@ func TranslateAgentgatewayPolicy(ctx krt.HandlerContext, policy *agentgateway.Ag
 	var agwPolicies []AgwPolicy
 
 	pctx := PolicyCtx{Krt: ctx, Collections: agw}
-	var policyTargets []ResolvedTarget
+	var ancestors []gwv1.PolicyAncestorStatus
+	var attachmentErrors []string
 	// TODO: add selectors
+	baseTranslatedPolicies, baseErr := translatePolicyToAgw(pctx, policy)
+	baseConds := setPolicyConditions(baseErr, len(baseTranslatedPolicies) > 0)
 	for _, target := range policy.Spec.TargetRefs {
-		var policyTarget *api.PolicyTarget
 		gk := schema.GroupKind{Group: string(target.Group), Kind: string(target.Kind)}
 
 		gatewayTargets := references.LookupGatewaysForTarget(ctx, utils.TypedNamespacedName{
@@ -138,6 +140,7 @@ func TranslateAgentgatewayPolicy(ctx krt.HandlerContext, policy *agentgateway.Ag
 			Kind:           gk.Kind,
 		}).UnsortedList()
 
+		var policyTarget *api.PolicyTarget
 		switch gk {
 		case wellknown.GatewayGVK.GroupKind():
 			policyTarget = &api.PolicyTarget{
@@ -169,123 +172,47 @@ func TranslateAgentgatewayPolicy(ctx krt.HandlerContext, policy *agentgateway.Ag
 			continue
 		}
 
-		ancestorRefs, attachmentErr := resolvePolicyAncestorRefs(ctx, policy.Namespace, gk, target.Name, agw, references)
-
-		policyTargets = append(policyTargets, ResolvedTarget{
-			AgentgatewayTarget: policyTarget,
-			GatewayTargets:     gatewayTargets,
-			AncestorRefs:       ancestorRefs,
-			AttachmentError:    attachmentErr,
-		})
-	}
-
-	baseTranslatedPolicies, baseErr := translatePolicyToAgw(pctx, policy)
-
-	var ancestors []gwv1.PolicyAncestorStatus
-	for _, policyTarget := range policyTargets {
-		translatedPolicies := clonePoliciesForTarget(baseTranslatedPolicies, policyTarget.AgentgatewayTarget)
+		translatedPolicies := clonePoliciesForTarget(baseTranslatedPolicies, policyTarget)
 		for _, translatedPolicy := range translatedPolicies {
-			for _, gatewayTarget := range policyTarget.GatewayTargets {
+			for _, gatewayTarget := range gatewayTargets {
 				agwPolicies = append(agwPolicies, AgwPolicy{
 					Gateway: ptr.Of(gatewayTarget),
 					Policy:  translatedPolicy,
 				})
 			}
 		}
-		var conds []metav1.Condition
-		if baseErr != nil {
-			// If we produced some policies alongside errors, treat as partial validity
-			if len(translatedPolicies) > 0 {
-				meta.SetStatusCondition(&conds, metav1.Condition{
-					Type:    string(shared.PolicyConditionAccepted),
-					Status:  metav1.ConditionTrue,
-					Reason:  string(shared.PolicyReasonPartiallyValid),
-					Message: baseErr.Error(),
-				})
-			} else {
-				// No policies produced and error present -> invalid
-				meta.SetStatusCondition(&conds, metav1.Condition{
-					Type:    string(shared.PolicyConditionAccepted),
-					Status:  metav1.ConditionTrue,
-					Reason:  string(shared.PolicyReasonInvalid),
-					Message: baseErr.Error(),
-				})
-				meta.SetStatusCondition(&conds, metav1.Condition{
-					Type:    string(shared.PolicyConditionAttached),
-					Status:  metav1.ConditionFalse,
-					Reason:  string(shared.PolicyReasonPending),
-					Message: "Policy is not attached due to invalid status",
-				})
-			}
-		} else {
-			// Check for partial validity
-			// Build success conditions per ancestor
-			meta.SetStatusCondition(&conds, metav1.Condition{
-				Type:    string(shared.PolicyConditionAccepted),
-				Status:  metav1.ConditionTrue,
-				Reason:  string(shared.PolicyReasonValid),
-				Message: reporter.PolicyAcceptedMsg,
-			})
-			meta.SetStatusCondition(&conds, metav1.Condition{
-				Type:    string(shared.PolicyConditionAttached),
-				Status:  metav1.ConditionTrue,
-				Reason:  string(shared.PolicyReasonAttached),
-				Message: reporter.PolicyAttachedMsg,
-			})
+
+		ancestorRefs, attachmentErr := resolvePolicyAncestorRefs(ctx, policy.Namespace, gk, target.Name, agw, references)
+		if attachmentErr != "" {
+			attachmentErrors = append(attachmentErrors, attachmentErr)
 		}
 
-		// If we cannot resolve this policy target to a Gateway (e.g., missing HTTPRoute),
-		// report the policy as not attached instead of falling back to a higher-cardinality ancestor.
-		if policyTarget.AttachmentError != "" {
-			meta.SetStatusCondition(&conds, metav1.Condition{
-				Type:    string(shared.PolicyConditionAccepted),
-				Status:  metav1.ConditionTrue,
-				Reason:  string(shared.PolicyReasonValid),
-				Message: reporter.PolicyAcceptedMsg,
-			})
-			meta.SetStatusCondition(&conds, metav1.Condition{
-				Type:    string(shared.PolicyConditionAttached),
-				Status:  metav1.ConditionFalse,
-				Reason:  string(shared.PolicyReasonPending),
-				Message: policyTarget.AttachmentError,
-			})
-		}
-		// TODO: validate the target exists with dataplane https://github.com/kgateway-dev/kgateway/issues/12275
-		// Ensure LastTransitionTime is set for all conditions
-		for i := range conds {
-			if conds[i].LastTransitionTime.IsZero() {
-				conds[i].LastTransitionTime = metav1.Now()
-			}
-		}
-
-		// Policy status SHOULD be reported per Gateway
-		// If we couldn't resolve a Gateway ancestor, report status against a summary ref.
-		appendAncestor := func(ar gwv1.ParentReference) {
+		for _, ar := range ancestorRefs {
 			// A policy should report at most one status per Gateway parent, even if multiple
 			// targetRefs resolve to the same Gateway.
 			if slices.IndexFunc(ancestors, func(existing gwv1.PolicyAncestorStatus) bool {
 				return existing.ControllerName == v1alpha2.GatewayController(agw.ControllerName) && parentRefEqual(existing.AncestorRef, ar)
 			}) != -1 {
-				return
+				continue
 			}
 			ancestors = append(ancestors, gwv1.PolicyAncestorStatus{
 				AncestorRef:    ar,
 				ControllerName: v1alpha2.GatewayController(agw.ControllerName),
-				Conditions:     conds,
+				Conditions:     baseConds,
 			})
 		}
-		if len(policyTarget.AncestorRefs) > 0 {
-			for _, ar := range policyTarget.AncestorRefs {
-				appendAncestor(ar)
-			}
-		} else if policyTarget.AttachmentError != "" {
-			// no ancestor refs resolved due to attachment error, report status against a summary ref
-			logger.Warn("failed to resolve ancestor refs", "error", policyTarget.AttachmentError)
-			appendAncestor(gwv1.ParentReference{
+	}
+
+	if len(attachmentErrors) > 0 {
+		logger.Warn("failed to resolve one or more ancestor refs", "errors", attachmentErrors)
+		ancestors = append(ancestors, gwv1.PolicyAncestorStatus{
+			AncestorRef: gwv1.ParentReference{
 				Group: ptr.Of(gwv1.Group(wellknown.AgentgatewayPolicyGVK.Group)),
 				Name:  "StatusSummary",
-			})
-		}
+			},
+			ControllerName: gwv1.GatewayController(agw.ControllerName),
+			Conditions:     setAttachmentErrorConditions(baseConds, attachmentErrors),
+		})
 	}
 
 	// Build final status from accumulated ancestors
@@ -319,6 +246,69 @@ func TranslateAgentgatewayPolicy(ctx krt.HandlerContext, policy *agentgateway.Ag
 	})
 
 	return &status, agwPolicies
+}
+
+func setPolicyConditions(err error, hasTranslatedPolicies bool) []metav1.Condition {
+	var conds []metav1.Condition
+	if err != nil {
+		// If we produced some policies alongside errors, treat as partial validity
+		if hasTranslatedPolicies {
+			meta.SetStatusCondition(&conds, metav1.Condition{
+				Type:    string(shared.PolicyConditionAccepted),
+				Status:  metav1.ConditionTrue,
+				Reason:  string(shared.PolicyReasonPartiallyValid),
+				Message: err.Error(),
+			})
+		} else {
+			// No policies produced and error present -> invalid
+			meta.SetStatusCondition(&conds, metav1.Condition{
+				Type:    string(shared.PolicyConditionAccepted),
+				Status:  metav1.ConditionTrue,
+				Reason:  string(shared.PolicyReasonInvalid),
+				Message: err.Error(),
+			})
+			meta.SetStatusCondition(&conds, metav1.Condition{
+				Type:    string(shared.PolicyConditionAttached),
+				Status:  metav1.ConditionFalse,
+				Reason:  string(shared.PolicyReasonPending),
+				Message: "Policy is not attached due to invalid status",
+			})
+		}
+	} else {
+		// Check for partial validity
+		// Build success conditions per ancestor
+		meta.SetStatusCondition(&conds, metav1.Condition{
+			Type:    string(shared.PolicyConditionAccepted),
+			Status:  metav1.ConditionTrue,
+			Reason:  string(shared.PolicyReasonValid),
+			Message: reporter.PolicyAcceptedMsg,
+		})
+		meta.SetStatusCondition(&conds, metav1.Condition{
+			Type:    string(shared.PolicyConditionAttached),
+			Status:  metav1.ConditionTrue,
+			Reason:  string(shared.PolicyReasonAttached),
+			Message: reporter.PolicyAttachedMsg,
+		})
+	}
+	// TODO: validate the target exists with dataplane https://github.com/kgateway-dev/kgateway/issues/12275
+	// Ensure LastTransitionTime is set for all conditions
+	for i := range conds {
+		if conds[i].LastTransitionTime.IsZero() {
+			conds[i].LastTransitionTime = metav1.Now()
+		}
+	}
+	return conds
+}
+
+func setAttachmentErrorConditions(baseConds []metav1.Condition, attachmentErrors []string) []metav1.Condition {
+	conds := append([]metav1.Condition(nil), baseConds...)
+	meta.SetStatusCondition(&conds, metav1.Condition{
+		Type:    string(shared.PolicyConditionAttached),
+		Status:  metav1.ConditionFalse,
+		Reason:  string(shared.PolicyReasonPending),
+		Message: strings.Join(attachmentErrors, "\n"),
+	})
+	return conds
 }
 
 func resolvePolicyAncestorRefs(

--- a/controller/pkg/agentgateway/plugins/traffic_plugin.go
+++ b/controller/pkg/agentgateway/plugins/traffic_plugin.go
@@ -179,9 +179,11 @@ func TranslateAgentgatewayPolicy(ctx krt.HandlerContext, policy *agentgateway.Ag
 		})
 	}
 
+	baseTranslatedPolicies, baseErr := translatePolicyToAgw(pctx, policy)
+
 	var ancestors []gwv1.PolicyAncestorStatus
 	for _, policyTarget := range policyTargets {
-		translatedPolicies, err := translatePolicyToAgw(pctx, policy, policyTarget.AgentgatewayTarget)
+		translatedPolicies := clonePoliciesForTarget(baseTranslatedPolicies, policyTarget.AgentgatewayTarget)
 		for _, translatedPolicy := range translatedPolicies {
 			for _, gatewayTarget := range policyTarget.GatewayTargets {
 				agwPolicies = append(agwPolicies, AgwPolicy{
@@ -191,14 +193,14 @@ func TranslateAgentgatewayPolicy(ctx krt.HandlerContext, policy *agentgateway.Ag
 			}
 		}
 		var conds []metav1.Condition
-		if err != nil {
+		if baseErr != nil {
 			// If we produced some policies alongside errors, treat as partial validity
 			if len(translatedPolicies) > 0 {
 				meta.SetStatusCondition(&conds, metav1.Condition{
 					Type:    string(shared.PolicyConditionAccepted),
 					Status:  metav1.ConditionTrue,
 					Reason:  string(shared.PolicyReasonPartiallyValid),
-					Message: err.Error(),
+					Message: baseErr.Error(),
 				})
 			} else {
 				// No policies produced and error present -> invalid
@@ -206,7 +208,7 @@ func TranslateAgentgatewayPolicy(ctx krt.HandlerContext, policy *agentgateway.Ag
 					Type:    string(shared.PolicyConditionAccepted),
 					Status:  metav1.ConditionTrue,
 					Reason:  string(shared.PolicyReasonInvalid),
-					Message: err.Error(),
+					Message: baseErr.Error(),
 				})
 				meta.SetStatusCondition(&conds, metav1.Condition{
 					Type:    string(shared.PolicyConditionAttached),
@@ -377,7 +379,6 @@ func policyTargetExists(ctx krt.HandlerContext, agw *AgwCollections, target util
 func translatePolicyToAgw(
 	ctx PolicyCtx,
 	policy *agentgateway.AgentgatewayPolicy,
-	policyTarget *api.PolicyTarget,
 ) ([]*api.Policy, error) {
 	agwPolicies := make([]*api.Policy, 0)
 	var errs []error
@@ -399,12 +400,22 @@ func translatePolicyToAgw(
 	if err != nil {
 		errs = append(errs, err)
 	}
-	for _, p := range agwPolicies {
-		p.Key += attachmentName(policyTarget)
-		p.Target = policyTarget
-	}
 
 	return agwPolicies, errors.Join(errs...)
+}
+
+func clonePoliciesForTarget(base []*api.Policy, policyTarget *api.PolicyTarget) []*api.Policy {
+	if len(base) == 0 {
+		return nil
+	}
+	out := make([]*api.Policy, 0, len(base))
+	for _, p := range base {
+		clone := protomarshal.ShallowClone(p)
+		clone.Key += attachmentName(policyTarget)
+		clone.Target = policyTarget
+		out = append(out, clone)
+	}
+	return out
 }
 
 func translateTrafficPolicyToAgw(


### PR DESCRIPTION
Before we had some type-specific status handling. Now, we consistently report up the Gateway that the target is attached to as part of the status with deduping.

The dedupe is concerning since translatePolicyToAgw is called per-target, which means in theory they could return different errors. and, its computed redundantly. This is refactored to just call translate once and then build a per-target condition.