### PR TITLE
fix(ui): parse namespace from service name when matching A2A policies

### DIFF
--- a/ui/src/lib/configMapper.ts
+++ b/ui/src/lib/configMapper.ts
@@ -180,9 +180,12 @@ function routeBackendMatchesA2aPolicy(rb: any, targets: A2aPolicyTarget[]): bool
   // RouteBackendReference, so fields appear at the top level of rb.
   if (rb.service) {
     const svc = rb.service;
-    const name = svc.name;
-    const rbHostname = typeof name === "string" ? name : (name?.hostname ?? "");
-    const rbNamespace = typeof name === "object" ? (name?.namespace ?? "") : "";
+    // NamespacedHostname always serializes as "namespace/hostname" string
+    // (see crates/agentgateway/src/types/discovery.rs Display impl).
+    const name: string = typeof svc.name === "string" ? svc.name : "";
+    const slashIdx = name.indexOf("/");
+    const rbNamespace = slashIdx >= 0 ? name.substring(0, slashIdx) : "";
+    const rbHostname = slashIdx >= 0 ? name.substring(slashIdx + 1) : name;
     const rbPort = typeof svc.port === "number" ? svc.port : undefined;
 
     return targets.some(


### PR DESCRIPTION
Fixes #1486

## Summary

`NamespacedHostname` always serializes as `"namespace/hostname"` (via its `Display` impl), but `routeBackendMatchesA2aPolicy()` compared the full `"namespace/hostname"` string against just the `hostname` from the A2A policy target. This caused A2A routes to show as "Service" in the Playground instead of "A2A".

## Change

Split `service.name` on `/` to extract namespace and hostname before comparing against the policy target. Also removed the dead object-format branch (`name?.hostname`) since `NamespacedHostname` never serializes as an object.

## Regression of #978 / #979

The original fix in #979 handled the string case but didn't account for the `namespace/` prefix in the serialized format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)