### PR TITLE
allow plugins to effect route status

### DIFF
--- a/controller/pkg/agentgateway/plugins/interfaces.go
+++ b/controller/pkg/agentgateway/plugins/interfaces.go
@@ -8,7 +8,10 @@ import (
 	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/kube/krt"
 	"istio.io/istio/pkg/ptr"
+	"istio.io/istio/pkg/slices"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/agentgateway/agentgateway/api"
 	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/ir"
@@ -59,6 +62,55 @@ type AddResourcesPlugin struct {
 	Listeners        krt.Collection[ir.AgwResource]
 	Routes           krt.Collection[ir.AgwResource]
 	AncestorBackends krt.Collection[*utils.AncestorBackend]
+	GatewayStatuses  krt.StatusCollection[*gwv1.Gateway, gwv1.GatewayStatus]
+	// ParentResolvers contribute additional parent resolution logic to the
+	// main route pipeline.
+	ParentResolvers []ParentResolver
+}
+
+// ParentInfo holds info about a "Parent" - something that can be referenced as a ParentRef in the API.
+type ParentInfo struct {
+	ParentGateway          types.NamespacedName
+	ParentGatewayClassName string
+	// ListenerKey is the internal key of the listener resource created for this parent.
+	ListenerKey string
+	// ServiceKey (optionally) links a parent reference to an individual Service.
+	ServiceKey *types.NamespacedName
+	// AllowedKinds indicates which kinds can be admitted by this Parent.
+	AllowedKinds []gwv1.RouteGroupKind
+	// Hostnames that must match to reference the Parent. Format is ns/hostname.
+	Hostnames []string
+	// OriginalHostname is the unprocessed form of Hostnames; how it appeared in users' config.
+	OriginalHostname string
+	// CreationTimestamp is used in determining listener precedence.
+	CreationTimestamp metav1.Time
+
+	SectionName    gwv1.SectionName
+	Port           gwv1.PortNumber
+	Protocol       gwv1.ProtocolType
+	TLSPassthrough bool
+}
+
+func (g ParentInfo) Equals(other ParentInfo) bool {
+	return g.ParentGateway == other.ParentGateway &&
+		g.ParentGatewayClassName == other.ParentGatewayClassName &&
+		g.ListenerKey == other.ListenerKey &&
+		ptr.Equal(g.ServiceKey, other.ServiceKey) &&
+		g.OriginalHostname == other.OriginalHostname &&
+		g.SectionName == other.SectionName &&
+		g.Port == other.Port &&
+		g.Protocol == other.Protocol &&
+		g.TLSPassthrough == other.TLSPassthrough &&
+		g.CreationTimestamp == other.CreationTimestamp &&
+		slices.EqualFunc(g.AllowedKinds, other.AllowedKinds, func(a, b gwv1.RouteGroupKind) bool {
+			return a.Kind == b.Kind && ptr.Equal(a.Group, b.Group)
+		}) &&
+		slices.Equal(g.Hostnames, other.Hostnames)
+}
+
+// ParentResolver resolves parent references for routes.
+type ParentResolver interface {
+	ParentsFor(ctx krt.HandlerContext, pk utils.TypedNamespacedName) []*ParentInfo
 }
 
 func ResourceName[T config.Namer](o T) *api.ResourceName {

--- a/controller/pkg/agentgateway/plugins/registry.go
+++ b/controller/pkg/agentgateway/plugins/registry.go
@@ -40,7 +40,11 @@ func MergePlugins(plug ...AgwPlugin) AgwPlugin {
 			if p.AddResourceExtension.GatewayStatuses != nil {
 				ret.AddResourceExtension.GatewayStatuses = p.AddResourceExtension.GatewayStatuses
 			}
-			ret.AddResourceExtension.ParentResolvers = append(ret.AddResourceExtension.ParentResolvers, p.AddResourceExtension.ParentResolvers...)
+			for _, r := range p.AddResourceExtension.ParentResolvers {
+				if r != nil {
+					ret.AddResourceExtension.ParentResolvers = append(ret.AddResourceExtension.ParentResolvers, r)
+				}
+			}
 		}
 	}
 	return ret

--- a/controller/pkg/agentgateway/plugins/registry.go
+++ b/controller/pkg/agentgateway/plugins/registry.go
@@ -37,6 +37,10 @@ func MergePlugins(plug ...AgwPlugin) AgwPlugin {
 			if p.AddResourceExtension.AncestorBackends != nil {
 				ret.AddResourceExtension.AncestorBackends = p.AddResourceExtension.AncestorBackends
 			}
+			if p.AddResourceExtension.GatewayStatuses != nil {
+				ret.AddResourceExtension.GatewayStatuses = p.AddResourceExtension.GatewayStatuses
+			}
+			ret.AddResourceExtension.ParentResolvers = append(ret.AddResourceExtension.ParentResolvers, p.AddResourceExtension.ParentResolvers...)
 		}
 	}
 	return ret

--- a/controller/pkg/agentgateway/translator/conversion.go
+++ b/controller/pkg/agentgateway/translator/conversion.go
@@ -733,11 +733,12 @@ func ReferenceAllowed(
 	hostnames []gwv1.Hostname,
 	localNamespace string,
 ) *ParentError {
-	if parentRef.Kind == wellknown.ServiceGVK.Kind {
+	if parent.ServiceKey != nil {
+		// Parent resolver already verified this reference exists.
+	} else if parentRef.Kind == wellknown.ServiceGVK.Kind {
+		// check that the referenced svc exists
 		key := parentRef.Namespace + "/" + parentRef.Name
 		svc := ptr.Flatten(krt.FetchOne(ctx.Krt, ctx.Services, krt.FilterKey(key)))
-
-		// check that the referenced svc exists
 		if svc == nil {
 			return &ParentError{
 				Reason:  ParentErrorNotAccepted,
@@ -914,30 +915,7 @@ func (p ParentReference) String() string {
 	return p.TypedNamespacedName.String() + "/" + string(p.SectionName) + "/" + fmt.Sprint(p.Port)
 }
 
-// ParentInfo holds info about a "Parent" - something that can be referenced as a ParentRef in the API.
-// Today, this is just Gateway
-type ParentInfo struct {
-	ParentGateway          types.NamespacedName
-	ParentGatewayClassName string
-	// ListenerKey is the internal key of the listener resource created for this parent.
-	ListenerKey string
-	// ServiceKey (optionally) links a parent reference to an individual Service.
-	ServiceKey *types.NamespacedName
-	// AllowedKinds indicates which kinds can be admitted by this Parent
-	AllowedKinds []gwv1.RouteGroupKind
-	// Hostnames is the hostnames that must be match to reference to the Parent. For gateway this is listener hostname
-	// Format is ns/hostname
-	Hostnames []string
-	// OriginalHostname is the unprocessed form of Hostnames; how it appeared in users' config
-	OriginalHostname string
-	// Timestamp the parent was created - used in determining listener precedence
-	CreationTimestamp metav1.Time
-
-	SectionName    gwv1.SectionName
-	Port           gwv1.PortNumber
-	Protocol       gwv1.ProtocolType
-	TLSPassthrough bool
-}
+type ParentInfo = plugins.ParentInfo
 
 // RouteParentReference holds information about a route's parent reference
 type RouteParentReference struct {

--- a/controller/pkg/agentgateway/translator/gateway_collection.go
+++ b/controller/pkg/agentgateway/translator/gateway_collection.go
@@ -195,23 +195,6 @@ func (g GatewayListener) Equals(other GatewayListener) bool {
 		g.ParentInfo.Equals(other.ParentInfo)
 }
 
-func (g ParentInfo) Equals(other ParentInfo) bool {
-	return g.ParentGateway == other.ParentGateway &&
-		g.ParentGatewayClassName == other.ParentGatewayClassName &&
-		g.ListenerKey == other.ListenerKey &&
-		ptr.Equal(g.ServiceKey, other.ServiceKey) &&
-		g.OriginalHostname == other.OriginalHostname &&
-		g.SectionName == other.SectionName &&
-		g.Port == other.Port &&
-		g.Protocol == other.Protocol &&
-		g.TLSPassthrough == other.TLSPassthrough &&
-		g.CreationTimestamp == other.CreationTimestamp &&
-		slices.EqualFunc(g.AllowedKinds, other.AllowedKinds, func(a, b gwv1.RouteGroupKind) bool {
-			return a.Kind == b.Kind && ptr.Equal(a.Group, b.Group)
-		}) &&
-		slices.Equal(g.Hostnames, other.Hostnames)
-}
-
 type GatewayCollectionConfig struct {
 	ControllerName string
 	Gateways       krt.Collection[*gwv1.Gateway]
@@ -550,12 +533,7 @@ func reportNotAllowedListenerSet(status *gwv1.ListenerSetStatus, obj *gwv1.Liste
 	status.Conditions = SetConditions(obj.Generation, status.Conditions, gatewayConditions)
 }
 
-// ParentResolver allows expanding a parent reference into the information needed
-// to link a route to the gateway(s) it applies to.
-type ParentResolver interface {
-	// Fetch returns the parents for a given parent key.
-	ParentsFor(ctx krt.HandlerContext, pk utils.TypedNamespacedName) []*ParentInfo
-}
+type ParentResolver = plugins.ParentResolver
 
 // RouteParents holds information about things Routes can reference as parents.
 type RouteParents struct {
@@ -568,6 +546,21 @@ func (p RouteParents) ParentsFor(ctx krt.HandlerContext, pk utils.TypedNamespace
 	return slices.Map(krt.Fetch(ctx, p.Gateways, krt.FilterIndex(p.GatewayIndex, pk)), func(gw *GatewayListener) *ParentInfo {
 		return &gw.ParentInfo
 	})
+}
+
+// CompositeParentResolver combines multiple ParentResolvers, concatenating
+// results from each. This allows plugins to contribute additional parent
+// resolution logic alongside the default Gateway-based resolution.
+type CompositeParentResolver struct {
+	Resolvers []ParentResolver
+}
+
+func (c *CompositeParentResolver) ParentsFor(ctx krt.HandlerContext, pk utils.TypedNamespacedName) []*ParentInfo {
+	var result []*ParentInfo
+	for _, r := range c.Resolvers {
+		result = append(result, r.ParentsFor(ctx, pk)...)
+	}
+	return result
 }
 
 // BuildRouteParents builds a RouteParents from a collection of gateways.

--- a/controller/pkg/syncer/syncer.go
+++ b/controller/pkg/syncer/syncer.go
@@ -163,6 +163,15 @@ func (s *Syncer) buildResourceCollections(krtopts krtutil.KrtOptions) {
 	gatewayFinalStatus := s.buildFinalGatewayStatus(gatewayInitialStatus, routeAttachments, krtopts)
 	status.RegisterStatus(s.statusCollections, gatewayFinalStatus, translator.GetStatus)
 
+	// Register plugin-provided gateway statuses. These statuses are scoped to a
+	// specific gatewayclass as we already filter out those Gateways in
+	// buildAgwResources and won't conflict with status written by the non-plugin
+	// one above.
+	if s.agwPlugins.AddResourceExtension != nil && s.agwPlugins.AddResourceExtension.GatewayStatuses != nil {
+		pluginGwFinalStatus := s.buildFinalGatewayStatus(s.agwPlugins.AddResourceExtension.GatewayStatuses, routeAttachments, krtopts)
+		status.RegisterStatus(s.statusCollections, pluginGwFinalStatus, translator.GetStatus)
+	}
+
 	listenerSetFinalStatus := s.buildFinalListenerSetStatus(gateways, listenerSetInitialStatus, routeAttachments, krtopts)
 	status.RegisterStatus(s.statusCollections, listenerSetFinalStatus, translator.GetStatus)
 
@@ -442,7 +451,13 @@ func (s *Syncer) buildAgwResources(gateways krt.Collection[*translator.GatewayLi
 	}
 
 	// Build routes
-	routeParents := translator.BuildRouteParents(filteredGateways)
+	var routeParents translator.ParentResolver = translator.BuildRouteParents(filteredGateways)
+
+	// Compose with plugin-provided parent resolvers.
+	if ext := s.agwPlugins.AddResourceExtension; ext != nil && len(ext.ParentResolvers) > 0 {
+		resolvers := append([]translator.ParentResolver{routeParents}, ext.ParentResolvers...)
+		routeParents = &translator.CompositeParentResolver{Resolvers: resolvers}
+	}
 
 	referenceTypes := plugins.DefaultReferenceTypes(s.agwCollections)
 	if s.buildReferenceTypesFunc != nil {

--- a/controller/pkg/syncer/syncer.go
+++ b/controller/pkg/syncer/syncer.go
@@ -455,7 +455,12 @@ func (s *Syncer) buildAgwResources(gateways krt.Collection[*translator.GatewayLi
 
 	// Compose with plugin-provided parent resolvers.
 	if ext := s.agwPlugins.AddResourceExtension; ext != nil && len(ext.ParentResolvers) > 0 {
-		resolvers := append([]translator.ParentResolver{routeParents}, ext.ParentResolvers...)
+		resolvers := []translator.ParentResolver{routeParents}
+		for _, r := range ext.ParentResolvers {
+			if r != nil {
+				resolvers = append(resolvers, r)
+			}
+		}
 		routeParents = &translator.CompositeParentResolver{Resolvers: resolvers}
 	}
 


### PR DESCRIPTION
* move ParentInfo and ParentResolver to avoid circular references in plugin
* add ParentResolver to plugins and call them from core route translation
* when plugin-resolved parents set a serviceKey, skip the existence check (TODO: expand this to allow plugins to further customize/takeover responsibility for existence checks)
* add GatewayStatuses to plugisn to allow writing status for additional gatewayclasses
