### PR TITLE
Support for jj workspaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@
 DOCKER_REGISTRY ?= ghcr.io
 DOCKER_REPO ?= agentgateway
 IMAGE_NAME ?= agentgateway
-VERSION ?= $(shell git describe --tags --always --dirty)
-GIT_REVISION ?= $(shell git rev-parse HEAD)
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || jj log -r @ -T 'commit_id.shortest(12)' --no-graph 2>/dev/null || echo unknown)
+GIT_REVISION ?= $(shell git rev-parse HEAD 2>/dev/null || jj log -r @ -T 'commit_id' --no-graph 2>/dev/null || echo unknown)
 IMAGE_TAG ?= $(VERSION)
 IMAGE_FULL_NAME ?= $(DOCKER_REGISTRY)/$(DOCKER_REPO)/$(IMAGE_NAME):$(IMAGE_TAG)
 DOCKER_BUILDER ?= docker

--- a/controller/Makefile
+++ b/controller/Makefile
@@ -106,7 +106,11 @@ fmt:  ## Format the code with golangci-lint
 
 .PHONY: fmt-changed
 fmt-changed: ## Format only the changed code with golangci-lint (skip deleted files)
-	git status -s -uno | awk '{print $$2}' | grep '.*.go$$' | xargs -r -I{} bash -lc '[ -f "{}" ] && $(CUSTOM_GOLANGCI_LINT_FMT) "{}" || true'
+	@if git -C .. rev-parse --show-toplevel >/dev/null 2>&1; then \
+		git -C .. status -s -uno | awk '{print $$2}'; \
+	else \
+		jj -R .. diff --name-only 2>/dev/null; \
+	fi | sed 's#^controller/##' | awk '/.*\.go$$/' | xargs -r -I{} bash -lc '[ -f "{}" ] && $(CUSTOM_GOLANGCI_LINT_FMT) "{}" || true'
 
 # must be a separate target so that make waits for it to complete before moving on
 .PHONY: mod-download

--- a/controller/test/testutils/project.go
+++ b/controller/test/testutils/project.go
@@ -1,17 +1,25 @@
 package testutils
 
 import (
+	"fmt"
 	"os/exec"
 	"path/filepath"
 	"strings"
 )
 
-// GitRootDirectory returns the path of the top-level directory of the working tree.
+// GitRootDirectory returns the repository root, falling back to the jj workspace
+// root if Git metadata is unavailable.
 func GitRootDirectory() string {
-	data, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
-	if err != nil {
-		panic(err)
+	data, err := exec.Command("git", "rev-parse", "--show-toplevel").CombinedOutput()
+	if err == nil {
+		return strings.TrimSpace(string(data))
 	}
+
+	data, jjErr := exec.Command("jj", "workspace", "root").CombinedOutput()
+	if jjErr != nil {
+		panic(fmt.Errorf("failed to determine repository root using git or jj: git: %w; jj: %w", err, jjErr))
+	}
+
 	return strings.TrimSpace(string(data))
 }
 

--- a/tools/check_clean_repo.sh
+++ b/tools/check_clean_repo.sh
@@ -1,8 +1,20 @@
 #!/bin/bash
+set -euo pipefail
 
-if [[ -n $(git status --porcelain) ]]; then
-  git status
-  git diff
-  echo "ERROR: Some files need to be updated, please run 'make gen' and include any changed files in your PR"
-  exit 1
+ROOT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+
+if git -C "$ROOT_DIR" rev-parse --show-toplevel >/dev/null 2>&1; then
+  if [[ -n $(git -C "$ROOT_DIR" status --porcelain) ]]; then
+    git -C "$ROOT_DIR" status
+    git -C "$ROOT_DIR" diff
+    echo "ERROR: Some files need to be updated, please run 'make gen' and include any changed files in your PR"
+    exit 1
+  fi
+elif jj -R "$ROOT_DIR" workspace root >/dev/null 2>&1; then
+  if [[ -n "$(cd "$ROOT_DIR" && jj diff --name-only)" ]]; then
+    (cd "$ROOT_DIR" && jj status)
+    (cd "$ROOT_DIR" && jj diff --git)
+    echo "ERROR: Some files need to be updated, please run 'make gen' and include any changed files in your PR"
+    exit 1
+  fi
 fi

--- a/tools/report_build_info.sh
+++ b/tools/report_build_info.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
-set -e
-if BUILD_GIT_REVISION=$(git rev-parse HEAD 2> /dev/null); then
-  if [[ -z "${IGNORE_DIRTY_TREE}" ]] && [[ -n "$(git status --porcelain 2>/dev/null)" ]]; then
+set -euo pipefail
+
+if BUILD_GIT_REVISION=$(git rev-parse HEAD 2>/dev/null); then
+  if [[ -z "${IGNORE_DIRTY_TREE:-}" ]] && [[ -n "$(git status --porcelain 2>/dev/null)" ]]; then
+    BUILD_GIT_REVISION=${BUILD_GIT_REVISION}"-dirty"
+  fi
+elif BUILD_GIT_REVISION=$(jj log -r @ -T 'commit_id' --no-graph 2>/dev/null); then
+  if [[ -z "${IGNORE_DIRTY_TREE:-}" ]] && [[ -n "$(jj diff --name-only 2>/dev/null)" ]]; then
     BUILD_GIT_REVISION=${BUILD_GIT_REVISION}"-dirty"
   fi
 else


### PR DESCRIPTION
Allows for building and testing the `proxy` and `controller` from a `jj` workspace that does not have a `.git` dir collocated.