### PR TITLE
standalone: drop policies that don't make sense

### DIFF
--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -1066,14 +1066,6 @@ pub struct SimpleLocalBackendPolicies {
 	#[serde(default)]
 	pub request_header_modifier: Option<filters::HeaderModifier>,
 
-	/// Headers to be modified in the response.
-	#[serde(default)]
-	pub response_header_modifier: Option<filters::HeaderModifier>,
-
-	/// Directly respond to the request with a redirect.
-	#[serde(default)]
-	pub request_redirect: Option<filters::RequestRedirect>,
-
 	/// Modify requests and responses sent to and from the backend.
 	#[serde(default)]
 	#[serde(deserialize_with = "de_transform")]
@@ -1096,10 +1088,6 @@ pub struct SimpleLocalBackendPolicies {
 	/// Specify TCP settings for the backend
 	#[serde(default)]
 	pub tcp: Option<backend::TCP>,
-
-	/// Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.
-	#[serde(default)]
-	pub health: Option<health::LocalHealthPolicy>,
 
 	/// Specify a tunnel to use when connecting to the backend
 	#[serde(default)]
@@ -1139,14 +1127,11 @@ impl LocalBackendPolicies {
 			simple:
 				SimpleLocalBackendPolicies {
 					request_header_modifier,
-					response_header_modifier,
-					request_redirect,
 					transformations,
 					backend_tls,
 					backend_auth,
 					http,
 					tcp,
-					health,
 					backend_tunnel,
 				},
 			mcp_authorization,
@@ -1166,12 +1151,6 @@ impl LocalBackendPolicies {
 		if let Some(p) = request_header_modifier {
 			pols.push(BackendPolicy::RequestHeaderModifier(p));
 		}
-		if let Some(p) = response_header_modifier {
-			pols.push(BackendPolicy::ResponseHeaderModifier(p));
-		}
-		if let Some(p) = request_redirect {
-			pols.push(BackendPolicy::RequestRedirect(p));
-		}
 		if let Some(p) = transformations {
 			pols.push(BackendPolicy::Transformation(p));
 		}
@@ -1190,11 +1169,6 @@ impl LocalBackendPolicies {
 		if let Some(mut p) = ai {
 			p.compile_model_alias_patterns();
 			pols.push(BackendPolicy::AI(Arc::new(p)))
-		}
-		if let Some(p) = health {
-			pols.push(BackendPolicy::Health(p.try_into().map_err(
-				|e: crate::cel::Error| anyhow::anyhow!("health.unhealthyExpression: {}", e),
-			)?));
 		}
 		Ok(pols)
 	}

--- a/schema/config.json
+++ b/schema/config.json
@@ -2147,30 +2147,6 @@
           ],
           "default": null
         },
-        "responseHeaderModifier": {
-          "description": "Headers to be modified in the response.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/HeaderModifier"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "requestRedirect": {
-          "description": "Directly respond to the request with a redirect.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/RequestRedirect"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
         "transformations": {
           "description": "Modify requests and responses sent to and from the backend.",
           "anyOf": [
@@ -2223,18 +2199,6 @@
           "anyOf": [
             {
               "$ref": "#/$defs/TCP"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "health": {
-          "description": "Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/LocalHealthPolicy"
             },
             {
               "type": "null"
@@ -2760,64 +2724,6 @@
         "secs",
         "nanos"
       ]
-    },
-    "LocalHealthPolicy": {
-      "description": "Local/config health policy with CEL as string; converted to Policy by compiling the expression.\nMirrors the proto `Health` message structure.",
-      "type": "object",
-      "properties": {
-        "unhealthyExpression": {
-          "description": "CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.\nWhen unset, any 5xx or connection failure is treated as unhealthy.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "eviction": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/LocalEviction"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      },
-      "additionalProperties": false
-    },
-    "LocalEviction": {
-      "description": "Local/config eviction sub-policy with duration as string; mirrors `Eviction`.",
-      "type": "object",
-      "properties": {
-        "duration": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "restoreHealth": {
-          "type": [
-            "number",
-            "null"
-          ],
-          "format": "double"
-        },
-        "consecutiveFailures": {
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "int32"
-        },
-        "healthThreshold": {
-          "type": [
-            "number",
-            "null"
-          ],
-          "format": "double"
-        }
-      },
-      "additionalProperties": false
     },
     "Tunnel": {
       "type": "object",
@@ -4345,30 +4251,6 @@
           ],
           "default": null
         },
-        "responseHeaderModifier": {
-          "description": "Headers to be modified in the response.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/HeaderModifier"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "requestRedirect": {
-          "description": "Directly respond to the request with a redirect.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/RequestRedirect"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
         "transformations": {
           "description": "Modify requests and responses sent to and from the backend.",
           "anyOf": [
@@ -4421,18 +4303,6 @@
           "anyOf": [
             {
               "$ref": "#/$defs/TCP"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "health": {
-          "description": "Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/LocalHealthPolicy"
             },
             {
               "type": "null"
@@ -4772,30 +4642,6 @@
           ],
           "default": null
         },
-        "responseHeaderModifier": {
-          "description": "Headers to be modified in the response.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/HeaderModifier"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "requestRedirect": {
-          "description": "Directly respond to the request with a redirect.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/RequestRedirect"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
         "transformations": {
           "description": "Modify requests and responses sent to and from the backend.",
           "anyOf": [
@@ -4848,18 +4694,6 @@
           "anyOf": [
             {
               "$ref": "#/$defs/TCP"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "health": {
-          "description": "Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/LocalHealthPolicy"
             },
             {
               "type": "null"
@@ -6220,6 +6054,64 @@
         "bedrock",
         "azureOpenAI"
       ]
+    },
+    "LocalHealthPolicy": {
+      "description": "Local/config health policy with CEL as string; converted to Policy by compiling the expression.\nMirrors the proto `Health` message structure.",
+      "type": "object",
+      "properties": {
+        "unhealthyExpression": {
+          "description": "CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.\nWhen unset, any 5xx or connection failure is treated as unhealthy.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "eviction": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LocalEviction"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "LocalEviction": {
+      "description": "Local/config eviction sub-policy with duration as string; mirrors `Eviction`.",
+      "type": "object",
+      "properties": {
+        "duration": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "restoreHealth": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        },
+        "consecutiveFailures": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int32"
+        },
+        "healthThreshold": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        }
+      },
+      "additionalProperties": false
     },
     "LLMRouteMatch": {
       "type": "object",

--- a/schema/config.md
+++ b/schema/config.md
@@ -191,20 +191,6 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.requestHeaderModifier.add`|object||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.requestHeaderModifier.set`|object||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.requestHeaderModifier.remove`|[]string||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.responseHeaderModifier.add`|object||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.responseHeaderModifier.set`|object||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.responseHeaderModifier.remove`|[]string||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.scheme`|string||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.authority`|string||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.authority.full`|string||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.authority.host`|string||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.authority.port`|integer||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.path`|object||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.path.full`|string||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.path.prefix`|string||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.status`|integer||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.transformations.request`|object||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.transformations.request.add`|object||
@@ -266,13 +252,6 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.connectTimeout`|object||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.connectTimeout.secs`|integer||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.connectTimeout.nanos`|integer||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.health.eviction.duration`|string||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.health.eviction.restoreHealth`|number||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.health.eviction.consecutiveFailures`|integer||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.health.eviction.healthThreshold`|number||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service`|object||
@@ -291,20 +270,6 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestHeaderModifier.add`|object||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestHeaderModifier.set`|object||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestHeaderModifier.remove`|[]string||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.responseHeaderModifier.add`|object||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.responseHeaderModifier.set`|object||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.responseHeaderModifier.remove`|[]string||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.scheme`|string||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.authority`|string||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.authority.full`|string||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.authority.host`|string||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.authority.port`|integer||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.path`|object||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.path.full`|string||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.path.prefix`|string||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.status`|integer||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.transformations.request`|object||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.transformations.request.add`|object||
@@ -366,13 +331,6 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.connectTimeout`|object||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.connectTimeout.secs`|integer||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.connectTimeout.nanos`|integer||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.health.eviction.duration`|string||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.health.eviction.restoreHealth`|number||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.health.eviction.consecutiveFailures`|integer||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.health.eviction.healthThreshold`|number||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service`|object||
@@ -391,20 +349,6 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.requestHeaderModifier.add`|object||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.requestHeaderModifier.set`|object||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.requestHeaderModifier.remove`|[]string||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.responseHeaderModifier.add`|object||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.responseHeaderModifier.set`|object||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.responseHeaderModifier.remove`|[]string||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.scheme`|string||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.authority`|string||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.authority.full`|string||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.authority.host`|string||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.authority.port`|integer||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.path`|object||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.path.full`|string||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.path.prefix`|string||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.status`|integer||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.transformations.request`|object||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.transformations.request.add`|object||
@@ -466,13 +410,6 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.connectTimeout`|object||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.connectTimeout.secs`|integer||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.connectTimeout.nanos`|integer||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.health.eviction.duration`|string||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.health.eviction.restoreHealth`|number||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.health.eviction.consecutiveFailures`|integer||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.health.eviction.healthThreshold`|number||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service`|object||
@@ -518,20 +455,6 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestHeaderModifier.add`|object||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestHeaderModifier.set`|object||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestHeaderModifier.remove`|[]string||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.responseHeaderModifier.add`|object||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.responseHeaderModifier.set`|object||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.responseHeaderModifier.remove`|[]string||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.scheme`|string||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.authority`|string||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.authority.full`|string||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.authority.host`|string||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.authority.port`|integer||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.path`|object||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.path.full`|string||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.path.prefix`|string||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.status`|integer||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.transformations.request`|object||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.transformations.request.add`|object||
@@ -593,13 +516,6 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.connectTimeout`|object||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.connectTimeout.secs`|integer||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.connectTimeout.nanos`|integer||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.health.eviction.duration`|string||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.health.eviction.restoreHealth`|number||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.health.eviction.consecutiveFailures`|integer||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.health.eviction.healthThreshold`|number||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service`|object||
@@ -618,20 +534,6 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.requestHeaderModifier.add`|object||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.requestHeaderModifier.set`|object||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.requestHeaderModifier.remove`|[]string||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.responseHeaderModifier.add`|object||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.responseHeaderModifier.set`|object||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.responseHeaderModifier.remove`|[]string||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.scheme`|string||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.authority`|string||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.authority.full`|string||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.authority.host`|string||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.authority.port`|integer||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.path`|object||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.path.full`|string||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.path.prefix`|string||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.status`|integer||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.transformations.request`|object||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.transformations.request.add`|object||
@@ -693,13 +595,6 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.connectTimeout`|object||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.connectTimeout.secs`|integer||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.connectTimeout.nanos`|integer||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.health.eviction.duration`|string||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.health.eviction.restoreHealth`|number||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.health.eviction.consecutiveFailures`|integer||
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.health.eviction.healthThreshold`|number||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service`|object||
@@ -797,20 +692,6 @@
 |`binds[].listeners[].routes[].policies.remoteRateLimit.policies.requestHeaderModifier.add`|object||
 |`binds[].listeners[].routes[].policies.remoteRateLimit.policies.requestHeaderModifier.set`|object||
 |`binds[].listeners[].routes[].policies.remoteRateLimit.policies.requestHeaderModifier.remove`|[]string||
-|`binds[].listeners[].routes[].policies.remoteRateLimit.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`binds[].listeners[].routes[].policies.remoteRateLimit.policies.responseHeaderModifier.add`|object||
-|`binds[].listeners[].routes[].policies.remoteRateLimit.policies.responseHeaderModifier.set`|object||
-|`binds[].listeners[].routes[].policies.remoteRateLimit.policies.responseHeaderModifier.remove`|[]string||
-|`binds[].listeners[].routes[].policies.remoteRateLimit.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`binds[].listeners[].routes[].policies.remoteRateLimit.policies.requestRedirect.scheme`|string||
-|`binds[].listeners[].routes[].policies.remoteRateLimit.policies.requestRedirect.authority`|string||
-|`binds[].listeners[].routes[].policies.remoteRateLimit.policies.requestRedirect.authority.full`|string||
-|`binds[].listeners[].routes[].policies.remoteRateLimit.policies.requestRedirect.authority.host`|string||
-|`binds[].listeners[].routes[].policies.remoteRateLimit.policies.requestRedirect.authority.port`|integer||
-|`binds[].listeners[].routes[].policies.remoteRateLimit.policies.requestRedirect.path`|object||
-|`binds[].listeners[].routes[].policies.remoteRateLimit.policies.requestRedirect.path.full`|string||
-|`binds[].listeners[].routes[].policies.remoteRateLimit.policies.requestRedirect.path.prefix`|string||
-|`binds[].listeners[].routes[].policies.remoteRateLimit.policies.requestRedirect.status`|integer||
 |`binds[].listeners[].routes[].policies.remoteRateLimit.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.policies.transformations.request`|object||
 |`binds[].listeners[].routes[].policies.remoteRateLimit.policies.transformations.request.add`|object||
@@ -872,13 +753,6 @@
 |`binds[].listeners[].routes[].policies.remoteRateLimit.policies.tcp.connectTimeout`|object||
 |`binds[].listeners[].routes[].policies.remoteRateLimit.policies.tcp.connectTimeout.secs`|integer||
 |`binds[].listeners[].routes[].policies.remoteRateLimit.policies.tcp.connectTimeout.nanos`|integer||
-|`binds[].listeners[].routes[].policies.remoteRateLimit.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`binds[].listeners[].routes[].policies.remoteRateLimit.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`binds[].listeners[].routes[].policies.remoteRateLimit.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`binds[].listeners[].routes[].policies.remoteRateLimit.policies.health.eviction.duration`|string||
-|`binds[].listeners[].routes[].policies.remoteRateLimit.policies.health.eviction.restoreHealth`|number||
-|`binds[].listeners[].routes[].policies.remoteRateLimit.policies.health.eviction.consecutiveFailures`|integer||
-|`binds[].listeners[].routes[].policies.remoteRateLimit.policies.health.eviction.healthThreshold`|number||
 |`binds[].listeners[].routes[].policies.remoteRateLimit.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.policies.backendTunnel.proxy.service`|object||
@@ -950,20 +824,6 @@
 |`binds[].listeners[].routes[].policies.extAuthz.policies.requestHeaderModifier.add`|object||
 |`binds[].listeners[].routes[].policies.extAuthz.policies.requestHeaderModifier.set`|object||
 |`binds[].listeners[].routes[].policies.extAuthz.policies.requestHeaderModifier.remove`|[]string||
-|`binds[].listeners[].routes[].policies.extAuthz.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`binds[].listeners[].routes[].policies.extAuthz.policies.responseHeaderModifier.add`|object||
-|`binds[].listeners[].routes[].policies.extAuthz.policies.responseHeaderModifier.set`|object||
-|`binds[].listeners[].routes[].policies.extAuthz.policies.responseHeaderModifier.remove`|[]string||
-|`binds[].listeners[].routes[].policies.extAuthz.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`binds[].listeners[].routes[].policies.extAuthz.policies.requestRedirect.scheme`|string||
-|`binds[].listeners[].routes[].policies.extAuthz.policies.requestRedirect.authority`|string||
-|`binds[].listeners[].routes[].policies.extAuthz.policies.requestRedirect.authority.full`|string||
-|`binds[].listeners[].routes[].policies.extAuthz.policies.requestRedirect.authority.host`|string||
-|`binds[].listeners[].routes[].policies.extAuthz.policies.requestRedirect.authority.port`|integer||
-|`binds[].listeners[].routes[].policies.extAuthz.policies.requestRedirect.path`|object||
-|`binds[].listeners[].routes[].policies.extAuthz.policies.requestRedirect.path.full`|string||
-|`binds[].listeners[].routes[].policies.extAuthz.policies.requestRedirect.path.prefix`|string||
-|`binds[].listeners[].routes[].policies.extAuthz.policies.requestRedirect.status`|integer||
 |`binds[].listeners[].routes[].policies.extAuthz.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`binds[].listeners[].routes[].policies.extAuthz.policies.transformations.request`|object||
 |`binds[].listeners[].routes[].policies.extAuthz.policies.transformations.request.add`|object||
@@ -1025,13 +885,6 @@
 |`binds[].listeners[].routes[].policies.extAuthz.policies.tcp.connectTimeout`|object||
 |`binds[].listeners[].routes[].policies.extAuthz.policies.tcp.connectTimeout.secs`|integer||
 |`binds[].listeners[].routes[].policies.extAuthz.policies.tcp.connectTimeout.nanos`|integer||
-|`binds[].listeners[].routes[].policies.extAuthz.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`binds[].listeners[].routes[].policies.extAuthz.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`binds[].listeners[].routes[].policies.extAuthz.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`binds[].listeners[].routes[].policies.extAuthz.policies.health.eviction.duration`|string||
-|`binds[].listeners[].routes[].policies.extAuthz.policies.health.eviction.restoreHealth`|number||
-|`binds[].listeners[].routes[].policies.extAuthz.policies.health.eviction.consecutiveFailures`|integer||
-|`binds[].listeners[].routes[].policies.extAuthz.policies.health.eviction.healthThreshold`|number||
 |`binds[].listeners[].routes[].policies.extAuthz.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`binds[].listeners[].routes[].policies.extAuthz.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`binds[].listeners[].routes[].policies.extAuthz.policies.backendTunnel.proxy.service`|object||
@@ -1071,20 +924,6 @@
 |`binds[].listeners[].routes[].policies.extProc.policies.requestHeaderModifier.add`|object||
 |`binds[].listeners[].routes[].policies.extProc.policies.requestHeaderModifier.set`|object||
 |`binds[].listeners[].routes[].policies.extProc.policies.requestHeaderModifier.remove`|[]string||
-|`binds[].listeners[].routes[].policies.extProc.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`binds[].listeners[].routes[].policies.extProc.policies.responseHeaderModifier.add`|object||
-|`binds[].listeners[].routes[].policies.extProc.policies.responseHeaderModifier.set`|object||
-|`binds[].listeners[].routes[].policies.extProc.policies.responseHeaderModifier.remove`|[]string||
-|`binds[].listeners[].routes[].policies.extProc.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`binds[].listeners[].routes[].policies.extProc.policies.requestRedirect.scheme`|string||
-|`binds[].listeners[].routes[].policies.extProc.policies.requestRedirect.authority`|string||
-|`binds[].listeners[].routes[].policies.extProc.policies.requestRedirect.authority.full`|string||
-|`binds[].listeners[].routes[].policies.extProc.policies.requestRedirect.authority.host`|string||
-|`binds[].listeners[].routes[].policies.extProc.policies.requestRedirect.authority.port`|integer||
-|`binds[].listeners[].routes[].policies.extProc.policies.requestRedirect.path`|object||
-|`binds[].listeners[].routes[].policies.extProc.policies.requestRedirect.path.full`|string||
-|`binds[].listeners[].routes[].policies.extProc.policies.requestRedirect.path.prefix`|string||
-|`binds[].listeners[].routes[].policies.extProc.policies.requestRedirect.status`|integer||
 |`binds[].listeners[].routes[].policies.extProc.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`binds[].listeners[].routes[].policies.extProc.policies.transformations.request`|object||
 |`binds[].listeners[].routes[].policies.extProc.policies.transformations.request.add`|object||
@@ -1146,13 +985,6 @@
 |`binds[].listeners[].routes[].policies.extProc.policies.tcp.connectTimeout`|object||
 |`binds[].listeners[].routes[].policies.extProc.policies.tcp.connectTimeout.secs`|integer||
 |`binds[].listeners[].routes[].policies.extProc.policies.tcp.connectTimeout.nanos`|integer||
-|`binds[].listeners[].routes[].policies.extProc.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`binds[].listeners[].routes[].policies.extProc.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`binds[].listeners[].routes[].policies.extProc.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`binds[].listeners[].routes[].policies.extProc.policies.health.eviction.duration`|string||
-|`binds[].listeners[].routes[].policies.extProc.policies.health.eviction.restoreHealth`|number||
-|`binds[].listeners[].routes[].policies.extProc.policies.health.eviction.consecutiveFailures`|integer||
-|`binds[].listeners[].routes[].policies.extProc.policies.health.eviction.healthThreshold`|number||
 |`binds[].listeners[].routes[].policies.extProc.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`binds[].listeners[].routes[].policies.extProc.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`binds[].listeners[].routes[].policies.extProc.policies.backendTunnel.proxy.service`|object||
@@ -1224,20 +1056,6 @@
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.requestHeaderModifier.add`|object||
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.requestHeaderModifier.set`|object||
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.requestHeaderModifier.remove`|[]string||
-|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.responseHeaderModifier.add`|object||
-|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.responseHeaderModifier.set`|object||
-|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.responseHeaderModifier.remove`|[]string||
-|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.requestRedirect.scheme`|string||
-|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.requestRedirect.authority`|string||
-|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.requestRedirect.authority.full`|string||
-|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.requestRedirect.authority.host`|string||
-|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.requestRedirect.authority.port`|integer||
-|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.requestRedirect.path`|object||
-|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.requestRedirect.path.full`|string||
-|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.requestRedirect.path.prefix`|string||
-|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.requestRedirect.status`|integer||
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.transformations.request`|object||
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.transformations.request.add`|object||
@@ -1299,13 +1117,6 @@
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.tcp.connectTimeout`|object||
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.tcp.connectTimeout.secs`|integer||
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.tcp.connectTimeout.nanos`|integer||
-|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.health.eviction.duration`|string||
-|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.health.eviction.restoreHealth`|number||
-|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.health.eviction.consecutiveFailures`|integer||
-|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.health.eviction.healthThreshold`|number||
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.backendTunnel.proxy.service`|object||
@@ -1351,20 +1162,6 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.requestHeaderModifier.add`|object||
 |`binds[].listeners[].routes[].backends[].ai.policies.requestHeaderModifier.set`|object||
 |`binds[].listeners[].routes[].backends[].ai.policies.requestHeaderModifier.remove`|[]string||
-|`binds[].listeners[].routes[].backends[].ai.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`binds[].listeners[].routes[].backends[].ai.policies.responseHeaderModifier.add`|object||
-|`binds[].listeners[].routes[].backends[].ai.policies.responseHeaderModifier.set`|object||
-|`binds[].listeners[].routes[].backends[].ai.policies.responseHeaderModifier.remove`|[]string||
-|`binds[].listeners[].routes[].backends[].ai.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`binds[].listeners[].routes[].backends[].ai.policies.requestRedirect.scheme`|string||
-|`binds[].listeners[].routes[].backends[].ai.policies.requestRedirect.authority`|string||
-|`binds[].listeners[].routes[].backends[].ai.policies.requestRedirect.authority.full`|string||
-|`binds[].listeners[].routes[].backends[].ai.policies.requestRedirect.authority.host`|string||
-|`binds[].listeners[].routes[].backends[].ai.policies.requestRedirect.authority.port`|integer||
-|`binds[].listeners[].routes[].backends[].ai.policies.requestRedirect.path`|object||
-|`binds[].listeners[].routes[].backends[].ai.policies.requestRedirect.path.full`|string||
-|`binds[].listeners[].routes[].backends[].ai.policies.requestRedirect.path.prefix`|string||
-|`binds[].listeners[].routes[].backends[].ai.policies.requestRedirect.status`|integer||
 |`binds[].listeners[].routes[].backends[].ai.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.transformations.request`|object||
 |`binds[].listeners[].routes[].backends[].ai.policies.transformations.request.add`|object||
@@ -1426,13 +1223,6 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.tcp.connectTimeout`|object||
 |`binds[].listeners[].routes[].backends[].ai.policies.tcp.connectTimeout.secs`|integer||
 |`binds[].listeners[].routes[].backends[].ai.policies.tcp.connectTimeout.nanos`|integer||
-|`binds[].listeners[].routes[].backends[].ai.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`binds[].listeners[].routes[].backends[].ai.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`binds[].listeners[].routes[].backends[].ai.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`binds[].listeners[].routes[].backends[].ai.policies.health.eviction.duration`|string||
-|`binds[].listeners[].routes[].backends[].ai.policies.health.eviction.restoreHealth`|number||
-|`binds[].listeners[].routes[].backends[].ai.policies.health.eviction.consecutiveFailures`|integer||
-|`binds[].listeners[].routes[].backends[].ai.policies.health.eviction.healthThreshold`|number||
 |`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.proxy.service`|object||
@@ -1474,20 +1264,6 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.requestHeaderModifier.add`|object||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.requestHeaderModifier.set`|object||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.requestHeaderModifier.remove`|[]string||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.responseHeaderModifier.add`|object||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.responseHeaderModifier.set`|object||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.responseHeaderModifier.remove`|[]string||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.scheme`|string||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.authority`|string||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.authority.full`|string||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.authority.host`|string||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.authority.port`|integer||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.path`|object||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.path.full`|string||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.path.prefix`|string||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.status`|integer||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.transformations.request`|object||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.transformations.request.add`|object||
@@ -1549,13 +1325,6 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.tcp.connectTimeout`|object||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.tcp.connectTimeout.secs`|integer||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.tcp.connectTimeout.nanos`|integer||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.health.eviction.duration`|string||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.health.eviction.restoreHealth`|number||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.health.eviction.consecutiveFailures`|integer||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.health.eviction.healthThreshold`|number||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service`|object||
@@ -1574,20 +1343,6 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestHeaderModifier.add`|object||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestHeaderModifier.set`|object||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestHeaderModifier.remove`|[]string||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.responseHeaderModifier.add`|object||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.responseHeaderModifier.set`|object||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.responseHeaderModifier.remove`|[]string||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.scheme`|string||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.authority`|string||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.authority.full`|string||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.authority.host`|string||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.authority.port`|integer||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.path`|object||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.path.full`|string||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.path.prefix`|string||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.status`|integer||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.transformations.request`|object||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.transformations.request.add`|object||
@@ -1649,13 +1404,6 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.connectTimeout`|object||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.connectTimeout.secs`|integer||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.connectTimeout.nanos`|integer||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.health.eviction.duration`|string||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.health.eviction.restoreHealth`|number||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.health.eviction.consecutiveFailures`|integer||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.health.eviction.healthThreshold`|number||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service`|object||
@@ -1674,20 +1422,6 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.requestHeaderModifier.add`|object||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.requestHeaderModifier.set`|object||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.requestHeaderModifier.remove`|[]string||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.responseHeaderModifier.add`|object||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.responseHeaderModifier.set`|object||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.responseHeaderModifier.remove`|[]string||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.scheme`|string||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.authority`|string||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.authority.full`|string||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.authority.host`|string||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.authority.port`|integer||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.path`|object||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.path.full`|string||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.path.prefix`|string||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.status`|integer||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.transformations.request`|object||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.transformations.request.add`|object||
@@ -1749,13 +1483,6 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.connectTimeout`|object||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.connectTimeout.secs`|integer||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.connectTimeout.nanos`|integer||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.health.eviction.duration`|string||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.health.eviction.restoreHealth`|number||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.health.eviction.consecutiveFailures`|integer||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.health.eviction.healthThreshold`|number||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service`|object||
@@ -1801,20 +1528,6 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestHeaderModifier.add`|object||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestHeaderModifier.set`|object||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestHeaderModifier.remove`|[]string||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.responseHeaderModifier.add`|object||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.responseHeaderModifier.set`|object||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.responseHeaderModifier.remove`|[]string||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.scheme`|string||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.authority`|string||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.authority.full`|string||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.authority.host`|string||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.authority.port`|integer||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.path`|object||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.path.full`|string||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.path.prefix`|string||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.status`|integer||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.transformations.request`|object||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.transformations.request.add`|object||
@@ -1876,13 +1589,6 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.connectTimeout`|object||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.connectTimeout.secs`|integer||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.connectTimeout.nanos`|integer||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.health.eviction.duration`|string||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.health.eviction.restoreHealth`|number||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.health.eviction.consecutiveFailures`|integer||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.health.eviction.healthThreshold`|number||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service`|object||
@@ -1901,20 +1607,6 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.requestHeaderModifier.add`|object||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.requestHeaderModifier.set`|object||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.requestHeaderModifier.remove`|[]string||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.responseHeaderModifier.add`|object||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.responseHeaderModifier.set`|object||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.responseHeaderModifier.remove`|[]string||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.scheme`|string||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.authority`|string||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.authority.full`|string||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.authority.host`|string||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.authority.port`|integer||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.path`|object||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.path.full`|string||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.path.prefix`|string||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.status`|integer||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.transformations.request`|object||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.transformations.request.add`|object||
@@ -1976,13 +1668,6 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.connectTimeout`|object||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.connectTimeout.secs`|integer||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.connectTimeout.nanos`|integer||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.health.eviction.duration`|string||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.health.eviction.restoreHealth`|number||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.health.eviction.consecutiveFailures`|integer||
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.health.eviction.healthThreshold`|number||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service`|object||
@@ -2048,20 +1733,6 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.requestHeaderModifier.add`|object||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.requestHeaderModifier.set`|object||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.requestHeaderModifier.remove`|[]string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.responseHeaderModifier.add`|object||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.responseHeaderModifier.set`|object||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.responseHeaderModifier.remove`|[]string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.requestRedirect.scheme`|string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.requestRedirect.authority`|string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.requestRedirect.authority.full`|string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.requestRedirect.authority.host`|string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.requestRedirect.authority.port`|integer||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.requestRedirect.path`|object||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.requestRedirect.path.full`|string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.requestRedirect.path.prefix`|string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.requestRedirect.status`|integer||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.transformations.request`|object||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.transformations.request.add`|object||
@@ -2123,13 +1794,6 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.tcp.connectTimeout`|object||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.tcp.connectTimeout.secs`|integer||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.tcp.connectTimeout.nanos`|integer||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.health.eviction.duration`|string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.health.eviction.restoreHealth`|number||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.health.eviction.consecutiveFailures`|integer||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.health.eviction.healthThreshold`|number||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.proxy.service`|object||
@@ -2171,20 +1835,6 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.requestHeaderModifier.add`|object||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.requestHeaderModifier.set`|object||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.requestHeaderModifier.remove`|[]string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.responseHeaderModifier.add`|object||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.responseHeaderModifier.set`|object||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.responseHeaderModifier.remove`|[]string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.scheme`|string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.authority`|string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.authority.full`|string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.authority.host`|string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.authority.port`|integer||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.path`|object||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.path.full`|string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.path.prefix`|string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.status`|integer||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.transformations.request`|object||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.transformations.request.add`|object||
@@ -2246,13 +1896,6 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.connectTimeout`|object||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.connectTimeout.secs`|integer||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.connectTimeout.nanos`|integer||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.health.eviction.duration`|string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.health.eviction.restoreHealth`|number||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.health.eviction.consecutiveFailures`|integer||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.health.eviction.healthThreshold`|number||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service`|object||
@@ -2271,20 +1914,6 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestHeaderModifier.add`|object||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestHeaderModifier.set`|object||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestHeaderModifier.remove`|[]string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.responseHeaderModifier.add`|object||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.responseHeaderModifier.set`|object||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.responseHeaderModifier.remove`|[]string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.scheme`|string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.authority`|string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.authority.full`|string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.authority.host`|string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.authority.port`|integer||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.path`|object||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.path.full`|string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.path.prefix`|string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.status`|integer||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.transformations.request`|object||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.transformations.request.add`|object||
@@ -2346,13 +1975,6 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.connectTimeout`|object||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.connectTimeout.secs`|integer||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.connectTimeout.nanos`|integer||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.health.eviction.duration`|string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.health.eviction.restoreHealth`|number||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.health.eviction.consecutiveFailures`|integer||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.health.eviction.healthThreshold`|number||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service`|object||
@@ -2371,20 +1993,6 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.requestHeaderModifier.add`|object||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.requestHeaderModifier.set`|object||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.requestHeaderModifier.remove`|[]string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.responseHeaderModifier.add`|object||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.responseHeaderModifier.set`|object||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.responseHeaderModifier.remove`|[]string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.scheme`|string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.authority`|string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.authority.full`|string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.authority.host`|string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.authority.port`|integer||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.path`|object||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.path.full`|string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.path.prefix`|string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.status`|integer||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.transformations.request`|object||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.transformations.request.add`|object||
@@ -2446,13 +2054,6 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.connectTimeout`|object||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.connectTimeout.secs`|integer||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.connectTimeout.nanos`|integer||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.health.eviction.duration`|string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.health.eviction.restoreHealth`|number||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.health.eviction.consecutiveFailures`|integer||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.health.eviction.healthThreshold`|number||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service`|object||
@@ -2498,20 +2099,6 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestHeaderModifier.add`|object||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestHeaderModifier.set`|object||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestHeaderModifier.remove`|[]string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.responseHeaderModifier.add`|object||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.responseHeaderModifier.set`|object||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.responseHeaderModifier.remove`|[]string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.scheme`|string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.authority`|string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.authority.full`|string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.authority.host`|string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.authority.port`|integer||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.path`|object||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.path.full`|string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.path.prefix`|string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.status`|integer||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.transformations.request`|object||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.transformations.request.add`|object||
@@ -2573,13 +2160,6 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.connectTimeout`|object||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.connectTimeout.secs`|integer||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.connectTimeout.nanos`|integer||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.health.eviction.duration`|string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.health.eviction.restoreHealth`|number||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.health.eviction.consecutiveFailures`|integer||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.health.eviction.healthThreshold`|number||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service`|object||
@@ -2598,20 +2178,6 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.requestHeaderModifier.add`|object||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.requestHeaderModifier.set`|object||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.requestHeaderModifier.remove`|[]string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.responseHeaderModifier.add`|object||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.responseHeaderModifier.set`|object||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.responseHeaderModifier.remove`|[]string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.scheme`|string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.authority`|string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.authority.full`|string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.authority.host`|string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.authority.port`|integer||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.path`|object||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.path.full`|string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.path.prefix`|string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.status`|integer||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.transformations.request`|object||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.transformations.request.add`|object||
@@ -2673,13 +2239,6 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.connectTimeout`|object||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.connectTimeout.secs`|integer||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.connectTimeout.nanos`|integer||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.health.eviction.duration`|string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.health.eviction.restoreHealth`|number||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.health.eviction.consecutiveFailures`|integer||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.health.eviction.healthThreshold`|number||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service`|object||
@@ -2723,20 +2282,6 @@
 |`binds[].listeners[].routes[].backends[].policies.requestHeaderModifier.add`|object||
 |`binds[].listeners[].routes[].backends[].policies.requestHeaderModifier.set`|object||
 |`binds[].listeners[].routes[].backends[].policies.requestHeaderModifier.remove`|[]string||
-|`binds[].listeners[].routes[].backends[].policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`binds[].listeners[].routes[].backends[].policies.responseHeaderModifier.add`|object||
-|`binds[].listeners[].routes[].backends[].policies.responseHeaderModifier.set`|object||
-|`binds[].listeners[].routes[].backends[].policies.responseHeaderModifier.remove`|[]string||
-|`binds[].listeners[].routes[].backends[].policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`binds[].listeners[].routes[].backends[].policies.requestRedirect.scheme`|string||
-|`binds[].listeners[].routes[].backends[].policies.requestRedirect.authority`|string||
-|`binds[].listeners[].routes[].backends[].policies.requestRedirect.authority.full`|string||
-|`binds[].listeners[].routes[].backends[].policies.requestRedirect.authority.host`|string||
-|`binds[].listeners[].routes[].backends[].policies.requestRedirect.authority.port`|integer||
-|`binds[].listeners[].routes[].backends[].policies.requestRedirect.path`|object||
-|`binds[].listeners[].routes[].backends[].policies.requestRedirect.path.full`|string||
-|`binds[].listeners[].routes[].backends[].policies.requestRedirect.path.prefix`|string||
-|`binds[].listeners[].routes[].backends[].policies.requestRedirect.status`|integer||
 |`binds[].listeners[].routes[].backends[].policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`binds[].listeners[].routes[].backends[].policies.transformations.request`|object||
 |`binds[].listeners[].routes[].backends[].policies.transformations.request.add`|object||
@@ -2798,13 +2343,6 @@
 |`binds[].listeners[].routes[].backends[].policies.tcp.connectTimeout`|object||
 |`binds[].listeners[].routes[].backends[].policies.tcp.connectTimeout.secs`|integer||
 |`binds[].listeners[].routes[].backends[].policies.tcp.connectTimeout.nanos`|integer||
-|`binds[].listeners[].routes[].backends[].policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`binds[].listeners[].routes[].backends[].policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`binds[].listeners[].routes[].backends[].policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`binds[].listeners[].routes[].backends[].policies.health.eviction.duration`|string||
-|`binds[].listeners[].routes[].backends[].policies.health.eviction.restoreHealth`|number||
-|`binds[].listeners[].routes[].backends[].policies.health.eviction.consecutiveFailures`|integer||
-|`binds[].listeners[].routes[].backends[].policies.health.eviction.healthThreshold`|number||
 |`binds[].listeners[].routes[].backends[].policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`binds[].listeners[].routes[].backends[].policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`binds[].listeners[].routes[].backends[].policies.backendTunnel.proxy.service`|object||
@@ -2846,20 +2384,6 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.requestHeaderModifier.add`|object||
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.requestHeaderModifier.set`|object||
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.requestHeaderModifier.remove`|[]string||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.responseHeaderModifier.add`|object||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.responseHeaderModifier.set`|object||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.responseHeaderModifier.remove`|[]string||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.scheme`|string||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.authority`|string||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.authority.full`|string||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.authority.host`|string||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.authority.port`|integer||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.path`|object||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.path.full`|string||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.path.prefix`|string||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.status`|integer||
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.transformations.request`|object||
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.transformations.request.add`|object||
@@ -2921,13 +2445,6 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.connectTimeout`|object||
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.connectTimeout.secs`|integer||
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.connectTimeout.nanos`|integer||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.health.eviction.duration`|string||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.health.eviction.restoreHealth`|number||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.health.eviction.consecutiveFailures`|integer||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.health.eviction.healthThreshold`|number||
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service`|object||
@@ -2946,20 +2463,6 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestHeaderModifier.add`|object||
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestHeaderModifier.set`|object||
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestHeaderModifier.remove`|[]string||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.responseHeaderModifier.add`|object||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.responseHeaderModifier.set`|object||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.responseHeaderModifier.remove`|[]string||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.scheme`|string||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.authority`|string||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.authority.full`|string||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.authority.host`|string||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.authority.port`|integer||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.path`|object||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.path.full`|string||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.path.prefix`|string||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.status`|integer||
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.transformations.request`|object||
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.transformations.request.add`|object||
@@ -3021,13 +2524,6 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.connectTimeout`|object||
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.connectTimeout.secs`|integer||
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.connectTimeout.nanos`|integer||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.health.eviction.duration`|string||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.health.eviction.restoreHealth`|number||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.health.eviction.consecutiveFailures`|integer||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.health.eviction.healthThreshold`|number||
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service`|object||
@@ -3046,20 +2542,6 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.requestHeaderModifier.add`|object||
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.requestHeaderModifier.set`|object||
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.requestHeaderModifier.remove`|[]string||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.responseHeaderModifier.add`|object||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.responseHeaderModifier.set`|object||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.responseHeaderModifier.remove`|[]string||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.scheme`|string||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.authority`|string||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.authority.full`|string||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.authority.host`|string||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.authority.port`|integer||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.path`|object||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.path.full`|string||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.path.prefix`|string||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.status`|integer||
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.transformations.request`|object||
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.transformations.request.add`|object||
@@ -3121,13 +2603,6 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.connectTimeout`|object||
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.connectTimeout.secs`|integer||
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.connectTimeout.nanos`|integer||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.health.eviction.duration`|string||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.health.eviction.restoreHealth`|number||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.health.eviction.consecutiveFailures`|integer||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.health.eviction.healthThreshold`|number||
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service`|object||
@@ -3173,20 +2648,6 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestHeaderModifier.add`|object||
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestHeaderModifier.set`|object||
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestHeaderModifier.remove`|[]string||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.responseHeaderModifier.add`|object||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.responseHeaderModifier.set`|object||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.responseHeaderModifier.remove`|[]string||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.scheme`|string||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.authority`|string||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.authority.full`|string||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.authority.host`|string||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.authority.port`|integer||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.path`|object||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.path.full`|string||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.path.prefix`|string||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.status`|integer||
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.transformations.request`|object||
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.transformations.request.add`|object||
@@ -3248,13 +2709,6 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.connectTimeout`|object||
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.connectTimeout.secs`|integer||
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.connectTimeout.nanos`|integer||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.health.eviction.duration`|string||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.health.eviction.restoreHealth`|number||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.health.eviction.consecutiveFailures`|integer||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.health.eviction.healthThreshold`|number||
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service`|object||
@@ -3273,20 +2727,6 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.requestHeaderModifier.add`|object||
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.requestHeaderModifier.set`|object||
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.requestHeaderModifier.remove`|[]string||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.responseHeaderModifier.add`|object||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.responseHeaderModifier.set`|object||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.responseHeaderModifier.remove`|[]string||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.scheme`|string||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.authority`|string||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.authority.full`|string||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.authority.host`|string||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.authority.port`|integer||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.path`|object||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.path.full`|string||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.path.prefix`|string||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.status`|integer||
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.transformations.request`|object||
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.transformations.request.add`|object||
@@ -3348,13 +2788,6 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.connectTimeout`|object||
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.connectTimeout.secs`|integer||
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.connectTimeout.nanos`|integer||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.health.eviction.duration`|string||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.health.eviction.restoreHealth`|number||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.health.eviction.consecutiveFailures`|integer||
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.health.eviction.healthThreshold`|number||
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service`|object||
@@ -3478,20 +2911,6 @@
 |`binds[].listeners[].policies.extAuthz.policies.requestHeaderModifier.add`|object||
 |`binds[].listeners[].policies.extAuthz.policies.requestHeaderModifier.set`|object||
 |`binds[].listeners[].policies.extAuthz.policies.requestHeaderModifier.remove`|[]string||
-|`binds[].listeners[].policies.extAuthz.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`binds[].listeners[].policies.extAuthz.policies.responseHeaderModifier.add`|object||
-|`binds[].listeners[].policies.extAuthz.policies.responseHeaderModifier.set`|object||
-|`binds[].listeners[].policies.extAuthz.policies.responseHeaderModifier.remove`|[]string||
-|`binds[].listeners[].policies.extAuthz.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`binds[].listeners[].policies.extAuthz.policies.requestRedirect.scheme`|string||
-|`binds[].listeners[].policies.extAuthz.policies.requestRedirect.authority`|string||
-|`binds[].listeners[].policies.extAuthz.policies.requestRedirect.authority.full`|string||
-|`binds[].listeners[].policies.extAuthz.policies.requestRedirect.authority.host`|string||
-|`binds[].listeners[].policies.extAuthz.policies.requestRedirect.authority.port`|integer||
-|`binds[].listeners[].policies.extAuthz.policies.requestRedirect.path`|object||
-|`binds[].listeners[].policies.extAuthz.policies.requestRedirect.path.full`|string||
-|`binds[].listeners[].policies.extAuthz.policies.requestRedirect.path.prefix`|string||
-|`binds[].listeners[].policies.extAuthz.policies.requestRedirect.status`|integer||
 |`binds[].listeners[].policies.extAuthz.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`binds[].listeners[].policies.extAuthz.policies.transformations.request`|object||
 |`binds[].listeners[].policies.extAuthz.policies.transformations.request.add`|object||
@@ -3553,13 +2972,6 @@
 |`binds[].listeners[].policies.extAuthz.policies.tcp.connectTimeout`|object||
 |`binds[].listeners[].policies.extAuthz.policies.tcp.connectTimeout.secs`|integer||
 |`binds[].listeners[].policies.extAuthz.policies.tcp.connectTimeout.nanos`|integer||
-|`binds[].listeners[].policies.extAuthz.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`binds[].listeners[].policies.extAuthz.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`binds[].listeners[].policies.extAuthz.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`binds[].listeners[].policies.extAuthz.policies.health.eviction.duration`|string||
-|`binds[].listeners[].policies.extAuthz.policies.health.eviction.restoreHealth`|number||
-|`binds[].listeners[].policies.extAuthz.policies.health.eviction.consecutiveFailures`|integer||
-|`binds[].listeners[].policies.extAuthz.policies.health.eviction.healthThreshold`|number||
 |`binds[].listeners[].policies.extAuthz.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`binds[].listeners[].policies.extAuthz.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`binds[].listeners[].policies.extAuthz.policies.backendTunnel.proxy.service`|object||
@@ -3599,20 +3011,6 @@
 |`binds[].listeners[].policies.extProc.policies.requestHeaderModifier.add`|object||
 |`binds[].listeners[].policies.extProc.policies.requestHeaderModifier.set`|object||
 |`binds[].listeners[].policies.extProc.policies.requestHeaderModifier.remove`|[]string||
-|`binds[].listeners[].policies.extProc.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`binds[].listeners[].policies.extProc.policies.responseHeaderModifier.add`|object||
-|`binds[].listeners[].policies.extProc.policies.responseHeaderModifier.set`|object||
-|`binds[].listeners[].policies.extProc.policies.responseHeaderModifier.remove`|[]string||
-|`binds[].listeners[].policies.extProc.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`binds[].listeners[].policies.extProc.policies.requestRedirect.scheme`|string||
-|`binds[].listeners[].policies.extProc.policies.requestRedirect.authority`|string||
-|`binds[].listeners[].policies.extProc.policies.requestRedirect.authority.full`|string||
-|`binds[].listeners[].policies.extProc.policies.requestRedirect.authority.host`|string||
-|`binds[].listeners[].policies.extProc.policies.requestRedirect.authority.port`|integer||
-|`binds[].listeners[].policies.extProc.policies.requestRedirect.path`|object||
-|`binds[].listeners[].policies.extProc.policies.requestRedirect.path.full`|string||
-|`binds[].listeners[].policies.extProc.policies.requestRedirect.path.prefix`|string||
-|`binds[].listeners[].policies.extProc.policies.requestRedirect.status`|integer||
 |`binds[].listeners[].policies.extProc.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`binds[].listeners[].policies.extProc.policies.transformations.request`|object||
 |`binds[].listeners[].policies.extProc.policies.transformations.request.add`|object||
@@ -3674,13 +3072,6 @@
 |`binds[].listeners[].policies.extProc.policies.tcp.connectTimeout`|object||
 |`binds[].listeners[].policies.extProc.policies.tcp.connectTimeout.secs`|integer||
 |`binds[].listeners[].policies.extProc.policies.tcp.connectTimeout.nanos`|integer||
-|`binds[].listeners[].policies.extProc.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`binds[].listeners[].policies.extProc.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`binds[].listeners[].policies.extProc.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`binds[].listeners[].policies.extProc.policies.health.eviction.duration`|string||
-|`binds[].listeners[].policies.extProc.policies.health.eviction.restoreHealth`|number||
-|`binds[].listeners[].policies.extProc.policies.health.eviction.consecutiveFailures`|integer||
-|`binds[].listeners[].policies.extProc.policies.health.eviction.healthThreshold`|number||
 |`binds[].listeners[].policies.extProc.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`binds[].listeners[].policies.extProc.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`binds[].listeners[].policies.extProc.policies.backendTunnel.proxy.service`|object||
@@ -3759,20 +3150,6 @@
 |`frontendPolicies.accessLog.otlp.policies.requestHeaderModifier.add`|object||
 |`frontendPolicies.accessLog.otlp.policies.requestHeaderModifier.set`|object||
 |`frontendPolicies.accessLog.otlp.policies.requestHeaderModifier.remove`|[]string||
-|`frontendPolicies.accessLog.otlp.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`frontendPolicies.accessLog.otlp.policies.responseHeaderModifier.add`|object||
-|`frontendPolicies.accessLog.otlp.policies.responseHeaderModifier.set`|object||
-|`frontendPolicies.accessLog.otlp.policies.responseHeaderModifier.remove`|[]string||
-|`frontendPolicies.accessLog.otlp.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`frontendPolicies.accessLog.otlp.policies.requestRedirect.scheme`|string||
-|`frontendPolicies.accessLog.otlp.policies.requestRedirect.authority`|string||
-|`frontendPolicies.accessLog.otlp.policies.requestRedirect.authority.full`|string||
-|`frontendPolicies.accessLog.otlp.policies.requestRedirect.authority.host`|string||
-|`frontendPolicies.accessLog.otlp.policies.requestRedirect.authority.port`|integer||
-|`frontendPolicies.accessLog.otlp.policies.requestRedirect.path`|object||
-|`frontendPolicies.accessLog.otlp.policies.requestRedirect.path.full`|string||
-|`frontendPolicies.accessLog.otlp.policies.requestRedirect.path.prefix`|string||
-|`frontendPolicies.accessLog.otlp.policies.requestRedirect.status`|integer||
 |`frontendPolicies.accessLog.otlp.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`frontendPolicies.accessLog.otlp.policies.transformations.request`|object||
 |`frontendPolicies.accessLog.otlp.policies.transformations.request.add`|object||
@@ -3834,13 +3211,6 @@
 |`frontendPolicies.accessLog.otlp.policies.tcp.connectTimeout`|object||
 |`frontendPolicies.accessLog.otlp.policies.tcp.connectTimeout.secs`|integer||
 |`frontendPolicies.accessLog.otlp.policies.tcp.connectTimeout.nanos`|integer||
-|`frontendPolicies.accessLog.otlp.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`frontendPolicies.accessLog.otlp.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`frontendPolicies.accessLog.otlp.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`frontendPolicies.accessLog.otlp.policies.health.eviction.duration`|string||
-|`frontendPolicies.accessLog.otlp.policies.health.eviction.restoreHealth`|number||
-|`frontendPolicies.accessLog.otlp.policies.health.eviction.consecutiveFailures`|integer||
-|`frontendPolicies.accessLog.otlp.policies.health.eviction.healthThreshold`|number||
 |`frontendPolicies.accessLog.otlp.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`frontendPolicies.accessLog.otlp.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`frontendPolicies.accessLog.otlp.policies.backendTunnel.proxy.service`|object||
@@ -3865,20 +3235,6 @@
 |`frontendPolicies.tracing.policies.requestHeaderModifier.add`|object||
 |`frontendPolicies.tracing.policies.requestHeaderModifier.set`|object||
 |`frontendPolicies.tracing.policies.requestHeaderModifier.remove`|[]string||
-|`frontendPolicies.tracing.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`frontendPolicies.tracing.policies.responseHeaderModifier.add`|object||
-|`frontendPolicies.tracing.policies.responseHeaderModifier.set`|object||
-|`frontendPolicies.tracing.policies.responseHeaderModifier.remove`|[]string||
-|`frontendPolicies.tracing.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`frontendPolicies.tracing.policies.requestRedirect.scheme`|string||
-|`frontendPolicies.tracing.policies.requestRedirect.authority`|string||
-|`frontendPolicies.tracing.policies.requestRedirect.authority.full`|string||
-|`frontendPolicies.tracing.policies.requestRedirect.authority.host`|string||
-|`frontendPolicies.tracing.policies.requestRedirect.authority.port`|integer||
-|`frontendPolicies.tracing.policies.requestRedirect.path`|object||
-|`frontendPolicies.tracing.policies.requestRedirect.path.full`|string||
-|`frontendPolicies.tracing.policies.requestRedirect.path.prefix`|string||
-|`frontendPolicies.tracing.policies.requestRedirect.status`|integer||
 |`frontendPolicies.tracing.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`frontendPolicies.tracing.policies.transformations.request`|object||
 |`frontendPolicies.tracing.policies.transformations.request.add`|object||
@@ -3940,13 +3296,6 @@
 |`frontendPolicies.tracing.policies.tcp.connectTimeout`|object||
 |`frontendPolicies.tracing.policies.tcp.connectTimeout.secs`|integer||
 |`frontendPolicies.tracing.policies.tcp.connectTimeout.nanos`|integer||
-|`frontendPolicies.tracing.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`frontendPolicies.tracing.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`frontendPolicies.tracing.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`frontendPolicies.tracing.policies.health.eviction.duration`|string||
-|`frontendPolicies.tracing.policies.health.eviction.restoreHealth`|number||
-|`frontendPolicies.tracing.policies.health.eviction.consecutiveFailures`|integer||
-|`frontendPolicies.tracing.policies.health.eviction.healthThreshold`|number||
 |`frontendPolicies.tracing.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`frontendPolicies.tracing.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`frontendPolicies.tracing.policies.backendTunnel.proxy.service`|object||
@@ -4081,20 +3430,6 @@
 |`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.requestHeaderModifier.add`|object||
 |`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.requestHeaderModifier.set`|object||
 |`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.requestHeaderModifier.remove`|[]string||
-|`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.responseHeaderModifier.add`|object||
-|`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.responseHeaderModifier.set`|object||
-|`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.responseHeaderModifier.remove`|[]string||
-|`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.scheme`|string||
-|`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.authority`|string||
-|`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.authority.full`|string||
-|`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.authority.host`|string||
-|`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.authority.port`|integer||
-|`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.path`|object||
-|`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.path.full`|string||
-|`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.path.prefix`|string||
-|`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.status`|integer||
 |`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.transformations.request`|object||
 |`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.transformations.request.add`|object||
@@ -4156,13 +3491,6 @@
 |`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.tcp.connectTimeout`|object||
 |`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.tcp.connectTimeout.secs`|integer||
 |`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.tcp.connectTimeout.nanos`|integer||
-|`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.health.eviction.duration`|string||
-|`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.health.eviction.restoreHealth`|number||
-|`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.health.eviction.consecutiveFailures`|integer||
-|`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.health.eviction.healthThreshold`|number||
 |`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service`|object||
@@ -4181,20 +3509,6 @@
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.requestHeaderModifier.add`|object||
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.requestHeaderModifier.set`|object||
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.requestHeaderModifier.remove`|[]string||
-|`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.responseHeaderModifier.add`|object||
-|`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.responseHeaderModifier.set`|object||
-|`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.responseHeaderModifier.remove`|[]string||
-|`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.scheme`|string||
-|`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.authority`|string||
-|`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.authority.full`|string||
-|`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.authority.host`|string||
-|`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.authority.port`|integer||
-|`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.path`|object||
-|`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.path.full`|string||
-|`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.path.prefix`|string||
-|`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.status`|integer||
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.transformations.request`|object||
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.transformations.request.add`|object||
@@ -4256,13 +3570,6 @@
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.connectTimeout`|object||
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.connectTimeout.secs`|integer||
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.connectTimeout.nanos`|integer||
-|`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.health.eviction.duration`|string||
-|`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.health.eviction.restoreHealth`|number||
-|`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.health.eviction.consecutiveFailures`|integer||
-|`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.health.eviction.healthThreshold`|number||
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service`|object||
@@ -4281,20 +3588,6 @@
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.requestHeaderModifier.add`|object||
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.requestHeaderModifier.set`|object||
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.requestHeaderModifier.remove`|[]string||
-|`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.responseHeaderModifier.add`|object||
-|`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.responseHeaderModifier.set`|object||
-|`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.responseHeaderModifier.remove`|[]string||
-|`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.scheme`|string||
-|`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.authority`|string||
-|`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.authority.full`|string||
-|`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.authority.host`|string||
-|`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.authority.port`|integer||
-|`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.path`|object||
-|`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.path.full`|string||
-|`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.path.prefix`|string||
-|`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.status`|integer||
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.transformations.request`|object||
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.transformations.request.add`|object||
@@ -4356,13 +3649,6 @@
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.tcp.connectTimeout`|object||
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.tcp.connectTimeout.secs`|integer||
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.tcp.connectTimeout.nanos`|integer||
-|`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.health.eviction.duration`|string||
-|`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.health.eviction.restoreHealth`|number||
-|`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.health.eviction.consecutiveFailures`|integer||
-|`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.health.eviction.healthThreshold`|number||
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service`|object||
@@ -4408,20 +3694,6 @@
 |`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.requestHeaderModifier.add`|object||
 |`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.requestHeaderModifier.set`|object||
 |`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.requestHeaderModifier.remove`|[]string||
-|`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.responseHeaderModifier.add`|object||
-|`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.responseHeaderModifier.set`|object||
-|`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.responseHeaderModifier.remove`|[]string||
-|`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.scheme`|string||
-|`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.authority`|string||
-|`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.authority.full`|string||
-|`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.authority.host`|string||
-|`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.authority.port`|integer||
-|`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.path`|object||
-|`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.path.full`|string||
-|`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.path.prefix`|string||
-|`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.status`|integer||
 |`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.transformations.request`|object||
 |`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.transformations.request.add`|object||
@@ -4483,13 +3755,6 @@
 |`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.connectTimeout`|object||
 |`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.connectTimeout.secs`|integer||
 |`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.connectTimeout.nanos`|integer||
-|`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.health.eviction.duration`|string||
-|`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.health.eviction.restoreHealth`|number||
-|`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.health.eviction.consecutiveFailures`|integer||
-|`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.health.eviction.healthThreshold`|number||
 |`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service`|object||
@@ -4508,20 +3773,6 @@
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.requestHeaderModifier.add`|object||
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.requestHeaderModifier.set`|object||
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.requestHeaderModifier.remove`|[]string||
-|`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.responseHeaderModifier.add`|object||
-|`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.responseHeaderModifier.set`|object||
-|`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.responseHeaderModifier.remove`|[]string||
-|`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.scheme`|string||
-|`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.authority`|string||
-|`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.authority.full`|string||
-|`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.authority.host`|string||
-|`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.authority.port`|integer||
-|`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.path`|object||
-|`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.path.full`|string||
-|`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.path.prefix`|string||
-|`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.status`|integer||
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.transformations.request`|object||
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.transformations.request.add`|object||
@@ -4583,13 +3834,6 @@
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.tcp.connectTimeout`|object||
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.tcp.connectTimeout.secs`|integer||
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.tcp.connectTimeout.nanos`|integer||
-|`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.health.eviction.duration`|string||
-|`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.health.eviction.restoreHealth`|number||
-|`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.health.eviction.consecutiveFailures`|integer||
-|`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.health.eviction.healthThreshold`|number||
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service`|object||
@@ -4687,20 +3931,6 @@
 |`policies[].policy.remoteRateLimit.policies.requestHeaderModifier.add`|object||
 |`policies[].policy.remoteRateLimit.policies.requestHeaderModifier.set`|object||
 |`policies[].policy.remoteRateLimit.policies.requestHeaderModifier.remove`|[]string||
-|`policies[].policy.remoteRateLimit.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`policies[].policy.remoteRateLimit.policies.responseHeaderModifier.add`|object||
-|`policies[].policy.remoteRateLimit.policies.responseHeaderModifier.set`|object||
-|`policies[].policy.remoteRateLimit.policies.responseHeaderModifier.remove`|[]string||
-|`policies[].policy.remoteRateLimit.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`policies[].policy.remoteRateLimit.policies.requestRedirect.scheme`|string||
-|`policies[].policy.remoteRateLimit.policies.requestRedirect.authority`|string||
-|`policies[].policy.remoteRateLimit.policies.requestRedirect.authority.full`|string||
-|`policies[].policy.remoteRateLimit.policies.requestRedirect.authority.host`|string||
-|`policies[].policy.remoteRateLimit.policies.requestRedirect.authority.port`|integer||
-|`policies[].policy.remoteRateLimit.policies.requestRedirect.path`|object||
-|`policies[].policy.remoteRateLimit.policies.requestRedirect.path.full`|string||
-|`policies[].policy.remoteRateLimit.policies.requestRedirect.path.prefix`|string||
-|`policies[].policy.remoteRateLimit.policies.requestRedirect.status`|integer||
 |`policies[].policy.remoteRateLimit.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`policies[].policy.remoteRateLimit.policies.transformations.request`|object||
 |`policies[].policy.remoteRateLimit.policies.transformations.request.add`|object||
@@ -4762,13 +3992,6 @@
 |`policies[].policy.remoteRateLimit.policies.tcp.connectTimeout`|object||
 |`policies[].policy.remoteRateLimit.policies.tcp.connectTimeout.secs`|integer||
 |`policies[].policy.remoteRateLimit.policies.tcp.connectTimeout.nanos`|integer||
-|`policies[].policy.remoteRateLimit.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`policies[].policy.remoteRateLimit.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`policies[].policy.remoteRateLimit.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`policies[].policy.remoteRateLimit.policies.health.eviction.duration`|string||
-|`policies[].policy.remoteRateLimit.policies.health.eviction.restoreHealth`|number||
-|`policies[].policy.remoteRateLimit.policies.health.eviction.consecutiveFailures`|integer||
-|`policies[].policy.remoteRateLimit.policies.health.eviction.healthThreshold`|number||
 |`policies[].policy.remoteRateLimit.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`policies[].policy.remoteRateLimit.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`policies[].policy.remoteRateLimit.policies.backendTunnel.proxy.service`|object||
@@ -4840,20 +4063,6 @@
 |`policies[].policy.extAuthz.policies.requestHeaderModifier.add`|object||
 |`policies[].policy.extAuthz.policies.requestHeaderModifier.set`|object||
 |`policies[].policy.extAuthz.policies.requestHeaderModifier.remove`|[]string||
-|`policies[].policy.extAuthz.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`policies[].policy.extAuthz.policies.responseHeaderModifier.add`|object||
-|`policies[].policy.extAuthz.policies.responseHeaderModifier.set`|object||
-|`policies[].policy.extAuthz.policies.responseHeaderModifier.remove`|[]string||
-|`policies[].policy.extAuthz.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`policies[].policy.extAuthz.policies.requestRedirect.scheme`|string||
-|`policies[].policy.extAuthz.policies.requestRedirect.authority`|string||
-|`policies[].policy.extAuthz.policies.requestRedirect.authority.full`|string||
-|`policies[].policy.extAuthz.policies.requestRedirect.authority.host`|string||
-|`policies[].policy.extAuthz.policies.requestRedirect.authority.port`|integer||
-|`policies[].policy.extAuthz.policies.requestRedirect.path`|object||
-|`policies[].policy.extAuthz.policies.requestRedirect.path.full`|string||
-|`policies[].policy.extAuthz.policies.requestRedirect.path.prefix`|string||
-|`policies[].policy.extAuthz.policies.requestRedirect.status`|integer||
 |`policies[].policy.extAuthz.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`policies[].policy.extAuthz.policies.transformations.request`|object||
 |`policies[].policy.extAuthz.policies.transformations.request.add`|object||
@@ -4915,13 +4124,6 @@
 |`policies[].policy.extAuthz.policies.tcp.connectTimeout`|object||
 |`policies[].policy.extAuthz.policies.tcp.connectTimeout.secs`|integer||
 |`policies[].policy.extAuthz.policies.tcp.connectTimeout.nanos`|integer||
-|`policies[].policy.extAuthz.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`policies[].policy.extAuthz.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`policies[].policy.extAuthz.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`policies[].policy.extAuthz.policies.health.eviction.duration`|string||
-|`policies[].policy.extAuthz.policies.health.eviction.restoreHealth`|number||
-|`policies[].policy.extAuthz.policies.health.eviction.consecutiveFailures`|integer||
-|`policies[].policy.extAuthz.policies.health.eviction.healthThreshold`|number||
 |`policies[].policy.extAuthz.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`policies[].policy.extAuthz.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`policies[].policy.extAuthz.policies.backendTunnel.proxy.service`|object||
@@ -4961,20 +4163,6 @@
 |`policies[].policy.extProc.policies.requestHeaderModifier.add`|object||
 |`policies[].policy.extProc.policies.requestHeaderModifier.set`|object||
 |`policies[].policy.extProc.policies.requestHeaderModifier.remove`|[]string||
-|`policies[].policy.extProc.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`policies[].policy.extProc.policies.responseHeaderModifier.add`|object||
-|`policies[].policy.extProc.policies.responseHeaderModifier.set`|object||
-|`policies[].policy.extProc.policies.responseHeaderModifier.remove`|[]string||
-|`policies[].policy.extProc.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`policies[].policy.extProc.policies.requestRedirect.scheme`|string||
-|`policies[].policy.extProc.policies.requestRedirect.authority`|string||
-|`policies[].policy.extProc.policies.requestRedirect.authority.full`|string||
-|`policies[].policy.extProc.policies.requestRedirect.authority.host`|string||
-|`policies[].policy.extProc.policies.requestRedirect.authority.port`|integer||
-|`policies[].policy.extProc.policies.requestRedirect.path`|object||
-|`policies[].policy.extProc.policies.requestRedirect.path.full`|string||
-|`policies[].policy.extProc.policies.requestRedirect.path.prefix`|string||
-|`policies[].policy.extProc.policies.requestRedirect.status`|integer||
 |`policies[].policy.extProc.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`policies[].policy.extProc.policies.transformations.request`|object||
 |`policies[].policy.extProc.policies.transformations.request.add`|object||
@@ -5036,13 +4224,6 @@
 |`policies[].policy.extProc.policies.tcp.connectTimeout`|object||
 |`policies[].policy.extProc.policies.tcp.connectTimeout.secs`|integer||
 |`policies[].policy.extProc.policies.tcp.connectTimeout.nanos`|integer||
-|`policies[].policy.extProc.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`policies[].policy.extProc.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`policies[].policy.extProc.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`policies[].policy.extProc.policies.health.eviction.duration`|string||
-|`policies[].policy.extProc.policies.health.eviction.restoreHealth`|number||
-|`policies[].policy.extProc.policies.health.eviction.consecutiveFailures`|integer||
-|`policies[].policy.extProc.policies.health.eviction.healthThreshold`|number||
 |`policies[].policy.extProc.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`policies[].policy.extProc.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`policies[].policy.extProc.policies.backendTunnel.proxy.service`|object||
@@ -5088,20 +4269,6 @@
 |`backends[].policies.requestHeaderModifier.add`|object||
 |`backends[].policies.requestHeaderModifier.set`|object||
 |`backends[].policies.requestHeaderModifier.remove`|[]string||
-|`backends[].policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`backends[].policies.responseHeaderModifier.add`|object||
-|`backends[].policies.responseHeaderModifier.set`|object||
-|`backends[].policies.responseHeaderModifier.remove`|[]string||
-|`backends[].policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`backends[].policies.requestRedirect.scheme`|string||
-|`backends[].policies.requestRedirect.authority`|string||
-|`backends[].policies.requestRedirect.authority.full`|string||
-|`backends[].policies.requestRedirect.authority.host`|string||
-|`backends[].policies.requestRedirect.authority.port`|integer||
-|`backends[].policies.requestRedirect.path`|object||
-|`backends[].policies.requestRedirect.path.full`|string||
-|`backends[].policies.requestRedirect.path.prefix`|string||
-|`backends[].policies.requestRedirect.status`|integer||
 |`backends[].policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`backends[].policies.transformations.request`|object||
 |`backends[].policies.transformations.request.add`|object||
@@ -5163,13 +4330,6 @@
 |`backends[].policies.tcp.connectTimeout`|object||
 |`backends[].policies.tcp.connectTimeout.secs`|integer||
 |`backends[].policies.tcp.connectTimeout.nanos`|integer||
-|`backends[].policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`backends[].policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`backends[].policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`backends[].policies.health.eviction.duration`|string||
-|`backends[].policies.health.eviction.restoreHealth`|number||
-|`backends[].policies.health.eviction.consecutiveFailures`|integer||
-|`backends[].policies.health.eviction.healthThreshold`|number||
 |`backends[].policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`backends[].policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`backends[].policies.backendTunnel.proxy.service`|object||
@@ -5211,20 +4371,6 @@
 |`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.requestHeaderModifier.add`|object||
 |`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.requestHeaderModifier.set`|object||
 |`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.requestHeaderModifier.remove`|[]string||
-|`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.responseHeaderModifier.add`|object||
-|`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.responseHeaderModifier.set`|object||
-|`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.responseHeaderModifier.remove`|[]string||
-|`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.scheme`|string||
-|`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.authority`|string||
-|`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.authority.full`|string||
-|`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.authority.host`|string||
-|`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.authority.port`|integer||
-|`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.path`|object||
-|`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.path.full`|string||
-|`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.path.prefix`|string||
-|`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.status`|integer||
 |`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.transformations.request`|object||
 |`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.transformations.request.add`|object||
@@ -5286,13 +4432,6 @@
 |`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.connectTimeout`|object||
 |`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.connectTimeout.secs`|integer||
 |`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.connectTimeout.nanos`|integer||
-|`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.health.eviction.duration`|string||
-|`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.health.eviction.restoreHealth`|number||
-|`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.health.eviction.consecutiveFailures`|integer||
-|`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.health.eviction.healthThreshold`|number||
 |`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service`|object||
@@ -5311,20 +4450,6 @@
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestHeaderModifier.add`|object||
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestHeaderModifier.set`|object||
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestHeaderModifier.remove`|[]string||
-|`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.responseHeaderModifier.add`|object||
-|`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.responseHeaderModifier.set`|object||
-|`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.responseHeaderModifier.remove`|[]string||
-|`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.scheme`|string||
-|`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.authority`|string||
-|`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.authority.full`|string||
-|`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.authority.host`|string||
-|`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.authority.port`|integer||
-|`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.path`|object||
-|`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.path.full`|string||
-|`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.path.prefix`|string||
-|`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.status`|integer||
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.transformations.request`|object||
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.transformations.request.add`|object||
@@ -5386,13 +4511,6 @@
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.connectTimeout`|object||
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.connectTimeout.secs`|integer||
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.connectTimeout.nanos`|integer||
-|`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.health.eviction.duration`|string||
-|`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.health.eviction.restoreHealth`|number||
-|`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.health.eviction.consecutiveFailures`|integer||
-|`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.health.eviction.healthThreshold`|number||
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service`|object||
@@ -5411,20 +4529,6 @@
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.requestHeaderModifier.add`|object||
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.requestHeaderModifier.set`|object||
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.requestHeaderModifier.remove`|[]string||
-|`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.responseHeaderModifier.add`|object||
-|`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.responseHeaderModifier.set`|object||
-|`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.responseHeaderModifier.remove`|[]string||
-|`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.scheme`|string||
-|`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.authority`|string||
-|`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.authority.full`|string||
-|`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.authority.host`|string||
-|`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.authority.port`|integer||
-|`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.path`|object||
-|`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.path.full`|string||
-|`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.path.prefix`|string||
-|`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.status`|integer||
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.transformations.request`|object||
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.transformations.request.add`|object||
@@ -5486,13 +4590,6 @@
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.connectTimeout`|object||
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.connectTimeout.secs`|integer||
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.connectTimeout.nanos`|integer||
-|`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.health.eviction.duration`|string||
-|`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.health.eviction.restoreHealth`|number||
-|`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.health.eviction.consecutiveFailures`|integer||
-|`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.health.eviction.healthThreshold`|number||
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service`|object||
@@ -5538,20 +4635,6 @@
 |`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestHeaderModifier.add`|object||
 |`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestHeaderModifier.set`|object||
 |`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestHeaderModifier.remove`|[]string||
-|`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.responseHeaderModifier.add`|object||
-|`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.responseHeaderModifier.set`|object||
-|`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.responseHeaderModifier.remove`|[]string||
-|`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.scheme`|string||
-|`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.authority`|string||
-|`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.authority.full`|string||
-|`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.authority.host`|string||
-|`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.authority.port`|integer||
-|`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.path`|object||
-|`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.path.full`|string||
-|`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.path.prefix`|string||
-|`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.status`|integer||
 |`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.transformations.request`|object||
 |`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.transformations.request.add`|object||
@@ -5613,13 +4696,6 @@
 |`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.connectTimeout`|object||
 |`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.connectTimeout.secs`|integer||
 |`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.connectTimeout.nanos`|integer||
-|`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.health.eviction.duration`|string||
-|`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.health.eviction.restoreHealth`|number||
-|`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.health.eviction.consecutiveFailures`|integer||
-|`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.health.eviction.healthThreshold`|number||
 |`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service`|object||
@@ -5638,20 +4714,6 @@
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.requestHeaderModifier.add`|object||
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.requestHeaderModifier.set`|object||
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.requestHeaderModifier.remove`|[]string||
-|`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.responseHeaderModifier.add`|object||
-|`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.responseHeaderModifier.set`|object||
-|`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.responseHeaderModifier.remove`|[]string||
-|`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.scheme`|string||
-|`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.authority`|string||
-|`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.authority.full`|string||
-|`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.authority.host`|string||
-|`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.authority.port`|integer||
-|`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.path`|object||
-|`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.path.full`|string||
-|`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.path.prefix`|string||
-|`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.status`|integer||
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.transformations.request`|object||
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.transformations.request.add`|object||
@@ -5713,13 +4775,6 @@
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.connectTimeout`|object||
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.connectTimeout.secs`|integer||
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.connectTimeout.nanos`|integer||
-|`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.health.eviction.duration`|string||
-|`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.health.eviction.restoreHealth`|number||
-|`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.health.eviction.consecutiveFailures`|integer||
-|`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.health.eviction.healthThreshold`|number||
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service`|object||
@@ -5835,20 +4890,6 @@
 |`llm.models[].guardrails.request[].openAIModeration.policies.requestHeaderModifier.add`|object||
 |`llm.models[].guardrails.request[].openAIModeration.policies.requestHeaderModifier.set`|object||
 |`llm.models[].guardrails.request[].openAIModeration.policies.requestHeaderModifier.remove`|[]string||
-|`llm.models[].guardrails.request[].openAIModeration.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`llm.models[].guardrails.request[].openAIModeration.policies.responseHeaderModifier.add`|object||
-|`llm.models[].guardrails.request[].openAIModeration.policies.responseHeaderModifier.set`|object||
-|`llm.models[].guardrails.request[].openAIModeration.policies.responseHeaderModifier.remove`|[]string||
-|`llm.models[].guardrails.request[].openAIModeration.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`llm.models[].guardrails.request[].openAIModeration.policies.requestRedirect.scheme`|string||
-|`llm.models[].guardrails.request[].openAIModeration.policies.requestRedirect.authority`|string||
-|`llm.models[].guardrails.request[].openAIModeration.policies.requestRedirect.authority.full`|string||
-|`llm.models[].guardrails.request[].openAIModeration.policies.requestRedirect.authority.host`|string||
-|`llm.models[].guardrails.request[].openAIModeration.policies.requestRedirect.authority.port`|integer||
-|`llm.models[].guardrails.request[].openAIModeration.policies.requestRedirect.path`|object||
-|`llm.models[].guardrails.request[].openAIModeration.policies.requestRedirect.path.full`|string||
-|`llm.models[].guardrails.request[].openAIModeration.policies.requestRedirect.path.prefix`|string||
-|`llm.models[].guardrails.request[].openAIModeration.policies.requestRedirect.status`|integer||
 |`llm.models[].guardrails.request[].openAIModeration.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`llm.models[].guardrails.request[].openAIModeration.policies.transformations.request`|object||
 |`llm.models[].guardrails.request[].openAIModeration.policies.transformations.request.add`|object||
@@ -5910,13 +4951,6 @@
 |`llm.models[].guardrails.request[].openAIModeration.policies.tcp.connectTimeout`|object||
 |`llm.models[].guardrails.request[].openAIModeration.policies.tcp.connectTimeout.secs`|integer||
 |`llm.models[].guardrails.request[].openAIModeration.policies.tcp.connectTimeout.nanos`|integer||
-|`llm.models[].guardrails.request[].openAIModeration.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`llm.models[].guardrails.request[].openAIModeration.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`llm.models[].guardrails.request[].openAIModeration.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`llm.models[].guardrails.request[].openAIModeration.policies.health.eviction.duration`|string||
-|`llm.models[].guardrails.request[].openAIModeration.policies.health.eviction.restoreHealth`|number||
-|`llm.models[].guardrails.request[].openAIModeration.policies.health.eviction.consecutiveFailures`|integer||
-|`llm.models[].guardrails.request[].openAIModeration.policies.health.eviction.healthThreshold`|number||
 |`llm.models[].guardrails.request[].openAIModeration.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`llm.models[].guardrails.request[].openAIModeration.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`llm.models[].guardrails.request[].openAIModeration.policies.backendTunnel.proxy.service`|object||
@@ -5935,20 +4969,6 @@
 |`llm.models[].guardrails.request[].bedrockGuardrails.policies.requestHeaderModifier.add`|object||
 |`llm.models[].guardrails.request[].bedrockGuardrails.policies.requestHeaderModifier.set`|object||
 |`llm.models[].guardrails.request[].bedrockGuardrails.policies.requestHeaderModifier.remove`|[]string||
-|`llm.models[].guardrails.request[].bedrockGuardrails.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`llm.models[].guardrails.request[].bedrockGuardrails.policies.responseHeaderModifier.add`|object||
-|`llm.models[].guardrails.request[].bedrockGuardrails.policies.responseHeaderModifier.set`|object||
-|`llm.models[].guardrails.request[].bedrockGuardrails.policies.responseHeaderModifier.remove`|[]string||
-|`llm.models[].guardrails.request[].bedrockGuardrails.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`llm.models[].guardrails.request[].bedrockGuardrails.policies.requestRedirect.scheme`|string||
-|`llm.models[].guardrails.request[].bedrockGuardrails.policies.requestRedirect.authority`|string||
-|`llm.models[].guardrails.request[].bedrockGuardrails.policies.requestRedirect.authority.full`|string||
-|`llm.models[].guardrails.request[].bedrockGuardrails.policies.requestRedirect.authority.host`|string||
-|`llm.models[].guardrails.request[].bedrockGuardrails.policies.requestRedirect.authority.port`|integer||
-|`llm.models[].guardrails.request[].bedrockGuardrails.policies.requestRedirect.path`|object||
-|`llm.models[].guardrails.request[].bedrockGuardrails.policies.requestRedirect.path.full`|string||
-|`llm.models[].guardrails.request[].bedrockGuardrails.policies.requestRedirect.path.prefix`|string||
-|`llm.models[].guardrails.request[].bedrockGuardrails.policies.requestRedirect.status`|integer||
 |`llm.models[].guardrails.request[].bedrockGuardrails.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`llm.models[].guardrails.request[].bedrockGuardrails.policies.transformations.request`|object||
 |`llm.models[].guardrails.request[].bedrockGuardrails.policies.transformations.request.add`|object||
@@ -6010,13 +5030,6 @@
 |`llm.models[].guardrails.request[].bedrockGuardrails.policies.tcp.connectTimeout`|object||
 |`llm.models[].guardrails.request[].bedrockGuardrails.policies.tcp.connectTimeout.secs`|integer||
 |`llm.models[].guardrails.request[].bedrockGuardrails.policies.tcp.connectTimeout.nanos`|integer||
-|`llm.models[].guardrails.request[].bedrockGuardrails.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`llm.models[].guardrails.request[].bedrockGuardrails.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`llm.models[].guardrails.request[].bedrockGuardrails.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`llm.models[].guardrails.request[].bedrockGuardrails.policies.health.eviction.duration`|string||
-|`llm.models[].guardrails.request[].bedrockGuardrails.policies.health.eviction.restoreHealth`|number||
-|`llm.models[].guardrails.request[].bedrockGuardrails.policies.health.eviction.consecutiveFailures`|integer||
-|`llm.models[].guardrails.request[].bedrockGuardrails.policies.health.eviction.healthThreshold`|number||
 |`llm.models[].guardrails.request[].bedrockGuardrails.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`llm.models[].guardrails.request[].bedrockGuardrails.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`llm.models[].guardrails.request[].bedrockGuardrails.policies.backendTunnel.proxy.service`|object||
@@ -6035,20 +5048,6 @@
 |`llm.models[].guardrails.request[].googleModelArmor.policies.requestHeaderModifier.add`|object||
 |`llm.models[].guardrails.request[].googleModelArmor.policies.requestHeaderModifier.set`|object||
 |`llm.models[].guardrails.request[].googleModelArmor.policies.requestHeaderModifier.remove`|[]string||
-|`llm.models[].guardrails.request[].googleModelArmor.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`llm.models[].guardrails.request[].googleModelArmor.policies.responseHeaderModifier.add`|object||
-|`llm.models[].guardrails.request[].googleModelArmor.policies.responseHeaderModifier.set`|object||
-|`llm.models[].guardrails.request[].googleModelArmor.policies.responseHeaderModifier.remove`|[]string||
-|`llm.models[].guardrails.request[].googleModelArmor.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`llm.models[].guardrails.request[].googleModelArmor.policies.requestRedirect.scheme`|string||
-|`llm.models[].guardrails.request[].googleModelArmor.policies.requestRedirect.authority`|string||
-|`llm.models[].guardrails.request[].googleModelArmor.policies.requestRedirect.authority.full`|string||
-|`llm.models[].guardrails.request[].googleModelArmor.policies.requestRedirect.authority.host`|string||
-|`llm.models[].guardrails.request[].googleModelArmor.policies.requestRedirect.authority.port`|integer||
-|`llm.models[].guardrails.request[].googleModelArmor.policies.requestRedirect.path`|object||
-|`llm.models[].guardrails.request[].googleModelArmor.policies.requestRedirect.path.full`|string||
-|`llm.models[].guardrails.request[].googleModelArmor.policies.requestRedirect.path.prefix`|string||
-|`llm.models[].guardrails.request[].googleModelArmor.policies.requestRedirect.status`|integer||
 |`llm.models[].guardrails.request[].googleModelArmor.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`llm.models[].guardrails.request[].googleModelArmor.policies.transformations.request`|object||
 |`llm.models[].guardrails.request[].googleModelArmor.policies.transformations.request.add`|object||
@@ -6110,13 +5109,6 @@
 |`llm.models[].guardrails.request[].googleModelArmor.policies.tcp.connectTimeout`|object||
 |`llm.models[].guardrails.request[].googleModelArmor.policies.tcp.connectTimeout.secs`|integer||
 |`llm.models[].guardrails.request[].googleModelArmor.policies.tcp.connectTimeout.nanos`|integer||
-|`llm.models[].guardrails.request[].googleModelArmor.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`llm.models[].guardrails.request[].googleModelArmor.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`llm.models[].guardrails.request[].googleModelArmor.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`llm.models[].guardrails.request[].googleModelArmor.policies.health.eviction.duration`|string||
-|`llm.models[].guardrails.request[].googleModelArmor.policies.health.eviction.restoreHealth`|number||
-|`llm.models[].guardrails.request[].googleModelArmor.policies.health.eviction.consecutiveFailures`|integer||
-|`llm.models[].guardrails.request[].googleModelArmor.policies.health.eviction.healthThreshold`|number||
 |`llm.models[].guardrails.request[].googleModelArmor.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`llm.models[].guardrails.request[].googleModelArmor.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`llm.models[].guardrails.request[].googleModelArmor.policies.backendTunnel.proxy.service`|object||
@@ -6162,20 +5154,6 @@
 |`llm.models[].guardrails.response[].bedrockGuardrails.policies.requestHeaderModifier.add`|object||
 |`llm.models[].guardrails.response[].bedrockGuardrails.policies.requestHeaderModifier.set`|object||
 |`llm.models[].guardrails.response[].bedrockGuardrails.policies.requestHeaderModifier.remove`|[]string||
-|`llm.models[].guardrails.response[].bedrockGuardrails.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`llm.models[].guardrails.response[].bedrockGuardrails.policies.responseHeaderModifier.add`|object||
-|`llm.models[].guardrails.response[].bedrockGuardrails.policies.responseHeaderModifier.set`|object||
-|`llm.models[].guardrails.response[].bedrockGuardrails.policies.responseHeaderModifier.remove`|[]string||
-|`llm.models[].guardrails.response[].bedrockGuardrails.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`llm.models[].guardrails.response[].bedrockGuardrails.policies.requestRedirect.scheme`|string||
-|`llm.models[].guardrails.response[].bedrockGuardrails.policies.requestRedirect.authority`|string||
-|`llm.models[].guardrails.response[].bedrockGuardrails.policies.requestRedirect.authority.full`|string||
-|`llm.models[].guardrails.response[].bedrockGuardrails.policies.requestRedirect.authority.host`|string||
-|`llm.models[].guardrails.response[].bedrockGuardrails.policies.requestRedirect.authority.port`|integer||
-|`llm.models[].guardrails.response[].bedrockGuardrails.policies.requestRedirect.path`|object||
-|`llm.models[].guardrails.response[].bedrockGuardrails.policies.requestRedirect.path.full`|string||
-|`llm.models[].guardrails.response[].bedrockGuardrails.policies.requestRedirect.path.prefix`|string||
-|`llm.models[].guardrails.response[].bedrockGuardrails.policies.requestRedirect.status`|integer||
 |`llm.models[].guardrails.response[].bedrockGuardrails.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`llm.models[].guardrails.response[].bedrockGuardrails.policies.transformations.request`|object||
 |`llm.models[].guardrails.response[].bedrockGuardrails.policies.transformations.request.add`|object||
@@ -6237,13 +5215,6 @@
 |`llm.models[].guardrails.response[].bedrockGuardrails.policies.tcp.connectTimeout`|object||
 |`llm.models[].guardrails.response[].bedrockGuardrails.policies.tcp.connectTimeout.secs`|integer||
 |`llm.models[].guardrails.response[].bedrockGuardrails.policies.tcp.connectTimeout.nanos`|integer||
-|`llm.models[].guardrails.response[].bedrockGuardrails.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`llm.models[].guardrails.response[].bedrockGuardrails.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`llm.models[].guardrails.response[].bedrockGuardrails.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`llm.models[].guardrails.response[].bedrockGuardrails.policies.health.eviction.duration`|string||
-|`llm.models[].guardrails.response[].bedrockGuardrails.policies.health.eviction.restoreHealth`|number||
-|`llm.models[].guardrails.response[].bedrockGuardrails.policies.health.eviction.consecutiveFailures`|integer||
-|`llm.models[].guardrails.response[].bedrockGuardrails.policies.health.eviction.healthThreshold`|number||
 |`llm.models[].guardrails.response[].bedrockGuardrails.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`llm.models[].guardrails.response[].bedrockGuardrails.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`llm.models[].guardrails.response[].bedrockGuardrails.policies.backendTunnel.proxy.service`|object||
@@ -6262,20 +5233,6 @@
 |`llm.models[].guardrails.response[].googleModelArmor.policies.requestHeaderModifier.add`|object||
 |`llm.models[].guardrails.response[].googleModelArmor.policies.requestHeaderModifier.set`|object||
 |`llm.models[].guardrails.response[].googleModelArmor.policies.requestHeaderModifier.remove`|[]string||
-|`llm.models[].guardrails.response[].googleModelArmor.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`llm.models[].guardrails.response[].googleModelArmor.policies.responseHeaderModifier.add`|object||
-|`llm.models[].guardrails.response[].googleModelArmor.policies.responseHeaderModifier.set`|object||
-|`llm.models[].guardrails.response[].googleModelArmor.policies.responseHeaderModifier.remove`|[]string||
-|`llm.models[].guardrails.response[].googleModelArmor.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`llm.models[].guardrails.response[].googleModelArmor.policies.requestRedirect.scheme`|string||
-|`llm.models[].guardrails.response[].googleModelArmor.policies.requestRedirect.authority`|string||
-|`llm.models[].guardrails.response[].googleModelArmor.policies.requestRedirect.authority.full`|string||
-|`llm.models[].guardrails.response[].googleModelArmor.policies.requestRedirect.authority.host`|string||
-|`llm.models[].guardrails.response[].googleModelArmor.policies.requestRedirect.authority.port`|integer||
-|`llm.models[].guardrails.response[].googleModelArmor.policies.requestRedirect.path`|object||
-|`llm.models[].guardrails.response[].googleModelArmor.policies.requestRedirect.path.full`|string||
-|`llm.models[].guardrails.response[].googleModelArmor.policies.requestRedirect.path.prefix`|string||
-|`llm.models[].guardrails.response[].googleModelArmor.policies.requestRedirect.status`|integer||
 |`llm.models[].guardrails.response[].googleModelArmor.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`llm.models[].guardrails.response[].googleModelArmor.policies.transformations.request`|object||
 |`llm.models[].guardrails.response[].googleModelArmor.policies.transformations.request.add`|object||
@@ -6337,13 +5294,6 @@
 |`llm.models[].guardrails.response[].googleModelArmor.policies.tcp.connectTimeout`|object||
 |`llm.models[].guardrails.response[].googleModelArmor.policies.tcp.connectTimeout.secs`|integer||
 |`llm.models[].guardrails.response[].googleModelArmor.policies.tcp.connectTimeout.nanos`|integer||
-|`llm.models[].guardrails.response[].googleModelArmor.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`llm.models[].guardrails.response[].googleModelArmor.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`llm.models[].guardrails.response[].googleModelArmor.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`llm.models[].guardrails.response[].googleModelArmor.policies.health.eviction.duration`|string||
-|`llm.models[].guardrails.response[].googleModelArmor.policies.health.eviction.restoreHealth`|number||
-|`llm.models[].guardrails.response[].googleModelArmor.policies.health.eviction.consecutiveFailures`|integer||
-|`llm.models[].guardrails.response[].googleModelArmor.policies.health.eviction.healthThreshold`|number||
 |`llm.models[].guardrails.response[].googleModelArmor.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`llm.models[].guardrails.response[].googleModelArmor.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`llm.models[].guardrails.response[].googleModelArmor.policies.backendTunnel.proxy.service`|object||
@@ -6413,20 +5363,6 @@
 |`llm.policies.extAuthz.policies.requestHeaderModifier.add`|object||
 |`llm.policies.extAuthz.policies.requestHeaderModifier.set`|object||
 |`llm.policies.extAuthz.policies.requestHeaderModifier.remove`|[]string||
-|`llm.policies.extAuthz.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`llm.policies.extAuthz.policies.responseHeaderModifier.add`|object||
-|`llm.policies.extAuthz.policies.responseHeaderModifier.set`|object||
-|`llm.policies.extAuthz.policies.responseHeaderModifier.remove`|[]string||
-|`llm.policies.extAuthz.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`llm.policies.extAuthz.policies.requestRedirect.scheme`|string||
-|`llm.policies.extAuthz.policies.requestRedirect.authority`|string||
-|`llm.policies.extAuthz.policies.requestRedirect.authority.full`|string||
-|`llm.policies.extAuthz.policies.requestRedirect.authority.host`|string||
-|`llm.policies.extAuthz.policies.requestRedirect.authority.port`|integer||
-|`llm.policies.extAuthz.policies.requestRedirect.path`|object||
-|`llm.policies.extAuthz.policies.requestRedirect.path.full`|string||
-|`llm.policies.extAuthz.policies.requestRedirect.path.prefix`|string||
-|`llm.policies.extAuthz.policies.requestRedirect.status`|integer||
 |`llm.policies.extAuthz.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`llm.policies.extAuthz.policies.transformations.request`|object||
 |`llm.policies.extAuthz.policies.transformations.request.add`|object||
@@ -6488,13 +5424,6 @@
 |`llm.policies.extAuthz.policies.tcp.connectTimeout`|object||
 |`llm.policies.extAuthz.policies.tcp.connectTimeout.secs`|integer||
 |`llm.policies.extAuthz.policies.tcp.connectTimeout.nanos`|integer||
-|`llm.policies.extAuthz.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`llm.policies.extAuthz.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`llm.policies.extAuthz.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`llm.policies.extAuthz.policies.health.eviction.duration`|string||
-|`llm.policies.extAuthz.policies.health.eviction.restoreHealth`|number||
-|`llm.policies.extAuthz.policies.health.eviction.consecutiveFailures`|integer||
-|`llm.policies.extAuthz.policies.health.eviction.healthThreshold`|number||
 |`llm.policies.extAuthz.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`llm.policies.extAuthz.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`llm.policies.extAuthz.policies.backendTunnel.proxy.service`|object||
@@ -6534,20 +5463,6 @@
 |`llm.policies.extProc.policies.requestHeaderModifier.add`|object||
 |`llm.policies.extProc.policies.requestHeaderModifier.set`|object||
 |`llm.policies.extProc.policies.requestHeaderModifier.remove`|[]string||
-|`llm.policies.extProc.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`llm.policies.extProc.policies.responseHeaderModifier.add`|object||
-|`llm.policies.extProc.policies.responseHeaderModifier.set`|object||
-|`llm.policies.extProc.policies.responseHeaderModifier.remove`|[]string||
-|`llm.policies.extProc.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`llm.policies.extProc.policies.requestRedirect.scheme`|string||
-|`llm.policies.extProc.policies.requestRedirect.authority`|string||
-|`llm.policies.extProc.policies.requestRedirect.authority.full`|string||
-|`llm.policies.extProc.policies.requestRedirect.authority.host`|string||
-|`llm.policies.extProc.policies.requestRedirect.authority.port`|integer||
-|`llm.policies.extProc.policies.requestRedirect.path`|object||
-|`llm.policies.extProc.policies.requestRedirect.path.full`|string||
-|`llm.policies.extProc.policies.requestRedirect.path.prefix`|string||
-|`llm.policies.extProc.policies.requestRedirect.status`|integer||
 |`llm.policies.extProc.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`llm.policies.extProc.policies.transformations.request`|object||
 |`llm.policies.extProc.policies.transformations.request.add`|object||
@@ -6609,13 +5524,6 @@
 |`llm.policies.extProc.policies.tcp.connectTimeout`|object||
 |`llm.policies.extProc.policies.tcp.connectTimeout.secs`|integer||
 |`llm.policies.extProc.policies.tcp.connectTimeout.nanos`|integer||
-|`llm.policies.extProc.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`llm.policies.extProc.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`llm.policies.extProc.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`llm.policies.extProc.policies.health.eviction.duration`|string||
-|`llm.policies.extProc.policies.health.eviction.restoreHealth`|number||
-|`llm.policies.extProc.policies.health.eviction.consecutiveFailures`|integer||
-|`llm.policies.extProc.policies.health.eviction.healthThreshold`|number||
 |`llm.policies.extProc.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`llm.policies.extProc.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`llm.policies.extProc.policies.backendTunnel.proxy.service`|object||
@@ -6682,20 +5590,6 @@
 |`mcp.targets[].policies.requestHeaderModifier.add`|object||
 |`mcp.targets[].policies.requestHeaderModifier.set`|object||
 |`mcp.targets[].policies.requestHeaderModifier.remove`|[]string||
-|`mcp.targets[].policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`mcp.targets[].policies.responseHeaderModifier.add`|object||
-|`mcp.targets[].policies.responseHeaderModifier.set`|object||
-|`mcp.targets[].policies.responseHeaderModifier.remove`|[]string||
-|`mcp.targets[].policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`mcp.targets[].policies.requestRedirect.scheme`|string||
-|`mcp.targets[].policies.requestRedirect.authority`|string||
-|`mcp.targets[].policies.requestRedirect.authority.full`|string||
-|`mcp.targets[].policies.requestRedirect.authority.host`|string||
-|`mcp.targets[].policies.requestRedirect.authority.port`|integer||
-|`mcp.targets[].policies.requestRedirect.path`|object||
-|`mcp.targets[].policies.requestRedirect.path.full`|string||
-|`mcp.targets[].policies.requestRedirect.path.prefix`|string||
-|`mcp.targets[].policies.requestRedirect.status`|integer||
 |`mcp.targets[].policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`mcp.targets[].policies.transformations.request`|object||
 |`mcp.targets[].policies.transformations.request.add`|object||
@@ -6757,13 +5651,6 @@
 |`mcp.targets[].policies.tcp.connectTimeout`|object||
 |`mcp.targets[].policies.tcp.connectTimeout.secs`|integer||
 |`mcp.targets[].policies.tcp.connectTimeout.nanos`|integer||
-|`mcp.targets[].policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`mcp.targets[].policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`mcp.targets[].policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`mcp.targets[].policies.health.eviction.duration`|string||
-|`mcp.targets[].policies.health.eviction.restoreHealth`|number||
-|`mcp.targets[].policies.health.eviction.consecutiveFailures`|integer||
-|`mcp.targets[].policies.health.eviction.healthThreshold`|number||
 |`mcp.targets[].policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`mcp.targets[].policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`mcp.targets[].policies.backendTunnel.proxy.service`|object||
@@ -6872,20 +5759,6 @@
 |`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.requestHeaderModifier.add`|object||
 |`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.requestHeaderModifier.set`|object||
 |`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.requestHeaderModifier.remove`|[]string||
-|`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.responseHeaderModifier.add`|object||
-|`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.responseHeaderModifier.set`|object||
-|`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.responseHeaderModifier.remove`|[]string||
-|`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.scheme`|string||
-|`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.authority`|string||
-|`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.authority.full`|string||
-|`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.authority.host`|string||
-|`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.authority.port`|integer||
-|`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.path`|object||
-|`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.path.full`|string||
-|`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.path.prefix`|string||
-|`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.requestRedirect.status`|integer||
 |`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.transformations.request`|object||
 |`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.transformations.request.add`|object||
@@ -6947,13 +5820,6 @@
 |`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.tcp.connectTimeout`|object||
 |`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.tcp.connectTimeout.secs`|integer||
 |`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.tcp.connectTimeout.nanos`|integer||
-|`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.health.eviction.duration`|string||
-|`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.health.eviction.restoreHealth`|number||
-|`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.health.eviction.consecutiveFailures`|integer||
-|`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.health.eviction.healthThreshold`|number||
 |`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service`|object||
@@ -6972,20 +5838,6 @@
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestHeaderModifier.add`|object||
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestHeaderModifier.set`|object||
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestHeaderModifier.remove`|[]string||
-|`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.responseHeaderModifier.add`|object||
-|`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.responseHeaderModifier.set`|object||
-|`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.responseHeaderModifier.remove`|[]string||
-|`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.scheme`|string||
-|`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.authority`|string||
-|`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.authority.full`|string||
-|`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.authority.host`|string||
-|`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.authority.port`|integer||
-|`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.path`|object||
-|`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.path.full`|string||
-|`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.path.prefix`|string||
-|`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.requestRedirect.status`|integer||
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.transformations.request`|object||
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.transformations.request.add`|object||
@@ -7047,13 +5899,6 @@
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.connectTimeout`|object||
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.connectTimeout.secs`|integer||
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.connectTimeout.nanos`|integer||
-|`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.health.eviction.duration`|string||
-|`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.health.eviction.restoreHealth`|number||
-|`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.health.eviction.consecutiveFailures`|integer||
-|`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.health.eviction.healthThreshold`|number||
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service`|object||
@@ -7072,20 +5917,6 @@
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.requestHeaderModifier.add`|object||
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.requestHeaderModifier.set`|object||
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.requestHeaderModifier.remove`|[]string||
-|`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.responseHeaderModifier.add`|object||
-|`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.responseHeaderModifier.set`|object||
-|`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.responseHeaderModifier.remove`|[]string||
-|`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.scheme`|string||
-|`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.authority`|string||
-|`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.authority.full`|string||
-|`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.authority.host`|string||
-|`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.authority.port`|integer||
-|`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.path`|object||
-|`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.path.full`|string||
-|`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.path.prefix`|string||
-|`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.requestRedirect.status`|integer||
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.transformations.request`|object||
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.transformations.request.add`|object||
@@ -7147,13 +5978,6 @@
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.connectTimeout`|object||
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.connectTimeout.secs`|integer||
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.connectTimeout.nanos`|integer||
-|`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.health.eviction.duration`|string||
-|`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.health.eviction.restoreHealth`|number||
-|`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.health.eviction.consecutiveFailures`|integer||
-|`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.health.eviction.healthThreshold`|number||
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service`|object||
@@ -7199,20 +6023,6 @@
 |`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestHeaderModifier.add`|object||
 |`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestHeaderModifier.set`|object||
 |`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestHeaderModifier.remove`|[]string||
-|`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.responseHeaderModifier.add`|object||
-|`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.responseHeaderModifier.set`|object||
-|`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.responseHeaderModifier.remove`|[]string||
-|`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.scheme`|string||
-|`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.authority`|string||
-|`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.authority.full`|string||
-|`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.authority.host`|string||
-|`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.authority.port`|integer||
-|`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.path`|object||
-|`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.path.full`|string||
-|`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.path.prefix`|string||
-|`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.requestRedirect.status`|integer||
 |`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.transformations.request`|object||
 |`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.transformations.request.add`|object||
@@ -7274,13 +6084,6 @@
 |`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.connectTimeout`|object||
 |`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.connectTimeout.secs`|integer||
 |`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.connectTimeout.nanos`|integer||
-|`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.health.eviction.duration`|string||
-|`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.health.eviction.restoreHealth`|number||
-|`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.health.eviction.consecutiveFailures`|integer||
-|`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.health.eviction.healthThreshold`|number||
 |`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service`|object||
@@ -7299,20 +6102,6 @@
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.requestHeaderModifier.add`|object||
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.requestHeaderModifier.set`|object||
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.requestHeaderModifier.remove`|[]string||
-|`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.responseHeaderModifier.add`|object||
-|`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.responseHeaderModifier.set`|object||
-|`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.responseHeaderModifier.remove`|[]string||
-|`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.scheme`|string||
-|`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.authority`|string||
-|`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.authority.full`|string||
-|`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.authority.host`|string||
-|`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.authority.port`|integer||
-|`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.path`|object||
-|`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.path.full`|string||
-|`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.path.prefix`|string||
-|`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.requestRedirect.status`|integer||
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.transformations.request`|object||
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.transformations.request.add`|object||
@@ -7374,13 +6163,6 @@
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.connectTimeout`|object||
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.connectTimeout.secs`|integer||
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.connectTimeout.nanos`|integer||
-|`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.health.eviction.duration`|string||
-|`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.health.eviction.restoreHealth`|number||
-|`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.health.eviction.consecutiveFailures`|integer||
-|`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.health.eviction.healthThreshold`|number||
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service`|object||
@@ -7478,20 +6260,6 @@
 |`mcp.policies.remoteRateLimit.policies.requestHeaderModifier.add`|object||
 |`mcp.policies.remoteRateLimit.policies.requestHeaderModifier.set`|object||
 |`mcp.policies.remoteRateLimit.policies.requestHeaderModifier.remove`|[]string||
-|`mcp.policies.remoteRateLimit.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`mcp.policies.remoteRateLimit.policies.responseHeaderModifier.add`|object||
-|`mcp.policies.remoteRateLimit.policies.responseHeaderModifier.set`|object||
-|`mcp.policies.remoteRateLimit.policies.responseHeaderModifier.remove`|[]string||
-|`mcp.policies.remoteRateLimit.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`mcp.policies.remoteRateLimit.policies.requestRedirect.scheme`|string||
-|`mcp.policies.remoteRateLimit.policies.requestRedirect.authority`|string||
-|`mcp.policies.remoteRateLimit.policies.requestRedirect.authority.full`|string||
-|`mcp.policies.remoteRateLimit.policies.requestRedirect.authority.host`|string||
-|`mcp.policies.remoteRateLimit.policies.requestRedirect.authority.port`|integer||
-|`mcp.policies.remoteRateLimit.policies.requestRedirect.path`|object||
-|`mcp.policies.remoteRateLimit.policies.requestRedirect.path.full`|string||
-|`mcp.policies.remoteRateLimit.policies.requestRedirect.path.prefix`|string||
-|`mcp.policies.remoteRateLimit.policies.requestRedirect.status`|integer||
 |`mcp.policies.remoteRateLimit.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`mcp.policies.remoteRateLimit.policies.transformations.request`|object||
 |`mcp.policies.remoteRateLimit.policies.transformations.request.add`|object||
@@ -7553,13 +6321,6 @@
 |`mcp.policies.remoteRateLimit.policies.tcp.connectTimeout`|object||
 |`mcp.policies.remoteRateLimit.policies.tcp.connectTimeout.secs`|integer||
 |`mcp.policies.remoteRateLimit.policies.tcp.connectTimeout.nanos`|integer||
-|`mcp.policies.remoteRateLimit.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`mcp.policies.remoteRateLimit.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`mcp.policies.remoteRateLimit.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`mcp.policies.remoteRateLimit.policies.health.eviction.duration`|string||
-|`mcp.policies.remoteRateLimit.policies.health.eviction.restoreHealth`|number||
-|`mcp.policies.remoteRateLimit.policies.health.eviction.consecutiveFailures`|integer||
-|`mcp.policies.remoteRateLimit.policies.health.eviction.healthThreshold`|number||
 |`mcp.policies.remoteRateLimit.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`mcp.policies.remoteRateLimit.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`mcp.policies.remoteRateLimit.policies.backendTunnel.proxy.service`|object||
@@ -7631,20 +6392,6 @@
 |`mcp.policies.extAuthz.policies.requestHeaderModifier.add`|object||
 |`mcp.policies.extAuthz.policies.requestHeaderModifier.set`|object||
 |`mcp.policies.extAuthz.policies.requestHeaderModifier.remove`|[]string||
-|`mcp.policies.extAuthz.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`mcp.policies.extAuthz.policies.responseHeaderModifier.add`|object||
-|`mcp.policies.extAuthz.policies.responseHeaderModifier.set`|object||
-|`mcp.policies.extAuthz.policies.responseHeaderModifier.remove`|[]string||
-|`mcp.policies.extAuthz.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`mcp.policies.extAuthz.policies.requestRedirect.scheme`|string||
-|`mcp.policies.extAuthz.policies.requestRedirect.authority`|string||
-|`mcp.policies.extAuthz.policies.requestRedirect.authority.full`|string||
-|`mcp.policies.extAuthz.policies.requestRedirect.authority.host`|string||
-|`mcp.policies.extAuthz.policies.requestRedirect.authority.port`|integer||
-|`mcp.policies.extAuthz.policies.requestRedirect.path`|object||
-|`mcp.policies.extAuthz.policies.requestRedirect.path.full`|string||
-|`mcp.policies.extAuthz.policies.requestRedirect.path.prefix`|string||
-|`mcp.policies.extAuthz.policies.requestRedirect.status`|integer||
 |`mcp.policies.extAuthz.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`mcp.policies.extAuthz.policies.transformations.request`|object||
 |`mcp.policies.extAuthz.policies.transformations.request.add`|object||
@@ -7706,13 +6453,6 @@
 |`mcp.policies.extAuthz.policies.tcp.connectTimeout`|object||
 |`mcp.policies.extAuthz.policies.tcp.connectTimeout.secs`|integer||
 |`mcp.policies.extAuthz.policies.tcp.connectTimeout.nanos`|integer||
-|`mcp.policies.extAuthz.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`mcp.policies.extAuthz.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`mcp.policies.extAuthz.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`mcp.policies.extAuthz.policies.health.eviction.duration`|string||
-|`mcp.policies.extAuthz.policies.health.eviction.restoreHealth`|number||
-|`mcp.policies.extAuthz.policies.health.eviction.consecutiveFailures`|integer||
-|`mcp.policies.extAuthz.policies.health.eviction.healthThreshold`|number||
 |`mcp.policies.extAuthz.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`mcp.policies.extAuthz.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`mcp.policies.extAuthz.policies.backendTunnel.proxy.service`|object||
@@ -7752,20 +6492,6 @@
 |`mcp.policies.extProc.policies.requestHeaderModifier.add`|object||
 |`mcp.policies.extProc.policies.requestHeaderModifier.set`|object||
 |`mcp.policies.extProc.policies.requestHeaderModifier.remove`|[]string||
-|`mcp.policies.extProc.policies.responseHeaderModifier`|object|Headers to be modified in the response.|
-|`mcp.policies.extProc.policies.responseHeaderModifier.add`|object||
-|`mcp.policies.extProc.policies.responseHeaderModifier.set`|object||
-|`mcp.policies.extProc.policies.responseHeaderModifier.remove`|[]string||
-|`mcp.policies.extProc.policies.requestRedirect`|object|Directly respond to the request with a redirect.|
-|`mcp.policies.extProc.policies.requestRedirect.scheme`|string||
-|`mcp.policies.extProc.policies.requestRedirect.authority`|string||
-|`mcp.policies.extProc.policies.requestRedirect.authority.full`|string||
-|`mcp.policies.extProc.policies.requestRedirect.authority.host`|string||
-|`mcp.policies.extProc.policies.requestRedirect.authority.port`|integer||
-|`mcp.policies.extProc.policies.requestRedirect.path`|object||
-|`mcp.policies.extProc.policies.requestRedirect.path.full`|string||
-|`mcp.policies.extProc.policies.requestRedirect.path.prefix`|string||
-|`mcp.policies.extProc.policies.requestRedirect.status`|integer||
 |`mcp.policies.extProc.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
 |`mcp.policies.extProc.policies.transformations.request`|object||
 |`mcp.policies.extProc.policies.transformations.request.add`|object||
@@ -7827,13 +6553,6 @@
 |`mcp.policies.extProc.policies.tcp.connectTimeout`|object||
 |`mcp.policies.extProc.policies.tcp.connectTimeout.secs`|integer||
 |`mcp.policies.extProc.policies.tcp.connectTimeout.nanos`|integer||
-|`mcp.policies.extProc.policies.health`|object|Health policy for backend outlier detection; evicts on unhealthy responses based on CEL condition and configurable duration.|
-|`mcp.policies.extProc.policies.health.unhealthyExpression`|string|CEL expression; `true` means unhealthy (evict). E.g. `response.code >= 500`.<br>When unset, any 5xx or connection failure is treated as unhealthy.|
-|`mcp.policies.extProc.policies.health.eviction`|object|Local/config eviction sub-policy with duration as string; mirrors `Eviction`.|
-|`mcp.policies.extProc.policies.health.eviction.duration`|string||
-|`mcp.policies.extProc.policies.health.eviction.restoreHealth`|number||
-|`mcp.policies.extProc.policies.health.eviction.consecutiveFailures`|integer||
-|`mcp.policies.extProc.policies.health.eviction.healthThreshold`|number||
 |`mcp.policies.extProc.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
 |`mcp.policies.extProc.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
 |`mcp.policies.extProc.policies.backendTunnel.proxy.service`|object||


### PR DESCRIPTION
These do not make sense for the secondary calls
