### PR TITLE
ext_proc: better handling of immediate response and fail_open

### DIFF
--- a/crates/agentgateway/src/http/ext_proc.rs
+++ b/crates/agentgateway/src/http/ext_proc.rs
@@ -1,5 +1,4 @@
 use std::convert::Infallible;
-use std::sync::atomic::{AtomicBool, Ordering};
 
 use ::http::HeaderMap;
 use anyhow::anyhow;
@@ -18,6 +17,7 @@ use tokio_stream::wrappers::ReceiverStream;
 
 use crate::cel::{Executor, Expression, RequestSnapshot};
 use crate::client::ResolvedDestination;
+use crate::http;
 use crate::http::envoy_proto_common;
 use crate::http::ext_proc::proto::{
 	BodyMutation, BodyResponse, HeaderMutation, HeaderValueOption, HeadersResponse, HttpBody,
@@ -243,7 +243,7 @@ impl ExtProcRequest {
 #[derive(Debug)]
 struct ExtProcInstance {
 	failure_mode: FailureMode,
-	skipped: Arc<AtomicBool>,
+	skipped: bool,
 	tx_req: Sender<ProcessingRequest>,
 	rx_resp_for_request: Option<Receiver<ProcessingResponse>>,
 	rx_resp_for_response: Option<Receiver<ProcessingResponse>>,
@@ -293,7 +293,6 @@ impl ExtProcInstance {
 		let (tx_resp_for_response, rx_resp_for_response) = tokio::sync::mpsc::channel(1);
 		tokio::task::spawn(async move {
 			while let Some(item) = rx_resp.recv().await {
-				trace!("received response item {item:?}");
 				match &item.response {
 					Some(processing_response::Response::ResponseBody(_))
 					| Some(processing_response::Response::ResponseHeaders(_))
@@ -336,7 +335,6 @@ impl ExtProcInstance {
 		req: http::Request,
 	) -> Result<(http::Request, Option<PolicyResponse>), Error> {
 		let headers = req_to_header_map(&req);
-		let buffer = http::buffer_limit(&req);
 
 		let exec = cel::Executor::new_request(&req);
 		// request_attributes should only be sent on first ProcessingRequest
@@ -362,23 +360,11 @@ impl ExtProcInstance {
 			})
 			.unwrap_or_default();
 
-		let (parts, body) = req.into_parts();
-
-		// For fail open we need a copy of the body. There is definitely a better way to do this, but for
-		// now its good enough?
-		let (body_copy, body) = if self.failure_mode == FailureMode::FailOpen {
-			let buffered = http::read_body_with_limit(body, buffer)
-				.await
-				.map_err(|e| Error::BodyBuffer(e.to_string()))?;
-			(Some(buffered.clone()), http::Body::from(buffered))
-		} else {
-			(None, body)
-		};
-		let end_of_stream = body.is_end_stream();
-		let had_body = !end_of_stream;
+		let failure_mode = self.failure_mode;
+		let end_of_stream = req.body().is_end_stream();
 
 		// Send the request headers to ext_proc.
-		self
+		if let Err(e) = self
 			.send_request(ProcessingRequest {
 				request: Some(Request::RequestHeaders(HttpHeaders {
 					headers,
@@ -389,140 +375,140 @@ impl ExtProcInstance {
 				protocol_config: Default::default(),
 				observability_mode: false,
 			})
-			.await?;
-
-		// The EPP will await for our headers and body. The body is going to be streaming in.
-		// We will spin off a task that is going to pipe the body to the ext_proc server as we read it.
-		let tx = self.tx_req.clone();
-
-		if had_body {
-			tokio::task::spawn(async move {
-				let mut stream = BodyStream::new(body);
-				while let Some(Ok(frame)) = stream.next().await {
-					let request = Some(if frame.is_data() {
-						let frame = frame.into_data().expect("already checked");
-						trace!("sending request body chunk...",);
-						Request::RequestBody(HttpBody {
-							body: frame.into(),
-							end_of_stream: false,
-						})
-					} else if frame.is_trailers() {
-						let frame = frame.into_trailers().expect("already checked");
-						Request::RequestTrailers(HttpTrailers {
-							trailers: to_header_map(&frame),
-						})
-					} else {
-						// http_body::Frame only has data and trailers variants
-						unreachable!("Frame is neither data nor trailers")
-					});
-
-					trace!("sending request body chunk...");
-					let Ok(()) = tx
-						.send(ProcessingRequest {
-							request,
-							metadata_context: metadata_context.as_deref().cloned(),
-							attributes: Default::default(),
-							protocol_config: Default::default(),
-							observability_mode: false,
-						})
-						.await
-					else {
-						// TODO: on error here we need a way to signal to the outer task to fail fast
-						return;
-					};
-				}
-
-				// Send end of stream marker - try to unwrap Arc to avoid final clone
-				let final_metadata = metadata_context.and_then(Arc::into_inner);
-				let _ = tx
-					.send(ProcessingRequest {
-						request: Some(Request::RequestBody(HttpBody {
-							body: Default::default(),
-							end_of_stream: true,
-						})),
-						metadata_context: final_metadata,
-						attributes: Default::default(),
-						protocol_config: Default::default(),
-						observability_mode: false,
-					})
-					.await;
-				trace!("body request done");
-			});
+			.await
+		{
+			if failure_mode == FailureMode::FailOpen {
+				trace!("fail open triggered");
+				self.skipped = true;
+				return Ok((req, None));
+			}
+			return Err(e);
 		}
-		// Now we need to build the new body. This is going to be streamed in from the ext_proc server.
-		let (tx_chunk, rx_chunk) = tokio::sync::mpsc::channel(1);
 
-		let body = http_body_util::StreamBody::new(ReceiverStream::new(rx_chunk));
-		let mut req = http::Request::from_parts(parts, http::Body::new(body));
+		// At this point, we start body handling. Fail open + streaming bodies is a disaster,
+		// as we could silently corrupt data.
+		// We behave approximately like Envoy here (https://github.com/envoyproxy/envoy/pull/41276); after
+		// the headers are sent we drop fail_open.
+		// In practice, this means that the server was running fine at the start of the request which covers
+		// all but edge cases around the server dying mid-request.
+		let (parts, body) = req.into_parts();
+		let had_body = !end_of_stream;
+		let tx = self.tx_req.clone();
+		if had_body {
+			tokio::task::spawn(Self::handle_body_stream(
+				metadata_context,
+				body,
+				tx,
+				Request::RequestBody,
+				Request::RequestTrailers,
+			));
+		}
+
+		// Now we need to build the new body. This is going to be streamed in from the ext_proc server.
+		let (mut tx_chunk, rx_chunk) = tokio::sync::mpsc::channel(1);
+
+		let upstream_body = http_body_util::StreamBody::new(ReceiverStream::new(rx_chunk));
+		let mut req = http::Request::from_parts(parts, http::Body::new(upstream_body));
 		req.headers_mut().remove(http::header::CONTENT_LENGTH);
-		let (tx_done, rx_done) = tokio::sync::oneshot::channel();
 		let mut rx = self
 			.rx_resp_for_request
 			.take()
 			.expect("mutate_request called twice");
-		let failure_mode = self.failure_mode;
-		let skipped = self.skipped.clone();
-		tokio::task::spawn(async move {
-			let mut req = Some(req);
-			let mut tx_done = Some(tx_done);
-			let mut tx_chunkh = Some(tx_chunk);
-			loop {
-				// Loop through all the ext_proc responses and process them
-				let Some(presp) = rx.recv().await else {
-					trace!("done receiving request");
-					if failure_mode == FailureMode::FailOpen
-						&& let Some(req) = req.take()
-						&& let Some(tx_done) = tx_done.take()
-					{
-						trace!("fail open triggered");
-						skipped.store(true, Ordering::SeqCst);
-						let (parts, _) = req.into_parts();
-						let new_req = http::Request::from_parts(parts, http::Body::from(body_copy.unwrap()));
-						let _ = tx_done.send(Ok((new_req, None)));
-						tx_chunkh.take();
-					}
-					return;
-				};
-				if let Some(resp) = to_immediate_response(&presp) {
-					trace!("got immediate response in request handler");
-					let _ = tx_done
-						.take()
-						.unwrap()
-						.send(Ok((http::Request::default(), Some(resp))));
-					tx_chunkh.take();
-					return;
+		loop {
+			let Some(presp) = rx.recv().await else {
+				if !had_body && failure_mode == FailureMode::FailOpen {
+					trace!("fail open triggered");
+					self.skipped = true;
+					return Ok((req, None));
 				}
-				if let Some(dm) = &presp.dynamic_metadata
-					&& let Err(e) = Self::extract_dynamic_metadata(req.as_mut(), dm)
-				{
-					warn!("Failed to extract ext_proc dynamic metadata: {}", e);
-				}
-				let Some(tx_chunk) = tx_chunkh.as_mut() else {
-					return;
-				};
-				let r = handle_response_for_request_mutation(had_body, req.as_mut(), tx_chunk, presp).await;
-				match r {
-					Ok((headers_done, eos)) => {
-						if headers_done
-							&& let Some(req) = req.take()
-							&& let Some(tx_done) = tx_done.take()
-						{
-							trace!("request complete!");
-							let _ = tx_done.send(Ok((req, None)));
-						}
-						if eos || !had_body {
-							trace!("request EOS!");
-							tx_chunkh.take();
-						}
-					},
-					Err(e) => {
-						warn!("error {e:?}");
-						return;
-					},
-				}
+				trace!("done receiving request");
+				return Err(Error::NoMoreResponses);
+			};
+			if let Some(resp) = to_immediate_response(&presp) {
+				trace!("got immediate response in request handler");
+				return Ok((req, Some(resp)));
 			}
-		});
-		rx_done.await.map_err(|_| Error::ResponseDropped)?
+			let (headers_done, eos) =
+				handle_response_for_request_mutation(had_body, Some(&mut req), &mut tx_chunk, presp).await;
+			if headers_done {
+				if !eos {
+					trace!("spawn body!");
+					// Moving rest of body handling to async
+					tokio::task::spawn(async move {
+						loop {
+							let Some(presp) = rx.recv().await else {
+								trace!("done receiving request");
+								return;
+							};
+							let (_, eos) =
+								handle_response_for_request_mutation(had_body, None, &mut tx_chunk, presp).await;
+							if eos || !had_body {
+								trace!("request EOS!");
+								drop(tx_chunk);
+								return;
+							}
+						}
+					});
+				}
+				return Ok((req, None));
+			}
+		}
+	}
+
+	async fn handle_body_stream(
+		metadata_context: Option<Arc<Metadata>>,
+		body: http::Body,
+		tx: Sender<ProcessingRequest>,
+		body_fn: fn(HttpBody) -> Request,
+		trail_fn: fn(HttpTrailers) -> Request,
+	) {
+		let mut stream = BodyStream::new(body);
+		while let Some(Ok(frame)) = stream.next().await {
+			let request = Some(if frame.is_data() {
+				let frame = frame.into_data().expect("already checked");
+				trace!("sending body chunk...",);
+				body_fn(HttpBody {
+					body: frame.into(),
+					end_of_stream: false,
+				})
+			} else if frame.is_trailers() {
+				let frame = frame.into_trailers().expect("already checked");
+				trail_fn(HttpTrailers {
+					trailers: to_header_map(&frame),
+				})
+			} else {
+				// http_body::Frame only has data and trailers variants
+				unreachable!("Frame is neither data nor trailers")
+			});
+			let Ok(()) = tx
+				.send(ProcessingRequest {
+					request,
+					metadata_context: metadata_context.as_deref().cloned(),
+					attributes: Default::default(),
+					protocol_config: Default::default(),
+					observability_mode: false,
+				})
+				.await
+			else {
+				return;
+			};
+		}
+
+		// Send end of stream marker - try to unwrap Arc to avoid final clone
+		let final_metadata = metadata_context.and_then(Arc::into_inner);
+		let _ = tx
+			.send(ProcessingRequest {
+				request: Some(body_fn(HttpBody {
+					body: Default::default(),
+					end_of_stream: true,
+				})),
+				metadata_context: final_metadata,
+				attributes: Default::default(),
+				protocol_config: Default::default(),
+				observability_mode: false,
+			})
+			.await;
+		trace!("body request done");
 	}
 
 	pub async fn mutate_response(
@@ -531,7 +517,7 @@ impl ExtProcInstance {
 		request: Option<&RequestSnapshot>,
 		resolved_destination_metadata: Option<SocketAddr>,
 	) -> Result<(http::Response, Option<PolicyResponse>), Error> {
-		if self.skipped.load(Ordering::SeqCst) {
+		if self.skipped {
 			return Ok((req, None));
 		}
 		let headers = resp_to_header_map(&req);
@@ -575,6 +561,7 @@ impl ExtProcInstance {
 		let had_body = !end_of_stream;
 
 		// Send the response headers to ext_proc.
+		// No response side fail_open handling.
 		self
 			.send_request(ProcessingRequest {
 				request: Some(Request::ResponseHeaders(HttpHeaders {
@@ -591,156 +578,61 @@ impl ExtProcInstance {
 		// The EPP will await for our headers and body. The body is going to be streaming in.
 		// We will spin off a task that is going to pipe the body to the ext_proc server as we read it.
 		let tx = self.tx_req.clone();
-
 		if had_body {
-			tokio::task::spawn(async move {
-				let mut stream = BodyStream::new(body);
-				while let Some(Ok(frame)) = stream.next().await {
-					let request = Some(if frame.is_data() {
-						let frame = frame.into_data().expect("already checked");
-						Request::ResponseBody(HttpBody {
-							body: frame.into(),
-							end_of_stream: false,
-						})
-					} else if frame.is_trailers() {
-						let frame = frame.into_trailers().expect("already checked");
-						Request::ResponseTrailers(HttpTrailers {
-							trailers: to_header_map(&frame),
-						})
-					} else {
-						// http_body::Frame only has data and trailers variants
-						unreachable!("Frame is neither data nor trailers")
-					});
-
-					trace!("sending response body chunk...");
-					let Ok(()) = tx
-						.send(ProcessingRequest {
-							request,
-							metadata_context: metadata_context.as_deref().cloned(),
-							attributes: HashMap::new(),
-							protocol_config: Default::default(),
-							observability_mode: false,
-						})
-						.await
-					else {
-						// TODO: on error here we need a way to signal to the outer task to fail fast
-						return;
-					};
-				}
-
-				// Send end of stream marker - try to unwrap Arc to avoid final clone
-				let final_metadata = metadata_context.and_then(Arc::into_inner);
-				let _ = tx
-					.send(ProcessingRequest {
-						request: Some(Request::ResponseBody(HttpBody {
-							body: Default::default(),
-							end_of_stream: true,
-						})),
-						metadata_context: final_metadata,
-						attributes: HashMap::new(),
-						protocol_config: Default::default(),
-						observability_mode: false,
-					})
-					.await;
-				trace!("body response done");
-			});
+			tokio::task::spawn(Self::handle_body_stream(
+				metadata_context,
+				body,
+				tx,
+				Request::ResponseBody,
+				Request::ResponseTrailers,
+			));
 		}
+
 		// Now we need to build the new body. This is going to be streamed in from the ext_proc server.
-		let (tx_chunk, rx_chunk) = tokio::sync::mpsc::channel(1);
+		let (mut tx_chunk, rx_chunk) = tokio::sync::mpsc::channel(1);
+
 		let body = http_body_util::StreamBody::new(ReceiverStream::new(rx_chunk));
 		let mut resp = http::Response::from_parts(parts, http::Body::new(body));
 		resp.headers_mut().remove(http::header::CONTENT_LENGTH);
-		let (tx_done, rx_done) = tokio::sync::oneshot::channel();
 		let mut rx = self
 			.rx_resp_for_response
 			.take()
-			.expect("mutate_request called twice");
-		tokio::task::spawn(async move {
-			let mut resp = Some(resp);
-			let mut tx_done = Some(tx_done);
-			let mut tx_chunkh = Some(tx_chunk);
-			loop {
-				// Loop through all the ext_proc responses and process them
-				let Some(presp) = rx.recv().await else {
-					trace!("done receiving response");
-					return;
-				};
-				if let Some(resp) = to_immediate_response(&presp) {
-					trace!("got immediate response in response handler");
-					let _ = tx_done
-						.take()
-						.unwrap()
-						.send(Ok((http::Response::default(), Some(resp))));
-					tx_chunkh.take();
-					return;
-				}
-				let Some(tx_chunk) = tx_chunkh.as_mut() else {
-					trace!("body done, skipping");
-					return;
-				};
-				let r =
-					handle_response_for_response_mutation(had_body, resp.as_mut(), tx_chunk, presp).await;
-				match r {
-					Ok((headers_done, eos)) => {
-						if headers_done
-							&& let Some(resp) = resp.take()
-							&& let Some(tx_done) = tx_done.take()
-						{
-							trace!("response complete!");
-							let _ = tx_done.send(Ok((resp, None)));
-						}
-						if eos || !had_body {
-							trace!("response EOS!");
-							tx_chunkh.take();
-						}
-					},
-					Err(e) => {
-						warn!("error {e:?}");
-						return;
-						// return tx_done.take().expect("must be called once").send(Err(e));
-					},
-				}
+			.expect("mutate_response called twice");
+		loop {
+			let Some(presp) = rx.recv().await else {
+				trace!("done receiving response");
+				return Err(Error::NoMoreResponses);
+			};
+			if let Some(dr) = to_immediate_response(&presp) {
+				trace!("got immediate response in request handler");
+				return Ok((resp, Some(dr)));
 			}
-		});
-		rx_done.await.map_err(|_| Error::ResponseDropped)?
-	}
-
-	pub(crate) fn extract_dynamic_metadata(
-		req: Option<&mut http::Request>,
-		metadata: &prost_wkt_types::Struct,
-	) -> Result<(), Error> {
-		let Some(req) = req else {
-			// Warn when metadata is sent after headers are processed (body/trailer phase)
-			if !metadata.fields.is_empty() {
-				warn!(
-					"ext_proc server sent dynamic_metadata after headers were processed; \
-					 metadata cannot be attached and will be ignored. Consider sending \
-					 metadata in the RequestHeaders response instead."
-				);
+			let (headers_done, eos) =
+				handle_response_for_response_mutation(had_body, Some(&mut resp), &mut tx_chunk, presp)
+					.await;
+			if headers_done {
+				if !eos {
+					trace!("spawn body!");
+					// Moving rest of body handling to async
+					tokio::task::spawn(async move {
+						loop {
+							let Some(presp) = rx.recv().await else {
+								trace!("done receiving response");
+								return;
+							};
+							let (_, eos) =
+								handle_response_for_response_mutation(had_body, None, &mut tx_chunk, presp).await;
+							if eos || !had_body {
+								trace!("response EOS!");
+								drop(tx_chunk);
+								return;
+							}
+						}
+					});
+				}
+				return Ok((resp, None));
 			}
-			return Ok(());
-		};
-
-		// Get or create metadata container, merging with existing metadata
-		let mut dynamic_metadata = req
-			.extensions_mut()
-			.remove::<Arc<ExtProcDynamicMetadata>>()
-			.map(|arc| (*arc).clone())
-			.unwrap_or_default();
-
-		// Merge new fields into existing metadata
-		for (key, value) in &metadata.fields {
-			let json_val = envoy_proto_common::prost_value_to_json(value).map_err(|e| {
-				Error::MetadataConversion(format!("failed to convert key '{}': {}", key, e))
-			})?;
-			dynamic_metadata.0.insert(key.clone(), json_val);
 		}
-
-		if !dynamic_metadata.0.is_empty() {
-			req.extensions_mut().insert(Arc::new(dynamic_metadata));
-		}
-
-		Ok(())
 	}
 }
 
@@ -758,7 +650,7 @@ fn to_immediate_response(rp: &ProcessingResponse) -> Option<PolicyResponse> {
 				::http::response::Builder::new().status(status.map(|s| s.code).unwrap_or(200) as u16);
 
 			if let Some(hm) = rb.headers_mut() {
-				let _ = apply_header_mutations(hm, headers.as_ref());
+				apply_header_mutations(hm, headers.as_ref());
 			}
 			let resp = rb
 				.body(http::Body::from(body.to_string()))
@@ -776,15 +668,29 @@ fn to_immediate_response(rp: &ProcessingResponse) -> Option<PolicyResponse> {
 // handle_response_for_request_mutation handles a single ext_proc response. If it returns 'true' we are done processing.
 async fn handle_response_for_request_mutation(
 	had_body: bool,
-	req: Option<&mut http::Request>,
+	mut req: Option<&mut http::Request>,
 	body_tx: &mut Sender<Result<Frame<Bytes>, Infallible>>,
 	presp: ProcessingResponse,
-) -> Result<(bool, bool), Error> {
+) -> (bool, bool) {
+	if let Some(dm) = &presp.dynamic_metadata {
+		if let Some(req) = req.as_mut() {
+			if let Err(e) = extract_dynamic_metadata(req, dm) {
+				warn!("Failed to extract ext_proc dynamic metadata: {}", e);
+			}
+		} else if !dm.fields.is_empty() {
+			warn!(
+				"ext_proc server sent dynamic_metadata after headers were processed; \
+					 metadata cannot be attached and will be ignored. Consider sending \
+					 metadata in the RequestHeaders response instead."
+			);
+		}
+	}
+
 	let res = matches!(presp.response, Some(Response::RequestHeaders(_)));
 	let cr = match presp.response {
 		Some(Response::RequestHeaders(HeadersResponse { response: None })) => {
 			trace!("no headers");
-			return Ok((res, false));
+			return (true, !had_body);
 		},
 		Some(Response::RequestHeaders(HeadersResponse { response: Some(cr) })) => {
 			trace!("got request headers back");
@@ -792,20 +698,27 @@ async fn handle_response_for_request_mutation(
 		},
 		Some(Response::RequestBody(BodyResponse { response: None })) => {
 			trace!("got empty request body back");
-			return Ok((res, true));
+			return (false, true);
 		},
 		Some(Response::RequestBody(BodyResponse { response: Some(cr) })) => {
 			trace!("got request body back");
 			cr
 		},
+		Some(Response::ImmediateResponse(_)) => {
+			if req.is_none() {
+				trace!("immediate response received after request sent; will apply only on the response");
+			}
+			// Handled out of this function.
+			return (true, true);
+		},
 		msg => {
 			// In theory, there can trailers too. EPP never sends them
 			warn!("ignoring response during request {msg:?}");
-			return Ok((res, false));
+			return (false, false);
 		},
 	};
 	if let Some(req) = req {
-		apply_header_mutations_request(req, cr.header_mutation.as_ref())?;
+		apply_header_mutations_request(req, cr.header_mutation.as_ref());
 	}
 	if let Some(BodyMutation { mutation: Some(b) }) = cr.body_mutation {
 		match b {
@@ -815,7 +728,7 @@ async fn handle_response_for_request_mutation(
 				let _ = body_tx.send(Ok(Frame::data(by.clone()))).await;
 
 				trace!(eos, "got stream request body");
-				return Ok((res, eos));
+				return (res, eos);
 			},
 			Mutation::Body(_) => {
 				warn!("Body() not valid for streaming mode, skipping...");
@@ -826,53 +739,44 @@ async fn handle_response_for_request_mutation(
 		}
 	} else if !had_body {
 		trace!("got headers back and do not expect body; we are done");
-		return Ok((res, true));
+		return (res, true);
 	}
 	trace!("still waiting for response...");
-	Ok((res, false))
+	(res, false)
 }
 
-fn apply_header_with_action(
-	headers: &mut HeaderMap,
-	hk: &HeaderName,
-	hvo: &HeaderValueOption,
-) -> Result<(), Error> {
+fn apply_header_with_action(headers: &mut HeaderMap, hk: &HeaderName, hvo: &HeaderValueOption) {
 	let Some(_) = hvo.header else {
-		return Ok(());
+		return;
 	};
 
 	// Skip content-length as the EPP sets it to invalid values
 	// https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/943
 	if hk == http::header::CONTENT_LENGTH {
 		debug!("skipping invalid content-length");
-		return Ok(());
+		return;
 	}
 
 	let _ = envoy_proto_common::apply_header_value_option(headers, hk, hvo);
-	Ok(())
 }
 
-fn apply_header_mutations(
-	headers: &mut HeaderMap,
-	h: Option<&HeaderMutation>,
-) -> Result<(), Error> {
+fn apply_header_mutations(headers: &mut HeaderMap, h: Option<&HeaderMutation>) {
 	if let Some(hm) = h {
 		for rm in &hm.remove_headers {
 			headers.remove(rm);
 		}
 		for set in &hm.set_headers {
 			let Some(h) = &set.header else { continue };
-			let hk = HeaderName::try_from(h.key.as_str())?;
-			apply_header_with_action(headers, &hk, set)?;
+			let Ok(hk) = HeaderName::try_from(h.key.as_str()) else {
+				warn!("invalid header key: {}", h.key);
+				continue;
+			};
+			apply_header_with_action(headers, &hk, set);
 		}
 	}
-	Ok(())
 }
 
-fn apply_header_mutations_request(
-	req: &mut http::Request,
-	h: Option<&HeaderMutation>,
-) -> Result<(), Error> {
+fn apply_header_mutations_request(req: &mut http::Request, h: Option<&HeaderMutation>) {
 	if let Some(hm) = h {
 		for rm in &hm.remove_headers {
 			req.headers_mut().remove(rm);
@@ -881,23 +785,21 @@ fn apply_header_mutations_request(
 			let Some(h) = &set.header else { continue };
 			match HeaderOrPseudo::try_from(h.key.as_str()) {
 				Ok(HeaderOrPseudo::Header(hk)) => {
-					apply_header_with_action(req.headers_mut(), &hk, set)?;
+					apply_header_with_action(req.headers_mut(), &hk, set);
 				},
 				Ok(_) => {
 					let mut rr = crate::http::RequestOrResponse::Request(req);
 					let _ = envoy_proto_common::apply_pseudo_header_option(&mut rr, set);
 				},
-				Err(_) => {},
+				Err(e) => {
+					warn!("invalid header key: {} {e}", h.key);
+				},
 			}
 		}
 	}
-	Ok(())
 }
 
-fn apply_header_mutations_response(
-	resp: &mut http::Response,
-	h: Option<&HeaderMutation>,
-) -> Result<(), Error> {
+fn apply_header_mutations_response(resp: &mut http::Response, h: Option<&HeaderMutation>) {
 	if let Some(hm) = h {
 		for rm in &hm.remove_headers {
 			resp.headers_mut().remove(rm);
@@ -906,17 +808,18 @@ fn apply_header_mutations_response(
 			let Some(h) = &set.header else { continue };
 			match crate::http::HeaderOrPseudo::try_from(h.key.as_str()) {
 				Ok(crate::http::HeaderOrPseudo::Header(hk)) => {
-					apply_header_with_action(resp.headers_mut(), &hk, set)?;
+					apply_header_with_action(resp.headers_mut(), &hk, set);
 				},
 				Ok(_) => {
 					let mut rr = crate::http::RequestOrResponse::Response(resp);
 					let _ = envoy_proto_common::apply_pseudo_header_option(&mut rr, set);
 				},
-				Err(_) => {},
+				Err(e) => {
+					warn!("invalid header key: {} {e}", h.key);
+				},
 			}
 		}
 	}
-	Ok(())
 }
 
 // handle_response_for_response_mutation handles a single ext_proc response. If it returns 'true' we are done processing.
@@ -925,27 +828,27 @@ async fn handle_response_for_response_mutation(
 	resp: Option<&mut http::Response>,
 	body_tx: &mut Sender<Result<Frame<Bytes>, Infallible>>,
 	presp: ProcessingResponse,
-) -> Result<(bool, bool), Error> {
+) -> (bool, bool) {
 	let res = matches!(presp.response, Some(Response::ResponseHeaders(_)));
 	let cr = match presp.response {
 		Some(Response::ResponseHeaders(HeadersResponse { response: None })) => {
 			trace!("no headers");
-			return Ok((res, false));
+			return (res, false);
 		},
 		Some(Response::ResponseHeaders(HeadersResponse { response: Some(cr) })) => cr,
 		Some(Response::ResponseBody(BodyResponse { response: Some(cr) })) => cr,
 		Some(Response::ResponseBody(BodyResponse { response: None })) => {
 			trace!("got empty response body back");
-			return Ok((res, true));
+			return (res, true);
 		},
 		msg => {
 			// In theory, there can trailers too. EPP never sends them
 			warn!("ignoring {msg:?}");
-			return Ok((res, false));
+			return (res, false);
 		},
 	};
 	if let Some(resp) = resp {
-		apply_header_mutations_response(resp, cr.header_mutation.as_ref())?;
+		apply_header_mutations_response(resp, cr.header_mutation.as_ref());
 	}
 	if let Some(BodyMutation { mutation: Some(b) }) = cr.body_mutation {
 		match b {
@@ -954,7 +857,7 @@ async fn handle_response_for_response_mutation(
 				let by = bytes::Bytes::from(bb.body);
 				let _ = body_tx.send(Ok(Frame::data(by.clone()))).await;
 				trace!(%eos, "got body chunk");
-				return Ok((res, eos));
+				return (res, eos);
 			},
 			Mutation::Body(_) => {
 				warn!("Body() not valid for streaming mode, skipping...");
@@ -965,10 +868,10 @@ async fn handle_response_for_response_mutation(
 		}
 	} else if !had_body {
 		trace!("got headers back and do not expect body; we are done");
-		return Ok((res, true));
+		return (res, true);
 	}
 	trace!("still waiting for response for response...");
-	Ok((res, false))
+	(res, false)
 }
 
 fn req_to_header_map(req: &http::Request) -> Option<proto::HeaderMap> {
@@ -1045,6 +948,31 @@ fn eval_to_struct(
 			})
 			.collect(),
 	})
+}
+
+pub(crate) fn extract_dynamic_metadata(
+	req: &mut http::Request,
+	metadata: &prost_wkt_types::Struct,
+) -> Result<(), Error> {
+	// Get or create metadata container, merging with existing metadata
+	let mut dynamic_metadata = req
+		.extensions_mut()
+		.remove::<Arc<ExtProcDynamicMetadata>>()
+		.map(|arc| (*arc).clone())
+		.unwrap_or_default();
+
+	// Merge new fields into existing metadata
+	for (key, value) in &metadata.fields {
+		let json_val = envoy_proto_common::prost_value_to_json(value)
+			.map_err(|e| Error::MetadataConversion(format!("failed to convert key '{}': {}", key, e)))?;
+		dynamic_metadata.0.insert(key.clone(), json_val);
+	}
+
+	if !dynamic_metadata.0.is_empty() {
+		req.extensions_mut().insert(Arc::new(dynamic_metadata));
+	}
+
+	Ok(())
 }
 
 #[derive(Clone, Debug)]

--- a/crates/agentgateway/src/http/ext_proc_tests.rs
+++ b/crates/agentgateway/src/http/ext_proc_tests.rs
@@ -122,6 +122,22 @@ async fn immediate_response_request() {
 }
 
 #[tokio::test]
+async fn immediate_response_request_body_is_deferred_to_response() {
+	let mock = simple_mock().await;
+	let (_mock, _ext_proc, _bind, io) = setup_ext_proc_mock(
+		mock,
+		ext_proc::FailureMode::FailClosed,
+		ExtProcMock::new(ImmediateResponseRequestBodyExtProc::default),
+		"{}",
+	)
+	.await;
+	let res = send_request_body(io, Method::POST, "http://lo", b"request").await;
+	assert_eq!(res.status(), 403);
+	let body = read_body_raw(res.into_body()).await;
+	assert_eq!(body.as_ref(), b"Access denied");
+}
+
+#[tokio::test]
 async fn immediate_response_response() {
 	let mock = simple_mock().await;
 	let (_mock, _ext_proc, _bind, io) = setup_ext_proc_mock(
@@ -154,6 +170,22 @@ async fn failure_fail_closed() {
 }
 
 #[tokio::test]
+async fn failure_fail_open_body() {
+	let mock = simple_mock().await;
+	let (_mock, _ext_proc, _bind, io) = setup_ext_proc_mock(
+		mock,
+		ext_proc::FailureMode::FailOpen,
+		ExtProcMock::new(FailureExtProcResponse::default),
+		"{}",
+	)
+	.await;
+
+	// If we have a body, we should NOT fail open
+	let res = send_request_body(io, Method::POST, "http://lo", b"request").await;
+	assert_eq!(res.status(), 500);
+}
+
+#[tokio::test]
 async fn failure_fail_open() {
 	let mock = simple_mock().await;
 	let (_mock, _ext_proc, _bind, io) = setup_ext_proc_mock(
@@ -163,10 +195,9 @@ async fn failure_fail_open() {
 		"{}",
 	)
 	.await;
-	let res = send_request_body(io, Method::POST, "http://lo", b"request").await;
+
+	let res = send_request(io, Method::POST, "http://lo").await;
 	assert_eq!(res.status(), 200);
-	let body = read_body(res.into_body()).await;
-	assert_eq!(body.body.as_ref(), b"request");
 }
 
 pub async fn setup_ext_proc_mock<T: Handler + Send + Sync + 'static>(
@@ -389,6 +420,45 @@ impl Handler for ImmediateResponseExtProc {
 }
 
 #[derive(Debug, Default)]
+struct ImmediateResponseRequestBodyExtProc {
+	sent: bool,
+}
+
+#[async_trait::async_trait]
+impl Handler for ImmediateResponseRequestBodyExtProc {
+	async fn handle_request_headers(
+		&mut self,
+		_: &HttpHeaders,
+		sender: &mpsc::Sender<Result<ProcessingResponse, Status>>,
+	) -> Result<(), Status> {
+		let _ = sender.send(request_header_response(None)).await;
+		Ok(())
+	}
+
+	async fn handle_request_body(
+		&mut self,
+		_: &proto::HttpBody,
+		sender: &mpsc::Sender<Result<ProcessingResponse, Status>>,
+	) -> Result<(), Status> {
+		if !self.sent {
+			self.sent = true;
+			let _ = sender
+				.send(immediate_response(proto::ImmediateResponse {
+					status: Some(proto::HttpStatus {
+						code: proto::StatusCode::Forbidden as i32,
+					}),
+					body: "Access denied".to_string(),
+					headers: None,
+					grpc_status: None,
+					details: "".to_string(),
+				}))
+				.await;
+		}
+		Ok(())
+	}
+}
+
+#[derive(Debug, Default)]
 struct ImmediateResponseExtProcResponse {
 	sent_req_body: bool,
 }
@@ -471,7 +541,7 @@ fn test_default_append_action_overwrite() {
 		}],
 	});
 
-	super::apply_header_mutations(&mut headers, mutation.as_ref()).unwrap();
+	super::apply_header_mutations(&mut headers, mutation.as_ref());
 
 	let values: Vec<_> = headers.get_all("existing").iter().collect();
 	assert_eq!(values.len(), 1);
@@ -507,7 +577,7 @@ fn test_append_if_exists_or_add() {
 		],
 	});
 
-	super::apply_header_mutations(&mut headers, mutation.as_ref()).unwrap();
+	super::apply_header_mutations(&mut headers, mutation.as_ref());
 
 	let values: Vec<_> = headers.get_all("existing").iter().collect();
 	assert_eq!(values.len(), 2);
@@ -545,7 +615,7 @@ fn test_add_if_absent() {
 		],
 	});
 
-	super::apply_header_mutations(&mut headers, mutation.as_ref()).unwrap();
+	super::apply_header_mutations(&mut headers, mutation.as_ref());
 
 	let values: Vec<_> = headers.get_all("existing").iter().collect();
 	assert_eq!(values.len(), 1);
@@ -582,7 +652,7 @@ fn test_overwrite_if_exists_or_add() {
 		],
 	});
 
-	super::apply_header_mutations(&mut headers, mutation.as_ref()).unwrap();
+	super::apply_header_mutations(&mut headers, mutation.as_ref());
 
 	let values: Vec<_> = headers.get_all("existing").iter().collect();
 	assert_eq!(values.len(), 1);
@@ -619,7 +689,7 @@ fn test_overwrite_if_exists() {
 		],
 	});
 
-	super::apply_header_mutations(&mut headers, mutation.as_ref()).unwrap();
+	super::apply_header_mutations(&mut headers, mutation.as_ref());
 
 	let values: Vec<_> = headers.get_all("existing").iter().collect();
 	assert_eq!(values.len(), 1);
@@ -638,7 +708,7 @@ fn test_remove_headers() {
 		set_headers: vec![],
 	});
 
-	super::apply_header_mutations(&mut headers, mutation.as_ref()).unwrap();
+	super::apply_header_mutations(&mut headers, mutation.as_ref());
 
 	assert!(headers.get("to-remove").is_none());
 	assert_eq!(headers.get("keep").unwrap(), "value");
@@ -665,7 +735,7 @@ fn test_apply_header_mutations_request() {
 		}],
 	});
 
-	super::apply_header_mutations_request(&mut req, mutation.as_ref()).unwrap();
+	super::apply_header_mutations_request(&mut req, mutation.as_ref());
 
 	let headers = req.headers();
 	assert!(headers.get("to-remove").is_none());
@@ -726,7 +796,7 @@ fn test_apply_pseudo_headers_request_with_raw_value() {
 		],
 	});
 
-	super::apply_header_mutations_request(&mut req, mutation.as_ref()).unwrap();
+	super::apply_header_mutations_request(&mut req, mutation.as_ref());
 
 	// Verify pseudo-headers were applied
 	assert_eq!(req.method(), "POST");
@@ -767,7 +837,7 @@ fn test_apply_pseudo_headers_request_with_value_field() {
 		],
 	});
 
-	super::apply_header_mutations_request(&mut req, mutation.as_ref()).unwrap();
+	super::apply_header_mutations_request(&mut req, mutation.as_ref());
 
 	// Verify pseudo-headers from value field were applied
 	assert_eq!(req.method(), "PUT");
@@ -795,7 +865,7 @@ fn test_pseudo_headers_request_raw_value_precedence() {
 		}],
 	});
 
-	super::apply_header_mutations_request(&mut req, mutation.as_ref()).unwrap();
+	super::apply_header_mutations_request(&mut req, mutation.as_ref());
 
 	// raw_value should take precedence
 	assert_eq!(req.method(), "DELETE");
@@ -822,7 +892,7 @@ fn test_apply_header_mutations_response() {
 		}],
 	});
 
-	super::apply_header_mutations_response(&mut resp, mutation.as_ref()).unwrap();
+	super::apply_header_mutations_response(&mut resp, mutation.as_ref());
 
 	let headers = resp.headers();
 	assert!(headers.get("to-remove").is_none());
@@ -854,7 +924,7 @@ fn test_apply_pseudo_headers_response_with_raw_value() {
 		}],
 	});
 
-	super::apply_header_mutations_response(&mut resp, mutation.as_ref()).unwrap();
+	super::apply_header_mutations_response(&mut resp, mutation.as_ref());
 
 	// Verify :status pseudo-header was applied
 	assert_eq!(resp.status(), 404);
@@ -882,7 +952,7 @@ fn test_apply_pseudo_headers_response_with_value_field() {
 		}],
 	});
 
-	super::apply_header_mutations_response(&mut resp, mutation.as_ref()).unwrap();
+	super::apply_header_mutations_response(&mut resp, mutation.as_ref());
 
 	// Verify :status pseudo-header from value field was applied
 	assert_eq!(resp.status(), 201);
@@ -908,7 +978,7 @@ fn test_pseudo_headers_response_raw_value_precedence() {
 		}],
 	});
 
-	super::apply_header_mutations_response(&mut resp, mutation.as_ref()).unwrap();
+	super::apply_header_mutations_response(&mut resp, mutation.as_ref());
 
 	// raw_value should take precedence
 	assert_eq!(resp.status(), 403);
@@ -956,7 +1026,7 @@ fn test_apply_mixed_headers_and_pseudo_headers_request() {
 		],
 	});
 
-	super::apply_header_mutations_request(&mut req, mutation.as_ref()).unwrap();
+	super::apply_header_mutations_request(&mut req, mutation.as_ref());
 
 	// Verify pseudo-header was applied
 	assert_eq!(req.method(), "POST");
@@ -1006,7 +1076,7 @@ fn test_apply_mixed_headers_and_pseudo_headers_response() {
 		],
 	});
 
-	super::apply_header_mutations_response(&mut resp, mutation.as_ref()).unwrap();
+	super::apply_header_mutations_response(&mut resp, mutation.as_ref());
 
 	// Verify pseudo-header was applied
 	assert_eq!(resp.status(), 201);
@@ -1044,7 +1114,7 @@ fn test_deprecated_append_true() {
 		],
 	});
 
-	super::apply_header_mutations(&mut headers, mutation.as_ref()).unwrap();
+	super::apply_header_mutations(&mut headers, mutation.as_ref());
 
 	let values: Vec<_> = headers.get_all("existing").iter().collect();
 	assert_eq!(values.len(), 2);
@@ -1071,7 +1141,7 @@ fn test_deprecated_append_false() {
 		}],
 	});
 
-	super::apply_header_mutations(&mut headers, mutation.as_ref()).unwrap();
+	super::apply_header_mutations(&mut headers, mutation.as_ref());
 
 	let values: Vec<_> = headers.get_all("existing").iter().collect();
 	assert_eq!(values.len(), 1);
@@ -1107,7 +1177,7 @@ fn test_value_field_instead_of_raw_value() {
 		],
 	});
 
-	super::apply_header_mutations(&mut headers, mutation.as_ref()).unwrap();
+	super::apply_header_mutations(&mut headers, mutation.as_ref());
 
 	let values: Vec<_> = headers.get_all("existing").iter().collect();
 	assert_eq!(values.len(), 2);
@@ -1133,7 +1203,7 @@ fn test_raw_value_takes_precedence_over_value() {
 		}],
 	});
 
-	super::apply_header_mutations(&mut headers, mutation.as_ref()).unwrap();
+	super::apply_header_mutations(&mut headers, mutation.as_ref());
 
 	assert_eq!(headers.get("test").unwrap(), "raw-value-wins");
 }
@@ -1156,7 +1226,7 @@ fn test_append_action_priority_over_deprecated_append() {
 		}],
 	});
 
-	super::apply_header_mutations(&mut headers, mutation.as_ref()).unwrap();
+	super::apply_header_mutations(&mut headers, mutation.as_ref());
 
 	let values: Vec<_> = headers.get_all("existing").iter().collect();
 	assert_eq!(values.len(), 1);
@@ -1276,8 +1346,8 @@ mod extract_dynamic_metadata_tests {
 	use prost_wkt_types::value::Kind;
 	use prost_wkt_types::{Struct, Value};
 
+	use super::super::extract_dynamic_metadata;
 	use super::*;
-	use crate::http::ext_proc::ExtProcInstance;
 
 	#[test]
 	fn test_extract_creates_extension() {
@@ -1295,7 +1365,7 @@ mod extract_dynamic_metadata_tests {
 			.body(Body::empty())
 			.unwrap();
 
-		ExtProcInstance::extract_dynamic_metadata(Some(&mut req), &metadata).unwrap();
+		extract_dynamic_metadata(&mut req, &metadata).unwrap();
 
 		let extracted = req
 			.extensions()
@@ -1330,7 +1400,7 @@ mod extract_dynamic_metadata_tests {
 			)]
 			.into(),
 		};
-		ExtProcInstance::extract_dynamic_metadata(Some(&mut req), &metadata).unwrap();
+		extract_dynamic_metadata(&mut req, &metadata).unwrap();
 
 		let extracted = req
 			.extensions()
@@ -1370,7 +1440,7 @@ mod extract_dynamic_metadata_tests {
 			)]
 			.into(),
 		};
-		ExtProcInstance::extract_dynamic_metadata(Some(&mut req), &metadata).unwrap();
+		extract_dynamic_metadata(&mut req, &metadata).unwrap();
 
 		let extracted = req
 			.extensions()
@@ -1384,21 +1454,6 @@ mod extract_dynamic_metadata_tests {
 	}
 
 	#[test]
-	fn test_extract_none_request_ok() {
-		let metadata = Struct {
-			fields: [(
-				"key".to_string(),
-				Value {
-					kind: Some(Kind::StringValue("value".to_string())),
-				},
-			)]
-			.into(),
-		};
-		let result = ExtProcInstance::extract_dynamic_metadata(None, &metadata);
-		assert!(result.is_ok());
-	}
-
-	#[test]
 	fn test_extract_empty_metadata_no_extension() {
 		let metadata = Struct {
 			fields: HashMap::new(),
@@ -1408,7 +1463,7 @@ mod extract_dynamic_metadata_tests {
 			.body(Body::empty())
 			.unwrap();
 
-		ExtProcInstance::extract_dynamic_metadata(Some(&mut req), &metadata).unwrap();
+		extract_dynamic_metadata(&mut req, &metadata).unwrap();
 
 		assert!(
 			req
@@ -1449,7 +1504,7 @@ mod extract_dynamic_metadata_tests {
 			.body(Body::empty())
 			.unwrap();
 
-		ExtProcInstance::extract_dynamic_metadata(Some(&mut req), &metadata).unwrap();
+		extract_dynamic_metadata(&mut req, &metadata).unwrap();
 
 		let extracted = req
 			.extensions()
@@ -1484,7 +1539,7 @@ mod extract_dynamic_metadata_tests {
 			)]
 			.into(),
 		};
-		ExtProcInstance::extract_dynamic_metadata(Some(&mut req), &metadata1).unwrap();
+		extract_dynamic_metadata(&mut req, &metadata1).unwrap();
 
 		let metadata2 = Struct {
 			fields: [(
@@ -1495,7 +1550,7 @@ mod extract_dynamic_metadata_tests {
 			)]
 			.into(),
 		};
-		ExtProcInstance::extract_dynamic_metadata(Some(&mut req), &metadata2).unwrap();
+		extract_dynamic_metadata(&mut req, &metadata2).unwrap();
 
 		let extracted = req
 			.extensions()

--- a/crates/agentgateway/src/test_helpers/extprocmock.rs
+++ b/crates/agentgateway/src/test_helpers/extprocmock.rs
@@ -1,12 +1,6 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use async_trait::async_trait;
-use tokio::sync::mpsc;
-use tokio::task::JoinHandle;
-use tokio_stream;
-use tonic::{Request, Response as TonicResponse, Status, Streaming};
-
 use crate::http::ext_proc::proto::external_processor_server::{
 	ExternalProcessor, ExternalProcessorServer,
 };
@@ -15,6 +9,12 @@ use crate::http::ext_proc::proto::{
 	processing_request, processing_response,
 };
 use crate::*;
+use async_trait::async_trait;
+use protos::envoy::service::ext_proc::v3::{BodyMutation, body_mutation};
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use tokio_stream;
+use tonic::{Request, Response as TonicResponse, Status, Streaming};
 
 pub fn request_header_response(cr: Option<CommonResponse>) -> Result<ProcessingResponse, Status> {
 	Ok(ProcessingResponse {
@@ -99,10 +99,22 @@ pub trait Handler {
 
 	async fn handle_request_body(
 		&mut self,
-		_body: &proto::HttpBody,
+		b: &proto::HttpBody,
 		sender: &mpsc::Sender<Result<ProcessingResponse, Status>>,
 	) -> Result<(), Status> {
-		let _ = sender.send(request_body_response(None)).await;
+		let _ = sender
+			.send(request_body_response(Some(CommonResponse {
+				body_mutation: Some(BodyMutation {
+					mutation: Some(body_mutation::Mutation::StreamedResponse(
+						proto::StreamedBodyResponse {
+							body: b.body.clone(),
+							end_of_stream: b.end_of_stream,
+						},
+					)),
+				}),
+				..Default::default()
+			})))
+			.await;
 		Ok(())
 	}
 
@@ -117,10 +129,22 @@ pub trait Handler {
 
 	async fn handle_response_body(
 		&mut self,
-		_body: &proto::HttpBody,
+		b: &proto::HttpBody,
 		sender: &mpsc::Sender<Result<ProcessingResponse, Status>>,
 	) -> Result<(), Status> {
-		let _ = sender.send(response_body_response(None)).await;
+		let _ = sender
+			.send(response_body_response(Some(CommonResponse {
+				body_mutation: Some(BodyMutation {
+					mutation: Some(body_mutation::Mutation::StreamedResponse(
+						proto::StreamedBodyResponse {
+							body: b.body.clone(),
+							end_of_stream: b.end_of_stream,
+						},
+					)),
+				}),
+				..Default::default()
+			})))
+			.await;
 		Ok(())
 	}
 


### PR DESCRIPTION
Fixes https://github.com/agentgateway/agentgateway/issues/1400

1. Handle immediate response in various phases of the lifecycle
2. Remove complex task message passing
3. Adopt Envoy's new fail_open strategy which is that it only triggers
   on the initial request failing unless there is no body.
