### PR TITLE
fix unit test flake

### DIFF
--- a/controller/pkg/agentgateway/jwks/fetcher_test.go
+++ b/controller/pkg/agentgateway/jwks/fetcher_test.go
@@ -292,14 +292,14 @@ func TestFetchJwksViaProxyWithTLS(t *testing.T) {
 			http.Error(w, "hijack not supported", http.StatusInternalServerError)
 			return
 		}
-		clientConn, _, err := hijacker.Hijack()
+		clientConn, clientBuf, err := hijacker.Hijack()
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 		go func() {
 			defer destConn.Close()
-			io.Copy(destConn, clientConn) //nolint:errcheck
+			io.Copy(destConn, clientBuf) //nolint:errcheck
 		}()
 		defer clientConn.Close()
 		io.Copy(clientConn, destConn) //nolint:errcheck
@@ -333,7 +333,7 @@ func TestFetchJwksViaProxyWithTLS(t *testing.T) {
 	awaitJwksUpdate(t, updates, source.RequestKey)
 	keyset := awaitStoredKeyset(t, f.cache, source.RequestKey)
 	assert.Equal(t, sampleJWKS, keyset.JwksJSON)
-	assert.Equal(t, int32(1), connectCount.Load(), "HTTPS request should have used CONNECT through the proxy")
+	assert.True(t, connectCount.Load() >= 1, "HTTPS request should have used CONNECT through the proxy")
 }
 
 func TestMakeFetchClientRejectsInvalidProxyURL(t *testing.T) {

--- a/controller/pkg/agentgateway/jwks/fetcher_test.go
+++ b/controller/pkg/agentgateway/jwks/fetcher_test.go
@@ -333,7 +333,7 @@ func TestFetchJwksViaProxyWithTLS(t *testing.T) {
 	awaitJwksUpdate(t, updates, source.RequestKey)
 	keyset := awaitStoredKeyset(t, f.cache, source.RequestKey)
 	assert.Equal(t, sampleJWKS, keyset.JwksJSON)
-	assert.True(t, connectCount.Load() >= 1, "HTTPS request should have used CONNECT through the proxy")
+	assert.Equal(t, int32(1), connectCount.Load(), "HTTPS request should have used CONNECT through the proxy")
 }
 
 func TestMakeFetchClientRejectsInvalidProxyURL(t *testing.T) {


### PR DESCRIPTION
Reported flake:
```
=== RUN   TestFetchJwksViaProxyWithTLS
2026-04-15T21:54:28.800119Z	info	http: TLS handshake error from 127.0.0.1:43800: tls: first record does not look like a TLS handshake
{"time":"2026-04-15T14:54:28.800403606-07:00","level":"error","msg":"error fetching jwks","component":"jwks_store","request_key":"63c03461060654000b4f021f99d690c23faae7fee186040e04acba98c0c07853","target":"https://127.0.0.1:43641/","error":"Get \"https://127.0.0.1:43641/\": EOF","retryAttempt":0,"next":"200ms"}
```

```
❯  go test ./controller/pkg/agentgateway/jwks/ -count=200 -v 2>&1 | tail -2  
PASS
ok      github.com/agentgateway/agentgateway/controller/pkg/agentgateway/jwks   304.566s
```

Read from clientBuf instead of raw clientConn, this flake can happen when the backend then receives a partial/garbled TLS ClientHello. 

```
❯ go test ./controller/pkg/agentgateway/jwks/ -run TestFetchJwksViaProxyWithTLS -count=200 -v 2>&1 | tail -2
PASS
ok      github.com/agentgateway/agentgateway/controller/pkg/agentgateway/jwks   5.150s
```