### PR TITLE
fix(controller): prevent phantom backend chains from attaching policies to missing targets

### DIFF
--- a/controller/pkg/agentgateway/plugins/interfaces.go
+++ b/controller/pkg/agentgateway/plugins/interfaces.go
@@ -28,18 +28,10 @@ type BackendPlugin struct {
 }
 
 type PolicyPlugin struct {
-	Build           func(PolicyPluginInput) (krt.StatusCollection[controllers.Object, any], krt.Collection[AgwPolicy])
+	Build func(PolicyPluginInput) (krt.StatusCollection[controllers.Object, any], krt.Collection[AgwPolicy])
+	// BuildReferences is called with the base ReferenceIndex (before PolicyAttachments)
+	// to avoid self-referential graph construction.
 	BuildReferences func(input PolicyPluginInput) krt.Collection[*PolicyAttachment]
-}
-
-// ApplyPolicies extracts all policies from the collection
-func (p *PolicyPlugin) ApplyPolicies(inputs PolicyPluginInput) (krt.Collection[AgwPolicy], krt.StatusCollection[controllers.Object, any], krt.Collection[*PolicyAttachment]) {
-	status, col := p.Build(inputs)
-	var refs krt.Collection[*PolicyAttachment]
-	if p.BuildReferences != nil {
-		refs = p.BuildReferences(inputs)
-	}
-	return col, status, refs
 }
 
 // AgwPolicy wraps an Agw policy for collection handling

--- a/controller/pkg/agentgateway/plugins/reference_indexes.go
+++ b/controller/pkg/agentgateway/plugins/reference_indexes.go
@@ -315,6 +315,21 @@ func (p ReferenceIndex) lookupGatewaysForBackend(ctx krt.HandlerContext, object 
 	return base
 }
 
+func IsBackendLikeTarget(policyTarget *api.PolicyTarget) bool {
+	return policyTarget.GetBackend() != nil || policyTarget.GetService() != nil
+}
+
+// TODO: PolicyAttachment and AncestorBackend are keyed by root object only (no port/section).
+// This means section-scoped targets (e.g. svc-a:9090 vs svc-a:8080) chain identically in the
+// recursive graph, causing over-attachment. A follow-up should add section-aware indexing to
+// support scoped recursive chaining without over-attachment.
+func (p ReferenceIndex) LookupGatewaysForPolicyTarget(ctx krt.HandlerContext, object utils.TypedNamespacedName, policyTarget *api.PolicyTarget) sets.Set[types.NamespacedName] {
+	if IsBackendLikeTarget(policyTarget) {
+		return p.LookupGatewaysForBackend(ctx, object)
+	}
+	return p.LookupGatewaysForTarget(ctx, object)
+}
+
 func (p ReferenceIndex) WithPolicyAttachments(references krt.IndexCollection[utils.TypedNamespacedName, *PolicyAttachment]) ReferenceIndex {
 	p.PolicyAttachments = references
 	return p

--- a/controller/pkg/agentgateway/plugins/testdata/backendpolicy/backend-chain-ancestor-backend.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/backendpolicy/backend-chain-ancestor-backend.yaml
@@ -5,7 +5,23 @@ metadata:
   namespace: default
 spec:
   static:
-    host: be.example.com
+    host: primary.example.com
+    port: 80
+  policies:
+    tunnel:
+      backendRef:
+        name: policy-be
+        group: agentgateway.dev
+        kind: AgentgatewayBackend
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayBackend
+metadata:
+  name: policy-be
+  namespace: default
+spec:
+  static:
+    host: policy.example.com
     port: 80
 ---
 apiVersion: agentgateway.dev/v1alpha1
@@ -15,17 +31,13 @@ metadata:
   namespace: default
 spec:
   targetRefs:
-    - kind: AgentgatewayBackend
-      name: be
-      group: agentgateway.dev
+  - kind: AgentgatewayBackend
+    name: policy-be
+    group: agentgateway.dev
   backend:
-    health:
-      unhealthyCondition: "response.code >= 500"
-      eviction:
-         duration: 60s
-         restoreHealth: 100
-         consecutiveFailures: 3
-         healthThreshold: 50
+    tls:
+      mtlsCertificateRef:
+        - name: mtls
 ---
 # Output
 output:
@@ -35,21 +47,15 @@ output:
   resource:
     policy:
       backend:
-        health:
-          eviction:
-            consecutiveFailures: 3
-            duration: 60s
-            healthThreshold: 0.5
-            restoreHealth: 1
-          unhealthyCondition: response.code >= 500
-      key: default/agw:health:default/be
+        backendTls: {}
+      key: default/agw:tls:default/policy-be
       name:
         kind: AgentgatewayPolicy
         name: agw
         namespace: default
       target:
         backend:
-          name: be
+          name: policy-be
           namespace: default
 status:
 - apiVersion: agentgateway.dev/v1alpha1
@@ -67,13 +73,8 @@ status:
         namespace: default
       conditions:
       - lastTransitionTime: fake
-        message: Policy accepted
-        reason: Valid
+        message: secret default/mtls not found
+        reason: PartiallyValid
         status: "True"
         type: Accepted
-      - lastTransitionTime: fake
-        message: Attached to all targets
-        reason: Attached
-        status: "True"
-        type: Attached
       controllerName: agentgateway.dev/agentgateway

--- a/controller/pkg/agentgateway/plugins/testdata/backendpolicy/policy-chain-existing-intermediate-target.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/backendpolicy/policy-chain-existing-intermediate-target.yaml
@@ -1,0 +1,153 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: via-existing
+  namespace: default
+spec:
+  parentRefs:
+    - name: test
+  rules:
+    - backendRefs:
+        - name: hop-be
+          group: agentgateway.dev
+          kind: AgentgatewayBackend
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayBackend
+metadata:
+  name: hop-be
+  namespace: default
+spec:
+  static:
+    host: hop.example.com
+    port: 80
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayBackend
+metadata:
+  name: policy-be
+  namespace: default
+spec:
+  static:
+    host: policy.example.com
+    port: 80
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: chain-source
+  namespace: default
+spec:
+  targetRefs:
+    - kind: AgentgatewayBackend
+      name: hop-be
+      group: agentgateway.dev
+  backend:
+    tunnel:
+      backendRef:
+        name: policy-be
+        group: agentgateway.dev
+        kind: AgentgatewayBackend
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: chain-target
+  namespace: default
+spec:
+  targetRefs:
+    - kind: AgentgatewayBackend
+      name: policy-be
+      group: agentgateway.dev
+  backend:
+    http:
+      version: HTTP2
+---
+# Output
+output:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
+    policy:
+      backend:
+        backendTunnel:
+          proxy:
+            backend: default/policy-be
+      key: default/chain-source:backend-tunnel:default/hop-be
+      name:
+        kind: AgentgatewayPolicy
+        name: chain-source
+        namespace: default
+      target:
+        backend:
+          name: hop-be
+          namespace: default
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
+    policy:
+      backend:
+        backendHttp:
+          version: HTTP2
+      key: default/chain-target:backend-http:default/policy-be
+      name:
+        kind: AgentgatewayPolicy
+        name: chain-target
+        namespace: default
+      target:
+        backend:
+          name: policy-be
+          namespace: default
+status:
+- apiVersion: agentgateway.dev/v1alpha1
+  kind: AgentgatewayPolicy
+  metadata:
+    name: chain-source
+    namespace: default
+  spec: null
+  status:
+    ancestors:
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: test
+        namespace: default
+      conditions:
+      - lastTransitionTime: fake
+        message: Policy accepted
+        reason: Valid
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: Attached to all targets
+        reason: Attached
+        status: "True"
+        type: Attached
+      controllerName: agentgateway.dev/agentgateway
+- apiVersion: agentgateway.dev/v1alpha1
+  kind: AgentgatewayPolicy
+  metadata:
+    name: chain-target
+    namespace: default
+  spec: null
+  status:
+    ancestors:
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: test
+        namespace: default
+      conditions:
+      - lastTransitionTime: fake
+        message: Policy accepted
+        reason: Valid
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: Attached to all targets
+        reason: Attached
+        status: "True"
+        type: Attached
+      controllerName: agentgateway.dev/agentgateway

--- a/controller/pkg/agentgateway/plugins/testdata/backendpolicy/policy-chain-missing-intermediate-target.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/backendpolicy/policy-chain-missing-intermediate-target.yaml
@@ -1,0 +1,105 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: via-missing
+  namespace: default
+spec:
+  parentRefs:
+    - name: test
+  rules:
+    - backendRefs:
+        - name: ghost
+          group: agentgateway.dev
+          kind: AgentgatewayBackend
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayBackend
+metadata:
+  name: policy-be
+  namespace: default
+spec:
+  static:
+    host: policy.example.com
+    port: 80
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: chain-source
+  namespace: default
+spec:
+  targetRefs:
+    - kind: AgentgatewayBackend
+      name: ghost
+      group: agentgateway.dev
+  backend:
+    tunnel:
+      backendRef:
+        name: policy-be
+        group: agentgateway.dev
+        kind: AgentgatewayBackend
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: chain-target
+  namespace: default
+spec:
+  targetRefs:
+    - kind: AgentgatewayBackend
+      name: policy-be
+      group: agentgateway.dev
+  backend:
+    http:
+      version: HTTP2
+---
+# Output
+output: []
+status:
+- apiVersion: agentgateway.dev/v1alpha1
+  kind: AgentgatewayPolicy
+  metadata:
+    name: chain-source
+    namespace: default
+  spec: null
+  status:
+    ancestors:
+    - ancestorRef:
+        group: agentgateway.dev
+        name: StatusSummary
+      conditions:
+      - lastTransitionTime: fake
+        message: Policy accepted
+        reason: Valid
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: 'Policy is not attached: AgentgatewayBackend default/ghost not found'
+        reason: Pending
+        status: "False"
+        type: Attached
+      controllerName: agentgateway.dev/agentgateway
+- apiVersion: agentgateway.dev/v1alpha1
+  kind: AgentgatewayPolicy
+  metadata:
+    name: chain-target
+    namespace: default
+  spec: null
+  status:
+    ancestors:
+    - ancestorRef:
+        group: agentgateway.dev
+        name: StatusSummary
+      conditions:
+      - lastTransitionTime: fake
+        message: Policy accepted
+        reason: Valid
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: 'Policy is not attached: AgentgatewayBackend default/policy-be is
+          not attached to any Gateway'
+        reason: Pending
+        status: "False"
+        type: Attached
+      controllerName: agentgateway.dev/agentgateway

--- a/controller/pkg/agentgateway/plugins/testdata/backendpolicy/policy-targets-missing-backend.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/backendpolicy/policy-targets-missing-backend.yaml
@@ -1,0 +1,47 @@
+# Policy targeting a non-existent backend should produce no output.
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: agw
+  namespace: default
+spec:
+  targetRefs:
+    - kind: AgentgatewayBackend
+      name: missing
+      group: agentgateway.dev
+  backend:
+    health:
+      unhealthyCondition: "response.code >= 500"
+      eviction:
+         duration: 60s
+         restoreHealth: 100
+         consecutiveFailures: 3
+         healthThreshold: 50
+---
+# Output
+output: []
+status:
+- apiVersion: agentgateway.dev/v1alpha1
+  kind: AgentgatewayPolicy
+  metadata:
+    name: agw
+    namespace: default
+  spec: null
+  status:
+    ancestors:
+    - ancestorRef:
+        group: agentgateway.dev
+        name: StatusSummary
+      conditions:
+      - lastTransitionTime: fake
+        message: Policy accepted
+        reason: Valid
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: 'Policy is not attached: AgentgatewayBackend default/missing not
+          found'
+        reason: Pending
+        status: "False"
+        type: Attached
+      controllerName: agentgateway.dev/agentgateway

--- a/controller/pkg/agentgateway/plugins/testdata/backendpolicy/service-port-chain-different-section.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/backendpolicy/service-port-chain-different-section.yaml
@@ -1,0 +1,156 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: svc-port
+  namespace: default
+spec:
+  parentRefs:
+    - name: test
+  rules:
+    - backendRefs:
+        - name: svc-a
+          port: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-a
+  namespace: default
+spec:
+  ports:
+    - name: http
+      port: 8080
+    - name: admin
+      port: 9090
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayBackend
+metadata:
+  name: policy-be
+  namespace: default
+spec:
+  static:
+    host: policy.example.com
+    port: 80
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: chain-source
+  namespace: default
+spec:
+  targetRefs:
+    - kind: Service
+      name: svc-a
+      group: ""
+      sectionName: "9090"
+  backend:
+    tunnel:
+      backendRef:
+        name: policy-be
+        group: agentgateway.dev
+        kind: AgentgatewayBackend
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: chain-target
+  namespace: default
+spec:
+  targetRefs:
+    - kind: AgentgatewayBackend
+      name: policy-be
+      group: agentgateway.dev
+  backend:
+    http:
+      version: HTTP2
+---
+# Output
+output:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
+    policy:
+      backend:
+        backendTunnel:
+          proxy:
+            backend: default/policy-be
+      key: default/chain-source:backend-tunnel:default/svc-a.default.svc.cluster.local/9090
+      name:
+        kind: AgentgatewayPolicy
+        name: chain-source
+        namespace: default
+      target:
+        service:
+          hostname: svc-a.default.svc.cluster.local
+          namespace: default
+          port: 9090
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
+    policy:
+      backend:
+        backendHttp:
+          version: HTTP2
+      key: default/chain-target:backend-http:default/policy-be
+      name:
+        kind: AgentgatewayPolicy
+        name: chain-target
+        namespace: default
+      target:
+        backend:
+          name: policy-be
+          namespace: default
+status:
+- apiVersion: agentgateway.dev/v1alpha1
+  kind: AgentgatewayPolicy
+  metadata:
+    name: chain-source
+    namespace: default
+  spec: null
+  status:
+    ancestors:
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: test
+        namespace: default
+      conditions:
+      - lastTransitionTime: fake
+        message: Policy accepted
+        reason: Valid
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: Attached to all targets
+        reason: Attached
+        status: "True"
+        type: Attached
+      controllerName: agentgateway.dev/agentgateway
+- apiVersion: agentgateway.dev/v1alpha1
+  kind: AgentgatewayPolicy
+  metadata:
+    name: chain-target
+    namespace: default
+  spec: null
+  status:
+    ancestors:
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: test
+        namespace: default
+      conditions:
+      - lastTransitionTime: fake
+        message: Policy accepted
+        reason: Valid
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: Attached to all targets
+        reason: Attached
+        status: "True"
+        type: Attached
+      controllerName: agentgateway.dev/agentgateway

--- a/controller/pkg/agentgateway/plugins/traffic_plugin.go
+++ b/controller/pkg/agentgateway/plugins/traffic_plugin.go
@@ -87,9 +87,6 @@ func ConvertStatusCollection[T controllers.Object, S any](col krt.Collection[krt
 
 // NewAgentPlugin creates a new AgentgatewayPolicy plugin
 func NewAgentPlugin(agw *AgwCollections, resolver remotehttp.Resolver, jwksLookup jwks.Lookup) AgwPlugin {
-	backendReferences := krt.NewManyCollection(agw.AgentgatewayPolicies, func(ctx krt.HandlerContext, policy *agentgateway.AgentgatewayPolicy) []*PolicyAttachment {
-		return BackendReferencesFromPolicy(policy)
-	})
 	return AgwPlugin{
 		ContributesPolicies: map[schema.GroupKind]PolicyPlugin{
 			wellknown.AgentgatewayPolicyGVK.GroupKind(): {
@@ -103,7 +100,9 @@ func NewAgentPlugin(agw *AgwCollections, resolver remotehttp.Resolver, jwksLooku
 					return ConvertStatusCollection(policyStatusCol), policyCol
 				},
 				BuildReferences: func(input PolicyPluginInput) krt.Collection[*PolicyAttachment] {
-					return backendReferences
+					return krt.NewManyCollection(agw.AgentgatewayPolicies, func(ctx krt.HandlerContext, policy *agentgateway.AgentgatewayPolicy) []*PolicyAttachment {
+						return BackendReferencesFromPolicy(ctx, policy, input.References)
+					}, agw.KrtOpts.ToOptions("AgentgatewayPolicyAttachments")...)
 				},
 			},
 		},
@@ -145,41 +144,49 @@ func TranslateAgentgatewayPolicy(ctx krt.HandlerContext, policy *agentgateway.Ag
 			continue
 		}
 
-		gatewayTargets := references.LookupGatewaysForBackend(ctx, utils.TypedNamespacedName{
+		targetObject := utils.TypedNamespacedName{
 			NamespacedName: types.NamespacedName{Namespace: policy.Namespace, Name: string(target.Name)},
 			Kind:           gk.Kind,
-		}).UnsortedList()
+		}
 
 		for _, policyTarget := range policyTargets {
-			translatedPolicies := clonePoliciesForTarget(baseTranslatedPolicies, policyTarget)
-			for _, translatedPolicy := range translatedPolicies {
-				for _, gatewayTarget := range gatewayTargets {
-					agwPolicies = append(agwPolicies, AgwPolicy{
-						Gateway: ptr.Of(gatewayTarget),
-						Policy:  translatedPolicy,
-					})
+			// For backend-like targets, skip gateway resolution when the target doesn't exist.
+			// A missing backend could still resolve via PolicyAttachments if another backend
+			// chain happens to reference the same name, which would push config for a phantom target.
+			// Gateway/route targets use direct lookup (no PolicyAttachments), so they're safe.
+			var gatewayTargets []types.NamespacedName
+			if !IsBackendLikeTarget(policyTarget) || targetExists {
+				gatewayTargets = references.LookupGatewaysForPolicyTarget(ctx, targetObject, policyTarget).UnsortedList()
+				translatedPolicies := clonePoliciesForTarget(baseTranslatedPolicies, policyTarget)
+				for _, translatedPolicy := range translatedPolicies {
+					for _, gatewayTarget := range gatewayTargets {
+						agwPolicies = append(agwPolicies, AgwPolicy{
+							Gateway: ptr.Of(gatewayTarget),
+							Policy:  translatedPolicy,
+						})
+					}
 				}
 			}
-		}
 
-		ancestorRefs, attachmentErr := resolvePolicyAncestorRefs(ctx, policy.Namespace, gk, target.Name, targetExists, references)
-		if attachmentErr != "" {
-			attachmentErrors = append(attachmentErrors, attachmentErr)
-		}
-
-		for _, ar := range ancestorRefs {
-			// A policy should report at most one status per Gateway parent, even if multiple
-			// targetRefs resolve to the same Gateway.
-			if slices.IndexFunc(ancestors, func(existing gwv1.PolicyAncestorStatus) bool {
-				return existing.ControllerName == gwv1.GatewayController(agw.ControllerName) && parentRefEqual(existing.AncestorRef, ar)
-			}) != -1 {
-				continue
+			ancestorRefs, attachmentErr := resolvePolicyAncestorRefs(policy.Namespace, targetObject, gatewayTargets, targetExists)
+			if attachmentErr != "" {
+				attachmentErrors = append(attachmentErrors, attachmentErr)
 			}
-			ancestors = append(ancestors, gwv1.PolicyAncestorStatus{
-				AncestorRef:    ar,
-				ControllerName: gwv1.GatewayController(agw.ControllerName),
-				Conditions:     baseConds,
-			})
+
+			for _, ar := range ancestorRefs {
+				// A policy should report at most one status per Gateway parent, even if multiple
+				// targetRefs resolve to the same Gateway.
+				if slices.IndexFunc(ancestors, func(existing gwv1.PolicyAncestorStatus) bool {
+					return existing.ControllerName == gwv1.GatewayController(agw.ControllerName) && parentRefEqual(existing.AncestorRef, ar)
+				}) != -1 {
+					continue
+				}
+				ancestors = append(ancestors, gwv1.PolicyAncestorStatus{
+					AncestorRef:    ar,
+					ControllerName: gwv1.GatewayController(agw.ControllerName),
+					Conditions:     baseConds,
+				})
+			}
 		}
 	}
 
@@ -292,24 +299,17 @@ func setAttachmentErrorConditions(baseConds []metav1.Condition, attachmentErrors
 }
 
 func resolvePolicyAncestorRefs(
-	ctx krt.HandlerContext,
 	policyNamespace string,
-	targetGK schema.GroupKind,
-	targetName gwv1.ObjectName,
+	targetObject utils.TypedNamespacedName,
+	gatewayTargets []types.NamespacedName,
 	targetExists bool,
-	references ReferenceIndex,
 ) ([]gwv1.ParentReference, string) {
 	if !targetExists {
-		return nil, fmt.Sprintf("Policy is not attached: %s %s/%s not found", targetGK.Kind, policyNamespace, targetName)
+		return nil, fmt.Sprintf("Policy is not attached: %s %s/%s not found", targetObject.Kind, policyNamespace, targetObject.Name)
 	}
 
-	object := utils.TypedNamespacedName{
-		NamespacedName: types.NamespacedName{Namespace: policyNamespace, Name: string(targetName)},
-		Kind:           targetGK.Kind,
-	}
-	gatewayTargets := references.LookupGatewaysForBackend(ctx, object).UnsortedList()
 	if len(gatewayTargets) == 0 {
-		return nil, fmt.Sprintf("Policy is not attached: %s %s/%s is not attached to any Gateway", targetGK.Kind, policyNamespace, targetName)
+		return nil, fmt.Sprintf("Policy is not attached: %s %s/%s is not attached to any Gateway", targetObject.Kind, policyNamespace, targetObject.Name)
 	}
 
 	refs := make([]gwv1.ParentReference, 0, len(gatewayTargets))
@@ -1500,28 +1500,60 @@ func DefaultString[T ~string](s *T, def string) string {
 	}
 	return string(*s)
 }
-func BackendReferencesFromPolicy(policy *agentgateway.AgentgatewayPolicy) []*PolicyAttachment {
-	var attachments []*PolicyAttachment
+
+// BackendReferencesFromPolicy only emits attachments for existing, unsectioned targets
+// to prevent phantom chains and section-scoped over-attachment.
+func BackendReferencesFromPolicy(ctx krt.HandlerContext, policy *agentgateway.AgentgatewayPolicy, references ReferenceIndex) []*PolicyAttachment {
 	s := policy.Spec
 	self := utils.TypedNamespacedName{
 		NamespacedName: types.NamespacedName{Namespace: policy.Namespace, Name: policy.Name},
 		Kind:           wellknown.AgentgatewayPolicyGVK.Kind,
 	}
-	app := func(ref gwv1.BackendObjectReference) {
-		for _, tgt := range s.TargetRefs {
+
+	existingTargets := make([]utils.TypedNamespacedName, 0, len(s.TargetRefs))
+	for _, tgt := range s.TargetRefs {
+		gk := schema.GroupKind{Group: string(tgt.Group), Kind: string(tgt.Kind)}
+		policyTarget, targetExists := references.PolicyTarget(ctx, policy.Namespace, tgt.Name, gk, tgt.SectionName)
+		if policyTarget == nil || !targetExists {
+			continue
+		}
+		existingTargets = append(existingTargets, utils.TypedNamespacedName{
+			NamespacedName: types.NamespacedName{Namespace: policy.Namespace, Name: string(tgt.Name)},
+			Kind:           string(tgt.Kind),
+		})
+	}
+	if len(existingTargets) == 0 {
+		return nil
+	}
+
+	backends := referencedBackendsFromPolicy(policy)
+	if len(backends) == 0 {
+		return nil
+	}
+
+	attachments := make([]*PolicyAttachment, 0, len(existingTargets)*len(backends))
+	for _, backend := range backends {
+		for _, tgt := range existingTargets {
 			attachments = append(attachments, &PolicyAttachment{
-				Target: utils.TypedNamespacedName{
-					NamespacedName: types.NamespacedName{Namespace: policy.Namespace, Name: string(tgt.Name)},
-					Kind:           string(tgt.Kind),
-				},
-				Backend: utils.TypedNamespacedName{
-					NamespacedName: types.NamespacedName{Namespace: DefaultString(ref.Namespace, policy.Namespace), Name: string(ref.Name)},
-					Kind:           DefaultString(ref.Kind, wellknown.ServiceKind),
-				},
-				Source: self,
+				Target:  tgt,
+				Backend: backend,
+				Source:  self,
 			})
 		}
 	}
+	return attachments
+}
+
+func referencedBackendsFromPolicy(policy *agentgateway.AgentgatewayPolicy) []utils.TypedNamespacedName {
+	var backends []utils.TypedNamespacedName
+	app := func(ref gwv1.BackendObjectReference) {
+		backends = append(backends, utils.TypedNamespacedName{
+			NamespacedName: types.NamespacedName{Namespace: DefaultString(ref.Namespace, policy.Namespace), Name: string(ref.Name)},
+			Kind:           DefaultString(ref.Kind, wellknown.ServiceKind),
+		})
+	}
+
+	s := policy.Spec
 	if s.Traffic != nil {
 		if s.Traffic.ExtAuth != nil {
 			app(s.Traffic.ExtAuth.BackendRef)
@@ -1551,7 +1583,7 @@ func BackendReferencesFromPolicy(policy *agentgateway.AgentgatewayPolicy) []*Pol
 	if s.Backend != nil {
 		BackendReferencesFromBackendPolicy(s.Backend, app)
 	}
-	return attachments
+	return backends
 }
 
 func BackendReferencesFromBackendPolicy(s *agentgateway.BackendFull, app func(ref gwv1.BackendObjectReference)) {


### PR DESCRIPTION
## Problem

- Prevent policies targeting missing backends from resolving via PolicyAttachments that coincidentally reference the
   same object name — generating XDS config for phantom targets
  - Add LookupGatewaysForPolicyTarget dispatch that routes backend-like targets through recursive PolicyAttachment
  lookup and other targets through direct attachment
  - Refactor BackendReferencesFromPolicy to validate target existence before emitting PolicyAttachments, keeping
  invalid hops out of the graph entirely
  - Remove unused ApplyPolicies helper

Known limitation: PolicyAttachment and AncestorBackend are keyed by root object identity (no port/section).
  Section-scoped targets chain at object level, which can cause over-attachment when the section doesn't match the
  route's port. A follow-up will add section-aware indexing.  Added this issues as TODO https://github.com/agentgateway/agentgateway/issues/1507