### PR TITLE
fix(otel): restore gen_ai.tool.name and add gen_ai.prompt.name

### DIFF
--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -828,7 +828,10 @@ async fn tool_call_exposes_payload_fields_to_access_log_cel() {
 	assert_eq!(result_json["hi"], "world");
 	assert!(log.get("mcp_error_cel").is_none());
 
-	assert!(log.get("gen_ai.tool.name").is_none());
+	assert_eq!(
+		log.get("gen_ai.tool.name"),
+		Some(&serde_json::json!("echo"))
+	);
 	assert!(log.get("gen_ai.tool.call.arguments").is_none());
 	assert!(log.get("gen_ai.tool.call.result").is_none());
 }
@@ -881,7 +884,10 @@ async fn tool_call_error_exposes_error_payload_to_access_log_cel() {
 			.is_some_and(|message| message.contains("tool"))
 	);
 	assert!(log.get("mcp_result_cel").is_none());
-	assert!(log.get("gen_ai.tool.name").is_none());
+	assert_eq!(
+		log.get("gen_ai.tool.name"),
+		Some(&serde_json::json!("does_not_exist"))
+	);
 	assert!(log.get("gen_ai.tool.call.arguments").is_none());
 	assert!(log.get("gen_ai.tool.call.result").is_none());
 }
@@ -931,7 +937,10 @@ async fn legacy_sse_tool_call_exposes_arguments_without_terminal_payloads() {
 	assert!(log.get("mcp_result_cel").is_none());
 	assert!(log.get("mcp_error_cel").is_none());
 
-	assert!(log.get("gen_ai.tool.name").is_none());
+	assert_eq!(
+		log.get("gen_ai.tool.name"),
+		Some(&serde_json::json!("echo"))
+	);
 	assert!(log.get("gen_ai.tool.call.arguments").is_none());
 	assert!(log.get("gen_ai.tool.call.result").is_none());
 }

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -723,6 +723,8 @@ fn access_log_payload_policy() -> crate::types::frontend::LoggingPolicy {
 				"mcp_session_cel": "mcp.sessionId",
 				"mcp_tool_name_cel": "mcp.tool.name",
 				"mcp_tool_target_cel": "mcp.tool.target",
+				"mcp_prompt_name_cel": "mcp.prompt.name",
+				"mcp_prompt_target_cel": "mcp.prompt.target",
 				"mcp_args_cel": "mcp.tool.arguments",
 				"mcp_result_cel": "mcp.tool.result",
 				"mcp_error_cel": "mcp.tool.error"
@@ -943,6 +945,43 @@ async fn legacy_sse_tool_call_exposes_arguments_without_terminal_payloads() {
 	);
 	assert!(log.get("gen_ai.tool.call.arguments").is_none());
 	assert!(log.get("gen_ai.tool.call.result").is_none());
+}
+
+#[tokio::test]
+async fn prompt_request_emits_gen_ai_prompt_name() {
+	let mock = mock_streamable_http_server(true).await;
+	let (_t, io) = setup_access_log_mcp_proxy(&mock).await;
+	let client = mcp_streamable_client(io).await;
+
+	let _result = client
+		.get_prompt(
+			rmcp::model::GetPromptRequestParams::new("example_prompt").with_arguments(
+				serde_json::json!({ "message": "hello" })
+					.as_object()
+					.cloned()
+					.unwrap(),
+			),
+		)
+		.await
+		.unwrap();
+
+	let log = agent_core::telemetry::testing::eventually_find(&[
+		("scope", "request"),
+		("mcp_prompt_name_cel", "example_prompt"),
+	])
+	.await
+	.unwrap();
+
+	assert_eq!(
+		log.get("mcp_method_cel"),
+		Some(&serde_json::json!("prompts/get"))
+	);
+	assert_eq!(
+		log.get("gen_ai.prompt.name"),
+		Some(&serde_json::json!("example_prompt"))
+	);
+	assert!(log.get("gen_ai.tool.name").is_none());
+	assert!(log.get("mcp_tool_name_cel").is_none());
 }
 
 async fn setup_proxy(

--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -891,6 +891,20 @@ impl Drop for DropOnLog {
 				None
 			}
 		});
+		let mcp_tool_name = mcp.as_ref().and_then(|m| {
+			if matches!(m.resource_type(), Some(MCPOperation::Tool)) {
+				m.resource_name().map(str::to_owned)
+			} else {
+				None
+			}
+		});
+		let mcp_prompt_name = mcp.as_ref().and_then(|m| {
+			if matches!(m.resource_type(), Some(MCPOperation::Prompt)) {
+				m.resource_name().map(str::to_owned)
+			} else {
+				None
+			}
+		});
 
 		let mut kv = vec![
 			("gateway", route_identifier.gateway.as_deref().map(display)),
@@ -938,6 +952,8 @@ impl Drop for DropOnLog {
 			("mcp.target", mcp_target.as_ref().map(display)),
 			("mcp.resource.type", mcp_resource_type.as_ref().map(display)),
 			("mcp.resource.uri", mcp_resource_uri.as_ref().map(display)),
+			("gen_ai.tool.name", mcp_tool_name.as_ref().map(display)),
+			("gen_ai.prompt.name", mcp_prompt_name.as_ref().map(display)),
 			(
 				"mcp.session.id",
 				mcp


### PR DESCRIPTION
This PR adds back `gen_ai.tool.name` (has been removed in https://github.com/agentgateway/agentgateway/pull/1331) and  adds `gen_ai.prompt.name` to the default span attributes.
