### PR TITLE
feat(mcp): Expose tool payloads on the MCP CEL context

### DIFF
--- a/architecture/cel.md
+++ b/architecture/cel.md
@@ -5,6 +5,10 @@ CEL is an expression language that can evaluate user-defined (at runtime) expres
 
 A simple example of an expression that could be used for MCP authorization: `jwt.sub == "test-user" && mcp.tool.name == "add"`.
 
+For post-request logging, tracing, and metrics CEL, MCP tool calls also expose payload fields such as
+`mcp.methodName`, `mcp.sessionId`, `mcp.tool.arguments`, `mcp.tool.result`, and `mcp.tool.error`.
+Request-time authorization keeps the `mcp` context identity-only, so those payload fields are absent during RBAC evaluation.
+
 While CEL is not as powerful as alternatives like Lua or WASM, it is pretty fast and good enough for many use cases.
 
 Agentgateway currently uses CEL for:

--- a/crates/agentgateway/src/cel/types.rs
+++ b/crates/agentgateway/src/cel/types.rs
@@ -10,7 +10,7 @@ use crate::http::ext_proc::ExtProcDynamicMetadata;
 use crate::http::transformation_cel::TransformationMetadata;
 use crate::http::{apikey, basicauth, jwt};
 use crate::llm::{LLMInfo, LLMRequest};
-use crate::mcp::{ResourceId, ResourceType};
+use crate::mcp::{MCPInfo, MCPTool};
 use crate::serdes::schema;
 use crate::transport::tls::TlsInfo;
 use crate::{apply, llm};
@@ -57,7 +57,7 @@ pub struct Executor<'a> {
 	#[dynamic(rename = "llmRequest")]
 	pub llm_request: Option<&'a serde_json::Value>,
 
-	pub mcp: Option<&'a ResourceType>,
+	pub mcp: Option<&'a MCPInfo>,
 
 	pub backend: ExtensionOrDirect<'a, BackendContext>,
 
@@ -267,7 +267,7 @@ impl<'a> Executor<'a> {
 	pub fn new_empty() -> Self {
 		Default::default()
 	}
-	pub fn new_mcp(req: Option<&'a RequestSnapshot>, mcp: &'a ResourceType) -> Self {
+	pub fn new_mcp(req: Option<&'a RequestSnapshot>, mcp: &'a MCPInfo) -> Self {
 		let mut this = Self::new_empty();
 		if let Some(req) = req {
 			this.set_request_snapshot(req);
@@ -275,7 +275,7 @@ impl<'a> Executor<'a> {
 		this.mcp = Some(mcp);
 		this
 	}
-	pub fn new_mcp_request<B>(req: &'a ::http::Request<B>, mcp: &'a ResourceType) -> Self {
+	pub fn new_mcp_request<B>(req: &'a ::http::Request<B>, mcp: &'a MCPInfo) -> Self {
 		let mut this = Self::new_empty();
 		this.set_request(req);
 		this.mcp = Some(mcp);
@@ -293,7 +293,7 @@ impl<'a> Executor<'a> {
 		req: Option<&'a RequestSnapshot>,
 		resp: Option<&'a ResponseSnapshot>,
 		llm: Option<&'a LLMContext>,
-		mcp: Option<&'a ResourceType>,
+		mcp: Option<&'a MCPInfo>,
 		end_time: Option<&'a RequestTime>,
 	) -> Self {
 		let mut this = Self::new_empty();
@@ -1252,9 +1252,10 @@ pub struct ExecutorSerde {
 	pub source: Option<SourceContext>,
 
 	/// `mcp` contains attributes about the MCP request.
-	// This is only included for schema generation; see build_with_mcp.
+	/// Request-time CEL only includes identity fields such as `tool`, `prompt`, or `resource`.
+	/// Post-request CEL may also include fields like `methodName`, `sessionId`, and tool payloads.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
-	pub mcp: Option<ResourceType>,
+	pub mcp: Option<MCPInfo>,
 
 	/// `backend` contains information about the backend being used.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1451,10 +1452,29 @@ pub fn full_example_executor() -> ExecutorSerde {
 				dimensions: None,
 			},
 		}),
-		mcp: Some(ResourceType::Tool(ResourceId::new(
-			"my-mcp-server".to_string(),
-			"get_weather".to_string(),
-		))),
+		mcp: Some(MCPInfo {
+			method_name: Some("tools/call".to_string()),
+			session_id: Some("session-123".to_string()),
+			tool: Some(MCPTool {
+				target: "my-mcp-server".to_string(),
+				name: "get_weather".to_string(),
+				arguments: Some(serde_json::Map::from_iter([(
+					"userId".to_string(),
+					json!("123"),
+				)])),
+				result: Some(json!({
+					"content": [],
+					"structuredContent": {
+						"status": "ok",
+						"forecast": "sunny",
+					},
+					"isError": false,
+				})),
+				error: None,
+			}),
+			prompt: None,
+			resource: None,
+		}),
 		backend: Some(BackendContext {
 			name: "my-backend".into(),
 			backend_type: BackendType::Service,

--- a/crates/agentgateway/src/http/authorization_tests.rs
+++ b/crates/agentgateway/src/http/authorization_tests.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::cel::RequestSnapshot;
 use crate::http::authorization::PolicySet;
 use crate::http::{Body, jwt};
-use crate::mcp::{ResourceId, ResourceType};
+use crate::mcp::{MCPInfo, ResourceId, ResourceType};
 use ::http::Method;
 #[cfg(test)]
 use assert_matches::assert_matches;
@@ -29,6 +29,13 @@ fn create_deny_policy_set(policies: Vec<&str>) -> PolicySet {
 	policy_set
 }
 
+fn tool_context(target: &str, name: &str) -> MCPInfo {
+	MCPInfo::from(&ResourceType::Tool(ResourceId::new(
+		target.to_string(),
+		name.to_string(),
+	)))
+}
+
 #[test]
 fn test_rbac_reject_exact_match() {
 	let policies = vec![r#"mcp.tool.name == "increment" && jwt.user == "admin""#];
@@ -38,10 +45,7 @@ fn test_rbac_reject_exact_match() {
 	rs.register(&mut ctx);
 
 	let req = req(json!({"sub": "1234567890"}));
-	let mcp = ResourceType::Tool(ResourceId::new(
-		"server".to_string(),
-		"increment".to_string(),
-	));
+	let mcp = tool_context("server", "increment");
 	let exec = cel::Executor::new_mcp(req.as_ref(), &mcp);
 
 	assert_matches!(rs.validate(&exec), false);
@@ -56,10 +60,7 @@ fn test_rbac_check_exact_match() {
 	rs.register(&mut ctx);
 
 	let req = req(json!({"sub": "1234567890"}));
-	let mcp = ResourceType::Tool(ResourceId::new(
-		"server".to_string(),
-		"increment".to_string(),
-	));
+	let mcp = tool_context("server", "increment");
 	let exec = cel::Executor::new_mcp(req.as_ref(), &mcp);
 
 	assert_matches!(rs.validate(&exec), true);
@@ -74,18 +75,12 @@ fn test_rbac_target() {
 	rs.register(&mut ctx);
 
 	let req = req(json!({"sub": "1234567890"}));
-	let mcp = ResourceType::Tool(ResourceId::new(
-		"server".to_string(),
-		"increment".to_string(),
-	));
+	let mcp = tool_context("server", "increment");
 	let exec = cel::Executor::new_mcp(req.as_ref(), &mcp);
 
 	assert_matches!(rs.validate(&exec), true);
 
-	let mcp = ResourceType::Tool(ResourceId::new(
-		"not-server".to_string(),
-		"increment".to_string(),
-	));
+	let mcp = tool_context("not-server", "increment");
 	let exec_different_target = cel::Executor::new_mcp(req.as_ref(), &mcp);
 
 	assert_matches!(rs.validate(&exec_different_target), false);
@@ -100,10 +95,7 @@ fn test_rbac_check_contains_match() {
 	rs.register(&mut ctx);
 
 	let req = req(json!({"groups": "admin"}));
-	let mcp = ResourceType::Tool(ResourceId::new(
-		"server".to_string(),
-		"increment".to_string(),
-	));
+	let mcp = tool_context("server", "increment");
 	let exec = cel::Executor::new_mcp(req.as_ref(), &mcp);
 
 	assert_matches!(rs.validate(&exec), true);
@@ -118,10 +110,7 @@ fn test_rbac_check_nested_key_match() {
 	rs.register(&mut ctx);
 
 	let req = req(json!({"user": {"role": "admin"}}));
-	let mcp = ResourceType::Tool(ResourceId::new(
-		"server".to_string(),
-		"increment".to_string(),
-	));
+	let mcp = tool_context("server", "increment");
 	let exec = cel::Executor::new_mcp(req.as_ref(), &mcp);
 
 	assert_matches!(rs.validate(&exec), true);
@@ -136,10 +125,7 @@ fn test_rbac_check_array_contains_match() {
 	rs.register(&mut ctx);
 
 	let req = req(json!({"roles": ["user", "admin", "developer"]}));
-	let mcp = ResourceType::Tool(ResourceId::new(
-		"server".to_string(),
-		"increment".to_string(),
-	));
+	let mcp = tool_context("server", "increment");
 	let exec = cel::Executor::new_mcp(req.as_ref(), &mcp);
 
 	assert_matches!(rs.validate(&exec), true);
@@ -155,10 +141,7 @@ fn test_deny_only_non_matching_allows() {
 	rs.register(&mut ctx);
 
 	let req = req(json!({"sub": "1234567890"}));
-	let mcp = ResourceType::Tool(ResourceId::new(
-		"server".to_string(),
-		"decrement".to_string(),
-	));
+	let mcp = tool_context("server", "decrement");
 	let exec = cel::Executor::new_mcp(req.as_ref(), &mcp);
 
 	// "decrement" does not match the deny rule, so it should be allowed
@@ -175,10 +158,7 @@ fn test_deny_only_matching_denies() {
 	rs.register(&mut ctx);
 
 	let req = req(json!({"sub": "1234567890"}));
-	let mcp = ResourceType::Tool(ResourceId::new(
-		"server".to_string(),
-		"increment".to_string(),
-	));
+	let mcp = tool_context("server", "increment");
 	let exec = cel::Executor::new_mcp(req.as_ref(), &mcp);
 
 	assert_matches!(rs.validate(&exec), false);
@@ -201,23 +181,17 @@ fn test_stacked_deny_policies() {
 	let req = req(json!({"sub": "1234567890"}));
 
 	// "increment" is denied by first policy
-	let mcp = ResourceType::Tool(ResourceId::new(
-		"server".to_string(),
-		"increment".to_string(),
-	));
+	let mcp = tool_context("server", "increment");
 	let exec = cel::Executor::new_mcp(req.as_ref(), &mcp);
 	assert_matches!(rs.validate(&exec), false);
 
 	// "decrement" is denied by second policy
-	let mcp = ResourceType::Tool(ResourceId::new(
-		"server".to_string(),
-		"decrement".to_string(),
-	));
+	let mcp = tool_context("server", "decrement");
 	let exec = cel::Executor::new_mcp(req.as_ref(), &mcp);
 	assert_matches!(rs.validate(&exec), false);
 
 	// "echo" is not denied by either policy, so it should be allowed
-	let mcp = ResourceType::Tool(ResourceId::new("server".to_string(), "echo".to_string()));
+	let mcp = tool_context("server", "echo");
 	let exec = cel::Executor::new_mcp(req.as_ref(), &mcp);
 	assert_matches!(rs.validate(&exec), true);
 }
@@ -241,28 +215,32 @@ fn test_mixed_allow_deny_default_deny() {
 	let req = req(json!({"sub": "1234567890"}));
 
 	// "allowed_tool" matches allow rule → allowed
-	let mcp = ResourceType::Tool(ResourceId::new(
-		"server".to_string(),
-		"allowed_tool".to_string(),
-	));
+	let mcp = tool_context("server", "allowed_tool");
 	let exec = cel::Executor::new_mcp(req.as_ref(), &mcp);
 	assert_matches!(rs.validate(&exec), true);
 
 	// "denied_tool" matches deny rule → denied (deny takes precedence)
-	let mcp = ResourceType::Tool(ResourceId::new(
-		"server".to_string(),
-		"denied_tool".to_string(),
-	));
+	let mcp = tool_context("server", "denied_tool");
 	let exec = cel::Executor::new_mcp(req.as_ref(), &mcp);
 	assert_matches!(rs.validate(&exec), false);
 
 	// "other_tool" matches neither → denied (allowlist semantics when allow rules exist)
-	let mcp = ResourceType::Tool(ResourceId::new(
-		"server".to_string(),
-		"other_tool".to_string(),
-	));
+	let mcp = tool_context("server", "other_tool");
 	let exec = cel::Executor::new_mcp(req.as_ref(), &mcp);
 	assert_matches!(rs.validate(&exec), false);
+}
+
+#[test]
+fn test_rbac_mcp_context_is_identity_only() {
+	let req = req(json!({"sub": "1234567890"}));
+	let mcp = tool_context("server", "increment");
+	let exec = cel::Executor::new_mcp(req.as_ref(), &mcp);
+	let expr = cel::Expression::new_strict(
+		r#"mcp.tool.name == "increment" && !has(mcp.tool.arguments) && !has(mcp.tool.result) && !has(mcp.tool.error)"#,
+	)
+	.unwrap();
+
+	assert!(exec.eval_bool(&expr));
 }
 
 #[divan::bench]
@@ -273,10 +251,7 @@ fn bench(b: Bencher) {
 	let rs = RuleSets::from(vec![rbac.clone()]);
 	rs.register(&mut ctx);
 	let req = req(json!({"role": "admin"}));
-	let mcp = ResourceType::Tool(ResourceId::new(
-		"server".to_string(),
-		"increment".to_string(),
-	));
+	let mcp = tool_context("server", "increment");
 	let exec = cel::Executor::new_mcp(req.as_ref(), &mcp);
 	b.bench(|| {
 		rs.validate(&exec);

--- a/crates/agentgateway/src/mcp/handler.rs
+++ b/crates/agentgateway/src/mcp/handler.rs
@@ -355,6 +355,7 @@ impl Relay {
 		r: JsonRpcRequest<ClientRequest>,
 		ctx: IncomingRequestContext,
 		service_name: &str,
+		mcp_log: Option<AsyncLog<MCPInfo>>,
 	) -> Result<Response, UpstreamError> {
 		let id = r.id.clone();
 		let Ok(us) = self.upstreams.get(service_name) else {
@@ -364,7 +365,7 @@ impl Relay {
 		};
 		let stream = us.generic_stream(r, &ctx).await?;
 
-		messages_to_response(id, stream)
+		messages_to_response(id, stream, mcp_log)
 	}
 	// For some requests, we don't have a sane mapping of incoming requests to a specific
 	// downstream service when multiplexing. Only forward when we have only one backend.
@@ -372,11 +373,12 @@ impl Relay {
 		&self,
 		r: JsonRpcRequest<ClientRequest>,
 		ctx: IncomingRequestContext,
+		mcp_log: Option<AsyncLog<MCPInfo>>,
 	) -> Result<Response, UpstreamError> {
 		let Some(service_name) = &self.upstreams.default_target_name else {
 			return Err(UpstreamError::InvalidMethod(r.request.method().to_string()));
 		};
-		self.send_single(r, ctx, service_name).await
+		self.send_single(r, ctx, service_name, mcp_log).await
 	}
 	pub async fn send_fanout_deletion(
 		&self,
@@ -421,11 +423,11 @@ impl Relay {
 			// FailClosed: unreachable — InitializeRequest would have failed with NoBackends.
 			// FailOpen: keep the SSE connection open so legacy SSE clients do not immediately
 			// reconnect in a tight loop after all upstream GET streams disappear.
-			return messages_to_response(RequestId::Number(0), Messages::pending());
+			return messages_to_response(RequestId::Number(0), Messages::pending(), None);
 		}
 
 		let ms = mergestream::MergeStream::new_without_merge(streams, self.upstreams.failure_mode);
-		messages_to_response(RequestId::Number(0), ms)
+		messages_to_response(RequestId::Number(0), ms, None)
 	}
 	pub async fn send_fanout(
 		&self,
@@ -460,7 +462,7 @@ impl Relay {
 		}
 
 		let ms = mergestream::MergeStream::new(streams, id.clone(), merge, self.upstreams.failure_mode);
-		messages_to_response(id, ms)
+		messages_to_response(id, ms, None)
 	}
 	pub async fn send_notification(
 		&self,
@@ -560,12 +562,19 @@ pub fn setup_request_log(
 fn messages_to_response(
 	id: RequestId,
 	stream: impl Stream<Item = Result<ServerJsonRpcMessage, ClientError>> + Send + 'static,
+	mcp_log: Option<AsyncLog<MCPInfo>>,
 ) -> Result<Response, UpstreamError> {
 	use futures_util::StreamExt;
-	use rmcp::model::ServerJsonRpcMessage;
+	let request_id = id.clone();
+	let mut captured_terminal = false;
 	let stream = stream.map(move |rpc| {
 		let r = match rpc {
-			Ok(rpc) => rpc,
+			Ok(rpc) => {
+				if !captured_terminal && let Some(log) = mcp_log.as_ref() {
+					captured_terminal = capture_terminal_mcp_payload(log, &request_id, &rpc);
+				}
+				rpc
+			},
 			Err(e) => {
 				ServerJsonRpcMessage::error(ErrorData::internal_error(e.to_string(), None), id.clone())
 			},
@@ -579,9 +588,131 @@ fn messages_to_response(
 	Ok(mcp::session::sse_stream_response(stream, None))
 }
 
+fn capture_terminal_mcp_payload(
+	log: &AsyncLog<MCPInfo>,
+	request_id: &RequestId,
+	message: &ServerJsonRpcMessage,
+) -> bool {
+	match message {
+		ServerJsonRpcMessage::Response(response) if response.id == *request_id => {
+			if let ServerResult::CallToolResult(result) = &response.result {
+				log.non_atomic_mutate(|mcp| mcp.capture_call_result(result));
+			}
+			true
+		},
+		ServerJsonRpcMessage::Error(error) if error.id == *request_id => {
+			log.non_atomic_mutate(|mcp| mcp.capture_call_error(&error.error));
+			true
+		},
+		_ => false,
+	}
+}
+
 fn accepted_response() -> Response {
 	::http::Response::builder()
 		.status(StatusCode::ACCEPTED)
 		.body(crate::http::Body::empty())
 		.expect("valid response")
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use futures_util::stream;
+	use rmcp::model::{CallToolResult, ListToolsResult};
+	use serde_json::json;
+
+	#[tokio::test]
+	async fn messages_to_response_captures_first_matching_tool_result() {
+		let log = AsyncLog::default();
+		let mut info = MCPInfo::default();
+		info.set_tool("mcp".to_string(), "echo".to_string());
+		log.store(Some(info));
+
+		let stream = stream::iter(vec![
+			Ok(ServerJsonRpcMessage::response(
+				ServerResult::ListToolsResult(ListToolsResult {
+					tools: vec![],
+					next_cursor: None,
+					meta: None,
+				}),
+				RequestId::Number(1),
+			)),
+			Ok(ServerJsonRpcMessage::response(
+				ServerResult::CallToolResult(CallToolResult::structured(json!({
+					"status": "ok",
+				}))),
+				RequestId::Number(42),
+			)),
+			Ok(ServerJsonRpcMessage::error(
+				ErrorData::internal_error("later error", None),
+				RequestId::Number(42),
+			)),
+		]);
+
+		let response = messages_to_response(RequestId::Number(42), stream, Some(log.clone())).unwrap();
+		let _ = crate::http::read_resp_body(response).await.unwrap();
+
+		let info = log.take().unwrap();
+		assert_eq!(
+			info.tool.as_ref().unwrap().result.as_ref().unwrap()["structuredContent"]["status"],
+			"ok"
+		);
+		assert!(info.tool.as_ref().unwrap().error.is_none());
+	}
+
+	#[tokio::test]
+	async fn messages_to_response_ignores_transport_errors_before_result() {
+		let log = AsyncLog::default();
+		let mut info = MCPInfo::default();
+		info.set_tool("mcp".to_string(), "echo".to_string());
+		log.store(Some(info));
+
+		let stream = stream::iter(vec![
+			Err(ClientError::new(anyhow::anyhow!("boom"))),
+			Ok(ServerJsonRpcMessage::response(
+				ServerResult::CallToolResult(CallToolResult::structured(json!({
+					"status": "ok",
+				}))),
+				RequestId::Number(7),
+			)),
+		]);
+		let response = messages_to_response(RequestId::Number(7), stream, Some(log.clone())).unwrap();
+		let _ = crate::http::read_resp_body(response).await.unwrap();
+
+		let info = log.take().unwrap();
+		assert_eq!(
+			info.tool.as_ref().unwrap().result.as_ref().unwrap()["structuredContent"]["status"],
+			"ok"
+		);
+		assert!(info.tool.as_ref().unwrap().error.is_none());
+	}
+
+	#[tokio::test]
+	async fn messages_to_response_captures_json_rpc_error() {
+		let log = AsyncLog::default();
+		let mut info = MCPInfo::default();
+		info.set_tool("mcp".to_string(), "echo".to_string());
+		log.store(Some(info));
+
+		let stream = stream::iter(vec![Ok(ServerJsonRpcMessage::error(
+			ErrorData::internal_error("boom", None),
+			RequestId::Number(7),
+		))]);
+		let response = messages_to_response(RequestId::Number(7), stream, Some(log.clone())).unwrap();
+		let _ = crate::http::read_resp_body(response).await.unwrap();
+
+		let info = log.take().unwrap();
+		assert!(info.tool.as_ref().unwrap().result.is_none());
+		assert_eq!(
+			info.tool.as_ref().unwrap().error.as_ref().unwrap()["code"],
+			-32603
+		);
+		assert!(
+			info.tool.as_ref().unwrap().error.as_ref().unwrap()["message"]
+				.as_str()
+				.unwrap()
+				.contains("boom")
+		);
+	}
 }

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -18,7 +18,7 @@ use crate::proxy::httpproxy::PolicyClient;
 use crate::test_helpers::proxymock::{
 	BIND_KEY, TestBind, basic_named_route, basic_route, setup_proxy_test, simple_bind,
 };
-use crate::types::agent::BackendPolicy;
+use crate::types::agent::{BackendPolicy, FrontendPolicy, PolicyTarget, TargetedPolicy};
 use crate::*;
 
 #[tokio::test]
@@ -565,6 +565,228 @@ async fn standard_sse_assertions(client: LegacyService) {
 		&ctr.content[0].raw.as_text().unwrap().text,
 		r#"{"hi":"world"}"#
 	);
+}
+
+fn access_log_payload_policy() -> crate::types::frontend::LoggingPolicy {
+	let mut policy: crate::types::frontend::LoggingPolicy =
+		serde_json::from_value(serde_json::json!({
+			"add": {
+				"mcp_trace": "mcp.tool.arguments.traceId",
+				"mcp_method_cel": "mcp.methodName",
+				"mcp_session_cel": "mcp.sessionId",
+				"mcp_tool_name_cel": "mcp.tool.name",
+				"mcp_tool_target_cel": "mcp.tool.target",
+				"mcp_args_cel": "mcp.tool.arguments",
+				"mcp_result_cel": "mcp.tool.result",
+				"mcp_error_cel": "mcp.tool.error"
+			}
+		}))
+		.unwrap();
+	policy.init_access_log_policy();
+	policy
+}
+
+async fn setup_access_log_mcp_proxy(mock: &MockServer) -> (TestBind, SocketAddr) {
+	let (mut t, io) = setup_proxy(mock, true, false).await;
+	let listener_name = t
+		.pi
+		.stores
+		.read_binds()
+		.bind(&BIND_KEY)
+		.unwrap()
+		.listeners
+		.iter()
+		.next()
+		.unwrap()
+		.name
+		.clone();
+	t.with_policy(TargetedPolicy {
+		key: "frontend/accessLog".into(),
+		name: None,
+		target: PolicyTarget::Gateway(listener_name.clone().into()),
+		policy: FrontendPolicy::AccessLog(access_log_payload_policy()).into(),
+	});
+	assert!(
+		t.pi
+			.stores
+			.read_binds()
+			.listener_frontend_policies(&listener_name)
+			.access_log
+			.is_some()
+	);
+	(t, io)
+}
+
+#[tokio::test]
+async fn tool_call_exposes_payload_fields_to_access_log_cel() {
+	let mock = mock_streamable_http_server(true).await;
+	let trace_id = format!("mcp-e2e-{}", uuid::Uuid::new_v4());
+	let (_t, io) = setup_access_log_mcp_proxy(&mock).await;
+	let client = mcp_streamable_client(io).await;
+
+	let result = client
+		.call_tool(rmcp::model::CallToolRequestParams {
+			meta: None,
+			task: None,
+			name: "echo".into(),
+			arguments: serde_json::json!({
+				"traceId": trace_id,
+				"hi": "world",
+			})
+			.as_object()
+			.cloned(),
+		})
+		.await
+		.unwrap();
+	let direct_result_text = &result.content[0].raw.as_text().unwrap().text;
+	let direct_result_json: serde_json::Value =
+		serde_json::from_str(direct_result_text).expect("tool result should be valid JSON text");
+	assert_eq!(direct_result_json["traceId"], trace_id);
+	assert_eq!(direct_result_json["hi"], "world");
+
+	let log = agent_core::telemetry::testing::eventually_find(&[
+		("scope", "request"),
+		("mcp_trace", &trace_id),
+	])
+	.await
+	.unwrap();
+
+	assert_eq!(
+		log.get("mcp_method_cel"),
+		Some(&serde_json::json!("tools/call"))
+	);
+	assert_eq!(
+		log.get("mcp_tool_name_cel"),
+		Some(&serde_json::json!("echo"))
+	);
+	assert_eq!(
+		log.get("mcp_tool_target_cel"),
+		Some(&serde_json::json!("mcp"))
+	);
+	assert_eq!(log["mcp_args_cel"]["traceId"], trace_id);
+	assert_eq!(log["mcp_args_cel"]["hi"], "world");
+	assert!(
+		log["mcp_session_cel"]
+			.as_str()
+			.is_some_and(|session_id| !session_id.is_empty())
+	);
+	assert_eq!(log["mcp_result_cel"]["isError"], false);
+
+	let result_text = log["mcp_result_cel"]["content"][0]["text"]
+		.as_str()
+		.expect("tool result text should be logged");
+	let result_json: serde_json::Value =
+		serde_json::from_str(result_text).expect("tool result should be valid JSON text");
+	assert_eq!(result_json["traceId"], trace_id);
+	assert_eq!(result_json["hi"], "world");
+	assert!(log.get("mcp_error_cel").is_none());
+
+	assert!(log.get("gen_ai.tool.name").is_none());
+	assert!(log.get("gen_ai.tool.call.arguments").is_none());
+	assert!(log.get("gen_ai.tool.call.result").is_none());
+}
+
+#[tokio::test]
+async fn tool_call_error_exposes_error_payload_to_access_log_cel() {
+	let mock = mock_streamable_http_server(true).await;
+	let trace_id = format!("mcp-e2e-error-{}", uuid::Uuid::new_v4());
+	let (_t, io) = setup_access_log_mcp_proxy(&mock).await;
+	let client = mcp_streamable_client(io).await;
+
+	let err = client
+		.call_tool(rmcp::model::CallToolRequestParams {
+			meta: None,
+			task: None,
+			name: "does_not_exist".into(),
+			arguments: serde_json::json!({
+				"traceId": trace_id,
+			})
+			.as_object()
+			.cloned(),
+		})
+		.await
+		.unwrap_err();
+	match &err {
+		rmcp::ServiceError::McpError(mcp_error) => assert_eq!(mcp_error.code.0, -32602),
+		other => panic!("Expected ServiceError::McpError, got: {other:?}"),
+	}
+
+	let log = agent_core::telemetry::testing::eventually_find(&[
+		("scope", "request"),
+		("mcp_trace", &trace_id),
+	])
+	.await
+	.unwrap();
+
+	assert_eq!(
+		log.get("mcp_method_cel"),
+		Some(&serde_json::json!("tools/call"))
+	);
+	assert_eq!(
+		log.get("mcp_tool_name_cel"),
+		Some(&serde_json::json!("does_not_exist"))
+	);
+	assert_eq!(log["mcp_args_cel"]["traceId"], trace_id);
+	assert_eq!(log["mcp_error_cel"]["code"], -32602);
+	assert!(
+		log["mcp_error_cel"]["message"]
+			.as_str()
+			.is_some_and(|message| message.contains("tool"))
+	);
+	assert!(log.get("mcp_result_cel").is_none());
+	assert!(log.get("gen_ai.tool.name").is_none());
+	assert!(log.get("gen_ai.tool.call.arguments").is_none());
+	assert!(log.get("gen_ai.tool.call.result").is_none());
+}
+
+#[tokio::test]
+async fn legacy_sse_tool_call_exposes_arguments_without_terminal_payloads() {
+	let mock = mock_streamable_http_server(true).await;
+	let trace_id = format!("mcp-e2e-sse-{}", uuid::Uuid::new_v4());
+	let (_t, io) = setup_access_log_mcp_proxy(&mock).await;
+	let client = mcp_sse_client(io).await;
+
+	let result = client
+		.call_tool(legacy_rmcp::model::CallToolRequestParam {
+			name: "echo".into(),
+			arguments: serde_json::json!({
+				"traceId": trace_id,
+				"hi": "world",
+			})
+			.as_object()
+			.cloned(),
+		})
+		.await
+		.unwrap();
+	let direct_result_text = &result.content[0].raw.as_text().unwrap().text;
+	let direct_result_json: serde_json::Value =
+		serde_json::from_str(direct_result_text).expect("tool result should be valid JSON text");
+	assert_eq!(direct_result_json["traceId"], trace_id);
+	assert_eq!(direct_result_json["hi"], "world");
+
+	let log = agent_core::telemetry::testing::eventually_find(&[
+		("scope", "request"),
+		("mcp_trace", &trace_id),
+	])
+	.await
+	.unwrap();
+
+	assert_eq!(
+		log.get("mcp_method_cel"),
+		Some(&serde_json::json!("tools/call"))
+	);
+	assert_eq!(
+		log.get("mcp_tool_name_cel"),
+		Some(&serde_json::json!("echo"))
+	);
+	assert_eq!(log["mcp_args_cel"]["traceId"], trace_id);
+	assert_eq!(log["mcp_args_cel"]["hi"], "world");
+	assert!(log.get("mcp_result_cel").is_none());
+	assert!(log.get("mcp_error_cel").is_none());
+
+	assert!(log.get("gen_ai.tool.name").is_none());
+	assert!(log.get("gen_ai.tool.call.arguments").is_none());
+	assert!(log.get("gen_ai.tool.call.result").is_none());
 }
 
 async fn setup_proxy(

--- a/crates/agentgateway/src/mcp/mod.rs
+++ b/crates/agentgateway/src/mcp/mod.rs
@@ -21,6 +21,7 @@ use prometheus_client::encoding::{EncodeLabelValue, LabelValueEncoder};
 pub use rbac::{McpAuthorization, McpAuthorizationSet, ResourceId, ResourceType};
 use rmcp::model::RequestId;
 pub use router::App;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
@@ -136,12 +137,155 @@ impl Display for MCPOperation {
 	}
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Default, Serialize, Deserialize, Clone, Debug, PartialEq, ::cel::DynamicType)]
+#[serde(rename_all = "camelCase")]
+#[dynamic(rename_all = "camelCase")]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+pub struct MCPTool {
+	/// The target handling the tool call after multiplexing resolution.
+	pub target: String,
+	/// The resolved tool name sent to the upstream target.
+	pub name: String,
+	/// The JSON arguments passed to the tool call.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub arguments: Option<serde_json::Map<String, serde_json::Value>>,
+	/// The terminal tool result payload, if available.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub result: Option<serde_json::Value>,
+	/// The terminal JSON-RPC error payload, if available.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub error: Option<serde_json::Value>,
+}
+
+#[derive(Default, Serialize, Deserialize, Clone, Debug, PartialEq, ::cel::DynamicType)]
+#[serde(rename_all = "camelCase")]
+#[dynamic(rename_all = "camelCase")]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
 pub struct MCPInfo {
+	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub method_name: Option<String>,
-	/// Tool name, etc
-	pub resource_name: Option<String>,
-	pub target_name: Option<String>,
-	pub resource: Option<MCPOperation>,
+	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub session_id: Option<String>,
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub tool: Option<MCPTool>,
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub prompt: Option<ResourceId>,
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub resource: Option<ResourceId>,
+}
+
+impl MCPInfo {
+	pub fn is_empty(&self) -> bool {
+		self.method_name.is_none()
+			&& self.session_id.is_none()
+			&& self.tool.is_none()
+			&& self.prompt.is_none()
+			&& self.resource.is_none()
+	}
+
+	pub fn resource_type(&self) -> Option<MCPOperation> {
+		if self.tool.is_some() {
+			Some(MCPOperation::Tool)
+		} else if self.prompt.is_some() {
+			Some(MCPOperation::Prompt)
+		} else if self.resource.is_some() {
+			Some(MCPOperation::Resource)
+		} else {
+			None
+		}
+	}
+
+	pub fn target_name(&self) -> Option<&str> {
+		self
+			.tool
+			.as_ref()
+			.map(|tool| tool.target.as_str())
+			.or_else(|| self.prompt.as_ref().map(ResourceId::target))
+			.or_else(|| self.resource.as_ref().map(ResourceId::target))
+	}
+
+	pub fn resource_name(&self) -> Option<&str> {
+		self
+			.tool
+			.as_ref()
+			.map(|tool| tool.name.as_str())
+			.or_else(|| self.prompt.as_ref().map(ResourceId::name))
+			.or_else(|| self.resource.as_ref().map(ResourceId::name))
+	}
+
+	pub fn set_tool(&mut self, target: String, name: String) {
+		self.prompt = None;
+		self.resource = None;
+		match self.tool.as_mut() {
+			Some(tool) => {
+				tool.target = target;
+				tool.name = name;
+			},
+			None => {
+				self.tool = Some(MCPTool {
+					target,
+					name,
+					..Default::default()
+				});
+			},
+		}
+	}
+
+	pub fn set_prompt(&mut self, target: String, name: String) {
+		self.tool = None;
+		self.resource = None;
+		self.prompt = Some(ResourceId::new(target, name));
+	}
+
+	pub fn set_resource(&mut self, target: String, name: String) {
+		self.tool = None;
+		self.prompt = None;
+		self.resource = Some(ResourceId::new(target, name));
+	}
+
+	pub fn capture_call_arguments(
+		&mut self,
+		arguments: Option<serde_json::Map<String, serde_json::Value>>,
+	) {
+		let Some(tool) = self.tool.as_mut() else {
+			return;
+		};
+
+		tool.arguments = arguments;
+	}
+
+	pub fn capture_call_result<T: serde::Serialize>(&mut self, result: &T) {
+		if let Some(tool) = self.tool.as_mut() {
+			tool.result = serde_json::to_value(result).ok();
+		}
+	}
+
+	pub fn capture_call_error<T: serde::Serialize>(&mut self, error: &T) {
+		if let Some(tool) = self.tool.as_mut() {
+			tool.error = serde_json::to_value(error).ok();
+		}
+	}
+}
+
+impl From<&ResourceType> for MCPInfo {
+	fn from(value: &ResourceType) -> Self {
+		match value {
+			ResourceType::Tool(tool) => Self {
+				tool: Some(MCPTool {
+					target: tool.target().to_string(),
+					name: tool.name().to_string(),
+					..Default::default()
+				}),
+				..Default::default()
+			},
+			ResourceType::Prompt(prompt) => Self {
+				prompt: Some(prompt.clone()),
+				..Default::default()
+			},
+			ResourceType::Resource(resource) => Self {
+				resource: Some(resource.clone()),
+				..Default::default()
+			},
+		}
+	}
 }

--- a/crates/agentgateway/src/mcp/rbac.rs
+++ b/crates/agentgateway/src/mcp/rbac.rs
@@ -36,7 +36,8 @@ impl McpAuthorizationSet {
 	}
 	pub fn validate(&self, res: &ResourceType, cel: &CelExecWrapper) -> bool {
 		tracing::debug!("Checking RBAC for resource: {:?}", res);
-		let exec = crate::cel::Executor::new_mcp_request(&cel.0, res);
+		let mcp = crate::mcp::MCPInfo::from(res);
+		let exec = crate::cel::Executor::new_mcp_request(&cel.0, &mcp);
 		self.0.validate(&exec)
 	}
 
@@ -95,5 +96,13 @@ pub struct ResourceId {
 impl ResourceId {
 	pub fn new(target: String, id: String) -> Self {
 		Self { target, id }
+	}
+
+	pub fn target(&self) -> &str {
+		&self.target
+	}
+
+	pub fn name(&self) -> &str {
+		&self.id
 	}
 }

--- a/crates/agentgateway/src/mcp/session.rs
+++ b/crates/agentgateway/src/mcp/session.rs
@@ -22,7 +22,7 @@ use crate::mcp::handler::{Relay, RelayInputs};
 use crate::mcp::mergestream::Messages;
 use crate::mcp::streamablehttp::{ServerSseMessage, StreamableHttpPostResponse};
 use crate::mcp::upstream::{IncomingRequestContext, UpstreamError};
-use crate::mcp::{ClientError, MCPOperation, rbac};
+use crate::mcp::{ClientError, rbac};
 use crate::proxy::ProxyError;
 use crate::{mcp, *};
 
@@ -236,9 +236,6 @@ impl Session {
 						res
 					},
 					ClientRequest::ListToolsRequest(_) => {
-						log.non_atomic_mutate(|l| {
-							l.resource = Some(MCPOperation::Tool);
-						});
 						self
 							.relay
 							.send_fanout(r, ctx, self.relay.merge_tools(cel))
@@ -251,9 +248,6 @@ impl Session {
 							.await
 					},
 					ClientRequest::ListPromptsRequest(_) => {
-						log.non_atomic_mutate(|l| {
-							l.resource = Some(MCPOperation::Prompt);
-						});
 						self
 							.relay
 							.send_fanout(r, ctx, self.relay.merge_prompts(cel))
@@ -261,9 +255,6 @@ impl Session {
 					},
 					ClientRequest::ListResourcesRequest(_) => {
 						if !self.relay.is_multiplexing() {
-							log.non_atomic_mutate(|l| {
-								l.resource = Some(MCPOperation::Resource);
-							});
 							self
 								.relay
 								.send_fanout(r, ctx, self.relay.merge_resources(cel))
@@ -278,9 +269,6 @@ impl Session {
 					},
 					ClientRequest::ListResourceTemplatesRequest(_) => {
 						if !self.relay.is_multiplexing() {
-							log.non_atomic_mutate(|l| {
-								l.resource = Some(MCPOperation::ResourceTemplates);
-							});
 							self
 								.relay
 								.send_fanout(r, ctx, self.relay.merge_resource_templates(cel))
@@ -297,10 +285,10 @@ impl Session {
 						let name = ctr.params.name.clone();
 						let (service_name, tool) = self.relay.parse_resource_name(&name)?;
 						span.rename_span(format!("{method} {service_name}"));
+						let call_arguments = ctr.params.arguments.clone();
 						log.non_atomic_mutate(|l| {
-							l.resource_name = Some(tool.to_string());
-							l.target_name = Some(service_name.to_string());
-							l.resource = Some(MCPOperation::Tool);
+							l.set_tool(service_name.to_string(), tool.to_string());
+							l.capture_call_arguments(call_arguments);
 						});
 						if !self.relay.policies.validate(
 							&rbac::ResourceType::Tool(rbac::ResourceId::new(
@@ -317,16 +305,17 @@ impl Session {
 
 						let tn = tool.to_string();
 						ctr.params.name = tn.into();
-						self.relay.send_single(r, ctx, service_name).await
+						self
+							.relay
+							.send_single(r, ctx, service_name, Some(log.clone()))
+							.await
 					},
 					ClientRequest::GetPromptRequest(gpr) => {
 						let name = gpr.params.name.clone();
 						let (service_name, prompt) = self.relay.parse_resource_name(&name)?;
 						span.rename_span(format!("{method} {service_name}"));
 						log.non_atomic_mutate(|l| {
-							l.target_name = Some(service_name.to_string());
-							l.resource_name = Some(prompt.to_string());
-							l.resource = Some(MCPOperation::Prompt);
+							l.set_prompt(service_name.to_string(), prompt.to_string());
 						});
 						if !self.relay.policies.validate(
 							&rbac::ResourceType::Prompt(rbac::ResourceId::new(
@@ -341,16 +330,14 @@ impl Session {
 							});
 						}
 						gpr.params.name = prompt.to_string();
-						self.relay.send_single(r, ctx, service_name).await
+						self.relay.send_single(r, ctx, service_name, None).await
 					},
 					ClientRequest::ReadResourceRequest(rrr) => {
 						if let Some(service_name) = self.relay.default_target_name() {
 							let uri = rrr.params.uri.clone();
 							span.rename_span(format!("{method} {service_name}"));
 							log.non_atomic_mutate(|l| {
-								l.target_name = Some(service_name.to_string());
-								l.resource_name = Some(uri.to_string());
-								l.resource = Some(MCPOperation::Resource);
+								l.set_resource(service_name.to_string(), uri.to_string());
 							});
 							if !self.relay.policies.validate(
 								&rbac::ResourceType::Resource(rbac::ResourceId::new(
@@ -364,7 +351,10 @@ impl Session {
 									resource_name: uri.to_string(),
 								});
 							}
-							self.relay.send_single_without_multiplexing(r, ctx).await
+							self
+								.relay
+								.send_single_without_multiplexing(r, ctx, None)
+								.await
 						} else {
 							// TODO(https://github.com/agentgateway/agentgateway/issues/404)
 							// Find a mapping of URL
@@ -387,7 +377,10 @@ impl Session {
 					ClientRequest::CompleteRequest(_) => {
 						// For now, we don't have a sane mapping of incoming requests to a specific
 						// downstream service when multiplexing. Only forward when we have only one backend.
-						self.relay.send_single_without_multiplexing(r, ctx).await
+						self
+							.relay
+							.send_single_without_multiplexing(r, ctx, None)
+							.await
 					},
 				}
 			},

--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -32,7 +32,7 @@ use crate::cel::{ContextBuilder, Expression, LLMContext};
 use crate::http::Request;
 use crate::http::health;
 use crate::llm::InputFormat;
-use crate::mcp::{MCPOperation, ResourceId, ResourceType};
+use crate::mcp::{MCPInfo, MCPOperation};
 use crate::proxy::ProxyResponseReason;
 use crate::telemetry::metrics::{
 	GenAILabels, GenAILabelsTokenUsage, HTTPLabels, MCPCall, Metrics, RouteIdentifier,
@@ -405,12 +405,7 @@ impl CelLogging {
 
 	pub fn build<'a>(
 		&'a self,
-		req: Option<&'a cel::RequestSnapshot>,
-		resp: Option<&'a cel::ResponseSnapshot>,
-		llm_response: Option<&'a LLMContext>,
-		mcp: Option<&'a ResourceType>,
-		end_time: Option<&'a cel::RequestTime>,
-		source_context: Option<&'a cel::SourceContext>,
+		inputs: CelLoggingBuildInputs<'a>,
 	) -> Result<CelLoggingExecutor<'a>, cel::Error> {
 		let CelLogging {
 			cel_context: _,
@@ -418,12 +413,18 @@ impl CelLogging {
 			fields,
 			metric_fields,
 		} = self;
-		let executor = if req.is_none() && source_context.is_some() {
+		let executor = if inputs.req.is_none() && inputs.source_context.is_some() {
 			// TCP case: use new_tcp_logger
-			cel::Executor::new_tcp_logger(source_context, end_time)
+			cel::Executor::new_tcp_logger(inputs.source_context, inputs.end_time)
 		} else {
 			// HTTP case: use new_logger
-			cel::Executor::new_logger(req, resp, llm_response, mcp, end_time)
+			cel::Executor::new_logger(
+				inputs.req,
+				inputs.resp,
+				inputs.llm_response,
+				inputs.mcp,
+				inputs.end_time,
+			)
 		};
 		Ok(CelLoggingExecutor {
 			executor,
@@ -432,6 +433,15 @@ impl CelLogging {
 			metric_fields,
 		})
 	}
+}
+
+pub struct CelLoggingBuildInputs<'a> {
+	pub req: Option<&'a cel::RequestSnapshot>,
+	pub resp: Option<&'a cel::ResponseSnapshot>,
+	pub llm_response: Option<&'a LLMContext>,
+	pub mcp: Option<&'a MCPInfo>,
+	pub end_time: Option<&'a cel::RequestTime>,
+	pub source_context: Option<&'a cel::SourceContext>,
 }
 
 #[derive(Debug)]
@@ -769,18 +779,7 @@ impl Drop for DropOnLog {
 		let llm_response = log.llm_response.take().map(Into::into);
 
 		let mcp = log.mcp_status.take();
-		let mcp_cel = mcp.as_ref().and_then(|m| {
-			let resource = ResourceId::new(
-				m.target_name.as_deref()?.to_string(),
-				m.resource_name.as_deref()?.to_string(),
-			);
-			match m.resource {
-				Some(MCPOperation::Prompt) => Some(ResourceType::Prompt(resource)),
-				Some(MCPOperation::Tool) => Some(ResourceType::Tool(resource)),
-				Some(MCPOperation::Resource) => Some(ResourceType::Resource(resource)),
-				_ => None,
-			}
-		});
+		let mcp_cel = mcp.as_ref().filter(|m| !m.is_empty());
 		let needs_cel_for_outputs = maybe_enable_log || enable_trace || enable_custom_metrics;
 		let needs_cel_for_eviction = log
 			.health_policy
@@ -791,14 +790,14 @@ impl Drop for DropOnLog {
 		let cel_exec = if needs_cel_for_outputs || needs_cel_for_eviction {
 			log
 				.cel
-				.build(
-					log.request_snapshot.as_ref(),
-					log.response_snapshot.as_ref(),
-					llm_response.as_ref(),
-					mcp_cel.as_ref(),
-					cel_end_time.as_ref(),
-					log.source_context.as_ref(),
-				)
+				.build(CelLoggingBuildInputs {
+					req: log.request_snapshot.as_ref(),
+					resp: log.response_snapshot.as_ref(),
+					llm_response: llm_response.as_ref(),
+					mcp: mcp_cel,
+					end_time: cel_end_time.as_ref(),
+					source_context: log.source_context.as_ref(),
+				})
 				.ok()
 		} else {
 			None
@@ -880,9 +879,9 @@ impl Drop for DropOnLog {
 				.mcp_requests
 				.get_or_create(&MCPCall {
 					method: mcp.method_name.as_ref().map(RichStrng::from).into(),
-					resource_type: mcp.resource.into(),
-					server: mcp.target_name.as_ref().map(RichStrng::from).into(),
-					resource: mcp.resource_name.as_ref().map(RichStrng::from).into(),
+					resource_type: mcp.resource_type().into(),
+					server: mcp.target_name().map(RichStrng::from).into(),
+					resource: mcp.resource_name().map(RichStrng::from).into(),
 
 					route: route_identifier.clone(),
 					custom: custom_metric_fields.clone(),
@@ -902,11 +901,22 @@ impl Drop for DropOnLog {
 
 		let trace_id = log.outgoing_span.as_ref().map(|id| id.trace_id());
 		let span_id = log.outgoing_span.as_ref().map(|id| id.span_id());
-
 		let fields = cel_exec.fields;
 		let reason = log.reason.and_then(|r| match r {
 			ProxyResponseReason::Upstream => None,
 			_ => Some(r),
+		});
+		let mcp_target = mcp
+			.as_ref()
+			.and_then(|m| m.target_name())
+			.map(str::to_owned);
+		let mcp_resource_type = mcp.as_ref().and_then(|m| m.resource_type());
+		let mcp_resource_uri = mcp.as_ref().and_then(|m| {
+			if matches!(m.resource_type(), Some(MCPOperation::Resource)) {
+				m.resource_name().map(str::to_owned)
+			} else {
+				None
+			}
 		});
 
 		let mut kv = vec![
@@ -952,37 +962,9 @@ impl Drop for DropOnLog {
 					.and_then(|m| m.method_name.as_ref())
 					.map(display),
 			),
-			(
-				"gen_ai.tool.name",
-				mcp.as_ref().and_then(|m| {
-					if matches!(m.resource, Some(MCPOperation::Tool)) {
-						m.resource_name.as_ref().map(display)
-					} else {
-						None
-					}
-				}),
-			),
-			(
-				"mcp.target",
-				mcp
-					.as_ref()
-					.and_then(|m| m.target_name.as_ref())
-					.map(display),
-			),
-			(
-				"mcp.resource.type",
-				mcp.as_ref().and_then(|m| m.resource.as_ref()).map(display),
-			),
-			(
-				"mcp.resource.uri",
-				mcp.as_ref().and_then(|m| {
-					if matches!(m.resource, Some(MCPOperation::Resource)) {
-						m.resource_name.as_ref().map(display)
-					} else {
-						None
-					}
-				}),
-			),
+			("mcp.target", mcp_target.as_ref().map(display)),
+			("mcp.resource.type", mcp_resource_type.as_ref().map(display)),
+			("mcp.resource.uri", mcp_resource_uri.as_ref().map(display)),
 			(
 				"mcp.session.id",
 				mcp

--- a/schema/cel.json
+++ b/schema/cel.json
@@ -465,91 +465,95 @@
       "additionalProperties": false
     },
     "mcp": {
-      "description": "`mcp` contains attributes about the MCP request.",
-      "anyOf": [
-        {
-          "oneOf": [
-            {
-              "description": "The tool being accessed",
-              "type": "object",
-              "properties": {
-                "tool": {
-                  "type": "object",
-                  "properties": {
-                    "target": {
-                      "description": "The target of the resource",
-                      "type": "string",
-                      "default": ""
-                    },
-                    "name": {
-                      "description": "The name of the resource",
-                      "type": "string",
-                      "default": ""
-                    }
-                  }
-                }
-              },
-              "required": [
-                "tool"
-              ],
-              "additionalProperties": false
-            },
-            {
-              "description": "The prompt being accessed",
-              "type": "object",
-              "properties": {
-                "prompt": {
-                  "type": "object",
-                  "properties": {
-                    "target": {
-                      "description": "The target of the resource",
-                      "type": "string",
-                      "default": ""
-                    },
-                    "name": {
-                      "description": "The name of the resource",
-                      "type": "string",
-                      "default": ""
-                    }
-                  }
-                }
-              },
-              "required": [
-                "prompt"
-              ],
-              "additionalProperties": false
-            },
-            {
-              "description": "The resource being accessed",
-              "type": "object",
-              "properties": {
-                "resource": {
-                  "type": "object",
-                  "properties": {
-                    "target": {
-                      "description": "The target of the resource",
-                      "type": "string",
-                      "default": ""
-                    },
-                    "name": {
-                      "description": "The name of the resource",
-                      "type": "string",
-                      "default": ""
-                    }
-                  }
-                }
-              },
-              "required": [
-                "resource"
-              ],
-              "additionalProperties": false
-            }
+      "description": "`mcp` contains attributes about the MCP request.\nRequest-time CEL only includes identity fields such as `tool`, `prompt`, or `resource`.\nPost-request CEL may also include fields like `methodName`, `sessionId`, and tool payloads.",
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "methodName": {
+          "type": [
+            "string",
+            "null"
           ]
         },
-        {
-          "type": "null"
+        "sessionId": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "tool": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "target": {
+              "description": "The target handling the tool call after multiplexing resolution.",
+              "type": "string"
+            },
+            "name": {
+              "description": "The resolved tool name sent to the upstream target.",
+              "type": "string"
+            },
+            "arguments": {
+              "description": "The JSON arguments passed to the tool call.",
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": true
+            },
+            "result": {
+              "description": "The terminal tool result payload, if available."
+            },
+            "error": {
+              "description": "The terminal JSON-RPC error payload, if available."
+            }
+          },
+          "required": [
+            "target",
+            "name"
+          ]
+        },
+        "prompt": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "target": {
+              "description": "The target of the resource",
+              "type": "string",
+              "default": ""
+            },
+            "name": {
+              "description": "The name of the resource",
+              "type": "string",
+              "default": ""
+            }
+          }
+        },
+        "resource": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "target": {
+              "description": "The target of the resource",
+              "type": "string",
+              "default": ""
+            },
+            "name": {
+              "description": "The name of the resource",
+              "type": "string",
+              "default": ""
+            }
+          }
         }
-      ]
+      }
     },
     "backend": {
       "description": "`backend` contains information about the backend being used.",

--- a/schema/cel.md
+++ b/schema/cel.md
@@ -64,10 +64,15 @@
 |`source.issuer`|string|The issuer from the downstream certificate, if available.|
 |`source.subject`|string|The subject from the downstream certificate, if available.|
 |`source.subjectCn`|string|The CN of the subject from the downstream certificate, if available.|
-|`mcp`|object|`mcp` contains attributes about the MCP request.|
+|`mcp`|object|`mcp` contains attributes about the MCP request.<br>Request-time CEL only includes identity fields such as `tool`, `prompt`, or `resource`.<br>Post-request CEL may also include fields like `methodName`, `sessionId`, and tool payloads.|
+|`mcp.methodName`|string||
+|`mcp.sessionId`|string||
 |`mcp.tool`|object||
-|`mcp.tool.target`|string|The target of the resource|
-|`mcp.tool.name`|string|The name of the resource|
+|`mcp.tool.target`|string|The target handling the tool call after multiplexing resolution.|
+|`mcp.tool.name`|string|The resolved tool name sent to the upstream target.|
+|`mcp.tool.arguments`|object|The JSON arguments passed to the tool call.|
+|`mcp.tool.result`|any|The terminal tool result payload, if available.|
+|`mcp.tool.error`|any|The terminal JSON-RPC error payload, if available.|
 |`mcp.prompt`|object||
 |`mcp.prompt.target`|string|The target of the resource|
 |`mcp.prompt.name`|string|The name of the resource|


### PR DESCRIPTION
Expose MCP tool call payloads through the existing `mcp` CEL surface instead of introducing a second post-request variable.

Request-time CEL and authorization still use `mcp` as the MCP identity surface, so RBAC expressions like `mcp.tool.name` and `mcp.tool.target` keep working unchanged. After request handling completes, the same `mcp` object can also carry `methodName`, `sessionId`, and tool payload fields such as `mcp.tool.arguments`, `mcp.tool.result`, and `mcp.tool.error`.

That keeps the public CEL model simpler than the earlier `mcp` plus `mcpLog` split, removes one extra MCP context type, and keeps the generated schema honest about the one object users actually query. Internally, authz still evaluates the smaller identity-only subset, while post-request logging and tracing evaluate the richer post-response view of the same MCP object.

For `tools/call`, the schema now explicitly documents:
- `mcp.methodName`
- `mcp.sessionId`
- `mcp.tool.target`
- `mcp.tool.name`
- `mcp.tool.arguments`
- `mcp.tool.result`
- `mcp.tool.error`

That means access-log CEL can use config like:

```yaml
frontendPolicies:
  accessLog:
    add:
      mcp_tool_name: mcp.tool.name
      mcp_method: mcp.methodName
      mcp_session: mcp.sessionId
      mcp_args: mcp.tool.arguments
      mcp_result: mcp.tool.result
      mcp_error: mcp.tool.error
```

Under multiplexing, `mcp.tool.target` and `mcp.tool.name` reflect the resolved upstream target and resolved tool name after gateway routing, which matches the identity used during authorization.

Legacy SSE keeps its non-blocking `202 Accepted` POST behavior, so terminal result and error payloads remain absent from the POST access log on that transport. Streamable HTTP exposes the full post-request MCP payload surface. This branch also regenerates the CEL schema/docs, removes redundant field-specific CEL tests, reuses the shared proxy test setup for MCP access-log coverage, and adds end-to-end MCP coverage for both transports.

Validated with `make gen`, `make lint`, and `make test`.