### PR TITLE
Fixed doc links

### DIFF
--- a/controller/api/v1alpha1/agentgateway/agentgateway_backend_types.go
+++ b/controller/api/v1alpha1/agentgateway/agentgateway_backend_types.go
@@ -261,7 +261,7 @@ type OpenAIConfig struct {
 	Model *ShortString `json:"model,omitempty"`
 }
 
-// AzureOpenAIConfig settings for the [Azure OpenAI](https://learn.microsoft.com/en-us/azure/ai-foundry/?view=foundry-classic) LLM provider.
+// AzureOpenAIConfig settings for the [Azure OpenAI](https://learn.microsoft.com/en-us/azure/foundry/?view=foundry-classic) LLM provider.
 // +kubebuilder:validation:XValidation:message="deploymentName is required for this apiVersion",rule="!has(self.apiVersion) || self.apiVersion == 'v1' ? true : has(self.deploymentName)"
 type AzureOpenAIConfig struct {
 	// The endpoint for the Azure OpenAI API to use, such as `my-endpoint.openai.azure.com`.
@@ -270,14 +270,14 @@ type AzureOpenAIConfig struct {
 	Endpoint ShortString `json:"endpoint"`
 
 	// The name of the Azure OpenAI model deployment to use.
-	// For more information, see the [Azure OpenAI model docs](https://learn.microsoft.com/en-us/azure/ai-foundry/foundry-models/concepts/models-sold-directly-by-azure?view=foundry-classic).
+	// For more information, see the [Azure OpenAI model docs](https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/models-sold-directly-by-azure?view=foundry-classic).
 	// This is required if `apiVersion` is not `v1`. For `v1`, the model can be
 	// set in the request.
 	// +optional
 	DeploymentName *ShortString `json:"deploymentName,omitempty"`
 
 	// The version of the Azure OpenAI API to use.
-	// For more information, see the [Azure OpenAI API version reference](https://learn.microsoft.com/en-us/azure/ai-foundry/?view=foundry-classicreference#api-specs).
+	// For more information, see the [Azure OpenAI API version reference](https://learn.microsoft.com/en-us/azure/foundry/openai/reference).
 	// If unset, defaults to `v1`.
 	// +optional
 	ApiVersion *TinyString `json:"apiVersion,omitempty"`

--- a/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
+++ b/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
@@ -683,12 +683,12 @@ type JWTAuthentication struct {
 
 type JWTProvider struct {
 	// `issuer` identifies the IdP that issued the JWT. This corresponds to the
-	// `iss` claim (https://tools.ietf.org/html/rfc7519#section-4.1.1).
+	// `iss` claim ([RFC 7519 §4.1.1](https://tools.ietf.org/html/rfc7519#section-4.1.1)).
 	// +required
 	Issuer ShortString `json:"issuer"`
 	// `audiences` specifies the list of allowed audiences that are allowed
 	// access. This corresponds to the `aud` claim
-	// (https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3).
+	// ([RFC 7519 §4.1.3](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3)).
 	// If unset, any audience is allowed.
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=64
@@ -1125,13 +1125,13 @@ type MCPAuthentication struct {
 	McpIDP *McpIDP `json:"provider,omitempty"`
 
 	// `issuer` identifies the IdP that issued the JWT. This corresponds to the
-	// `iss` claim (https://tools.ietf.org/html/rfc7519#section-4.1.1).
+	// `iss` claim ([RFC 7519 §4.1.1](https://tools.ietf.org/html/rfc7519#section-4.1.1)).
 	// +optional
 	Issuer ShortString `json:"issuer,omitempty"`
 
 	// `audiences` specifies the list of allowed audiences that are allowed
 	// access. This corresponds to the `aud` claim
-	// (https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3).
+	// ([RFC 7519 §4.1.3](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3)).
 	// If unset, any audience is allowed.
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=64

--- a/controller/api/v1alpha1/shared/overlay_types.go
+++ b/controller/api/v1alpha1/shared/overlay_types.go
@@ -21,7 +21,7 @@ type ObjectMetadata struct {
 
 // KubernetesResourceOverlay provides a mechanism to customize generated
 // Kubernetes resources using [Strategic Merge
-// Patch](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-api-machinery/strategic-merge-patch.md)
+// Patch](https://github.com/kubernetes/community/blob/main/contributors/devel/sig-api-machinery/strategic-merge-patch.md)
 // semantics.
 //
 // # Overlay Application Order

--- a/controller/api/v1alpha1/shared/shared_types.go
+++ b/controller/api/v1alpha1/shared/shared_types.go
@@ -112,7 +112,7 @@ type PolicyAncestorStatus struct {
 	// Example: `example.net/gateway-controller`.
 	//
 	// The format of this field is `DOMAIN "/" PATH`, where `DOMAIN` and `PATH` are
-	// valid Kubernetes names
+	// valid
 	// ([Kubernetes names](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names)).
 	//
 	// Controllers MUST populate this field when writing status. Controllers

--- a/controller/api/v1alpha1/shared/shared_types.go
+++ b/controller/api/v1alpha1/shared/shared_types.go
@@ -113,7 +113,7 @@ type PolicyAncestorStatus struct {
 	//
 	// The format of this field is `DOMAIN "/" PATH`, where `DOMAIN` and `PATH` are
 	// valid Kubernetes names
-	// (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+	// ([Kubernetes names](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names)).
 	//
 	// Controllers MUST populate this field when writing status. Controllers
 	// should ensure that entries in status populated with their `ControllerName`

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
@@ -144,7 +144,7 @@ spec:
                                   apiVersion:
                                     description: |-
                                       The version of the Azure OpenAI API to use.
-                                      For more information, see the [Azure OpenAI API version reference](https://learn.microsoft.com/en-us/azure/ai-foundry/?view=foundry-classicreference#api-specs).
+                                      For more information, see the [Azure OpenAI API version reference](https://learn.microsoft.com/en-us/azure/foundry/openai/reference).
                                       If unset, defaults to `v1`.
                                     maxLength: 64
                                     minLength: 1
@@ -152,7 +152,7 @@ spec:
                                   deploymentName:
                                     description: |-
                                       The name of the Azure OpenAI model deployment to use.
-                                      For more information, see the [Azure OpenAI model docs](https://learn.microsoft.com/en-us/azure/ai-foundry/foundry-models/concepts/models-sold-directly-by-azure?view=foundry-classic).
+                                      For more information, see the [Azure OpenAI model docs](https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/models-sold-directly-by-azure?view=foundry-classic).
                                       This is required if `apiVersion` is not `v1`. For `v1`, the model can be
                                       set in the request.
                                     maxLength: 256
@@ -6530,7 +6530,7 @@ spec:
                           apiVersion:
                             description: |-
                               The version of the Azure OpenAI API to use.
-                              For more information, see the [Azure OpenAI API version reference](https://learn.microsoft.com/en-us/azure/ai-foundry/?view=foundry-classicreference#api-specs).
+                              For more information, see the [Azure OpenAI API version reference](https://learn.microsoft.com/en-us/azure/foundry/openai/reference).
                               If unset, defaults to `v1`.
                             maxLength: 64
                             minLength: 1
@@ -6538,7 +6538,7 @@ spec:
                           deploymentName:
                             description: |-
                               The name of the Azure OpenAI model deployment to use.
-                              For more information, see the [Azure OpenAI model docs](https://learn.microsoft.com/en-us/azure/ai-foundry/foundry-models/concepts/models-sold-directly-by-azure?view=foundry-classic).
+                              For more information, see the [Azure OpenAI model docs](https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/models-sold-directly-by-azure?view=foundry-classic).
                               This is required if `apiVersion` is not `v1`. For `v1`, the model can be
                               set in the request.
                             maxLength: 256
@@ -12685,7 +12685,7 @@ spec:
                             description: |-
                               `audiences` specifies the list of allowed audiences that are allowed
                               access. This corresponds to the `aud` claim
-                              (https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3).
+                              ([RFC 7519 §4.1.3](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3)).
                               If unset, any audience is allowed.
                             items:
                               type: string
@@ -12695,7 +12695,7 @@ spec:
                           issuer:
                             description: |-
                               `issuer` identifies the IdP that issued the JWT. This corresponds to the
-                              `iss` claim (https://tools.ietf.org/html/rfc7519#section-4.1.1).
+                              `iss` claim ([RFC 7519 §4.1.1](https://tools.ietf.org/html/rfc7519#section-4.1.1)).
                             maxLength: 256
                             minLength: 1
                             type: string

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
@@ -5051,7 +5051,7 @@ spec:
                             description: |-
                               `audiences` specifies the list of allowed audiences that are allowed
                               access. This corresponds to the `aud` claim
-                              (https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3).
+                              ([RFC 7519 §4.1.3](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3)).
                               If unset, any audience is allowed.
                             items:
                               type: string
@@ -5061,7 +5061,7 @@ spec:
                           issuer:
                             description: |-
                               `issuer` identifies the IdP that issued the JWT. This corresponds to the
-                              `iss` claim (https://tools.ietf.org/html/rfc7519#section-4.1.1).
+                              `iss` claim ([RFC 7519 §4.1.1](https://tools.ietf.org/html/rfc7519#section-4.1.1)).
                             maxLength: 256
                             minLength: 1
                             type: string
@@ -7660,7 +7660,7 @@ spec:
                               description: |-
                                 `audiences` specifies the list of allowed audiences that are allowed
                                 access. This corresponds to the `aud` claim
-                                (https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3).
+                                ([RFC 7519 §4.1.3](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3)).
                                 If unset, any audience is allowed.
                               items:
                                 type: string
@@ -7670,7 +7670,7 @@ spec:
                             issuer:
                               description: |-
                                 `issuer` identifies the IdP that issued the JWT. This corresponds to the
-                                `iss` claim (https://tools.ietf.org/html/rfc7519#section-4.1.1).
+                                `iss` claim ([RFC 7519 §4.1.1](https://tools.ietf.org/html/rfc7519#section-4.1.1)).
                               maxLength: 256
                               minLength: 1
                               type: string

--- a/controller/install/helm/agentgateway/values.yaml
+++ b/controller/install/helm/agentgateway/values.yaml
@@ -202,7 +202,7 @@ inferenceExtension:
   # -- Enable Inference Extension support in the agentgateway controller.
   enabled: false
 
-# -- List of namespace selectors (OR'ed): each entry can use 'matchLabels' or 'matchExpressions' (AND'ed within each entry if used together). Agentgateway includes the selected namespaces in config discovery. For more information, see the docs https://kgateway.dev/docs/envoy/latest/install/advanced/.
+# -- List of namespace selectors (OR'ed): each entry can use 'matchLabels' or 'matchExpressions' (AND'ed within each entry if used together). Agentgateway includes the selected namespaces in config discovery. For more information, see the docs https://kgateway.dev/docs/envoy/latest/install/advanced/#namespace-discovery.
 discoveryNamespaceSelectors: []
 
 # -- Map of GatewayClass names to GatewayParameters references that will be set on

--- a/controller/install/helm/agentgateway/values.yaml
+++ b/controller/install/helm/agentgateway/values.yaml
@@ -202,7 +202,7 @@ inferenceExtension:
   # -- Enable Inference Extension support in the agentgateway controller.
   enabled: false
 
-# -- List of namespace selectors (OR'ed): each entry can use 'matchLabels' or 'matchExpressions' (AND'ed within each entry if used together). Agentgateway includes the selected namespaces in config discovery. For more information, see the docs https://kgateway.dev/docs/latest/install/advanced/#namespace-discovery.
+# -- List of namespace selectors (OR'ed): each entry can use 'matchLabels' or 'matchExpressions' (AND'ed within each entry if used together). Agentgateway includes the selected namespaces in config discovery. For more information, see the docs https://kgateway.dev/docs/envoy/latest/install/advanced/.
 discoveryNamespaceSelectors: []
 
 # -- Map of GatewayClass names to GatewayParameters references that will be set on


### PR DESCRIPTION
Most of the fixes are straightforward. But in lychee, we were getting an extra parentheses on some, like this:

> https://tools.ietf.org/html/rfc7519#section-4.1.1%29
> Found on: public/docs/kubernetes/1.0.x/reference/api/index.html, public/docs/kubernetes/latest/reference/api/index.html, public/docs/kubernetes/main/reference/api/index.html

Adding standard markdown formatting around those links in hopes of giving it a firm end point.