### PR TITLE
helm: add valueFrom support to extraEnv

### DIFF
--- a/controller/install/helm/agentgateway/templates/deployment.yaml
+++ b/controller/install/helm/agentgateway/templates/deployment.yaml
@@ -104,9 +104,30 @@ spec:
             - name: AGW_DISCOVERY_NAMESPACE_SELECTORS
               value: {{ .Values.discoveryNamespaceSelectors | toJson | quote }}
             {{- if .Values.controller.extraEnv }}
-            {{- range $key, $value := .Values.controller.extraEnv }}
+            {{- $extraEnv := .Values.controller.extraEnv }}
+            {{- range $key := keys $extraEnv | sortAlpha }}
+            {{- $value := index $extraEnv $key }}
             - name: {{ $key }}
+              {{- if kindIs "map" $value }}
+              {{- $hasValue := hasKey $value "value" }}
+              {{- $hasValueFrom := hasKey $value "valueFrom" }}
+              {{- if and $hasValue $hasValueFrom }}
+              {{- fail (printf "controller.extraEnv.%s cannot set both value and valueFrom" $key) }}
+              {{- else if $hasValue }}
+              value: {{ get $value "value" | quote }}
+              {{- else if $hasValueFrom }}
+              {{- $valueFrom := get $value "valueFrom" }}
+              {{- if not $valueFrom }}
+              {{- fail (printf "controller.extraEnv.%s.valueFrom must be non-empty" $key) }}
+              {{- end }}
+              valueFrom:
+{{- toYaml $valueFrom | nindent 16 }}
+              {{- else }}
+              {{- fail (printf "controller.extraEnv.%s must set either value or valueFrom" $key) }}
+              {{- end }}
+              {{- else }}
               value: {{ $value | quote }}
+              {{- end }}
             {{- end }}
             {{- end }}
             {{- if .Values.inferenceExtension.enabled }}

--- a/controller/install/helm/agentgateway/values.yaml
+++ b/controller/install/helm/agentgateway/values.yaml
@@ -112,6 +112,16 @@ controller:
     # -- Traffic distribution.
     trafficDistribution: ""
   # -- Add extra environment variables to the controller container.
+  # Supports either a direct scalar value:
+  # extraEnv:
+  #   LOG_FORMAT: json
+  # Or Kubernetes valueFrom sources:
+  # extraEnv:
+  #   API_TOKEN:
+  #     valueFrom:
+  #       secretKeyRef:
+  #         name: agentgateway-secrets
+  #         key: apiToken
   extraEnv: {}
   # -- Configure TLS settings for the xDS gRPC servers.
   xds:

--- a/controller/test/helm/helm_version_test.go
+++ b/controller/test/helm/helm_version_test.go
@@ -134,12 +134,14 @@ func extractImageLines(output string) string {
 
 // TestHelmChartTemplate tests helm template output for both kgateway and agentgateway charts
 // with different values configurations.
+// NOTE: The test cases contain YAML blocks that are indented with 2 spaces, do not use tabs.
 func TestHelmChartTemplate(t *testing.T) {
 	charts := []string{"agentgateway"}
 
 	valuesCases := []struct {
-		name       string
-		valuesYAML string
+		name          string
+		valuesYAML    string
+		expectedError string
 	}{
 		{
 			name:       "default",
@@ -241,6 +243,45 @@ func TestHelmChartTemplate(t *testing.T) {
     another-label: "true"
 `,
 		},
+		{
+			name: "extra-env",
+			valuesYAML: `controller:
+  extraEnv:
+    LOG_FORMAT: json
+    ENABLE_AUDIT: "true"
+    API_TOKEN:
+      valueFrom:
+        secretKeyRef:
+          name: agentgateway-secrets
+          key: apiToken
+    API_KEY:
+      valueFrom:
+        secretKeyRef:
+          name: agentgateway-secrets
+          key: apiKey
+`,
+		},
+		{
+			name: "extra-env-invalid-value-and-valuefrom",
+			valuesYAML: `controller:
+  extraEnv:
+    BAD_ENV:
+      value: "x"
+      valueFrom:
+        secretKeyRef:
+          name: bad-secret
+          key: token
+`,
+			expectedError: "controller.extraEnv.BAD_ENV cannot set both value and valueFrom",
+		},
+		{
+			name: "extra-env-invalid-neither-value-nor-valuefrom",
+			valuesYAML: `controller:
+  extraEnv:
+    BAD_ENV: {}
+`,
+			expectedError: "controller.extraEnv.BAD_ENV must set either value or valueFrom",
+		},
 	}
 
 	for _, chart := range charts {
@@ -279,6 +320,12 @@ func TestHelmChartTemplate(t *testing.T) {
 				helmCmd.Stderr = &stderr
 
 				err = helmCmd.Run()
+				if vc.expectedError != "" {
+					require.Error(t, err, "helm template should fail")
+					require.Contains(t, stderr.String(), vc.expectedError)
+					return
+				}
+
 				require.NoError(t, err, "helm template failed: %s", stderr.String())
 
 				got := output.Bytes()

--- a/controller/test/helm/testdata/agentgateway/extra-env.golden
+++ b/controller/test/helm/testdata/agentgateway/extra-env.golden
@@ -1,0 +1,362 @@
+---
+# Source: agentgateway/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-release-agentgateway
+  namespace: default
+  labels:
+    helm.sh/chart: agentgateway-0.0.2
+    agentgateway: agentgateway
+    app.kubernetes.io/name: agentgateway
+    app.kubernetes.io/instance: test-release
+    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: agentgateway/templates/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: agentgateway-default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  - namespaces
+  - nodes
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - serviceaccounts
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - agentgateway.dev
+  resources:
+  - agentgatewaybackends
+  - agentgatewayparameters
+  - agentgatewaypolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - agentgateway.dev
+  resources:
+  - agentgatewaybackends/status
+  - agentgatewayparameters/status
+  - agentgatewaypolicies/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - update
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - backendtlspolicies
+  - gateways
+  - grpcroutes
+  - httproutes
+  - listenersets
+  - referencegrants
+  - tcproutes
+  - tlsroutes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - backendtlspolicies/status
+  - gatewayclasses/status
+  - gateways/status
+  - grpcroutes/status
+  - httproutes/status
+  - listenersets/status
+  - tcproutes/status
+  - tlsroutes/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gatewayclasses
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - destinationrules
+  - serviceentries
+  - workloadentries
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - security.istio.io
+  resources:
+  - authorizationpolicies
+  verbs:
+  - get
+  - list
+  - watch
+---
+# Source: agentgateway/templates/serviceaccount.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: agentgateway-role-default
+subjects:
+- kind: ServiceAccount
+  name: test-release-agentgateway
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: agentgateway-default
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: agentgateway/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-release-agentgateway
+  namespace: default
+  labels:
+    helm.sh/chart: agentgateway-0.0.2
+    agentgateway: agentgateway
+    app.kubernetes.io/name: agentgateway
+    app.kubernetes.io/instance: test-release
+    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+  - name: grpc-xds-agw
+    protocol: TCP
+    port: 9978
+    targetPort: grpc-xds-agw
+  - name: health
+    protocol: TCP
+    port: 9093
+    targetPort: health
+  - name: metrics
+    protocol: TCP
+    port: 9092
+    targetPort: metrics
+  selector:
+    agentgateway: agentgateway
+    app.kubernetes.io/name: agentgateway
+    app.kubernetes.io/instance: test-release
+---
+# Source: agentgateway/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-release-agentgateway
+  namespace: default
+  labels:
+    helm.sh/chart: agentgateway-0.0.2
+    agentgateway: agentgateway
+    app.kubernetes.io/name: agentgateway
+    app.kubernetes.io/instance: test-release
+    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      agentgateway: agentgateway
+      app.kubernetes.io/name: agentgateway
+      app.kubernetes.io/instance: test-release
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: "/metrics"
+        prometheus.io/port: "9092"
+        prometheus.io/scrape: "true"
+      labels:
+        agentgateway: agentgateway
+        app.kubernetes.io/name: agentgateway
+        app.kubernetes.io/instance: test-release
+    spec:
+      serviceAccountName: test-release-agentgateway
+      containers:
+        - name: controller
+          image: "cr.agentgateway.dev/controller:v0.0.1"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 9978
+              name: grpc-xds-agw
+              protocol: TCP
+            - containerPort: 9093
+              name: health
+              protocol: TCP
+            - containerPort: 9092
+              name: metrics
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 9093
+            initialDelaySeconds: 1
+            periodSeconds: 10
+          startupProbe:
+            httpGet:
+              path: /readyz
+              port: 9093
+            initialDelaySeconds: 0
+            periodSeconds: 1
+            
+            failureThreshold: 120
+          env:
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "1"
+                  resource: limits.cpu
+            - name: AGW_PROXY_IMAGE_REGISTRY
+              value: cr.agentgateway.dev
+            - name: AGW_PROXY_IMAGE_REPOSITORY
+              value: agentgateway
+
+            - name: AGW_LOG_LEVEL
+              value: "info"
+            - name: AGW_XDS_SERVICE_NAME
+              value: test-release-agentgateway
+            - name: AGW_AGENTGATEWAY_XDS_SERVICE_PORT
+              value: "9978"
+            - name: AGW_DISCOVERY_NAMESPACE_SELECTORS
+              value: "[]"
+            - name: API_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: apiKey
+                  name: agentgateway-secrets
+            - name: API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  key: apiToken
+                  name: agentgateway-secrets
+            - name: ENABLE_AUDIT
+              value: "true"
+            - name: LOG_FORMAT
+              value: "json"
+            - name: AGW_GATEWAY_CLASS_PARAMETERS_REFS
+              value: "{}"
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          resources:
+            {}


### PR DESCRIPTION
extends the `controller.extraEnv` value to support `valueFrom` K8s sources, e.g. `Secrets`