### PR TITLE
Add mask support for bedrock guardrails

### DIFF
--- a/crates/agentgateway/src/llm/policy/bedrock_guardrails.rs
+++ b/crates/agentgateway/src/llm/policy/bedrock_guardrails.rs
@@ -32,6 +32,12 @@ pub struct GuardrailContentBlock {
 	pub text: GuardrailTextBlock,
 }
 
+/// Output content from guardrail with masked/anonymized text
+#[derive(Debug, Clone, Deserialize)]
+pub struct GuardrailOutputContent {
+	pub text: String,
+}
+
 /// Request body for ApplyGuardrail API
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -58,12 +64,49 @@ pub enum GuardrailAction {
 pub struct ApplyGuardrailResponse {
 	/// The action taken by the guardrail
 	pub action: GuardrailAction,
+	/// Outputs with masked text (if configured with mask)
+	#[serde(default)]
+	pub outputs: Vec<GuardrailOutputContent>,
+	/// Assessment details containing action type (BLOCKED, ANONYMIZED, etc.)
+	#[serde(default)]
+	pub assessments: Vec<serde_json::Value>,
 }
 
 impl ApplyGuardrailResponse {
-	/// Returns true if the guardrail intervened
+	/// Returns true if the guardrail blocked content
 	pub fn is_blocked(&self) -> bool {
-		self.action == GuardrailAction::GuardrailIntervened
+		self.action == GuardrailAction::GuardrailIntervened && self.has_blocked_assessment()
+	}
+
+	/// Returns true if the guardrail anonymized/masked content
+	pub fn is_anonymized(&self) -> bool {
+		self.action == GuardrailAction::GuardrailIntervened && !self.has_blocked_assessment()
+	}
+
+	/// Returns the masked output texts
+	pub fn output_texts(&self) -> Vec<String> {
+		self.outputs.iter().map(|o| o.text.clone()).collect()
+	}
+
+	/// Check if any assessment contains a BLOCKED action
+	fn has_blocked_assessment(&self) -> bool {
+		self.assessments.iter().any(Self::value_contains_blocked)
+	}
+
+	/// Search for "action": "BLOCKED" in JSON value
+	fn value_contains_blocked(value: &serde_json::Value) -> bool {
+		match value {
+			serde_json::Value::Object(map) => {
+				if let Some(serde_json::Value::String(action)) = map.get("action")
+					&& action == "BLOCKED"
+				{
+					return true;
+				}
+				map.values().any(Self::value_contains_blocked)
+			},
+			serde_json::Value::Array(arr) => arr.iter().any(Self::value_contains_blocked),
+			_ => false,
+		}
 	}
 }
 
@@ -210,6 +253,13 @@ async fn send_guardrail_request(
 			guardrail_version = %guardrails.guardrail_version,
 			source = ?source,
 			"Bedrock guardrail blocked content"
+		);
+	} else if resp.is_anonymized() {
+		tracing::debug!(
+			guardrail_id = %guardrails.guardrail_identifier,
+			guardrail_version = %guardrails.guardrail_version,
+			source = ?source,
+			"Bedrock guardrail anonymized content"
 		);
 	}
 

--- a/crates/agentgateway/src/llm/policy/mod.rs
+++ b/crates/agentgateway/src/llm/policy/mod.rs
@@ -433,22 +433,37 @@ impl Policy {
 					}
 				},
 				RequestGuardKind::BedrockGuardrails(bg) => {
-					if let Some(res) =
-						Self::apply_bedrock_guardrails_request(req, claims.clone(), &client, &g.rejection, bg)
-							.await?
+					match Self::apply_bedrock_guardrails_request(
+						req,
+						claims.clone(),
+						&client,
+						&g.rejection,
+						bg,
+					)
+					.await?
 					{
-						Self::record_guardrail_trip(
-							&client,
-							crate::telemetry::metrics::GuardrailPhase::Request,
-							crate::telemetry::metrics::GuardrailAction::Reject,
-						);
-						return Ok(Some(res));
-					} else {
-						Self::record_guardrail_trip(
-							&client,
-							crate::telemetry::metrics::GuardrailPhase::Request,
-							crate::telemetry::metrics::GuardrailAction::Allow,
-						);
+						GuardrailOutcome::Rejected(res) => {
+							Self::record_guardrail_trip(
+								&client,
+								crate::telemetry::metrics::GuardrailPhase::Request,
+								crate::telemetry::metrics::GuardrailAction::Reject,
+							);
+							return Ok(Some(res));
+						},
+						GuardrailOutcome::Masked => {
+							Self::record_guardrail_trip(
+								&client,
+								crate::telemetry::metrics::GuardrailPhase::Request,
+								crate::telemetry::metrics::GuardrailAction::Mask,
+							);
+						},
+						GuardrailOutcome::None => {
+							Self::record_guardrail_trip(
+								&client,
+								crate::telemetry::metrics::GuardrailPhase::Request,
+								crate::telemetry::metrics::GuardrailAction::Allow,
+							);
+						},
 					}
 				},
 				RequestGuardKind::GoogleModelArmor(gma) => {
@@ -520,12 +535,20 @@ impl Policy {
 		client: &PolicyClient,
 		rej: &RequestRejection,
 		guardrails: &BedrockGuardrails,
-	) -> anyhow::Result<Option<Response>> {
+	) -> anyhow::Result<GuardrailOutcome> {
 		let resp = bedrock_guardrails::send_request(req, claims.clone(), client, guardrails).await?;
 		if resp.is_blocked() {
-			Ok(Some(rej.as_response()))
+			Ok(GuardrailOutcome::Rejected(rej.as_response()))
+		} else if resp.is_anonymized() {
+			let output_texts = resp.output_texts();
+			let mut msgs = req.get_messages();
+			for (msg, text) in msgs.iter_mut().zip(output_texts) {
+				msg.content = text.into();
+			}
+			req.set_messages(msgs);
+			Ok(GuardrailOutcome::Masked)
 		} else {
-			Ok(None)
+			Ok(GuardrailOutcome::None)
 		}
 	}
 
@@ -535,7 +558,7 @@ impl Policy {
 		client: &PolicyClient,
 		rej: &RequestRejection,
 		guardrails: &BedrockGuardrails,
-	) -> anyhow::Result<Option<Response>> {
+	) -> anyhow::Result<GuardrailOutcome> {
 		// Extract text content from response choices
 		let content: Vec<String> = resp
 			.to_webhook_choices()
@@ -544,15 +567,23 @@ impl Policy {
 			.collect();
 
 		if content.is_empty() {
-			return Ok(None);
+			return Ok(GuardrailOutcome::None);
 		}
 
 		let guardrail_resp =
 			bedrock_guardrails::send_response(content, claims, client, guardrails).await?;
 		if guardrail_resp.is_blocked() {
-			Ok(Some(rej.as_response()))
+			Ok(GuardrailOutcome::Rejected(rej.as_response()))
+		} else if guardrail_resp.is_anonymized() {
+			let output_texts = guardrail_resp.output_texts();
+			let mut choices = resp.to_webhook_choices();
+			for (choice, text) in choices.iter_mut().zip(output_texts) {
+				choice.message.content = text.into();
+			}
+			resp.set_webhook_choices(choices)?;
+			Ok(GuardrailOutcome::Masked)
 		} else {
-			Ok(None)
+			Ok(GuardrailOutcome::None)
 		}
 	}
 
@@ -1030,21 +1061,31 @@ impl Policy {
 					}
 				},
 				ResponseGuardKind::BedrockGuardrails(bg) => {
-					if let Some(res) =
-						Self::apply_bedrock_guardrails_response(resp, None, client, &g.rejection, bg).await?
+					match Self::apply_bedrock_guardrails_response(resp, None, client, &g.rejection, bg)
+						.await?
 					{
-						Self::record_guardrail_trip(
-							client,
-							crate::telemetry::metrics::GuardrailPhase::Response,
-							crate::telemetry::metrics::GuardrailAction::Reject,
-						);
-						return Ok(Some(res));
-					} else {
-						Self::record_guardrail_trip(
-							client,
-							crate::telemetry::metrics::GuardrailPhase::Response,
-							crate::telemetry::metrics::GuardrailAction::Allow,
-						);
+						GuardrailOutcome::Rejected(res) => {
+							Self::record_guardrail_trip(
+								client,
+								crate::telemetry::metrics::GuardrailPhase::Response,
+								crate::telemetry::metrics::GuardrailAction::Reject,
+							);
+							return Ok(Some(res));
+						},
+						GuardrailOutcome::Masked => {
+							Self::record_guardrail_trip(
+								client,
+								crate::telemetry::metrics::GuardrailPhase::Response,
+								crate::telemetry::metrics::GuardrailAction::Mask,
+							);
+						},
+						GuardrailOutcome::None => {
+							Self::record_guardrail_trip(
+								client,
+								crate::telemetry::metrics::GuardrailPhase::Response,
+								crate::telemetry::metrics::GuardrailAction::Allow,
+							);
+						},
 					}
 				},
 				ResponseGuardKind::GoogleModelArmor(gma) => {

--- a/crates/agentgateway/src/llm/policy/tests.rs
+++ b/crates/agentgateway/src/llm/policy/tests.rs
@@ -348,19 +348,33 @@ mod bedrock_guardrails_tests {
 	#[test]
 	fn test_apply_guardrail_response_is_blocked_true() {
 		let json = json!({
-			"action": "GUARDRAIL_INTERVENED"
+			"action": "GUARDRAIL_INTERVENED",
+			"outputs": [{"text": "Sorry, I can't help with that."}],
+			"assessments": [{
+				"contentPolicy": {
+					"filters": [{
+						"action": "BLOCKED",
+						"type": "HATE",
+						"confidence": "HIGH"
+					}]
+				}
+			}]
 		});
 		let response: ApplyGuardrailResponse = serde_json::from_value(json).unwrap();
 		assert!(response.is_blocked());
+		assert!(!response.is_anonymized());
 	}
 
 	#[test]
 	fn test_apply_guardrail_response_is_blocked_false() {
 		let json = json!({
-			"action": "NONE"
+			"action": "NONE",
+			"outputs": [{"text": "Hello, world!"}],
+			"assessments": [{}]
 		});
 		let response: ApplyGuardrailResponse = serde_json::from_value(json).unwrap();
 		assert!(!response.is_blocked());
+		assert!(!response.is_anonymized());
 	}
 
 	#[test]
@@ -410,6 +424,15 @@ mod bedrock_guardrails_tests {
 		let json = json!({
 			"action": "GUARDRAIL_INTERVENED",
 			"outputs": [{"text": "I can't help with that request."}],
+			"assessments": [{
+				"topicPolicy": {
+					"topics": [{
+						"action": "BLOCKED",
+						"name": "Finance",
+						"type": "DENY"
+					}]
+				}
+			}],
 			"usage": {
 				"topicPolicyUnits": 1,
 				"contentPolicyUnits": 0,
@@ -417,10 +440,106 @@ mod bedrock_guardrails_tests {
 			}
 		});
 
-		// Our struct only cares about the action field
 		let response: ApplyGuardrailResponse = serde_json::from_value(json).unwrap();
 		assert!(response.is_blocked());
+		assert!(!response.is_anonymized());
 		assert_eq!(response.action, GuardrailAction::GuardrailIntervened);
+	}
+
+	#[test]
+	fn test_apply_guardrail_response_anonymized() {
+		let json = json!({
+			"action": "GUARDRAIL_INTERVENED",
+			"outputs": [{"text": "My name is {NAME} and my email is {EMAIL}"}],
+			"assessments": [{
+				"sensitiveInformationPolicy": {
+					"piiEntities": [
+						{
+							"action": "ANONYMIZED",
+							"match": "John Doe",
+							"type": "NAME"
+						},
+						{
+							"action": "ANONYMIZED",
+							"match": "john@example.com",
+							"type": "EMAIL"
+						}
+					]
+				}
+			}]
+		});
+		let response: ApplyGuardrailResponse = serde_json::from_value(json).unwrap();
+		assert!(!response.is_blocked());
+		assert!(response.is_anonymized());
+		assert_eq!(
+			response.output_texts(),
+			vec!["My name is {NAME} and my email is {EMAIL}"]
+		);
+	}
+
+	#[test]
+	fn test_apply_guardrail_response_mixed_block_and_anonymize() {
+		let json = json!({
+			"action": "GUARDRAIL_INTERVENED",
+			"outputs": [{"text": "blocked"}],
+			"assessments": [{
+				"sensitiveInformationPolicy": {
+					"piiEntities": [{
+						"action": "ANONYMIZED",
+						"match": "John Doe",
+						"type": "NAME"
+					}]
+				},
+				"contentPolicy": {
+					"filters": [{
+						"action": "BLOCKED",
+						"type": "HATE",
+						"confidence": "HIGH"
+					}]
+				}
+			}]
+		});
+		let response: ApplyGuardrailResponse = serde_json::from_value(json).unwrap();
+		assert!(response.is_blocked());
+		assert!(!response.is_anonymized());
+	}
+
+	#[test]
+	fn test_apply_guardrail_response_output_texts() {
+		let json = json!({
+			"action": "GUARDRAIL_INTERVENED",
+			"outputs": [
+				{"text": "First message with {NAME}"},
+				{"text": "Second message with {EMAIL}"}
+			],
+			"assessments": [{
+				"sensitiveInformationPolicy": {
+					"piiEntities": [{
+						"action": "ANONYMIZED",
+						"match": "test",
+						"type": "NAME"
+					}]
+				}
+			}]
+		});
+		let response: ApplyGuardrailResponse = serde_json::from_value(json).unwrap();
+		assert!(response.is_anonymized());
+		assert_eq!(
+			response.output_texts(),
+			vec!["First message with {NAME}", "Second message with {EMAIL}"]
+		);
+	}
+
+	#[test]
+	fn test_apply_guardrail_response_intervened_no_assessments() {
+		let json = json!({
+			"action": "GUARDRAIL_INTERVENED",
+			"outputs": [{"text": "modified content"}],
+			"assessments": []
+		});
+		let response: ApplyGuardrailResponse = serde_json::from_value(json).unwrap();
+		assert!(!response.is_blocked());
+		assert!(response.is_anonymized());
 	}
 }
 

--- a/examples/ai-prompt-guard/bedrock-config.yaml
+++ b/examples/ai-prompt-guard/bedrock-config.yaml
@@ -17,8 +17,14 @@ binds:
                 guardrailIdentifier: bedrock-guardrail-identifier
                 guardrailVersion: DRAFT
                 region: us-west-2
+                policies:
+                  backendAuth:
+                    aws: {}
             response:
             - bedrockGuardrails:
                 guardrailIdentifier: bedrock-guardrail-identifier
                 guardrailVersion: DRAFT
                 region: us-west-2
+                policies:
+                  backendAuth:
+                    aws: {}


### PR DESCRIPTION
Fixes: https://github.com/agentgateway/agentgateway/issues/1607

Tested in standalone mode with simple bedrock policy to mask emails:
<img width="1135" height="302" alt="Screenshot 2026-04-22 at 12 43 18 PM" src="https://github.com/user-attachments/assets/e293efdd-6c24-47a0-a4a9-bae787ba17ae" />

Run the example in the repo pointing to your bedrock guardrail instance: `agentgateway -f examples/ai-prompt-guard/bedrock-config.yaml` 

```
❯ curl http://localhost:3000   -H "Content-Type: application/json"   -H "Authorization: Bearer $OPENAI_API_KEY"   -d '{
    "model": "gpt-4o-mini",
    "messages": [
      {
        "role": "system",
        "content": "You are a helpful assistant."
      },
      {
        "role": "user",
        "content": "Return a fake email address"
      }
    ]
  }' 
{"model":"gpt-4o-mini-2024-07-18","service_tier":"default","usage":{"prompt_tokens":22,"completion_tokens":28,"total_tokens":50,"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0},"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0}},"choices":[{"message":{"content":"Sure! Here’s a fake email address: {EMAIL}. Please let me know if you need another one or any additional information!","role":"assistant","refusal":null,"annotations":[]},"index":0,"logprobs":null,"finish_reason":"stop"}],"id":"chatcmpl-DXV7fmHPEcOHOnC2DA2v200cUqGxr","object":"chat.completion","created":1776876831,"system_fingerprint":"fp_e3fec59ca6"}% 
```