### PR TITLE
Apply backend policy to mcp backend 

### DIFF
--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -186,6 +186,101 @@ async fn stream_to_stream_single_tls() {
 	);
 }
 
+/// Test that RequestHeaderModifier backend policies are applied to MCP backends.
+#[tokio::test]
+async fn mcp_backend_request_header_modifier_applied() {
+	use crate::http::filters::HeaderModifier;
+
+	let mock = mock_streamable_http_server(true).await;
+
+	// Create policies that will be applied at the backend level:
+	// 1. RequestHeaderModifier adds a custom header
+	// 2. BackendAuth adds authorization
+	let header_modifier = HeaderModifier {
+		add: vec![(
+			"x-test-policy-header".parse().unwrap(),
+			"policy-value".parse().unwrap(),
+		)],
+		set: vec![],
+		remove: vec![],
+	};
+
+	let policies = vec![
+		BackendPolicy::RequestHeaderModifier(header_modifier),
+		BackendPolicy::BackendAuth(BackendAuth::Key(SecretString::new("test-key".into()))),
+	];
+
+	let (_bind, io) = setup_proxy_policies(&mock, true, false, policies).await;
+
+	let client = mcp_streamable_client(io).await;
+
+	// Call a tool - the echo_http tool returns the Authorization header value
+	// which confirms that BackendAuth policy was applied via apply_backend_policies
+	let ctr = client
+		.call_tool(
+			rmcp::model::CallToolRequestParams::new("echo_http").with_arguments(
+				serde_json::json!({"hi": "world"})
+					.as_object()
+					.cloned()
+					.unwrap(),
+			),
+		)
+		.await
+		.unwrap();
+
+	// Verify the BackendAuth policy was applied
+	assert_eq!(
+		&ctr.content[0].raw.as_text().unwrap().text,
+		r#"Bearer test-key"#,
+		"Backend authentication should be applied via apply_backend_policies"
+	);
+}
+
+/// Test that BackendAuth::Passthrough fails for MCP backends because Claims are never extracted.
+/// This test demonstrates the bug: the MCP code path early-returns before apply_backend_policies
+/// is called, so Claims are never extracted from the JWT. When the request goes through the
+/// indirect path (MCP -> PolicyClient -> make_backend_call), the new request has no Claims
+/// extension, so Passthrough auth cannot access the JWT.
+#[tokio::test]
+#[should_panic(expected = "Expected JWT to be forwarded via Passthrough auth")]
+async fn mcp_backend_passthrough_auth_fails_missing_claims() {
+	let mock = mock_streamable_http_server(true).await;
+
+	// Configure BackendAuth::Passthrough policy
+	// This should forward the JWT from Claims extension as Authorization header
+	let policies = vec![BackendPolicy::BackendAuth(BackendAuth::Passthrough {})];
+
+	let (_bind, io) = setup_proxy_policies(&mock, true, false, policies).await;
+
+	let client = mcp_streamable_client(io).await;
+
+	// Call a tool - the echo_http tool returns the Authorization header value
+	// With Passthrough auth, we expect the JWT to be forwarded as "Bearer <jwt>"
+	let ctr = client
+		.call_tool(
+			rmcp::model::CallToolRequestParams::new("echo_http").with_arguments(
+				serde_json::json!({"hi": "world"})
+					.as_object()
+					.cloned()
+					.unwrap(),
+			),
+		)
+		.await
+		.unwrap();
+
+	// This assertion will fail because:
+	// 1. MCP branch early-returns without calling apply_backend_policies
+	// 2. Claims are never extracted from the original request
+	// 3. The new request created by MCP client has no Claims extension
+	// 4. Passthrough auth cannot find Claims, so Authorization header is empty
+	let auth_header = &ctr.content[0].raw.as_text().unwrap().text;
+	assert!(
+		auth_header.starts_with("Bearer "),
+		"Expected JWT to be forwarded via Passthrough auth, but got: {}",
+		auth_header
+	);
+}
+
 /// Test that calling a tool denied by MCP authorization policy returns proper JSON-RPC error
 /// with INVALID_PARAMS error code (-32602) and message "Unknown tool: {tool_name}"
 #[tokio::test]

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -402,6 +402,158 @@ MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgltxBTVDLg7C6vE1T
 	);
 }
 
+/// Route JWT validation removes the `Authorization` header and stores the token in `Claims`.
+/// `BackendAuth::Passthrough` must run on the **incoming** MCP gateway request (before MCP
+/// `serve`) so `apply_backend_policies` can restore `Bearer <jwt>` for snapshots used by MCP
+/// authorization. Otherwise `request.headers["authorization"]` is empty in CEL even though the
+/// nested upstream client may still forward credentials.
+///
+/// This test sets an allowlist that only permits tools when `authorization` starts with `Bearer `.
+/// If `Backend::MCP` skipped `apply_backend_policies`, `list_tools` would return nothing.
+#[tokio::test]
+async fn mcp_authorization_cel_sees_bearer_header_after_jwt_and_passthrough() {
+	use std::collections::HashMap;
+
+	use ::http::{HeaderName, HeaderValue};
+	use jsonwebtoken::jwk::JwkSet;
+	use jsonwebtoken::{Algorithm, EncodingKey, Header};
+	use rmcp::ServiceExt;
+	use rmcp::model::{ClientCapabilities, ClientInfo, Implementation};
+	use rmcp::transport::StreamableHttpClientTransport;
+	use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
+	use serde::Serialize;
+
+	use crate::http::jwt;
+	use crate::types::agent::{JwtAuthentication, TrafficPolicy};
+
+	const TEST_PRIVATE_KEY_PEM: &str = "-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgltxBTVDLg7C6vE1T
+7OtwJIZ/dpm8ygE2MBTjPCY3hgahRANCAARYzu50EeBrT0rELmTGroaGtn0zdjxL
+1lOGr9fGw5wOGcXO0+Gn5F5sIxGyTM0FwnUHFNz2SoixZR5dtxhNc+Lo
+-----END PRIVATE KEY-----
+";
+	const TEST_KEY_ID: &str = "test-key-1";
+	const TEST_ISSUER: &str = "https://test.example.com";
+	const TEST_CLIENT_ID: &str = "test-client";
+
+	#[derive(Serialize)]
+	struct TestClaims<'a> {
+		iss: &'a str,
+		aud: &'a str,
+		exp: u64,
+		sub: &'a str,
+	}
+
+	let test_jwks = || -> JwkSet {
+		serde_json::from_value(serde_json::json!({
+			"keys": [{
+				"use": "sig",
+				"kty": "EC",
+				"kid": TEST_KEY_ID,
+				"crv": "P-256",
+				"alg": "ES256",
+				"x": "WM7udBHga09KxC5kxq6GhrZ9M3Y8S9ZThq_XxsOcDhk",
+				"y": "xc7T4afkXmwjEbJMzQXCdQcU3PZKiLFlHl23GE1z4ug"
+			}]
+		}))
+		.expect("jwks json")
+	};
+
+	let now = std::time::SystemTime::now()
+		.duration_since(std::time::UNIX_EPOCH)
+		.unwrap()
+		.as_secs();
+	let header = Header {
+		kid: Some(TEST_KEY_ID.to_string()),
+		alg: Algorithm::ES256,
+		..Default::default()
+	};
+	let test_jwt = jsonwebtoken::encode(
+		&header,
+		&TestClaims {
+			iss: TEST_ISSUER,
+			aud: TEST_CLIENT_ID,
+			exp: now + 600,
+			sub: "test-user",
+		},
+		&EncodingKey::from_ec_pem(TEST_PRIVATE_KEY_PEM.as_bytes()).expect("encoding key"),
+	)
+	.expect("signed jwt");
+
+	let mock = mock_streamable_http_server(true).await;
+
+	// Allow tools only when the gateway request still exposes a Bearer token on the Authorization
+	// header (after JWT validation, that requires Passthrough on the MCP hop).
+	let allow_only_with_bearer = McpAuthorization::new(RuleSet::new(PolicySet::new(
+		vec![Arc::new(
+			cel::Expression::new_strict(r#"request.headers["authorization"].startsWith("Bearer ")"#)
+				.unwrap(),
+		)],
+		vec![],
+		vec![],
+	)));
+
+	let backend_policies = vec![
+		BackendPolicy::BackendAuth(BackendAuth::Passthrough {}),
+		BackendPolicy::McpAuthorization(allow_only_with_bearer),
+	];
+
+	let mut t = setup_proxy_test("{}")
+		.unwrap()
+		.with_mcp_backend_policies(mock.addr, true, false, backend_policies)
+		.with_bind(simple_bind(basic_route(mock.addr)));
+
+	let jwt_provider = jwt::Provider::from_jwks(
+		test_jwks(),
+		TEST_ISSUER.to_string(),
+		Some(vec![TEST_CLIENT_ID.to_string()]),
+		jwt::JWTValidationOptions::default(),
+	)
+	.expect("jwt provider");
+	let jwt_auth = JwtAuthentication {
+		jwt: jwt::Jwt::from_providers(vec![jwt_provider], jwt::Mode::Strict),
+		mcp: None,
+	};
+
+	t.with_policy(TargetedPolicy {
+		key: "jwt-auth".into(),
+		name: None,
+		target: PolicyTarget::Route(RouteName {
+			name: "route".into(),
+			namespace: "".into(),
+			rule_name: None,
+			kind: None,
+		}),
+		policy: TrafficPolicy::JwtAuth(jwt_auth).into(),
+	});
+
+	let io = t.serve_real_listener(BIND_KEY).await;
+
+	let mut headers = HashMap::new();
+	headers.insert(
+		HeaderName::from_static("authorization"),
+		HeaderValue::from_str(&format!("Bearer {}", test_jwt)).unwrap(),
+	);
+	let config = StreamableHttpClientTransportConfig::with_uri(format!("http://{io}/mcp"))
+		.custom_headers(headers);
+	let transport = StreamableHttpClientTransport::from_config(config);
+	let client_info = ClientInfo::new(
+		ClientCapabilities::default(),
+		Implementation::new("test-client".to_string(), "0.0.1"),
+	);
+	let client = client_info
+		.serve(transport)
+		.await
+		.expect("client should connect");
+
+	let tools = client.list_tools(None).await.expect("list_tools");
+	let names: Vec<String> = tools.tools.iter().map(|t| t.name.to_string()).collect();
+	assert!(
+		names.contains(&"echo".to_string()),
+		"allowlist requires Bearer in request.headers[authorization] after Passthrough; got tools: {names:?}"
+	);
+}
+
 /// Test that calling a tool denied by MCP authorization policy returns proper JSON-RPC error
 /// with INVALID_PARAMS error code (-32602) and message "Unknown tool: {tool_name}"
 #[tokio::test]

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -236,14 +236,12 @@ async fn mcp_backend_request_header_modifier_applied() {
 	);
 }
 
-/// Test that BackendAuth::Passthrough fails for MCP backends because Claims are never extracted.
-/// This test demonstrates the bug: the MCP code path early-returns before apply_backend_policies
-/// is called, so Claims are never extracted from the JWT. When the request goes through the
-/// indirect path (MCP -> PolicyClient -> make_backend_call), the new request has no Claims
-/// extension, so Passthrough auth cannot access the JWT.
+/// Test that BackendAuth::Passthrough works correctly for MCP backends.
+/// This verifies the fix: apply_backend_policies is now called in the MCP code path
+/// before the early return, ensuring Claims are extracted from the JWT and policies
+/// that depend on request context (like Passthrough auth) work correctly.
 #[tokio::test]
-#[should_panic(expected = "Expected JWT to be forwarded via Passthrough auth")]
-async fn mcp_backend_passthrough_auth_fails_missing_claims() {
+async fn mcp_backend_passthrough_auth_works() {
 	let mock = mock_streamable_http_server(true).await;
 
 	// Configure BackendAuth::Passthrough policy
@@ -268,11 +266,7 @@ async fn mcp_backend_passthrough_auth_fails_missing_claims() {
 		.await
 		.unwrap();
 
-	// This assertion will fail because:
-	// 1. MCP branch early-returns without calling apply_backend_policies
-	// 2. Claims are never extracted from the original request
-	// 3. The new request created by MCP client has no Claims extension
-	// 4. Passthrough auth cannot find Claims, so Authorization header is empty
+	// Verify the Passthrough auth policy was applied and JWT was forwarded
 	let auth_header = &ctr.content[0].raw.as_text().unwrap().text;
 	assert!(
 		auth_header.starts_with("Bearer "),

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -20,7 +20,7 @@ use crate::proxy::httpproxy::PolicyClient;
 use crate::test_helpers::proxymock::{
 	BIND_KEY, TestBind, basic_named_route, basic_route, setup_proxy_test, simple_bind,
 };
-use crate::types::agent::{BackendPolicy, FrontendPolicy, PolicyTarget, TargetedPolicy};
+use crate::types::agent::{BackendPolicy, FrontendPolicy, PolicyTarget, RouteName, TargetedPolicy};
 use crate::*;
 
 #[tokio::test]
@@ -180,10 +180,9 @@ async fn stream_to_stream_single_tls() {
 		)
 		.await
 		.unwrap();
-	assert_eq!(
-		&ctr.content[0].raw.as_text().unwrap().text,
-		r#"Bearer my-key"#
-	);
+	let response: serde_json::Value =
+		serde_json::from_str(&ctr.content[0].raw.as_text().unwrap().text).unwrap();
+	assert_eq!(response["authorization"], "Bearer my-key");
 }
 
 /// Test that RequestHeaderModifier backend policies are applied to MCP backends.
@@ -214,8 +213,7 @@ async fn mcp_backend_request_header_modifier_applied() {
 
 	let client = mcp_streamable_client(io).await;
 
-	// Call a tool - the echo_http tool returns the Authorization header value
-	// which confirms that BackendAuth policy was applied via apply_backend_policies
+	// Call a tool - the echo_http tool returns HTTP headers as JSON
 	let ctr = client
 		.call_tool(
 			rmcp::model::CallToolRequestParams::new("echo_http").with_arguments(
@@ -228,31 +226,156 @@ async fn mcp_backend_request_header_modifier_applied() {
 		.await
 		.unwrap();
 
+	// Parse the JSON response
+	let response: serde_json::Value =
+		serde_json::from_str(&ctr.content[0].raw.as_text().unwrap().text).unwrap();
+
 	// Verify the BackendAuth policy was applied
 	assert_eq!(
-		&ctr.content[0].raw.as_text().unwrap().text,
-		r#"Bearer test-key"#,
+		response["authorization"], "Bearer test-key",
 		"Backend authentication should be applied via apply_backend_policies"
+	);
+
+	// Verify the RequestHeaderModifier policy was applied
+	assert_eq!(
+		response["x-test-policy-header"], "policy-value",
+		"RequestHeaderModifier should add x-test-policy-header via apply_backend_policies"
 	);
 }
 
 /// Test that BackendAuth::Passthrough works correctly for MCP backends.
-/// This verifies the fix: apply_backend_policies is now called in the MCP code path
-/// before the early return, ensuring Claims are extracted from the JWT and policies
-/// that depend on request context (like Passthrough auth) work correctly.
 #[tokio::test]
 async fn mcp_backend_passthrough_auth_works() {
+	use std::collections::HashMap;
+
+	use ::http::{HeaderName, HeaderValue};
+	use jsonwebtoken::jwk::JwkSet;
+	use jsonwebtoken::{Algorithm, EncodingKey, Header};
+	use rmcp::ServiceExt;
+	use rmcp::model::{ClientCapabilities, ClientInfo, Implementation};
+	use rmcp::transport::StreamableHttpClientTransport;
+	use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
+	use serde::Serialize;
+
+	use crate::http::jwt;
+	use crate::types::agent::{JwtAuthentication, TrafficPolicy};
+
+	// Test key and issuer constants
+	const TEST_PRIVATE_KEY_PEM: &str = "-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgltxBTVDLg7C6vE1T
+7OtwJIZ/dpm8ygE2MBTjPCY3hgahRANCAARYzu50EeBrT0rELmTGroaGtn0zdjxL
+1lOGr9fGw5wOGcXO0+Gn5F5sIxGyTM0FwnUHFNz2SoixZR5dtxhNc+Lo
+-----END PRIVATE KEY-----
+";
+	const TEST_KEY_ID: &str = "test-key-1";
+	const TEST_ISSUER: &str = "https://test.example.com";
+	const TEST_CLIENT_ID: &str = "test-client";
+
+	#[derive(Serialize)]
+	struct TestClaims<'a> {
+		iss: &'a str,
+		aud: &'a str,
+		exp: u64,
+		sub: &'a str,
+	}
+
+	// Helper to create a test JWKS
+	let test_jwks = || -> JwkSet {
+		serde_json::from_value(serde_json::json!({
+			"keys": [{
+				"use": "sig",
+				"kty": "EC",
+				"kid": TEST_KEY_ID,
+				"crv": "P-256",
+				"alg": "ES256",
+				"x": "WM7udBHga09KxC5kxq6GhrZ9M3Y8S9ZThq_XxsOcDhk",
+				"y": "xc7T4afkXmwjEbJMzQXCdQcU3PZKiLFlHl23GE1z4ug"
+			}]
+		}))
+		.expect("jwks json")
+	};
+
+	// Create a test JWT token
+	let now = std::time::SystemTime::now()
+		.duration_since(std::time::UNIX_EPOCH)
+		.unwrap()
+		.as_secs();
+	let header = Header {
+		kid: Some(TEST_KEY_ID.to_string()),
+		alg: Algorithm::ES256,
+		..Default::default()
+	};
+	let test_jwt = jsonwebtoken::encode(
+		&header,
+		&TestClaims {
+			iss: TEST_ISSUER,
+			aud: TEST_CLIENT_ID,
+			exp: now + 600,
+			sub: "test-user",
+		},
+		&EncodingKey::from_ec_pem(TEST_PRIVATE_KEY_PEM.as_bytes()).expect("encoding key"),
+	)
+	.expect("signed jwt");
+
+	// Set up the mock MCP server
 	let mock = mock_streamable_http_server(true).await;
 
-	// Configure BackendAuth::Passthrough policy
-	// This should forward the JWT from Claims extension as Authorization header
-	let policies = vec![BackendPolicy::BackendAuth(BackendAuth::Passthrough {})];
+	// Configure BackendAuth::Passthrough policy on the MCP backend
+	let backend_policies = vec![BackendPolicy::BackendAuth(BackendAuth::Passthrough {})];
 
-	let (_bind, io) = setup_proxy_policies(&mock, true, false, policies).await;
+	// Set up the proxy with JWT authentication
+	let mut t = setup_proxy_test("{}")
+		.unwrap()
+		.with_mcp_backend_policies(mock.addr, true, false, backend_policies)
+		.with_bind(simple_bind(basic_route(mock.addr)));
 
-	let client = mcp_streamable_client(io).await;
+	// Configure JWT authentication policy
+	let jwt_provider = jwt::Provider::from_jwks(
+		test_jwks(),
+		TEST_ISSUER.to_string(),
+		Some(vec![TEST_CLIENT_ID.to_string()]),
+		jwt::JWTValidationOptions::default(),
+	)
+	.expect("jwt provider");
+	let jwt_auth = JwtAuthentication {
+		jwt: jwt::Jwt::from_providers(vec![jwt_provider], jwt::Mode::Strict),
+		mcp: None,
+	};
 
-	// Call a tool - the echo_http tool returns the Authorization header value
+	// Apply JWT auth policy to the route
+	t.with_policy(TargetedPolicy {
+		key: "jwt-auth".into(),
+		name: None,
+		target: PolicyTarget::Route(RouteName {
+			name: "route".into(),
+			namespace: "".into(),
+			rule_name: None,
+			kind: None,
+		}),
+		policy: TrafficPolicy::JwtAuth(jwt_auth).into(),
+	});
+
+	let io = t.serve_real_listener(BIND_KEY).await;
+
+	// Create a client with the JWT in the Authorization header
+	let mut headers = HashMap::new();
+	headers.insert(
+		HeaderName::from_static("authorization"),
+		HeaderValue::from_str(&format!("Bearer {}", test_jwt)).unwrap(),
+	);
+	let config = StreamableHttpClientTransportConfig::with_uri(format!("http://{io}/mcp"))
+		.custom_headers(headers);
+	let transport = StreamableHttpClientTransport::from_config(config);
+	let client_info = ClientInfo::new(
+		ClientCapabilities::default(),
+		Implementation::new("test-client".to_string(), "0.0.1".to_string()),
+	);
+	let client = client_info
+		.serve(transport)
+		.await
+		.expect("client should connect");
+
+	// Call a tool - the echo_http tool returns HTTP headers as JSON
 	// With Passthrough auth, we expect the JWT to be forwarded as "Bearer <jwt>"
 	let ctr = client
 		.call_tool(
@@ -266,12 +389,16 @@ async fn mcp_backend_passthrough_auth_works() {
 		.await
 		.unwrap();
 
-	// Verify the Passthrough auth policy was applied and JWT was forwarded
-	let auth_header = &ctr.content[0].raw.as_text().unwrap().text;
-	assert!(
-		auth_header.starts_with("Bearer "),
-		"Expected JWT to be forwarded via Passthrough auth, but got: {}",
-		auth_header
+	// Parse the JSON response
+	let response: serde_json::Value =
+		serde_json::from_str(&ctr.content[0].raw.as_text().unwrap().text).unwrap();
+
+	// Verify the Passthrough auth policy was applied and the exact JWT was forwarded
+	let forwarded_auth = response["authorization"].as_str().unwrap_or("");
+	let expected_auth = format!("Bearer {}", test_jwt);
+	assert_eq!(
+		forwarded_auth, expected_auth,
+		"Expected JWT to be forwarded via Passthrough auth"
 	);
 }
 
@@ -1032,6 +1159,7 @@ mod mockserver {
 		ErrorData as McpError, RoleServer, ServerHandler, prompt, prompt_handler, prompt_router,
 		schemars, tool, tool_handler, tool_router,
 	};
+	use serde_json::Map;
 	use serde_json::json;
 	use tokio::sync::Mutex;
 
@@ -1129,13 +1257,28 @@ mod mockserver {
 		#[tool(description = "Echo HTTP attributes")]
 		fn echo_http(&self, rq: RequestContext<RoleServer>) -> Result<CallToolResult, McpError> {
 			let ext = rq.extensions.get::<Parts>();
-			Ok(CallToolResult::success(vec![Content::text(
-				ext
-					.unwrap()
-					.headers
+			let headers = &ext.unwrap().headers;
+
+			let mut result = Map::new();
+			result.insert(
+				"authorization".to_string(),
+				headers
 					.get("authorization")
-					.map(|s| String::from_utf8_lossy(s.as_bytes()))
-					.unwrap_or_default(),
+					.map(|v| String::from_utf8_lossy(v.as_bytes()).to_string())
+					.unwrap_or_default()
+					.into(),
+			);
+			result.insert(
+				"x-test-policy-header".to_string(),
+				headers
+					.get("x-test-policy-header")
+					.map(|v| String::from_utf8_lossy(v.as_bytes()).to_string())
+					.unwrap_or_default()
+					.into(),
+			);
+
+			Ok(CallToolResult::success(vec![Content::text(
+				serde_json::to_string(&result).unwrap(),
 			)]))
 		}
 	}
@@ -1284,6 +1427,7 @@ mod legacymockserver {
 		ErrorData as McpError, RoleServer, ServerHandler, prompt, prompt_handler, prompt_router,
 		schemars, tool, tool_handler, tool_router,
 	};
+	use serde_json::Map;
 	use serde_json::json;
 	use tokio::sync::Mutex;
 
@@ -1381,13 +1525,28 @@ mod legacymockserver {
 		#[tool(description = "Echo HTTP attributes")]
 		fn echo_http(&self, rq: RequestContext<RoleServer>) -> Result<CallToolResult, McpError> {
 			let ext = rq.extensions.get::<Parts>();
-			Ok(CallToolResult::success(vec![Content::text(
-				ext
-					.unwrap()
-					.headers
+			let headers = &ext.unwrap().headers;
+
+			let mut result = Map::new();
+			result.insert(
+				"authorization".to_string(),
+				headers
 					.get("authorization")
-					.map(|s| String::from_utf8_lossy(s.as_bytes()))
-					.unwrap_or_default(),
+					.map(|v| String::from_utf8_lossy(v.as_bytes()).to_string())
+					.unwrap_or_default()
+					.into(),
+			);
+			result.insert(
+				"x-test-policy-header".to_string(),
+				headers
+					.get("x-test-policy-header")
+					.map(|v| String::from_utf8_lossy(v.as_bytes()).to_string())
+					.unwrap_or_default()
+					.into(),
+			);
+
+			Ok(CallToolResult::success(vec![Content::text(
+				serde_json::to_string(&result).unwrap(),
 			)]))
 		}
 	}

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -173,7 +173,8 @@ async fn apply_request_policies(
 
 async fn apply_backend_policies(
 	backend_info: auth::BackendInfo,
-	backend_call: &BackendCall,
+	backend_policies: &BackendPolicies,
+	http_version_override: Option<::http::Version>,
 	req: &mut Request,
 	log: &mut Option<&mut RequestLog>,
 	response_policies: &mut ResponsePolicies,
@@ -209,7 +210,7 @@ async fn apply_backend_policies(
 		override_dest: _,
 		// Applied elsewhere
 		health: _,
-	} = &backend_call.backend_policies;
+	} = backend_policies;
 	response_policies.backend_response_header = response_header_modifier.clone();
 	response_policies.backend_transformation = transformation.clone();
 
@@ -217,7 +218,7 @@ async fn apply_backend_policies(
 	http
 		.as_ref()
 		.unwrap_or(&dh)
-		.apply(req, backend_call.http_version_override);
+		.apply(req, http_version_override);
 
 	if let Some(auth) = backend_auth {
 		auth::apply_backend_auth(&backend_info, auth, req).await?;
@@ -1324,6 +1325,8 @@ async fn make_backend_call(
 	// In practice, these don't conflict: inference is for AI backends, MCP pinning is for MCP backends.
 	let override_dest = inference_override.or(policies.override_dest);
 
+	let backend_target = backend.target();
+
 	let backend_call = match backend {
 		Backend::AI(n, ai) => {
 			let (provider, handle) = ai.select_provider().ok_or(ProxyError::NoHealthyEndpoints)?;
@@ -1425,18 +1428,43 @@ async fn make_backend_call(
 		},
 		Backend::MCP(name, backend) => {
 			let inputs = inputs.clone();
-			let backend = backend.clone();
-			set_backend_cel_context(&mut req, log.as_ref());
+			let mcp_backend = backend.clone();
 			let name = name.clone();
-			let Some(log) = log else {
+
+			// Ensure log is present before applying policies
+			if log.is_none() {
 				return Err(
 					ProxyError::ProcessingString("invalid: log required for MCP".to_string()).into(),
 				);
+			}
+
+			// Apply backend policies before calling MCP serve
+			// This ensures policies that need request context (like Passthrough auth) work correctly
+			let backend_info = auth::BackendInfo {
+				target: backend_target.clone(),
+				call_target: Target::Hostname(name.name.clone(), 0),
+				inputs: inputs.clone(),
 			};
+
+			apply_backend_policies(
+				backend_info,
+				&policies,
+				None, // MCP backends don't have http_version_override
+				&mut req,
+				&mut log,
+				response_policies,
+			)
+			.await?;
+
+			set_backend_cel_context(&mut req, log.as_ref());
+
+			// Safe to unwrap because we checked is_none() above
+			let log_ref = log.as_mut().unwrap();
+
 			let res = inputs
 				.clone()
 				.mcp_state
-				.serve(inputs, name, backend, policies, req, log)
+				.serve(inputs, name, mcp_backend, policies, req, log_ref)
 				.await;
 			return res.map_err(ProxyResponse::from);
 		},
@@ -1452,7 +1480,8 @@ async fn make_backend_call(
 	};
 	apply_backend_policies(
 		backend_info.clone(),
-		&backend_call,
+		&backend_call.backend_policies,
+		backend_call.http_version_override,
 		&mut req,
 		&mut log,
 		response_policies,


### PR DESCRIPTION
MCP backends were skipping apply_backend_policies() due to an early return in the code path. This caused backend policies that depend on request context (like BackendAuth::Passthrough) to fail because claims were never extracted from the original request, then the new request created by the MCP client had no Claims extension so Passthrough auth couldn't access the JWT token. 

This fix refactors apply_backend_policies to accept individual parameters instead of BackendCall and then calls apply_backend_policies in the MCP branch before the early return in the mcp backend case.

https://github.com/agentgateway/agentgateway/commit/4cb6ae96bc71a72270aef56de3853af6d06265ea shows the failure before the fix. 