### PR TITLE
docs: add bitcoin-mcp example with rate limiting

### DIFF
--- a/examples/bitcoin/README.md
+++ b/examples/bitcoin/README.md
@@ -1,0 +1,38 @@
+# Bitcoin MCP Example
+
+This example proxies [bitcoin-mcp](https://github.com/Bortlesboat/bitcoin-mcp) through agentgateway, adding rate limiting and CORS support.
+
+bitcoin-mcp provides 49 tools for querying the Bitcoin network: fee estimation, mempool analysis, block inspection, transaction decoding, mining stats, and more. It works out of the box with the free Satoshi API — no Bitcoin node required.
+
+## Prerequisites
+
+```bash
+pip install bitcoin-mcp
+```
+
+## Running the example
+
+```bash
+agentgateway -f examples/bitcoin/config.yaml
+```
+
+Connect any MCP client to `http://localhost:3000`.
+
+## What's included
+
+- **Rate limiting**: 30 burst requests, refill 1 token every 2 seconds
+- **CORS**: permissive for development (lock down `allowOrigins` in production)
+- **stdio transport**: agentgateway launches `bitcoin-mcp` as a child process
+
+## Example queries
+
+Once connected, try:
+
+- "What are the current Bitcoin fees?"
+- "Analyze the mempool"
+- "Get the current block height"
+- "Give me a Bitcoin situation summary"
+
+## Adding security
+
+See the [authorization example](../authorization/) to add JWT authentication and RBAC policies. For Bitcoin, you might restrict write tools (`send_raw_transaction`, `generate_keypair`) to admin users while keeping the 47 read-only tools open to all authenticated agents.

--- a/examples/bitcoin/config.yaml
+++ b/examples/bitcoin/config.yaml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=https://agentgateway.dev/schema/config
+#
+# Bitcoin MCP Example
+#
+# Proxies bitcoin-mcp (49 Bitcoin network analysis tools) through
+# agentgateway with rate limiting and CORS support.
+#
+# Prerequisites:
+#   pip install bitcoin-mcp
+#
+# Usage:
+#   agentgateway -f examples/bitcoin/config.yaml
+#
+# Then connect any MCP client to http://localhost:3000
+#
+binds:
+- port: 3000
+  listeners:
+  - routes:
+    - policies:
+        localRateLimit:
+          - maxTokens: 30
+            tokensPerFill: 1
+            fillInterval: 2s
+        cors:
+          allowOrigins:
+          - "*"
+          allowHeaders:
+          - mcp-protocol-version
+          - content-type
+          - cache-control
+          exposeHeaders:
+          - "Mcp-Session-Id"
+      backends:
+      - mcp:
+          targets:
+          - name: bitcoin-mcp
+            stdio:
+              cmd: uvx
+              args:
+                - bitcoin-mcp


### PR DESCRIPTION
## Summary

Add an example showing how to proxy [bitcoin-mcp](https://github.com/Bortlesboat/bitcoin-mcp) through agentgateway with rate limiting and CORS.

bitcoin-mcp provides 49 tools for Bitcoin network analysis (fee estimation, mempool analysis, block inspection, transaction decoding, mining stats) and works with zero configuration via PyPI.

## What's included

- `examples/bitcoin/config.yaml` — agentgateway config with rate limiting (30 burst, 1/2s refill)
- `examples/bitcoin/README.md` — usage instructions, example queries, and a pointer to the authorization example for adding RBAC

## Why

Bitcoin/financial data is a compelling use case for agentgateway's security features. This example provides a starting point for anyone wanting to add governance to financial MCP tools.

## Test plan

- [x] `agentgateway -f examples/bitcoin/config.yaml` starts successfully
- [x] `agentgateway -f examples/bitcoin/config.yaml --validate-only` passes
- [x] README follows existing examples pattern