### PR TITLE
Drain listener on change

### DIFF
--- a/crates/agentgateway/src/proxy/gateway.rs
+++ b/crates/agentgateway/src/proxy/gateway.rs
@@ -34,7 +34,7 @@ use crate::types::agent::{
 use crate::types::discovery::Service;
 use crate::types::discovery::gatewayaddress::Destination;
 use crate::types::frontend;
-use crate::{ProxyInputs, client};
+use crate::{ProxyInputs, Stores, client};
 use agent_core::strng;
 use agent_hbone::server::H2Request;
 
@@ -421,6 +421,7 @@ impl Gateway {
 					bind_name,
 					inputs,
 					None,
+					None,
 					raw_stream,
 					Arc::new(policies),
 					drain,
@@ -441,12 +442,14 @@ impl Gateway {
 				)
 				.await
 				{
-					Ok((selected_listener, stream)) => match selected_listener.protocol {
+					Ok((selected_listener, stream)) => match &selected_listener.protocol {
 						ListenerProtocol::HTTPS(_) => {
+							let rx = inputs.stores.read_binds().subscribe_listener_changes();
 							let _ = Self::proxy(
 								bind_name,
 								inputs,
 								Some(selected_listener),
+								Some(rx),
 								stream,
 								Arc::new(policies),
 								drain,
@@ -502,10 +505,12 @@ impl Gateway {
 							{
 								Ok((selected_listener, tls_stream)) => match selected_listener.protocol {
 									ListenerProtocol::HTTPS(_) => {
+										let rx = inputs.stores.read_binds().subscribe_listener_changes();
 										let _ = Self::proxy(
 											bind_name,
 											inputs,
 											Some(selected_listener),
+											Some(rx),
 											tls_stream,
 											Arc::new(policies),
 											drain,
@@ -543,8 +548,16 @@ impl Gateway {
 							}
 						} else {
 							// Plaintext HTTP
-							let err =
-								Self::proxy(bind_name, inputs, None, stream, Arc::new(policies), drain).await;
+							let err = Self::proxy(
+								bind_name,
+								inputs,
+								None,
+								None,
+								stream,
+								Arc::new(policies),
+								drain,
+							)
+							.await;
 							if let Err(e) = err {
 								warn!(src.addr = %peer_addr, "proxy error: {e}");
 							}
@@ -610,6 +623,7 @@ impl Gateway {
 		bind_name: BindKey,
 		inputs: Arc<ProxyInputs>,
 		selected_listener: Option<Arc<Listener>>,
+		listener_change: Option<watch::Receiver<u64>>,
 		mut stream: Socket,
 		policies: Arc<FrontendPolices>,
 		drain: DrainWatcher,
@@ -670,7 +684,7 @@ impl Gateway {
 		let proxy = super::httpproxy::HTTPProxy {
 			bind_name,
 			inputs,
-			selected_listener,
+			selected_listener: selected_listener.clone(),
 			target_address,
 		};
 		let connection = Arc::new(stream.get_ext());
@@ -689,6 +703,7 @@ impl Gateway {
 			.http
 			.as_ref()
 			.and_then(|h| h.max_connection_duration);
+		let drain_proxy = proxy.clone();
 
 		let serve = server.serve_connection_with_upgrades(
 			TokioIo::new(stream),
@@ -699,32 +714,50 @@ impl Gateway {
 				async move { proxy.proxy(connection, req).map(Ok::<_, Infallible>).await }
 			}),
 		);
-		// Pin the connection so we can call graceful_shutdown() on it
-		tokio::pin!(serve);
-		let drain_signal = drain.wait_for_drain();
-		tokio::pin!(drain_signal);
-
-		let max_connection_duration = async {
-			match max_connection_duration {
-				Some(d) => tokio::time::sleep(d).await,
-				None => std::future::pending().await,
-			}
-		};
-		let res = tokio::select! {
-			res = serve.as_mut() => res,
-			_guard = &mut drain_signal => {
-				// Drain signaled, initiate graceful shutdown (GOAWAY/Connection:close)
-				// then wait for in-flight requests to complete
-				serve.as_mut().graceful_shutdown();
-				serve.await
-			},
-			_ = max_connection_duration => {
-				debug!("connection closed: max connection duration reached");
-				// Initiate graceful shutdown then wait for in-flight requests to complete
-				serve.as_mut().graceful_shutdown();
-				serve.await
-			},
-		};
+		let (connection_drain_tx, connection_drain_rx) = drain::new();
+		let parent_drain = drain.clone();
+		let listener_drain = selected_listener.clone().zip(listener_change);
+		let watch_task = tokio::spawn(async move {
+			let max_connection_duration = async {
+				match max_connection_duration {
+					Some(d) => tokio::time::sleep(d).await,
+					None => std::future::pending::<()>().await,
+				}
+			};
+			tokio::pin!(max_connection_duration);
+			let mode = if let Some((serving_listener, listener_change)) = listener_drain {
+				let stores = drain_proxy.inputs.stores.clone();
+				let bind_name = drain_proxy.bind_name.clone();
+				let listener_key = serving_listener.key.clone();
+				tokio::select! {
+					drain = parent_drain.wait_for_drain() => drain.mode(),
+					_ = Self::wait_for_listener_change(
+						stores,
+						bind_name.clone(),
+						serving_listener.clone(),
+						listener_change,
+					) => {
+						info!(bind=%bind_name, listener=%listener_key, "listener changed, draining downstream TLS connection");
+						drain::DrainMode::Graceful
+					},
+					_ = &mut max_connection_duration => {
+						debug!("connection closed: max connection duration reached");
+						drain::DrainMode::Graceful
+					},
+				}
+			} else {
+				tokio::select! {
+					drain = parent_drain.wait_for_drain() => drain.mode(),
+					_ = &mut max_connection_duration => {
+						debug!("connection closed: max connection duration reached");
+						drain::DrainMode::Graceful
+					},
+				}
+			};
+			connection_drain_tx.start_drain_and_wait(mode).await;
+		});
+		let res = connection_drain_rx.wrap_connection(serve).await;
+		watch_task.abort();
 		match res {
 			Ok(_) => Ok(()),
 			Err(e) => {
@@ -766,6 +799,39 @@ impl Gateway {
 			target_address,
 		};
 		proxy.proxy(stream).await
+	}
+
+	async fn wait_for_listener_change(
+		stores: Stores,
+		bind_name: BindKey,
+		listener_snapshot: Arc<Listener>,
+		mut listener_change_rx: watch::Receiver<u64>,
+	) {
+		if Self::listener_snapshot_changed(&stores, &bind_name, &listener_snapshot) {
+			return;
+		}
+		loop {
+			if listener_change_rx.changed().await.is_err() {
+				return;
+			}
+			if Self::listener_snapshot_changed(&stores, &bind_name, &listener_snapshot) {
+				return;
+			}
+		}
+	}
+
+	fn listener_snapshot_changed(
+		stores: &Stores,
+		bind_name: &BindKey,
+		serving_listener: &Listener,
+	) -> bool {
+		match stores
+			.read_binds()
+			.get_bind_listener(bind_name, &serving_listener.key)
+		{
+			Some(current) => current.as_ref() != serving_listener,
+			None => true,
+		}
 	}
 
 	// maybe_terminate_tls will observe the TLS handshake, and once the client hello has been received, select
@@ -1093,6 +1159,7 @@ impl Gateway {
 				bind_name,
 				pi,
 				Some(listener),
+				None,
 				socket,
 				Arc::new(policies),
 				drain,

--- a/crates/agentgateway/src/proxy/gateway_test.rs
+++ b/crates/agentgateway/src/proxy/gateway_test.rs
@@ -1151,6 +1151,65 @@ async fn tls_connection_reuses_listener_after_route_insert() {
 }
 
 #[tokio::test]
+async fn tls_connection_drains_when_listener_changes() {
+	let existing = body_mock(b"existing-route").await;
+	let bind = https_bind();
+	let t = setup_proxy_test("{}")
+		.unwrap()
+		.with_backend(*existing.address())
+		.with_bind(bind)
+		.with_route(route_with_prefix(*existing.address(), "/existing"));
+
+	let (mut sender, conn) = serve_https_http1_connection(&t, "a.example.com").await;
+
+	let res = sender
+		.send_request(
+			::http::Request::builder()
+				.method(Method::GET)
+				.uri("/existing")
+				.version(Version::HTTP_11)
+				.header(header::HOST, "a.example.com")
+				.body(Body::empty())
+				.unwrap(),
+		)
+		.await
+		.unwrap();
+	assert_eq!(res.status(), 200);
+
+	t.pi.stores.binds.write().insert_listener(
+		Listener {
+			key: LISTENER_KEY,
+			name: Default::default(),
+			hostname: strng::new("*.example.com"),
+			protocol: ListenerProtocol::HTTPS(crate::types::agent::ServerTLSConfig::new_invalid()),
+		},
+		BIND_KEY,
+	);
+
+	tokio::time::timeout(std::time::Duration::from_secs(1), async {
+		while !conn.is_finished() {
+			tokio::task::yield_now().await;
+		}
+	})
+	.await
+	.expect("connection should drain after listener change");
+
+	let res = sender
+		.send_request(
+			::http::Request::builder()
+				.method(Method::GET)
+				.uri("/existing")
+				.version(Version::HTTP_11)
+				.header(header::HOST, "a.example.com")
+				.body(Body::empty())
+				.unwrap(),
+		)
+		.await;
+	assert_matches!(res, Err(_));
+	let _ = conn.await;
+}
+
+#[tokio::test]
 async fn tls_backend_connection() {
 	let (mock, certs) = tls_mock().await;
 	let backend_tls = http::backendtls::ResolvedBackendTLS {

--- a/crates/agentgateway/src/proxy/gateway_test.rs
+++ b/crates/agentgateway/src/proxy/gateway_test.rs
@@ -1186,11 +1186,11 @@ async fn tls_connection_drains_when_listener_changes() {
 		BIND_KEY,
 	);
 
-	tokio::time::timeout(std::time::Duration::from_secs(1), async {
-		while !conn.is_finished() {
-			tokio::task::yield_now().await;
-		}
-	})
+	agent_core::test_helpers::check_eventually(
+		Duration::from_secs(1),
+		|| async { conn.is_finished() },
+		|b| *b,
+	)
 	.await
 	.expect("connection should drain after listener change");
 

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -642,7 +642,8 @@ impl HTTPProxy {
 		.await
 		.snapshot_on_err(log, &mut req)?;
 
-		Self::detect_misdirected(log, bind, &req, &selected_listener).snapshot_on_err(log, &mut req)?;
+		Self::detect_misdirected(log, &bind, &req, &selected_listener)
+			.snapshot_on_err(log, &mut req)?;
 
 		let selected_route_chain =
 			select_route_chain(&inputs, self.target_address, &selected_listener, &req)
@@ -957,9 +958,9 @@ impl HTTPProxy {
 
 	fn detect_misdirected(
 		log: &RequestLog,
-		bind: Arc<Bind>,
+		bind: &Bind,
 		req: &Request,
-		selected_listener: &Arc<Listener>,
+		selected_listener: &Listener,
 	) -> Result<(), ProxyError> {
 		if log.tls_info.is_none() {
 			// Only applicable for HTTPS

--- a/crates/agentgateway/src/proxy/mod.rs
+++ b/crates/agentgateway/src/proxy/mod.rs
@@ -4,6 +4,8 @@ pub mod proxy_protocol;
 pub mod request_builder;
 pub mod tcpproxy;
 
+use std::sync::Arc;
+
 use agent_pool::Error as HyperError;
 pub use gateway::Gateway;
 use rmcp::ErrorData;

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -31,6 +31,7 @@ use anyhow::Context;
 use futures_core::Stream;
 use hashbrown::{Equivalent, HashMap as HbHashMap};
 use itertools::Itertools;
+use tokio::sync::watch;
 use tracing::{Level, instrument, warn};
 
 #[derive(Debug)]
@@ -95,6 +96,8 @@ pub struct Store {
 	pending_listeners: HashMap<BindKey, HashMap<ListenerKey, Listener>>,
 	http_routes: HbHashMap<RouteTarget, Arc<RouteSet>>,
 	tcp_routes: HbHashMap<RouteTarget, Arc<TCPRouteSet>>,
+	listener_change_tx: watch::Sender<u64>,
+	listener_change_rx: watch::Receiver<u64>,
 
 	tx: tokio::sync::mpsc::UnboundedSender<BindEvent>,
 	rx: Option<tokio::sync::mpsc::UnboundedReceiver<BindEvent>>,
@@ -494,6 +497,7 @@ impl Store {
 
 	pub fn new(ipv6_enabled: bool, threading_mode: crate::ThreadingMode) -> Self {
 		let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+		let (listener_change_tx, listener_change_rx) = watch::channel(0);
 		Self {
 			ipv6_enabled,
 			core_ids: match threading_mode {
@@ -510,6 +514,8 @@ impl Store {
 			pending_listeners: Default::default(),
 			http_routes: Default::default(),
 			tcp_routes: Default::default(),
+			listener_change_tx,
+			listener_change_rx,
 			tx,
 			rx: Some(rx),
 		}
@@ -544,6 +550,45 @@ impl Store {
 			.cloned()
 	}
 
+	pub fn subscribe_listener_changes(&self) -> watch::Receiver<u64> {
+		self.listener_change_rx.clone()
+	}
+
+	pub fn get_bind_listener(&self, bind: &BindKey, listener: &ListenerKey) -> Option<Arc<Listener>> {
+		self
+			.binds
+			.get(bind)
+			.and_then(|bind| bind.listeners.inner.get(listener).cloned())
+	}
+
+	fn notify_listener_changed(&self) {
+		self
+			.listener_change_tx
+			.send_modify(|epoch| *epoch = epoch.saturating_add(1));
+	}
+
+	fn bind_listener_changed(old: &Bind, new: &Bind) -> bool {
+		for new_listener in new.listeners.iter() {
+			let Some(old_listener) = old.listeners.get(&new_listener.key) else {
+				// If a new listener is added, no need to notify
+				continue;
+			};
+			if old_listener != new_listener {
+				return true;
+			}
+		}
+		for old_listener in old.listeners.iter() {
+			let Some(new_listener) = new.listeners.get(&old_listener.key) else {
+				// If an old listener is removed, we do need to notify!
+				return true;
+			};
+			if old_listener != new_listener {
+				return true;
+			}
+		}
+		false
+	}
+
 	fn insert_http_route_target(&mut self, target: RouteTarget, route: Route) {
 		let routes = self
 			.http_routes
@@ -562,6 +607,7 @@ impl Store {
 
 	fn upsert_bind(&mut self, key: BindKey, mut bind: Bind) {
 		debug!(bind=%bind.key, "insert bind");
+		let old_bind = self.binds.get(&key).cloned();
 
 		for (_, listener) in self
 			.pending_listeners
@@ -584,6 +630,11 @@ impl Store {
 				},
 			}
 		};
+		if let Some(old_bind) = old_bind.as_deref()
+			&& Self::bind_listener_changed(old_bind, &bind)
+		{
+			self.notify_listener_changed();
+		}
 		self.binds.insert(key.clone(), Arc::new(bind.clone()));
 		if let Some(listeners) = listeners {
 			let _ = self.tx.send(BindEvent::Add(bind, listeners));

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -48,7 +48,7 @@ pub struct Bind {
 
 pub type BindKey = Strng;
 
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, Eq, PartialEq, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Listener {
 	pub key: ListenerKey,
@@ -71,7 +71,7 @@ impl Listener {
 
 type Alpns = Vec<Vec<u8>>;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 struct ServerTlsInputs {
 	cert_pem: Vec<u8>,
 	key_pem: Vec<u8>,
@@ -131,6 +131,12 @@ pub struct ServerTLSConfig {
 	/// Original strict verifier used when ALLOW_INSECURE_FALLBACK is enabled.
 	insecure_fallback_verifier: Option<Arc<dyn ClientCertVerifier>>,
 	per_profile_config: Arc<RwLock<HashMap<ServerTlsProfileKey, Arc<ServerConfig>>>>,
+}
+impl Eq for ServerTLSConfig {}
+impl PartialEq for ServerTLSConfig {
+	fn eq(&self, other: &Self) -> bool {
+		self.inputs == other.inputs
+	}
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EncodeLabelValue)]
@@ -426,7 +432,7 @@ pub fn parse_key(key: &[u8]) -> Result<PrivateKeyDer<'static>, anyhow::Error> {
 		_ => Err(anyhow!("unsupported key")),
 	}
 }
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, Eq, PartialEq, serde::Serialize)]
 pub enum ListenerProtocol {
 	/// HTTP
 	HTTP,


### PR DESCRIPTION
When a listener changes, active connections on that listener are closed. "Change" is detected by equality. The only real fields that can change, practically speaking, for a listener is TLS configs.