### PR TITLE
fix: coalesce consecutive same-role messages in Bedrock Converse translation

### DIFF
--- a/crates/agentgateway/src/llm/conversion/bedrock.rs
+++ b/crates/agentgateway/src/llm/conversion/bedrock.rs
@@ -393,7 +393,10 @@ pub mod from_completions {
 						content: vec![bedrock::ContentBlock::Text(s.clone())],
 					}),
 			})
-			.collect();
+			.fold(Vec::new(), |mut msgs, msg| {
+				helpers::push_or_merge_message(&mut msgs, msg);
+				msgs
+			});
 
 		let inference_config = bedrock::InferenceConfiguration {
 			max_tokens: req.max_tokens(),
@@ -1706,7 +1709,7 @@ pub mod from_responses {
 						EasyInputContent::ContentList(parts) => input_parts_to_blocks(parts),
 					};
 
-					messages.push(bedrock::Message { role, content });
+					helpers::push_or_merge_message(&mut messages, bedrock::Message { role, content });
 				},
 				InputItem::Item(Item::Message(MessageItem::Input(msg))) => {
 					let role = match msg.role {
@@ -1727,7 +1730,7 @@ pub mod from_responses {
 					};
 
 					let content = input_parts_to_blocks(&msg.content);
-					messages.push(bedrock::Message { role, content });
+					helpers::push_or_merge_message(&mut messages, bedrock::Message { role, content });
 				},
 				InputItem::Item(Item::Message(MessageItem::Output(msg))) => {
 					let content = msg
@@ -1741,10 +1744,13 @@ pub mod from_responses {
 						})
 						.collect::<Vec<_>>();
 					if !content.is_empty() {
-						messages.push(bedrock::Message {
-							role: bedrock::Role::Assistant,
-							content,
-						});
+						helpers::push_or_merge_message(
+							&mut messages,
+							bedrock::Message {
+								role: bedrock::Role::Assistant,
+								content,
+							},
+						);
 					}
 				},
 				InputItem::Item(Item::FunctionCall(call)) => {
@@ -1757,14 +1763,17 @@ pub mod from_responses {
 						continue;
 					};
 
-					messages.push(bedrock::Message {
-						role: bedrock::Role::Assistant,
-						content: vec![bedrock::ContentBlock::ToolUse(bedrock::ToolUseBlock {
-							tool_use_id: call.call_id,
-							name: call.name,
-							input,
-						})],
-					});
+					helpers::push_or_merge_message(
+						&mut messages,
+						bedrock::Message {
+							role: bedrock::Role::Assistant,
+							content: vec![bedrock::ContentBlock::ToolUse(bedrock::ToolUseBlock {
+								tool_use_id: call.call_id,
+								name: call.name,
+								input,
+							})],
+						},
+					);
 				},
 				InputItem::Item(Item::FunctionCallOutput(output)) => {
 					let output_text = match output.output {
@@ -1779,28 +1788,34 @@ pub mod from_responses {
 							.join("\n"),
 					};
 
-					messages.push(bedrock::Message {
-						role: bedrock::Role::User,
-						content: vec![bedrock::ContentBlock::ToolResult(
-							bedrock::ToolResultBlock {
-								tool_use_id: output.call_id,
-								content: vec![bedrock::ToolResultContentBlock::Text(output_text)],
-								// Responses tool outputs do not carry explicit success/error metadata.
-								// Leave Bedrock status unset instead of assuming success.
-								status: None,
-							},
-						)],
-					});
+					helpers::push_or_merge_message(
+						&mut messages,
+						bedrock::Message {
+							role: bedrock::Role::User,
+							content: vec![bedrock::ContentBlock::ToolResult(
+								bedrock::ToolResultBlock {
+									tool_use_id: output.call_id,
+									content: vec![bedrock::ToolResultContentBlock::Text(output_text)],
+									// Responses tool outputs do not carry explicit success/error metadata.
+									// Leave Bedrock status unset instead of assuming success.
+									status: None,
+								},
+							)],
+						},
+					);
 				},
 				InputItem::Item(Item::CustomToolCall(call)) => {
-					messages.push(bedrock::Message {
-						role: bedrock::Role::Assistant,
-						content: vec![bedrock::ContentBlock::ToolUse(bedrock::ToolUseBlock {
-							tool_use_id: call.call_id,
-							name: call.name,
-							input: serde_json::json!({ "input": call.input }),
-						})],
-					});
+					helpers::push_or_merge_message(
+						&mut messages,
+						bedrock::Message {
+							role: bedrock::Role::Assistant,
+							content: vec![bedrock::ContentBlock::ToolUse(bedrock::ToolUseBlock {
+								tool_use_id: call.call_id,
+								name: call.name,
+								input: serde_json::json!({ "input": call.input }),
+							})],
+						},
+					);
 				},
 				InputItem::Item(Item::CustomToolCallOutput(CustomToolCallOutput {
 					call_id,
@@ -1819,18 +1834,21 @@ pub mod from_responses {
 							.join("\n"),
 					};
 
-					messages.push(bedrock::Message {
-						role: bedrock::Role::User,
-						content: vec![bedrock::ContentBlock::ToolResult(
-							bedrock::ToolResultBlock {
-								tool_use_id: call_id,
-								content: vec![bedrock::ToolResultContentBlock::Text(output_text)],
-								// Responses tool outputs do not carry explicit success/error metadata.
-								// Leave Bedrock status unset instead of assuming success.
-								status: None,
-							},
-						)],
-					});
+					helpers::push_or_merge_message(
+						&mut messages,
+						bedrock::Message {
+							role: bedrock::Role::User,
+							content: vec![bedrock::ContentBlock::ToolResult(
+								bedrock::ToolResultBlock {
+									tool_use_id: call_id,
+									content: vec![bedrock::ToolResultContentBlock::Text(output_text)],
+									// Responses tool outputs do not carry explicit success/error metadata.
+									// Leave Bedrock status unset instead of assuming success.
+									status: None,
+								},
+							)],
+						},
+					);
 				},
 				_ => {
 					tracing::debug!("Skipping unsupported Responses input item for Bedrock translation");
@@ -2645,6 +2663,20 @@ mod helpers {
 		let timestamp = chrono::Utc::now().timestamp_millis();
 		let random: u32 = rand::random();
 		format!("msg_{:x}{:08x}", timestamp, random)
+	}
+
+	/// Push a message, or merge it into the last message if roles match.
+	/// Bedrock's Converse API requires strict user/assistant alternation;
+	/// this handles the OpenAI convention where each parallel tool result
+	/// is a separate `tool` role message (all mapped to Bedrock `User`).
+	pub fn push_or_merge_message(messages: &mut Vec<bedrock::Message>, msg: bedrock::Message) {
+		if let Some(last) = messages.last_mut()
+			&& last.role == msg.role
+		{
+			last.content.extend(msg.content);
+		} else {
+			messages.push(msg);
+		}
 	}
 }
 

--- a/crates/agentgateway/src/llm/tests.rs
+++ b/crates/agentgateway/src/llm/tests.rs
@@ -155,6 +155,7 @@ mod requests {
 		("basic", &[ANTHROPIC, BEDROCK]),
 		("full", &[ANTHROPIC, BEDROCK]),
 		("tool-call", &[ANTHROPIC, BEDROCK]),
+		("parallel-tool-call", &[BEDROCK]),
 		("reasoning", &[ANTHROPIC, BEDROCK]),
 		("reasoning_max", &[ANTHROPIC]),
 	];
@@ -167,6 +168,7 @@ mod requests {
 		("basic", &[BEDROCK]),
 		("instructions", &[BEDROCK]),
 		("input-list", &[BEDROCK]),
+		("parallel-tool-call", &[BEDROCK]),
 	];
 	pub const COUNT_TOKENS_REQUESTS: &[(&str, &[&str])] = &[
 		("basic", &[ANTHROPIC, BEDROCK, VERTEX]),

--- a/crates/agentgateway/src/llm/tests/requests/completions/parallel-tool-call.bedrock.snap
+++ b/crates/agentgateway/src/llm/tests/requests/completions/parallel-tool-call.bedrock.snap
@@ -1,0 +1,94 @@
+---
+source: crates/agentgateway/src/llm/tests.rs
+description: src/llm/tests/requests/completions/parallel-tool-call.json
+info:
+  model: gpt-3.5-turbo
+  messages:
+    - role: user
+      content: How is the weather in Columbus and New York?
+    - role: assistant
+      content: ~
+      tool_calls:
+        - id: call_1
+          type: function
+          function:
+            name: get_weather
+            arguments: "{\"location\":\"Columbus, OH\"}"
+        - id: call_2
+          type: function
+          function:
+            name: get_weather
+            arguments: "{\"location\":\"New York, NY\"}"
+    - role: tool
+      tool_call_id: call_1
+      content: "{ \"temperature\": 15, \"condition\": \"Cloudy\" }"
+    - role: tool
+      tool_call_id: call_2
+      content: "{ \"temperature\": 22, \"condition\": \"Sunny\" }"
+---
+{
+  "modelId": "gpt-3.5-turbo",
+  "messages": [
+    {
+      "role": "user",
+      "content": [
+        {
+          "text": "How is the weather in Columbus and New York?"
+        }
+      ]
+    },
+    {
+      "role": "assistant",
+      "content": [
+        {
+          "toolUse": {
+            "toolUseId": "call_1",
+            "name": "get_weather",
+            "input": {
+              "location": "Columbus, OH"
+            }
+          }
+        },
+        {
+          "toolUse": {
+            "toolUseId": "call_2",
+            "name": "get_weather",
+            "input": {
+              "location": "New York, NY"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "role": "user",
+      "content": [
+        {
+          "toolResult": {
+            "toolUseId": "call_1",
+            "content": [
+              {
+                "text": "{ \"temperature\": 15, \"condition\": \"Cloudy\" }"
+              }
+            ],
+            "status": null
+          }
+        },
+        {
+          "toolResult": {
+            "toolUseId": "call_2",
+            "content": [
+              {
+                "text": "{ \"temperature\": 22, \"condition\": \"Sunny\" }"
+              }
+            ],
+            "status": null
+          }
+        }
+      ]
+    }
+  ],
+  "inferenceConfig": {
+    "maxTokens": 4096
+  }
+}

--- a/crates/agentgateway/src/llm/tests/requests/completions/parallel-tool-call.json
+++ b/crates/agentgateway/src/llm/tests/requests/completions/parallel-tool-call.json
@@ -1,0 +1,41 @@
+{
+  "model": "gpt-3.5-turbo",
+  "messages": [
+    {
+      "role": "user",
+      "content": "How is the weather in Columbus and New York?"
+    },
+    {
+      "role": "assistant",
+      "content": null,
+      "tool_calls": [
+        {
+          "id": "call_1",
+          "type": "function",
+          "function": {
+            "name": "get_weather",
+            "arguments": "{\"location\":\"Columbus, OH\"}"
+          }
+        },
+        {
+          "id": "call_2",
+          "type": "function",
+          "function": {
+            "name": "get_weather",
+            "arguments": "{\"location\":\"New York, NY\"}"
+          }
+        }
+      ]
+    },
+    {
+      "role": "tool",
+      "tool_call_id": "call_1",
+      "content": "{ \"temperature\": 15, \"condition\": \"Cloudy\" }"
+    },
+    {
+      "role": "tool",
+      "tool_call_id": "call_2",
+      "content": "{ \"temperature\": 22, \"condition\": \"Sunny\" }"
+    }
+  ]
+}

--- a/crates/agentgateway/src/llm/tests/requests/responses/parallel-tool-call.bedrock.snap
+++ b/crates/agentgateway/src/llm/tests/requests/responses/parallel-tool-call.bedrock.snap
@@ -1,0 +1,93 @@
+---
+source: crates/agentgateway/src/llm/tests.rs
+description: src/llm/tests/requests/responses/parallel-tool-call.json
+info:
+  model: gpt-4o
+  max_output_tokens: 1024
+  input:
+    - type: message
+      role: user
+      content:
+        - type: input_text
+          text: How is the weather in Columbus and New York?
+    - type: function_call
+      call_id: call_1
+      name: get_weather
+      arguments: "{\"location\":\"Columbus, OH\"}"
+    - type: function_call
+      call_id: call_2
+      name: get_weather
+      arguments: "{\"location\":\"New York, NY\"}"
+    - type: function_call_output
+      call_id: call_1
+      output: "{ \"temperature\": 15, \"condition\": \"Cloudy\" }"
+    - type: function_call_output
+      call_id: call_2
+      output: "{ \"temperature\": 22, \"condition\": \"Sunny\" }"
+---
+{
+  "modelId": "gpt-4o",
+  "messages": [
+    {
+      "role": "user",
+      "content": [
+        {
+          "text": "How is the weather in Columbus and New York?"
+        }
+      ]
+    },
+    {
+      "role": "assistant",
+      "content": [
+        {
+          "toolUse": {
+            "toolUseId": "call_1",
+            "name": "get_weather",
+            "input": {
+              "location": "Columbus, OH"
+            }
+          }
+        },
+        {
+          "toolUse": {
+            "toolUseId": "call_2",
+            "name": "get_weather",
+            "input": {
+              "location": "New York, NY"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "role": "user",
+      "content": [
+        {
+          "toolResult": {
+            "toolUseId": "call_1",
+            "content": [
+              {
+                "text": "{ \"temperature\": 15, \"condition\": \"Cloudy\" }"
+              }
+            ],
+            "status": null
+          }
+        },
+        {
+          "toolResult": {
+            "toolUseId": "call_2",
+            "content": [
+              {
+                "text": "{ \"temperature\": 22, \"condition\": \"Sunny\" }"
+              }
+            ],
+            "status": null
+          }
+        }
+      ]
+    }
+  ],
+  "inferenceConfig": {
+    "maxTokens": 1024
+  }
+}

--- a/crates/agentgateway/src/llm/tests/requests/responses/parallel-tool-call.json
+++ b/crates/agentgateway/src/llm/tests/requests/responses/parallel-tool-call.json
@@ -1,0 +1,33 @@
+{
+  "model": "gpt-4o",
+  "max_output_tokens": 1024,
+  "input": [
+    {
+      "type": "message",
+      "role": "user",
+      "content": [{"type": "input_text", "text": "How is the weather in Columbus and New York?"}]
+    },
+    {
+      "type": "function_call",
+      "call_id": "call_1",
+      "name": "get_weather",
+      "arguments": "{\"location\":\"Columbus, OH\"}"
+    },
+    {
+      "type": "function_call",
+      "call_id": "call_2",
+      "name": "get_weather",
+      "arguments": "{\"location\":\"New York, NY\"}"
+    },
+    {
+      "type": "function_call_output",
+      "call_id": "call_1",
+      "output": "{ \"temperature\": 15, \"condition\": \"Cloudy\" }"
+    },
+    {
+      "type": "function_call_output",
+      "call_id": "call_2",
+      "output": "{ \"temperature\": 22, \"condition\": \"Sunny\" }"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

The OpenAI Chat Completions API represents parallel tool results as separate `tool` role messages. When translating to Bedrock's Converse API, each is mapped to a Bedrock `User` message. This produces consecutive same-role messages, which Bedrock rejects (messages must strictly alternate user/assistant).

The same issue exists in the Responses API path where consecutive `FunctionCallOutput` and `CustomToolCallOutput` items each produce separate `User` messages.

## Changes

- Add `helpers::coalesce_consecutive_messages` — merges consecutive messages with the same role by combining their content vectors
- Apply in `from_completions::translate_internal` after message collection
- Apply in `from_responses` after the message-building loop
- The `from_messages` (Anthropic) path is unaffected because Anthropic format already bundles tool results into a single user message

## Testing

- Added `test_completions_consecutive_tool_messages_are_merged_into_single_user_message` — constructs an OpenAI request with an assistant message containing two parallel tool calls followed by two consecutive tool result messages, verifies the output has 3 Bedrock messages (User, Assistant, User) with both ToolResult blocks merged into the final User message
- All 27 existing bedrock conversion tests continue to pass
