### PR TITLE
mcp: make stateless defer DELETE send

### DIFF
--- a/crates/agentgateway/src/http/mod.rs
+++ b/crates/agentgateway/src/http/mod.rs
@@ -216,6 +216,7 @@ pub use ::http::uri::{Authority, Scheme};
 pub use ::http::{
 	HeaderMap, HeaderName, HeaderValue, Method, StatusCode, Uri, header, status, uri,
 };
+use axum_core::BoxError;
 use bytes::Bytes;
 use cel::Value;
 use http::uri::PathAndQuery;
@@ -746,16 +747,19 @@ pin_project_lite::pin_project! {
 	}
 }
 
-impl<B, D> DropBody<B, D> {
+impl<B, D> DropBody<B, D>
+where
+	D: Send + 'static,
+	B: http_body::Body<Data = Bytes> + Send + Unpin + 'static,
+	B::Error: Into<BoxError>,
+{
+	#[allow(clippy::new_ret_no_self)]
 	pub fn new(body: B, dropper: D) -> Body {
 		Body::new(Self { body, dropper })
 	}
 }
 
-impl<B: http_body::Body + Debug + Unpin, D> http_body::Body for DropBody<B, D>
-where
-	B::Data: Debug,
-{
+impl<B: http_body::Body + Unpin, D> http_body::Body for DropBody<B, D> {
 	type Data = B::Data;
 	type Error = B::Error;
 

--- a/crates/agentgateway/src/http/mod.rs
+++ b/crates/agentgateway/src/http/mod.rs
@@ -747,8 +747,8 @@ pin_project_lite::pin_project! {
 }
 
 impl<B, D> DropBody<B, D> {
-	pub fn new(body: B, dropper: D) -> Self {
-		Self { body, dropper }
+	pub fn new(body: B, dropper: D) -> Body {
+		Body::new(Self { body, dropper })
 	}
 }
 

--- a/crates/agentgateway/src/mcp/sse.rs
+++ b/crates/agentgateway/src/mcp/sse.rs
@@ -122,10 +122,10 @@ impl LegacySSEService {
 		);
 		let (parts, _) = request.into_parts();
 		Ok(Sse::new(stream).into_response().map(|b| {
-			http::Body::new(DropBody::new(
+			DropBody::new(
 				b,
 				session::dropper(self.session_manager.clone(), session, parts),
-			))
+			)
 		}))
 	}
 }

--- a/crates/agentgateway/src/mcp/streamablehttp.rs
+++ b/crates/agentgateway/src/mcp/streamablehttp.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crate::http::{Request, Response};
+use crate::http::{DropBody, Request, Response};
 use crate::mcp::handler::RelayInputs;
 use crate::mcp::session::SessionManager;
 use crate::*;
@@ -124,7 +124,7 @@ impl StreamableHttpService {
 				trace!("cleaning up stateless session");
 				let _ = session.delete_session(part).await;
 			});
-			return response.map(|r| r.map(|b| HoldBody::wrap(b, tx)));
+			return response.map(|r| r.map(|b| DropBody::new(b, tx)));
 		}
 
 		let session_id = part
@@ -218,53 +218,4 @@ fn accepted_response() -> Response {
 		.status(StatusCode::ACCEPTED)
 		.body(crate::http::Body::empty())
 		.expect("valid response")
-}
-
-pin_project_lite::pin_project! {
-	/// HoldBody keep-alive some data (T) to RAII
-	#[must_use]
-	#[derive(Debug)]
-	struct HoldBody<B, T> {
-		#[pin]
-		body: B,
-		keep_alive: T,
-	}
-}
-
-impl<B, T> HoldBody<B, T> {
-	pub fn wrap(body: B, keep_alive: T) -> http::Body
-	where
-		T: Send + 'static,
-		B: Body<Data = Bytes> + Unpin + Send + 'static,
-		B::Error: Into<BoxError> + Debug,
-	{
-		axum_core::body::Body::new(HoldBody { body, keep_alive })
-	}
-}
-
-impl<B, T> Body for HoldBody<B, T>
-where
-	B: Body + Unpin,
-	<B as Body>::Error: std::fmt::Debug,
-{
-	type Data = B::Data;
-	type Error = B::Error;
-
-	#[inline]
-	fn poll_frame(
-		mut self: Pin<&mut Self>,
-		cx: &mut Context<'_>,
-	) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
-		self.as_mut().project().body.poll_frame(cx)
-	}
-
-	#[inline]
-	fn is_end_stream(&self) -> bool {
-		self.body.is_end_stream()
-	}
-
-	#[inline]
-	fn size_hint(&self) -> SizeHint {
-		self.body.size_hint()
-	}
 }

--- a/crates/agentgateway/src/mcp/streamablehttp.rs
+++ b/crates/agentgateway/src/mcp/streamablehttp.rs
@@ -5,8 +5,6 @@ use crate::mcp::handler::RelayInputs;
 use crate::mcp::session::SessionManager;
 use crate::*;
 use ::http::StatusCode;
-use axum_core::BoxError;
-use http_body::{Body, Frame, SizeHint};
 use rmcp::model::{ClientJsonRpcMessage, ClientRequest, ServerJsonRpcMessage};
 use rmcp::transport::common::http_header::{
 	EVENT_STREAM_MIME_TYPE, HEADER_SESSION_ID, JSON_MIME_TYPE,

--- a/crates/agentgateway/src/mcp/streamablehttp.rs
+++ b/crates/agentgateway/src/mcp/streamablehttp.rs
@@ -5,6 +5,8 @@ use crate::mcp::handler::RelayInputs;
 use crate::mcp::session::SessionManager;
 use crate::*;
 use ::http::StatusCode;
+use axum_core::BoxError;
+use http_body::{Body, Frame, SizeHint};
 use rmcp::model::{ClientJsonRpcMessage, ClientRequest, ServerJsonRpcMessage};
 use rmcp::transport::common::http_header::{
 	EVENT_STREAM_MIME_TYPE, HEADER_SESSION_ID, JSON_MIME_TYPE,
@@ -114,9 +116,15 @@ impl StreamableHttpService {
 				.stateless_send_and_initialize(part.clone(), message)
 				.await;
 
+			let (tx, rx) = tokio::sync::oneshot::channel::<()>();
 			// Clean up upstream resources (e.g., stdio processes)
-			let _ = session.delete_session(part).await;
-			return response;
+			tokio::task::spawn(async move {
+				// Wait until the response is actually completed.
+				let _ = rx.await;
+				trace!("cleaning up stateless session");
+				let _ = session.delete_session(part).await;
+			});
+			return response.map(|r| r.map(|b| HoldBody::wrap(b, tx)));
 		}
 
 		let session_id = part
@@ -210,4 +218,53 @@ fn accepted_response() -> Response {
 		.status(StatusCode::ACCEPTED)
 		.body(crate::http::Body::empty())
 		.expect("valid response")
+}
+
+pin_project_lite::pin_project! {
+	/// HoldBody keep-alive some data (T) to RAII
+	#[must_use]
+	#[derive(Debug)]
+	struct HoldBody<B, T> {
+		#[pin]
+		body: B,
+		keep_alive: T,
+	}
+}
+
+impl<B, T> HoldBody<B, T> {
+	pub fn wrap(body: B, keep_alive: T) -> http::Body
+	where
+		T: Send + 'static,
+		B: Body<Data = Bytes> + Unpin + Send + 'static,
+		B::Error: Into<BoxError> + Debug,
+	{
+		axum_core::body::Body::new(HoldBody { body, keep_alive })
+	}
+}
+
+impl<B, T> Body for HoldBody<B, T>
+where
+	B: Body + Unpin,
+	<B as Body>::Error: std::fmt::Debug,
+{
+	type Data = B::Data;
+	type Error = B::Error;
+
+	#[inline]
+	fn poll_frame(
+		mut self: Pin<&mut Self>,
+		cx: &mut Context<'_>,
+	) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+		self.as_mut().project().body.poll_frame(cx)
+	}
+
+	#[inline]
+	fn is_end_stream(&self) -> bool {
+		self.body.is_end_stream()
+	}
+
+	#[inline]
+	fn size_hint(&self) -> SizeHint {
+		self.body.size_hint()
+	}
 }


### PR DESCRIPTION
Before, we send delete ~immediately. Some servers cut off the SSE stream
if the session is removed. instead, wait until the entire response is
complete.
