### PR TITLE
fix finding listener for HBONE path

### DIFF
--- a/crates/agentgateway/src/proxy/gateway.rs
+++ b/crates/agentgateway/src/proxy/gateway.rs
@@ -20,8 +20,6 @@ use tokio::task::{AbortHandle, JoinSet};
 use tokio_stream::StreamExt;
 use tracing::{Instrument, debug, error, event, info, info_span, warn};
 
-use agent_core::strng;
-
 use crate::proxy::ProxyError;
 use crate::store::{Event, FrontendPolices};
 use crate::telemetry::metrics::TCPLabels;
@@ -34,6 +32,7 @@ use crate::types::agent::{
 };
 use crate::types::frontend;
 use crate::{ProxyInputs, client};
+use agent_core::strng;
 
 #[cfg(test)]
 #[path = "gateway_test.rs"]
@@ -1100,33 +1099,42 @@ impl Gateway {
 			drain_tx: None,
 		};
 
+		// Look up the real HBONE listener for policy resolution (gateway/listener-targeted
+		// policies require the listener's name to match).
+		let listener = pi
+			.stores
+			.read_binds()
+			.bind(&bind_name)
+			.and_then(|b| {
+				b.listeners
+					.inner
+					.values()
+					.find(|l| matches!(l.protocol, ListenerProtocol::HBONE))
+					.cloned()
+			})
+			.or_else(|| {
+				// Synthetic fallback so route selection works via VIP lookup.
+				// We may eventually elide the need to generate an HBONE listener at all.
+				Some(Arc::new(Listener {
+					key: Default::default(),
+					name: crate::types::agent::ListenerName {
+						gateway_name: pi.cfg.xds.gateway.clone(),
+						gateway_namespace: pi.cfg.xds.namespace.clone(),
+						listener_name: strng::EMPTY,
+						listener_set: None,
+					},
+					hostname: Default::default(),
+					protocol: ListenerProtocol::HBONE,
+					tcp_routes: Default::default(),
+					routes: Default::default(),
+				}))
+			});
+
 		let socket = Socket::from_hbone(ext, socket_addr, con);
 		if is_http {
-			let _ = Self::proxy(bind_name, pi, None, socket, policies.clone(), drain).await;
+			let _ = Self::proxy(bind_name, pi, listener, socket, policies.clone(), drain).await;
 		} else {
-			// TCP: create a synthetic HBONE listener for the TCP proxy path
-			let listener = Arc::new(Listener {
-				key: Default::default(),
-				name: crate::types::agent::ListenerName {
-					gateway_name: strng::EMPTY,
-					gateway_namespace: strng::EMPTY,
-					listener_name: strng::literal!("_waypoint-tcp"),
-					listener_set: None,
-				},
-				hostname: Default::default(),
-				protocol: ListenerProtocol::HBONE,
-				tcp_routes: Default::default(),
-				routes: Default::default(),
-			});
-			Self::proxy_tcp(
-				bind_name,
-				pi,
-				Some(listener),
-				socket,
-				policies.clone(),
-				drain,
-			)
-			.await;
+			Self::proxy_tcp(bind_name, pi, listener, socket, policies.clone(), drain).await;
 		}
 	}
 


### PR DESCRIPTION
This fixes two issues:

1. the same thing #1392 fixes - avoids ListenerNotFound when we get to proxy_http
2. passing the synthetic listener with a bogus listener name and empty gateway name breaks on the TCP path would break policy lookup
  * get_backend_policies gets a route path that contains a listener_name
  * internal_backend_policy gets a gateway with empty names
  * as_gateway_target_ref produces a PolicyTargetRef with empty stuff, so we miss in policies_by_target
