### PR TITLE
agentgateway/controller: plausible ephemeral controller/readme 

### DIFF
--- a/controller/README.md
+++ b/controller/README.md
@@ -1,0 +1,4 @@
+At time of writing this folder contains alot of logic that only works when run in the context of https://github.com/kgateway-dev/kgateway
+
+It may be easiest to run commands from there unless you want to pull from ci. 
+A good example is all references of hack/kind/setup-kind.sh working in kgateway but being replaced by est/setup/setup-kind-ci.sh when ci was [enabled](https://github.com/agentgateway/agentgateway/pull/938)


### PR DESCRIPTION
While digging in to agentgateway it seemed that the controller package still has old references via kgateway specifics. 
This PR does NOT fix anything and explicitly punts on the idea of changing the scripts as they are and is mainly raised to start a quick discussion for understanding.
There is a rather high chance that this is just noise, if it is the case please feel free to close as I may have missed a setup step while skimming things.