### PR TITLE
allow plugging in parentRef resolution

### DIFF
--- a/controller/pkg/agentgateway/translator/conversion.go
+++ b/controller/pkg/agentgateway/translator/conversion.go
@@ -840,7 +840,7 @@ func ReferenceAllowed(
 	return nil
 }
 
-func extractParentReferenceInfo(ctx RouteContext, parents RouteParents, obj controllers.Object) []RouteParentReference {
+func extractParentReferenceInfo(ctx RouteContext, parents ParentResolver, obj controllers.Object) []RouteParentReference {
 	routeRefs, hostnames, kind := GetCommonRouteInfo(obj)
 	localNamespace := obj.GetNamespace()
 	var parentRefs []RouteParentReference
@@ -855,7 +855,7 @@ func extractParentReferenceInfo(ctx RouteContext, parents RouteParents, obj cont
 			Port:                ptr.OrEmpty(ref.Port),
 		}
 		gk := ir
-		currentParents := parents.Fetch(ctx.Krt, gk)
+		currentParents := parents.ParentsFor(ctx.Krt, gk)
 		appendParent := func(pr *ParentInfo, pk ParentReference) {
 			bannedHostnames := sets.New[string]()
 			for _, gw := range currentParents {

--- a/controller/pkg/agentgateway/translator/gateway_collection.go
+++ b/controller/pkg/agentgateway/translator/gateway_collection.go
@@ -549,6 +549,13 @@ func reportNotAllowedListenerSet(status *gwv1.ListenerSetStatus, obj *gwv1.Liste
 	status.Conditions = SetConditions(obj.Generation, status.Conditions, gatewayConditions)
 }
 
+// ParentResolver allows expanding a parent reference into the information needed
+// to link a route to the gateway(s) it applies to.
+type ParentResolver interface {
+	// Fetch returns the parents for a given parent key.
+	ParentsFor(ctx krt.HandlerContext, pk utils.TypedNamespacedName) []*ParentInfo
+}
+
 // RouteParents holds information about things Routes can reference as parents.
 type RouteParents struct {
 	Gateways     krt.Collection[*GatewayListener]
@@ -556,7 +563,7 @@ type RouteParents struct {
 }
 
 // Fetch returns the parents for a given parent key.
-func (p RouteParents) Fetch(ctx krt.HandlerContext, pk utils.TypedNamespacedName) []*ParentInfo {
+func (p RouteParents) ParentsFor(ctx krt.HandlerContext, pk utils.TypedNamespacedName) []*ParentInfo {
 	return slices.Map(krt.Fetch(ctx, p.Gateways, krt.FilterIndex(p.GatewayIndex, pk)), func(gw *GatewayListener) *ParentInfo {
 		return &gw.ParentInfo
 	})

--- a/controller/pkg/agentgateway/translator/route_collections.go
+++ b/controller/pkg/agentgateway/translator/route_collections.go
@@ -493,7 +493,7 @@ type RouteContext struct {
 // RouteContextInputs defines the collections needed to translate a route.
 type RouteContextInputs struct {
 	Grants         ReferenceGrants
-	RouteParents   RouteParents
+	RouteParents   ParentResolver
 	Services       krt.Collection[*corev1.Service]
 	InferencePools krt.Collection[*inf.InferencePool]
 	Namespaces     krt.Collection[*corev1.Namespace]


### PR DESCRIPTION
A plugin that add routes can re-use the main route generation logic but re-implement or wrap this interface to allow changing the parentRef lookup behavior. 

