### PR TITLE
pool: ensure per-version TLS still pools

### DIFF
--- a/crates/agentgateway/src/http/backendtls.rs
+++ b/crates/agentgateway/src/http/backendtls.rs
@@ -32,8 +32,8 @@ pub static INSECURE_TRUST: Lazy<BackendTLS> = Lazy::new(|| {
 pub struct PerAlpnConfig {
 	config: Arc<ClientConfig>,
 	allow_custom_alpn: bool,
-	h1: std::sync::OnceLock<Arc<ClientConfig>>,
-	h2: std::sync::OnceLock<Arc<ClientConfig>>,
+	h1: Arc<std::sync::OnceLock<Arc<ClientConfig>>>,
+	h2: Arc<std::sync::OnceLock<Arc<ClientConfig>>>,
 }
 
 impl PerAlpnConfig {


### PR DESCRIPTION
We were making distinct configs before, breaking pooling. This is
unrelated to the recent pool change.
