### PR TITLE
cel: do not buffer bodies when we do not need to

### DIFF
--- a/crates/agentgateway/src/cel/mod.rs
+++ b/crates/agentgateway/src/cel/mod.rs
@@ -146,11 +146,29 @@ impl ContextBuilder {
 		// TODO: different types
 		self.request_attributes |= expression.attributes
 	}
+	/// register_log_expression registers the given expressions attributes as required attributes.
+	/// This should only be used for "log" expressions. Log expressions are ones that run after the complete
+	/// request and response (including the body) are complete. I.e. if its not executed during DropOnLog,
+	/// its probably not the correct usage.
+	/// The benefit of this compared to register_expression is that we can do more optimal processing of
+	/// bodies, as we know they will complete before we need them, so we can lazily observe the body instead
+	/// of proactively buffering.
+	pub fn register_log_expression(&mut self, expression: &Expression) {
+		self.logging_attributes |= expression.attributes
+	}
 	fn any_has(&self, attr: impl Into<FlagSet<Attributes>>) -> bool {
 		let x = attr.into();
 		self.request_attributes.contains(x)
 			|| self.response_attributes.contains(x)
 			|| self.logging_attributes.contains(x)
+	}
+	fn before_log_has(&self, attr: impl Into<FlagSet<Attributes>>) -> bool {
+		let x = attr.into();
+		self.request_attributes.contains(x) || self.response_attributes.contains(x)
+	}
+	fn log_only_has(&self, attr: impl Into<FlagSet<Attributes>>) -> bool {
+		let x = attr.into();
+		self.logging_attributes.contains(x) && !self.before_log_has(x)
 	}
 	pub fn maybe_snapshot_response(
 		&self,
@@ -185,7 +203,7 @@ impl ContextBuilder {
 		}
 	}
 	pub async fn maybe_buffer_request_body(&self, req: &mut crate::http::Request) {
-		if self.any_has(Attributes::RequestBody) {
+		if self.before_log_has(Attributes::RequestBody) {
 			if req.extensions().get::<BufferedBody>().is_some() {
 				return;
 			}
@@ -193,10 +211,25 @@ impl ContextBuilder {
 				return;
 			};
 			req.extensions_mut().insert(BufferedBody(body));
+		} else if self.log_only_has(Attributes::RequestBody) {
+			if req.extensions().get::<BufferedBody>().is_some() {
+				return;
+			}
+			if req
+				.extensions()
+				.get::<crate::http::RecordedBodyHandle>()
+				.is_some()
+			{
+				return;
+			}
+			let body = std::mem::replace(req.body_mut(), crate::http::Body::empty());
+			let (body, handle) = crate::http::RecordedBody::new(body);
+			*req.body_mut() = crate::http::Body::new(body);
+			req.extensions_mut().insert(handle);
 		}
 	}
 	pub async fn maybe_buffer_response_body(&self, resp: &mut crate::http::Response) {
-		if self.any_has(Attributes::ResponseBody) {
+		if self.before_log_has(Attributes::ResponseBody) {
 			if resp.extensions().get::<BufferedBody>().is_some() {
 				return;
 			}
@@ -204,6 +237,21 @@ impl ContextBuilder {
 				return;
 			};
 			resp.extensions_mut().insert(BufferedBody(body));
+		} else if self.log_only_has(Attributes::ResponseBody) {
+			if resp.extensions().get::<BufferedBody>().is_some() {
+				return;
+			}
+			if resp
+				.extensions()
+				.get::<crate::http::RecordedBodyHandle>()
+				.is_some()
+			{
+				return;
+			}
+			let body = std::mem::replace(resp.body_mut(), crate::http::Body::empty());
+			let (body, handle) = crate::http::RecordedBody::new(body);
+			*resp.body_mut() = crate::http::Body::new(body);
+			resp.extensions_mut().insert(handle);
 		}
 	}
 

--- a/crates/agentgateway/src/cel/mod.rs
+++ b/crates/agentgateway/src/cel/mod.rs
@@ -223,7 +223,8 @@ impl ContextBuilder {
 				return;
 			}
 			let body = std::mem::replace(req.body_mut(), crate::http::Body::empty());
-			let (body, handle) = crate::http::RecordedBody::new(body);
+			let limit = crate::http::buffer_limit(req);
+			let (body, handle) = crate::http::RecordedBody::new_with_limit(body, limit);
 			*req.body_mut() = crate::http::Body::new(body);
 			req.extensions_mut().insert(handle);
 		}
@@ -249,7 +250,8 @@ impl ContextBuilder {
 				return;
 			}
 			let body = std::mem::replace(resp.body_mut(), crate::http::Body::empty());
-			let (body, handle) = crate::http::RecordedBody::new(body);
+			let limit = crate::http::response_buffer_limit(resp);
+			let (body, handle) = crate::http::RecordedBody::new_with_limit(body, limit);
 			*resp.body_mut() = crate::http::Body::new(body);
 			resp.extensions_mut().insert(handle);
 		}

--- a/crates/agentgateway/src/cel/tests.rs
+++ b/crates/agentgateway/src/cel/tests.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 
 use http::{HeaderValue, Method};
+use http_body_util::BodyExt;
 use serde_json::json;
 
 use super::*;
@@ -69,6 +70,98 @@ fn expression() {
 		.body(Body::empty())
 		.unwrap();
 	assert_eq!(Value::Bool(true), eval_request(expr, req).unwrap());
+}
+
+#[tokio::test]
+async fn log_only_request_body_records_without_buffering() {
+	let exp = Expression::new_strict("request.body").unwrap();
+	let mut cb = ContextBuilder::new();
+	cb.register_log_expression(&exp);
+	let mut req = ::http::Request::builder()
+		.method(Method::POST)
+		.uri("http://example.com")
+		.body(Body::from("hello"))
+		.unwrap();
+
+	cb.maybe_buffer_request_body(&mut req).await;
+
+	assert!(req.extensions().get::<BufferedBody>().is_none());
+	assert!(
+		req
+			.extensions()
+			.get::<crate::http::RecordedBodyHandle>()
+			.is_some()
+	);
+
+	let snapshot = cb.maybe_snapshot_request(&mut req, false).unwrap();
+	let body = std::mem::replace(req.body_mut(), Body::empty());
+	let sent = body.collect().await.unwrap().to_bytes();
+	assert_eq!(sent, bytes::Bytes::from_static(b"hello"));
+
+	let exec = Executor::new_logger(Some(&snapshot), None, None, None, None);
+	assert_eq!(
+		helpers::value_as_byte_or_json(exec.eval(&exp).unwrap()).unwrap(),
+		bytes::Bytes::from_static(b"hello")
+	);
+}
+
+#[tokio::test]
+async fn request_body_expression_buffers_before_log() {
+	let exp = Expression::new_strict("request.body").unwrap();
+	let mut cb = ContextBuilder::new();
+	cb.register_expression(&exp);
+	let mut req = ::http::Request::builder()
+		.method(Method::POST)
+		.uri("http://example.com")
+		.body(Body::from("hello"))
+		.unwrap();
+
+	cb.maybe_buffer_request_body(&mut req).await;
+
+	assert!(req.extensions().get::<BufferedBody>().is_some());
+	assert!(
+		req
+			.extensions()
+			.get::<crate::http::RecordedBodyHandle>()
+			.is_none()
+	);
+	let exec = Executor::new_request(&req);
+	assert_eq!(
+		helpers::value_as_byte_or_json(exec.eval(&exp).unwrap()).unwrap(),
+		bytes::Bytes::from_static(b"hello")
+	);
+}
+
+#[tokio::test]
+async fn log_only_response_body_records_without_buffering() {
+	let exp = Expression::new_strict("response.body").unwrap();
+	let mut cb = ContextBuilder::new();
+	cb.register_log_expression(&exp);
+	let mut resp = ::http::Response::builder()
+		.status(200)
+		.body(Body::from("world"))
+		.unwrap();
+
+	cb.maybe_buffer_response_body(&mut resp).await;
+
+	assert!(resp.extensions().get::<BufferedBody>().is_none());
+	assert!(
+		resp
+			.extensions()
+			.get::<crate::http::RecordedBodyHandle>()
+			.is_some()
+	);
+
+	let snapshot = cb.maybe_snapshot_response(&mut resp).unwrap();
+	let body = std::mem::replace(resp.body_mut(), Body::empty());
+	let sent = body.collect().await.unwrap().to_bytes();
+	assert_eq!(sent, bytes::Bytes::from_static(b"world"));
+
+	let exec = Executor::new_logger(None, Some(&snapshot), None, None, None);
+	assert_eq!(
+		helpers::value_as_byte_or_json(exec.eval(&exp).unwrap()).unwrap(),
+		bytes::Bytes::from_static(b"world")
+	);
 }
 
 #[test]

--- a/crates/agentgateway/src/cel/types.rs
+++ b/crates/agentgateway/src/cel/types.rs
@@ -26,7 +26,7 @@ use crate::cel::{Error, Expression, ROOT_CONTEXT, query};
 use crate::http::ext_authz::ExtAuthzDynamicMetadata;
 use crate::http::ext_proc::ExtProcDynamicMetadata;
 use crate::http::transformation_cel::TransformationMetadata;
-use crate::http::{apikey, basicauth, jwt};
+use crate::http::{RecordedBodyHandle, apikey, basicauth, jwt};
 use crate::llm::{LLMInfo, LLMRequest};
 use crate::mcp::{MCPInfo, MCPTool};
 use crate::serdes::schema;
@@ -70,6 +70,10 @@ pub struct Executor<'a> {
 
 fn is_extension_or_direct_none<T: Send + Sync + 'static>(e: &ExtensionOrDirect<T>) -> bool {
 	e.deref().is_none()
+}
+
+fn is_body_extension_or_direct_none(e: &BodyExtensionOrDirect) -> bool {
+	e.is_none()
 }
 
 #[apply(schema!)]
@@ -502,6 +506,7 @@ pub fn snapshot_request(req: &mut crate::http::Request, clear: bool) -> RequestS
 		version: req.version(),
 		headers: req.headers().clone(),
 		body: ext::<BufferedBody>(req, clear),
+		recorded_body: ext::<RecordedBodyHandle>(req, clear),
 
 		jwt: ext::<jwt::Claims>(req, clear),
 		api_key: ext::<apikey::Claims>(req, clear),
@@ -523,29 +528,26 @@ pub fn snapshot_response(resp: &mut crate::http::Response) -> ResponseSnapshot {
 		code: resp.status(),
 		headers: resp.headers().clone(),
 		body: resp.extensions_mut().remove::<BufferedBody>(),
+		recorded_body: resp.extensions_mut().remove::<RecordedBodyHandle>(),
 	}
 }
 
 #[derive(Debug, Clone)]
 pub struct RequestSnapshot {
-	/// The request's method
 	pub method: http::Method,
 
-	/// The request's URI
 	pub path: http::Uri,
 
 	pub host: Option<::http::uri::Authority>,
 
 	pub scheme: Option<::http::uri::Scheme>,
 
-	/// The request's version
 	pub version: http::Version,
 
-	// TODO: do not use header_map, which will make multi-headers a list
-	/// The request's headers
 	pub headers: http::HeaderMap,
 
 	pub body: Option<BufferedBody>,
+	pub recorded_body: Option<RecordedBodyHandle>,
 
 	pub jwt: Option<jwt::Claims>,
 
@@ -599,8 +601,8 @@ pub struct RequestRef<'a> {
 	/// The request's headers
 	pub headers: Headers<'a>,
 
-	#[serde(skip_serializing_if = "is_extension_or_direct_none")]
-	pub body: ExtensionOrDirect<'a, BufferedBody>,
+	#[serde(skip_serializing_if = "is_body_extension_or_direct_none")]
+	pub body: BodyExtensionOrDirect<'a>,
 
 	#[serde(skip_serializing_if = "is_extension_or_direct_none")]
 	pub start_time: ExtensionOrDirect<'a, RequestTime>,
@@ -609,14 +611,12 @@ pub struct RequestRef<'a> {
 	pub end_time: Option<&'a RequestTime>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct ResponseSnapshot {
-	#[serde(with = "http_serde::status_code")]
 	pub code: http::StatusCode,
-	#[serde(with = "http_serde::header_map")]
 	pub headers: http::HeaderMap,
-	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub body: Option<BufferedBody>,
+	pub recorded_body: Option<RecordedBodyHandle>,
 }
 
 #[derive(Debug, Clone, Serialize, cel::DynamicType)]
@@ -627,8 +627,8 @@ pub struct ResponseRef<'a> {
 	/// The headers of the response.
 	pub headers: Headers<'a>,
 
-	#[serde(skip_serializing_if = "is_extension_or_direct_none")]
-	pub body: ExtensionOrDirect<'a, BufferedBody>,
+	#[serde(skip_serializing_if = "is_body_extension_or_direct_none")]
+	pub body: BodyExtensionOrDirect<'a>,
 }
 
 impl<'a> From<&'a ResponseSnapshot> for ResponseRef<'a> {
@@ -636,7 +636,10 @@ impl<'a> From<&'a ResponseSnapshot> for ResponseRef<'a> {
 		Self {
 			code: value.code.as_u16(),
 			headers: Headers::new(&value.headers),
-			body: value.body.as_ref().into(),
+			body: BodyExtensionOrDirect::Direct {
+				buffered: value.body.as_ref(),
+				recorded: value.recorded_body.as_ref(),
+			},
 		}
 	}
 }
@@ -728,7 +731,10 @@ impl<'a> From<&'a RequestSnapshot> for RequestRef<'a> {
 			scheme: value.scheme.as_ref(),
 			version: value.version,
 			headers: Headers::new(&value.headers),
-			body: value.body.as_ref().into(),
+			body: BodyExtensionOrDirect::Direct {
+				buffered: value.body.as_ref(),
+				recorded: value.recorded_body.as_ref(),
+			},
 			start_time: value.start_time.as_ref().into(),
 			end_time: None,
 		}
@@ -745,7 +751,7 @@ impl<'a, B> From<&'a ::http::Request<B>> for RequestRef<'a> {
 			scheme: req.uri().scheme(),
 			version: req.version(),
 			headers: Headers::new(req.headers()),
-			body: req.extensions().into(),
+			body: BodyExtensionOrDirect::Extension(req.extensions()),
 			start_time: req.extensions().into(),
 			// Only known in snapshot phase...
 			end_time: None,
@@ -758,7 +764,7 @@ impl<'a> From<&'a crate::http::Response> for ResponseRef<'a> {
 		Self {
 			code: resp.status().as_u16(),
 			headers: Headers::new(resp.headers()),
-			body: resp.extensions().into(),
+			body: BodyExtensionOrDirect::Extension(resp.extensions()),
 		}
 	}
 }
@@ -799,6 +805,77 @@ impl DynamicType for BufferedBody {
 
 	fn materialize(&self) -> Value<'_> {
 		Value::Bytes(BytesValue::Bytes(self.0.clone()))
+	}
+}
+
+#[derive(Debug, Clone)]
+pub enum BodyExtensionOrDirect<'a> {
+	Extension(&'a http::Extensions),
+	Direct {
+		buffered: Option<&'a BufferedBody>,
+		recorded: Option<&'a RecordedBodyHandle>,
+	},
+}
+
+impl BodyExtensionOrDirect<'_> {
+	fn buffered(&self) -> Option<&BufferedBody> {
+		match self {
+			BodyExtensionOrDirect::Extension(e) => e.get::<BufferedBody>(),
+			BodyExtensionOrDirect::Direct { buffered, .. } => *buffered,
+		}
+	}
+
+	fn recorded(&self) -> Option<&RecordedBodyHandle> {
+		match self {
+			BodyExtensionOrDirect::Extension(e) => e.get::<RecordedBodyHandle>(),
+			BodyExtensionOrDirect::Direct { recorded, .. } => *recorded,
+		}
+	}
+
+	fn bytes(&self) -> Option<Bytes> {
+		if let Some(buffered) = self.buffered() {
+			Some(buffered.0.clone())
+		} else {
+			self.recorded().map(RecordedBodyHandle::bytes)
+		}
+	}
+
+	fn is_none(&self) -> bool {
+		self.buffered().is_none() && self.recorded().is_none()
+	}
+}
+
+impl Default for BodyExtensionOrDirect<'_> {
+	fn default() -> Self {
+		Self::Direct {
+			buffered: None,
+			recorded: None,
+		}
+	}
+}
+
+impl Serialize for BodyExtensionOrDirect<'_> {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: serde::Serializer,
+	{
+		match self.bytes() {
+			Some(bytes) => BufferedBody(bytes).serialize(serializer),
+			None => serializer.serialize_none(),
+		}
+	}
+}
+
+impl DynamicType for BodyExtensionOrDirect<'_> {
+	fn auto_materialize(&self) -> bool {
+		true
+	}
+
+	fn materialize(&self) -> Value<'_> {
+		match self.bytes() {
+			Some(bytes) => Value::Bytes(BytesValue::Bytes(bytes)),
+			None => Value::Null,
+		}
 	}
 }
 
@@ -1464,7 +1541,10 @@ impl ExecutorSerde {
 				scheme: req.scheme.as_ref(),
 				version: req.version,
 				headers: Headers::new(&req.headers),
-				body: ExtensionOrDirect::Direct(req.body.as_ref()),
+				body: BodyExtensionOrDirect::Direct {
+					buffered: req.body.as_ref(),
+					recorded: None,
+				},
 				start_time: ExtensionOrDirect::Direct(req.start_time.as_ref()),
 				end_time: req.end_time.as_ref(),
 			});
@@ -1475,7 +1555,10 @@ impl ExecutorSerde {
 			exec.response = Some(ResponseRef {
 				code: resp.code,
 				headers: Headers::new(&resp.headers),
-				body: ExtensionOrDirect::Direct(resp.body.as_ref()),
+				body: BodyExtensionOrDirect::Direct {
+					buffered: resp.body.as_ref(),
+					recorded: None,
+				},
 			});
 		}
 		exec.llm_request = self.llm_request.as_ref();

--- a/crates/agentgateway/src/http/mod.rs
+++ b/crates/agentgateway/src/http/mod.rs
@@ -23,6 +23,7 @@ pub(crate) mod oauth;
 pub mod oidc;
 pub mod outlierdetection;
 mod peekbody;
+mod recordbody;
 pub mod remoteratelimit;
 pub mod sessionpersistence;
 #[cfg(any(test, feature = "internal_benches"))]
@@ -33,6 +34,8 @@ pub type Error = axum_core::Error;
 pub type Body = axum_core::body::Body;
 pub type Request = ::http::Request<Body>;
 pub type Response = ::http::Response<Body>;
+
+pub use recordbody::{RecordedBody, RecordedBodyHandle};
 
 pub(crate) fn iter_request_cookies<'a>(
 	req: &'a Request,

--- a/crates/agentgateway/src/http/recordbody.rs
+++ b/crates/agentgateway/src/http/recordbody.rs
@@ -10,7 +10,14 @@ use crate::http::buflist::BufList;
 
 #[derive(Clone, Debug)]
 pub struct RecordedBodyHandle {
-	state: Arc<Mutex<RecordedBodyState>>,
+	inner: Arc<Mutex<RecordedBodyHandleInner>>,
+	limit: usize,
+}
+
+#[derive(Debug)]
+struct RecordedBodyHandleInner {
+	state: RecordedBodyState,
+	recorded: usize,
 }
 
 #[derive(Debug)]
@@ -27,8 +34,8 @@ impl Default for RecordedBodyState {
 
 impl RecordedBodyHandle {
 	pub fn bytes(&self) -> Bytes {
-		let mut state = self.state.lock();
-		match &mut *state {
+		let mut inner = self.inner.lock();
+		match &mut inner.state {
 			RecordedBodyState::Recording(buffer) => {
 				// This *should* not happen... but that is a recommended pattern of the caller, not something
 				// we enforce.
@@ -41,26 +48,28 @@ impl RecordedBodyHandle {
 	}
 
 	fn push(&self, bytes: Bytes) {
-		let mut state = self.state.lock();
-		if let RecordedBodyState::Recording(buffer) = &mut *state {
-			buffer.push(bytes);
+		let mut inner = self.inner.lock();
+		let remaining = self.limit.saturating_sub(inner.recorded);
+		if let RecordedBodyState::Recording(buffer) = &mut inner.state {
+			let to_record = bytes.len().min(remaining);
+			if to_record == 0 {
+				return;
+			}
+			buffer.push(bytes.slice(0..to_record));
+			inner.recorded += to_record;
 		} else {
 			debug_assert!(false, "push() cannot be called on a complete body handle.")
 		}
 	}
 
 	fn complete(&self) {
-		let mut state = self.state.lock();
-		let RecordedBodyState::Recording(buffer) = &mut *state else {
-			debug_assert!(
-				false,
-				"complete() cannot be called on a complete body handle."
-			);
+		let mut inner = self.inner.lock();
+		let RecordedBodyState::Recording(buffer) = &mut inner.state else {
 			return;
 		};
 		let mut buffer = std::mem::take(buffer);
 		let len = buffer.remaining();
-		*state = RecordedBodyState::Complete(buffer.copy_to_bytes(len));
+		inner.state = RecordedBodyState::Complete(buffer.copy_to_bytes(len));
 	}
 }
 
@@ -78,8 +87,16 @@ pub struct RecordedBody<B = crate::http::Body> {
 
 impl<B> RecordedBody<B> {
 	pub fn new(inner: B) -> (Self, RecordedBodyHandle) {
+		Self::new_with_limit(inner, usize::MAX)
+	}
+
+	pub fn new_with_limit(inner: B, limit: usize) -> (Self, RecordedBodyHandle) {
 		let handle = RecordedBodyHandle {
-			state: Arc::new(Mutex::new(RecordedBodyState::default())),
+			inner: Arc::new(Mutex::new(RecordedBodyHandleInner {
+				state: RecordedBodyState::default(),
+				recorded: 0,
+			})),
+			limit,
 		};
 		(
 			Self {
@@ -126,7 +143,10 @@ where
 				}
 				Poll::Ready(Some(Ok(Frame::data(bytes))))
 			},
-			Err(Ok(trailers)) => Poll::Ready(Some(Ok(Frame::trailers(trailers)))),
+			Err(Ok(trailers)) => {
+				this.handle.complete();
+				Poll::Ready(Some(Ok(Frame::trailers(trailers))))
+			},
 			Err(Err(_unknown)) => {
 				tracing::warn!("An unknown body frame has been recorded");
 				Poll::Ready(None)
@@ -172,6 +192,49 @@ mod tests {
 
 		assert_eq!(got, Bytes::from_static(b"hello world"));
 		assert_eq!(recorded.bytes(), Bytes::from_static(b"hello world"));
+	}
+
+	#[tokio::test]
+	async fn reuses_completed_bytes() {
+		let (body, recorded) = RecordedBody::new(mock_body(vec![b"hello", b"world"]));
+
+		let got = crate::http::Body::new(body)
+			.collect()
+			.await
+			.unwrap()
+			.to_bytes();
+
+		assert_eq!(got, Bytes::from_static(b"helloworld"));
+		assert_eq!(recorded.bytes(), Bytes::from_static(b"helloworld"));
+		assert_eq!(recorded.bytes(), Bytes::from_static(b"helloworld"));
+	}
+
+	#[tokio::test]
+	async fn records_up_to_limit() {
+		let (body, recorded) = RecordedBody::new_with_limit(mock_body(vec![b"hello", b"world"]), 7);
+
+		let got = crate::http::Body::new(body)
+			.collect()
+			.await
+			.unwrap()
+			.to_bytes();
+
+		assert_eq!(got, Bytes::from_static(b"helloworld"));
+		assert_eq!(recorded.bytes(), Bytes::from_static(b"hellowo"));
+	}
+
+	#[tokio::test]
+	async fn zero_limit_records_nothing() {
+		let (body, recorded) = RecordedBody::new_with_limit(mock_body(vec![b"hello"]), 0);
+
+		let got = crate::http::Body::new(body)
+			.collect()
+			.await
+			.unwrap()
+			.to_bytes();
+
+		assert_eq!(got, Bytes::from_static(b"hello"));
+		assert!(recorded.bytes().is_empty());
 	}
 
 	#[tokio::test]

--- a/crates/agentgateway/src/http/recordbody.rs
+++ b/crates/agentgateway/src/http/recordbody.rs
@@ -1,0 +1,212 @@
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use bytes::{Buf, Bytes};
+use http_body::{Body, Frame, SizeHint};
+use parking_lot::Mutex;
+
+use crate::http::buflist::BufList;
+
+#[derive(Clone, Debug)]
+pub struct RecordedBodyHandle {
+	state: Arc<Mutex<RecordedBodyState>>,
+}
+
+#[derive(Debug)]
+enum RecordedBodyState {
+	Recording(BufList),
+	Complete(Bytes),
+}
+
+impl Default for RecordedBodyState {
+	fn default() -> Self {
+		Self::Recording(BufList::default())
+	}
+}
+
+impl RecordedBodyHandle {
+	pub fn bytes(&self) -> Bytes {
+		let mut state = self.state.lock();
+		match &mut *state {
+			RecordedBodyState::Recording(buffer) => {
+				// This *should* not happen... but that is a recommended pattern of the caller, not something
+				// we enforce.
+				let mut buffer = buffer.clone();
+				let len = buffer.remaining();
+				buffer.copy_to_bytes(len)
+			},
+			RecordedBodyState::Complete(bytes) => bytes.clone(),
+		}
+	}
+
+	fn push(&self, bytes: Bytes) {
+		let mut state = self.state.lock();
+		if let RecordedBodyState::Recording(buffer) = &mut *state {
+			buffer.push(bytes);
+		} else {
+			debug_assert!(false, "push() cannot be called on a complete body handle.")
+		}
+	}
+
+	fn complete(&self) {
+		let mut state = self.state.lock();
+		let RecordedBodyState::Recording(buffer) = &mut *state else {
+			debug_assert!(
+				false,
+				"complete() cannot be called on a complete body handle."
+			);
+			return;
+		};
+		let mut buffer = std::mem::take(buffer);
+		let len = buffer.remaining();
+		*state = RecordedBodyState::Complete(buffer.copy_to_bytes(len));
+	}
+}
+
+/// Wraps an HTTP body and records each polled data frame while passing the
+/// bytes through unchanged.
+///
+/// The recorded data is shared through a [`RecordedBodyHandle`]. This is meant
+/// for consumers that inspect the captured bytes after the wrapped body has
+/// been fully drained.
+#[derive(Debug)]
+pub struct RecordedBody<B = crate::http::Body> {
+	inner: B,
+	handle: RecordedBodyHandle,
+}
+
+impl<B> RecordedBody<B> {
+	pub fn new(inner: B) -> (Self, RecordedBodyHandle) {
+		let handle = RecordedBodyHandle {
+			state: Arc::new(Mutex::new(RecordedBodyState::default())),
+		};
+		(
+			Self {
+				inner,
+				handle: handle.clone(),
+			},
+			handle,
+		)
+	}
+
+	pub fn handle(&self) -> RecordedBodyHandle {
+		self.handle.clone()
+	}
+}
+
+impl<B> Body for RecordedBody<B>
+where
+	B: Body + Unpin,
+	B::Error: Into<axum_core::Error>,
+{
+	type Data = Bytes;
+	type Error = axum_core::Error;
+
+	fn poll_frame(
+		self: Pin<&mut Self>,
+		cx: &mut Context<'_>,
+	) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+		let this = self.get_mut();
+		let frame = match futures::ready!(Pin::new(&mut this.inner).poll_frame(cx)) {
+			Some(Ok(frame)) => frame,
+			Some(Err(error)) => return Poll::Ready(Some(Err(error.into()))),
+			None => {
+				this.handle.complete();
+				return Poll::Ready(None);
+			},
+		};
+
+		match frame.into_data().map_err(Frame::into_trailers) {
+			Ok(mut data) => {
+				let len = data.remaining();
+				let bytes = data.copy_to_bytes(len);
+				if bytes.has_remaining() {
+					this.handle.push(bytes.clone());
+				}
+				Poll::Ready(Some(Ok(Frame::data(bytes))))
+			},
+			Err(Ok(trailers)) => Poll::Ready(Some(Ok(Frame::trailers(trailers)))),
+			Err(Err(_unknown)) => {
+				tracing::warn!("An unknown body frame has been recorded");
+				Poll::Ready(None)
+			},
+		}
+	}
+
+	fn is_end_stream(&self) -> bool {
+		self.inner.is_end_stream()
+	}
+
+	fn size_hint(&self) -> SizeHint {
+		self.inner.size_hint()
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use bytes::Bytes;
+	use http_body::Frame;
+	use http_body_util::{BodyExt, StreamBody};
+
+	use super::*;
+
+	fn mock_body(data: Vec<&'static [u8]>) -> crate::http::Body {
+		let iter = data
+			.into_iter()
+			.map(|d| Ok::<_, crate::http::Error>(Frame::data(Bytes::from_static(d))));
+		crate::http::Body::new(StreamBody::new(futures_util::stream::iter(iter)))
+	}
+
+	#[tokio::test]
+	async fn records_polled_bytes() {
+		let (body, recorded) = RecordedBody::new(mock_body(vec![b"hello", b" ", b"world"]));
+
+		assert!(recorded.bytes().is_empty());
+
+		let got = crate::http::Body::new(body)
+			.collect()
+			.await
+			.unwrap()
+			.to_bytes();
+
+		assert_eq!(got, Bytes::from_static(b"hello world"));
+		assert_eq!(recorded.bytes(), Bytes::from_static(b"hello world"));
+	}
+
+	#[tokio::test]
+	async fn exposes_partial_progress() {
+		let (mut body, recorded) = RecordedBody::new(mock_body(vec![b"hello", b"world"]));
+		let first = body.frame().await.unwrap().unwrap().into_data().unwrap();
+
+		assert_eq!(first, Bytes::from_static(b"hello"));
+		assert_eq!(recorded.bytes(), Bytes::from_static(b"hello"));
+
+		let rest = crate::http::Body::new(body)
+			.collect()
+			.await
+			.unwrap()
+			.to_bytes();
+
+		assert_eq!(rest, Bytes::from_static(b"world"));
+		assert_eq!(recorded.bytes(), Bytes::from_static(b"helloworld"));
+	}
+
+	#[tokio::test]
+	async fn passes_trailers_without_recording_them() {
+		let mut trailers = http::HeaderMap::new();
+		trailers.insert("x-test", "value".parse().unwrap());
+		let frames = vec![
+			Ok::<_, crate::http::Error>(Frame::data(Bytes::from_static(b"hello"))),
+			Ok::<_, crate::http::Error>(Frame::trailers(trailers.clone())),
+		];
+		let body = crate::http::Body::new(StreamBody::new(futures_util::stream::iter(frames)));
+		let (body, recorded) = RecordedBody::new(body);
+
+		let got = crate::http::Body::new(body).collect().await.unwrap();
+
+		assert_eq!(got.trailers(), Some(&trailers));
+		assert_eq!(got.to_bytes(), Bytes::from_static(b"hello"));
+		assert_eq!(recorded.bytes(), Bytes::from_static(b"hello"));
+	}
+}

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -173,10 +173,10 @@ impl FrontendPolices {
 			return;
 		};
 		if let Some(f) = filter {
-			ctx.register_expression(f)
+			ctx.register_log_expression(f)
 		}
 		for (_, v) in fields_add.iter() {
-			ctx.register_expression(v)
+			ctx.register_log_expression(v)
 		}
 	}
 }

--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -371,13 +371,13 @@ impl CelLogging {
 	pub fn new(cfg: Config, metrics: MetricsConfig) -> Self {
 		let mut cel_context = cel::ContextBuilder::new();
 		if let Some(f) = &cfg.filter {
-			cel_context.register_expression(f.as_ref());
+			cel_context.register_log_expression(f.as_ref());
 		}
 		for v in cfg.fields.add.values_unordered() {
-			cel_context.register_expression(v.as_ref());
+			cel_context.register_log_expression(v.as_ref());
 		}
 		for v in metrics.metric_fields.add.values_unordered() {
-			cel_context.register_expression(v.as_ref());
+			cel_context.register_log_expression(v.as_ref());
 		}
 
 		Self {
@@ -390,7 +390,7 @@ impl CelLogging {
 
 	pub fn register(&mut self, fields: &LoggingFields) {
 		for v in fields.add.values_unordered() {
-			self.cel_context.register_expression(v.as_ref());
+			self.cel_context.register_log_expression(v.as_ref());
 		}
 	}
 

--- a/schema/cel-functions.md
+++ b/schema/cel-functions.md
@@ -3,6 +3,16 @@
 The table below lists the CEL functions available in agentgateway.
 See the [CEL documentation](https://agentgateway.dev/docs/standalone/latest/reference/cel/) for more information.
 
+## Body Variables
+
+`request.body` and `response.body` expose body bytes to CEL. Capturing these values is bounded by the configured body buffer limit. The default limit is 2 MiB.
+
+When a body variable is used by request-time or response-time expressions, agentgateway eagerly buffers the body so the expression can inspect it before forwarding continues. If the body exceeds the configured limit, buffering fails and the expression cannot read a complete body.
+
+When a body variable is used only by logging, tracing, or other post request/response expressions, agentgateway does not eagerly buffer the body. Instead, it records bytes as the proxy stream is polled and makes the recorded bytes available to the log expression after the stream is done.
+
+If the recorded log-only body exceeds the configured limit, `request.body` or `response.body` contains the truncated prefix up to that limit. The proxied stream itself is still forwarded in full and is not failed due to the logging capture limit. There is currently no CEL field that indicates truncation.
+
 ## Functions
 
 | Function           | Purpose                                                                                                                                                                                                                                                                          |


### PR DESCRIPTION
If we are only accessing the bodies in the logging phase after they have
been finished, we can just record them as they come in. This enables
streaming + body logging.

Signed-off-by: John Howard <john.howard@solo.io>
