### PR TITLE
Fix backend policy merge

### DIFF
--- a/crates/agentgateway/src/llm/policy/bedrock_guardrails.rs
+++ b/crates/agentgateway/src/llm/policy/bedrock_guardrails.rs
@@ -168,7 +168,7 @@ async fn send_guardrail_request(
 	);
 
 	let resp = client
-		.call_with_explicit_policies(req, mock_be, pols)
+		.call_with_explicit_policies_list(req, mock_be, pols)
 		.await?;
 
 	let status = resp.status();

--- a/crates/agentgateway/src/llm/policy/google_model_armor.rs
+++ b/crates/agentgateway/src/llm/policy/google_model_armor.rs
@@ -364,7 +364,7 @@ async fn send_model_armor_request<T: Serialize>(
 	);
 
 	let resp = client
-		.call_with_explicit_policies(req, mock_be, pols)
+		.call_with_explicit_policies_list(req, mock_be, pols)
 		.await?;
 
 	let resp: SanitizeResponse = json::from_response_body(resp).await?;

--- a/crates/agentgateway/src/llm/policy/moderation.rs
+++ b/crates/agentgateway/src/llm/policy/moderation.rs
@@ -46,7 +46,7 @@ pub async fn send_request(
 		Target::Hostname(strng::literal!("api.openai.com"), 443),
 	);
 	let resp = client
-		.call_with_explicit_policies(req, mock_be, pols)
+		.call_with_explicit_policies_list(req, mock_be, pols)
 		.await?;
 	let resp: async_openai::types::moderations::CreateModerationResponse =
 		json::from_response_body(resp).await?;

--- a/crates/agentgateway/src/mcp/router.rs
+++ b/crates/agentgateway/src/mcp/router.rs
@@ -87,7 +87,7 @@ impl App {
 					let backend_policies = backend_policies
 						.clone()
 						.merge(binds.sub_backend_policies(sub_backend_target, inline_pols));
-					tracing::debug!("merged policies {:#?}", backend_policies);
+					tracing::trace!("merged policies {:?}", backend_policies);
 					Ok::<_, ProxyError>(Arc::new(McpTarget {
 						name: t.name.clone(),
 						spec: t.spec.clone(),

--- a/crates/agentgateway/src/mcp/router.rs
+++ b/crates/agentgateway/src/mcp/router.rs
@@ -87,7 +87,7 @@ impl App {
 					let backend_policies = backend_policies
 						.clone()
 						.merge(binds.sub_backend_policies(sub_backend_target, inline_pols));
-					tracing::error!("howardjohn: merged policies {:#?}", backend_policies);
+					tracing::debug!("merged policies {:#?}", backend_policies);
 					Ok::<_, ProxyError>(Arc::new(McpTarget {
 						name: t.name.clone(),
 						spec: t.spec.clone(),
@@ -106,7 +106,6 @@ impl App {
 		};
 		let sm = self.session.clone();
 		let client = PolicyClient { inputs: pi.clone() };
-		tracing::error!("howardjohn: lookup authn from {backend_policies:#?}");
 		let authorization_policies = backend_policies
 			.mcp_authorization
 			.unwrap_or_else(|| McpAuthorizationSet::new(RuleSets::from(Vec::new())));

--- a/crates/agentgateway/src/mcp/router.rs
+++ b/crates/agentgateway/src/mcp/router.rs
@@ -87,6 +87,7 @@ impl App {
 					let backend_policies = backend_policies
 						.clone()
 						.merge(binds.sub_backend_policies(sub_backend_target, inline_pols));
+					tracing::error!("howardjohn: merged policies {:#?}", backend_policies);
 					Ok::<_, ProxyError>(Arc::new(McpTarget {
 						name: t.name.clone(),
 						spec: t.spec.clone(),
@@ -105,6 +106,7 @@ impl App {
 		};
 		let sm = self.session.clone();
 		let client = PolicyClient { inputs: pi.clone() };
+		tracing::error!("howardjohn: lookup authn from {backend_policies:#?}");
 		let authorization_policies = backend_policies
 			.mcp_authorization
 			.unwrap_or_else(|| McpAuthorizationSet::new(RuleSets::from(Vec::new())));

--- a/crates/agentgateway/src/mcp/upstream/client.rs
+++ b/crates/agentgateway/src/mcp/upstream/client.rs
@@ -60,9 +60,10 @@ impl McpHttpClient {
 			policies.override_dest = Some(pinned.0);
 		}
 
+		tracing::error!("howardjohn: call with policies: {:#?}", policies);
 		let resp = self
 			.client
-			.call_with_default_policies(req, &self.backend, policies)
+			.call_with_explicit_policies(req, &self.backend, policies)
 			.await?;
 
 		// Capture resolved destination on first request if stateful

--- a/crates/agentgateway/src/mcp/upstream/client.rs
+++ b/crates/agentgateway/src/mcp/upstream/client.rs
@@ -60,7 +60,6 @@ impl McpHttpClient {
 			policies.override_dest = Some(pinned.0);
 		}
 
-		tracing::error!("howardjohn: call with policies: {:#?}", policies);
 		let resp = self
 			.client
 			.call_with_explicit_policies(req, &self.backend, policies)

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -180,6 +180,10 @@ async fn apply_backend_policies(
 	log: &mut Option<&mut RequestLog>,
 	response_policies: &mut ResponsePolicies,
 ) -> Result<(), ProxyResponse> {
+	tracing::error!(
+		"howardjohn: apply backend pol for {:?}",
+		backend_call.target
+	);
 	let BackendPolicies {
 		backend_tls: _,
 		backend_auth,
@@ -1278,6 +1282,7 @@ async fn make_backend_call(
 	let policy_client = PolicyClient {
 		inputs: inputs.clone(),
 	};
+	tracing::error!("howardjohn: CALL {backend:?}");
 
 	// The MCP backend aggregates multiple backends into a single backend.
 	// In some cases, we want to treat this as a normal backend, so we swap it out.
@@ -2178,20 +2183,20 @@ impl PolicyClient {
 			.await
 	}
 
-	pub async fn call_with_default_policies(
+	pub async fn call_with_explicit_policies(
 		&self,
 		req: Request,
 		backend: &SimpleBackend,
-		defaults: BackendPolicies,
+		policies: BackendPolicies,
 	) -> Result<Response, ProxyError> {
-		let backend = Backend::from(backend.clone()).into();
-		let pols = defaults.merge(get_backend_policies(&self.inputs, &backend, &[], None));
+		let backend = Backend::from(backend.clone());
+		tracing::error!("howardjohn: EXPLICIT END {:?}", &policies.transformation);
 		self
-			.internal_call_with_policies(req, backend.backend, pols)
+			.internal_call_with_policies(req, backend, policies)
 			.await
 	}
 
-	pub async fn call_with_explicit_policies(
+	pub async fn call_with_explicit_policies_list(
 		&self,
 		req: Request,
 		backend: SimpleBackend,

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -180,10 +180,6 @@ async fn apply_backend_policies(
 	log: &mut Option<&mut RequestLog>,
 	response_policies: &mut ResponsePolicies,
 ) -> Result<(), ProxyResponse> {
-	tracing::error!(
-		"howardjohn: apply backend pol for {:?}",
-		backend_call.target
-	);
 	let BackendPolicies {
 		backend_tls: _,
 		backend_auth,
@@ -1282,7 +1278,6 @@ async fn make_backend_call(
 	let policy_client = PolicyClient {
 		inputs: inputs.clone(),
 	};
-	tracing::error!("howardjohn: CALL {backend:?}");
 
 	// The MCP backend aggregates multiple backends into a single backend.
 	// In some cases, we want to treat this as a normal backend, so we swap it out.
@@ -2190,7 +2185,6 @@ impl PolicyClient {
 		policies: BackendPolicies,
 	) -> Result<Response, ProxyError> {
 		let backend = Backend::from(backend.clone());
-		tracing::error!("howardjohn: EXPLICIT END {:?}", &policies.transformation);
 		self
 			.internal_call_with_policies(req, backend, policies)
 			.await

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -701,6 +701,7 @@ impl Store {
 		gateway: Option<&ListenerName>,
 		route: Option<&RouteName>,
 	) -> BackendPolicies {
+		tracing::error!("howardjohn: lookup {:?} {:?} {:?} {:?} {:?}", backend, sub_backend, inline_policies, gateway, route);
 		let backend_rules =
 			backend.and_then(|t| self.policies_by_target.get(&PolicyTargetRef::Backend(t)));
 		let sub_backend_rules =

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -712,6 +712,7 @@ impl Store {
 		// UNLESS backend is None, in which case we need to look up the base backend
 		let has_section = sub_backend.as_ref().is_some_and(|t| match t {
 			BackendTargetRef::Backend { section, .. } => section.is_some(),
+			BackendTargetRef::Service { port, .. } => port.is_some(),
 			_ => false,
 		});
 		let sub_backend_rules = if has_section || backend.is_none() {

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -701,16 +701,20 @@ impl Store {
 		gateway: Option<&ListenerName>,
 		route: Option<&RouteName>,
 	) -> BackendPolicies {
-		let backend_rules =
-			backend.and_then(|t| self.policies_by_target.get(&PolicyTargetRef::Backend(t)));
+		let backend_rules = backend.as_ref().and_then(|t| {
+			self
+				.policies_by_target
+				.get(&PolicyTargetRef::Backend(t.clone()))
+		});
 
 		// Only use sub_backend rules if there's an actual section specified
 		// (avoid duplicating backend_rules when section is None)
+		// UNLESS backend is None, in which case we need to look up the base backend
 		let has_section = sub_backend.as_ref().is_some_and(|t| match t {
 			BackendTargetRef::Backend { section, .. } => section.is_some(),
 			_ => false,
 		});
-		let sub_backend_rules = if has_section {
+		let sub_backend_rules = if has_section || backend.is_none() {
 			sub_backend.and_then(|t| self.policies_by_target.get(&PolicyTargetRef::Backend(t)))
 		} else {
 			None
@@ -726,7 +730,7 @@ impl Store {
 
 		// Precedence (highest to lowest):
 		// backendRef inline > RouteRule attached > SubBackend attached > Route attached >
-		// Backend inline > Backend attached > Listener attached > Gateway attached
+		// Backend inline > Backend/Service attached > Listener attached > Gateway attached
 		//
 		// inline_policies array structure (from httpproxy.rs):
 		//   [0]: Backend inline policies (from Backend spec)

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -701,11 +701,21 @@ impl Store {
 		gateway: Option<&ListenerName>,
 		route: Option<&RouteName>,
 	) -> BackendPolicies {
-		tracing::error!("howardjohn: lookup {:?} {:?} {:?} {:?} {:?}", backend, sub_backend, inline_policies, gateway, route);
 		let backend_rules =
 			backend.and_then(|t| self.policies_by_target.get(&PolicyTargetRef::Backend(t)));
-		let sub_backend_rules =
-			sub_backend.and_then(|t| self.policies_by_target.get(&PolicyTargetRef::Backend(t)));
+
+		// Only use sub_backend rules if there's an actual section specified
+		// (avoid duplicating backend_rules when section is None)
+		let has_section = sub_backend.as_ref().is_some_and(|t| match t {
+			BackendTargetRef::Backend { section, .. } => section.is_some(),
+			_ => false,
+		});
+		let sub_backend_rules = if has_section {
+			sub_backend.and_then(|t| self.policies_by_target.get(&PolicyTargetRef::Backend(t)))
+		} else {
+			None
+		};
+
 		let route_rule_rules =
 			route.and_then(|t| self.policies_by_target.get(&t.as_route_rule_target_ref()));
 		let route_rules = route.and_then(|t| self.policies_by_target.get(&t.as_route_target_ref()));
@@ -714,25 +724,44 @@ impl Store {
 		let gateway_rules =
 			gateway.and_then(|t| self.policies_by_target.get(&t.as_gateway_target_ref()));
 
-		// RouteRule > Route > SubBackend > Backend/Service > Gateway
-		// Most specific (route context) to least specific (gateway-wide default)
-		let rules = route_rule_rules
+		// Precedence (highest to lowest):
+		// backendRef inline > RouteRule attached > SubBackend attached > Route attached >
+		// Backend inline > Backend attached > Listener attached > Gateway attached
+		//
+		// inline_policies array structure (from httpproxy.rs):
+		//   [0]: Backend inline policies (from Backend spec)
+		//   [1+]: backendRef inline policies (from Route's backendRef, if present)
+
+		// Split inline policies: backendRef inline (all but first) vs Backend inline (first)
+		let backend_inline_iter = inline_policies.first().into_iter().flat_map(|p| p.iter());
+		let backend_ref_inline_iter = inline_policies.iter().skip(1).flat_map(|p| p.iter());
+
+		// Build the attached rules chain with Backend inline inserted in the correct position
+		let attached_rules = route_rule_rules
 			.iter()
 			.copied()
 			.flatten()
 			.chain(sub_backend_rules.iter().copied().flatten())
 			.chain(route_rules.iter().copied().flatten())
-			.chain(backend_rules.iter().copied().flatten())
-			.chain(listener_rules.iter().copied().flatten())
-			.chain(gateway_rules.iter().copied().flatten())
 			.unique()
 			.filter_map(|n| self.policies_by_key.get(n))
-			.filter_map(|p| p.policy.as_backend());
-		let rules = inline_policies
-			.iter()
-			.rev()
-			.flat_map(|p| p.iter())
-			.chain(rules);
+			.filter_map(|p| p.policy.as_backend())
+			// Insert Backend inline here (after Route, before Backend attached)
+			.chain(backend_inline_iter)
+			.chain(
+				backend_rules
+					.iter()
+					.copied()
+					.flatten()
+					.chain(listener_rules.iter().copied().flatten())
+					.chain(gateway_rules.iter().copied().flatten())
+					.unique()
+					.filter_map(|n| self.policies_by_key.get(n))
+					.filter_map(|p| p.policy.as_backend()),
+			);
+
+		// Prepend backendRef inline (highest priority)
+		let rules = backend_ref_inline_iter.chain(attached_rules);
 
 		let mut mcp_authz = Vec::new();
 		let mut pol = BackendPolicies::default();
@@ -1473,6 +1502,7 @@ mod tests {
 
 	use super::*;
 	use crate::telemetry::log::OrderedStringMap;
+	use crate::types::agent::{BackendTarget, PolicyType};
 	use crate::types::frontend::LoggingPolicy;
 
 	fn listener() -> ListenerName {
@@ -1767,5 +1797,144 @@ mod tests {
 		let bind = Bind::try_from_xds(&xds_bind, true).unwrap();
 		assert_eq!(bind.address.port(), 9090);
 		assert_eq!(bind.address.ip(), IpAddr::V6(Ipv6Addr::UNSPECIFIED));
+	}
+
+	/// Tests backend policy merging precedence:
+	/// Section-level (sectionName) > Backend inline > Backend attached
+	#[test]
+	fn backend_policy_merging_precedence() {
+		use crate::http::filters::HeaderModifier;
+
+		let mut store = Store::default();
+
+		// Create backend-attached policy (lowest priority) - sets x-foo=bar
+		let backend_attached_policy_key: PolicyKey = strng::new("backend-attached-policy");
+		let backend_attached_policy = TargetedPolicy {
+			key: backend_attached_policy_key.clone(),
+			name: None,
+			target: PolicyTarget::Backend(BackendTarget::Backend {
+				name: strng::new("test-backend"),
+				namespace: strng::new("test-ns"),
+				section: None,
+			}),
+			policy: PolicyType::Backend(BackendPolicy::RequestHeaderModifier(HeaderModifier {
+				add: vec![],
+				set: vec![(strng::new("x-foo"), strng::new("bar"))],
+				remove: vec![],
+			})),
+		};
+		store.insert_policy(backend_attached_policy);
+
+		// Create section-level policy (highest priority) - sets x-foo=bar3
+		let section_policy_key: PolicyKey = strng::new("section-policy");
+		let section_policy = TargetedPolicy {
+			key: section_policy_key.clone(),
+			name: None,
+			target: PolicyTarget::Backend(BackendTarget::Backend {
+				name: strng::new("test-backend"),
+				namespace: strng::new("test-ns"),
+				section: Some(strng::new("target")),
+			}),
+			policy: PolicyType::Backend(BackendPolicy::RequestHeaderModifier(HeaderModifier {
+				add: vec![],
+				set: vec![(strng::new("x-foo"), strng::new("bar3"))],
+				remove: vec![],
+			})),
+		};
+		store.insert_policy(section_policy);
+
+		// Create backend inline policies (middle priority) - sets x-foo=bar2
+		let backend_inline_policies = vec![BackendPolicy::RequestHeaderModifier(HeaderModifier {
+			add: vec![],
+			set: vec![(strng::new("x-foo"), strng::new("bar2"))],
+			remove: vec![],
+		})];
+
+		// Test case 1: Backend without section - should use backend inline (bar2) over backend attached (bar)
+		let policies_no_section = store.backend_policies(
+			BackendTargetRef::Backend {
+				name: "test-backend",
+				namespace: "test-ns",
+				section: None,
+			},
+			&[&backend_inline_policies],
+			None,
+		);
+
+		assert!(
+			policies_no_section.request_header_modifier.is_some(),
+			"Expected request header modifier to be present"
+		);
+		let modifier = policies_no_section
+			.request_header_modifier
+			.as_ref()
+			.unwrap();
+		assert_eq!(
+			modifier.set.len(),
+			1,
+			"Expected exactly one header to be set"
+		);
+		assert_eq!(
+			modifier.set[0],
+			(strng::new("x-foo"), strng::new("bar2")),
+			"Backend inline policy (bar2) should win over backend attached policy (bar)"
+		);
+
+		// Test case 2: Backend with section - should use section policy (bar3) over all others
+		let policies_with_section = store.backend_policies(
+			BackendTargetRef::Backend {
+				name: "test-backend",
+				namespace: "test-ns",
+				section: Some("target"),
+			},
+			&[&backend_inline_policies],
+			None,
+		);
+
+		assert!(
+			policies_with_section.request_header_modifier.is_some(),
+			"Expected request header modifier to be present"
+		);
+		let modifier = policies_with_section
+			.request_header_modifier
+			.as_ref()
+			.unwrap();
+		assert_eq!(
+			modifier.set.len(),
+			1,
+			"Expected exactly one header to be set"
+		);
+		assert_eq!(
+			modifier.set[0],
+			(strng::new("x-foo"), strng::new("bar3")),
+			"Section policy (bar3) should win over backend inline (bar2) and backend attached (bar)"
+		);
+
+		// Test case 3: Backend without any inline policies - should use backend attached (bar)
+		let policies_no_inline = store.backend_policies(
+			BackendTargetRef::Backend {
+				name: "test-backend",
+				namespace: "test-ns",
+				section: None,
+			},
+			&[],
+			None,
+		);
+
+		assert!(
+			policies_no_inline.request_header_modifier.is_some(),
+			"Expected request header modifier to be present"
+		);
+		let modifier = policies_no_inline.request_header_modifier.as_ref().unwrap();
+		assert_eq!(
+			modifier.set.len(),
+			1,
+			"Expected exactly one header to be set"
+		);
+		assert_eq!(
+			modifier.set[0],
+			(strng::new("x-foo"), strng::new("bar")),
+			"Backend attached policy (bar) should be used when no inline policies exist"
+		);
 	}
 }

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -728,44 +728,25 @@ impl Store {
 		let gateway_rules =
 			gateway.and_then(|t| self.policies_by_target.get(&t.as_gateway_target_ref()));
 
-		// Precedence (highest to lowest):
-		// backendRef inline > RouteRule attached > SubBackend attached > Route attached >
-		// Backend inline > Backend/Service attached > Listener attached > Gateway attached
-		//
-		// inline_policies array structure (from httpproxy.rs):
-		//   [0]: Backend inline policies (from Backend spec)
-		//   [1+]: backendRef inline policies (from Route's backendRef, if present)
-
-		// Split inline policies: backendRef inline (all but first) vs Backend inline (first)
-		let backend_inline_iter = inline_policies.first().into_iter().flat_map(|p| p.iter());
-		let backend_ref_inline_iter = inline_policies.iter().skip(1).flat_map(|p| p.iter());
-
-		// Build the attached rules chain with Backend inline inserted in the correct position
-		let attached_rules = route_rule_rules
+		// RouteRule > Route > SubBackend > Backend/Service > Gateway
+		// Most specific (route context) to least specific (gateway-wide default)
+		let rules = route_rule_rules
 			.iter()
 			.copied()
 			.flatten()
 			.chain(sub_backend_rules.iter().copied().flatten())
 			.chain(route_rules.iter().copied().flatten())
+			.chain(backend_rules.iter().copied().flatten())
+			.chain(listener_rules.iter().copied().flatten())
+			.chain(gateway_rules.iter().copied().flatten())
 			.unique()
 			.filter_map(|n| self.policies_by_key.get(n))
-			.filter_map(|p| p.policy.as_backend())
-			// Insert Backend inline here (after Route, before Backend attached)
-			.chain(backend_inline_iter)
-			.chain(
-				backend_rules
-					.iter()
-					.copied()
-					.flatten()
-					.chain(listener_rules.iter().copied().flatten())
-					.chain(gateway_rules.iter().copied().flatten())
-					.unique()
-					.filter_map(|n| self.policies_by_key.get(n))
-					.filter_map(|p| p.policy.as_backend()),
-			);
-
-		// Prepend backendRef inline (highest priority)
-		let rules = backend_ref_inline_iter.chain(attached_rules);
+			.filter_map(|p| p.policy.as_backend());
+		let rules = inline_policies
+			.iter()
+			.rev()
+			.flat_map(|p| p.iter())
+			.chain(rules);
 
 		let mut mcp_authz = Vec::new();
 		let mut pol = BackendPolicies::default();
@@ -1804,14 +1785,14 @@ mod tests {
 	}
 
 	/// Tests backend policy merging precedence:
-	/// Section-level (sectionName) > Backend inline > Backend attached
+	/// Inline policies > Attached policies (with SubBackend > Backend among attached)
 	#[test]
 	fn backend_policy_merging_precedence() {
 		use crate::http::filters::HeaderModifier;
 
 		let mut store = Store::default();
 
-		// Create backend-attached policy (lowest priority) - sets x-foo=bar
+		// Create backend-attached policy - sets x-foo=bar
 		let backend_attached_policy_key: PolicyKey = strng::new("backend-attached-policy");
 		let backend_attached_policy = TargetedPolicy {
 			key: backend_attached_policy_key.clone(),
@@ -1829,7 +1810,7 @@ mod tests {
 		};
 		store.insert_policy(backend_attached_policy);
 
-		// Create section-level policy (highest priority) - sets x-foo=bar3
+		// Create section-level attached policy - sets x-foo=bar3
 		let section_policy_key: PolicyKey = strng::new("section-policy");
 		let section_policy = TargetedPolicy {
 			key: section_policy_key.clone(),
@@ -1847,14 +1828,14 @@ mod tests {
 		};
 		store.insert_policy(section_policy);
 
-		// Create backend inline policies (middle priority) - sets x-foo=bar2
+		// Create inline policies - sets x-foo=bar2
 		let backend_inline_policies = vec![BackendPolicy::RequestHeaderModifier(HeaderModifier {
 			add: vec![],
 			set: vec![(strng::new("x-foo"), strng::new("bar2"))],
 			remove: vec![],
 		})];
 
-		// Test case 1: Backend without section - should use backend inline (bar2) over backend attached (bar)
+		// Test case 1: Inline policy beats backend attached policy
 		let policies_no_section = store.backend_policies(
 			BackendTargetRef::Backend {
 				name: "test-backend",
@@ -1881,10 +1862,10 @@ mod tests {
 		assert_eq!(
 			modifier.set[0],
 			(strng::new("x-foo"), strng::new("bar2")),
-			"Backend inline policy (bar2) should win over backend attached policy (bar)"
+			"Inline policy (bar2) should win over backend attached policy (bar)"
 		);
 
-		// Test case 2: Backend with section - should use section policy (bar3) over all others
+		// Test case 2: Inline policy beats section attached policy
 		let policies_with_section = store.backend_policies(
 			BackendTargetRef::Backend {
 				name: "test-backend",
@@ -1910,11 +1891,11 @@ mod tests {
 		);
 		assert_eq!(
 			modifier.set[0],
-			(strng::new("x-foo"), strng::new("bar3")),
-			"Section policy (bar3) should win over backend inline (bar2) and backend attached (bar)"
+			(strng::new("x-foo"), strng::new("bar2")),
+			"Inline policy (bar2) should win over section attached policy (bar3)"
 		);
 
-		// Test case 3: Backend without any inline policies - should use backend attached (bar)
+		// Test case 3: Without inline policies, backend attached policy is used
 		let policies_no_inline = store.backend_policies(
 			BackendTargetRef::Backend {
 				name: "test-backend",
@@ -1939,6 +1920,36 @@ mod tests {
 			modifier.set[0],
 			(strng::new("x-foo"), strng::new("bar")),
 			"Backend attached policy (bar) should be used when no inline policies exist"
+		);
+
+		// Test case 4: Without inline policies, section attached policy beats backend attached
+		let policies_section_no_inline = store.backend_policies(
+			BackendTargetRef::Backend {
+				name: "test-backend",
+				namespace: "test-ns",
+				section: Some("target"),
+			},
+			&[],
+			None,
+		);
+
+		assert!(
+			policies_section_no_inline.request_header_modifier.is_some(),
+			"Expected request header modifier to be present"
+		);
+		let modifier = policies_section_no_inline
+			.request_header_modifier
+			.as_ref()
+			.unwrap();
+		assert_eq!(
+			modifier.set.len(),
+			1,
+			"Expected exactly one header to be set"
+		);
+		assert_eq!(
+			modifier.set[0],
+			(strng::new("x-foo"), strng::new("bar3")),
+			"Section attached policy (bar3) should win over backend attached policy (bar)"
 		);
 	}
 }

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -701,26 +701,10 @@ impl Store {
 		gateway: Option<&ListenerName>,
 		route: Option<&RouteName>,
 	) -> BackendPolicies {
-		let backend_rules = backend.as_ref().and_then(|t| {
-			self
-				.policies_by_target
-				.get(&PolicyTargetRef::Backend(t.clone()))
-		});
-
-		// Only use sub_backend rules if there's an actual section specified
-		// (avoid duplicating backend_rules when section is None)
-		// UNLESS backend is None, in which case we need to look up the base backend
-		let has_section = sub_backend.as_ref().is_some_and(|t| match t {
-			BackendTargetRef::Backend { section, .. } => section.is_some(),
-			BackendTargetRef::Service { port, .. } => port.is_some(),
-			_ => false,
-		});
-		let sub_backend_rules = if has_section || backend.is_none() {
-			sub_backend.and_then(|t| self.policies_by_target.get(&PolicyTargetRef::Backend(t)))
-		} else {
-			None
-		};
-
+		let backend_rules =
+			backend.and_then(|t| self.policies_by_target.get(&PolicyTargetRef::Backend(t)));
+		let sub_backend_rules =
+			sub_backend.and_then(|t| self.policies_by_target.get(&PolicyTargetRef::Backend(t)));
 		let route_rule_rules =
 			route.and_then(|t| self.policies_by_target.get(&t.as_route_rule_target_ref()));
 		let route_rules = route.and_then(|t| self.policies_by_target.get(&t.as_route_target_ref()));


### PR DESCRIPTION
Cleans up policy merging so policies merged once upstream and passed through explicitly, rather than being re-merged at multiple layers. 

Before when backend policies are attached at multiple levels (inline on the backend spec, via an AgentgatewayPolicy targeting the backend, and via an AgentgatewayPolicy targeting a specific section) the merge logic produced incorrect results:

```
apiVersion: agentgateway.dev/v1alpha1
kind: AgentgatewayBackend
metadata:
  name: mcp
spec:
  mcp:
    targets:
    - name: target
      static:
        host: mcpbin.is.solo.io
        path: /remote/mcp
        port: 443
  policies:
    auth:
      key: "foo"
    transformation:
      request:
        set:
        - name: x-foo
          value: bar2
---
apiVersion: agentgateway.dev/v1alpha1
kind: AgentgatewayPolicy
metadata:
  name: mcp-obo-authn
spec:
  targetRefs:
    - group: agentgateway.dev
      kind: AgentgatewayBackend
      name: mcp
  backend:
    transformation:
      request:
        set:
        - name: x-foo
          value: bar
---
apiVersion: agentgateway.dev/v1alpha1
kind: AgentgatewayPolicy
metadata:
  name: mcp-obo-authn-section
spec:
  targetRefs:
    - group: agentgateway.dev
      kind: AgentgatewayBackend
      name: mcp
      sectionName: target
  backend:
    transformation:
      request:
        set:
        - name: x-foo
          value: bar3
```

Expected precedence is: inline (bar2) > section-attached (bar3) > backend-attached (bar).

