### PR TITLE
Use agentgateway.dev annotations

### DIFF
--- a/controller/api/annotations/agentgateway.go
+++ b/controller/api/annotations/agentgateway.go
@@ -1,4 +1,7 @@
 package annotations
 
+// LegacyMCPServiceHTTPPath is the legacy annotation used to specify the HTTP path for the MCP service. Users should switch to MCPServiceHTTPPath.
+const LegacyMCPServiceHTTPPath = "kgateway.dev/mcp-path"
+
 // MCPServiceHTTPPath is the annotation used to specify the HTTP path for the MCP service
-const MCPServiceHTTPPath = "kgateway.dev/mcp-path"
+const MCPServiceHTTPPath = "agentgateway.dev/mcp-path"

--- a/controller/pkg/agentgateway/plugins/a2a_plugin.go
+++ b/controller/pkg/agentgateway/plugins/a2a_plugin.go
@@ -17,7 +17,8 @@ import (
 )
 
 const (
-	a2aProtocol = "kgateway.dev/a2a"
+	legacyA2aProtocol = "kgateway.dev/a2a"
+	a2aProtocol       = "agentgateway.dev/a2a"
 )
 
 // NewA2APlugin creates a new A2A policy plugin
@@ -48,7 +49,8 @@ func translatePoliciesForService(krtctx krt.HandlerContext, svc *corev1.Service,
 	}).UnsortedList()
 
 	for _, port := range svc.Spec.Ports {
-		if port.AppProtocol != nil && *port.AppProtocol == a2aProtocol {
+		// support legacy kgateway.dev/a2a and agentgateway.dev/a2a
+		if port.AppProtocol != nil && (*port.AppProtocol == a2aProtocol || *port.AppProtocol == legacyA2aProtocol) {
 			logger.Debug("found A2A service", "service", svc.Name, "namespace", svc.Namespace, "port", port.Port)
 			hostname := fmt.Sprintf("%s.%s.svc.%s", svc.Name, svc.Namespace, clusterDomain)
 			policy := &api.Policy{

--- a/controller/pkg/agentgateway/translator/testdata/backends/a2a.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/backends/a2a.yaml
@@ -11,7 +11,7 @@ spec:
     - protocol: TCP
       port: 9090
       targetPort: 9090
-      appProtocol: kgateway.dev/a2a
+      appProtocol: agentgateway.dev/a2a
 ---
 # Output
 output:

--- a/controller/pkg/agentgateway/translator/testdata/backends/mcp-selector.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/backends/mcp-selector.yaml
@@ -10,11 +10,11 @@ spec:
     test: test
   ports:
     - protocol: TCP
-      appProtocol: kgateway.dev/mcp
+      appProtocol: agentgateway.dev/mcp
       port: 80
       targetPort: test
     - protocol: TCP
-      appProtocol: kgateway.dev/mcp-sse
+      appProtocol: agentgateway.dev/mcp-sse
       port: 90
       targetPort: test-2
 ---

--- a/controller/pkg/agentgateway/translator/testdata/backends/mcp-service-backendref.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/backends/mcp-service-backendref.yaml
@@ -21,7 +21,7 @@ spec:
   ports:
   - name: mcp-http
     port: 9090
-    appProtocol: kgateway.dev/mcp
+    appProtocol: agentgateway.dev/mcp
 ---
 # Output
 output:

--- a/controller/pkg/agentgateway/translator/testdata/backends/mcp-service-selector-sse.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/backends/mcp-service-selector-sse.yaml
@@ -21,12 +21,12 @@ metadata:
   labels:
     app: mcp-server
   annotations:
-    kgateway.dev/mcp-http-path: /custom-path
+    agentgateway.dev/mcp-http-path: /custom-path
 spec:
   ports:
   - name: mcp
     port: 8080
-    appProtocol: kgateway.dev/mcp-sse
+    appProtocol: agentgateway.dev/mcp-sse
 ---
 # Output
 output:

--- a/controller/pkg/agentgateway/translator/testdata/backends/mcp-service-selector-streamable.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/backends/mcp-service-selector-streamable.yaml
@@ -23,7 +23,7 @@ spec:
   ports:
   - name: mcp-http
     port: 9090
-    appProtocol: kgateway.dev/mcp
+    appProtocol: agentgateway.dev/mcp
 ---
 # Output
 output:

--- a/controller/pkg/agentgateway/translator/testdata/backends/tls.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/backends/tls.yaml
@@ -6,13 +6,13 @@ metadata:
   labels:
     app: mcp-app
   annotations:
-    kgateway.dev/mcp-path: /test
+    agentgateway.dev/mcp-path: /test
 spec:
   selector:
     test: test
   ports:
     - protocol: TCP
-      appProtocol: kgateway.dev/mcp
+      appProtocol: agentgateway.dev/mcp
       port: 80
       targetPort: test
 ---

--- a/controller/pkg/reports/reporter_test.go
+++ b/controller/pkg/reports/reporter_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/agentgateway/agentgateway/controller/pkg/wellknown"
 )
 
-const fakeCondition = "kgateway.dev/SomeCondition"
+const fakeCondition = "agentgateway.dev/SomeCondition"
 
 var ctx = context.Background()
 
@@ -41,7 +41,7 @@ func TestBuildGatewayStatus(t *testing.T) {
 	t.Run("preserve conditions set externally", func(t *testing.T) {
 		gw := gw()
 		gw.Status.Conditions = append(gw.Status.Conditions, metav1.Condition{
-			Type:   "gateway.kgateway.dev/SomeCondition",
+			Type:   "gateway.agentgateway.dev/SomeCondition",
 			Status: metav1.ConditionFalse,
 		})
 		rm := reports.NewReportMap()

--- a/controller/pkg/syncer/README.md
+++ b/controller/pkg/syncer/README.md
@@ -910,7 +910,7 @@ spec:
     - protocol: TCP
       port: 3001
       targetPort: 3001
-      appProtocol: kgateway.dev/mcp
+      appProtocol: agentgateway.dev/mcp
   type: ClusterIP
 EOF
 ```
@@ -1002,7 +1002,7 @@ spec:
   ports:
   - port: 80
     targetPort: 8000
-    appProtocol: kgateway.dev/mcp
+    appProtocol: agentgateway.dev/mcp
 EOF
 ```
 
@@ -1044,11 +1044,11 @@ spec:
     - protocol: TCP
       port: 9090
       targetPort: 9090
-      appProtocol: kgateway.dev/a2a
+      appProtocol: agentgateway.dev/a2a
 EOF
 ```
 
-Note, you must use `kgateway.dev/a2a` as the app protocol for the kgateway control plane to configure agentgateway to use a2a.
+Note, you must use `agentgateway.dev/a2a` as the app protocol for the kgateway control plane to configure agentgateway to use a2a.
 
 Apply the routing config:
 ```shell
@@ -1539,7 +1539,7 @@ spec:
     - protocol: TCP
       port: 3001
       targetPort: 3001
-      appProtocol: kgateway.dev/mcp
+      appProtocol: agentgateway.dev/mcp
   type: ClusterIP
 EOF
 ```
@@ -1764,7 +1764,7 @@ EOF
 
 ```shell
 kubectl apply -f- <<EOF
-apiVersion: gateway.kgateway.dev/v1alpha1
+apiVersion: gateway.agentgateway.dev/v1alpha1
 kind: AgentgatewayPolicy
 metadata:
   name: token-rate-limit

--- a/controller/pkg/syncer/backend/mcp.go
+++ b/controller/pkg/syncer/backend/mcp.go
@@ -103,6 +103,12 @@ func TranslateMCPSelectorTargets(
 				targetName = service.Name + "-" + port.Name
 			}
 
+			path := service.Annotations[apiannotations.MCPServiceHTTPPath]
+			// use legacy annotation for backwards compatibility
+			if path == "" && service.Annotations[apiannotations.LegacyMCPServiceHTTPPath] != "" {
+				path = service.Annotations[apiannotations.LegacyMCPServiceHTTPPath]
+			}
+
 			svcHostname := kubeutils.ServiceFQDN(service.ObjectMeta)
 			mcpTargets = append(mcpTargets, &api.MCPTarget{
 				Name: targetName,
@@ -116,7 +122,7 @@ func TranslateMCPSelectorTargets(
 					Port: uint32(port.Port), //nolint:gosec // G115: Kubernetes service ports are always positive
 				},
 				Protocol: toMCPProtocol(appProtocol),
-				Path:     service.Annotations[apiannotations.MCPServiceHTTPPath],
+				Path:     path,
 			})
 		}
 	}

--- a/controller/pkg/syncer/backend/testdata/Service_selector_MCPBackend_backend_-_legacy_annotation_path.yaml
+++ b/controller/pkg/syncer/backend/testdata/Service_selector_MCPBackend_backend_-_legacy_annotation_path.yaml
@@ -1,0 +1,14 @@
+- key: test-ns/service-mcp-backend-legacy
+  mcp:
+    targets:
+    - backend:
+        port: 8080
+        service:
+          hostname: mcp-service-legacy.test-ns.svc.cluster.local
+          namespace: test-ns
+      name: mcp-service-legacy-mcp
+      path: /legacy/mcp/path
+      protocol: STREAMABLE_HTTP
+  name:
+    name: service-mcp-backend-legacy
+    namespace: test-ns

--- a/controller/pkg/syncer/backend/testdata/Service_selector_MCPBackend_backend_-_new_annotation_takes_precedence.yaml
+++ b/controller/pkg/syncer/backend/testdata/Service_selector_MCPBackend_backend_-_new_annotation_takes_precedence.yaml
@@ -1,0 +1,14 @@
+- key: test-ns/service-mcp-backend-precedence
+  mcp:
+    targets:
+    - backend:
+        port: 8080
+        service:
+          hostname: mcp-service-both.test-ns.svc.cluster.local
+          namespace: test-ns
+      name: mcp-service-both-mcp
+      path: /new/path
+      protocol: STREAMABLE_HTTP
+  name:
+    name: service-mcp-backend-precedence
+    namespace: test-ns

--- a/controller/pkg/syncer/backend/translate_test.go
+++ b/controller/pkg/syncer/backend/translate_test.go
@@ -133,6 +133,56 @@ func TestBuildMCP(t *testing.T) {
 			inputs: []any{createMockMCPServiceWithProtocol("test-ns", "mcp-service", "app=mcp-server", "agentgateway.dev/mcp")},
 		},
 		{
+			name: "Service selector MCPBackend backend - legacy annotation path",
+			backend: &agentgateway.AgentgatewayBackend{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "service-mcp-backend-legacy",
+					Namespace: "test-ns",
+				},
+				Spec: agentgateway.AgentgatewayBackendSpec{
+					MCP: &agentgateway.MCPBackend{
+						Targets: []agentgateway.McpTargetSelector{
+							{
+								Selector: &agentgateway.McpSelector{
+									Service: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app": "mcp-server-legacy",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			inputs: []any{createMockMCPServiceWithLegacyAnnotation("test-ns", "mcp-service-legacy", "app=mcp-server-legacy", "/legacy/mcp/path")},
+		},
+		{
+			name: "Service selector MCPBackend backend - new annotation takes precedence",
+			backend: &agentgateway.AgentgatewayBackend{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "service-mcp-backend-precedence",
+					Namespace: "test-ns",
+				},
+				Spec: agentgateway.AgentgatewayBackendSpec{
+					MCP: &agentgateway.MCPBackend{
+						Targets: []agentgateway.McpTargetSelector{
+							{
+								Selector: &agentgateway.McpSelector{
+									Service: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app": "mcp-server-both",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			inputs: []any{createMockMCPServiceWithBothAnnotations("test-ns", "mcp-service-both", "app=mcp-server-both", "/new/path", "/legacy/path")},
+		},
+		{
 			name: "Service backendRef MCPBackend backend - same namespace",
 			backend: &agentgateway.AgentgatewayBackend{
 				ObjectMeta: metav1.ObjectMeta{
@@ -774,6 +824,81 @@ func createMockMCPServiceWithProtocol(namespace, serviceName, _ /* labels */, ap
 	}
 }
 
+// createMockMCPServiceWithLegacyAnnotation creates a mock service with the legacy kgateway.dev/mcp-path annotation
+func createMockMCPServiceWithLegacyAnnotation(namespace, serviceName, labels, legacyPath string) *corev1.Service {
+	// Parse labels
+	labelsMap := make(map[string]string)
+	if labels != "" {
+		// Simple parsing for "key=value" format
+		for _, label := range []string{labels} {
+			if len(label) > 0 {
+				parts := []string{"app", "mcp-server-legacy"} // hardcoded for test
+				if len(parts) == 2 {
+					labelsMap[parts[0]] = parts[1]
+				}
+			}
+		}
+	}
+
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      serviceName,
+			Namespace: namespace,
+			Labels:    labelsMap,
+			Annotations: map[string]string{
+				"kgateway.dev/mcp-path": legacyPath,
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Name:        "mcp",
+					Port:        8080,
+					AppProtocol: ptr.Of("agentgateway.dev/mcp"),
+				},
+			},
+		},
+	}
+}
+
+// createMockMCPServiceWithBothAnnotations creates a mock service with both new and legacy annotations to test precedence
+func createMockMCPServiceWithBothAnnotations(namespace, serviceName, labels, newPath, legacyPath string) *corev1.Service {
+	// Parse labels
+	labelsMap := make(map[string]string)
+	if labels != "" {
+		// Simple parsing for "key=value" format
+		for _, label := range []string{labels} {
+			if len(label) > 0 {
+				parts := []string{"app", "mcp-server-both"} // hardcoded for test
+				if len(parts) == 2 {
+					labelsMap[parts[0]] = parts[1]
+				}
+			}
+		}
+	}
+
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      serviceName,
+			Namespace: namespace,
+			Labels:    labelsMap,
+			Annotations: map[string]string{
+				"agentgateway.dev/mcp-path": newPath,
+				"kgateway.dev/mcp-path":     legacyPath,
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Name:        "mcp",
+					Port:        8080,
+					AppProtocol: ptr.Of("agentgateway.dev/mcp"),
+				},
+			},
+		},
+	}
+}
+
 // createMockMCPService creates a mock service collection with a specific MCPBackend service
 func createMockMCPService(namespace, serviceName, labels string) *corev1.Service {
 	// Parse labels
@@ -801,7 +926,7 @@ func createMockMCPService(namespace, serviceName, labels string) *corev1.Service
 				{
 					Name:        "mcp",
 					Port:        8080,
-					AppProtocol: ptr.Of("kgateway.dev/mcp"),
+					AppProtocol: ptr.Of("agentgateway.dev/mcp"),
 				},
 			},
 		},
@@ -825,7 +950,7 @@ func createMockMultipleNamespaceServices() []any {
 					{
 						Name:        "mcp",
 						Port:        8080,
-						AppProtocol: ptr.Of("kgateway.dev/mcp"),
+						AppProtocol: ptr.Of("agentgateway.dev/mcp"),
 					},
 				},
 			},
@@ -843,7 +968,7 @@ func createMockMultipleNamespaceServices() []any {
 					{
 						Name:        "mcp",
 						Port:        8080,
-						AppProtocol: ptr.Of("kgateway.dev/mcp"),
+						AppProtocol: ptr.Of("agentgateway.dev/mcp"),
 					},
 				},
 			},
@@ -861,7 +986,7 @@ func createMockMultipleNamespaceServices() []any {
 					{
 						Name:        "mcp",
 						Port:        8080,
-						AppProtocol: ptr.Of("kgateway.dev/mcp"),
+						AppProtocol: ptr.Of("agentgateway.dev/mcp"),
 					},
 				},
 			},

--- a/controller/test/e2e/tests/base/base_suite.go
+++ b/controller/test/e2e/tests/base/base_suite.go
@@ -82,7 +82,7 @@ var (
 )
 
 // selfManagedGatewayAnnotation is the annotation used to mark a Gateway as self-managed in e2e tests
-const selfManagedGatewayAnnotation = "e2e.kgateway.dev/self-managed"
+const selfManagedGatewayAnnotation = "e2e.agentgateway.dev/self-managed"
 
 // TestCase defines the manifests and resources used by a test or test suite.
 type TestCase struct {

--- a/controller/test/e2e/tests/manifests/agent-gateway-base.yaml
+++ b/controller/test/e2e/tests/manifests/agent-gateway-base.yaml
@@ -188,7 +188,7 @@ spec:
     - protocol: TCP
       port: 9999
       targetPort: 9999
-      appProtocol: kgateway.dev/a2a
+      appProtocol: agentgateway.dev/a2a
 ---
 apiVersion: v1
 kind: Service
@@ -231,7 +231,7 @@ spec:
   ports:
     - port: 80
       targetPort: 8000
-      appProtocol: kgateway.dev/mcp
+      appProtocol: agentgateway.dev/mcp
 ---
 apiVersion: v1
 kind: Service
@@ -246,7 +246,7 @@ spec:
     - name: http
       port: 80
       targetPort: 3001
-      appProtocol: kgateway.dev/mcp
+      appProtocol: agentgateway.dev/mcp
   type: ClusterIP
 ---
 apiVersion: v1


### PR DESCRIPTION
Clean up to remove kgateway.dev annotations, but keep backwards compatibility. 