### PR TITLE
feat(mcp): merge upstream instructions when multiplexing

### DIFF
--- a/crates/agentgateway/src/mcp/handler.rs
+++ b/crates/agentgateway/src/mcp/handler.rs
@@ -211,20 +211,28 @@ impl Relay {
 				}
 				// If we got here in FailOpen mode, it means the only target failed.
 				// Return a default info response to keep the client session alive.
-				return Ok(Self::get_info(pv, multiplexing).into());
+				return Ok(Self::get_info(pv, multiplexing, Vec::new()).into());
 			}
 
-			// Multiplexing is more complex. We need to find the lowest protocol version that all servers support.
-			let lowest_version = s
-				.into_iter()
-				.flat_map(|(_, v)| match v {
-					ServerResult::InitializeResult(r) => Some(r.protocol_version),
-					_ => None,
-				})
-				.min_by_key(|i| i.to_string())
-				.unwrap_or(pv);
-			// For now, we just send our own info. In the future, we should merge the results from each upstream.
-			Ok(Self::get_info(lowest_version, multiplexing).into())
+			// Multiplexing is more complex. We need to find the lowest protocol version
+			// that all servers support and merge instructions from all upstreams.
+			let mut lowest_version = pv;
+			let mut upstream_instructions: Vec<(String, String)> = Vec::new();
+
+			for (server_name, v) in s {
+				if let ServerResult::InitializeResult(r) = v {
+					if r.protocol_version.to_string() < lowest_version.to_string() {
+						lowest_version = r.protocol_version;
+					}
+					if let Some(instructions) = r.instructions
+						&& !instructions.is_empty()
+					{
+						upstream_instructions.push((server_name.to_string(), instructions));
+					}
+				}
+			}
+
+			Ok(Self::get_info(lowest_version, multiplexing, upstream_instructions).into())
 		})
 	}
 
@@ -477,7 +485,11 @@ impl Relay {
 
 		Ok(accepted_response())
 	}
-	fn get_info(pv: ProtocolVersion, multiplexing: bool) -> ServerInfo {
+	fn get_info(
+		pv: ProtocolVersion,
+		multiplexing: bool,
+		upstream_instructions: Vec<(String, String)>,
+	) -> ServerInfo {
 		let capabilities = if multiplexing {
 			ServerCapabilities {
 				completions: None,
@@ -502,9 +514,16 @@ impl Relay {
 				resources: Some(ResourcesCapability::default()),
 			}
 		};
-		let instructions = Some(
-            "This server is a gateway to a set of mcp servers. It is responsible for routing requests to the correct server and aggregating the results.".to_string(),
-        );
+		let gateway_preamble = "This server is a gateway to a set of mcp servers. It is responsible for routing requests to the correct server and aggregating the results.";
+		let instructions = if upstream_instructions.is_empty() {
+			Some(gateway_preamble.to_string())
+		} else {
+			let mut merged = String::from(gateway_preamble);
+			for (server_name, instruction) in &upstream_instructions {
+				merged.push_str(&format!("\n\n[{server_name}]\n{instruction}"));
+			}
+			Some(merged)
+		};
 		ServerInfo {
 			protocol_version: pv,
 			capabilities,

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -1481,6 +1481,197 @@ fn test_set_sessions_rejects_mismatched_target_set() {
 	);
 }
 
+#[test]
+fn test_merge_initialize_merges_upstream_instructions_when_multiplexing() {
+	use rmcp::model::{
+		Implementation, InitializeResult, ProtocolVersion, ServerCapabilities, ServerResult,
+	};
+
+	let relay = Relay::new(
+		McpBackendGroup {
+			targets: vec![
+				fake_streamable_target("alpha", SocketAddr::from(([127, 0, 0, 1], 30101))),
+				fake_streamable_target("beta", SocketAddr::from(([127, 0, 0, 1], 30102))),
+			],
+			stateful: true,
+			failure_mode: FailureMode::FailClosed,
+		},
+		empty_mcp_policies(),
+		PolicyClient {
+			inputs: setup_proxy_test("{}").unwrap().pi,
+		},
+	)
+	.unwrap();
+
+	let merge_fn = relay.merge_initialize(ProtocolVersion::V_2025_06_18, true);
+
+	let results: Vec<(Strng, ServerResult)> = vec![
+		(
+			"alpha".into(),
+			ServerResult::InitializeResult(InitializeResult {
+				protocol_version: ProtocolVersion::V_2025_06_18,
+				capabilities: ServerCapabilities::default(),
+				server_info: Implementation {
+					name: "alpha-server".to_string(),
+					version: "1.0".to_string(),
+					..Default::default()
+				},
+				instructions: Some("Alpha server: handles data processing.".to_string()),
+			}),
+		),
+		(
+			"beta".into(),
+			ServerResult::InitializeResult(InitializeResult {
+				protocol_version: ProtocolVersion::V_2025_06_18,
+				capabilities: ServerCapabilities::default(),
+				server_info: Implementation {
+					name: "beta-server".to_string(),
+					version: "1.0".to_string(),
+					..Default::default()
+				},
+				instructions: Some("Beta server: handles notifications.".to_string()),
+			}),
+		),
+	];
+
+	let result = merge_fn(results).unwrap();
+	let info = match result {
+		ServerResult::InitializeResult(ir) => ir,
+		other => panic!("expected InitializeResult, got: {:?}", other),
+	};
+
+	let instructions = info.instructions.expect("instructions should be present");
+	assert!(
+		instructions.contains("Alpha server: handles data processing."),
+		"merged instructions should contain alpha's instructions, got: {instructions}"
+	);
+	assert!(
+		instructions.contains("Beta server: handles notifications."),
+		"merged instructions should contain beta's instructions, got: {instructions}"
+	);
+	assert!(
+		instructions.contains("[alpha]"),
+		"merged instructions should label alpha's section, got: {instructions}"
+	);
+	assert!(
+		instructions.contains("[beta]"),
+		"merged instructions should label beta's section, got: {instructions}"
+	);
+	assert!(
+		instructions.contains("gateway"),
+		"merged instructions should contain gateway preamble, got: {instructions}"
+	);
+}
+
+#[test]
+fn test_merge_initialize_no_instructions_when_multiplexing() {
+	use rmcp::model::{
+		Implementation, InitializeResult, ProtocolVersion, ServerCapabilities, ServerResult,
+	};
+
+	let relay = Relay::new(
+		McpBackendGroup {
+			targets: vec![fake_streamable_target(
+				"alpha",
+				SocketAddr::from(([127, 0, 0, 1], 30103)),
+			)],
+			stateful: true,
+			failure_mode: FailureMode::FailClosed,
+		},
+		empty_mcp_policies(),
+		PolicyClient {
+			inputs: setup_proxy_test("{}").unwrap().pi,
+		},
+	)
+	.unwrap();
+
+	let merge_fn = relay.merge_initialize(ProtocolVersion::V_2025_06_18, true);
+
+	let results: Vec<(Strng, ServerResult)> = vec![(
+		"alpha".into(),
+		ServerResult::InitializeResult(InitializeResult {
+			protocol_version: ProtocolVersion::V_2025_06_18,
+			capabilities: ServerCapabilities::default(),
+			server_info: Implementation {
+				name: "alpha-server".to_string(),
+				version: "1.0".to_string(),
+				..Default::default()
+			},
+			instructions: None,
+		}),
+	)];
+
+	let result = merge_fn(results).unwrap();
+	let info = match result {
+		ServerResult::InitializeResult(ir) => ir,
+		other => panic!("expected InitializeResult, got: {:?}", other),
+	};
+
+	let instructions = info.instructions.expect("instructions should be present");
+	// When no upstream provides instructions, only the gateway preamble should be present
+	assert!(
+		instructions.contains("gateway"),
+		"should contain gateway preamble, got: {instructions}"
+	);
+	assert!(
+		!instructions.contains("[alpha]"),
+		"should not contain server sections when no instructions provided, got: {instructions}"
+	);
+}
+
+#[test]
+fn test_merge_initialize_forwards_single_backend_without_multiplexing() {
+	use rmcp::model::{
+		Implementation, InitializeResult, ProtocolVersion, ServerCapabilities, ServerResult,
+	};
+
+	let relay = Relay::new(
+		McpBackendGroup {
+			targets: vec![fake_streamable_target(
+				"solo",
+				SocketAddr::from(([127, 0, 0, 1], 30104)),
+			)],
+			stateful: true,
+			failure_mode: FailureMode::FailClosed,
+		},
+		empty_mcp_policies(),
+		PolicyClient {
+			inputs: setup_proxy_test("{}").unwrap().pi,
+		},
+	)
+	.unwrap();
+
+	let merge_fn = relay.merge_initialize(ProtocolVersion::V_2025_06_18, false);
+
+	let results: Vec<(Strng, ServerResult)> = vec![(
+		"solo".into(),
+		ServerResult::InitializeResult(InitializeResult {
+			protocol_version: ProtocolVersion::V_2025_06_18,
+			capabilities: ServerCapabilities::default(),
+			server_info: Implementation {
+				name: "solo-server".to_string(),
+				version: "1.0".to_string(),
+				..Default::default()
+			},
+			instructions: Some("Solo server instructions.".to_string()),
+		}),
+	)];
+
+	let result = merge_fn(results).unwrap();
+	let info = match result {
+		ServerResult::InitializeResult(ir) => ir,
+		other => panic!("expected InitializeResult, got: {:?}", other),
+	};
+
+	// Non-multiplexing should forward the upstream's instructions directly
+	assert_eq!(
+		info.instructions.as_deref(),
+		Some("Solo server instructions."),
+		"non-multiplexing should forward upstream instructions unchanged"
+	);
+	assert_eq!(info.server_info.name, "solo-server");
+}
+
 #[tokio::test]
 async fn test_runtime_fanout_fail_open() {
 	use crate::mcp::mergestream::{MergeStream, Messages};


### PR DESCRIPTION
## Summary

- When multiplexing multiple MCP backend targets, `merge_initialize` discarded all upstream servers' instructions and replaced them with a hardcoded gateway description
- Upstream instructions are now collected from each backend's `InitializeResult` and merged into the final response, prefixed with the server name for disambiguation
- Added three unit tests covering: merged instructions with multiple backends, no upstream instructions, and single backend without multiplexing

Closes #1346

## Test plan

- [x] `cargo test -p agentgateway test_merge_initialize` — 3 new unit tests pass
- [x] `cargo test -p agentgateway` — all 82 tests pass
- [x] `make lint` — passes (fmt + clippy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)