### PR TITLE
Filter unused secrets

### DIFF
--- a/controller/pkg/agentgateway/jwks/config_map_syncer.go
+++ b/controller/pkg/agentgateway/jwks/config_map_syncer.go
@@ -41,6 +41,7 @@ func NewConfigMapSyncer(client apiclient.Client, storePrefix, deploymentNamespac
 	cmCollection := krt.NewFilteredInformer[*corev1.ConfigMap](client,
 		kclient.Filter{
 			ObjectFilter:  client.ObjectFilter(),
+			Namespace:     deploymentNamespace,
 			LabelSelector: JwksStoreLabelSelector(storePrefix)},
 		krtOptions.ToOptions("config_map_syncer/ConfigMaps")...)
 

--- a/controller/pkg/agentgateway/plugins/collection.go
+++ b/controller/pkg/agentgateway/plugins/collection.go
@@ -133,7 +133,8 @@ func NewAgwCollections(
 
 		Secrets: krt.WrapClient(
 			kclient.NewFiltered[*corev1.Secret](client, kubetypes.Filter{
-				ObjectFilter: client.ObjectFilter(),
+				FieldSelector: apiclient.SecretsFieldSelector,
+				ObjectFilter:  client.ObjectFilter(),
 			}),
 		),
 		ConfigMaps: krt.WrapClient(

--- a/controller/pkg/apiclient/filters.go
+++ b/controller/pkg/apiclient/filters.go
@@ -1,0 +1,17 @@
+package apiclient
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
+)
+
+// SecretsFieldSelector is an optimization to avoid excessive secret bloat.
+// We only care about TLS certificates.
+// Unfortunately, it is not as simple as selecting type=kubernetes.io/tls; we support generic types.
+// Its also likely users have started to use random types and expect them to continue working.
+// This makes the assumption we will never care about Helm secrets or SA token secrets - two common
+// large secrets in clusters.
+// This is a best effort optimization only; the code would behave correctly if we watched all secrets.
+var SecretsFieldSelector = fields.AndSelectors(
+	fields.OneTermNotEqualSelector("type", "helm.sh/release.v1"),
+	fields.OneTermNotEqualSelector("type", string(corev1.SecretTypeServiceAccountToken))).String()

--- a/controller/pkg/controller/gw_controller.go
+++ b/controller/pkg/controller/gw_controller.go
@@ -31,6 +31,7 @@ import (
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/agentgateway/agentgateway/controller/api/v1alpha1/agentgateway"
+	"github.com/agentgateway/agentgateway/controller/pkg/apiclient"
 	"github.com/agentgateway/agentgateway/controller/pkg/deployer"
 	"github.com/agentgateway/agentgateway/controller/pkg/logging"
 	"github.com/agentgateway/agentgateway/controller/pkg/pluginsdk"
@@ -86,7 +87,10 @@ func NewGatewayReconciler(
 		deploymentClient: kclient.NewFiltered[*appsv1.Deployment](cfg.Client, filter),
 		svcAccountClient: kclient.NewFiltered[*corev1.ServiceAccount](cfg.Client, filter),
 		configMapClient:  kclient.NewFiltered[*corev1.ConfigMap](cfg.Client, filter),
-		secretClient:     kclient.NewFiltered[*corev1.Secret](cfg.Client, filter),
+		secretClient: kclient.NewFiltered[*corev1.Secret](cfg.Client, kclient.Filter{
+			FieldSelector: apiclient.SecretsFieldSelector,
+			ObjectFilter:  cfg.Client.ObjectFilter(),
+		}),
 	}
 
 	// Reuse the parameter clients from the deployer to avoid duplicate watches

--- a/controller/pkg/deployer/agentgateway_parameters.go
+++ b/controller/pkg/deployer/agentgateway_parameters.go
@@ -176,9 +176,12 @@ func newAgentgatewayParametersHelmValuesGenerator(cli apiclient.Client, inputs *
 	return &agentgatewayParametersHelmValuesGenerator{
 		agwParamClient: kclient.NewFilteredDelayed[*agentgateway.AgentgatewayParameters](cli, wellknown.AgentgatewayParametersGVR, filter),
 		gwClassClient:  kclient.NewFilteredDelayed[*gwv1.GatewayClass](cli, wellknown.GatewayClassGVR, filter),
-		secretClient:   kclient.NewFiltered[*corev1.Secret](cli, filter),
-		inputs:         inputs,
-		sessionKeyGen:  generateSessionKey,
+		secretClient: kclient.NewFiltered[*corev1.Secret](cli, kclient.Filter{
+			FieldSelector: apiclient.SecretsFieldSelector,
+			ObjectFilter:  cli.ObjectFilter(),
+		}),
+		inputs:        inputs,
+		sessionKeyGen: generateSessionKey,
 	}
 }
 


### PR DESCRIPTION
https://github.com/agentgateway/agentgateway/issues/1341

Also drops a duplicate watch on configmaps by once watching with ns filter and another time without (preventing watch dedupe)