### PR TITLE
fix: route non-success streaming responses through buffered error path

### DIFF
--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -816,7 +816,10 @@ impl AIProvider {
 		include_completion_in_log: bool,
 		resp: Response,
 	) -> Result<Response, AIError> {
-		if req.streaming {
+		// Non-success responses are plain JSON, not event-stream data — route
+		// them through the buffered error-handling path so the body is forwarded
+		// intact instead of being silently consumed by the streaming decoder.
+		if req.streaming && resp.status().is_success() {
 			return self
 				.process_streaming(req, rate_limit, log, include_completion_in_log, resp)
 				.await;

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -816,10 +816,9 @@ impl AIProvider {
 		include_completion_in_log: bool,
 		resp: Response,
 	) -> Result<Response, AIError> {
-		// For the streaming backends we target here, non-success responses are
-		// typically plain (non-event-stream) bodies — route them through the
-		// buffered error-handling path so the body is forwarded intact instead
-		// of being silently consumed by the streaming decoder.
+		// Non-success responses are plain JSON, not event-stream data.
+		// Only enter the streaming path for successful responses; errors
+		// fall through to the buffered path where process_error translates them.
 		if req.streaming && resp.status().is_success() {
 			return self
 				.process_streaming(req, rate_limit, log, include_completion_in_log, resp)

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -816,9 +816,10 @@ impl AIProvider {
 		include_completion_in_log: bool,
 		resp: Response,
 	) -> Result<Response, AIError> {
-		// Non-success responses are plain JSON, not event-stream data — route
-		// them through the buffered error-handling path so the body is forwarded
-		// intact instead of being silently consumed by the streaming decoder.
+		// For the streaming backends we target here, non-success responses are
+		// typically plain (non-event-stream) bodies — route them through the
+		// buffered error-handling path so the body is forwarded intact instead
+		// of being silently consumed by the streaming decoder.
 		if req.streaming && resp.status().is_success() {
 			return self
 				.process_streaming(req, rate_limit, log, include_completion_in_log, resp)

--- a/crates/agentgateway/src/llm/tests.rs
+++ b/crates/agentgateway/src/llm/tests.rs
@@ -927,12 +927,15 @@ fn test_get_messages() {
 /// response, the error body must be translated and forwarded instead of being
 /// silently consumed by the streaming decoder.
 ///
-/// This test calls `process_error` directly for each Bedrock input format to
-/// verify the error translation produces a non-empty, valid JSON body.  The
-/// condition change in `process_response` (`resp.status().is_success()`) ensures
-/// this path is actually reached for streaming requests.
-#[test]
-fn bedrock_error_body_is_translated_for_all_input_formats() {
+/// This test demonstrates the bug and the fix by feeding a Bedrock 400 JSON
+/// error body through both code paths:
+///   1. process_streaming (the old, buggy path) — produces empty body
+///   2. buffered process_error (the fixed path)  — produces proper translated body
+///
+/// The condition change in process_response (`resp.status().is_success()`)
+/// ensures path (2) is taken for non-success responses.
+#[tokio::test]
+async fn streaming_error_response_body_is_not_swallowed() {
 	let bedrock = AIProvider::Bedrock(bedrock::Provider {
 		model: Some(strng::new("anthropic.claude-3-5-sonnet-20241022-v2:0")),
 		region: strng::new("us-west-2"),
@@ -940,54 +943,80 @@ fn bedrock_error_body_is_translated_for_all_input_formats() {
 		guardrail_version: None,
 	});
 
-	// Simulated Bedrock ValidationException error body.
-	let bedrock_error = Bytes::from(
-		r#"{"message":"Expected toolResult blocks at messages.2.content for the following Ids: tooluse_abc123"}"#,
+	// A real Bedrock ValidationException error body (plain JSON, not event-stream).
+	let error_json = r#"{"message":"Expected toolResult blocks at messages.2.content for the following Ids: tooluse_abc123"}"#;
+
+	let streaming_req = LLMRequest {
+		input_tokens: None,
+		input_format: InputFormat::Completions,
+		request_model: "input-model".into(),
+		provider: Default::default(),
+		streaming: true,
+		params: Default::default(),
+		prompt: None,
+	};
+
+	// ---- Path 1: process_streaming (buggy path) ----
+	// The AWS EventStream decoder consumes the JSON bytes and produces nothing.
+	let body = Body::from(error_json.as_bytes().to_vec());
+	let mut resp = Response::new(body);
+	*resp.status_mut() = ::http::StatusCode::BAD_REQUEST;
+	resp.headers_mut().insert(
+		::http::header::CONTENT_TYPE,
+		"application/json".parse().unwrap(),
+	);
+	resp.headers_mut().insert(
+		::http::header::CONTENT_LENGTH,
+		error_json.len().to_string().parse().unwrap(),
 	);
 
-	let formats = [
-		InputFormat::Completions,
-		InputFormat::Messages,
-		InputFormat::Responses,
-		InputFormat::Embeddings,
-	];
+	let log = AsyncLog::default();
+	let streaming_resp = bedrock
+		.process_streaming(
+			streaming_req.clone(),
+			LLMResponsePolicies::default(),
+			log,
+			false,
+			resp,
+		)
+		.await
+		.expect("process_streaming should not fail");
 
-	for format in formats {
-		let req = LLMRequest {
-			input_tokens: None,
-			input_format: format,
-			request_model: "input-model".into(),
-			provider: Default::default(),
-			streaming: true,
-			params: Default::default(),
-			prompt: None,
-		};
+	let streaming_body = streaming_resp
+		.collect()
+		.await
+		.unwrap()
+		.to_bytes();
 
-		let result = bedrock.process_error(&req, ::http::StatusCode::BAD_REQUEST, &bedrock_error);
-		let body = result.unwrap_or_else(|e| {
-			panic!("process_error failed for {format:?}: {e}");
-		});
+	// The streaming decoder silently swallows the JSON error — body is empty.
+	assert!(
+		streaming_body.is_empty(),
+		"process_streaming should produce empty body for JSON error input (bug demonstration), got {} bytes",
+		streaming_body.len(),
+	);
 
-		assert!(
-			!body.is_empty(),
-			"process_error returned empty body for {format:?}",
-		);
+	// ---- Path 2: buffered process_error (fixed path) ----
+	// This is the path taken after the fix when resp.status().is_success() is false.
+	let error_bytes = Bytes::from(error_json);
+	let translated = bedrock
+		.process_error(&streaming_req, ::http::StatusCode::BAD_REQUEST, &error_bytes)
+		.expect("process_error should succeed");
 
-		let parsed: Value = serde_json::from_slice(&body).unwrap_or_else(|e| {
-			panic!(
-				"process_error returned invalid JSON for {format:?}: {e}\nbody: {}",
-				String::from_utf8_lossy(&body)
-			);
-		});
+	assert!(
+		!translated.is_empty(),
+		"process_error should produce non-empty translated body",
+	);
 
-		// Verify the translated error contains the original message.
-		let message = parsed
-			.pointer("/error/message")
-			.and_then(|v| v.as_str())
-			.unwrap_or_default();
-		assert!(
-			message.contains("toolResult"),
-			"translated error for {format:?} should preserve the original message, got: {message}",
-		);
-	}
+	let parsed: Value = serde_json::from_slice(&translated)
+		.expect("translated error should be valid JSON");
+
+	// Verify the original Bedrock error message is preserved in the translation.
+	let message = parsed
+		.pointer("/error/message")
+		.and_then(|v| v.as_str())
+		.unwrap_or_default();
+	assert!(
+		message.contains("toolResult"),
+		"translated error should preserve the original message, got: {message}",
+	);
 }

--- a/crates/agentgateway/src/llm/tests.rs
+++ b/crates/agentgateway/src/llm/tests.rs
@@ -927,13 +927,17 @@ fn test_get_messages() {
 /// response, the error body must be translated and forwarded instead of being
 /// silently consumed by the streaming decoder.
 ///
-/// This test demonstrates the bug and the fix by feeding a Bedrock 400 JSON
-/// error body through both code paths:
-///   1. process_streaming (the old, buggy path) — produces empty body
-///   2. buffered process_error (the fixed path)  — produces proper translated body
+/// This test proves the bug exists and the fix works by exercising both paths:
+///   1. process_streaming with a 400 JSON body → empty output (the bug)
+///   2. process_error with the same body → correct translated output (the fix)
 ///
-/// The condition change in process_response (`resp.status().is_success()`)
-/// ensures path (2) is taken for non-success responses.
+/// The one-line condition change in process_response gates between these paths.
+///
+/// NOTE: We cannot call process_response directly in a unit test because it
+/// requires PolicyClient, which wraps ProxyInputs (full proxy runtime with
+/// Config, Stores, client::Client, Metrics, mcp::App — none of which have
+/// test constructors). An integration test via tests/common/gateway.rs with
+/// a mock backend returning 400 would cover the routing end-to-end.
 #[tokio::test]
 async fn streaming_error_response_body_is_not_swallowed() {
 	let bedrock = AIProvider::Bedrock(bedrock::Provider {

--- a/crates/agentgateway/src/llm/tests.rs
+++ b/crates/agentgateway/src/llm/tests.rs
@@ -922,3 +922,72 @@ fn test_get_messages() {
 		"get-messages-messages",
 	);
 }
+
+/// Regression test for #1340: when a streaming request receives a non-success
+/// response, the error body must be translated and forwarded instead of being
+/// silently consumed by the streaming decoder.
+///
+/// This test calls `process_error` directly for each Bedrock input format to
+/// verify the error translation produces a non-empty, valid JSON body.  The
+/// condition change in `process_response` (`resp.status().is_success()`) ensures
+/// this path is actually reached for streaming requests.
+#[test]
+fn bedrock_error_body_is_translated_for_all_input_formats() {
+	let bedrock = AIProvider::Bedrock(bedrock::Provider {
+		model: Some(strng::new("anthropic.claude-3-5-sonnet-20241022-v2:0")),
+		region: strng::new("us-west-2"),
+		guardrail_identifier: None,
+		guardrail_version: None,
+	});
+
+	// Simulated Bedrock ValidationException error body.
+	let bedrock_error = Bytes::from(
+		r#"{"message":"Expected toolResult blocks at messages.2.content for the following Ids: tooluse_abc123"}"#,
+	);
+
+	let formats = [
+		InputFormat::Completions,
+		InputFormat::Messages,
+		InputFormat::Responses,
+		InputFormat::Embeddings,
+	];
+
+	for format in formats {
+		let req = LLMRequest {
+			input_tokens: None,
+			input_format: format,
+			request_model: "input-model".into(),
+			provider: Default::default(),
+			streaming: true,
+			params: Default::default(),
+			prompt: None,
+		};
+
+		let result = bedrock.process_error(&req, ::http::StatusCode::BAD_REQUEST, &bedrock_error);
+		let body = result.unwrap_or_else(|e| {
+			panic!("process_error failed for {format:?}: {e}");
+		});
+
+		assert!(
+			!body.is_empty(),
+			"process_error returned empty body for {format:?}",
+		);
+
+		let parsed: Value = serde_json::from_slice(&body).unwrap_or_else(|e| {
+			panic!(
+				"process_error returned invalid JSON for {format:?}: {e}\nbody: {}",
+				String::from_utf8_lossy(&body)
+			);
+		});
+
+		// Verify the translated error contains the original message.
+		let message = parsed
+			.pointer("/error/message")
+			.and_then(|v| v.as_str())
+			.unwrap_or_default();
+		assert!(
+			message.contains("toolResult"),
+			"translated error for {format:?} should preserve the original message, got: {message}",
+		);
+	}
+}

--- a/crates/agentgateway/src/llm/tests.rs
+++ b/crates/agentgateway/src/llm/tests.rs
@@ -923,23 +923,17 @@ fn test_get_messages() {
 	);
 }
 
-/// Regression test for #1340: when a streaming request receives a non-success
-/// response, the error body must be translated and forwarded instead of being
-/// silently consumed by the streaming decoder.
+/// Verifies that `process_response` routes a non-success response through
+/// the buffered error path even when the request has `streaming: true`.
 ///
-/// This test proves the bug exists and the fix works by exercising both paths:
-///   1. process_streaming with a 400 JSON body → empty output (the bug)
-///   2. process_error with the same body → correct translated output (the fix)
-///
-/// The one-line condition change in process_response gates between these paths.
-///
-/// NOTE: We cannot call process_response directly in a unit test because it
-/// requires PolicyClient, which wraps ProxyInputs (full proxy runtime with
-/// Config, Stores, client::Client, Metrics, mcp::App — none of which have
-/// test constructors). An integration test via tests/common/gateway.rs with
-/// a mock backend returning 400 would cover the routing end-to-end.
+/// Constructs a Bedrock 400 JSON error response and passes it through
+/// `process_response` with a streaming `LLMRequest`. Asserts the returned
+/// body is non-empty, valid JSON, and preserves the original error message.
 #[tokio::test]
-async fn streaming_error_response_body_is_not_swallowed() {
+async fn process_response_routes_streaming_error_to_buffered_path() {
+	use crate::proxy::httpproxy::PolicyClient;
+	use crate::test_helpers::proxymock::setup_proxy_test;
+
 	let bedrock = AIProvider::Bedrock(bedrock::Provider {
 		model: Some(strng::new("anthropic.claude-3-5-sonnet-20241022-v2:0")),
 		region: strng::new("us-west-2"),
@@ -947,10 +941,9 @@ async fn streaming_error_response_body_is_not_swallowed() {
 		guardrail_version: None,
 	});
 
-	// A real Bedrock ValidationException error body (plain JSON, not event-stream).
 	let error_json = r#"{"message":"Expected toolResult blocks at messages.2.content for the following Ids: tooluse_abc123"}"#;
 
-	let streaming_req = LLMRequest {
+	let req = LLMRequest {
 		input_tokens: None,
 		input_format: InputFormat::Completions,
 		request_model: "input-model".into(),
@@ -960,8 +953,6 @@ async fn streaming_error_response_body_is_not_swallowed() {
 		prompt: None,
 	};
 
-	// ---- Path 1: process_streaming (buggy path) ----
-	// The AWS EventStream decoder consumes the JSON bytes and produces nothing.
 	let body = Body::from(error_json.as_bytes().to_vec());
 	let mut resp = Response::new(body);
 	*resp.status_mut() = ::http::StatusCode::BAD_REQUEST;
@@ -969,52 +960,34 @@ async fn streaming_error_response_body_is_not_swallowed() {
 		::http::header::CONTENT_TYPE,
 		"application/json".parse().unwrap(),
 	);
-	resp.headers_mut().insert(
-		::http::header::CONTENT_LENGTH,
-		error_json.len().to_string().parse().unwrap(),
-	);
 
-	let log = AsyncLog::default();
-	let streaming_resp = bedrock
-		.process_streaming(
-			streaming_req.clone(),
+	let client = PolicyClient {
+		inputs: setup_proxy_test("{}").unwrap().pi,
+	};
+
+	let result = bedrock
+		.process_response(
+			client,
+			req,
 			LLMResponsePolicies::default(),
-			log,
+			AsyncLog::default(),
 			false,
 			resp,
 		)
 		.await
-		.expect("process_streaming should not fail");
+		.expect("process_response should succeed for error responses");
 
-	let streaming_body = streaming_resp
-		.collect()
-		.await
-		.unwrap()
-		.to_bytes();
+	assert_eq!(result.status(), ::http::StatusCode::BAD_REQUEST);
 
-	// The streaming decoder silently swallows the JSON error — body is empty.
+	let result_body = result.collect().await.unwrap().to_bytes();
 	assert!(
-		streaming_body.is_empty(),
-		"process_streaming should produce empty body for JSON error input (bug demonstration), got {} bytes",
-		streaming_body.len(),
+		!result_body.is_empty(),
+		"error response body must not be empty",
 	);
 
-	// ---- Path 2: buffered process_error (fixed path) ----
-	// This is the path taken after the fix when resp.status().is_success() is false.
-	let error_bytes = Bytes::from(error_json);
-	let translated = bedrock
-		.process_error(&streaming_req, ::http::StatusCode::BAD_REQUEST, &error_bytes)
-		.expect("process_error should succeed");
+	let parsed: Value =
+		serde_json::from_slice(&result_body).expect("translated error should be valid JSON");
 
-	assert!(
-		!translated.is_empty(),
-		"process_error should produce non-empty translated body",
-	);
-
-	let parsed: Value = serde_json::from_slice(&translated)
-		.expect("translated error should be valid JSON");
-
-	// Verify the original Bedrock error message is preserved in the translation.
 	let message = parsed
 		.pointer("/error/message")
 		.and_then(|v| v.as_str())


### PR DESCRIPTION
## Summary

When a streaming request (`stream: true` in OpenAI Chat Completions, or `stream: true` in Anthropic Messages) receives a non-2xx error response from the backend, the error response body is silently dropped. The client receives the correct status code and headers (including `Content-Length`) but zero body bytes, causing `unexpected EOF` / `connection closed before message completed`.

## Root Cause

`process_response` dispatches to `process_streaming` based solely on `req.streaming`, without checking the response status:

```rust
if req.streaming {
    return self.process_streaming(req, ..., resp).await;
}
```

Backend error responses (4xx, 5xx) are plain JSON (`application/json`), not event-stream data. The streaming parsers — specifically the AWS EventStream decoder for Bedrock — interpret the JSON bytes as binary frame headers. For example, `{"me` (the start of `{"message":"..."}`') is read as a big-endian u32 frame length of ~2 GB. The decoder returns `Incomplete` forever, producing zero output bytes.

Meanwhile, the original `Content-Length` header from the backend is preserved through `resp.map(|b| ...)`. The client sees `Content-Length: 116` but receives 0 bytes → `unexpected EOF`.

The non-streaming path correctly handles errors via `process_error` → `translate_error`, but is unreachable when `req.streaming == true`.

## Fix

Add a response status check before entering the streaming path:

```rust
if req.streaming && resp.status().is_success() {
    return self.process_streaming(req, ..., resp).await;
}
```

Non-success responses now fall through to the buffered path where `process_error` translates the backend error format to the frontend format and the body is forwarded intact.

## Impact

This affects **every** streaming request to any backend that returns plain JSON error responses — which is standard behavior for AWS Bedrock, and likely other providers. Without this fix, clients cannot read error details from streaming requests, making debugging backend rejections (e.g. `ValidationException`) impossible.

Fixes #1340
