### PR TITLE
Build proxy in makefile setup

### DIFF
--- a/controller/Makefile
+++ b/controller/Makefile
@@ -182,6 +182,7 @@ e2e-test: testbox-docker kind-load-testbox
 e2e-test: go-test
 e2e-test: TEST_TAG = e2e
 e2e-test: GO_TEST_ARGS = $(E2E_GO_TEST_ARGS)
+e2e-test: export VERSION := $(VERSION)
 
 
 # https://go.dev/blog/cover#heat-maps

--- a/controller/Makefile
+++ b/controller/Makefile
@@ -423,6 +423,10 @@ agentgateway-controller-docker: agentgateway-controller $(CONTROLLER_OUTPUT_DIR)
 		--build-arg GOARCH=$(GOARCH) \
 		-t $(IMAGE_REGISTRY)/$(AGENTGATEWAY_IMAGE_REPO):$(VERSION)
 
+.PHONY: agentgateway-docker
+agentgateway-docker: ## Build the proxy Docker image from the root Makefile
+	$(MAKE) -C .. docker IMAGE_TAG=$(VERSION)
+
 .PHONY: agentgateway-controller-docker-local
 agentgateway-controller-docker-local: agentgateway-controller $(CONTROLLER_OUTPUT_DIR)/Dockerfile.agentgateway
 	docker buildx build --push $(PLATFORM) $(CONTROLLER_OUTPUT_DIR) -f $(CONTROLLER_OUTPUT_DIR)/Dockerfile.agentgateway \
@@ -632,6 +636,7 @@ kind-reload-%: kind-build-and-load-% kind-set-image-% ; ## Use to build specifie
 
 .PHONY: kind-build-and-load ## Use to build all images and load them into kind
 kind-build-and-load: kind-build-and-load-agentgateway-controller
+kind-build-and-load: kind-build-and-load-agentgateway
 kind-build-and-load: kind-build-and-load-testbox
 
 .PHONY: kind-load ## Use to load all images into kind

--- a/controller/test/e2e/test.go
+++ b/controller/test/e2e/test.go
@@ -187,6 +187,14 @@ func (i *TestInstallation) InstallAgentgatewayCoreFromLocalChart(ctx context.Con
 
 	// Use absolute chart paths so tests work regardless of current working directory.
 	coreChartPath := filepath.Join(fsutils.GetModuleRoot(), "controller", "install", "helm", "agentgateway")
+
+	extraArgs := i.Metadata.ExtraHelmArgs
+	// If VERSION is set, override the chart's AppVersion so locally-built images are used
+	// instead of trying to pull the chart's default appVersion from the remote registry.
+	if tag, ok := os.LookupEnv(testutils.Version); ok && tag != "" {
+		extraArgs = append(extraArgs, "--set-string", "image.tag="+tag)
+	}
+
 	// and then install the main chart
 	err := i.Actions.Helm().WithReceiver(os.Stdout).Upgrade(
 		ctx,
@@ -200,7 +208,7 @@ func (i *TestInstallation) InstallAgentgatewayCoreFromLocalChart(ctx context.Con
 			},
 			ReleaseName: helmutils.AgentgatewayChartName,
 			Chart:       coreChartPath,
-			ExtraArgs:   i.Metadata.ExtraHelmArgs,
+			ExtraArgs:   extraArgs,
 		})
 	i.AssertionsT(t).Require.NoError(err)
 	i.AssertionsT(t).EventuallyGatewayInstallSucceeded(ctx)

--- a/controller/test/testutils/env.go
+++ b/controller/test/testutils/env.go
@@ -71,6 +71,11 @@ const (
 	// DefaultNamespace is the default namespace to use for resources that don't specify one
 	// Typically "default" for kind/k8s clusters, may differ for OpenShift/CRC
 	DefaultNamespace = "DEFAULT_NAMESPACE"
+
+	// Version is the image tag used for the controller and proxy images.
+	// When set, this overrides the chart's AppVersion, ensuring locally-built
+	// images (loaded via `make setup`) are used instead of pulling from the registry.
+	Version = "VERSION"
 )
 
 // ShouldSkipInstallAndTeardown returns true if kgateway installation and teardown should be skipped.


### PR DESCRIPTION
`make deploy-agentgateway` will now setup the cluster and build + load the proxy. 

Now you can do:
```
VERSION=v1.0.1-dev go test -tags=e2e -v -timeout=25m ./test/e2e/tests/... -run TestAgentgatewayIntegration
```

The old `TEST_MODE=e2e ./controller/test/setup/setup-kind-ci.sh` should work as is. 
