### PR TITLE
FIX #1434: always use streamable HTTP for MCP playground

### DIFF
--- a/crates/agentgateway/src/agentcore.rs
+++ b/crates/agentgateway/src/agentcore.rs
@@ -1,6 +1,6 @@
 use percent_encoding::{NON_ALPHANUMERIC, utf8_percent_encode};
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct AgentCoreConfig {
 	pub agent_runtime_arn: String,

--- a/crates/agentgateway/src/aws.rs
+++ b/crates/agentgateway/src/aws.rs
@@ -1,11 +1,11 @@
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct AwsBackendConfig {
 	#[serde(flatten)]
 	pub service: AwsService,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub enum AwsService {
 	AgentCore(crate::agentcore::AgentCoreConfig),

--- a/crates/agentgateway/src/proxy/tcpproxy.rs
+++ b/crates/agentgateway/src/proxy/tcpproxy.rs
@@ -13,7 +13,7 @@ use crate::telemetry::metrics::TCPLabels;
 use crate::transport::stream::{Socket, TCPConnectionInfo, TLSConnectionInfo, WaypointTLSInfo};
 use crate::types::agent::{
 	BackendPolicy, BindKey, Listener, ListenerProtocol, SimpleBackend, SimpleBackendReference,
-	SimpleBackendWithPolicies, TCPRoute, TCPRouteBackend, TCPRouteBackendReference,
+	SimpleBackendWithPolicies, TCPRoute, TCPRouteBackend, TCPRouteBackendReference, Target,
 	TransportProtocol,
 };
 use crate::types::discovery::{NetworkAddress, WaypointIdentity, gatewayaddress::Destination};
@@ -225,6 +225,22 @@ impl TCPProxy {
 				network_gateway: None,
 				backend_policies,
 			},
+			SimpleBackend::Aws(_, config) => {
+				let default_policies = BackendPolicies {
+					backend_tls: Some(http::backendtls::SYSTEM_TRUST.clone()),
+					backend_auth: Some(http::auth::BackendAuth::Aws(
+						http::auth::AwsAuth::Implicit {},
+					)),
+					..Default::default()
+				};
+				BackendCall {
+					target: Target::Hostname(config.get_host().into(), 443),
+					http_version_override: None,
+					transport_override: None,
+					network_gateway: None,
+					backend_policies: default_policies.merge(backend_policies),
+				}
+			},
 			SimpleBackend::Invalid => return Err(ProxyError::BackendDoesNotExist),
 		};
 		Ok(backend_call)
@@ -412,7 +428,7 @@ mod tests {
 
 	use agent_core::strng;
 
-	use crate::store::Stores;
+	use crate::store::{BackendPolicies, Stores};
 	use crate::types::agent::{ListenerProtocol, SimpleBackendReference};
 	use crate::types::discovery::{
 		GatewayAddress, NamespacedHostname, NetworkAddress, Service, WaypointIdentity,
@@ -778,5 +794,124 @@ mod tests {
 		);
 		assert!(route.is_some(), "should fall through to default");
 		assert_eq!(route.unwrap().key.as_str(), "_waypoint-default-tcp");
+	}
+
+	fn make_proxy_inputs() -> Arc<crate::ProxyInputs> {
+		use crate::client::Client;
+		use crate::{BackendConfig, client};
+		use agent_core::metrics;
+		use hickory_resolver::config::{ResolverConfig, ResolverOpts};
+		use prometheus_client::registry::Registry;
+
+		let config = crate::config::parse_config("{}".to_string(), None).unwrap();
+		let encoder = config.session_encoder.clone();
+		let stores = Stores::with_ipv6_enabled(config.ipv6_enabled);
+		let client = Client::new(
+			&client::Config {
+				resolver_cfg: ResolverConfig::default(),
+				resolver_opts: ResolverOpts::default(),
+			},
+			None,
+			BackendConfig::default(),
+			None,
+		);
+		Arc::new(crate::ProxyInputs {
+			cfg: Arc::new(config),
+			stores: stores.clone(),
+			metrics: Arc::new(crate::metrics::Metrics::new(
+				metrics::sub_registry(&mut Registry::default()),
+				Default::default(),
+			)),
+			upstream: client,
+			ca: None,
+			mcp_state: crate::mcp::App::new(stores, encoder),
+		})
+	}
+
+	fn make_aws_simple_backend() -> super::SimpleBackend {
+		use crate::aws::{AwsBackendConfig, AwsService};
+		super::SimpleBackend::Aws(
+			crate::types::agent::ResourceName::new(strng::new("test-aws"), strng::new("ns")),
+			AwsBackendConfig {
+				service: AwsService::AgentCore(
+					crate::agentcore::AgentCoreConfig::new(
+						"arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/abc123".to_string(),
+						None,
+					)
+					.unwrap(),
+				),
+			},
+		)
+	}
+
+	#[test]
+	fn test_build_backend_call_aws_defaults() {
+		let inputs = make_proxy_inputs();
+		let backend = make_aws_simple_backend();
+		let result = super::TCPProxy::build_backend_call(
+			&mut None,
+			None,
+			&inputs,
+			&backend,
+			BackendPolicies::default(),
+		)
+		.unwrap();
+
+		assert!(
+			matches!(
+				&result.target,
+				super::Target::Hostname(h, 443)
+					if h.as_str() == "bedrock-agentcore.us-east-1.amazonaws.com"
+			),
+			"target should be Hostname with port 443"
+		);
+		assert!(result.backend_policies.backend_tls.is_some());
+		assert!(
+			matches!(
+				&result.backend_policies.backend_auth,
+				Some(crate::http::auth::BackendAuth::Aws(
+					crate::http::auth::AwsAuth::Implicit {}
+				))
+			),
+			"should default to AWS implicit auth"
+		);
+		assert!(result.http_version_override.is_none());
+		assert!(result.transport_override.is_none());
+		assert!(result.network_gateway.is_none());
+	}
+
+	#[test]
+	fn test_build_backend_call_aws_user_policies_override() {
+		use crate::http::auth::{AwsAuth, BackendAuth};
+		use secrecy::SecretString;
+
+		let inputs = make_proxy_inputs();
+		let backend = make_aws_simple_backend();
+
+		let user_policies = BackendPolicies {
+			backend_auth: Some(BackendAuth::Aws(AwsAuth::ExplicitConfig {
+				access_key_id: SecretString::from("AKID"),
+				secret_access_key: SecretString::from("SECRET"),
+				region: Some("us-west-2".to_string()),
+				session_token: None,
+			})),
+			..Default::default()
+		};
+
+		let result =
+			super::TCPProxy::build_backend_call(&mut None, None, &inputs, &backend, user_policies)
+				.unwrap();
+
+		assert!(
+			matches!(
+				&result.backend_policies.backend_auth,
+				Some(BackendAuth::Aws(AwsAuth::ExplicitConfig { .. }))
+			),
+			"user-provided auth should override default implicit auth"
+		);
+		assert!(
+			result.backend_policies.backend_tls.is_some(),
+			"TLS should still be present from defaults"
+		);
 	}
 }

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -1009,6 +1009,7 @@ impl From<SimpleBackend> for Backend {
 		match value {
 			SimpleBackend::Service(svc, port) => Backend::Service(svc, port),
 			SimpleBackend::Opaque(name, target) => Backend::Opaque(name, target),
+			SimpleBackend::Aws(name, cfg) => Backend::Aws(name, cfg),
 			SimpleBackend::Invalid => Backend::Invalid,
 		}
 	}
@@ -1020,6 +1021,7 @@ pub enum SimpleBackend {
 	Service(Arc<Service>, u16),
 	#[serde(rename = "host")]
 	Opaque(ResourceName, Target), // Hostname or IP
+	Aws(ResourceName, crate::aws::AwsBackendConfig),
 	Invalid,
 }
 
@@ -1028,6 +1030,7 @@ impl fmt::Display for SimpleBackend {
 		match self {
 			SimpleBackend::Service(service, port) => write!(f, "{}:{}", service.hostname, port),
 			SimpleBackend::Opaque(name, _) => write!(f, "{}", name),
+			SimpleBackend::Aws(name, _) => write!(f, "{}", name),
 			SimpleBackend::Invalid => write!(f, "invalid"),
 		}
 	}
@@ -1040,6 +1043,7 @@ impl TryFrom<Backend> for SimpleBackend {
 		match value {
 			Backend::Service(svc, port) => Ok(SimpleBackend::Service(svc, port)),
 			Backend::Opaque(name, tgt) => Ok(SimpleBackend::Opaque(name, tgt)),
+			Backend::Aws(rn, cfg) => Ok(SimpleBackend::Aws(rn, cfg)),
 			Backend::Invalid => Ok(SimpleBackend::Invalid),
 			_ => anyhow::bail!("unsupported backend type"),
 		}
@@ -1097,6 +1101,7 @@ impl SimpleBackend {
 			SimpleBackend::Service(svc, port) => {
 				format!("{}:{port}", svc.hostname)
 			},
+			SimpleBackend::Aws(_, cfg) => format!("{}:{}", cfg.get_host(), 443),
 			SimpleBackend::Opaque(_, tgt) => tgt.hostport(),
 			SimpleBackend::Invalid => "invalid".to_string(),
 		}
@@ -1114,6 +1119,11 @@ impl SimpleBackend {
 				namespace: name.namespace.as_ref(),
 				section: None,
 			},
+			SimpleBackend::Aws(name, _) => BackendTargetRef::Backend {
+				name: name.name.as_ref(),
+				namespace: name.namespace.as_ref(),
+				section: None,
+			},
 			SimpleBackend::Invalid => BackendTargetRef::Invalid,
 		}
 	}
@@ -1122,6 +1132,7 @@ impl SimpleBackend {
 		match self {
 			SimpleBackend::Service(_, _) => cel::BackendType::Service,
 			SimpleBackend::Opaque(_, _) => cel::BackendType::Static,
+			SimpleBackend::Aws(_, _) => cel::BackendType::Dynamic,
 			SimpleBackend::Invalid => cel::BackendType::Unknown,
 		}
 	}
@@ -2815,5 +2826,81 @@ jwtValidationOptions:
 			},
 			_ => panic!("Expected LocalJwtConfig::Single"),
 		}
+	}
+
+	fn make_aws_config() -> crate::aws::AwsBackendConfig {
+		crate::aws::AwsBackendConfig {
+			service: crate::aws::AwsService::AgentCore(
+				crate::agentcore::AgentCoreConfig::new(
+					"arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/abc123".to_string(),
+					None,
+				)
+				.unwrap(),
+			),
+		}
+	}
+
+	fn make_aws_simple_backend() -> SimpleBackend {
+		SimpleBackend::Aws(
+			ResourceName::new(strng::new("test-aws"), strng::new("ns")),
+			make_aws_config(),
+		)
+	}
+
+	#[test]
+	fn test_simple_backend_aws_to_backend_conversion() {
+		let sb = make_aws_simple_backend();
+		let backend: Backend = sb.into();
+		assert!(
+			matches!(backend, Backend::Aws(ref name, ref config) if name.name.as_str() == "test-aws" && config == &make_aws_config())
+		);
+	}
+
+	#[test]
+	fn test_backend_aws_to_simple_backend_roundtrip() {
+		let backend = Backend::Aws(
+			ResourceName::new(strng::new("test-aws"), strng::new("ns")),
+			make_aws_config(),
+		);
+		let sb: SimpleBackend = backend.try_into().unwrap();
+		assert!(
+			matches!(sb, SimpleBackend::Aws(ref name, ref config) if name.name.as_str() == "test-aws" && config == &make_aws_config())
+		);
+	}
+
+	#[test]
+	fn test_simple_backend_aws_display() {
+		let sb = make_aws_simple_backend();
+		assert_eq!(sb.to_string(), "ns/test-aws");
+	}
+
+	#[test]
+	fn test_simple_backend_aws_hostport() {
+		let sb = make_aws_simple_backend();
+		assert_eq!(
+			sb.hostport(),
+			"bedrock-agentcore.us-east-1.amazonaws.com:443"
+		);
+	}
+
+	#[test]
+	fn test_simple_backend_aws_target_ref() {
+		let sb = make_aws_simple_backend();
+		assert_eq!(
+			sb.target(),
+			BackendTargetRef::Backend {
+				name: "test-aws",
+				namespace: "ns",
+				section: None,
+			}
+		);
+	}
+
+	#[test]
+	fn test_simple_backend_aws_backend_type() {
+		let sb = make_aws_simple_backend();
+		assert_eq!(sb.backend_type(), cel::BackendType::Dynamic);
+		assert_eq!(sb.backend_info().backend_type, cel::BackendType::Dynamic);
+		assert_eq!(sb.backend_info().backend_name, strng::new("ns/test-aws"));
 	}
 }

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -738,36 +738,43 @@ impl LocalBackend {
 				let mut backends = vec![];
 				for (idx, t) in tgt.targets.iter().enumerate() {
 					let name = strng::format!("mcp/{}/{}", name.clone(), idx);
+					let mut process_backend = |backend: McpBackendHost| {
+						Ok(match backend.process()? {
+							ProcessedMcpBackendHost::Inline { backend, path, tls } => {
+								let (bref, be) = mcp_to_simple_backend_and_ref(local_name(name.clone()), backend);
+								if let Some(b) = be {
+									backends.push(Self::make_mcp_backend(b, t.policies.clone(), tls)?);
+								}
+								(bref, Some(path))
+							},
+							ProcessedMcpBackendHost::Reference { .. } if t.policies.is_some() => {
+								anyhow::bail!(
+									"cannot use backend reference when policies are defined for an MCP target"
+								);
+							},
+							ProcessedMcpBackendHost::Reference { backend, path } => (backend, path),
+						})
+					};
+
 					let spec = match t.spec.clone() {
 						LocalMcpTargetSpec::Sse { backend } => {
-							let (backend, path, tls) = backend.process()?;
-							let (bref, be) = mcp_to_simple_backend_and_ref(local_name(name.clone()), backend);
-							if let Some(b) = be {
-								backends.push(Self::make_mcp_backend(b, t.policies.clone(), tls)?);
-							}
+							let (bref, path) = process_backend(backend)?;
 							McpTargetSpec::Sse(SseTargetSpec {
 								backend: bref,
-								path: path.clone(),
+								path: path.ok_or_else(|| anyhow!("path is required when backend is set"))?,
 							})
 						},
 						LocalMcpTargetSpec::Mcp { backend } => {
-							let (backend, path, tls) = backend.process()?;
-							let (bref, be) = mcp_to_simple_backend_and_ref(local_name(name.clone()), backend);
-							if let Some(b) = be {
-								backends.push(Self::make_mcp_backend(b, t.policies.clone(), tls)?);
-							}
+							let (bref, path) = process_backend(backend)?;
 							McpTargetSpec::Mcp(StreamableHTTPTargetSpec {
 								backend: bref,
-								path: path.clone(),
+								path: path.ok_or_else(|| anyhow!("path is required when backend is set"))?,
 							})
 						},
 						LocalMcpTargetSpec::Stdio { cmd, args, env } => McpTargetSpec::Stdio { cmd, args, env },
 						LocalMcpTargetSpec::OpenAPI { backend, schema } => {
-							let (backend, _, tls) = backend.process()?;
-							let (bref, be) = mcp_to_simple_backend_and_ref(local_name(name.clone()), backend);
-							if let Some(b) = be {
-								backends.push(Self::make_mcp_backend(b, t.policies.clone(), tls)?);
-							}
+							let (bref, _) = process_backend(backend)?;
+
 							let openapi_schema = schema.load_openapi_schema(client.clone()).await?;
 							McpTargetSpec::OpenAPI(OpenAPITarget {
 								backend: bref,
@@ -875,44 +882,110 @@ pub struct LocalMcpTarget {
 	pub policies: Option<MCPLocalBackendPolicies>,
 }
 
-#[apply(schema_de!)]
-// Ideally this would be an enum of Simple|Explicit, but serde bug prevents it:
-// https://github.com/serde-rs/serde/issues/1600
-pub struct McpBackendHost {
-	host: String,
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[cfg_attr(feature = "schema", schemars(with = "McpBackendHostSerde"))]
+pub enum McpBackendHost {
+	Host {
+		host: String,
+		port: Option<u16>,
+		path: Option<String>,
+	},
+	Backend {
+		backend: BackendKey,
+		path: Option<String>,
+	},
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+struct McpBackendHostSerde {
+	host: Option<String>,
 	port: Option<u16>,
 	path: Option<String>,
+	backend: Option<BackendKey>,
+}
+
+pub enum ProcessedMcpBackendHost {
+	Inline {
+		backend: Target,
+		path: String,
+		tls: bool,
+	},
+	Reference {
+		backend: SimpleBackendReference,
+		path: Option<String>,
+	},
+}
+
+impl<'de> serde::Deserialize<'de> for McpBackendHost {
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: serde::Deserializer<'de>,
+	{
+		let raw = McpBackendHostSerde::deserialize(deserializer)?;
+		match (raw.host, raw.port, raw.path, raw.backend) {
+			(Some(host), port, path, None) => Ok(Self::Host { host, port, path }),
+			(None, None, path, Some(backend)) => Ok(Self::Backend { backend, path }),
+			(None, Some(_), _, Some(_)) | (Some(_), _, _, Some(_)) => Err(serde::de::Error::custom(
+				"cannot mix host/port with backend for MCP target backend configuration",
+			)),
+			(None, Some(_), _, None) => Err(serde::de::Error::custom(
+				"host is required when port is set for MCP target backend configuration",
+			)),
+			(None, None, Some(_), None) => Err(serde::de::Error::custom(
+				"host or backend is required when path is set for MCP target backend configuration",
+			)),
+			(None, None, None, None) => Err(serde::de::Error::custom(
+				"host or backend is required for MCP target backend configuration",
+			)),
+		}
+	}
 }
 
 impl McpBackendHost {
-	pub fn process(&self) -> anyhow::Result<(Target, String, bool)> {
-		let McpBackendHost { host, port, path } = self;
-		Ok(match (host, port, path) {
-			(host, Some(port), Some(path)) => {
-				let b = Target::from((host.as_str(), *port));
-				(b, path.clone(), false)
+	pub fn process(&self) -> anyhow::Result<ProcessedMcpBackendHost> {
+		Ok(match self {
+			McpBackendHost::Backend { backend, path } => ProcessedMcpBackendHost::Reference {
+				backend: SimpleBackendReference::Backend(backend.clone()),
+				path: path.clone(),
 			},
-			(host, None, None) => {
-				let uri = Uri::try_from(host.as_str())?;
-				let Some(host) = uri.host() else {
-					anyhow::bail!("no host")
-				};
-				let scheme = uri.scheme().unwrap_or(&http::Scheme::HTTP);
-				let port = uri.port_u16();
-				let path = uri.path();
-				let port = match (scheme, port) {
-					(s, p) if s == &http::Scheme::HTTP => p.unwrap_or(80),
-					(s, p) if s == &http::Scheme::HTTPS => p.unwrap_or(443),
-					(_, _) => {
-						anyhow::bail!("invalid scheme: {:?}", scheme);
-					},
-				};
+			McpBackendHost::Host { host, port, path } => match (host, port, path) {
+				(host, Some(port), Some(path)) => {
+					let b = Target::from((host.as_str(), *port));
+					ProcessedMcpBackendHost::Inline {
+						backend: b,
+						path: path.clone(),
+						tls: false,
+					}
+				},
+				(host, None, None) => {
+					let uri = Uri::try_from(host.as_str())?;
+					let Some(host) = uri.host() else {
+						anyhow::bail!("no host")
+					};
+					let scheme = uri.scheme().unwrap_or(&http::Scheme::HTTP);
+					let port = uri.port_u16();
+					let path = uri.path();
+					let port = match (scheme, port) {
+						(s, p) if s == &http::Scheme::HTTP => p.unwrap_or(80),
+						(s, p) if s == &http::Scheme::HTTPS => p.unwrap_or(443),
+						(_, _) => {
+							anyhow::bail!("invalid scheme: {:?}", scheme);
+						},
+					};
 
-				let b = Target::from((host, port));
-				(b, path.to_string(), scheme == &http::Scheme::HTTPS)
-			},
-			_ => {
-				anyhow::bail!("if port or path is set, both must be set; otherwise, use only host")
+					let b = Target::from((host, port));
+					ProcessedMcpBackendHost::Inline {
+						backend: b,
+						path: path.to_string(),
+						tls: scheme == &http::Scheme::HTTPS,
+					}
+				},
+				_ => {
+					anyhow::bail!("if port or path is set, both must be set; otherwise, use only host")
+				},
 			},
 		})
 	}

--- a/crates/agentgateway/src/types/local_tests.rs
+++ b/crates/agentgateway/src/types/local_tests.rs
@@ -154,6 +154,11 @@ async fn test_named_mcp_backend_config() {
 }
 
 #[tokio::test]
+async fn test_mcp_to_aws_backend_config() {
+	test_config_parsing("mcp_to_aws_backend").await;
+}
+
+#[tokio::test]
 async fn test_llm_config() {
 	test_config_parsing("llm").await;
 }
@@ -419,6 +424,101 @@ policies:
 		err
 			.to_string()
 			.contains("cannot mix gateway-phase oidc with route-phase oidc"),
+		"{err}"
+	);
+}
+
+#[tokio::test]
+async fn test_mcp_named_backend_reference_reuses_existing_backend() {
+	let normalized = normalize_test_yaml(
+		r#"
+backends:
+- name: shared-upstream
+  host: example.com:443
+binds:
+- port: 3000
+  listeners:
+  - routes:
+    - backends:
+      - mcp:
+          targets:
+          - name: remote
+            mcp:
+              backend: shared-upstream
+              path: /mcp
+"#,
+	)
+	.await
+	.expect("named MCP backend reference should normalize");
+
+	assert_eq!(
+		normalized.backends.len(),
+		2,
+		"should keep the explicit backend plus the MCP backend, without a synthetic target backend"
+	);
+
+	let mcp_backend = normalized
+		.backends
+		.iter()
+		.find(|backend| matches!(backend.backend, crate::types::agent::Backend::MCP(_, _)))
+		.expect("normalized MCP backend");
+
+	let crate::types::agent::Backend::MCP(_, mcp_backend) = &mcp_backend.backend else {
+		panic!("expected MCP backend");
+	};
+	let target = mcp_backend.targets.first().expect("remote target");
+	let crate::types::agent::McpTargetSpec::Mcp(target_spec) = &target.spec else {
+		panic!("expected streamable MCP target");
+	};
+	assert_eq!(
+		target_spec.backend,
+		crate::types::agent::SimpleBackendReference::Backend("shared-upstream".into())
+	);
+	assert_eq!(target_spec.path, "/mcp");
+}
+
+#[tokio::test]
+async fn test_mcp_named_backend_reference_requires_path_for_mcp() {
+	let err = normalize_test_yaml(
+		r#"
+backends:
+- name: shared-upstream
+  host: example.com:443
+binds:
+- port: 3000
+  listeners:
+  - routes:
+    - backends:
+      - mcp:
+          targets:
+          - name: remote
+            mcp:
+              backend: shared-upstream
+"#,
+	)
+	.await
+	.expect_err("named MCP backend reference should require a path");
+
+	assert!(
+		err
+			.to_string()
+			.contains("path is required when backend is set"),
+		"{err}"
+	);
+}
+
+#[test]
+fn test_mcp_backend_host_rejects_mixed_host_and_backend() {
+	let err = serde_json::from_value::<super::McpBackendHost>(serde_json::json!({
+		"host": "https://example.com/mcp",
+		"backend": "shared-upstream"
+	}))
+	.expect_err("mixed host and backend should be rejected");
+
+	assert!(
+		err
+			.to_string()
+			.contains("cannot mix host/port with backend for MCP target backend configuration"),
 		"{err}"
 	);
 }

--- a/crates/agentgateway/src/types/local_tests/mcp_to_aws_backend_config.yaml
+++ b/crates/agentgateway/src/types/local_tests/mcp_to_aws_backend_config.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=../../schema/local.json
+# Top-level named MCP backend referenced by a route via its key.
+binds:
+- port: 3000
+  listeners:
+  - routes:
+    - backends:
+      - backend: /shared-mcp
+backends:
+- name: shared-mcp
+  mcp:
+    targets:
+    - name: default
+      mcp:
+        backend: /aws-agent-core-mcp-target
+        path: /mcp
+- name: aws-agent-core-mcp-target
+  aws:
+    agentCore:
+      agentRuntimeArn: arn:aws:bedrock-agentcore:us-east-1:12345678:runtime/mcp-runtime
+  policies:
+    backendAuth:
+      aws: {}

--- a/crates/agentgateway/src/types/local_tests/mcp_to_aws_backend_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/mcp_to_aws_backend_normalized.snap
@@ -1,0 +1,62 @@
+---
+source: crates/agentgateway/src/types/local_tests.rs
+assertion_line: 137
+description: "Config normalization test for mcp_to_aws_backend: YAML -> LocalConfig -> NormalizedLocalConfig -> YAML"
+---
+binds:
+  - key: bind/3000
+    address: "[::]:3000"
+    protocol: http
+    tunnelProtocol: direct
+    listeners:
+      ns/name/bind/3000/listener0:
+        gatewayName: name
+        gatewayNamespace: ns
+        hostname: ""
+        key: ns/name/bind/3000/listener0
+        listenerName: listener0
+        protocol: HTTP
+        routes:
+          ns/name/bind/3000/listener0/default/route0:
+            backends:
+              - backend: /shared-mcp
+                weight: 1
+            key: ns/name/bind/3000/listener0/default/route0
+            matches:
+              - path:
+                  pathPrefix: /
+            name: route0
+            namespace: default
+        tcpRoutes: {}
+policies: []
+backends:
+  - backend:
+      mcp:
+        name: shared-mcp
+        namespace: ""
+        target:
+          targets:
+            - mcp:
+                backend:
+                  backend: /aws-agent-core-mcp-target
+                path: /mcp
+              name: default
+          stateful: true
+          alwaysUsePrefix: false
+          failureMode: failClosed
+  - backend:
+      aws:
+        name: aws-agent-core-mcp-target
+        namespace: ""
+        target:
+          agentCore:
+            agentRuntimeArn: "arn:aws:bedrock-agentcore:us-east-1:12345678:runtime/mcp-runtime"
+            qualifier: ~
+            region: us-east-1
+            accountId: "12345678"
+    inlinePolicies:
+      - backendAuth:
+          aws: {}
+route_groups: []
+workloads: []
+services: []

--- a/schema/config.json
+++ b/schema/config.json
@@ -4255,7 +4255,10 @@
               "type": "object",
               "properties": {
                 "host": {
-                  "type": "string"
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "port": {
                   "type": [
@@ -4271,12 +4274,15 @@
                     "string",
                     "null"
                   ]
+                },
+                "backend": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 }
               },
-              "additionalProperties": false,
-              "required": [
-                "host"
-              ]
+              "additionalProperties": false
             }
           },
           "required": [
@@ -4290,7 +4296,10 @@
               "type": "object",
               "properties": {
                 "host": {
-                  "type": "string"
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "port": {
                   "type": [
@@ -4306,12 +4315,15 @@
                     "string",
                     "null"
                   ]
+                },
+                "backend": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 }
               },
-              "additionalProperties": false,
-              "required": [
-                "host"
-              ]
+              "additionalProperties": false
             }
           },
           "required": [
@@ -4357,7 +4369,10 @@
               "type": "object",
               "properties": {
                 "host": {
-                  "type": "string"
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "port": {
                   "type": [
@@ -4374,13 +4389,18 @@
                     "null"
                   ]
                 },
+                "backend": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
                 "schema": {
                   "$ref": "#/$defs/FileInlineOrRemote"
                 }
               },
               "additionalProperties": false,
               "required": [
-                "host",
                 "schema"
               ]
             }

--- a/schema/config.md
+++ b/schema/config.md
@@ -1207,10 +1207,12 @@
 |`binds[].listeners[].routes[].backends[].mcp.targets[].sse.host`|string||
 |`binds[].listeners[].routes[].backends[].mcp.targets[].sse.port`|integer||
 |`binds[].listeners[].routes[].backends[].mcp.targets[].sse.path`|string||
+|`binds[].listeners[].routes[].backends[].mcp.targets[].sse.backend`|string||
 |`binds[].listeners[].routes[].backends[].mcp.targets[].mcp`|object||
 |`binds[].listeners[].routes[].backends[].mcp.targets[].mcp.host`|string||
 |`binds[].listeners[].routes[].backends[].mcp.targets[].mcp.port`|integer||
 |`binds[].listeners[].routes[].backends[].mcp.targets[].mcp.path`|string||
+|`binds[].listeners[].routes[].backends[].mcp.targets[].mcp.backend`|string||
 |`binds[].listeners[].routes[].backends[].mcp.targets[].stdio`|object||
 |`binds[].listeners[].routes[].backends[].mcp.targets[].stdio.cmd`|string||
 |`binds[].listeners[].routes[].backends[].mcp.targets[].stdio.args`|[]string||
@@ -1219,6 +1221,7 @@
 |`binds[].listeners[].routes[].backends[].mcp.targets[].openapi.host`|string||
 |`binds[].listeners[].routes[].backends[].mcp.targets[].openapi.port`|integer||
 |`binds[].listeners[].routes[].backends[].mcp.targets[].openapi.path`|string||
+|`binds[].listeners[].routes[].backends[].mcp.targets[].openapi.backend`|string||
 |`binds[].listeners[].routes[].backends[].mcp.targets[].openapi.schema`|object||
 |`binds[].listeners[].routes[].backends[].mcp.targets[].openapi.schema.file`|string||
 |`binds[].listeners[].routes[].backends[].mcp.targets[].openapi.schema.url`|string||
@@ -5186,10 +5189,12 @@
 |`backends[].mcp.targets[].sse.host`|string||
 |`backends[].mcp.targets[].sse.port`|integer||
 |`backends[].mcp.targets[].sse.path`|string||
+|`backends[].mcp.targets[].sse.backend`|string||
 |`backends[].mcp.targets[].mcp`|object||
 |`backends[].mcp.targets[].mcp.host`|string||
 |`backends[].mcp.targets[].mcp.port`|integer||
 |`backends[].mcp.targets[].mcp.path`|string||
+|`backends[].mcp.targets[].mcp.backend`|string||
 |`backends[].mcp.targets[].stdio`|object||
 |`backends[].mcp.targets[].stdio.cmd`|string||
 |`backends[].mcp.targets[].stdio.args`|[]string||
@@ -5198,6 +5203,7 @@
 |`backends[].mcp.targets[].openapi.host`|string||
 |`backends[].mcp.targets[].openapi.port`|integer||
 |`backends[].mcp.targets[].openapi.path`|string||
+|`backends[].mcp.targets[].openapi.backend`|string||
 |`backends[].mcp.targets[].openapi.schema`|object||
 |`backends[].mcp.targets[].openapi.schema.file`|string||
 |`backends[].mcp.targets[].openapi.schema.url`|string||
@@ -8677,10 +8683,12 @@
 |`routeGroups[].routes[].backends[].mcp.targets[].sse.host`|string||
 |`routeGroups[].routes[].backends[].mcp.targets[].sse.port`|integer||
 |`routeGroups[].routes[].backends[].mcp.targets[].sse.path`|string||
+|`routeGroups[].routes[].backends[].mcp.targets[].sse.backend`|string||
 |`routeGroups[].routes[].backends[].mcp.targets[].mcp`|object||
 |`routeGroups[].routes[].backends[].mcp.targets[].mcp.host`|string||
 |`routeGroups[].routes[].backends[].mcp.targets[].mcp.port`|integer||
 |`routeGroups[].routes[].backends[].mcp.targets[].mcp.path`|string||
+|`routeGroups[].routes[].backends[].mcp.targets[].mcp.backend`|string||
 |`routeGroups[].routes[].backends[].mcp.targets[].stdio`|object||
 |`routeGroups[].routes[].backends[].mcp.targets[].stdio.cmd`|string||
 |`routeGroups[].routes[].backends[].mcp.targets[].stdio.args`|[]string||
@@ -8689,6 +8697,7 @@
 |`routeGroups[].routes[].backends[].mcp.targets[].openapi.host`|string||
 |`routeGroups[].routes[].backends[].mcp.targets[].openapi.port`|integer||
 |`routeGroups[].routes[].backends[].mcp.targets[].openapi.path`|string||
+|`routeGroups[].routes[].backends[].mcp.targets[].openapi.backend`|string||
 |`routeGroups[].routes[].backends[].mcp.targets[].openapi.schema`|object||
 |`routeGroups[].routes[].backends[].mcp.targets[].openapi.schema.file`|string||
 |`routeGroups[].routes[].backends[].mcp.targets[].openapi.schema.url`|string||
@@ -11969,10 +11978,12 @@
 |`mcp.targets[].sse.host`|string||
 |`mcp.targets[].sse.port`|integer||
 |`mcp.targets[].sse.path`|string||
+|`mcp.targets[].sse.backend`|string||
 |`mcp.targets[].mcp`|object||
 |`mcp.targets[].mcp.host`|string||
 |`mcp.targets[].mcp.port`|integer||
 |`mcp.targets[].mcp.path`|string||
+|`mcp.targets[].mcp.backend`|string||
 |`mcp.targets[].stdio`|object||
 |`mcp.targets[].stdio.cmd`|string||
 |`mcp.targets[].stdio.args`|[]string||
@@ -11981,6 +11992,7 @@
 |`mcp.targets[].openapi.host`|string||
 |`mcp.targets[].openapi.port`|integer||
 |`mcp.targets[].openapi.path`|string||
+|`mcp.targets[].openapi.backend`|string||
 |`mcp.targets[].openapi.schema`|object||
 |`mcp.targets[].openapi.schema.file`|string||
 |`mcp.targets[].openapi.schema.url`|string||

--- a/ui/src/app/playground/page.tsx
+++ b/ui/src/app/playground/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { Client as McpClient } from "@modelcontextprotocol/sdk/client/index.js";
-import { SSEClientTransport as McpSseTransport } from "@modelcontextprotocol/sdk/client/sse.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import {
   ClientRequest as McpClientRequest,
   Result as McpResult,
@@ -127,6 +127,34 @@ interface UiState {
 
 const HTTP_METHODS = ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"];
 
+const appendPathSegment = (base: string, segment: string) =>
+  base.endsWith("/") ? `${base}${segment}` : `${base}/${segment}`;
+
+const getMcpConnectionEndpoint = (routeInfo: RouteInfo): string => {
+  const exactPath = routeInfo.route.matches?.[0]?.path?.exact;
+  const normalizedEndpoint = routeInfo.endpoint.endsWith("/sse")
+    ? `${routeInfo.endpoint.slice(0, -4)}/mcp`
+    : routeInfo.endpoint;
+
+  if (normalizedEndpoint.endsWith("/mcp")) {
+    return normalizedEndpoint;
+  }
+
+  if (exactPath && exactPath !== "/") {
+    return normalizedEndpoint;
+  }
+
+  return appendPathSegment(normalizedEndpoint, "mcp");
+};
+
+const getConnectionEndpoint = (routeInfo: RouteInfo, backendType: "mcp" | "a2a" | "http") => {
+  if (backendType === "mcp") {
+    return getMcpConnectionEndpoint(routeInfo);
+  }
+
+  return routeInfo.endpoint;
+};
+
 export default function PlaygroundPage() {
   const { binds } = useServer();
   const [routes, setRoutes] = useState<RouteInfo[]>([]);
@@ -229,7 +257,7 @@ export default function PlaygroundPage() {
     setConnectionState((prev) => ({
       ...prev,
       connectionType: backendType,
-      selectedEndpoint: routeInfo.endpoint,
+      selectedEndpoint: getConnectionEndpoint(routeInfo, backendType),
       selectedListenerName: routeInfo.listener.name || null,
       selectedListenerProtocol: routeInfo.listener.protocol,
     }));
@@ -441,21 +469,23 @@ export default function PlaygroundPage() {
     resetClientState();
 
     const backendType = getRouteBackendType(selectedRoute);
+    const connectionEndpoint = getConnectionEndpoint(selectedRoute, backendType);
 
     try {
       if (backendType === "mcp") {
-        setConnectionState((prev) => ({ ...prev, connectionType: "mcp" }));
+        setConnectionState((prev) => ({
+          ...prev,
+          connectionType: "mcp",
+          selectedEndpoint: connectionEndpoint,
+        }));
 
-        // TODO: Support acting as a stateless client
         const client = new McpClient(
           { name: "agentgateway-dashboard", version: "0.1.0" },
           { capabilities: {} }
         );
 
         const headers: Record<string, string> = {
-          Accept: "text/event-stream",
           "Cache-Control": "no-cache",
-          "mcp-protocol-version": "2024-11-05",
         };
 
         // Only add auth header if token is provided and not empty
@@ -463,18 +493,7 @@ export default function PlaygroundPage() {
           headers["Authorization"] = `Bearer ${connectionState.authToken}`;
         }
 
-        const sseUrl = selectedRoute.endpoint.endsWith("/")
-          ? `${selectedRoute.endpoint}sse`
-          : `${selectedRoute.endpoint}/sse`;
-        const transport = new McpSseTransport(new URL(sseUrl), {
-          eventSourceInit: {
-            fetch: (url, init) => {
-              return fetch(url, {
-                ...init,
-                headers: headers as HeadersInit,
-              });
-            },
-          },
+        const transport = new StreamableHTTPClientTransport(new URL(connectionEndpoint), {
           requestInit: {
             headers: headers as HeadersInit,
             credentials: "omit",
@@ -594,9 +613,7 @@ export default function PlaygroundPage() {
         errorMessage.includes("404") ||
         error?.code === 404
       ) {
-        toast.error(
-          `❌ Not Found (404): Endpoint '${selectedRoute?.endpoint || "unknown"}' not found`
-        );
+        toast.error(`❌ Not Found (404): Endpoint '${connectionEndpoint || "unknown"}' not found`);
       } else if (
         errorMessage.includes("Failed to fetch") ||
         errorMessage.includes("NetworkError") ||
@@ -607,12 +624,13 @@ export default function PlaygroundPage() {
         let detailedMessage = "❌ Connection Failed - Possible causes:\n";
         detailedMessage += "• CORS: Server needs 'Access-Control-Allow-Origin' header\n";
         detailedMessage += "• Network: Server may be down or unreachable\n";
-        detailedMessage += "• Headers: Missing required headers (Accept, mcp-protocol-version)\n";
-        detailedMessage += `• URL: Check if '${selectedRoute?.endpoint || "unknown"}/sse' is correct\n`;
+        detailedMessage +=
+          "• Headers: Missing required headers (content-type, mcp-protocol-version)\n";
+        detailedMessage += `• URL: Check if '${connectionEndpoint}' is correct\n`;
         detailedMessage += "• Config: Verify agentgateway is running with correct config";
 
         console.error("CORS/Network error details:", {
-          url: `${selectedRoute?.endpoint || "unknown"}/sse`,
+          url: connectionEndpoint,
           headers: error?.headers,
           mode: "cors",
           credentials: "omit",


### PR DESCRIPTION
## Summary

This changes the Playground to always use streamable HTTP for MCP connections.

Fixes #1434

The previous implementation kept the legacy SSE flow and only added streamable HTTP behavior conditionally.

Based on review feedback(PR #1435), this PR instead removes the old SSE assumption from the Playground and standardizes MCP connections on streamable HTTP.

<img width="1195" height="626" alt="스크린샷 2026-04-19 오후 4 57 57" src="https://github.com/user-attachments/assets/01363d40-9e1f-4363-9180-bbac582d1f59" />

## What changed

- replaced the Playground MCP SSE client transport with streamable HTTP
- changed MCP connection URLs to use the streamable MCP endpoint
- kept route endpoint calculation safe for explicit MCP paths
- updated the connection panel to reflect the actual MCP endpoint and transport
- updated error messages to reference the effective MCP URL

## Why

Agentgateway can support streamable HTTP for MCP routes, and keeping a separate legacy SSE flow in
the Playground no longer provides value.

Standardizing on streamable HTTP simplifies the UI and avoids the incorrect `/sse` behavior that
caused Playground MCP connection failures.

## Testing

- ran `cd ui && npm run build`
- manually verified Playground MCP connections use streamable HTTP
- manually verified the connection panel displays an `/mcp` endpoint and `STREAMABLE HTTP`