### PR TITLE
locality loadbalancing and failover

### DIFF
--- a/controller/Makefile
+++ b/controller/Makefile
@@ -582,6 +582,17 @@ else
 	kubectl apply --kustomize "https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd?ref=$(GIE_CRD_VERSION)"
 endif
 
+# Source the Istio CRDs from the vendored istio.io/istio module so the CRD
+# version always matches the API version agentgateway is compiled against.
+# The controller consumes Istio's ambient collections (WorkloadEntry,
+# ServiceEntry, AuthorizationPolicy...) so these CRDs must exist for those
+# informers to receive objects.
+ISTIO_CRDS_FILE := $(shell go list -m -f '{{.Dir}}' istio.io/istio)/manifests/charts/base/files/crd-all.gen.yaml
+
+.PHONY: istio-crds
+istio-crds: ## Install Istio CRDs (WorkloadEntry, ServiceEntry, etc.) from the vendored istio module
+	kubectl apply --server-side -f "$(ISTIO_CRDS_FILE)"
+
 .PHONY: metallb
 metallb: ## Install the MetalLB load balancer
 	kubectl apply -f ./test/setup/metallb.yaml
@@ -592,7 +603,7 @@ metallb: ## Install the MetalLB load balancer
 deploy-agentgateway: package-agentgateway-charts deploy-agentgateway-crd-chart deploy-agentgateway-chart ## Deploy the agentgateway chart and CRDs
 
 .PHONY: setup-base
-setup-base: kind-create gw-api-crds gie-crds metallb ## Setup the base infrastructure (kind cluster, CRDs, and MetalLB)
+setup-base: kind-create gw-api-crds gie-crds istio-crds metallb ## Setup the base infrastructure (kind cluster, CRDs, and MetalLB)
 
 # Creates a functional kind cluster, builds and loads all images, and packages charts
 # Does NOT deploy anything to the cluster

--- a/controller/test/e2e/features/agentgateway/locality/suite.go
+++ b/controller/test/e2e/features/agentgateway/locality/suite.go
@@ -1,0 +1,280 @@
+//go:build e2e
+
+package locality
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/onsi/gomega"
+	"github.com/stretchr/testify/suite"
+	"istio.io/istio/pkg/ptr"
+	"istio.io/istio/pkg/test/util/retry"
+	"istio.io/istio/pkg/util/sets"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/agentgateway/agentgateway/controller/pkg/utils/requestutils/curl"
+	"github.com/agentgateway/agentgateway/controller/test/e2e"
+	"github.com/agentgateway/agentgateway/controller/test/e2e/common"
+	"github.com/agentgateway/agentgateway/controller/test/e2e/tests/base"
+)
+
+var _ e2e.NewSuiteFunc = NewTestingSuite
+
+type testingSuite struct {
+	*base.BaseTestingSuite
+
+	workloadEntries []weSpec
+}
+
+func NewTestingSuite(ctx context.Context, testInst *e2e.TestInstallation) suite.TestingSuite {
+	return &testingSuite{
+		BaseTestingSuite: base.NewBaseTestingSuite(ctx, testInst, setup, testCases),
+	}
+}
+
+func (s *testingSuite) SetupSuite() {
+	s.BaseTestingSuite.SetupSuite()
+
+	// we deploy pods via the yamls, and then we need to copy their IPs onto WorkloadEntries
+	// we do this because WorkloadEntry is easier to override locality on, without messing with node info
+	zoneAIP := s.waitPodIP("app=" + backendZoneA)
+	zoneBIP := s.waitPodIP("app=" + backendZoneB)
+	regionBIP := s.waitPodIP("app=" + backendRegionB)
+	s.workloadEntries = []weSpec{
+		{"we-zone-a", zoneAIP, sameRegion + "/" + sameZone},
+		{"we-zone-b", zoneBIP, sameRegion + "/" + otherZone},
+		{"we-region-b", regionBIP, otherRegion + "/" + sameZone},
+	}
+	s.resetWorkloadEntries()
+
+	s.TestInstallation.AssertionsT(s.T()).EventuallyGatewayCondition(
+		s.Ctx, gatewayName, namespace, gwv1.GatewayConditionProgrammed, metav1.ConditionTrue,
+	)
+	s.TestInstallation.AssertionsT(s.T()).EventuallyHTTPRouteCondition(
+		s.Ctx, routeName, namespace, gwv1.RouteConditionAccepted, metav1.ConditionTrue,
+	)
+}
+
+func (s *testingSuite) SetupTest() {
+	s.resetWorkloadEntries()
+}
+
+func (s *testingSuite) TearDownSuite() {
+	_ = s.TestInstallation.ClusterContext.Cli.RunCommand(
+		s.Ctx, "-n", namespace, "delete", "workloadentry", "--all", "--ignore-not-found=true",
+	)
+	s.BaseTestingSuite.TearDownSuite()
+}
+
+func (s *testingSuite) TestPreferSameZone() {
+	s.setTrafficDistribution("PreferSameZone")
+
+	s.assertTrafficGoesTo(backendZoneA)
+	s.deleteWorkloadEntry("we-zone-a")
+	s.assertTrafficGoesTo(backendZoneB)
+	s.deleteWorkloadEntry("we-zone-b")
+	s.assertTrafficGoesTo(backendRegionB)
+}
+
+func (s *testingSuite) TestPreferSameRegion() {
+	s.setTrafficDistribution("PreferSameRegion")
+
+	s.assertTrafficGoesTo(backendZoneA, backendZoneB)
+	s.deleteWorkloadEntry("we-zone-a")
+	s.assertTrafficGoesTo(backendZoneB)
+	s.deleteWorkloadEntry("we-zone-b")
+	s.assertTrafficGoesTo(backendRegionB)
+}
+
+// TestInternalTrafficPolicyLocal verifies the policy is honored: WorkloadEntries
+// have no node association, so with InternalTrafficPolicy: Local nothing is
+// eligible and every request should 503.
+func (s *testingSuite) TestInternalTrafficPolicyLocal() {
+	s.setInternalTrafficPolicy(corev1.ServiceInternalTrafficPolicyLocal)
+	s.assertServiceUnavailable()
+}
+
+// ---------- helpers ----------
+
+type weSpec struct {
+	name     string
+	address  string
+	locality string
+}
+
+func (s *testingSuite) resetWorkloadEntries() {
+	s.applyWorkloadEntries(s.workloadEntries)
+}
+
+func (s *testingSuite) setTrafficDistribution(trafficDistribution string) {
+	s.updateService(func(svc *corev1.Service) {
+		svc.Spec.TrafficDistribution = ptr.Of(trafficDistribution)
+	})
+}
+
+func (s *testingSuite) setInternalTrafficPolicy(policy corev1.ServiceInternalTrafficPolicy) {
+	s.updateService(func(svc *corev1.Service) {
+		svc.Spec.InternalTrafficPolicy = ptr.Of(policy)
+	})
+}
+
+func (s *testingSuite) updateService(mutate func(*corev1.Service)) {
+	svcs := s.TestInstallation.ClusterContext.Clientset.CoreV1().Services(namespace)
+	svc, err := svcs.Get(s.Ctx, serviceName, metav1.GetOptions{})
+	s.Require().NoError(err)
+	mutate(svc)
+	_, err = svcs.Update(s.Ctx, svc, metav1.UpdateOptions{})
+	s.Require().NoError(err)
+}
+
+func (s *testingSuite) applyWorkloadEntries(entries []weSpec) {
+	err := s.TestInstallation.ClusterContext.IstioClient.ApplyYAMLContents("", workloadEntriesYAML(entries))
+	s.Require().NoError(err)
+}
+
+func (s *testingSuite) deleteWorkloadEntry(name string) {
+	err := s.TestInstallation.ClusterContext.Cli.RunCommand(
+		s.Ctx, "-n", namespace, "delete", "workloadentry", name, "--ignore-not-found=true",
+	)
+	s.Require().NoError(err)
+}
+
+// workloadEntriesYAML renders a set of WorkloadEntries, each labeled so the
+// Service's selector picks it up.
+func workloadEntriesYAML(entries []weSpec) string {
+	var b strings.Builder
+	for i, e := range entries {
+		if i > 0 {
+			b.WriteString("\n---\n")
+		}
+		fmt.Fprintf(&b, `apiVersion: networking.istio.io/v1
+kind: WorkloadEntry
+metadata:
+  name: %s
+  namespace: %s
+  labels:
+    locality-pool: locality-svc-workloadentry
+spec:
+  address: %s
+  locality: %q
+  ports:
+    http: 80
+`, e.name, namespace, e.address, e.locality)
+	}
+	return b.String()
+}
+
+func (s *testingSuite) waitPodIP(labelSelector string) string {
+	var ip string
+	s.TestInstallation.AssertionsT(s.T()).Gomega.Eventually(func(g gomega.Gomega) {
+		pods, err := s.TestInstallation.ClusterContext.Clientset.
+			CoreV1().Pods(namespace).
+			List(s.Ctx, metav1.ListOptions{LabelSelector: labelSelector})
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		g.Expect(pods.Items).To(gomega.HaveLen(1))
+		g.Expect(pods.Items[0].Status.PodIP).NotTo(gomega.BeEmpty())
+		ip = pods.Items[0].Status.PodIP
+	}).WithTimeout(30 * time.Second).WithPolling(500 * time.Millisecond).Should(gomega.Succeed())
+	return ip
+}
+
+func (s *testingSuite) assertTrafficGoesTo(expectedBackends ...string) {
+	const requestsPerAttempt = 20
+
+	gw := s.gateway()
+	addr := gw.ResolvedAddress()
+	opts := append(common.GatewayAddressOptions(addr),
+		curl.WithHostHeader(hostname),
+		curl.WithPath("/"),
+	)
+
+	want := sets.New(expectedBackends...)
+	retry.UntilSuccessOrFail(s.T(), func() error {
+		got := sets.New[string]()
+		for i := range requestsPerAttempt {
+			body, err := curlBody(opts...)
+			if err != nil {
+				return fmt.Errorf("request %d: %w", i, err)
+			}
+			for line := range strings.Lines(body) {
+				name, ok := strings.CutPrefix(strings.TrimSpace(line), "Hostname=")
+				if !ok {
+					continue
+				}
+				for b := range want {
+					if strings.HasPrefix(name, b+"-") {
+						got.Insert(b)
+					}
+				}
+			}
+		}
+		if !got.Equals(want) {
+			return fmt.Errorf("got responses from %v, want %v", got, want)
+		}
+		return nil
+	}, retry.Timeout(45*time.Second), retry.Delay(500*time.Millisecond))
+}
+
+func (s *testingSuite) assertServiceUnavailable() {
+	const requestsPerAttempt = 20
+
+	gw := s.gateway()
+	addr := gw.ResolvedAddress()
+	opts := append(common.GatewayAddressOptions(addr),
+		curl.WithHostHeader(hostname),
+		curl.WithPath("/"),
+	)
+
+	retry.UntilSuccessOrFail(s.T(), func() error {
+		for i := range requestsPerAttempt {
+			status, err := curlStatus(opts...)
+			if err != nil {
+				return fmt.Errorf("request %d: %w", i, err)
+			}
+			if status != 503 {
+				return fmt.Errorf("request %d: got status %d, want 503", i, status)
+			}
+		}
+		return nil
+	}, retry.Timeout(45*time.Second), retry.Delay(500*time.Millisecond))
+}
+
+func (s *testingSuite) gateway() common.Gateway {
+	name := types.NamespacedName{Namespace: namespace, Name: gatewayName}
+	return common.Gateway{
+		NamespacedName: name,
+		Address:        common.ResolveGatewayAddress(s.Ctx, s.TestInstallation, name),
+	}
+}
+
+func curlBody(opts ...curl.Option) (string, error) {
+	resp, err := curl.ExecuteRequest(opts...)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode != 200 {
+		return string(b), fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+	return string(b), nil
+}
+
+func curlStatus(opts ...curl.Option) (int, error) {
+	resp, err := curl.ExecuteRequest(opts...)
+	if err != nil {
+		return 0, err
+	}
+	resp.Body.Close()
+	return resp.StatusCode, nil
+}

--- a/controller/test/e2e/features/agentgateway/locality/suite.go
+++ b/controller/test/e2e/features/agentgateway/locality/suite.go
@@ -65,6 +65,7 @@ func (s *testingSuite) SetupSuite() {
 
 func (s *testingSuite) SetupTest() {
 	s.resetWorkloadEntries()
+	s.resetService()
 }
 
 func (s *testingSuite) TearDownSuite() {
@@ -78,16 +79,6 @@ func (s *testingSuite) TestPreferSameZone() {
 	s.setTrafficDistribution("PreferSameZone")
 
 	s.assertTrafficGoesTo(backendZoneA)
-	s.deleteWorkloadEntry("we-zone-a")
-	s.assertTrafficGoesTo(backendZoneB)
-	s.deleteWorkloadEntry("we-zone-b")
-	s.assertTrafficGoesTo(backendRegionB)
-}
-
-func (s *testingSuite) TestPreferSameRegion() {
-	s.setTrafficDistribution("PreferSameRegion")
-
-	s.assertTrafficGoesTo(backendZoneA, backendZoneB)
 	s.deleteWorkloadEntry("we-zone-a")
 	s.assertTrafficGoesTo(backendZoneB)
 	s.deleteWorkloadEntry("we-zone-b")
@@ -112,6 +103,13 @@ type weSpec struct {
 
 func (s *testingSuite) resetWorkloadEntries() {
 	s.applyWorkloadEntries(s.workloadEntries)
+}
+
+func (s *testingSuite) resetService() {
+	s.updateService(func(svc *corev1.Service) {
+		svc.Spec.TrafficDistribution = nil
+		svc.Spec.InternalTrafficPolicy = nil
+	})
 }
 
 func (s *testingSuite) setTrafficDistribution(trafficDistribution string) {
@@ -161,7 +159,7 @@ metadata:
   name: %s
   namespace: %s
   labels:
-    locality-pool: locality-svc-workloadentry
+    app: locality-svc-workloadentry
 spec:
   address: %s
   locality: %q

--- a/controller/test/e2e/features/agentgateway/locality/suite.go
+++ b/controller/test/e2e/features/agentgateway/locality/suite.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http"
 	"strings"
 	"time"
 
@@ -264,7 +265,7 @@ func curlBody(opts ...curl.Option) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		return string(b), fmt.Errorf("unexpected status %d", resp.StatusCode)
 	}
 	return string(b), nil

--- a/controller/test/e2e/features/agentgateway/locality/testdata/backends.yaml
+++ b/controller/test/e2e/features/agentgateway/locality/testdata/backends.yaml
@@ -1,0 +1,95 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend-zone-a
+  namespace: agentgateway-locality
+  labels:
+    app.kubernetes.io/name: backend-zone-a
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: backend-zone-a
+  template:
+    metadata:
+      labels:
+        app: backend-zone-a
+        app.kubernetes.io/name: backend-zone-a
+    spec:
+      containers:
+        - image: ghcr.io/agentgateway/testbox:0.0.1
+          imagePullPolicy: IfNotPresent
+          name: testbox
+          ports:
+            - name: http
+              containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            periodSeconds: 2
+            failureThreshold: 10
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend-zone-b
+  namespace: agentgateway-locality
+  labels:
+    app.kubernetes.io/name: backend-zone-b
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: backend-zone-b
+  template:
+    metadata:
+      labels:
+        app: backend-zone-b
+        app.kubernetes.io/name: backend-zone-b
+    spec:
+      containers:
+        - image: ghcr.io/agentgateway/testbox:0.0.1
+          imagePullPolicy: IfNotPresent
+          name: testbox
+          ports:
+            - name: http
+              containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            periodSeconds: 2
+            failureThreshold: 10
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend-region-b
+  namespace: agentgateway-locality
+  labels:
+    app.kubernetes.io/name: backend-region-b
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: backend-region-b
+  template:
+    metadata:
+      labels:
+        app: backend-region-b
+        app.kubernetes.io/name: backend-region-b
+    spec:
+      containers:
+        - image: ghcr.io/agentgateway/testbox:0.0.1
+          imagePullPolicy: IfNotPresent
+          name: testbox
+          ports:
+            - name: http
+              containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            periodSeconds: 2
+            failureThreshold: 10

--- a/controller/test/e2e/features/agentgateway/locality/testdata/gateway.yaml
+++ b/controller/test/e2e/features/agentgateway/locality/testdata/gateway.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: agentgateway-locality
+---
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: gateway
+  namespace: agentgateway-locality
+spec:
+  gatewayClassName: agentgateway
+  listeners:
+    - protocol: HTTP
+      port: 80
+      name: http
+      allowedRoutes:
+        namespaces:
+          from: Same

--- a/controller/test/e2e/features/agentgateway/locality/testdata/service-route.yaml
+++ b/controller/test/e2e/features/agentgateway/locality/testdata/service-route.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: locality-svc
+  namespace: agentgateway-locality
+spec:
+  # select the WorkloadEntry, not  the Pods from the deployment
+  # the WorkloadEntries lets us override locality
+  selector:
+    app: locality-svc-workloadentry
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+      protocol: TCP
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: locality-route
+  namespace: agentgateway-locality
+spec:
+  parentRefs:
+    - name: gateway
+  hostnames:
+    - "locality.test"
+  rules:
+    - backendRefs:
+        - name: locality-svc
+          port: 80

--- a/controller/test/e2e/features/agentgateway/locality/types.go
+++ b/controller/test/e2e/features/agentgateway/locality/types.go
@@ -40,7 +40,7 @@ var (
 	}
 
 	testCases = map[string]*base.TestCase{
-		"TestFailoverWorkloadRemoval": {},
-		"TestFailoverHealthiness":     {},
+		"TestPreferSameZone":             {},
+		"TestInternalTrafficPolicyLocal": {},
 	}
 )

--- a/controller/test/e2e/features/agentgateway/locality/types.go
+++ b/controller/test/e2e/features/agentgateway/locality/types.go
@@ -1,0 +1,46 @@
+//go:build e2e
+
+package locality
+
+import (
+	"path/filepath"
+
+	"github.com/agentgateway/agentgateway/controller/pkg/utils/fsutils"
+	"github.com/agentgateway/agentgateway/controller/test/e2e/tests/base"
+)
+
+const (
+	namespace = "agentgateway-locality"
+
+	gatewayName = "gateway"
+	serviceName = "locality-svc"
+	routeName   = "locality-route"
+	hostname    = "locality.test"
+
+	// Labels on the sole kind node — see controller/test/setup/setup-kind-ci.sh.
+	// The gateway's own Workload gets these via WDS, so a WorkloadEntry with
+	// locality "region/zone" is what counts as "same zone" for PreferClose.
+	sameRegion  = "region"
+	sameZone    = "zone"
+	otherZone   = "other-zone"
+	otherRegion = "other-region"
+
+	backendZoneA   = "backend-zone-a"
+	backendZoneB   = "backend-zone-b"
+	backendRegionB = "backend-region-b"
+)
+
+var (
+	gatewayManifest      = filepath.Join(fsutils.MustGetThisDir(), "testdata", "gateway.yaml")
+	backendsManifest     = filepath.Join(fsutils.MustGetThisDir(), "testdata", "backends.yaml")
+	serviceRouteManifest = filepath.Join(fsutils.MustGetThisDir(), "testdata", "service-route.yaml")
+
+	setup = base.TestCase{
+		Manifests: []string{gatewayManifest, backendsManifest, serviceRouteManifest},
+	}
+
+	testCases = map[string]*base.TestCase{
+		"TestFailoverWorkloadRemoval": {},
+		"TestFailoverHealthiness":     {},
+	}
+)

--- a/controller/test/e2e/tests/agent_gateway_tests.go
+++ b/controller/test/e2e/tests/agent_gateway_tests.go
@@ -15,6 +15,7 @@ import (
 	"github.com/agentgateway/agentgateway/controller/test/e2e/features/agentgateway/extauth"
 	"github.com/agentgateway/agentgateway/controller/test/e2e/features/agentgateway/extproc"
 	"github.com/agentgateway/agentgateway/controller/test/e2e/features/agentgateway/jwtauth"
+	"github.com/agentgateway/agentgateway/controller/test/e2e/features/agentgateway/locality"
 	"github.com/agentgateway/agentgateway/controller/test/e2e/features/agentgateway/mcp"
 	"github.com/agentgateway/agentgateway/controller/test/e2e/features/agentgateway/otel"
 	"github.com/agentgateway/agentgateway/controller/test/e2e/features/agentgateway/policystatus"
@@ -34,6 +35,7 @@ func AgentgatewaySuiteRunner() e2e.SuiteRunner {
 	agentgatewaySuiteRunner.Register("BasicAuth", basicauth.NewTestingSuite)
 	agentgatewaySuiteRunner.Register("ApiKeyAuth", apikeyauth.NewTestingSuite)
 	agentgatewaySuiteRunner.Register("JwtAuth", jwtauth.NewTestingSuite)
+	agentgatewaySuiteRunner.Register("Locality", locality.NewTestingSuite)
 	agentgatewaySuiteRunner.Register("CSRF", csrf.NewTestingSuite)
 	agentgatewaySuiteRunner.Register("Delegation", delegation.NewTestingSuite)
 	agentgatewaySuiteRunner.Register("Extauth", extauth.NewTestingSuite)

--- a/controller/test/setup/setup-kind-ci.sh
+++ b/controller/test/setup/setup-kind-ci.sh
@@ -245,7 +245,7 @@ function step_deploy_helm() {
 	   "$@"
 }
 function step_setup_gateway_api() {
-	make --no-print-directory -C controller gw-api-crds gie-crds
+	make --no-print-directory -C controller gw-api-crds gie-crds istio-crds
 }
 function step_preload_images() {(
   if [[ "${TEST_MODE}" == "e2e" ]]; then

--- a/crates/agentgateway/src/app.rs
+++ b/crates/agentgateway/src/app.rs
@@ -82,6 +82,8 @@ pub async fn run(config: Arc<Config>) -> anyhow::Result<Bound> {
 			.await?;
 	let stores = state_mgr.stores();
 
+	state_manager::start_self_workload_resolution(&config, stores.clone(), &ready);
+
 	let mut xds_rx_for_task = xds_rx.clone();
 	tokio::spawn(async move {
 		// When we get the initial XDS state, unblock readiness

--- a/crates/agentgateway/src/config.rs
+++ b/crates/agentgateway/src/config.rs
@@ -13,6 +13,7 @@ use serde::de::DeserializeOwned;
 use crate::control::caclient;
 use crate::telemetry::log::{LoggingFields, MetricFields};
 use crate::telemetry::trc;
+use crate::types;
 use crate::types::discovery::{Identity, WaypointIdentity};
 use crate::{
 	Address, Config, ConfigSource, DnsLookupFamily, NestedRawConfig, RawLoggingLevel, StringOrInt,
@@ -213,6 +214,55 @@ pub fn parse_config(contents: String, filename: Option<PathBuf>) -> anyhow::Resu
 		None
 	};
 	let network = parse("NETWORK")?.or(raw.network).unwrap_or_default();
+
+	// Self-identity for locality-aware load balancing.
+	// Priority:
+	//  1. Operator explicitly set LOCALITY -> Static. This is the one field WDS would otherwise
+	//     fill in from the node, so it's the only real "override" signal. NETWORK and NODE_NAME
+	//     are commonly set by istio-ambient/downward-API in normal k8s deploys and must not
+	//     bypass WDS.
+	//  2. POD_NAME+NAMESPACE known -> WDS. Standard k8s case: the control plane delivers our
+	//     own Workload with locality derived from the node we're scheduled on.
+	//  3. No pod identity but some env (NODE_NAME / NETWORK) -> Static with what we have.
+	//     Covers non-pod deploys where WDS self-lookup isn't possible.
+	let locality_env = parse::<String>("LOCALITY")?;
+	let node_env =
+		empty_to_none(Some(ENV.node_name.clone())).or_else(|| parse("NODE_NAME").ok().flatten());
+	let pod_name =
+		empty_to_none(Some(ENV.pod_name.clone())).or_else(|| parse("POD_NAME").ok().flatten());
+	let pod_namespace =
+		empty_to_none(Some(ENV.pod_namespace.clone())).or_else(|| parse("NAMESPACE").ok().flatten());
+
+	let build_static = || types::discovery::Workload {
+		name: pod_name.clone().unwrap_or_default().into(),
+		namespace: pod_namespace.clone().unwrap_or_default().into(),
+		network: network.clone().into(),
+		node: node_env.clone().unwrap_or_default().into(),
+		cluster_id: cluster.clone().into(),
+		locality: locality_env
+			.as_deref()
+			.map(types::discovery::Locality::parse)
+			.unwrap_or_default(),
+		..Default::default()
+	};
+
+	let self_identity = if locality_env.is_some() {
+		Some(types::discovery::SelfIdentitySource::Static(Arc::new(
+			build_static(),
+		)))
+	} else if let (Some(name), Some(ns)) = (pod_name.clone(), pod_namespace.clone()) {
+		Some(types::discovery::SelfIdentitySource::Wds {
+			name: name.into(),
+			namespace: ns.into(),
+			cluster_id: cluster.clone().into(),
+		})
+	} else if node_env.is_some() || !network.is_empty() {
+		Some(types::discovery::SelfIdentitySource::Static(Arc::new(
+			build_static(),
+		)))
+	} else {
+		None
+	};
 	let termination_min_deadline = parse_duration("CONNECTION_MIN_TERMINATION_DEADLINE")?
 		.or(raw.connection_min_termination_deadline)
 		.unwrap_or_default();
@@ -274,7 +324,8 @@ pub fn parse_config(contents: String, filename: Option<PathBuf>) -> anyhow::Resu
 
 	Ok(crate::Config {
 		ipv6_enabled,
-		network: network.into(),
+		network: network.clone().into(),
+		self_identity,
 		admin_addr,
 		stats_addr,
 		readiness_addr,

--- a/crates/agentgateway/src/lib.rs
+++ b/crates/agentgateway/src/lib.rs
@@ -470,6 +470,9 @@ impl schemars::JsonSchema for StringBoolFloat {
 pub struct Config {
 	pub ipv6_enabled: bool,
 	pub network: Strng,
+	/// How the gateway discovers its own workload for locality-aware load balancing.
+	/// `None` disables locality filtering — any LoadBalancer config on services is ignored.
+	pub self_identity: Option<types::discovery::SelfIdentitySource>,
 	#[serde(with = "serde_dur")]
 	pub termination_max_deadline: Duration,
 	#[serde(with = "serde_dur")]

--- a/crates/agentgateway/src/proxy/gateway.rs
+++ b/crates/agentgateway/src/proxy/gateway.rs
@@ -42,6 +42,10 @@ use agent_hbone::server::H2Request;
 #[path = "gateway_test.rs"]
 mod tests;
 
+#[cfg(test)]
+#[path = "locality_test.rs"]
+mod locality_tests;
+
 #[derive(Debug, Clone, PartialEq)]
 
 pub enum HboneAddress {

--- a/crates/agentgateway/src/proxy/locality_test.rs
+++ b/crates/agentgateway/src/proxy/locality_test.rs
@@ -177,7 +177,7 @@ async fn strict_mode_drops_non_matching_endpoints() {
 			Step::Hit {
 				hits: 3,
 				want_status: StatusCode::SERVICE_UNAVAILABLE,
-				want: Expect::Exact(vec![("other-zone", 0), ("other-region", 0)]),
+				want: Expect::Exact(vec![("other-zone", 0), ("other-zone-2", 0)]),
 			},
 		],
 	})
@@ -542,6 +542,75 @@ async fn service_lb_preference_change_rebuckets() {
 					("same-zone", 0),
 					("same-region", 0),
 				]),
+			},
+		],
+	})
+	.await;
+}
+
+// some properties of the service cause us to fully exclude and endpoint from all buckets
+// and we must recover them when we change those properties to something more permissive
+#[tokio::test]
+async fn strict_then_failover_recovers_dropped_endpoints() {
+	let endpoints = vec![
+		Ep {
+			label: "other-zone",
+			svc: "app",
+			loc: ("r1", "z2", "node-b"),
+			healthy: true,
+		},
+		Ep {
+			label: "other-zone-2",
+			svc: "app",
+			loc: ("r1", "z3", "node-c"),
+			healthy: true,
+		},
+	];
+	run(Case {
+		self_loc: Some(("r1", "z1", "node-a")),
+		steps: vec![
+			// Failover + [Zone]: both endpoints share the fallback bucket (zone mismatch),
+			// so traffic spreads across them.
+			Step::Sync {
+				services: vec![Svc {
+					name: "app",
+					mode: Failover,
+					scopes: vec![Zone],
+				}],
+				endpoints: endpoints.clone(),
+			},
+			Step::Hit {
+				hits: 10,
+				want_status: StatusCode::OK,
+				want: Expect::Spread(vec!["other-zone", "other-zone-2"]),
+			},
+			// Strict + [Node]: nothing matches, every endpoint is dropped.
+			Step::Sync {
+				services: vec![Svc {
+					name: "app",
+					mode: Strict,
+					scopes: vec![Node],
+				}],
+				endpoints: endpoints.clone(),
+			},
+			Step::Hit {
+				hits: 3,
+				want_status: StatusCode::SERVICE_UNAVAILABLE,
+				want: Expect::Exact(vec![("other-zone", 0), ("other-zone-2", 0)]),
+			},
+			// Back to Failover + [Zone]: the same workloads should be reachable again.
+			Step::Sync {
+				services: vec![Svc {
+					name: "app",
+					mode: Failover,
+					scopes: vec![Zone],
+				}],
+				endpoints,
+			},
+			Step::Hit {
+				hits: 10,
+				want_status: StatusCode::OK,
+				want: Expect::Spread(vec!["other-zone", "other-zone-2"]),
 			},
 		],
 	})

--- a/crates/agentgateway/src/proxy/locality_test.rs
+++ b/crates/agentgateway/src/proxy/locality_test.rs
@@ -343,6 +343,93 @@ async fn unhealthy_local_zone_falls_back_to_next_tier() {
 	.await;
 }
 
+// split between higher bucket
+#[tokio::test]
+async fn shared_bucket_splits_within_and_skips_lower_tier() {
+	run(Case {
+		self_loc: Some(("r1", "z1", "node-a")),
+		steps: vec![
+			Step::Sync {
+				services: vec![Svc {
+					name: "app",
+					mode: Failover,
+					scopes: vec![Zone],
+				}],
+				endpoints: vec![
+					Ep {
+						label: "a",
+						svc: "app",
+						loc: ("r1", "z1", "node-a"),
+						healthy: true,
+					},
+					Ep {
+						label: "b",
+						svc: "app",
+						loc: ("r1", "z1", "node-b"),
+						healthy: true,
+					},
+					Ep {
+						label: "c",
+						svc: "app",
+						loc: ("r1", "z2", "node-c"),
+						healthy: true,
+					},
+				],
+			},
+			// Spread over {a,b} sums to `hits`, which implicitly rules out c receiving traffic.
+			Step::Hit {
+				hits: 20,
+				want_status: StatusCode::OK,
+				want: Expect::Spread(vec!["a", "b"]),
+			},
+		],
+	})
+	.await;
+}
+
+// use the only healthy endpoint in the higher bucket
+#[tokio::test]
+async fn shared_bucket_with_one_unhealthy_stays_in_bucket() {
+	run(Case {
+		self_loc: Some(("r1", "z1", "node-a")),
+		steps: vec![
+			Step::Sync {
+				services: vec![Svc {
+					name: "app",
+					mode: Failover,
+					scopes: vec![Zone],
+				}],
+				endpoints: vec![
+					Ep {
+						label: "a",
+						svc: "app",
+						loc: ("r1", "z1", "node-a"),
+						healthy: false,
+					},
+					Ep {
+						label: "b",
+						svc: "app",
+						loc: ("r1", "z1", "node-b"),
+						healthy: true,
+					},
+					Ep {
+						label: "c",
+						svc: "app",
+						loc: ("r1", "z2", "node-c"),
+						healthy: true,
+					},
+				],
+			},
+			Step::Hit {
+				hits: 10,
+				want_status: StatusCode::OK,
+				want: Expect::Exact(vec![("a", 0), ("b", 10), ("c", 0)]),
+			},
+		],
+	})
+	.await;
+}
+
 // ---------- lifecycle ----------
 
 /// Workloads arrive before their service. Before the service exists, requests 503 and endpoints

--- a/crates/agentgateway/src/proxy/locality_test.rs
+++ b/crates/agentgateway/src/proxy/locality_test.rs
@@ -1,0 +1,792 @@
+//! Locality-aware load balancing end-to-end tests.
+//!
+//! Tests exercise the Service → endpoint selection path through the proxy against wiremock
+//! servers, one per endpoint. Each test is a sequence of declarative steps (Sync / SetSelf / Hit)
+//! so we can cover both static bucketing and lifecycle scenarios — services arriving after
+//! workloads, LB config changes, late self-identity resolution, etc.
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+
+use agent_core::strng;
+use http::{Method, StatusCode};
+use wiremock::MockServer;
+
+use crate::store::{DiscoveryPreviousState, LocalWorkload};
+use crate::test_helpers::proxymock::*;
+use crate::types::agent::{
+	BackendReference, PathMatch, Route, RouteBackendReference, RouteMatch, RouteName,
+};
+use crate::types::discovery::{
+	HealthStatus, LoadBalancer, LoadBalancerHealthPolicy, LoadBalancerMode, LoadBalancerScopes,
+	Locality, NamespacedHostname, Service, Workload,
+};
+
+use LoadBalancerMode::{Failover, Standard, Strict};
+use LoadBalancerScopes::{Node, Region, Zone};
+
+// ---------- tests ----------
+
+/// PreferSameZone (Region + Zone): all traffic lands on the same-zone endpoint even when
+/// other zones are healthy.
+#[tokio::test]
+async fn prefer_same_zone_pins_to_local_zone() {
+	run(Case {
+		self_loc: Some(("r1", "z1", "node-a")),
+		steps: vec![
+			Step::Sync {
+				services: vec![Svc {
+					name: "app",
+					mode: Failover,
+					scopes: vec![Region, Zone],
+				}],
+				endpoints: vec![
+					Ep {
+						label: "local",
+						svc: "app",
+						loc: ("r1", "z1", "node-a"),
+						healthy: true,
+					},
+					Ep {
+						label: "other-zone",
+						svc: "app",
+						loc: ("r1", "z2", "node-b"),
+						healthy: true,
+					},
+					Ep {
+						label: "other-region",
+						svc: "app",
+						loc: ("r2", "z1", "node-c"),
+						healthy: true,
+					},
+				],
+			},
+			Step::Hit {
+				hits: 10,
+				want_status: StatusCode::OK,
+				want: Expect::Exact(vec![("local", 10), ("other-zone", 0), ("other-region", 0)]),
+			},
+		],
+	})
+	.await;
+}
+
+/// Failover: when the local-zone endpoint is absent, traffic spills to the next-best bucket
+/// (same region, different zone) before the worst tier.
+#[tokio::test]
+async fn failover_spills_to_next_tier_when_local_missing() {
+	run(Case {
+		self_loc: Some(("r1", "z1", "node-a")),
+		steps: vec![
+			Step::Sync {
+				services: vec![Svc {
+					name: "app",
+					mode: Failover,
+					scopes: vec![Region, Zone],
+				}],
+				endpoints: vec![
+					Ep {
+						label: "same-region",
+						svc: "app",
+						loc: ("r1", "z2", "node-b"),
+						healthy: true,
+					},
+					Ep {
+						label: "other-region",
+						svc: "app",
+						loc: ("r2", "z1", "node-c"),
+						healthy: true,
+					},
+				],
+			},
+			Step::Hit {
+				hits: 10,
+				want_status: StatusCode::OK,
+				want: Expect::Exact(vec![("same-region", 10), ("other-region", 0)]),
+			},
+		],
+	})
+	.await;
+}
+
+/// PreferSameNode beats zone-only matches.
+#[tokio::test]
+async fn prefer_same_node_pins_to_local_node() {
+	run(Case {
+		self_loc: Some(("r1", "z1", "node-a")),
+		steps: vec![
+			Step::Sync {
+				services: vec![Svc {
+					name: "app",
+					mode: Failover,
+					scopes: vec![Node],
+				}],
+				endpoints: vec![
+					Ep {
+						label: "same-node",
+						svc: "app",
+						loc: ("r1", "z1", "node-a"),
+						healthy: true,
+					},
+					Ep {
+						label: "same-zone",
+						svc: "app",
+						loc: ("r1", "z1", "node-b"),
+						healthy: true,
+					},
+				],
+			},
+			Step::Hit {
+				hits: 6,
+				want_status: StatusCode::OK,
+				want: Expect::Exact(vec![("same-node", 6), ("same-zone", 0)]),
+			},
+		],
+	})
+	.await;
+}
+
+/// Strict mode drops endpoints that don't fully match; with no survivors the gateway returns
+/// 503 (NoHealthyEndpoints) rather than spilling to a worse locality.
+#[tokio::test]
+async fn strict_mode_drops_non_matching_endpoints() {
+	run(Case {
+		self_loc: Some(("r1", "z1", "node-a")),
+		steps: vec![
+			Step::Sync {
+				services: vec![Svc {
+					name: "app",
+					mode: Strict,
+					scopes: vec![Region, Zone],
+				}],
+				endpoints: vec![
+					Ep {
+						label: "other-zone",
+						svc: "app",
+						loc: ("r1", "z2", "node-b"),
+						healthy: true,
+					},
+					Ep {
+						label: "other-region",
+						svc: "app",
+						loc: ("r2", "z1", "node-c"),
+						healthy: true,
+					},
+				],
+			},
+			Step::Hit {
+				hits: 3,
+				want_status: StatusCode::SERVICE_UNAVAILABLE,
+				want: Expect::Exact(vec![("other-zone", 0), ("other-region", 0)]),
+			},
+		],
+	})
+	.await;
+}
+
+/// Strict mode keeps a fully-matching endpoint and ignores the rest.
+#[tokio::test]
+async fn strict_mode_keeps_full_matches() {
+	run(Case {
+		self_loc: Some(("r1", "z1", "node-a")),
+		steps: vec![
+			Step::Sync {
+				services: vec![Svc {
+					name: "app",
+					mode: Strict,
+					scopes: vec![Region, Zone],
+				}],
+				endpoints: vec![
+					Ep {
+						label: "match",
+						svc: "app",
+						loc: ("r1", "z1", "node-a"),
+						healthy: true,
+					},
+					Ep {
+						label: "drop",
+						svc: "app",
+						loc: ("r1", "z2", "node-b"),
+						healthy: true,
+					},
+				],
+			},
+			Step::Hit {
+				hits: 5,
+				want_status: StatusCode::OK,
+				want: Expect::Exact(vec![("match", 5), ("drop", 0)]),
+			},
+		],
+	})
+	.await;
+}
+
+/// Standard mode: preferences are configured but mode disables bucketing — every endpoint is
+/// eligible regardless of locality.
+#[tokio::test]
+async fn standard_mode_ignores_locality() {
+	run(Case {
+		self_loc: Some(("r1", "z1", "node-a")),
+		steps: vec![
+			Step::Sync {
+				services: vec![Svc {
+					name: "app",
+					mode: Standard,
+					scopes: vec![Zone],
+				}],
+				endpoints: vec![
+					Ep {
+						label: "z1",
+						svc: "app",
+						loc: ("r1", "z1", "node-a"),
+						healthy: true,
+					},
+					Ep {
+						label: "z2",
+						svc: "app",
+						loc: ("r1", "z2", "node-b"),
+						healthy: true,
+					},
+					Ep {
+						label: "z3",
+						svc: "app",
+						loc: ("r1", "z3", "node-c"),
+						healthy: true,
+					},
+				],
+			},
+			Step::Hit {
+				hits: 30,
+				want_status: StatusCode::OK,
+				want: Expect::Spread(vec!["z1", "z2", "z3"]),
+			},
+		],
+	})
+	.await;
+}
+
+/// No self-identity configured: ranker collapses every endpoint into bucket 0, so all endpoints
+/// stay reachable and requests spread across them.
+#[tokio::test]
+async fn missing_self_identity_keeps_all_endpoints_reachable() {
+	for mode in [Failover, Standard, Strict] {
+		run(Case {
+			self_loc: None,
+			steps: vec![
+				Step::Sync {
+					services: vec![Svc {
+						name: "app",
+						mode: mode,
+						scopes: vec![Zone],
+					}],
+					endpoints: vec![
+						Ep {
+							label: "a",
+							svc: "app",
+							loc: ("r1", "z1", "node-a"),
+							healthy: true,
+						},
+						Ep {
+							label: "b",
+							svc: "app",
+							loc: ("r1", "z2", "node-b"),
+							healthy: true,
+						},
+					],
+				},
+				Step::Hit {
+					hits: 20,
+					want_status: StatusCode::OK,
+					want: Expect::Spread(vec!["a", "b"]),
+				},
+			],
+		})
+		.await;
+	}
+}
+
+/// Default health_policy = OnlyHealthy, so an unhealthy endpoint is excluded from the service
+/// entirely; its bucket is empty and traffic spills to the next tier.
+#[tokio::test]
+async fn unhealthy_local_zone_falls_back_to_next_tier() {
+	run(Case {
+		self_loc: Some(("r1", "z1", "node-a")),
+		steps: vec![
+			Step::Sync {
+				services: vec![Svc {
+					name: "app",
+					mode: Failover,
+					scopes: vec![Region, Zone],
+				}],
+				endpoints: vec![
+					Ep {
+						label: "local-bad",
+						svc: "app",
+						loc: ("r1", "z1", "node-a"),
+						healthy: false,
+					},
+					Ep {
+						label: "same-region",
+						svc: "app",
+						loc: ("r1", "z2", "node-b"),
+						healthy: true,
+					},
+				],
+			},
+			Step::Hit {
+				hits: 6,
+				want_status: StatusCode::OK,
+				want: Expect::Exact(vec![("local-bad", 0), ("same-region", 6)]),
+			},
+		],
+	})
+	.await;
+}
+
+// ---------- lifecycle ----------
+
+/// Workloads arrive before their service. Before the service exists, requests 503 and endpoints
+/// sit in `staged_services`. When the service lands, staged endpoints are bucketed and served.
+#[tokio::test]
+async fn service_arrives_after_workloads() {
+	let endpoints = vec![
+		Ep {
+			label: "local",
+			svc: "app",
+			loc: ("r1", "z1", "node-a"),
+			healthy: true,
+		},
+		Ep {
+			label: "other-zone",
+			svc: "app",
+			loc: ("r1", "z2", "node-b"),
+			healthy: true,
+		},
+	];
+	run(Case {
+		self_loc: Some(("r1", "z1", "node-a")),
+		steps: vec![
+			// Workloads only — service does not exist yet.
+			Step::Sync {
+				services: vec![],
+				endpoints: endpoints.clone(),
+			},
+			// Backend ref can't resolve to a service yet — 500, not 503 (which would mean
+			// "service exists but has no healthy endpoints").
+			Step::Hit {
+				hits: 3,
+				want_status: StatusCode::INTERNAL_SERVER_ERROR,
+				want: Expect::Exact(vec![("local", 0), ("other-zone", 0)]),
+			},
+			// Service arrives; previously-staged endpoints should be bucketed against its LB.
+			Step::Sync {
+				services: vec![Svc {
+					name: "app",
+					mode: Failover,
+					scopes: vec![Region, Zone],
+				}],
+				endpoints,
+			},
+			Step::Hit {
+				hits: 10,
+				want_status: StatusCode::OK,
+				want: Expect::Exact(vec![("local", 10), ("other-zone", 0)]),
+			},
+		],
+	})
+	.await;
+}
+
+/// Changing a service's LB preferences rebuilds its EndpointSet with the new ranker.
+/// Flip preferences between Hits to verify the same endpoint pool gets re-bucketed in place.
+#[tokio::test]
+async fn service_lb_preference_change_rebuckets() {
+	let endpoints = vec![
+		Ep {
+			label: "same-node",
+			svc: "app",
+			loc: ("r1", "z1", "node-a"),
+			healthy: true,
+		},
+		Ep {
+			label: "same-zone",
+			svc: "app",
+			loc: ("r1", "z1", "node-b"),
+			healthy: true,
+		},
+		Ep {
+			label: "same-region",
+			svc: "app",
+			loc: ("r1", "z2", "node-c"),
+			healthy: true,
+		},
+	];
+	run(Case {
+		self_loc: Some(("r1", "z1", "node-a")),
+		steps: vec![
+			// Start with Zone-only: same-node and same-zone share bucket 0.
+			Step::Sync {
+				services: vec![Svc {
+					name: "app",
+					mode: Failover,
+					scopes: vec![Zone],
+				}],
+				endpoints: endpoints.clone(),
+			},
+			Step::Hit {
+				hits: 20,
+				want_status: StatusCode::OK,
+				want: Expect::Spread(vec!["same-node", "same-zone"]),
+			},
+			// Tighten to Node: only same-node is in bucket 0.
+			Step::Sync {
+				services: vec![Svc {
+					name: "app",
+					mode: Failover,
+					scopes: vec![Node],
+				}],
+				endpoints,
+			},
+			Step::Hit {
+				hits: 10,
+				want_status: StatusCode::OK,
+				want: Expect::Exact(vec![
+					("same-node", 10),
+					("same-zone", 0),
+					("same-region", 0),
+				]),
+			},
+		],
+	})
+	.await;
+}
+
+/// Late self-identity: gateway starts without self-identity (all endpoints collapse to bucket 0),
+/// then WDS delivers its workload and rebucket_all re-ranks existing endpoints by locality.
+#[tokio::test]
+async fn late_self_identity_rebuckets() {
+	let endpoints = vec![
+		Ep {
+			label: "local",
+			svc: "app",
+			loc: ("r1", "z1", "node-a"),
+			healthy: true,
+		},
+		Ep {
+			label: "other-zone",
+			svc: "app",
+			loc: ("r1", "z2", "node-b"),
+			healthy: true,
+		},
+	];
+	run(Case {
+		self_loc: None,
+		steps: vec![
+			Step::Sync {
+				services: vec![Svc {
+					name: "app",
+					mode: Failover,
+					scopes: vec![Region, Zone],
+				}],
+				endpoints,
+			},
+			// Without self-identity, ranker puts everything in bucket 0 — requests spread.
+			Step::Hit {
+				hits: 20,
+				want_status: StatusCode::OK,
+				want: Expect::Spread(vec!["local", "other-zone"]),
+			},
+			// Self-identity resolves; rebucket_all pins traffic to the local zone.
+			Step::SetSelf(("r1", "z1", "node-a")),
+			Step::Hit {
+				hits: 10,
+				want_status: StatusCode::OK,
+				want: Expect::Exact(vec![("local", 10), ("other-zone", 0)]),
+			},
+		],
+	})
+	.await;
+}
+
+//  --- helpers and harness ---
+
+const SVC_NAMESPACE: &str = "default";
+/// Hostname the test route targets. A service named "app" fills this backend.
+const ROUTE_TARGET: &str = "app";
+const SVC_PORT: u16 = 80;
+
+fn svc_hostname(name: &str) -> String {
+	format!("{name}.{SVC_NAMESPACE}.svc.cluster.local")
+}
+
+fn svc_key(name: &str) -> String {
+	format!("{SVC_NAMESPACE}/{}", svc_hostname(name))
+}
+
+fn locality(region: &str, zone: &str) -> Locality {
+	Locality {
+		region: region.into(),
+		zone: zone.into(),
+		subzone: strng::EMPTY,
+	}
+}
+
+fn self_workload(loc: Locality, node: &str) -> Workload {
+	Workload {
+		uid: "self-uid".into(),
+		name: "self".into(),
+		namespace: SVC_NAMESPACE.into(),
+		locality: loc,
+		node: node.into(),
+		..Default::default()
+	}
+}
+
+/// Route that dispatches every request to whatever service is named `ROUTE_TARGET`.
+fn service_route() -> Route {
+	Route {
+		key: "r".into(),
+		service_key: None,
+		name: RouteName {
+			name: "r".into(),
+			namespace: SVC_NAMESPACE.into(),
+			rule_name: None,
+			kind: None,
+		},
+		hostnames: Default::default(),
+		matches: vec![RouteMatch {
+			headers: vec![],
+			path: PathMatch::PathPrefix("/".into()),
+			method: None,
+			query: vec![],
+		}],
+		inline_policies: Default::default(),
+		backends: vec![RouteBackendReference {
+			weight: 1,
+			backend: BackendReference::Service {
+				name: NamespacedHostname {
+					namespace: SVC_NAMESPACE.into(),
+					hostname: svc_hostname(ROUTE_TARGET).into(),
+				},
+				port: SVC_PORT,
+			},
+			inline_policies: Default::default(),
+		}],
+	}
+}
+
+/// (region, zone, node)
+type Loc = (&'static str, &'static str, &'static str);
+
+struct Svc {
+	name: &'static str,
+	mode: LoadBalancerMode,
+	scopes: Vec<LoadBalancerScopes>,
+}
+
+#[derive(Clone)]
+struct Ep {
+	label: &'static str,
+	svc: &'static str,
+	loc: Loc,
+	healthy: bool,
+}
+
+enum Expect {
+	/// Per-label request-count deltas since the previous Hit. Labels omitted are not checked.
+	Exact(Vec<(&'static str, usize)>),
+	/// Every listed label must receive ≥1 request this step; counts must sum to `hits`.
+	Spread(Vec<&'static str>),
+}
+
+enum Step {
+	/// Replace the full service+workload set. Empty `services` means no service exists yet.
+	Sync {
+		services: Vec<Svc>,
+		endpoints: Vec<Ep>,
+	},
+	/// Set self-identity and trigger rebucket_all. Can only be called once per test
+	/// (SelfWorkload is a OnceLock).
+	SetSelf(Loc),
+	/// Fire traffic; assert response status; assert per-label deltas since the previous Hit.
+	Hit {
+		hits: usize,
+		want_status: StatusCode,
+		want: Expect,
+	},
+}
+
+struct Case {
+	/// Initial self-identity, set before the first Sync so initial bucketing is correct.
+	/// Use None to test late resolution with Step::SetSelf.
+	self_loc: Option<Loc>,
+	steps: Vec<Step>,
+}
+
+struct Harness {
+	_bind: TestBind,
+	client: hyper_util::client::legacy::Client<MemoryConnector, crate::http::Body>,
+	mocks: HashMap<&'static str, MockServer>,
+	/// Cumulative received counts observed at the previous Hit, per label.
+	baseline: HashMap<&'static str, usize>,
+	prev: DiscoveryPreviousState,
+}
+
+impl Harness {
+	async fn mock_addr(&mut self, label: &'static str) -> SocketAddr {
+		if !self.mocks.contains_key(label) {
+			self.mocks.insert(label, simple_mock().await);
+		}
+		*self.mocks[label].address()
+	}
+
+	async fn mock_count(&self, label: &str) -> usize {
+		self.mocks[label].received_requests().await.unwrap().len()
+	}
+}
+
+fn build_service(s: &Svc) -> Service {
+	Service {
+		name: s.name.into(),
+		namespace: SVC_NAMESPACE.into(),
+		hostname: svc_hostname(s.name).into(),
+		ports: HashMap::from([(SVC_PORT, SVC_PORT)]),
+		load_balancer: Some(LoadBalancer {
+			routing_preferences: s.scopes.clone(),
+			mode: s.mode.clone(),
+			health_policy: LoadBalancerHealthPolicy::default(),
+		}),
+		..Default::default()
+	}
+}
+
+fn build_workload(
+	label: &str,
+	addr: SocketAddr,
+	loc: Locality,
+	node: &str,
+	svc: &str,
+	status: HealthStatus,
+) -> LocalWorkload {
+	LocalWorkload {
+		workload: Workload {
+			uid: format!("wl-{label}").into(),
+			name: format!("pod-{label}").into(),
+			namespace: SVC_NAMESPACE.into(),
+			workload_ips: vec![addr.ip()],
+			locality: loc,
+			node: node.into(),
+			status,
+			..Default::default()
+		},
+		services: HashMap::from([(svc_key(svc), HashMap::from([(SVC_PORT, addr.port())]))]),
+	}
+}
+
+async fn run(c: Case) {
+	let t = setup_proxy_test("{}").unwrap();
+	if let Some((r, z, n)) = c.self_loc {
+		t.inputs()
+			.stores
+			.discovery
+			.read()
+			.self_workload
+			.set(self_workload(locality(r, z), n));
+	}
+	let t = t.with_bind(simple_bind(service_route()));
+	let client = t.serve_http(BIND_KEY);
+	let mut h = Harness {
+		_bind: t,
+		client,
+		mocks: HashMap::new(),
+		baseline: HashMap::new(),
+		prev: Default::default(),
+	};
+
+	for step in c.steps {
+		match step {
+			Step::Sync {
+				services,
+				endpoints,
+			} => apply_sync(&mut h, services, endpoints).await,
+			Step::SetSelf(loc) => apply_set_self(&mut h, loc),
+			Step::Hit {
+				hits,
+				want_status,
+				want,
+			} => apply_hit(&mut h, hits, want_status, want).await,
+		}
+	}
+}
+
+async fn apply_sync(h: &mut Harness, services: Vec<Svc>, endpoints: Vec<Ep>) {
+	let mut workloads = Vec::with_capacity(endpoints.len());
+	for ep in &endpoints {
+		let addr = h.mock_addr(ep.label).await;
+		let (r, z, n) = ep.loc;
+		let status = if ep.healthy {
+			HealthStatus::Healthy
+		} else {
+			HealthStatus::Unhealthy
+		};
+		workloads.push(build_workload(
+			ep.label,
+			addr,
+			locality(r, z),
+			n,
+			ep.svc,
+			status,
+		));
+	}
+	let svcs: Vec<Service> = services.iter().map(build_service).collect();
+	let prev = std::mem::take(&mut h.prev);
+	h.prev = h
+		._bind
+		.inputs()
+		.stores
+		.discovery
+		.sync_local(svcs, workloads, prev)
+		.unwrap();
+}
+
+fn apply_set_self(h: &mut Harness, loc: Loc) {
+	let pi = h._bind.inputs();
+	let store = pi.stores.discovery.read();
+	let (r, z, n) = loc;
+	store.self_workload.set(self_workload(locality(r, z), n));
+	store.rebucket_all();
+}
+
+async fn apply_hit(h: &mut Harness, hits: usize, want_status: StatusCode, want: Expect) {
+	for _ in 0..hits {
+		let res = send_request(h.client.clone(), Method::GET, "http://app/").await;
+		assert_eq!(res.status(), want_status);
+	}
+	let labels: Vec<&'static str> = h.mocks.keys().copied().collect();
+	let mut snapshot = HashMap::with_capacity(labels.len());
+	for label in labels {
+		snapshot.insert(label, h.mock_count(label).await);
+	}
+	let delta = |label: &'static str| -> usize {
+		snapshot.get(label).copied().unwrap_or(0) - h.baseline.get(label).copied().unwrap_or(0)
+	};
+
+	match want {
+		Expect::Exact(wants) => {
+			for (label, want) in &wants {
+				let got = delta(label);
+				assert_eq!(got, *want, "label={label}");
+			}
+		},
+		Expect::Spread(labels) => {
+			let mut total = 0;
+			for label in &labels {
+				let got = delta(label);
+				assert!(got > 0, "label={label} got 0, want >0");
+				total += got;
+			}
+			assert_eq!(total, hits, "total hits");
+		},
+	}
+	h.baseline = snapshot;
+}

--- a/crates/agentgateway/src/proxy/locality_test.rs
+++ b/crates/agentgateway/src/proxy/locality_test.rs
@@ -276,7 +276,7 @@ async fn missing_self_identity_keeps_all_endpoints_reachable() {
 				Step::Sync {
 					services: vec![Svc {
 						name: "app",
-						mode: mode,
+						mode,
 						scopes: vec![Zone],
 					}],
 					endpoints: vec![

--- a/crates/agentgateway/src/proxy/locality_test.rs
+++ b/crates/agentgateway/src/proxy/locality_test.rs
@@ -650,13 +650,14 @@ fn service_route() -> Route {
 		inline_policies: Default::default(),
 		backends: vec![RouteBackendReference {
 			weight: 1,
-			backend: BackendReference::Service {
+			target: BackendReference::Service {
 				name: NamespacedHostname {
 					namespace: SVC_NAMESPACE.into(),
 					hostname: svc_hostname(ROUTE_TARGET).into(),
 				},
 				port: SVC_PORT,
-			},
+			}
+			.into(),
 			inline_policies: Default::default(),
 		}],
 	}
@@ -780,7 +781,7 @@ async fn run(c: Case) {
 			.self_workload
 			.set(self_workload(locality(r, z), n));
 	}
-	let t = t.with_bind(simple_bind(service_route()));
+	let t = t.with_bind(simple_bind()).with_route(service_route());
 	let client = t.serve_http(BIND_KEY);
 	let mut h = Harness {
 		_bind: t,

--- a/crates/agentgateway/src/state_manager.rs
+++ b/crates/agentgateway/src/state_manager.rs
@@ -254,8 +254,9 @@ pub fn start_self_workload_resolution(
 			let name = name.clone();
 			let namespace = namespace.clone();
 			let cluster_id = cluster_id.clone();
+			let has_xds = config.xds.address.is_some();
 			tokio::spawn(async move {
-				watch_self_workload(stores, name, namespace, cluster_id, Some(task)).await;
+				watch_self_workload(stores, name, namespace, cluster_id, Some(task), has_xds).await;
 			});
 		},
 		None => {},
@@ -268,6 +269,7 @@ async fn watch_self_workload(
 	namespace: Strng,
 	cluster_id: Strng,
 	mut ready_task: Option<readiness::BlockReady>,
+	has_xds: bool,
 ) {
 	let mut inserts = stores.discovery.read().workloads.subscribe_inserts();
 
@@ -290,6 +292,11 @@ async fn watch_self_workload(
 			store.rebucket_all();
 			return;
 		}
+	}
+
+	// Without XDS nothing will ever insert workloads; drop the task and stop.
+	if !has_xds {
+		return;
 	}
 
 	// wait for any change before starting our timeout if the control plane is down, or xDS is
@@ -325,5 +332,92 @@ async fn watch_self_workload(
 				}
 			}
 		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::store::{DiscoveryPreviousState, LocalWorkload, Stores};
+	use crate::types::discovery::Workload;
+	use agent_core::readiness::Ready;
+
+	const TASK_NAME: &str = "self workload";
+
+	fn test_config() -> crate::Config {
+		crate::config::parse_config("{}".to_string(), None).expect("parse default config")
+	}
+
+	fn test_stores() -> Stores {
+		Stores::new(false, crate::ThreadingMode::Multithreaded)
+	}
+
+	fn wds_identity(name: &str, ns: &str, cluster: &str) -> SelfIdentitySource {
+		SelfIdentitySource::Wds {
+			name: name.into(),
+			namespace: ns.into(),
+			cluster_id: cluster.into(),
+		}
+	}
+
+	async fn wait_task_dropped(ready: &Ready) {
+		while ready.pending().contains(TASK_NAME) {
+			tokio::time::sleep(Duration::from_millis(10)).await;
+		}
+	}
+
+	#[tokio::test]
+	async fn wds_without_xds_must_not_block_readiness_forever() {
+		let mut config = test_config();
+		assert!(
+			config.xds.address.is_none(),
+			"precondition violated — XDS_ADDRESS leaked from env"
+		);
+		config.self_identity = Some(wds_identity("gw", "ns", "c"));
+
+		let stores = test_stores();
+		let ready = Ready::new();
+		start_self_workload_resolution(&config, stores, &ready);
+
+		assert!(ready.pending().contains(TASK_NAME));
+
+		tokio::time::timeout(Duration::from_secs(5), wait_task_dropped(&ready))
+			.await
+			.expect("'self workload' readiness task blocked forever without XDS");
+	}
+
+	#[tokio::test]
+	async fn wds_populates_self_workload_when_matching_workload_is_inserted() {
+		let mut config = test_config();
+		config.xds.address = Some("http://example.invalid:15010".to_string());
+		config.self_identity = Some(wds_identity("gw", "ns", "c"));
+
+		let stores = test_stores();
+		let ready = Ready::new();
+		start_self_workload_resolution(&config, stores.clone(), &ready);
+
+		let workload = Workload {
+			uid: "uid-1".into(),
+			name: "gw".into(),
+			namespace: "ns".into(),
+			cluster_id: "c".into(),
+			..Default::default()
+		};
+		stores
+			.discovery
+			.sync_local(
+				vec![],
+				vec![LocalWorkload {
+					workload,
+					services: Default::default(),
+				}],
+				DiscoveryPreviousState::default(),
+			)
+			.expect("sync_local");
+
+		tokio::time::timeout(Duration::from_secs(5), wait_task_dropped(&ready))
+			.await
+			.expect("task should clear once matching workload is inserted");
+		assert!(stores.discovery.read().self_workload.get().is_some());
 	}
 }

--- a/crates/agentgateway/src/state_manager.rs
+++ b/crates/agentgateway/src/state_manager.rs
@@ -5,9 +5,12 @@ use agent_core::prelude::*;
 use notify::{EventKind, RecursiveMode};
 use tokio::fs;
 
+use agent_core::readiness;
+
 use crate::client::Client;
 use crate::store::Stores;
 use crate::types::agent::ListenerTarget;
+use crate::types::discovery::SelfIdentitySource;
 use crate::types::proto::agent::Resource as ADPResource;
 use crate::types::proto::workload::Address as XdsAddress;
 use crate::{ConfigSource, client, control, store};
@@ -223,4 +226,104 @@ impl LocalClient {
 pub struct PreviousState {
 	pub binds: store::BindPreviousState,
 	pub discovery: store::DiscoveryPreviousState,
+}
+
+const SELF_WORKLOAD_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Populates the discovery store's self_workload according to `config.self_identity`.
+///
+/// For `Static`, sets the cached workload synchronously and rebuckets.
+/// For `Wds`, blocks readiness until WDS delivers the workload or timeout expires.
+pub fn start_self_workload_resolution(
+	config: &crate::Config,
+	stores: Stores,
+	ready: &readiness::Ready,
+) {
+	match &config.self_identity {
+		Some(SelfIdentitySource::Static(w)) => {
+			let store = stores.discovery.read();
+			store.self_workload.set((**w).clone());
+			store.rebucket_all();
+		},
+		Some(SelfIdentitySource::Wds {
+			name,
+			namespace,
+			cluster_id,
+		}) => {
+			let task = ready.register_task("self workload");
+			let name = name.clone();
+			let namespace = namespace.clone();
+			let cluster_id = cluster_id.clone();
+			tokio::spawn(async move {
+				watch_self_workload(stores, name, namespace, cluster_id, Some(task)).await;
+			});
+		},
+		None => {},
+	}
+}
+
+async fn watch_self_workload(
+	stores: Stores,
+	name: Strng,
+	namespace: Strng,
+	cluster_id: Strng,
+	mut ready_task: Option<readiness::BlockReady>,
+) {
+	let mut inserts = stores.discovery.read().workloads.subscribe_inserts();
+
+	// allow a cluster id mismatch as a very common misconfiguration is that the control plane and
+	// dataplane mismatch on this but if we do hit a conflict (should be rare) we use the cluster_id
+	// as a tiebreaker
+	let lookup = || {
+		let store = stores.discovery.read();
+		store
+			.workloads
+			.find_by_name(&name, &namespace)
+			.max_by_key(|w| w.cluster_id == cluster_id)
+			.cloned()
+	};
+
+	{
+		let store = stores.discovery.read();
+		if let Some(w) = lookup() {
+			store.self_workload.set((*w).clone());
+			store.rebucket_all();
+			return;
+		}
+	}
+
+	// wait for any change before starting our timeout if the control plane is down, or xDS is
+	// otherwise slow we don't want to bail early without locality info
+	if inserts.changed().await.is_err() {
+		return;
+	}
+
+	let deadline = tokio::time::sleep(SELF_WORKLOAD_TIMEOUT);
+	tokio::pin!(deadline);
+	loop {
+		{
+			let store = stores.discovery.read();
+			if let Some(w) = lookup() {
+				store.self_workload.set((*w).clone());
+				store.rebucket_all();
+				return;
+			}
+		}
+		tokio::select! {
+			_ = &mut deadline, if ready_task.is_some() => {
+				warn!(
+					%namespace, %name,
+					"timed out waiting for own workload in WDS after {:?}; unblocking readiness, still watching",
+					SELF_WORKLOAD_TIMEOUT
+				);
+				// drop the task, but keep looping so we can still populate the self_workload if it shows up later
+				ready_task = None;
+			}
+			r = inserts.changed() => {
+				if r.is_err() {
+					return;
+				}
+			}
+		}
+	}
 }

--- a/crates/agentgateway/src/store/discovery.rs
+++ b/crates/agentgateway/src/store/discovery.rs
@@ -72,7 +72,7 @@ impl Store {
 
 				svc.endpoints.rebucket(|ep: &Endpoint| {
 					let wl = &self.workloads.find_uid(&ep.workload_uid)?;
-					ranker.bucket_for(&wl)
+					ranker.bucket_for(wl)
 				});
 			}
 		}
@@ -142,10 +142,10 @@ impl Store {
 
 		// inserting endpoints requires grabbing the workload's locality info to bucket them
 		let insert_ep = |ep: Endpoint| {
-			if let Some(wl) = self.workloads.find_uid(&ep.workload_uid) {
-				if service.should_include_endpoint(ep.status) {
-					service.endpoints.insert(ep, &wl, &ranker);
-				}
+			if let Some(wl) = self.workloads.find_uid(&ep.workload_uid)
+				&& service.should_include_endpoint(ep.status)
+			{
+				service.endpoints.insert(ep, &wl, &ranker);
 			}
 		};
 

--- a/crates/agentgateway/src/store/discovery.rs
+++ b/crates/agentgateway/src/store/discovery.rs
@@ -44,6 +44,7 @@ impl Store {
 				insert_notifier: Sender::new(()),
 				by_addr: Default::default(),
 				by_uid: Default::default(),
+				by_service: Default::default(),
 			},
 			services: Default::default(),
 			self_workload: SelfWorkload::new(),
@@ -127,40 +128,43 @@ impl Store {
 		Ok(())
 	}
 	pub fn insert_service_internal(&mut self, mut service: Service) {
-		let ranker = LocalityRanker::new(service.load_balancer.as_ref(), self.self_workload.get());
-		let prev = self
-			.services
-			.get_by_namespaced_host(&service.namespaced_hostname());
-
-		// build a fresh EndpointSet every time the Service changes so we can handle changes to
-		// locality settings, and health requirements.
-		// TODO there may be some optimizations here when we know the lb setting didn't change
-		// and our self_workload info was the same, but we'd need mut access to the old service to
-		// take its endpointset
-		service.endpoints = EndpointSet::new_empty(ranker.priority_levels());
 		let key = service.namespaced_hostname();
+		let prev = self.services.get_by_namespaced_host(&key);
 
-		// inserting endpoints requires grabbing the workload's locality info to bucket them
-		let insert_ep = |ep: Endpoint| {
-			if let Some(wl) = self.workloads.find_uid(&ep.workload_uid)
-				&& service.should_include_endpoint(ep.status)
-			{
-				service.endpoints.insert(ep, &wl, &ranker);
-			}
-		};
+		// endpoints that came in before the service
+		let had_staged = self.services.staged_services.remove(&key).is_some();
 
-		// old endpoints get re-inserted to update locality bucketing
-		if let Some(prev) = prev {
-			for (ep, _) in prev.endpoints.all_endpoints() {
-				insert_ep((*ep).clone());
-			}
+		// we don't need to rebuild endpoints when LB strategy hasn't changed
+		// but if it did, we need to rebuild from WorkloadStore because the Service's
+		// own list of endpoints may exclude things due to STRICT or health policy
+		//
+		// just to be safe, check staged endpoints before using the fastpath,
+		// but we shouldn't have an existing service and staged at the same time
+		if let Some(prev) = &prev
+			&& prev.load_balancer == service.load_balancer
+			&& !had_staged
+		{
+			service.endpoints = prev.endpoints.clone();
+			self.services.insert(service);
+			return;
 		}
 
-		// add endpoints that arrived after before the service
-		if let Some(staged) = self.services.staged_services.remove(&key) {
-			for (_, ep) in staged {
-				insert_ep(ep.clone());
+		let ranker = LocalityRanker::new(service.load_balancer.as_ref(), self.self_workload.get());
+		service.endpoints = EndpointSet::new_empty(ranker.priority_levels());
+
+		for wl in self.workloads.iter_by_service(&key) {
+			let Some(ports) = wl.services.get(&key) else {
+				continue;
+			};
+			if !service.should_include_endpoint(wl.status) {
+				continue;
 			}
+			let ep = Endpoint {
+				workload_uid: wl.uid.clone(),
+				port: ports.clone(),
+				status: wl.status,
+			};
+			service.endpoints.insert(ep, wl, &ranker);
 		}
 
 		self.services.insert(service);
@@ -222,6 +226,8 @@ pub struct WorkloadStore {
 	// is simpler (and only requires a channelsize of 1)
 	insert_notifier: Sender<()>,
 
+	/// by_service maps a service key to the workload UIDs that are a part of it
+	by_service: HashMap<NamespacedHostname, HashSet<Strng>>,
 	/// by_addr maps workload network addresses to workloads
 	by_addr: HashMap<NetworkAddress, WorkloadByAddr>,
 	/// by_uid maps workload UIDs to workloads
@@ -242,6 +248,13 @@ impl WorkloadStore {
 					.and_modify(|ws| ws.insert(w.clone()))
 					.or_insert_with(|| WorkloadByAddr::Single(w.clone()));
 			}
+		}
+		for svc in w.services.keys() {
+			self
+				.by_service
+				.entry(svc.clone())
+				.or_default()
+				.insert(w.uid.clone());
 		}
 		self.by_uid.insert(w.uid.clone(), w.clone());
 
@@ -267,6 +280,14 @@ impl WorkloadStore {
 						}
 					}
 				}
+				for svc in prev.services.keys() {
+					if let Some(set) = self.by_service.get_mut(svc) {
+						set.remove(&prev.uid);
+						if set.is_empty() {
+							self.by_service.remove(svc);
+						}
+					}
+				}
 
 				Some(prev.deref().clone())
 			},
@@ -282,6 +303,17 @@ impl WorkloadStore {
 	/// Finds the workload by address, as an arc.
 	pub fn find_address(&self, addr: &NetworkAddress) -> Option<Arc<Workload>> {
 		self.by_addr.get(addr).map(WorkloadByAddr::get)
+	}
+
+	pub fn iter_by_service<'a>(
+		&'a self,
+		svc: &NamespacedHostname,
+	) -> impl Iterator<Item = &'a Arc<Workload>> + 'a {
+		self
+			.by_service
+			.get(svc)
+			.into_iter()
+			.flat_map(|uids| uids.iter().filter_map(|uid| self.by_uid.get(uid)))
 	}
 
 	/// Finds a workload by name and namespace.
@@ -381,7 +413,7 @@ impl ServiceStore {
 	fn remove_endpoint(&mut self, prev_workload: &Workload) {
 		let mut services_to_update = HashSet::new();
 		let workload_uid = &prev_workload.uid;
-		for svc in prev_workload.services.iter() {
+		for svc in prev_workload.services.keys() {
 			// Remove the endpoint from the staged services.
 			self
 				.staged_services
@@ -636,7 +668,23 @@ impl StoreUpdater {
 		let source = s.self_workload.get().cloned();
 		for wl in workloads {
 			trace!("inserting local workload {}", &wl.workload.uid);
-			let w = Arc::new(wl.workload);
+			let mut workload = wl.workload;
+			// Merge the LocalWorkload's per-service port maps into Workload.services so the
+			// workload carries the full membership info. `insert_service_internal` relies on
+			// this to rebuild the EndpointSet when a Service's LB config changes.
+			for (host, ports) in &wl.services {
+				let Some((namespace, hostname)) = host.split_once('/') else {
+					continue;
+				};
+				workload.services.insert(
+					NamespacedHostname {
+						namespace: namespace.into(),
+						hostname: hostname.into(),
+					},
+					ports.clone(),
+				);
+			}
+			let w = Arc::new(workload);
 			// First, remove the entry entirely to make sure things are cleaned up properly.
 			s.remove_workload_for_insert(&w.uid);
 

--- a/crates/agentgateway/src/store/discovery.rs
+++ b/crates/agentgateway/src/store/discovery.rs
@@ -15,7 +15,9 @@ use types::proto::workload::{
 	Address as XdsAddress, PortList, Service as XdsService, Workload as XdsWorkload,
 };
 
+use crate::store::SelfWorkload;
 use crate::types::discovery::{Endpoint, InboundProtocol, NetworkMode, Service, Workload};
+use crate::types::loadbalancer::{EndpointSet, LocalityRanker};
 use crate::*;
 
 #[derive(Debug)]
@@ -23,6 +25,8 @@ pub struct Store {
 	pub workloads: WorkloadStore,
 
 	pub services: ServiceStore,
+
+	pub self_workload: SelfWorkload,
 }
 
 impl Store {}
@@ -42,8 +46,38 @@ impl Store {
 				by_uid: Default::default(),
 			},
 			services: Default::default(),
+			self_workload: SelfWorkload::new(),
 		}
 	}
+
+	/// Recompute every endpoint's bucket against the current locality information.
+	/// Called when self-identity resolves (static or WDS).
+	pub fn rebucket_all(&self) {
+		let Some(source) = self.self_workload.get() else {
+			return;
+		};
+		for services in self.services.by_host.values() {
+			for svc in services {
+				let ranker = LocalityRanker::new(svc.load_balancer.as_ref(), Some(source));
+
+				// bucket count should only change on service updates
+				// if this assertion fails that means:
+				// - ranker has more buckets can lead to endpoints being dropped
+				// - ranker has fewer buckets can lead to stale endpoints in higher buckets
+				debug_assert_eq!(
+					ranker.priority_levels(),
+					svc.endpoints.num_buckets(),
+					"bucket count changed unexpectedly",
+				);
+
+				svc.endpoints.rebucket(|ep: &Endpoint| {
+					let wl = &self.workloads.find_uid(&ep.workload_uid)?;
+					ranker.bucket_for(&wl)
+				});
+			}
+		}
+	}
+
 	pub fn insert_address(&mut self, a: XdsAddress) -> anyhow::Result<()> {
 		match a.r#type {
 			Some(XdsType::Workload(w)) => self.insert_workload(w),
@@ -75,7 +109,7 @@ impl Store {
 		self.workloads.insert(workload.clone());
 		self
 			.services
-			.insert_endpoint_for_services(&workload, &services)?;
+			.insert_endpoint_for_services(&workload, &services, self.self_workload.get())?;
 
 		Ok(())
 	}
@@ -93,13 +127,40 @@ impl Store {
 		Ok(())
 	}
 	pub fn insert_service_internal(&mut self, mut service: Service) {
-		// If the service already exists, add existing endpoints into the new service.
-		if let Some(prev) = self
+		let ranker = LocalityRanker::new(service.load_balancer.as_ref(), self.self_workload.get());
+		let prev = self
 			.services
-			.get_by_namespaced_host(&service.namespaced_hostname())
-		{
-			// TODO: if health mode changes we are in trouble
-			service.endpoints = prev.endpoints.clone();
+			.get_by_namespaced_host(&service.namespaced_hostname());
+
+		// build a fresh EndpointSet every time the Service changes so we can handle changes to
+		// locality settings, and health requirements.
+		// TODO there may be some optimizations here when we know the lb setting didn't change
+		// and our self_workload info was the same, but we'd need mut access to the old service to
+		// take its endpointset
+		service.endpoints = EndpointSet::new_empty(ranker.priority_levels());
+		let key = service.namespaced_hostname();
+
+		// inserting endpoints requires grabbing the workload's locality info to bucket them
+		let insert_ep = |ep: Endpoint| {
+			if let Some(wl) = self.workloads.find_uid(&ep.workload_uid) {
+				if service.should_include_endpoint(ep.status) {
+					service.endpoints.insert(ep, &wl, &ranker);
+				}
+			}
+		};
+
+		// old endpoints get re-inserted to update locality bucketing
+		if let Some(prev) = prev {
+			for (ep, _) in prev.endpoints.all_endpoints() {
+				insert_ep((*ep).clone());
+			}
+		}
+
+		// add endpoints that arrived after before the service
+		if let Some(staged) = self.services.staged_services.remove(&key) {
+			for (_, ep) in staged {
+				insert_ep(ep.clone());
+			}
 		}
 
 		self.services.insert(service);
@@ -222,6 +283,25 @@ impl WorkloadStore {
 	pub fn find_address(&self, addr: &NetworkAddress) -> Option<Arc<Workload>> {
 		self.by_addr.get(addr).map(WorkloadByAddr::get)
 	}
+
+	/// Finds a workload by name and namespace.
+	/// Currently O(n) as we only use it in one place at startup.
+	/// Add an index if we use it on a more hot path.
+	pub fn find_by_name<'a>(
+		&'a self,
+		name: &'a Strng,
+		namespace: &'a Strng,
+	) -> impl Iterator<Item = &'a Arc<Workload>> + 'a {
+		self
+			.by_uid
+			.values()
+			.filter(move |w| w.name == *name && w.namespace == *namespace)
+	}
+
+	/// Subscribe to "any workload inserted" events. The receiver's `changed()` wakes on each insert.
+	pub fn subscribe_inserts(&self) -> tokio::sync::watch::Receiver<()> {
+		self.insert_notifier.subscribe()
+	}
 }
 
 /// Data store for service information.
@@ -246,6 +326,7 @@ impl ServiceStore {
 		&mut self,
 		workload: &Arc<Workload>,
 		services: &HashMap<String, PortList>,
+		locality_source: Option<&Workload>,
 	) -> anyhow::Result<()> {
 		for (namespaced_host, ports) in services {
 			// Parse the namespaced hostname for the service.
@@ -257,14 +338,22 @@ impl ServiceStore {
 					port: crate::types::discovery::ports_from_xds(ports),
 					status: workload.status,
 				},
+				workload,
+				locality_source,
 			)
 		}
 		Ok(())
 	}
-	fn insert_endpoint(&mut self, service_name: NamespacedHostname, ep: Endpoint) {
+
+	fn insert_endpoint(
+		&mut self,
+		service_name: NamespacedHostname,
+		ep: Endpoint,
+		dest_workload: &Workload,
+		locality_source: Option<&Workload>,
+	) {
 		let ep_uid = ep.workload_uid.clone();
 		if let Some(svc) = self.get_by_namespaced_host(&service_name) {
-			// We may or may not accept the endpoint based on it's health
 			if !svc.should_include_endpoint(ep.status) {
 				trace!(
 					"service doesn't accept pod with status {:?}, skip",
@@ -272,7 +361,8 @@ impl ServiceStore {
 				);
 				return;
 			}
-			svc.endpoints.insert(ep);
+			let ranker = LocalityRanker::new(svc.load_balancer.as_ref(), locality_source);
+			svc.endpoints.insert(ep, dest_workload, &ranker);
 		} else {
 			// We received workload endpoints, but don't have the Service yet.
 			// This can happen due to ordering issues.
@@ -354,31 +444,11 @@ impl ServiceStore {
 		}
 	}
 
-	/// Adds the given service.
+	/// Register a service in the lookup indexes. The caller must ensure the Service's endpoints have
+	/// been properly inserted and bucketed, including endpoints for staged_services.
 	fn insert(&mut self, service: Service) {
-		self.insert_internal(service, false)
-	}
-
-	fn insert_internal(&mut self, service: Service, endpoint_update_only: bool) {
 		let namespaced_hostname = service.namespaced_hostname();
-		// If we're replacing an existing service, remove the old one from all data structures.
-		if !endpoint_update_only {
-			// First add any staged service endpoints. Due to ordering issues, we may have received
-			// the workloads before their associated services.
-			if let Some(endpoints) = self.staged_services.remove(&namespaced_hostname) {
-				trace!(
-					"staged service found, inserting {} endpoints",
-					endpoints.len()
-				);
-				for (_, ep) in endpoints {
-					if service.should_include_endpoint(ep.status) {
-						service.endpoints.insert(ep);
-					}
-				}
-			}
-
-			let _ = self.remove(&namespaced_hostname);
-		}
+		let _ = self.remove(&namespaced_hostname);
 
 		// Create the Arc.
 		let service = Arc::new(service);
@@ -563,6 +633,7 @@ impl StoreUpdater {
 			services: Default::default(),
 			workloads: Default::default(),
 		};
+		let source = s.self_workload.get().cloned();
 		for wl in workloads {
 			trace!("inserting local workload {}", &wl.workload.uid);
 			let w = Arc::new(wl.workload);
@@ -576,7 +647,8 @@ impl StoreUpdater {
 				.into_iter()
 				.map(|(k, v)| (k, crate::types::discovery::port_list_from_ports(v)))
 				.collect();
-			s.services.insert_endpoint_for_services(&w, &services)?;
+			s.services
+				.insert_endpoint_for_services(&w, &services, source.as_ref())?;
 			old_workloads.remove(&w.uid);
 			next_state.workloads.insert(w.uid.clone());
 		}

--- a/crates/agentgateway/src/store/mod.rs
+++ b/crates/agentgateway/src/store/mod.rs
@@ -1,6 +1,6 @@
 mod binds;
 
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 pub use binds::{
 	BackendPolicies, BindEvent, BindListeners, FrontendPolices, GatewayPolicies, LLMRequestPolicies,
@@ -18,6 +18,29 @@ pub use discovery::{
 };
 
 use crate::store;
+use crate::types::discovery::Workload;
+
+/// Set-once holder for the gateway's own Workload (locality-aware LB reads this).
+/// Populated at startup in Static mode, or when WDS delivers a matching workload in Wds mode.
+/// TODO ArcSwap or something to support updates after startup
+#[derive(Clone, Debug, Default)]
+pub struct SelfWorkload(Arc<OnceLock<Workload>>);
+
+impl SelfWorkload {
+	pub fn new() -> Self {
+		Self::default()
+	}
+	pub fn get(&self) -> Option<&Workload> {
+		self.0.get()
+	}
+	/// First call wins; later calls are no-ops.
+	pub fn set(&self, w: Workload) {
+		let _ = self.0.set(w);
+	}
+	pub fn is_resolved(&self) -> bool {
+		self.0.get().is_some()
+	}
+}
 
 #[derive(Clone, Debug)]
 pub struct Stores {

--- a/crates/agentgateway/src/test_helpers/proxymock.rs
+++ b/crates/agentgateway/src/test_helpers/proxymock.rs
@@ -3,7 +3,7 @@ use std::net::SocketAddr;
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
-use std::time::{Duration, Instant, SystemTime};
+use std::time::Instant;
 
 use agent_core::drain::{DrainTrigger, DrainWatcher};
 use agent_core::strng::Strng;
@@ -1010,34 +1010,5 @@ pub fn is_json_subset(subset: &Value, superset: &Value) -> bool {
 
 		// For primitive values, they must be exactly equal
 		_ => subset == superset,
-	}
-}
-
-/// check_eventually runs a function many times until it reaches the expected result.
-/// If it doesn't the last result is returned
-pub async fn check_eventually<F, CF, T, Fut>(dur: Duration, f: F, expected: CF) -> Result<T, T>
-where
-	F: Fn() -> Fut,
-	Fut: Future<Output = T>,
-	T: Eq + Debug,
-	CF: Fn(&T) -> bool,
-{
-	use std::ops::Add;
-	let mut delay = Duration::from_millis(10);
-	let end = SystemTime::now().add(dur);
-	let mut last: T;
-	let mut attempts = 0;
-	loop {
-		attempts += 1;
-		last = f().await;
-		if expected(&last) {
-			return Ok(last);
-		}
-		trace!("attempt {attempts} with delay {delay:?}");
-		if SystemTime::now().add(delay) > end {
-			return Err(last);
-		}
-		tokio::time::sleep(delay).await;
-		delay *= 2;
 	}
 }

--- a/crates/agentgateway/src/types/discovery.rs
+++ b/crates/agentgateway/src/types/discovery.rs
@@ -199,6 +199,22 @@ impl<'de> Deserialize<'de> for NetworkAddress {
 	}
 }
 
+/// Identifies the agentgateway's own workload for locality-aware load balancing.
+///
+/// `Static`: all fields come directly from env/config. Ready immediately.
+/// `Wds`: the gateway's own pod is resolved out of the WDS workload store using
+/// `(namespace, name)`. Readiness blocks until it resolves (or times out).
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SelfIdentitySource {
+	Static(Arc<Workload>),
+	Wds {
+		name: Strng,
+		namespace: Strng,
+		cluster_id: Strng,
+	},
+}
+
 #[derive(Debug, Default, Hash, Eq, PartialEq, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct Workload {
@@ -426,6 +442,18 @@ pub struct Locality {
 	pub region: Strng,
 	pub zone: Strng,
 	pub subzone: Strng,
+}
+
+impl Locality {
+	/// Parse an Istio-style locality string "region/zone/subzone" (trailing parts optional).
+	pub fn parse(s: &str) -> Self {
+		let mut parts = s.splitn(3, '/');
+		Locality {
+			region: parts.next().unwrap_or_default().into(),
+			zone: parts.next().unwrap_or_default().into(),
+			subzone: parts.next().unwrap_or_default().into(),
+		}
+	}
 }
 
 #[derive(Debug, Hash, Eq, PartialEq, Clone, serde::Serialize, serde::Deserialize)]

--- a/crates/agentgateway/src/types/discovery.rs
+++ b/crates/agentgateway/src/types/discovery.rs
@@ -215,7 +215,7 @@ pub enum SelfIdentitySource {
 	},
 }
 
-#[derive(Debug, Default, Hash, Eq, PartialEq, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Default, Eq, PartialEq, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct Workload {
 	pub workload_ips: Vec<IpAddr>,
@@ -270,7 +270,7 @@ pub struct Workload {
 	pub locality: Locality,
 
 	#[serde(default, skip_serializing_if = "is_default")]
-	pub services: Vec<NamespacedHostname>,
+	pub services: HashMap<NamespacedHostname, HashMap<u16, u16>>,
 
 	#[serde(default = "default_capacity")]
 	pub capacity: u32,
@@ -744,17 +744,23 @@ impl Workload {
 			.collect::<Result<Vec<_>, _>>()?;
 
 		let workload_type = resource.workload_type().as_str_name().to_lowercase();
-		let services: Vec<NamespacedHostname> = resource
+		let services: HashMap<NamespacedHostname, HashMap<u16, u16>> = resource
 			.services
-			.keys()
-			.map(|namespaced_host| match namespaced_host.split_once('/') {
-				Some((namespace, hostname)) => Ok(NamespacedHostname {
-					namespace: namespace.into(),
-					hostname: hostname.into(),
-				}),
-				None => Err(ProtoError::NamespacedHostnameParse(namespaced_host.clone())),
+			.iter()
+			.map(|(namespaced_host, ports)| {
+				let (namespace, hostname) = namespaced_host
+					.split_once('/')
+					.ok_or_else(|| ProtoError::NamespacedHostnameParse(namespaced_host.clone()))?;
+
+				Ok((
+					NamespacedHostname {
+						namespace: namespace.into(),
+						hostname: hostname.into(),
+					},
+					ports_from_xds(ports),
+				))
 			})
-			.collect::<Result<_, _>>()?;
+			.collect::<Result<_, ProtoError>>()?;
 		let wl = Workload {
 			workload_ips: addresses,
 			waypoint: wp,

--- a/crates/agentgateway/src/types/loadbalancer.rs
+++ b/crates/agentgateway/src/types/loadbalancer.rs
@@ -993,15 +993,14 @@ mod tests {
 			Some(1.0),
 		);
 
-		// Give the eviction event time to be processed
-		tokio::time::sleep(Duration::from_millis(50)).await;
-
-		// Endpoint should now be rejected
-		let group = eps.best_bucket();
-		assert!(
-			group.rejected.contains_key(&key),
-			"endpoint should be evicted"
-		);
+		// Poll until the eviction event is processed
+		agent_core::test_helpers::check_eventually(
+			Duration::from_millis(500),
+			|| async { eps.best_bucket().rejected.contains_key(&key) },
+			|rejected| *rejected,
+		)
+		.await
+		.expect("endpoint should be evicted");
 
 		// Wait for uneviction (100ms eviction duration + buffer)
 		tokio::time::sleep(Duration::from_millis(150)).await;

--- a/crates/agentgateway/src/types/loadbalancer.rs
+++ b/crates/agentgateway/src/types/loadbalancer.rs
@@ -9,7 +9,9 @@ use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
 use tokio::sync::mpsc;
 use tokio::time::sleep_until;
 
-use crate::types::discovery::{Endpoint, Service, Workload};
+use crate::types::discovery::{
+	Endpoint, LoadBalancer, LoadBalancerMode, LoadBalancerScopes, Service, Workload,
+};
 use crate::*;
 
 type EndpointKey = Strng;
@@ -49,20 +51,24 @@ pub struct EndpointSet<T> {
 	buckets: Vec<Atomic<EndpointGroup<T>>>,
 	tx_eviction: mpsc::Sender<EvictionEvent>,
 
-	// Updates to `bucket` are atomically swapped to make read actions fast.
-	// However, this introduces a TOCTOU race when we have add/delete and evictions on the same time.
-	// Practically speaking, these are all handled by the single main thread, but use a mutex to verify this.
-	// Note: we could have both of these handled by the worker, but the add/remove come from XDS without any async support.
+	// Updates to `buckets` are atomically swapped to make reads fast, but every writer does
+	// load→modify→store, which races when two writers touch the same bucket concurrently.
+	// action_mutex serializes all mutators: XDS add/delete, rebucket, and the eviction worker.
+	// Readers don't take it — they just load_full the ArcSwap.
 	action_mutex: Arc<Mutex<()>>,
 }
 fn contains_target_port(ep: &Endpoint, wanted_target: u16) -> bool {
 	ep.port.values().any(|tp| *tp == wanted_target)
 }
 impl EndpointSet<Endpoint> {
-	pub fn insert(&self, ep: Endpoint) {
-		// Currently, buckets are not supported
-		self.insert_key(ep.workload_uid.clone(), ep, 0)
+	pub fn insert(&self, ep: Endpoint, dest_workload: &Workload, ranker: &LocalityRanker) {
+		let bucket = match ranker.bucket_for(dest_workload) {
+			Some(b) => b,
+			None => return, // Strict mode mismatch — drop
+		};
+		self.insert_key(ep.workload_uid.clone(), ep, bucket)
 	}
+
 	pub fn select_endpoint(
 		&self,
 		workloads: &store::WorkloadStore,
@@ -70,17 +76,30 @@ impl EndpointSet<Endpoint> {
 		svc_port: u16,
 		override_dest: Option<SocketAddr>,
 	) -> Option<(Arc<Endpoint>, ActiveHandle, Arc<Workload>)> {
-		let target_port = svc.ports.get(&svc_port).copied();
-
-		if target_port.is_none() {
-			// Port doesn't exist on the service at all, this is invalid
+		let Some(target_port) = svc.ports.get(&svc_port).copied() else {
 			debug!("service {} does not have port {}", svc.hostname, svc_port);
 			return None;
 		};
 
-		let iter = svc.endpoints.iter();
+		let viable = |endpoint: &Arc<Endpoint>| -> Option<Arc<Workload>> {
+			let Some(wl) = workloads.find_uid(&endpoint.workload_uid) else {
+				debug!("failed to fetch workload for {}", endpoint.workload_uid);
+				return None;
+			};
+			if target_port == 0 && !endpoint.port.contains_key(&svc_port) {
+				trace!(
+					"filter endpoint {}, no service port {}",
+					endpoint.workload_uid, svc_port
+				);
+				return None;
+			}
+			Some(wl)
+		};
+
 		let selected = if let Some(o) = override_dest {
-			iter.iter().find_map(|(ep, ep_info)| {
+			// Explicit destination bypasses bucketing and health — search every endpoint
+			// (active + rejected) so an evicted-but-explicitly-targeted backend is still reachable.
+			self.all_endpoints().find_map(|(ep, info)| {
 				let Some(wl) = workloads.find_uid(&ep.workload_uid) else {
 					debug!("failed to fetch workload for {}", ep.workload_uid);
 					return None;
@@ -88,71 +107,137 @@ impl EndpointSet<Endpoint> {
 				if !wl.workload_ips.contains(&o.ip()) {
 					return None;
 				}
-				if !contains_target_port(ep, o.port()) {
+				if !contains_target_port(&ep, o.port()) {
 					return None;
 				}
-				Some((ep.clone(), ep_info, wl))
+				Some((ep, info, wl))
 			})
 		} else {
+			// best_bucket() picks the first non-empty bucket (best locality tier).
+			let iter = svc.endpoints.iter();
 			let index = iter.index();
 			if index.is_empty() {
 				return None;
 			}
-			// Intentionally allow `rand::seq::index::sample` so we can pick the same element twice
+			// Do not use `rand::seq::index::sample` so we can pick the same element twice
 			// This avoids starvation where the worst endpoint gets 0 traffic
-			let a = rand::rng().random_range(0..index.len());
-			let b = rand::rng().random_range(0..index.len());
+			let mut rng = rand::rng();
+			let a = rng.random_range(0..index.len());
+			let b = rng.random_range(0..index.len());
 			let best = [a, b]
 				.into_iter()
 				.filter_map(|idx| {
 					let (_, EndpointWithInfo { endpoint, info }) =
 						index.get_index(idx).expect("index already checked");
-					let Some(wl) = workloads.find_uid(&endpoint.workload_uid) else {
-						debug!("failed to fetch workload for {}", endpoint.workload_uid);
-						return None;
-					};
-					if target_port.unwrap_or_default() == 0 && !endpoint.port.contains_key(&svc_port) {
-						// Filter workload out, it doesn't have a matching port
-						// This is not great, since if we have a lot of partial endpoints we hit bad cases.
-						// However, this is rare enough in typical workloads that its not a big deal ATM.
-						trace!(
-							"filter endpoint {}, it does not have service port {}",
-							endpoint.workload_uid, svc_port
-						);
-						return None;
-					}
-					Some((endpoint.clone(), info, wl))
+					let wl = viable(endpoint)?;
+					Some((endpoint.clone(), info.clone(), wl))
 				})
 				.max_by(|(_, a, _), (_, b, _)| a.score().total_cmp(&b.score()));
-			if let Some(best) = best {
-				Some(best)
-			} else {
-				// Fallback to O(n) lookup
-				iter
-					.iter()
-					.filter_map(|(ep, ep_info)| {
-						let Some(wl) = workloads.find_uid(&ep.workload_uid) else {
-							debug!("failed to fetch workload for {}", ep.workload_uid);
-							return None;
-						};
-						if target_port.unwrap_or_default() == 0 && !ep.port.contains_key(&svc_port) {
-							// Filter workload out, it doesn't have a matching port
-							trace!(
-								"filter endpoint {}, it does not have service port {}",
-								ep.workload_uid, svc_port
-							);
-							return None;
-						}
-						Some((ep.clone(), ep_info, wl))
-					})
-					.max_by(|(_, a, _), (_, b, _)| a.score().total_cmp(&b.score()))
-			}
+
+			best.or_else(|| {
+				// Slow fallback: scan buckets in locality order, returning the first bucket
+				// that yields any match. Per-bucket: prefer active, fall back to rejected
+				// when active is empty (mirrors the fast path's `index()` semantics).
+				self.buckets.iter().find_map(|bucket| {
+					let group = bucket.load_full();
+					let map = if !group.active.is_empty() {
+						&group.active
+					} else {
+						&group.rejected
+					};
+					map
+						.iter()
+						.filter_map(|(_, ewi)| {
+							let wl = viable(&ewi.endpoint)?;
+							Some((ewi.endpoint.clone(), ewi.info.clone(), wl))
+						})
+						.max_by(|(_, a, _), (_, b, _)| a.score().total_cmp(&b.score()))
+				})
+			})
 		};
 		let (ep, ep_info, wl) = selected?;
 		let handle = svc
 			.endpoints
-			.start_request(ep.workload_uid.clone(), ep_info);
+			.start_request(ep.workload_uid.clone(), &ep_info);
 		Some((ep, handle, wl))
+	}
+}
+
+/// Computes an endpoint's locality bucket from a service's `routing_preferences`.
+/// Rank = length of the consecutive-matching prefix of preferences.
+/// Bucket = `num_preferences - rank` (so bucket 0 = best match).
+pub struct LocalityRanker<'a> {
+	lb: Option<&'a LoadBalancer>,
+	source: Option<&'a Workload>,
+}
+
+impl<'a> LocalityRanker<'a> {
+	pub fn new(lb: Option<&'a LoadBalancer>, source: Option<&'a Workload>) -> Self {
+		Self { lb, source }
+	}
+
+	/// Number of buckets needed. Modes that don't bucket (Standard/Passthrough) get 1 even if
+	/// preferences are set, so every endpoint has somewhere to land.
+	pub fn priority_levels(&self) -> usize {
+		match self.lb {
+			Some(lb) if Self::uses_buckets(lb) => lb.routing_preferences.len() + 1,
+			_ => 1,
+		}
+	}
+
+	/// Bucket index for the given destination workload. Lower = better match.
+	/// Returns `None` for Strict-mode endpoints that don't fully match (should be dropped).
+	/// If source is unknown, returns 0 so all endpoints stay reachable until rebucketed.
+	pub fn bucket_for(&self, wl: &Workload) -> Option<usize> {
+		if self.source.is_none() {
+			return Some(0);
+		}
+		// Non-bucketing modes collapse to bucket 0 — preferences, if present, are ignored
+		// instead of silently dropping endpoints into out-of-range buckets.
+		if let Some(lb) = self.lb
+			&& !Self::uses_buckets(lb)
+		{
+			return Some(0);
+		}
+		let rank = self.rank(wl)?;
+		let n = self.lb.map(|lb| lb.routing_preferences.len()).unwrap_or(0);
+		Some(n.saturating_sub(rank))
+	}
+
+	fn uses_buckets(lb: &LoadBalancer) -> bool {
+		!matches!(
+			lb.mode,
+			LoadBalancerMode::Standard | LoadBalancerMode::Passthrough
+		)
+	}
+
+	/// Returns the rank for this endpoint, or `None` if Strict mode requires full match and we
+	/// did not reach it.
+	pub fn rank(&self, wl: &Workload) -> Option<usize> {
+		let (lb, src) = match (self.lb, self.source) {
+			(Some(lb), Some(src)) => (lb, src),
+			_ => return Some(0),
+		};
+		let mut rank = 0usize;
+		for scope in &lb.routing_preferences {
+			let matches = match scope {
+				LoadBalancerScopes::Region => src.locality.region == wl.locality.region,
+				LoadBalancerScopes::Zone => src.locality.zone == wl.locality.zone,
+				LoadBalancerScopes::Subzone => src.locality.subzone == wl.locality.subzone,
+				LoadBalancerScopes::Node => src.node == wl.node,
+				LoadBalancerScopes::Cluster => src.cluster_id == wl.cluster_id,
+				LoadBalancerScopes::Network => src.network == wl.network,
+			};
+			if matches {
+				rank += 1;
+			} else {
+				break;
+			}
+		}
+		if lb.mode == LoadBalancerMode::Strict && rank != lb.routing_preferences.len() {
+			return None;
+		}
+		Some(rank)
 	}
 }
 
@@ -218,15 +303,18 @@ impl<T: Clone + Sync + Send + 'static> EndpointSet<T> {
 		Self::new_with_buckets(buckets)
 	}
 	pub fn new_empty(priority_levels: usize) -> Self {
-		Self::new_with_buckets(vec![Default::default(); priority_levels])
+		// Each bucket needs its own ArcSwap; `vec![x; n]` would clone one Arc n times
+		// and have every bucket share the same backing storage.
+		Self::new_with_buckets((0..priority_levels).map(|_| Default::default()).collect())
 	}
 	fn new_with_buckets(buckets: Vec<Atomic<EndpointGroup<T>>>) -> Self {
 		let (tx_eviction, rx_eviction) = mpsc::channel(10);
-		Self::worker(rx_eviction, buckets.clone());
+		let action_mutex = Arc::new(Mutex::new(()));
+		Self::worker(rx_eviction, buckets.clone(), action_mutex.clone());
 		Self {
 			buckets,
 			tx_eviction,
-			action_mutex: Arc::new(Mutex::new(())),
+			action_mutex,
 		}
 	}
 
@@ -296,21 +384,91 @@ impl<T: Clone + Sync + Send + 'static> EndpointSet<T> {
 		ActiveEndpointsIter(self.best_bucket())
 	}
 
+	/// Iterate every endpoint across all buckets. Active endpoints from all buckets
+	/// are yielded before any rejected endpoint, e.g.:
+	///   active in bucket 0
+	///   active in bucket 1
+	///   rejected in bucket 0
+	///   rejected in bucket 1
+	pub fn all_endpoints(&self) -> AllEndpointsIter<'_, T> {
+		AllEndpointsIter {
+			buckets: &self.buckets,
+			bucket_idx: 0,
+			current: None,
+			in_rejected: false,
+		}
+	}
+
 	pub fn insert_key(&self, key: EndpointKey, ep: T, bucket: usize) {
 		self.event(EndpointEvent::Add(key, EndpointWithInfo::new(ep), bucket))
 	}
 	pub fn remove(&self, key: EndpointKey) {
 		self.event(EndpointEvent::Delete(key))
 	}
+
+	pub fn num_buckets(&self) -> usize {
+		self.buckets.len()
+	}
+
+	/// Re-distribute every endpoint across buckets using `f`. Endpoints where `f` returns
+	/// `None` are dropped (e.g. Strict mode mismatch). EndpointInfo (health, latency, ejection
+	/// state) is preserved — same Arcs, just moved between buckets.
+	///
+	/// Bucket count stays the same. If the number of buckets needs to change (LB config change),
+	/// rebuild the EndpointSet instead.
+	pub fn rebucket<F>(&self, ranker: F)
+	where
+		F: Fn(&T) -> Option<usize>,
+	{
+		let _mu = self.action_mutex.lock();
+		let n = self.buckets.len();
+
+		let mut new_groups: Vec<EndpointGroup<T>> = (0..n).map(|_| EndpointGroup::default()).collect();
+
+		for bucket in &self.buckets {
+			let g = bucket.load_full();
+			for (entries, rejected) in [(&g.active, false), (&g.rejected, true)] {
+				for (key, ep) in entries {
+					let Some(b) = ranker(ep.endpoint.as_ref()) else {
+						continue;
+					};
+					if b >= n {
+						continue;
+					}
+					let target = if rejected {
+						&mut new_groups[b].rejected
+					} else {
+						&mut new_groups[b].active
+					};
+					target.insert(key.clone(), ep.clone());
+				}
+			}
+		}
+
+		for (i, group) in new_groups.into_iter().enumerate() {
+			self.buckets[i].store(Arc::new(group));
+		}
+	}
+
 	fn event(&self, item: EndpointEvent<T>) {
 		let _mu = self.action_mutex.lock();
 
 		match item {
 			EndpointEvent::Add(key, ep, bucket) => {
-				let mut eps = Arc::unwrap_or_clone(self.buckets[bucket].load_full());
+				let Some(slot) = self.buckets.get(bucket) else {
+					// TODO this currently cannot happen, but we could maybe get better
+					// structural guarantees if we stored the lb settings along with the EndpointSet
+					// so that an inserter will always be able to tell the bucket count
+					trace!(
+						"bucket {bucket} out of range (have {}), dropping endpoint {key}",
+						self.buckets.len()
+					);
+					return;
+				};
+				let mut eps = Arc::unwrap_or_clone(slot.load_full());
 				eps.rejected.swap_remove(&key);
 				eps.active.insert(key, ep);
-				self.buckets[bucket].store(Arc::new(eps));
+				slot.store(Arc::new(eps));
 			},
 			EndpointEvent::Delete(key) => {
 				let Some(bucket) = Self::find_bucket_atomic(self.buckets.as_slice(), &key) else {
@@ -326,6 +484,7 @@ impl<T: Clone + Sync + Send + 'static> EndpointSet<T> {
 	fn worker(
 		mut eviction_events: mpsc::Receiver<EvictionEvent>,
 		buckets: Vec<Atomic<EndpointGroup<T>>>,
+		action_mutex: Arc<Mutex<()>>,
 	) {
 		tokio::task::spawn(async move {
 			let mut uneviction_heap: BinaryHeap<UnevictEntry> = Default::default();
@@ -334,6 +493,9 @@ impl<T: Clone + Sync + Send + 'static> EndpointSet<T> {
 					uneviction_heap.pop().expect("heap is empty");
 
 				trace!(%key, "unevict");
+				// Serialize against XDS add/delete and rebucket — without this, their load→store
+				// can overwrite (or be overwritten by) this handler's mutation.
+				let _mu = action_mutex.lock();
 				let Some(bucket) = Self::find_bucket_atomic(buckets.as_slice(), &key) else {
 					return;
 				};
@@ -360,6 +522,7 @@ impl<T: Clone + Sync + Send + 'static> EndpointSet<T> {
 					restore_health,
 				} = item;
 
+				let _mu = action_mutex.lock();
 				let Some(bucket) = Self::find_bucket_atomic(buckets.as_slice(), &key) else {
 					return;
 				};
@@ -629,6 +792,53 @@ where
 			seq.serialize_element(&b.load_full())?;
 		}
 		seq.end()
+	}
+}
+
+/// Non-allocating iterator over every endpoint across all buckets. Yields all active
+/// endpoints first (across every bucket), then all rejected.
+///
+/// Snapshot is per-bucket-per-phase, not whole-set: a concurrent rebucket or eviction
+/// can be partially observed across loads. Callers that scan-then-discard (e.g. selection)
+/// are unaffected; do not use for invariants that span buckets.
+pub struct AllEndpointsIter<'a, T> {
+	buckets: &'a [Atomic<EndpointGroup<T>>],
+	bucket_idx: usize,
+	current: Option<(Arc<EndpointGroup<T>>, usize)>,
+	in_rejected: bool,
+}
+
+impl<T> Iterator for AllEndpointsIter<'_, T> {
+	type Item = (Arc<T>, Arc<EndpointInfo>);
+
+	fn next(&mut self) -> Option<Self::Item> {
+		loop {
+			if let Some((group, idx)) = &mut self.current {
+				let map = if self.in_rejected {
+					&group.rejected
+				} else {
+					&group.active
+				};
+				if let Some((_, ewi)) = map.get_index(*idx) {
+					*idx += 1;
+					return Some((ewi.endpoint.clone(), ewi.info.clone()));
+				}
+				self.current = None;
+			}
+			if self.bucket_idx < self.buckets.len() {
+				let bucket = &self.buckets[self.bucket_idx];
+				self.bucket_idx += 1;
+				self.current = Some((bucket.load_full(), 0));
+				continue;
+			}
+			// Active phase exhausted across all buckets — restart for rejected phase.
+			if !self.in_rejected {
+				self.in_rejected = true;
+				self.bucket_idx = 0;
+				continue;
+			}
+			return None;
+		}
 	}
 }
 
@@ -902,5 +1112,245 @@ mod tests {
 			3,
 			"consecutive_failures should NOT be reset on uneviction"
 		);
+	}
+
+	// --- AllEndpointsIter ---
+
+	fn build_group(
+		active: &[&'static str],
+		rejected: &[&'static str],
+	) -> EndpointGroup<&'static str> {
+		let mut group = EndpointGroup::default();
+		for v in active {
+			group.active.insert((*v).into(), EndpointWithInfo::new(*v));
+		}
+		for v in rejected {
+			group
+				.rejected
+				.insert((*v).into(), EndpointWithInfo::new(*v));
+		}
+		group
+	}
+
+	fn install(eps: &EndpointSet<&'static str>, idx: usize, g: EndpointGroup<&'static str>) {
+		eps.buckets[idx].store(Arc::new(g));
+	}
+
+	fn collect_values(eps: &EndpointSet<&'static str>) -> Vec<&'static str> {
+		eps.all_endpoints().map(|(ep, _)| *ep).collect()
+	}
+
+	#[tokio::test]
+	async fn all_endpoints_empty() {
+		let eps = EndpointSet::<&'static str>::new_empty(2);
+		assert!(collect_values(&eps).is_empty());
+	}
+
+	#[tokio::test]
+	async fn all_endpoints_active_before_rejected_across_buckets() {
+		let eps = EndpointSet::<&'static str>::new_empty(2);
+		install(&eps, 0, build_group(&["a0"], &["r0"]));
+		install(&eps, 1, build_group(&["a1"], &["r1"]));
+		// All actives across buckets first, then all rejecteds.
+		assert_eq!(collect_values(&eps), vec!["a0", "a1", "r0", "r1"]);
+	}
+
+	#[tokio::test]
+	async fn all_endpoints_skips_empty_buckets_and_phases() {
+		let eps = EndpointSet::<&'static str>::new_empty(3);
+		install(&eps, 0, build_group(&["a0"], &[]));
+		// bucket 1 left empty
+		install(&eps, 2, build_group(&[], &["r2"]));
+		assert_eq!(collect_values(&eps), vec!["a0", "r2"]);
+	}
+
+	// --- rebucket ---
+
+	#[tokio::test]
+	async fn rebucket_moves_endpoints_between_buckets() {
+		// Start with endpoints "a" and "b" both in bucket 0.
+		let eps = EndpointSet::<&'static str>::new_empty(2);
+		install(&eps, 0, build_group(&["a", "b"], &[]));
+
+		// Rebucket: send "a" to bucket 1, keep "b" in bucket 0.
+		eps.rebucket(|endpoint| Some(if *endpoint == "a" { 1 } else { 0 }));
+
+		let bucket_0 = eps.buckets[0].load_full();
+		let bucket_1 = eps.buckets[1].load_full();
+
+		assert_eq!(bucket_0.active.len(), 1, "bucket 0 should only contain b");
+		assert!(bucket_0.active.contains_key(&Strng::from("b")));
+
+		assert_eq!(bucket_1.active.len(), 1, "bucket 1 should only contain a");
+		assert!(bucket_1.active.contains_key(&Strng::from("a")));
+	}
+
+	#[tokio::test]
+	async fn rebucket_drops_none_and_out_of_range() {
+		let eps = EndpointSet::<&'static str>::new_empty(2);
+		install(&eps, 0, build_group(&["keep", "drop", "out_of_range"], &[]));
+
+		eps.rebucket(|endpoint| match *endpoint {
+			"keep" => Some(0),
+			"drop" => None,
+			// Callers should size buckets correctly; this guards against crashing
+			// if an out-of-range index sneaks through.
+			"out_of_range" => Some(99),
+			_ => None,
+		});
+
+		assert_eq!(eps.buckets[0].load_full().active.len(), 1);
+		assert_eq!(eps.buckets[1].load_full().active.len(), 0);
+	}
+
+	#[tokio::test]
+	async fn rebucket_preserves_active_rejected_split() {
+		let eps = EndpointSet::<&'static str>::new_empty(2);
+		install(&eps, 0, build_group(&["a"], &["r"]));
+
+		// Move everything to bucket 1.
+		eps.rebucket(|_| Some(1));
+
+		let bucket_0 = eps.buckets[0].load_full();
+		let bucket_1 = eps.buckets[1].load_full();
+
+		assert!(
+			bucket_1.active.contains_key(&Strng::from("a")),
+			"active stays active"
+		);
+		assert!(
+			bucket_1.rejected.contains_key(&Strng::from("r")),
+			"rejected stays rejected"
+		);
+		assert_eq!(bucket_0.active.len(), 0);
+		assert_eq!(bucket_0.rejected.len(), 0);
+	}
+
+	#[tokio::test]
+	async fn rebucket_preserves_endpoint_info_arc() {
+		// Health/eviction state lives in EndpointInfo; rebucket must share the
+		// same Arc rather than cloning the value.
+		let eps = EndpointSet::<&'static str>::new_empty(2);
+		install(&eps, 0, build_group(&["a"], &[]));
+
+		let key = Strng::from("a");
+		let info_before = Arc::as_ptr(&eps.buckets[0].load_full().active.get(&key).unwrap().info);
+
+		eps.rebucket(|_| Some(1));
+
+		let info_after = Arc::as_ptr(&eps.buckets[1].load_full().active.get(&key).unwrap().info);
+		assert_eq!(info_before, info_after);
+	}
+
+	// --- LocalityRanker ---
+
+	use crate::types::discovery::{
+		LoadBalancer, LoadBalancerHealthPolicy, LoadBalancerMode, LoadBalancerScopes, Locality,
+	};
+
+	fn wl(network: &str, region: &str, zone: &str, node: &str, cluster: &str) -> Workload {
+		Workload {
+			network: network.into(),
+			locality: Locality {
+				region: region.into(),
+				zone: zone.into(),
+				subzone: "".into(),
+			},
+			node: node.into(),
+			cluster_id: cluster.into(),
+			..Default::default()
+		}
+	}
+
+	fn lb(mode: LoadBalancerMode, prefs: Vec<LoadBalancerScopes>) -> LoadBalancer {
+		LoadBalancer {
+			routing_preferences: prefs,
+			mode,
+			health_policy: LoadBalancerHealthPolicy::default(),
+		}
+	}
+
+	#[test]
+	fn ranker_no_source_always_bucket_zero() {
+		for mode in [
+			LoadBalancerMode::Failover,
+			LoadBalancerMode::Strict,
+			LoadBalancerMode::Standard,
+			LoadBalancerMode::Passthrough,
+		] {
+			let lbc = lb(mode, vec![LoadBalancerScopes::Zone]);
+			let r = LocalityRanker::new(Some(&lbc), None);
+			assert_eq!(r.bucket_for(&wl("n1", "r1", "z1", "_", "_")), Some(0));
+		}
+	}
+
+	#[test]
+	fn ranker_standard_and_passthrough_ignore_preferences() {
+		// the control plane should not send preferences along with this mode, this is a defensive
+		// check to ensure we ignore them if we do receive them in a non-bucketing mode
+		let src = wl("n1", "r1", "z1", "_", "_");
+		for mode in [LoadBalancerMode::Standard, LoadBalancerMode::Passthrough] {
+			let lbc = lb(mode.clone(), vec![LoadBalancerScopes::Zone]);
+			let r = LocalityRanker::new(Some(&lbc), Some(&src));
+			assert_eq!(r.priority_levels(), 1, "mode {mode:?}");
+			assert_eq!(
+				r.bucket_for(&wl("n1", "r1", "z1", "_", "_")),
+				Some(0),
+				"mode {mode:?} matching endpoint"
+			);
+			assert_eq!(
+				r.bucket_for(&wl("n1", "r1", "z9", "_", "_")),
+				Some(0),
+				"mode {mode:?} non-matching endpoint"
+			);
+		}
+	}
+
+	#[test]
+	fn ranker_prefix_match_counts() {
+		let src = wl("n1", "r1", "z1", "node1", "c1");
+		let lbc = lb(
+			LoadBalancerMode::Failover,
+			vec![
+				LoadBalancerScopes::Network,
+				LoadBalancerScopes::Region,
+				LoadBalancerScopes::Zone,
+			],
+		);
+		let r = LocalityRanker::new(Some(&lbc), Some(&src));
+		// full match -> 3
+		assert_eq!(r.rank(&wl("n1", "r1", "z1", "_", "_")), Some(3));
+		// miss on zone -> 2
+		assert_eq!(r.rank(&wl("n1", "r1", "z2", "_", "_")), Some(2));
+		// miss on region breaks the chain before zone is evaluated
+		assert_eq!(r.rank(&wl("n1", "r2", "z1", "_", "_")), Some(1));
+		// miss on first preference -> 0
+		assert_eq!(r.rank(&wl("n2", "r1", "z1", "_", "_")), Some(0));
+	}
+
+	#[test]
+	fn ranker_strict_drops_sub_full_match() {
+		let src = wl("n1", "r1", "z1", "_", "_");
+		let lbc = lb(
+			LoadBalancerMode::Strict,
+			vec![LoadBalancerScopes::Network, LoadBalancerScopes::Zone],
+		);
+		let r = LocalityRanker::new(Some(&lbc), Some(&src));
+		assert_eq!(r.rank(&wl("n1", "_", "z1", "_", "_")), Some(2));
+		assert_eq!(r.rank(&wl("n1", "_", "z2", "_", "_")), None);
+		assert_eq!(r.rank(&wl("n2", "_", "z1", "_", "_")), None);
+	}
+
+	#[test]
+	fn ranker_node_and_cluster_scopes() {
+		let src = wl("_", "_", "_", "nodeA", "clusterA");
+		let lbc = lb(
+			LoadBalancerMode::Failover,
+			vec![LoadBalancerScopes::Cluster, LoadBalancerScopes::Node],
+		);
+		let r = LocalityRanker::new(Some(&lbc), Some(&src));
+		assert_eq!(r.rank(&wl("_", "_", "_", "nodeA", "clusterA")), Some(2));
+		assert_eq!(r.rank(&wl("_", "_", "_", "nodeB", "clusterA")), Some(1));
+		assert_eq!(r.rank(&wl("_", "_", "_", "nodeA", "clusterB")), Some(0));
 	}
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -11,6 +11,7 @@ pub mod responsechannel;
 pub mod signal;
 pub mod strng;
 pub mod telemetry;
+pub mod test_helpers;
 pub mod timestamp;
 mod tokio_metrics;
 pub mod version;

--- a/crates/core/src/telemetry.rs
+++ b/crates/core/src/telemetry.rs
@@ -587,8 +587,7 @@ pub mod testing {
 	use std::io;
 	use std::io::IoSlice;
 	use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
-	use std::time::{Duration, SystemTime};
-	use tracing::trace;
+	use std::time::Duration;
 	use tracing_subscriber::fmt;
 	use tracing_subscriber::fmt::writer::Tee;
 	use tracing_subscriber::layer::SubscriberExt;
@@ -624,39 +623,10 @@ pub mod testing {
 		}
 	}
 
-	/// check_eventually runs a function many times until it reaches the expected result.
-	/// If it doesn't the last result is returned
-	async fn check_eventually<F, CF, T, Fut>(dur: Duration, f: F, expected: CF) -> Result<T, T>
-	where
-		F: Fn() -> Fut,
-		Fut: Future<Output = T>,
-		T: Eq + Debug,
-		CF: Fn(&T) -> bool,
-	{
-		use std::ops::Add;
-		let mut delay = Duration::from_millis(10);
-		let end = SystemTime::now().add(dur);
-		let mut last: T;
-		let mut attempts = 0;
-		loop {
-			attempts += 1;
-			last = f().await;
-			if expected(&last) {
-				return Ok(last);
-			}
-			trace!("attempt {attempts} with delay {delay:?}");
-			if SystemTime::now().add(delay) > end {
-				return Err(last);
-			}
-			tokio::time::sleep(delay).await;
-			delay *= 2;
-		}
-	}
-
 	/// eventually_find waits until at least one log line matches the given keys.
 	/// If not found, panics
 	pub async fn eventually_find(want: &[(&str, &str)]) -> Option<Value> {
-		check_eventually(
+		crate::test_helpers::check_eventually(
 			Duration::from_secs(1),
 			|| async { find(want).into_iter().next() },
 			|log| log.is_some(),

--- a/crates/core/src/test_helpers.rs
+++ b/crates/core/src/test_helpers.rs
@@ -1,0 +1,32 @@
+use std::future::Future;
+use std::ops::Add;
+use std::time::{Duration, SystemTime};
+
+use tracing::trace;
+
+/// check_eventually runs a function many times until it reaches the expected result.
+/// If it doesn't the last result is returned.
+pub async fn check_eventually<F, CF, T, Fut>(dur: Duration, f: F, expected: CF) -> Result<T, T>
+where
+	F: Fn() -> Fut,
+	Fut: Future<Output = T>,
+	CF: Fn(&T) -> bool,
+{
+	let mut delay = Duration::from_millis(10);
+	let end = SystemTime::now().add(dur);
+	let mut last: T;
+	let mut attempts = 0;
+	loop {
+		attempts += 1;
+		last = f().await;
+		if expected(&last) {
+			return Ok(last);
+		}
+		trace!("attempt {attempts} with delay {delay:?}");
+		if SystemTime::now().add(delay) > end {
+			return Err(last);
+		}
+		tokio::time::sleep(delay).await;
+		delay *= 2;
+	}
+}


### PR DESCRIPTION
as WDS already depends on Istio code, we already get the LoadBalancer settings propagated based on traffic distribution fields on Services. This PR makes it so the proxy actually implements failover.

Because the gateway  is always the locality source, so we can bucket endpoints as discovery comes in rather than doing the O(endpoints) bucketing on the request path. There are some follow ups here to avoid rescanning all the endpoints when there are no-op pushes to Services. 

Currently the logic to load our own locality info is:
* if we're using xds and we know our own name, wait for our own workload to come across in xds/wds
* after 60 seconds, bail (we get wrong locality lb until the workload shows up) 
* otherwise we piece together what info we can from env vars/static config

fixes https://github.com/agentgateway/agentgateway/issues/841
fixes https://github.com/agentgateway/agentgateway/issues/840
fixes https://github.com/agentgateway/agentgateway/issues/839


