### PR TITLE
feat: support OTEL_SERVICE_NAME and OTEL_RESOURCE_ATTRIBUTES env vars

### DIFF
--- a/crates/agentgateway/src/telemetry/trc.rs
+++ b/crates/agentgateway/src/telemetry/trc.rs
@@ -501,10 +501,16 @@ pub fn set_resource_defaults_from_config(cfg: &crate::Config) {
 		attrs.push(KeyValue::new("host.name", self_id.hostname().to_string()));
 	}
 	// Use gateway name/namespace as authoritative service identity
-	let service_name = cfg.xds.gateway.to_string();
-	let service_namespace = cfg.xds.namespace.to_string();
-	attrs.retain(|kv| kv.key.as_str() != "service.namespace");
-	attrs.push(KeyValue::new("service.namespace", service_namespace));
+	let (service_name, service_namespace) = if cfg.xds.address.is_some() {
+		(cfg.xds.gateway.to_string(), cfg.xds.namespace.to_string())
+	} else {
+		(Default::default(), Default::default())
+	};
+
+	if !service_namespace.is_empty() {
+		attrs.retain(|kv| kv.key.as_str() != "service.namespace");
+		attrs.push(KeyValue::new("service.namespace", service_namespace));
+	}
 
 	// Resolve service name: config > OTEL_SERVICE_NAME env > default
 	let resolved_service_name = if service_name.is_empty() {


### PR DESCRIPTION
- slight tweak of #1396 

- check xds address is set before overwriting env var values, otherwise OTEL_SERVICE_NAME & OTEL_RESOURCE_ATTRIBUTES values are overidden with "default" - <https://github.com/agentgateway/agentgateway/blob/cf5ade8a4960b8ea1e0ed43a0a35e3c4dc11da74/crates/agentgateway/src/config.rs#L84>
