### PR TITLE
docs: move deprecation notice

### DIFF
--- a/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
+++ b/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
@@ -243,9 +243,6 @@ type BackendFull struct {
 	// `mcp` specifies settings for MCP workloads. This is only applicable when
 	// connecting to a `Backend` of type `mcp`.
 	//
-	// This field is deprecated; prefer to use traffic policy `jwtAuthentication.mcp`, which ensures authentication runs before
-	// other policies such as transformation and rate limiting.
-	//
 	// +optional
 	MCP *BackendMCP `json:"mcp,omitempty"`
 }
@@ -1111,6 +1108,10 @@ type BackendMCP struct {
 	// +optional
 	Authorization *shared.Authorization `json:"authorization,omitempty"`
 	// `authentication` defines `MCPBackend`-specific authentication rules.
+	//
+	// This field is deprecated; prefer to use traffic policy `jwtAuthentication.mcp`, which ensures authentication runs before
+	// other policies such as transformation and rate limiting.
+	//
 	// +optional
 	Authentication *MCPAuthentication `json:"authentication,omitempty"`
 }

--- a/controller/hack/utils/oss_compliance/osa_provided.md
+++ b/controller/hack/utils/oss_compliance/osa_provided.md
@@ -51,8 +51,8 @@ Name|Version|License
 [sigs.k8s.io/controller-runtime](https://sigs.k8s.io/controller-runtime)|v0.23.3|Apache License 2.0
 [sigs.k8s.io/controller-tools](https://sigs.k8s.io/controller-tools)|v0.20.1|Apache License 2.0
 [sigs.k8s.io/gateway-api](https://sigs.k8s.io/gateway-api)|v1.5.1|Apache License 2.0
-[sigs.k8s.io/gateway-api-inference-extension](https://sigs.k8s.io/gateway-api-inference-extension)|v1.5.0-rc.2|Apache License 2.0
-[gateway-api-inference-extension/conformance](https://sigs.k8s.io/gateway-api-inference-extension/conformance)|v1.5.0-rc.2|Apache License 2.0
+[sigs.k8s.io/gateway-api-inference-extension](https://sigs.k8s.io/gateway-api-inference-extension)|v1.5.0|Apache License 2.0
+[gateway-api-inference-extension/conformance](https://sigs.k8s.io/gateway-api-inference-extension/conformance)|v1.5.0|Apache License 2.0
 [gateway-api/conformance](https://sigs.k8s.io/gateway-api/conformance)|v1.5.1|Apache License 2.0
 [sigs.k8s.io/yaml](https://sigs.k8s.io/yaml)|v1.6.0|MIT License
 [cmd/goimports](https://golang.org/x/tools/cmd/goimports)|latest|MIT License

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
@@ -12673,13 +12673,13 @@ spec:
                     description: |-
                       `mcp` specifies settings for MCP workloads. This is only applicable when
                       connecting to a `Backend` of type `mcp`.
-
-                      This field is deprecated; prefer to use traffic policy `jwtAuthentication.mcp`, which ensures authentication runs before
-                      other policies such as transformation and rate limiting.
                     properties:
                       authentication:
-                        description: '`authentication` defines `MCPBackend`-specific
-                          authentication rules.'
+                        description: |-
+                          `authentication` defines `MCPBackend`-specific authentication rules.
+
+                          This field is deprecated; prefer to use traffic policy `jwtAuthentication.mcp`, which ensures authentication runs before
+                          other policies such as transformation and rate limiting.
                         properties:
                           audiences:
                             description: |-

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
@@ -5039,13 +5039,13 @@ spec:
                     description: |-
                       `mcp` specifies settings for MCP workloads. This is only applicable when
                       connecting to a `Backend` of type `mcp`.
-
-                      This field is deprecated; prefer to use traffic policy `jwtAuthentication.mcp`, which ensures authentication runs before
-                      other policies such as transformation and rate limiting.
                     properties:
                       authentication:
-                        description: '`authentication` defines `MCPBackend`-specific
-                          authentication rules.'
+                        description: |-
+                          `authentication` defines `MCPBackend`-specific authentication rules.
+
+                          This field is deprecated; prefer to use traffic policy `jwtAuthentication.mcp`, which ensures authentication runs before
+                          other policies such as transformation and rate limiting.
                         properties:
                           audiences:
                             description: |-


### PR DESCRIPTION
We meant to deprecate mcp.authentication not also mcp.authorization

Signed-off-by: John Howard <john.howard@solo.io>
