### PR TITLE
fix(controller): Service-targeted policies dropped due to init ordering and missing PolicyAttachment traversal

### DIFF
--- a/controller/pkg/agentgateway/plugins/traffic_plugin.go
+++ b/controller/pkg/agentgateway/plugins/traffic_plugin.go
@@ -142,7 +142,7 @@ func TranslateAgentgatewayPolicy(ctx krt.HandlerContext, policy *agentgateway.Ag
 			continue
 		}
 
-		gatewayTargets := references.LookupGatewaysForTarget(ctx, utils.TypedNamespacedName{
+		gatewayTargets := references.LookupGatewaysForBackend(ctx, utils.TypedNamespacedName{
 			NamespacedName: types.NamespacedName{Namespace: policy.Namespace, Name: string(target.Name)},
 			Kind:           gk.Kind,
 		}).UnsortedList()
@@ -302,7 +302,7 @@ func resolvePolicyAncestorRefs(
 		NamespacedName: types.NamespacedName{Namespace: policyNamespace, Name: string(targetName)},
 		Kind:           targetGK.Kind,
 	}
-	gatewayTargets := references.LookupGatewaysForTarget(ctx, object).UnsortedList()
+	gatewayTargets := references.LookupGatewaysForBackend(ctx, object).UnsortedList()
 	if len(gatewayTargets) == 0 {
 		return nil, fmt.Sprintf("Policy is not attached: %s %s/%s is not attached to any Gateway", targetGK.Kind, policyNamespace, targetName)
 	}

--- a/controller/pkg/agentgateway/translator/testdata/references/service-targeted-backend-policy-via-traffic-policy.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/references/service-targeted-backend-policy-via-traffic-policy.yaml
@@ -56,3 +56,49 @@ spec:
       mtlsCertificateRef:
         - name: client-tls
       sni: processor.default.svc.cluster.local
+
+---
+# Output
+output:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
+    policy:
+      backend:
+        backendTls:
+          cert: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJiakNDQVJPZ0F3SUJBZ0lVTFpDLzFkMEhpMlRFUGk5MUtwamVZbzgzZ1pBd0NnWUlLb1pJemowRUF3SXcKRERFS01BZ0dBMVVFQXd3QllUQWVGdzB5TlRFeE1qVXlNRFE0TURLYUZ3MHlOVEV4TWpZeU1EUTRNREphTUF3eApDakFJQmdOVkJBTU1BV0V3V1RBVEJnY3Foa2pPUFFJQkJnZ3Foa2pPUFFNQkJ3TkNBQVIvc1UybWRnbkhab2Z6CmR0b0tRZm5FMWdrVE9HY2JJaWFUeDdXUGpZcXF1c1p5ZWYybTBpbkgrcnJVRFBJY2tTRlQ5dnlzRVJFVTBKcGMKL3JTZmVVOG9vMU13VVRBZEJnTlZIUTRFRmdRVWdNQ01qYnRKZnQ2VjAyT1JWMzZQcmpBWWNPd3dId1lEVlIwagpCQmd3Rm9BVWdNQ01qYnRKZnQ2VjAyT1JWMzZQcmpBWWNPd3dEd1lEVlIwVEFRSC9CQVV3QXdFQi96QUtCZ2dxCmhrak9QUVFEQWdOSkFEQkdBaUVBcW9ISTVENUt2VFR4YVVubW1mc0Nzem1vazZWR0dsZ3hpVm5HVmpKNHJ5VUMKSVFENExVcTRZMjVPbG4zQnNlbE1nT0M5VWNFS3dLRGlOTDZlMkc4S09EcU0wZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
+          hostname: processor.default.svc.cluster.local
+          key: LS0tLS1CRUdJTiBFQyBQUklWQVRFIEtFWS0tLS0tCk1IY0NBUUVFSUxRblhESm5qZFRianhhV2NKQkJOK0FDVjh3UDRxR3RZdVA0VjdZSXdJdGRvQW9HQ0NxR1NNNDkKQXdFSG9VUURRZ0FFZjdGTnBuWUp4MmFIODNiYUNrSDV4TllKRXpobkd5SW1rOGUxajQyS3Fyckdjbm45cHRJcAp4L3E2MUF6eUhKRWhVL2I4ckJFUkZOQ2FYUDYwbjNsUEtBPT0KLS0tLS1FTkQgRUMgUFJJVkFURSBLRVktLS0tLQo=
+      key: default/processor-backend-tls:tls:default/processor.default.svc.cluster.local
+      name:
+        kind: AgentgatewayPolicy
+        name: processor-backend-tls
+        namespace: default
+      target:
+        service:
+          hostname: processor.default.svc.cluster.local
+          namespace: default
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
+    policy:
+      key: traffic/default/ext-proc:extproc:default/test
+      name:
+        kind: AgentgatewayPolicy
+        name: ext-proc
+        namespace: default
+      target:
+        gateway:
+          name: test
+          namespace: default
+      traffic:
+        extProc:
+          target:
+            port: 9002
+            service:
+              hostname: processor.default.svc.cluster.local
+              namespace: default
+        phase: GATEWAY
+status: []

--- a/controller/pkg/agentgateway/translator/testdata/references/service-targeted-backend-policy-via-traffic-policy.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/references/service-targeted-backend-policy-via-traffic-policy.yaml
@@ -1,0 +1,58 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: processor
+  namespace: default
+spec:
+  selector:
+    app: processor
+  ports:
+    - protocol: TCP
+      port: 9002
+      targetPort: 9002
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: client-tls
+  namespace: default
+type: kubernetes.io/tls
+data:
+  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJiakNDQVJPZ0F3SUJBZ0lVTFpDLzFkMEhpMlRFUGk5MUtwamVZbzgzZ1pBd0NnWUlLb1pJemowRUF3SXcKRERFS01BZ0dBMVVFQXd3QllUQWVGdzB5TlRFeE1qVXlNRFE0TURLYUZ3MHlOVEV4TWpZeU1EUTRNREphTUF3eApDakFJQmdOVkJBTU1BV0V3V1RBVEJnY3Foa2pPUFFJQkJnZ3Foa2pPUFFNQkJ3TkNBQVIvc1UybWRnbkhab2Z6CmR0b0tRZm5FMWdrVE9HY2JJaWFUeDdXUGpZcXF1c1p5ZWYybTBpbkgrcnJVRFBJY2tTRlQ5dnlzRVJFVTBKcGMKL3JTZmVVOG9vMU13VVRBZEJnTlZIUTRFRmdRVWdNQ01qYnRKZnQ2VjAyT1JWMzZQcmpBWWNPd3dId1lEVlIwagpCQmd3Rm9BVWdNQ01qYnRKZnQ2VjAyT1JWMzZQcmpBWWNPd3dEd1lEVlIwVEFRSC9CQVV3QXdFQi96QUtCZ2dxCmhrak9QUVFEQWdOSkFEQkdBaUVBcW9ISTVENUt2VFR4YVVubW1mc0Nzem1vazZWR0dsZ3hpVm5HVmpKNHJ5VUMKSVFENExVcTRZMjVPbG4zQnNlbE1nT0M5VWNFS3dLRGlOTDZlMkc4S09EcU0wZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
+  tls.key: LS0tLS1CRUdJTiBFQyBQUklWQVRFIEtFWS0tLS0tCk1IY0NBUUVFSUxRblhESm5qZFRianhhV2NKQkJOK0FDVjh3UDRxR3RZdVA0VjdZSXdJdGRvQW9HQ0NxR1NNNDkKQXdFSG9VUURRZ0FFZjdGTnBuWUp4MmFIODNiYUNrSDV4TllKRXpobkd5SW1rOGUxajQyS3Fyckdjbm45cHRJcAp4L3E2MUF6eUhKRWhVL2I4ckJFUkZOQ2FYUDYwbjNsUEtBPT0KLS0tLS1FTkQgRUMgUFJJVkFURSBLRVktLS0tLQo=
+---
+# ext-proc policy targets Gateway, with backendRef to processor Service
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: ext-proc
+  namespace: default
+spec:
+  targetRefs:
+    - kind: Gateway
+      name: test
+      group: gateway.networking.k8s.io
+  traffic:
+    phase: PreRouting
+    extProc:
+      backendRef:
+        name: processor
+        port: 9002
+---
+# backend TLS policy targets the processor Service (not the Gateway)
+# This should still be associated with the gateway via the ext-proc policy's backendRef
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: processor-backend-tls
+  namespace: default
+spec:
+  targetRefs:
+    - kind: Service
+      name: processor
+      group: ""
+  backend:
+    tls:
+      mtlsCertificateRef:
+        - name: client-tls
+      sni: processor.default.svc.cluster.local

--- a/controller/pkg/syncer/policy_collections.go
+++ b/controller/pkg/syncer/policy_collections.go
@@ -14,22 +14,32 @@ import (
 
 type PolicyStatusCollections = map[schema.GroupKind]krt.StatusCollection[controllers.Object, any]
 
-func AgwPolicyCollection(agwPlugins plugins.AgwPlugin, references plugins.ReferenceIndex, krtopts krtutil.KrtOptions) (krt.Collection[ir.AgwResource], krt.Collection[*plugins.PolicyAttachment], PolicyStatusCollections) {
-	var allPolicies []krt.Collection[plugins.AgwPolicy]
+// CollectPolicyReferences collects backend references from all plugins without
+// building policies. This allows the reference index to be fully populated
+// (including PolicyAttachments from e.g. ext_proc backendRefs) before policies
+// like BackendTLSPolicy run and need to look up gateways for backends.
+func CollectPolicyReferences(agwPlugins plugins.AgwPlugin, references plugins.ReferenceIndex, krtopts krtutil.KrtOptions) krt.Collection[*plugins.PolicyAttachment] {
 	var allReferences []krt.Collection[*plugins.PolicyAttachment]
-	policyStatusMap := PolicyStatusCollections{}
-	// Collect all policies from registered plugins.
-	// Note: Only one plugin should be used per source GVK.
-	// Avoid joining collections per-GVK before passing them to a plugin.
-	for gvk, plugin := range agwPlugins.ContributesPolicies {
-		policy, policyStatus, refs := plugin.ApplyPolicies(plugins.PolicyPluginInput{References: references})
-		if refs != nil {
-			allReferences = append(allReferences, refs)
+	for _, plugin := range agwPlugins.ContributesPolicies {
+		if plugin.BuildReferences != nil {
+			refs := plugin.BuildReferences(plugins.PolicyPluginInput{References: references})
+			if refs != nil {
+				allReferences = append(allReferences, refs)
+			}
 		}
-		allPolicies = append(allPolicies, policy)
-		if policyStatus != nil {
-			// some plugins may not have a status collection (a2a services, etc.)
-			policyStatusMap[gvk] = policyStatus
+	}
+	return krt.JoinCollection(allReferences, krtopts.ToOptions("PolicyReferences")...)
+}
+
+// BuildPolicies builds all policies using the provided (fully-populated) reference index.
+func BuildPolicies(agwPlugins plugins.AgwPlugin, references plugins.ReferenceIndex, krtopts krtutil.KrtOptions) (krt.Collection[ir.AgwResource], PolicyStatusCollections) {
+	var allPolicies []krt.Collection[plugins.AgwPolicy]
+	policyStatusMap := PolicyStatusCollections{}
+	for gvk, plugin := range agwPlugins.ContributesPolicies {
+		status, col := plugin.Build(plugins.PolicyPluginInput{References: references})
+		allPolicies = append(allPolicies, col)
+		if status != nil {
+			policyStatusMap[gvk] = status
 		}
 	}
 	joinPolicies := krt.JoinCollection(allPolicies, krtopts.ToOptions("JoinPolicies")...)
@@ -38,7 +48,5 @@ func AgwPolicyCollection(agwPlugins plugins.AgwPlugin, references plugins.Refere
 		return ptr.Of(translator.ToResourceForGateway(*i.Gateway, i))
 	}, krtopts.ToOptions("AllPolicies")...)
 
-	allRefsCol := krt.JoinCollection(allReferences, krtopts.ToOptions("PolicyReferences")...)
-
-	return allPoliciesCol, allRefsCol, policyStatusMap
+	return allPoliciesCol, policyStatusMap
 }

--- a/controller/pkg/syncer/syncer.go
+++ b/controller/pkg/syncer/syncer.go
@@ -480,14 +480,12 @@ func (s *Syncer) buildAgwResources(gateways krt.Collection[*translator.GatewayLi
 	})
 	ancestorCollection := ancestorsIndex.AsCollection(append(krtopts.ToOptions("AncestorBackend"), utils.TypedNamespacedNameIndexCollectionFunc)...)
 
-	// First, make the policies with access to the route-level attachment references.
 	referenceIndex := plugins.BuildReferenceIndex(ancestorCollection, routeAttachmentsIndex, referenceTypes)
-	agwPolicies, policyReferences, policyStatuses := AgwPolicyCollection(s.agwPlugins, referenceIndex, krtopts)
-	for _, col := range policyStatuses {
-		status.RegisterStatus(s.statusCollections, col, translator.GetStatus)
-	}
 
-	// Next, build backend references.
+	// Phase 1: Collect policy references (e.g. ext_proc backendRefs) BEFORE building
+	// policies. This ensures BackendTLSPolicy can look up gateways for backends that
+	// are only reachable via PolicyAttachments (like ext_proc processor Services).
+	policyReferences := CollectPolicyReferences(s.agwPlugins, referenceIndex, krtopts)
 	backendPolicyReferences := AgwBackendReferencesCollection(s.agwPlugins, krtopts)
 	joinedPolicyReferences := krt.JoinCollection([]krt.Collection[*plugins.PolicyAttachment]{policyReferences, backendPolicyReferences}, krtopts.ToOptions("JoinPolicyAttachment")...)
 	policyReferencesIndex := krt.NewIndex(joinedPolicyReferences, "policyReferences", func(o *plugins.PolicyAttachment) []utils.TypedNamespacedName {
@@ -496,7 +494,13 @@ func (s *Syncer) buildAgwResources(gateways krt.Collection[*translator.GatewayLi
 	policyReferencesIndexCollection := policyReferencesIndex.AsCollection(append(krtopts.ToOptions("PolicyReferencesIndex"), utils.TypedNamespacedNameIndexCollectionFunc)...)
 	referenceIndex = referenceIndex.WithPolicyAttachments(policyReferencesIndexCollection)
 
-	// Finally, build the backend collection with backend+route references
+	// Phase 2: Build policies with the fully-populated reference index.
+	agwPolicies, policyStatuses := BuildPolicies(s.agwPlugins, referenceIndex, krtopts)
+	for _, col := range policyStatuses {
+		status.RegisterStatus(s.statusCollections, col, translator.GetStatus)
+	}
+
+	// Build the backend collection with backend+route references
 	agwBackends, agwBackendStatus := AgwBackendCollection(s.agwPlugins, referenceIndex, krtopts)
 	for _, col := range agwBackendStatus {
 		status.RegisterStatus(s.statusCollections, col, translator.GetStatus)


### PR DESCRIPTION
## Changes
1. **Split `AgwPolicyCollection` into two phases** (authored by @alexeldeib):
   - `CollectPolicyReferences`: collects `PolicyAttachments` from all plugins first
   - `BuildPolicies`: builds policies with the fully-populated `ReferenceIndex`
2. **Use `LookupGatewaysForBackend` in `TranslateAgentgatewayPolicy`**: traverses `PolicyAttachments` to resolve gateway associations for indirectly-referenced targets.
3. **Add golden test**: validates that a Service-targeted backend TLS policy is correctly associated with a gateway when the Service is only referenced via an ext_proc policy's `backendRef`.
