### PR TITLE
Fix CEL response.body access when upstream returns compressed response

### DIFF
--- a/crates/agentgateway/src/cel/mod.rs
+++ b/crates/agentgateway/src/cel/mod.rs
@@ -8,6 +8,7 @@ pub use cel::Value;
 pub use cel::types::dynamic::DynamicType;
 use cel::{Context, ExecutionError, ParseError, ParseErrors, Program};
 use flagset::FlagSet;
+use headers::{ContentEncoding, HeaderMapExt};
 pub use helpers::*;
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize, Serializer};
@@ -200,10 +201,29 @@ impl ContextBuilder {
 			if resp.extensions().get::<BufferedBody>().is_some() {
 				return;
 			}
-			let Ok(body) = crate::http::inspect_response_body(resp).await else {
-				return;
-			};
-			resp.extensions_mut().insert(BufferedBody(body));
+			// If the upstream compressed the response body, decompress before buffering so
+			// CEL expressions like `json(response.body)` can parse plaintext/JSON. The
+			// decompressed bytes replace the body stream and the encoding headers are removed
+			// so downstream clients still receive a valid (uncompressed) response.
+			let ce = resp.headers().typed_get::<ContentEncoding>();
+			if ce.is_some() {
+				let limit = crate::http::response_buffer_limit(resp);
+				let body = std::mem::replace(resp.body_mut(), axum_core::body::Body::empty());
+				let Ok((_, bytes)) =
+					crate::http::compression::to_bytes_with_decompression(body, ce.as_ref(), limit).await
+				else {
+					return;
+				};
+				resp.headers_mut().remove(http::header::CONTENT_ENCODING);
+				resp.headers_mut().remove(http::header::CONTENT_LENGTH);
+				*resp.body_mut() = axum_core::body::Body::from(bytes.clone());
+				resp.extensions_mut().insert(BufferedBody(bytes));
+			} else {
+				let Ok(body) = crate::http::inspect_response_body(resp).await else {
+					return;
+				};
+				resp.extensions_mut().insert(BufferedBody(body));
+			}
 		}
 	}
 

--- a/crates/agentgateway/src/cel/mod.rs
+++ b/crates/agentgateway/src/cel/mod.rs
@@ -8,7 +8,6 @@ pub use cel::Value;
 pub use cel::types::dynamic::DynamicType;
 use cel::{Context, ExecutionError, ParseError, ParseErrors, Program};
 use flagset::FlagSet;
-use headers::{ContentEncoding, HeaderMapExt};
 pub use helpers::*;
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize, Serializer};
@@ -201,31 +200,10 @@ impl ContextBuilder {
 			if resp.extensions().get::<BufferedBody>().is_some() {
 				return;
 			}
-			let ce = resp.headers().typed_get::<ContentEncoding>();
-			if ce.is_some() {
-				// Peek the compressed bytes without consuming the body, then decompress a copy
-				// for CEL. The body and headers are left intact so downstream clients receive
-				// the original compressed response.
-				let Ok(compressed) = crate::http::inspect_response_body(resp).await else {
-					return;
-				};
-				let limit = crate::http::response_buffer_limit(resp);
-				let Ok((_, plain)) = crate::http::compression::to_bytes_with_decompression(
-					axum_core::body::Body::from(compressed),
-					ce.as_ref(),
-					limit,
-				)
-				.await
-				else {
-					return;
-				};
-				resp.extensions_mut().insert(BufferedBody(plain));
-			} else {
-				let Ok(body) = crate::http::inspect_response_body(resp).await else {
-					return;
-				};
-				resp.extensions_mut().insert(BufferedBody(body));
-			}
+			let Ok(body) = crate::http::inspect_response_body(resp).await else {
+				return;
+			};
+			resp.extensions_mut().insert(BufferedBody(body));
 		}
 	}
 

--- a/crates/agentgateway/src/cel/mod.rs
+++ b/crates/agentgateway/src/cel/mod.rs
@@ -201,23 +201,25 @@ impl ContextBuilder {
 			if resp.extensions().get::<BufferedBody>().is_some() {
 				return;
 			}
-			// If the upstream compressed the response body, decompress before buffering so
-			// CEL expressions like `json(response.body)` can parse plaintext/JSON. The
-			// decompressed bytes replace the body stream and the encoding headers are removed
-			// so downstream clients still receive a valid (uncompressed) response.
 			let ce = resp.headers().typed_get::<ContentEncoding>();
 			if ce.is_some() {
+				// Peek the compressed bytes without consuming the body, then decompress a copy
+				// for CEL. The body and headers are left intact so downstream clients receive
+				// the original compressed response.
+				let Ok(compressed) = crate::http::inspect_response_body(resp).await else {
+					return;
+				};
 				let limit = crate::http::response_buffer_limit(resp);
-				let body = std::mem::replace(resp.body_mut(), axum_core::body::Body::empty());
-				let Ok((_, bytes)) =
-					crate::http::compression::to_bytes_with_decompression(body, ce.as_ref(), limit).await
+				let Ok((_, plain)) = crate::http::compression::to_bytes_with_decompression(
+					axum_core::body::Body::from(compressed),
+					ce.as_ref(),
+					limit,
+				)
+				.await
 				else {
 					return;
 				};
-				resp.headers_mut().remove(http::header::CONTENT_ENCODING);
-				resp.headers_mut().remove(http::header::CONTENT_LENGTH);
-				*resp.body_mut() = axum_core::body::Body::from(bytes.clone());
-				resp.extensions_mut().insert(BufferedBody(bytes));
+				resp.extensions_mut().insert(BufferedBody(plain));
 			} else {
 				let Ok(body) = crate::http::inspect_response_body(resp).await else {
 					return;

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -917,7 +917,9 @@ impl AIProvider {
 		// Snapshot decompressed bytes for CEL response.body access before re-compression,
 		// so maybe_buffer_response_body can skip decompression entirely.
 		if encoding.is_some() {
-			parts.extensions.insert(crate::cel::BufferedBody(bytes.clone()));
+			parts
+				.extensions
+				.insert(crate::cel::BufferedBody(bytes.clone()));
 		}
 
 		// count_tokens has simplified response handling (just format translation)

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -914,6 +914,12 @@ impl AIProvider {
 				.await
 				.map_err(|e| map_compression_error(e, &parts.headers))?;
 
+		// Snapshot decompressed bytes for CEL response.body access before re-compression,
+		// so maybe_buffer_response_body can skip decompression entirely.
+		if encoding.is_some() {
+			parts.extensions.insert(crate::cel::BufferedBody(bytes.clone()));
+		}
+
 		// count_tokens has simplified response handling (just format translation)
 		if req.input_format == InputFormat::CountTokens {
 			let (bytes, count) = match self {


### PR DESCRIPTION
Fixes https://github.com/agentgateway/agentgateway/issues/1580 

Tested locally with mock python server:
```
  python3 -c "
  import gzip, json
  from http.server import HTTPServer, BaseHTTPRequestHandler

class H(BaseHTTPRequestHandler):
  def do_POST(self):
    enc = self.headers.get('Accept-Encoding', '')
    body = json.dumps({'model': 'gpt-4', 'choices': []}).encode()

    if 'gzip' in enc:
      out = gzip.compress(body)
      self.send_response(200)
      self.send_header('Content-Type', 'application/json')
      self.send_header('Content-Encoding', 'gzip')
      self.send_header('Content-Length', str(len(out)))
      self.end_headers()
      self.wfile.write(out)
    else:
      self.send_response(200)
      self.send_header('Content-Type', 'application/json')
      self.send_header('Content-Length', str(len(body)))
      self.end_headers()
      self.wfile.write(body)

  def log_message(self, *a):
    pass

  HTTPServer(('', 8000), H).serve_forever()
  "
```

Then this agw config:
```
binds:
- port: 4000
  listeners:
  - protocol: HTTP
    routes:
    - policies:
        transformations:
          request:
            set:
              x-requested-model: 'string(json(request.body).model)'
          response:
            set:
              x-actual-model: 'string(json(response.body).model)'
      backends:
      - host: localhost:8000
```

Before fix (on main):
```
❯    curl -s -D - -o /dev/null http://localhost:4000/v1/chat/completions \
     -H 'Content-Type: application/json' \
     -H 'Accept-Encoding: gzip' \
     -d '{"model":"gpt-4","messages":[{"role":"user","content":"Hi"}]}'
HTTP/1.0 200 OK
server: BaseHTTP/0.6 Python/3.14.3
date: Mon, 20 Apr 2026 18:32:42 GMT
content-type: application/json
content-encoding: gzip
content-length: 52
```

After fix:

```
curl -s -D - -o /dev/null http://localhost:4000/v1/chat/completions \
     -H 'Content-Type: application/json' \
     -H 'Accept-Encoding: gzip' \
     -d '{"model":"gpt-4","messages":[{"role":"user","content":"Hi"}]}'

HTTP/1.0 200 OK
server: BaseHTTP/0.6 Python/3.14.3
date: Mon, 20 Apr 2026 18:28:12 GMT
content-type: application/json
x-actual-model: gpt-4 # still here :) 
content-length: 33
```