### PR TITLE
Fix #900: system-assigned managed identity crashes with NoopClient panic

### DIFF
--- a/crates/agentgateway/src/http/auth.rs
+++ b/crates/agentgateway/src/http/auth.rs
@@ -747,24 +747,29 @@ mod azure {
 				AzureAuthCredentialSource::ManagedIdentity {
 					user_assigned_identity,
 				} => {
-					let options: Option<azure_identity::ManagedIdentityCredentialOptions> =
-						user_assigned_identity.as_ref().map(|uami| {
-							azure_identity::ManagedIdentityCredentialOptions {
-								user_assigned_id: match uami {
-									AzureUserAssignedIdentity::ClientId(cid) => {
-										Some(UserAssignedId::ClientId(cid.to_string()))
-									},
-									AzureUserAssignedIdentity::ObjectId(oid) => {
-										Some(UserAssignedId::ObjectId(oid.to_string()))
-									},
-									AzureUserAssignedIdentity::ResourceId(rid) => {
-										Some(UserAssignedId::ResourceId(rid.to_string()))
-									},
-								},
-								client_options,
-							}
-						});
-					Ok(azure_identity::ManagedIdentityCredential::new(options)?)
+					// Always construct ManagedIdentityCredentialOptions so that the
+					// custom reqwest-backed transport is injected regardless of whether
+					// a user-assigned identity is specified.
+					//
+					// Before this fix, .map() short-circuited to None for system-assigned
+					// identity (managedIdentity: {}), causing ManagedIdentityCredential::new(None)
+					// to fall back to NoopClient which panics on every IMDS request.
+					// See: https://github.com/agentgateway/agentgateway/issues/900
+					let options = azure_identity::ManagedIdentityCredentialOptions {
+						user_assigned_id: user_assigned_identity.as_ref().map(|uami| match uami {
+							AzureUserAssignedIdentity::ClientId(cid) => {
+								UserAssignedId::ClientId(cid.to_string())
+							},
+							AzureUserAssignedIdentity::ObjectId(oid) => {
+								UserAssignedId::ObjectId(oid.to_string())
+							},
+							AzureUserAssignedIdentity::ResourceId(rid) => {
+								UserAssignedId::ResourceId(rid.to_string())
+							},
+						}),
+						client_options,
+					};
+					Ok(azure_identity::ManagedIdentityCredential::new(Some(options))?)
 				},
 				AzureAuthCredentialSource::WorkloadIdentity {} => {
 					Ok(azure_identity::WorkloadIdentityCredential::new(Some(

--- a/crates/agentgateway/src/http/auth.rs
+++ b/crates/agentgateway/src/http/auth.rs
@@ -757,19 +757,17 @@ mod azure {
 					// See: https://github.com/agentgateway/agentgateway/issues/900
 					let options = azure_identity::ManagedIdentityCredentialOptions {
 						user_assigned_id: user_assigned_identity.as_ref().map(|uami| match uami {
-							AzureUserAssignedIdentity::ClientId(cid) => {
-								UserAssignedId::ClientId(cid.to_string())
-							},
-							AzureUserAssignedIdentity::ObjectId(oid) => {
-								UserAssignedId::ObjectId(oid.to_string())
-							},
+							AzureUserAssignedIdentity::ClientId(cid) => UserAssignedId::ClientId(cid.to_string()),
+							AzureUserAssignedIdentity::ObjectId(oid) => UserAssignedId::ObjectId(oid.to_string()),
 							AzureUserAssignedIdentity::ResourceId(rid) => {
 								UserAssignedId::ResourceId(rid.to_string())
 							},
 						}),
 						client_options,
 					};
-					Ok(azure_identity::ManagedIdentityCredential::new(Some(options))?)
+					Ok(azure_identity::ManagedIdentityCredential::new(Some(
+						options,
+					))?)
 				},
 				AzureAuthCredentialSource::WorkloadIdentity {} => {
 					Ok(azure_identity::WorkloadIdentityCredential::new(Some(


### PR DESCRIPTION
## Summary

Fix system-assigned managed identity crash caused by NoopClient panic.

## Problem

When `managedIdentity: {}` is configured (system-assigned), the gateway panics on the first IMDS request:

**Root cause:** The `.map()` call short-circuits to `None` when `user_assigned_identity` is `None`, so `ManagedIdentityCredential::new(None)` is called. The Azure SDK then falls back to its default `NoopClient` instead of the custom reqwest-backed transport.

## Fix

Always construct `ManagedIdentityCredentialOptions` with the custom transport, making `user_assigned_id` the only optional field. When `user_assigned_id` is `None`, the SDK treats it as system-assigned — same behaviour as before, but now with the correct HTTP client.

## Behaviour after fix

| Configuration | Before | After |
|---|---|---|
| `managedIdentity: {}` (system-assigned) | 💥 Panic | ✅ Works |
| `managedIdentity: { clientId: "..." }` | ✅ Works | ✅ Works |
| `managedIdentity: { objectId: "..." }` | ✅ Works | ✅ Works |
| `managedIdentity: { resourceId: "..." }` | ✅ Works | ✅ Works |

## Files changed

- `crates/agentgateway/src/http/auth.rs` — fix `ManagedIdentity` arm in `build_credential()`

Fixes #900