### PR TITLE
proxy: apply service targeted policy

### DIFF
--- a/crates/agentgateway/src/http/route.rs
+++ b/crates/agentgateway/src/http/route.rs
@@ -159,7 +159,7 @@ pub fn select_best_route(
 			// No service-keyed routes: fall through to hostname matching with default route
 			let default_route = Route {
 				key: strng::literal!("_waypoint-default"),
-				service_key: None,
+				service_key: Some(svc.namespaced_hostname()),
 				name: RouteName {
 					name: strng::literal!("_waypoint-default"),
 					namespace: svc.namespace.clone(),

--- a/crates/agentgateway/src/proxy/gateway.rs
+++ b/crates/agentgateway/src/proxy/gateway.rs
@@ -987,7 +987,6 @@ impl Gateway {
 		// Determine protocol from service discovery. Default to HTTP since the vast
 		// majority of waypoint traffic is HTTP; only use TCP when there is a positive
 		// signal via explicit AppProtocol::Tcp/Tls (from istio/istio#59259).
-		let should_sniff_tls = svc.port_is_tls(socket_addr.port());
 		let is_http = !svc.port_is_tcp(socket_addr.port());
 
 		let Ok(resp) = req.send_response(build_response(StatusCode::OK)).await else {
@@ -1000,8 +999,21 @@ impl Gateway {
 			drain_tx: None,
 		};
 
-		// Look up the real HBONE listener for policy resolution (gateway/listener-targeted
-		// policies require the listener's name to match).
+		let socket = Socket::from_hbone(ext, socket_addr, con);
+		Self::handle_waypoint(bind_name, pi, svc, socket, is_http, drain).await;
+	}
+
+	/// Resolve the HBONE listener and dispatch to the HTTP or TCP proxy.
+	pub(crate) async fn handle_waypoint(
+		bind_name: BindKey,
+		pi: Arc<ProxyInputs>,
+		svc: Arc<crate::types::discovery::Service>,
+		mut socket: Socket,
+		is_http: bool,
+		drain: DrainWatcher,
+	) {
+		// Find HBONE listener, or fall back to a synthetic one using gateway
+		// config names so gateway/listener-targeted policies still match.
 		let listener = pi
 			.stores
 			.read_binds()
@@ -1031,13 +1043,13 @@ impl Gateway {
 				})
 			});
 
+		let should_sniff_tls = svc.port_is_tls(socket.target_address().port());
 		let wps = WaypointService(svc);
 		// Ensure we load policies per-stream so we don't cache stale policies on long-lived HBONE connections.
 		let policies = pi
 			.stores
 			.read_binds()
 			.listener_frontend_policies(&listener.name, Some(wps.as_policy_ref()));
-		let mut socket = Socket::from_hbone(ext, socket_addr, con);
 		socket.ext_mut().insert(wps);
 		if is_http {
 			let _ = Self::proxy(

--- a/crates/agentgateway/src/proxy/gateway_test.rs
+++ b/crates/agentgateway/src/proxy/gateway_test.rs
@@ -2194,3 +2194,113 @@ async fn auto_protocol_peek_timeout() {
 	tokio::time::sleep(std::time::Duration::from_secs(10)).await;
 	// If we reach here, the timeout worked (auto-advance means no real wait).
 }
+
+/// HTTP request through the waypoint path with an HBONE listener reaches the backend.
+#[tokio::test]
+async fn waypoint_http_basic() {
+	let mock = simple_mock().await;
+	let t = setup_proxy_test("{}")
+		.unwrap()
+		.with_backend(*mock.address())
+		.with_bind(waypoint_bind(ListenerProtocol::HBONE))
+		.with_waypoint_service(*mock.address());
+	let io = t.serve_waypoint_http(BIND_KEY);
+	let res = send_request(io, Method::GET, "http://my-svc.default.svc.cluster.local").await;
+	assert_eq!(res.status(), 200);
+	let body = read_body(res.into_body()).await;
+	assert_eq!(body.method, Method::GET);
+}
+
+/// Waypoint fallback (no HBONE listener) still proxies HTTP successfully.
+#[tokio::test]
+async fn waypoint_http_fallback() {
+	let mock = simple_mock().await;
+	let t = setup_proxy_test("{}")
+		.unwrap()
+		.with_backend(*mock.address())
+		.with_bind(waypoint_bind(ListenerProtocol::HTTP))
+		.with_waypoint_service(*mock.address());
+	let io = t.serve_waypoint_http(BIND_KEY);
+	let res = send_request(io, Method::POST, "http://my-svc.default.svc.cluster.local").await;
+	assert_eq!(res.status(), 200);
+	let body = read_body(res.into_body()).await;
+	assert_eq!(body.method, Method::POST);
+}
+
+/// Network authorization policy allows HTTP waypoint traffic when source matches.
+#[tokio::test]
+async fn waypoint_http_policy_allow() {
+	let mock = simple_mock().await;
+	let mut t = setup_proxy_test("{}")
+		.unwrap()
+		.with_backend(*mock.address())
+		.with_bind(waypoint_bind(ListenerProtocol::HBONE))
+		.with_waypoint_service(*mock.address());
+	t.attach_frontend_policy(json!({
+		"networkAuthorization": {
+			"rules": ["source.port == 12345"],
+		},
+	}))
+	.await;
+	let io = t.serve_waypoint_http(BIND_KEY);
+	let res = send_request(io, Method::GET, "http://my-svc.default.svc.cluster.local").await;
+	assert_eq!(res.status(), 200);
+}
+
+/// Network authorization policy denies HTTP waypoint traffic when source doesn't match.
+#[tokio::test]
+async fn waypoint_http_policy_deny() {
+	let mock = simple_mock().await;
+	let mut t = setup_proxy_test("{}")
+		.unwrap()
+		.with_backend(*mock.address())
+		.with_bind(waypoint_bind(ListenerProtocol::HBONE))
+		.with_waypoint_service(*mock.address());
+	t.attach_frontend_policy(json!({
+		"networkAuthorization": {
+			"rules": ["source.port == 54321"],
+		},
+	}))
+	.await;
+	let io = t.serve_waypoint_http(BIND_KEY);
+	RequestBuilder::new(Method::GET, "http://my-svc.default.svc.cluster.local")
+		.send(io)
+		.await
+		.expect_err("should be denied by network authorization");
+}
+
+/// TCP through the waypoint path reaches the backend.
+#[tokio::test]
+async fn waypoint_tcp_basic() {
+	let mock = simple_mock().await;
+	let t = setup_proxy_test("{}")
+		.unwrap()
+		.with_backend(*mock.address())
+		.with_bind(waypoint_bind(ListenerProtocol::HBONE))
+		.with_waypoint_service(*mock.address());
+	let io = t.serve_waypoint_tcp(BIND_KEY);
+	let res = send_request(io, Method::GET, "http://my-svc.default.svc.cluster.local").await;
+	assert_eq!(res.status(), 200);
+}
+
+/// Network authorization policy denies TCP waypoint traffic when source doesn't match.
+#[tokio::test]
+async fn waypoint_tcp_policy_deny() {
+	let mock = simple_mock().await;
+	let mut t = setup_proxy_test("{}")
+		.unwrap()
+		.with_backend(*mock.address())
+		.with_bind(waypoint_bind(ListenerProtocol::HBONE))
+		.with_waypoint_service(*mock.address());
+	t.attach_frontend_policy(json!({
+		"networkAuthorization": {
+			"rules": ["source.port == 54321"],
+		},
+	}))
+	.await;
+	let io = t.serve_waypoint_tcp(BIND_KEY);
+	RequestBuilder::new(Method::GET, "http://my-svc.default.svc.cluster.local")
+		.send(io)
+		.await
+		.expect_err("should be denied by network authorization");
+}

--- a/crates/agentgateway/src/proxy/gateway_test.rs
+++ b/crates/agentgateway/src/proxy/gateway_test.rs
@@ -2195,7 +2195,6 @@ async fn auto_protocol_peek_timeout() {
 	// If we reach here, the timeout worked (auto-advance means no real wait).
 }
 
-/// HTTP request through the waypoint path with an HBONE listener reaches the backend.
 #[tokio::test]
 async fn waypoint_http_basic() {
 	let mock = simple_mock().await;
@@ -2211,7 +2210,6 @@ async fn waypoint_http_basic() {
 	assert_eq!(body.method, Method::GET);
 }
 
-/// Waypoint fallback (no HBONE listener) still proxies HTTP successfully.
 #[tokio::test]
 async fn waypoint_http_fallback() {
 	let mock = simple_mock().await;
@@ -2227,9 +2225,70 @@ async fn waypoint_http_fallback() {
 	assert_eq!(body.method, Method::POST);
 }
 
-/// Network authorization policy allows HTTP waypoint traffic when source matches.
 #[tokio::test]
-async fn waypoint_http_policy_allow() {
+async fn waypoint_tcp_basic() {
+	let mock = simple_mock().await;
+	let t = setup_proxy_test("{}")
+		.unwrap()
+		.with_backend(*mock.address())
+		.with_bind(waypoint_bind(ListenerProtocol::HBONE))
+		.with_waypoint_service(*mock.address());
+	let io = t.serve_waypoint_tcp(BIND_KEY);
+	let res = send_request(io, Method::GET, "http://my-svc.default.svc.cluster.local").await;
+	assert_eq!(res.status(), 200);
+}
+
+#[tokio::test]
+async fn waypoint_service_policy_header_modifier() {
+	let mock = simple_mock().await;
+	let mut t = setup_proxy_test("{}")
+		.unwrap()
+		.with_backend(*mock.address())
+		.with_bind(waypoint_bind(ListenerProtocol::HBONE))
+		.with_waypoint_service(*mock.address());
+	t.attach_service_policy(json!({
+		"requestHeaderModifier": {
+			"add": { "x-svc-req": "from-service" },
+		},
+		"responseHeaderModifier": {
+			"add": { "x-svc-resp": "from-service" },
+		},
+	}))
+	.await;
+	let io = t.serve_waypoint_http(BIND_KEY);
+	let res = send_request(io, Method::GET, "http://my-svc.default.svc.cluster.local").await;
+	assert_eq!(res.status(), 200);
+	assert_eq!(res.hdr("x-svc-resp"), "from-service");
+	let body = read_body(res.into_body()).await;
+	assert_eq!(
+		body.headers.get("x-svc-req").unwrap().as_bytes(),
+		b"from-service"
+	);
+}
+
+#[tokio::test]
+async fn waypoint_service_policy_direct_response() {
+	let mock = simple_mock().await;
+	let mut t = setup_proxy_test("{}")
+		.unwrap()
+		.with_backend(*mock.address())
+		.with_bind(waypoint_bind(ListenerProtocol::HBONE))
+		.with_waypoint_service(*mock.address());
+	t.attach_service_policy(json!({
+		"directResponse": {
+			"status": 418,
+			"body": "teapot",
+		},
+	}))
+	.await;
+	let io = t.serve_waypoint_http(BIND_KEY);
+	let res = send_request(io, Method::GET, "http://my-svc.default.svc.cluster.local").await;
+	assert_eq!(res.status(), 418);
+	assert_eq!(read_body!(res).as_bytes(), b"teapot");
+}
+
+#[tokio::test]
+async fn waypoint_gateway_policy_authz_allow() {
 	let mock = simple_mock().await;
 	let mut t = setup_proxy_test("{}")
 		.unwrap()
@@ -2247,9 +2306,8 @@ async fn waypoint_http_policy_allow() {
 	assert_eq!(res.status(), 200);
 }
 
-/// Network authorization policy denies HTTP waypoint traffic when source doesn't match.
 #[tokio::test]
-async fn waypoint_http_policy_deny() {
+async fn waypoint_gateway_policy_authz_deny() {
 	let mock = simple_mock().await;
 	let mut t = setup_proxy_test("{}")
 		.unwrap()
@@ -2269,23 +2327,9 @@ async fn waypoint_http_policy_deny() {
 		.expect_err("should be denied by network authorization");
 }
 
-/// TCP through the waypoint path reaches the backend.
+/// Gateway-targeted network authorization applies to TCP waypoint path.
 #[tokio::test]
-async fn waypoint_tcp_basic() {
-	let mock = simple_mock().await;
-	let t = setup_proxy_test("{}")
-		.unwrap()
-		.with_backend(*mock.address())
-		.with_bind(waypoint_bind(ListenerProtocol::HBONE))
-		.with_waypoint_service(*mock.address());
-	let io = t.serve_waypoint_tcp(BIND_KEY);
-	let res = send_request(io, Method::GET, "http://my-svc.default.svc.cluster.local").await;
-	assert_eq!(res.status(), 200);
-}
-
-/// Network authorization policy denies TCP waypoint traffic when source doesn't match.
-#[tokio::test]
-async fn waypoint_tcp_policy_deny() {
+async fn waypoint_tcp_gateway_policy_authz_deny() {
 	let mock = simple_mock().await;
 	let mut t = setup_proxy_test("{}")
 		.unwrap()

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -620,6 +620,7 @@ impl HTTPProxy {
 
 		let route_path = RoutePath {
 			route: &selected_route.name,
+			service: selected_route.service_key.as_ref(),
 			listener: &selected_listener.name,
 		};
 

--- a/crates/agentgateway/src/proxy/tcpproxy.rs
+++ b/crates/agentgateway/src/proxy/tcpproxy.rs
@@ -144,6 +144,7 @@ impl TCPProxy {
 
 		let route_path = RoutePath {
 			route: &selected_route.name,
+			service: selected_route.service_key.as_ref(),
 			listener: &selected_listener.name,
 		};
 

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -395,6 +395,8 @@ impl Default for Store {
 #[derive(Debug, Clone)]
 pub struct RoutePath<'a> {
 	pub listener: &'a ListenerName,
+	// the originally intended service, pre-routing
+	pub service: Option<&'a NamespacedHostname>,
 	pub route: &'a RouteName,
 }
 
@@ -481,13 +483,18 @@ impl Store {
 	}
 
 	pub fn route_policies(&self, path: &RoutePath<'_>, inline: &[TrafficPolicy]) -> RoutePolicies {
-		let &RoutePath { listener, route } = path;
+		let &RoutePath {
+			listener,
+			service,
+			route,
+		} = path;
 		let gateway = self
 			.policies_by_target
 			.get(&listener.as_gateway_target_ref());
 		let listener = self
 			.policies_by_target
 			.get(&listener.as_listener_target_ref());
+		let service = service.and_then(|s| self.policies_by_target.get(&s.as_policy_target_ref()));
 		let route_rule = self
 			.policies_by_target
 			.get(&route.as_route_rule_target_ref());
@@ -497,6 +504,7 @@ impl Store {
 			.copied()
 			.flatten()
 			.chain(route.iter().copied().flatten())
+			.chain(service.iter().copied().flatten())
 			.chain(listener.iter().copied().flatten())
 			.chain(gateway.iter().copied().flatten())
 			.filter_map(|n| self.policies_by_key.get(n))
@@ -1629,6 +1637,7 @@ mod tests {
 		let http_pols = store.route_policies(
 			&RoutePath {
 				listener: &listener,
+				service: None,
 				route: &http_route,
 			},
 			&[],
@@ -1638,6 +1647,7 @@ mod tests {
 		let grpc_pols = store.route_policies(
 			&RoutePath {
 				listener: &listener,
+				service: None,
 				route: &grpc_route,
 			},
 			&[],

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -713,7 +713,7 @@ impl Store {
 		let gateway_rules =
 			gateway.and_then(|t| self.policies_by_target.get(&t.as_gateway_target_ref()));
 
-		// RouteRule > Route > SubBackend > Backend > Service > Gateway
+		// RouteRule > Route > SubBackend > Backend/Service > Gateway
 		// Most specific (route context) to least specific (gateway-wide default)
 		let rules = route_rule_rules
 			.iter()

--- a/crates/agentgateway/src/test_helpers/proxymock.rs
+++ b/crates/agentgateway/src/test_helpers/proxymock.rs
@@ -416,8 +416,7 @@ impl TestBind {
 	pub fn with_waypoint_service(self, backend_addr: SocketAddr) -> Self {
 		use crate::store::LocalWorkload;
 		use crate::types::discovery::{
-			GatewayAddress, NetworkAddress, Service, Workload,
-			gatewayaddress::Destination,
+			GatewayAddress, NetworkAddress, Service, Workload, gatewayaddress::Destination,
 		};
 		let svc = Service {
 			name: strng::literal!("my-svc"),
@@ -429,12 +428,10 @@ impl TestBind {
 			}],
 			ports: std::collections::HashMap::from([(80, backend_addr.port())]),
 			waypoint: Some(GatewayAddress {
-				destination: Destination::Hostname(
-					crate::types::discovery::NamespacedHostname {
-						namespace: strng::literal!("default"),
-						hostname: strng::literal!("default.default.svc.cluster.local"),
-					},
-				),
+				destination: Destination::Hostname(crate::types::discovery::NamespacedHostname {
+					namespace: strng::literal!("default"),
+					hostname: strng::literal!("default.default.svc.cluster.local"),
+				}),
 				hbone_mtls_port: 15008,
 			}),
 			..Default::default()
@@ -452,7 +449,8 @@ impl TestBind {
 				std::collections::HashMap::from([(80, backend_addr.port())]),
 			)]),
 		};
-		self.pi
+		self
+			.pi
 			.stores
 			.discovery
 			.sync_local(vec![svc], vec![wl], Default::default())

--- a/crates/agentgateway/src/test_helpers/proxymock.rs
+++ b/crates/agentgateway/src/test_helpers/proxymock.rs
@@ -688,6 +688,32 @@ impl TestBind {
 			});
 		}
 	}
+	pub async fn attach_service_policy(&mut self, p: serde_json::Value) {
+		let oidc_key = strng::format!("oidc/{}", self.policies + 1);
+		let pol: local::FilterOrPolicy = serde_json::from_value(p).unwrap();
+		let pols = local::split_policies(
+			self.pi.upstream.clone(),
+			pol,
+			self.pi.cfg.as_policy_context(oidc_key),
+		)
+		.await
+		.unwrap();
+		assert!(pols.backend_policies.is_empty());
+		for v in pols.route_policies {
+			self.policies += 1;
+			let key = strng::format!("pol/{}", self.policies);
+			self.with_policy(TargetedPolicy {
+				key,
+				name: None,
+				target: PolicyTarget::Backend(BackendTarget::Service {
+					hostname: strng::literal!("my-svc.default.svc.cluster.local"),
+					namespace: strng::literal!("default"),
+					port: None,
+				}),
+				policy: (v, PolicyPhase::Route).into(),
+			});
+		}
+	}
 	pub async fn attach_frontend_policy(&mut self, p: serde_json::Value) {
 		let cfg = serde_json::json!({
 			"frontendPolicies": p,

--- a/crates/agentgateway/src/test_helpers/proxymock.rs
+++ b/crates/agentgateway/src/test_helpers/proxymock.rs
@@ -246,6 +246,28 @@ pub fn simple_bind(route: Route) -> Bind {
 	}
 }
 
+pub fn waypoint_bind(protocol: ListenerProtocol) -> Bind {
+	Bind {
+		key: BIND_KEY,
+		address: "127.0.0.1:15008".parse().unwrap(),
+		listeners: ListenerSet::from_list([Listener {
+			key: LISTENER_KEY,
+			name: crate::types::agent::ListenerName {
+				gateway_name: strng::literal!("default"),
+				gateway_namespace: strng::literal!("default"),
+				listener_name: strng::EMPTY,
+				listener_set: None,
+			},
+			hostname: Default::default(),
+			protocol,
+			tcp_routes: Default::default(),
+			routes: Default::default(),
+		}]),
+		protocol: BindProtocol::http,
+		tunnel_protocol: Default::default(),
+	}
+}
+
 pub fn simple_tcp_bind(route: TCPRoute) -> Bind {
 	Bind {
 		key: BIND_KEY,
@@ -387,6 +409,54 @@ impl TestBind {
 	}
 	pub fn with_route(self, r: Route) -> Self {
 		self.pi.stores.binds.write().insert_route(r, LISTENER_KEY);
+		self
+	}
+
+	/// Insert a service + workload via sync_local so endpoint linking is exercised.
+	pub fn with_waypoint_service(self, backend_addr: SocketAddr) -> Self {
+		use crate::store::LocalWorkload;
+		use crate::types::discovery::{
+			GatewayAddress, NetworkAddress, Service, Workload,
+			gatewayaddress::Destination,
+		};
+		let svc = Service {
+			name: strng::literal!("my-svc"),
+			namespace: strng::literal!("default"),
+			hostname: strng::literal!("my-svc.default.svc.cluster.local"),
+			vips: vec![NetworkAddress {
+				network: strng::EMPTY,
+				address: "127.0.0.1".parse().unwrap(),
+			}],
+			ports: std::collections::HashMap::from([(80, backend_addr.port())]),
+			waypoint: Some(GatewayAddress {
+				destination: Destination::Hostname(
+					crate::types::discovery::NamespacedHostname {
+						namespace: strng::literal!("default"),
+						hostname: strng::literal!("default.default.svc.cluster.local"),
+					},
+				),
+				hbone_mtls_port: 15008,
+			}),
+			..Default::default()
+		};
+		let wl = LocalWorkload {
+			workload: Workload {
+				uid: strng::literal!("test-wl-uid"),
+				name: strng::literal!("test-wl"),
+				namespace: strng::literal!("default"),
+				workload_ips: vec![backend_addr.ip()],
+				..Default::default()
+			},
+			services: std::collections::HashMap::from([(
+				"default/my-svc.default.svc.cluster.local".to_string(),
+				std::collections::HashMap::from([(80, backend_addr.port())]),
+			)]),
+		};
+		self.pi
+			.stores
+			.discovery
+			.sync_local(vec![svc], vec![wl], Default::default())
+			.unwrap();
 		self
 	}
 
@@ -661,14 +731,17 @@ impl TestBind {
 	pub fn with_policy(&mut self, p: TargetedPolicy) {
 		self.pi.stores.binds.write().insert_policy(p);
 	}
-	pub fn serve_http(&self, bind_name: BindKey) -> Client<MemoryConnector, Body> {
-		let io = self.serve(bind_name);
+	fn memory_client(io: DuplexStream) -> Client<MemoryConnector, Body> {
 		::hyper_util::client::legacy::Client::builder(TokioExecutor::new())
 			.timer(TokioTimer::new())
 			.build(MemoryConnector {
 				tls_config: None,
 				io: Arc::new(Mutex::new(Some(io))),
 			})
+	}
+
+	pub fn serve_http(&self, bind_name: BindKey) -> Client<MemoryConnector, Body> {
+		Self::memory_client(self.serve(bind_name))
 	}
 	pub fn serve_https(
 		&self,
@@ -706,6 +779,43 @@ impl TestBind {
 				io: Arc::new(Mutex::new(Some(io))),
 			})
 	}
+	pub fn serve_waypoint_http(&self, bind_name: BindKey) -> Client<MemoryConnector, Body> {
+		Self::memory_client(self.serve_waypoint(bind_name, true))
+	}
+
+	pub fn serve_waypoint_tcp(&self, bind_name: BindKey) -> Client<MemoryConnector, Body> {
+		Self::memory_client(self.serve_waypoint(bind_name, false))
+	}
+
+	fn serve_waypoint(&self, bind_name: BindKey, is_http: bool) -> DuplexStream {
+		let (client, server) = tokio::io::duplex(8192);
+		let server = Socket::from_memory(
+			server,
+			TCPConnectionInfo {
+				peer_addr: "127.0.0.1:12345".parse().unwrap(),
+				local_addr: "127.0.0.1:80".parse().unwrap(),
+				start: Instant::now(),
+				raw_peer_addr: None,
+			},
+		);
+		let svc = self
+			.pi
+			.stores
+			.read_discovery()
+			.services
+			.get_by_vip(&crate::types::discovery::NetworkAddress {
+				network: self.pi.cfg.network.clone(),
+				address: "127.0.0.1".parse().unwrap(),
+			})
+			.unwrap_or_else(|| Arc::new(crate::types::discovery::Service::default()));
+		let pi = self.pi.clone();
+		let drain = self.drain_rx.clone();
+		tokio::spawn(async move {
+			Gateway::handle_waypoint(bind_name, pi, svc, server, is_http, drain).await;
+		});
+		client
+	}
+
 	pub fn serve(&self, bind_name: BindKey) -> DuplexStream {
 		let (client, server) = tokio::io::duplex(8192);
 		let server = Socket::from_memory(

--- a/crates/agentgateway/src/types/discovery.rs
+++ b/crates/agentgateway/src/types/discovery.rs
@@ -27,6 +27,16 @@ pub struct NamespacedHostname {
 	pub hostname: Strng,
 }
 
+impl NamespacedHostname {
+	pub fn as_policy_target_ref(&self) -> super::agent::PolicyTargetRef {
+		super::agent::PolicyTargetRef::Backend(super::agent::BackendTargetRef::Service {
+			hostname: &self.hostname,
+			namespace: &self.namespace,
+			port: None,
+		})
+	}
+}
+
 impl FromStr for NamespacedHostname {
 	type Err = ProtoError;
 


### PR DESCRIPTION
* waypoint routes will either have a service_key (either in the explicit route over xds _or_ in the implicit/default route)
* service_key will be used to lookup policies as a `PolicyTarget::Backend(BackendTarget::Service(...))`

also adds some tests on the general hbone path + various policies on that path