### PR TITLE
Better handle invalid route backends

### DIFF
--- a/controller/pkg/agentgateway/plugins/reference_indexes.go
+++ b/controller/pkg/agentgateway/plugins/reference_indexes.go
@@ -34,7 +34,6 @@ const (
 type BackendReferenceError struct {
 	Reason  BackendReferenceErrorReason
 	Message string
-	Backend *api.BackendReference
 }
 
 func (e *BackendReferenceError) Error() string {
@@ -126,108 +125,84 @@ func DefaultReferenceTypes(agw *AgwCollections) ReferenceTypes {
 			}
 		},
 		RouteBackend: func(krtctx krt.HandlerContext, defaultNamespace string, gk schema.GroupKind, name gwv1.ObjectName, namespace *gwv1.Namespace, port *gwv1.PortNumber) (*api.BackendReference, error) {
-			ns := string(ptr.OrDefault(namespace, gwv1.Namespace(defaultNamespace)))
-			switch gk {
-			case wellknown.InferencePoolGVK.GroupKind():
-				if strings.Contains(string(name), ".") {
-					return nil, &BackendReferenceError{
-						Reason:  BackendReferenceErrorReasonUnsupportedValue,
-						Message: "service name invalid; the name of the Service must be used, not the hostname.",
-					}
-				}
-				key := ns + "/" + string(name)
-				svc := ptr.Flatten(krt.FetchOne(krtctx, agw.InferencePools, krt.FilterKey(key)))
-				if svc == nil {
-					return nil, &BackendReferenceError{
-						Reason:  BackendReferenceErrorReasonBackendNotFound,
-						Message: fmt.Sprintf("backendRef %s not found", key),
-					}
-				}
-				return &api.BackendReference{
-					Kind: &api.BackendReference_Service_{
-						Service: &api.BackendReference_Service{
-							Hostname:  kubeutils.GetInferenceServiceHostname(string(name), ns),
-							Namespace: ns,
-						},
-					},
-					Port: uint32(svc.Spec.TargetPorts[0].Number), //nolint:gosec // G115: validated 1-65535
-				}, nil
-			case wellknown.HostnameGVK.GroupKind():
-				if port == nil {
-					return nil, &BackendReferenceError{
-						Reason:  BackendReferenceErrorReasonUnsupportedValue,
-						Message: "port is required in backendRef for Hostname kind",
-					}
-				}
-				if namespace != nil {
-					return nil, &BackendReferenceError{
-						Reason:  BackendReferenceErrorReasonUnsupportedValue,
-						Message: "namespace may not be set with Hostname type",
-					}
-				}
-				return &api.BackendReference{
-					Kind: &api.BackendReference_Service_{
-						Service: &api.BackendReference_Service{
-							Hostname:  string(name),
-							Namespace: ns,
-						},
-					},
-					Port: uint32(*port), //nolint:gosec // G115: validated 1-65535
-				}, nil
-			case wellknown.ServiceGVK.GroupKind():
-				if strings.Contains(string(name), ".") {
-					return nil, &BackendReferenceError{
-						Reason:  BackendReferenceErrorReasonUnsupportedValue,
-						Message: "service name invalid; the name of the Service must be used, not the hostname.",
-					}
-				}
-				if port == nil {
-					return nil, &BackendReferenceError{
-						Reason:  BackendReferenceErrorReasonUnsupportedValue,
-						Message: "port is required in backendRef",
-					}
-				}
-				key := ns + "/" + string(name)
-				backendRef := &api.BackendReference{
-					Kind: &api.BackendReference_Service_{
-						Service: &api.BackendReference_Service{
-							Hostname:  kubeutils.GetServiceHostname(string(name), ns),
-							Namespace: ns,
-						},
-					},
-					Port: uint32(*port), //nolint:gosec // G115: validated 1-65535
-				}
-				svc := ptr.Flatten(krt.FetchOne(krtctx, agw.Services, krt.FilterKey(key)))
-				if svc == nil {
-					return nil, &BackendReferenceError{
-						Reason:  BackendReferenceErrorReasonBackendNotFound,
-						Message: fmt.Sprintf("backend(%s) not found", kubeutils.GetServiceHostname(string(name), ns)),
-						Backend: backendRef,
-					}
-				}
-				return backendRef, nil
-			case wellknown.AgentgatewayBackendGVK.GroupKind():
-				key := ns + "/" + string(name)
-				be := ptr.Flatten(krt.FetchOne(krtctx, agw.Backends, krt.FilterKey(key)))
-				if be == nil {
-					return nil, &BackendReferenceError{
-						Reason:  BackendReferenceErrorReasonBackendNotFound,
-						Message: fmt.Sprintf("Backend not found: %s", key),
-					}
-				}
-				return &api.BackendReference{
-					Kind: &api.BackendReference_Backend{
-						Backend: key,
-					},
-				}, nil
-			default:
-				return nil, &BackendReferenceError{
-					Reason:  BackendReferenceErrorReasonInvalidKind,
-					Message: fmt.Sprintf("referencing unsupported backendRef: group %q kind %q", gk.Group, gk.Kind),
-				}
-			}
+			return DefaultRouteBackend(krtctx, agw, defaultNamespace, gk, name, namespace, port)
 		},
 	}
+}
+
+func DefaultRouteBackend(krtctx krt.HandlerContext, agw *AgwCollections, defaultNamespace string, gk schema.GroupKind, name gwv1.ObjectName, namespace *gwv1.Namespace, port *gwv1.PortNumber) (*api.BackendReference, error) {
+	ns := string(ptr.OrDefault(namespace, gwv1.Namespace(defaultNamespace)))
+	// All MUST return a BackendReference. We may not be able to fully populate it, though; this will get replaced with 'invalid'
+	ref := &api.BackendReference{}
+	switch gk {
+	case wellknown.InferencePoolGVK.GroupKind():
+		if strings.Contains(string(name), ".") {
+			return ref, &BackendReferenceError{
+				Reason:  BackendReferenceErrorReasonUnsupportedValue,
+				Message: "InferencePool name invalid; the name of the InferencePool must be used, not the hostname.",
+			}
+		}
+		key := ns + "/" + string(name)
+		svc := ptr.Flatten(krt.FetchOne(krtctx, agw.InferencePools, krt.FilterKey(key)))
+		if svc == nil {
+			return ref, &BackendReferenceError{
+				Reason:  BackendReferenceErrorReasonBackendNotFound,
+				Message: fmt.Sprintf("backendRef %s not found", key),
+			}
+		}
+		ref.Kind = &api.BackendReference_Service_{
+			Service: &api.BackendReference_Service{
+				Hostname:  kubeutils.GetInferenceServiceHostname(string(name), ns),
+				Namespace: ns,
+			},
+		}
+		ref.Port = uint32(svc.Spec.TargetPorts[0].Number) //nolint:gosec // G115: validated 1-65535
+	case wellknown.ServiceGVK.GroupKind():
+		if strings.Contains(string(name), ".") {
+			return ref, &BackendReferenceError{
+				Reason:  BackendReferenceErrorReasonUnsupportedValue,
+				Message: "service name invalid; the name of the Service must be used, not the hostname.",
+			}
+		}
+		if port == nil { // Validated by CEL so shouldn't happen
+			return ref, &BackendReferenceError{
+				Reason:  BackendReferenceErrorReasonUnsupportedValue,
+				Message: "port is required in Service backendRef",
+			}
+		}
+		// Populate resp now, so even if the service doesn't exist we can return a better error (Service not found vs invalid)
+		ref.Kind = &api.BackendReference_Service_{
+			Service: &api.BackendReference_Service{
+				Hostname:  kubeutils.GetServiceHostname(string(name), ns),
+				Namespace: ns,
+			}}
+		ref.Port = uint32(*port) //nolint:gosec // G115: validated 1-65535
+		key := ns + "/" + string(name)
+		svc := ptr.Flatten(krt.FetchOne(krtctx, agw.Services, krt.FilterKey(key)))
+		if svc == nil {
+			return ref, &BackendReferenceError{
+				Reason:  BackendReferenceErrorReasonBackendNotFound,
+				Message: fmt.Sprintf("backend(%s) not found", kubeutils.GetServiceHostname(string(name), ns)),
+			}
+		}
+	case wellknown.AgentgatewayBackendGVK.GroupKind():
+		key := ns + "/" + string(name)
+		ref.Kind = &api.BackendReference_Backend{Backend: key}
+		// Populate resp now, so even if the service doesn't exist we can return a better error (Service not found vs invalid)
+		be := ptr.Flatten(krt.FetchOne(krtctx, agw.Backends, krt.FilterKey(key)))
+		if be == nil {
+			return ref, &BackendReferenceError{
+				Reason:  BackendReferenceErrorReasonBackendNotFound,
+				Message: fmt.Sprintf("Backend not found: %s", key),
+			}
+		}
+	default:
+		return ref, &BackendReferenceError{
+			Reason:  BackendReferenceErrorReasonInvalidKind,
+			Message: fmt.Sprintf("referencing unsupported backendRef: group %q kind %q", gk.Group, gk.Kind),
+		}
+	}
+	return ref, nil
 }
 
 type RouteAttachment struct {

--- a/controller/pkg/agentgateway/translator/conversion.go
+++ b/controller/pkg/agentgateway/translator/conversion.go
@@ -604,19 +604,6 @@ func buildAgwDestination(
 	ns string,
 	k schema.GroupVersionKind,
 ) (*api.RouteBackend, *reporter.RouteCondition) {
-	ref := NormalizeReference(to.Group, to.Kind, wellknown.ServiceGVK)
-	// check if the reference is allowed
-	if toNs := to.Namespace; toNs != nil && string(*toNs) != ns {
-		if !ctx.Grants.BackendAllowed(ctx.Krt, k, to.Name, *toNs, ns, ref) {
-			return nil, &reporter.RouteCondition{
-				Type:    gwv1.RouteConditionResolvedRefs,
-				Status:  metav1.ConditionFalse,
-				Reason:  gwv1.RouteReasonRefNotPermitted,
-				Message: fmt.Sprintf("backendRef %v/%v not accessible to a %s in namespace %q (missing a ReferenceGrant?)", to.Name, *toNs, k.Kind, ns),
-			}
-		}
-	}
-
 	weight := int32(1) // default
 	if to.Weight != nil {
 		weight = *to.Weight
@@ -624,16 +611,27 @@ func buildAgwDestination(
 	rb := &api.RouteBackend{
 		Weight: weight,
 	}
+	ref := NormalizeReference(to.Group, to.Kind, wellknown.ServiceGVK)
+	// check if the reference is allowed
+	if toNs := to.Namespace; toNs != nil && string(*toNs) != ns {
+		if !ctx.Grants.BackendAllowed(ctx.Krt, k, to.Name, *toNs, ns, ref) {
+			return rb, &reporter.RouteCondition{
+				Type:    gwv1.RouteConditionResolvedRefs,
+				Status:  metav1.ConditionFalse,
+				Reason:  gwv1.RouteReasonRefNotPermitted,
+				Message: fmt.Sprintf("backendRef %v/%v not accessible to a %s in namespace %q (missing a ReferenceGrant?)", to.Name, *toNs, k.Kind, ns),
+			}
+		}
+	}
 	backendRef, err := ctx.References.RouteBackend(ctx.Krt, ns, ref.GroupKind(), to.Name, to.Namespace, to.Port)
+	// Even in the error case, we still populate a partial backend
+	rb.Backend = backendRef
 	if err != nil {
 		var backendErr *plugins.BackendReferenceError
 		if errors.As(err, &backendErr) {
-			if backendErr.Backend != nil {
-				rb.Backend = backendErr.Backend
-			}
 			switch backendErr.Reason {
 			case plugins.BackendReferenceErrorReasonUnsupportedValue:
-				return nil, &reporter.RouteCondition{
+				return rb, &reporter.RouteCondition{
 					Type:    gwv1.RouteConditionAccepted,
 					Status:  metav1.ConditionFalse,
 					Reason:  gwv1.RouteReasonUnsupportedValue,
@@ -647,7 +645,7 @@ func buildAgwDestination(
 					Message: backendErr.Message,
 				}
 			case plugins.BackendReferenceErrorReasonInvalidKind:
-				return nil, &reporter.RouteCondition{
+				return rb, &reporter.RouteCondition{
 					Type:    gwv1.RouteConditionResolvedRefs,
 					Status:  metav1.ConditionFalse,
 					Reason:  gwv1.RouteReasonInvalidKind,
@@ -655,14 +653,13 @@ func buildAgwDestination(
 				}
 			}
 		}
-		return nil, &reporter.RouteCondition{
+		return rb, &reporter.RouteCondition{
 			Type:    gwv1.RouteConditionResolvedRefs,
 			Status:  metav1.ConditionFalse,
 			Reason:  gwv1.RouteReasonInvalidKind,
 			Message: err.Error(),
 		}
 	}
-	rb.Backend = backendRef
 	return rb, nil
 }
 

--- a/controller/pkg/agentgateway/translator/testdata/routes/grpc-invalid.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/routes/grpc-invalid.yaml
@@ -25,7 +25,8 @@ output:
   resource:
     route:
       backends:
-      - {}
+      - backend: {}
+        weight: 1
       key: default/example-grpc-route.00.grpc.http
       listenerKey: default/test-gateway.http
       matches:

--- a/controller/pkg/agentgateway/translator/testdata/routes/httproute-missing-dest.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/routes/httproute-missing-dest.yaml
@@ -10,15 +10,19 @@ spec:
   - backendRefs:
     - name: unknown
       port: 8080
+      weight: 2
     - name: cross-ns-no-ref-grant
       namespace: other
       port: 8080
+      weight: 4
     - name: unknown-backend
       group: agentgateway.dev
       kind: AgentgatewayBackend
+      weight: 6
     - name: unknown-kind
       group: example.com
       kind: NotBackend
+      weight: 8
 ---
 # Output
 output:
@@ -33,10 +37,13 @@ output:
           service:
             hostname: unknown.default.svc.cluster.local
             namespace: default
-        weight: 1
-      - {}
-      - weight: 1
-      - {}
+        weight: 2
+      - weight: 4
+      - backend:
+          backend: default/unknown-backend
+        weight: 6
+      - backend: {}
+        weight: 8
       key: default/missing-dest.00.http
       listenerKey: default/test-gateway.http
       name:


### PR DESCRIPTION
Per GW API spec we should send a weight-proportional amount of traffic to invalid backends. We did not and instead sent a backend `{}` which implies `weight=0` which implies no traffic.