### PR TITLE
allow attaching routes to services

### DIFF
--- a/api/resource.pb.go
+++ b/api/resource.pb.go
@@ -2143,6 +2143,8 @@ type Route struct {
 	Key string `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
 	// Key for the listener this is a part of.
 	ListenerKey string `protobuf:"bytes,2,opt,name=listener_key,json=listenerKey,proto3" json:"listener_key,omitempty"`
+	// Service this route targets (set when parentRef is a Service).
+	ServiceKey *workloadapi.NamespacedHostname `protobuf:"bytes,9,opt,name=service_key,json=serviceKey,proto3" json:"service_key,omitempty"`
 	// User facing name for this resource
 	Name            *RouteName           `protobuf:"bytes,3,opt,name=name,proto3" json:"name,omitempty"`
 	Hostnames       []string             `protobuf:"bytes,5,rep,name=hostnames,proto3" json:"hostnames,omitempty"`
@@ -2197,6 +2199,13 @@ func (x *Route) GetListenerKey() string {
 	return ""
 }
 
+func (x *Route) GetServiceKey() *workloadapi.NamespacedHostname {
+	if x != nil {
+		return x.ServiceKey
+	}
+	return nil
+}
+
 func (x *Route) GetName() *RouteName {
 	if x != nil {
 		return x.Name
@@ -2238,6 +2247,8 @@ type TCPRoute struct {
 	Key string `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
 	// Key for the listener this is a part of.
 	ListenerKey string `protobuf:"bytes,2,opt,name=listener_key,json=listenerKey,proto3" json:"listener_key,omitempty"`
+	// Service this route targets (set when parentRef is a Service).
+	ServiceKey *workloadapi.NamespacedHostname `protobuf:"bytes,9,opt,name=service_key,json=serviceKey,proto3" json:"service_key,omitempty"`
 	// User facing name for this resource
 	Name          *RouteName      `protobuf:"bytes,3,opt,name=name,proto3" json:"name,omitempty"`
 	Hostnames     []string        `protobuf:"bytes,5,rep,name=hostnames,proto3" json:"hostnames,omitempty"`
@@ -2288,6 +2299,13 @@ func (x *TCPRoute) GetListenerKey() string {
 		return x.ListenerKey
 	}
 	return ""
+}
+
+func (x *TCPRoute) GetServiceKey() *workloadapi.NamespacedHostname {
+	if x != nil {
+		return x.ServiceKey
+	}
+	return nil
 }
 
 func (x *TCPRoute) GetName() *RouteName {
@@ -11103,18 +11121,22 @@ const file_resource_proto_rawDesc = "" +
 	"\x04name\x18\x03 \x01(\v2'.agentgateway.dev.resource.ListenerNameR\x04name\x12\x1a\n" +
 	"\bhostname\x18\x04 \x01(\tR\bhostname\x12?\n" +
 	"\bprotocol\x18\x05 \x01(\x0e2#.agentgateway.dev.resource.ProtocolR\bprotocol\x126\n" +
-	"\x03tls\x18\x06 \x01(\v2$.agentgateway.dev.resource.TLSConfigR\x03tls\"\xf3\x02\n" +
+	"\x03tls\x18\x06 \x01(\v2$.agentgateway.dev.resource.TLSConfigR\x03tls\"\xb8\x03\n" +
 	"\x05Route\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12!\n" +
-	"\flistener_key\x18\x02 \x01(\tR\vlistenerKey\x128\n" +
+	"\flistener_key\x18\x02 \x01(\tR\vlistenerKey\x12C\n" +
+	"\vservice_key\x18\t \x01(\v2\".istio.workload.NamespacedHostnameR\n" +
+	"serviceKey\x128\n" +
 	"\x04name\x18\x03 \x01(\v2$.agentgateway.dev.resource.RouteNameR\x04name\x12\x1c\n" +
 	"\thostnames\x18\x05 \x03(\tR\thostnames\x12?\n" +
 	"\amatches\x18\x06 \x03(\v2%.agentgateway.dev.resource.RouteMatchR\amatches\x12C\n" +
 	"\bbackends\x18\a \x03(\v2'.agentgateway.dev.resource.RouteBackendR\bbackends\x12W\n" +
-	"\x10traffic_policies\x18\b \x03(\v2,.agentgateway.dev.resource.TrafficPolicySpecR\x0ftrafficPolicies\"\xdc\x01\n" +
+	"\x10traffic_policies\x18\b \x03(\v2,.agentgateway.dev.resource.TrafficPolicySpecR\x0ftrafficPolicies\"\xa1\x02\n" +
 	"\bTCPRoute\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12!\n" +
-	"\flistener_key\x18\x02 \x01(\tR\vlistenerKey\x128\n" +
+	"\flistener_key\x18\x02 \x01(\tR\vlistenerKey\x12C\n" +
+	"\vservice_key\x18\t \x01(\v2\".istio.workload.NamespacedHostnameR\n" +
+	"serviceKey\x128\n" +
 	"\x04name\x18\x03 \x01(\v2$.agentgateway.dev.resource.RouteNameR\x04name\x12\x1c\n" +
 	"\thostnames\x18\x05 \x03(\tR\thostnames\x12C\n" +
 	"\bbackends\x18\x06 \x03(\v2'.agentgateway.dev.resource.RouteBackendR\bbackends\"\x86\x03\n" +
@@ -12109,22 +12131,23 @@ var file_resource_proto_goTypes = []any{
 	nil, // 161: agentgateway.dev.resource.BackendPolicySpec.Ai.ModelAliasesEntry
 	nil, // 162: agentgateway.dev.resource.BackendPolicySpec.Ai.RoutesEntry
 	(*BackendPolicySpec_McpAuthentication_ResourceMetadata)(nil), // 163: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata
-	nil,                              // 164: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntry
-	(*AIBackend_HostOverride)(nil),   // 165: agentgateway.dev.resource.AIBackend.HostOverride
-	(*AIBackend_OpenAI)(nil),         // 166: agentgateway.dev.resource.AIBackend.OpenAI
-	(*AIBackend_Gemini)(nil),         // 167: agentgateway.dev.resource.AIBackend.Gemini
-	(*AIBackend_Vertex)(nil),         // 168: agentgateway.dev.resource.AIBackend.Vertex
-	(*AIBackend_Anthropic)(nil),      // 169: agentgateway.dev.resource.AIBackend.Anthropic
-	(*AIBackend_Bedrock)(nil),        // 170: agentgateway.dev.resource.AIBackend.Bedrock
-	(*AIBackend_AzureOpenAI)(nil),    // 171: agentgateway.dev.resource.AIBackend.AzureOpenAI
-	(*AIBackend_Provider)(nil),       // 172: agentgateway.dev.resource.AIBackend.Provider
-	(*AIBackend_ProviderGroup)(nil),  // 173: agentgateway.dev.resource.AIBackend.ProviderGroup
-	(*BackendReference_Service)(nil), // 174: agentgateway.dev.resource.BackendReference.Service
-	(*workloadapi.Workload)(nil),     // 175: istio.workload.Workload
-	(*workloadapi.Service)(nil),      // 176: istio.workload.Service
-	(*durationpb.Duration)(nil),      // 177: google.protobuf.Duration
-	(*structpb.Struct)(nil),          // 178: google.protobuf.Struct
-	(*structpb.Value)(nil),           // 179: google.protobuf.Value
+	nil,                                    // 164: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntry
+	(*AIBackend_HostOverride)(nil),         // 165: agentgateway.dev.resource.AIBackend.HostOverride
+	(*AIBackend_OpenAI)(nil),               // 166: agentgateway.dev.resource.AIBackend.OpenAI
+	(*AIBackend_Gemini)(nil),               // 167: agentgateway.dev.resource.AIBackend.Gemini
+	(*AIBackend_Vertex)(nil),               // 168: agentgateway.dev.resource.AIBackend.Vertex
+	(*AIBackend_Anthropic)(nil),            // 169: agentgateway.dev.resource.AIBackend.Anthropic
+	(*AIBackend_Bedrock)(nil),              // 170: agentgateway.dev.resource.AIBackend.Bedrock
+	(*AIBackend_AzureOpenAI)(nil),          // 171: agentgateway.dev.resource.AIBackend.AzureOpenAI
+	(*AIBackend_Provider)(nil),             // 172: agentgateway.dev.resource.AIBackend.Provider
+	(*AIBackend_ProviderGroup)(nil),        // 173: agentgateway.dev.resource.AIBackend.ProviderGroup
+	(*BackendReference_Service)(nil),       // 174: agentgateway.dev.resource.BackendReference.Service
+	(*workloadapi.Workload)(nil),           // 175: istio.workload.Workload
+	(*workloadapi.Service)(nil),            // 176: istio.workload.Service
+	(*workloadapi.NamespacedHostname)(nil), // 177: istio.workload.NamespacedHostname
+	(*durationpb.Duration)(nil),            // 178: google.protobuf.Duration
+	(*structpb.Struct)(nil),                // 179: google.protobuf.Struct
+	(*structpb.Value)(nil),                 // 180: google.protobuf.Value
 }
 var file_resource_proto_depIdxs = []int32{
 	31,  // 0: agentgateway.dev.resource.Resource.bind:type_name -> agentgateway.dev.resource.Bind
@@ -12141,234 +12164,236 @@ var file_resource_proto_depIdxs = []int32{
 	33,  // 11: agentgateway.dev.resource.Listener.name:type_name -> agentgateway.dev.resource.ListenerName
 	0,   // 12: agentgateway.dev.resource.Listener.protocol:type_name -> agentgateway.dev.resource.Protocol
 	41,  // 13: agentgateway.dev.resource.Listener.tls:type_name -> agentgateway.dev.resource.TLSConfig
-	32,  // 14: agentgateway.dev.resource.Route.name:type_name -> agentgateway.dev.resource.RouteName
-	58,  // 15: agentgateway.dev.resource.Route.matches:type_name -> agentgateway.dev.resource.RouteMatch
-	70,  // 16: agentgateway.dev.resource.Route.backends:type_name -> agentgateway.dev.resource.RouteBackend
-	75,  // 17: agentgateway.dev.resource.Route.traffic_policies:type_name -> agentgateway.dev.resource.TrafficPolicySpec
-	32,  // 18: agentgateway.dev.resource.TCPRoute.name:type_name -> agentgateway.dev.resource.RouteName
-	70,  // 19: agentgateway.dev.resource.TCPRoute.backends:type_name -> agentgateway.dev.resource.RouteBackend
-	35,  // 20: agentgateway.dev.resource.Policy.name:type_name -> agentgateway.dev.resource.TypedResourceName
-	71,  // 21: agentgateway.dev.resource.Policy.target:type_name -> agentgateway.dev.resource.PolicyTarget
-	75,  // 22: agentgateway.dev.resource.Policy.traffic:type_name -> agentgateway.dev.resource.TrafficPolicySpec
-	76,  // 23: agentgateway.dev.resource.Policy.backend:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	73,  // 24: agentgateway.dev.resource.Policy.frontend:type_name -> agentgateway.dev.resource.FrontendPolicySpec
-	34,  // 25: agentgateway.dev.resource.Backend.name:type_name -> agentgateway.dev.resource.ResourceName
-	77,  // 26: agentgateway.dev.resource.Backend.static:type_name -> agentgateway.dev.resource.StaticBackend
-	81,  // 27: agentgateway.dev.resource.Backend.ai:type_name -> agentgateway.dev.resource.AIBackend
-	82,  // 28: agentgateway.dev.resource.Backend.mcp:type_name -> agentgateway.dev.resource.MCPBackend
-	78,  // 29: agentgateway.dev.resource.Backend.dynamic:type_name -> agentgateway.dev.resource.DynamicForwardProxy
-	79,  // 30: agentgateway.dev.resource.Backend.aws:type_name -> agentgateway.dev.resource.AwsBackend
-	76,  // 31: agentgateway.dev.resource.Backend.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	5,   // 32: agentgateway.dev.resource.TLSConfig.cipher_suites:type_name -> agentgateway.dev.resource.TLSConfig.CipherSuite
-	3,   // 33: agentgateway.dev.resource.TLSConfig.min_version:type_name -> agentgateway.dev.resource.TLSConfig.TLSVersion
-	3,   // 34: agentgateway.dev.resource.TLSConfig.max_version:type_name -> agentgateway.dev.resource.TLSConfig.TLSVersion
-	4,   // 35: agentgateway.dev.resource.TLSConfig.mtls_mode:type_name -> agentgateway.dev.resource.TLSConfig.MTLSMode
-	177, // 36: agentgateway.dev.resource.Timeout.request:type_name -> google.protobuf.Duration
-	177, // 37: agentgateway.dev.resource.Timeout.backend_request:type_name -> google.protobuf.Duration
-	177, // 38: agentgateway.dev.resource.Retry.backoff:type_name -> google.protobuf.Duration
-	45,  // 39: agentgateway.dev.resource.BackendAuthPolicy.passthrough:type_name -> agentgateway.dev.resource.Passthrough
-	46,  // 40: agentgateway.dev.resource.BackendAuthPolicy.key:type_name -> agentgateway.dev.resource.Key
-	47,  // 41: agentgateway.dev.resource.BackendAuthPolicy.gcp:type_name -> agentgateway.dev.resource.Gcp
-	48,  // 42: agentgateway.dev.resource.BackendAuthPolicy.aws:type_name -> agentgateway.dev.resource.Aws
-	49,  // 43: agentgateway.dev.resource.BackendAuthPolicy.azure:type_name -> agentgateway.dev.resource.Azure
-	86,  // 44: agentgateway.dev.resource.Gcp.access_token:type_name -> agentgateway.dev.resource.Gcp.AccessToken
-	87,  // 45: agentgateway.dev.resource.Gcp.id_token:type_name -> agentgateway.dev.resource.Gcp.IdToken
-	50,  // 46: agentgateway.dev.resource.Aws.explicit_config:type_name -> agentgateway.dev.resource.AwsExplicitConfig
-	51,  // 47: agentgateway.dev.resource.Aws.implicit:type_name -> agentgateway.dev.resource.AwsImplicit
-	52,  // 48: agentgateway.dev.resource.Azure.explicit_config:type_name -> agentgateway.dev.resource.AzureExplicitConfig
-	56,  // 49: agentgateway.dev.resource.Azure.developer_implicit:type_name -> agentgateway.dev.resource.AzureDeveloperImplicit
-	57,  // 50: agentgateway.dev.resource.Azure.implicit:type_name -> agentgateway.dev.resource.AzureImplicit
-	53,  // 51: agentgateway.dev.resource.AzureExplicitConfig.client_secret:type_name -> agentgateway.dev.resource.AzureClientSecret
-	54,  // 52: agentgateway.dev.resource.AzureExplicitConfig.managed_identity_credential:type_name -> agentgateway.dev.resource.AzureManagedIdentityCredential
-	55,  // 53: agentgateway.dev.resource.AzureExplicitConfig.workload_identity_credential:type_name -> agentgateway.dev.resource.AzureWorkloadIdentityCredential
-	88,  // 54: agentgateway.dev.resource.AzureManagedIdentityCredential.user_assigned_identity:type_name -> agentgateway.dev.resource.AzureManagedIdentityCredential.UserAssignedIdentity
-	59,  // 55: agentgateway.dev.resource.RouteMatch.path:type_name -> agentgateway.dev.resource.PathMatch
-	62,  // 56: agentgateway.dev.resource.RouteMatch.headers:type_name -> agentgateway.dev.resource.HeaderMatch
-	61,  // 57: agentgateway.dev.resource.RouteMatch.method:type_name -> agentgateway.dev.resource.MethodMatch
-	60,  // 58: agentgateway.dev.resource.RouteMatch.query_params:type_name -> agentgateway.dev.resource.QueryMatch
-	177, // 59: agentgateway.dev.resource.CORS.max_age:type_name -> google.protobuf.Duration
-	69,  // 60: agentgateway.dev.resource.HeaderModifier.add:type_name -> agentgateway.dev.resource.Header
-	69,  // 61: agentgateway.dev.resource.HeaderModifier.set:type_name -> agentgateway.dev.resource.Header
-	89,  // 62: agentgateway.dev.resource.RequestMirrors.mirrors:type_name -> agentgateway.dev.resource.RequestMirrors.Mirror
-	84,  // 63: agentgateway.dev.resource.RouteBackend.backend:type_name -> agentgateway.dev.resource.BackendReference
-	76,  // 64: agentgateway.dev.resource.RouteBackend.backend_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	92,  // 65: agentgateway.dev.resource.PolicyTarget.gateway:type_name -> agentgateway.dev.resource.PolicyTarget.GatewayTarget
-	93,  // 66: agentgateway.dev.resource.PolicyTarget.route:type_name -> agentgateway.dev.resource.PolicyTarget.RouteTarget
-	91,  // 67: agentgateway.dev.resource.PolicyTarget.backend:type_name -> agentgateway.dev.resource.PolicyTarget.BackendTarget
-	90,  // 68: agentgateway.dev.resource.PolicyTarget.service:type_name -> agentgateway.dev.resource.PolicyTarget.ServiceTarget
-	177, // 69: agentgateway.dev.resource.KeepaliveConfig.time:type_name -> google.protobuf.Duration
-	177, // 70: agentgateway.dev.resource.KeepaliveConfig.interval:type_name -> google.protobuf.Duration
-	96,  // 71: agentgateway.dev.resource.FrontendPolicySpec.tcp:type_name -> agentgateway.dev.resource.FrontendPolicySpec.TCP
-	95,  // 72: agentgateway.dev.resource.FrontendPolicySpec.tls:type_name -> agentgateway.dev.resource.FrontendPolicySpec.TLS
-	94,  // 73: agentgateway.dev.resource.FrontendPolicySpec.http:type_name -> agentgateway.dev.resource.FrontendPolicySpec.HTTP
-	97,  // 74: agentgateway.dev.resource.FrontendPolicySpec.logging:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging
-	98,  // 75: agentgateway.dev.resource.FrontendPolicySpec.tracing:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Tracing
-	8,   // 76: agentgateway.dev.resource.TrafficPolicySpec.phase:type_name -> agentgateway.dev.resource.TrafficPolicySpec.PolicyPhase
-	42,  // 77: agentgateway.dev.resource.TrafficPolicySpec.timeout:type_name -> agentgateway.dev.resource.Timeout
-	43,  // 78: agentgateway.dev.resource.TrafficPolicySpec.retry:type_name -> agentgateway.dev.resource.Retry
-	104, // 79: agentgateway.dev.resource.TrafficPolicySpec.local_rate_limit:type_name -> agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit
-	105, // 80: agentgateway.dev.resource.TrafficPolicySpec.ext_authz:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth
-	106, // 81: agentgateway.dev.resource.TrafficPolicySpec.authorization:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RBAC
-	108, // 82: agentgateway.dev.resource.TrafficPolicySpec.jwt:type_name -> agentgateway.dev.resource.TrafficPolicySpec.JWT
-	111, // 83: agentgateway.dev.resource.TrafficPolicySpec.transformation:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy
-	103, // 84: agentgateway.dev.resource.TrafficPolicySpec.remote_rate_limit:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit
-	114, // 85: agentgateway.dev.resource.TrafficPolicySpec.csrf:type_name -> agentgateway.dev.resource.TrafficPolicySpec.CSRF
-	115, // 86: agentgateway.dev.resource.TrafficPolicySpec.ext_proc:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc
-	65,  // 87: agentgateway.dev.resource.TrafficPolicySpec.request_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
-	65,  // 88: agentgateway.dev.resource.TrafficPolicySpec.response_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
-	67,  // 89: agentgateway.dev.resource.TrafficPolicySpec.request_redirect:type_name -> agentgateway.dev.resource.RequestRedirect
-	68,  // 90: agentgateway.dev.resource.TrafficPolicySpec.url_rewrite:type_name -> agentgateway.dev.resource.UrlRewrite
-	66,  // 91: agentgateway.dev.resource.TrafficPolicySpec.request_mirror:type_name -> agentgateway.dev.resource.RequestMirrors
-	64,  // 92: agentgateway.dev.resource.TrafficPolicySpec.direct_response:type_name -> agentgateway.dev.resource.DirectResponse
-	63,  // 93: agentgateway.dev.resource.TrafficPolicySpec.cors:type_name -> agentgateway.dev.resource.CORS
-	109, // 94: agentgateway.dev.resource.TrafficPolicySpec.basic_auth:type_name -> agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication
-	110, // 95: agentgateway.dev.resource.TrafficPolicySpec.api_key_auth:type_name -> agentgateway.dev.resource.TrafficPolicySpec.APIKey
-	116, // 96: agentgateway.dev.resource.TrafficPolicySpec.host_rewrite:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HostRewrite
-	135, // 97: agentgateway.dev.resource.BackendPolicySpec.a2a:type_name -> agentgateway.dev.resource.BackendPolicySpec.A2a
-	136, // 98: agentgateway.dev.resource.BackendPolicySpec.inference_routing:type_name -> agentgateway.dev.resource.BackendPolicySpec.InferenceRouting
-	139, // 99: agentgateway.dev.resource.BackendPolicySpec.backend_tls:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTLS
-	44,  // 100: agentgateway.dev.resource.BackendPolicySpec.auth:type_name -> agentgateway.dev.resource.BackendAuthPolicy
-	143, // 101: agentgateway.dev.resource.BackendPolicySpec.mcp_authorization:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthorization
-	144, // 102: agentgateway.dev.resource.BackendPolicySpec.mcp_authentication:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication
-	134, // 103: agentgateway.dev.resource.BackendPolicySpec.ai:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai
-	65,  // 104: agentgateway.dev.resource.BackendPolicySpec.request_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
-	65,  // 105: agentgateway.dev.resource.BackendPolicySpec.response_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
-	67,  // 106: agentgateway.dev.resource.BackendPolicySpec.request_redirect:type_name -> agentgateway.dev.resource.RequestRedirect
-	66,  // 107: agentgateway.dev.resource.BackendPolicySpec.request_mirror:type_name -> agentgateway.dev.resource.RequestMirrors
-	140, // 108: agentgateway.dev.resource.BackendPolicySpec.backend_http:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendHTTP
-	142, // 109: agentgateway.dev.resource.BackendPolicySpec.backend_tcp:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTCP
-	111, // 110: agentgateway.dev.resource.BackendPolicySpec.transformation:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy
-	138, // 111: agentgateway.dev.resource.BackendPolicySpec.health:type_name -> agentgateway.dev.resource.BackendPolicySpec.Health
-	141, // 112: agentgateway.dev.resource.BackendPolicySpec.backend_tunnel:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTunnel
-	80,  // 113: agentgateway.dev.resource.AwsBackend.agent_core:type_name -> agentgateway.dev.resource.AwsAgentCoreBackend
-	173, // 114: agentgateway.dev.resource.AIBackend.provider_groups:type_name -> agentgateway.dev.resource.AIBackend.ProviderGroup
-	83,  // 115: agentgateway.dev.resource.MCPBackend.targets:type_name -> agentgateway.dev.resource.MCPTarget
-	26,  // 116: agentgateway.dev.resource.MCPBackend.stateful_mode:type_name -> agentgateway.dev.resource.MCPBackend.StatefulMode
-	27,  // 117: agentgateway.dev.resource.MCPBackend.prefix_mode:type_name -> agentgateway.dev.resource.MCPBackend.PrefixMode
-	28,  // 118: agentgateway.dev.resource.MCPBackend.failure_mode:type_name -> agentgateway.dev.resource.MCPBackend.FailureMode
-	84,  // 119: agentgateway.dev.resource.MCPTarget.backend:type_name -> agentgateway.dev.resource.BackendReference
-	29,  // 120: agentgateway.dev.resource.MCPTarget.protocol:type_name -> agentgateway.dev.resource.MCPTarget.Protocol
-	174, // 121: agentgateway.dev.resource.BackendReference.service:type_name -> agentgateway.dev.resource.BackendReference.Service
-	84,  // 122: agentgateway.dev.resource.RequestMirrors.Mirror.backend:type_name -> agentgateway.dev.resource.BackendReference
-	177, // 123: agentgateway.dev.resource.FrontendPolicySpec.HTTP.http1_idle_timeout:type_name -> google.protobuf.Duration
-	177, // 124: agentgateway.dev.resource.FrontendPolicySpec.HTTP.http2_keepalive_interval:type_name -> google.protobuf.Duration
-	177, // 125: agentgateway.dev.resource.FrontendPolicySpec.HTTP.http2_keepalive_timeout:type_name -> google.protobuf.Duration
-	177, // 126: agentgateway.dev.resource.FrontendPolicySpec.TLS.handshake_timeout:type_name -> google.protobuf.Duration
-	85,  // 127: agentgateway.dev.resource.FrontendPolicySpec.TLS.alpn:type_name -> agentgateway.dev.resource.Alpn
-	5,   // 128: agentgateway.dev.resource.FrontendPolicySpec.TLS.cipher_suites:type_name -> agentgateway.dev.resource.TLSConfig.CipherSuite
-	3,   // 129: agentgateway.dev.resource.FrontendPolicySpec.TLS.min_version:type_name -> agentgateway.dev.resource.TLSConfig.TLSVersion
-	3,   // 130: agentgateway.dev.resource.FrontendPolicySpec.TLS.max_version:type_name -> agentgateway.dev.resource.TLSConfig.TLSVersion
-	72,  // 131: agentgateway.dev.resource.FrontendPolicySpec.TCP.keepalives:type_name -> agentgateway.dev.resource.KeepaliveConfig
-	101, // 132: agentgateway.dev.resource.FrontendPolicySpec.Logging.fields:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging.Fields
-	102, // 133: agentgateway.dev.resource.FrontendPolicySpec.Logging.otlp_access_log:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog
-	84,  // 134: agentgateway.dev.resource.FrontendPolicySpec.Tracing.provider_backend:type_name -> agentgateway.dev.resource.BackendReference
-	99,  // 135: agentgateway.dev.resource.FrontendPolicySpec.Tracing.attributes:type_name -> agentgateway.dev.resource.FrontendPolicySpec.TracingAttribute
-	99,  // 136: agentgateway.dev.resource.FrontendPolicySpec.Tracing.resources:type_name -> agentgateway.dev.resource.FrontendPolicySpec.TracingAttribute
-	7,   // 137: agentgateway.dev.resource.FrontendPolicySpec.Tracing.protocol:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Tracing.Protocol
-	100, // 138: agentgateway.dev.resource.FrontendPolicySpec.Logging.Fields.add:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging.Field
-	84,  // 139: agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog.provider_backend:type_name -> agentgateway.dev.resource.BackendReference
-	76,  // 140: agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	6,   // 141: agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog.protocol:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog.Protocol
-	117, // 142: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.descriptors:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor
-	84,  // 143: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.target:type_name -> agentgateway.dev.resource.BackendReference
-	10,  // 144: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.failure_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.FailureMode
-	177, // 145: agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit.fill_interval:type_name -> google.protobuf.Duration
-	11,  // 146: agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit.type:type_name -> agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit.Type
-	84,  // 147: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.target:type_name -> agentgateway.dev.resource.BackendReference
-	120, // 148: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.grpc:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol
-	121, // 149: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.http:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol
-	12,  // 150: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.failure_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.FailureMode
-	119, // 151: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.include_request_body:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.BodyOptions
-	74,  // 152: agentgateway.dev.resource.TrafficPolicySpec.JWTProvider.jwt_validation_options:type_name -> agentgateway.dev.resource.JWTValidationOptions
-	13,  // 153: agentgateway.dev.resource.TrafficPolicySpec.JWT.mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.JWT.Mode
-	107, // 154: agentgateway.dev.resource.TrafficPolicySpec.JWT.providers:type_name -> agentgateway.dev.resource.TrafficPolicySpec.JWTProvider
-	14,  // 155: agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication.mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication.Mode
-	126, // 156: agentgateway.dev.resource.TrafficPolicySpec.APIKey.api_keys:type_name -> agentgateway.dev.resource.TrafficPolicySpec.APIKey.User
-	15,  // 157: agentgateway.dev.resource.TrafficPolicySpec.APIKey.mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.APIKey.Mode
-	127, // 158: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.request:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform
-	127, // 159: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.response:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform
-	84,  // 160: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.target:type_name -> agentgateway.dev.resource.BackendReference
-	16,  // 161: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.failure_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.FailureMode
-	129, // 162: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.request_attributes:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.RequestAttributesEntry
-	130, // 163: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.response_attributes:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ResponseAttributesEntry
-	132, // 164: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.metadata_context:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.MetadataContextEntry
-	17,  // 165: agentgateway.dev.resource.TrafficPolicySpec.HostRewrite.mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HostRewrite.Mode
-	118, // 166: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor.entries:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Entry
-	9,   // 167: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor.type:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Type
-	122, // 168: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.context:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.ContextEntry
-	123, // 169: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.metadata:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.MetadataEntry
-	124, // 170: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.add_request_headers:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.AddRequestHeadersEntry
-	125, // 171: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.metadata:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.MetadataEntry
-	178, // 172: agentgateway.dev.resource.TrafficPolicySpec.APIKey.User.metadata:type_name -> google.protobuf.Struct
-	112, // 173: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.set:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HeaderTransformation
-	112, // 174: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.add:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HeaderTransformation
-	113, // 175: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.body:type_name -> agentgateway.dev.resource.TrafficPolicySpec.BodyTransformation
-	128, // 176: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.metadata:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.MetadataEntry
-	133, // 177: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext.context:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext.ContextEntry
-	131, // 178: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.MetadataContextEntry.value:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext
-	156, // 179: agentgateway.dev.resource.BackendPolicySpec.Ai.prompt_guard:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard
-	158, // 180: agentgateway.dev.resource.BackendPolicySpec.Ai.defaults:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.DefaultsEntry
-	159, // 181: agentgateway.dev.resource.BackendPolicySpec.Ai.overrides:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.OverridesEntry
-	160, // 182: agentgateway.dev.resource.BackendPolicySpec.Ai.transformations:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.TransformationsEntry
-	146, // 183: agentgateway.dev.resource.BackendPolicySpec.Ai.prompts:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment
-	161, // 184: agentgateway.dev.resource.BackendPolicySpec.Ai.model_aliases:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ModelAliasesEntry
-	157, // 185: agentgateway.dev.resource.BackendPolicySpec.Ai.prompt_caching:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptCaching
-	162, // 186: agentgateway.dev.resource.BackendPolicySpec.Ai.routes:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RoutesEntry
-	84,  // 187: agentgateway.dev.resource.BackendPolicySpec.InferenceRouting.endpoint_picker:type_name -> agentgateway.dev.resource.BackendReference
-	21,  // 188: agentgateway.dev.resource.BackendPolicySpec.InferenceRouting.failure_mode:type_name -> agentgateway.dev.resource.BackendPolicySpec.InferenceRouting.FailureMode
-	177, // 189: agentgateway.dev.resource.BackendPolicySpec.Eviction.duration:type_name -> google.protobuf.Duration
-	137, // 190: agentgateway.dev.resource.BackendPolicySpec.Health.eviction:type_name -> agentgateway.dev.resource.BackendPolicySpec.Eviction
-	22,  // 191: agentgateway.dev.resource.BackendPolicySpec.BackendTLS.verification:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTLS.VerificationMode
-	85,  // 192: agentgateway.dev.resource.BackendPolicySpec.BackendTLS.alpn:type_name -> agentgateway.dev.resource.Alpn
-	23,  // 193: agentgateway.dev.resource.BackendPolicySpec.BackendHTTP.version:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendHTTP.HttpVersion
-	177, // 194: agentgateway.dev.resource.BackendPolicySpec.BackendHTTP.request_timeout:type_name -> google.protobuf.Duration
-	84,  // 195: agentgateway.dev.resource.BackendPolicySpec.BackendTunnel.proxy:type_name -> agentgateway.dev.resource.BackendReference
-	72,  // 196: agentgateway.dev.resource.BackendPolicySpec.BackendTCP.keepalive:type_name -> agentgateway.dev.resource.KeepaliveConfig
-	177, // 197: agentgateway.dev.resource.BackendPolicySpec.BackendTCP.connect_timeout:type_name -> google.protobuf.Duration
-	24,  // 198: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.provider:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.McpIDP
-	163, // 199: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.resource_metadata:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata
-	25,  // 200: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.mode:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.Mode
-	74,  // 201: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.jwt_validation_options:type_name -> agentgateway.dev.resource.JWTValidationOptions
-	145, // 202: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment.append:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Message
-	145, // 203: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment.prepend:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Message
-	18,  // 204: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRule.builtin:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.BuiltinRegexRule
-	19,  // 205: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules.action:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ActionKind
-	147, // 206: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules.rules:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRule
-	84,  // 207: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.backend:type_name -> agentgateway.dev.resource.BackendReference
-	62,  // 208: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.forward_header_matches:type_name -> agentgateway.dev.resource.HeaderMatch
-	76,  // 209: agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	76,  // 210: agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	76,  // 211: agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	153, // 212: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.rejection:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestRejection
-	148, // 213: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.regex:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules
-	149, // 214: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.webhook:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook
-	152, // 215: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.google_model_armor:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor
-	151, // 216: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.bedrock_guardrails:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails
-	153, // 217: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.rejection:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestRejection
-	148, // 218: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.regex:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules
-	149, // 219: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.webhook:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook
-	150, // 220: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.openai_moderation:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation
-	152, // 221: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.google_model_armor:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor
-	151, // 222: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.bedrock_guardrails:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails
-	155, // 223: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.request:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard
-	154, // 224: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.response:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard
-	20,  // 225: agentgateway.dev.resource.BackendPolicySpec.Ai.RoutesEntry.value:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RouteType
-	164, // 226: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.extra:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntry
-	179, // 227: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntry.value:type_name -> google.protobuf.Value
-	165, // 228: agentgateway.dev.resource.AIBackend.Provider.host_override:type_name -> agentgateway.dev.resource.AIBackend.HostOverride
-	166, // 229: agentgateway.dev.resource.AIBackend.Provider.openai:type_name -> agentgateway.dev.resource.AIBackend.OpenAI
-	167, // 230: agentgateway.dev.resource.AIBackend.Provider.gemini:type_name -> agentgateway.dev.resource.AIBackend.Gemini
-	168, // 231: agentgateway.dev.resource.AIBackend.Provider.vertex:type_name -> agentgateway.dev.resource.AIBackend.Vertex
-	169, // 232: agentgateway.dev.resource.AIBackend.Provider.anthropic:type_name -> agentgateway.dev.resource.AIBackend.Anthropic
-	170, // 233: agentgateway.dev.resource.AIBackend.Provider.bedrock:type_name -> agentgateway.dev.resource.AIBackend.Bedrock
-	171, // 234: agentgateway.dev.resource.AIBackend.Provider.azureopenai:type_name -> agentgateway.dev.resource.AIBackend.AzureOpenAI
-	76,  // 235: agentgateway.dev.resource.AIBackend.Provider.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	172, // 236: agentgateway.dev.resource.AIBackend.ProviderGroup.providers:type_name -> agentgateway.dev.resource.AIBackend.Provider
-	237, // [237:237] is the sub-list for method output_type
-	237, // [237:237] is the sub-list for method input_type
-	237, // [237:237] is the sub-list for extension type_name
-	237, // [237:237] is the sub-list for extension extendee
-	0,   // [0:237] is the sub-list for field type_name
+	177, // 14: agentgateway.dev.resource.Route.service_key:type_name -> istio.workload.NamespacedHostname
+	32,  // 15: agentgateway.dev.resource.Route.name:type_name -> agentgateway.dev.resource.RouteName
+	58,  // 16: agentgateway.dev.resource.Route.matches:type_name -> agentgateway.dev.resource.RouteMatch
+	70,  // 17: agentgateway.dev.resource.Route.backends:type_name -> agentgateway.dev.resource.RouteBackend
+	75,  // 18: agentgateway.dev.resource.Route.traffic_policies:type_name -> agentgateway.dev.resource.TrafficPolicySpec
+	177, // 19: agentgateway.dev.resource.TCPRoute.service_key:type_name -> istio.workload.NamespacedHostname
+	32,  // 20: agentgateway.dev.resource.TCPRoute.name:type_name -> agentgateway.dev.resource.RouteName
+	70,  // 21: agentgateway.dev.resource.TCPRoute.backends:type_name -> agentgateway.dev.resource.RouteBackend
+	35,  // 22: agentgateway.dev.resource.Policy.name:type_name -> agentgateway.dev.resource.TypedResourceName
+	71,  // 23: agentgateway.dev.resource.Policy.target:type_name -> agentgateway.dev.resource.PolicyTarget
+	75,  // 24: agentgateway.dev.resource.Policy.traffic:type_name -> agentgateway.dev.resource.TrafficPolicySpec
+	76,  // 25: agentgateway.dev.resource.Policy.backend:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	73,  // 26: agentgateway.dev.resource.Policy.frontend:type_name -> agentgateway.dev.resource.FrontendPolicySpec
+	34,  // 27: agentgateway.dev.resource.Backend.name:type_name -> agentgateway.dev.resource.ResourceName
+	77,  // 28: agentgateway.dev.resource.Backend.static:type_name -> agentgateway.dev.resource.StaticBackend
+	81,  // 29: agentgateway.dev.resource.Backend.ai:type_name -> agentgateway.dev.resource.AIBackend
+	82,  // 30: agentgateway.dev.resource.Backend.mcp:type_name -> agentgateway.dev.resource.MCPBackend
+	78,  // 31: agentgateway.dev.resource.Backend.dynamic:type_name -> agentgateway.dev.resource.DynamicForwardProxy
+	79,  // 32: agentgateway.dev.resource.Backend.aws:type_name -> agentgateway.dev.resource.AwsBackend
+	76,  // 33: agentgateway.dev.resource.Backend.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	5,   // 34: agentgateway.dev.resource.TLSConfig.cipher_suites:type_name -> agentgateway.dev.resource.TLSConfig.CipherSuite
+	3,   // 35: agentgateway.dev.resource.TLSConfig.min_version:type_name -> agentgateway.dev.resource.TLSConfig.TLSVersion
+	3,   // 36: agentgateway.dev.resource.TLSConfig.max_version:type_name -> agentgateway.dev.resource.TLSConfig.TLSVersion
+	4,   // 37: agentgateway.dev.resource.TLSConfig.mtls_mode:type_name -> agentgateway.dev.resource.TLSConfig.MTLSMode
+	178, // 38: agentgateway.dev.resource.Timeout.request:type_name -> google.protobuf.Duration
+	178, // 39: agentgateway.dev.resource.Timeout.backend_request:type_name -> google.protobuf.Duration
+	178, // 40: agentgateway.dev.resource.Retry.backoff:type_name -> google.protobuf.Duration
+	45,  // 41: agentgateway.dev.resource.BackendAuthPolicy.passthrough:type_name -> agentgateway.dev.resource.Passthrough
+	46,  // 42: agentgateway.dev.resource.BackendAuthPolicy.key:type_name -> agentgateway.dev.resource.Key
+	47,  // 43: agentgateway.dev.resource.BackendAuthPolicy.gcp:type_name -> agentgateway.dev.resource.Gcp
+	48,  // 44: agentgateway.dev.resource.BackendAuthPolicy.aws:type_name -> agentgateway.dev.resource.Aws
+	49,  // 45: agentgateway.dev.resource.BackendAuthPolicy.azure:type_name -> agentgateway.dev.resource.Azure
+	86,  // 46: agentgateway.dev.resource.Gcp.access_token:type_name -> agentgateway.dev.resource.Gcp.AccessToken
+	87,  // 47: agentgateway.dev.resource.Gcp.id_token:type_name -> agentgateway.dev.resource.Gcp.IdToken
+	50,  // 48: agentgateway.dev.resource.Aws.explicit_config:type_name -> agentgateway.dev.resource.AwsExplicitConfig
+	51,  // 49: agentgateway.dev.resource.Aws.implicit:type_name -> agentgateway.dev.resource.AwsImplicit
+	52,  // 50: agentgateway.dev.resource.Azure.explicit_config:type_name -> agentgateway.dev.resource.AzureExplicitConfig
+	56,  // 51: agentgateway.dev.resource.Azure.developer_implicit:type_name -> agentgateway.dev.resource.AzureDeveloperImplicit
+	57,  // 52: agentgateway.dev.resource.Azure.implicit:type_name -> agentgateway.dev.resource.AzureImplicit
+	53,  // 53: agentgateway.dev.resource.AzureExplicitConfig.client_secret:type_name -> agentgateway.dev.resource.AzureClientSecret
+	54,  // 54: agentgateway.dev.resource.AzureExplicitConfig.managed_identity_credential:type_name -> agentgateway.dev.resource.AzureManagedIdentityCredential
+	55,  // 55: agentgateway.dev.resource.AzureExplicitConfig.workload_identity_credential:type_name -> agentgateway.dev.resource.AzureWorkloadIdentityCredential
+	88,  // 56: agentgateway.dev.resource.AzureManagedIdentityCredential.user_assigned_identity:type_name -> agentgateway.dev.resource.AzureManagedIdentityCredential.UserAssignedIdentity
+	59,  // 57: agentgateway.dev.resource.RouteMatch.path:type_name -> agentgateway.dev.resource.PathMatch
+	62,  // 58: agentgateway.dev.resource.RouteMatch.headers:type_name -> agentgateway.dev.resource.HeaderMatch
+	61,  // 59: agentgateway.dev.resource.RouteMatch.method:type_name -> agentgateway.dev.resource.MethodMatch
+	60,  // 60: agentgateway.dev.resource.RouteMatch.query_params:type_name -> agentgateway.dev.resource.QueryMatch
+	178, // 61: agentgateway.dev.resource.CORS.max_age:type_name -> google.protobuf.Duration
+	69,  // 62: agentgateway.dev.resource.HeaderModifier.add:type_name -> agentgateway.dev.resource.Header
+	69,  // 63: agentgateway.dev.resource.HeaderModifier.set:type_name -> agentgateway.dev.resource.Header
+	89,  // 64: agentgateway.dev.resource.RequestMirrors.mirrors:type_name -> agentgateway.dev.resource.RequestMirrors.Mirror
+	84,  // 65: agentgateway.dev.resource.RouteBackend.backend:type_name -> agentgateway.dev.resource.BackendReference
+	76,  // 66: agentgateway.dev.resource.RouteBackend.backend_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	92,  // 67: agentgateway.dev.resource.PolicyTarget.gateway:type_name -> agentgateway.dev.resource.PolicyTarget.GatewayTarget
+	93,  // 68: agentgateway.dev.resource.PolicyTarget.route:type_name -> agentgateway.dev.resource.PolicyTarget.RouteTarget
+	91,  // 69: agentgateway.dev.resource.PolicyTarget.backend:type_name -> agentgateway.dev.resource.PolicyTarget.BackendTarget
+	90,  // 70: agentgateway.dev.resource.PolicyTarget.service:type_name -> agentgateway.dev.resource.PolicyTarget.ServiceTarget
+	178, // 71: agentgateway.dev.resource.KeepaliveConfig.time:type_name -> google.protobuf.Duration
+	178, // 72: agentgateway.dev.resource.KeepaliveConfig.interval:type_name -> google.protobuf.Duration
+	96,  // 73: agentgateway.dev.resource.FrontendPolicySpec.tcp:type_name -> agentgateway.dev.resource.FrontendPolicySpec.TCP
+	95,  // 74: agentgateway.dev.resource.FrontendPolicySpec.tls:type_name -> agentgateway.dev.resource.FrontendPolicySpec.TLS
+	94,  // 75: agentgateway.dev.resource.FrontendPolicySpec.http:type_name -> agentgateway.dev.resource.FrontendPolicySpec.HTTP
+	97,  // 76: agentgateway.dev.resource.FrontendPolicySpec.logging:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging
+	98,  // 77: agentgateway.dev.resource.FrontendPolicySpec.tracing:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Tracing
+	8,   // 78: agentgateway.dev.resource.TrafficPolicySpec.phase:type_name -> agentgateway.dev.resource.TrafficPolicySpec.PolicyPhase
+	42,  // 79: agentgateway.dev.resource.TrafficPolicySpec.timeout:type_name -> agentgateway.dev.resource.Timeout
+	43,  // 80: agentgateway.dev.resource.TrafficPolicySpec.retry:type_name -> agentgateway.dev.resource.Retry
+	104, // 81: agentgateway.dev.resource.TrafficPolicySpec.local_rate_limit:type_name -> agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit
+	105, // 82: agentgateway.dev.resource.TrafficPolicySpec.ext_authz:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth
+	106, // 83: agentgateway.dev.resource.TrafficPolicySpec.authorization:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RBAC
+	108, // 84: agentgateway.dev.resource.TrafficPolicySpec.jwt:type_name -> agentgateway.dev.resource.TrafficPolicySpec.JWT
+	111, // 85: agentgateway.dev.resource.TrafficPolicySpec.transformation:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy
+	103, // 86: agentgateway.dev.resource.TrafficPolicySpec.remote_rate_limit:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit
+	114, // 87: agentgateway.dev.resource.TrafficPolicySpec.csrf:type_name -> agentgateway.dev.resource.TrafficPolicySpec.CSRF
+	115, // 88: agentgateway.dev.resource.TrafficPolicySpec.ext_proc:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc
+	65,  // 89: agentgateway.dev.resource.TrafficPolicySpec.request_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
+	65,  // 90: agentgateway.dev.resource.TrafficPolicySpec.response_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
+	67,  // 91: agentgateway.dev.resource.TrafficPolicySpec.request_redirect:type_name -> agentgateway.dev.resource.RequestRedirect
+	68,  // 92: agentgateway.dev.resource.TrafficPolicySpec.url_rewrite:type_name -> agentgateway.dev.resource.UrlRewrite
+	66,  // 93: agentgateway.dev.resource.TrafficPolicySpec.request_mirror:type_name -> agentgateway.dev.resource.RequestMirrors
+	64,  // 94: agentgateway.dev.resource.TrafficPolicySpec.direct_response:type_name -> agentgateway.dev.resource.DirectResponse
+	63,  // 95: agentgateway.dev.resource.TrafficPolicySpec.cors:type_name -> agentgateway.dev.resource.CORS
+	109, // 96: agentgateway.dev.resource.TrafficPolicySpec.basic_auth:type_name -> agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication
+	110, // 97: agentgateway.dev.resource.TrafficPolicySpec.api_key_auth:type_name -> agentgateway.dev.resource.TrafficPolicySpec.APIKey
+	116, // 98: agentgateway.dev.resource.TrafficPolicySpec.host_rewrite:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HostRewrite
+	135, // 99: agentgateway.dev.resource.BackendPolicySpec.a2a:type_name -> agentgateway.dev.resource.BackendPolicySpec.A2a
+	136, // 100: agentgateway.dev.resource.BackendPolicySpec.inference_routing:type_name -> agentgateway.dev.resource.BackendPolicySpec.InferenceRouting
+	139, // 101: agentgateway.dev.resource.BackendPolicySpec.backend_tls:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTLS
+	44,  // 102: agentgateway.dev.resource.BackendPolicySpec.auth:type_name -> agentgateway.dev.resource.BackendAuthPolicy
+	143, // 103: agentgateway.dev.resource.BackendPolicySpec.mcp_authorization:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthorization
+	144, // 104: agentgateway.dev.resource.BackendPolicySpec.mcp_authentication:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication
+	134, // 105: agentgateway.dev.resource.BackendPolicySpec.ai:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai
+	65,  // 106: agentgateway.dev.resource.BackendPolicySpec.request_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
+	65,  // 107: agentgateway.dev.resource.BackendPolicySpec.response_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
+	67,  // 108: agentgateway.dev.resource.BackendPolicySpec.request_redirect:type_name -> agentgateway.dev.resource.RequestRedirect
+	66,  // 109: agentgateway.dev.resource.BackendPolicySpec.request_mirror:type_name -> agentgateway.dev.resource.RequestMirrors
+	140, // 110: agentgateway.dev.resource.BackendPolicySpec.backend_http:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendHTTP
+	142, // 111: agentgateway.dev.resource.BackendPolicySpec.backend_tcp:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTCP
+	111, // 112: agentgateway.dev.resource.BackendPolicySpec.transformation:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy
+	138, // 113: agentgateway.dev.resource.BackendPolicySpec.health:type_name -> agentgateway.dev.resource.BackendPolicySpec.Health
+	141, // 114: agentgateway.dev.resource.BackendPolicySpec.backend_tunnel:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTunnel
+	80,  // 115: agentgateway.dev.resource.AwsBackend.agent_core:type_name -> agentgateway.dev.resource.AwsAgentCoreBackend
+	173, // 116: agentgateway.dev.resource.AIBackend.provider_groups:type_name -> agentgateway.dev.resource.AIBackend.ProviderGroup
+	83,  // 117: agentgateway.dev.resource.MCPBackend.targets:type_name -> agentgateway.dev.resource.MCPTarget
+	26,  // 118: agentgateway.dev.resource.MCPBackend.stateful_mode:type_name -> agentgateway.dev.resource.MCPBackend.StatefulMode
+	27,  // 119: agentgateway.dev.resource.MCPBackend.prefix_mode:type_name -> agentgateway.dev.resource.MCPBackend.PrefixMode
+	28,  // 120: agentgateway.dev.resource.MCPBackend.failure_mode:type_name -> agentgateway.dev.resource.MCPBackend.FailureMode
+	84,  // 121: agentgateway.dev.resource.MCPTarget.backend:type_name -> agentgateway.dev.resource.BackendReference
+	29,  // 122: agentgateway.dev.resource.MCPTarget.protocol:type_name -> agentgateway.dev.resource.MCPTarget.Protocol
+	174, // 123: agentgateway.dev.resource.BackendReference.service:type_name -> agentgateway.dev.resource.BackendReference.Service
+	84,  // 124: agentgateway.dev.resource.RequestMirrors.Mirror.backend:type_name -> agentgateway.dev.resource.BackendReference
+	178, // 125: agentgateway.dev.resource.FrontendPolicySpec.HTTP.http1_idle_timeout:type_name -> google.protobuf.Duration
+	178, // 126: agentgateway.dev.resource.FrontendPolicySpec.HTTP.http2_keepalive_interval:type_name -> google.protobuf.Duration
+	178, // 127: agentgateway.dev.resource.FrontendPolicySpec.HTTP.http2_keepalive_timeout:type_name -> google.protobuf.Duration
+	178, // 128: agentgateway.dev.resource.FrontendPolicySpec.TLS.handshake_timeout:type_name -> google.protobuf.Duration
+	85,  // 129: agentgateway.dev.resource.FrontendPolicySpec.TLS.alpn:type_name -> agentgateway.dev.resource.Alpn
+	5,   // 130: agentgateway.dev.resource.FrontendPolicySpec.TLS.cipher_suites:type_name -> agentgateway.dev.resource.TLSConfig.CipherSuite
+	3,   // 131: agentgateway.dev.resource.FrontendPolicySpec.TLS.min_version:type_name -> agentgateway.dev.resource.TLSConfig.TLSVersion
+	3,   // 132: agentgateway.dev.resource.FrontendPolicySpec.TLS.max_version:type_name -> agentgateway.dev.resource.TLSConfig.TLSVersion
+	72,  // 133: agentgateway.dev.resource.FrontendPolicySpec.TCP.keepalives:type_name -> agentgateway.dev.resource.KeepaliveConfig
+	101, // 134: agentgateway.dev.resource.FrontendPolicySpec.Logging.fields:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging.Fields
+	102, // 135: agentgateway.dev.resource.FrontendPolicySpec.Logging.otlp_access_log:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog
+	84,  // 136: agentgateway.dev.resource.FrontendPolicySpec.Tracing.provider_backend:type_name -> agentgateway.dev.resource.BackendReference
+	99,  // 137: agentgateway.dev.resource.FrontendPolicySpec.Tracing.attributes:type_name -> agentgateway.dev.resource.FrontendPolicySpec.TracingAttribute
+	99,  // 138: agentgateway.dev.resource.FrontendPolicySpec.Tracing.resources:type_name -> agentgateway.dev.resource.FrontendPolicySpec.TracingAttribute
+	7,   // 139: agentgateway.dev.resource.FrontendPolicySpec.Tracing.protocol:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Tracing.Protocol
+	100, // 140: agentgateway.dev.resource.FrontendPolicySpec.Logging.Fields.add:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging.Field
+	84,  // 141: agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog.provider_backend:type_name -> agentgateway.dev.resource.BackendReference
+	76,  // 142: agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	6,   // 143: agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog.protocol:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog.Protocol
+	117, // 144: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.descriptors:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor
+	84,  // 145: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.target:type_name -> agentgateway.dev.resource.BackendReference
+	10,  // 146: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.failure_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.FailureMode
+	178, // 147: agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit.fill_interval:type_name -> google.protobuf.Duration
+	11,  // 148: agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit.type:type_name -> agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit.Type
+	84,  // 149: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.target:type_name -> agentgateway.dev.resource.BackendReference
+	120, // 150: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.grpc:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol
+	121, // 151: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.http:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol
+	12,  // 152: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.failure_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.FailureMode
+	119, // 153: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.include_request_body:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.BodyOptions
+	74,  // 154: agentgateway.dev.resource.TrafficPolicySpec.JWTProvider.jwt_validation_options:type_name -> agentgateway.dev.resource.JWTValidationOptions
+	13,  // 155: agentgateway.dev.resource.TrafficPolicySpec.JWT.mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.JWT.Mode
+	107, // 156: agentgateway.dev.resource.TrafficPolicySpec.JWT.providers:type_name -> agentgateway.dev.resource.TrafficPolicySpec.JWTProvider
+	14,  // 157: agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication.mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication.Mode
+	126, // 158: agentgateway.dev.resource.TrafficPolicySpec.APIKey.api_keys:type_name -> agentgateway.dev.resource.TrafficPolicySpec.APIKey.User
+	15,  // 159: agentgateway.dev.resource.TrafficPolicySpec.APIKey.mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.APIKey.Mode
+	127, // 160: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.request:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform
+	127, // 161: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.response:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform
+	84,  // 162: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.target:type_name -> agentgateway.dev.resource.BackendReference
+	16,  // 163: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.failure_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.FailureMode
+	129, // 164: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.request_attributes:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.RequestAttributesEntry
+	130, // 165: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.response_attributes:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ResponseAttributesEntry
+	132, // 166: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.metadata_context:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.MetadataContextEntry
+	17,  // 167: agentgateway.dev.resource.TrafficPolicySpec.HostRewrite.mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HostRewrite.Mode
+	118, // 168: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor.entries:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Entry
+	9,   // 169: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor.type:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Type
+	122, // 170: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.context:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.ContextEntry
+	123, // 171: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.metadata:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.MetadataEntry
+	124, // 172: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.add_request_headers:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.AddRequestHeadersEntry
+	125, // 173: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.metadata:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.MetadataEntry
+	179, // 174: agentgateway.dev.resource.TrafficPolicySpec.APIKey.User.metadata:type_name -> google.protobuf.Struct
+	112, // 175: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.set:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HeaderTransformation
+	112, // 176: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.add:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HeaderTransformation
+	113, // 177: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.body:type_name -> agentgateway.dev.resource.TrafficPolicySpec.BodyTransformation
+	128, // 178: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.metadata:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.MetadataEntry
+	133, // 179: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext.context:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext.ContextEntry
+	131, // 180: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.MetadataContextEntry.value:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext
+	156, // 181: agentgateway.dev.resource.BackendPolicySpec.Ai.prompt_guard:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard
+	158, // 182: agentgateway.dev.resource.BackendPolicySpec.Ai.defaults:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.DefaultsEntry
+	159, // 183: agentgateway.dev.resource.BackendPolicySpec.Ai.overrides:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.OverridesEntry
+	160, // 184: agentgateway.dev.resource.BackendPolicySpec.Ai.transformations:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.TransformationsEntry
+	146, // 185: agentgateway.dev.resource.BackendPolicySpec.Ai.prompts:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment
+	161, // 186: agentgateway.dev.resource.BackendPolicySpec.Ai.model_aliases:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ModelAliasesEntry
+	157, // 187: agentgateway.dev.resource.BackendPolicySpec.Ai.prompt_caching:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptCaching
+	162, // 188: agentgateway.dev.resource.BackendPolicySpec.Ai.routes:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RoutesEntry
+	84,  // 189: agentgateway.dev.resource.BackendPolicySpec.InferenceRouting.endpoint_picker:type_name -> agentgateway.dev.resource.BackendReference
+	21,  // 190: agentgateway.dev.resource.BackendPolicySpec.InferenceRouting.failure_mode:type_name -> agentgateway.dev.resource.BackendPolicySpec.InferenceRouting.FailureMode
+	178, // 191: agentgateway.dev.resource.BackendPolicySpec.Eviction.duration:type_name -> google.protobuf.Duration
+	137, // 192: agentgateway.dev.resource.BackendPolicySpec.Health.eviction:type_name -> agentgateway.dev.resource.BackendPolicySpec.Eviction
+	22,  // 193: agentgateway.dev.resource.BackendPolicySpec.BackendTLS.verification:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTLS.VerificationMode
+	85,  // 194: agentgateway.dev.resource.BackendPolicySpec.BackendTLS.alpn:type_name -> agentgateway.dev.resource.Alpn
+	23,  // 195: agentgateway.dev.resource.BackendPolicySpec.BackendHTTP.version:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendHTTP.HttpVersion
+	178, // 196: agentgateway.dev.resource.BackendPolicySpec.BackendHTTP.request_timeout:type_name -> google.protobuf.Duration
+	84,  // 197: agentgateway.dev.resource.BackendPolicySpec.BackendTunnel.proxy:type_name -> agentgateway.dev.resource.BackendReference
+	72,  // 198: agentgateway.dev.resource.BackendPolicySpec.BackendTCP.keepalive:type_name -> agentgateway.dev.resource.KeepaliveConfig
+	178, // 199: agentgateway.dev.resource.BackendPolicySpec.BackendTCP.connect_timeout:type_name -> google.protobuf.Duration
+	24,  // 200: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.provider:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.McpIDP
+	163, // 201: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.resource_metadata:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata
+	25,  // 202: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.mode:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.Mode
+	74,  // 203: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.jwt_validation_options:type_name -> agentgateway.dev.resource.JWTValidationOptions
+	145, // 204: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment.append:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Message
+	145, // 205: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment.prepend:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Message
+	18,  // 206: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRule.builtin:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.BuiltinRegexRule
+	19,  // 207: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules.action:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ActionKind
+	147, // 208: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules.rules:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRule
+	84,  // 209: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.backend:type_name -> agentgateway.dev.resource.BackendReference
+	62,  // 210: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.forward_header_matches:type_name -> agentgateway.dev.resource.HeaderMatch
+	76,  // 211: agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	76,  // 212: agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	76,  // 213: agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	153, // 214: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.rejection:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestRejection
+	148, // 215: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.regex:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules
+	149, // 216: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.webhook:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook
+	152, // 217: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.google_model_armor:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor
+	151, // 218: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.bedrock_guardrails:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails
+	153, // 219: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.rejection:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestRejection
+	148, // 220: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.regex:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules
+	149, // 221: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.webhook:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook
+	150, // 222: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.openai_moderation:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation
+	152, // 223: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.google_model_armor:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor
+	151, // 224: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.bedrock_guardrails:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails
+	155, // 225: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.request:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard
+	154, // 226: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.response:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard
+	20,  // 227: agentgateway.dev.resource.BackendPolicySpec.Ai.RoutesEntry.value:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RouteType
+	164, // 228: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.extra:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntry
+	180, // 229: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntry.value:type_name -> google.protobuf.Value
+	165, // 230: agentgateway.dev.resource.AIBackend.Provider.host_override:type_name -> agentgateway.dev.resource.AIBackend.HostOverride
+	166, // 231: agentgateway.dev.resource.AIBackend.Provider.openai:type_name -> agentgateway.dev.resource.AIBackend.OpenAI
+	167, // 232: agentgateway.dev.resource.AIBackend.Provider.gemini:type_name -> agentgateway.dev.resource.AIBackend.Gemini
+	168, // 233: agentgateway.dev.resource.AIBackend.Provider.vertex:type_name -> agentgateway.dev.resource.AIBackend.Vertex
+	169, // 234: agentgateway.dev.resource.AIBackend.Provider.anthropic:type_name -> agentgateway.dev.resource.AIBackend.Anthropic
+	170, // 235: agentgateway.dev.resource.AIBackend.Provider.bedrock:type_name -> agentgateway.dev.resource.AIBackend.Bedrock
+	171, // 236: agentgateway.dev.resource.AIBackend.Provider.azureopenai:type_name -> agentgateway.dev.resource.AIBackend.AzureOpenAI
+	76,  // 237: agentgateway.dev.resource.AIBackend.Provider.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	172, // 238: agentgateway.dev.resource.AIBackend.ProviderGroup.providers:type_name -> agentgateway.dev.resource.AIBackend.Provider
+	239, // [239:239] is the sub-list for method output_type
+	239, // [239:239] is the sub-list for method input_type
+	239, // [239:239] is the sub-list for extension type_name
+	239, // [239:239] is the sub-list for extension extendee
+	0,   // [0:239] is the sub-list for field type_name
 }
 
 func init() { file_resource_proto_init() }

--- a/controller/pkg/agentgateway/translator/conversion.go
+++ b/controller/pkg/agentgateway/translator/conversion.go
@@ -22,7 +22,6 @@ import (
 	"istio.io/istio/pkg/ptr"
 	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/util/sets"
-	"istio.io/istio/pkg/workloadapi"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	klabels "k8s.io/apimachinery/pkg/labels"
@@ -926,7 +925,7 @@ type ParentInfo struct {
 	// ListenerKey is the internal key of the listener resource created for this parent.
 	ListenerKey string
 	// ServiceKey (optionally) links a parent reference to an individual Service.
-	ServiceKey *workloadapi.NamespacedHostname
+	ServiceKey *types.NamespacedName
 	// AllowedKinds indicates which kinds can be admitted by this Parent
 	AllowedKinds []gwv1.RouteGroupKind
 	// Hostnames is the hostnames that must be match to reference to the Parent. For gateway this is listener hostname
@@ -948,7 +947,7 @@ type RouteParentReference struct {
 	// ListenerKey is the internal key of the listener resource created for this parent.
 	ListenerKey string
 	// ServiceKey (optionally) links a parent reference to an individual Service.
-	ServiceKey *workloadapi.NamespacedHostname
+	ServiceKey *types.NamespacedName
 	// InternalKind is the Kind of the Parent
 	InternalKind string
 	// DeniedReason, if present, indicates why the reference was not valid

--- a/controller/pkg/agentgateway/translator/conversion.go
+++ b/controller/pkg/agentgateway/translator/conversion.go
@@ -22,6 +22,7 @@ import (
 	"istio.io/istio/pkg/ptr"
 	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/util/sets"
+	"istio.io/istio/pkg/workloadapi"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	klabels "k8s.io/apimachinery/pkg/labels"
@@ -875,6 +876,7 @@ func extractParentReferenceInfo(ctx RouteContext, parents ParentResolver, obj co
 			rpi := RouteParentReference{
 				ParentGateway:     pr.ParentGateway,
 				ListenerKey:       pr.ListenerKey,
+				ServiceKey:        pr.ServiceKey,
 				InternalKind:      ir.Kind,
 				Hostname:          pr.OriginalHostname,
 				DeniedReason:      deniedReason,
@@ -923,6 +925,8 @@ type ParentInfo struct {
 	ParentGatewayClassName string
 	// ListenerKey is the internal key of the listener resource created for this parent.
 	ListenerKey string
+	// ServiceKey (optionally) links a parent reference to an individual Service.
+	ServiceKey *workloadapi.NamespacedHostname
 	// AllowedKinds indicates which kinds can be admitted by this Parent
 	AllowedKinds []gwv1.RouteGroupKind
 	// Hostnames is the hostnames that must be match to reference to the Parent. For gateway this is listener hostname
@@ -943,6 +947,8 @@ type ParentInfo struct {
 type RouteParentReference struct {
 	// ListenerKey is the internal key of the listener resource created for this parent.
 	ListenerKey string
+	// ServiceKey (optionally) links a parent reference to an individual Service.
+	ServiceKey *workloadapi.NamespacedHostname
 	// InternalKind is the Kind of the Parent
 	InternalKind string
 	// DeniedReason, if present, indicates why the reference was not valid

--- a/controller/pkg/agentgateway/translator/gateway_collection.go
+++ b/controller/pkg/agentgateway/translator/gateway_collection.go
@@ -199,6 +199,7 @@ func (g ParentInfo) Equals(other ParentInfo) bool {
 	return g.ParentGateway == other.ParentGateway &&
 		g.ParentGatewayClassName == other.ParentGatewayClassName &&
 		g.ListenerKey == other.ListenerKey &&
+		ptr.Equal(g.ServiceKey, other.ServiceKey) &&
 		g.OriginalHostname == other.OriginalHostname &&
 		g.SectionName == other.SectionName &&
 		g.Port == other.Port &&

--- a/controller/pkg/agentgateway/translator/route_collections.go
+++ b/controller/pkg/agentgateway/translator/route_collections.go
@@ -298,22 +298,40 @@ func resourceMapper(t any, parent RouteParentReference) *api.Resource {
 		// safety: a shallow clone is ok because we only modify a top level field (Key)
 		inner := protomarshal.ShallowClone(tt.TCPRoute)
 		inner.ListenerKey = parent.ListenerKey
-		if sec := string(parent.ParentSection); sec != "" {
-			inner.Key += "." + sec
+		inner.ServiceKey = parent.ServiceKey
+		inner.Key += routeKeySuffix(parent)
+		if inner.ServiceKey != nil {
+			// if linked by Service, no need for hostname matching
+			inner.Hostnames = nil
 		}
+
 		return ToAgwResource(AgwTCPRoute{TCPRoute: inner})
 	case AgwRoute:
 		// safety: a shallow clone is ok because we only modify a top level field (Key)
 		inner := protomarshal.ShallowClone(tt.Route)
 		inner.ListenerKey = parent.ListenerKey
-		if sec := string(parent.ParentSection); sec != "" {
-			inner.Key += "." + sec
+		inner.ServiceKey = parent.ServiceKey
+		inner.Key += routeKeySuffix(parent)
+		if inner.ServiceKey != nil {
+			// if linked by Service, no need for hostname matching
+			inner.Hostnames = nil
 		}
+
 		return ToAgwResource(AgwRoute{Route: inner})
 	default:
 		log.Fatalf("unknown route kind %T", t)
 		return nil
 	}
+}
+
+func routeKeySuffix(parent RouteParentReference) string {
+	if parent.ServiceKey != nil {
+		return ".svc." + parent.ServiceKey.Namespace + "." + parent.ServiceKey.Hostname
+	}
+	if sec := string(parent.ParentSection); sec != "" {
+		return "." + sec
+	}
+	return ""
 }
 
 // reasonResolvedRefs picks a ResolvedRefs reason from a conversion failure condition.

--- a/controller/pkg/agentgateway/translator/route_collections.go
+++ b/controller/pkg/agentgateway/translator/route_collections.go
@@ -14,6 +14,7 @@ import (
 	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/util/protomarshal"
 	"istio.io/istio/pkg/util/sets"
+	"istio.io/istio/pkg/workloadapi"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -293,12 +294,20 @@ func ProcessParentReferences[T any](
 }
 
 func resourceMapper(t any, parent RouteParentReference) *api.Resource {
+	var serviceKey *workloadapi.NamespacedHostname
+	if parent.ServiceKey != nil {
+		serviceKey = &workloadapi.NamespacedHostname{
+			Namespace: parent.ServiceKey.Namespace,
+			Hostname:  parent.ServiceKey.Name,
+		}
+	}
+
 	switch tt := t.(type) {
 	case AgwTCPRoute:
 		// safety: a shallow clone is ok because we only modify a top level field (Key)
 		inner := protomarshal.ShallowClone(tt.TCPRoute)
 		inner.ListenerKey = parent.ListenerKey
-		inner.ServiceKey = parent.ServiceKey
+		inner.ServiceKey = serviceKey
 		inner.Key += routeKeySuffix(parent)
 		if inner.ServiceKey != nil {
 			// if linked by Service, no need for hostname matching
@@ -310,7 +319,7 @@ func resourceMapper(t any, parent RouteParentReference) *api.Resource {
 		// safety: a shallow clone is ok because we only modify a top level field (Key)
 		inner := protomarshal.ShallowClone(tt.Route)
 		inner.ListenerKey = parent.ListenerKey
-		inner.ServiceKey = parent.ServiceKey
+		inner.ServiceKey = serviceKey
 		inner.Key += routeKeySuffix(parent)
 		if inner.ServiceKey != nil {
 			// if linked by Service, no need for hostname matching
@@ -326,7 +335,7 @@ func resourceMapper(t any, parent RouteParentReference) *api.Resource {
 
 func routeKeySuffix(parent RouteParentReference) string {
 	if parent.ServiceKey != nil {
-		return ".svc." + parent.ServiceKey.Namespace + "." + parent.ServiceKey.Hostname
+		return ".svc." + parent.ServiceKey.Namespace + "." + parent.ServiceKey.Name
 	}
 	if sec := string(parent.ParentSection); sec != "" {
 		return "." + sec

--- a/crates/agentgateway/src/http/route.rs
+++ b/crates/agentgateway/src/http/route.rs
@@ -164,10 +164,9 @@ pub fn select_best_route(
 			return None;
 		}
 
-		// GAMMA: check service-keyed routes first.
 		// When routes are attached to a Service via parentRef, they take priority
-		// and bypass hostname matching. If service routes exist but none match,
-		// the request is rejected (no default fallback).
+		// over listener-attached routes. If service routes exist but none match,
+		// the request is rejected (per GAMMA spec).
 		let svc_nh = svc.namespaced_hostname();
 		let (has_svc_routes, svc_route_match) = {
 			let binds = stores.read_binds();

--- a/crates/agentgateway/src/http/route.rs
+++ b/crates/agentgateway/src/http/route.rs
@@ -9,7 +9,7 @@ use crate::http::Request;
 use crate::types::agent;
 use crate::types::agent::{
 	BackendReference, HeaderMatch, HeaderValueMatch, Listener, ListenerProtocol, PathMatch,
-	QueryValueMatch, Route, RouteBackendReference, RouteName,
+	QueryValueMatch, Route, RouteBackendReference, RouteMatch, RouteName,
 };
 use crate::types::discovery::gatewayaddress::Destination;
 use crate::types::discovery::{NetworkAddress, WaypointIdentity};
@@ -18,6 +18,86 @@ use crate::*;
 #[cfg(any(test, feature = "internal_benches"))]
 #[path = "route_test.rs"]
 mod tests;
+
+/// Check if a RouteMatch matches the given request (path, method, headers, query).
+fn matches_request(m: &RouteMatch, request: &Request) -> bool {
+	let path_matches = match &m.path {
+		PathMatch::Exact(p) => request.uri().path() == p.as_str(),
+		PathMatch::Regex(r) => {
+			let path = request.uri().path();
+			r.find(path)
+				.map(|m| m.start() == 0 && m.end() == path.len())
+				.unwrap_or(false)
+		},
+		PathMatch::PathPrefix(p) => {
+			let p = p.trim_end_matches('/');
+			let Some(suffix) = request.uri().path().trim_end_matches('/').strip_prefix(p) else {
+				return false;
+			};
+			// TODO this is not right!!
+			suffix.is_empty() || suffix.starts_with('/')
+		},
+	};
+	if !path_matches {
+		return false;
+	}
+
+	if let Some(method) = &m.method
+		&& request.method().as_str() != method.method.as_str()
+	{
+		return false;
+	}
+	for HeaderMatch { name, value } in &m.headers {
+		let Some(have) = http::get_pseudo_or_header_value(name, request) else {
+			return false;
+		};
+		match value {
+			HeaderValueMatch::Exact(want) => {
+				if have.as_ref() != *want {
+					return false;
+				}
+			},
+			HeaderValueMatch::Regex(want) => {
+				let Some(have_str) = have.to_str().ok() else {
+					return false;
+				};
+				let Some(m) = want.find(have_str) else {
+					return false;
+				};
+				if !(m.start() == 0 && m.end() == have_str.len()) {
+					return false;
+				}
+			},
+		}
+	}
+	// TODO: this re-parses the query string on every call; hoist to caller if this becomes a hot path.
+	let query = request
+		.uri()
+		.query()
+		.map(|q| url::form_urlencoded::parse(q.as_bytes()).collect::<HashMap<_, _>>())
+		.unwrap_or_default();
+	for agent::QueryMatch { name, value } in &m.query {
+		let Some(have) = query.get(name.as_str()) else {
+			return false;
+		};
+		match value {
+			QueryValueMatch::Exact(want) => {
+				if have.as_ref() != want.as_str() {
+					return false;
+				}
+			},
+			QueryValueMatch::Regex(want) => {
+				let Some(m) = want.find(have) else {
+					return false;
+				};
+				if !(m.start() == 0 && m.end() == have.len()) {
+					return false;
+				}
+			},
+		}
+	}
+	true
+}
 
 pub fn select_best_route(
 	stores: Stores,
@@ -83,9 +163,43 @@ pub fn select_best_route(
 			);
 			return None;
 		}
-		// TODO: only build this if we don't match one
+
+		// GAMMA: check service-keyed routes first.
+		// When routes are attached to a Service via parentRef, they take priority
+		// and bypass hostname matching. If service routes exist but none match,
+		// the request is rejected (no default fallback).
+		let svc_nh = svc.namespaced_hostname();
+		let (has_svc_routes, svc_route_match) = {
+			let binds = stores.read_binds();
+			match binds.get_service_routes(&svc_nh) {
+				Some(svc_routes) => {
+					let mut result = None;
+					for hnm in agent::HostnameMatch::all_matches(&svc.hostname) {
+						result = svc_routes
+							.get_hostname(&hnm)
+							.find(|(_, m)| matches_request(m, request))
+							.map(|(route, matcher)| (route, matcher.path.clone()));
+						if result.is_some() {
+							break;
+						}
+					}
+					(true, result)
+				},
+				None => (false, None),
+			}
+		};
+		if let Some(result) = svc_route_match {
+			return Some(result);
+		}
+		if has_svc_routes {
+			// GAMMA: service routes exist but none matched -> reject
+			return None;
+		}
+
+		// No service-keyed routes: fall through to hostname matching with default route
 		let default_route = Route {
 			key: strng::literal!("_waypoint-default"),
+			service_key: None,
 			name: RouteName {
 				name: strng::literal!("_waypoint-default"),
 				namespace: svc.namespace.clone(),
@@ -104,7 +218,6 @@ pub fn select_best_route(
 				inline_policies: Vec::new(),
 			}],
 		};
-		// If there is no route, use a default one
 		let def = Some((
 			Arc::new(default_route),
 			PathMatch::PathPrefix(strng::new("/")),
@@ -115,89 +228,7 @@ pub fn select_best_route(
 	};
 	for hnm in agent::HostnameMatch::all_matches(&host) {
 		let mut candidates = listener.routes.get_hostname(&hnm);
-		let best_match = candidates.find(|(_, m)| {
-			let path_matches = match &m.path {
-				PathMatch::Exact(p) => request.uri().path() == p.as_str(),
-				PathMatch::Regex(r) => {
-					// Regex has no defined ordering. We will order by the length of the regex expression.
-					let path = request.uri().path();
-					r.find(path)
-						.map(|m| m.start() == 0 && m.end() == path.len())
-						.unwrap_or(false)
-				},
-				PathMatch::PathPrefix(p) => {
-					let p = p.trim_end_matches('/');
-					let Some(suffix) = request.uri().path().trim_end_matches('/').strip_prefix(p) else {
-						return false;
-					};
-					// TODO this is not right!!
-					suffix.is_empty() || suffix.starts_with('/')
-				},
-			};
-			if !path_matches {
-				return false;
-			}
-
-			if let Some(method) = &m.method
-				&& request.method().as_str() != method.method.as_str()
-			{
-				return false;
-			}
-			for HeaderMatch { name, value } in &m.headers {
-				let Some(have) = http::get_pseudo_or_header_value(name, request) else {
-					return false;
-				};
-				match value {
-					HeaderValueMatch::Exact(want) => {
-						if have.as_ref() != *want {
-							return false;
-						}
-					},
-					HeaderValueMatch::Regex(want) => {
-						// Must be a valid string to do regex match
-						let Some(have_str) = have.to_str().ok() else {
-							return false;
-						};
-						let Some(m) = want.find(have_str) else {
-							return false;
-						};
-						// Make sure we matched the entire thing
-						if !(m.start() == 0 && m.end() == have_str.len()) {
-							return false;
-						}
-					},
-				}
-			}
-			let query = request
-				.uri()
-				.query()
-				.map(|q| url::form_urlencoded::parse(q.as_bytes()).collect::<HashMap<_, _>>())
-				.unwrap_or_default();
-			for agent::QueryMatch { name, value } in &m.query {
-				let Some(have) = query.get(name.as_str()) else {
-					return false;
-				};
-
-				match value {
-					QueryValueMatch::Exact(want) => {
-						if have.as_ref() != want.as_str() {
-							return false;
-						}
-					},
-					QueryValueMatch::Regex(want) => {
-						// Must be a valid string to do regex match
-						let Some(m) = want.find(have) else {
-							return false;
-						};
-						// Make sure we matched the entire thing
-						if !(m.start() == 0 && m.end() == have.len()) {
-							return false;
-						}
-					},
-				}
-			}
-			true
-		});
+		let best_match = candidates.find(|(_, m)| matches_request(m, request));
 		if let Some((route, matcher)) = best_match {
 			return Some((route, matcher.path.clone()));
 		}

--- a/crates/agentgateway/src/http/route_test.rs
+++ b/crates/agentgateway/src/http/route_test.rs
@@ -41,6 +41,7 @@ fn run_test(req: &Request, routes: &[(&str, Vec<&str>, Vec<RouteMatch>)]) -> Opt
 fn setup_listener(routes: &[(&str, Vec<&str>, Vec<RouteMatch>)]) -> Arc<Listener> {
 	let mk_route = |name: &str, hostnames: Vec<&str>, matches: Vec<RouteMatch>| Route {
 		key: name.into(),
+		service_key: None,
 		hostnames: hostnames.into_iter().map(|s| s.into()).collect(),
 		matches,
 		name: Default::default(),
@@ -1208,6 +1209,305 @@ async fn test_waypoint_unknown_vip() {
 	assert!(result.is_none(), "should return None for unknown VIP");
 }
 
+/// Create stores with a service and optionally insert service-keyed routes into the bind store.
+fn stores_with_service_routes(svc: Service, routes: Vec<Route>) -> Stores {
+	let stores = stores_with_services(vec![svc]);
+	{
+		let mut binds = stores.binds.write();
+		for r in routes {
+			let sk = r
+				.service_key
+				.clone()
+				.expect("test routes must have service_key");
+			binds.insert_service_route(r, sk);
+		}
+	}
+	stores
+}
+
+fn service_route(key: &str, service_key: NamespacedHostname, matches: Vec<RouteMatch>) -> Route {
+	Route {
+		key: strng::new(key),
+		service_key: Some(service_key),
+		name: Default::default(),
+		hostnames: vec![], // GAMMA: hostname matching skipped for service routes
+		matches,
+		backends: vec![],
+		inline_policies: vec![],
+	}
+}
+
+fn svc_nh() -> NamespacedHostname {
+	NamespacedHostname {
+		namespace: strng::new("default"),
+		hostname: strng::new("my-app.default.svc.cluster.local"),
+	}
+}
+
+fn waypoint_svc() -> Service {
+	make_service(
+		"my-app",
+		"default",
+		"my-app.default.svc.cluster.local",
+		"10.0.0.100",
+		"network",
+		Some(GatewayAddress {
+			destination: Destination::Hostname(NamespacedHostname {
+				namespace: strng::new("istio-system"),
+				hostname: strng::new("my-waypoint.istio-system.svc.cluster.local"),
+			}),
+			hbone_mtls_port: 15008,
+		}),
+	)
+}
+
+fn waypoint_self_id() -> WaypointIdentity {
+	WaypointIdentity {
+		gateway: strng::new("my-waypoint"),
+		namespace: strng::new("istio-system"),
+	}
+}
+
+#[tokio::test]
+async fn test_service_route_path_match() {
+	let stores = stores_with_service_routes(
+		waypoint_svc(),
+		vec![
+			service_route(
+				"api-route",
+				svc_nh(),
+				vec![RouteMatch {
+					path: PathMatch::PathPrefix(strng::new("/api")),
+					headers: vec![],
+					method: None,
+					query: vec![],
+				}],
+			),
+			service_route(
+				"health-route",
+				svc_nh(),
+				vec![RouteMatch {
+					path: PathMatch::Exact(strng::new("/healthz")),
+					headers: vec![],
+					method: None,
+					query: vec![],
+				}],
+			),
+		],
+	);
+	let self_id = waypoint_self_id();
+	let listener = hbone_listener();
+	let dst = SocketAddr::new("10.0.0.100".parse().unwrap(), 80);
+
+	// /api/v1 matches the prefix route
+	let req = request(
+		"http://my-app.default.svc.cluster.local/api/v1",
+		http::Method::GET,
+		&[],
+	);
+	let result = super::select_best_route(
+		stores.clone(),
+		strng::literal!("network"),
+		Some(&self_id),
+		dst,
+		&listener,
+		&req,
+	);
+	assert_eq!(result.unwrap().0.key.as_str(), "api-route");
+
+	// /healthz matches the exact route (higher priority than prefix)
+	let req = request(
+		"http://my-app.default.svc.cluster.local/healthz",
+		http::Method::GET,
+		&[],
+	);
+	let result = super::select_best_route(
+		stores.clone(),
+		strng::literal!("network"),
+		Some(&self_id),
+		dst,
+		&listener,
+		&req,
+	);
+	assert_eq!(result.unwrap().0.key.as_str(), "health-route");
+}
+
+#[tokio::test]
+async fn test_service_route_method_match() {
+	let stores = stores_with_service_routes(
+		waypoint_svc(),
+		vec![
+			service_route(
+				"get-route",
+				svc_nh(),
+				vec![RouteMatch {
+					path: PathMatch::PathPrefix(strng::new("/")),
+					headers: vec![],
+					method: Some(MethodMatch {
+						method: strng::new("GET"),
+					}),
+					query: vec![],
+				}],
+			),
+			service_route(
+				"post-route",
+				svc_nh(),
+				vec![RouteMatch {
+					path: PathMatch::PathPrefix(strng::new("/")),
+					headers: vec![],
+					method: Some(MethodMatch {
+						method: strng::new("POST"),
+					}),
+					query: vec![],
+				}],
+			),
+		],
+	);
+	let self_id = waypoint_self_id();
+	let listener = hbone_listener();
+	let dst = SocketAddr::new("10.0.0.100".parse().unwrap(), 80);
+
+	let req = request(
+		"http://my-app.default.svc.cluster.local/",
+		http::Method::POST,
+		&[],
+	);
+	let result = super::select_best_route(
+		stores.clone(),
+		strng::literal!("network"),
+		Some(&self_id),
+		dst,
+		&listener,
+		&req,
+	);
+	assert_eq!(result.unwrap().0.key.as_str(), "post-route");
+}
+
+#[tokio::test]
+async fn test_service_route_header_match() {
+	let stores = stores_with_service_routes(
+		waypoint_svc(),
+		vec![service_route(
+			"header-route",
+			svc_nh(),
+			vec![RouteMatch {
+				path: PathMatch::PathPrefix(strng::new("/")),
+				headers: vec![HeaderMatch {
+					name: crate::http::HeaderOrPseudo::Header(http::HeaderName::from_static("x-custom")),
+					value: HeaderValueMatch::Exact(http::HeaderValue::from_static("special")),
+				}],
+				method: None,
+				query: vec![],
+			}],
+		)],
+	);
+	let self_id = waypoint_self_id();
+	let listener = hbone_listener();
+	let dst = SocketAddr::new("10.0.0.100".parse().unwrap(), 80);
+
+	// With matching header -> matches
+	let req = request(
+		"http://my-app.default.svc.cluster.local/",
+		http::Method::GET,
+		&[("x-custom", "special")],
+	);
+	let result = super::select_best_route(
+		stores.clone(),
+		strng::literal!("network"),
+		Some(&self_id),
+		dst,
+		&listener,
+		&req,
+	);
+	assert_eq!(result.unwrap().0.key.as_str(), "header-route");
+
+	// Without matching header -> GAMMA reject (service routes exist, none match)
+	let req = request(
+		"http://my-app.default.svc.cluster.local/",
+		http::Method::GET,
+		&[],
+	);
+	let result = super::select_best_route(
+		stores.clone(),
+		strng::literal!("network"),
+		Some(&self_id),
+		dst,
+		&listener,
+		&req,
+	);
+	assert!(
+		result.is_none(),
+		"should reject when service routes exist but none match"
+	);
+}
+
+#[tokio::test]
+async fn test_service_route_rejects_unmatched() {
+	// GAMMA: if service routes exist but request doesn't match any, reject
+	let stores = stores_with_service_routes(
+		waypoint_svc(),
+		vec![service_route(
+			"only-api",
+			svc_nh(),
+			vec![RouteMatch {
+				path: PathMatch::PathPrefix(strng::new("/api")),
+				headers: vec![],
+				method: None,
+				query: vec![],
+			}],
+		)],
+	);
+	let self_id = waypoint_self_id();
+	let listener = hbone_listener();
+	let dst = SocketAddr::new("10.0.0.100".parse().unwrap(), 80);
+
+	let req = request(
+		"http://my-app.default.svc.cluster.local/other",
+		http::Method::GET,
+		&[],
+	);
+	let result = super::select_best_route(
+		stores.clone(),
+		strng::literal!("network"),
+		Some(&self_id),
+		dst,
+		&listener,
+		&req,
+	);
+	assert!(
+		result.is_none(),
+		"GAMMA: should reject when service routes exist but none match"
+	);
+}
+
+#[tokio::test]
+async fn test_no_service_routes_falls_through_to_default() {
+	// No service-keyed routes -> default passthrough route
+	let stores = stores_with_services(vec![waypoint_svc()]);
+	let self_id = waypoint_self_id();
+	let listener = hbone_listener();
+	let dst = SocketAddr::new("10.0.0.100".parse().unwrap(), 80);
+
+	let req = request(
+		"http://my-app.default.svc.cluster.local/anything",
+		http::Method::GET,
+		&[],
+	);
+	let result = super::select_best_route(
+		stores,
+		strng::literal!("network"),
+		Some(&self_id),
+		dst,
+		&listener,
+		&req,
+	);
+	assert!(
+		result.is_some(),
+		"should fall through to default route when no service routes"
+	);
+	assert_eq!(result.unwrap().0.key.as_str(), "_waypoint-default");
+}
+
 #[divan::bench(args = [(1,1), (100, 100), (5000,100)])]
 fn bench(b: Bencher, (host, route): (u64, u64)) {
 	let mut routes = vec![];
@@ -1238,6 +1538,7 @@ fn bench(b: Bencher, (host, route): (u64, u64)) {
 				.into_iter()
 				.map(|(name, host, matches)| Route {
 					key: name.into(),
+					service_key: None,
 					name: Default::default(),
 					hostnames: host.into_iter().map(|s| s.into()).collect(),
 					matches,

--- a/crates/agentgateway/src/proxy/tcpproxy.rs
+++ b/crates/agentgateway/src/proxy/tcpproxy.rs
@@ -220,14 +220,17 @@ fn select_best_route(
 	if matches!(listener.protocol, ListenerProtocol::HBONE) {
 		let svc = resolve_waypoint_service(stores, network, dst, self_addr)?;
 
-		// GAMMA: check service-keyed TCP routes first
+		// When routes are attached to a Service via parentRef, they take priority
+		// over listener-attached routes. If service routes exist but none match,
+		// the request is rejected (per GAMMA spec).
 		let svc_nh = svc.namespaced_hostname();
 		{
 			let binds = stores.read_binds();
 			if let Some(svc_tcp_routes) = binds.get_service_tcp_routes(&svc_nh) {
-				// Service TCP routes exist — use the first match (pre-sorted by precedence)
-				if let Some(r) = svc_tcp_routes.get_hostname(&agent::HostnameMatchRef::None) {
-					return Some(Arc::new(r.clone()));
+				for hnm in agent::HostnameMatch::all_matches(&svc.hostname) {
+					if let Some(r) = svc_tcp_routes.get_hostname(&hnm) {
+						return Some(Arc::new(r.clone()));
+					}
 				}
 				// GAMMA: service routes exist but none matched -> reject
 				return None;

--- a/crates/agentgateway/src/proxy/tcpproxy.rs
+++ b/crates/agentgateway/src/proxy/tcpproxy.rs
@@ -216,23 +216,55 @@ fn select_best_route(
 		}
 	}
 
-	// For HBONE waypoints, generate a default passthrough route to the service
+	// For HBONE waypoints, check service-keyed routes then fall back to default
 	if matches!(listener.protocol, ListenerProtocol::HBONE) {
-		return waypoint_default_tcp_route(stores, network, dst, self_addr);
+		let svc = resolve_waypoint_service(stores, network, dst, self_addr)?;
+
+		// GAMMA: check service-keyed TCP routes first
+		let svc_nh = svc.namespaced_hostname();
+		{
+			let binds = stores.read_binds();
+			if let Some(svc_tcp_routes) = binds.get_service_tcp_routes(&svc_nh) {
+				// Service TCP routes exist — use the first match (pre-sorted by precedence)
+				if let Some(r) = svc_tcp_routes.get_hostname(&agent::HostnameMatchRef::None) {
+					return Some(Arc::new(r.clone()));
+				}
+				// GAMMA: service routes exist but none matched -> reject
+				return None;
+			}
+		}
+
+		// No service-keyed routes: generate default passthrough
+		return Some(Arc::new(TCPRoute {
+			key: strng::literal!("_waypoint-default-tcp"),
+			service_key: None,
+			name: crate::types::agent::RouteName {
+				name: strng::literal!("_waypoint-default-tcp"),
+				namespace: svc.namespace.clone(),
+				rule_name: None,
+				kind: None,
+			},
+			hostnames: vec![],
+			backends: vec![TCPRouteBackendReference {
+				weight: 1,
+				backend: SimpleBackendReference::Service {
+					name: svc.namespaced_hostname(),
+					port: dst.port(),
+				},
+				inline_policies: Vec::new(),
+			}],
+		}));
 	}
 	None
 }
 
-/// Generate a default TCP route for waypoint proxies, routing to the service
-/// identified by the destination VIP. Mirrors the HTTP default route in route.rs.
-/// Includes waypoint self-verification: the service must have a waypoint config
-/// that matches this proxy instance.
-fn waypoint_default_tcp_route(
+/// Resolve the waypoint service from a VIP and verify this proxy owns it.
+fn resolve_waypoint_service(
 	stores: &Stores,
 	network: &Strng,
 	dst: SocketAddr,
 	self_addr: Option<&WaypointIdentity>,
-) -> Option<Arc<TCPRoute>> {
+) -> Option<Arc<crate::types::discovery::Service>> {
 	let self_id = self_addr.or_else(|| {
 		warn!("waypoint requires self address for TCP routing");
 		None
@@ -246,7 +278,6 @@ fn waypoint_default_tcp_route(
 			address: dst.ip(),
 		})?;
 
-	// Verify the service is bound to this waypoint
 	let wp = svc.waypoint.as_ref()?;
 	let is_ours = match &wp.destination {
 		Destination::Address(addr) => {
@@ -272,24 +303,7 @@ fn waypoint_default_tcp_route(
 		return None;
 	}
 
-	Some(Arc::new(TCPRoute {
-		key: strng::literal!("_waypoint-default-tcp"),
-		name: crate::types::agent::RouteName {
-			name: strng::literal!("_waypoint-default-tcp"),
-			namespace: svc.namespace.clone(),
-			rule_name: None,
-			kind: None,
-		},
-		hostnames: vec![],
-		backends: vec![TCPRouteBackendReference {
-			weight: 1,
-			backend: SimpleBackendReference::Service {
-				name: svc.namespaced_hostname(),
-				port: dst.port(),
-			},
-			inline_policies: Vec::new(),
-		}],
-	}))
+	Some(svc)
 }
 
 fn select_tcp_backend(route: &TCPRoute) -> Option<TCPRouteBackendReference> {
@@ -419,7 +433,14 @@ mod tests {
 		let dst = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 50)), 3306);
 		let self_addr = make_self_addr("my-waypoint", "istio-system");
 
-		let route = super::waypoint_default_tcp_route(&stores, &network, dst, Some(&self_addr));
+		let route = super::select_best_route(
+			None,
+			hbone_listener(),
+			&stores,
+			&network,
+			dst,
+			Some(&self_addr),
+		);
 		assert!(
 			route.is_some(),
 			"should generate default TCP route for known service"
@@ -443,7 +464,14 @@ mod tests {
 		let dst = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 99)), 3306);
 		let self_addr = make_self_addr("my-waypoint", "istio-system");
 
-		let route = super::waypoint_default_tcp_route(&stores, &network, dst, Some(&self_addr));
+		let route = super::select_best_route(
+			None,
+			hbone_listener(),
+			&stores,
+			&network,
+			dst,
+			Some(&self_addr),
+		);
 		assert!(route.is_none(), "should return None for unknown VIP");
 	}
 
@@ -469,7 +497,14 @@ mod tests {
 		let dst = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 50)), 3306);
 		let self_addr = make_self_addr("my-waypoint", "istio-system");
 
-		let route = super::waypoint_default_tcp_route(&stores, &network, dst, Some(&self_addr));
+		let route = super::select_best_route(
+			None,
+			hbone_listener(),
+			&stores,
+			&network,
+			dst,
+			Some(&self_addr),
+		);
 		assert!(
 			route.is_none(),
 			"should reject service bound to different waypoint"
@@ -492,7 +527,14 @@ mod tests {
 		let dst = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 50)), 3306);
 		let self_addr = make_self_addr("my-waypoint", "istio-system");
 
-		let route = super::waypoint_default_tcp_route(&stores, &network, dst, Some(&self_addr));
+		let route = super::select_best_route(
+			None,
+			hbone_listener(),
+			&stores,
+			&network,
+			dst,
+			Some(&self_addr),
+		);
 		assert!(
 			route.is_none(),
 			"should reject service without waypoint config"
@@ -519,7 +561,7 @@ mod tests {
 		let network = strng::literal!("network");
 		let dst = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 50)), 3306);
 
-		let route = super::waypoint_default_tcp_route(&stores, &network, dst, None);
+		let route = super::select_best_route(None, hbone_listener(), &stores, &network, dst, None);
 		assert!(
 			route.is_none(),
 			"should return None when self_addr not configured"
@@ -587,5 +629,89 @@ mod tests {
 			route.is_none(),
 			"non-HBONE listener should not generate default route"
 		);
+	}
+
+	#[tokio::test]
+	async fn test_service_tcp_route_match() {
+		let svc = make_service(
+			"mysql-db",
+			"default",
+			"mysql-db.default.svc.cluster.local",
+			"10.0.0.50",
+			"network",
+			Some(GatewayAddress {
+				destination: Destination::Hostname(NamespacedHostname {
+					namespace: strng::new("istio-system"),
+					hostname: strng::new("my-waypoint.istio-system.svc.cluster.local"),
+				}),
+				hbone_mtls_port: 15008,
+			}),
+		);
+		let stores = stores_with_services(vec![svc]);
+		let svc_key = NamespacedHostname {
+			namespace: strng::new("default"),
+			hostname: strng::new("mysql-db.default.svc.cluster.local"),
+		};
+		{
+			let mut binds = stores.binds.write();
+			binds.insert_service_tcp_route(
+				crate::types::agent::TCPRoute {
+					key: strng::literal!("mysql-tcp-route"),
+					service_key: Some(svc_key.clone()),
+					name: Default::default(),
+					hostnames: vec![],
+					backends: vec![],
+				},
+				svc_key,
+			);
+		}
+		let network = strng::literal!("network");
+		let dst = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 50)), 3306);
+		let self_addr = make_self_addr("my-waypoint", "istio-system");
+
+		let route = super::select_best_route(
+			None,
+			hbone_listener(),
+			&stores,
+			&network,
+			dst,
+			Some(&self_addr),
+		);
+		assert!(route.is_some(), "should match service TCP route");
+		assert_eq!(route.unwrap().key.as_str(), "mysql-tcp-route");
+	}
+
+	#[tokio::test]
+	async fn test_service_tcp_route_no_routes_falls_to_default() {
+		// Service exists but no service-keyed TCP routes -> default passthrough
+		let svc = make_service(
+			"mysql-db",
+			"default",
+			"mysql-db.default.svc.cluster.local",
+			"10.0.0.50",
+			"network",
+			Some(GatewayAddress {
+				destination: Destination::Hostname(NamespacedHostname {
+					namespace: strng::new("istio-system"),
+					hostname: strng::new("my-waypoint.istio-system.svc.cluster.local"),
+				}),
+				hbone_mtls_port: 15008,
+			}),
+		);
+		let stores = stores_with_services(vec![svc]);
+		let network = strng::literal!("network");
+		let dst = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 50)), 3306);
+		let self_addr = make_self_addr("my-waypoint", "istio-system");
+
+		let route = super::select_best_route(
+			None,
+			hbone_listener(),
+			&stores,
+			&network,
+			dst,
+			Some(&self_addr),
+		);
+		assert!(route.is_some(), "should fall through to default");
+		assert_eq!(route.unwrap().key.as_str(), "_waypoint-default-tcp");
 	}
 }

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -20,8 +20,10 @@ use crate::store::Event;
 use crate::types::agent::{
 	A2aPolicy, Backend, BackendKey, BackendPolicy, BackendTargetRef, BackendWithPolicies, Bind,
 	BindKey, FrontendPolicy, Listener, ListenerKey, ListenerName, McpAuthentication, PolicyKey,
-	PolicyTarget, Route, RouteKey, RouteName, TCPRoute, TargetedPolicy, TracingPolicy, TrafficPolicy,
+	PolicyTarget, Route, RouteKey, RouteName, RouteSet, TCPRoute, TCPRouteSet, TargetedPolicy,
+	TracingPolicy, TrafficPolicy,
 };
+use crate::types::discovery::NamespacedHostname;
 use crate::types::proto::agent::resource::Kind as XdsKind;
 use crate::types::proto::agent::{
 	Backend as XdsBackend, Bind as XdsBind, Listener as XdsListener, Policy as XdsPolicy,
@@ -55,6 +57,10 @@ pub struct Store {
 	staged_listeners: HashMap<BindKey, HashMap<ListenerKey, Listener>>,
 	staged_routes: HashMap<ListenerKey, HashMap<RouteKey, Route>>,
 	staged_tcp_routes: HashMap<ListenerKey, HashMap<RouteKey, TCPRoute>>,
+
+	// Service-keyed routes (GAMMA spec: routes with parentRef targeting a Service)
+	service_routes: HashMap<NamespacedHostname, RouteSet>,
+	service_tcp_routes: HashMap<NamespacedHostname, TCPRouteSet>,
 
 	tx: tokio::sync::broadcast::Sender<Event<Arc<Bind>>>,
 }
@@ -380,6 +386,8 @@ impl Store {
 			staged_routes: Default::default(),
 			staged_listeners: Default::default(),
 			staged_tcp_routes: Default::default(),
+			service_routes: Default::default(),
+			service_tcp_routes: Default::default(),
 			tx,
 		}
 	}
@@ -846,6 +854,9 @@ impl Store {
         fields(route),
     )]
 	pub fn remove_route(&mut self, route: RouteKey) {
+		if self.remove_service_route(&route) {
+			return;
+		}
 		let Some((_, bind, listener)) = self.binds.iter().find_map(|(k, v)| {
 			let l = v.listeners.iter().find(|l| l.routes.contains(&route));
 			l.map(|l| (k.clone(), v.clone(), l.clone()))
@@ -866,6 +877,9 @@ impl Store {
         fields(tcp_route),
     )]
 	pub fn remove_tcp_route(&mut self, tcp_route: RouteKey) {
+		if self.remove_service_tcp_route(&tcp_route) {
+			return;
+		}
 		let Some((_, bind, listener)) = self.binds.iter().find_map(|(k, v)| {
 			let l = v
 				.listeners
@@ -1035,6 +1049,56 @@ impl Store {
 		self.insert_bind(bind);
 	}
 
+	pub fn insert_service_route(&mut self, r: Route, service_key: NamespacedHostname) {
+		debug!(service=%service_key, route=%r.key, "insert service route");
+		self
+			.service_routes
+			.entry(service_key)
+			.or_default()
+			.insert(r);
+	}
+
+	pub fn insert_service_tcp_route(&mut self, r: TCPRoute, service_key: NamespacedHostname) {
+		debug!(service=%service_key, route=%r.key, "insert service tcp route");
+		self
+			.service_tcp_routes
+			.entry(service_key)
+			.or_default()
+			.insert(r);
+	}
+
+	fn remove_service_route(&mut self, route_key: &RouteKey) -> bool {
+		let mut found = false;
+		self.service_routes.retain(|_, route_set| {
+			if route_set.contains(route_key) {
+				route_set.remove(route_key);
+				found = true;
+			}
+			!route_set.is_empty()
+		});
+		found
+	}
+
+	fn remove_service_tcp_route(&mut self, route_key: &RouteKey) -> bool {
+		let mut found = false;
+		self.service_tcp_routes.retain(|_, route_set| {
+			if route_set.contains(route_key) {
+				route_set.remove(route_key);
+				found = true;
+			}
+			!route_set.is_empty()
+		});
+		found
+	}
+
+	pub fn get_service_routes(&self, key: &NamespacedHostname) -> Option<&RouteSet> {
+		self.service_routes.get(key)
+	}
+
+	pub fn get_service_tcp_routes(&self, key: &NamespacedHostname) -> Option<&TCPRouteSet> {
+		self.service_tcp_routes.get(key)
+	}
+
 	fn remove_resource(&mut self, res: &Strng) {
 		trace!("removing res {res}...");
 		let Some(old) = self.resources.remove(res) else {
@@ -1112,12 +1176,20 @@ impl Store {
 	}
 	fn insert_xds_route(&mut self, raw: XdsRoute) -> anyhow::Result<()> {
 		let (route, listener_name) = Route::try_from_xds(&raw)?;
-		self.insert_route(route, listener_name);
+		if let Some(sk) = route.service_key.clone() {
+			self.insert_service_route(route, sk);
+		} else {
+			self.insert_route(route, listener_name);
+		}
 		Ok(())
 	}
 	fn insert_xds_tcp_route(&mut self, raw: XdsTcpRoute) -> anyhow::Result<()> {
 		let (route, listener_name) = TCPRoute::try_from_xds(&raw)?;
-		self.insert_tcp_route(route, listener_name);
+		if let Some(sk) = route.service_key.clone() {
+			self.insert_service_tcp_route(route, sk);
+		} else {
+			self.insert_tcp_route(route, listener_name);
+		}
 		Ok(())
 	}
 	fn insert_xds_backend(&mut self, raw: XdsBackend) -> anyhow::Result<()> {

--- a/crates/agentgateway/src/test_helpers/proxymock.rs
+++ b/crates/agentgateway/src/test_helpers/proxymock.rs
@@ -165,6 +165,7 @@ pub fn basic_route(target: SocketAddr) -> Route {
 pub fn basic_named_route(target: Strng) -> Route {
 	Route {
 		key: "route".into(),
+		service_key: None,
 		name: RouteName {
 			name: "route".into(),
 			namespace: Default::default(),
@@ -190,6 +191,7 @@ pub fn basic_named_route(target: Strng) -> Route {
 pub fn basic_named_tcp_route(target: Strng) -> TCPRoute {
 	TCPRoute {
 		key: "route".into(),
+		service_key: None,
 		name: RouteName {
 			name: "route".into(),
 			namespace: Default::default(),

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -508,6 +508,9 @@ pub type ListenerKey = Strng;
 pub struct Route {
 	// Internal name
 	pub key: RouteKey,
+	/// Service this route targets (set when parentRef is a Service).
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub service_key: Option<crate::types::discovery::NamespacedHostname>,
 	#[serde(flatten)]
 	// User facing name of the route
 	pub name: RouteName,
@@ -739,6 +742,9 @@ impl BackendTargetRef<'_> {
 pub struct TCPRoute {
 	// Internal name
 	pub key: RouteKey,
+	/// Service this route targets (set when parentRef is a Service).
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub service_key: Option<crate::types::discovery::NamespacedHostname>,
 	// User facing name of the route
 	#[serde(flatten)]
 	pub name: RouteName,
@@ -2332,6 +2338,7 @@ mod tests {
 	fn route(key: &'static str, hostnames: Vec<&'static str>, matches: Vec<RouteMatch>) -> Route {
 		Route {
 			key: strng::new(key),
+			service_key: None,
 			name: RouteName::default(),
 			hostnames: hostnames.into_iter().map(strng::new).collect(),
 			matches,
@@ -2343,6 +2350,7 @@ mod tests {
 	fn tcp_route(key: &'static str, hostnames: Vec<&'static str>) -> TCPRoute {
 		TCPRoute {
 			key: strng::new(key),
+			service_key: None,
 			name: RouteName::default(),
 			hostnames: hostnames.into_iter().map(strng::new).collect(),
 			backends: vec![],

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -637,10 +637,22 @@ impl Listener {
 	}
 }
 
+/// Convert a proto NamespacedHostname to the Rust type.
+fn service_key_from_proto(
+	sk: Option<&proto::workload::NamespacedHostname>,
+) -> Option<NamespacedHostname> {
+	sk.filter(|sk| !sk.namespace.is_empty() || !sk.hostname.is_empty())
+		.map(|sk| NamespacedHostname {
+			namespace: Strng::from(&sk.namespace),
+			hostname: Strng::from(&sk.hostname),
+		})
+}
+
 impl TCPRoute {
 	pub fn try_from_xds(s: &proto::agent::TcpRoute) -> Result<(Self, ListenerKey), ProtoError> {
 		let r = TCPRoute {
 			key: strng::new(&s.key),
+			service_key: service_key_from_proto(s.service_key.as_ref()),
 			name: s
 				.name
 				.as_ref()
@@ -672,6 +684,7 @@ impl Route {
 			.into();
 		let r = Route {
 			key: strng::new(&s.key),
+			service_key: service_key_from_proto(s.service_key.as_ref()),
 			name,
 			hostnames: s.hostnames.iter().map(strng::new).collect(),
 			matches: s

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -1576,6 +1576,7 @@ json(request.body).model
 
 	let model_list_route = Route {
 		key: strng::new("llm:admin:model-list"),
+		service_key: None,
 		name: RouteName {
 			name: strng::new("admin:model-list"),
 			namespace: strng::new("internal"),
@@ -1753,6 +1754,7 @@ json(request.body).model
 
 		let model_route = Route {
 			key: route_key.clone(),
+			service_key: None,
 			name: RouteName {
 				name: strng::format!("model:{}", model_config.name),
 				namespace: strng::new("internal"),
@@ -1901,6 +1903,7 @@ async fn convert_mcp_config(
 	let mut routes = RouteSet::default();
 	let route = Route {
 		key: strng::new("mcp:default"),
+		service_key: None,
 		name: RouteName {
 			name: strng::new("default"),
 			namespace: strng::new("internal"),
@@ -2152,6 +2155,7 @@ pub async fn convert_route(
 	}
 	let route = Route {
 		key,
+		service_key: None,
 		name: RouteName {
 			name: route_name,
 			namespace,
@@ -2417,6 +2421,7 @@ async fn convert_tcp_route(
 	}
 	let route = TCPRoute {
 		key,
+		service_key: None,
 		name: RouteName {
 			name: route_name,
 			namespace,

--- a/crates/protos/proto/resource.proto
+++ b/crates/protos/proto/resource.proto
@@ -88,6 +88,8 @@ message Route {
   string key = 1;
   // Key for the listener this is a part of.
   string listener_key = 2;
+  // Service this route targets (set when parentRef is a Service).
+  istio.workload.NamespacedHostname service_key = 9;
   // User facing name for this resource
   RouteName name = 3;
 
@@ -102,6 +104,8 @@ message TCPRoute {
   string key = 1;
   // Key for the listener this is a part of.
   string listener_key = 2;
+  // Service this route targets (set when parentRef is a Service).
+  istio.workload.NamespacedHostname service_key = 9;
   // User facing name for this resource
   RouteName name = 3;
 


### PR DESCRIPTION
https://github.com/agentgateway/agentgateway/pull/1352 could set this ServiceKey to attach routes directly to services

* add serviceKey to the Route and TCPRoute protos
* plumb serviceKey from ParentInfo into those protos as routes are attached to their parents
* refactor route selection in the proxy to share some code between paths that use service or listener attached routes

most of the diff is proto regen + tests