### PR TITLE
controller: retain last transition time

### DIFF
--- a/controller/pkg/agentgateway/plugins/status.go
+++ b/controller/pkg/agentgateway/plugins/status.go
@@ -1,6 +1,8 @@
 package plugins
 
 import (
+	"fmt"
+
 	"istio.io/istio/pilot/pkg/model/kstatus"
 	"istio.io/istio/pkg/maps"
 	"istio.io/istio/pkg/ptr"
@@ -55,8 +57,41 @@ func mergeAncestors(controllerName string, existing []gwv1.PolicyAncestorStatus,
 	existing = existing[:n]
 	// Add all remaining ones.
 	existing = append(existing, incoming...)
-	// There is a max of 16
-	return existing[:min(len(existing), 16)]
+	// There is a max of 16. If we exceed this, insert an entry describing the truncation
+	if len(existing) > 16 {
+		lastOwned := -1
+		for i := range min(len(existing), 16) {
+			if string(existing[i].ControllerName) == controllerName {
+				lastOwned = i
+			}
+		}
+		if lastOwned == -1 {
+			// We didn't own any of them... just truncate. :-(
+			return existing[:16]
+		}
+
+		ignored := len(existing) - 15
+		trimmed := make([]gwv1.PolicyAncestorStatus, 0, 16)
+		trimmed = append(trimmed, existing[:lastOwned]...)
+		trimmed = append(trimmed, existing[lastOwned+1:16]...)
+		trimmed = append(trimmed, gwv1.PolicyAncestorStatus{
+			AncestorRef: gwv1.ParentReference{
+				Group: ptr.Of(gwv1.Group("agentgateway.dev")),
+				Name:  "StatusSummary",
+			},
+			ControllerName: gwv1.GatewayController(controllerName),
+			Conditions: []metav1.Condition{
+				{
+					Type:    "StatusSummarized",
+					Status:  metav1.ConditionTrue,
+					Reason:  "StatusSummary",
+					Message: fmt.Sprintf("%d AncestorRefs ignored due to max status size", ignored),
+				},
+			},
+		})
+		return trimmed
+	}
+	return existing
 }
 
 func parentRefEqual(a, b gwv1.ParentReference) bool {
@@ -76,7 +111,7 @@ func setAncestorStatus(
 	controller gwv1.GatewayController,
 ) gwv1.PolicyAncestorStatus {
 	currentAncestor := slices.FindFunc(status.Ancestors, func(ex gwv1.PolicyAncestorStatus) bool {
-		return parentRefEqual(ex.AncestorRef, pr)
+		return ex.ControllerName == controller && parentRefEqual(ex.AncestorRef, pr)
 	})
 	var currentConds []metav1.Condition
 	if currentAncestor != nil {

--- a/controller/pkg/agentgateway/plugins/status_test.go
+++ b/controller/pkg/agentgateway/plugins/status_test.go
@@ -1,0 +1,88 @@
+package plugins
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestMergeAncestorsSummarizesWhenOwnedAncestorFitsInFirst16(t *testing.T) {
+	const controllerName = "agentgateway.dev/controller"
+
+	var incoming []gwv1.PolicyAncestorStatus
+	for i := range 17 {
+		controller := "other.dev/controller"
+		name := gwv1.ObjectName("other-" + string(rune('a'+i)))
+		if i == 14 {
+			controller = controllerName
+			name = "ours"
+		}
+		incoming = append(incoming, gwv1.PolicyAncestorStatus{
+			AncestorRef:    gwv1.ParentReference{Name: name},
+			ControllerName: gwv1.GatewayController(controller),
+		})
+	}
+
+	got := mergeAncestors(controllerName, nil, incoming)
+
+	if len(got) != 16 {
+		t.Fatalf("expected 16 ancestors, got %d", len(got))
+	}
+	if got[15].AncestorRef.Name != "StatusSummary" {
+		t.Fatalf("expected final ancestor to be StatusSummary, got %q", got[15].AncestorRef.Name)
+	}
+	if got[15].ControllerName != gwv1.GatewayController(controllerName) {
+		t.Fatalf("expected summary controller %q, got %q", controllerName, got[15].ControllerName)
+	}
+	if got[15].AncestorRef.Group == nil || *got[15].AncestorRef.Group != gwv1.Group("agentgateway.dev") {
+		t.Fatalf("expected summary group agentgateway.dev, got %#v", got[15].AncestorRef.Group)
+	}
+	if len(got[15].Conditions) != 1 {
+		t.Fatalf("expected one summary condition, got %d", len(got[15].Conditions))
+	}
+	cond := got[15].Conditions[0]
+	if cond != (metav1.Condition{
+		Type:    "StatusSummarized",
+		Status:  metav1.ConditionTrue,
+		Reason:  "StatusSummary",
+		Message: "2 AncestorRefs ignored due to max status size",
+	}) {
+		t.Fatalf("unexpected summary condition: %#v", cond)
+	}
+	for _, ancestor := range got[:15] {
+		if ancestor.AncestorRef.Name == "ours" {
+			t.Fatalf("expected owned ancestor to be replaced by summary")
+		}
+	}
+}
+
+func TestMergeAncestorsTruncatesWhenNoOwnedAncestorFitsInFirst16(t *testing.T) {
+	const controllerName = "agentgateway.dev/controller"
+
+	var incoming []gwv1.PolicyAncestorStatus
+	for i := range 17 {
+		controller := "other.dev/controller"
+		if i == 16 {
+			controller = controllerName
+		}
+		incoming = append(incoming, gwv1.PolicyAncestorStatus{
+			AncestorRef:    gwv1.ParentReference{Name: gwv1.ObjectName("ancestor-" + string(rune('a'+i)))},
+			ControllerName: gwv1.GatewayController(controller),
+		})
+	}
+
+	got := mergeAncestors(controllerName, nil, incoming)
+
+	if len(got) != 16 {
+		t.Fatalf("expected 16 ancestors, got %d", len(got))
+	}
+	if got[15].AncestorRef.Name == "StatusSummary" {
+		t.Fatalf("did not expect summary ancestor when first 16 are not ours")
+	}
+	for _, ancestor := range got {
+		if ancestor.AncestorRef.Name == "ancestor-q" {
+			t.Fatalf("expected 17th ancestor to be truncated")
+		}
+	}
+}

--- a/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/status-update.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/status-update.yaml
@@ -1,0 +1,108 @@
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: example-policy
+  namespace: default
+spec:
+  targetRefs:
+    - kind: Gateway
+      name: test
+      group: gateway.networking.k8s.io
+  traffic:
+    cors:
+      allowOrigins:
+        - https://ignored.com
+      maxAge: 5
+status:
+  ancestors:
+    # A different controller.. we should not touch it
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: other-gw
+      conditions:
+        - lastTransitionTime: "2026-04-22T17:57:23Z"
+          message: Accepted by fake controller
+          reason: Valid
+          status: "True"
+          type: Accepted
+      controllerName: other-controller.example.com/controller
+    # our controller with stale status; we must wipe it out
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: some-old-gateway-stale
+        namespace: agentgateway-base
+      conditions:
+        - lastTransitionTime: "2026-04-22T17:57:23Z"
+          message: Policy accepted
+          observedGeneration: 1
+          reason: Valid
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2026-04-22T17:57:23Z"
+          message: Attached to all targets
+          observedGeneration: 1
+          reason: Attached
+          status: "True"
+          type: Attached
+      controllerName: agentgateway.dev/agentgateway
+---
+# Output
+output:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
+    policy:
+      key: traffic/default/example-policy:cors:default/test
+      name:
+        kind: AgentgatewayPolicy
+        name: example-policy
+        namespace: default
+      target:
+        gateway:
+          name: test
+          namespace: default
+      traffic:
+        cors:
+          allowOrigins:
+          - https://ignored.com
+          maxAge: 5s
+status:
+- apiVersion: agentgateway.dev/v1alpha1
+  kind: AgentgatewayPolicy
+  metadata:
+    name: example-policy
+    namespace: default
+  spec: null
+  status:
+    ancestors:
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: other-gw
+      conditions:
+      - lastTransitionTime: fake
+        message: Accepted by fake controller
+        reason: Valid
+        status: "True"
+        type: Accepted
+      controllerName: other-controller.example.com/controller
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: test
+        namespace: default
+      conditions:
+      - lastTransitionTime: fake
+        message: Policy accepted
+        reason: Valid
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: Attached to all targets
+        reason: Attached
+        status: "True"
+        type: Attached
+      controllerName: agentgateway.dev/agentgateway

--- a/controller/pkg/agentgateway/plugins/traffic_plugin.go
+++ b/controller/pkg/agentgateway/plugins/traffic_plugin.go
@@ -133,6 +133,7 @@ func TranslateAgentgatewayPolicy(
 	jwksLookup jwks.Lookup,
 ) (*gwv1.PolicyStatus, []AgwPolicy) {
 	var agwPolicies []AgwPolicy
+	existingStatus := policy.Status.DeepCopy()
 
 	pctx := PolicyCtx{Krt: ctx, Collections: agw, References: references, Resolver: resolver, JWKSLookup: jwksLookup}
 	var ancestors []gwv1.PolicyAncestorStatus
@@ -188,7 +189,7 @@ func TranslateAgentgatewayPolicy(
 				}) != -1 {
 					continue
 				}
-				ancestors = append(ancestors, setAncestorStatus(ar, &policy.Status, policy.Generation, baseConds, controller))
+				ancestors = append(ancestors, setAncestorStatus(ar, existingStatus, policy.Generation, baseConds, controller))
 			}
 		}
 	}
@@ -198,12 +199,12 @@ func TranslateAgentgatewayPolicy(
 		ancestors = append(ancestors, setAncestorStatus(gwv1.ParentReference{
 			Group: ptr.Of(gwv1.Group(wellknown.AgentgatewayPolicyGVK.Group)),
 			Name:  "StatusSummary",
-		}, &policy.Status, policy.Generation, attachmentErrorConditionMap(baseConds, attachmentErrors), controller))
+		}, existingStatus, policy.Generation, attachmentErrorConditionMap(baseConds, attachmentErrors), controller))
 	}
 
 	// Build final status from accumulated ancestors
 	status := gwv1.PolicyStatus{
-		Ancestors: mergeAncestors(agw.ControllerName, policy.Status.Ancestors, ancestors),
+		Ancestors: mergeAncestors(agw.ControllerName, existingStatus.Ancestors, ancestors),
 	}
 
 	// sort all parents for consistency with Equals and for Update
@@ -257,11 +258,7 @@ func policyConditionMap(err error, hasTranslatedPolicies bool) map[string]*condi
 }
 
 func attachmentErrorConditionMap(baseConds map[string]*condition, attachmentErrors []string) map[string]*condition {
-	conds := make(map[string]*condition, len(baseConds)+1)
-	for k, v := range baseConds {
-		copy := *v
-		conds[k] = &copy
-	}
+	conds := maps.Clone(baseConds)
 	conds[string(shared.PolicyConditionAttached)] = &condition{
 		status:  metav1.ConditionFalse,
 		reason:  string(shared.PolicyReasonPending),

--- a/controller/pkg/agentgateway/plugins/traffic_plugin.go
+++ b/controller/pkg/agentgateway/plugins/traffic_plugin.go
@@ -230,7 +230,7 @@ func policyConditionMap(err error, hasTranslatedPolicies bool) map[string]*condi
 		} else {
 			// No policies produced and error present -> invalid
 			conds[string(shared.PolicyConditionAccepted)] = &condition{
-				status:  metav1.ConditionTrue,
+				status:  metav1.ConditionFalse,
 				reason:  string(shared.PolicyReasonInvalid),
 				message: err.Error(),
 			}

--- a/controller/pkg/agentgateway/plugins/traffic_plugin.go
+++ b/controller/pkg/agentgateway/plugins/traffic_plugin.go
@@ -21,7 +21,6 @@ import (
 	"istio.io/istio/pkg/util/protomarshal"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -125,7 +124,14 @@ type ResolvedTarget struct {
 }
 
 // TranslateAgentgatewayPolicy generates policies for a single traffic policy
-func TranslateAgentgatewayPolicy(ctx krt.HandlerContext, policy *agentgateway.AgentgatewayPolicy, agw *AgwCollections, references ReferenceIndex, resolver remotehttp.Resolver, jwksLookup jwks.Lookup) (*gwv1.PolicyStatus, []AgwPolicy) {
+func TranslateAgentgatewayPolicy(
+	ctx krt.HandlerContext,
+	policy *agentgateway.AgentgatewayPolicy,
+	agw *AgwCollections,
+	references ReferenceIndex,
+	resolver remotehttp.Resolver,
+	jwksLookup jwks.Lookup,
+) (*gwv1.PolicyStatus, []AgwPolicy) {
 	var agwPolicies []AgwPolicy
 
 	pctx := PolicyCtx{Krt: ctx, Collections: agw, References: references, Resolver: resolver, JWKSLookup: jwksLookup}
@@ -133,7 +139,8 @@ func TranslateAgentgatewayPolicy(ctx krt.HandlerContext, policy *agentgateway.Ag
 	var attachmentErrors []string
 	// TODO: add selectors
 	baseTranslatedPolicies, baseErr := translatePolicyToAgw(pctx, policy)
-	baseConds := setPolicyConditions(baseErr, len(baseTranslatedPolicies) > 0)
+	baseConds := policyConditionMap(baseErr, len(baseTranslatedPolicies) > 0)
+	controller := gwv1.GatewayController(agw.ControllerName)
 	for _, target := range policy.Spec.TargetRefs {
 		gk := schema.GroupKind{Group: string(target.Group), Kind: string(target.Kind)}
 
@@ -177,52 +184,26 @@ func TranslateAgentgatewayPolicy(ctx krt.HandlerContext, policy *agentgateway.Ag
 				// A policy should report at most one status per Gateway parent, even if multiple
 				// targetRefs resolve to the same Gateway.
 				if slices.IndexFunc(ancestors, func(existing gwv1.PolicyAncestorStatus) bool {
-					return existing.ControllerName == gwv1.GatewayController(agw.ControllerName) && parentRefEqual(existing.AncestorRef, ar)
+					return existing.ControllerName == controller && parentRefEqual(existing.AncestorRef, ar)
 				}) != -1 {
 					continue
 				}
-				ancestors = append(ancestors, gwv1.PolicyAncestorStatus{
-					AncestorRef:    ar,
-					ControllerName: gwv1.GatewayController(agw.ControllerName),
-					Conditions:     baseConds,
-				})
+				ancestors = append(ancestors, setAncestorStatus(ar, &policy.Status, policy.Generation, baseConds, controller))
 			}
 		}
 	}
 
 	if len(attachmentErrors) > 0 {
 		logger.Warn("failed to resolve one or more ancestor refs", "errors", attachmentErrors)
-		ancestors = append(ancestors, gwv1.PolicyAncestorStatus{
-			AncestorRef: gwv1.ParentReference{
-				Group: ptr.Of(gwv1.Group(wellknown.AgentgatewayPolicyGVK.Group)),
-				Name:  "StatusSummary",
-			},
-			ControllerName: gwv1.GatewayController(agw.ControllerName),
-			Conditions:     setAttachmentErrorConditions(baseConds, attachmentErrors),
-		})
+		ancestors = append(ancestors, setAncestorStatus(gwv1.ParentReference{
+			Group: ptr.Of(gwv1.Group(wellknown.AgentgatewayPolicyGVK.Group)),
+			Name:  "StatusSummary",
+		}, &policy.Status, policy.Generation, attachmentErrorConditionMap(baseConds, attachmentErrors), controller))
 	}
 
 	// Build final status from accumulated ancestors
-	status := gwv1.PolicyStatus{Ancestors: ancestors}
-
-	if len(status.Ancestors) > 15 {
-		ignored := status.Ancestors[15:]
-		status.Ancestors = status.Ancestors[:15]
-		status.Ancestors = append(status.Ancestors, gwv1.PolicyAncestorStatus{
-			AncestorRef: gwv1.ParentReference{
-				Group: ptr.Of(gwv1.Group("gateway.kgateway.dev")),
-				Name:  "StatusSummary",
-			},
-			ControllerName: gwv1.GatewayController(agw.ControllerName),
-			Conditions: []metav1.Condition{
-				{
-					Type:    "StatusSummarized",
-					Status:  metav1.ConditionTrue,
-					Reason:  "StatusSummary",
-					Message: fmt.Sprintf("%d AncestorRefs ignored due to max status size", len(ignored)),
-				},
-			},
-		})
+	status := gwv1.PolicyStatus{
+		Ancestors: mergeAncestors(agw.ControllerName, policy.Status.Ancestors, ancestors),
 	}
 
 	// sort all parents for consistency with Equals and for Update
@@ -235,66 +216,57 @@ func TranslateAgentgatewayPolicy(ctx krt.HandlerContext, policy *agentgateway.Ag
 	return &status, agwPolicies
 }
 
-func setPolicyConditions(err error, hasTranslatedPolicies bool) []metav1.Condition {
-	var conds []metav1.Condition
+func policyConditionMap(err error, hasTranslatedPolicies bool) map[string]*condition {
+	conds := map[string]*condition{}
 	if err != nil {
 		// If we produced some policies alongside errors, treat as partial validity
 		if hasTranslatedPolicies {
-			meta.SetStatusCondition(&conds, metav1.Condition{
-				Type:    string(shared.PolicyConditionAccepted),
-				Status:  metav1.ConditionTrue,
-				Reason:  string(shared.PolicyReasonPartiallyValid),
-				Message: err.Error(),
-			})
+			conds[string(shared.PolicyConditionAccepted)] = &condition{
+				status:  metav1.ConditionTrue,
+				reason:  string(shared.PolicyReasonPartiallyValid),
+				message: err.Error(),
+			}
 		} else {
 			// No policies produced and error present -> invalid
-			meta.SetStatusCondition(&conds, metav1.Condition{
-				Type:    string(shared.PolicyConditionAccepted),
-				Status:  metav1.ConditionTrue,
-				Reason:  string(shared.PolicyReasonInvalid),
-				Message: err.Error(),
-			})
-			meta.SetStatusCondition(&conds, metav1.Condition{
-				Type:    string(shared.PolicyConditionAttached),
-				Status:  metav1.ConditionFalse,
-				Reason:  string(shared.PolicyReasonPending),
-				Message: "Policy is not attached due to invalid status",
-			})
+			conds[string(shared.PolicyConditionAccepted)] = &condition{
+				status:  metav1.ConditionTrue,
+				reason:  string(shared.PolicyReasonInvalid),
+				message: err.Error(),
+			}
+			conds[string(shared.PolicyConditionAttached)] = &condition{
+				status:  metav1.ConditionFalse,
+				reason:  string(shared.PolicyReasonPending),
+				message: "Policy is not attached due to invalid status",
+			}
 		}
 	} else {
 		// Check for partial validity
 		// Build success conditions per ancestor
-		meta.SetStatusCondition(&conds, metav1.Condition{
-			Type:    string(shared.PolicyConditionAccepted),
-			Status:  metav1.ConditionTrue,
-			Reason:  string(shared.PolicyReasonValid),
-			Message: reporter.PolicyAcceptedMsg,
-		})
-		meta.SetStatusCondition(&conds, metav1.Condition{
-			Type:    string(shared.PolicyConditionAttached),
-			Status:  metav1.ConditionTrue,
-			Reason:  string(shared.PolicyReasonAttached),
-			Message: reporter.PolicyAttachedMsg,
-		})
-	}
-	// TODO: validate the target exists with dataplane https://github.com/kgateway-dev/kgateway/issues/12275
-	// Ensure LastTransitionTime is set for all conditions
-	for i := range conds {
-		if conds[i].LastTransitionTime.IsZero() {
-			conds[i].LastTransitionTime = metav1.Now()
+		conds[string(shared.PolicyConditionAccepted)] = &condition{
+			status:  metav1.ConditionTrue,
+			reason:  string(shared.PolicyReasonValid),
+			message: reporter.PolicyAcceptedMsg,
+		}
+		conds[string(shared.PolicyConditionAttached)] = &condition{
+			status:  metav1.ConditionTrue,
+			reason:  string(shared.PolicyReasonAttached),
+			message: reporter.PolicyAttachedMsg,
 		}
 	}
 	return conds
 }
 
-func setAttachmentErrorConditions(baseConds []metav1.Condition, attachmentErrors []string) []metav1.Condition {
-	conds := append([]metav1.Condition(nil), baseConds...)
-	meta.SetStatusCondition(&conds, metav1.Condition{
-		Type:    string(shared.PolicyConditionAttached),
-		Status:  metav1.ConditionFalse,
-		Reason:  string(shared.PolicyReasonPending),
-		Message: strings.Join(attachmentErrors, "\n"),
-	})
+func attachmentErrorConditionMap(baseConds map[string]*condition, attachmentErrors []string) map[string]*condition {
+	conds := make(map[string]*condition, len(baseConds)+1)
+	for k, v := range baseConds {
+		copy := *v
+		conds[k] = &copy
+	}
+	conds[string(shared.PolicyConditionAttached)] = &condition{
+		status:  metav1.ConditionFalse,
+		reason:  string(shared.PolicyReasonPending),
+		message: strings.Join(attachmentErrors, "\n"),
+	}
 	return conds
 }
 


### PR DESCRIPTION
Before, each iteration would trigger the status to change.

So for example if I have a Gateway targetted policy, and the gtw
changes, we now would re-write status

Signed-off-by: John Howard <john.howard@solo.io>
