### PR TITLE
feat: add cacheMessageOffset to PromptCachingConfig

### DIFF
--- a/api/resource.pb.go
+++ b/api/resource.pb.go
@@ -10461,13 +10461,14 @@ func (x *BackendPolicySpec_Ai_PromptGuard) GetResponse() []*BackendPolicySpec_Ai
 
 // Default JSON key-value pairs to add to the LLM request if the key is not set in the request.
 type BackendPolicySpec_Ai_PromptCaching struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	CacheSystem   bool                   `protobuf:"varint,1,opt,name=cache_system,json=cacheSystem,proto3" json:"cache_system,omitempty"`
-	CacheMessages bool                   `protobuf:"varint,2,opt,name=cache_messages,json=cacheMessages,proto3" json:"cache_messages,omitempty"`
-	CacheTools    bool                   `protobuf:"varint,3,opt,name=cache_tools,json=cacheTools,proto3" json:"cache_tools,omitempty"`
-	MinTokens     *uint32                `protobuf:"varint,4,opt,name=min_tokens,json=minTokens,proto3,oneof" json:"min_tokens,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state              protoimpl.MessageState `protogen:"open.v1"`
+	CacheSystem        bool                   `protobuf:"varint,1,opt,name=cache_system,json=cacheSystem,proto3" json:"cache_system,omitempty"`
+	CacheMessages      bool                   `protobuf:"varint,2,opt,name=cache_messages,json=cacheMessages,proto3" json:"cache_messages,omitempty"`
+	CacheTools         bool                   `protobuf:"varint,3,opt,name=cache_tools,json=cacheTools,proto3" json:"cache_tools,omitempty"`
+	MinTokens          *uint32                `protobuf:"varint,4,opt,name=min_tokens,json=minTokens,proto3,oneof" json:"min_tokens,omitempty"`
+	CacheMessageOffset *uint32                `protobuf:"varint,5,opt,name=cache_message_offset,json=cacheMessageOffset,proto3,oneof" json:"cache_message_offset,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *BackendPolicySpec_Ai_PromptCaching) Reset() {
@@ -10524,6 +10525,13 @@ func (x *BackendPolicySpec_Ai_PromptCaching) GetCacheTools() bool {
 func (x *BackendPolicySpec_Ai_PromptCaching) GetMinTokens() uint32 {
 	if x != nil && x.MinTokens != nil {
 		return *x.MinTokens
+	}
+	return 0
+}
+
+func (x *BackendPolicySpec_Ai_PromptCaching) GetCacheMessageOffset() uint32 {
+	if x != nil && x.CacheMessageOffset != nil {
+		return *x.CacheMessageOffset
 	}
 	return 0
 }
@@ -11793,7 +11801,7 @@ const file_resource_proto_rawDesc = "" +
 	"\vPolicyPhase\x12\t\n" +
 	"\x05ROUTE\x10\x00\x12\v\n" +
 	"\aGATEWAY\x10\x01B\x06\n" +
-	"\x04kind\"\xb6B\n" +
+	"\x04kind\"\x86C\n" +
 	"\x11BackendPolicySpec\x12D\n" +
 	"\x03a2a\x18\x01 \x01(\v20.agentgateway.dev.resource.BackendPolicySpec.A2aH\x00R\x03a2a\x12l\n" +
 	"\x11inference_routing\x18\x02 \x01(\v2=.agentgateway.dev.resource.BackendPolicySpec.InferenceRoutingH\x00R\x10inferenceRouting\x12Z\n" +
@@ -11813,7 +11821,7 @@ const file_resource_proto_rawDesc = "" +
 	"backendTcp\x12k\n" +
 	"\x0etransformation\x18\x0e \x01(\v2A.agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicyH\x00R\x0etransformation\x12M\n" +
 	"\x06health\x18\x0f \x01(\v23.agentgateway.dev.resource.BackendPolicySpec.HealthH\x00R\x06health\x12c\n" +
-	"\x0ebackend_tunnel\x18\x10 \x01(\v2:.agentgateway.dev.resource.BackendPolicySpec.BackendTunnelH\x00R\rbackendTunnel\x1a\x93\"\n" +
+	"\x0ebackend_tunnel\x18\x10 \x01(\v2:.agentgateway.dev.resource.BackendPolicySpec.BackendTunnelH\x00R\rbackendTunnel\x1a\xe3\"\n" +
 	"\x02Ai\x12^\n" +
 	"\fprompt_guard\x18\x01 \x01(\v2;.agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuardR\vpromptGuard\x12Y\n" +
 	"\bdefaults\x18\x02 \x03(\v2=.agentgateway.dev.resource.BackendPolicySpec.Ai.DefaultsEntryR\bdefaults\x12\\\n" +
@@ -11880,15 +11888,17 @@ const file_resource_proto_rawDesc = "" +
 	"\x04kind\x1a\xc0\x01\n" +
 	"\vPromptGuard\x12V\n" +
 	"\arequest\x18\x01 \x03(\v2<.agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuardR\arequest\x12Y\n" +
-	"\bresponse\x18\x02 \x03(\v2=.agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuardR\bresponse\x1a\xad\x01\n" +
+	"\bresponse\x18\x02 \x03(\v2=.agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuardR\bresponse\x1a\xfd\x01\n" +
 	"\rPromptCaching\x12!\n" +
 	"\fcache_system\x18\x01 \x01(\bR\vcacheSystem\x12%\n" +
 	"\x0ecache_messages\x18\x02 \x01(\bR\rcacheMessages\x12\x1f\n" +
 	"\vcache_tools\x18\x03 \x01(\bR\n" +
 	"cacheTools\x12\"\n" +
 	"\n" +
-	"min_tokens\x18\x04 \x01(\rH\x00R\tminTokens\x88\x01\x01B\r\n" +
-	"\v_min_tokens\x1a;\n" +
+	"min_tokens\x18\x04 \x01(\rH\x00R\tminTokens\x88\x01\x01\x125\n" +
+	"\x14cache_message_offset\x18\x05 \x01(\rH\x01R\x12cacheMessageOffset\x88\x01\x01B\r\n" +
+	"\v_min_tokensB\x17\n" +
+	"\x15_cache_message_offset\x1a;\n" +
 	"\rDefaultsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a<\n" +

--- a/controller/api/v1alpha1/agentgateway/ai_policy.go
+++ b/controller/api/v1alpha1/agentgateway/ai_policy.go
@@ -401,4 +401,13 @@ type PromptCachingConfig struct {
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:default=1024
 	MinTokens int `json:"minTokens,omitempty"`
+
+	// CacheMessageOffset shifts the message cache point further back in the
+	// conversation. 0 (default) places it at the second-to-last message.
+	// Higher values move it N additional messages towards the start, clamped
+	// to bounds.
+	// +optional
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:default=0
+	CacheMessageOffset int `json:"cacheMessageOffset,omitempty"`
 }

--- a/controller/pkg/agentgateway/plugins/backend_policies.go
+++ b/controller/pkg/agentgateway/plugins/backend_policies.go
@@ -622,6 +622,9 @@ func translateBackendAI(ctx PolicyCtx, agwPolicy *agentgateway.AgentgatewayPolic
 			CacheTools:    aiSpec.PromptCaching.CacheTools,
 		}
 		translatedAIPolicy.PromptCaching.MinTokens = ptr.Of(uint32(aiSpec.PromptCaching.MinTokens)) //nolint:gosec // G115: MinTokens is validated by kubebuilder to be >= 0
+		if aiSpec.PromptCaching.CacheMessageOffset > 0 {
+			translatedAIPolicy.PromptCaching.CacheMessageOffset = ptr.Of(uint32(aiSpec.PromptCaching.CacheMessageOffset)) //nolint:gosec // G115: CacheMessageOffset is validated by kubebuilder to be >= 0
+		}
 	}
 
 	if aiSpec.Routes != nil {

--- a/controller/pkg/syncer/README.md
+++ b/controller/pkg/syncer/README.md
@@ -1901,7 +1901,7 @@ EOF
 ```
 
 #### Bedrock prompt caching
-Enable Bedrock prompt caching via `AgentgatewayPolicy.spec.backend.ai.promptCaching` to reduce costs on repeated prompts and tool specs. Set `minTokens` to avoid caching short prompts; only Bedrock models support this feature.
+Enable Bedrock prompt caching via `AgentgatewayPolicy.spec.backend.ai.promptCaching` to reduce costs on repeated prompts and tool specs. Set `minTokens` to avoid caching short prompts; only Bedrock models support this feature. Use `cacheMessageOffset` to shift the message cache point further back in the conversation (0 = default second-to-last message; higher values move it N additional messages toward the start).
 
 ```shell
 kubectl apply -f- <<EOF

--- a/crates/agentgateway/src/llm/conversion/bedrock.rs
+++ b/crates/agentgateway/src/llm/conversion/bedrock.rs
@@ -556,7 +556,10 @@ pub mod from_completions {
 
 		if let Some(caching) = prompt_caching {
 			if caching.cache_messages && supports_caching {
-				helpers::insert_cache_point_in_last_user_message(&mut bedrock_request.messages);
+				helpers::insert_message_cache_point(
+					&mut bedrock_request.messages,
+					caching.cache_message_offset,
+				);
 			}
 			if caching.cache_tools
 				&& supports_caching
@@ -2019,7 +2022,7 @@ pub mod from_responses {
 		// Apply user message and tool caching
 		if let Some(caching) = prompt_caching {
 			if caching.cache_messages && supports_caching {
-				insert_cache_point_in_last_user_message(&mut bedrock_request.messages);
+				insert_message_cache_point(&mut bedrock_request.messages, caching.cache_message_offset);
 			}
 			if caching.cache_tools
 				&& supports_caching
@@ -2561,7 +2564,7 @@ mod helpers {
 		(word_count * 13) / 10
 	}
 
-	pub fn insert_cache_point_in_last_user_message(messages: &mut [bedrock::Message]) {
+	pub fn insert_message_cache_point(messages: &mut [bedrock::Message], offset: usize) {
 		// Strategy: Cache everything BEFORE the last message (not including it)
 		// This caches the conversation history but not the current turn's input
 		//
@@ -2572,6 +2575,10 @@ mod helpers {
 		// This way:
 		//   - Conversation history: cached (cheap reads on subsequent turns)
 		//   - Current input: full price (it's new each turn anyway)
+		//
+		// The `offset` parameter shifts the cache point further back:
+		//   offset 0 → second-to-last message (default)
+		//   offset N → N additional messages back from default, clamped to bounds
 
 		let len = messages.len();
 
@@ -2580,16 +2587,16 @@ mod helpers {
 			return;
 		}
 
-		// Insert cache point in the second-to-last message
-		// This caches all history BEFORE the current turn
-		let second_to_last_idx = len - 2;
-		messages[second_to_last_idx]
+		// Clamp so the index never goes below 0
+		let target_idx = (len - 2).saturating_sub(offset);
+		messages[target_idx]
 			.content
 			.push(bedrock::ContentBlock::CachePoint(create_cache_point()));
 
 		tracing::debug!(
-			"Inserted cachePoint before last message (in message at index {})",
-			second_to_last_idx
+			"Inserted cachePoint in message at index {} (offset={})",
+			target_idx,
+			offset
 		);
 	}
 

--- a/crates/agentgateway/src/llm/conversion/bedrock_tests.rs
+++ b/crates/agentgateway/src/llm/conversion/bedrock_tests.rs
@@ -1225,3 +1225,77 @@ fn test_embeddings_error_translation() {
 	assert_eq!(error_resp["error"]["type"], "invalid_request_error");
 	assert_eq!(error_resp["error"]["message"], "Model not found");
 }
+
+fn make_message(role: types::bedrock::Role, text: &str) -> types::bedrock::Message {
+	types::bedrock::Message {
+		role,
+		content: vec![types::bedrock::ContentBlock::Text(text.to_string())],
+	}
+}
+
+fn has_cache_point(msg: &types::bedrock::Message) -> bool {
+	msg
+		.content
+		.iter()
+		.any(|b| matches!(b, types::bedrock::ContentBlock::CachePoint(_)))
+}
+
+#[test]
+fn test_insert_cache_point_default_offset() {
+	let mut msgs = vec![
+		make_message(types::bedrock::Role::User, "Hello"),
+		make_message(types::bedrock::Role::Assistant, "Hi"),
+		make_message(types::bedrock::Role::User, "How are you?"),
+	];
+	helpers::insert_message_cache_point(&mut msgs, 0);
+	assert!(has_cache_point(&msgs[1]));
+	assert!(!has_cache_point(&msgs[0]));
+	assert!(!has_cache_point(&msgs[2]));
+}
+
+#[test]
+fn test_insert_cache_point_offset_shifts_back() {
+	let mut msgs = vec![
+		make_message(types::bedrock::Role::User, "a"),
+		make_message(types::bedrock::Role::Assistant, "b"),
+		make_message(types::bedrock::Role::User, "c"),
+		make_message(types::bedrock::Role::Assistant, "d"),
+		make_message(types::bedrock::Role::User, "e"),
+	];
+	helpers::insert_message_cache_point(&mut msgs, 2);
+	// default position is index 3 (len-2), offset 2 → index 1
+	assert!(has_cache_point(&msgs[1]));
+	for (i, msg) in msgs.iter().enumerate() {
+		if i != 1 {
+			assert!(!has_cache_point(msg));
+		}
+	}
+}
+
+#[test]
+fn test_insert_cache_point_offset_clamps_to_zero() {
+	let mut msgs = vec![
+		make_message(types::bedrock::Role::User, "a"),
+		make_message(types::bedrock::Role::Assistant, "b"),
+		make_message(types::bedrock::Role::User, "c"),
+	];
+	// offset 100 should clamp to index 0
+	helpers::insert_message_cache_point(&mut msgs, 100);
+	assert!(has_cache_point(&msgs[0]));
+	assert!(!has_cache_point(&msgs[1]));
+	assert!(!has_cache_point(&msgs[2]));
+}
+
+#[test]
+fn test_insert_cache_point_single_message_noop() {
+	let mut msgs = vec![make_message(types::bedrock::Role::User, "only")];
+	helpers::insert_message_cache_point(&mut msgs, 0);
+	assert!(!has_cache_point(&msgs[0]));
+}
+
+#[test]
+fn test_insert_cache_point_empty_messages_noop() {
+	let mut msgs: Vec<types::bedrock::Message> = vec![];
+	helpers::insert_message_cache_point(&mut msgs, 0);
+	assert!(msgs.is_empty());
+}

--- a/crates/agentgateway/src/llm/policy/mod.rs
+++ b/crates/agentgateway/src/llm/policy/mod.rs
@@ -187,6 +187,9 @@ pub struct PromptCachingConfig {
 
 	#[serde(rename = "minTokens")]
 	pub min_tokens: Option<usize>,
+
+	#[serde(rename = "cacheMessageOffset")]
+	pub cache_message_offset: usize,
 }
 
 impl Default for PromptCachingConfig {
@@ -196,6 +199,7 @@ impl Default for PromptCachingConfig {
 			cache_messages: true,
 			cache_tools: false,
 			min_tokens: Some(1024),
+			cache_message_offset: 0,
 		}
 	}
 }

--- a/crates/agentgateway/src/llm/policy/tests.rs
+++ b/crates/agentgateway/src/llm/policy/tests.rs
@@ -161,6 +161,7 @@ fn test_prompt_caching_policy_deserialization() {
 	assert!(caching.cache_messages);
 	assert!(!caching.cache_tools);
 	assert_eq!(caching.min_tokens, Some(1024));
+	assert_eq!(caching.cache_message_offset, 0);
 }
 
 #[test]
@@ -179,6 +180,7 @@ fn test_prompt_caching_policy_defaults() {
 	assert!(caching.cache_messages); // Default: true
 	assert!(!caching.cache_tools); // Default: false
 	assert_eq!(caching.min_tokens, Some(1024)); // Default: 1024
+	assert_eq!(caching.cache_message_offset, 0); // Default: 0
 }
 
 #[test]
@@ -210,6 +212,24 @@ fn test_prompt_caching_explicit_disable() {
 
 	// Should be None when explicitly set to null
 	assert!(policy.prompt_caching.is_none());
+}
+
+#[test]
+fn test_prompt_caching_with_offset() {
+	use serde_json::json;
+
+	let json = json!({
+		"promptCaching": {
+			"cacheMessages": true,
+			"cacheMessageOffset": 4
+		}
+	});
+
+	let policy: Policy = serde_json::from_value(json).unwrap();
+	let caching = policy.prompt_caching.unwrap();
+
+	assert!(caching.cache_messages);
+	assert_eq!(caching.cache_message_offset, 4);
 }
 
 #[test]

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -2174,6 +2174,7 @@ fn convert_prompt_caching(
 		cache_messages: pc.cache_messages,
 		cache_tools: pc.cache_tools,
 		min_tokens: pc.min_tokens.map(|t| t as usize),
+		cache_message_offset: pc.cache_message_offset.unwrap_or(0) as usize,
 	}
 }
 

--- a/crates/protos/proto/resource.proto
+++ b/crates/protos/proto/resource.proto
@@ -954,6 +954,7 @@ message BackendPolicySpec {
       bool cache_messages = 2;
       bool cache_tools = 3;
       optional uint32 min_tokens = 4;
+      optional uint32 cache_message_offset = 5;
     }
 
     map<string, string> defaults = 2;

--- a/schema/config.json
+++ b/schema/config.json
@@ -3014,6 +3014,12 @@
           "format": "uint",
           "minimum": 0,
           "default": 1024
+        },
+        "cacheMessageOffset": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0,
+          "default": 0
         }
       },
       "additionalProperties": false

--- a/schema/config.md
+++ b/schema/config.md
@@ -732,6 +732,7 @@
 |`binds[].listeners[].routes[].policies.ai.promptCaching.cacheMessages`|boolean||
 |`binds[].listeners[].routes[].policies.ai.promptCaching.cacheTools`|boolean||
 |`binds[].listeners[].routes[].policies.ai.promptCaching.minTokens`|integer||
+|`binds[].listeners[].routes[].policies.ai.promptCaching.cacheMessageOffset`|integer||
 |`binds[].listeners[].routes[].policies.ai.routes`|object||
 |`binds[].listeners[].routes[].policies.backendTLS`|object|Send TLS to the backend.|
 |`binds[].listeners[].routes[].policies.backendTLS.cert`|string||
@@ -2000,6 +2001,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptCaching.cacheMessages`|boolean||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptCaching.cacheTools`|boolean||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptCaching.minTokens`|integer||
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptCaching.cacheMessageOffset`|integer||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.routes`|object||
 |`binds[].listeners[].routes[].backends[].ai.groups`|[]object||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers`|[]object||
@@ -2697,6 +2699,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptCaching.cacheMessages`|boolean||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptCaching.cacheTools`|boolean||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptCaching.minTokens`|integer||
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptCaching.cacheMessageOffset`|integer||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.routes`|object||
 |`binds[].listeners[].routes[].backends[].aws`|object||
 |`binds[].listeners[].routes[].backends[].aws.agentCore`|object||
@@ -3372,6 +3375,7 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptCaching.cacheMessages`|boolean||
 |`binds[].listeners[].routes[].backends[].policies.ai.promptCaching.cacheTools`|boolean||
 |`binds[].listeners[].routes[].backends[].policies.ai.promptCaching.minTokens`|integer||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptCaching.cacheMessageOffset`|integer||
 |`binds[].listeners[].routes[].backends[].policies.ai.routes`|object||
 |`binds[].listeners[].tcpRoutes`|[]object||
 |`binds[].listeners[].tcpRoutes[].name`|string||
@@ -4592,6 +4596,7 @@
 |`policies[].policy.ai.promptCaching.cacheMessages`|boolean||
 |`policies[].policy.ai.promptCaching.cacheTools`|boolean||
 |`policies[].policy.ai.promptCaching.minTokens`|integer||
+|`policies[].policy.ai.promptCaching.cacheMessageOffset`|integer||
 |`policies[].policy.ai.routes`|object||
 |`policies[].policy.backendTLS`|object|Send TLS to the backend.|
 |`policies[].policy.backendTLS.cert`|string||
@@ -5707,6 +5712,7 @@
 |`backends[].policies.ai.promptCaching.cacheMessages`|boolean||
 |`backends[].policies.ai.promptCaching.cacheTools`|boolean||
 |`backends[].policies.ai.promptCaching.minTokens`|integer||
+|`backends[].policies.ai.promptCaching.cacheMessageOffset`|integer||
 |`backends[].policies.ai.routes`|object||
 |`llm`|object||
 |`llm.port`|integer||
@@ -7353,6 +7359,7 @@
 |`mcp.policies.ai.promptCaching.cacheMessages`|boolean||
 |`mcp.policies.ai.promptCaching.cacheTools`|boolean||
 |`mcp.policies.ai.promptCaching.minTokens`|integer||
+|`mcp.policies.ai.promptCaching.cacheMessageOffset`|integer||
 |`mcp.policies.ai.routes`|object||
 |`mcp.policies.backendTLS`|object|Send TLS to the backend.|
 |`mcp.policies.backendTLS.cert`|string||


### PR DESCRIPTION
Add `cacheMessageOffset` field to `PromptCachingConfig`. When set, shifts the Bedrock message cache point further back from the default second-to-last position.

- `cacheMessageOffset: 0` (default): no change in behavior
- `cacheMessageOffset: N`: cache point moves N additional messages toward the start, clamped to bounds

This gives callers control over which portion of the conversation is covered by the cache prefix — useful for agentic workloads where mid-conversation compaction may mutate recent messages.
