### PR TITLE
feat: enable ListResourcesRequest with multiplexing

### DIFF
--- a/crates/agentgateway/src/mcp/handler.rs
+++ b/crates/agentgateway/src/mcp/handler.rs
@@ -37,6 +37,22 @@ fn resource_name(default_target_name: Option<&String>, target: &str, name: &str)
 	}
 }
 
+fn resource_uri(default_target_name: Option<&String>, target: &str, uri: &str) -> String {
+	if default_target_name.is_none() {
+		// Transform URI to service+scheme:// format for multiplexing
+		// e.g., "http://example.com" becomes "service+http://example.com"
+		if let Some(scheme_end) = uri.find("://") {
+			let (scheme, rest) = uri.split_at(scheme_end);
+			format!("{target}+{scheme}{rest}")
+		} else {
+			// URI must have a scheme - if not, return as-is and let validation handle it
+			uri.to_string()
+		}
+	} else {
+		uri.to_string()
+	}
+}
+
 #[derive(Debug, Clone)]
 pub struct Relay {
 	upstreams: Arc<upstream::UpstreamGroup>,
@@ -276,6 +292,7 @@ impl Relay {
 	}
 	pub fn merge_resources(&self, cel: CelExecWrapper) -> Box<MergeFn> {
 		let policies = self.policies.clone();
+		let default_target_name = self.upstreams.default_target_name.clone();
 		Box::new(move |streams| {
 			let resources = streams
 				.into_iter()
@@ -295,8 +312,11 @@ impl Relay {
 								&cel,
 							)
 						})
-						// TODO(https://github.com/agentgateway/agentgateway/issues/404) map this to the service name,
-						// if we add support for multiple services.
+						// Prefix URI with service name when multiplexing to avoid conflicts
+						.map(|mut r| {
+							r.uri = resource_uri(default_target_name.as_ref(), server_name.as_str(), &r.uri);
+							r
+						})
 						.collect_vec()
 				})
 				.collect_vec();
@@ -492,8 +512,11 @@ impl Relay {
 		upstream_instructions: Vec<(String, String)>,
 	) -> ServerInfo {
 		let capabilities = if multiplexing {
-			// These are not supported when multiplexing.
-			ServerCapabilities::builder().enable_tools().build()
+			// Resources are now supported with multiplexing using proper URI prefixing
+			ServerCapabilities::builder()
+				.enable_tools()
+				.enable_resources()
+				.build()
 		} else {
 			ServerCapabilities::builder()
 				.enable_tools()

--- a/crates/agentgateway/src/mcp/session.rs
+++ b/crates/agentgateway/src/mcp/session.rs
@@ -250,18 +250,10 @@ impl Session {
 							.await
 					},
 					ClientRequest::ListResourcesRequest(_) => {
-						if !self.relay.is_multiplexing() {
-							self
-								.relay
-								.send_fanout(r, ctx, self.relay.merge_resources(cel))
-								.await
-						} else {
-							// TODO(https://github.com/agentgateway/agentgateway/issues/404)
-							// Find a mapping of URL
-							Err(UpstreamError::InvalidMethodWithMultiplexing(
-								r.request.method().to_string(),
-							))
-						}
+						self
+							.relay
+							.send_fanout(r, ctx, self.relay.merge_resources(cel))
+							.await
 					},
 					ClientRequest::ListResourceTemplatesRequest(_) => {
 						if !self.relay.is_multiplexing() {


### PR DESCRIPTION
Previously, ListResourcesRequest was blocked when multiplexing was enabled, returning InvalidMethodWithMultiplexing error. This was due to potential URI conflicts when multiple upstream servers had resources with the same URI.

This change:
- Removes the multiplexing check in session.rs for ListResourcesRequest
- Adds URI prefixing in handler.rs merge_resources() function, similar to how merge_tools() and merge_prompts() handle multiplexing
- Resources from different services are now prefixed with service names (e.g., 'service1_/path/to/resource') to avoid conflicts

Fixes #404