### PR TITLE
fix: handle missing fields in Vertex AI Gemini completions responses

### DIFF
--- a/crates/agentgateway/src/llm/conversion/completions.rs
+++ b/crates/agentgateway/src/llm/conversion/completions.rs
@@ -218,7 +218,7 @@ pub mod from_messages {
 					.unwrap_or(0),
 				output_tokens: usage
 					.as_ref()
-					.map(|u| u.completion_tokens as usize)
+					.map(|u| u.completion_tokens_or_inferred() as usize)
 					.unwrap_or(0),
 				cache_creation_input_tokens: None,
 				cache_read_input_tokens: None,
@@ -409,7 +409,12 @@ pub mod from_messages {
 
 			let (input_tokens, output_tokens) = usage
 				.as_ref()
-				.map(|u| (u.prompt_tokens as usize, u.completion_tokens as usize))
+				.map(|u| {
+					(
+						u.prompt_tokens as usize,
+						u.completion_tokens_or_inferred() as usize,
+					)
+				})
 				.unwrap_or((0, 0));
 
 			push_event(
@@ -433,7 +438,7 @@ pub mod from_messages {
 			if let Some(usage) = usage {
 				log.non_atomic_mutate(|r| {
 					r.response.input_tokens = Some(usage.prompt_tokens as u64);
-					r.response.output_tokens = Some(usage.completion_tokens as u64);
+					r.response.output_tokens = Some(usage.completion_tokens_or_inferred() as u64);
 					r.response.total_tokens = Some(usage.total_tokens as u64);
 				});
 			}
@@ -975,7 +980,7 @@ pub fn passthrough_stream(
 									.prompt_tokens_details
 									.as_ref()
 									.and_then(|d| d.audio_tokens);
-								r.response.output_tokens = Some(u.completion_tokens as u64);
+								r.response.output_tokens = Some(u.completion_tokens_or_inferred() as u64);
 								r.response.output_audio_tokens = u
 									.completion_tokens_details
 									.as_ref()

--- a/crates/agentgateway/src/llm/conversion/completions.rs
+++ b/crates/agentgateway/src/llm/conversion/completions.rs
@@ -218,7 +218,7 @@ pub mod from_messages {
 					.unwrap_or(0),
 				output_tokens: usage
 					.as_ref()
-					.map(|u| u.completion_tokens_or_inferred() as usize)
+					.map(|u| u.completion_tokens as usize)
 					.unwrap_or(0),
 				cache_creation_input_tokens: None,
 				cache_read_input_tokens: None,
@@ -409,12 +409,7 @@ pub mod from_messages {
 
 			let (input_tokens, output_tokens) = usage
 				.as_ref()
-				.map(|u| {
-					(
-						u.prompt_tokens as usize,
-						u.completion_tokens_or_inferred() as usize,
-					)
-				})
+				.map(|u| (u.prompt_tokens as usize, u.completion_tokens as usize))
 				.unwrap_or((0, 0));
 
 			push_event(
@@ -438,7 +433,7 @@ pub mod from_messages {
 			if let Some(usage) = usage {
 				log.non_atomic_mutate(|r| {
 					r.response.input_tokens = Some(usage.prompt_tokens as u64);
-					r.response.output_tokens = Some(usage.completion_tokens_or_inferred() as u64);
+					r.response.output_tokens = Some(usage.completion_tokens as u64);
 					r.response.total_tokens = Some(usage.total_tokens as u64);
 				});
 			}
@@ -980,7 +975,7 @@ pub fn passthrough_stream(
 									.prompt_tokens_details
 									.as_ref()
 									.and_then(|d| d.audio_tokens);
-								r.response.output_tokens = Some(u.completion_tokens_or_inferred() as u64);
+								r.response.output_tokens = Some(u.completion_tokens as u64);
 								r.response.output_audio_tokens = u
 									.completion_tokens_details
 									.as_ref()

--- a/crates/agentgateway/src/llm/tests.rs
+++ b/crates/agentgateway/src/llm/tests.rs
@@ -1098,3 +1098,25 @@ fn usage_completion_tokens_explicit_value_preserved() {
 	};
 	assert_eq!(usage.completion_tokens_or_inferred(), 20);
 }
+
+#[test]
+fn streaming_usage_completion_tokens_inferred_from_total_minus_prompt() {
+	let usage = types::completions::typed::Usage {
+		prompt_tokens: 10,
+		completion_tokens: 0,
+		total_tokens: 25,
+		..Default::default()
+	};
+	assert_eq!(usage.completion_tokens_or_inferred(), 15);
+}
+
+#[test]
+fn streaming_usage_completion_tokens_explicit_value_preserved() {
+	let usage = types::completions::typed::Usage {
+		prompt_tokens: 10,
+		completion_tokens: 20,
+		total_tokens: 30,
+		..Default::default()
+	};
+	assert_eq!(usage.completion_tokens_or_inferred(), 20);
+}

--- a/crates/agentgateway/src/llm/tests.rs
+++ b/crates/agentgateway/src/llm/tests.rs
@@ -1076,3 +1076,25 @@ fn completions_response_missing_message_and_usage_fields() {
 	assert_eq!(usage.completion_tokens, 0);
 	assert_eq!(usage.total_tokens, 12);
 }
+
+#[test]
+fn usage_completion_tokens_inferred_from_total_minus_prompt() {
+	let usage = types::completions::Usage {
+		prompt_tokens: 10,
+		completion_tokens: 0,
+		total_tokens: 25,
+		..Default::default()
+	};
+	assert_eq!(usage.completion_tokens_or_inferred(), 15);
+}
+
+#[test]
+fn usage_completion_tokens_explicit_value_preserved() {
+	let usage = types::completions::Usage {
+		prompt_tokens: 10,
+		completion_tokens: 20,
+		total_tokens: 30,
+		..Default::default()
+	};
+	assert_eq!(usage.completion_tokens_or_inferred(), 20);
+}

--- a/crates/agentgateway/src/llm/tests.rs
+++ b/crates/agentgateway/src/llm/tests.rs
@@ -1054,3 +1054,25 @@ fn setup_request_openai_normalizes_trailing_slash_in_path_prefix() {
 	assert_eq!(req.uri().path(), "/v1/custom/chat/completions");
 	assert_eq!(req.uri().query(), Some("trace=repro"));
 }
+
+#[test]
+fn completions_response_missing_message_and_usage_fields() {
+	// Gemini's OpenAI-compat endpoint can omit `message` from choices and
+	// `completion_tokens` from usage. Verify deserialization succeeds with defaults.
+	let json = r#"{
+		"id": "1",
+		"object": "chat.completion",
+		"created": 0,
+		"model": "google/gemini-2.5-flash",
+		"choices": [{"index": 0, "finish_reason": "length"}],
+		"usage": {"prompt_tokens": 5, "total_tokens": 12}
+	}"#;
+	let resp: types::completions::Response = serde_json::from_str(json).unwrap();
+	assert_eq!(resp.choices.len(), 1);
+	assert_eq!(resp.choices[0].message.content, None);
+	assert_eq!(resp.choices[0].message.role, None);
+	let usage = resp.usage.unwrap();
+	assert_eq!(usage.prompt_tokens, 5);
+	assert_eq!(usage.completion_tokens, 0);
+	assert_eq!(usage.total_tokens, 12);
+}

--- a/crates/agentgateway/src/llm/tests.rs
+++ b/crates/agentgateway/src/llm/tests.rs
@@ -408,6 +408,8 @@ mod response {
 		("basic", ALL_COMPLETIONS),
 		("audio", ALL_COMPLETIONS),
 		("openrouter_reasoning", ALL_COMPLETIONS),
+		("gemini_zero_completion_tokens", ALL_COMPLETIONS),
+		("gemini_with_completion_tokens", ALL_COMPLETIONS),
 	];
 	const COMPLETIONS_STREAM_RESPONSES: &[(&str, &[&str])] = &[("stream", ALL_COMPLETIONS)];
 
@@ -1075,48 +1077,4 @@ fn completions_response_missing_message_and_usage_fields() {
 	assert_eq!(usage.prompt_tokens, 5);
 	assert_eq!(usage.completion_tokens, 0);
 	assert_eq!(usage.total_tokens, 12);
-}
-
-#[test]
-fn usage_completion_tokens_inferred_from_total_minus_prompt() {
-	let usage = types::completions::Usage {
-		prompt_tokens: 10,
-		completion_tokens: 0,
-		total_tokens: 25,
-		..Default::default()
-	};
-	assert_eq!(usage.completion_tokens_or_inferred(), 15);
-}
-
-#[test]
-fn usage_completion_tokens_explicit_value_preserved() {
-	let usage = types::completions::Usage {
-		prompt_tokens: 10,
-		completion_tokens: 20,
-		total_tokens: 30,
-		..Default::default()
-	};
-	assert_eq!(usage.completion_tokens_or_inferred(), 20);
-}
-
-#[test]
-fn streaming_usage_completion_tokens_inferred_from_total_minus_prompt() {
-	let usage = types::completions::typed::Usage {
-		prompt_tokens: 10,
-		completion_tokens: 0,
-		total_tokens: 25,
-		..Default::default()
-	};
-	assert_eq!(usage.completion_tokens_or_inferred(), 15);
-}
-
-#[test]
-fn streaming_usage_completion_tokens_explicit_value_preserved() {
-	let usage = types::completions::typed::Usage {
-		prompt_tokens: 10,
-		completion_tokens: 20,
-		total_tokens: 30,
-		..Default::default()
-	};
-	assert_eq!(usage.completion_tokens_or_inferred(), 20);
 }

--- a/crates/agentgateway/src/llm/tests/response/completions/gemini_with_completion_tokens.completions-completions.snap
+++ b/crates/agentgateway/src/llm/tests/response/completions/gemini_with_completion_tokens.completions-completions.snap
@@ -1,0 +1,48 @@
+---
+source: crates/agentgateway/src/llm/tests.rs
+description: src/llm/tests/response/completions/gemini_with_completion_tokens.json
+info:
+  model: gemini-2.5-flash
+  usage:
+    prompt_tokens: 7
+    completion_tokens: 12
+    total_tokens: 402
+  choices:
+    - message:
+        content: "Hello! I'm functioning perfectly and ready to assist.\n\n"
+        role: assistant
+      finish_reason: length
+      index: 0
+  created: 1775595257
+  id: 9W7VaabzK7KPjMcPnYGiuAU
+  object: chat.completion
+---
+{
+  "response": {
+    "model": "gemini-2.5-flash",
+    "usage": {
+      "prompt_tokens": 7,
+      "completion_tokens": 12,
+      "total_tokens": 402
+    },
+    "choices": [
+      {
+        "message": {
+          "content": "Hello! I'm functioning perfectly and ready to assist.\n\n",
+          "role": "assistant"
+        },
+        "finish_reason": "length",
+        "index": 0
+      }
+    ],
+    "created": "[date]",
+    "id": "[id]",
+    "object": "chat.completion"
+  },
+  "parsed": {
+    "input_tokens": 7,
+    "output_tokens": 12,
+    "total_tokens": 402,
+    "provider_model": "gemini-2.5-flash"
+  }
+}

--- a/crates/agentgateway/src/llm/tests/response/completions/gemini_with_completion_tokens.completions-detect.snap
+++ b/crates/agentgateway/src/llm/tests/response/completions/gemini_with_completion_tokens.completions-detect.snap
@@ -1,0 +1,48 @@
+---
+source: crates/agentgateway/src/llm/tests.rs
+description: src/llm/tests/response/completions/gemini_with_completion_tokens.json
+info:
+  model: gemini-2.5-flash
+  usage:
+    prompt_tokens: 7
+    completion_tokens: 12
+    total_tokens: 402
+  choices:
+    - message:
+        content: "Hello! I'm functioning perfectly and ready to assist.\n\n"
+        role: assistant
+      finish_reason: length
+      index: 0
+  created: 1775595257
+  id: 9W7VaabzK7KPjMcPnYGiuAU
+  object: chat.completion
+---
+{
+  "response": {
+    "model": "gemini-2.5-flash",
+    "usage": {
+      "prompt_tokens": 7,
+      "completion_tokens": 12,
+      "total_tokens": 402
+    },
+    "choices": [
+      {
+        "message": {
+          "content": "Hello! I'm functioning perfectly and ready to assist.\n\n",
+          "role": "assistant"
+        },
+        "finish_reason": "length",
+        "index": 0
+      }
+    ],
+    "created": "[date]",
+    "id": "[id]",
+    "object": "chat.completion"
+  },
+  "parsed": {
+    "input_tokens": 7,
+    "output_tokens": 12,
+    "total_tokens": 402,
+    "provider_model": "gemini-2.5-flash"
+  }
+}

--- a/crates/agentgateway/src/llm/tests/response/completions/gemini_with_completion_tokens.completions-messages.snap
+++ b/crates/agentgateway/src/llm/tests/response/completions/gemini_with_completion_tokens.completions-messages.snap
@@ -1,0 +1,45 @@
+---
+source: crates/agentgateway/src/llm/tests.rs
+description: src/llm/tests/response/completions/gemini_with_completion_tokens.json
+info:
+  model: gemini-2.5-flash
+  usage:
+    prompt_tokens: 7
+    completion_tokens: 12
+    total_tokens: 402
+  choices:
+    - message:
+        content: "Hello! I'm functioning perfectly and ready to assist.\n\n"
+        role: assistant
+      finish_reason: length
+      index: 0
+  created: 1775595257
+  id: 9W7VaabzK7KPjMcPnYGiuAU
+  object: chat.completion
+---
+{
+  "response": {
+    "id": "[id]",
+    "type": "message",
+    "role": "assistant",
+    "content": [
+      {
+        "type": "text",
+        "text": "Hello! I'm functioning perfectly and ready to assist.\n\n"
+      }
+    ],
+    "model": "gemini-2.5-flash",
+    "stop_reason": "max_tokens",
+    "stop_sequence": null,
+    "usage": {
+      "input_tokens": 7,
+      "output_tokens": 12
+    }
+  },
+  "parsed": {
+    "input_tokens": 7,
+    "output_tokens": 12,
+    "total_tokens": 19,
+    "provider_model": "gemini-2.5-flash"
+  }
+}

--- a/crates/agentgateway/src/llm/tests/response/completions/gemini_with_completion_tokens.json
+++ b/crates/agentgateway/src/llm/tests/response/completions/gemini_with_completion_tokens.json
@@ -1,0 +1,21 @@
+{
+  "model": "gemini-2.5-flash",
+  "usage": {
+    "prompt_tokens": 7,
+    "completion_tokens": 12,
+    "total_tokens": 402
+  },
+  "choices": [
+    {
+      "message": {
+        "content": "Hello! I'm functioning perfectly and ready to assist.\n\n",
+        "role": "assistant"
+      },
+      "finish_reason": "length",
+      "index": 0
+    }
+  ],
+  "created": 1775595257,
+  "id": "9W7VaabzK7KPjMcPnYGiuAU",
+  "object": "chat.completion"
+}

--- a/crates/agentgateway/src/llm/tests/response/completions/gemini_zero_completion_tokens.completions-completions.snap
+++ b/crates/agentgateway/src/llm/tests/response/completions/gemini_zero_completion_tokens.completions-completions.snap
@@ -1,0 +1,46 @@
+---
+source: crates/agentgateway/src/llm/tests.rs
+description: src/llm/tests/response/completions/gemini_zero_completion_tokens.json
+info:
+  model: gemini-2.5-flash
+  usage:
+    prompt_tokens: 7
+    completion_tokens: 0
+    total_tokens: 8
+  choices:
+    - message:
+        role: assistant
+      finish_reason: length
+      index: 0
+  created: 1775595226
+  id: 2m7Vaca_HdfC1MkP1trPwAM
+  object: chat.completion
+---
+{
+  "response": {
+    "model": "gemini-2.5-flash",
+    "usage": {
+      "prompt_tokens": 7,
+      "completion_tokens": 0,
+      "total_tokens": 8
+    },
+    "choices": [
+      {
+        "message": {
+          "role": "assistant"
+        },
+        "finish_reason": "length",
+        "index": 0
+      }
+    ],
+    "created": "[date]",
+    "id": "[id]",
+    "object": "chat.completion"
+  },
+  "parsed": {
+    "input_tokens": 7,
+    "output_tokens": 0,
+    "total_tokens": 8,
+    "provider_model": "gemini-2.5-flash"
+  }
+}

--- a/crates/agentgateway/src/llm/tests/response/completions/gemini_zero_completion_tokens.completions-detect.snap
+++ b/crates/agentgateway/src/llm/tests/response/completions/gemini_zero_completion_tokens.completions-detect.snap
@@ -1,0 +1,46 @@
+---
+source: crates/agentgateway/src/llm/tests.rs
+description: src/llm/tests/response/completions/gemini_zero_completion_tokens.json
+info:
+  model: gemini-2.5-flash
+  usage:
+    prompt_tokens: 7
+    completion_tokens: 0
+    total_tokens: 8
+  choices:
+    - message:
+        role: assistant
+      finish_reason: length
+      index: 0
+  created: 1775595226
+  id: 2m7Vaca_HdfC1MkP1trPwAM
+  object: chat.completion
+---
+{
+  "response": {
+    "model": "gemini-2.5-flash",
+    "usage": {
+      "prompt_tokens": 7,
+      "completion_tokens": 0,
+      "total_tokens": 8
+    },
+    "choices": [
+      {
+        "message": {
+          "role": "assistant"
+        },
+        "finish_reason": "length",
+        "index": 0
+      }
+    ],
+    "created": "[date]",
+    "id": "[id]",
+    "object": "chat.completion"
+  },
+  "parsed": {
+    "input_tokens": 7,
+    "output_tokens": 0,
+    "total_tokens": 8,
+    "provider_model": "gemini-2.5-flash"
+  }
+}

--- a/crates/agentgateway/src/llm/tests/response/completions/gemini_zero_completion_tokens.completions-messages.snap
+++ b/crates/agentgateway/src/llm/tests/response/completions/gemini_zero_completion_tokens.completions-messages.snap
@@ -1,0 +1,39 @@
+---
+source: crates/agentgateway/src/llm/tests.rs
+description: src/llm/tests/response/completions/gemini_zero_completion_tokens.json
+info:
+  model: gemini-2.5-flash
+  usage:
+    prompt_tokens: 7
+    completion_tokens: 0
+    total_tokens: 8
+  choices:
+    - message:
+        role: assistant
+      finish_reason: length
+      index: 0
+  created: 1775595226
+  id: 2m7Vaca_HdfC1MkP1trPwAM
+  object: chat.completion
+---
+{
+  "response": {
+    "id": "[id]",
+    "type": "message",
+    "role": "assistant",
+    "content": [],
+    "model": "gemini-2.5-flash",
+    "stop_reason": "max_tokens",
+    "stop_sequence": null,
+    "usage": {
+      "input_tokens": 7,
+      "output_tokens": 0
+    }
+  },
+  "parsed": {
+    "input_tokens": 7,
+    "output_tokens": 0,
+    "total_tokens": 7,
+    "provider_model": "gemini-2.5-flash"
+  }
+}

--- a/crates/agentgateway/src/llm/tests/response/completions/gemini_zero_completion_tokens.json
+++ b/crates/agentgateway/src/llm/tests/response/completions/gemini_zero_completion_tokens.json
@@ -1,0 +1,20 @@
+{
+  "model": "gemini-2.5-flash",
+  "usage": {
+    "prompt_tokens": 7,
+    "completion_tokens": 0,
+    "total_tokens": 8
+  },
+  "choices": [
+    {
+      "message": {
+        "role": "assistant"
+      },
+      "finish_reason": "length",
+      "index": 0
+    }
+  ],
+  "created": 1775595226,
+  "id": "2m7Vaca_HdfC1MkP1trPwAM",
+  "object": "chat.completion"
+}

--- a/crates/agentgateway/src/llm/types/completions.rs
+++ b/crates/agentgateway/src/llm/types/completions.rs
@@ -73,12 +73,13 @@ pub struct Response {
 
 #[derive(Debug, Deserialize, Clone, Serialize)]
 pub struct Choice {
+	#[serde(default)]
 	pub message: ResponseMessage,
 	#[serde(flatten, default)]
 	pub rest: serde_json::Value,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+#[derive(Default, Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub struct ResponseMessage {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub content: Option<String>,
@@ -107,13 +108,16 @@ pub struct UsagePromptDetails {
 	pub rest: serde_json::Value,
 }
 
-#[derive(Debug, Deserialize, Clone, Serialize)]
+#[derive(Default, Debug, Deserialize, Clone, Serialize)]
 pub struct Usage {
 	/// Number of tokens in the prompt.
+	#[serde(default)]
 	pub prompt_tokens: u32,
 	/// Number of tokens in the generated completion.
+	#[serde(default)]
 	pub completion_tokens: u32,
 	/// Total number of tokens used in the request (prompt + completion).
+	#[serde(default)]
 	pub total_tokens: u32,
 	/// Breakdown of tokens used in a completion.
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -469,10 +473,13 @@ pub mod typed {
 	#[derive(Default, Debug, Deserialize, Clone, Serialize)]
 	pub struct Usage {
 		/// Number of tokens in the prompt.
+		#[serde(default)]
 		pub prompt_tokens: u32,
 		/// Number of tokens in the generated completion.
+		#[serde(default)]
 		pub completion_tokens: u32,
 		/// Total number of tokens used in the request (prompt + completion).
+		#[serde(default)]
 		pub total_tokens: u32,
 		/// Breakdown of tokens used in a completion.
 		#[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/agentgateway/src/llm/types/completions.rs
+++ b/crates/agentgateway/src/llm/types/completions.rs
@@ -153,7 +153,10 @@ impl ResponseType for Response {
 					.and_then(|d| d.audio_tokens)
 			}),
 
-			output_tokens: self.usage.as_ref().map(|u| u.completion_tokens_or_inferred() as u64),
+			output_tokens: self
+				.usage
+				.as_ref()
+				.map(|u| u.completion_tokens_or_inferred() as u64),
 			output_image_tokens: None,
 			output_text_tokens: None,
 			output_audio_tokens: self.usage.as_ref().and_then(|u| {
@@ -505,6 +508,18 @@ pub mod typed {
 		/// Tokens written to cache (costs)
 		#[serde(skip_serializing_if = "Option::is_none")]
 		pub cache_creation_input_tokens: Option<u64>,
+	}
+
+	impl Usage {
+		pub fn completion_tokens_or_inferred(&self) -> u32 {
+			if self.completion_tokens > 0 {
+				return self.completion_tokens;
+			}
+			if self.total_tokens > self.prompt_tokens {
+				return self.total_tokens - self.prompt_tokens;
+			}
+			0
+		}
 	}
 
 	#[derive(Debug, Deserialize, Clone, Serialize)]

--- a/crates/agentgateway/src/llm/types/completions.rs
+++ b/crates/agentgateway/src/llm/types/completions.rs
@@ -129,6 +129,18 @@ pub struct Usage {
 	pub rest: serde_json::Value,
 }
 
+impl Usage {
+	pub fn completion_tokens_or_inferred(&self) -> u32 {
+		if self.completion_tokens > 0 {
+			return self.completion_tokens;
+		}
+		if self.total_tokens > self.prompt_tokens {
+			return self.total_tokens - self.prompt_tokens;
+		}
+		0
+	}
+}
+
 impl ResponseType for Response {
 	fn to_llm_response(&self, include_completion_in_log: bool) -> LLMResponse {
 		LLMResponse {
@@ -141,7 +153,7 @@ impl ResponseType for Response {
 					.and_then(|d| d.audio_tokens)
 			}),
 
-			output_tokens: self.usage.as_ref().map(|u| u.completion_tokens as u64),
+			output_tokens: self.usage.as_ref().map(|u| u.completion_tokens_or_inferred() as u64),
 			output_image_tokens: None,
 			output_text_tokens: None,
 			output_audio_tokens: self.usage.as_ref().and_then(|u| {

--- a/crates/agentgateway/src/llm/types/completions.rs
+++ b/crates/agentgateway/src/llm/types/completions.rs
@@ -129,18 +129,6 @@ pub struct Usage {
 	pub rest: serde_json::Value,
 }
 
-impl Usage {
-	pub fn completion_tokens_or_inferred(&self) -> u32 {
-		if self.completion_tokens > 0 {
-			return self.completion_tokens;
-		}
-		if self.total_tokens > self.prompt_tokens {
-			return self.total_tokens - self.prompt_tokens;
-		}
-		0
-	}
-}
-
 impl ResponseType for Response {
 	fn to_llm_response(&self, include_completion_in_log: bool) -> LLMResponse {
 		LLMResponse {
@@ -153,10 +141,7 @@ impl ResponseType for Response {
 					.and_then(|d| d.audio_tokens)
 			}),
 
-			output_tokens: self
-				.usage
-				.as_ref()
-				.map(|u| u.completion_tokens_or_inferred() as u64),
+			output_tokens: self.usage.as_ref().map(|u| u.completion_tokens as u64),
 			output_image_tokens: None,
 			output_text_tokens: None,
 			output_audio_tokens: self.usage.as_ref().and_then(|u| {
@@ -508,18 +493,6 @@ pub mod typed {
 		/// Tokens written to cache (costs)
 		#[serde(skip_serializing_if = "Option::is_none")]
 		pub cache_creation_input_tokens: Option<u64>,
-	}
-
-	impl Usage {
-		pub fn completion_tokens_or_inferred(&self) -> u32 {
-			if self.completion_tokens > 0 {
-				return self.completion_tokens;
-			}
-			if self.total_tokens > self.prompt_tokens {
-				return self.total_tokens - self.prompt_tokens;
-			}
-			0
-		}
 	}
 
 	#[derive(Debug, Deserialize, Clone, Serialize)]


### PR DESCRIPTION
## Summary
Gemini's OpenAI-compatible endpoint intermittently omits `message` from choices and `completion_tokens`/`prompt_tokens` from usage. Add instead of returning 503. Follows the same pattern as #977.

- Add `#[serde(default)]` to `Choice.message` and `Usage` token count fields in `completions.rs`
- Derive `Default` on `ResponseMessage` and `Usage` so missing fields deserialize to zero/empty values
- Add test that verifies deserialization succeeds when Gemini omits these fields

Fixes #1464
