### PR TITLE
cleanup logging: executor is now cheap

### DIFF
--- a/crates/agentgateway/src/cel/types.rs
+++ b/crates/agentgateway/src/cel/types.rs
@@ -312,13 +312,13 @@ impl<'a> Executor<'a> {
 	}
 	pub fn new_tcp_logger(
 		source_context: Option<&'a SourceContext>,
-		end_time: Option<&'a RequestTime>,
+		end_time: &'a RequestTime,
 	) -> Self {
 		let mut this = Self::new_empty();
 		// For TCP connections, set the source context directly
 		this.source = ExtensionOrDirect::Direct(source_context);
 		if let Some(f) = this.request.as_mut() {
-			f.end_time = end_time;
+			f.end_time = Some(end_time);
 		}
 		this
 	}

--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -402,10 +402,7 @@ impl CelLogging {
 		&mut self.cel_context
 	}
 
-	pub fn build<'a>(
-		&'a self,
-		inputs: CelLoggingBuildInputs<'a>,
-	) -> Result<CelLoggingExecutor<'a>, cel::Error> {
+	pub fn build<'a>(&'a self, inputs: CelLoggingBuildInputs<'a>) -> CelLoggingExecutor<'a> {
 		let CelLogging {
 			cel_context: _,
 			filter,
@@ -422,15 +419,15 @@ impl CelLogging {
 				inputs.resp,
 				inputs.llm_response,
 				inputs.mcp,
-				inputs.end_time,
+				Some(inputs.end_time),
 			)
 		};
-		Ok(CelLoggingExecutor {
+		CelLoggingExecutor {
 			executor,
 			filter,
 			fields,
 			metric_fields,
-		})
+		}
 	}
 }
 
@@ -439,7 +436,7 @@ pub struct CelLoggingBuildInputs<'a> {
 	pub resp: Option<&'a cel::ResponseSnapshot>,
 	pub llm_response: Option<&'a LLMContext>,
 	pub mcp: Option<&'a MCPInfo>,
-	pub end_time: Option<&'a cel::RequestTime>,
+	pub end_time: &'a cel::RequestTime,
 	pub source_context: Option<&'a cel::SourceContext>,
 }
 
@@ -464,7 +461,7 @@ impl DropOnLog {
 	/// Computes (health, eviction_duration, restore_health) for finish_request.
 	/// `unhealthy` should already be evaluated (preferably with the shared CEL executor when available).
 	/// When no CEL expression is set, the default treats 4xx, 5xx, or connection failures as unhealthy.
-	fn eviction_unhealthy(log: &RequestLog, cel_exec: Option<&CelLoggingExecutor<'_>>) -> bool {
+	fn eviction_unhealthy(log: &RequestLog, cel_exec: &CelLoggingExecutor<'_>) -> bool {
 		let default_unhealthy = log.status.is_none_or(|s| s.is_server_error());
 		let Some(policy) = &log.health_policy else {
 			return default_unhealthy;
@@ -472,10 +469,7 @@ impl DropOnLog {
 		let Some(expr) = &policy.unhealthy_expression else {
 			return default_unhealthy;
 		};
-		match cel_exec {
-			Some(cel_exec) => cel_exec.executor.eval_bool(expr.as_ref()),
-			None => default_unhealthy,
-		}
+		cel_exec.executor.eval_bool(expr.as_ref())
 	}
 
 	/// Returns (health, eviction_duration, restore_health).
@@ -765,48 +759,30 @@ impl Drop for DropOnLog {
 			custom: CustomField::default(),
 		};
 
-		let enable_custom_metrics = !log.cel.metric_fields.add.is_empty();
-
 		// Always run request_handle/finish_request first so LLM provider eviction (failover) runs
 		// even when logging/tracing/metrics are disabled.
 		let end_time = Timestamp::now();
 		let duration = end_time.duration_since(&log.start);
 		let enable_trace = log.tracer.is_some();
-		// We will later check it also matches a filter, but filter is slower
-		let maybe_enable_log = agent_core::telemetry::enabled("request", &Level::INFO);
 
 		let llm_response = log.llm_response.take().map(Into::into);
 
 		let mcp = log.mcp_status.take();
 		let mcp_cel = mcp.as_ref().filter(|m| !m.is_empty());
-		let needs_cel_for_outputs = maybe_enable_log || enable_trace || enable_custom_metrics;
-		let needs_cel_for_eviction = log
-			.health_policy
-			.as_ref()
-			.is_some_and(|p| p.unhealthy_expression.is_some());
-		let cel_end_time = (needs_cel_for_outputs || needs_cel_for_eviction)
-			.then(|| cel::RequestTime(end_time.as_datetime()));
-		let cel_exec = if needs_cel_for_outputs || needs_cel_for_eviction {
-			log
-				.cel
-				.build(CelLoggingBuildInputs {
-					req: log.request_snapshot.as_ref(),
-					resp: log.response_snapshot.as_ref(),
-					llm_response: llm_response.as_ref(),
-					mcp: mcp_cel,
-					end_time: cel_end_time.as_ref(),
-					source_context: log.source_context.as_ref(),
-				})
-				.ok()
-		} else {
-			None
-		};
-
+		let cel_end_time = cel::RequestTime(end_time.as_datetime());
+		let cel_exec = log.cel.build(CelLoggingBuildInputs {
+			req: log.request_snapshot.as_ref(),
+			resp: log.response_snapshot.as_ref(),
+			llm_response: llm_response.as_ref(),
+			mcp: mcp_cel,
+			end_time: &cel_end_time,
+			source_context: log.source_context.as_ref(),
+		});
 		if let Some(rh) = log.request_handle.take() {
 			let current_health = rh.health_score();
 			let consecutive_failures = rh.consecutive_failures();
 			let times_ejected = rh.times_ejected();
-			let unhealthy = Self::eviction_unhealthy(&log, cel_exec.as_ref());
+			let unhealthy = Self::eviction_unhealthy(&log, &cel_exec);
 			let (health, eviction_duration, restore_health) = Self::eviction_decision(
 				&log,
 				current_health,
@@ -816,24 +792,6 @@ impl Drop for DropOnLog {
 			);
 			rh.finish_request(health, duration, eviction_duration, restore_health);
 		}
-		if !maybe_enable_log && !enable_trace && !enable_custom_metrics {
-			// Report our non-customized metrics
-			if !is_tcp {
-				log.metrics.requests.get_or_create(&http_labels).inc();
-				if let Some(retry_count) = log.retry_attempt {
-					log
-						.metrics
-						.retries
-						.get_or_create(&http_labels)
-						.inc_by(retry_count as u64);
-				}
-			}
-			return;
-		}
-		let Some(cel_exec) = cel_exec else {
-			tracing::warn!("failed to build CEL context");
-			return;
-		};
 
 		let custom_metric_fields = CustomField::new(
 			// For metrics, keep empty values which will become 'unknown'
@@ -903,6 +861,7 @@ impl Drop for DropOnLog {
 				.inc();
 		}
 
+		let maybe_enable_log = agent_core::telemetry::enabled("request", &Level::INFO);
 		let enable_logs = maybe_enable_log && cel_exec.eval_filter();
 		if !enable_logs && !enable_trace {
 			return;


### PR DESCRIPTION
Before it was super expensive to make this; now its ~free so we don't
need hacks to skip it.

Verified with a quick perf test + flamegraph