### PR TITLE
client: better error messages

### DIFF
--- a/crates/agentgateway/src/proxy/mod.rs
+++ b/crates/agentgateway/src/proxy/mod.rs
@@ -162,7 +162,7 @@ pub enum ProxyError {
 	BackendAuthenticationFailed(anyhow::Error),
 	#[error("parsing body: {0}")]
 	Body(http::Error),
-	#[error("upstream call failed: {0}")]
+	#[error("upstream call failed: {0:?}")]
 	UpstreamCallFailed(HyperError),
 	#[error("upstream call timeout")]
 	UpstreamCallTimeout,

--- a/crates/hyper-util-fork/src/client/legacy/client.rs
+++ b/crates/hyper-util-fork/src/client/legacy/client.rs
@@ -1455,12 +1455,16 @@ impl fmt::Debug for Builder {
 
 impl fmt::Debug for Error {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-		let mut f = f.debug_tuple("hyper_util::client::legacy::Error");
-		f.field(&self.kind);
 		if let Some(ref cause) = self.source {
-			f.field(cause);
+			if let Some(he) = cause.downcast_ref::<hyper::Error>() {
+				if let Some(src) = he.source() {
+					return write!(f, "{:?}: {}: {}", self.kind, cause, src);
+				}
+			}
+			write!(f, "{:?}: {}", self.kind, cause)
+		} else {
+			write!(f, "{:?}", self.kind)
 		}
-		f.finish()
 	}
 }
 


### PR DESCRIPTION
Before/after
```
upstream call failed: SendRequest: user body write aborted
upstream call failed: SendRequest: user body write aborted: early end, expected 5 more bytes
```