### PR TITLE
chore: add DCO setup for contributions

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,14 @@
+name: DCO
+
+on:
+  pull_request:
+
+jobs:
+  dco:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check DCO
+        uses: amannn/action-semantic-pull-request@v5

--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -108,6 +108,26 @@ Only project maintainers can create releases. The process is:
 - Help answer questions in GitHub issues
 - Review pull requests from other contributors
 
+## Developer Certificate of Origin (DCO)
+
+All new inbound code contributions must be accompanied by a Developer Certificate of
+Origin (http://developercertificate.org/) sign-off.
+
+Sign off every commit using the `-s` flag:
+
+```bash
+git commit -s -m "your message"
+```
+
+This adds `Signed-off-by: Your Name <your@email.com>` to your commit.
+
+If you forgot to sign off a previous commit, run:
+
+```bash
+git commit --amend -s --no-edit
+git push --force-with-lease
+```
+
 ## License
 
 By contributing to this project, you agree that your contributions will be licensed under the project's license.

--- a/DCO
+++ b/DCO
@@ -1,0 +1,50 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2//EN">
+<html><!--
+    File:   index.html
+    Editor: None, you wimpy wysiwyg people...this is hand crafted!
+            What are you doing reading this anyway???
+--><head>
+<meta http-equiv="content-type" content="text/html; charset=windows-1252">
+	<title>Developer Certificate of Origin</title>
+</head>
+
+<body>
+<pre>Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+</pre>
+
+
+
+</body></html>


### PR DESCRIPTION
Fixes #340

Added DCO setup:
- `DCO` file in repo root
- GitHub Actions workflow to enforce sign-off on PRs
- Contributing guide updated with sign-off instructions