### PR TITLE
test: add MCP level tests for extauth and ratelimit policies

### DIFF
--- a/crates/agentgateway/src/http/ext_proc_tests.rs
+++ b/crates/agentgateway/src/http/ext_proc_tests.rs
@@ -17,9 +17,10 @@ use crate::http::ext_proc::proto::{
 };
 use crate::http::ext_proc::{ExtProcDynamicMetadata, proto};
 use crate::http::{Body, ext_proc};
+use crate::test_helpers::MockInstance;
 use crate::test_helpers::extprocmock::{
-	ExtProcMock, ExtProcMockInstance, Handler, immediate_response, request_body_response,
-	request_header_response, response_body_response, response_header_response,
+	ExtProcMock, Handler, immediate_response, request_body_response, request_header_response,
+	response_body_response, response_header_response,
 };
 use crate::test_helpers::proxymock::*;
 use crate::*;
@@ -207,7 +208,7 @@ pub async fn setup_ext_proc_mock<T: Handler + Send + Sync + 'static>(
 	config: &str,
 ) -> (
 	MockServer,
-	ExtProcMockInstance,
+	MockInstance,
 	TestBind,
 	Client<MemoryConnector, Body>,
 ) {
@@ -224,7 +225,7 @@ pub async fn setup_ext_proc_mock_with_meta<T: Handler + Send + Sync + 'static>(
 	response_attributes: Option<HashMap<String, Arc<Expression>>>,
 ) -> (
 	MockServer,
-	ExtProcMockInstance,
+	MockInstance,
 	TestBind,
 	Client<MemoryConnector, Body>,
 ) {

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -2278,3 +2278,80 @@ async fn try_mcp_streamable_client(
 
 	client_info.serve(transport).await
 }
+
+#[tokio::test]
+async fn mcp_remote_ratelimit_deny() {
+	use protos::envoy::service::ratelimit::v3::rate_limit_service_server::{
+		RateLimitService, RateLimitServiceServer,
+	};
+	use protos::envoy::service::ratelimit::v3::{
+		RateLimitRequest, RateLimitResponse, rate_limit_response::Code,
+	};
+
+	// Mock rate limit server that always returns OVER_LIMIT
+	struct DenyAllRateLimit;
+
+	#[tonic::async_trait]
+	impl RateLimitService for DenyAllRateLimit {
+		async fn should_rate_limit(
+			&self,
+			_request: tonic::Request<RateLimitRequest>,
+		) -> Result<tonic::Response<RateLimitResponse>, tonic::Status> {
+			Ok(tonic::Response::new(RateLimitResponse {
+				overall_code: Code::OverLimit as i32,
+				statuses: vec![],
+				response_headers_to_add: vec![],
+				request_headers_to_add: vec![],
+				raw_body: b"rate limit exceeded by mock".to_vec(),
+				dynamic_metadata: None,
+				quota: None,
+			}))
+		}
+	}
+
+	// Start the mock gRPC server
+	let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+	let ratelimit_addr = listener.local_addr().unwrap();
+
+	tokio::spawn(async move {
+		let server = tonic::transport::Server::builder()
+			.add_service(RateLimitServiceServer::new(DenyAllRateLimit))
+			.serve_with_incoming(tokio_stream::wrappers::TcpListenerStream::new(listener));
+		let _ = server.await;
+	});
+
+	// Small delay to ensure server is ready
+	tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+	let mock = mock_streamable_http_server(true).await;
+	let mut t = setup_proxy_test("{}")
+		.unwrap()
+		.with_mcp_backend(mock.addr, true, false)
+		.with_bind(simple_bind(basic_route(mock.addr)));
+
+	// Attach remoteRateLimit policy pointing to our mock server
+	t.attach_route_policy(serde_json::json!({
+		"remoteRateLimit": {
+			"host": ratelimit_addr.to_string(),
+			"domain": "test",
+			"descriptors": [{
+				"entries": [
+					{"key": "generic_key", "value": "\"test\""}
+				],
+				"type": "requests"
+			}]
+		}
+	}))
+	.await;
+
+	let io = t.serve_real_listener(BIND_KEY).await;
+
+	// Client should fail to initialize due to rate limit denial
+	let result = try_mcp_streamable_client(io).await;
+	let err = result.expect_err("Client initialization should be rate limited");
+	let err_msg = err.to_string();
+	assert!(
+		err_msg.contains("429") && err_msg.contains("rate limit exceeded by mock"),
+		"Expected 429 rate limit from remote service, got: {err_msg}"
+	);
+}

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -2254,9 +2254,11 @@ async fn mcp_extauth_deny() {
 
 	// Client should fail to initialize due to ext_authz denial
 	let result = try_mcp_streamable_client(io).await;
+	let err = result.expect_err("Client initialization should be denied by ext_authz");
+	let err_msg = err.to_string();
 	assert!(
-		result.is_err(),
-		"Client initialization should be denied by ext_authz"
+		err_msg.contains("403") && err_msg.contains("denied by mock ext_authz"),
+		"Expected 403 denial from ext_authz, got: {err_msg}"
 	);
 }
 

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -17,9 +17,11 @@ use crate::mcp::McpAuthorization;
 use crate::mcp::handler::Relay;
 use crate::mcp::router::{McpBackendGroup, McpTarget};
 use crate::proxy::httpproxy::PolicyClient;
+use crate::test_helpers::extauthmock::{ExtAuthMock, deny_response};
 use crate::test_helpers::proxymock::{
 	BIND_KEY, TestBind, basic_named_route, basic_route, setup_proxy_test, simple_bind,
 };
+use crate::test_helpers::ratelimitmock::{RateLimitMock, over_limit_response};
 use crate::types::agent::{BackendPolicy, FrontendPolicy, PolicyTarget, TargetedPolicy};
 use crate::*;
 
@@ -2181,62 +2183,22 @@ async fn mcp_local_ratelimit() {
 
 #[tokio::test]
 async fn mcp_extauth_deny() {
-	use protos::envoy::service::auth::v3::authorization_server::{
-		Authorization, AuthorizationServer,
-	};
-	use protos::envoy::service::auth::v3::{CheckRequest, CheckResponse, DeniedHttpResponse};
-	use protos::envoy::service::common::v3::{HttpStatus, StatusCode};
-
-	// Mock ext_authz server that denies all requests
 	struct DenyAllAuthz;
 
-	#[tonic::async_trait]
-	impl Authorization for DenyAllAuthz {
+	#[async_trait::async_trait]
+	impl crate::test_helpers::extauthmock::Handler for DenyAllAuthz {
 		async fn check(
-			&self,
-			_request: tonic::Request<CheckRequest>,
-		) -> Result<tonic::Response<CheckResponse>, tonic::Status> {
-			Ok(tonic::Response::new(CheckResponse {
-				// Status code 7 = PERMISSION_DENIED
-				status: Some(protos::envoy::service::common::v3::Status {
-					code: 7,
-					message: "denied".to_string(),
-					details: vec![],
-				}),
-				http_response: Some(
-					protos::envoy::service::auth::v3::check_response::HttpResponse::DeniedResponse(
-						DeniedHttpResponse {
-							status: Some(HttpStatus {
-								code: StatusCode::Forbidden as i32,
-							}),
-							headers: vec![],
-							body: "denied by mock ext_authz".to_string(),
-						},
-					),
-				),
-				dynamic_metadata: None,
-			}))
+			&mut self,
+			_request: &crate::http::ext_authz::proto::CheckRequest,
+		) -> Result<crate::http::ext_authz::proto::CheckResponse, tonic::Status> {
+			deny_response(
+				crate::http::ext_authz::proto::StatusCode::Forbidden,
+				"denied by mock ext_authz",
+			)
 		}
 	}
 
-	// Start the mock gRPC server
-	let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-	let authz_addr = listener.local_addr().unwrap();
-
-	tokio::spawn(async move {
-		let server = tonic::transport::Server::builder()
-			.add_service(AuthorizationServer::new(DenyAllAuthz))
-			.serve_with_incoming(tokio_stream::wrappers::TcpListenerStream::new(listener));
-		let _ = server.await;
-	});
-
-	// Wait for server to be ready (probe until connection succeeds)
-	for _ in 0..50 {
-		if tokio::net::TcpStream::connect(authz_addr).await.is_ok() {
-			break;
-		}
-		tokio::time::sleep(std::time::Duration::from_millis(1)).await;
-	}
+	let authz = ExtAuthMock::new(|| DenyAllAuthz).spawn().await;
 
 	let mock = mock_streamable_http_server(true).await;
 	let mut t = setup_proxy_test("{}")
@@ -2247,7 +2209,7 @@ async fn mcp_extauth_deny() {
 	// Attach extAuthz policy pointing to our mock server
 	t.attach_route_policy(serde_json::json!({
 		"extAuthz": {
-			"host": authz_addr.to_string(),
+			"host": authz.address.to_string(),
 			"protocol": {
 				"grpc": {}
 			}
@@ -2286,52 +2248,19 @@ async fn try_mcp_streamable_client(
 
 #[tokio::test]
 async fn mcp_remote_ratelimit_deny() {
-	use protos::envoy::service::ratelimit::v3::rate_limit_service_server::{
-		RateLimitService, RateLimitServiceServer,
-	};
-	use protos::envoy::service::ratelimit::v3::{
-		RateLimitRequest, RateLimitResponse, rate_limit_response::Code,
-	};
-
-	// Mock rate limit server that always returns OVER_LIMIT
 	struct DenyAllRateLimit;
 
-	#[tonic::async_trait]
-	impl RateLimitService for DenyAllRateLimit {
+	#[async_trait::async_trait]
+	impl crate::test_helpers::ratelimitmock::Handler for DenyAllRateLimit {
 		async fn should_rate_limit(
-			&self,
-			_request: tonic::Request<RateLimitRequest>,
-		) -> Result<tonic::Response<RateLimitResponse>, tonic::Status> {
-			Ok(tonic::Response::new(RateLimitResponse {
-				overall_code: Code::OverLimit as i32,
-				statuses: vec![],
-				response_headers_to_add: vec![],
-				request_headers_to_add: vec![],
-				raw_body: b"rate limit exceeded by mock".to_vec(),
-				dynamic_metadata: None,
-				quota: None,
-			}))
+			&mut self,
+			_request: &crate::http::remoteratelimit::proto::RateLimitRequest,
+		) -> Result<crate::http::remoteratelimit::proto::RateLimitResponse, tonic::Status> {
+			over_limit_response(b"rate limit exceeded by mock".to_vec())
 		}
 	}
 
-	// Start the mock gRPC server
-	let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-	let ratelimit_addr = listener.local_addr().unwrap();
-
-	tokio::spawn(async move {
-		let server = tonic::transport::Server::builder()
-			.add_service(RateLimitServiceServer::new(DenyAllRateLimit))
-			.serve_with_incoming(tokio_stream::wrappers::TcpListenerStream::new(listener));
-		let _ = server.await;
-	});
-
-	// Wait for server to be ready (probe until connection succeeds)
-	for _ in 0..50 {
-		if tokio::net::TcpStream::connect(ratelimit_addr).await.is_ok() {
-			break;
-		}
-		tokio::time::sleep(std::time::Duration::from_millis(1)).await;
-	}
+	let ratelimit = RateLimitMock::new(|| DenyAllRateLimit).spawn().await;
 
 	let mock = mock_streamable_http_server(true).await;
 	let mut t = setup_proxy_test("{}")
@@ -2342,7 +2271,7 @@ async fn mcp_remote_ratelimit_deny() {
 	// Attach remoteRateLimit policy pointing to our mock server
 	t.attach_route_policy(serde_json::json!({
 		"remoteRateLimit": {
-			"host": ratelimit_addr.to_string(),
+			"host": ratelimit.address.to_string(),
 			"domain": "test",
 			"descriptors": [{
 				"entries": [

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -2230,8 +2230,13 @@ async fn mcp_extauth_deny() {
 		let _ = server.await;
 	});
 
-	// Small delay to ensure server is ready
-	tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+	// Wait for server to be ready (probe until connection succeeds)
+	for _ in 0..50 {
+		if tokio::net::TcpStream::connect(authz_addr).await.is_ok() {
+			break;
+		}
+		tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+	}
 
 	let mock = mock_streamable_http_server(true).await;
 	let mut t = setup_proxy_test("{}")
@@ -2320,8 +2325,13 @@ async fn mcp_remote_ratelimit_deny() {
 		let _ = server.await;
 	});
 
-	// Small delay to ensure server is ready
-	tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+	// Wait for server to be ready (probe until connection succeeds)
+	for _ in 0..50 {
+		if tokio::net::TcpStream::connect(ratelimit_addr).await.is_ok() {
+			break;
+		}
+		tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+	}
 
 	let mock = mock_streamable_http_server(true).await;
 	let mut t = setup_proxy_test("{}")

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -2127,3 +2127,152 @@ async fn test_runtime_fanout_fail_open_all_fail() {
 		res.err()
 	);
 }
+
+#[tokio::test]
+async fn mcp_local_ratelimit() {
+	let mock = mock_streamable_http_server(true).await;
+	let mut t = setup_proxy_test("{}")
+		.unwrap()
+		.with_mcp_backend(mock.addr, true, false)
+		.with_bind(simple_bind(basic_route(mock.addr)));
+
+	// Attach local rate limit policy
+	// MCP protocol overhead: initialize + notification + SSE GET = 3 requests
+	// Allow 5 total: overhead (3) + tool calls (2), then rate limit the 6th
+	t.attach_route_policy(serde_json::json!({
+		"localRateLimit": [{
+			"maxTokens": 5,
+			"tokensPerFill": 1,
+			"fillInterval": "10s",
+			"type": "requests"
+		}]
+	}))
+	.await;
+
+	let io = t.serve_real_listener(BIND_KEY).await;
+	let client = mcp_streamable_client(io).await;
+
+	// First two calls should succeed
+	let result1 = client
+		.call_tool(
+			rmcp::model::CallToolRequestParams::new("echo")
+				.with_arguments(serde_json::json!({"n": 1}).as_object().cloned().unwrap()),
+		)
+		.await;
+	assert!(result1.is_ok(), "First request should succeed");
+
+	let result2 = client
+		.call_tool(
+			rmcp::model::CallToolRequestParams::new("echo")
+				.with_arguments(serde_json::json!({"n": 2}).as_object().cloned().unwrap()),
+		)
+		.await;
+	assert!(result2.is_ok(), "Second request should succeed");
+
+	// Third call should be rate limited
+	let result3 = client
+		.call_tool(
+			rmcp::model::CallToolRequestParams::new("echo")
+				.with_arguments(serde_json::json!({"n": 3}).as_object().cloned().unwrap()),
+		)
+		.await;
+	assert!(result3.is_err(), "Third request should be rate limited");
+}
+
+#[tokio::test]
+async fn mcp_extauth_deny() {
+	use protos::envoy::service::auth::v3::authorization_server::{
+		Authorization, AuthorizationServer,
+	};
+	use protos::envoy::service::auth::v3::{CheckRequest, CheckResponse, DeniedHttpResponse};
+	use protos::envoy::service::common::v3::{HttpStatus, StatusCode};
+
+	// Mock ext_authz server that denies all requests
+	struct DenyAllAuthz;
+
+	#[tonic::async_trait]
+	impl Authorization for DenyAllAuthz {
+		async fn check(
+			&self,
+			_request: tonic::Request<CheckRequest>,
+		) -> Result<tonic::Response<CheckResponse>, tonic::Status> {
+			Ok(tonic::Response::new(CheckResponse {
+				// Status code 7 = PERMISSION_DENIED
+				status: Some(protos::envoy::service::common::v3::Status {
+					code: 7,
+					message: "denied".to_string(),
+					details: vec![],
+				}),
+				http_response: Some(
+					protos::envoy::service::auth::v3::check_response::HttpResponse::DeniedResponse(
+						DeniedHttpResponse {
+							status: Some(HttpStatus {
+								code: StatusCode::Forbidden as i32,
+							}),
+							headers: vec![],
+							body: "denied by mock ext_authz".to_string(),
+						},
+					),
+				),
+				dynamic_metadata: None,
+			}))
+		}
+	}
+
+	// Start the mock gRPC server
+	let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+	let authz_addr = listener.local_addr().unwrap();
+
+	tokio::spawn(async move {
+		let server = tonic::transport::Server::builder()
+			.add_service(AuthorizationServer::new(DenyAllAuthz))
+			.serve_with_incoming(tokio_stream::wrappers::TcpListenerStream::new(listener));
+		let _ = server.await;
+	});
+
+	// Small delay to ensure server is ready
+	tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+	let mock = mock_streamable_http_server(true).await;
+	let mut t = setup_proxy_test("{}")
+		.unwrap()
+		.with_mcp_backend(mock.addr, true, false)
+		.with_bind(simple_bind(basic_route(mock.addr)));
+
+	// Attach extAuthz policy pointing to our mock server
+	t.attach_route_policy(serde_json::json!({
+		"extAuthz": {
+			"host": authz_addr.to_string(),
+			"protocol": {
+				"grpc": {}
+			}
+		}
+	}))
+	.await;
+
+	let io = t.serve_real_listener(BIND_KEY).await;
+
+	// Client should fail to initialize due to ext_authz denial
+	let result = try_mcp_streamable_client(io).await;
+	assert!(
+		result.is_err(),
+		"Client initialization should be denied by ext_authz"
+	);
+}
+
+async fn try_mcp_streamable_client(
+	s: SocketAddr,
+) -> Result<RunningService<RoleClient, InitializeRequestParams>, rmcp::service::ClientInitializeError>
+{
+	use rmcp::ServiceExt;
+	use rmcp::model::{ClientCapabilities, ClientInfo, Implementation};
+	use rmcp::transport::StreamableHttpClientTransport;
+	let transport =
+		StreamableHttpClientTransport::<reqwest::Client>::from_uri(format!("http://{s}/mcp"));
+	let client_info = ClientInfo::new(
+		ClientCapabilities::default(),
+		Implementation::new("test client".to_string(), "0.0.1".to_string()),
+	);
+
+	client_info.serve(transport).await
+}

--- a/crates/agentgateway/src/test_helpers/extauthmock.rs
+++ b/crates/agentgateway/src/test_helpers/extauthmock.rs
@@ -1,0 +1,92 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tonic::{Request, Response as TonicResponse, Status};
+
+use crate::http::ext_authz::proto::authorization_server::{Authorization, AuthorizationServer};
+use crate::http::ext_authz::proto::check_response::HttpResponse;
+use crate::http::ext_authz::proto::{self, CheckRequest, CheckResponse, DeniedHttpResponse};
+
+pub fn allow_response(http_response: Option<HttpResponse>) -> Result<CheckResponse, Status> {
+	Ok(CheckResponse {
+		status: Some(proto::Status {
+			code: 0,
+			message: String::new(),
+			details: vec![],
+		}),
+		http_response,
+		dynamic_metadata: None,
+	})
+}
+
+pub fn deny_response(
+	status_code: proto::StatusCode,
+	body: impl Into<String>,
+) -> Result<CheckResponse, Status> {
+	Ok(CheckResponse {
+		status: Some(proto::Status {
+			code: 7,
+			message: "denied".to_string(),
+			details: vec![],
+		}),
+		http_response: Some(HttpResponse::DeniedResponse(DeniedHttpResponse {
+			status: Some(proto::HttpStatus {
+				code: status_code as i32,
+			}),
+			headers: vec![],
+			body: body.into(),
+		})),
+		dynamic_metadata: None,
+	})
+}
+
+#[async_trait]
+pub trait Handler {
+	async fn check(&mut self, _request: &CheckRequest) -> Result<CheckResponse, Status> {
+		allow_response(None)
+	}
+}
+
+/// Mock ext_authz server for testing
+pub struct ExtAuthMock<T> {
+	handler: Arc<dyn Fn() -> T + Send + Sync + 'static>,
+}
+
+impl<T> Clone for ExtAuthMock<T> {
+	fn clone(&self) -> Self {
+		Self {
+			handler: self.handler.clone(),
+		}
+	}
+}
+
+impl<T> ExtAuthMock<T>
+where
+	T: Handler + Send + Sync + 'static,
+{
+	pub fn new(handler: impl Fn() -> T + Send + Sync + 'static) -> Self {
+		Self {
+			handler: Arc::new(handler),
+		}
+	}
+
+	pub async fn spawn(&self) -> super::common::MockInstance {
+		let srv = AuthorizationServer::new(self.clone());
+		super::common::spawn_service(srv).await
+	}
+}
+
+#[tonic::async_trait]
+impl<T> Authorization for ExtAuthMock<T>
+where
+	T: Handler + Send + Sync + 'static,
+{
+	async fn check(
+		&self,
+		request: Request<CheckRequest>,
+	) -> Result<TonicResponse<CheckResponse>, Status> {
+		let mut handler = (self.handler.clone())();
+		let response = handler.check(request.get_ref()).await?;
+		Ok(TonicResponse::new(response))
+	}
+}

--- a/crates/agentgateway/src/test_helpers/extprocmock.rs
+++ b/crates/agentgateway/src/test_helpers/extprocmock.rs
@@ -2,13 +2,13 @@ use crate::http::ext_proc::proto::external_processor_server::{
 	ExternalProcessor, ExternalProcessorServer,
 };
 use crate::http::ext_proc::proto::{
-	self, processing_request, processing_response, CommonResponse, HttpHeaders, HttpTrailers,
-	ProcessingRequest, ProcessingResponse,
+	self, CommonResponse, HttpHeaders, HttpTrailers, ProcessingRequest, ProcessingResponse,
+	processing_request, processing_response,
 };
 use crate::test_helpers::common::MockInstance;
 use crate::*;
 use async_trait::async_trait;
-use protos::envoy::service::ext_proc::v3::{body_mutation, BodyMutation};
+use protos::envoy::service::ext_proc::v3::{BodyMutation, body_mutation};
 use std::sync::Arc;
 use tokio::sync::mpsc;
 use tokio_stream;

--- a/crates/agentgateway/src/test_helpers/extprocmock.rs
+++ b/crates/agentgateway/src/test_helpers/extprocmock.rs
@@ -1,18 +1,16 @@
-use std::net::SocketAddr;
-use std::sync::Arc;
-
 use crate::http::ext_proc::proto::external_processor_server::{
 	ExternalProcessor, ExternalProcessorServer,
 };
 use crate::http::ext_proc::proto::{
-	self, CommonResponse, HttpHeaders, HttpTrailers, ProcessingRequest, ProcessingResponse,
-	processing_request, processing_response,
+	self, processing_request, processing_response, CommonResponse, HttpHeaders, HttpTrailers,
+	ProcessingRequest, ProcessingResponse,
 };
+use crate::test_helpers::common::MockInstance;
 use crate::*;
 use async_trait::async_trait;
-use protos::envoy::service::ext_proc::v3::{BodyMutation, body_mutation};
+use protos::envoy::service::ext_proc::v3::{body_mutation, BodyMutation};
+use std::sync::Arc;
 use tokio::sync::mpsc;
-use tokio::task::JoinHandle;
 use tokio_stream;
 use tonic::{Request, Response as TonicResponse, Status, Streaming};
 
@@ -170,17 +168,6 @@ pub struct ExtProcMock<T> {
 	handler: Arc<dyn Fn() -> T + Send + Sync + 'static>,
 }
 
-pub struct ExtProcMockInstance {
-	pub address: SocketAddr,
-	handle: JoinHandle<()>,
-}
-
-impl Drop for ExtProcMockInstance {
-	fn drop(&mut self) {
-		self.handle.abort();
-	}
-}
-
 impl<T> Clone for ExtProcMock<T> {
 	fn clone(&self) -> Self {
 		Self {
@@ -200,33 +187,9 @@ where
 		}
 	}
 
-	pub async fn spawn(&self) -> ExtProcMockInstance {
-		use hyper::server::conn::http2;
-		let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-
-		let addr = listener.local_addr().unwrap();
-		let s: ExtProcMock<T> = self.clone();
-		let srv = ExternalProcessorServer::new(s);
-		let task = tokio::spawn(async move {
-			while let Ok((socket, _)) = listener.accept().await {
-				let srv = srv.clone();
-				tokio::spawn(async move {
-					if let Err(err) = http2::Builder::new(::hyper_util::rt::TokioExecutor::new())
-						.serve_connection(
-							hyper_util::rt::TokioIo::new(socket),
-							super::hyper_tower::TowerToHyperService::new(srv),
-						)
-						.await
-					{
-						error!("Error serving connection: {:?}", err);
-					}
-				});
-			}
-		});
-		ExtProcMockInstance {
-			address: addr,
-			handle: task,
-		}
+	pub async fn spawn(&self) -> MockInstance {
+		let srv = ExternalProcessorServer::new(self.clone());
+		super::common::spawn_service(srv).await
 	}
 }
 

--- a/crates/agentgateway/src/test_helpers/mod.rs
+++ b/crates/agentgateway/src/test_helpers/mod.rs
@@ -1,4 +1,61 @@
+pub mod extauthmock;
 pub mod extprocmock;
 mod hyper_tower;
 #[cfg(any(test, feature = "internal_benches"))]
 pub mod proxymock;
+pub mod ratelimitmock;
+pub use common::MockInstance;
+
+mod common {
+	use hyper::server::conn::http2;
+	use std::net::SocketAddr;
+	use tokio::task::JoinHandle;
+	use tonic::body::Body;
+	use tower::BoxError;
+	use tracing::error;
+
+	pub struct MockInstance {
+		pub address: SocketAddr,
+		handle: JoinHandle<()>,
+	}
+
+	impl Drop for MockInstance {
+		fn drop(&mut self) {
+			self.handle.abort();
+		}
+	}
+
+	pub async fn spawn_service<S>(srv: S) -> MockInstance
+	where
+		S: tower::Service<hyper::Request<Body>, Response = http::Response<Body>>
+			+ Clone
+			+ Send
+			+ Sync
+			+ 'static,
+		S::Future: Send + 'static,
+		S::Error: Into<BoxError> + 'static,
+	{
+		let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+		let addr = listener.local_addr().unwrap();
+		let task = tokio::spawn(async move {
+			while let Ok((socket, _)) = listener.accept().await {
+				let srv = srv.clone();
+				tokio::spawn(async move {
+					if let Err(err) = http2::Builder::new(::hyper_util::rt::TokioExecutor::new())
+						.serve_connection(
+							hyper_util::rt::TokioIo::new(socket),
+							super::hyper_tower::TowerToHyperService::new(srv),
+						)
+						.await
+					{
+						error!("Error serving connection: {:?}", err);
+					}
+				});
+			}
+		});
+		MockInstance {
+			address: addr,
+			handle: task,
+		}
+	}
+}

--- a/crates/agentgateway/src/test_helpers/ratelimitmock.rs
+++ b/crates/agentgateway/src/test_helpers/ratelimitmock.rs
@@ -1,0 +1,88 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tonic::{Request, Response as TonicResponse, Status};
+
+use crate::http::remoteratelimit::proto::rate_limit_response::Code;
+use crate::http::remoteratelimit::proto::rate_limit_service_server::{
+	RateLimitService, RateLimitServiceServer,
+};
+use crate::http::remoteratelimit::proto::{RateLimitRequest, RateLimitResponse};
+
+pub fn ok_response() -> Result<RateLimitResponse, Status> {
+	Ok(RateLimitResponse {
+		overall_code: Code::Ok as i32,
+		statuses: vec![],
+		response_headers_to_add: vec![],
+		request_headers_to_add: vec![],
+		raw_body: vec![],
+		dynamic_metadata: None,
+		quota: None,
+	})
+}
+
+pub fn over_limit_response(raw_body: impl Into<Vec<u8>>) -> Result<RateLimitResponse, Status> {
+	Ok(RateLimitResponse {
+		overall_code: Code::OverLimit as i32,
+		statuses: vec![],
+		response_headers_to_add: vec![],
+		request_headers_to_add: vec![],
+		raw_body: raw_body.into(),
+		dynamic_metadata: None,
+		quota: None,
+	})
+}
+
+#[async_trait]
+pub trait Handler {
+	async fn should_rate_limit(
+		&mut self,
+		_request: &RateLimitRequest,
+	) -> Result<RateLimitResponse, Status> {
+		ok_response()
+	}
+}
+
+/// Mock remote ratelimit server for testing
+pub struct RateLimitMock<T> {
+	handler: Arc<dyn Fn() -> T + Send + Sync + 'static>,
+}
+
+impl<T> Clone for RateLimitMock<T> {
+	fn clone(&self) -> Self {
+		Self {
+			handler: self.handler.clone(),
+		}
+	}
+}
+
+impl<T> RateLimitMock<T>
+where
+	T: Handler + Send + Sync + 'static,
+{
+	pub fn new(handler: impl Fn() -> T + Send + Sync + 'static) -> Self {
+		Self {
+			handler: Arc::new(handler),
+		}
+	}
+
+	pub async fn spawn(&self) -> super::common::MockInstance {
+		let srv = RateLimitServiceServer::new(self.clone());
+		super::common::spawn_service(srv).await
+	}
+}
+
+#[tonic::async_trait]
+impl<T> RateLimitService for RateLimitMock<T>
+where
+	T: Handler + Send + Sync + 'static,
+{
+	async fn should_rate_limit(
+		&self,
+		request: Request<RateLimitRequest>,
+	) -> Result<TonicResponse<RateLimitResponse>, Status> {
+		let mut handler = (self.handler.clone())();
+		let response = handler.should_rate_limit(request.get_ref()).await?;
+		Ok(TonicResponse::new(response))
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `mcp_local_ratelimit` test to verify local rate limiting works with MCP backends
- Adds `mcp_extauth_deny` test to verify external authorization denial works with MCP backends
- Adds `mcp_remote_ratelimit_deny` test to verify remote rate limiting works with MCP backends

All three tests use mock gRPC servers where applicable and validate that policy enforcement correctly propagates through the MCP protocol layer.

Closes #554