### PR TITLE
fix listener attached routes for hbone

### DIFF
--- a/crates/agentgateway/src/http/route_test.rs
+++ b/crates/agentgateway/src/http/route_test.rs
@@ -1508,6 +1508,78 @@ async fn test_no_service_routes_falls_through_to_default() {
 	assert_eq!(result.unwrap().0.key.as_str(), "_waypoint-default");
 }
 
+#[tokio::test]
+async fn test_hbone_listener_route_overrides_default() {
+	// An HBONE listener with a directly-attached route should use that route,
+	// not the generated _waypoint-default.
+	let stores = stores_with_services(vec![waypoint_svc()]);
+	let self_id = waypoint_self_id();
+
+	// Create an HBONE listener with a route attached directly
+	let listener = Arc::new(Listener {
+		key: Default::default(),
+		name: Default::default(),
+		hostname: Default::default(),
+		protocol: ListenerProtocol::HBONE,
+		tcp_routes: Default::default(),
+		routes: RouteSet::from_list(vec![Route {
+			key: strng::literal!("listener-api-route"),
+			service_key: None,
+			name: Default::default(),
+			hostnames: vec![],
+			matches: vec![RouteMatch {
+				path: PathMatch::PathPrefix(strng::new("/api")),
+				headers: vec![],
+				method: None,
+				query: vec![],
+			}],
+			backends: vec![],
+			inline_policies: vec![],
+		}]),
+	});
+	let dst = SocketAddr::new("10.0.0.100".parse().unwrap(), 80);
+
+	// Request matching the listener route
+	let req = request(
+		"http://my-app.default.svc.cluster.local/api/v1",
+		http::Method::GET,
+		&[],
+	);
+	let result = super::select_best_route(
+		stores.clone(),
+		strng::literal!("network"),
+		Some(&self_id),
+		dst,
+		&listener,
+		&req,
+	);
+	assert_eq!(
+		result.unwrap().0.key.as_str(),
+		"listener-api-route",
+		"should use the listener-attached route, not _waypoint-default"
+	);
+
+	// Request NOT matching the listener route falls to default
+	let req = request(
+		"http://my-app.default.svc.cluster.local/other",
+		http::Method::GET,
+		&[],
+	);
+	let result = super::select_best_route(
+		stores,
+		strng::literal!("network"),
+		Some(&self_id),
+		dst,
+		&listener,
+		&req,
+	);
+	assert_eq!(
+		result.unwrap().0.key.as_str(),
+		"_waypoint-default",
+		"non-matching request should fall through to default"
+	);
+}
+
 #[divan::bench(args = [(1,1), (100, 100), (5000,100)])]
 fn bench(b: Bencher, (host, route): (u64, u64)) {
 	let mut routes = vec![];

--- a/crates/agentgateway/src/proxy/gateway.rs
+++ b/crates/agentgateway/src/proxy/gateway.rs
@@ -20,8 +20,6 @@ use tokio::task::{AbortHandle, JoinSet};
 use tokio_stream::StreamExt;
 use tracing::{Instrument, debug, error, event, info, info_span, warn};
 
-use agent_core::strng;
-
 use crate::proxy::ProxyError;
 use crate::store::{Event, FrontendPolices};
 use crate::telemetry::metrics::TCPLabels;
@@ -1100,33 +1098,20 @@ impl Gateway {
 			drain_tx: None,
 		};
 
+		// Look up the real HBONE listener from the bind's ListenerSet
+		let listener = pi.stores.read_binds().bind(&bind_name).and_then(|b| {
+			b.listeners
+				.inner
+				.values()
+				.find(|l| matches!(l.protocol, ListenerProtocol::HBONE))
+				.cloned()
+		});
+
 		let socket = Socket::from_hbone(ext, socket_addr, con);
 		if is_http {
-			let _ = Self::proxy(bind_name, pi, None, socket, policies.clone(), drain).await;
+			let _ = Self::proxy(bind_name, pi, listener, socket, policies.clone(), drain).await;
 		} else {
-			// TCP: create a synthetic HBONE listener for the TCP proxy path
-			let listener = Arc::new(Listener {
-				key: Default::default(),
-				name: crate::types::agent::ListenerName {
-					gateway_name: strng::EMPTY,
-					gateway_namespace: strng::EMPTY,
-					listener_name: strng::literal!("_waypoint-tcp"),
-					listener_set: None,
-				},
-				hostname: Default::default(),
-				protocol: ListenerProtocol::HBONE,
-				tcp_routes: Default::default(),
-				routes: Default::default(),
-			});
-			Self::proxy_tcp(
-				bind_name,
-				pi,
-				Some(listener),
-				socket,
-				policies.clone(),
-				drain,
-			)
-			.await;
+			Self::proxy_tcp(bind_name, pi, listener, socket, policies.clone(), drain).await;
 		}
 	}
 

--- a/crates/agentgateway/src/proxy/tcpproxy.rs
+++ b/crates/agentgateway/src/proxy/tcpproxy.rs
@@ -359,7 +359,9 @@ mod tests {
 	use agent_core::strng;
 
 	use crate::store::Stores;
-	use crate::types::agent::{ListenerProtocol, SimpleBackendReference};
+	use crate::types::agent::{
+		ListenerProtocol, SimpleBackendReference, TCPRoute, TCPRouteBackendReference, TCPRouteSet,
+	};
 	use crate::types::discovery::{
 		GatewayAddress, NamespacedHostname, NetworkAddress, Service, WaypointIdentity,
 		gatewayaddress::Destination,
@@ -724,5 +726,67 @@ mod tests {
 		);
 		assert!(route.is_some(), "should fall through to default");
 		assert_eq!(route.unwrap().key.as_str(), "_waypoint-default-tcp");
+	}
+
+	#[tokio::test]
+	async fn test_hbone_listener_tcp_route_overrides_default() {
+		// An HBONE listener with a directly-attached TCP route should use that
+		// route, not the generated _waypoint-default-tcp.
+		let svc = make_service(
+			"mysql-db",
+			"default",
+			"mysql-db.default.svc.cluster.local",
+			"10.0.0.50",
+			"network",
+			Some(GatewayAddress {
+				destination: Destination::Hostname(NamespacedHostname {
+					namespace: strng::new("istio-system"),
+					hostname: strng::new("my-waypoint.istio-system.svc.cluster.local"),
+				}),
+				hbone_mtls_port: 15008,
+			}),
+		);
+		let stores = stores_with_services(vec![svc]);
+		let network = strng::literal!("network");
+		let dst = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 50)), 3306);
+		let self_addr = make_self_addr("my-waypoint", "istio-system");
+
+		// HBONE listener with a custom TCP route attached directly
+		let listener = Arc::new(crate::types::agent::Listener {
+			key: Default::default(),
+			name: crate::types::agent::ListenerName {
+				gateway_name: strng::EMPTY,
+				gateway_namespace: strng::EMPTY,
+				listener_name: strng::literal!("test"),
+				listener_set: None,
+			},
+			hostname: Default::default(),
+			protocol: ListenerProtocol::HBONE,
+			tcp_routes: TCPRouteSet::from_list(vec![TCPRoute {
+				key: strng::literal!("listener-mysql-route"),
+				service_key: None,
+				name: Default::default(),
+				hostnames: vec![],
+				backends: vec![TCPRouteBackendReference {
+					weight: 1,
+					backend: SimpleBackendReference::Service {
+						name: NamespacedHostname {
+							namespace: strng::new("default"),
+							hostname: strng::new("mysql-db.default.svc.cluster.local"),
+						},
+						port: 3306,
+					},
+					inline_policies: vec![],
+				}],
+			}]),
+			routes: Default::default(),
+		});
+
+		let route = super::select_best_route(None, listener, &stores, &network, dst, Some(&self_addr));
+		assert_eq!(
+			route.unwrap().key.as_str(),
+			"listener-mysql-route",
+			"should use the listener-attached TCP route, not _waypoint-default-tcp"
+		);
 	}
 }


### PR DESCRIPTION
similar to #1392 but rather than making the "best_match_http" find the hbone listener, we pass the listener into `proxy` so we don't hit that best_match_http at all

another change here is that we pass the listener for the TCP path rather than constructing a synthetic one, so that we can use listener-attached TCP route if they exist