### PR TITLE
Cleanup SSE streams when clients disconnect without DELETE

### DIFF
--- a/crates/agentgateway/src/mcp/mergestream.rs
+++ b/crates/agentgateway/src/mcp/mergestream.rs
@@ -26,6 +26,12 @@ impl Messages {
 	pub fn from_result<T: Into<ServerResult>>(id: RequestId, result: T) -> Self {
 		Self::from(ServerJsonRpcMessage::response(result.into(), id))
 	}
+
+	pub(crate) fn boxed(
+		stream: BoxStream<'static, Result<ServerJsonRpcMessage, ClientError>>,
+	) -> Self {
+		Messages(stream)
+	}
 }
 
 impl Stream for Messages {

--- a/crates/agentgateway/src/mcp/upstream/sse.rs
+++ b/crates/agentgateway/src/mcp/upstream/sse.rs
@@ -1,9 +1,12 @@
 use ::http::Uri;
 use ::http::header::{ACCEPT, CONTENT_TYPE};
 use anyhow::anyhow;
+use futures_core::Stream;
 use futures_core::stream::BoxStream;
 use futures_util::{StreamExt, TryFutureExt};
 use headers::HeaderMapExt;
+use parking_lot::Mutex;
+use pin_project_lite::pin_project;
 use rmcp::model::{
 	ClientJsonRpcMessage, ClientNotification, ClientRequest, JsonRpcRequest, ServerJsonRpcMessage,
 };
@@ -30,13 +33,32 @@ struct ClientCore {
 pub struct Client {
 	client: ClientCore,
 
-	active_stream: Arc<tokio::sync::Mutex<Option<Arc<super::stdio::Process>>>>,
+	active_stream: Arc<Mutex<Option<std::sync::Weak<super::stdio::Process>>>>,
 }
 
 struct SseClient {
 	client: ClientCore,
 
 	events: BoxedSseStream,
+}
+
+pin_project! {
+	struct GuardedMessages {
+		#[pin]
+		inner: Messages,
+		_guard: Arc<Process>,
+	}
+}
+
+impl Stream for GuardedMessages {
+	type Item = Result<ServerJsonRpcMessage, ClientError>;
+
+	fn poll_next(
+		self: std::pin::Pin<&mut Self>,
+		cx: &mut std::task::Context<'_>,
+	) -> std::task::Poll<Option<Self::Item>> {
+		self.project().inner.poll_next(cx)
+	}
 }
 
 impl crate::mcp::upstream::stdio::MCPTransport for SseClient {
@@ -172,17 +194,24 @@ impl Client {
 	}
 
 	pub async fn stop(&self) -> Result<(), UpstreamError> {
-		let mut stream = self.active_stream.lock().await;
-		if let Some(s) = stream.as_ref() {
+		let stream = self
+			.active_stream
+			.lock()
+			.take()
+			.and_then(|stream| stream.upgrade());
+		if let Some(s) = stream {
 			s.stop().await?;
 		}
-		*stream = None;
 		Ok(())
 	}
 	async fn get_stream(&self, ctx: &IncomingRequestContext) -> Result<Arc<Process>, UpstreamError> {
-		let mut stream = self.active_stream.lock().await;
-		if let Some(s) = stream.clone() {
-			return Ok(s);
+		if let Some(stream) = self
+			.active_stream
+			.lock()
+			.as_ref()
+			.and_then(std::sync::Weak::upgrade)
+		{
+			return Ok(stream);
 		}
 
 		let (post_uri, sse) = self.establish_sse(ctx).await?;
@@ -195,7 +224,11 @@ impl Client {
 		};
 
 		let proc = Arc::new(Process::new(transport));
-		*stream = Some(proc.clone());
+		let mut stream = self.active_stream.lock();
+		if let Some(existing) = stream.as_ref().and_then(std::sync::Weak::upgrade) {
+			return Ok(existing);
+		}
+		*stream = Some(Arc::downgrade(&proc));
 		Ok(proc)
 	}
 	async fn establish_sse(
@@ -226,7 +259,16 @@ impl Client {
 		ctx: &IncomingRequestContext,
 	) -> Result<Messages, UpstreamError> {
 		let stream = self.get_stream(ctx).await?;
-		stream.get_event_stream().await
+		let messages = stream.get_event_stream().await?;
+		// We want to drop the Process handle when the stream is done, so that we can close it if we are
+		// the last reference.
+		Ok(Messages::boxed(
+			GuardedMessages {
+				inner: messages,
+				_guard: stream,
+			}
+			.boxed(),
+		))
 	}
 	pub async fn send_message(
 		&self,

--- a/crates/agentgateway/src/mcp/upstream/sse.rs
+++ b/crates/agentgateway/src/mcp/upstream/sse.rs
@@ -5,13 +5,13 @@ use futures_core::Stream;
 use futures_core::stream::BoxStream;
 use futures_util::{StreamExt, TryFutureExt};
 use headers::HeaderMapExt;
-use parking_lot::Mutex;
 use pin_project_lite::pin_project;
 use rmcp::model::{
 	ClientJsonRpcMessage, ClientNotification, ClientRequest, JsonRpcRequest, ServerJsonRpcMessage,
 };
 use rmcp::transport::common::http_header::EVENT_STREAM_MIME_TYPE;
 use sse_stream::{Sse, SseStream};
+use std::sync::Weak;
 
 use crate::client::ResolvedDestination;
 use crate::mcp::ClientError;
@@ -33,7 +33,7 @@ struct ClientCore {
 pub struct Client {
 	client: ClientCore,
 
-	active_stream: Arc<Mutex<Option<std::sync::Weak<super::stdio::Process>>>>,
+	active_stream: Arc<tokio::sync::Mutex<Option<std::sync::Weak<super::stdio::Process>>>>,
 }
 
 struct SseClient {
@@ -194,23 +194,15 @@ impl Client {
 	}
 
 	pub async fn stop(&self) -> Result<(), UpstreamError> {
-		let stream = self
-			.active_stream
-			.lock()
-			.take()
-			.and_then(|stream| stream.upgrade());
-		if let Some(s) = stream {
+		let mut stream = self.active_stream.lock().await;
+		if let Some(s) = stream.take().and_then(|stream| stream.upgrade()) {
 			s.stop().await?;
 		}
 		Ok(())
 	}
 	async fn get_stream(&self, ctx: &IncomingRequestContext) -> Result<Arc<Process>, UpstreamError> {
-		if let Some(stream) = self
-			.active_stream
-			.lock()
-			.as_ref()
-			.and_then(std::sync::Weak::upgrade)
-		{
+		let mut stream = self.active_stream.lock().await;
+		if let Some(stream) = stream.as_ref().and_then(Weak::upgrade) {
 			return Ok(stream);
 		}
 
@@ -224,10 +216,6 @@ impl Client {
 		};
 
 		let proc = Arc::new(Process::new(transport));
-		let mut stream = self.active_stream.lock();
-		if let Some(existing) = stream.as_ref().and_then(std::sync::Weak::upgrade) {
-			return Ok(existing);
-		}
 		*stream = Some(Arc::downgrade(&proc));
 		Ok(proc)
 	}

--- a/crates/agentgateway/src/mcp/upstream/stdio.rs
+++ b/crates/agentgateway/src/mcp/upstream/stdio.rs
@@ -126,12 +126,15 @@ impl Process {
 			let mut shutdown_resp = None;
 			loop {
 				tokio::select! {
-					Some((msg, ctx)) = sender_rx.recv() => {
-						if let Err(e) = proc.send(msg, &ctx).await {
-							error!("Error sending message to stdio process: {:?}", e);
-							terminal_err = Some(e);
-							break;
-						}
+					req = sender_rx.recv() => match req {
+						Some((msg, ctx)) => {
+							if let Err(e) = proc.send(msg, &ctx).await {
+								error!("Error sending message to stdio process: {:?}", e);
+								terminal_err = Some(e);
+								break;
+							}
+						},
+						None => break,
 					},
 					msg = proc.receive() => {
 						match msg {
@@ -152,12 +155,12 @@ impl Process {
 							}
 						}
 					},
-					Some((_, resp)) = shutdown_rx.recv() => {
-						shutdown_resp = Some(resp);
-						break;
-					},
-					else => {
-						break;
+					req = shutdown_rx.recv() => match req {
+						Some((_, resp)) => {
+							shutdown_resp = Some(resp);
+							break;
+						},
+						None => break,
 					},
 				}
 			}


### PR DESCRIPTION
For https://github.com/agentgateway/agentgateway/issues/1536

Before, we would have a upstream GET stream to the server that we kept until the session was deleted. if a user never deleted a session, we would keep it around forever.

This instead makes the GET stream only stay around as long as there are current GET or POST requests incoming active for the session.

This means if they disappear we will have nothing leaked. If they come back, its fine; we just re-establish the GET stream.

This only impacts SSE backend calls. Streamable HTTP has no impact, nor does stiod.

This does not entirely fix the issue; we don't do the same for stdio since that would break the session. For stdio we need a TTL on the session