### PR TITLE
otel: respect standard vars

### DIFF
--- a/crates/agentgateway/src/config.rs
+++ b/crates/agentgateway/src/config.rs
@@ -8,7 +8,6 @@ use agent_core::durfmt;
 use agent_core::env::ENV;
 use agent_core::prelude::*;
 use secrecy::ExposeSecret;
-use serde::de::DeserializeOwned;
 
 use crate::control::caclient;
 use crate::telemetry::log::{LoggingFields, MetricFields};
@@ -18,6 +17,13 @@ use crate::{
 	Address, Config, ConfigSource, DnsLookupFamily, NestedRawConfig, RawLoggingLevel, StringOrInt,
 	ThreadingMode, XDSConfig, cel, client, serdes, telemetry,
 };
+
+#[derive(Default)]
+struct TracingEnvOverrides {
+	endpoint: Option<String>,
+	headers: Option<std::collections::HashMap<String, String>>,
+	protocol: Option<trc::Protocol>,
+}
 
 pub fn parse_config(contents: String, filename: Option<PathBuf>) -> anyhow::Result<Config> {
 	let nested: NestedRawConfig = serdes::yamlviajson::from_str(&contents)?;
@@ -202,8 +208,7 @@ pub fn parse_config(contents: String, filename: Option<PathBuf>) -> anyhow::Resu
 		.unwrap_or_default();
 	let termination_max_deadline =
 		parse_duration("CONNECTION_TERMINATION_DEADLINE")?.or(raw.connection_termination_deadline);
-	let otlp = empty_to_none(parse("OTLP_ENDPOINT")?)
-		.or(raw.tracing.as_ref().map(|t| t.otlp_endpoint.clone()));
+	let tracing_env = resolve_tracing_env_overrides()?;
 
 	let mut otlp_headers = raw
 		.tracing
@@ -211,11 +216,12 @@ pub fn parse_config(contents: String, filename: Option<PathBuf>) -> anyhow::Resu
 		.map(|t| t.headers.clone())
 		.unwrap_or_default();
 
-	if let Some(env_headers) = parse_otlp_headers("OTLP_HEADERS")? {
+	if let Some(env_headers) = tracing_env.headers.clone() {
 		otlp_headers.extend(env_headers);
 	}
 
-	let otlp_protocol = parse_serde("OTLP_PROTOCOL")?
+	let otlp_protocol = tracing_env
+		.protocol
 		.or(raw.tracing.as_ref().map(|t| t.otlp_protocol))
 		.unwrap_or_default();
 	// Parse admin_addr from environment variable or config file
@@ -294,8 +300,15 @@ pub fn parse_config(contents: String, filename: Option<PathBuf>) -> anyhow::Resu
 			.tracing
 			.clone()
 			.map(|t| {
+				let (otlp_endpoint, otlp_path) = normalize_tracing_endpoint(
+					tracing_env.endpoint.clone().or(t.otlp_endpoint.clone()),
+					t.path.clone(),
+				)?;
+				let endpoint = otlp_endpoint.context(
+					"config.tracing requires otlpEndpoint or one of OTLP_ENDPOINT, OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, or OTEL_EXPORTER_OTLP_ENDPOINT",
+				)?;
 				Ok::<_, anyhow::Error>(trc::DeprecatedConfig {
-					endpoint: otlp.clone(),
+					endpoint: Some(endpoint),
 					headers: otlp_headers.clone(),
 					protocol: otlp_protocol,
 
@@ -330,7 +343,7 @@ pub fn parse_config(contents: String, filename: Option<PathBuf>) -> anyhow::Resu
 						.map(cel::Expression::new_strict)
 						.transpose()?
 						.map(Arc::new),
-					path: t.path.clone().unwrap_or_else(|| "/v1/traces".to_string()),
+					path: otlp_path.unwrap_or_else(|| "/v1/traces".to_string()),
 				})
 			})
 			.transpose()?,
@@ -458,15 +471,6 @@ where
 	}
 }
 
-fn parse_serde<T: DeserializeOwned>(env: &str) -> anyhow::Result<Option<T>> {
-	match env::var(env) {
-		Ok(val) => serde_json::from_str(&val)
-			.map(|v| Some(v))
-			.map_err(|e| anyhow::anyhow!("invalid env var {}={} ({})", env, val, e)),
-		Err(_) => Ok(None),
-	}
-}
-
 fn parse_default<T: FromStr>(env: &str, default: T) -> anyhow::Result<T>
 where
 	<T as FromStr>::Err: std::error::Error + Sync + Send,
@@ -560,6 +564,80 @@ fn parse_otlp_headers(
 		Err(env::VarError::NotPresent) => Ok(None),
 		Err(e) => Err(anyhow::anyhow!("error reading {}: {}", env_key, e)),
 	}
+}
+
+fn parse_otlp_protocol(env_key: &str) -> anyhow::Result<Option<trc::Protocol>> {
+	match env::var(env_key) {
+		Ok(raw) => {
+			let protocol = match raw.trim().trim_matches('"').to_ascii_lowercase().as_str() {
+				"grpc" => trc::Protocol::Grpc,
+				"http" | "http/protobuf" => trc::Protocol::Http,
+				"http/json" => {
+					anyhow::bail!(
+						"invalid env var {}={} (http/json is not supported; use grpc or http/protobuf)",
+						env_key,
+						raw
+					)
+				},
+				_ => {
+					anyhow::bail!(
+						"invalid env var {}={} (expected grpc or http/protobuf)",
+						env_key,
+						raw
+					)
+				},
+			};
+			Ok(Some(protocol))
+		},
+		Err(env::VarError::NotPresent) => Ok(None),
+		Err(e) => Err(anyhow::anyhow!("error reading {}: {}", env_key, e)),
+	}
+}
+
+fn resolve_tracing_env_overrides() -> anyhow::Result<TracingEnvOverrides> {
+	let endpoint = empty_to_none(parse::<String>("OTLP_ENDPOINT")?)
+		.or(empty_to_none(parse::<String>(
+			"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+		)?))
+		.or(empty_to_none(parse::<String>(
+			"OTEL_EXPORTER_OTLP_ENDPOINT",
+		)?));
+	let headers = parse_otlp_headers("OTLP_HEADERS")?
+		.or(parse_otlp_headers("OTEL_EXPORTER_OTLP_TRACES_HEADERS")?)
+		.or(parse_otlp_headers("OTEL_EXPORTER_OTLP_HEADERS")?);
+	let protocol = parse_otlp_protocol("OTLP_PROTOCOL")?
+		.or(parse_otlp_protocol("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL")?)
+		.or(parse_otlp_protocol("OTEL_EXPORTER_OTLP_PROTOCOL")?);
+
+	Ok(TracingEnvOverrides {
+		endpoint,
+		headers,
+		protocol,
+	})
+}
+
+fn normalize_tracing_endpoint(
+	endpoint: Option<String>,
+	path: Option<String>,
+) -> anyhow::Result<(Option<String>, Option<String>)> {
+	let endpoint = validate_uri(empty_to_none(endpoint))?;
+	let Some(endpoint) = endpoint else {
+		return Ok((None, path));
+	};
+
+	let uri: http::Uri = endpoint.parse()?;
+	let endpoint = match (uri.scheme_str(), uri.authority()) {
+		(Some(scheme), Some(authority)) => format!("{scheme}://{authority}"),
+		_ => endpoint,
+	};
+	let path = match uri.path_and_query().map(|pq| pq.as_str()) {
+		Some(path_and_query) if !path_and_query.is_empty() && path_and_query != "/" => {
+			Some(path_and_query.to_string())
+		},
+		_ => path,
+	};
+
+	Ok((Some(endpoint), path))
 }
 
 /// If the resolved config has no nameservers, fall back to defaults while
@@ -726,12 +804,44 @@ mod parse_headers_tests {
 mod tests {
 	use super::*;
 	use std::env;
+	use std::ffi::OsString;
 	use std::sync::{LazyLock, Mutex};
 
 	static ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
 	fn lock_env() -> std::sync::MutexGuard<'static, ()> {
 		ENV_LOCK.lock().expect("env mutex poisoned")
+	}
+
+	struct TempEnvVar {
+		key: String,
+		previous: Option<OsString>,
+	}
+
+	impl TempEnvVar {
+		fn set(key: &str, value: &str) -> Self {
+			let previous = env::var_os(key);
+			unsafe {
+				env::set_var(key, value);
+			}
+			Self {
+				key: key.to_string(),
+				previous,
+			}
+		}
+	}
+
+	impl Drop for TempEnvVar {
+		fn drop(&mut self) {
+			match &self.previous {
+				Some(value) => unsafe {
+					env::set_var(&self.key, value);
+				},
+				None => unsafe {
+					env::remove_var(&self.key);
+				},
+			}
+		}
 	}
 
 	#[test]
@@ -783,6 +893,131 @@ mod tests {
 
 		// Test missing env var
 		assert_eq!(parse_otlp_headers("NONEXISTENT_VAR").unwrap(), None);
+	}
+
+	#[test]
+	fn tracing_accepts_standard_otlp_env_vars() {
+		let _env_lock = lock_env();
+		let _endpoint = TempEnvVar::set(
+			"OTEL_EXPORTER_OTLP_ENDPOINT",
+			"http://collector.example:4318",
+		);
+		let _protocol = TempEnvVar::set("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf");
+
+		let config = parse_config(
+			r#"
+config:
+  tracing: {}
+"#
+			.to_string(),
+			None,
+		)
+		.expect("config should parse");
+
+		let tracing = config.tracing.expect("tracing config should exist");
+		assert_eq!(
+			tracing.endpoint.as_deref(),
+			Some("http://collector.example:4318")
+		);
+		assert_eq!(tracing.protocol, trc::Protocol::Http);
+		assert_eq!(tracing.path, "/v1/traces");
+	}
+
+	#[test]
+	fn tracing_prefers_signal_specific_otlp_env_vars() {
+		let _env_lock = lock_env();
+		let _endpoint = TempEnvVar::set(
+			"OTEL_EXPORTER_OTLP_ENDPOINT",
+			"http://collector.example:4318",
+		);
+		let _traces_endpoint = TempEnvVar::set(
+			"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+			"http://traces.example:4318/custom/traces",
+		);
+		let _headers = TempEnvVar::set("OTEL_EXPORTER_OTLP_HEADERS", "authorization=general");
+		let _traces_headers =
+			TempEnvVar::set("OTEL_EXPORTER_OTLP_TRACES_HEADERS", "authorization=traces");
+		let _protocol = TempEnvVar::set("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc");
+		let _traces_protocol = TempEnvVar::set("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL", "http/protobuf");
+
+		let config = parse_config(
+			r#"
+config:
+  tracing: {}
+"#
+			.to_string(),
+			None,
+		)
+		.expect("config should parse");
+
+		let tracing = config.tracing.expect("tracing config should exist");
+		assert_eq!(
+			tracing.endpoint.as_deref(),
+			Some("http://traces.example:4318")
+		);
+		assert_eq!(tracing.path, "/custom/traces");
+		assert_eq!(
+			tracing.headers.get("authorization"),
+			Some(&"traces".to_string())
+		);
+		assert_eq!(tracing.protocol, trc::Protocol::Http);
+	}
+
+	#[test]
+	fn tracing_prefers_legacy_otlp_env_vars() {
+		let _env_lock = lock_env();
+		let _legacy_endpoint = TempEnvVar::set("OTLP_ENDPOINT", "http://legacy.example:4317");
+		let _standard_endpoint = TempEnvVar::set(
+			"OTEL_EXPORTER_OTLP_ENDPOINT",
+			"http://collector.example:4318",
+		);
+		let _legacy_headers = TempEnvVar::set("OTLP_HEADERS", "authorization=legacy");
+		let _standard_headers = TempEnvVar::set("OTEL_EXPORTER_OTLP_HEADERS", "authorization=standard");
+		let _legacy_protocol = TempEnvVar::set("OTLP_PROTOCOL", "grpc");
+		let _standard_protocol = TempEnvVar::set("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf");
+
+		let config = parse_config(
+			r#"
+config:
+  tracing: {}
+"#
+			.to_string(),
+			None,
+		)
+		.expect("config should parse");
+
+		let tracing = config.tracing.expect("tracing config should exist");
+		assert_eq!(
+			tracing.endpoint.as_deref(),
+			Some("http://legacy.example:4317")
+		);
+		assert_eq!(
+			tracing.headers.get("authorization"),
+			Some(&"legacy".to_string())
+		);
+		assert_eq!(tracing.protocol, trc::Protocol::Grpc);
+	}
+
+	#[test]
+	fn tracing_requires_endpoint_from_config_or_env() {
+		let _env_lock = lock_env();
+
+		let err = parse_config(
+			r#"
+config:
+  tracing: {}
+"#
+			.to_string(),
+			None,
+		)
+		.expect_err("missing tracing endpoint should fail");
+
+		assert!(
+			err
+				.to_string()
+				.contains("config.tracing requires otlpEndpoint"),
+			"unexpected error: {err}"
+		);
 	}
 
 	#[test]

--- a/crates/agentgateway/src/config.rs
+++ b/crates/agentgateway/src/config.rs
@@ -8,7 +8,6 @@ use agent_core::durfmt;
 use agent_core::env::ENV;
 use agent_core::prelude::*;
 use secrecy::ExposeSecret;
-use serde::de::DeserializeOwned;
 
 use crate::control::caclient;
 use crate::telemetry::log::{LoggingFields, MetricFields};
@@ -18,6 +17,13 @@ use crate::{
 	Address, Config, ConfigSource, DnsLookupFamily, NestedRawConfig, RawLoggingLevel, StringOrInt,
 	ThreadingMode, XDSConfig, cel, client, serdes, telemetry, types,
 };
+
+#[derive(Default)]
+struct TracingEnvOverrides {
+	endpoint: Option<String>,
+	headers: Option<std::collections::HashMap<String, String>>,
+	protocol: Option<trc::Protocol>,
+}
 
 pub fn parse_config(contents: String, filename: Option<PathBuf>) -> anyhow::Result<Config> {
 	let nested: NestedRawConfig = serdes::yamlviajson::from_str(&contents)?;
@@ -267,8 +273,7 @@ pub fn parse_config(contents: String, filename: Option<PathBuf>) -> anyhow::Resu
 		.unwrap_or_default();
 	let termination_max_deadline =
 		parse_duration("CONNECTION_TERMINATION_DEADLINE")?.or(raw.connection_termination_deadline);
-	let otlp = empty_to_none(parse("OTLP_ENDPOINT")?)
-		.or(raw.tracing.as_ref().map(|t| t.otlp_endpoint.clone()));
+	let tracing_env = resolve_tracing_env_overrides()?;
 
 	let mut otlp_headers = raw
 		.tracing
@@ -276,11 +281,12 @@ pub fn parse_config(contents: String, filename: Option<PathBuf>) -> anyhow::Resu
 		.map(|t| t.headers.clone())
 		.unwrap_or_default();
 
-	if let Some(env_headers) = parse_otlp_headers("OTLP_HEADERS")? {
+	if let Some(env_headers) = tracing_env.headers.clone() {
 		otlp_headers.extend(env_headers);
 	}
 
-	let otlp_protocol = parse_serde("OTLP_PROTOCOL")?
+	let otlp_protocol = tracing_env
+		.protocol
 		.or(raw.tracing.as_ref().map(|t| t.otlp_protocol))
 		.unwrap_or_default();
 	// Parse admin_addr from environment variable or config file
@@ -360,8 +366,15 @@ pub fn parse_config(contents: String, filename: Option<PathBuf>) -> anyhow::Resu
 			.tracing
 			.clone()
 			.map(|t| {
+				let (otlp_endpoint, otlp_path) = normalize_tracing_endpoint(
+					tracing_env.endpoint.clone().or(t.otlp_endpoint.clone()),
+					t.path.clone(),
+				)?;
+				let endpoint = otlp_endpoint.context(
+					"config.tracing requires otlpEndpoint or one of OTLP_ENDPOINT, OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, or OTEL_EXPORTER_OTLP_ENDPOINT",
+				)?;
 				Ok::<_, anyhow::Error>(trc::DeprecatedConfig {
-					endpoint: otlp.clone(),
+					endpoint: Some(endpoint),
 					headers: otlp_headers.clone(),
 					protocol: otlp_protocol,
 
@@ -396,7 +409,7 @@ pub fn parse_config(contents: String, filename: Option<PathBuf>) -> anyhow::Resu
 						.map(cel::Expression::new_strict)
 						.transpose()?
 						.map(Arc::new),
-					path: t.path.clone().unwrap_or_else(|| "/v1/traces".to_string()),
+					path: otlp_path.unwrap_or_else(|| "/v1/traces".to_string()),
 				})
 			})
 			.transpose()?,
@@ -531,15 +544,6 @@ where
 	}
 }
 
-fn parse_serde<T: DeserializeOwned>(env: &str) -> anyhow::Result<Option<T>> {
-	match env::var(env) {
-		Ok(val) => serde_json::from_str(&val)
-			.map(|v| Some(v))
-			.map_err(|e| anyhow::anyhow!("invalid env var {}={} ({})", env, val, e)),
-		Err(_) => Ok(None),
-	}
-}
-
 fn parse_default<T: FromStr>(env: &str, default: T) -> anyhow::Result<T>
 where
 	<T as FromStr>::Err: std::error::Error + Sync + Send,
@@ -633,6 +637,80 @@ fn parse_otlp_headers(
 		Err(env::VarError::NotPresent) => Ok(None),
 		Err(e) => Err(anyhow::anyhow!("error reading {}: {}", env_key, e)),
 	}
+}
+
+fn parse_otlp_protocol(env_key: &str) -> anyhow::Result<Option<trc::Protocol>> {
+	match env::var(env_key) {
+		Ok(raw) => {
+			let protocol = match raw.trim().trim_matches('"').to_ascii_lowercase().as_str() {
+				"grpc" => trc::Protocol::Grpc,
+				"http" | "http/protobuf" => trc::Protocol::Http,
+				"http/json" => {
+					anyhow::bail!(
+						"invalid env var {}={} (http/json is not supported; use grpc or http/protobuf)",
+						env_key,
+						raw
+					)
+				},
+				_ => {
+					anyhow::bail!(
+						"invalid env var {}={} (expected grpc or http/protobuf)",
+						env_key,
+						raw
+					)
+				},
+			};
+			Ok(Some(protocol))
+		},
+		Err(env::VarError::NotPresent) => Ok(None),
+		Err(e) => Err(anyhow::anyhow!("error reading {}: {}", env_key, e)),
+	}
+}
+
+fn resolve_tracing_env_overrides() -> anyhow::Result<TracingEnvOverrides> {
+	let endpoint = empty_to_none(parse::<String>("OTLP_ENDPOINT")?)
+		.or(empty_to_none(parse::<String>(
+			"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+		)?))
+		.or(empty_to_none(parse::<String>(
+			"OTEL_EXPORTER_OTLP_ENDPOINT",
+		)?));
+	let headers = parse_otlp_headers("OTLP_HEADERS")?
+		.or(parse_otlp_headers("OTEL_EXPORTER_OTLP_TRACES_HEADERS")?)
+		.or(parse_otlp_headers("OTEL_EXPORTER_OTLP_HEADERS")?);
+	let protocol = parse_otlp_protocol("OTLP_PROTOCOL")?
+		.or(parse_otlp_protocol("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL")?)
+		.or(parse_otlp_protocol("OTEL_EXPORTER_OTLP_PROTOCOL")?);
+
+	Ok(TracingEnvOverrides {
+		endpoint,
+		headers,
+		protocol,
+	})
+}
+
+fn normalize_tracing_endpoint(
+	endpoint: Option<String>,
+	path: Option<String>,
+) -> anyhow::Result<(Option<String>, Option<String>)> {
+	let endpoint = validate_uri(empty_to_none(endpoint))?;
+	let Some(endpoint) = endpoint else {
+		return Ok((None, path));
+	};
+
+	let uri: http::Uri = endpoint.parse()?;
+	let endpoint = match (uri.scheme_str(), uri.authority()) {
+		(Some(scheme), Some(authority)) => format!("{scheme}://{authority}"),
+		_ => endpoint,
+	};
+	let path = match uri.path_and_query().map(|pq| pq.as_str()) {
+		Some(path_and_query) if !path_and_query.is_empty() && path_and_query != "/" => {
+			Some(path_and_query.to_string())
+		},
+		_ => path,
+	};
+
+	Ok((Some(endpoint), path))
 }
 
 /// If the resolved config has no nameservers, fall back to defaults while
@@ -799,6 +877,7 @@ mod parse_headers_tests {
 #[cfg(test)]
 mod tests {
 	use std::env;
+	use std::ffi::OsString;
 	use std::sync::{LazyLock, Mutex};
 
 	use super::*;
@@ -807,6 +886,37 @@ mod tests {
 
 	fn lock_env() -> std::sync::MutexGuard<'static, ()> {
 		ENV_LOCK.lock().expect("env mutex poisoned")
+	}
+
+	struct TempEnvVar {
+		key: String,
+		previous: Option<OsString>,
+	}
+
+	impl TempEnvVar {
+		fn set(key: &str, value: &str) -> Self {
+			let previous = env::var_os(key);
+			unsafe {
+				env::set_var(key, value);
+			}
+			Self {
+				key: key.to_string(),
+				previous,
+			}
+		}
+	}
+
+	impl Drop for TempEnvVar {
+		fn drop(&mut self) {
+			match &self.previous {
+				Some(value) => unsafe {
+					env::set_var(&self.key, value);
+				},
+				None => unsafe {
+					env::remove_var(&self.key);
+				},
+			}
+		}
 	}
 
 	#[test]
@@ -858,6 +968,131 @@ mod tests {
 
 		// Test missing env var
 		assert_eq!(parse_otlp_headers("NONEXISTENT_VAR").unwrap(), None);
+	}
+
+	#[test]
+	fn tracing_accepts_standard_otlp_env_vars() {
+		let _env_lock = lock_env();
+		let _endpoint = TempEnvVar::set(
+			"OTEL_EXPORTER_OTLP_ENDPOINT",
+			"http://collector.example:4318",
+		);
+		let _protocol = TempEnvVar::set("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf");
+
+		let config = parse_config(
+			r#"
+config:
+  tracing: {}
+"#
+			.to_string(),
+			None,
+		)
+		.expect("config should parse");
+
+		let tracing = config.tracing.expect("tracing config should exist");
+		assert_eq!(
+			tracing.endpoint.as_deref(),
+			Some("http://collector.example:4318")
+		);
+		assert_eq!(tracing.protocol, trc::Protocol::Http);
+		assert_eq!(tracing.path, "/v1/traces");
+	}
+
+	#[test]
+	fn tracing_prefers_signal_specific_otlp_env_vars() {
+		let _env_lock = lock_env();
+		let _endpoint = TempEnvVar::set(
+			"OTEL_EXPORTER_OTLP_ENDPOINT",
+			"http://collector.example:4318",
+		);
+		let _traces_endpoint = TempEnvVar::set(
+			"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+			"http://traces.example:4318/custom/traces",
+		);
+		let _headers = TempEnvVar::set("OTEL_EXPORTER_OTLP_HEADERS", "authorization=general");
+		let _traces_headers =
+			TempEnvVar::set("OTEL_EXPORTER_OTLP_TRACES_HEADERS", "authorization=traces");
+		let _protocol = TempEnvVar::set("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc");
+		let _traces_protocol = TempEnvVar::set("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL", "http/protobuf");
+
+		let config = parse_config(
+			r#"
+config:
+  tracing: {}
+"#
+			.to_string(),
+			None,
+		)
+		.expect("config should parse");
+
+		let tracing = config.tracing.expect("tracing config should exist");
+		assert_eq!(
+			tracing.endpoint.as_deref(),
+			Some("http://traces.example:4318")
+		);
+		assert_eq!(tracing.path, "/custom/traces");
+		assert_eq!(
+			tracing.headers.get("authorization"),
+			Some(&"traces".to_string())
+		);
+		assert_eq!(tracing.protocol, trc::Protocol::Http);
+	}
+
+	#[test]
+	fn tracing_prefers_legacy_otlp_env_vars() {
+		let _env_lock = lock_env();
+		let _legacy_endpoint = TempEnvVar::set("OTLP_ENDPOINT", "http://legacy.example:4317");
+		let _standard_endpoint = TempEnvVar::set(
+			"OTEL_EXPORTER_OTLP_ENDPOINT",
+			"http://collector.example:4318",
+		);
+		let _legacy_headers = TempEnvVar::set("OTLP_HEADERS", "authorization=legacy");
+		let _standard_headers = TempEnvVar::set("OTEL_EXPORTER_OTLP_HEADERS", "authorization=standard");
+		let _legacy_protocol = TempEnvVar::set("OTLP_PROTOCOL", "grpc");
+		let _standard_protocol = TempEnvVar::set("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf");
+
+		let config = parse_config(
+			r#"
+config:
+  tracing: {}
+"#
+			.to_string(),
+			None,
+		)
+		.expect("config should parse");
+
+		let tracing = config.tracing.expect("tracing config should exist");
+		assert_eq!(
+			tracing.endpoint.as_deref(),
+			Some("http://legacy.example:4317")
+		);
+		assert_eq!(
+			tracing.headers.get("authorization"),
+			Some(&"legacy".to_string())
+		);
+		assert_eq!(tracing.protocol, trc::Protocol::Grpc);
+	}
+
+	#[test]
+	fn tracing_requires_endpoint_from_config_or_env() {
+		let _env_lock = lock_env();
+
+		let err = parse_config(
+			r#"
+config:
+  tracing: {}
+"#
+			.to_string(),
+			None,
+		)
+		.expect_err("missing tracing endpoint should fail");
+
+		assert!(
+			err
+				.to_string()
+				.contains("config.tracing requires otlpEndpoint"),
+			"unexpected error: {err}"
+		);
 	}
 
 	#[test]

--- a/crates/agentgateway/src/http/transformation_cel.rs
+++ b/crates/agentgateway/src/http/transformation_cel.rs
@@ -263,6 +263,10 @@ impl Transformation {
 				}
 			}
 		}
+		if let RequestOrResponse::Request(r) = &mut r {
+		tracing::error!("howardjohn: {:?} {:?}", r, http::DebugExtensions(r));
+
+		}
 		for (k, v) in &cfg.add {
 			let val = Self::exec_header(&r, v, k, request);
 			r.apply_header(k, val, true);

--- a/crates/agentgateway/src/lib.rs
+++ b/crates/agentgateway/src/lib.rs
@@ -282,7 +282,7 @@ pub struct RawSession {
 
 #[apply(schema_de!)]
 pub struct RawTracing {
-	otlp_endpoint: String,
+	otlp_endpoint: Option<String>,
 	#[serde(default)]
 	headers: HashMap<String, String>,
 	#[serde(default)]

--- a/crates/agentgateway/src/lib.rs
+++ b/crates/agentgateway/src/lib.rs
@@ -297,7 +297,7 @@ pub struct RawMcpConfig {
 
 #[apply(schema_de!)]
 pub struct RawTracing {
-	otlp_endpoint: String,
+	otlp_endpoint: Option<String>,
 	#[serde(default)]
 	headers: HashMap<String, String>,
 	#[serde(default)]

--- a/schema/config.json
+++ b/schema/config.json
@@ -369,7 +369,10 @@
       "type": "object",
       "properties": {
         "otlpEndpoint": {
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "headers": {
           "type": "object",
@@ -422,10 +425,7 @@
           ]
         }
       },
-      "additionalProperties": false,
-      "required": [
-        "otlpEndpoint"
-      ]
+      "additionalProperties": false
     },
     "Protocol": {
       "type": "string",


### PR DESCRIPTION
prob need to do this for access logs too.

Should this be on-by-default if they set the var? for tracing or logs or both?