### PR TITLE
Do not unecessarily fanout initialize for stateless MCP

### DIFF
--- a/crates/agentgateway/src/mcp/handler.rs
+++ b/crates/agentgateway/src/mcp/handler.rs
@@ -486,6 +486,22 @@ impl Relay {
 
 		Ok(accepted_response())
 	}
+
+	pub async fn send_notification_single(
+		&self,
+		r: ClientNotification,
+		ctx: IncomingRequestContext,
+		service_name: &str,
+	) -> Result<Response, UpstreamError> {
+		let Ok(us) = self.upstreams.get(service_name) else {
+			return Err(UpstreamError::InvalidRequest(format!(
+				"unknown service {service_name}"
+			)));
+		};
+		us.generic_notification(r, &ctx).await?;
+		Ok(accepted_response())
+	}
+
 	fn get_info(
 		pv: ProtocolVersion,
 		multiplexing: bool,

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -4,7 +4,7 @@ use agent_core::strng;
 use itertools::Itertools;
 use openapiv3::OpenAPI;
 use rmcp::RoleClient;
-use rmcp::model::InitializeRequestParams;
+use rmcp::model::{ClientJsonRpcMessage, InitializeRequestParams, RequestId};
 use rmcp::service::RunningService;
 use rmcp::transport::StreamableHttpServerConfig;
 use secrecy::SecretString;
@@ -154,6 +154,7 @@ async fn stateless_multiplex_tool_call_initializes_only_target() {
 		.with_bind(simple_bind(basic_named_route(strng::new("/mcp"))));
 	let io = t.serve_real_listener(strng::new("bind")).await;
 	let client = mcp_streamable_client(io).await;
+	let b_init_before = mock_b.init_count().await;
 
 	// A direct tool call to one target should initialize only that target.
 	let _ = client
@@ -167,15 +168,77 @@ async fn stateless_multiplex_tool_call_initializes_only_target() {
 		)
 		.await
 		.unwrap();
+	let b_init_after = mock_b.init_count().await;
+	assert_eq!(b_init_after, b_init_before);
+}
 
-	// Calling b_get_init_count itself performs one initialize for target b.
-	// If target b had already been initialized by fanout, this would return 2.
-	let b_init_count = client
-		.call_tool(rmcp::model::CallToolRequestParams::new("b_get_init_count"))
+#[tokio::test]
+async fn stateless_multiplex_delete_session_skips_uninitialized_targets() {
+	let mock_a = mock_streamable_http_server(true).await;
+	let mock_b = mock_streamable_http_server(true).await;
+	let relay = Relay::new(
+		McpBackendGroup {
+			targets: vec![
+				fake_streamable_target("a", mock_a.addr),
+				fake_streamable_target("b", mock_b.addr),
+			],
+			stateful: false,
+			failure_mode: FailureMode::FailClosed,
+		},
+		empty_mcp_policies(),
+		PolicyClient {
+			inputs: setup_proxy_test("{}").unwrap().pi,
+		},
+	)
+	.unwrap();
+	let session_manager =
+		super::session::SessionManager::new(http::sessionpersistence::Encoder::base64());
+	let mut session = session_manager.create_stateless_session(relay);
+	let parts = ::http::Request::<()>::builder()
+		.method(http::Method::POST)
+		.uri("http://example.test/mcp")
+		.body(())
+		.unwrap()
+		.into_parts()
+		.0;
+
+	session
+		.stateless_send_and_initialize(
+			parts.clone(),
+			ClientJsonRpcMessage::request(
+				rmcp::model::CallToolRequest::new(
+					rmcp::model::CallToolRequestParams::new("a_echo").with_arguments(
+						serde_json::json!({"hi": "world"})
+							.as_object()
+							.cloned()
+							.unwrap(),
+					),
+				)
+				.into(),
+				RequestId::Number(1),
+			),
+		)
 		.await
 		.unwrap();
-	let b_init_count_text = &b_init_count.content[0].raw.as_text().unwrap().text;
-	assert_eq!(b_init_count_text, "1");
+
+	let sessions = match http::sessionpersistence::SessionState::decode(
+		session.id.as_ref(),
+		&http::sessionpersistence::Encoder::base64(),
+	)
+	.unwrap()
+	{
+		http::sessionpersistence::SessionState::MCP(state) => state.sessions,
+		_ => panic!("expected MCP session state"),
+	};
+	assert_eq!(sessions.len(), 2);
+	assert_eq!(sessions[0].target_name.as_deref(), Some("a"));
+	assert!(sessions[0].session.is_some());
+	assert_eq!(sessions[1].target_name.as_deref(), Some("b"));
+	assert!(sessions[1].session.is_none());
+
+	let response = session.delete_session(parts).await.unwrap();
+	assert_eq!(response.status(), http::StatusCode::ACCEPTED);
+	assert_eq!(mock_b.init_count().await, 0);
 }
 
 #[tokio::test]
@@ -906,7 +969,14 @@ pub async fn mcp_sse_client(s: SocketAddr) -> LegacyService {
 
 struct MockServer {
 	addr: SocketAddr,
+	init_counter: std::sync::Arc<tokio::sync::Mutex<i32>>,
 	_cancel: tokio::sync::oneshot::Sender<()>,
+}
+
+impl MockServer {
+	async fn init_count(&self) -> i32 {
+		*self.init_counter.lock().await
+	}
 }
 
 async fn mock_streamable_http_server(stateful: bool) -> MockServer {
@@ -914,9 +984,13 @@ async fn mock_streamable_http_server(stateful: bool) -> MockServer {
 	use rmcp::transport::streamable_http_server::StreamableHttpService;
 	use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
 	agent_core::telemetry::testing::setup_test_logging();
+	let init_counter = std::sync::Arc::new(tokio::sync::Mutex::new(0_i32));
 
 	let service = StreamableHttpService::new(
-		|| Ok(Counter::new()),
+		{
+			let init_counter = init_counter.clone();
+			move || Ok(Counter::new(init_counter.clone()))
+		},
 		LocalSessionManager::default().into(),
 		StreamableHttpServerConfig::default()
 			.with_sse_retry(None)
@@ -935,7 +1009,11 @@ async fn mock_streamable_http_server(stateful: bool) -> MockServer {
 			.await;
 		info!("server stopped");
 	});
-	MockServer { addr, _cancel: tx }
+	MockServer {
+		addr,
+		init_counter,
+		_cancel: tx,
+	}
 }
 
 async fn mock_sse_server() -> MockServer {
@@ -966,7 +1044,11 @@ async fn mock_sse_server() -> MockServer {
 			})
 			.await;
 	});
-	MockServer { addr, _cancel: tx }
+	MockServer {
+		addr,
+		init_counter: std::sync::Arc::new(tokio::sync::Mutex::new(0)),
+		_cancel: tx,
+	}
 }
 mod mockserver {
 	use std::sync::Arc;
@@ -1016,10 +1098,10 @@ mod mockserver {
 	#[tool_router]
 	impl Counter {
 		#[allow(dead_code)]
-		pub fn new() -> Self {
+		pub fn new(init_counter: Arc<Mutex<i32>>) -> Self {
 			Self {
 				counter: Arc::new(Mutex::new(0)),
-				init_counter: Arc::new(Mutex::new(0)),
+				init_counter,
 				tool_router: Self::tool_router(),
 				prompt_router: Self::prompt_router(),
 			}

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -141,6 +141,44 @@ async fn stream_to_multiplex() {
 }
 
 #[tokio::test]
+async fn stateless_multiplex_tool_call_initializes_only_target() {
+	let mock_a = mock_streamable_http_server(true).await;
+	let mock_b = mock_streamable_http_server(true).await;
+	let t = setup_proxy_test("{}")
+		.unwrap()
+		.with_multiplex_mcp_backend(
+			"mcp",
+			vec![("a", mock_a.addr, false), ("b", mock_b.addr, false)],
+			false,
+		)
+		.with_bind(simple_bind(basic_named_route(strng::new("/mcp"))));
+	let io = t.serve_real_listener(strng::new("bind")).await;
+	let client = mcp_streamable_client(io).await;
+
+	// A direct tool call to one target should initialize only that target.
+	let _ = client
+		.call_tool(
+			rmcp::model::CallToolRequestParams::new("a_echo").with_arguments(
+				serde_json::json!({"hi": "world"})
+					.as_object()
+					.cloned()
+					.unwrap(),
+			),
+		)
+		.await
+		.unwrap();
+
+	// Calling b_get_init_count itself performs one initialize for target b.
+	// If target b had already been initialized by fanout, this would return 2.
+	let b_init_count = client
+		.call_tool(rmcp::model::CallToolRequestParams::new("b_get_init_count"))
+		.await
+		.unwrap();
+	let b_init_count_text = &b_init_count.content[0].raw.as_text().unwrap().text;
+	assert_eq!(b_init_count_text, "1");
+}
+
+#[tokio::test]
 async fn stateless_to_stateful() {
 	let mock = mock_streamable_http_server(true).await;
 	let (_bind, io) = setup_proxy(&mock, false, false).await;
@@ -970,6 +1008,7 @@ mod mockserver {
 	#[derive(Clone)]
 	pub struct Counter {
 		counter: Arc<Mutex<i32>>,
+		init_counter: Arc<Mutex<i32>>,
 		tool_router: ToolRouter<Counter>,
 		prompt_router: PromptRouter<Counter>,
 	}
@@ -980,6 +1019,7 @@ mod mockserver {
 		pub fn new() -> Self {
 			Self {
 				counter: Arc::new(Mutex::new(0)),
+				init_counter: Arc::new(Mutex::new(0)),
 				tool_router: Self::tool_router(),
 				prompt_router: Self::prompt_router(),
 			}
@@ -1047,6 +1087,14 @@ mod mockserver {
 					.get("authorization")
 					.map(|s| String::from_utf8_lossy(s.as_bytes()))
 					.unwrap_or_default(),
+			)]))
+		}
+
+		#[tool(description = "Get initialize call count")]
+		async fn get_init_count(&self) -> Result<CallToolResult, McpError> {
+			let init_counter = self.init_counter.lock().await;
+			Ok(CallToolResult::success(vec![Content::text(
+				init_counter.to_string(),
 			)]))
 		}
 	}
@@ -1176,6 +1224,8 @@ mod mockserver {
 			_request: InitializeRequestParams,
 			_: RequestContext<RoleServer>,
 		) -> Result<InitializeResult, McpError> {
+			let mut init_counter = self.init_counter.lock().await;
+			*init_counter += 1;
 			Ok(self.get_info())
 		}
 	}

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -154,6 +154,7 @@ async fn stateless_multiplex_tool_call_initializes_only_target() {
 		.with_bind(simple_bind(basic_named_route(strng::new("/mcp"))));
 	let io = t.serve_real_listener(strng::new("bind")).await;
 	let client = mcp_streamable_client(io).await;
+	let a_init_before = mock_a.init_count().await;
 	let b_init_before = mock_b.init_count().await;
 
 	// A direct tool call to one target should initialize only that target.
@@ -168,7 +169,44 @@ async fn stateless_multiplex_tool_call_initializes_only_target() {
 		)
 		.await
 		.unwrap();
+	let a_init_after = mock_a.init_count().await;
 	let b_init_after = mock_b.init_count().await;
+	assert_eq!(a_init_after, a_init_before + 1);
+	assert_eq!(b_init_after, b_init_before);
+}
+
+#[tokio::test]
+async fn stateless_multiplex_get_prompt_initializes_only_target() {
+	let mock_a = mock_streamable_http_server(true).await;
+	let mock_b = mock_streamable_http_server(true).await;
+	let t = setup_proxy_test("{}")
+		.unwrap()
+		.with_multiplex_mcp_backend(
+			"mcp",
+			vec![("a", mock_a.addr, false), ("b", mock_b.addr, false)],
+			false,
+		)
+		.with_bind(simple_bind(basic_named_route(strng::new("/mcp"))));
+	let io = t.serve_real_listener(strng::new("bind")).await;
+	let client = mcp_streamable_client(io).await;
+	let a_init_before = mock_a.init_count().await;
+	let b_init_before = mock_b.init_count().await;
+
+	let _ = client
+		.get_prompt(
+			rmcp::model::GetPromptRequestParams::new("a_example_prompt").with_arguments(
+				serde_json::json!({"message": "hello"})
+					.as_object()
+					.cloned()
+					.unwrap(),
+			),
+		)
+		.await
+		.unwrap();
+
+	let a_init_after = mock_a.init_count().await;
+	let b_init_after = mock_b.init_count().await;
+	assert_eq!(a_init_after, a_init_before + 1);
 	assert_eq!(b_init_after, b_init_before);
 }
 

--- a/crates/agentgateway/src/mcp/session.rs
+++ b/crates/agentgateway/src/mcp/session.rs
@@ -10,8 +10,7 @@ use anyhow::anyhow;
 use futures_util::StreamExt;
 use headers::HeaderMapExt;
 use rmcp::model::{
-	ClientInfo, ClientJsonRpcMessage, ClientNotification, ClientRequest, ConstString, Implementation,
-	InitializeRequest, JsonRpcRequest, ProtocolVersion, RequestId, ServerJsonRpcMessage,
+	ClientInfo, ClientJsonRpcMessage, ClientNotification, ClientRequest, ConstString, Implementation, InitializeRequest, JsonRpcRequest, ProtocolVersion, RequestId, RootsCapabilities, ServerJsonRpcMessage
 };
 use rmcp::transport::common::http_header::{EVENT_STREAM_MIME_TYPE, JSON_MIME_TYPE};
 use sse_stream::{KeepAlive, Sse, SseBody, SseStream};
@@ -235,7 +234,7 @@ impl Session {
 			l.session_id = Some(session_id);
 		});
 
-		init_request.params.capabilities.roots = None;
+		init_request.params.capabilities.roots = self.get_roots_capabilities();
 		self
 			.relay
 			.send_single(
@@ -300,7 +299,7 @@ impl Session {
 						// Instead, we hijack this to tell them not to so they do not send requests that we cannot
 						// actually support
 						// This could probably be more easily done without multiplexing but for now neither supports.
-						ir.params.capabilities.roots = None;
+						ir.params.capabilities.roots = self.get_roots_capabilities();
 
 						let pv = ir.params.protocol_version.clone();
 						let res = self
@@ -498,6 +497,10 @@ impl Session {
 				"unsupported message type".to_string(),
 			)),
 		}
+	}
+
+	fn get_roots_capabilities(&self) -> Option<RootsCapabilities> {
+		None
 	}
 }
 

--- a/crates/agentgateway/src/mcp/session.rs
+++ b/crates/agentgateway/src/mcp/session.rs
@@ -11,7 +11,7 @@ use futures_util::StreamExt;
 use headers::HeaderMapExt;
 use rmcp::model::{
 	ClientInfo, ClientJsonRpcMessage, ClientNotification, ClientRequest, ConstString, Implementation,
-	ProtocolVersion, RequestId, ServerJsonRpcMessage,
+	InitializeRequest, JsonRpcRequest, ProtocolVersion, RequestId, ServerJsonRpcMessage,
 };
 use rmcp::transport::common::http_header::{EVENT_STREAM_MIME_TYPE, JSON_MIME_TYPE};
 use sse_stream::{KeepAlive, Sse, SseBody, SseStream};
@@ -47,6 +47,7 @@ impl Session {
 		};
 		Self::handle_error(req_id, self.send_internal(parts, message).await).await
 	}
+
 	/// send a message to upstream server(s), when using stateless mode. In stateless mode, every message
 	/// is wrapped in an InitializeRequest (except the actual InitializeRequest from the downstream).
 	/// This ensures servers that require an InitializeRequest behave correctly.
@@ -56,28 +57,65 @@ impl Session {
 		parts: Parts,
 		message: ClientJsonRpcMessage,
 	) -> Result<Response, ProxyError> {
-		let is_init = matches!(&message, ClientJsonRpcMessage::Request(r) if matches!(&r.request, &ClientRequest::InitializeRequest(_)));
+		let (req_id, request_type) = match &message {
+			ClientJsonRpcMessage::Request(r) => (Some(r.id.clone()), Some(&r.request)),
+			_ => (None, None),
+		};
+		let is_init = request_type.is_some_and(|r| matches!(r, ClientRequest::InitializeRequest(_)));
 		if !is_init {
-			// first, send the initialize
 			let init_request = rmcp::model::InitializeRequest::new(get_client_info());
-			let _ = self
-				.send(
-					parts.clone(),
-					ClientJsonRpcMessage::request(init_request.into(), RequestId::Number(0)),
-				)
-				.await?;
-
-			// And we need to notify as well.
-			let notification = ClientJsonRpcMessage::notification(
-				rmcp::model::InitializedNotification {
-					method: Default::default(),
-					extensions: Default::default(),
-				}
-				.into(),
-			);
-			let _ = self.send(parts.clone(), notification).await?;
+			// first, determine how widely to send the initialize
+			match request_type {
+				// TOOD(keithmattix): what other message types should we handle here? Should we try to define a trait?
+				Some(ClientRequest::CallToolRequest(ctr)) => {
+					// Only one MCP server will respond to this request, so we can just send an initialize to that one
+					// instead of fanning out.
+					let name = ctr.params.name.clone();
+					let (service_name, _) = match self.relay.parse_resource_name(&name) {
+						Ok(target) => target,
+						Err(err) => return Self::handle_error(req_id.clone(), Err(err)).await,
+					};
+					let res = self
+						.send_init_single(parts.clone(), init_request, service_name)
+						.await;
+					// N.B - doing this here to avoid a mutable borrow on self (after an immutable borrow in parse_resource_name)
+					if let Some(sessions) = self.relay.get_sessions() {
+						let s = http::sessionpersistence::SessionState::MCP(
+							http::sessionpersistence::MCPSessionState::new(sessions),
+						);
+						if let Ok(id) = s.encode(&self.encoder) {
+							self.id = id.into();
+						}
+					}
+					Self::handle_error(req_id, res).await?;
+					let _ = Self::handle_error(
+						None,
+						self
+							.send_initialized_notification_single(parts.clone(), service_name)
+							.await,
+					)
+					.await?;
+				},
+				_ => {
+					// We should fan out the initialize request to all MCP servers
+					let _ = self
+						.send(
+							parts.clone(),
+							ClientJsonRpcMessage::request(init_request.into(), RequestId::Number(0)),
+						)
+						.await?;
+					let notification = ClientJsonRpcMessage::notification(
+						rmcp::model::InitializedNotification {
+							method: Default::default(),
+							extensions: Default::default(),
+						}
+						.into(),
+					);
+					let _ = self.send(parts.clone(), notification).await?;
+				},
+			}
 		}
-		// Now we can send the message like normal
+		// Now we can send the original message like normal
 		self.send(parts, message).await
 	}
 
@@ -179,6 +217,57 @@ impl Session {
 		}
 	}
 
+	async fn send_init_single(
+		&self,
+		parts: Parts,
+		mut init_request: InitializeRequest,
+		service_name: &str,
+	) -> Result<Response, UpstreamError> {
+		let method = init_request.method.as_str().to_string();
+		let ctx = IncomingRequestContext::new(&parts);
+		let (_, log, _) = mcp::handler::setup_request_log(parts, &method);
+		let session_id = self.id.to_string();
+		log.non_atomic_mutate(|l| {
+			l.method_name = Some(method.clone());
+			l.session_id = Some(session_id);
+		});
+
+		init_request.params.capabilities.roots = None;
+		self
+			.relay
+			.send_single(
+				JsonRpcRequest::new(RequestId::Number(0), init_request.into()),
+				ctx,
+				service_name,
+				Some(log),
+			)
+			.await
+	}
+
+	async fn send_initialized_notification_single(
+		&self,
+		parts: Parts,
+		service_name: &str,
+	) -> Result<Response, UpstreamError> {
+		let initialized = rmcp::model::InitializedNotification {
+			method: Default::default(),
+			extensions: Default::default(),
+		};
+		let method = initialized.method.as_str().to_string();
+		let ctx = IncomingRequestContext::new(&parts);
+		let (_, log, _) = mcp::handler::setup_request_log(parts, &method);
+		let session_id = self.id.to_string();
+		log.non_atomic_mutate(|l| {
+			l.method_name = Some(method.clone());
+			l.session_id = Some(session_id);
+		});
+
+		self
+			.relay
+			.send_notification_single(initialized.into(), ctx, service_name)
+			.await
+	}
+
 	async fn send_internal(
 		&mut self,
 		parts: Parts,
@@ -237,6 +326,8 @@ impl Session {
 							.send_fanout(r, ctx, self.relay.merge_tools(cel))
 							.await
 					},
+					// TODO(keithmattix): should we forward pings or should we do our own independent pings
+					// as heuristic for the connection pool (and handle client pings as a local reply from agentgateway)?
 					ClientRequest::PingRequest(_) | ClientRequest::SetLevelRequest(_) => {
 						self
 							.relay

--- a/crates/agentgateway/src/mcp/session.rs
+++ b/crates/agentgateway/src/mcp/session.rs
@@ -10,7 +10,9 @@ use anyhow::anyhow;
 use futures_util::StreamExt;
 use headers::HeaderMapExt;
 use rmcp::model::{
-	ClientInfo, ClientJsonRpcMessage, ClientNotification, ClientRequest, ConstString, Implementation, InitializeRequest, JsonRpcRequest, ProtocolVersion, RequestId, RootsCapabilities, ServerJsonRpcMessage
+	ClientInfo, ClientJsonRpcMessage, ClientNotification, ClientRequest, ConstString, Implementation,
+	InitializeRequest, JsonRpcRequest, ProtocolVersion, RequestId, RootsCapabilities,
+	ServerJsonRpcMessage,
 };
 use rmcp::transport::common::http_header::{EVENT_STREAM_MIME_TYPE, JSON_MIME_TYPE};
 use sse_stream::{KeepAlive, Sse, SseBody, SseStream};

--- a/crates/agentgateway/src/mcp/session.rs
+++ b/crates/agentgateway/src/mcp/session.rs
@@ -66,10 +66,14 @@ impl Session {
 			let init_request = rmcp::model::InitializeRequest::new(get_client_info());
 			// first, determine how widely to send the initialize
 			match request_type {
-				Some(ClientRequest::CallToolRequest(ctr)) => {
-					// Only one MCP server will respond to this request, so we can just send an initialize to that one
-					// instead of fanning out.
-					let name = ctr.params.name.clone();
+				Some(ClientRequest::CallToolRequest(_)) | Some(ClientRequest::GetPromptRequest(_)) => {
+					// Single-target methods only hit one backend, so initialize/initialized should be scoped
+					// to that backend rather than fanning out.
+					let name = match request_type {
+						Some(ClientRequest::CallToolRequest(ctr)) => ctr.params.name.to_string(),
+						Some(ClientRequest::GetPromptRequest(gpr)) => gpr.params.name.clone(),
+						_ => unreachable!("match arm guarantees single-target request type"),
+					};
 					let (service_name, _) = match self.relay.parse_resource_name(&name) {
 						Ok(target) => target,
 						Err(err) => return Self::handle_error(req_id.clone(), Err(err)).await,

--- a/crates/agentgateway/src/mcp/session.rs
+++ b/crates/agentgateway/src/mcp/session.rs
@@ -57,7 +57,6 @@ impl Session {
 		parts: Parts,
 		message: ClientJsonRpcMessage,
 	) -> Result<Response, ProxyError> {
-		let mut init_target: Option<String> = None;
 		let (req_id, request_type) = match &message {
 			ClientJsonRpcMessage::Request(r) => (Some(r.id.clone()), Some(&r.request)),
 			_ => (None, None),
@@ -75,7 +74,6 @@ impl Session {
 						Ok(target) => target,
 						Err(err) => return Self::handle_error(req_id.clone(), Err(err)).await,
 					};
-					init_target = Some(service_name.to_string());
 					let res = self
 						.send_init_single(parts.clone(), init_request, service_name)
 						.await;
@@ -87,7 +85,15 @@ impl Session {
 							self.id = id.into();
 						}
 					}
-					Self::handle_error(req_id, res).await?;
+					Self::handle_error(Some(RequestId::Number(0)), res).await?;
+					// Now send the initialized notification
+					let _ = Self::handle_error(
+						None,
+						self
+							.send_initialized_notification_single(parts.clone(), service_name)
+							.await,
+					)
+					.await?;
 				},
 				_ => {
 					// We should fan out the initialize request to all MCP servers
@@ -97,29 +103,18 @@ impl Session {
 							ClientJsonRpcMessage::request(init_request.into(), RequestId::Number(0)),
 						)
 						.await?;
+					let notification = ClientJsonRpcMessage::notification(
+						rmcp::model::InitializedNotification {
+							method: Default::default(),
+							extensions: Default::default(),
+						}
+						.into(),
+					);
+					let _ = self.send(parts.clone(), notification).await?;
 				},
 			}
-			// And we need to notify as well.
-			if let Some(service_name) = init_target.as_deref() {
-				let _ = Self::handle_error(
-					None,
-					self
-						.send_initialized_single(parts.clone(), service_name)
-						.await,
-				)
-				.await?;
-			} else {
-				let notification = ClientJsonRpcMessage::notification(
-					rmcp::model::InitializedNotification {
-						method: Default::default(),
-						extensions: Default::default(),
-					}
-					.into(),
-				);
-				let _ = self.send(parts.clone(), notification).await?;
-			}
 		}
-		// Now we can send the message like normal
+		// Now we can send the message like normal (if it's tools/call, it'll go to the initialized target)
 		self.send(parts, message).await
 	}
 
@@ -248,7 +243,7 @@ impl Session {
 			.await
 	}
 
-	async fn send_initialized_single(
+	async fn send_initialized_notification_single(
 		&self,
 		parts: Parts,
 		service_name: &str,

--- a/crates/agentgateway/src/mcp/session.rs
+++ b/crates/agentgateway/src/mcp/session.rs
@@ -57,6 +57,7 @@ impl Session {
 		parts: Parts,
 		message: ClientJsonRpcMessage,
 	) -> Result<Response, ProxyError> {
+		let mut init_target: Option<String> = None;
 		let (req_id, request_type) = match &message {
 			ClientJsonRpcMessage::Request(r) => (Some(r.id.clone()), Some(&r.request)),
 			_ => (None, None),
@@ -66,7 +67,6 @@ impl Session {
 			let init_request = rmcp::model::InitializeRequest::new(get_client_info());
 			// first, determine how widely to send the initialize
 			match request_type {
-				// TOOD(keithmattix): what other message types should we handle here? Should we try to define a trait?
 				Some(ClientRequest::CallToolRequest(ctr)) => {
 					// Only one MCP server will respond to this request, so we can just send an initialize to that one
 					// instead of fanning out.
@@ -75,10 +75,10 @@ impl Session {
 						Ok(target) => target,
 						Err(err) => return Self::handle_error(req_id.clone(), Err(err)).await,
 					};
+					init_target = Some(service_name.to_string());
 					let res = self
 						.send_init_single(parts.clone(), init_request, service_name)
 						.await;
-					// N.B - doing this here to avoid a mutable borrow on self (after an immutable borrow in parse_resource_name)
 					if let Some(sessions) = self.relay.get_sessions() {
 						let s = http::sessionpersistence::SessionState::MCP(
 							http::sessionpersistence::MCPSessionState::new(sessions),
@@ -88,13 +88,6 @@ impl Session {
 						}
 					}
 					Self::handle_error(req_id, res).await?;
-					let _ = Self::handle_error(
-						None,
-						self
-							.send_initialized_notification_single(parts.clone(), service_name)
-							.await,
-					)
-					.await?;
 				},
 				_ => {
 					// We should fan out the initialize request to all MCP servers
@@ -104,18 +97,29 @@ impl Session {
 							ClientJsonRpcMessage::request(init_request.into(), RequestId::Number(0)),
 						)
 						.await?;
-					let notification = ClientJsonRpcMessage::notification(
-						rmcp::model::InitializedNotification {
-							method: Default::default(),
-							extensions: Default::default(),
-						}
-						.into(),
-					);
-					let _ = self.send(parts.clone(), notification).await?;
 				},
 			}
+			// And we need to notify as well.
+			if let Some(service_name) = init_target.as_deref() {
+				let _ = Self::handle_error(
+					None,
+					self
+						.send_initialized_single(parts.clone(), service_name)
+						.await,
+				)
+				.await?;
+			} else {
+				let notification = ClientJsonRpcMessage::notification(
+					rmcp::model::InitializedNotification {
+						method: Default::default(),
+						extensions: Default::default(),
+					}
+					.into(),
+				);
+				let _ = self.send(parts.clone(), notification).await?;
+			}
 		}
-		// Now we can send the original message like normal
+		// Now we can send the message like normal
 		self.send(parts, message).await
 	}
 
@@ -244,7 +248,7 @@ impl Session {
 			.await
 	}
 
-	async fn send_initialized_notification_single(
+	async fn send_initialized_single(
 		&self,
 		parts: Parts,
 		service_name: &str,

--- a/crates/agentgateway/src/mcp/upstream/mod.rs
+++ b/crates/agentgateway/src/mcp/upstream/mod.rs
@@ -134,7 +134,9 @@ impl Upstream {
 				c.stop().await?;
 			},
 			Upstream::McpStreamable(c) => {
-				c.send_delete(ctx).await?;
+				if c.has_session_id() {
+					c.send_delete(ctx).await?;
+				}
 			},
 			Upstream::McpSSE(c) => {
 				c.stop().await?;

--- a/crates/agentgateway/src/mcp/upstream/streamablehttp.rs
+++ b/crates/agentgateway/src/mcp/upstream/streamablehttp.rs
@@ -52,6 +52,10 @@ impl Client {
 		}
 	}
 
+	pub fn has_session_id(&self) -> bool {
+		self.session_id.load().is_some()
+	}
+
 	pub async fn send_request(
 		&self,
 		req: JsonRpcRequest<ClientRequest>,

--- a/crates/core/src/readiness.rs
+++ b/crates/core/src/readiness.rs
@@ -36,7 +36,7 @@ impl Ready {
 	/// register_task allows a caller to add a dependency to be marked "ready".
 	pub fn register_task(&self, name: &str) -> BlockReady {
 		let mut state = self.0.lock().unwrap();
-		let was_ready = state.pending.is_empty();
+		let was_ready: bool = state.pending.is_empty();
 		state.pending.insert(name.to_string());
 		if was_ready {
 			state.ready_tx.send_replace(false);


### PR DESCRIPTION
Fixes #1442. If the client sends a request that's destined for just one target (e.g. tools/call or get_prompt), only one backend can serve the traffic, so we don't need to fan out initialize requests to all backends. Similarly, we should only send deletes if there's a session id