### PR TITLE
docs: fix wrong API group in AgentgatewayPolicy rate-limit example

### DIFF
--- a/controller/pkg/syncer/README.md
+++ b/controller/pkg/syncer/README.md
@@ -1764,7 +1764,7 @@ EOF
 
 ```shell
 kubectl apply -f- <<EOF
-apiVersion: gateway.agentgateway.dev/v1alpha1
+apiVersion: agentgateway.dev/v1alpha1
 kind: AgentgatewayPolicy
 metadata:
   name: token-rate-limit


### PR DESCRIPTION
## Problem

The token-based rate-limit example in `controller/pkg/syncer/README.md` uses the wrong API group:

```yaml
# Wrong
apiVersion: gateway.agentgateway.dev/v1alpha1
kind: AgentgatewayPolicy
```

Anyone copying this example verbatim gets:

```
error: no matches for kind "AgentgatewayPolicy" in version "gateway.agentgateway.dev/v1alpha1"
```

## Fix

One-character prefix removed — consistent with all other 19 `apiVersion` examples in the same file:

```yaml
# Correct
apiVersion: agentgateway.dev/v1alpha1
kind: AgentgatewayPolicy
```

## Verification

```bash
kubectl api-resources | grep agentgateway
# agentgatewaypolicies  agpol  agentgateway.dev/v1alpha1  true  AgentgatewayPolicy
```