### PR TITLE
mcp: when stdio server fails, send error to client

### DIFF
--- a/crates/agentgateway/src/mcp/upstream/mod.rs
+++ b/crates/agentgateway/src/mcp/upstream/mod.rs
@@ -84,6 +84,8 @@ pub enum UpstreamError {
 	Proxy(#[from] ProxyError),
 	#[error("stdio upstream error: {0}")]
 	Stdio(#[from] io::Error),
+	#[error("stdio server exited")]
+	StdioShutdown,
 	#[error("upstream closed on send")]
 	Send,
 	#[error("upstream closed on receive")]

--- a/crates/agentgateway/src/mcp/upstream/stdio.rs
+++ b/crates/agentgateway/src/mcp/upstream/stdio.rs
@@ -133,18 +133,22 @@ impl Process {
 							break;
 						}
 					},
-					Some(msg) = proc.receive() => {
+					msg = proc.receive() => {
 						match msg {
-							JsonRpcMessage::Response(res) => {
+							Some(JsonRpcMessage::Response(res)) => {
 								let req_id = res.id.clone();
 								if let Some(sender) = pending_requests_clone.lock().unwrap().remove(&req_id) {
 									let _ = sender.send(ServerJsonRpcMessage::Response(res));
 								}
 							},
-							other => {
+							Some(other) => {
 								if let Some(sender) = event_stream_send.load().as_ref() {
 									let _ = sender.send(other).await;
 								}
+							},
+							None => {
+								terminal_err = Some(UpstreamError::StdioShutdown);
+								break;
 							}
 						}
 					},


### PR DESCRIPTION
Today we just hang forever

fixes https://github.com/agentgateway/agentgateway/issues/431
