### PR TITLE
fix: Vertex AI compatibility for Claude Code proxy requests

### DIFF
--- a/crates/agentgateway/src/llm/tests/requests/messages/reasoning.bedrock.snap
+++ b/crates/agentgateway/src/llm/tests/requests/messages/reasoning.bedrock.snap
@@ -8,9 +8,15 @@ info:
     type: adaptive
   output_config:
     effort: high
+  output_format: markdown
   messages:
     - role: user
-      content: Give one concise insight about distributed consensus.
+      content:
+        - type: text
+          text: Give one concise insight about distributed consensus.
+          cache_control:
+            type: ephemeral
+            scope: turn
 ---
 {
   "modelId": "claude-opus-4-6",
@@ -20,6 +26,11 @@ info:
       "content": [
         {
           "text": "Give one concise insight about distributed consensus."
+        },
+        {
+          "cachePoint": {
+            "type": "default"
+          }
         }
       ]
     }

--- a/crates/agentgateway/src/llm/tests/requests/messages/reasoning.json
+++ b/crates/agentgateway/src/llm/tests/requests/messages/reasoning.json
@@ -7,10 +7,20 @@
   "output_config": {
     "effort": "high"
   },
+  "output_format": "markdown",
   "messages": [
     {
       "role": "user",
-      "content": "Give one concise insight about distributed consensus."
+      "content": [
+        {
+          "type": "text",
+          "text": "Give one concise insight about distributed consensus.",
+          "cache_control": {
+            "type": "ephemeral",
+            "scope": "turn"
+          }
+        }
+      ]
     }
   ]
 }

--- a/crates/agentgateway/src/llm/tests/requests/messages/reasoning.vertex.snap
+++ b/crates/agentgateway/src/llm/tests/requests/messages/reasoning.vertex.snap
@@ -8,23 +8,34 @@ info:
     type: adaptive
   output_config:
     effort: high
+  output_format: markdown
   messages:
     - role: user
-      content: Give one concise insight about distributed consensus.
+      content:
+        - type: text
+          text: Give one concise insight about distributed consensus.
+          cache_control:
+            type: ephemeral
+            scope: turn
 ---
 {
   "messages": [
     {
       "role": "user",
-      "content": "Give one concise insight about distributed consensus."
+      "content": [
+        {
+          "type": "text",
+          "text": "Give one concise insight about distributed consensus.",
+          "cache_control": {
+            "type": "ephemeral"
+          }
+        }
+      ]
     }
   ],
   "anthropic_version": "vertex-2023-10-16",
   "max_tokens": 1024,
   "thinking": {
     "type": "adaptive"
-  },
-  "output_config": {
-    "effort": "high"
   }
 }

--- a/crates/agentgateway/src/llm/types/messages.rs
+++ b/crates/agentgateway/src/llm/types/messages.rs
@@ -43,14 +43,14 @@ pub enum ContentBlock {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
+#[serde(untagged)]
 pub enum ContentPart {
 	Text {
+		r#type: String,
 		text: String,
 		#[serde(flatten, default)]
 		rest: serde_json::Value,
 	},
-	#[serde(untagged)]
 	Unknown(serde_json::Value),
 }
 
@@ -62,14 +62,14 @@ pub enum TextBlock {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
+#[serde(untagged)]
 pub enum TextPart {
 	Text {
+		r#type: String,
 		text: String,
 		#[serde(flatten, default)]
 		rest: serde_json::Value,
 	},
-	#[serde(untagged)]
 	Unknown(serde_json::Value),
 }
 
@@ -233,6 +233,7 @@ impl RequestType for Request {
 				system_prompts
 					.into_iter()
 					.map(|p| TextPart::Text {
+						r#type: "text".to_string(),
 						text: p.content.to_string(),
 						rest: Default::default(),
 					})
@@ -282,6 +283,7 @@ pub fn prepend_prompts_helper(
 		let mut items: Vec<TextPart> = match std::mem::take(system) {
 			Some(TextBlock::Array(existing)) => existing,
 			Some(TextBlock::Text(text)) => vec![TextPart::Text {
+				r#type: "text".to_string(),
 				text,
 				rest: Default::default(),
 			}],
@@ -291,6 +293,7 @@ pub fn prepend_prompts_helper(
 		items.splice(
 			0..0,
 			system_prompts.into_iter().map(|p| TextPart::Text {
+				r#type: "text".to_string(),
 				text: p.content.to_string(),
 				rest: Default::default(),
 			}),
@@ -316,6 +319,7 @@ pub fn append_prompts_helper(
 	if !system_prompts.is_empty() {
 		let mut items: Vec<TextPart> = match std::mem::take(system) {
 			Some(TextBlock::Text(text)) => vec![TextPart::Text {
+				r#type: "text".to_string(),
 				text,
 				rest: Default::default(),
 			}],
@@ -324,6 +328,7 @@ pub fn append_prompts_helper(
 		};
 
 		items.extend(system_prompts.into_iter().map(|p| TextPart::Text {
+			r#type: "text".to_string(),
 			text: p.content.to_string(),
 			rest: Default::default(),
 		}));

--- a/crates/agentgateway/src/llm/vertex.rs
+++ b/crates/agentgateway/src/llm/vertex.rs
@@ -30,34 +30,38 @@ impl Provider {
 	}
 
 	pub fn prepare_anthropic_message_body(&self, body: Vec<u8>) -> Result<Vec<u8>, AIError> {
-		let mut body: Map<String, Value> =
-			serde_json::from_slice(&body).map_err(AIError::RequestMarshal)?;
-
-		body.insert(
-			"anthropic_version".to_string(),
-			Value::String(ANTHROPIC_VERSION.to_string()),
-		);
-		body.remove("model");
-
-		serde_json::to_vec(&body).map_err(AIError::RequestMarshal)
+		self.prepare_anthropic_body(body, |b| {
+			b.remove("model");
+		})
 	}
 
 	pub fn prepare_anthropic_count_tokens_body(&self, body: Vec<u8>) -> Result<Vec<u8>, AIError> {
+		self.prepare_anthropic_body(body, |b| {
+			if let Some(Value::String(model)) = b.get("model") {
+				let normalized = self
+					.configured_model(Some(model))
+					.map(|s| s.to_string())
+					.unwrap_or_else(|| model.clone());
+				b.insert("model".to_string(), Value::String(normalized));
+			}
+		})
+	}
+
+	/// Shared pipeline for Vertex Anthropic requests: parse, inject version,
+	/// apply caller-specific model handling, strip unsupported fields, serialize.
+	fn prepare_anthropic_body(
+		&self,
+		body: Vec<u8>,
+		apply: impl FnOnce(&mut Map<String, Value>),
+	) -> Result<Vec<u8>, AIError> {
 		let mut body: Map<String, Value> =
 			serde_json::from_slice(&body).map_err(AIError::RequestMarshal)?;
-
 		body.insert(
 			"anthropic_version".to_string(),
 			Value::String(ANTHROPIC_VERSION.to_string()),
 		);
-
-		if let Some(Value::String(model)) = body.get("model") {
-			let normalized = self
-				.configured_model(Some(model))
-				.map(|s| s.to_string())
-				.unwrap_or_else(|| model.clone());
-			body.insert("model".to_string(), Value::String(normalized));
-		}
+		apply(&mut body);
+		remove_unsupported_vertex_fields(&mut body);
 		serde_json::to_vec(&body).map_err(AIError::RequestMarshal)
 	}
 
@@ -150,6 +154,34 @@ impl Provider {
 	}
 }
 
+fn remove_unsupported_vertex_fields(body: &mut Map<String, Value>) {
+	body.remove("output_config");
+	body.remove("output_format");
+	// Vertex supports cache_control but not the "scope" child from the prompt-caching-scope beta.
+	for value in body.values_mut() {
+		remove_nested_field(value, "cache_control", "scope");
+	}
+}
+
+fn remove_nested_field(value: &mut Value, key: &str, child: &str) {
+	match value {
+		Value::Object(map) => {
+			if let Some(Value::Object(nested)) = map.get_mut(key) {
+				nested.remove(child);
+			}
+			for v in map.values_mut() {
+				remove_nested_field(v, key, child);
+			}
+		},
+		Value::Array(arr) => {
+			for v in arr {
+				remove_nested_field(v, key, child);
+			}
+		},
+		_ => {},
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
@@ -208,5 +240,174 @@ mod tests {
 			region: region.map(strng::new),
 		};
 		assert_eq!(p.get_host(None).as_str(), expected);
+	}
+
+	#[test]
+	fn test_remove_top_level_output_fields() {
+		let mut body: Map<String, Value> = serde_json::from_value(serde_json::json!({
+			"model": "claude-sonnet-4-5-20251001",
+			"output_config": {"format": "json"},
+			"output_format": "markdown",
+			"messages": [{"role": "user", "content": "hello"}]
+		}))
+		.unwrap();
+		remove_unsupported_vertex_fields(&mut body);
+		assert!(!body.contains_key("output_config"));
+		assert!(!body.contains_key("output_format"));
+		assert!(body.contains_key("model"));
+		assert!(body.contains_key("messages"));
+	}
+
+	#[test]
+	fn test_output_fields_preserved_when_nested() {
+		let mut body: Map<String, Value> = serde_json::from_value(serde_json::json!({
+			"messages": [{
+				"role": "user",
+				"content": "hello",
+				"output_config": {"format": "json"},
+				"output_format": "markdown"
+			}]
+		}))
+		.unwrap();
+		remove_unsupported_vertex_fields(&mut body);
+		let msg = body["messages"][0].as_object().unwrap();
+		assert!(msg.contains_key("output_config"));
+		assert!(msg.contains_key("output_format"));
+	}
+
+	#[test]
+	fn test_cache_control_scope_removed_recursively() {
+		let mut body: Map<String, Value> = serde_json::from_value(serde_json::json!({
+			"system": [{
+				"type": "text",
+				"text": "You are helpful.",
+				"cache_control": {"type": "ephemeral", "scope": "turn"}
+			}],
+			"messages": [{
+				"role": "user",
+				"content": [{
+					"type": "text",
+					"text": "hello",
+					"cache_control": {"type": "ephemeral", "scope": "session"}
+				}]
+			}]
+		}))
+		.unwrap();
+		remove_unsupported_vertex_fields(&mut body);
+		let sys_cc = body["system"][0]["cache_control"].as_object().unwrap();
+		assert_eq!(sys_cc.get("type").unwrap(), "ephemeral");
+		assert!(!sys_cc.contains_key("scope"));
+		let msg_cc = body["messages"][0]["content"][0]["cache_control"]
+			.as_object()
+			.unwrap();
+		assert_eq!(msg_cc.get("type").unwrap(), "ephemeral");
+		assert!(!msg_cc.contains_key("scope"));
+	}
+
+	#[test]
+	fn test_cache_control_without_scope_untouched() {
+		let mut body: Map<String, Value> = serde_json::from_value(serde_json::json!({
+			"messages": [{
+				"role": "user",
+				"content": [{
+					"type": "text",
+					"text": "hello",
+					"cache_control": {"type": "ephemeral"}
+				}]
+			}]
+		}))
+		.unwrap();
+		let expected = body.clone();
+		remove_unsupported_vertex_fields(&mut body);
+		assert_eq!(body, expected);
+	}
+
+	#[test]
+	fn test_cache_control_non_object_untouched() {
+		let mut body: Map<String, Value> = serde_json::from_value(serde_json::json!({
+			"messages": [{
+				"role": "user",
+				"content": [{
+					"type": "text",
+					"text": "hello",
+					"cache_control": "enabled"
+				}]
+			}]
+		}))
+		.unwrap();
+		let expected = body.clone();
+		remove_unsupported_vertex_fields(&mut body);
+		assert_eq!(body, expected);
+	}
+
+	#[test]
+	fn test_realistic_anthropic_messages_body() {
+		let mut body: Map<String, Value> = serde_json::from_value(serde_json::json!({
+			"model": "claude-sonnet-4-5-20251001",
+			"max_tokens": 1024,
+			"output_config": {"format": "json"},
+			"output_format": "markdown",
+			"system": [{
+				"type": "text",
+				"text": "You are a helpful assistant.",
+				"cache_control": {"type": "ephemeral", "scope": "turn"}
+			}],
+			"messages": [
+				{
+					"role": "user",
+					"content": [
+						{
+							"type": "text",
+							"text": "What is 2+2?",
+							"cache_control": {"type": "ephemeral", "scope": "session"}
+						},
+						{
+							"type": "image",
+							"source": {"type": "base64", "data": "abc"},
+							"cache_control": {"type": "ephemeral"}
+						}
+					]
+				},
+				{
+					"role": "assistant",
+					"content": [{"type": "text", "text": "4"}]
+				}
+			]
+		}))
+		.unwrap();
+		remove_unsupported_vertex_fields(&mut body);
+
+		// Top-level fields removed
+		assert!(!body.contains_key("output_config"));
+		assert!(!body.contains_key("output_format"));
+		// Preserved fields
+		assert_eq!(body["max_tokens"], 1024);
+		assert_eq!(body["model"], "claude-sonnet-4-5-20251001");
+
+		// System cache_control: scope removed, type kept
+		let sys_cc = body["system"][0]["cache_control"].as_object().unwrap();
+		assert_eq!(sys_cc.len(), 1);
+		assert_eq!(sys_cc["type"], "ephemeral");
+
+		// First user content block: scope removed
+		let user_cc = body["messages"][0]["content"][0]["cache_control"]
+			.as_object()
+			.unwrap();
+		assert_eq!(user_cc.len(), 1);
+		assert_eq!(user_cc["type"], "ephemeral");
+
+		// Second user content block: no scope, so unchanged (still has type)
+		let img_cc = body["messages"][0]["content"][1]["cache_control"]
+			.as_object()
+			.unwrap();
+		assert_eq!(img_cc.len(), 1);
+		assert_eq!(img_cc["type"], "ephemeral");
+
+		// Assistant content untouched (no cache_control)
+		assert!(
+			body["messages"][1]["content"][0]
+				.get("cache_control")
+				.is_none()
+		);
 	}
 }


### PR DESCRIPTION
# fix: Vertex AI compatibility for Claude Code proxy requests

## Summary

When using agentgateway as a proxy for **Claude Code** with the **Vertex AI Anthropic provider**, requests fail due to two issues:

1. **Serde deserialization** — `#[serde(tag = "type")]` on passthrough content block enums fails on unknown content types like `thinking`, `tool_use`, etc.
2. **Unsupported body fields** — Vertex rejects fields like `output_config` and `cache_control.scope` that Claude Code sends via beta features

This PR fixes both in code.

> **Note:** To use agentgateway as a Claude Code proxy, you also need an `AgentgatewayPolicy` to rewrite the `anthropic-beta` request header to only include Vertex-supported values. Vertex hard-resets TCP connections on unrecognized beta header values. See the "Beta header policy" section below for the recommended configuration.

## Changes

### `messages.rs` — Fix content block passthrough

Switch `ContentPart` and `TextPart` from internally-tagged to untagged serde enums:

```rust
// Before: requires "type" field on every content block
#[serde(tag = "type", rename_all = "snake_case")]
pub enum ContentPart {
    Text { text: String, ... },
    #[serde(untagged)]
    Unknown(serde_json::Value),
}

// After: tries Text first (needs type + text fields), falls back to Unknown
#[serde(untagged)]
pub enum ContentPart {
    Text { r#type: String, text: String, ... },
    Unknown(serde_json::Value),
}
```

This allows `thinking`, `tool_use`, `tool_result`, and other content block types to pass through without deserialization errors.

### `vertex.rs` — Strip unsupported fields and deduplicate body preparation

Extract a shared `prepare_anthropic_body` pipeline that both `prepare_anthropic_message_body` and `prepare_anthropic_count_tokens_body` use. The pipeline: parse → inject `anthropic_version` → apply caller-specific model handling → strip unsupported fields → serialize.

Unsupported field removal:
- `output_config` and `output_format` — removed at top level only (not recursively)
- `cache_control.scope` — removed recursively via `remove_nested_field`, since `cache_control` can appear on content blocks at any depth

Fields that Vertex **does** support (verified empirically) are intentionally kept:
- `metadata` (user attribution)
- `context_management` (compaction, context editing)
- `thinking` (including `"type": "adaptive"`)

### Required: Beta header policy

Vertex rejects unknown `anthropic-beta` header values with a TCP connection reset (not a clean HTTP error). An `AgentgatewayPolicy` is required to rewrite the header:

```yaml
traffic:
  headerModifiers:
    request:
      set:
      - name: anthropic-beta
        value: "interleaved-thinking-2025-05-14,output-128k-2025-02-19,context-management-2025-06-27,compact-2026-01-12"
```

---

## Testing Evidence

### 1. `missing field 'type'` — fixed

**Before:**
```
error="processing failed: failed to marshal request: missing field `type`"
```

**After:** All content block types pass through as `Unknown(Value)`. No deserialization errors.

---

### 2. `output_config` rejection — fixed

**Before:**
```json
{"type":"error","error":{"type":"invalid_request_error",
  "message":"output_config: Extra inputs are not permitted"}}
```

**After:** `output_config` stripped before reaching Vertex. Returns `200 OK`.

---

### 3. `cache_control.scope` rejection — fixed

Claude Code sends `"cache_control": {"type": "ephemeral", "scope": "global"}` via the `prompt-caching-scope` beta.

**Before:**
```json
{"type":"error","error":{"type":"invalid_request_error",
  "message":"system.2.cache_control.ephemeral.scope: Extra inputs are not permitted"}}
```

**After:** `scope` stripped recursively. Caching still works:
```
cache_creation_input_tokens: 31962
```

---

### 4. Unsupported beta headers — fixed via policy

Claude Code sends an `anthropic-beta` header with all its enabled betas. Several of these are not supported on Vertex AI and cause a hard **TCP connection reset** (not a clean 400 error):

| Beta header value | Vertex support |
|---|---|
| `interleaved-thinking-2025-05-14` | Supported |
| `output-128k-2025-02-19` | Supported |
| `context-management-2025-06-27` | Supported |
| `compact-2026-01-12` | Supported |
| `prompt-caching-scope-2026-01-05` | **Rejected** (connection reset) |
| `structured-outputs-2025-12-15` | **Rejected** (connection reset) |
| `effort-2025-11-24` | **Rejected** (connection reset) |
| `redact-thinking-2026-02-12` | **Rejected** (400 error) |
| `claude-code-20250219` | **Rejected** (connection reset) |

**Before:**
```bash
$ curl -s ... -H "anthropic-beta: interleaved-thinking-2025-05-14,prompt-caching-scope-2026-01-05"
upstream connect error or disconnect/reset before headers. reset reason: connection termination
```

**After:** An `AgentgatewayPolicy` with `headerModifiers.request.set` rewrites the header to only include Vertex-supported values. The original header from the client is replaced entirely:
```bash
# Client sends: anthropic-beta: claude-code-20250219,interleaved-thinking-2025-05-14,...,prompt-caching-scope-2026-01-05
# Policy rewrites to: interleaved-thinking-2025-05-14,output-128k-2025-02-19,context-management-2025-06-27,compact-2026-01-12
# Result: 200 OK
```

---

### 5. `context_management` and `metadata` — verified supported

```bash
curl -s -o /dev/null -w "%{http_code}" ... -d '{"context_management": {"edits": [...]}, ...}'
# 200

curl -s -o /dev/null -w "%{http_code}" ... -d '{"metadata": {"user_id": "test"}, ...}'
# 200
```

These are intentionally **not** stripped.

---

### 6. End-to-end: Claude Code via agentgateway

```bash
$ ANTHROPIC_BASE_URL=https://agentgateway.example.com/claude ANTHROPIC_AUTH_TOKEN=dummy claude
> hi
Hi! What are you working on today?
```

```
http.status=200 gen_ai.request.model=claude-haiku-4-5-20251001 duration=774ms
http.status=200 gen_ai.request.model=claude-opus-4-6 duration=1681ms
```