### PR TITLE
fix: make index lookup nil-safe after Istio bump

### DIFF
--- a/controller/pkg/agentgateway/plugins/backend_tls_plugin.go
+++ b/controller/pkg/agentgateway/plugins/backend_tls_plugin.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/agentgateway/agentgateway/api"
 	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/utils"
+	"github.com/agentgateway/agentgateway/controller/pkg/pluginsdk/krtutil"
 	"github.com/agentgateway/agentgateway/controller/pkg/wellknown"
 )
 
@@ -129,16 +130,14 @@ func translatePoliciesForBackendTLS(
 			}
 		}
 
-		backendTLSPoliciesForThisTarget := krt.FetchOne(krtctx, targetIndex, krt.FilterKey(tgtRef.String()))
-		if backendTLSPoliciesForThisTarget != nil {
-			if err := checkConflicted(btls, target, backendTLSPoliciesForThisTarget); err != nil {
-				conds[string(gwv1.PolicyConditionAccepted)].error = &ConfigError{
-					Reason:  string(gwv1.PolicyReasonConflicted),
-					Message: err.Error(),
-				}
-				// We cannot send this policy to agentgateway, as it would not know the priority logic.
-				continue
+		backendTLSPoliciesForThisTarget := krtutil.FetchIndexObjects(krtctx, targetIndex, tgtRef)
+		if err := checkConflicted(btls, target, backendTLSPoliciesForThisTarget); err != nil {
+			conds[string(gwv1.PolicyConditionAccepted)].error = &ConfigError{
+				Reason:  string(gwv1.PolicyReasonConflicted),
+				Message: err.Error(),
 			}
+			// We cannot send this policy to agentgateway, as it would not know the priority logic.
+			continue
 		}
 
 		switch string(target.Kind) {
@@ -253,9 +252,9 @@ func translatePoliciesForBackendTLS(
 func checkConflicted(
 	btls *gwv1.BackendTLSPolicy,
 	target gwv1.LocalPolicyTargetReferenceWithSectionName,
-	allMatches *krt.IndexObject[utils.TypedNamespacedName, *gwv1.BackendTLSPolicy],
+	allMatches []*gwv1.BackendTLSPolicy,
 ) error {
-	for _, m := range allMatches.Objects {
+	for _, m := range allMatches {
 		if m.UID == btls.UID {
 			// This is ourself, skip it
 			continue

--- a/controller/pkg/agentgateway/plugins/reference_indexes.go
+++ b/controller/pkg/agentgateway/plugins/reference_indexes.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/agentgateway/agentgateway/api"
 	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/utils"
+	"github.com/agentgateway/agentgateway/controller/pkg/pluginsdk/krtutil"
 	"github.com/agentgateway/agentgateway/controller/pkg/utils/kubeutils"
 	"github.com/agentgateway/agentgateway/controller/pkg/wellknown"
 )
@@ -275,43 +276,33 @@ func (p ReferenceIndex) LookupGatewaysForTarget(ctx krt.HandlerContext, object u
 		return sets.New(object.NamespacedName)
 	case wellknown.HTTPRouteGVK.Kind, wellknown.GRPCRouteGVK.Kind, wellknown.TCPRouteGVK.Kind, wellknown.TLSRouteGVK.Kind:
 		gateways := sets.New[types.NamespacedName]()
-		if a := krt.FetchOne(ctx, p.attachments, krt.FilterKey(object.String())); a != nil {
-			for _, ancestor := range a.Objects {
-				gateways.Insert(ancestor.Gateway)
-			}
+		for _, ancestor := range krtutil.FetchIndexObjects(ctx, p.attachments, object) {
+			gateways.Insert(ancestor.Gateway)
 		}
 		return gateways
 	default:
 		gateways := sets.New[types.NamespacedName]()
-		if a := krt.FetchOne(ctx, p.Ancestors, krt.FilterKey(object.String())); a != nil {
-			for _, ancestor := range a.Objects {
-				gateways.Insert(ancestor.Gateway)
-			}
+		for _, ancestor := range krtutil.FetchIndexObjects(ctx, p.Ancestors, object) {
+			gateways.Insert(ancestor.Gateway)
 		}
 		return gateways
 	}
 }
 
 func (p ReferenceIndex) LookupGatewaysForBackend(ctx krt.HandlerContext, object utils.TypedNamespacedName) sets.Set[types.NamespacedName] {
-	return p.lookupGatewaysForBackend(ctx, object, map[string]struct{}{})
+	return p.lookupGatewaysForBackend(ctx, object, sets.New[utils.TypedNamespacedName]())
 }
 
-func (p ReferenceIndex) lookupGatewaysForBackend(ctx krt.HandlerContext, object utils.TypedNamespacedName, seen map[string]struct{}) sets.Set[types.NamespacedName] {
-	key := object.String()
-	if _, ok := seen[key]; ok {
+func (p ReferenceIndex) lookupGatewaysForBackend(ctx krt.HandlerContext, object utils.TypedNamespacedName, seen sets.Set[utils.TypedNamespacedName]) sets.Set[types.NamespacedName] {
+	if seen.InsertContains(object) {
 		return sets.New[types.NamespacedName]()
 	}
-	seen[key] = struct{}{}
 
 	base := p.LookupGatewaysForTarget(ctx, object)
 	if p.PolicyAttachments == nil {
 		return base
 	}
-	attachment := krt.FetchOne(ctx, p.PolicyAttachments, krt.FilterKey(key))
-	if attachment == nil {
-		return base
-	}
-	for _, pref := range attachment.Objects {
+	for _, pref := range krtutil.FetchIndexObjects(ctx, p.PolicyAttachments, object) {
 		base = base.Union(p.lookupGatewaysForBackend(ctx, pref.Target, seen))
 	}
 	return base

--- a/controller/pkg/pluginsdk/krtutil/index.go
+++ b/controller/pkg/pluginsdk/krtutil/index.go
@@ -1,0 +1,23 @@
+package krtutil
+
+import (
+	"fmt"
+
+	"istio.io/istio/pkg/kube/krt"
+)
+
+func FetchIndexObjects[K comparable, O any](ctx krt.HandlerContext, index krt.IndexCollection[K, O], name K) []O {
+	res := krt.FetchOne(ctx, index, krt.FilterKey(toString(name)))
+	if res == nil {
+		return nil
+	}
+	return res.Objects
+}
+
+func toString(rk any) string {
+	tk, ok := rk.(string)
+	if !ok {
+		return rk.(fmt.Stringer).String()
+	}
+	return tk
+}

--- a/controller/pkg/syncer/syncer.go
+++ b/controller/pkg/syncer/syncer.go
@@ -258,18 +258,18 @@ func (s *Syncer) buildFinalListenerSetStatus(
 				counts[r.ListenerName]++
 			}
 			for idx, l := range i.Obj.Spec.Listeners {
-				gatewayListener := krt.FetchOne(ctx, gatewayIndex, krt.FilterKey(utils.SectionedNamespacedName{
+				gatewayListeners := krtutil.FetchIndexObjects(ctx, gatewayIndex, utils.SectionedNamespacedName{
 					NamespacedName: types.NamespacedName{
 						Namespace: i.Obj.Namespace,
 						Name:      i.Obj.Name,
 					},
 					SectionName: l.Name,
-				}.String()))
-				if len(gatewayListener.Objects) == 0 {
+				})
+				if len(gatewayListeners) == 0 {
 					continue
 				}
 
-				obj := gatewayListener.Objects[0]
+				obj := gatewayListeners[0]
 				if !obj.Valid {
 					invalidListenerCount++
 				} else {


### PR DESCRIPTION
https://github.com/agentgateway/agentgateway/pull/1477 triggers a new
race, as Index can now be nil. To avoid adding a bunch of nil-checks
everywhere, introduce a common helper
