### PR TITLE
jwks: do not fetch unconditionally on startup

### DIFF
--- a/controller/pkg/agentgateway/jwks/fetcher.go
+++ b/controller/pkg/agentgateway/jwks/fetcher.go
@@ -335,6 +335,14 @@ func (f *Fetcher) AddOrUpdateKeyset(source JwksSource) error {
 		return fmt.Errorf("error parsing jwks url %w", err)
 	}
 
+	nextFetchAt := time.Now()
+	if cached, ok := f.cache.GetJwks(source.RequestKey); ok && !cached.FetchedAt.IsZero() {
+		expiresAt := cached.FetchedAt.Add(source.TTL)
+		if expiresAt.After(nextFetchAt) {
+			nextFetchAt = expiresAt
+		}
+	}
+
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
@@ -342,7 +350,7 @@ func (f *Fetcher) AddOrUpdateKeyset(source JwksSource) error {
 	state.generation++
 	state.source = source
 	f.requests[source.RequestKey] = state
-	f.scheduleAtLocked(source.RequestKey, state.generation, time.Now(), 0)
+	f.scheduleAtLocked(source.RequestKey, state.generation, nextFetchAt, 0)
 
 	return nil
 }

--- a/controller/pkg/agentgateway/jwks/fetcher_test.go
+++ b/controller/pkg/agentgateway/jwks/fetcher_test.go
@@ -79,6 +79,52 @@ func TestAddOrUpdateKeysetReplacesExistingScheduleEntry(t *testing.T) {
 	assert.Equal(t, uint64(2), fetch.Generation)
 }
 
+func TestAddOrUpdateKeysetUsesFreshCachedFetchedAtToDelayStartupRefresh(t *testing.T) {
+	f := NewFetcher(NewCache())
+	source := testSource()
+	freshFetchedAt := time.Now().Add(-1 * time.Minute).UTC()
+	f.cache.keysets[source.RequestKey] = Keyset{
+		RequestKey: source.RequestKey,
+		URL:        source.Target.URL,
+		FetchedAt:  freshFetchedAt,
+		JwksJSON:   sampleJWKS,
+	}
+
+	assert.NoError(t, f.AddOrUpdateKeyset(source))
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	fetch := f.schedule.Peek()
+	require.NotNil(t, fetch)
+	assert.Equal(t, source.RequestKey, fetch.RequestKey)
+	assert.WithinDuration(t, freshFetchedAt.Add(source.TTL), fetch.At, time.Second)
+}
+
+func TestAddOrUpdateKeysetImmediatelyRefreshesStaleCachedKeyset(t *testing.T) {
+	f := NewFetcher(NewCache())
+	source := testSource()
+	f.cache.keysets[source.RequestKey] = Keyset{
+		RequestKey: source.RequestKey,
+		URL:        source.Target.URL,
+		FetchedAt:  time.Now().Add(-2 * source.TTL).UTC(),
+		JwksJSON:   sampleJWKS,
+	}
+
+	before := time.Now()
+	assert.NoError(t, f.AddOrUpdateKeyset(source))
+	after := time.Now()
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	fetch := f.schedule.Peek()
+	require.NotNil(t, fetch)
+	assert.Equal(t, source.RequestKey, fetch.RequestKey)
+	assert.False(t, fetch.At.Before(before))
+	assert.False(t, fetch.At.After(after))
+}
+
 func TestFetcherWithEmptyJwksFetchSchedule(t *testing.T) {
 	ctx := t.Context()
 


### PR DESCRIPTION
In testing with a large number of jwks, everytime the controller restarts we have a HUGE flood of requests for the endpoints. Given we know they are fresh, there is no need.

Signed-off-by: John Howard <john.howard@solo.io>
