### PR TITLE
fix: use protocol-filtered matching in detect_misdirected

### DIFF
--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -899,9 +899,14 @@ impl HTTPProxy {
 		//     * If no other Listener matches the Host, the Gateway MUST return a
 		//       404.
 		let host = http::get_host(req).map_err(|_| ProxyError::RouteNotFound)?;
+		// Use protocol-filtered matching: since we're in a TLS context (checked
+		// above), only compare against other TLS-capable listeners. Without this
+		// filter, an HTTP listener with the same wildcard hostname could be
+		// returned by best_match(), causing a spurious 421 when BindProtocol::auto
+		// serves both HTTP and HTTPS listeners on the same bind.
 		let new_best_listener = bind
 			.listeners
-			.best_match(host)
+			.best_match_tls(host)
 			.filter(|l| l.key != selected_listener.key);
 
 		// "If another listener has a more specific match..."


### PR DESCRIPTION
detect_misdirected() used unfiltered best_match() to verify the TLS-selected listener, which could return an HTTP listener with the same wildcard hostname. Since ListenerSet uses HashMap (non-deterministic iteration), this caused spurious 421 errors when BindProtocol::auto serves both HTTP and HTTPS listeners on the same bind.

Use best_match_tls() instead, matching the protocol-aware pattern already used in TLS handshake listener selection (gateway.rs) and the HTTP fallback path (best_match_http).