### PR TITLE
cleanup: remove rustls-pemfile and need for wiremock fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,10 +228,9 @@ dependencies = [
  "prost-wkt-types",
  "protos",
  "rand 0.10.1",
- "rcgen 0.14.7",
+ "rcgen",
  "regex",
- "reqwest 0.12.28",
- "reqwest 0.13.2",
+ "reqwest",
  "rmcp 0.10.0",
  "rmcp 1.5.0",
  "rstest",
@@ -1083,28 +1082,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "axum-server"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ab4a3ec9ea8a657c72d99a03a824af695bd0fb5ec639ccbd9cd3543b41a5f9"
-dependencies = [
- "arc-swap",
- "bytes",
- "fs-err",
- "http 1.4.0",
- "http-body 1.0.1",
- "hyper",
- "hyper-util",
- "pin-project-lite",
- "rustls",
- "rustls-pemfile",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls",
- "tower-service",
 ]
 
 [[package]]
@@ -2701,7 +2678,7 @@ dependencies = [
  "hmac 0.13.0",
  "http 1.4.0",
  "jsonwebtoken",
- "reqwest 0.13.2",
+ "reqwest",
  "rustc_version",
  "rustls",
  "rustls-pki-types",
@@ -3107,7 +3084,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -5156,19 +5132,6 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
-dependencies = [
- "pem",
- "ring",
- "rustls-pki-types",
- "time",
- "yasna",
-]
-
-[[package]]
-name = "rcgen"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10b99e0098aa4082912d4c649628623db6aba77335e4f4569ff5083a6448b32e"
@@ -5282,50 +5245,6 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2",
- "http 1.4.0",
- "http-body 1.0.1",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tokio-util",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-streams 0.4.2",
- "web-sys",
- "webpki-roots",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
@@ -5364,7 +5283,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams 0.5.0",
+ "wasm-streams",
  "web-sys",
 ]
 
@@ -5406,7 +5325,6 @@ dependencies = [
  "pastey",
  "pin-project-lite",
  "rand 0.9.4",
- "reqwest 0.12.28",
  "rmcp-macros 0.10.0",
  "schemars 1.0.4",
  "serde",
@@ -5440,7 +5358,7 @@ dependencies = [
  "pin-project-lite",
  "process-wrap",
  "rand 0.10.1",
- "reqwest 0.13.2",
+ "reqwest",
  "rmcp-macros 1.5.0",
  "schemars 1.0.4",
  "serde",
@@ -5582,7 +5500,6 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -5599,15 +5516,6 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]
@@ -7304,19 +7212,6 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
-dependencies = [
- "futures-util",
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "wasm-streams"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
@@ -7365,15 +7260,6 @@ name = "webpki-root-certs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -7810,10 +7696,10 @@ dependencies = [
 [[package]]
 name = "wiremock"
 version = "0.6.5"
-source = "git+https://github.com/howardjohn/wiremock-rs?rev=e55f5b96083125fdabc3e62f92790ee15ae3a10d#e55f5b96083125fdabc3e62f92790ee15ae3a10d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
 dependencies = [
  "assert-json-diff",
- "axum-server",
  "base64",
  "deadpool",
  "futures",
@@ -7823,9 +7709,7 @@ dependencies = [
  "hyper-util",
  "log",
  "once_cell",
- "rcgen 0.13.2",
  "regex",
- "rustls-pki-types",
  "serde",
  "serde_json",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,6 @@
 [patch.crates-io]
 schemars = { git = "https://github.com/howardjohn/schemars", rev = "4364354fa41897a0c2001d891c0a9a38eafedb82" }
 http-serde = { git = "https://gitlab.com/howardjohn/http-serde", rev = "163f20f551c2cf6032254b6dbbe246b91ce727ad" }
-wiremock = { git = "https://github.com/howardjohn/wiremock-rs", rev = "e55f5b96083125fdabc3e62f92790ee15ae3a10d" }
 
 [workspace]
 resolver = "2"
@@ -207,7 +206,7 @@ tracing-subscriber = { version = "0.3", features = [
 ] }
 url = "2.5"
 uuid = { version = "1.23", features = ["v4"] }
-wiremock = { version = "0.6", features = ["tls"] }
+wiremock = "0.6"
 x509-parser = { version = "0.18", default-features = false, features = ["verify-aws"] }
 which = "8.0"
 websocket-sans-io = '0.1'

--- a/crates/agentgateway/Cargo.toml
+++ b/crates/agentgateway/Cargo.toml
@@ -181,20 +181,12 @@ rmcp = { version = "1.5", features = [
 ] }
 # We need SSE client for testing but they removed it for some reason :-(
 # https://github.com/modelcontextprotocol/rust-sdk/pull/562
-legacy-rmcp = { package = "rmcp", version = "0.10.0", features = ["transport-sse-server",
+legacy-rmcp = { package = "rmcp", version = "0.10.0", features = [
+    "transport-sse-server",
     "transport-sse-client",
-    "transport-sse-client-reqwest",
     "client",
-    "reqwest"
 ] }
 reqwest.workspace = true
-# TODO(https://github.com/modelcontextprotocol/rust-sdk/pull/667)
-legacyreqwest = { package = "reqwest", version = "0.12", default-features = false, features = [
-    "http2",
-    "charset",
-    "macos-system-configuration",
-    "rustls-tls",
-] }
 
 [lints.clippy]
 # This rule makes code more confusing

--- a/crates/agentgateway/src/http/ext_proc_tests.rs
+++ b/crates/agentgateway/src/http/ext_proc_tests.rs
@@ -238,34 +238,24 @@ async fn dynamic_metadata() {
 	assert_eq!(body.as_ref(), b"");
 }
 
-pub async fn setup_ext_proc_mock<T: Handler + Send + Sync + 'static>(
-	mock: MockServer,
+pub async fn setup_ext_proc_mock<T: Handler + Send + Sync + 'static, M: HasAddress>(
+	mock: M,
 	failure_mode: ext_proc::FailureMode,
 	mock_ext_proc: ExtProcMock<T>,
 	config: &str,
-) -> (
-	MockServer,
-	MockInstance,
-	TestBind,
-	Client<MemoryConnector, Body>,
-) {
+) -> (M, MockInstance, TestBind, Client<MemoryConnector, Body>) {
 	setup_ext_proc_mock_with_meta(mock, failure_mode, mock_ext_proc, config, None, None, None).await
 }
 
-pub async fn setup_ext_proc_mock_with_meta<T: Handler + Send + Sync + 'static>(
-	mock: MockServer,
+pub async fn setup_ext_proc_mock_with_meta<T: Handler + Send + Sync + 'static, M: HasAddress>(
+	mock: M,
 	failure_mode: ext_proc::FailureMode,
 	mock_ext_proc: ExtProcMock<T>,
 	config: &str,
 	metadata_context: Option<HashMap<String, HashMap<String, Arc<Expression>>>>,
 	request_attributes: Option<HashMap<String, Arc<Expression>>>,
 	response_attributes: Option<HashMap<String, Arc<Expression>>>,
-) -> (
-	MockServer,
-	MockInstance,
-	TestBind,
-	Client<MemoryConnector, Body>,
-) {
+) -> (M, MockInstance, TestBind, Client<MemoryConnector, Body>) {
 	let ext_proc = mock_ext_proc.spawn().await;
 
 	let t = setup_proxy_test(config)

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -1,6 +1,7 @@
 use std::net::SocketAddr;
 
 use agent_core::strng;
+use futures::StreamExt;
 use itertools::Itertools;
 use openapiv3::OpenAPI;
 use rmcp::RoleClient;
@@ -1033,13 +1034,105 @@ type LegacyService = legacy_rmcp::service::RunningService<
 	legacy_rmcp::model::InitializeRequestParam,
 >;
 
+#[derive(Clone, Debug, Default)]
+struct LegacySseClient {
+	inner: reqwest::Client,
+}
+
+impl legacy_rmcp::transport::sse_client::SseClient for LegacySseClient {
+	type Error = reqwest::Error;
+
+	async fn post_message(
+		&self,
+		uri: http::Uri,
+		message: legacy_rmcp::model::ClientJsonRpcMessage,
+		auth_token: Option<String>,
+	) -> Result<(), legacy_rmcp::transport::sse_client::SseTransportError<Self::Error>> {
+		use legacy_rmcp::transport::sse_client::SseTransportError;
+
+		let mut request_builder = self.inner.post(uri.to_string()).json(&message);
+		if let Some(auth_header) = auth_token {
+			request_builder = request_builder.bearer_auth(auth_header);
+		}
+
+		let response = request_builder
+			.send()
+			.await
+			.map_err(SseTransportError::Client)?;
+		response
+			.error_for_status()
+			.map_err(SseTransportError::Client)?;
+		Ok(())
+	}
+
+	async fn get_stream(
+		&self,
+		uri: http::Uri,
+		last_event_id: Option<String>,
+		auth_token: Option<String>,
+	) -> Result<
+		legacy_rmcp::transport::common::client_side_sse::BoxedSseResponse,
+		legacy_rmcp::transport::sse_client::SseTransportError<Self::Error>,
+	> {
+		use legacy_rmcp::transport::common::http_header::{
+			EVENT_STREAM_MIME_TYPE, HEADER_LAST_EVENT_ID,
+		};
+		use legacy_rmcp::transport::sse_client::SseTransportError;
+		use reqwest::header::{ACCEPT, CONTENT_TYPE};
+
+		let mut request_builder = self
+			.inner
+			.get(uri.to_string())
+			.header(ACCEPT, EVENT_STREAM_MIME_TYPE);
+		if let Some(auth_header) = auth_token {
+			request_builder = request_builder.bearer_auth(auth_header);
+		}
+		if let Some(last_event_id) = last_event_id {
+			request_builder = request_builder.header(HEADER_LAST_EVENT_ID, last_event_id);
+		}
+
+		let response = request_builder
+			.send()
+			.await
+			.map_err(SseTransportError::Client)?
+			.error_for_status()
+			.map_err(SseTransportError::Client)?;
+
+		match response.headers().get(CONTENT_TYPE) {
+			Some(content_type) => {
+				if !content_type
+					.as_bytes()
+					.starts_with(EVENT_STREAM_MIME_TYPE.as_bytes())
+				{
+					return Err(SseTransportError::UnexpectedContentType(Some(
+						String::from_utf8_lossy(content_type.as_bytes()).to_string(),
+					)));
+				}
+			},
+			None => {
+				return Err(SseTransportError::UnexpectedContentType(None));
+			},
+		}
+
+		Ok(sse_stream::SseStream::from_byte_stream(response.bytes_stream()).boxed())
+	}
+}
+
 pub async fn mcp_sse_client(s: SocketAddr) -> LegacyService {
 	use legacy_rmcp::ServiceExt;
 	use legacy_rmcp::model::{ClientCapabilities, ClientInfo, Implementation};
 	use legacy_rmcp::transport::SseClientTransport;
-	let transport = SseClientTransport::<legacyreqwest::Client>::start(format!("http://{s}/sse"))
-		.await
-		.unwrap();
+	use legacy_rmcp::transport::sse_client::SseClientConfig;
+
+	let transport = SseClientTransport::start_with_client(
+		LegacySseClient::default(),
+		SseClientConfig {
+			sse_endpoint: format!("http://{s}/sse").into(),
+			..Default::default()
+		},
+	)
+	.await
+	.unwrap();
 	let client_info = ClientInfo {
 		protocol_version: Default::default(),
 		capabilities: ClientCapabilities::default(),

--- a/crates/agentgateway/src/proxy/gateway_test.rs
+++ b/crates/agentgateway/src/proxy/gateway_test.rs
@@ -1,3 +1,4 @@
+use std::convert::Infallible;
 use std::sync::{Arc, Mutex as StdMutex};
 
 use crate::http::tests_common::*;
@@ -26,7 +27,6 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::oneshot;
 use url::{Position, Url};
-use wiremock::{Mock, MockServer, ResponseTemplate};
 use x509_parser::nom::AsBytes;
 
 const TEST_PRIVATE_KEY_PEM: &str = "-----BEGIN PRIVATE KEY-----
@@ -143,34 +143,48 @@ fn query_param(uri: &str, name: &str) -> String {
 		.unwrap_or_else(|| panic!("missing query param {name}"))
 }
 
-async fn oidc_backend_mock() -> (MockServer, Arc<StdMutex<Option<String>>>) {
-	let token_response = Arc::new(StdMutex::new(None));
-	let mock = MockServer::start().await;
-	let token_response_clone = Arc::clone(&token_response);
-	Mock::given(wiremock::matchers::path_regex("/.*"))
-		.respond_with(move |req: &wiremock::Request| {
-			if req.method == Method::POST && req.url.path() == "/token" {
-				let id_token = token_response_clone
-					.lock()
-					.expect("token mutex")
-					.clone()
-					.expect("token response configured");
-				return ResponseTemplate::new(200).set_body_json(json!({
-					"id_token": id_token,
-				}));
-			}
+async fn handle_oidc_backend_request(
+	req: hyper::Request<hyper::body::Incoming>,
+	token_response: Arc<StdMutex<Option<String>>>,
+) -> Result<Response, Infallible> {
+	if req.method() == Method::POST && req.uri().path() == "/token" {
+		let id_token = token_response
+			.lock()
+			.expect("token mutex")
+			.clone()
+			.expect("token response configured");
+		return Ok(
+			::http::Response::builder()
+				.status(200)
+				.header(::http::header::CONTENT_TYPE, "application/json")
+				.body(Body::from(
+					serde_json::to_vec(&json!({
+						"id_token": id_token,
+					}))
+					.unwrap(),
+				))
+				.unwrap(),
+		);
+	}
 
-			let request = RequestDump {
-				method: req.method.clone(),
-				uri: req.url.to_string().parse().expect("request uri"),
-				headers: req.headers.clone(),
-				body: bytes::Bytes::copy_from_slice(&req.body),
-				version: req.version,
-			};
-			ResponseTemplate::new(200).set_body_json(request)
-		})
-		.mount(&mock)
-		.await;
+	echo_request(req).await
+}
+
+async fn oidc_backend_mock() -> (LocalMockServer, Arc<StdMutex<Option<String>>>) {
+	let token_response = Arc::new(StdMutex::new(None));
+
+	// Keep this local instead of relying on wiremock so the OIDC proxy tests keep
+	// asserting the actual backend HTTP version while avoiding extra test-only TLS
+	// and crypto dependencies.
+	let mock = spawn_http_mock({
+		let token_response = Arc::clone(&token_response);
+		move |req| {
+			let token_response = Arc::clone(&token_response);
+			async move { handle_oidc_backend_request(req, token_response).await }
+		}
+	})
+	.await;
+
 	(mock, token_response)
 }
 
@@ -993,6 +1007,7 @@ async fn tls_termination() {
 #[tokio::test]
 async fn tls_backend_connection() {
 	let (mock, certs) = tls_mock().await;
+	assert!(mock.uri().starts_with("https://"));
 	let backend_tls = http::backendtls::ResolvedBackendTLS {
 		root: Some(certs.root_cert.pem().into_bytes()),
 		hostname: Some("localhost".to_string()),
@@ -1367,9 +1382,10 @@ async fn tunnel_absolute_form() {
 	let res = send_request(io.clone(), Method::GET, "http://lo/foo").await;
 	assert_eq!(res.status(), 200);
 	let body = read_body(res.into_body()).await;
-	// Unfortunately, wiremock obscures whether it is an absolute form or not and makes the typical case hardcoded
-	// to "http://localhost". But our assertion here is good enough.
-	assert_eq!(&body.uri.to_string(), "http://lo/foo");
+	assert_eq!(body.uri.scheme_str(), Some("http"));
+	assert_eq!(body.uri.authority().map(|a| a.as_str()), Some("lo"));
+	assert_eq!(body.uri.path(), "/foo");
+	assert_eq!(body.headers.get(header::HOST).unwrap().as_bytes(), b"lo");
 	assert_eq!(
 		body.headers.get("proxy-authorization").unwrap().as_bytes(),
 		b"Basic my-key"

--- a/crates/agentgateway/src/test_helpers/proxymock.rs
+++ b/crates/agentgateway/src/test_helpers/proxymock.rs
@@ -1,3 +1,4 @@
+use std::convert::Infallible;
 use std::fmt::Debug;
 use std::net::SocketAddr;
 use std::pin::Pin;
@@ -11,17 +12,19 @@ use agent_core::{drain, metrics, strng};
 use axum::body::to_bytes;
 use bytes::Bytes;
 use http::{HeaderMap, HeaderName, HeaderValue, Method, Uri};
+use http_body_util::BodyExt;
 use hyper_util::client::legacy::Client;
 use hyper_util::rt::{TokioExecutor, TokioIo, TokioTimer};
 use itertools::Itertools;
 use prometheus_client::registry::Registry;
-use rustls_pki_types::ServerName;
+use rustls_pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer, ServerName};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tokio::io::DuplexStream;
+use tokio::net::TcpListener;
+use tokio::sync::oneshot;
 use tokio_rustls::TlsConnector;
 use tracing::{info, trace};
-use wiremock::tls_certs::MockTlsCertificates;
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use crate::http::backendtls::BackendTLS;
@@ -101,25 +104,69 @@ pub struct RequestDump {
 	pub body: Bytes,
 }
 
-pub async fn basic_setup() -> (MockServer, TestBind, Client<MemoryConnector, Body>) {
+pub trait HasAddress {
+	fn address(&self) -> &SocketAddr;
+}
+
+impl HasAddress for MockServer {
+	fn address(&self) -> &SocketAddr {
+		MockServer::address(self)
+	}
+}
+
+#[derive(Debug)]
+pub struct LocalMockServer {
+	scheme: &'static str,
+	address: SocketAddr,
+	shutdown_tx: Option<oneshot::Sender<()>>,
+}
+
+impl LocalMockServer {
+	pub fn address(&self) -> &SocketAddr {
+		&self.address
+	}
+
+	pub fn uri(&self) -> String {
+		format!("{}://{}", self.scheme, self.address)
+	}
+}
+
+impl HasAddress for LocalMockServer {
+	fn address(&self) -> &SocketAddr {
+		&self.address
+	}
+}
+
+impl Drop for LocalMockServer {
+	fn drop(&mut self) {
+		if let Some(shutdown_tx) = self.shutdown_tx.take() {
+			let _ = shutdown_tx.send(());
+		}
+	}
+}
+
+pub type EchoMockServer = LocalMockServer;
+pub type TlsMockServer = LocalMockServer;
+
+pub async fn basic_setup() -> (EchoMockServer, TestBind, Client<MemoryConnector, Body>) {
 	let mock = simple_mock().await;
 	setup_mock(mock)
 }
 
-pub fn setup_mock(mock: MockServer) -> (MockServer, TestBind, Client<MemoryConnector, Body>) {
+pub fn setup_mock<M: HasAddress>(mock: M) -> (M, TestBind, Client<MemoryConnector, Body>) {
 	let t = base_gateway(&mock);
 	let io = t.serve_http(BIND_KEY);
 	(mock, t, io)
 }
 
-pub fn base_gateway(mock: &MockServer) -> TestBind {
+pub fn base_gateway(mock: &impl HasAddress) -> TestBind {
 	setup_proxy_test("{}")
 		.unwrap()
 		.with_backend(*mock.address())
 		.with_bind(simple_bind(basic_route(*mock.address())))
 }
 
-pub fn setup_tcp_mock(mock: MockServer) -> (MockServer, TestBind, Client<MemoryConnector, Body>) {
+pub fn setup_tcp_mock<M: HasAddress>(mock: M) -> (M, TestBind, Client<MemoryConnector, Body>) {
 	let t = setup_proxy_test("{}")
 		.unwrap()
 		.with_backend(*mock.address())
@@ -131,21 +178,21 @@ pub fn setup_tcp_mock(mock: MockServer) -> (MockServer, TestBind, Client<MemoryC
 	(mock, t, io)
 }
 
-pub fn setup_llm_mock(
-	mock: MockServer,
+pub fn setup_llm_mock<M: HasAddress>(
+	mock: M,
 	provider: AIProvider,
 	tokenize: bool,
 	config: &str,
-) -> (MockServer, TestBind, Client<MemoryConnector, Body>) {
+) -> (M, TestBind, Client<MemoryConnector, Body>) {
 	let provider = llm_named_provider(&mock, provider, tokenize);
 	setup_llm_named_provider_mock(mock, provider, config)
 }
 
-pub fn setup_llm_named_provider_mock(
-	mock: MockServer,
+pub fn setup_llm_named_provider_mock<M: HasAddress>(
+	mock: M,
 	provider: LocalNamedAIProvider,
 	config: &str,
-) -> (MockServer, TestBind, Client<MemoryConnector, Body>) {
+) -> (M, TestBind, Client<MemoryConnector, Body>) {
 	let t = setup_proxy_test(config).unwrap();
 	let be = crate::types::local::LocalAIBackend::Provider(provider)
 		.translate()
@@ -161,7 +208,7 @@ pub fn setup_llm_named_provider_mock(
 }
 
 pub fn llm_named_provider(
-	mock: &MockServer,
+	mock: &impl HasAddress,
 	provider: AIProvider,
 	tokenize: bool,
 ) -> LocalNamedAIProvider {
@@ -298,45 +345,199 @@ pub async fn body_mock(body: &[u8]) -> MockServer {
 	mock
 }
 
-pub async fn simple_mock() -> MockServer {
-	let mock = wiremock::MockServer::start().await;
-	Mock::given(wiremock::matchers::path_regex("/.*"))
-		.respond_with(|req: &wiremock::Request| {
-			let r = RequestDump {
-				method: req.method.clone(),
-				uri: req.url.to_string().parse().unwrap(),
-				headers: req.headers.clone(),
-				body: Bytes::copy_from_slice(&req.body),
-				version: req.version,
-			};
-			ResponseTemplate::new(200).set_body_json(r)
-		})
-		.mount(&mock)
-		.await;
-	mock
+pub async fn simple_mock() -> EchoMockServer {
+	spawn_http_mock(echo_request).await
 }
 
-// Spawn a mock TLS server. It will always respond on h2,http/1.1 ALPN
-pub async fn tls_mock() -> (MockServer, MockTlsCertificates) {
+pub async fn tls_mock() -> (TlsMockServer, TlsMockCertificates) {
 	let _ = rustls::crypto::CryptoProvider::install_default(Arc::unwrap_or_clone(tls::provider()));
-	let certs = wiremock::tls_certs::MockTlsCertificates::random();
-	let mock = wiremock::MockServer::builder()
-		.start_https(certs.get_server_config())
-		.await;
-	Mock::given(wiremock::matchers::path_regex("/.*"))
-		.respond_with(|req: &wiremock::Request| {
-			let r = RequestDump {
-				method: req.method.clone(),
-				uri: req.url.to_string().parse().unwrap(),
-				headers: req.headers.clone(),
-				body: Bytes::copy_from_slice(&req.body),
-				version: req.version,
-			};
-			ResponseTemplate::new(200).set_body_json(r)
-		})
-		.mount(&mock)
-		.await;
+	let (server_config, certs) = build_tls_mock_config();
+	let mock = spawn_tls_mock_with_config(server_config, echo_request).await;
 	(mock, certs)
+}
+
+#[derive(Clone, Debug)]
+pub struct TlsMockCertificates {
+	pub root_cert: rcgen::Certificate,
+}
+
+fn build_tls_mock_config() -> (rustls::ServerConfig, TlsMockCertificates) {
+	use rcgen::{
+		BasicConstraints, CertificateParams, CertifiedIssuer, DistinguishedName, DnType,
+		ExtendedKeyUsagePurpose, IsCa, KeyPair, KeyUsagePurpose, SanType,
+	};
+
+	let mut ca_params = CertificateParams::default();
+	let mut ca_dn = DistinguishedName::new();
+	ca_dn.push(DnType::CommonName, "agentgateway test ca");
+	ca_params.distinguished_name = ca_dn;
+	ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+	ca_params.key_usages = vec![
+		KeyUsagePurpose::DigitalSignature,
+		KeyUsagePurpose::KeyCertSign,
+		KeyUsagePurpose::CrlSign,
+	];
+	let ca_key = KeyPair::generate_for(&rcgen::PKCS_ECDSA_P256_SHA256).unwrap();
+	let ca = CertifiedIssuer::self_signed(ca_params, ca_key).unwrap();
+
+	let mut leaf_params = CertificateParams::new(vec!["localhost".to_string()]).unwrap();
+	let mut leaf_dn = DistinguishedName::new();
+	leaf_dn.push(DnType::CommonName, "localhost");
+	leaf_params.distinguished_name = leaf_dn;
+	leaf_params
+		.subject_alt_names
+		.push(SanType::IpAddress("127.0.0.1".parse().unwrap()));
+	leaf_params
+		.subject_alt_names
+		.push(SanType::IpAddress("::1".parse().unwrap()));
+	leaf_params.key_usages = vec![
+		KeyUsagePurpose::DigitalSignature,
+		KeyUsagePurpose::KeyEncipherment,
+	];
+	leaf_params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ServerAuth];
+	let leaf_key = KeyPair::generate_for(&rcgen::PKCS_ECDSA_P256_SHA256).unwrap();
+	let leaf_cert = leaf_params.signed_by(&leaf_key, &ca).unwrap();
+
+	let certs = TlsMockCertificates {
+		root_cert: ca.as_ref().clone(),
+	};
+	let cert_chain = vec![
+		CertificateDer::from(leaf_cert),
+		CertificateDer::from(ca.as_ref().clone()),
+	];
+	let key_der: PrivateKeyDer<'static> = PrivatePkcs8KeyDer::from(leaf_key).into();
+	let mut server_config = rustls::ServerConfig::builder_with_provider(tls::provider())
+		.with_protocol_versions(tls::ALL_TLS_VERSIONS)
+		.expect("tls mock config must be valid")
+		.with_no_client_auth()
+		.with_single_cert(cert_chain, key_der)
+		.unwrap();
+	server_config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
+
+	(server_config, certs)
+}
+
+pub async fn echo_request(
+	req: hyper::Request<hyper::body::Incoming>,
+) -> Result<Response, Infallible> {
+	let (parts, body) = req.into_parts();
+	let body = body.collect().await.unwrap().to_bytes();
+	let dump = RequestDump {
+		method: parts.method,
+		uri: parts.uri,
+		headers: parts.headers,
+		version: parts.version,
+		body,
+	};
+
+	Ok(
+		::http::Response::builder()
+			.status(200)
+			.header(::http::header::CONTENT_TYPE, "application/json")
+			.body(Body::from(serde_json::to_vec(&dump).unwrap()))
+			.unwrap(),
+	)
+}
+
+async fn spawn_tcp_mock_server<F, Fut>(
+	listener: TcpListener,
+	scheme: &'static str,
+	listener_name: &'static str,
+	on_accept: F,
+) -> LocalMockServer
+where
+	F: Fn(tokio::net::TcpStream) -> Fut + Clone + Send + 'static,
+	Fut: std::future::Future<Output = ()> + Send + 'static,
+{
+	let address = listener.local_addr().unwrap();
+	let (shutdown_tx, mut shutdown_rx) = oneshot::channel();
+
+	tokio::spawn(async move {
+		loop {
+			tokio::select! {
+				_ = &mut shutdown_rx => break,
+				accepted = listener.accept() => {
+					let (stream, _) = match accepted {
+						Ok(conn) => conn,
+						Err(err) => {
+							trace!("{listener_name} failed: {err:?}");
+							break;
+						},
+					};
+					let on_accept = on_accept.clone();
+					tokio::spawn(on_accept(stream));
+				},
+			}
+		}
+	});
+
+	LocalMockServer {
+		scheme,
+		address,
+		shutdown_tx: Some(shutdown_tx),
+	}
+}
+
+pub async fn spawn_http_mock<H, Fut>(handler: H) -> LocalMockServer
+where
+	H: Fn(hyper::Request<hyper::body::Incoming>) -> Fut + Clone + Send + 'static,
+	Fut: std::future::Future<Output = Result<Response, Infallible>> + Send + 'static,
+{
+	let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+	spawn_tcp_mock_server(listener, "http", "mock listener", move |stream| {
+		let handler = handler.clone();
+		async move {
+			let builder = hyper_util::server::conn::auto::Builder::new(TokioExecutor::new());
+			let service = hyper::service::service_fn(move |req| {
+				let handler = handler.clone();
+				async move { handler(req).await }
+			});
+			if let Err(err) = builder
+				.serve_connection(TokioIo::new(stream), service)
+				.await
+			{
+				trace!("mock connection failed: {err:?}");
+			}
+		}
+	})
+	.await
+}
+
+pub async fn spawn_tls_mock_with_config<H, Fut>(
+	server_config: rustls::ServerConfig,
+	handler: H,
+) -> LocalMockServer
+where
+	H: Fn(hyper::Request<hyper::body::Incoming>) -> Fut + Clone + Send + 'static,
+	Fut: std::future::Future<Output = Result<Response, Infallible>> + Send + 'static,
+{
+	let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+	let acceptor = tokio_rustls::TlsAcceptor::from(Arc::new(server_config));
+	spawn_tcp_mock_server(listener, "https", "mock tls listener", move |stream| {
+		let acceptor = acceptor.clone();
+		let handler = handler.clone();
+		async move {
+			let tls_stream = match acceptor.accept(stream).await {
+				Ok(stream) => stream,
+				Err(err) => {
+					trace!("mock tls accept failed: {err:?}");
+					return;
+				},
+			};
+			let builder = hyper_util::server::conn::auto::Builder::new(TokioExecutor::new());
+			let service = hyper::service::service_fn(move |req| {
+				let handler = handler.clone();
+				async move { handler(req).await }
+			});
+			if let Err(err) = builder
+				.serve_connection(TokioIo::new(tls_stream), service)
+				.await
+			{
+				trace!("mock tls connection failed: {err:?}");
+			}
+		}
+	})
+	.await
 }
 
 pub struct TestBind {

--- a/crates/core/src/telemetry/nonblocking.rs
+++ b/crates/core/src/telemetry/nonblocking.rs
@@ -40,11 +40,11 @@ pub const DEFAULT_BUFFERED_LINES_LIMIT: usize = 128_000;
 ///
 /// # Examples
 ///
-/// ``` rust
-/// # #[clippy::allow(needless_doctest_main)]
+/// ``` rust,no_run
 /// fn main () {
 /// # fn doc() {
-///     let (non_blocking, _guard) = tracing_appender::non_blocking(std::io::stdout());
+///     use agent_core::telemetry::nonblocking::NonBlockingBuilder;
+///     let (non_blocking, _guard) = NonBlockingBuilder::default().finish(std::io::stdout());
 ///     let subscriber = tracing_subscriber::fmt().with_writer(non_blocking);
 ///     tracing::subscriber::with_default(subscriber.finish(), || {
 ///         // Emit some tracing events within context of the non_blocking `_guard` and tracing subscriber


### PR DESCRIPTION
Fixes https://github.com/agentgateway/agentgateway/issues/983

- drop the patched wiremock TLS/test-only dependency path while keeping wiremock for the broader test suite
- add lightweight local HTTP/TLS echo mocks with shared address helpers and correct http/https URIs
- switch proxy/OIDC/tunnel tests to the local mocks and tighten the plaintext tunnel absolute-form assertions
- keep legacy rmcp SSE coverage with a tiny local client adapter that reuses the workspace reqwest client instead of pulling in reqwest 0.12