### PR TITLE
ext authz: include query params in HTTP callouts

### DIFF
--- a/crates/agentgateway/src/http/ext_authz.rs
+++ b/crates/agentgateway/src/http/ext_authz.rs
@@ -572,7 +572,8 @@ impl ExtAuthz {
 					},
 				}
 			},
-			None => Uri::try_from(req.uri().path()).expect("pre-validated"),
+			None => Uri::try_from(http::get_path_and_query(req.uri()))
+				.map_err(|_| ProxyError::ExternalAuthorizationFailed(None))?,
 		};
 
 		// If the user defined their own path expression, use that.

--- a/crates/agentgateway/src/http/mod.rs
+++ b/crates/agentgateway/src/http/mod.rs
@@ -611,6 +611,13 @@ pub fn classify_content_type(h: &HeaderMap) -> WellKnownContentTypes {
 	WellKnownContentTypes::Unknown
 }
 
+pub fn get_path_and_query(req: &Uri) -> &str {
+	req
+		.path_and_query()
+		.map(|pq| pq.as_str())
+		.unwrap_or_else(|| req.path())
+}
+
 pub fn get_host(req: &Request) -> Result<&str, ProxyError> {
 	// We expect a normalized request, so this will always be in the URI
 	// TODO: handle absolute HTTP/1.1 form


### PR DESCRIPTION
Signed-off-by: John Howard <john.howard@solo.io>
