### PR TITLE
fix(mcp/openapi): include path-level parameters in tool schema

### DIFF
--- a/crates/agentgateway/src/mcp/upstream/openapi/mod.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/mod.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -277,6 +278,25 @@ fn resolve_request_body<'a>(
 	}
 }
 
+fn parameter_type(parameter: &Parameter) -> Result<ParameterType, ParseError> {
+	match parameter {
+		Parameter::Header { .. } => Ok(ParameterType::Header),
+		Parameter::Query { .. } => Ok(ParameterType::Query),
+		Parameter::Path { .. } => Ok(ParameterType::Path),
+		_ => Err(ParseError::UnsupportedReference(
+			"parameter type COOKIE is not supported".to_string(),
+		)),
+	}
+}
+
+fn parameter_merge_name(parameter: &Parameter) -> String {
+	let name = &parameter.parameter_data_ref().name;
+	match parameter {
+		Parameter::Header { .. } => name.to_ascii_lowercase(),
+		_ => name.clone(),
+	}
+}
+
 /// We need to rework this and I don't want to forget.
 ///
 /// We need to be able to handle data which can end up in multiple destinations:
@@ -342,39 +362,45 @@ pub(crate) fn parse_openapi_schema(
 								final_schema.properties.insert(name.clone(), schema.clone());
 							}
 
+							let mut parameters: Vec<&Parameter> = Vec::new();
+							let mut parameter_indexes: HashMap<(String, ParameterType), usize> = HashMap::new();
+							for parameter_ref in item.parameters.iter() {
+								let parameter = resolve_parameter(parameter_ref, open_api)?;
+								let Ok(param_type) = parameter_type(parameter) else {
+									continue;
+								};
+								let key = (parameter_merge_name(parameter), param_type);
+								match parameter_indexes.entry(key) {
+									Entry::Occupied(e) => parameters[*e.get()] = parameter,
+									Entry::Vacant(e) => {
+										e.insert(parameters.len());
+										parameters.push(parameter);
+									},
+								}
+							}
+							for parameter_ref in op.parameters.iter() {
+								let parameter = resolve_parameter(parameter_ref, open_api)?;
+								let key = (parameter_merge_name(parameter), parameter_type(parameter)?);
+								match parameter_indexes.entry(key) {
+									Entry::Occupied(e) => parameters[*e.get()] = parameter,
+									Entry::Vacant(e) => {
+										e.insert(parameters.len());
+										parameters.push(parameter);
+									},
+								}
+							}
+
 							let mut param_schemas: HashMap<ParameterType, Vec<(String, JsonObject, bool)>> =
 								HashMap::new();
-							op.parameters
+							parameters
 								.iter()
-								.try_for_each(|p| -> Result<(), ParseError> {
-									let item = resolve_parameter(p, open_api)?;
-									let (name, schema, required) = build_schema_property(open_api, item)?;
-									match item {
-										Parameter::Header { .. } => {
-											param_schemas
-												.entry(ParameterType::Header)
-												.or_insert_with(Vec::new)
-												.push((name, schema, required));
-											Ok(())
-										},
-										Parameter::Query { .. } => {
-											param_schemas
-												.entry(ParameterType::Query)
-												.or_insert_with(Vec::new)
-												.push((name, schema, required));
-											Ok(())
-										},
-										Parameter::Path { .. } => {
-											param_schemas
-												.entry(ParameterType::Path)
-												.or_insert_with(Vec::new)
-												.push((name, schema, required));
-											Ok(())
-										},
-										_ => Err(ParseError::UnsupportedReference(
-											"parameter type COOKIE is not supported".to_string(),
-										)),
-									}
+								.try_for_each(|parameter| -> Result<(), ParseError> {
+									let (name, schema, required) = build_schema_property(open_api, parameter)?;
+									param_schemas
+										.entry(parameter_type(parameter)?)
+										.or_insert_with(Vec::new)
+										.push((name, schema, required));
+									Ok(())
 								})?;
 
 							// Extract allowed header names before consuming param_schemas

--- a/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
@@ -705,6 +705,445 @@ async fn test_get_server_prefix_multiple_servers_err() {
 	assert!(result.is_err(), "multiple servers should yield error");
 }
 
+fn tool_schema_for<'a>(
+	tools: &'a [(Tool, UpstreamOpenAPICall)],
+	tool_name: &str,
+) -> &'a serde_json::Map<String, serde_json::Value> {
+	tools
+		.iter()
+		.find(|(tool, _)| tool.name == tool_name)
+		.map(|(tool, _)| &*tool.input_schema)
+		.expect("tool should exist")
+}
+
+fn nested_schema<'a>(
+	schema: &'a serde_json::Map<String, serde_json::Value>,
+	name: &str,
+) -> &'a serde_json::Map<String, serde_json::Value> {
+	schema
+		.get("properties")
+		.and_then(serde_json::Value::as_object)
+		.and_then(|props| props.get(name))
+		.and_then(serde_json::Value::as_object)
+		.expect("nested schema should exist")
+}
+
+#[test]
+fn test_parse_openapi_schema_includes_path_level_parameters_in_tool_schema() {
+	let raw = r#"{
+		"openapi": "3.0.0",
+		"info": {"title": "Path Params", "version": "1.0.0"},
+		"paths": {
+			"/workspaces/{workspace_gid}/tags": {
+				"parameters": [
+					{
+						"name": "workspace_gid",
+						"in": "path",
+						"required": true,
+						"schema": {"type": "string"}
+					}
+				],
+				"get": {
+					"operationId": "getTagsForWorkspace",
+					"summary": "Get tags in a workspace",
+					"responses": {
+						"200": {"description": "ok"}
+					}
+				}
+			}
+		}
+	}"#;
+	let open_api: OpenAPI = serde_json::from_str(raw).expect("valid OpenAPI schema");
+	let tools = super::parse_openapi_schema(&open_api).expect("schema should parse");
+	let (_tool, upstream) = tools
+		.iter()
+		.find(|(tool, _)| tool.name == "getTagsForWorkspace")
+		.expect("tool should exist");
+
+	assert_eq!(upstream.path, "/workspaces/{workspace_gid}/tags");
+
+	let schema = tool_schema_for(&tools, "getTagsForWorkspace");
+	let path_schema = nested_schema(schema, "path");
+	let properties = path_schema
+		.get("properties")
+		.and_then(serde_json::Value::as_object)
+		.expect("path object should include properties");
+	assert!(
+		properties.contains_key("workspace_gid"),
+		"path-level workspace_gid should be exposed in tool schema"
+	);
+	let required = path_schema
+		.get("required")
+		.and_then(serde_json::Value::as_array)
+		.expect("path object should include required array");
+	assert!(
+		required.iter().any(|value| value == "workspace_gid"),
+		"workspace_gid should be required in the path schema"
+	);
+}
+
+#[test]
+fn test_parse_openapi_schema_operation_level_parameter_overrides_path_level_parameter() {
+	let raw = r#"{
+		"openapi": "3.0.0",
+		"info": {"title": "Path Params", "version": "1.0.0"},
+		"paths": {
+			"/workspaces/{workspace_gid}/tags": {
+				"parameters": [
+					{
+						"name": "workspace_gid",
+						"in": "path",
+						"required": true,
+						"description": "path-level parameter",
+						"schema": {"type": "string"}
+					}
+				],
+				"get": {
+					"operationId": "getTagsForWorkspace",
+					"parameters": [
+						{
+							"name": "workspace_gid",
+							"in": "path",
+							"required": true,
+							"description": "operation-level parameter",
+							"schema": {"type": "string", "pattern": "^ws_"}
+						}
+					],
+					"responses": {
+						"200": {"description": "ok"}
+					}
+				}
+			}
+		}
+	}"#;
+	let open_api: OpenAPI = serde_json::from_str(raw).expect("valid OpenAPI schema");
+	let tools = super::parse_openapi_schema(&open_api).expect("schema should parse");
+
+	let schema = tool_schema_for(&tools, "getTagsForWorkspace");
+	let path_schema = nested_schema(schema, "path");
+	let path_properties = path_schema
+		.get("properties")
+		.and_then(serde_json::Value::as_object)
+		.expect("path object should include properties");
+	let workspace_gid = path_properties
+		.get("workspace_gid")
+		.and_then(serde_json::Value::as_object)
+		.expect("workspace_gid property should exist");
+	assert_eq!(
+		workspace_gid.get("description"),
+		Some(&json!("operation-level parameter"))
+	);
+	assert_eq!(workspace_gid.get("pattern"), Some(&json!("^ws_")));
+
+	let required = path_schema
+		.get("required")
+		.and_then(serde_json::Value::as_array)
+		.expect("path object should include required array");
+	assert_eq!(required, &vec![json!("workspace_gid")]);
+}
+
+#[test]
+fn test_parse_openapi_schema_operation_level_override_preserves_parameter_order() {
+	let raw = r#"{
+		"openapi": "3.0.0",
+		"info": {"title": "Path Params", "version": "1.0.0"},
+		"paths": {
+			"/workspaces/{workspace_gid}/tags/{tag_gid}": {
+				"parameters": [
+					{
+						"name": "workspace_gid",
+						"in": "path",
+						"required": true,
+						"schema": {"type": "string"}
+					},
+					{
+						"name": "tag_gid",
+						"in": "path",
+						"required": true,
+						"schema": {"type": "string"}
+					}
+				],
+				"get": {
+					"operationId": "getWorkspaceTag",
+					"parameters": [
+						{
+							"name": "workspace_gid",
+							"in": "path",
+							"required": true,
+							"description": "operation-level parameter",
+							"schema": {"type": "string", "pattern": "^ws_"}
+						}
+					],
+					"responses": {
+						"200": {"description": "ok"}
+					}
+				}
+			}
+		}
+	}"#;
+	let open_api: OpenAPI = serde_json::from_str(raw).expect("valid OpenAPI schema");
+	let tools = super::parse_openapi_schema(&open_api).expect("schema should parse");
+
+	let schema = tool_schema_for(&tools, "getWorkspaceTag");
+	let path_schema = nested_schema(schema, "path");
+	let required = path_schema
+		.get("required")
+		.and_then(serde_json::Value::as_array)
+		.expect("path object should include required array");
+	assert_eq!(required, &vec![json!("workspace_gid"), json!("tag_gid")]);
+
+	let path_properties = path_schema
+		.get("properties")
+		.and_then(serde_json::Value::as_object)
+		.expect("path object should include properties");
+	let workspace_gid = path_properties
+		.get("workspace_gid")
+		.and_then(serde_json::Value::as_object)
+		.expect("workspace_gid property should exist");
+	assert_eq!(
+		workspace_gid.get("description"),
+		Some(&json!("operation-level parameter"))
+	);
+	assert_eq!(workspace_gid.get("pattern"), Some(&json!("^ws_")));
+}
+
+#[test]
+fn test_parse_openapi_schema_operation_level_header_override_is_case_insensitive() {
+	let raw = r#"{
+		"openapi": "3.0.0",
+		"info": {"title": "Header Params", "version": "1.0.0"},
+		"paths": {
+			"/workspaces": {
+				"parameters": [
+					{
+						"name": "X-Request-Id",
+						"in": "header",
+						"required": true,
+						"description": "path-level header",
+						"schema": {"type": "string"}
+					}
+				],
+				"get": {
+					"operationId": "listWorkspaces",
+					"parameters": [
+						{
+							"name": "x-request-id",
+							"in": "header",
+							"required": true,
+							"description": "operation-level header",
+							"schema": {"type": "string", "pattern": "^req_"}
+						}
+					],
+					"responses": {
+						"200": {"description": "ok"}
+					}
+				}
+			}
+		}
+	}"#;
+	let open_api: OpenAPI = serde_json::from_str(raw).expect("valid OpenAPI schema");
+	let tools = super::parse_openapi_schema(&open_api).expect("schema should parse");
+	let (tool, upstream) = tools
+		.iter()
+		.find(|(tool, _)| tool.name == "listWorkspaces")
+		.expect("tool should exist");
+
+	assert_eq!(
+		upstream.allowed_headers,
+		HashSet::from(["x-request-id".to_string()])
+	);
+
+	let schema = &*tool.input_schema;
+	let header_schema = nested_schema(schema, "header");
+	let header_properties = header_schema
+		.get("properties")
+		.and_then(serde_json::Value::as_object)
+		.expect("header object should include properties");
+	assert_eq!(header_properties.len(), 1);
+	let request_id = header_properties
+		.get("x-request-id")
+		.and_then(serde_json::Value::as_object)
+		.expect("operation-level header should win");
+	assert_eq!(
+		request_id.get("description"),
+		Some(&json!("operation-level header"))
+	);
+	assert_eq!(request_id.get("pattern"), Some(&json!("^req_")));
+
+	let required = header_schema
+		.get("required")
+		.and_then(serde_json::Value::as_array)
+		.expect("header object should include required array");
+	assert_eq!(required, &vec![json!("x-request-id")]);
+}
+
+#[test]
+fn test_parse_openapi_schema_includes_path_and_operation_parameters_in_different_locations() {
+	let raw = r#"{
+		"openapi": "3.0.0",
+		"info": {"title": "Mixed Params", "version": "1.0.0"},
+		"paths": {
+			"/workspaces/{workspace_gid}/tags": {
+				"parameters": [
+					{
+						"name": "workspace_gid",
+						"in": "path",
+						"required": true,
+						"schema": {"type": "string"}
+					}
+				],
+				"get": {
+					"operationId": "getTagsForWorkspace",
+					"parameters": [
+						{
+							"name": "limit",
+							"in": "query",
+							"required": false,
+							"schema": {"type": "integer"}
+						}
+					],
+					"responses": {
+						"200": {"description": "ok"}
+					}
+				}
+			}
+		}
+	}"#;
+	let open_api: OpenAPI = serde_json::from_str(raw).expect("valid OpenAPI schema");
+	let tools = super::parse_openapi_schema(&open_api).expect("schema should parse");
+
+	let schema = tool_schema_for(&tools, "getTagsForWorkspace");
+	let path_schema = nested_schema(schema, "path");
+	let query_schema = nested_schema(schema, "query");
+
+	let top_level_required = schema
+		.get("required")
+		.and_then(serde_json::Value::as_array)
+		.expect("root schema should include required array");
+	assert_eq!(top_level_required, &vec![json!("path")]);
+
+	let path_properties = path_schema
+		.get("properties")
+		.and_then(serde_json::Value::as_object)
+		.expect("path object should include properties");
+	assert!(path_properties.contains_key("workspace_gid"));
+
+	let query_properties = query_schema
+		.get("properties")
+		.and_then(serde_json::Value::as_object)
+		.expect("query object should include properties");
+	assert!(query_properties.contains_key("limit"));
+	assert_eq!(
+		query_schema
+			.get("required")
+			.and_then(serde_json::Value::as_array),
+		Some(&vec![]),
+		"optional query params should not mark any fields as required"
+	);
+}
+
+#[test]
+fn test_parse_openapi_schema_resolves_ref_path_level_parameters() {
+	let raw = r##"{
+		"openapi": "3.0.0",
+		"info": {"title": "Path Params", "version": "1.0.0"},
+		"components": {
+			"parameters": {
+				"WorkspaceGid": {
+					"name": "workspace_gid",
+					"in": "path",
+					"required": true,
+					"description": "workspace identifier",
+					"schema": {"type": "string"}
+				}
+			}
+		},
+		"paths": {
+			"/workspaces/{workspace_gid}/tags": {
+				"parameters": [
+					{
+						"$ref": "#/components/parameters/WorkspaceGid"
+					}
+				],
+				"get": {
+					"operationId": "getTagsForWorkspace",
+					"responses": {
+						"200": {"description": "ok"}
+					}
+				}
+			}
+		}
+	}"##;
+	let open_api: OpenAPI = serde_json::from_str(raw).expect("valid OpenAPI schema");
+	let tools = super::parse_openapi_schema(&open_api).expect("schema should parse");
+
+	let schema = tool_schema_for(&tools, "getTagsForWorkspace");
+	let path_schema = nested_schema(schema, "path");
+	let path_properties = path_schema
+		.get("properties")
+		.and_then(serde_json::Value::as_object)
+		.expect("path object should include properties");
+	let workspace_gid = path_properties
+		.get("workspace_gid")
+		.and_then(serde_json::Value::as_object)
+		.expect("workspace_gid property should exist");
+	assert_eq!(
+		workspace_gid.get("description"),
+		Some(&json!("workspace identifier"))
+	);
+}
+
+#[test]
+fn test_parse_openapi_schema_ignores_path_level_cookie_parameters() {
+	let raw = r#"{
+		"openapi": "3.0.0",
+		"info": {"title": "Cookie Params", "version": "1.0.0"},
+		"paths": {
+			"/workspaces/{workspace_gid}/tags": {
+				"parameters": [
+					{
+						"name": "session",
+						"in": "cookie",
+						"required": false,
+						"schema": {"type": "string"}
+					},
+					{
+						"name": "workspace_gid",
+						"in": "path",
+						"required": true,
+						"schema": {"type": "string"}
+					}
+				],
+				"get": {
+					"operationId": "getTagsForWorkspace",
+					"responses": {
+						"200": {"description": "ok"}
+					}
+				}
+			}
+		}
+	}"#;
+	let open_api: OpenAPI = serde_json::from_str(raw).expect("valid OpenAPI schema");
+	let tools = super::parse_openapi_schema(&open_api).expect("schema should parse");
+
+	let schema = tool_schema_for(&tools, "getTagsForWorkspace");
+	let properties = schema
+		.get("properties")
+		.and_then(serde_json::Value::as_object)
+		.expect("root schema should include properties");
+	assert!(
+		!properties.contains_key("cookie"),
+		"path-level cookie parameters should not create a cookie schema"
+	);
+
+	let path_schema = nested_schema(schema, "path");
+	let path_properties = path_schema
+		.get("properties")
+		.and_then(serde_json::Value::as_object)
+		.expect("path object should include properties");
+	assert!(path_properties.contains_key("workspace_gid"));
+}
+
 #[rstest]
 #[case::empty_string(json!({"verbose": ""}), vec![("verbose", "")])]
 #[case::string_value(json!({"verbose": "true"}), vec![("verbose", "true")])]

--- a/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
@@ -788,72 +788,13 @@ fn test_parse_openapi_schema_operation_level_parameter_overrides_path_level_para
 		"openapi": "3.0.0",
 		"info": {"title": "Path Params", "version": "1.0.0"},
 		"paths": {
-			"/workspaces/{workspace_gid}/tags": {
-				"parameters": [
-					{
-						"name": "workspace_gid",
-						"in": "path",
-						"required": true,
-						"description": "path-level parameter",
-						"schema": {"type": "string"}
-					}
-				],
-				"get": {
-					"operationId": "getTagsForWorkspace",
-					"parameters": [
-						{
-							"name": "workspace_gid",
-							"in": "path",
-							"required": true,
-							"description": "operation-level parameter",
-							"schema": {"type": "string", "pattern": "^ws_"}
-						}
-					],
-					"responses": {
-						"200": {"description": "ok"}
-					}
-				}
-			}
-		}
-	}"#;
-	let open_api: OpenAPI = serde_json::from_str(raw).expect("valid OpenAPI schema");
-	let tools = super::parse_openapi_schema(&open_api).expect("schema should parse");
-
-	let schema = tool_schema_for(&tools, "getTagsForWorkspace");
-	let path_schema = nested_schema(schema, "path");
-	let path_properties = path_schema
-		.get("properties")
-		.and_then(serde_json::Value::as_object)
-		.expect("path object should include properties");
-	let workspace_gid = path_properties
-		.get("workspace_gid")
-		.and_then(serde_json::Value::as_object)
-		.expect("workspace_gid property should exist");
-	assert_eq!(
-		workspace_gid.get("description"),
-		Some(&json!("operation-level parameter"))
-	);
-	assert_eq!(workspace_gid.get("pattern"), Some(&json!("^ws_")));
-
-	let required = path_schema
-		.get("required")
-		.and_then(serde_json::Value::as_array)
-		.expect("path object should include required array");
-	assert_eq!(required, &vec![json!("workspace_gid")]);
-}
-
-#[test]
-fn test_parse_openapi_schema_operation_level_override_preserves_parameter_order() {
-	let raw = r#"{
-		"openapi": "3.0.0",
-		"info": {"title": "Path Params", "version": "1.0.0"},
-		"paths": {
 			"/workspaces/{workspace_gid}/tags/{tag_gid}": {
 				"parameters": [
 					{
 						"name": "workspace_gid",
 						"in": "path",
 						"required": true,
+						"description": "path-level parameter",
 						"schema": {"type": "string"}
 					},
 					{
@@ -886,12 +827,6 @@ fn test_parse_openapi_schema_operation_level_override_preserves_parameter_order(
 
 	let schema = tool_schema_for(&tools, "getWorkspaceTag");
 	let path_schema = nested_schema(schema, "path");
-	let required = path_schema
-		.get("required")
-		.and_then(serde_json::Value::as_array)
-		.expect("path object should include required array");
-	assert_eq!(required, &vec![json!("workspace_gid"), json!("tag_gid")]);
-
 	let path_properties = path_schema
 		.get("properties")
 		.and_then(serde_json::Value::as_object)
@@ -905,6 +840,17 @@ fn test_parse_openapi_schema_operation_level_override_preserves_parameter_order(
 		Some(&json!("operation-level parameter"))
 	);
 	assert_eq!(workspace_gid.get("pattern"), Some(&json!("^ws_")));
+
+	let required = path_schema
+		.get("required")
+		.and_then(serde_json::Value::as_array)
+		.expect("path object should include required array");
+	assert_eq!(required, &vec![json!("workspace_gid"), json!("tag_gid")]);
+
+	assert!(
+		path_properties.contains_key("tag_gid"),
+		"the unmodified sibling path parameter should keep its slot"
+	);
 }
 
 #[test]
@@ -975,122 +921,6 @@ fn test_parse_openapi_schema_operation_level_header_override_is_case_insensitive
 		.and_then(serde_json::Value::as_array)
 		.expect("header object should include required array");
 	assert_eq!(required, &vec![json!("x-request-id")]);
-}
-
-#[test]
-fn test_parse_openapi_schema_includes_path_and_operation_parameters_in_different_locations() {
-	let raw = r#"{
-		"openapi": "3.0.0",
-		"info": {"title": "Mixed Params", "version": "1.0.0"},
-		"paths": {
-			"/workspaces/{workspace_gid}/tags": {
-				"parameters": [
-					{
-						"name": "workspace_gid",
-						"in": "path",
-						"required": true,
-						"schema": {"type": "string"}
-					}
-				],
-				"get": {
-					"operationId": "getTagsForWorkspace",
-					"parameters": [
-						{
-							"name": "limit",
-							"in": "query",
-							"required": false,
-							"schema": {"type": "integer"}
-						}
-					],
-					"responses": {
-						"200": {"description": "ok"}
-					}
-				}
-			}
-		}
-	}"#;
-	let open_api: OpenAPI = serde_json::from_str(raw).expect("valid OpenAPI schema");
-	let tools = super::parse_openapi_schema(&open_api).expect("schema should parse");
-
-	let schema = tool_schema_for(&tools, "getTagsForWorkspace");
-	let path_schema = nested_schema(schema, "path");
-	let query_schema = nested_schema(schema, "query");
-
-	let top_level_required = schema
-		.get("required")
-		.and_then(serde_json::Value::as_array)
-		.expect("root schema should include required array");
-	assert_eq!(top_level_required, &vec![json!("path")]);
-
-	let path_properties = path_schema
-		.get("properties")
-		.and_then(serde_json::Value::as_object)
-		.expect("path object should include properties");
-	assert!(path_properties.contains_key("workspace_gid"));
-
-	let query_properties = query_schema
-		.get("properties")
-		.and_then(serde_json::Value::as_object)
-		.expect("query object should include properties");
-	assert!(query_properties.contains_key("limit"));
-	assert_eq!(
-		query_schema
-			.get("required")
-			.and_then(serde_json::Value::as_array),
-		Some(&vec![]),
-		"optional query params should not mark any fields as required"
-	);
-}
-
-#[test]
-fn test_parse_openapi_schema_resolves_ref_path_level_parameters() {
-	let raw = r##"{
-		"openapi": "3.0.0",
-		"info": {"title": "Path Params", "version": "1.0.0"},
-		"components": {
-			"parameters": {
-				"WorkspaceGid": {
-					"name": "workspace_gid",
-					"in": "path",
-					"required": true,
-					"description": "workspace identifier",
-					"schema": {"type": "string"}
-				}
-			}
-		},
-		"paths": {
-			"/workspaces/{workspace_gid}/tags": {
-				"parameters": [
-					{
-						"$ref": "#/components/parameters/WorkspaceGid"
-					}
-				],
-				"get": {
-					"operationId": "getTagsForWorkspace",
-					"responses": {
-						"200": {"description": "ok"}
-					}
-				}
-			}
-		}
-	}"##;
-	let open_api: OpenAPI = serde_json::from_str(raw).expect("valid OpenAPI schema");
-	let tools = super::parse_openapi_schema(&open_api).expect("schema should parse");
-
-	let schema = tool_schema_for(&tools, "getTagsForWorkspace");
-	let path_schema = nested_schema(schema, "path");
-	let path_properties = path_schema
-		.get("properties")
-		.and_then(serde_json::Value::as_object)
-		.expect("path object should include properties");
-	let workspace_gid = path_properties
-		.get("workspace_gid")
-		.and_then(serde_json::Value::as_object)
-		.expect("workspace_gid property should exist");
-	assert_eq!(
-		workspace_gid.get("description"),
-		Some(&json!("workspace identifier"))
-	);
 }
 
 #[test]


### PR DESCRIPTION
  OpenAPI 3.0 allows parameters to be declared on a PathItem and shared
  across every operation on that path. These were previously dropped when
  building the MCP tool input schema, so tools for endpoints like in Asana API
  /workspaces/{workspace_gid}/tags were generated without workspace_gid
  and calls failed with unresolved path templates.

  Merge path-level and operation-level parameters, deduplicated by
  (name, in) with operation-level taking precedence per spec. Header
  names are lowercased for the merge key since HTTP headers are
  case-insensitive.