### PR TITLE
feat: expose source workload identity in CEL context

### DIFF
--- a/crates/agentgateway/src/cel/types.rs
+++ b/crates/agentgateway/src/cel/types.rs
@@ -109,6 +109,26 @@ pub struct SourceContext {
 	#[serde(flatten, default, deserialize_with = "none_if_empty")]
 	#[dynamic(flatten)]
 	pub tls: Option<crate::transport::tls::TlsInfo>,
+	/// The workload identity of the downstream connection, resolved from the
+	/// workload discovery store by source IP. Available when the source pod is
+	/// known to the mesh.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub workload: Option<WorkloadContext>,
+}
+
+#[apply(schema!)]
+#[derive(cel::DynamicType)]
+/// The workload identity of the downstream connection, resolved from the source IP.
+pub struct WorkloadContext {
+	/// The pod name of the source workload.
+	#[serde(default)]
+	pub name: String,
+	/// The namespace of the source workload.
+	#[serde(default)]
+	pub namespace: String,
+	/// The service account of the source workload.
+	#[serde(default)]
+	pub service_account: String,
 }
 fn none_if_empty<'de, D>(deserializer: D) -> Result<Option<TlsInfo>, D::Error>
 where
@@ -1467,6 +1487,7 @@ pub fn full_example_executor() -> ExecutorSerde {
 				subject: Default::default(),
 				subject_cn: Some("cn".into()),
 			}),
+			workload: None,
 		}),
 		jwt: Some(jwt::Claims {
 			inner: serde_json::Map::from_iter(vec![

--- a/crates/agentgateway/src/cel/types.rs
+++ b/crates/agentgateway/src/cel/types.rs
@@ -122,13 +122,35 @@ pub struct SourceContext {
 pub struct WorkloadContext {
 	/// The pod name of the source workload.
 	#[serde(default)]
-	pub name: String,
+	pub name: Strng,
 	/// The namespace of the source workload.
 	#[serde(default)]
-	pub namespace: String,
+	pub namespace: Strng,
 	/// The service account of the source workload.
 	#[serde(default)]
-	pub service_account: String,
+	pub service_account: Strng,
+}
+
+impl WorkloadContext {
+	/// Resolve the source workload from the discovery store by IP address.
+	pub fn from_stores(
+		stores: &crate::Stores,
+		network: &Strng,
+		addr: IpAddr,
+	) -> Option<WorkloadContext> {
+		let discovery = stores.read_discovery();
+		discovery
+			.workloads
+			.find_address(&crate::types::discovery::NetworkAddress {
+				network: network.clone(),
+				address: addr,
+			})
+			.map(|w| WorkloadContext {
+				name: w.name.clone(),
+				namespace: w.namespace.clone(),
+				service_account: w.service_account.clone(),
+			})
+	}
 }
 fn none_if_empty<'de, D>(deserializer: D) -> Result<Option<TlsInfo>, D::Error>
 where
@@ -1487,7 +1509,11 @@ pub fn full_example_executor() -> ExecutorSerde {
 				subject: Default::default(),
 				subject_cn: Some("cn".into()),
 			}),
-			workload: None,
+			workload: Some(WorkloadContext {
+				name: "pod-1".into(),
+				namespace: "ns-1".into(),
+				service_account: "sa-1".into(),
+			}),
 		}),
 		jwt: Some(jwt::Claims {
 			inner: serde_json::Map::from_iter(vec![

--- a/crates/agentgateway/src/cel/types.rs
+++ b/crates/agentgateway/src/cel/types.rs
@@ -109,17 +109,32 @@ pub struct SourceContext {
 	#[serde(flatten, default, deserialize_with = "none_if_empty")]
 	#[dynamic(flatten)]
 	pub tls: Option<crate::transport::tls::TlsInfo>,
-	/// The workload identity of the downstream connection, resolved from the
+	/// The workload context of the downstream connection, resolved from the
 	/// workload discovery store by source IP. Available when the source pod is
 	/// known to the controller's workload discovery store.
+	///
+	/// Fields are nested under `unverified` to signal that they are derived
+	/// from the source IP (not cryptographically authenticated). Policy
+	/// authors should prefer `source.identity.*` for trust-sensitive checks.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub workload: Option<WorkloadContext>,
 }
 
 #[apply(schema!)]
 #[derive(cel::DynamicType)]
-/// The workload identity of the downstream connection, resolved from the source IP.
+/// Workload context wrapper. All fields live under `unverified` to make it
+/// clear that the data is resolved by IP, not cryptographically verified.
 pub struct WorkloadContext {
+	/// Unverified workload metadata resolved from the source IP.
+	pub unverified: UnverifiedMetadata,
+}
+
+#[apply(schema!)]
+#[derive(cel::DynamicType)]
+/// Unverified workload metadata resolved from the workload discovery store
+/// by source IP. These fields are **not** cryptographically authenticated;
+/// prefer `source.identity.*` for trust-sensitive policy decisions.
+pub struct UnverifiedMetadata {
 	/// The pod name of the source workload.
 	#[serde(default)]
 	pub name: Strng,
@@ -146,9 +161,11 @@ impl WorkloadContext {
 				address: addr,
 			})
 			.map(|w| WorkloadContext {
-				name: w.name.clone(),
-				namespace: w.namespace.clone(),
-				service_account: w.service_account.clone(),
+				unverified: UnverifiedMetadata {
+					name: w.name.clone(),
+					namespace: w.namespace.clone(),
+					service_account: w.service_account.clone(),
+				},
 			})
 	}
 }
@@ -1510,9 +1527,11 @@ pub fn full_example_executor() -> ExecutorSerde {
 				subject_cn: Some("cn".into()),
 			}),
 			workload: Some(WorkloadContext {
-				name: "pod-1".into(),
-				namespace: "ns-1".into(),
-				service_account: "sa-1".into(),
+				unverified: UnverifiedMetadata {
+					name: "pod-1".into(),
+					namespace: "ns-1".into(),
+					service_account: "sa-1".into(),
+				},
 			}),
 		}),
 		jwt: Some(jwt::Claims {

--- a/crates/agentgateway/src/cel/types.rs
+++ b/crates/agentgateway/src/cel/types.rs
@@ -111,7 +111,7 @@ pub struct SourceContext {
 	pub tls: Option<crate::transport::tls::TlsInfo>,
 	/// The workload identity of the downstream connection, resolved from the
 	/// workload discovery store by source IP. Available when the source pod is
-	/// known to the mesh.
+	/// known to the controller's workload discovery store.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub workload: Option<WorkloadContext>,
 }

--- a/crates/agentgateway/src/cel/types.rs
+++ b/crates/agentgateway/src/cel/types.rs
@@ -117,7 +117,7 @@ pub struct SourceContext {
 	/// from the source IP (not cryptographically authenticated). Policy
 	/// authors should prefer `source.identity.*` for trust-sensitive checks.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
-	pub workload: Option<WorkloadContext>,
+	pub unverified_workload: Option<WorkloadContext>,
 }
 
 #[apply(schema!)]
@@ -125,16 +125,6 @@ pub struct SourceContext {
 /// Workload context wrapper. All fields live under `unverified` to make it
 /// clear that the data is resolved by IP, not cryptographically verified.
 pub struct WorkloadContext {
-	/// Unverified workload metadata resolved from the source IP.
-	pub unverified: UnverifiedMetadata,
-}
-
-#[apply(schema!)]
-#[derive(cel::DynamicType)]
-/// Unverified workload metadata resolved from the workload discovery store
-/// by source IP. These fields are **not** cryptographically authenticated;
-/// prefer `source.identity.*` for trust-sensitive policy decisions.
-pub struct UnverifiedMetadata {
 	/// The pod name of the source workload.
 	#[serde(default)]
 	pub name: Strng,
@@ -161,11 +151,9 @@ impl WorkloadContext {
 				address: addr,
 			})
 			.map(|w| WorkloadContext {
-				unverified: UnverifiedMetadata {
-					name: w.name.clone(),
-					namespace: w.namespace.clone(),
-					service_account: w.service_account.clone(),
-				},
+				name: w.name.clone(),
+				namespace: w.namespace.clone(),
+				service_account: w.service_account.clone(),
 			})
 	}
 }
@@ -1526,12 +1514,10 @@ pub fn full_example_executor() -> ExecutorSerde {
 				subject: Default::default(),
 				subject_cn: Some("cn".into()),
 			}),
-			workload: Some(WorkloadContext {
-				unverified: UnverifiedMetadata {
-					name: "pod-1".into(),
-					namespace: "ns-1".into(),
-					service_account: "sa-1".into(),
-				},
+			unverified_workload: Some(WorkloadContext {
+				name: "pod-1".into(),
+				namespace: "ns-1".into(),
+				service_account: "sa-1".into(),
 			}),
 		}),
 		jwt: Some(jwt::Claims {

--- a/crates/agentgateway/src/cel/types_test.rs
+++ b/crates/agentgateway/src/cel/types_test.rs
@@ -31,7 +31,7 @@ fn build_test_request() -> crate::http::Request {
 		address: "127.0.0.1".parse().unwrap(),
 		port: 54321,
 		tls: None,
-		workload: None,
+		unverified_workload: None,
 	};
 	req.extensions_mut().insert(source);
 
@@ -269,7 +269,7 @@ fn test_extension_or_direct_serialization() {
 		address: "192.168.1.1".parse().unwrap(),
 		port: 8080,
 		tls: None,
-		workload: None,
+		unverified_workload: None,
 	};
 	let ext_or_direct: ExtensionOrDirect<SourceContext> = ExtensionOrDirect::Direct(Some(&value));
 	let json = serde_json::to_value(&ext_or_direct).expect("failed to serialize");
@@ -280,42 +280,4 @@ fn test_extension_or_direct_serialization() {
 	let ext_or_direct_none: ExtensionOrDirect<SourceContext> = ExtensionOrDirect::Direct(None);
 	let json_none = serde_json::to_value(&ext_or_direct_none).expect("failed to serialize");
 	assert!(json_none.is_null());
-}
-
-#[test]
-fn test_source_workload_cel_fields() {
-	use super::*;
-	use serde_json::json;
-
-	// Build an ExecutorSerde with workload context populated.
-	let exec_serde: ExecutorSerde = serde_json::from_value(json!({
-		"source": {
-			"address": "10.0.0.1",
-			"port": 12345,
-			"workload": {
-				"unverified": {
-					"name": "agent-a",
-					"namespace": "agents",
-					"serviceAccount": "agent-a-sa"
-				}
-			}
-		}
-	}))
-	.expect("deserialize");
-	let exec = exec_serde.as_executor();
-
-	let eval = |expr_str: &str| -> serde_json::Value {
-		let expr = Expression::new_strict(expr_str).expect("compile");
-		exec.eval(&expr).expect("eval").json().expect("json")
-	};
-
-	assert_eq!(eval("source.workload.unverified.name"), json!("agent-a"));
-	assert_eq!(
-		eval("source.workload.unverified.namespace"),
-		json!("agents")
-	);
-	assert_eq!(
-		eval("source.workload.unverified.serviceAccount"),
-		json!("agent-a-sa")
-	);
 }

--- a/crates/agentgateway/src/cel/types_test.rs
+++ b/crates/agentgateway/src/cel/types_test.rs
@@ -293,9 +293,11 @@ fn test_source_workload_cel_fields() {
 			"address": "10.0.0.1",
 			"port": 12345,
 			"workload": {
-				"name": "agent-a",
-				"namespace": "agents",
-				"serviceAccount": "agent-a-sa"
+				"unverified": {
+					"name": "agent-a",
+					"namespace": "agents",
+					"serviceAccount": "agent-a-sa"
+				}
 			}
 		}
 	}))
@@ -307,7 +309,7 @@ fn test_source_workload_cel_fields() {
 		exec.eval(&expr).expect("eval").json().expect("json")
 	};
 
-	assert_eq!(eval("source.workload.name"), json!("agent-a"));
-	assert_eq!(eval("source.workload.namespace"), json!("agents"));
-	assert_eq!(eval("source.workload.serviceAccount"), json!("agent-a-sa"));
+	assert_eq!(eval("source.workload.unverified.name"), json!("agent-a"));
+	assert_eq!(eval("source.workload.unverified.namespace"), json!("agents"));
+	assert_eq!(eval("source.workload.unverified.serviceAccount"), json!("agent-a-sa"));
 }

--- a/crates/agentgateway/src/cel/types_test.rs
+++ b/crates/agentgateway/src/cel/types_test.rs
@@ -281,3 +281,33 @@ fn test_extension_or_direct_serialization() {
 	let json_none = serde_json::to_value(&ext_or_direct_none).expect("failed to serialize");
 	assert!(json_none.is_null());
 }
+
+#[test]
+fn test_source_workload_cel_fields() {
+	use super::*;
+	use serde_json::json;
+
+	// Build an ExecutorSerde with workload context populated.
+	let exec_serde: ExecutorSerde = serde_json::from_value(json!({
+		"source": {
+			"address": "10.0.0.1",
+			"port": 12345,
+			"workload": {
+				"name": "agent-a",
+				"namespace": "agents",
+				"serviceAccount": "agent-a-sa"
+			}
+		}
+	}))
+	.expect("deserialize");
+	let exec = exec_serde.as_executor();
+
+	let eval = |expr_str: &str| -> serde_json::Value {
+		let expr = Expression::new_strict(expr_str).expect("compile");
+		exec.eval(&expr).expect("eval").json().expect("json")
+	};
+
+	assert_eq!(eval("source.workload.name"), json!("agent-a"));
+	assert_eq!(eval("source.workload.namespace"), json!("agents"));
+	assert_eq!(eval("source.workload.serviceAccount"), json!("agent-a-sa"));
+}

--- a/crates/agentgateway/src/cel/types_test.rs
+++ b/crates/agentgateway/src/cel/types_test.rs
@@ -31,6 +31,7 @@ fn build_test_request() -> crate::http::Request {
 		address: "127.0.0.1".parse().unwrap(),
 		port: 54321,
 		tls: None,
+		workload: None,
 	};
 	req.extensions_mut().insert(source);
 
@@ -268,6 +269,7 @@ fn test_extension_or_direct_serialization() {
 		address: "192.168.1.1".parse().unwrap(),
 		port: 8080,
 		tls: None,
+		workload: None,
 	};
 	let ext_or_direct: ExtensionOrDirect<SourceContext> = ExtensionOrDirect::Direct(Some(&value));
 	let json = serde_json::to_value(&ext_or_direct).expect("failed to serialize");

--- a/crates/agentgateway/src/cel/types_test.rs
+++ b/crates/agentgateway/src/cel/types_test.rs
@@ -310,6 +310,12 @@ fn test_source_workload_cel_fields() {
 	};
 
 	assert_eq!(eval("source.workload.unverified.name"), json!("agent-a"));
-	assert_eq!(eval("source.workload.unverified.namespace"), json!("agents"));
-	assert_eq!(eval("source.workload.unverified.serviceAccount"), json!("agent-a-sa"));
+	assert_eq!(
+		eval("source.workload.unverified.namespace"),
+		json!("agents")
+	);
+	assert_eq!(
+		eval("source.workload.unverified.serviceAccount"),
+		json!("agent-a-sa")
+	);
 }

--- a/crates/agentgateway/src/http/authorization_tests.rs
+++ b/crates/agentgateway/src/http/authorization_tests.rs
@@ -185,7 +185,7 @@ fn test_network_authorization_allows_source_cidr() {
 		address: IpAddr::V4(Ipv4Addr::new(10, 1, 2, 3)),
 		port: 15000,
 		tls: None,
-		workload: None,
+		unverified_workload: None,
 	};
 
 	assert_matches!(network_authz.apply(&source), Ok(()));
@@ -204,7 +204,7 @@ fn test_network_authorization_deny_takes_precedence() {
 		address: IpAddr::V4(Ipv4Addr::new(10, 1, 2, 3)),
 		port: 15000,
 		tls: None,
-		workload: None,
+		unverified_workload: None,
 	};
 
 	assert_matches!(network_authz.apply(&source), Err(_));

--- a/crates/agentgateway/src/http/authorization_tests.rs
+++ b/crates/agentgateway/src/http/authorization_tests.rs
@@ -185,6 +185,7 @@ fn test_network_authorization_allows_source_cidr() {
 		address: IpAddr::V4(Ipv4Addr::new(10, 1, 2, 3)),
 		port: 15000,
 		tls: None,
+		workload: None,
 	};
 
 	assert_matches!(network_authz.apply(&source), Ok(()));
@@ -203,6 +204,7 @@ fn test_network_authorization_deny_takes_precedence() {
 		address: IpAddr::V4(Ipv4Addr::new(10, 1, 2, 3)),
 		port: 15000,
 		tls: None,
+		workload: None,
 	};
 
 	assert_matches!(network_authz.apply(&source), Err(_));

--- a/crates/agentgateway/src/proxy/gateway.rs
+++ b/crates/agentgateway/src/proxy/gateway.rs
@@ -642,7 +642,7 @@ impl Gateway {
 			.get_or_create(&transport_labels)
 			.inc();
 
-		let workload = crate::cel::WorkloadContext::from_stores(
+		let unverified_workload = crate::cel::WorkloadContext::from_stores(
 			&inputs.stores,
 			&inputs.cfg.network,
 			tcp.peer_addr.ip(),
@@ -651,7 +651,7 @@ impl Gateway {
 			address: tcp.peer_addr.ip(),
 			port: tcp.peer_addr.port(),
 			tls: tls.and_then(|t| t.src_identity.clone()),
-			workload,
+			unverified_workload,
 		};
 		if let Some(network_authorization) = policies.network_authorization.as_ref()
 			&& let Err(e) = network_authorization.apply(&src)

--- a/crates/agentgateway/src/proxy/gateway.rs
+++ b/crates/agentgateway/src/proxy/gateway.rs
@@ -642,10 +642,25 @@ impl Gateway {
 			.get_or_create(&transport_labels)
 			.inc();
 
+		let workload = {
+			let discovery = inputs.stores.read_discovery();
+			discovery
+				.workloads
+				.find_address(&crate::types::discovery::NetworkAddress {
+					network: inputs.cfg.network.clone(),
+					address: tcp.peer_addr.ip(),
+				})
+				.map(|w| crate::cel::WorkloadContext {
+					name: w.name.to_string(),
+					namespace: w.namespace.to_string(),
+					service_account: w.service_account.to_string(),
+				})
+		};
 		let src = crate::cel::SourceContext {
 			address: tcp.peer_addr.ip(),
 			port: tcp.peer_addr.port(),
 			tls: tls.and_then(|t| t.src_identity.clone()),
+			workload,
 		};
 		if let Some(network_authorization) = policies.network_authorization.as_ref()
 			&& let Err(e) = network_authorization.apply(&src)

--- a/crates/agentgateway/src/proxy/gateway.rs
+++ b/crates/agentgateway/src/proxy/gateway.rs
@@ -642,20 +642,11 @@ impl Gateway {
 			.get_or_create(&transport_labels)
 			.inc();
 
-		let workload = {
-			let discovery = inputs.stores.read_discovery();
-			discovery
-				.workloads
-				.find_address(&crate::types::discovery::NetworkAddress {
-					network: inputs.cfg.network.clone(),
-					address: tcp.peer_addr.ip(),
-				})
-				.map(|w| crate::cel::WorkloadContext {
-					name: w.name.to_string(),
-					namespace: w.namespace.to_string(),
-					service_account: w.service_account.to_string(),
-				})
-		};
+		let workload = crate::cel::WorkloadContext::from_stores(
+			&inputs.stores,
+			&inputs.cfg.network,
+			tcp.peer_addr.ip(),
+		);
 		let src = crate::cel::SourceContext {
 			address: tcp.peer_addr.ip(),
 			port: tcp.peer_addr.port(),

--- a/crates/agentgateway/src/proxy/tcpproxy.rs
+++ b/crates/agentgateway/src/proxy/tcpproxy.rs
@@ -37,7 +37,7 @@ impl TCPProxy {
 			.ext::<TCPConnectionInfo>()
 			.expect("tcp connection must be set");
 		let tls = connection.ext::<TLSConnectionInfo>();
-		let workload = crate::cel::WorkloadContext::from_stores(
+		let unverified_workload = crate::cel::WorkloadContext::from_stores(
 			&self.inputs.stores,
 			&self.inputs.cfg.network,
 			tcp.peer_addr.ip(),
@@ -46,7 +46,7 @@ impl TCPProxy {
 			address: tcp.peer_addr.ip(),
 			port: tcp.peer_addr.port(),
 			tls: tls.and_then(|t| t.src_identity.clone()),
-			workload,
+			unverified_workload,
 		};
 		let mut log: DropOnLog = RequestLog::new(
 			log::CelLogging::new(

--- a/crates/agentgateway/src/proxy/tcpproxy.rs
+++ b/crates/agentgateway/src/proxy/tcpproxy.rs
@@ -37,20 +37,11 @@ impl TCPProxy {
 			.ext::<TCPConnectionInfo>()
 			.expect("tcp connection must be set");
 		let tls = connection.ext::<TLSConnectionInfo>();
-		let workload = {
-			let discovery = self.inputs.stores.read_discovery();
-			discovery
-				.workloads
-				.find_address(&crate::types::discovery::NetworkAddress {
-					network: self.inputs.cfg.network.clone(),
-					address: tcp.peer_addr.ip(),
-				})
-				.map(|w| crate::cel::WorkloadContext {
-					name: w.name.to_string(),
-					namespace: w.namespace.to_string(),
-					service_account: w.service_account.to_string(),
-				})
-		};
+		let workload = crate::cel::WorkloadContext::from_stores(
+			&self.inputs.stores,
+			&self.inputs.cfg.network,
+			tcp.peer_addr.ip(),
+		);
 		let src = SourceContext {
 			address: tcp.peer_addr.ip(),
 			port: tcp.peer_addr.port(),

--- a/crates/agentgateway/src/proxy/tcpproxy.rs
+++ b/crates/agentgateway/src/proxy/tcpproxy.rs
@@ -37,10 +37,25 @@ impl TCPProxy {
 			.ext::<TCPConnectionInfo>()
 			.expect("tcp connection must be set");
 		let tls = connection.ext::<TLSConnectionInfo>();
+		let workload = {
+			let discovery = self.inputs.stores.read_discovery();
+			discovery
+				.workloads
+				.find_address(&crate::types::discovery::NetworkAddress {
+					network: self.inputs.cfg.network.clone(),
+					address: tcp.peer_addr.ip(),
+				})
+				.map(|w| crate::cel::WorkloadContext {
+					name: w.name.to_string(),
+					namespace: w.namespace.to_string(),
+					service_account: w.service_account.to_string(),
+				})
+		};
 		let src = SourceContext {
 			address: tcp.peer_addr.ip(),
 			port: tcp.peer_addr.port(),
 			tls: tls.and_then(|t| t.src_identity.clone()),
+			workload,
 		};
 		let mut log: DropOnLog = RequestLog::new(
 			log::CelLogging::new(

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -1712,7 +1712,7 @@ mod tests {
 					address: "10.1.2.3".parse().unwrap(),
 					port: 12345,
 					tls: None,
-					workload: None,
+					unverified_workload: None,
 				})
 				.is_ok()
 		);
@@ -1722,7 +1722,7 @@ mod tests {
 					address: "192.168.1.2".parse().unwrap(),
 					port: 12345,
 					tls: None,
-					workload: None,
+					unverified_workload: None,
 				})
 				.is_ok()
 		);
@@ -1732,7 +1732,7 @@ mod tests {
 					address: "172.16.0.1".parse().unwrap(),
 					port: 12345,
 					tls: None,
-					workload: None,
+					unverified_workload: None,
 				})
 				.is_err()
 		);

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -1712,6 +1712,7 @@ mod tests {
 					address: "10.1.2.3".parse().unwrap(),
 					port: 12345,
 					tls: None,
+					workload: None,
 				})
 				.is_ok()
 		);
@@ -1721,6 +1722,7 @@ mod tests {
 					address: "192.168.1.2".parse().unwrap(),
 					port: 12345,
 					tls: None,
+					workload: None,
 				})
 				.is_ok()
 		);
@@ -1730,6 +1732,7 @@ mod tests {
 					address: "172.16.0.1".parse().unwrap(),
 					port: 12345,
 					tls: None,
+					workload: None,
 				})
 				.is_err()
 		);

--- a/schema/cel.json
+++ b/schema/cel.json
@@ -523,29 +523,39 @@
           "default": null
         },
         "workload": {
-          "description": "The workload identity of the downstream connection, resolved from the\nworkload discovery store by source IP. Available when the source pod is\nknown to the controller's workload discovery store.",
+          "description": "The workload context of the downstream connection, resolved from the\nworkload discovery store by source IP. Available when the source pod is\nknown to the controller's workload discovery store.\n\nFields are nested under `unverified` to signal that they are derived\nfrom the source IP (not cryptographically authenticated). Policy\nauthors should prefer `source.identity.*` for trust-sensitive checks.",
           "type": [
             "object",
             "null"
           ],
           "properties": {
-            "name": {
-              "description": "The pod name of the source workload.",
-              "type": "string",
-              "default": ""
-            },
-            "namespace": {
-              "description": "The namespace of the source workload.",
-              "type": "string",
-              "default": ""
-            },
-            "serviceAccount": {
-              "description": "The service account of the source workload.",
-              "type": "string",
-              "default": ""
+            "unverified": {
+              "description": "Unverified workload metadata resolved from the source IP.",
+              "type": "object",
+              "properties": {
+                "name": {
+                  "description": "The pod name of the source workload.",
+                  "type": "string",
+                  "default": ""
+                },
+                "namespace": {
+                  "description": "The namespace of the source workload.",
+                  "type": "string",
+                  "default": ""
+                },
+                "serviceAccount": {
+                  "description": "The service account of the source workload.",
+                  "type": "string",
+                  "default": ""
+                }
+              },
+              "additionalProperties": false
             }
           },
-          "additionalProperties": false
+          "additionalProperties": false,
+          "required": [
+            "unverified"
+          ]
         }
       },
       "additionalProperties": false

--- a/schema/cel.json
+++ b/schema/cel.json
@@ -522,40 +522,30 @@
           ],
           "default": null
         },
-        "workload": {
+        "unverifiedWorkload": {
           "description": "The workload context of the downstream connection, resolved from the\nworkload discovery store by source IP. Available when the source pod is\nknown to the controller's workload discovery store.\n\nFields are nested under `unverified` to signal that they are derived\nfrom the source IP (not cryptographically authenticated). Policy\nauthors should prefer `source.identity.*` for trust-sensitive checks.",
           "type": [
             "object",
             "null"
           ],
           "properties": {
-            "unverified": {
-              "description": "Unverified workload metadata resolved from the source IP.",
-              "type": "object",
-              "properties": {
-                "name": {
-                  "description": "The pod name of the source workload.",
-                  "type": "string",
-                  "default": ""
-                },
-                "namespace": {
-                  "description": "The namespace of the source workload.",
-                  "type": "string",
-                  "default": ""
-                },
-                "serviceAccount": {
-                  "description": "The service account of the source workload.",
-                  "type": "string",
-                  "default": ""
-                }
-              },
-              "additionalProperties": false
+            "name": {
+              "description": "The pod name of the source workload.",
+              "type": "string",
+              "default": ""
+            },
+            "namespace": {
+              "description": "The namespace of the source workload.",
+              "type": "string",
+              "default": ""
+            },
+            "serviceAccount": {
+              "description": "The service account of the source workload.",
+              "type": "string",
+              "default": ""
             }
           },
-          "additionalProperties": false,
-          "required": [
-            "unverified"
-          ]
+          "additionalProperties": false
         }
       },
       "additionalProperties": false

--- a/schema/cel.json
+++ b/schema/cel.json
@@ -521,6 +521,31 @@
             "null"
           ],
           "default": null
+        },
+        "workload": {
+          "description": "The workload identity of the downstream connection, resolved from the\nworkload discovery store by source IP. Available when the source pod is\nknown to the controller's workload discovery store.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "name": {
+              "description": "The pod name of the source workload.",
+              "type": "string",
+              "default": ""
+            },
+            "namespace": {
+              "description": "The namespace of the source workload.",
+              "type": "string",
+              "default": ""
+            },
+            "serviceAccount": {
+              "description": "The service account of the source workload.",
+              "type": "string",
+              "default": ""
+            }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false

--- a/schema/cel.md
+++ b/schema/cel.md
@@ -71,6 +71,10 @@
 |`source.issuer`|string|The issuer from the downstream certificate, if available.|
 |`source.subject`|string|The subject from the downstream certificate, if available.|
 |`source.subjectCn`|string|The CN of the subject from the downstream certificate, if available.|
+|`source.workload`|object|The workload identity of the downstream connection, resolved from the<br>workload discovery store by source IP. Available when the source pod is<br>known to the controller's workload discovery store.|
+|`source.workload.name`|string|The pod name of the source workload.|
+|`source.workload.namespace`|string|The namespace of the source workload.|
+|`source.workload.serviceAccount`|string|The service account of the source workload.|
 |`mcp`|object|`mcp` contains attributes about the MCP request.<br>Request-time CEL only includes identity fields such as `tool`, `prompt`, or `resource`.<br>Post-request CEL may also include fields like `methodName`, `sessionId`, and tool payloads.|
 |`mcp.methodName`|string||
 |`mcp.sessionId`|string||

--- a/schema/cel.md
+++ b/schema/cel.md
@@ -71,11 +71,10 @@
 |`source.issuer`|string|The issuer from the downstream certificate, if available.|
 |`source.subject`|string|The subject from the downstream certificate, if available.|
 |`source.subjectCn`|string|The CN of the subject from the downstream certificate, if available.|
-|`source.workload`|object|The workload context of the downstream connection, resolved from the<br>workload discovery store by source IP. Available when the source pod is<br>known to the controller's workload discovery store.<br><br>Fields are nested under `unverified` to signal that they are derived<br>from the source IP (not cryptographically authenticated). Policy<br>authors should prefer `source.identity.*` for trust-sensitive checks.|
-|`source.workload.unverified`|object|Unverified workload metadata resolved from the source IP.|
-|`source.workload.unverified.name`|string|The pod name of the source workload.|
-|`source.workload.unverified.namespace`|string|The namespace of the source workload.|
-|`source.workload.unverified.serviceAccount`|string|The service account of the source workload.|
+|`source.unverifiedWorkload`|object|The workload context of the downstream connection, resolved from the<br>workload discovery store by source IP. Available when the source pod is<br>known to the controller's workload discovery store.<br><br>Fields are nested under `unverified` to signal that they are derived<br>from the source IP (not cryptographically authenticated). Policy<br>authors should prefer `source.identity.*` for trust-sensitive checks.|
+|`source.unverifiedWorkload.name`|string|The pod name of the source workload.|
+|`source.unverifiedWorkload.namespace`|string|The namespace of the source workload.|
+|`source.unverifiedWorkload.serviceAccount`|string|The service account of the source workload.|
 |`mcp`|object|`mcp` contains attributes about the MCP request.<br>Request-time CEL only includes identity fields such as `tool`, `prompt`, or `resource`.<br>Post-request CEL may also include fields like `methodName`, `sessionId`, and tool payloads.|
 |`mcp.methodName`|string||
 |`mcp.sessionId`|string||

--- a/schema/cel.md
+++ b/schema/cel.md
@@ -71,10 +71,11 @@
 |`source.issuer`|string|The issuer from the downstream certificate, if available.|
 |`source.subject`|string|The subject from the downstream certificate, if available.|
 |`source.subjectCn`|string|The CN of the subject from the downstream certificate, if available.|
-|`source.workload`|object|The workload identity of the downstream connection, resolved from the<br>workload discovery store by source IP. Available when the source pod is<br>known to the controller's workload discovery store.|
-|`source.workload.name`|string|The pod name of the source workload.|
-|`source.workload.namespace`|string|The namespace of the source workload.|
-|`source.workload.serviceAccount`|string|The service account of the source workload.|
+|`source.workload`|object|The workload context of the downstream connection, resolved from the<br>workload discovery store by source IP. Available when the source pod is<br>known to the controller's workload discovery store.<br>Fields are nested under `unverified` to signal that they are derived<br>from the source IP, not cryptographically authenticated. Prefer<br>`source.identity.*` for trust-sensitive checks.|
+|`source.workload.unverified`|object|Unverified workload metadata resolved from the source IP.|
+|`source.workload.unverified.name`|string|The pod name of the source workload.|
+|`source.workload.unverified.namespace`|string|The namespace of the source workload.|
+|`source.workload.unverified.serviceAccount`|string|The service account of the source workload.|
 |`mcp`|object|`mcp` contains attributes about the MCP request.<br>Request-time CEL only includes identity fields such as `tool`, `prompt`, or `resource`.<br>Post-request CEL may also include fields like `methodName`, `sessionId`, and tool payloads.|
 |`mcp.methodName`|string||
 |`mcp.sessionId`|string||

--- a/schema/cel.md
+++ b/schema/cel.md
@@ -71,7 +71,7 @@
 |`source.issuer`|string|The issuer from the downstream certificate, if available.|
 |`source.subject`|string|The subject from the downstream certificate, if available.|
 |`source.subjectCn`|string|The CN of the subject from the downstream certificate, if available.|
-|`source.workload`|object|The workload context of the downstream connection, resolved from the<br>workload discovery store by source IP. Available when the source pod is<br>known to the controller's workload discovery store.<br>Fields are nested under `unverified` to signal that they are derived<br>from the source IP, not cryptographically authenticated. Prefer<br>`source.identity.*` for trust-sensitive checks.|
+|`source.workload`|object|The workload context of the downstream connection, resolved from the<br>workload discovery store by source IP. Available when the source pod is<br>known to the controller's workload discovery store.<br><br>Fields are nested under `unverified` to signal that they are derived<br>from the source IP (not cryptographically authenticated). Policy<br>authors should prefer `source.identity.*` for trust-sensitive checks.|
 |`source.workload.unverified`|object|Unverified workload metadata resolved from the source IP.|
 |`source.workload.unverified.name`|string|The pod name of the source workload.|
 |`source.workload.unverified.namespace`|string|The namespace of the source workload.|


### PR DESCRIPTION
Closes #1460

## Summary
- Resolves source IP → workload identity via the WDS store and exposes it as `source.workload.name`, `source.workload.namespace`, and `source.workload.serviceAccount` in CEL expressions
- Enables authorization, transformation, and access logging policies to use source workload identity without requiring mTLS
- Populates the workload context in both HTTP (gateway) and TCP proxy paths

## Motivation
When using AgentGateway as a proxy for inter-service traffic, the gateway receives requests from source pods but has no way to expose the resolved workload identity in policy expressions. The WDS store already maps source IPs to workload metadata — this PR wires that lookup into the CEL context.

The workload store is populated via WDS from the controller, which watches Kubernetes pods directly. This works for any pod the controller can see — it does not require the source pod to be enrolled in a service mesh.

## Example: Authorization based on source service account

Only allow requests from pods running as specific service accounts:

```yaml
apiVersion: agentgateway.dev/v1alpha1
kind: AgentgatewayPolicy
metadata:
  name: restrict-by-source-sa
spec:
  targetRefs:
    - group: gateway.networking.k8s.io
      kind: HTTPRoute
      name: internal-api
  traffic:
    authorization:
      action: Allow
      policy:
        matchExpressions:
          - "source.workload.serviceAccount in ['agent-orchestrator', 'agent-scheduler']"
```

## Example: Source-aware routing with header injection

Inject source identity headers so the receiving service knows which workload made the request:

```yaml
apiVersion: agentgateway.dev/v1alpha1
kind: AgentgatewayPolicy
metadata:
  name: inject-caller-identity
spec:
  targetRefs:
    - group: gateway.networking.k8s.io
      kind: Gateway
      name: agent-gateway
  traffic:
    transformation:
      request:
        set:
          - name: x-source-workload
            value: "source.workload.name"
          - name: x-source-namespace
            value: "source.workload.namespace"
          - name: x-source-service-account
            value: "source.workload.serviceAccount"
```

## Example: Per-caller access logging

Include source workload identity in access logs for audit:

```yaml
apiVersion: agentgateway.dev/v1alpha1
kind: AgentgatewayPolicy
metadata:
  name: audit-log-with-source
spec:
  targetRefs:
    - group: gateway.networking.k8s.io
      kind: Gateway
      name: agent-gateway
  frontend:
    accessLog:
      attributes:
        add:
          - name: "source.workload"
            expression: "source.workload.name"
          - name: "source.namespace"
            expression: "source.workload.namespace"
          - name: "source.sa"
            expression: "source.workload.serviceAccount"
```

## Test plan
- [x] Existing tests pass with `workload: None` added to all `SourceContext` constructions
- [x] `cargo check` passes
- [x] Unit test for `source.workload.name`, `source.workload.namespace`, `source.workload.serviceAccount` CEL evaluation
- [ ] Manual verification: deploy AgentGateway with WDS enabled, send request from a known pod, verify `source.workload.name` resolves in CEL

🤖 Generated with [Claude Code](https://claude.com/claude-code)