### PR TITLE
Support additional trusted trust domains on hbone income

### DIFF
--- a/crates/agentgateway/src/config.rs
+++ b/crates/agentgateway/src/config.rs
@@ -181,8 +181,7 @@ pub fn parse_config(contents: String, filename: Option<PathBuf>) -> anyhow::Resu
 			crate::control::RootCert::Default
 		};
 		// Build the allowed trust domains list. The local trust domain is always first.
-		// ADDITIONAL_TRUST_DOMAINS is a comma-separated list of extra domains to accept
-		// (e.g. peer cluster trust domains in a multi-cluster peering setup).
+		// ADDITIONAL_TRUST_DOMAINS is a comma-separated list of extra domains to accept.
 		let mut allowed_trust_domains: Vec<Strng> = vec![td.clone().into()];
 		let additional = parse("ADDITIONAL_TRUST_DOMAINS")?
 			.or(raw.additional_trust_domains)

--- a/crates/agentgateway/src/config.rs
+++ b/crates/agentgateway/src/config.rs
@@ -180,6 +180,19 @@ pub fn parse_config(contents: String, filename: Option<PathBuf>) -> anyhow::Resu
 		} else {
 			crate::control::RootCert::Default
 		};
+		// Build the allowed trust domains list. The local trust domain is always first.
+		// ADDITIONAL_TRUST_DOMAINS is a comma-separated list of extra domains to accept
+		// (e.g. peer cluster trust domains in a multi-cluster peering setup).
+		let mut allowed_trust_domains: Vec<Strng> = vec![td.clone().into()];
+		let additional = parse("ADDITIONAL_TRUST_DOMAINS")?
+			.or(raw.additional_trust_domains)
+			.unwrap_or_default();
+		for domain in additional.split(',') {
+			let domain = domain.trim();
+			if !domain.is_empty() {
+				allowed_trust_domains.push(domain.into());
+			}
+		}
 		Some(caclient::Config {
 			address: addr,
 			secret_ttl: Duration::from_secs(86400),
@@ -188,10 +201,10 @@ pub fn parse_config(contents: String, filename: Option<PathBuf>) -> anyhow::Resu
 				namespace: ns.into(),
 				service_account: sa.into(),
 			},
-
 			auth,
 			ca_cert: ca_root_cert,
 			ca_headers: ca_headers?,
+			allowed_trust_domains,
 		})
 	} else {
 		None

--- a/crates/agentgateway/src/config.rs
+++ b/crates/agentgateway/src/config.rs
@@ -203,7 +203,7 @@ pub fn parse_config(contents: String, filename: Option<PathBuf>) -> anyhow::Resu
 			auth,
 			ca_cert: ca_root_cert,
 			ca_headers: ca_headers?,
-			allowed_trust_domains,
+			allowed_trust_domains: allowed_trust_domains.into(),
 		})
 	} else {
 		None

--- a/crates/agentgateway/src/config.rs
+++ b/crates/agentgateway/src/config.rs
@@ -192,6 +192,9 @@ pub fn parse_config(contents: String, filename: Option<PathBuf>) -> anyhow::Resu
 				allowed_trust_domains.push(domain.into());
 			}
 		}
+		let skip_validate_trust_domain = parse::<bool>("SKIP_VALIDATE_TRUST_DOMAIN")?
+			.or(raw.skip_validate_trust_domain)
+			.unwrap_or(false);
 		Some(caclient::Config {
 			address: addr,
 			secret_ttl: Duration::from_secs(86400),
@@ -204,6 +207,7 @@ pub fn parse_config(contents: String, filename: Option<PathBuf>) -> anyhow::Resu
 			ca_cert: ca_root_cert,
 			ca_headers: ca_headers?,
 			allowed_trust_domains: allowed_trust_domains.into(),
+			skip_validate_trust_domain,
 		})
 	} else {
 		None

--- a/crates/agentgateway/src/control/caclient.rs
+++ b/crates/agentgateway/src/control/caclient.rs
@@ -199,8 +199,9 @@ impl WorkloadCertificate {
 		)
 		.build()?;
 		// Verify the client's SPIFFE trust domain is in the allowed set.
-		// The list always includes the local trust domain.
-		// An empty list disables the check and relies solely on CA-level trust.
+		// TrustDomainVerifier treats an empty allow-list as "check disabled" and
+		// falls back to CA-level trust only; the config-populated list used here
+		// normally includes the local trust domain.
 		let client_cert_verifier = transport::tls::trustdomain::TrustDomainVerifier::new(
 			raw_client_cert_verifier,
 			self.allowed_trust_domains.clone(),

--- a/crates/agentgateway/src/control/caclient.rs
+++ b/crates/agentgateway/src/control/caclient.rs
@@ -67,6 +67,7 @@ pub struct Config {
 	pub ca_cert: RootCert,
 	pub ca_headers: Vec<(String, String)>,
 	pub allowed_trust_domains: Arc<[Strng]>,
+	pub skip_validate_trust_domain: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -85,6 +86,7 @@ pub struct WorkloadCertificate {
 	expiry: Expiration,
 	identity: Identity,
 	allowed_trust_domains: Arc<[Strng]>,
+	skip_validate_trust_domain: bool,
 }
 
 impl WorkloadCertificate {
@@ -93,6 +95,7 @@ impl WorkloadCertificate {
 		cert: &[u8],
 		chain: Vec<&[u8]>,
 		allowed_trust_domains: Arc<[Strng]>,
+		skip_validate_trust_domain: bool,
 	) -> Result<WorkloadCertificate, Error> {
 		let cert = parse_cert(cert.to_vec())?;
 		let mut roots_store = RootCertStore::empty();
@@ -134,6 +137,7 @@ impl WorkloadCertificate {
 			chain: cert_and_chain,
 			identity,
 			allowed_trust_domains,
+			skip_validate_trust_domain,
 		})
 	}
 	pub fn is_expired(&self) -> bool {
@@ -198,15 +202,17 @@ impl WorkloadCertificate {
 			transport::tls::provider(),
 		)
 		.build()?;
-		// Verify the client's SPIFFE trust domain is in the allowed set.
-		// allowed_trust_domains always contains at least the local trust domain (populated
-		// at config build time), so trust-domain verification is always enforced here.
-		// TrustDomainVerifier's empty-list bypass is a safety valve that cannot be reached
-		// through normal Config construction.
-		let client_cert_verifier = transport::tls::trustdomain::TrustDomainVerifier::new(
-			raw_client_cert_verifier,
-			self.allowed_trust_domains.clone(),
-		);
+		// Verify the client's SPIFFE trust domain is in the allowed set, unless explicitly
+		// disabled via skip_validate_trust_domain. CA-level certificate validation still applies.
+		let client_cert_verifier: Arc<dyn rustls::server::danger::ClientCertVerifier> =
+			if self.skip_validate_trust_domain {
+				raw_client_cert_verifier
+			} else {
+				transport::tls::trustdomain::TrustDomainVerifier::new(
+					raw_client_cert_verifier,
+					self.allowed_trust_domains.clone(),
+				)
+			};
 		let mut sc = ServerConfig::builder_with_provider(transport::tls::provider())
 			.with_protocol_versions(transport::tls::ALL_TLS_VERSIONS)
 			.expect("server config must be valid")
@@ -522,6 +528,7 @@ impl CaClient {
 			leaf_cert,
 			chain_certs,
 			config.allowed_trust_domains.clone(),
+			config.skip_validate_trust_domain,
 		)?);
 
 		// Verify the certificate matches our identity

--- a/crates/agentgateway/src/control/caclient.rs
+++ b/crates/agentgateway/src/control/caclient.rs
@@ -66,7 +66,7 @@ pub struct Config {
 	pub auth: AuthSource,
 	pub ca_cert: RootCert,
 	pub ca_headers: Vec<(String, String)>,
-	pub allowed_trust_domains: Vec<Strng>,
+	pub allowed_trust_domains: Arc<[Strng]>,
 }
 
 #[derive(Clone, Debug)]
@@ -84,7 +84,7 @@ pub struct WorkloadCertificate {
 	private_key: PrivateKeyDer<'static>,
 	expiry: Expiration,
 	identity: Identity,
-	allowed_trust_domains: Vec<Strng>,
+	allowed_trust_domains: Arc<[Strng]>,
 }
 
 impl WorkloadCertificate {
@@ -92,7 +92,7 @@ impl WorkloadCertificate {
 		key: &[u8],
 		cert: &[u8],
 		chain: Vec<&[u8]>,
-		allowed_trust_domains: Vec<Strng>,
+		allowed_trust_domains: Arc<[Strng]>,
 	) -> Result<WorkloadCertificate, Error> {
 		let cert = parse_cert(cert.to_vec())?;
 		let mut roots_store = RootCertStore::empty();
@@ -199,9 +199,10 @@ impl WorkloadCertificate {
 		)
 		.build()?;
 		// Verify the client's SPIFFE trust domain is in the allowed set.
-		// TrustDomainVerifier treats an empty allow-list as "check disabled" and
-		// falls back to CA-level trust only; the config-populated list used here
-		// normally includes the local trust domain.
+		// allowed_trust_domains always contains at least the local trust domain (populated
+		// at config build time), so trust-domain verification is always enforced here.
+		// TrustDomainVerifier's empty-list bypass is a safety valve that cannot be reached
+		// through normal Config construction.
 		let client_cert_verifier = transport::tls::trustdomain::TrustDomainVerifier::new(
 			raw_client_cert_verifier,
 			self.allowed_trust_domains.clone(),

--- a/crates/agentgateway/src/control/caclient.rs
+++ b/crates/agentgateway/src/control/caclient.rs
@@ -66,6 +66,7 @@ pub struct Config {
 	pub auth: AuthSource,
 	pub ca_cert: RootCert,
 	pub ca_headers: Vec<(String, String)>,
+	pub allowed_trust_domains: Vec<Strng>,
 }
 
 #[derive(Clone, Debug)]
@@ -83,10 +84,16 @@ pub struct WorkloadCertificate {
 	private_key: PrivateKeyDer<'static>,
 	expiry: Expiration,
 	identity: Identity,
+	allowed_trust_domains: Vec<Strng>,
 }
 
 impl WorkloadCertificate {
-	fn new(key: &[u8], cert: &[u8], chain: Vec<&[u8]>) -> Result<WorkloadCertificate, Error> {
+	fn new(
+		key: &[u8],
+		cert: &[u8],
+		chain: Vec<&[u8]>,
+		allowed_trust_domains: Vec<Strng>,
+	) -> Result<WorkloadCertificate, Error> {
 		let cert = parse_cert(cert.to_vec())?;
 		let mut roots_store = RootCertStore::empty();
 		let identity = cert
@@ -126,6 +133,7 @@ impl WorkloadCertificate {
 			private_key: key,
 			chain: cert_and_chain,
 			identity,
+			allowed_trust_domains,
 		})
 	}
 	pub fn is_expired(&self) -> bool {
@@ -183,8 +191,6 @@ impl WorkloadCertificate {
 		})
 	}
 	pub fn hbone_termination(&self) -> Result<ServerConfig, Error> {
-		let Identity::Spiffe { trust_domain, .. } = &self.identity;
-
 		// TODO: this is too expensive to build per request
 		let roots = self.roots.clone();
 		let raw_client_cert_verifier = rustls::server::WebPkiClientVerifier::builder_with_provider(
@@ -192,9 +198,12 @@ impl WorkloadCertificate {
 			transport::tls::provider(),
 		)
 		.build()?;
+		// Verify the client's SPIFFE trust domain is in the allowed set.
+		// The list always includes the local trust domain.
+		// An empty list disables the check and relies solely on CA-level trust.
 		let client_cert_verifier = transport::tls::trustdomain::TrustDomainVerifier::new(
 			raw_client_cert_verifier,
-			Some(trust_domain.clone()),
+			self.allowed_trust_domains.clone(),
 		);
 		let mut sc = ServerConfig::builder_with_provider(transport::tls::provider())
 			.with_protocol_versions(transport::tls::ALL_TLS_VERSIONS)
@@ -510,6 +519,7 @@ impl CaClient {
 			&private_key,
 			leaf_cert,
 			chain_certs,
+			config.allowed_trust_domains.clone(),
 		)?);
 
 		// Verify the certificate matches our identity

--- a/crates/agentgateway/src/lib.rs
+++ b/crates/agentgateway/src/lib.rs
@@ -153,6 +153,8 @@ pub struct RawConfig {
 	/// Comma-separated list of additional SPIFFE trust domains accepted on inbound HBONE
 	/// connections. The local trust_domain is always implicitly included.
 	additional_trust_domains: Option<String>,
+	/// When true, skip SPIFFE trust-domain verification on inbound HBONE connections.
+	skip_validate_trust_domain: Option<bool>,
 	service_account: Option<String>,
 	cluster_id: Option<String>,
 	network: Option<String>,

--- a/crates/agentgateway/src/lib.rs
+++ b/crates/agentgateway/src/lib.rs
@@ -150,6 +150,9 @@ pub struct RawConfig {
 	namespace: Option<String>,
 	gateway: Option<String>,
 	trust_domain: Option<String>,
+	/// Comma-separated list of additional SPIFFE trust domains accepted on inbound HBONE
+	/// connections. The local trust_domain is always implicitly included.
+	additional_trust_domains: Option<String>,
 	service_account: Option<String>,
 	cluster_id: Option<String>,
 	network: Option<String>,

--- a/crates/agentgateway/src/transport/tls.rs
+++ b/crates/agentgateway/src/transport/tls.rs
@@ -547,39 +547,45 @@ pub mod trustdomain {
 	#[derive(Debug)]
 	pub struct TrustDomainVerifier {
 		base: Arc<dyn ClientCertVerifier>,
-		trust_domain: Option<Strng>,
+		allowed_trust_domains: Vec<Strng>,
 	}
 
 	impl TrustDomainVerifier {
-		pub fn new(base: Arc<dyn ClientCertVerifier>, trust_domain: Option<Strng>) -> Arc<Self> {
-			Arc::new(Self { base, trust_domain })
+		pub fn new(base: Arc<dyn ClientCertVerifier>, allowed_trust_domains: Vec<Strng>) -> Arc<Self> {
+			Arc::new(Self {
+				base,
+				allowed_trust_domains,
+			})
 		}
 
 		fn verify_trust_domain(&self, client_cert: &CertificateDer<'_>) -> Result<(), rustls::Error> {
 			use x509_parser::prelude::*;
-			let Some(want_trust_domain) = &self.trust_domain else {
-				// No need to verify
+			if self.allowed_trust_domains.is_empty() {
+				// No restriction configured; rely on CA-level trust only.
 				return Ok(());
-			};
+			}
 			let (_, c) = X509Certificate::from_der(client_cert)
 				.map_err(|_e| rustls::Error::InvalidCertificate(rustls::CertificateError::BadEncoding))?;
 			let (ids, _) = super::sans(c).map_err(|_e| {
 				rustls::Error::InvalidCertificate(rustls::CertificateError::ApplicationVerificationFailure)
 			})?;
 			trace!(
-				"verifying client identities {ids:?} against trust domain {:?}",
-				want_trust_domain
+				"verifying client identities {ids:?} against allowed trust domains {:?}",
+				self.allowed_trust_domains
 			);
 			ids
 				.iter()
 				.find(|id| match id {
-					Identity::Spiffe { trust_domain, .. } => trust_domain == want_trust_domain,
+					Identity::Spiffe { trust_domain, .. } => {
+						self.allowed_trust_domains.contains(trust_domain)
+					},
 				})
 				.ok_or_else(|| {
 					rustls::Error::InvalidCertificate(rustls::CertificateError::Other(rustls::OtherError(
 						Arc::new(super::LocalError::Invalid(format!(
-							"identity verification error: peer did not present the expected trustdomain ({}), got {}",
-							&self.trust_domain.as_ref().unwrap(),
+							"identity verification error: peer did not present an allowed trustdomain \
+							(allowed: [{}]), got {}",
+							self.allowed_trust_domains.join(", "),
 							super::display_list(&ids)
 						))),
 					)))
@@ -628,6 +634,136 @@ pub mod trustdomain {
 
 		fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
 			self.base.supported_verify_schemes()
+		}
+	}
+
+	#[cfg(test)]
+	mod tests {
+		use std::time::{Duration, SystemTime};
+
+		use rcgen::{
+			CertificateParams, DistinguishedName, DnType, ExtendedKeyUsagePurpose, Issuer, KeyPair,
+			KeyUsagePurpose, SanType, SerialNumber,
+		};
+		use rustls::pki_types::CertificateDer;
+
+		use super::*;
+
+		/// Generate a self-signed cert with a SPIFFE URI SAN for the given trust domain.
+		fn make_spiffe_cert(trust_domain: &str) -> CertificateDer<'static> {
+			let kp = KeyPair::generate().unwrap();
+			let ca_kp = KeyPair::generate().unwrap();
+
+			let mut params = CertificateParams::default();
+			params.not_before = SystemTime::now().into();
+			params.not_after = (SystemTime::now() + Duration::from_secs(3600)).into();
+			params.serial_number = Some(SerialNumber::from_slice(&[1]));
+			let mut dn = DistinguishedName::new();
+			dn.push(DnType::OrganizationName, trust_domain);
+			params.distinguished_name = dn;
+			params.key_usages = vec![KeyUsagePurpose::DigitalSignature];
+			params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ClientAuth];
+			let spiffe_uri = format!("spiffe://{trust_domain}/ns/default/sa/test");
+			params.subject_alt_names = vec![SanType::URI(spiffe_uri.try_into().unwrap())];
+
+			let mut ca_params = CertificateParams::default();
+			ca_params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+			ca_params.not_before = SystemTime::now().into();
+			ca_params.not_after = (SystemTime::now() + Duration::from_secs(3600)).into();
+			let _ca_cert = ca_params.self_signed(&ca_kp).unwrap();
+			let issuer = Issuer::from_params(&ca_params, &ca_kp);
+
+			let cert = params.signed_by(&kp, &issuer).unwrap();
+			CertificateDer::from(cert.der().to_vec())
+		}
+
+		/// Minimal no-op ClientCertVerifier — only used to satisfy TrustDomainVerifier's
+		/// constructor; none of its methods are called by verify_trust_domain.
+		#[derive(Debug)]
+		struct NopClientVerifier;
+
+		impl ClientCertVerifier for NopClientVerifier {
+			fn root_hint_subjects(&self) -> &[rustls::DistinguishedName] {
+				&[]
+			}
+
+			fn verify_client_cert(
+				&self,
+				_end_entity: &CertificateDer<'_>,
+				_intermediates: &[CertificateDer<'_>],
+				_now: UnixTime,
+			) -> Result<ClientCertVerified, rustls::Error> {
+				Ok(ClientCertVerified::assertion())
+			}
+
+			fn verify_tls12_signature(
+				&self,
+				_message: &[u8],
+				_cert: &CertificateDer<'_>,
+				_dss: &DigitallySignedStruct,
+			) -> Result<HandshakeSignatureValid, rustls::Error> {
+				Ok(HandshakeSignatureValid::assertion())
+			}
+
+			fn verify_tls13_signature(
+				&self,
+				_message: &[u8],
+				_cert: &CertificateDer<'_>,
+				_dss: &DigitallySignedStruct,
+			) -> Result<HandshakeSignatureValid, rustls::Error> {
+				Ok(HandshakeSignatureValid::assertion())
+			}
+
+			fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+				vec![]
+			}
+		}
+
+		fn verifier(domains: &[&str]) -> Arc<TrustDomainVerifier> {
+			let allowed: Vec<Strng> = domains.iter().map(strng::new).collect();
+			TrustDomainVerifier::new(Arc::new(NopClientVerifier), allowed)
+		}
+
+		#[test]
+		fn empty_list_always_passes() {
+			let v = verifier(&[]);
+			let cert = make_spiffe_cert("any.domain");
+			assert!(v.verify_trust_domain(&cert).is_ok());
+		}
+
+		#[test]
+		fn single_domain_matching_cert_passes() {
+			let v = verifier(&["cluster.local"]);
+			let cert = make_spiffe_cert("cluster.local");
+			assert!(v.verify_trust_domain(&cert).is_ok());
+		}
+
+		#[test]
+		fn single_domain_mismatched_cert_rejected() {
+			let v = verifier(&["cluster.local"]);
+			let cert = make_spiffe_cert("other.domain");
+			assert!(v.verify_trust_domain(&cert).is_err());
+		}
+
+		#[test]
+		fn multiple_domains_first_matches() {
+			let v = verifier(&["cluster.local", "peer.cluster"]);
+			let cert = make_spiffe_cert("cluster.local");
+			assert!(v.verify_trust_domain(&cert).is_ok());
+		}
+
+		#[test]
+		fn multiple_domains_second_matches() {
+			let v = verifier(&["cluster.local", "peer.cluster"]);
+			let cert = make_spiffe_cert("peer.cluster");
+			assert!(v.verify_trust_domain(&cert).is_ok());
+		}
+
+		#[test]
+		fn multiple_domains_no_match_rejected() {
+			let v = verifier(&["cluster.local", "peer.cluster"]);
+			let cert = make_spiffe_cert("untrusted.domain");
+			assert!(v.verify_trust_domain(&cert).is_err());
 		}
 	}
 }

--- a/crates/agentgateway/src/transport/tls.rs
+++ b/crates/agentgateway/src/transport/tls.rs
@@ -547,11 +547,14 @@ pub mod trustdomain {
 	#[derive(Debug)]
 	pub struct TrustDomainVerifier {
 		base: Arc<dyn ClientCertVerifier>,
-		allowed_trust_domains: Vec<Strng>,
+		allowed_trust_domains: Arc<[Strng]>,
 	}
 
 	impl TrustDomainVerifier {
-		pub fn new(base: Arc<dyn ClientCertVerifier>, allowed_trust_domains: Vec<Strng>) -> Arc<Self> {
+		pub fn new(
+			base: Arc<dyn ClientCertVerifier>,
+			allowed_trust_domains: Arc<[Strng]>,
+		) -> Arc<Self> {
 			Arc::new(Self {
 				base,
 				allowed_trust_domains,
@@ -720,7 +723,7 @@ pub mod trustdomain {
 		}
 
 		fn verifier(domains: &[&str]) -> Arc<TrustDomainVerifier> {
-			let allowed: Vec<Strng> = domains.iter().map(strng::new).collect();
+			let allowed: Arc<[Strng]> = domains.iter().map(strng::new).collect();
 			TrustDomainVerifier::new(Arc::new(NopClientVerifier), allowed)
 		}
 

--- a/crates/agentgateway/src/transport/tls.rs
+++ b/crates/agentgateway/src/transport/tls.rs
@@ -649,7 +649,7 @@ pub mod trustdomain {
 
 		use super::*;
 
-		/// Generate a self-signed cert with a SPIFFE URI SAN for the given trust domain.
+		/// Generate a leaf cert with a SPIFFE URI SAN for the given trust domain, signed by a test CA.
 		fn make_spiffe_cert(trust_domain: &str) -> CertificateDer<'static> {
 			let kp = KeyPair::generate().unwrap();
 			let ca_kp = KeyPair::generate().unwrap();

--- a/schema/config.json
+++ b/schema/config.json
@@ -128,7 +128,7 @@
           ]
         },
         "additionalTrustDomains": {
-          "description": "Comma-separated list of additional SPIFFE trust domains accepted on inbound HBONE\nconnections. The local trust_domain is always implicitly included.",
+          "description": "Comma-separated list of additional SPIFFE trust domains accepted on inbound HBONE\nconnections. The local trust domain is always implicitly included.",
           "type": [
             "string",
             "null"

--- a/schema/config.json
+++ b/schema/config.json
@@ -127,6 +127,13 @@
             "null"
           ]
         },
+        "additionalTrustDomains": {
+          "description": "Comma-separated list of additional SPIFFE trust domains accepted on inbound HBONE\nconnections. The local trust_domain is always implicitly included.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "serviceAccount": {
           "type": [
             "string",

--- a/schema/config.json
+++ b/schema/config.json
@@ -134,6 +134,13 @@
             "null"
           ]
         },
+        "skipValidateTrustDomain": {
+          "description": "When true, skip SPIFFE trust-domain verification on inbound HBONE connections.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "serviceAccount": {
           "type": [
             "string",

--- a/schema/config.json
+++ b/schema/config.json
@@ -128,7 +128,7 @@
           ]
         },
         "additionalTrustDomains": {
-          "description": "Comma-separated list of additional SPIFFE trust domains accepted on inbound HBONE\nconnections. The local trust domain is always implicitly included.",
+          "description": "Comma-separated list of additional SPIFFE trust domains accepted on inbound HBONE\nconnections. The local trust_domain is always implicitly included.",
           "type": [
             "string",
             "null"

--- a/schema/config.md
+++ b/schema/config.md
@@ -16,6 +16,7 @@
 |`config.gateway`|string||
 |`config.trustDomain`|string||
 |`config.additionalTrustDomains`|string|Comma-separated list of additional SPIFFE trust domains accepted on inbound HBONE<br>connections. The local trust_domain is always implicitly included.|
+|`config.skipValidateTrustDomain`|boolean|When true, skip SPIFFE trust-domain verification on inbound HBONE connections.|
 |`config.serviceAccount`|string||
 |`config.clusterId`|string||
 |`config.network`|string||

--- a/schema/config.md
+++ b/schema/config.md
@@ -15,6 +15,7 @@
 |`config.namespace`|string||
 |`config.gateway`|string||
 |`config.trustDomain`|string||
+|`config.additionalTrustDomains`|string|Comma-separated list of additional SPIFFE trust domains accepted on inbound HBONE<br>connections. The local trust_domain is always implicitly included.|
 |`config.serviceAccount`|string||
 |`config.clusterId`|string||
 |`config.network`|string||

--- a/schema/config.md
+++ b/schema/config.md
@@ -15,7 +15,7 @@
 |`config.namespace`|string||
 |`config.gateway`|string||
 |`config.trustDomain`|string||
-|`config.additionalTrustDomains`|string|Comma-separated list of additional SPIFFE trust domains accepted on inbound HBONE<br>connections. The local trust domain is always implicitly included.|
+|`config.additionalTrustDomains`|string|Comma-separated list of additional SPIFFE trust domains accepted on inbound HBONE<br>connections. The local trust_domain is always implicitly included.|
 |`config.serviceAccount`|string||
 |`config.clusterId`|string||
 |`config.network`|string||

--- a/schema/config.md
+++ b/schema/config.md
@@ -15,7 +15,7 @@
 |`config.namespace`|string||
 |`config.gateway`|string||
 |`config.trustDomain`|string||
-|`config.additionalTrustDomains`|string|Comma-separated list of additional SPIFFE trust domains accepted on inbound HBONE<br>connections. The local trust_domain is always implicitly included.|
+|`config.additionalTrustDomains`|string|Comma-separated list of additional SPIFFE trust domains accepted on inbound HBONE<br>connections. The local trust domain is always implicitly included.|
 |`config.serviceAccount`|string||
 |`config.clusterId`|string||
 |`config.network`|string||


### PR DESCRIPTION
Add `additionalTrustDomains` config option (also settable via `ADDITIONAL_TRUST_DOMAINS` env var) to allow inbound HBONE connections from different trusted trust domains.

The local trust domain (if set) is always implicitly included.
An empty additional list preserves existing single-domain behavior.

Also added a `skip_validate_trust_domain` config option (`SKIP_VALIDATE_TRUST_DOMAIN` env var) to completely disable verification.