### PR TITLE
Strip encoding headers

### DIFF
--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -916,10 +916,14 @@ impl AIProvider {
 
 		// Snapshot decompressed bytes for CEL response.body access before re-compression,
 		// so maybe_buffer_response_body can skip decompression entirely.
+		// Also strip encoding headers now that the body is decompressed; the chat
+		// completions path re-adds Content-Encoding when it re-compresses.
 		if encoding.is_some() {
 			parts
 				.extensions
 				.insert(crate::cel::BufferedBody(bytes.clone()));
+			parts.headers.remove(header::CONTENT_ENCODING);
+			parts.headers.remove(header::TRANSFER_ENCODING);
 		}
 
 		// count_tokens has simplified response handling (just format translation)
@@ -993,6 +997,9 @@ impl AIProvider {
 		};
 
 		let body = if let Some(encoding) = encoding {
+			parts
+				.headers
+				.insert(header::CONTENT_ENCODING, HeaderValue::from_static(encoding));
 			Body::from(
 				http::compression::encode_body(&body, encoding)
 					.await


### PR DESCRIPTION
Fixes https://github.com/agentgateway/agentgateway/issues/1620 

Tested with similar setup test server as https://github.com/agentgateway/agentgateway/pull/1601 but an AI backend:
```
binds:                                                                                                                                                                                                         
- port: 4000                                                                                                                                                                                                   
  listeners:                                                                                                                                                                                                   
  - name: test                                                                                                                                                                                                 
    routes:                                               
    - backends:
      - ai:
          name: openai
          provider:                                                                                                                                                                                            
            openAI: {}                                                                                                                                                                                         
          hostOverride: localhost:8000                                                                                                                                                                         
      policies:                                                                                                                                                                                                
        ai:                                               
          routes:
            /v1/embeddings: embeddings
            /v1/chat/completions: completions 
``` 

Before:
```
curl -sS -D - -o /tmp/body.bin http://localhost:4000/v1/embeddings \
    -H 'Content-Type: application/json' \
      -H 'Accept-Encoding: gzip' \
        -d '{"model":"text-embedding-3-large","input":"hello","encoding_format":"float","dimensions":3}'
HTTP/1.0 200 OK
server: BaseHTTP/0.6 Python/3.14.3
date: Thu, 23 Apr 2026 17:00:02 GMT
content-type: application/json
content-encoding: gzip
content-length: 140
```

Now gzip is stripped:
```
❯ curl -sS -D - -o /tmp/body.bin http://localhost:4000/v1/embeddings \
    -H 'Content-Type: application/json' \
      -H 'Accept-Encoding: gzip' \
        -d '{"model":"text-embedding-3-large","input":"hello","encoding_format":"float","dimensions":3}'
HTTP/1.0 200 OK
server: BaseHTTP/0.6 Python/3.14.3
date: Thu, 23 Apr 2026 17:15:05 GMT
content-type: application/json
content-length: 180 
```

Removing `TRANSFER_ENCODING` too since that's what was on the streaming path, but we might not need to since it gets overwritten anyway when we send the response. 
