### PR TITLE
xds: better error handling semantics for regex, cel, RLS

### DIFF
--- a/crates/agentgateway/src/cel/mod.rs
+++ b/crates/agentgateway/src/cel/mod.rs
@@ -217,23 +217,27 @@ impl ContextBuilder {
 
 impl Expression {
 	/// new_permissive compiles the expression. If the expression cannot be compiled, its instead replaced
-	/// with an expression that always fails to evaluate
-	pub fn new_permissive(original_expression: impl Into<String>) -> Self {
+	/// with an expression that always fails to evaluate. The returned error is the compilation error
+	/// from the original expression, if one was suppressed.
+	pub fn new_permissive(original_expression: impl Into<String>) -> (Self, Option<Error>) {
 		let expr = original_expression.into();
 		match Self::new_strict(&expr) {
-			Ok(ok) => ok,
+			Ok(ok) => (ok, None),
 			Err(err) => {
 				debug!("ignoring failed expression: {}", err);
 				let fail_message =
 					serde_json::to_string(&format!("the expression {expr:?} could not be compiled"))
 						.expect("string serialization must succeed");
-				Self {
-					attributes: Default::default(),
-					expression: Self::new_strict(format!("fail({fail_message})"))
-						.expect("must be valid")
-						.expression,
-					original_expression: expr,
-				}
+				(
+					Self {
+						attributes: Default::default(),
+						expression: Self::new_strict(format!("fail({fail_message})"))
+							.expect("must be valid")
+							.expression,
+						original_expression: expr,
+					},
+					Some(err),
+				)
 			},
 		}
 	}

--- a/crates/agentgateway/src/cel/tests.rs
+++ b/crates/agentgateway/src/cel/tests.rs
@@ -36,16 +36,17 @@ fn test_permissive() {
 				.contains("could not be compiled")
 		);
 	};
-	let valid = Expression::new_permissive("1 + 1");
+	let (valid, err) = Expression::new_permissive("1 + 1");
+	assert!(err.is_none());
 	assert_eq!(2, exec.eval(&valid).unwrap().json().unwrap());
 
-	assert_compile_failure(Expression::new_permissive("1 +"));
+	assert_compile_failure(Expression::new_permissive("1 +").0);
 
-	assert_compile_failure(Expression::new_permissive("'"));
+	assert_compile_failure(Expression::new_permissive("'").0);
 
-	assert_compile_failure(Expression::new_permissive("\"h"));
+	assert_compile_failure(Expression::new_permissive("\"h").0);
 
-	assert_compile_failure(Expression::new_permissive(r#"" || true || "#));
+	assert_compile_failure(Expression::new_permissive(r#"" || true || "#).0);
 }
 #[test]
 fn test_eval() {

--- a/crates/agentgateway/src/http/route.rs
+++ b/crates/agentgateway/src/http/route.rs
@@ -28,6 +28,7 @@ fn matches_request(m: &RouteMatch, request: &Request) -> bool {
 				.map(|m| m.start() == 0 && m.end() == path.len())
 				.unwrap_or(false)
 		},
+		PathMatch::Invalid => false,
 		PathMatch::PathPrefix(p) => {
 			let p = p.trim_end_matches('/');
 			let Some(suffix) = request.uri().path().trim_end_matches('/').strip_prefix(p) else {
@@ -67,6 +68,7 @@ fn matches_request(m: &RouteMatch, request: &Request) -> bool {
 					return false;
 				}
 			},
+			HeaderValueMatch::Invalid => return false,
 		}
 	}
 	// TODO: this re-parses the query string on every call; hoist to caller if this becomes a hot path.
@@ -93,6 +95,7 @@ fn matches_request(m: &RouteMatch, request: &Request) -> bool {
 					return false;
 				}
 			},
+			QueryValueMatch::Invalid => return false,
 		}
 	}
 	true
@@ -267,6 +270,8 @@ fn get_path_rank(path: &PathMatch) -> u8 {
 		PathMatch::Exact(_) => 3,
 		PathMatch::PathPrefix(_) => 2,
 		PathMatch::Regex(_) => 1,
+		// Because this can never match, its rank is irrelevant
+		PathMatch::Invalid => 0,
 	}
 }
 
@@ -274,5 +279,7 @@ fn get_path_length(path: &PathMatch) -> usize {
 	match path {
 		PathMatch::Exact(p) | PathMatch::PathPrefix(p) => p.len(),
 		PathMatch::Regex(r) => r.as_str().len(),
+		// Because this can never match, its rank is irrelevant
+		PathMatch::Invalid => 0,
 	}
 }

--- a/crates/agentgateway/src/http/transformation_cel.rs
+++ b/crates/agentgateway/src/http/transformation_cel.rs
@@ -40,20 +40,35 @@ pub struct LocalTransform {
 pub struct TransformationMetadata(pub serde_json::Map<String, serde_json::Value>);
 
 impl TransformerConfig {
-	fn try_from_local_config(req: LocalTransform, strict: bool) -> anyhow::Result<Self> {
-		let compile = |s: &str| {
+	fn try_from_local_config<F>(
+		req: LocalTransform,
+		strict: bool,
+		warnings: &mut F,
+	) -> anyhow::Result<Self>
+	where
+		F: FnMut(&str, &cel::Error),
+	{
+		fn compile<F>(s: &str, strict: bool, warnings: &mut F) -> anyhow::Result<cel::Expression>
+		where
+			F: FnMut(&str, &cel::Error),
+		{
 			if strict {
-				cel::Expression::new_strict(s)
+				Ok(cel::Expression::new_strict(s)?)
 			} else {
-				Ok(cel::Expression::new_permissive(s))
+				let (expression, err) = cel::Expression::new_permissive(s);
+				if let Some(err) = &err {
+					warnings(s, err);
+				}
+				Ok(expression)
 			}
-		};
+		}
+
 		let set = req
 			.set
 			.into_iter()
 			.map(|(k, v)| {
 				let tk = HeaderOrPseudo::try_from(k.as_str())?;
-				let tv = compile(v.as_str())?;
+				let tv = compile(v.as_str(), strict, warnings)?;
 				Ok::<_, anyhow::Error>((tk, tv))
 			})
 			.collect::<Result<_, _>>()?;
@@ -62,7 +77,7 @@ impl TransformerConfig {
 			.into_iter()
 			.map(|(k, v)| {
 				let tk = HeaderOrPseudo::try_from(k.as_str())?;
-				let tv = compile(v.as_str())?;
+				let tv = compile(v.as_str(), strict, warnings)?;
 				Ok::<_, anyhow::Error>((tk, tv))
 			})
 			.collect::<Result<_, _>>()?;
@@ -71,11 +86,14 @@ impl TransformerConfig {
 			.into_iter()
 			.map(|k| HeaderName::try_from(k.as_str()))
 			.collect::<Result<_, _>>()?;
-		let body = req.body.map(|b| compile(b.as_str())).transpose()?;
+		let body = req
+			.body
+			.map(|b| compile(b.as_str(), strict, warnings))
+			.transpose()?;
 		let metadata = req
 			.metadata
 			.into_iter()
-			.map(|(k, v)| Ok::<_, anyhow::Error>((k, compile(v.as_str())?)))
+			.map(|(k, v)| Ok::<_, anyhow::Error>((k, compile(v.as_str(), strict, warnings)?)))
 			.collect::<Result<_, _>>()?;
 		Ok(TransformerConfig {
 			set,
@@ -92,14 +110,25 @@ impl Transformation {
 		value: LocalTransformationConfig,
 		strict: bool,
 	) -> anyhow::Result<Self> {
+		Self::try_from_local_config_with_warnings(value, strict, |_, _| {})
+	}
+
+	pub fn try_from_local_config_with_warnings<F>(
+		value: LocalTransformationConfig,
+		strict: bool,
+		mut warnings: F,
+	) -> anyhow::Result<Self>
+	where
+		F: FnMut(&str, &cel::Error),
+	{
 		let LocalTransformationConfig { request, response } = value;
 		let request = if let Some(req) = request {
-			TransformerConfig::try_from_local_config(req, strict)?
+			TransformerConfig::try_from_local_config(req, strict, &mut warnings)?
 		} else {
 			Default::default()
 		};
 		let response = if let Some(resp) = response {
-			TransformerConfig::try_from_local_config(resp, strict)?
+			TransformerConfig::try_from_local_config(resp, strict, &mut warnings)?
 		} else {
 			Default::default()
 		};

--- a/crates/agentgateway/src/llm/policy/mod.rs
+++ b/crates/agentgateway/src/llm/policy/mod.rs
@@ -907,6 +907,7 @@ impl Policy {
 						continue;
 					}
 				},
+				HeaderValueMatch::Invalid => continue,
 			}
 			headers.insert(header_name, have.clone());
 		}

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -665,6 +665,7 @@ impl HTTPProxy {
 				}
 			},
 			PathMatch::Regex(r) => r.as_str().into(),
+			PathMatch::Invalid => strng::literal!("<invalid>"),
 		});
 		req.extensions_mut().insert(path_match);
 

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -1360,7 +1360,6 @@ impl Store {
 		diagnostics: &mut Diagnostics,
 	) -> anyhow::Result<()> {
 		let policy = crate::types::agent_xds::targeted_policy_from_proto(&raw, diagnostics)?;
-		tracing::error!("howardjohn: policy {:?}", diagnostics);
 		self.insert_policy(policy);
 		Ok(())
 	}

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -1360,6 +1360,7 @@ impl Store {
 		diagnostics: &mut Diagnostics,
 	) -> anyhow::Result<()> {
 		let policy = crate::types::agent_xds::targeted_policy_from_proto(&raw, diagnostics)?;
+		tracing::error!("howardjohn: policy {:?}", diagnostics);
 		self.insert_policy(policy);
 		Ok(())
 	}

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -834,6 +834,7 @@ pub enum QueryValueMatch {
 		#[cfg_attr(feature = "schema", schemars(with = "String"))]
 		regex::Regex,
 	),
+	Invalid,
 }
 
 #[apply(schema!)]
@@ -848,6 +849,7 @@ pub enum HeaderValueMatch {
 		#[cfg_attr(feature = "schema", schemars(with = "String"))]
 		regex::Regex,
 	),
+	Invalid,
 }
 
 #[apply(schema!)]
@@ -859,6 +861,7 @@ pub enum PathMatch {
 		#[cfg_attr(feature = "schema", schemars(with = "String"))]
 		regex::Regex,
 	),
+	Invalid,
 }
 
 #[apply(schema!)]
@@ -1797,6 +1800,7 @@ fn get_path_rank(path: &PathMatch) -> i32 {
 		// Prefix/Regex -- we will defer to the length
 		PathMatch::PathPrefix(_) => 2,
 		PathMatch::Regex(_) => 2,
+		PathMatch::Invalid => 0,
 	}
 }
 
@@ -1805,6 +1809,7 @@ fn get_path_length(path: &PathMatch) -> usize {
 		PathMatch::Exact(s) => s.len(),
 		PathMatch::PathPrefix(s) => s.len(),
 		PathMatch::Regex(r) => r.as_str().len(),
+		PathMatch::Invalid => 0,
 	}
 }
 

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -65,7 +65,6 @@ fn permissive_cel_expression(
 ) -> cel::Expression {
 	let original_expression = original_expression.into();
 	let (expression, err) = cel::Expression::new_permissive(original_expression.clone());
-	tracing::error!("howardjohn: build permissive {:?} {:?}", expression, err);
 	if let Some(err) = err {
 		diagnostics.add_warning(format!(
 			"invalid CEL expression for {}: {err}; replacing {original_expression:?} with an expression that always fails",

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -58,6 +58,48 @@ impl Diagnostics {
 	}
 }
 
+fn permissive_cel_expression(
+	diagnostics: &mut Diagnostics,
+	context: impl AsRef<str>,
+	original_expression: impl Into<String>,
+) -> cel::Expression {
+	let original_expression = original_expression.into();
+	let (expression, err) = cel::Expression::new_permissive(original_expression.clone());
+	tracing::error!("howardjohn: build permissive {:?} {:?}", expression, err);
+	if let Some(err) = err {
+		diagnostics.add_warning(format!(
+			"invalid CEL expression for {}: {err}; replacing {original_expression:?} with an expression that always fails",
+			context.as_ref(),
+		));
+	}
+	expression
+}
+
+fn permissive_cel_expression_arc(
+	diagnostics: &mut Diagnostics,
+	context: impl AsRef<str>,
+	original_expression: impl Into<String>,
+) -> Arc<cel::Expression> {
+	Arc::new(permissive_cel_expression(
+		diagnostics,
+		context,
+		original_expression,
+	))
+}
+
+fn regex_or_warn_invalid(
+	diagnostics: &mut Diagnostics,
+	context: impl AsRef<str>,
+	pattern: &str,
+) -> Result<regex::Regex, regex::Error> {
+	regex::Regex::new(pattern).inspect_err(|err| {
+		diagnostics.add_warning(format!(
+			"invalid regex for {}: {err}; replacing {pattern:?} with a matcher that never matches",
+			context.as_ref(),
+		));
+	})
+}
+
 fn convert_tls_cipher_suites(
 	raw_suites: &[i32],
 	diagnostics: &mut Diagnostics,
@@ -188,30 +230,40 @@ fn route_backend_reference_from_proto(
 	})
 }
 
-impl From<&proto::agent::backend_policy_spec::McpAuthorization> for McpAuthorization {
-	fn from(rbac: &proto::agent::backend_policy_spec::McpAuthorization) -> Self {
-		let mut allow_exprs = Vec::new();
-		// We do NOT want to NACK invalid CEL expressions. Instead, we ensure they always evaluate to errors.
-		for allow_rule in &rbac.allow {
-			let expr = cel::Expression::new_permissive(allow_rule);
-			allow_exprs.push(Arc::new(expr));
-		}
-
-		let mut deny_exprs = Vec::new();
-		for deny_rule in &rbac.deny {
-			let expr = cel::Expression::new_permissive(deny_rule);
-			deny_exprs.push(Arc::new(expr));
-		}
-
-		let mut require_exprs = Vec::new();
-		for require_rule in &rbac.require {
-			let expr = cel::Expression::new_permissive(require_rule);
-			require_exprs.push(Arc::new(expr));
-		}
-
-		let policy_set = authorization::PolicySet::new(allow_exprs, deny_exprs, require_exprs);
-		McpAuthorization::new(authorization::RuleSet::new(policy_set))
+fn mcp_authorization_from_proto(
+	rbac: &proto::agent::backend_policy_spec::McpAuthorization,
+	diagnostics: &mut Diagnostics,
+) -> McpAuthorization {
+	let mut allow_exprs = Vec::new();
+	// We do NOT want to NACK invalid CEL expressions. Instead, we ensure they always evaluate to errors.
+	for allow_rule in &rbac.allow {
+		allow_exprs.push(permissive_cel_expression_arc(
+			diagnostics,
+			"backend.mcpAuthorization.allow",
+			allow_rule,
+		));
 	}
+
+	let mut deny_exprs = Vec::new();
+	for deny_rule in &rbac.deny {
+		deny_exprs.push(permissive_cel_expression_arc(
+			diagnostics,
+			"backend.mcpAuthorization.deny",
+			deny_rule,
+		));
+	}
+
+	let mut require_exprs = Vec::new();
+	for require_rule in &rbac.require {
+		require_exprs.push(permissive_cel_expression_arc(
+			diagnostics,
+			"backend.mcpAuthorization.require",
+			require_rule,
+		));
+	}
+
+	let policy_set = authorization::PolicySet::new(allow_exprs, deny_exprs, require_exprs);
+	McpAuthorization::new(authorization::RuleSet::new(policy_set))
 }
 
 fn mcp_authentication_from_proto(
@@ -376,7 +428,9 @@ fn convert_backend_ai_policy(
 					Kind::Regex(rr) => {
 						llm::policy::RequestGuardKind::Regex(convert_regex_rules(rr, diagnostics))
 					},
-					Kind::Webhook(wh) => llm::policy::RequestGuardKind::Webhook(convert_webhook(wh)?),
+					Kind::Webhook(wh) => {
+						llm::policy::RequestGuardKind::Webhook(convert_webhook(wh, diagnostics)?)
+					},
 					Kind::OpenaiModeration(m) => {
 						let pols = m
 							.inline_policies
@@ -464,7 +518,7 @@ fn convert_backend_ai_policy(
 					llm::policy::ResponseGuardKind::Regex(convert_regex_rules(rr, diagnostics))
 				},
 				response_guard::Kind::Webhook(wh) => {
-					llm::policy::ResponseGuardKind::Webhook(convert_webhook(wh).ok()?)
+					llm::policy::ResponseGuardKind::Webhook(convert_webhook(wh, diagnostics).ok()?)
 				},
 				response_guard::Kind::GoogleModelArmor(gma) => {
 					let pols = gma
@@ -546,8 +600,12 @@ fn convert_backend_ai_policy(
 				ai.transformations
 					.iter()
 					.map(|(k, v)| {
-						let ve = cel::Expression::new_permissive(v);
-						Ok::<_, ProtoError>((k.to_owned(), Arc::new(ve)))
+						let ve = permissive_cel_expression_arc(
+							diagnostics,
+							format!("backend.ai.transformations.{k}"),
+							v,
+						);
+						Ok::<_, ProtoError>((k.to_owned(), ve))
 					})
 					.collect::<Result<_, _>>()?,
 			)
@@ -1054,7 +1112,7 @@ fn mcp_target_from_proto(
 
 fn route_match_from_proto(
 	s: &proto::agent::RouteMatch,
-	_diagnostics: &mut Diagnostics,
+	diagnostics: &mut Diagnostics,
 ) -> Result<RouteMatch, ProtoError> {
 	use crate::types::proto::agent::path_match::*;
 	let path = match &s.path {
@@ -1067,7 +1125,9 @@ fn route_match_from_proto(
 		}) => PathMatch::Exact(strng::new(prefix)),
 		Some(proto::agent::PathMatch {
 			kind: Some(Kind::Regex(r)),
-		}) => PathMatch::Regex(regex::Regex::new(r)?),
+		}) => regex_or_warn_invalid(diagnostics, "route.path", r)
+			.map(PathMatch::Regex)
+			.unwrap_or(PathMatch::Invalid),
 		Some(proto::agent::PathMatch { kind: None }) => {
 			return Err(ProtoError::Generic("invalid path match".to_string()));
 		},
@@ -1075,7 +1135,7 @@ fn route_match_from_proto(
 	let method = s.method.as_ref().map(|m| MethodMatch {
 		method: strng::new(&m.exact),
 	});
-	let headers = match convert_header_match(&s.headers) {
+	let headers = match convert_header_match(diagnostics, "route.headers", &s.headers) {
 		Ok(h) => h,
 		Err(e) => return Err(ProtoError::Generic(format!("invalid header match: {e}"))),
 	};
@@ -1091,7 +1151,9 @@ fn route_match_from_proto(
 			}),
 			Some(proto::agent::query_match::Value::Regex(e)) => Ok(QueryMatch {
 				name: strng::new(&h.name),
-				value: QueryValueMatch::Regex(regex::Regex::new(e)?),
+				value: regex_or_warn_invalid(diagnostics, format!("route.queryParams.{}", h.name), e)
+					.map(QueryValueMatch::Regex)
+					.unwrap_or(QueryValueMatch::Invalid),
 			}),
 		})
 		.collect::<Result<Vec<_>, _>>()?;
@@ -1111,36 +1173,46 @@ fn default_as_none<T: Default + PartialEq>(i: T) -> Option<T> {
 	}
 }
 
-impl From<&proto::agent::traffic_policy_spec::Rbac> for Authorization {
-	fn from(rbac: &proto::agent::traffic_policy_spec::Rbac) -> Self {
-		// Convert allow rules
-		let mut allow_exprs = Vec::new();
-		for allow_rule in &rbac.allow {
-			let expr = cel::Expression::new_permissive(allow_rule);
-			allow_exprs.push(Arc::new(expr));
-		}
-		// Convert deny rules
-		let mut deny_exprs = Vec::new();
-		for deny_rule in &rbac.deny {
-			let expr = cel::Expression::new_permissive(deny_rule);
-			deny_exprs.push(Arc::new(expr));
-		}
-
-		let mut require_exprs = Vec::new();
-		for require_rule in &rbac.require {
-			let expr = cel::Expression::new_permissive(require_rule);
-			require_exprs.push(Arc::new(expr));
-		}
-
-		// Create PolicySet using the same pattern as in de_policies function
-		let policy_set = authorization::PolicySet::new(allow_exprs, deny_exprs, require_exprs);
-		Authorization(authorization::RuleSet::new(policy_set))
+fn authorization_from_proto(
+	rbac: &proto::agent::traffic_policy_spec::Rbac,
+	diagnostics: &mut Diagnostics,
+) -> Authorization {
+	// Convert allow rules
+	let mut allow_exprs = Vec::new();
+	for allow_rule in &rbac.allow {
+		allow_exprs.push(permissive_cel_expression_arc(
+			diagnostics,
+			"traffic.authorization.allow",
+			allow_rule,
+		));
 	}
+	// Convert deny rules
+	let mut deny_exprs = Vec::new();
+	for deny_rule in &rbac.deny {
+		deny_exprs.push(permissive_cel_expression_arc(
+			diagnostics,
+			"traffic.authorization.deny",
+			deny_rule,
+		));
+	}
+
+	let mut require_exprs = Vec::new();
+	for require_rule in &rbac.require {
+		require_exprs.push(permissive_cel_expression_arc(
+			diagnostics,
+			"traffic.authorization.require",
+			require_rule,
+		));
+	}
+
+	// Create PolicySet using the same pattern as in de_policies function
+	let policy_set = authorization::PolicySet::new(allow_exprs, deny_exprs, require_exprs);
+	Authorization(authorization::RuleSet::new(policy_set))
 }
 
 fn transformation_from_proto(
 	spec: &proto::agent::traffic_policy_spec::TransformationPolicy,
-	_diagnostics: &mut Diagnostics,
+	diagnostics: &mut Diagnostics,
 ) -> Result<Transformation, ProtoError> {
 	fn convert_transform(
 		t: &Option<proto::agent::traffic_policy_spec::transformation_policy::Transform>,
@@ -1181,8 +1253,12 @@ fn transformation_from_proto(
 	let request = Some(convert_transform(&spec.request));
 	let response = Some(convert_transform(&spec.response));
 	let config = LocalTransformationConfig { request, response };
-	Transformation::try_from_local_config(config, false)
-		.map_err(|e| ProtoError::Generic(e.to_string()))
+	Transformation::try_from_local_config_with_warnings(config, false, |expression, err| {
+		diagnostics.add_warning(format!(
+			"invalid CEL expression for transformation: {err}; replacing {expression:?} with an expression that always fails",
+		));
+	})
+	.map_err(|e| ProtoError::Generic(e.to_string()))
 }
 
 fn backend_policy_from_proto(
@@ -1252,7 +1328,7 @@ fn backend_policy_from_proto(
 			BackendPolicy::BackendAuth(backend_auth_from_proto(auth.clone(), diagnostics)?)
 		},
 		Some(bps::Kind::McpAuthorization(rbac)) => {
-			BackendPolicy::McpAuthorization(McpAuthorization::from(rbac))
+			BackendPolicy::McpAuthorization(mcp_authorization_from_proto(rbac, diagnostics))
 		},
 		Some(bps::Kind::McpAuthentication(ma)) => {
 			BackendPolicy::McpAuthentication(mcp_authentication_from_proto(ma, diagnostics)?)
@@ -1329,18 +1405,23 @@ fn backend_policy_from_proto(
 				.collect::<Vec<_>>();
 			BackendPolicy::RequestMirror(mirrors)
 		},
-		Some(bps::Kind::Health(h)) => BackendPolicy::Health(convert_health(h)),
+		Some(bps::Kind::Health(h)) => BackendPolicy::Health(convert_health(h, diagnostics)),
 		None => return Err(ProtoError::MissingRequiredField),
 	})
 }
 
-fn convert_health(h: &proto::agent::backend_policy_spec::Health) -> health::Policy {
+fn convert_health(
+	h: &proto::agent::backend_policy_spec::Health,
+	diagnostics: &mut Diagnostics,
+) -> health::Policy {
 	let unhealthy_expression = if h.unhealthy_condition.is_empty() {
 		None
 	} else {
-		Some(Arc::new(cel::Expression::new_permissive(
+		Some(permissive_cel_expression_arc(
+			diagnostics,
+			"backend.health.unhealthyCondition",
 			&h.unhealthy_condition,
-		)))
+		))
 	};
 	let eviction = h.eviction.as_ref().map(|ev| health::Eviction {
 		duration: ev.duration.map(convert_duration),
@@ -1447,8 +1528,12 @@ fn traffic_policy_from_proto(
 						.metadata
 						.iter()
 						.map(|(k, v)| {
-							let ve = cel::Expression::new_permissive(v);
-							Ok::<_, ProtoError>((k.to_owned(), Arc::new(ve)))
+							let ve = permissive_cel_expression_arc(
+								diagnostics,
+								format!("traffic.extAuthz.grpc.metadata.{k}"),
+								v,
+							);
+							Ok::<_, ProtoError>((k.to_owned(), ve))
 						})
 						.collect::<Result<_, _>>()?;
 					http::ext_authz::Protocol::Grpc {
@@ -1461,16 +1546,12 @@ fn traffic_policy_from_proto(
 					}
 				},
 				external_auth::Protocol::Http(h) => http::ext_authz::Protocol::Http {
-					path: h
-						.path
-						.as_ref()
-						.map(cel::Expression::new_permissive)
-						.map(Arc::new),
-					redirect: h
-						.redirect
-						.as_ref()
-						.map(cel::Expression::new_permissive)
-						.map(Arc::new),
+					path: h.path.as_ref().map(|expr| {
+						permissive_cel_expression_arc(diagnostics, "traffic.extAuthz.http.path", expr)
+					}),
+					redirect: h.redirect.as_ref().map(|expr| {
+						permissive_cel_expression_arc(diagnostics, "traffic.extAuthz.http.redirect", expr)
+					}),
 					include_response_headers: h
 						.include_response_headers
 						.iter()
@@ -1481,8 +1562,12 @@ fn traffic_policy_from_proto(
 						.iter()
 						.map(|(k, v)| {
 							let tk = HeaderOrPseudo::try_from(k.as_str())?;
-							let tv = cel::Expression::new_permissive(v.as_str());
-							Ok::<_, anyhow::Error>((tk, Arc::new(tv)))
+							let tv = permissive_cel_expression_arc(
+								diagnostics,
+								format!("traffic.extAuthz.http.addRequestHeaders.{k}"),
+								v.as_str(),
+							);
+							Ok::<_, anyhow::Error>((tk, tv))
 						})
 						.collect::<Result<_, _>>()
 						.map_err(|e| ProtoError::Generic(e.to_string()))?,
@@ -1490,7 +1575,11 @@ fn traffic_policy_from_proto(
 						.metadata
 						.iter()
 						.map(|(k, v)| {
-							let ve = cel::Expression::new_permissive(v);
+							let ve = permissive_cel_expression(
+								diagnostics,
+								format!("traffic.extAuthz.http.metadata.{k}"),
+								v,
+							);
 							Ok::<_, ProtoError>((k.to_owned(), Arc::new(ve)))
 						})
 						.collect::<Result<_, _>>()?,
@@ -1520,7 +1609,9 @@ fn traffic_policy_from_proto(
 				include_request_body,
 			})
 		},
-		Some(tps::Kind::Authorization(rbac)) => TrafficPolicy::Authorization(Authorization::from(rbac)),
+		Some(tps::Kind::Authorization(rbac)) => {
+			TrafficPolicy::Authorization(authorization_from_proto(rbac, diagnostics))
+		},
 		Some(tps::Kind::Jwt(jwt)) => {
 			let mode = match tps::jwt::Mode::try_from(jwt.mode)
 				.map_err(|_| ProtoError::EnumParse("invalid JWT mode".to_string()))?
@@ -1615,7 +1706,11 @@ fn traffic_policy_from_proto(
 							.map(|e| {
 								http::remoteratelimit::Descriptor(
 									e.key.clone(),
-									cel::Expression::new_permissive(e.value.clone()),
+									permissive_cel_expression(
+										diagnostics,
+										format!("traffic.remoteRateLimit.descriptors.{}", e.key),
+										e.value.clone(),
+									),
 								)
 							})
 							.collect();
@@ -1629,20 +1724,18 @@ fn traffic_policy_from_proto(
 								},
 								tps::remote_rate_limit::Type::Tokens => http::localratelimit::RateLimitType::Tokens,
 							},
-							limit_override: d
-								.limit_override
-								.as_ref()
-								.map(|expr| Arc::new(cel::Expression::new_permissive(expr))),
+							limit_override: d.limit_override.as_ref().map(|expr| {
+								permissive_cel_expression_arc(
+									diagnostics,
+									"traffic.remoteRateLimit.limitOverride",
+									expr,
+								)
+							}),
 						})
 					},
 				)
 				.collect::<Result<Vec<_>, _>>()?;
 			let target = resolve_simple_reference(rrl.target.as_ref());
-			if matches!(target, SimpleBackendReference::Invalid) {
-				return Err(ProtoError::Generic(
-					"remote_rate_limit: target must be set".into(),
-				));
-			}
 			let failure_mode = match tps::remote_rate_limit::FailureMode::try_from(rrl.failure_mode) {
 				Ok(tps::remote_rate_limit::FailureMode::FailOpen) => {
 					http::remoteratelimit::FailureMode::FailOpen
@@ -1671,6 +1764,8 @@ fn traffic_policy_from_proto(
 				_ => http::ext_proc::FailureMode::FailClosed,
 			};
 			fn to_cel_attrs(
+				diagnostics: &mut Diagnostics,
+				context: &str,
 				attrs: &HashMap<String, String>,
 			) -> Option<HashMap<String, Arc<cel::Expression>>> {
 				if attrs.is_empty() {
@@ -1679,7 +1774,12 @@ fn traffic_policy_from_proto(
 					Some(
 						attrs
 							.iter()
-							.map(|(k, v)| (k.clone(), Arc::new(cel::Expression::new_permissive(v))))
+							.map(|(k, v)| {
+								(
+									k.clone(),
+									permissive_cel_expression_arc(diagnostics, format!("{context}.{k}"), v),
+								)
+							})
 							.collect(),
 					)
 				}
@@ -1689,8 +1789,16 @@ fn traffic_policy_from_proto(
 				// Not supported inline from xDS
 				policies: Vec::new(),
 				failure_mode,
-				request_attributes: to_cel_attrs(&ep.request_attributes),
-				response_attributes: to_cel_attrs(&ep.response_attributes),
+				request_attributes: to_cel_attrs(
+					diagnostics,
+					"traffic.extProc.requestAttributes",
+					&ep.request_attributes,
+				),
+				response_attributes: to_cel_attrs(
+					diagnostics,
+					"traffic.extProc.responseAttributes",
+					&ep.response_attributes,
+				),
 				metadata_context: if ep.metadata_context.is_empty() {
 					None
 				} else {
@@ -1703,7 +1811,16 @@ fn traffic_policy_from_proto(
 									data
 										.context
 										.iter()
-										.map(|(k, v)| (k.clone(), Arc::new(cel::Expression::new_permissive(v))))
+										.map(|(k, v)| {
+											(
+												k.clone(),
+												permissive_cel_expression_arc(
+													diagnostics,
+													format!("traffic.extProc.metadataContext.{namespace}.{k}"),
+													v,
+												),
+											)
+										})
 										.collect(),
 								);
 								meta
@@ -1954,20 +2071,29 @@ fn frontend_policy_from_proto(
 		Some(fps::Kind::NetworkAuthorization(rbac)) => {
 			let mut allow_exprs = Vec::new();
 			for allow_rule in &rbac.allow {
-				let expr = cel::Expression::new_permissive(allow_rule);
-				allow_exprs.push(Arc::new(expr));
+				allow_exprs.push(permissive_cel_expression_arc(
+					diagnostics,
+					"frontend.networkAuthorization.allow",
+					allow_rule,
+				));
 			}
 
 			let mut deny_exprs = Vec::new();
 			for deny_rule in &rbac.deny {
-				let expr = cel::Expression::new_permissive(deny_rule);
-				deny_exprs.push(Arc::new(expr));
+				deny_exprs.push(permissive_cel_expression_arc(
+					diagnostics,
+					"frontend.networkAuthorization.deny",
+					deny_rule,
+				));
 			}
 
 			let mut require_exprs = Vec::new();
 			for require_rule in &rbac.require {
-				let expr = cel::Expression::new_permissive(require_rule);
-				require_exprs.push(Arc::new(expr));
+				require_exprs.push(permissive_cel_expression_arc(
+					diagnostics,
+					"frontend.networkAuthorization.require",
+					require_rule,
+				));
 			}
 
 			let policy_set = authorization::PolicySet::new(allow_exprs, deny_exprs, require_exprs);
@@ -1984,8 +2110,12 @@ fn frontend_policy_from_proto(
 						.add
 						.iter()
 						.map(|f| {
-							let expr = cel::Expression::new_permissive(&f.expression);
-							Ok::<_, ProtoError>((f.name.clone(), Arc::new(expr)))
+							let expr = permissive_cel_expression_arc(
+								diagnostics,
+								format!("frontend.logging.fields.add.{}", f.name),
+								&f.expression,
+							);
+							Ok::<_, ProtoError>((f.name.clone(), expr))
 						})
 						.collect::<Result<Vec<_>, _>>()?;
 					let rm = f.remove.clone();
@@ -2022,8 +2152,7 @@ fn frontend_policy_from_proto(
 				filter: p
 					.filter
 					.as_ref()
-					.map(cel::Expression::new_permissive)
-					.map(Arc::new),
+					.map(|expr| permissive_cel_expression_arc(diagnostics, "frontend.logging.filter", expr)),
 				add: Arc::new(add),
 				remove: Arc::new(FzHashSet::new(rm)),
 				otlp,
@@ -2034,7 +2163,7 @@ fn frontend_policy_from_proto(
 		},
 		Some(fps::Kind::Tracing(t)) => {
 			// Convert protobuf to TracingConfig
-			let tracing_config = types::agent::TracingConfig::from(t);
+			let tracing_config = tracing_config_from_proto(t, diagnostics);
 
 			// Prepare LoggingFields with the CEL attributes from TracingConfig
 			let logging_fields = Arc::new(crate::telemetry::log::LoggingFields {
@@ -2052,62 +2181,74 @@ fn frontend_policy_from_proto(
 	})
 }
 
-impl From<&proto::agent::frontend_policy_spec::Tracing> for types::agent::TracingConfig {
-	fn from(t: &proto::agent::frontend_policy_spec::Tracing) -> Self {
-		let provider_backend = resolve_simple_reference(t.provider_backend.as_ref());
+fn tracing_config_from_proto(
+	t: &proto::agent::frontend_policy_spec::Tracing,
+	diagnostics: &mut Diagnostics,
+) -> types::agent::TracingConfig {
+	let provider_backend = resolve_simple_reference(t.provider_backend.as_ref());
 
-		let attributes: OrderedStringMap<Arc<cel::Expression>> = t
-			.attributes
-			.iter()
-			.map(|a| {
-				let expr = cel::Expression::new_permissive(&a.value);
-				(a.name.clone(), Arc::new(expr))
-			})
-			.collect();
+	let attributes: OrderedStringMap<Arc<cel::Expression>> = t
+		.attributes
+		.iter()
+		.map(|a| {
+			(
+				a.name.clone(),
+				permissive_cel_expression_arc(
+					diagnostics,
+					format!("frontend.tracing.attributes.{}", a.name),
+					&a.value,
+				),
+			)
+		})
+		.collect();
 
-		let resources: OrderedStringMap<Arc<cel::Expression>> = t
-			.resources
-			.iter()
-			.map(|a| {
-				let expr = cel::Expression::new_permissive(&a.value);
-				(a.name.clone(), Arc::new(expr))
-			})
-			.collect();
+	let resources: OrderedStringMap<Arc<cel::Expression>> = t
+		.resources
+		.iter()
+		.map(|a| {
+			(
+				a.name.clone(),
+				permissive_cel_expression_arc(
+					diagnostics,
+					format!("frontend.tracing.resources.{}", a.name),
+					&a.value,
+				),
+			)
+		})
+		.collect();
 
-		// Optional per-policy sampling overrides
-		let random_sampling = t
-			.random_sampling
-			.as_ref()
-			.map(|s| Arc::new(cel::Expression::new_permissive(s)));
-		let client_sampling = t
-			.client_sampling
-			.as_ref()
-			.map(|s| Arc::new(cel::Expression::new_permissive(s)));
+	// Optional per-policy sampling overrides
+	let random_sampling = t
+		.random_sampling
+		.as_ref()
+		.map(|s| permissive_cel_expression_arc(diagnostics, "frontend.tracing.randomSampling", s));
+	let client_sampling = t
+		.client_sampling
+		.as_ref()
+		.map(|s| permissive_cel_expression_arc(diagnostics, "frontend.tracing.clientSampling", s));
 
-		let path = t.path.clone().unwrap_or_else(|| "/v1/traces".to_string());
+	let path = t.path.clone().unwrap_or_else(|| "/v1/traces".to_string());
 
-		let protocol =
-			match crate::types::proto::agent::frontend_policy_spec::tracing::Protocol::try_from(
-				t.protocol,
-			) {
-				Ok(crate::types::proto::agent::frontend_policy_spec::tracing::Protocol::Grpc) => {
-					types::agent::TracingProtocol::Grpc
-				},
-				_ => types::agent::TracingProtocol::Http,
-			};
+	let protocol =
+		match crate::types::proto::agent::frontend_policy_spec::tracing::Protocol::try_from(t.protocol)
+		{
+			Ok(crate::types::proto::agent::frontend_policy_spec::tracing::Protocol::Grpc) => {
+				types::agent::TracingProtocol::Grpc
+			},
+			_ => types::agent::TracingProtocol::Http,
+		};
 
-		types::agent::TracingConfig {
-			provider_backend,
-			// Not supported inline from xDS
-			policies: Vec::new(),
-			attributes,
-			resources,
-			remove: t.remove.clone(),
-			random_sampling,
-			client_sampling,
-			path,
-			protocol,
-		}
+	types::agent::TracingConfig {
+		provider_backend,
+		// Not supported inline from xDS
+		policies: Vec::new(),
+		attributes,
+		resources,
+		remove: t.remove.clone(),
+		random_sampling,
+		client_sampling,
+		path,
+		protocol,
 	}
 }
 
@@ -2288,10 +2429,15 @@ fn convert_prompt_caching(
 
 fn convert_webhook(
 	w: &proto::agent::backend_policy_spec::ai::Webhook,
+	diagnostics: &mut Diagnostics,
 ) -> Result<llm::policy::Webhook, ProtoError> {
 	let target = resolve_simple_reference(w.backend.as_ref());
 
-	let forward_header_matches = convert_header_match(&w.forward_header_matches)?;
+	let forward_header_matches = convert_header_match(
+		diagnostics,
+		"backend.ai.webhook.forwardHeaderMatches",
+		&w.forward_header_matches,
+	)?;
 
 	Ok(llm::policy::Webhook {
 		target,
@@ -2383,7 +2529,11 @@ fn resolve_reference(target: Option<&proto::agent::BackendReference>) -> Backend
 	}
 }
 
-fn convert_header_match(h: &[proto::agent::HeaderMatch]) -> Result<Vec<HeaderMatch>, ProtoError> {
+fn convert_header_match(
+	diagnostics: &mut Diagnostics,
+	context: &str,
+	h: &[proto::agent::HeaderMatch],
+) -> Result<Vec<HeaderMatch>, ProtoError> {
 	let headers = h
 		.iter()
 		.map(|h| match &h.value {
@@ -2396,7 +2546,9 @@ fn convert_header_match(h: &[proto::agent::HeaderMatch]) -> Result<Vec<HeaderMat
 			}),
 			Some(proto::agent::header_match::Value::Regex(e)) => Ok(HeaderMatch {
 				name: crate::http::HeaderOrPseudo::try_from(h.name.as_str())?,
-				value: HeaderValueMatch::Regex(regex::Regex::new(e)?),
+				value: regex_or_warn_invalid(diagnostics, format!("{context}.{}", h.name), e)
+					.map(HeaderValueMatch::Regex)
+					.unwrap_or(HeaderValueMatch::Invalid),
 			}),
 		})
 		.collect::<Result<Vec<_>, _>>()?;

--- a/schema/config.json
+++ b/schema/config.json
@@ -938,6 +938,12 @@
     "HeaderValueMatch": {
       "oneOf": [
         {
+          "type": "string",
+          "enum": [
+            "invalid"
+          ]
+        },
+        {
           "type": "object",
           "properties": {
             "exact": {
@@ -965,6 +971,12 @@
     },
     "PathMatch": {
       "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "invalid"
+          ]
+        },
         {
           "type": "object",
           "properties": {
@@ -1021,6 +1033,12 @@
     },
     "QueryValueMatch": {
       "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "invalid"
+          ]
+        },
         {
           "type": "object",
           "properties": {


### PR DESCRIPTION
For https://github.com/agentgateway/agentgateway/issues/1438

* CEL expressions emit warning on error instead of silent
* Regex now "do not match" instead of NACKing
* Invalid remote RL backend respects failure mode

Example:
```
{
  "code": "OK",
  "component": "krtxds",
  "connection": "agentgateway~10.13.0.30~gateway-8d999965d-gpsxz.default~default.svc.cluster.local-5",
  "level": "warn",
  "message": [
    {
      "key": "policy/traffic/default/policy:rbac:default/gateway",
      "warn": "invalid CEL expression for traffic.authorization.allow: parse: ERROR: <input>:1:3: Syntax error: mismatched input '<EOF>' expecting {'[', '{', '(', ')', '.', '-', '!', 'true', 'false', 'null', NUM_FLOAT, NUM_INT, NUM_UINT, STRING, BYTES, IDENTIFIER}\n| f(\n| ..^; replacing \"f(\" with an expression that always fails"
    }
  ],
  "msg": "ADS: ACK ERROR",
  "time": "2026-04-24T00:01:45.700902054Z",
  "type": "RDS"
}
```

Signed-off-by: John Howard <john.howard@solo.io>
