### PR TITLE
agentgatewaypolicy: fix secret keys in AzureAuth API description

### DIFF
--- a/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
+++ b/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
@@ -1050,7 +1050,7 @@ type AwsAuth struct {
 
 type AzureAuth struct {
 	// `secretRef` references a Kubernetes `Secret` containing the Azure
-	// credentials. The `Secret` must have keys `clientId`, `tenantId`, and
+	// credentials. The `Secret` must have keys `clientID`, `tenantID`, and
 	// `clientSecret`.
 	//
 	// +optional

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
@@ -569,7 +569,7 @@ spec:
                                                                 secretRef:
                                                                   description: |-
                                                                     `secretRef` references a Kubernetes `Secret` containing the Azure
-                                                                    credentials. The `Secret` must have keys `clientId`, `tenantId`, and
+                                                                    credentials. The `Secret` must have keys `clientID`, `tenantID`, and
                                                                     `clientSecret`.
                                                                   properties:
                                                                     name:
@@ -1138,7 +1138,7 @@ spec:
                                                                 secretRef:
                                                                   description: |-
                                                                     `secretRef` references a Kubernetes `Secret` containing the Azure
-                                                                    credentials. The `Secret` must have keys `clientId`, `tenantId`, and
+                                                                    credentials. The `Secret` must have keys `clientID`, `tenantID`, and
                                                                     `clientSecret`.
                                                                   properties:
                                                                     name:
@@ -1703,7 +1703,7 @@ spec:
                                                                 secretRef:
                                                                   description: |-
                                                                     `secretRef` references a Kubernetes `Secret` containing the Azure
-                                                                    credentials. The `Secret` must have keys `clientId`, `tenantId`, and
+                                                                    credentials. The `Secret` must have keys `clientID`, `tenantID`, and
                                                                     `clientSecret`.
                                                                   properties:
                                                                     name:
@@ -2494,7 +2494,7 @@ spec:
                                                                 secretRef:
                                                                   description: |-
                                                                     `secretRef` references a Kubernetes `Secret` containing the Azure
-                                                                    credentials. The `Secret` must have keys `clientId`, `tenantId`, and
+                                                                    credentials. The `Secret` must have keys `clientID`, `tenantID`, and
                                                                     `clientSecret`.
                                                                   properties:
                                                                     name:
@@ -3063,7 +3063,7 @@ spec:
                                                                 secretRef:
                                                                   description: |-
                                                                     `secretRef` references a Kubernetes `Secret` containing the Azure
-                                                                    credentials. The `Secret` must have keys `clientId`, `tenantId`, and
+                                                                    credentials. The `Secret` must have keys `clientID`, `tenantID`, and
                                                                     `clientSecret`.
                                                                   properties:
                                                                     name:
@@ -3909,7 +3909,7 @@ spec:
                                           secretRef:
                                             description: |-
                                               `secretRef` references a Kubernetes `Secret` containing the Azure
-                                              credentials. The `Secret` must have keys `clientId`, `tenantId`, and
+                                              credentials. The `Secret` must have keys `clientID`, `tenantID`, and
                                               `clientSecret`.
                                             properties:
                                               name:
@@ -5252,7 +5252,7 @@ spec:
                                         secretRef:
                                           description: |-
                                             `secretRef` references a Kubernetes `Secret` containing the Azure
-                                            credentials. The `Secret` must have keys `clientId`, `tenantId`, and
+                                            credentials. The `Secret` must have keys `clientID`, `tenantID`, and
                                             `clientSecret`.
                                           properties:
                                             name:
@@ -5994,7 +5994,7 @@ spec:
                                                 secretRef:
                                                   description: |-
                                                     `secretRef` references a Kubernetes `Secret` containing the Azure
-                                                    credentials. The `Secret` must have keys `clientId`, `tenantId`, and
+                                                    credentials. The `Secret` must have keys `clientID`, `tenantID`, and
                                                     `clientSecret`.
                                                   properties:
                                                     name:
@@ -6518,7 +6518,7 @@ spec:
                                                 secretRef:
                                                   description: |-
                                                     `secretRef` references a Kubernetes `Secret` containing the Azure
-                                                    credentials. The `Secret` must have keys `clientId`, `tenantId`, and
+                                                    credentials. The `Secret` must have keys `clientID`, `tenantID`, and
                                                     `clientSecret`.
                                                   properties:
                                                     name:
@@ -7039,7 +7039,7 @@ spec:
                                                 secretRef:
                                                   description: |-
                                                     `secretRef` references a Kubernetes `Secret` containing the Azure
-                                                    credentials. The `Secret` must have keys `clientId`, `tenantId`, and
+                                                    credentials. The `Secret` must have keys `clientID`, `tenantID`, and
                                                     `clientSecret`.
                                                   properties:
                                                     name:
@@ -7777,7 +7777,7 @@ spec:
                                                 secretRef:
                                                   description: |-
                                                     `secretRef` references a Kubernetes `Secret` containing the Azure
-                                                    credentials. The `Secret` must have keys `clientId`, `tenantId`, and
+                                                    credentials. The `Secret` must have keys `clientID`, `tenantID`, and
                                                     `clientSecret`.
                                                   properties:
                                                     name:
@@ -8301,7 +8301,7 @@ spec:
                                                 secretRef:
                                                   description: |-
                                                     `secretRef` references a Kubernetes `Secret` containing the Azure
-                                                    credentials. The `Secret` must have keys `clientId`, `tenantId`, and
+                                                    credentials. The `Secret` must have keys `clientID`, `tenantID`, and
                                                     `clientSecret`.
                                                   properties:
                                                     name:
@@ -9097,7 +9097,7 @@ spec:
                           secretRef:
                             description: |-
                               `secretRef` references a Kubernetes `Secret` containing the Azure
-                              credentials. The `Secret` must have keys `clientId`, `tenantId`, and
+                              credentials. The `Secret` must have keys `clientID`, `tenantID`, and
                               `clientSecret`.
                             properties:
                               name:

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
@@ -346,7 +346,7 @@ spec:
                                                 secretRef:
                                                   description: |-
                                                     `secretRef` references a Kubernetes `Secret` containing the Azure
-                                                    credentials. The `Secret` must have keys `clientId`, `tenantId`, and
+                                                    credentials. The `Secret` must have keys `clientID`, `tenantID`, and
                                                     `clientSecret`.
                                                   properties:
                                                     name:
@@ -870,7 +870,7 @@ spec:
                                                 secretRef:
                                                   description: |-
                                                     `secretRef` references a Kubernetes `Secret` containing the Azure
-                                                    credentials. The `Secret` must have keys `clientId`, `tenantId`, and
+                                                    credentials. The `Secret` must have keys `clientID`, `tenantID`, and
                                                     `clientSecret`.
                                                   properties:
                                                     name:
@@ -1391,7 +1391,7 @@ spec:
                                                 secretRef:
                                                   description: |-
                                                     `secretRef` references a Kubernetes `Secret` containing the Azure
-                                                    credentials. The `Secret` must have keys `clientId`, `tenantId`, and
+                                                    credentials. The `Secret` must have keys `clientID`, `tenantID`, and
                                                     `clientSecret`.
                                                   properties:
                                                     name:
@@ -2129,7 +2129,7 @@ spec:
                                                 secretRef:
                                                   description: |-
                                                     `secretRef` references a Kubernetes `Secret` containing the Azure
-                                                    credentials. The `Secret` must have keys `clientId`, `tenantId`, and
+                                                    credentials. The `Secret` must have keys `clientID`, `tenantID`, and
                                                     `clientSecret`.
                                                   properties:
                                                     name:
@@ -2653,7 +2653,7 @@ spec:
                                                 secretRef:
                                                   description: |-
                                                     `secretRef` references a Kubernetes `Secret` containing the Azure
-                                                    credentials. The `Secret` must have keys `clientId`, `tenantId`, and
+                                                    credentials. The `Secret` must have keys `clientID`, `tenantID`, and
                                                     `clientSecret`.
                                                   properties:
                                                     name:
@@ -3449,7 +3449,7 @@ spec:
                           secretRef:
                             description: |-
                               `secretRef` references a Kubernetes `Secret` containing the Azure
-                              credentials. The `Secret` must have keys `clientId`, `tenantId`, and
+                              credentials. The `Secret` must have keys `clientID`, `tenantID`, and
                               `clientSecret`.
                             properties:
                               name:


### PR DESCRIPTION
Fix the reference to the casing for the secret keys used in AzureAuth.

These changes reflect the constant in https://github.com/agentgateway/agentgateway/blob/main/controller/pkg/wellknown/constants.go#L12