### PR TITLE
drop tonic responses in spawned task

### DIFF
--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -1282,13 +1282,19 @@ impl opentelemetry_sdk::logs::LogExporter for PolicyGrpcLogExporter {
 			}
 			let req =
 				opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest { resource_logs };
+			// Drop tonic Response inside the spawned task so guard is released on the Tokio runtime, not on
+			// the BatchProcessor OS thread which has no Tokio context.
 			handle
-				.spawn(async move { client.export(req).await })
+				.spawn(async move {
+					client
+						.export(req)
+						.await
+						.map(|_| ())
+						.map_err(|e| e.message().to_string())
+				})
 				.await
 				.map_err(|e| OTelSdkError::InternalFailure(e.to_string()))?
-				.map(|_| ())
-				.map_err(|e: tonic::Status| OTelSdkError::InternalFailure(e.message().to_string()))
-				as OTelSdkResult
+				.map_err(OTelSdkError::InternalFailure) as OTelSdkResult
 		}
 	}
 

--- a/crates/agentgateway/src/telemetry/trc.rs
+++ b/crates/agentgateway/src/telemetry/trc.rs
@@ -309,14 +309,19 @@ impl opentelemetry_sdk::trace::SpanExporter for PolicyGrpcSpanExporter {
 			let req = opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest {
 				resource_spans,
 			};
-			// Ensure export runs on the application's Tokio runtime
+			// Drop tonic Response inside the spawned task so guard is released on the Tokio runtime, not on
+			// the BatchProcessor OS thread which has no Tokio context.
 			handle
-				.spawn(async move { client.export(req).await })
+				.spawn(async move {
+					client
+						.export(req)
+						.await
+						.map(|_| ())
+						.map_err(|e| e.message().to_string())
+				})
 				.await
 				.map_err(|e| OTelSdkError::InternalFailure(e.to_string()))?
-				.map(|_| ())
-				.map_err(|e: tonic::Status| OTelSdkError::InternalFailure(e.message().to_string()))
-				as OTelSdkResult
+				.map_err(OTelSdkError::InternalFailure) as OTelSdkResult
 		}
 	}
 


### PR DESCRIPTION
Fixes: https://github.com/agentgateway/agentgateway/issues/1621 

The tonic Response must be dropped inside the spawned task so that the capacity guard gets released in the Tokio runtime, not the BatchProcessor thread. 

**On main:**
```
❯ ./target/debug/agentgateway -f examples/telemetry/config.yaml
...
2026-04-23T20:41:11.041600Z     info    agent_core::readiness   Task 'state manager' complete (8.052459ms), marking server ready        
2026-04-23T20:41:11.041596Z     info    proxy::gateway  started bind    bind="bind/3000"
2026-04-23T20:41:12.735329Z     info    request gateway=default/default listener=listener0 route=default/route0 src.addr=[::1]:50475 http.method=POST http.host=localhost http.path=/mcp http.version=HTTP/1.1 http.status=406 trace.id=c546b597c9908d5c4b7b63ba3532a0a9 span.id=9dbd139c31a2aeba protocol=mcp error="mcp: client must accept both application/json and text/event-stream" reason=MCP duration=1ms

thread 'OpenTelemetry.Traces.BatchProcessor' (36209706) panicked at /Users/ninapolshakova/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/hyper-util-0.1.20/src/rt/tokio.rs:289:20:
there is no reactor running, must be called from the context of a Tokio 1.x runtime
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

When running test curl:
```
curl -X POST http://localhost:3000/mcp -H "Content-Type: application/json"  -d '{"jsonrpc":"2.0","method":"initialize","id":1,"params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"0.1"}}}'
```

**With fix no panic:**
```
2026-04-23T20:38:51.147871Z     info    management::hyper_helpers       listener established    address=[::]:15021 component="readiness"
2026-04-23T20:38:51.150514Z     info    state_manager   Watching config file: examples/telemetry/config.yaml    
2026-04-23T20:38:51.153558Z     info    state_manager   loaded config from File("examples/telemetry/config.yaml")       
2026-04-23T20:38:51.153985Z     info    agent_core::readiness   Task 'agentgateway' complete (8.27175ms), still awaiting 1 tasks        
2026-04-23T20:38:51.154003Z     info    management::hyper_helpers       listener established    address=127.0.0.1:15000 component="admin"
2026-04-23T20:38:51.154061Z     info    management::hyper_helpers       listener established    address=[::]:15020 component="stats"
2026-04-23T20:38:51.154087Z     info    proxy::gateway  started bind    bind="bind/3000"
2026-04-23T20:38:51.154152Z     info    agent_core::readiness   Task 'state manager' complete (8.437791ms), marking server ready        
2026-04-23T20:38:52.848311Z     info    request gateway=default/default listener=listener0 route=default/route0 src.addr=[::1]:50443 http.method=POST http.host=localhost http.path=/mcp http.version=HTTP/1.1 http.status=406 trace.id=e5f016108f59f1e97dc6ca4f4a828366 span.id=29170777f81a29a0 protocol=mcp error="mcp: client must accept both application/json and text/event-stream" reason=MCP duration=0ms
```

