### PR TITLE
fix(jwks): clear cache on remove and sweep startup orphans

### DIFF
--- a/controller/pkg/agentgateway/jwks/cache.go
+++ b/controller/pkg/agentgateway/jwks/cache.go
@@ -51,27 +51,39 @@ func (c *JwksCache) GetJwks(requestKey remotehttp.FetchKey) (Keyset, bool) {
 	return keyset, ok
 }
 
-func (c *JwksCache) addJwks(requestKey remotehttp.FetchKey, requestURL string, jwks jose.JSONWebKeySet) error {
+func buildKeyset(requestKey remotehttp.FetchKey, requestURL string, jwks jose.JSONWebKeySet) (Keyset, error) {
 	serializedJwks, err := json.Marshal(jwks)
 	if err != nil {
-		return err
+		return Keyset{}, err
 	}
-
-	c.l.Lock()
-	defer c.l.Unlock()
-
-	keyset := Keyset{
+	return Keyset{
 		RequestKey: requestKey,
 		URL:        requestURL,
 		FetchedAt:  time.Now(),
 		JwksJSON:   string(serializedJwks),
-	}
-	c.keysets[requestKey] = keyset
-	return nil
+	}, nil
 }
 
-func (c *JwksCache) deleteJwks(requestKey remotehttp.FetchKey) {
+func (c *JwksCache) putKeyset(keyset Keyset) {
 	c.l.Lock()
+	defer c.l.Unlock()
+	c.keysets[keyset.RequestKey] = keyset
+}
+
+func (c *JwksCache) deleteJwks(requestKey remotehttp.FetchKey) bool {
+	c.l.Lock()
+	defer c.l.Unlock()
+	_, existed := c.keysets[requestKey]
 	delete(c.keysets, requestKey)
-	c.l.Unlock()
+	return existed
+}
+
+func (c *JwksCache) Keys() []remotehttp.FetchKey {
+	c.l.Lock()
+	defer c.l.Unlock()
+	keys := make([]remotehttp.FetchKey, 0, len(c.keysets))
+	for k := range c.keysets {
+		keys = append(keys, k)
+	}
+	return keys
 }

--- a/controller/pkg/agentgateway/jwks/fetcher.go
+++ b/controller/pkg/agentgateway/jwks/fetcher.go
@@ -299,19 +299,17 @@ func (f *Fetcher) maybeFetchJwks(ctx context.Context) {
 			continue
 		}
 
-		state, ok = f.lookup(fetch.RequestKey)
-		if !ok || state.generation != fetch.Generation {
-			continue
-		}
-
-		if err := f.cache.addJwks(fetch.RequestKey, requestURL, jwks); err != nil {
+		keyset, err := buildKeyset(fetch.RequestKey, requestURL, jwks)
+		if err != nil {
 			logger.Error("error adding jwks", "request_key", fetch.RequestKey, "jwks_uri", requestURL, "error", err)
 			next := nextRetryDelay(fetch.RetryAttempt)
 			f.scheduleAt(fetch.RequestKey, state.generation, now.Add(next), fetch.RetryAttempt+1)
 			continue
 		}
 
-		f.scheduleAt(fetch.RequestKey, state.generation, now.Add(state.source.TTL), 0)
+		if !f.commitFetchResult(fetch.RequestKey, fetch.Generation, keyset, now.Add(state.source.TTL)) {
+			continue
+		}
 		updates.Insert(fetch.RequestKey)
 	}
 
@@ -347,22 +345,66 @@ func (f *Fetcher) AddOrUpdateKeyset(source JwksSource) error {
 	return nil
 }
 
-func (f *Fetcher) RemoveKeyset(requestKey remotehttp.FetchKey) {
+// commitFetchResult publishes a freshly fetched keyset to the cache and
+// re-schedules the next fetch, atomically under f.mu so that a concurrent
+// RemoveKeyset cannot interleave between the liveness check and the cache
+// write and leave a stale keyset behind. Returns false if the request has
+// been removed or superseded by a newer generation since the fetch was
+// dispatched; in that case the result is discarded.
+func (f *Fetcher) commitFetchResult(requestKey remotehttp.FetchKey, generation uint64, keyset Keyset, nextFetchAt time.Time) bool {
 	f.mu.Lock()
-	_, ok := f.requests[requestKey]
-	if ok {
-		delete(f.requests, requestKey)
-		f.schedule.Remove(requestKey)
+	defer f.mu.Unlock()
+
+	state, ok := f.requests[requestKey]
+	if !ok || state.generation != generation {
+		return false
+	}
+
+	f.cache.putKeyset(keyset)
+	f.scheduleAtLocked(requestKey, generation, nextFetchAt, 0)
+	return true
+}
+
+// SweepOrphans drops any cache entries that do not correspond to a live
+// request. Intended to be called once at startup after the request collection
+// has synced, to reconcile persisted keysets whose owning policies were
+// deleted while the controller was down.
+func (f *Fetcher) SweepOrphans() {
+	f.mu.Lock()
+	orphans := sets.New[remotehttp.FetchKey]()
+	for _, key := range f.cache.Keys() {
+		if _, ok := f.requests[key]; !ok {
+			orphans.Insert(key)
+			f.cache.deleteJwks(key)
+		}
 	}
 	f.mu.Unlock()
 
-	if !ok {
+	if orphans.IsEmpty() {
 		return
 	}
 
-	f.cache.deleteJwks(requestKey)
+	f.notifySubscribers(orphans)
+}
+
+func (f *Fetcher) RemoveKeyset(requestKey remotehttp.FetchKey) {
+	f.mu.Lock()
+	_, hadRequest := f.requests[requestKey]
+	if hadRequest {
+		delete(f.requests, requestKey)
+		f.schedule.Remove(requestKey)
+	}
+	hadCache := f.cache.deleteJwks(requestKey)
+	f.mu.Unlock()
+
+	if !hadRequest && !hadCache {
+		return
+	}
+
 	f.notifySubscribers(sets.New(requestKey))
-	signalWake(f.wake)
+	if hadRequest {
+		signalWake(f.wake)
+	}
 }
 
 func (f *Fetcher) fetchJwks(ctx context.Context, source JwksSource) (string, jose.JSONWebKeySet, error) {

--- a/controller/pkg/agentgateway/jwks/fetcher_test.go
+++ b/controller/pkg/agentgateway/jwks/fetcher_test.go
@@ -49,7 +49,7 @@ func TestRemoveKeysetFromFetcher(t *testing.T) {
 	f := NewFetcher(NewCache())
 
 	assert.NoError(t, f.AddOrUpdateKeyset(source))
-	f.cache.keysets[source.RequestKey] = Keyset{RequestKey: source.RequestKey, URL: source.Target.URL, JwksJSON: "jwks"}
+	seedJwksCacheForTest(f.cache, source.RequestKey, source.Target.URL)
 
 	f.RemoveKeyset(source.RequestKey)
 
@@ -60,6 +60,23 @@ func TestRemoveKeysetFromFetcher(t *testing.T) {
 	assert.False(t, ok)
 	_, ok = f.cache.GetJwks(source.RequestKey)
 	assert.False(t, ok)
+}
+
+// RemoveKeyset must clear the cache even when f.requests didn't own the key.
+// The cache can be seeded by LoadPersistedKeysets at startup without a
+// corresponding Fetcher request; if a later event (e.g. manual CM deletion)
+// drives RemoveKeyset, the early-return path leaves the cache stale.
+func TestRemoveKeysetClearsCacheEvenWithoutRequest(t *testing.T) {
+	source := testSource()
+	f := NewFetcher(NewCache())
+	// Simulate LoadPersistedKeysets populating the cache without the fetcher
+	// ever seeing an AddOrUpdateKeyset.
+	seedJwksCacheForTest(f.cache, source.RequestKey, source.Target.URL)
+
+	f.RemoveKeyset(source.RequestKey)
+
+	_, ok := f.cache.GetJwks(source.RequestKey)
+	assert.False(t, ok, "cache should be cleared even when request was not tracked")
 }
 
 func TestAddOrUpdateKeysetReplacesExistingScheduleEntry(t *testing.T) {
@@ -369,6 +386,17 @@ func testSourceWithURL(requestURL string) JwksSource {
 		Target:     target,
 		TTL:        5 * time.Minute,
 	}
+}
+
+// seedJwksCacheForTest writes a synthetic keyset into the cache through
+// putKeyset so the cache lock is respected, rather than reaching into the
+// unexported map directly.
+func seedJwksCacheForTest(cache *JwksCache, requestKey remotehttp.FetchKey, url string) {
+	cache.putKeyset(Keyset{
+		RequestKey: requestKey,
+		URL:        url,
+		JwksJSON:   `{"keys":[]}`,
+	})
 }
 
 type stubJwksClient struct {

--- a/controller/pkg/agentgateway/jwks/store.go
+++ b/controller/pkg/agentgateway/jwks/store.go
@@ -89,6 +89,9 @@ func (s *Store) Start(ctx context.Context) error {
 	if !registration.WaitUntilSynced(ctx.Done()) {
 		return nil
 	}
+
+	s.jwksFetcher.SweepOrphans()
+
 	close(s.ready)
 
 	<-ctx.Done()

--- a/controller/pkg/agentgateway/jwks/store_test.go
+++ b/controller/pkg/agentgateway/jwks/store_test.go
@@ -2,9 +2,11 @@ package jwks
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
+	"github.com/go-jose/go-jose/v4"
 	"github.com/stretchr/testify/assert"
 	"istio.io/istio/pkg/kube/krt"
 	corev1 "k8s.io/api/core/v1"
@@ -106,6 +108,7 @@ func TestStoreTracksSharedRequestCollectionLifecycle(t *testing.T) {
 		"agentgateway-system",
 	)
 	store := NewStore(requests, persisted, DefaultJwksStorePrefix)
+	store.jwksFetcher.defaultJwksClient = offlineStubJwksClient{}
 	go func() {
 		_ = store.Start(ctx)
 	}()
@@ -148,13 +151,16 @@ func TestStoreLoadsPersistedKeysetsBeforeServing(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
-	requests := krt.NewStaticCollection[SharedJwksRequest](alwaysSynced{}, nil)
+	requests := krt.NewStaticCollection[SharedJwksRequest](alwaysSynced{}, []SharedJwksRequest{
+		testSharedJwksRequest(target.URL, 5*time.Minute),
+	})
 	persisted := NewPersistedEntriesFromCollection(
 		krt.NewStaticCollection[*corev1.ConfigMap](alwaysSynced{}, []*corev1.ConfigMap{cm}),
 		DefaultJwksStorePrefix,
 		"agentgateway-system",
 	)
 	store := NewStore(requests, persisted, DefaultJwksStorePrefix)
+	store.jwksFetcher.defaultJwksClient = offlineStubJwksClient{}
 	go func() {
 		_ = store.Start(ctx)
 	}()
@@ -163,6 +169,232 @@ func TestStoreLoadsPersistedKeysetsBeforeServing(t *testing.T) {
 	actual, ok := store.JwksByRequestKey(keyset.RequestKey)
 	assert.True(t, ok)
 	assert.Equal(t, keyset, actual)
+}
+
+// Reproducer for https://github.com/agentgateway/agentgateway/issues/1616.
+// Stand up the full AgentPolicy -> ... -> SharedJwksRequest KRT derivation,
+// populate the fetcher cache (simulating a successful remote fetch), then
+// delete the AgentPolicy and assert the cache is cleared.
+func TestStoreClearsCacheWhenLastPolicyDeleted(t *testing.T) {
+	krtOpts := testKrtOptions(t)
+	uri := "https://issuer.example/jwks"
+	requestKey := remotehttp.FetchTarget{URL: uri}.Key()
+
+	policies := dynamicRemotePolicies(t, []*agentgateway.AgentgatewayPolicy{
+		testRemotePolicy("one", uri, 5*time.Minute),
+	}, krtOpts)
+
+	collections := NewCollections(CollectionInputs{
+		AgentgatewayPolicies: policies,
+		Backends:             krt.NewStaticCollection[*agentgateway.AgentgatewayBackend](alwaysSynced{}, nil),
+		Resolver: jwksResolverFunc(func(owner RemoteJwksOwner) (*ResolvedJwksRequest, error) {
+			return resolvedJwksRequest(owner, owner.Remote.JwksPath), nil
+		}),
+		KrtOpts: krtOpts,
+	})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	persisted := NewPersistedEntriesFromCollection(
+		krt.NewStaticCollection[*corev1.ConfigMap](alwaysSynced{}, nil),
+		DefaultJwksStorePrefix,
+		"agentgateway-system",
+	)
+	store := NewStore(collections.SharedRequests, persisted, DefaultJwksStorePrefix)
+	store.jwksFetcher.defaultJwksClient = offlineStubJwksClient{}
+	go func() {
+		_ = store.Start(ctx)
+	}()
+
+	assert.Eventually(t, store.HasSynced, testEventuallyTimeout, testEventuallyPoll)
+	awaitJwksFetchState(t, store.jwksFetcher, requestKey)
+
+	seedJwksCacheForTest(store.jwksCache, requestKey, uri)
+	_, ok := store.JwksByRequestKey(requestKey)
+	assert.True(t, ok, "cache should be populated before policy deletion")
+
+	// Delete the AgentPolicy.
+	policies.Reset(nil)
+
+	// f.requests should be cleared.
+	awaitNoJwksFetchState(t, store.jwksFetcher, requestKey)
+
+	// Cache should also be cleared -- otherwise the CM controller will
+	// re-create the ConfigMap on every reconcile.
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		_, ok := store.JwksByRequestKey(requestKey)
+		assert.False(c, ok, "cache should be cleared when last policy is deleted")
+	}, testEventuallyTimeout, testEventuallyPoll)
+}
+
+// Variant: the user's report said "I had some AgPolicies" (plural). Test the
+// case where two policies share a key and both are removed in one burst.
+func TestStoreClearsCacheWhenAllSharedPoliciesDeleted(t *testing.T) {
+	krtOpts := testKrtOptions(t)
+	uri := "https://issuer.example/jwks"
+	requestKey := remotehttp.FetchTarget{URL: uri}.Key()
+
+	policies := dynamicRemotePolicies(t, []*agentgateway.AgentgatewayPolicy{
+		testRemotePolicy("one", uri, 5*time.Minute),
+		testRemotePolicy("two", uri, 5*time.Minute),
+	}, krtOpts)
+
+	collections := NewCollections(CollectionInputs{
+		AgentgatewayPolicies: policies,
+		Backends:             krt.NewStaticCollection[*agentgateway.AgentgatewayBackend](alwaysSynced{}, nil),
+		Resolver: jwksResolverFunc(func(owner RemoteJwksOwner) (*ResolvedJwksRequest, error) {
+			return resolvedJwksRequest(owner, owner.Remote.JwksPath), nil
+		}),
+		KrtOpts: krtOpts,
+	})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	persisted := NewPersistedEntriesFromCollection(
+		krt.NewStaticCollection[*corev1.ConfigMap](alwaysSynced{}, nil),
+		DefaultJwksStorePrefix,
+		"agentgateway-system",
+	)
+	store := NewStore(collections.SharedRequests, persisted, DefaultJwksStorePrefix)
+	store.jwksFetcher.defaultJwksClient = offlineStubJwksClient{}
+	go func() {
+		_ = store.Start(ctx)
+	}()
+
+	assert.Eventually(t, store.HasSynced, testEventuallyTimeout, testEventuallyPoll)
+	awaitJwksFetchState(t, store.jwksFetcher, requestKey)
+
+	seedJwksCacheForTest(store.jwksCache, requestKey, uri)
+
+	policies.Reset(nil)
+
+	awaitNoJwksFetchState(t, store.jwksFetcher, requestKey)
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		_, ok := store.JwksByRequestKey(requestKey)
+		assert.False(c, ok)
+	}, testEventuallyTimeout, testEventuallyPoll)
+}
+
+// Variant: controller starts with ConfigMap already persisted (warm start),
+// an AgentPolicy exists that matches it, then the AgentPolicy is deleted.
+// This exercises the path where the cache is seeded by LoadPersistedKeysets
+// AND subsequently AddOrUpdateKeyset fires from the register replay.
+func TestStoreClearsCacheWhenPolicyDeletedAfterWarmStart(t *testing.T) {
+	krtOpts := testKrtOptions(t)
+	uri := "https://issuer.example/jwks"
+	requestKey := remotehttp.FetchTarget{URL: uri}.Key()
+
+	persistedKeyset := Keyset{
+		RequestKey: requestKey,
+		URL:        uri,
+		JwksJSON:   `{"keys":[]}`,
+	}
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      JwksConfigMapName(DefaultJwksStorePrefix, requestKey),
+			Namespace: "agentgateway-system",
+			Labels:    JwksStoreConfigMapLabel(DefaultJwksStorePrefix),
+		},
+	}
+	assert.NoError(t, SetJwksInConfigMap(cm, persistedKeyset))
+
+	policies := dynamicRemotePolicies(t, []*agentgateway.AgentgatewayPolicy{
+		testRemotePolicy("one", uri, 5*time.Minute),
+	}, krtOpts)
+
+	collections := NewCollections(CollectionInputs{
+		AgentgatewayPolicies: policies,
+		Backends:             krt.NewStaticCollection[*agentgateway.AgentgatewayBackend](alwaysSynced{}, nil),
+		Resolver: jwksResolverFunc(func(owner RemoteJwksOwner) (*ResolvedJwksRequest, error) {
+			return resolvedJwksRequest(owner, owner.Remote.JwksPath), nil
+		}),
+		KrtOpts: krtOpts,
+	})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	persisted := NewPersistedEntriesFromCollection(
+		krt.NewStaticCollection[*corev1.ConfigMap](alwaysSynced{}, []*corev1.ConfigMap{cm}),
+		DefaultJwksStorePrefix,
+		"agentgateway-system",
+	)
+	store := NewStore(collections.SharedRequests, persisted, DefaultJwksStorePrefix)
+	store.jwksFetcher.defaultJwksClient = offlineStubJwksClient{}
+	go func() {
+		_ = store.Start(ctx)
+	}()
+
+	assert.Eventually(t, store.HasSynced, testEventuallyTimeout, testEventuallyPoll)
+	awaitJwksFetchState(t, store.jwksFetcher, requestKey)
+	_, ok := store.JwksByRequestKey(requestKey)
+	assert.True(t, ok, "cache should be seeded from persisted ConfigMap")
+
+	policies.Reset(nil)
+
+	awaitNoJwksFetchState(t, store.jwksFetcher, requestKey)
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		_, ok := store.JwksByRequestKey(requestKey)
+		assert.False(c, ok)
+	}, testEventuallyTimeout, testEventuallyPoll)
+}
+
+// Variant: orphan CM exists at startup with no matching AgentPolicy. The
+// cache gets seeded from persistence but f.requests never gets the key,
+// so there's no trigger to delete the CM at all.
+func TestStoreClearsOrphanCacheAtStartup(t *testing.T) {
+	krtOpts := testKrtOptions(t)
+	uri := "https://issuer.example/jwks"
+	requestKey := remotehttp.FetchTarget{URL: uri}.Key()
+
+	persistedKeyset := Keyset{
+		RequestKey: requestKey,
+		URL:        uri,
+		JwksJSON:   `{"keys":[]}`,
+	}
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      JwksConfigMapName(DefaultJwksStorePrefix, requestKey),
+			Namespace: "agentgateway-system",
+			Labels:    JwksStoreConfigMapLabel(DefaultJwksStorePrefix),
+		},
+	}
+	assert.NoError(t, SetJwksInConfigMap(cm, persistedKeyset))
+
+	// No AgentPolicies exist.
+	policies := dynamicRemotePolicies(t, nil, krtOpts)
+	collections := NewCollections(CollectionInputs{
+		AgentgatewayPolicies: policies,
+		Backends:             krt.NewStaticCollection[*agentgateway.AgentgatewayBackend](alwaysSynced{}, nil),
+		Resolver: jwksResolverFunc(func(owner RemoteJwksOwner) (*ResolvedJwksRequest, error) {
+			return resolvedJwksRequest(owner, owner.Remote.JwksPath), nil
+		}),
+		KrtOpts: krtOpts,
+	})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	persisted := NewPersistedEntriesFromCollection(
+		krt.NewStaticCollection[*corev1.ConfigMap](alwaysSynced{}, []*corev1.ConfigMap{cm}),
+		DefaultJwksStorePrefix,
+		"agentgateway-system",
+	)
+	store := NewStore(collections.SharedRequests, persisted, DefaultJwksStorePrefix)
+	store.jwksFetcher.defaultJwksClient = offlineStubJwksClient{}
+	go func() {
+		_ = store.Start(ctx)
+	}()
+
+	assert.Eventually(t, store.HasSynced, testEventuallyTimeout, testEventuallyPoll)
+
+	// After sync, the orphan cache entry should be cleared.
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		_, ok := store.JwksByRequestKey(requestKey)
+		assert.False(c, ok, "orphan cache entry should be cleared after sync")
+	}, testEventuallyTimeout, testEventuallyPoll)
 }
 
 func TestStoreHasSyncedReflectsReadyState(t *testing.T) {
@@ -176,6 +408,16 @@ func TestStoreHasSyncedReflectsReadyState(t *testing.T) {
 
 	assert.True(t, store.HasSynced())
 }
+
+// offlineStubJwksClient fails every fetch so Store tests don't depend on
+// DNS or network resolution of the fake issuer URLs used as test fixtures.
+type offlineStubJwksClient struct{}
+
+func (offlineStubJwksClient) FetchJwks(_ context.Context, _ remotehttp.FetchTarget) (jose.JSONWebKeySet, error) {
+	return jose.JSONWebKeySet{}, errOfflineStub
+}
+
+var errOfflineStub = fmt.Errorf("offline stub")
 
 type jwksResolverFunc func(owner RemoteJwksOwner) (*ResolvedJwksRequest, error)
 


### PR DESCRIPTION
Two drift paths between Fetcher.requests and JwksCache left stale keysets behind, causing ConfigMaps to persist after their owning AgentPolicy was removed and to reappear when manually deleted:

* RemoveKeyset returned early before calling cache.deleteJwks when the fetcher had never tracked the request. A cache entry seeded by LoadPersistedKeysets could therefore never be evicted, and any reconcile would see a populated cache and recreate the CM.
* A ConfigMap persisted from a previous lifecycle with no matching AgentPolicy on restart was loaded into the cache but nothing drove a reconcile to remove it. The orphan entry survived until an AgentPolicy with the same request key was added and removed.
* An in-flight fetch that completed between the post-fetch liveness check and the cache write could repopulate a keyset that RemoveKeyset had just evicted.

RemoveKeyset now always evicts from the cache and notifies subscribers when either the request or the cache entry existed, with the cache write held under f.mu so the lock order is consistently f.mu -> cache.l. maybeFetchJwks builds the keyset outside any lock and commits it via commitFetchResult, which re-checks liveness and writes the cache atomically under f.mu. Fetcher.SweepOrphans, invoked from Store.Start after the shared request collection has synced and before HasSynced flips, drops cache entries without a live request so the ConfigMap controller reconciles them away.

fixes https://github.com/agentgateway/agentgateway/issues/1616