### PR TITLE
controller: faster deployer tests

### DIFF
--- a/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
+++ b/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
@@ -35,7 +35,7 @@ type AgentgatewayPolicy struct {
 
 	// status defines the current state of AgentgatewayPolicy.
 	// +optional
-	Status gwv1.PolicyStatus `json:"status,omitempty"`
+	Status gwv1.PolicyStatus `json:"status,omitzero"`
 	// TODO: embed this into a typed Status field when
 	// https://github.com/kubernetes/kubernetes/issues/131533 is resolved
 }

--- a/controller/test/deployer/deployer_helm.go
+++ b/controller/test/deployer/deployer_helm.go
@@ -16,6 +16,7 @@ import (
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/yaml"
 
+	apitests "github.com/agentgateway/agentgateway/controller/api/tests"
 	"github.com/agentgateway/agentgateway/controller/api/v1alpha1/agentgateway"
 	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/plugins"
 	"github.com/agentgateway/agentgateway/controller/pkg/apiclient"
@@ -143,27 +144,17 @@ func (dt DeployerTester) GetObjects(
 	filePath := filepath.Join(dir, "testdata/", tt.InputFile)
 	inputFile := filePath + ".yaml"
 
-	gvkToStructuralSchema, err := testutils.GetStructuralSchemas(crdDir)
-	require.NoError(t, err, "error getting structural schemas")
+	validator := apitests.NewAgentgatewayValidatorSkipMissing(t)
 
-	objs, err := testutils.LoadFromFiles(inputFile, scheme, gvkToStructuralSchema)
+	objs, err := testutils.LoadFromFiles(inputFile, scheme, validator)
 	require.NoError(t, err, "error loading files from input file")
 
 	return objs
 }
 
-func (dt DeployerTester) RunHelmChartTest(
-	t *testing.T,
-	tt HelmTestCase,
-	scheme *runtime.Scheme,
-	dir string,
-	crdDir string,
-	fakeClient apiclient.Client,
-) {
+func (dt DeployerTester) RunHelmChartTest(t *testing.T, tt HelmTestCase, scheme *runtime.Scheme, dir string, fakeClient apiclient.Client, objs []client.Object) {
 	filePath := filepath.Join(dir, "testdata/", tt.InputFile)
 	outputFile := filePath + "-out.yaml"
-
-	objs := dt.GetObjects(t, tt, scheme, dir, crdDir)
 
 	_, gtw := ExtractCommonObjs(t, objs)
 	if gtw == nil {

--- a/controller/test/deployer/deployer_helm.go
+++ b/controller/test/deployer/deployer_helm.go
@@ -139,7 +139,6 @@ func (dt DeployerTester) GetObjects(
 	tt HelmTestCase,
 	scheme *runtime.Scheme,
 	dir string,
-	crdDir string,
 ) []client.Object {
 	filePath := filepath.Join(dir, "testdata/", tt.InputFile)
 	inputFile := filePath + ".yaml"

--- a/controller/test/deployer/internal_helm_test.go
+++ b/controller/test/deployer/internal_helm_test.go
@@ -453,8 +453,9 @@ wIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQBtestcertdata
 
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
-			fakeClient := fake.NewClient(t, tester.GetObjects(t, tt, scheme, dir, crdDir)...)
-			tester.RunHelmChartTest(t, tt, scheme, dir, crdDir, fakeClient)
+			objs := tester.GetObjects(t, tt, scheme, dir, crdDir)
+			fakeClient := fake.NewClient(t, objs...)
+			tester.RunHelmChartTest(t, tt, scheme, dir, fakeClient, objs)
 		})
 	}
 }

--- a/controller/test/deployer/internal_helm_test.go
+++ b/controller/test/deployer/internal_helm_test.go
@@ -35,7 +35,6 @@ import (
 	"github.com/agentgateway/agentgateway/controller/pkg/utils/fsutils"
 	"github.com/agentgateway/agentgateway/controller/pkg/version"
 	"github.com/agentgateway/agentgateway/controller/pkg/wellknown"
-	"github.com/agentgateway/agentgateway/controller/test/testutils"
 )
 
 func mockVersion(t *testing.T) {
@@ -447,13 +446,12 @@ wIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQBtestcertdata
 
 	dir := fsutils.MustGetThisDir()
 	scheme := schemes.GatewayScheme()
-	crdDir := filepath.Join(testutils.ControllerRootDirectory(), testutils.AgwCRDPath)
 
 	VerifyAllYAMLFilesReferenced(t, filepath.Join(dir, "testdata"), tests)
 
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
-			objs := tester.GetObjects(t, tt, scheme, dir, crdDir)
+			objs := tester.GetObjects(t, tt, scheme, dir)
 			fakeClient := fake.NewClient(t, objs...)
 			tester.RunHelmChartTest(t, tt, scheme, dir, fakeClient, objs)
 		})

--- a/controller/test/e2e/tests/base/base_suite.go
+++ b/controller/test/e2e/tests/base/base_suite.go
@@ -14,21 +14,21 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/stretchr/testify/suite"
+	"istio.io/istio/pkg/config/crd"
 	"istio.io/istio/pkg/maps"
 	"istio.io/istio/pkg/test/util/assert"
 	"istio.io/istio/pkg/test/util/yml"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	apiserverschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	apitests "github.com/agentgateway/agentgateway/controller/api/tests"
 	"github.com/agentgateway/agentgateway/controller/test/e2e"
 	"github.com/agentgateway/agentgateway/controller/test/e2e/defaults"
 	"github.com/agentgateway/agentgateway/controller/test/testutils"
@@ -131,7 +131,7 @@ type BaseTestingSuite struct {
 	CrdPath string
 
 	// used internally to parse the manifest files
-	gvkToStructuralSchema map[schema.GroupVersionKind]*apiserverschema.Structural
+	validator *crd.Validator
 
 	// gwApiVersion stores the detected Gateway API version (detected once and cached)
 	gwApiVersion *semver.Version
@@ -471,9 +471,7 @@ func (s *BaseTestingSuite) setupHelpers() {
 	if s.CrdPath == "" {
 		s.CrdPath = testutils.AgwCRDPath
 	}
-	var err error
-	s.gvkToStructuralSchema, err = testutils.GetStructuralSchemasForBothCharts()
-	s.Require().NoError(err)
+	s.validator = apitests.NewAgentgatewayValidatorSkipMissing(s.T())
 }
 
 // loadManifestResources populates the `manifestResources` for the given test case, by parsing each
@@ -486,14 +484,14 @@ func (s *BaseTestingSuite) loadManifestResources(testCase *TestCase) {
 
 	var resources []client.Object
 	for _, manifest := range testCase.Manifests {
-		objs, err := testutils.LoadFromFiles(manifest, s.TestInstallation.ClusterContext.Client.Scheme(), s.gvkToStructuralSchema)
+		objs, err := testutils.LoadFromFiles(manifest, s.TestInstallation.ClusterContext.Client.Scheme(), s.validator)
 		s.Require().NoError(err)
 		resources = append(resources, objs...)
 	}
 	for manifest, transform := range testCase.ManifestsWithTransform {
 		// we don't need to transform the resource since the transformation applies to the spec and not object metadata,
 		// which ensures that parsed Go objects in manifestResources can be used normally
-		objs, err := testutils.LoadFromFileWithTransform(manifest, s.TestInstallation.ClusterContext.Client.Scheme(), s.gvkToStructuralSchema, transform)
+		objs, err := testutils.LoadFromFileWithTransform(manifest, s.TestInstallation.ClusterContext.Client.Scheme(), s.validator, transform)
 		s.Require().NoError(err)
 		resources = append(resources, objs...)
 	}

--- a/controller/test/testutils/file_loader.go
+++ b/controller/test/testutils/file_loader.go
@@ -11,8 +11,7 @@ import (
 	"strings"
 
 	"github.com/ghodss/yaml"
-	apiserverschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
-	apiextensionsvalidation "k8s.io/apiextensions-apiserver/pkg/apiserver/validation"
+	"istio.io/istio/pkg/config/crd"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -25,18 +24,14 @@ var ErrNoFilesFound = errors.New("no k8s files found")
 // FileContentTransformer is a function that transforms a file's contents
 type FileContentTransformer func(content string) string
 
-func LoadFromFiles(
-	filename string,
-	scheme *runtime.Scheme,
-	gvkToStructuralSchema map[schema.GroupVersionKind]*apiserverschema.Structural,
-) ([]client.Object, error) {
-	return LoadFromFileWithTransform(filename, scheme, gvkToStructuralSchema, nil)
+func LoadFromFiles(filename string, scheme *runtime.Scheme, validator *crd.Validator) ([]client.Object, error) {
+	return LoadFromFileWithTransform(filename, scheme, validator, nil)
 }
 
 func LoadFromFileWithTransform(
 	filename string,
 	scheme *runtime.Scheme,
-	gvkToStructuralSchema map[schema.GroupVersionKind]*apiserverschema.Structural,
+	validator *crd.Validator,
 	transformer FileContentTransformer,
 ) ([]client.Object, error) {
 	fileOrDir, err := os.Stat(filename)
@@ -68,7 +63,7 @@ func LoadFromFileWithTransform(
 
 	var resources []client.Object
 	for _, file := range yamlFiles {
-		objs, err := parseFile(file, scheme, gvkToStructuralSchema, transformer)
+		objs, err := parseFile(file, scheme, validator, transformer)
 		if err != nil {
 			return nil, err
 		}
@@ -93,7 +88,7 @@ func LoadFromFileWithTransform(
 func parseFile(
 	filename string,
 	scheme *runtime.Scheme,
-	gvkToStructuralSchema map[schema.GroupVersionKind]*apiserverschema.Structural,
+	validator *crd.Validator,
 	transformer FileContentTransformer,
 ) ([]runtime.Object, error) {
 	file, err := os.ReadFile(filename)
@@ -150,21 +145,8 @@ func parseFile(
 			)
 			continue
 		}
-
-		if structuralSchema, ok := gvkToStructuralSchema[gvk]; ok {
-			unstructuredObj, objYamlWithDefaults, err := ApplyDefaults(objYaml, structuralSchema)
-			if err != nil {
-				return nil, fmt.Errorf("failed to apply defaults for %s: %w", gvk, err)
-			}
-			validator := apiextensionsvalidation.NewSchemaValidatorFromOpenAPI(structuralSchema.ToKubeOpenAPI())
-			validationErrs := apiextensionsvalidation.ValidateCustomResource(nil, unstructuredObj.UnstructuredContent(), validator)
-			if len(validationErrs) > 0 {
-				agg := validationErrs.ToAggregate()
-				return nil, fmt.Errorf("failed to validate %s: %w", gvk, agg)
-			}
-			if err := yaml.Unmarshal(objYamlWithDefaults, obj); err != nil {
-				return nil, fmt.Errorf("failed to unmarshal object with defaults for %s: %w", gvk, err)
-			}
+		if err := validator.ValidateCustomResource(obj); err != nil {
+			return nil, err
 		}
 
 		genericResources = append(genericResources, obj)


### PR DESCRIPTION
With -race, this took 53s on my fast machine before. now it takes 3.

The problem was we parsed all CRDs each time, now we do it once (and
ruse more code)
