### PR TITLE
expose ancestor backends from plugins

### DIFF
--- a/controller/pkg/agentgateway/plugins/interfaces.go
+++ b/controller/pkg/agentgateway/plugins/interfaces.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/agentgateway/agentgateway/api"
 	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/ir"
+	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/utils"
 )
 
 type PolicyPluginInput struct {
@@ -54,24 +55,10 @@ func (p AgwPolicy) ResourceName() string {
 }
 
 type AddResourcesPlugin struct {
-	Binds     krt.Collection[ir.AgwResource]
-	Listeners krt.Collection[ir.AgwResource]
-	Routes    krt.Collection[ir.AgwResource]
-}
-
-// AddBinds extracts all bind resources from the collection
-func (p *AddResourcesPlugin) AddBinds() krt.Collection[ir.AgwResource] {
-	return p.Binds
-}
-
-// AddListeners extracts all routes resources from the collection
-func (p *AddResourcesPlugin) AddListeners() krt.Collection[ir.AgwResource] {
-	return p.Listeners
-}
-
-// AddRoutes extracts all routes resources from the collection
-func (p *AddResourcesPlugin) AddRoutes() krt.Collection[ir.AgwResource] {
-	return p.Routes
+	Binds            krt.Collection[ir.AgwResource]
+	Listeners        krt.Collection[ir.AgwResource]
+	Routes           krt.Collection[ir.AgwResource]
+	AncestorBackends krt.Collection[*utils.AncestorBackend]
 }
 
 func ResourceName[T config.Namer](o T) *api.ResourceName {

--- a/controller/pkg/agentgateway/plugins/registry.go
+++ b/controller/pkg/agentgateway/plugins/registry.go
@@ -34,6 +34,9 @@ func MergePlugins(plug ...AgwPlugin) AgwPlugin {
 			if p.AddResourceExtension.Routes != nil {
 				ret.AddResourceExtension.Routes = p.AddResourceExtension.Routes
 			}
+			if p.AddResourceExtension.AncestorBackends != nil {
+				ret.AddResourceExtension.AncestorBackends = p.AddResourceExtension.AncestorBackends
+			}
 		}
 	}
 	return ret

--- a/controller/pkg/kgateway/agentgatewaysyncer/syncer.go
+++ b/controller/pkg/kgateway/agentgatewaysyncer/syncer.go
@@ -463,8 +463,13 @@ func (s *Syncer) buildAgwResources(gateways krt.Collection[*translator.GatewayLi
 	}
 
 	agwRoutes, routeAttachments, ancestorBackends := translator.AgwRouteCollection(s.statusCollections, s.agwCollections.HTTPRoutes, s.agwCollections.GRPCRoutes, s.agwCollections.TCPRoutes, s.agwCollections.TLSRoutes, routeInputs, krtopts)
-	if s.agwPlugins.AddResourceExtension != nil && s.agwPlugins.AddResourceExtension.Routes != nil {
-		agwRoutes = krt.JoinCollection([]krt.Collection[agwir.AgwResource]{agwRoutes, s.agwPlugins.AddResourceExtension.Routes})
+	if s.agwPlugins.AddResourceExtension != nil {
+		if s.agwPlugins.AddResourceExtension.Routes != nil {
+			agwRoutes = krt.JoinCollection([]krt.Collection[agwir.AgwResource]{agwRoutes, s.agwPlugins.AddResourceExtension.Routes})
+		}
+		if s.agwPlugins.AddResourceExtension.AncestorBackends != nil {
+			ancestorBackends = krt.JoinCollection([]krt.Collection[*utils.AncestorBackend]{ancestorBackends, s.agwPlugins.AddResourceExtension.AncestorBackends})
+		}
 	}
 	routeAttachmentsIndex := krt.NewIndex(routeAttachments, "from", func(o *plugins.RouteAttachment) []utils.TypedNamespacedName {
 		return []utils.TypedNamespacedName{o.From}


### PR DESCRIPTION
We can add routes and backends, but without sending the ancestor information the backends will not be sent to the proxy because they don't seem to be referenced by any route. 