### PR TITLE
feat(vertex): make region optional with global default

### DIFF
--- a/controller/api/v1alpha1/agentgateway/agentgateway_backend_types.go
+++ b/controller/api/v1alpha1/agentgateway/agentgateway_backend_types.go
@@ -275,8 +275,10 @@ type VertexAIConfig struct {
 	ProjectId TinyString `json:"projectId"`
 
 	// The location of the Google Cloud Project that you use for the Vertex AI.
-	// +required
-	Region TinyString `json:"region"`
+	// Defaults to global if not specified.
+	// +optional
+	// +kubebuilder:default=global
+	Region TinyString `json:"region,omitempty"`
 }
 
 // AnthropicConfig settings for the [Anthropic](https://platform.claude.com/docs/en/release-notes/overview) LLM provider.

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
@@ -6365,14 +6365,15 @@ spec:
                                     minLength: 1
                                     type: string
                                   region:
-                                    description: The location of the Google Cloud
-                                      Project that you use for the Vertex AI.
+                                    default: global
+                                    description: |-
+                                      The location of the Google Cloud Project that you use for the Vertex AI.
+                                      Defaults to global if not specified.
                                     maxLength: 64
                                     minLength: 1
                                     type: string
                                 required:
                                 - projectId
-                                - region
                                 type: object
                             required:
                             - name
@@ -6548,14 +6549,15 @@ spec:
                             minLength: 1
                             type: string
                           region:
-                            description: The location of the Google Cloud Project
-                              that you use for the Vertex AI.
+                            default: global
+                            description: |-
+                              The location of the Google Cloud Project that you use for the Vertex AI.
+                              Defaults to global if not specified.
                             maxLength: 64
                             minLength: 1
                             type: string
                         required:
                         - projectId
-                        - region
                         type: object
                     type: object
                     x-kubernetes-validations:

--- a/controller/pkg/client/clientset/versioned/fake/clientset_generated.go
+++ b/controller/pkg/client/clientset/versioned/fake/clientset_generated.go
@@ -18,10 +18,6 @@ import (
 // It's backed by a very simple object tracker that processes creates, updates and deletions as-is,
 // without applying any field management, validations and/or defaults. It shouldn't be considered a replacement
 // for a real clientset and is mostly useful in simple unit tests.
-//
-// Deprecated: NewClientset replaces this with support for field management, which significantly improves
-// server side apply testing. NewClientset is only available when apply configurations are generated (e.g.
-// via --with-applyconfig).
 func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 	o := testing.NewObjectTracker(scheme, codecs.UniversalDecoder())
 	for _, obj := range objects {

--- a/crates/agentgateway/src/llm/vertex.rs
+++ b/crates/agentgateway/src/llm/vertex.rs
@@ -114,12 +114,9 @@ impl Provider {
 
 	pub fn get_host(&self, _request_model: Option<&str>) -> Strng {
 		match &self.region {
-			None => {
-				strng::literal!("aiplatform.googleapis.com")
-			},
-			Some(region) => {
-				strng::format!("{region}-aiplatform.googleapis.com")
-			},
+			None => strng::literal!("aiplatform.googleapis.com"),
+			Some(region) if region == "global" => strng::literal!("aiplatform.googleapis.com"),
+			Some(region) => strng::format!("{region}-aiplatform.googleapis.com"),
 		}
 	}
 
@@ -198,5 +195,18 @@ mod tests {
 		};
 		let actual = p.anthropic_model(req).map(|m| m.to_string());
 		assert_eq!(actual.as_deref(), expected);
+	}
+
+	#[rstest::rstest]
+	#[case::no_region(None, "aiplatform.googleapis.com")]
+	#[case::global_region(Some("global"), "aiplatform.googleapis.com")]
+	#[case::regional(Some("us-central1"), "us-central1-aiplatform.googleapis.com")]
+	fn test_get_host(#[case] region: Option<&str>, #[case] expected: &str) {
+		let p = Provider {
+			project_id: strng::new("test-project"),
+			model: None,
+			region: region.map(strng::new),
+		};
+		assert_eq!(p.get_host(None).as_str(), expected);
 	}
 }

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -765,7 +765,7 @@ impl TryFrom<&proto::agent::Backend> for BackendWithPolicies {
 							Some(proto::agent::ai_backend::provider::Provider::Vertex(vertex)) => {
 								AIProvider::Vertex(llm::vertex::Provider {
 									model: vertex.model.as_deref().map(strng::new),
-									region: Some(strng::new(&vertex.region)),
+									region: (!vertex.region.is_empty()).then(|| strng::new(&vertex.region)),
 									project_id: strng::new(&vertex.project_id),
 								})
 							},
@@ -2412,6 +2412,90 @@ mod tests {
 		let path = config.get_path();
 		assert!(path.starts_with("/runtimes/"));
 		assert!(path.contains("qualifier=v1"));
+		Ok(())
+	}
+
+	#[tokio::test]
+	async fn test_vertex_provider_empty_region_is_none() -> Result<(), ProtoError> {
+		use proto::agent::ai_backend::Vertex;
+		use proto::agent::ai_backend::provider::Provider;
+
+		let proto_backend = proto::agent::Backend {
+			key: "test-ns/vertex-backend".to_string(),
+			name: Some(proto::agent::ResourceName {
+				name: "vertex-backend".to_string(),
+				namespace: "test-ns".to_string(),
+			}),
+			kind: Some(proto::agent::backend::Kind::Ai(proto::agent::AiBackend {
+				provider_groups: vec![proto::agent::ai_backend::ProviderGroup {
+					providers: vec![proto::agent::ai_backend::Provider {
+						name: "vertex".to_string(),
+						host_override: None,
+						path_override: None,
+						provider: Some(Provider::Vertex(Vertex {
+							model: None,
+							region: "".to_string(),
+							project_id: "my-project".to_string(),
+						})),
+						inline_policies: vec![],
+					}],
+				}],
+			})),
+			inline_policies: vec![],
+		};
+
+		let bw = BackendWithPolicies::try_from(&proto_backend)?;
+		let Backend::AI(_, ai_backend) = &bw.backend else {
+			panic!("Expected Backend::AI, got {:?}", bw.backend);
+		};
+		let providers = ai_backend.providers.iter();
+		let (provider, _) = providers.iter().next().unwrap();
+		let AIProvider::Vertex(vertex) = &provider.provider else {
+			panic!("Expected AIProvider::Vertex");
+		};
+		assert!(vertex.region.is_none(), "empty region should map to None");
+		Ok(())
+	}
+
+	#[tokio::test]
+	async fn test_vertex_provider_with_region() -> Result<(), ProtoError> {
+		use proto::agent::ai_backend::Vertex;
+		use proto::agent::ai_backend::provider::Provider;
+
+		let proto_backend = proto::agent::Backend {
+			key: "test-ns/vertex-backend".to_string(),
+			name: Some(proto::agent::ResourceName {
+				name: "vertex-backend".to_string(),
+				namespace: "test-ns".to_string(),
+			}),
+			kind: Some(proto::agent::backend::Kind::Ai(proto::agent::AiBackend {
+				provider_groups: vec![proto::agent::ai_backend::ProviderGroup {
+					providers: vec![proto::agent::ai_backend::Provider {
+						name: "vertex".to_string(),
+						host_override: None,
+						path_override: None,
+						provider: Some(Provider::Vertex(Vertex {
+							model: None,
+							region: "us-central1".to_string(),
+							project_id: "my-project".to_string(),
+						})),
+						inline_policies: vec![],
+					}],
+				}],
+			})),
+			inline_policies: vec![],
+		};
+
+		let bw = BackendWithPolicies::try_from(&proto_backend)?;
+		let Backend::AI(_, ai_backend) = &bw.backend else {
+			panic!("Expected Backend::AI, got {:?}", bw.backend);
+		};
+		let providers = ai_backend.providers.iter();
+		let (provider, _) = providers.iter().next().unwrap();
+		let AIProvider::Vertex(vertex) = &provider.provider else {
+			panic!("Expected AIProvider::Vertex");
+		};
+		assert_eq!(vertex.region.as_deref(), Some("us-central1"));
 		Ok(())
 	}
 }


### PR DESCRIPTION
- Handle 'global' region explicitly in get_host(), returning aiplatform.googleapis.com instead of global-aiplatform.googleapis.com
- Make VertexAI Region field optional with default 'global' in CRD
- Add unit tests for get_host() covering all region cases