### PR TITLE
mcp: add session TTL

### DIFF
--- a/crates/agentgateway/src/config.rs
+++ b/crates/agentgateway/src/config.rs
@@ -426,6 +426,13 @@ pub fn parse_config(contents: String, filename: Option<PathBuf>) -> anyhow::Resu
 			role: ENV.role.clone(),
 			node_id: ENV.node_id.clone(),
 		},
+		mcp: crate::McpConfig {
+			session_ttl: raw
+				.mcp
+				.as_ref()
+				.and_then(|m| m.session_ttl)
+				.unwrap_or(crate::mcp::DEFAULT_SESSION_IDLE_TTL),
+		},
 		session_encoder,
 		oidc_cookie_encoder,
 		hbone: Arc::new(agent_hbone::Config {

--- a/crates/agentgateway/src/lib.rs
+++ b/crates/agentgateway/src/lib.rs
@@ -169,6 +169,9 @@ pub struct RawConfig {
 	/// Configuration for stateful session management
 	session: Option<RawSession>,
 
+	/// MCP gateway settings.
+	mcp: Option<RawMcpConfig>,
+
 	#[serde(default, with = "serde_dur_option")]
 	#[cfg_attr(feature = "schema", schemars(with = "Option<String>"))]
 	connection_termination_deadline: Option<Duration>,
@@ -283,6 +286,13 @@ pub struct RawSession {
 	#[cfg_attr(feature = "schema", schemars(with = "String"))]
 	#[serde(serialize_with = "ser_redact", deserialize_with = "deser_key")]
 	key: secrecy::SecretString,
+}
+
+#[apply(schema_de!)]
+pub struct RawMcpConfig {
+	#[serde(default, with = "serde_dur_option")]
+	#[cfg_attr(feature = "schema", schemars(with = "Option<String>"))]
+	session_ttl: Option<Duration>,
 }
 
 #[apply(schema_de!)]
@@ -483,6 +493,14 @@ pub struct Config {
 	pub admin_runtime_handle: Option<tokio::runtime::Handle>,
 
 	pub backend: BackendConfig,
+	pub mcp: McpConfig,
+}
+
+#[apply(schema!)]
+pub struct McpConfig {
+	#[serde(with = "serde_dur")]
+	#[cfg_attr(feature = "schema", schemars(with = "String"))]
+	pub session_ttl: Duration,
 }
 
 impl Config {

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -223,7 +223,7 @@ async fn stateless_multiplex_delete_session_skips_uninitialized_targets() {
 				fake_streamable_target("b", mock_b.addr),
 			],
 			stateful: false,
-			failure_mode: FailureMode::FailClosed,
+			..Default::default()
 		},
 		empty_mcp_policies(),
 		PolicyClient {
@@ -1653,8 +1653,7 @@ mod legacymockserver {
 async fn test_zero_targets_fail_closed() {
 	let backend = McpBackendGroup {
 		targets: vec![],
-		stateful: true,
-		failure_mode: FailureMode::FailClosed,
+		..Default::default()
 	};
 	let client = PolicyClient {
 		inputs: setup_proxy_test("{}").unwrap().pi,
@@ -1667,8 +1666,8 @@ async fn test_zero_targets_fail_closed() {
 async fn test_zero_targets_fail_open() {
 	let backend = McpBackendGroup {
 		targets: vec![],
-		stateful: true,
 		failure_mode: FailureMode::FailOpen,
+		..Default::default()
 	};
 	let client = PolicyClient {
 		inputs: setup_proxy_test("{}").unwrap().pi,
@@ -1706,6 +1705,7 @@ async fn test_setup_partial_success_fail_open() {
 		],
 		stateful: false,
 		failure_mode: FailureMode::FailOpen,
+		..Default::default()
 	};
 	let client = PolicyClient {
 		inputs: setup_proxy_test("{}").unwrap().pi,
@@ -1743,6 +1743,7 @@ async fn test_all_targets_fail_open_still_errors() {
 		],
 		stateful: false,
 		failure_mode: FailureMode::FailOpen,
+		..Default::default()
 	};
 	let client = PolicyClient {
 		inputs: setup_proxy_test("{}").unwrap().pi,
@@ -1864,8 +1865,7 @@ fn test_openapi_targets_emit_stateless_session_state() {
 				"openapi",
 				SocketAddr::from(([127, 0, 0, 1], 30031)),
 			)],
-			stateful: true,
-			failure_mode: FailureMode::FailClosed,
+			..Default::default()
 		},
 		empty_mcp_policies(),
 		PolicyClient {
@@ -1912,8 +1912,7 @@ fn test_sse_targets_emit_stateless_session_state() {
 				"sse",
 				SocketAddr::from(([127, 0, 0, 1], 30032)),
 			)],
-			stateful: true,
-			failure_mode: FailureMode::FailClosed,
+			..Default::default()
 		},
 		empty_mcp_policies(),
 		PolicyClient {
@@ -1958,7 +1957,7 @@ async fn test_stdio_targets_remain_non_stateless() {
 		McpBackendGroup {
 			targets: vec![fake_stdio_target("stdio")],
 			stateful: false,
-			failure_mode: FailureMode::FailClosed,
+			..Default::default()
 		},
 		empty_mcp_policies(),
 		PolicyClient {
@@ -1982,6 +1981,7 @@ async fn test_fanout_deletion_fail_open_skips_failed_upstreams() {
 			],
 			stateful: true,
 			failure_mode: FailureMode::FailOpen,
+			session_idle_ttl: crate::mcp::DEFAULT_SESSION_IDLE_TTL,
 		},
 		empty_mcp_policies(),
 		PolicyClient {
@@ -2013,8 +2013,7 @@ fn test_set_sessions_matches_by_target_name() {
 				fake_streamable_target("alpha", SocketAddr::from(([127, 0, 0, 1], 30001))),
 				fake_streamable_target("beta", SocketAddr::from(([127, 0, 0, 1], 30002))),
 			],
-			stateful: true,
-			failure_mode: FailureMode::FailClosed,
+			..Default::default()
 		},
 		empty_mcp_policies(),
 		PolicyClient {
@@ -2062,8 +2061,7 @@ fn test_set_sessions_rejects_mismatched_target_set() {
 				fake_streamable_target("alpha", SocketAddr::from(([127, 0, 0, 1], 30011))),
 				fake_streamable_target("beta", SocketAddr::from(([127, 0, 0, 1], 30012))),
 			],
-			stateful: true,
-			failure_mode: FailureMode::FailClosed,
+			..Default::default()
 		},
 		empty_mcp_policies(),
 		PolicyClient {
@@ -2106,8 +2104,7 @@ fn test_merge_initialize_merges_upstream_instructions_when_multiplexing() {
 				fake_streamable_target("alpha", SocketAddr::from(([127, 0, 0, 1], 30101))),
 				fake_streamable_target("beta", SocketAddr::from(([127, 0, 0, 1], 30102))),
 			],
-			stateful: true,
-			failure_mode: FailureMode::FailClosed,
+			..Default::default()
 		},
 		empty_mcp_policies(),
 		PolicyClient {
@@ -2180,8 +2177,7 @@ fn test_merge_initialize_no_instructions_when_multiplexing() {
 				"alpha",
 				SocketAddr::from(([127, 0, 0, 1], 30103)),
 			)],
-			stateful: true,
-			failure_mode: FailureMode::FailClosed,
+			..Default::default()
 		},
 		empty_mcp_policies(),
 		PolicyClient {
@@ -2231,8 +2227,7 @@ fn test_merge_initialize_forwards_single_backend_without_multiplexing() {
 				"solo",
 				SocketAddr::from(([127, 0, 0, 1], 30104)),
 			)],
-			stateful: true,
-			failure_mode: FailureMode::FailClosed,
+			..Default::default()
 		},
 		empty_mcp_policies(),
 		PolicyClient {

--- a/crates/agentgateway/src/mcp/mod.rs
+++ b/crates/agentgateway/src/mcp/mod.rs
@@ -11,6 +11,7 @@ mod upstream;
 use std::fmt::{Display, Write};
 use std::io;
 use std::sync::Arc;
+use std::time::Duration;
 
 #[cfg(feature = "schema")]
 use crate::JsonSchema;
@@ -37,6 +38,8 @@ pub enum FailureMode {
 	/// If ALL targets fail, still return an error.
 	FailOpen,
 }
+
+pub(crate) const DEFAULT_SESSION_IDLE_TTL: Duration = Duration::from_mins(30);
 
 #[cfg(test)]
 #[path = "mcp_tests.rs"]

--- a/crates/agentgateway/src/mcp/router.rs
+++ b/crates/agentgateway/src/mcp/router.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use agent_core::prelude::Strng;
 use axum::response::Response;
 
-use crate::ProxyInputs;
 use crate::http::authorization::RuleSets;
 use crate::http::sessionpersistence::Encoder;
 use crate::http::*;
@@ -21,6 +21,7 @@ use crate::telemetry::log::RequestLog;
 use crate::types::agent::{
 	BackendTargetRef, McpBackend, McpTargetSpec, ResourceName, SimpleBackend, SimpleBackendReference,
 };
+use crate::{ProxyInputs, mcp};
 
 #[derive(Debug, Clone)]
 pub struct App {
@@ -30,7 +31,7 @@ pub struct App {
 
 impl App {
 	pub fn new(state: Stores, encoder: Encoder) -> Self {
-		let session: Arc<SessionManager> = Arc::new(crate::mcp::session::SessionManager::new(encoder));
+		let session = crate::mcp::session::SessionManager::new(encoder);
 		Self { state, session }
 	}
 
@@ -102,6 +103,7 @@ impl App {
 				targets: nt,
 				stateful: backend.stateful,
 				failure_mode: backend.failure_mode,
+				session_idle_ttl: backend.session_idle_ttl,
 			}
 		};
 		let sm = self.session.clone();
@@ -171,6 +173,18 @@ pub struct McpBackendGroup {
 	pub targets: Vec<Arc<McpTarget>>,
 	pub stateful: bool,
 	pub failure_mode: FailureMode,
+	pub session_idle_ttl: Duration,
+}
+
+impl Default for McpBackendGroup {
+	fn default() -> Self {
+		Self {
+			targets: vec![],
+			stateful: true,
+			failure_mode: crate::mcp::FailureMode::default(),
+			session_idle_ttl: mcp::DEFAULT_SESSION_IDLE_TTL,
+		}
+	}
 }
 
 #[derive(Debug)]

--- a/crates/agentgateway/src/mcp/router.rs
+++ b/crates/agentgateway/src/mcp/router.rs
@@ -106,7 +106,8 @@ impl App {
 				session_idle_ttl: backend.session_idle_ttl,
 			}
 		};
-		let sm = self.session.clone();
+		let sessions = self.session.clone();
+		sessions.ensure_idle_running();
 		let client = PolicyClient { inputs: pi.clone() };
 		let authorization_policies = backend_policies
 			.mcp_authorization
@@ -138,7 +139,7 @@ impl App {
 		if req.uri().path() == "/sse" {
 			// Legacy handling
 			// Assume this is streamable HTTP otherwise
-			let sse = LegacySSEService::new(sm);
+			let sse = LegacySSEService::new(sessions);
 			Box::pin(sse.handle(
 				req,
 				RelayInputs {
@@ -150,7 +151,7 @@ impl App {
 			.await
 		} else {
 			let streamable = StreamableHttpService::new(
-				sm,
+				sessions,
 				StreamableHttpServerConfig {
 					stateful_mode: backend.stateful,
 				},

--- a/crates/agentgateway/src/mcp/session.rs
+++ b/crates/agentgateway/src/mcp/session.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 use std::convert::Infallible;
 use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
+use std::time::{Duration, Instant};
 
 use ::http::StatusCode;
 use ::http::header::CONTENT_TYPE;
@@ -34,6 +36,15 @@ pub struct Session {
 	pub id: Arc<str>,
 	tx: Option<Sender<ServerJsonRpcMessage>>,
 }
+
+#[derive(Debug, Clone)]
+struct SessionEntry {
+	session: Session,
+	last_access: Instant,
+	idle_ttl: Duration,
+}
+
+const SESSION_REAP_INTERVAL: Duration = Duration::from_secs(30);
 
 impl Session {
 	/// send a message to upstream server(s)
@@ -509,7 +520,8 @@ impl Session {
 #[derive(Debug)]
 pub struct SessionManager {
 	encoder: http::sessionpersistence::Encoder,
-	sessions: RwLock<HashMap<String, Session>>,
+	sessions: Arc<RwLock<HashMap<String, SessionEntry>>>,
+	idle_reaper: Option<tokio::task::AbortHandle>,
 }
 
 fn session_id() -> Arc<str> {
@@ -517,23 +529,21 @@ fn session_id() -> Arc<str> {
 }
 
 impl SessionManager {
-	pub fn new(encoder: http::sessionpersistence::Encoder) -> Self {
-		Self {
+	pub fn new(encoder: http::sessionpersistence::Encoder) -> Arc<Self> {
+		let sessions = Arc::new(RwLock::new(HashMap::new()));
+		let task = tokio::spawn(run_idle_reaper(sessions.clone()));
+		Arc::new(Self {
 			encoder,
-			sessions: Default::default(),
-		}
+			sessions,
+			idle_reaper: Some(task.abort_handle()),
+		})
 	}
 
 	pub fn get_session(&self, id: &str, builder: RelayInputs) -> Option<Session> {
-		Some(
-			self
-				.sessions
-				.read()
-				.ok()?
-				.get(id)
-				.cloned()?
-				.with_inputs(builder),
-		)
+		let mut sessions = self.sessions.write().ok()?;
+		let entry = sessions.get_mut(id)?;
+		entry.last_access = Instant::now();
+		Some(entry.session.clone().with_inputs(builder))
 	}
 
 	pub fn get_or_resume_session(
@@ -541,9 +551,11 @@ impl SessionManager {
 		id: &str,
 		builder: RelayInputs,
 	) -> Result<Option<Session>, mcp::Error> {
-		if let Some(s) = self.sessions.read().expect("poisoned").get(id).cloned() {
-			return Ok(Some(s.with_inputs(builder)));
+		if let Some(s) = self.sessions.write().expect("poisoned").get_mut(id) {
+			s.last_access = Instant::now();
+			return Ok(Some(s.session.clone().with_inputs(builder)));
 		}
+		let idle_ttl = builder.backend.session_idle_ttl;
 		let d = http::sessionpersistence::SessionState::decode(id, &self.encoder)
 			.map_err(|_| mcp::Error::InvalidSessionIdHeader)?;
 		let http::sessionpersistence::SessionState::MCP(state) = d else {
@@ -562,7 +574,14 @@ impl SessionManager {
 			encoder: self.encoder.clone(),
 		};
 		let mut sm = self.sessions.write().expect("write lock");
-		sm.insert(id.to_string(), sess.clone());
+		sm.insert(
+			id.to_string(),
+			SessionEntry {
+				session: sess.clone(),
+				last_access: Instant::now(),
+				idle_ttl,
+			},
+		);
 		Ok(Some(sess))
 	}
 
@@ -579,9 +598,16 @@ impl SessionManager {
 		}
 	}
 
-	pub fn insert_session(&self, sess: Session) {
+	pub fn insert_session(&self, sess: Session, idle_ttl: Duration) {
 		let mut sm = self.sessions.write().expect("write lock");
-		sm.insert(sess.id.to_string(), sess);
+		sm.insert(
+			sess.id.to_string(),
+			SessionEntry {
+				session: sess,
+				last_access: Instant::now(),
+				idle_ttl,
+			},
+		);
 	}
 
 	/// create_stateless_session creates a session for stateless mode.
@@ -600,7 +626,11 @@ impl SessionManager {
 
 	/// create_legacy_session establishes a legacy SSE session.
 	/// These will have the ability to send messages to them via a channel.
-	pub fn create_legacy_session(&self, relay: Relay) -> (Session, Receiver<ServerJsonRpcMessage>) {
+	pub fn create_legacy_session(
+		&self,
+		relay: Relay,
+		idle_ttl: Duration,
+	) -> (Session, Receiver<ServerJsonRpcMessage>) {
 		let (tx, rx) = tokio::sync::mpsc::channel(64);
 		let id = session_id();
 		let sess = Session {
@@ -610,17 +640,52 @@ impl SessionManager {
 			encoder: self.encoder.clone(),
 		};
 		let mut sm = self.sessions.write().expect("write lock");
-		sm.insert(id.to_string(), sess.clone());
+		sm.insert(
+			id.to_string(),
+			SessionEntry {
+				session: sess.clone(),
+				last_access: Instant::now(),
+				idle_ttl,
+			},
+		);
 		(sess, rx)
 	}
 
 	pub async fn delete_session(&self, id: &str, parts: Parts) -> Option<Response> {
 		let sess = {
 			let mut sm = self.sessions.write().expect("write lock");
-			sm.remove(id)?
+			sm.remove(id)?.session
 		};
 		// Swallow the error
 		sess.delete_session(parts).await.ok()
+	}
+}
+
+impl Drop for SessionManager {
+	fn drop(&mut self) {
+		if let Some(abort) = self.idle_reaper.take() {
+			abort.abort();
+		}
+	}
+}
+
+async fn run_idle_reaper(sessions: Arc<RwLock<HashMap<String, SessionEntry>>>) {
+	let mut ticker = tokio::time::interval(SESSION_REAP_INTERVAL);
+	ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+	loop {
+		ticker.tick().await;
+		reap_expired_entries(&sessions);
+	}
+}
+
+fn reap_expired_entries(sessions: &Arc<RwLock<HashMap<String, SessionEntry>>>) {
+	let now = Instant::now();
+	let mut guard = sessions.write().expect("write lock");
+	let pre = guard.len();
+	guard.retain(|_, entry| now.duration_since(entry.last_access) < entry.idle_ttl);
+	let post = guard.len();
+	if post < pre {
+		tracing::debug!("reaped {} sessions", pre - post);
 	}
 }
 

--- a/crates/agentgateway/src/mcp/session.rs
+++ b/crates/agentgateway/src/mcp/session.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 use std::convert::Infallible;
-use std::sync::Arc;
-use std::sync::Mutex as StdMutex;
+use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
 
 use ::http::StatusCode;
@@ -521,7 +520,7 @@ impl Session {
 pub struct SessionManager {
 	encoder: http::sessionpersistence::Encoder,
 	sessions: Arc<RwLock<HashMap<String, SessionEntry>>>,
-	idle_reaper: Option<tokio::task::AbortHandle>,
+	idle_reaper: OnceLock<tokio::task::AbortHandle>,
 }
 
 fn session_id() -> Arc<str> {
@@ -530,13 +529,17 @@ fn session_id() -> Arc<str> {
 
 impl SessionManager {
 	pub fn new(encoder: http::sessionpersistence::Encoder) -> Arc<Self> {
-		let sessions = Arc::new(RwLock::new(HashMap::new()));
-		let task = tokio::spawn(run_idle_reaper(sessions.clone()));
 		Arc::new(Self {
 			encoder,
-			sessions,
-			idle_reaper: Some(task.abort_handle()),
+			sessions: Arc::new(RwLock::new(HashMap::new())),
+			idle_reaper: OnceLock::new(),
 		})
+	}
+
+	pub fn ensure_idle_running(&self) {
+		self
+			.idle_reaper
+			.get_or_init(|| tokio::spawn(run_idle_reaper(self.sessions.clone())).abort_handle());
 	}
 
 	pub fn get_session(&self, id: &str, builder: RelayInputs) -> Option<Session> {

--- a/crates/agentgateway/src/mcp/sse.rs
+++ b/crates/agentgateway/src/mcp/sse.rs
@@ -90,11 +90,12 @@ impl LegacySSEService {
 		request: Request,
 		inputs: RelayInputs,
 	) -> Result<Response, ProxyError> {
+		let idle_ttl = inputs.backend.session_idle_ttl;
 		let relay = inputs.build_new_connections()?;
 
 		// GET requests establish an SSE stream.
 		// We will return the sessionId, and all future responses will get sent on the rx channel to send to this channel.
-		let (session, rx) = self.session_manager.create_legacy_session(relay);
+		let (session, rx) = self.session_manager.create_legacy_session(relay, idle_ttl);
 		let mut base_url = request
 			.extensions()
 			.get::<filters::OriginalUrl>()

--- a/crates/agentgateway/src/mcp/streamablehttp.rs
+++ b/crates/agentgateway/src/mcp/streamablehttp.rs
@@ -147,6 +147,7 @@ impl StreamableHttpService {
 		{
 			return mcp::Error::MissingSessionHeader.into();
 		}
+		let idle_ttl = inputs.backend.session_idle_ttl;
 		let relay = inputs.build_new_connections()?;
 		let mut session = self.session_manager.create_session(relay);
 		let mut resp = session.send(part, message).await?;
@@ -155,7 +156,7 @@ impl StreamableHttpService {
 			return mcp::Error::InvalidSessionIdHeader.into();
 		};
 		resp.headers_mut().insert(HEADER_SESSION_ID, sid);
-		self.session_manager.insert_session(session);
+		self.session_manager.insert_session(session, idle_ttl);
 		Ok(resp)
 	}
 

--- a/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
@@ -1166,6 +1166,7 @@ async fn test_openapi_from_url() {
 		stateful_mode: McpStatefulMode::Stateful,
 		prefix_mode: None,
 		failure_mode: None,
+		session_idle_ttl: None,
 	});
 
 	// Convert to runtime backends

--- a/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
@@ -1166,12 +1166,13 @@ async fn test_openapi_from_url() {
 		stateful_mode: McpStatefulMode::Stateful,
 		prefix_mode: None,
 		failure_mode: None,
-		session_idle_ttl: None,
 	});
 
 	// Convert to runtime backends
 	let backend_name = ResourceName::new("test-users".into(), "".into());
-	let result = local_backend.as_backends(backend_name, client).await;
+	let result = local_backend
+		.as_backends(backend_name, client, crate::mcp::DEFAULT_SESSION_IDLE_TTL)
+		.await;
 
 	// Verify the conversion succeeded
 	assert!(

--- a/crates/agentgateway/src/test_helpers/proxymock.rs
+++ b/crates/agentgateway/src/test_helpers/proxymock.rs
@@ -531,6 +531,7 @@ impl TestBind {
 				stateful,
 				always_use_prefix: false,
 				failure_mode: FailureMode::FailClosed,
+				session_idle_ttl: crate::mcp::DEFAULT_SESSION_IDLE_TTL,
 			},
 		);
 		{
@@ -579,6 +580,7 @@ impl TestBind {
 				stateful,
 				always_use_prefix: false,
 				failure_mode: FailureMode::FailClosed,
+				session_idle_ttl: crate::mcp::DEFAULT_SESSION_IDLE_TTL,
 			},
 		);
 		{

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -5,7 +5,7 @@ use std::fmt::{Display, Formatter};
 use std::net::{IpAddr, SocketAddr};
 use std::num::NonZeroU16;
 use std::sync::{Arc, RwLock};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::anyhow;
 use hashbrown::Equivalent;
@@ -1248,6 +1248,9 @@ pub struct McpBackend {
 	/// Behavior when one or more MCP targets fail to initialize or fail during fanout.
 	/// Defaults to `failClosed`.
 	pub failure_mode: FailureMode,
+	#[serde(with = "crate::serdes::serde_dur")]
+	#[cfg_attr(feature = "schema", schemars(with = "String"))]
+	pub session_idle_ttl: Duration,
 }
 
 impl McpBackend {

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -961,6 +961,7 @@ impl TryFrom<&proto::agent::Backend> for BackendWithPolicies {
 						proto::agent::mcp_backend::FailureMode::FailOpen => FailureMode::FailOpen,
 						proto::agent::mcp_backend::FailureMode::FailClosed => FailureMode::FailClosed,
 					},
+					session_idle_ttl: crate::mcp::DEFAULT_SESSION_IDLE_TTL,
 				},
 			),
 			None => {

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -727,6 +727,7 @@ impl LocalBackend {
 		&self,
 		name: ResourceName,
 		client: client::Client,
+		mcp_session_ttl: Duration,
 	) -> anyhow::Result<Vec<BackendWithPolicies>> {
 		Ok(match self {
 			LocalBackend::Service { .. } => vec![], // These stay as references
@@ -800,9 +801,7 @@ impl LocalBackend {
 						McpPrefixMode::Conditional => false,
 					}),
 					failure_mode: tgt.failure_mode.unwrap_or_default(),
-					session_idle_ttl: tgt
-						.session_idle_ttl
-						.unwrap_or(crate::mcp::DEFAULT_SESSION_IDLE_TTL),
+					session_idle_ttl: mcp_session_ttl,
 				};
 				backends.push(Backend::MCP(name, m).into());
 				backends
@@ -874,13 +873,6 @@ pub struct LocalMcpBackend {
 	/// Defaults to `failClosed`.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub failure_mode: Option<FailureMode>,
-	#[serde(
-		default,
-		skip_serializing_if = "Option::is_none",
-		with = "crate::serdes::serde_dur_option"
-	)]
-	#[cfg_attr(feature = "schema", schemars(with = "Option<String>"))]
-	pub session_idle_ttl: Option<Duration>,
 }
 
 #[apply(schema_de!)]
@@ -1578,7 +1570,9 @@ async fn convert(
 			.unwrap_or_default();
 		let name = local_name(b.name);
 		let lb: LocalBackend = b.spec.into();
-		let mut bws = lb.as_backends(name.clone(), client.clone()).await?;
+		let mut bws = lb
+			.as_backends(name.clone(), client.clone(), config.mcp.session_ttl)
+			.await?;
 
 		// as_backends may expand a single LocalBackend into multiple Backends (e.g. MCP)
 		// attach the policies to the "main" one
@@ -2257,7 +2251,11 @@ async fn convert_mcp_config(
 	};
 
 	let backends = LocalBackend::MCP(backend)
-		.as_backends(local_name(strng::new("mcp")), client)
+		.as_backends(
+			local_name(strng::new("mcp")),
+			client,
+			config.mcp.session_ttl,
+		)
 		.await?;
 
 	Ok((bind, vec![], backends))
@@ -2455,7 +2453,7 @@ pub async fn convert_route(
 		};
 		let backends = b
 			.backend
-			.as_backends(be_name.clone(), client.clone())
+			.as_backends(be_name.clone(), client.clone(), config.mcp.session_ttl)
 			.await?;
 		let bref = RouteBackendReference {
 			weight: b.weight,

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::path::PathBuf;
 use std::sync::{Arc, OnceLock};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use crate::agentcore;
 use crate::client::Client;
@@ -800,6 +800,9 @@ impl LocalBackend {
 						McpPrefixMode::Conditional => false,
 					}),
 					failure_mode: tgt.failure_mode.unwrap_or_default(),
+					session_idle_ttl: tgt
+						.session_idle_ttl
+						.unwrap_or(crate::mcp::DEFAULT_SESSION_IDLE_TTL),
 				};
 				backends.push(Backend::MCP(name, m).into());
 				backends
@@ -871,6 +874,13 @@ pub struct LocalMcpBackend {
 	/// Defaults to `failClosed`.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub failure_mode: Option<FailureMode>,
+	#[serde(
+		default,
+		skip_serializing_if = "Option::is_none",
+		with = "crate::serdes::serde_dur_option"
+	)]
+	#[cfg_attr(feature = "schema", schemars(with = "Option<String>"))]
+	pub session_idle_ttl: Option<Duration>,
 }
 
 #[apply(schema_de!)]

--- a/crates/agentgateway/src/types/local_tests.rs
+++ b/crates/agentgateway/src/types/local_tests.rs
@@ -112,7 +112,7 @@ async fn test_config_parsing(test_name: &str) {
 
 	// Create a test client. Ideally we could have a fake one
 	let client = test_client();
-	let config = crate::config::parse_config("{}".to_string(), None).unwrap();
+	let config = crate::config::parse_config(yaml_str.clone(), None).unwrap();
 
 	let normalized = NormalizedLocalConfig::from(
 		&config,

--- a/crates/agentgateway/src/types/local_tests/basic_config.yaml
+++ b/crates/agentgateway/src/types/local_tests/basic_config.yaml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=../../schema/local.json
+config:
+  mcp:
+    sessionTtl: 8m
 frontendPolicies:
   accessLog:
     add:

--- a/crates/agentgateway/src/types/local_tests/basic_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/basic_normalized.snap
@@ -65,7 +65,7 @@ backends:
           stateful: true
           alwaysUsePrefix: false
           failureMode: failClosed
-          sessionIdleTtl: 30m0s
+          sessionIdleTtl: 8m0s
 route_groups: []
 workloads: []
 services: []

--- a/crates/agentgateway/src/types/local_tests/basic_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/basic_normalized.snap
@@ -65,6 +65,7 @@ backends:
           stateful: true
           alwaysUsePrefix: false
           failureMode: failClosed
+          sessionIdleTtl: 30m0s
 route_groups: []
 workloads: []
 services: []

--- a/crates/agentgateway/src/types/local_tests/health_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/health_normalized.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/agentgateway/src/types/local_tests.rs
-assertion_line: 48
-description: "Config normalization test for eviction: YAML -> LocalConfig -> NormalizedLocalConfig -> YAML"
+description: "Config normalization test for health: YAML -> LocalConfig -> NormalizedLocalConfig -> YAML"
 ---
 binds:
   - key: bind/3000
@@ -49,6 +48,7 @@ backends:
           stateful: true
           alwaysUsePrefix: false
           failureMode: failClosed
+          sessionIdleTtl: 30m0s
 route_groups: []
 workloads: []
 services: []

--- a/crates/agentgateway/src/types/local_tests/mcp_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/mcp_normalized.snap
@@ -70,6 +70,7 @@ backends:
           stateful: true
           alwaysUsePrefix: false
           failureMode: failClosed
+          sessionIdleTtl: 30m0s
 route_groups: []
 workloads: []
 services: []

--- a/crates/agentgateway/src/types/local_tests/mcp_simple_config.yaml
+++ b/crates/agentgateway/src/types/local_tests/mcp_simple_config.yaml
@@ -1,3 +1,6 @@
+config:
+  mcp:
+    sessionTtl: 45m
 mcp:
   targets:
   - name: time

--- a/crates/agentgateway/src/types/local_tests/mcp_simple_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/mcp_simple_normalized.snap
@@ -48,6 +48,7 @@ backends:
           stateful: true
           alwaysUsePrefix: false
           failureMode: failClosed
+          sessionIdleTtl: 30m0s
 route_groups: []
 workloads: []
 services: []

--- a/crates/agentgateway/src/types/local_tests/mcp_simple_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/mcp_simple_normalized.snap
@@ -48,7 +48,7 @@ backends:
           stateful: true
           alwaysUsePrefix: false
           failureMode: failClosed
-          sessionIdleTtl: 30m0s
+          sessionIdleTtl: 45m0s
 route_groups: []
 workloads: []
 services: []

--- a/crates/agentgateway/src/types/local_tests/mcp_to_aws_backend_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/mcp_to_aws_backend_normalized.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/agentgateway/src/types/local_tests.rs
-assertion_line: 137
 description: "Config normalization test for mcp_to_aws_backend: YAML -> LocalConfig -> NormalizedLocalConfig -> YAML"
 ---
 binds:
@@ -44,6 +43,7 @@ backends:
           stateful: true
           alwaysUsePrefix: false
           failureMode: failClosed
+          sessionIdleTtl: 30m0s
   - backend:
       aws:
         name: aws-agent-core-mcp-target

--- a/crates/agentgateway/src/types/local_tests/named_mcp_backend_config.yaml
+++ b/crates/agentgateway/src/types/local_tests/named_mcp_backend_config.yaml
@@ -1,5 +1,8 @@
 # yaml-language-server: $schema=../../schema/local.json
 # Top-level named MCP backend referenced by a route via its key.
+config:
+  mcp:
+    sessionTtl: 12m
 binds:
 - port: 3000
   listeners:

--- a/crates/agentgateway/src/types/local_tests/named_mcp_backend_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/named_mcp_backend_normalized.snap
@@ -43,7 +43,7 @@ backends:
           stateful: true
           alwaysUsePrefix: false
           failureMode: failClosed
-          sessionIdleTtl: 30m0s
+          sessionIdleTtl: 12m0s
 route_groups: []
 workloads: []
 services: []

--- a/crates/agentgateway/src/types/local_tests/named_mcp_backend_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/named_mcp_backend_normalized.snap
@@ -43,6 +43,7 @@ backends:
           stateful: true
           alwaysUsePrefix: false
           failureMode: failClosed
+          sessionIdleTtl: 30m0s
 route_groups: []
 workloads: []
 services: []

--- a/schema/config.json
+++ b/schema/config.json
@@ -4219,6 +4219,12 @@
               "type": "null"
             }
           ]
+        },
+        "sessionIdleTtl": {
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "additionalProperties": false,
@@ -6578,6 +6584,12 @@
             {
               "type": "null"
             }
+          ]
+        },
+        "sessionIdleTtl": {
+          "type": [
+            "string",
+            "null"
           ]
         },
         "policies": {

--- a/schema/config.json
+++ b/schema/config.json
@@ -197,6 +197,17 @@
             }
           ]
         },
+        "mcp": {
+          "description": "MCP gateway settings.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RawMcpConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "connectionTerminationDeadline": {
           "type": [
             "string",
@@ -340,6 +351,19 @@
       "required": [
         "key"
       ]
+    },
+    "RawMcpConfig": {
+      "type": "object",
+      "properties": {
+        "sessionTtl": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        }
+      },
+      "additionalProperties": false
     },
     "RawTracing": {
       "type": "object",
@@ -4219,12 +4243,6 @@
               "type": "null"
             }
           ]
-        },
-        "sessionIdleTtl": {
-          "type": [
-            "string",
-            "null"
-          ]
         }
       },
       "additionalProperties": false,
@@ -6584,12 +6602,6 @@
             {
               "type": "null"
             }
-          ]
-        },
-        "sessionIdleTtl": {
-          "type": [
-            "string",
-            "null"
           ]
         },
         "policies": {

--- a/schema/config.md
+++ b/schema/config.md
@@ -25,6 +25,8 @@
 |`config.readinessAddr`|string|Readiness probe server address in the format "ip:port"|
 |`config.session`|object|Configuration for stateful session management|
 |`config.session.key`|string|The AES-256-GCM session protection key to be used for session tokens.<br>If not set, sessions will not be encrypted.<br>For example, generated via `openssl rand -hex 32`.|
+|`config.mcp`|object|MCP gateway settings.|
+|`config.mcp.sessionTtl`|string||
 |`config.connectionTerminationDeadline`|string||
 |`config.connectionMinTerminationDeadline`|string||
 |`config.workerThreads`|string||
@@ -1306,7 +1308,6 @@
 |`binds[].listeners[].routes[].backends[].mcp.statefulMode`|string||
 |`binds[].listeners[].routes[].backends[].mcp.prefixMode`|string||
 |`binds[].listeners[].routes[].backends[].mcp.failureMode`|string|Behavior when one or more MCP targets fail to initialize or fail during fanout.<br>Defaults to `failClosed`.|
-|`binds[].listeners[].routes[].backends[].mcp.sessionIdleTtl`|string||
 |`binds[].listeners[].routes[].backends[].ai`|object||
 |`binds[].listeners[].routes[].backends[].ai.name`|string||
 |`binds[].listeners[].routes[].backends[].ai.provider`|object|Exactly one of openAI, gemini, vertex, anthropic, bedrock, or azure may be set.|
@@ -12078,7 +12079,6 @@
 |`mcp.statefulMode`|string||
 |`mcp.prefixMode`|string||
 |`mcp.failureMode`|string|Behavior when one or more MCP targets fail to initialize or fail during fanout.<br>Defaults to `failClosed`.|
-|`mcp.sessionIdleTtl`|string||
 |`mcp.policies`|object||
 |`mcp.policies.requestHeaderModifier`|object|Headers to be modified in the request.|
 |`mcp.policies.requestHeaderModifier.add`|object||

--- a/schema/config.md
+++ b/schema/config.md
@@ -1306,6 +1306,7 @@
 |`binds[].listeners[].routes[].backends[].mcp.statefulMode`|string||
 |`binds[].listeners[].routes[].backends[].mcp.prefixMode`|string||
 |`binds[].listeners[].routes[].backends[].mcp.failureMode`|string|Behavior when one or more MCP targets fail to initialize or fail during fanout.<br>Defaults to `failClosed`.|
+|`binds[].listeners[].routes[].backends[].mcp.sessionIdleTtl`|string||
 |`binds[].listeners[].routes[].backends[].ai`|object||
 |`binds[].listeners[].routes[].backends[].ai.name`|string||
 |`binds[].listeners[].routes[].backends[].ai.provider`|object|Exactly one of openAI, gemini, vertex, anthropic, bedrock, or azure may be set.|
@@ -12077,6 +12078,7 @@
 |`mcp.statefulMode`|string||
 |`mcp.prefixMode`|string||
 |`mcp.failureMode`|string|Behavior when one or more MCP targets fail to initialize or fail during fanout.<br>Defaults to `failClosed`.|
+|`mcp.sessionIdleTtl`|string||
 |`mcp.policies`|object||
 |`mcp.policies.requestHeaderModifier`|object|Headers to be modified in the request.|
 |`mcp.policies.requestHeaderModifier.add`|object||


### PR DESCRIPTION
When a client does not delete a session, it is leaked. With SSE/stdio backend this is even worse: these use real resources.

This adds a TTL to cleanup stale sessions, defaulting to 30min.