### PR TITLE
llm: synthesize /v1/models from configured models and aliases

### DIFF
--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -385,7 +385,14 @@ impl AIProvider {
 		path_prefix: Option<&str>,
 		has_host_override: bool,
 	) -> anyhow::Result<()> {
-		if matches!(route_type, RouteType::Passthrough | RouteType::Detect) {
+		// `Models` joins `Passthrough`/`Detect` here: providers have no universal
+		// models-endpoint mapping, and the typical client path (`/v1/models`) is
+		// already the upstream's models catalog. Rewriting it via `path_suffix`
+		// would send the client to completions/messages instead.
+		if matches!(
+			route_type,
+			RouteType::Passthrough | RouteType::Detect | RouteType::Models
+		) {
 			return Ok(());
 		}
 

--- a/crates/agentgateway/src/proxy/gateway_test.rs
+++ b/crates/agentgateway/src/proxy/gateway_test.rs
@@ -2348,3 +2348,92 @@ async fn waypoint_tcp_gateway_policy_authz_deny() {
 		.await
 		.expect_err("should be denied by network authorization");
 }
+
+/// `/v1/models` with an explicit provider `model` plus non-wildcard modelAliases
+/// returns a synthetic OpenAI-compatible catalog without contacting upstream.
+#[tokio::test]
+async fn llm_models_synthetic_response() {
+	let mock = simple_mock().await;
+	let (mock, mut bind, io) = setup_llm_mock(
+		mock,
+		AIProvider::OpenAI(openai::Provider {
+			model: Some(strng::new("gpt-4o")),
+		}),
+		false,
+		"{}",
+	);
+	bind
+		.attach_route_policy(json!({
+			"ai": {
+				"routes": {
+					"/v1/models": "models",
+				},
+				"modelAliases": {
+					"smart": "gpt-4o",
+					"gpt-*": "gpt-4o",
+				},
+			}
+		}))
+		.await;
+
+	let res = send_request(io, Method::GET, "http://lo/v1/models").await;
+	assert_eq!(res.status(), 200);
+	assert_eq!(
+		res
+			.headers()
+			.get(header::CONTENT_TYPE)
+			.map(|v| v.to_str().unwrap()),
+		Some("application/json")
+	);
+	let body = read_body_raw(res.into_body()).await;
+	let body: Value = serde_json::from_slice(&body).unwrap();
+	assert_eq!(body["object"], "list");
+	let ids: Vec<&str> = body["data"]
+		.as_array()
+		.unwrap()
+		.iter()
+		.map(|m| m["id"].as_str().unwrap())
+		.collect();
+	// Explicit model + non-wildcard alias, wildcard alias excluded.
+	assert_eq!(ids, vec!["gpt-4o", "smart"]);
+	let owners: Vec<&str> = body["data"]
+		.as_array()
+		.unwrap()
+		.iter()
+		.map(|m| m["owned_by"].as_str().unwrap())
+		.collect();
+	assert!(owners.iter().all(|o| *o == "openai"));
+	// Upstream must not have been contacted.
+	assert!(mock.received_requests().await.unwrap().is_empty());
+}
+
+/// `/v1/models` with no explicit provider model and no aliases falls through
+/// to the upstream's real catalog (path-translating passthrough).
+#[tokio::test]
+async fn llm_models_fallthrough_to_upstream() {
+	let upstream_body =
+		br#"{"object":"list","data":[{"id":"from-upstream","object":"model","owned_by":"openai"}]}"#;
+	let mock = body_mock(upstream_body).await;
+	let (mock, mut bind, io) = setup_llm_mock(
+		mock,
+		AIProvider::OpenAI(openai::Provider { model: None }),
+		false,
+		"{}",
+	);
+	bind
+		.attach_route_policy(json!({
+			"ai": {
+				"routes": {
+					"/v1/models": "models",
+				}
+			}
+		}))
+		.await;
+
+	let res = send_request(io, Method::GET, "http://lo/v1/models").await;
+	assert_eq!(res.status(), 200);
+	let body = read_body_raw(res.into_body()).await;
+	assert_eq!(body.as_ref(), upstream_body);
+	// The upstream should have been contacted exactly once.
+	assert_eq!(mock.received_requests().await.unwrap().len(), 1);
+}

--- a/crates/agentgateway/src/proxy/gateway_test.rs
+++ b/crates/agentgateway/src/proxy/gateway_test.rs
@@ -2,13 +2,14 @@ use std::sync::{Arc, Mutex as StdMutex};
 
 use crate::http::tests_common::*;
 use crate::http::{Body, Response};
-use crate::llm::{AIProvider, openai};
+use crate::llm::{AIProvider, anthropic, openai};
 use crate::proxy::request_builder::RequestBuilder;
 use crate::read_body;
 use crate::test_helpers::proxymock::*;
 use crate::types::agent::{
-	Backend, BackendPolicy, BackendWithPolicies, Bind, BindProtocol, Listener, ListenerProtocol,
-	ListenerSet, PathMatch, ResourceName, Route, RouteMatch, RouteSet, Target,
+	Backend, BackendPolicy, BackendReference, BackendWithPolicies, Bind, BindProtocol, Listener,
+	ListenerProtocol, ListenerSet, PathMatch, ResourceName, Route, RouteBackendReference, RouteMatch,
+	RouteName, RouteSet, Target,
 };
 use crate::types::backend;
 use crate::*;
@@ -2511,6 +2512,109 @@ async fn llm_models_backend_aliases_replace_route_aliases() {
 	// `backend-only` replaces `route-only`; explicit provider model still present.
 	assert_eq!(ids, vec!["backend-only", "gpt-4o"]);
 	assert!(mock.received_requests().await.unwrap().is_empty());
+}
+
+/// Wire two AI backends (OpenAI + Anthropic) on the same route and assert
+/// `/v1/models` aggregates per-backend explicit models plus shared route-level
+/// aliases, dedups by id (first seen wins), attributes `owned_by` correctly,
+/// and never contacts the upstreams.
+#[tokio::test]
+async fn llm_models_multi_backend_aggregation() {
+	let mock_oai = simple_mock().await;
+	let mock_anthro = simple_mock().await;
+
+	let t = setup_proxy_test("{}").unwrap();
+	for (mock, provider) in [
+		(
+			&mock_oai,
+			AIProvider::OpenAI(openai::Provider {
+				model: Some(strng::new("gpt-4o")),
+			}),
+		),
+		(
+			&mock_anthro,
+			AIProvider::Anthropic(anthropic::Provider {
+				model: Some(strng::new("claude-3-opus")),
+			}),
+		),
+	] {
+		let be =
+			crate::types::local::LocalAIBackend::Provider(llm_named_provider(mock, provider, false))
+				.translate()
+				.unwrap();
+		let b = Backend::AI(
+			ResourceName::new(strng::format!("{}", mock.address()), "".into()),
+			be,
+		);
+		t.pi.stores.binds.write().insert_backend(b.name(), b.into());
+	}
+
+	let route = Route {
+		key: "route".into(),
+		service_key: None,
+		name: RouteName {
+			name: "route".into(),
+			namespace: Default::default(),
+			rule_name: None,
+			kind: None,
+		},
+		hostnames: Default::default(),
+		matches: vec![RouteMatch {
+			headers: vec![],
+			path: PathMatch::PathPrefix("/".into()),
+			method: None,
+			query: vec![],
+		}],
+		inline_policies: Default::default(),
+		backends: vec![
+			RouteBackendReference {
+				weight: 1,
+				backend: BackendReference::Backend(strng::format!("/{}", mock_oai.address())),
+				inline_policies: Default::default(),
+			},
+			RouteBackendReference {
+				weight: 1,
+				backend: BackendReference::Backend(strng::format!("/{}", mock_anthro.address())),
+				inline_policies: Default::default(),
+			},
+		],
+	};
+	let mut t = t.with_bind(simple_bind(route));
+	t.attach_route_policy(json!({
+		"ai": {
+			"routes": { "/v1/models": "models" },
+			"modelAliases": { "smart": "gpt-4o" },
+		}
+	}))
+	.await;
+	let io = t.serve_http(BIND_KEY);
+
+	let res = send_request(io, Method::GET, "http://lo/v1/models").await;
+	assert_eq!(res.status(), 200);
+	let body = read_body_raw(res.into_body()).await;
+	let body: Value = serde_json::from_slice(&body).unwrap();
+
+	let entries: Vec<(&str, &str)> = body["data"]
+		.as_array()
+		.unwrap()
+		.iter()
+		.map(|m| (m["id"].as_str().unwrap(), m["owned_by"].as_str().unwrap()))
+		.collect();
+
+	// BTreeMap yields ids in sorted order. Explicit provider models keep their
+	// own owner; the shared alias `smart` is inserted once and attributed to
+	// the first backend that saw it (OpenAI — listed first on the route).
+	assert_eq!(
+		entries,
+		vec![
+			("claude-3-opus", "anthropic"),
+			("gpt-4o", "openai"),
+			("smart", "openai"),
+		]
+	);
+
+	assert!(mock_oai.received_requests().await.unwrap().is_empty());
+	assert!(mock_anthro.received_requests().await.unwrap().is_empty());
 }
 
 /// `/v1/models` with no explicit provider model and no aliases falls through

--- a/crates/agentgateway/src/proxy/gateway_test.rs
+++ b/crates/agentgateway/src/proxy/gateway_test.rs
@@ -2644,6 +2644,10 @@ async fn llm_models_fallthrough_to_upstream() {
 	assert_eq!(res.status(), 200);
 	let body = read_body_raw(res.into_body()).await;
 	assert_eq!(body.as_ref(), upstream_body);
-	// The upstream should have been contacted exactly once.
-	assert_eq!(mock.received_requests().await.unwrap().len(), 1);
+	// Exactly one upstream hit, and the path must be preserved — a regression
+	// that rewrites to `/v1/chat/completions` would otherwise pass since the
+	// mock matches any path.
+	let requests = mock.received_requests().await.unwrap();
+	assert_eq!(requests.len(), 1);
+	assert_eq!(requests[0].url.path(), "/v1/models");
 }

--- a/crates/agentgateway/src/proxy/gateway_test.rs
+++ b/crates/agentgateway/src/proxy/gateway_test.rs
@@ -2407,6 +2407,112 @@ async fn llm_models_synthetic_response() {
 	assert!(mock.received_requests().await.unwrap().is_empty());
 }
 
+/// Attach a backend-level `ai` policy at `addr` (mirrors
+/// `AgentgatewayBackend.spec.policies.ai` in K8s mode).
+fn attach_backend_ai(bind: &mut TestBind, addr: &std::net::SocketAddr, p: serde_json::Value) {
+	let mut policy: crate::llm::Policy = serde_json::from_value(p).unwrap();
+	policy.compile_model_alias_patterns();
+	let key = strng::format!("backend-ai/{}", addr);
+	bind.with_policy(crate::types::agent::TargetedPolicy {
+		key,
+		name: None,
+		target: crate::types::agent::PolicyTarget::Backend(
+			crate::types::agent::BackendTarget::Backend {
+				name: addr.to_string().into(),
+				namespace: Default::default(),
+				section: None,
+			},
+		),
+		policy: BackendPolicy::AI(Arc::new(policy)).into(),
+	});
+}
+
+/// `/v1/models` triggers synthesis from a backend-level `ai` policy with
+/// no route-level `ai` policy — exercises `AgentgatewayBackend.spec.policies.ai`.
+#[tokio::test]
+async fn llm_models_backend_level_policy() {
+	let mock = simple_mock().await;
+	let (mock, mut bind, io) = setup_llm_mock(
+		mock,
+		AIProvider::OpenAI(openai::Provider {
+			model: Some(strng::new("gpt-4o")),
+		}),
+		false,
+		"{}",
+	);
+	let addr = *mock.address();
+	attach_backend_ai(
+		&mut bind,
+		&addr,
+		json!({
+			"routes": { "/v1/models": "models" },
+			"modelAliases": {
+				"smart": "gpt-4o",
+				"gpt-*": "gpt-4o",
+			},
+		}),
+	);
+
+	let res = send_request(io, Method::GET, "http://lo/v1/models").await;
+	assert_eq!(res.status(), 200);
+	let body = read_body_raw(res.into_body()).await;
+	let body: Value = serde_json::from_slice(&body).unwrap();
+	let ids: Vec<&str> = body["data"]
+		.as_array()
+		.unwrap()
+		.iter()
+		.map(|m| m["id"].as_str().unwrap())
+		.collect();
+	assert_eq!(ids, vec!["gpt-4o", "smart"]);
+	assert!(mock.received_requests().await.unwrap().is_empty());
+}
+
+/// When a backend defines `modelAliases`, the runtime merge replaces the
+/// route-level aliases entirely. The synthetic response must mirror this
+/// so we don't advertise aliases the merged policy would not accept.
+#[tokio::test]
+async fn llm_models_backend_aliases_replace_route_aliases() {
+	let mock = simple_mock().await;
+	let (mock, mut bind, io) = setup_llm_mock(
+		mock,
+		AIProvider::OpenAI(openai::Provider {
+			model: Some(strng::new("gpt-4o")),
+		}),
+		false,
+		"{}",
+	);
+	let addr = *mock.address();
+	bind
+		.attach_route_policy(json!({
+			"ai": {
+				"routes": { "/v1/models": "models" },
+				"modelAliases": { "route-only": "gpt-4o" },
+			}
+		}))
+		.await;
+	attach_backend_ai(
+		&mut bind,
+		&addr,
+		json!({
+			"modelAliases": { "backend-only": "gpt-4o" },
+		}),
+	);
+
+	let res = send_request(io, Method::GET, "http://lo/v1/models").await;
+	assert_eq!(res.status(), 200);
+	let body = read_body_raw(res.into_body()).await;
+	let body: Value = serde_json::from_slice(&body).unwrap();
+	let ids: Vec<&str> = body["data"]
+		.as_array()
+		.unwrap()
+		.iter()
+		.map(|m| m["id"].as_str().unwrap())
+		.collect();
+	// `backend-only` replaces `route-only`; explicit provider model still present.
+	assert_eq!(ids, vec!["backend-only", "gpt-4o"]);
+	assert!(mock.received_requests().await.unwrap().is_empty());
+}
+
 /// `/v1/models` with no explicit provider model and no aliases falls through
 /// to the upstream's real catalog (path-translating passthrough).
 #[tokio::test]

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -654,6 +654,71 @@ impl HTTPProxy {
 		)
 		.await
 		.snapshot_on_err(log, &mut req)?;
+
+		// If the route resolves to Models and the gateway has explicit knowledge of
+		// which models are available (via explicit provider `model` fields or route-level
+		// aliases), return a synthetic response scoped to this route's backends.
+		// If no explicit knowledge exists, fall through and forward to upstream so the
+		// client gets the provider's real catalog.
+		if let Some(RouteType::Models) = route_policies
+			.llm
+			.as_ref()
+			.map(|p| p.resolve_route(req.uri().path()))
+		{
+			let mut models: std::collections::BTreeSet<(Strng, Strng)> =
+				std::collections::BTreeSet::new();
+			let mut fallback_owner: Option<Strng> = None;
+
+			for backend_ref in &selected_route.backends {
+				if let Ok(resolved) = resolve_backend(backend_ref.clone(), self.inputs.as_ref())
+					&& let Backend::AI(_, ai_backend) = &resolved.backend.backend
+				{
+					for (provider, _info) in ai_backend.providers.iter().iter() {
+						let owner = provider.provider.provider();
+						fallback_owner.get_or_insert_with(|| owner.clone());
+						if let Some(m) = provider.provider.override_model() {
+							models.insert((m, owner));
+						}
+					}
+				}
+			}
+
+			if let Some(policy) = route_policies.llm.as_ref() {
+				let owner = fallback_owner
+					.clone()
+					.unwrap_or_else(|| strng::literal!("openai"));
+				for alias in policy.model_aliases.keys() {
+					if !alias.contains('*') {
+						models.insert((alias.clone(), owner.clone()));
+					}
+				}
+			}
+
+			if !models.is_empty() {
+				let data: Vec<_> = models
+					.iter()
+					.map(|(id, owned_by)| {
+						serde_json::json!({
+							"id": id,
+							"object": "model",
+							"created": 0,
+							"owned_by": owned_by,
+						})
+					})
+					.collect();
+				let body = serde_json::json!({ "object": "list", "data": data });
+
+				return Ok(
+					::http::Response::builder()
+						.status(::http::StatusCode::OK)
+						.header(::http::header::CONTENT_TYPE, "application/json")
+						.body(http::Body::from(body.to_string()))
+						.expect("Failed to build models response"),
+				);
+			}
+			// Fall through: no explicit models or aliases configured, forward upstream.
+		}
+
 		let selected_backend = select_backend(selected_route.as_ref(), &req)
 			.ok_or(ProxyError::NoValidBackends)
 			.snapshot_on_err(log, &mut req)?;
@@ -1589,15 +1654,21 @@ async fn make_backend_call(
 					(req, response_policies, Some(llm_request))
 				},
 				RouteType::Models => {
-					return Ok(
-						::http::Response::builder()
-							.status(::http::StatusCode::NOT_IMPLEMENTED)
-							.header(::http::header::CONTENT_TYPE, "application/json")
-							.body(http::Body::from(format!(
-								"{{\"error\":\"Route '{route_type:?}' not implemented\"}}"
-							)))
-							.expect("Failed to build response"),
-					);
+					// Reached only when no explicit models/aliases were configured and the
+					// synthetic handler in proxy() fell through. Behave like a path-translating
+					// passthrough so the client receives the upstream's real model catalog.
+					llm
+						.provider
+						.setup_request(
+							&mut req,
+							route_type,
+							None,
+							llm.path_override.as_deref(),
+							llm.path_prefix.as_deref(),
+							llm.host_override.is_some(),
+						)
+						.map_err(ProxyError::Processing)?;
+					(req, LLMResponsePolicies::default(), None)
 				},
 				RouteType::Passthrough | RouteType::Realtime => {
 					// For passthrough, we only need to setup the response so we get default TLS, hostname, etc set.

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -658,91 +658,96 @@ impl HTTPProxy {
 		// If the route resolves to Models and the gateway has explicit knowledge of
 		// which models are available (via explicit provider `model` fields or
 		// modelAliases on either the route or its backends), return a synthetic
-		// response scoped to this route's backends.
-		// If no explicit knowledge exists, fall through and forward to upstream so the
-		// client gets the provider's real catalog.
+		// response scoped to this route's backends. If no explicit knowledge exists,
+		// fall through and forward to upstream so the client gets the provider's
+		// real catalog.
 		//
-		// Resolving the route type requires inspecting each backend's resolved LLM
-		// policy because `routes` and `modelAliases` are backend-phase config
-		// (`AgentgatewayBackend.spec.policies.ai`) and aren't merged into route-level
-		// policies until after backend selection.
+		// Detection and alias collection mirror runtime semantics: for each backend
+		// we compute the effective LLM policy via `merge_backend_policies` (backend
+		// `routes`/`modelAliases` replace route-level ones when non-empty), then
+		// decide whether that backend would resolve the path to `RouteType::Models`
+		// and which aliases would actually be accepted. This ensures we never
+		// advertise an id that no backend-merged policy would honor.
 		{
 			let path = req.uri().path();
-			let mut llm_policies: Vec<Arc<llm::Policy>> = Vec::new();
-			if let Some(p) = route_policies.llm.as_ref() {
-				llm_policies.push(p.clone());
-			}
+			let base: Arc<LLMRequestPolicies> = Arc::new(LLMRequestPolicies {
+				llm: route_policies.llm.clone(),
+				..Default::default()
+			});
 
 			// Dedup by model id; first seen (owner, explicit vs alias) wins.
 			let mut models: std::collections::BTreeMap<Strng, Strng> = std::collections::BTreeMap::new();
-			let mut fallback_owner: Option<Strng> = None;
+			let mut is_models_route = false;
 
 			for backend_ref in &selected_route.backends {
-				if let Ok(resolved) = resolve_backend(backend_ref.clone(), self.inputs.as_ref()) {
-					let backend_policies = get_backend_policies(
-						self.inputs.as_ref(),
-						&resolved.backend,
-						&resolved.inline_policies,
-						Some(route_path.clone()),
-					);
-					if let Some(p) = backend_policies.llm {
-						llm_policies.push(p);
-					}
-					if let Backend::AI(_, ai_backend) = &resolved.backend.backend {
-						for (provider, _info) in ai_backend.providers.iter().iter() {
-							let owner = provider.provider.provider();
-							fallback_owner.get_or_insert_with(|| owner.clone());
-							if let Some(m) = provider.provider.override_model() {
-								models.entry(m).or_insert(owner);
-							}
+				let Ok(resolved) = resolve_backend(backend_ref.clone(), self.inputs.as_ref()) else {
+					continue;
+				};
+				let backend_policies = get_backend_policies(
+					self.inputs.as_ref(),
+					&resolved.backend,
+					&resolved.inline_policies,
+					Some(route_path.clone()),
+				);
+				let effective = Arc::clone(&base).merge_backend_policies(backend_policies.llm.clone());
+				let Some(policy) = effective.llm.as_ref() else {
+					continue;
+				};
+				if policy.resolve_route(path) != RouteType::Models {
+					continue;
+				}
+				is_models_route = true;
+
+				// Explicit provider model(s) for this backend, and the owner used
+				// both for that id and for any aliases merged onto this backend.
+				let mut alias_owner: Option<Strng> = None;
+				if let Backend::AI(_, ai_backend) = &resolved.backend.backend {
+					for (provider, _info) in ai_backend.providers.iter().iter() {
+						let owner = provider.provider.provider();
+						alias_owner.get_or_insert_with(|| owner.clone());
+						if let Some(m) = provider.provider.override_model() {
+							models.entry(m).or_insert_with(|| owner.clone());
 						}
+					}
+				}
+				let alias_owner = alias_owner.unwrap_or_else(|| strng::literal!("openai"));
+
+				// Aliases come from the effective (merged) policy so backend-defined
+				// aliases correctly replace route-level aliases when present.
+				for alias in policy.model_aliases.keys() {
+					if !alias.contains('*') {
+						models
+							.entry(alias.clone())
+							.or_insert_with(|| alias_owner.clone());
 					}
 				}
 			}
 
-			let is_models_route = llm_policies
-				.iter()
-				.any(|p| p.resolve_route(path) == RouteType::Models);
-
-			if is_models_route {
-				let alias_owner = fallback_owner
-					.clone()
-					.unwrap_or_else(|| strng::literal!("openai"));
-				for policy in &llm_policies {
-					for alias in policy.model_aliases.keys() {
-						if !alias.contains('*') {
-							models
-								.entry(alias.clone())
-								.or_insert_with(|| alias_owner.clone());
-						}
-					}
-				}
-
-				if !models.is_empty() {
-					let data: Vec<_> = models
-						.iter()
-						.map(|(id, owned_by)| {
-							serde_json::json!({
-								"id": id,
-								"object": "model",
-								"created": 0,
-								"owned_by": owned_by,
-							})
+			if is_models_route && !models.is_empty() {
+				let data: Vec<_> = models
+					.iter()
+					.map(|(id, owned_by)| {
+						serde_json::json!({
+							"id": id,
+							"object": "model",
+							"created": 0,
+							"owned_by": owned_by,
 						})
-						.collect();
-					let body = serde_json::json!({ "object": "list", "data": data });
+					})
+					.collect();
+				let body = serde_json::json!({ "object": "list", "data": data });
 
-					let mut response = ::http::Response::new(http::Body::from(body.to_string()));
-					*response.status_mut() = ::http::StatusCode::OK;
-					response.headers_mut().insert(
-						::http::header::CONTENT_TYPE,
-						::http::HeaderValue::from_static("application/json"),
-					);
-					return Err::<Response, _>(ProxyResponse::DirectResponse(Box::new(response)))
-						.snapshot_on_err(log, &mut req);
-				}
-				// Fall through: Models route but nothing explicit to advertise, forward upstream.
+				let mut response = ::http::Response::new(http::Body::from(body.to_string()));
+				*response.status_mut() = ::http::StatusCode::OK;
+				response.headers_mut().insert(
+					::http::header::CONTENT_TYPE,
+					::http::HeaderValue::from_static("application/json"),
+				);
+				return Err::<Response, _>(ProxyResponse::DirectResponse(Box::new(response)))
+					.snapshot_on_err(log, &mut req);
 			}
+			// Fall through: either no backend resolves to Models or nothing explicit
+			// to advertise — forward upstream so the client gets the real catalog.
 		}
 
 		let selected_backend = select_backend(selected_route.as_ref(), &req)

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -668,8 +668,21 @@ impl HTTPProxy {
 		// decide whether that backend would resolve the path to `RouteType::Models`
 		// and which aliases would actually be accepted. This ensures we never
 		// advertise an id that no backend-merged policy would honor.
-		{
-			let path = req.uri().path();
+		//
+		// Pre-filter to keep this off hot paths:
+		//   * Non-GET methods (completions/embeddings/messages are all POST).
+		//   * GETs whose route-level LLM policy already classifies the path as
+		//     something other than Models. When there's no route-level LLM policy
+		//     we can't decide without inspecting each backend, so we enter the
+		//     per-backend loop — this preserves backend-only `ai.routes` configs.
+		let path = req.uri().path();
+		let maybe_models_route = req.method() == ::http::Method::GET
+			&& route_policies
+				.llm
+				.as_ref()
+				.is_none_or(|p| p.resolve_route(path) == RouteType::Models);
+
+		if maybe_models_route {
 			let base: Arc<LLMRequestPolicies> = Arc::new(LLMRequestPolicies {
 				llm: route_policies.llm.clone(),
 				..Default::default()
@@ -699,7 +712,9 @@ impl HTTPProxy {
 				is_models_route = true;
 
 				// Explicit provider model(s) for this backend, and the owner used
-				// both for that id and for any aliases merged onto this backend.
+				// for any aliases merged onto this backend. Stays `None` when the
+				// backend has no concrete AI provider so we don't advertise
+				// aliases with a misleading `owned_by`.
 				let mut alias_owner: Option<Strng> = None;
 				if let Backend::AI(_, ai_backend) = &resolved.backend.backend {
 					for (provider, _info) in ai_backend.providers.iter().iter() {
@@ -710,15 +725,17 @@ impl HTTPProxy {
 						}
 					}
 				}
-				let alias_owner = alias_owner.unwrap_or_else(|| strng::literal!("openai"));
 
 				// Aliases come from the effective (merged) policy so backend-defined
-				// aliases correctly replace route-level aliases when present.
-				for alias in policy.model_aliases.keys() {
-					if !alias.contains('*') {
-						models
-							.entry(alias.clone())
-							.or_insert_with(|| alias_owner.clone());
+				// aliases correctly replace route-level aliases when present. Skipped
+				// when no owner could be derived for this backend.
+				if let Some(alias_owner) = alias_owner {
+					for alias in policy.model_aliases.keys() {
+						if !alias.contains('*') {
+							models
+								.entry(alias.clone())
+								.or_insert_with(|| alias_owner.clone());
+						}
 					}
 				}
 			}

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -671,16 +671,14 @@ impl HTTPProxy {
 		//
 		// Pre-filter to keep this off hot paths:
 		//   * Non-GET methods (completions/embeddings/messages are all POST).
-		//   * GETs whose route-level LLM policy already classifies the path as
-		//     something other than Models. When there's no route-level LLM policy
-		//     we can't decide without inspecting each backend, so we enter the
-		//     per-backend loop — this preserves backend-only `ai.routes` configs.
+		//   * GETs whose path clearly is not a models listing request.
+		//
+		// Do not consult the route-level LLM policy here: backend-level `ai.routes`
+		// can replace the route-level mapping during `merge_backend_policies`, so
+		// the effective policy for a backend can still resolve `/.../models` to
+		// `RouteType::Models` even when the route-level policy alone would not.
 		let path = req.uri().path();
-		let maybe_models_route = req.method() == ::http::Method::GET
-			&& route_policies
-				.llm
-				.as_ref()
-				.is_none_or(|p| p.resolve_route(path) == RouteType::Models);
+		let maybe_models_route = req.method() == ::http::Method::GET && path.ends_with("/models");
 
 		if maybe_models_route {
 			let base: Arc<LLMRequestPolicies> = Arc::new(LLMRequestPolicies {

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -656,67 +656,93 @@ impl HTTPProxy {
 		.snapshot_on_err(log, &mut req)?;
 
 		// If the route resolves to Models and the gateway has explicit knowledge of
-		// which models are available (via explicit provider `model` fields or route-level
-		// aliases), return a synthetic response scoped to this route's backends.
+		// which models are available (via explicit provider `model` fields or
+		// modelAliases on either the route or its backends), return a synthetic
+		// response scoped to this route's backends.
 		// If no explicit knowledge exists, fall through and forward to upstream so the
 		// client gets the provider's real catalog.
-		if let Some(RouteType::Models) = route_policies
-			.llm
-			.as_ref()
-			.map(|p| p.resolve_route(req.uri().path()))
+		//
+		// Resolving the route type requires inspecting each backend's resolved LLM
+		// policy because `routes` and `modelAliases` are backend-phase config
+		// (`AgentgatewayBackend.spec.policies.ai`) and aren't merged into route-level
+		// policies until after backend selection.
 		{
-			let mut models: std::collections::BTreeSet<(Strng, Strng)> =
-				std::collections::BTreeSet::new();
+			let path = req.uri().path();
+			let mut llm_policies: Vec<Arc<llm::Policy>> = Vec::new();
+			if let Some(p) = route_policies.llm.as_ref() {
+				llm_policies.push(p.clone());
+			}
+
+			// Dedup by model id; first seen (owner, explicit vs alias) wins.
+			let mut models: std::collections::BTreeMap<Strng, Strng> = std::collections::BTreeMap::new();
 			let mut fallback_owner: Option<Strng> = None;
 
 			for backend_ref in &selected_route.backends {
-				if let Ok(resolved) = resolve_backend(backend_ref.clone(), self.inputs.as_ref())
-					&& let Backend::AI(_, ai_backend) = &resolved.backend.backend
-				{
-					for (provider, _info) in ai_backend.providers.iter().iter() {
-						let owner = provider.provider.provider();
-						fallback_owner.get_or_insert_with(|| owner.clone());
-						if let Some(m) = provider.provider.override_model() {
-							models.insert((m, owner));
+				if let Ok(resolved) = resolve_backend(backend_ref.clone(), self.inputs.as_ref()) {
+					let backend_policies = get_backend_policies(
+						self.inputs.as_ref(),
+						&resolved.backend,
+						&resolved.inline_policies,
+						Some(route_path.clone()),
+					);
+					if let Some(p) = backend_policies.llm {
+						llm_policies.push(p);
+					}
+					if let Backend::AI(_, ai_backend) = &resolved.backend.backend {
+						for (provider, _info) in ai_backend.providers.iter().iter() {
+							let owner = provider.provider.provider();
+							fallback_owner.get_or_insert_with(|| owner.clone());
+							if let Some(m) = provider.provider.override_model() {
+								models.entry(m).or_insert(owner);
+							}
 						}
 					}
 				}
 			}
 
-			if let Some(policy) = route_policies.llm.as_ref() {
-				let owner = fallback_owner
+			let is_models_route = llm_policies
+				.iter()
+				.any(|p| p.resolve_route(path) == RouteType::Models);
+
+			if is_models_route {
+				let alias_owner = fallback_owner
 					.clone()
 					.unwrap_or_else(|| strng::literal!("openai"));
-				for alias in policy.model_aliases.keys() {
-					if !alias.contains('*') {
-						models.insert((alias.clone(), owner.clone()));
+				for policy in &llm_policies {
+					for alias in policy.model_aliases.keys() {
+						if !alias.contains('*') {
+							models
+								.entry(alias.clone())
+								.or_insert_with(|| alias_owner.clone());
+						}
 					}
 				}
-			}
 
-			if !models.is_empty() {
-				let data: Vec<_> = models
-					.iter()
-					.map(|(id, owned_by)| {
-						serde_json::json!({
-							"id": id,
-							"object": "model",
-							"created": 0,
-							"owned_by": owned_by,
+				if !models.is_empty() {
+					let data: Vec<_> = models
+						.iter()
+						.map(|(id, owned_by)| {
+							serde_json::json!({
+								"id": id,
+								"object": "model",
+								"created": 0,
+								"owned_by": owned_by,
+							})
 						})
-					})
-					.collect();
-				let body = serde_json::json!({ "object": "list", "data": data });
+						.collect();
+					let body = serde_json::json!({ "object": "list", "data": data });
 
-				return Ok(
-					::http::Response::builder()
-						.status(::http::StatusCode::OK)
-						.header(::http::header::CONTENT_TYPE, "application/json")
-						.body(http::Body::from(body.to_string()))
-						.expect("Failed to build models response"),
-				);
+					let mut response = ::http::Response::new(http::Body::from(body.to_string()));
+					*response.status_mut() = ::http::StatusCode::OK;
+					response.headers_mut().insert(
+						::http::header::CONTENT_TYPE,
+						::http::HeaderValue::from_static("application/json"),
+					);
+					return Err::<Response, _>(ProxyResponse::DirectResponse(Box::new(response)))
+						.snapshot_on_err(log, &mut req);
+				}
+				// Fall through: Models route but nothing explicit to advertise, forward upstream.
 			}
-			// Fall through: no explicit models or aliases configured, forward upstream.
 		}
 
 		let selected_backend = select_backend(selected_route.as_ref(), &req)


### PR DESCRIPTION
Fixes #1462

## Summary

`RouteType::Models` previously returned `NOT_IMPLEMENTED` in Kubernetes mode and behaved as a path-translating passthrough in standalone mode — exposing the full upstream catalog instead of the gateway's scoped model set. This PR makes `RouteType::Models` generate an OpenAI-compatible `/v1/models` response from the models the gateway already knows about, scoped per-HTTPRoute.

## Behavior

Resolution happens in `proxy()` before backend selection. Each backend's resolved LLM policy is inspected (so `routes` and `modelAliases` configured at backend level via `AgentgatewayBackend.spec.policies.ai` are recognized):

- **Explicit provider `model`** on a backend → included in the synthetic list
- **Non-wildcard `modelAliases`** (route- or backend-level) → included as first-class model IDs (wildcard entries like `gpt-*` are pattern matchers, not concrete models, so they are excluded)
- **Multiple backends on the route** → aggregated, deduplicated and sorted (scope is per-route, not per-gateway — so BBR setups with one HTTPRoute per model correctly surface only what that route can reach)
- **No explicit model and no alias** → falls through to the upstream's real `/v1/models` endpoint, preserving the prior passthrough behavior
- **`owned_by`** uses the provider name (`openai`, `anthropic`, `vertex`, …); aliases inherit the owner of the first backend on the route

Standalone mode (`llm.models:`) is unchanged — it already emits a `DirectResponse` with the configured model list at config-load time.

## Example

```yaml
apiVersion: agentgateway.dev/v1alpha1
kind: AgentgatewayBackend
metadata:
  name: gpt
  namespace: default
spec:
  ai:
    provider:
      openai:
        model: gpt-4o
  policies:
    ai:
      modelAliases:
        smart: gpt-4o
      routes:
        "/v1/models": Models
---
apiVersion: agentgateway.dev/v1alpha1
kind: AgentgatewayBackend
metadata:
  name: claude
  namespace: default
spec:
  ai:
    provider:
      anthropic:
        model: claude-sonnet-4@20250514
  policies:
    ai:
      routes:
        "/v1/models": Models
---
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: llm-models
  namespace: default
spec:
  parentRefs:
    - name: gateway
  rules:
    - backendRefs:
        - group: agentgateway.dev
          kind: AgentgatewayBackend
          name: gpt
        - group: agentgateway.dev
          kind: AgentgatewayBackend
          name: claude
      matches:
        - path:
            type: PathPrefix
            value: /v1/models
```

```bash
$ curl http://gateway/v1/models
```

```json
{
  "object": "list",
  "data": [
    {"id": "claude-sonnet-4@20250514", "object": "model", "created": 0, "owned_by": "anthropic"},
    {"id": "gpt-4o",                   "object": "model", "created": 0, "owned_by": "openai"},
    {"id": "smart",                    "object": "model", "created": 0, "owned_by": "openai"}
  ]
}
```

## Test plan

- [x] `cargo build -p agentgateway`
- [x] `cargo clippy -p agentgateway --lib` — clean
- [x] `cargo test -p agentgateway --lib` — 760 tests pass, no regressions
- [x] Manually traced all use cases (explicit model, aliases, wildcards, multi-backend BBR, no-config fall-through, standalone mode, explicit `Passthrough`, multi-provider failover, backend-level vs route-level policy)

## What doesn't change

- `Passthrough` behavior — still forwards to upstream as-is
- Standalone `llm.models:` generation (config-time `DirectResponse`)
- `RouteType` enum — `Models` variant already existed
- No new CRD fields, no new API, no new dependencies