### PR TITLE
logging: only need 1 entry for config refresh

### DIFF
--- a/crates/agentgateway/src/state_manager.rs
+++ b/crates/agentgateway/src/state_manager.rs
@@ -152,11 +152,11 @@ impl LocalClient {
 						|| (current_config_path.is_some() && current_config_path != real_config_path))
 				}) {
 					real_config_path = current_config_path.clone();
-					info!("Config file changed, reloading...");
+					debug!("Config file changed, reloading...");
 					match lc.reload_config(next_state.clone()).await {
 						Ok(nxt) => {
 							next_state = nxt;
-							info!("Config reloaded successfully")
+							debug!("Config reloaded successfully")
 						},
 						Err(e) => {
 							error!("Failed to reload config: {}", e)


### PR DESCRIPTION
today we log 3 lines; a bit much...

Signed-off-by: John Howard <john.howard@solo.io>
