### PR TITLE
Fix make run: no v prefix

### DIFF
--- a/controller/Makefile
+++ b/controller/Makefile
@@ -497,11 +497,11 @@ release-charts: package-agentgateway-charts
 
 .PHONY: deploy-agentgateway-crd-chart
 deploy-agentgateway-crd-chart: ## Deploy the agentgateway crd chart
-	$(HELM) upgrade --install agentgateway-crds $(TEST_ASSET_DIR)/agentgateway-crds-$(VERSION).tgz --namespace $(INSTALL_NAMESPACE) --create-namespace
+	$(HELM) upgrade --install agentgateway-crds $(TEST_ASSET_DIR)/agentgateway-crds-$(HELM_CHART_VERSION_NO_V).tgz --namespace $(INSTALL_NAMESPACE) --create-namespace
 
 .PHONY: deploy-agentgateway-chart
 deploy-agentgateway-chart: ## Deploy the agentgateway chart
-	$(HELM) upgrade --install agentgateway $(TEST_ASSET_DIR)/agentgateway-$(VERSION).tgz \
+	$(HELM) upgrade --install agentgateway $(TEST_ASSET_DIR)/agentgateway-$(HELM_CHART_VERSION_NO_V).tgz \
 	--namespace $(INSTALL_NAMESPACE) --create-namespace \
 	--set image.registry=$(IMAGE_REGISTRY) \
 	--set image.tag=$(VERSION) \


### PR DESCRIPTION
Found an issue with the helm version `make run` when checking https://github.com/agentgateway/agentgateway/issues/1115 was fixed.

```
Error: path "agentgateway/controller/_test/agentgateway-crds-v1.0.1-dev.tgz" not found                                                                                                
make: *** [Makefile:500: deploy-agentgateway-crd-chart] Error 1 
```

The deploy targets were using `$(VERSION)` (which is `v1.0.1-dev`) but the package targets create files using `$(HELM_CHART_VERSION_NO_V)` (which is `1.0.1-dev` - without the "v" prefix). `make run` now uses the correct version. 
                                     