### PR TITLE
Fix: regex path prase httproute

### DIFF
--- a/controller/pkg/agentgateway/translator/agw.go
+++ b/controller/pkg/agentgateway/translator/agw.go
@@ -67,7 +67,9 @@ func CreateAgwPathMatch(match gwv1.HTTPRouteMatch) (*api.PathMatch, *reporter.Ro
 	if match.Path.Type != nil {
 		tp = *match.Path.Type
 	}
-	// Path value must start with "/". If empty/nil, coerce to "/".
+	// For non-regex path match types, ensure the path starts with "/".
+	// If the value is empty or nil, default to "/".
+	// RegularExpression paths are not modified to support full regex patterns (e.g. "^/.*$").
 	dest := "/"
 	if match.Path.Value != nil && *match.Path.Value != "" {
 		dest = *match.Path.Value

--- a/controller/pkg/agentgateway/translator/agw.go
+++ b/controller/pkg/agentgateway/translator/agw.go
@@ -72,8 +72,10 @@ func CreateAgwPathMatch(match gwv1.HTTPRouteMatch) (*api.PathMatch, *reporter.Ro
 	if match.Path.Value != nil && *match.Path.Value != "" {
 		dest = *match.Path.Value
 	}
-	if !strings.HasPrefix(dest, "/") {
-		dest = "/" + dest
+	if tp != gwv1.PathMatchRegularExpression {
+		if !strings.HasPrefix(dest, "/") {
+			dest = "/" + dest
+		}
 	}
 	switch tp {
 	case gwv1.PathMatchPathPrefix:

--- a/controller/pkg/agentgateway/translator/testdata/routes/httproute-path-prefix-regex.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/routes/httproute-path-prefix-regex.yaml
@@ -37,7 +37,7 @@ output:
       listenerKey: default/test-gateway.http
       matches:
       - path:
-          pathPrefix: /
+          regex: ^/.*$
       name:
         kind: HTTPRoute
         name: regex-route
@@ -46,7 +46,7 @@ status:
 - apiVersion: gateway.networking.k8s.io/v1
   kind: HTTPRoute
   metadata:
-    name: test-route
+    name: regex-route
     namespace: default
   spec: null
   status:
@@ -62,11 +62,6 @@ status:
         reason: ResolvedRefs
         status: "True"
         type: ResolvedRefs
-      - lastTransitionTime: fake
-        message: ""
-        reason: Programmed
-        status: "True"
-        type: Programmed
       controllerName: agentgateway.dev/agentgateway
       parentRef:
         group: gateway.networking.k8s.io

--- a/controller/pkg/agentgateway/translator/testdata/routes/httproute-path-prefix-regex.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/routes/httproute-path-prefix-regex.yaml
@@ -1,0 +1,75 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: regex-route
+  namespace: default
+spec:
+  parentRefs:
+  - name: test-gateway
+  hostnames:
+  - example.com
+  rules:
+  - matches:
+    - path:
+        type: RegularExpression
+        value: ^/.*$
+    backendRefs:
+    - name: test-service
+      port: 80
+---
+# Output
+output:
+- gateway:
+    Name: test-gateway
+    Namespace: default
+  resource:
+    route:
+      backends:
+      - backend:
+          port: 80
+          service:
+            hostname: test-service.default.svc.cluster.local
+            namespace: default
+        weight: 1
+      hostnames:
+      - example.com
+      key: default/regex-route.00.http
+      listenerKey: default/test-gateway.http
+      matches:
+      - path:
+          pathPrefix: /
+      name:
+        kind: HTTPRoute
+        name: regex-route
+        namespace: default
+status:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    name: test-route
+    namespace: default
+  spec: null
+  status:
+    parents:
+    - conditions:
+      - lastTransitionTime: fake
+        message: ""
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: ""
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      - lastTransitionTime: fake
+        message: ""
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      controllerName: agentgateway.dev/agentgateway
+      parentRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: test-gateway
+        namespace: default


### PR DESCRIPTION
### Description

Part of the Mentorship Program https://github.com/kgateway-dev/kgateway.dev/issues/606
Issue: https://github.com/agentgateway/agentgateway/issues/1573

This PR fixes an issue where AgentGateway only supported literal HTTPRoute paths, while regex-based paths were not handled correctly. Regex path matching is now fully supported.
