### PR TITLE
fix(cel): properties list drops segment after bracket accessor

### DIFF
--- a/crates/agentgateway/src/cel/properties.rs
+++ b/crates/agentgateway/src/cel/properties.rs
@@ -8,6 +8,10 @@ pub(super) fn properties<'e>(
 		Unspecified => {},
 		Optimized { original, .. } => properties(&original.expr, all, path),
 		Call(call) => {
+			// A Call produces a computed value, so any outer Select chain we inherited
+			// does not name a property on Idents inside the call. Drop it so e.g.
+			// `a["b"].c` tracks `a`, not `a.c`.
+			path.clear();
 			if let Some(t) = &call.target {
 				properties(&t.expr, all, path)
 			}

--- a/crates/agentgateway/src/cel/tests.rs
+++ b/crates/agentgateway/src/cel/tests.rs
@@ -323,9 +323,11 @@ fn test_properties() {
 	test(r#"!a.b"#, &["a.b"]);
 	test(r#"a.b < c"#, &["a.b", "c"]);
 	test(r#"a.b + c + 2"#, &["a.b", "c"]);
-	// This is not right! Should just be 'a' probably
-	test(r#"a["b"].c"#, &["a.c"]);
+	test(r#"a["b"].c"#, &["a"]);
+	test(r#"a["b"]["c"]"#, &["a"]);
 	test(r#"a.b[0]"#, &["a.b"]);
+	test(r#"a.b[0].c"#, &["a.b"]);
+	test(r#"a[b.c]"#, &["a", "b.c"]);
 	test(r#"{"a":"b"}.a"#, &[]);
 	// Test extauthz namespace recognition
 	test(r#"extauthz.user_id"#, &["extauthz.user_id"]);


### PR DESCRIPTION
For the expression: `a["b"].c`

Before:

```
Select(field="c")		path=[]
	Call(fn="_[_]")		push "c", path=["c"]
		Ident("a")		push "a", emit ["a","c"], clear
		Literal("b")	ignored

Out: [["a", "c"]]
```

After:

<pre>
Select(field="c")		path=[]
	Call(fn="_[_]")		push "c"     → path=["c"]
		Ident("a")		<b>clear()</b>, push "a", emit ["a"], clear
		Literal("b")	ignored

Out: [["a"]]

</pre>