### PR TITLE
Trust standalone EPP-selected destinations

### DIFF
--- a/crates/agentgateway/src/http/ext_proc.rs
+++ b/crates/agentgateway/src/http/ext_proc.rs
@@ -72,10 +72,27 @@ pub enum FailureMode {
 	FailOpen,
 }
 
+#[apply(schema!)]
+#[derive(Default, Copy, PartialEq, Eq)]
+/// Controls how an endpoint-picker-selected destination is used.
+pub enum InferenceRoutingDestinationMode {
+	/// Require the selected destination to match agentgateway's local service endpoints.
+	#[default]
+	Validated,
+	/// Trust the selected destination directly without local endpoint validation.
+	Passthrough,
+}
+
 #[apply(schema_ser_schema!)]
 pub struct InferenceRouting {
 	#[serde(rename = "endpointPicker")]
 	pub target: Arc<SimpleBackendReference>,
+	#[serde(
+		default,
+		rename = "destinationMode",
+		skip_serializing_if = "crate::serdes::is_default"
+	)]
+	pub destination_mode: InferenceRoutingDestinationMode,
 	#[serde(default, skip_serializing_if = "crate::serdes::is_default")]
 	#[cfg_attr(feature = "schema", schemars(skip))]
 	pub failure_mode: FailureMode,
@@ -85,6 +102,8 @@ pub struct InferenceRouting {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct InferenceRoutingConfig {
 	endpoint_picker: Arc<SimpleBackendReference>,
+	#[serde(default)]
+	destination_mode: InferenceRoutingDestinationMode,
 }
 
 impl<'de> serde::Deserialize<'de> for InferenceRouting {
@@ -92,10 +111,13 @@ impl<'de> serde::Deserialize<'de> for InferenceRouting {
 	where
 		D: serde::Deserializer<'de>,
 	{
-		let InferenceRoutingConfig { endpoint_picker } =
-			InferenceRoutingConfig::deserialize(deserializer)?;
+		let InferenceRoutingConfig {
+			endpoint_picker,
+			destination_mode,
+		} = InferenceRoutingConfig::deserialize(deserializer)?;
 		Ok(Self {
 			target: endpoint_picker,
+			destination_mode,
 			// TODO: expose fail-open configuration for standalone EPP once the fallback behavior is
 			// explicitly supported and documented end-to-end.
 			failure_mode: FailureMode::FailClosed,
@@ -106,11 +128,13 @@ impl<'de> serde::Deserialize<'de> for InferenceRouting {
 #[derive(Debug, Default)]
 pub struct InferencePoolRouter {
 	ext_proc: Option<ExtProcInstance>,
+	destination_mode: InferenceRoutingDestinationMode,
 }
 
 #[derive(Debug, Default)]
 pub struct InferenceRequestResult {
 	pub destination: Option<SocketAddr>,
+	pub destination_mode: InferenceRoutingDestinationMode,
 	pub policy_response: PolicyResponse,
 	pub failed_open: bool,
 }
@@ -118,6 +142,7 @@ pub struct InferenceRequestResult {
 impl InferenceRouting {
 	pub fn build(&self, client: PolicyClient) -> InferencePoolRouter {
 		InferencePoolRouter {
+			destination_mode: self.destination_mode,
 			ext_proc: Some(ExtProcInstance::new(
 				client,
 				Vec::new(),
@@ -152,6 +177,7 @@ impl InferencePoolRouter {
 			.map_err(|e| ProxyError::Processing(anyhow!("EPP returned invalid address: {e}")))?;
 		Ok(InferenceRequestResult {
 			destination: dest,
+			destination_mode: self.destination_mode,
 			policy_response: pr.unwrap_or_default(),
 			failed_open,
 		})

--- a/crates/agentgateway/src/http/ext_proc_tests.rs
+++ b/crates/agentgateway/src/http/ext_proc_tests.rs
@@ -296,12 +296,7 @@ const STANDALONE_SERVICE_PORT: u16 = 8000;
 
 #[derive(Clone)]
 struct StandaloneInferenceRouter {
-	target: SocketAddr,
-	request_headers_seen: Arc<AtomicUsize>,
-}
-
-#[derive(Debug)]
-struct NoDestinationInferenceRouter {
+	target: Option<SocketAddr>,
 	request_headers_seen: Arc<AtomicUsize>,
 }
 
@@ -314,35 +309,24 @@ impl Handler for StandaloneInferenceRouter {
 	) -> Result<(), Status> {
 		self.request_headers_seen.fetch_add(1, Ordering::SeqCst);
 		let _ = sender
-			.send(request_header_response(Some(CommonResponse {
-				header_mutation: Some(HeaderMutation {
-					set_headers: vec![HeaderValueOption {
-						header: Some(HeaderValue {
-							key: "x-gateway-destination-endpoint".to_string(),
-							value: self.target.to_string(),
-							raw_value: Vec::new(),
-						}),
-						append: Some(false),
-						..Default::default()
-					}],
-					remove_headers: vec![],
-				}),
-				..Default::default()
+			.send(request_header_response(self.target.map(|target| {
+				CommonResponse {
+					header_mutation: Some(HeaderMutation {
+						set_headers: vec![HeaderValueOption {
+							header: Some(HeaderValue {
+								key: "x-gateway-destination-endpoint".to_string(),
+								value: target.to_string(),
+								raw_value: Vec::new(),
+							}),
+							append: Some(false),
+							..Default::default()
+						}],
+						remove_headers: vec![],
+					}),
+					..Default::default()
+				}
 			})))
 			.await;
-		Ok(())
-	}
-}
-
-#[async_trait::async_trait]
-impl Handler for NoDestinationInferenceRouter {
-	async fn handle_request_headers(
-		&mut self,
-		_headers: &HttpHeaders,
-		sender: &Sender<Result<ProcessingResponse, Status>>,
-	) -> Result<(), Status> {
-		self.request_headers_seen.fetch_add(1, Ordering::SeqCst);
-		let _ = sender.send(request_header_response(None)).await;
 		Ok(())
 	}
 }
@@ -379,7 +363,7 @@ fn configure_standalone_service(t: &TestBind) {
 }
 
 async fn setup_inference_routing_mock(
-	target: SocketAddr,
+	target: Option<SocketAddr>,
 	request_headers_seen: Arc<AtomicUsize>,
 ) -> (MockInstance, TestBind, Client<MemoryConnector, Body>) {
 	let ext_proc = ExtProcMock::new(move || StandaloneInferenceRouter {
@@ -420,7 +404,7 @@ async fn standalone_inference_routing_uses_epp_selected_destination_without_loca
 	let backend_b = named_backend("backend-b").await;
 	let request_headers_seen = Arc::new(AtomicUsize::new(0));
 	let (_ext_proc, _bind, io) =
-		setup_inference_routing_mock(*backend_b.address(), request_headers_seen.clone()).await;
+		setup_inference_routing_mock(Some(*backend_b.address()), request_headers_seen.clone()).await;
 
 	let res = send_request(io, Method::GET, "http://lo").await;
 	assert_eq!(res.status(), 200);
@@ -454,35 +438,8 @@ async fn standalone_inference_routing_uses_epp_selected_destination_without_loca
 #[tokio::test]
 async fn standalone_inference_routing_requires_epp_selected_destination() {
 	let request_headers_seen = Arc::new(AtomicUsize::new(0));
-	let request_headers_seen_for_handler = request_headers_seen.clone();
-	let ext_proc = ExtProcMock::new(move || NoDestinationInferenceRouter {
-		request_headers_seen: request_headers_seen_for_handler.clone(),
-	})
-	.spawn()
-	.await;
-
-	let mut t = setup_proxy_test("{}").unwrap().with_bind(simple_bind());
-	configure_standalone_service(&t);
-	t.attach_route(json!({
-		"name": "standalone-epp",
-		"backends": [
-			{
-				"service": {
-					"name": STANDALONE_SERVICE_REF,
-					"port": STANDALONE_SERVICE_PORT,
-				},
-				"policies": {
-					"inferenceRouting": {
-						"endpointPicker": {
-							"host": ext_proc.address.to_string(),
-						},
-					},
-				},
-			}
-		],
-	}))
-	.await;
-	let io = t.serve_http(BIND_KEY);
+	let (_ext_proc, _bind, io) =
+		setup_inference_routing_mock(None, request_headers_seen.clone()).await;
 
 	let res = send_request(io, Method::GET, "http://lo").await;
 	assert_eq!(res.status(), 503);

--- a/crates/agentgateway/src/http/ext_proc_tests.rs
+++ b/crates/agentgateway/src/http/ext_proc_tests.rs
@@ -365,6 +365,7 @@ fn configure_standalone_service(t: &TestBind) {
 async fn setup_inference_routing_mock(
 	target: Option<SocketAddr>,
 	request_headers_seen: Arc<AtomicUsize>,
+	destination_mode: Option<&'static str>,
 ) -> (MockInstance, TestBind, Client<MemoryConnector, Body>) {
 	let ext_proc = ExtProcMock::new(move || StandaloneInferenceRouter {
 		target,
@@ -375,6 +376,14 @@ async fn setup_inference_routing_mock(
 
 	let mut t = setup_proxy_test("{}").unwrap().with_bind(simple_bind());
 	configure_standalone_service(&t);
+	let mut inference_routing = json!({
+		"endpointPicker": {
+			"host": ext_proc.address.to_string(),
+		},
+	});
+	if let Some(destination_mode) = destination_mode {
+		inference_routing["destinationMode"] = json!(destination_mode);
+	}
 	t.attach_route(json!({
 		"name": "standalone-epp",
 		"backends": [
@@ -384,11 +393,7 @@ async fn setup_inference_routing_mock(
 					"port": STANDALONE_SERVICE_PORT,
 				},
 				"policies": {
-					"inferenceRouting": {
-						"endpointPicker": {
-							"host": ext_proc.address.to_string(),
-						},
-					},
+					"inferenceRouting": inference_routing,
 				},
 			}
 		],
@@ -403,8 +408,12 @@ async fn standalone_inference_routing_uses_epp_selected_destination_without_loca
 	let backend_a = named_backend("backend-a").await;
 	let backend_b = named_backend("backend-b").await;
 	let request_headers_seen = Arc::new(AtomicUsize::new(0));
-	let (_ext_proc, _bind, io) =
-		setup_inference_routing_mock(Some(*backend_b.address()), request_headers_seen.clone()).await;
+	let (_ext_proc, _bind, io) = setup_inference_routing_mock(
+		Some(*backend_b.address()),
+		request_headers_seen.clone(),
+		Some("passthrough"),
+	)
+	.await;
 
 	let res = send_request(io, Method::GET, "http://lo").await;
 	assert_eq!(res.status(), 200);
@@ -436,10 +445,36 @@ async fn standalone_inference_routing_uses_epp_selected_destination_without_loca
 }
 
 #[tokio::test]
+async fn standalone_inference_routing_validates_selected_destination_by_default() {
+	let backend = named_backend("backend").await;
+	let request_headers_seen = Arc::new(AtomicUsize::new(0));
+	let (_ext_proc, _bind, io) =
+		setup_inference_routing_mock(Some(*backend.address()), request_headers_seen.clone(), None)
+			.await;
+
+	let res = send_request(io, Method::GET, "http://lo").await;
+	assert_eq!(res.status(), 503);
+	assert_eq!(
+		request_headers_seen.load(Ordering::SeqCst),
+		1,
+		"gateway should consult the local EPP",
+	);
+	assert_eq!(
+		backend
+			.received_requests()
+			.await
+			.expect("backend recording should be enabled")
+			.len(),
+		0,
+		"validated mode should reject destinations outside local service endpoints",
+	);
+}
+
+#[tokio::test]
 async fn standalone_inference_routing_requires_epp_selected_destination() {
 	let request_headers_seen = Arc::new(AtomicUsize::new(0));
 	let (_ext_proc, _bind, io) =
-		setup_inference_routing_mock(None, request_headers_seen.clone()).await;
+		setup_inference_routing_mock(None, request_headers_seen.clone(), Some("passthrough")).await;
 
 	let res = send_request(io, Method::GET, "http://lo").await;
 	assert_eq!(res.status(), 503);

--- a/crates/agentgateway/src/http/ext_proc_tests.rs
+++ b/crates/agentgateway/src/http/ext_proc_tests.rs
@@ -300,6 +300,11 @@ struct StandaloneInferenceRouter {
 	request_headers_seen: Arc<AtomicUsize>,
 }
 
+#[derive(Debug)]
+struct NoDestinationInferenceRouter {
+	request_headers_seen: Arc<AtomicUsize>,
+}
+
 #[async_trait::async_trait]
 impl Handler for StandaloneInferenceRouter {
 	async fn handle_request_headers(
@@ -329,6 +334,19 @@ impl Handler for StandaloneInferenceRouter {
 	}
 }
 
+#[async_trait::async_trait]
+impl Handler for NoDestinationInferenceRouter {
+	async fn handle_request_headers(
+		&mut self,
+		_headers: &HttpHeaders,
+		sender: &Sender<Result<ProcessingResponse, Status>>,
+	) -> Result<(), Status> {
+		self.request_headers_seen.fetch_add(1, Ordering::SeqCst);
+		let _ = sender.send(request_header_response(None)).await;
+		Ok(())
+	}
+}
+
 async fn named_backend(body: &'static str) -> MockServer {
 	let mock = MockServer::start().await;
 	Mock::given(wiremock::matchers::path_regex("/.*"))
@@ -338,9 +356,8 @@ async fn named_backend(body: &'static str) -> MockServer {
 	mock
 }
 
-fn configure_standalone_service_endpoints(t: &TestBind, endpoint_ports: &[u16]) {
-	use crate::store::LocalWorkload;
-	use crate::types::discovery::{NetworkAddress, Service, Workload};
+fn configure_standalone_service(t: &TestBind) {
+	use crate::types::discovery::{NetworkAddress, Service};
 
 	let service = Service {
 		name: "model-service".into(),
@@ -350,36 +367,18 @@ fn configure_standalone_service_endpoints(t: &TestBind, endpoint_ports: &[u16]) 
 			network: strng::EMPTY,
 			address: "127.0.0.1".parse().unwrap(),
 		}],
-		ports: HashMap::from([(STANDALONE_SERVICE_PORT, 0)]),
+		ports: HashMap::from([(STANDALONE_SERVICE_PORT, STANDALONE_SERVICE_PORT)]),
 		..Default::default()
 	};
-	let workloads = endpoint_ports
-		.iter()
-		.enumerate()
-		.map(|(idx, port)| LocalWorkload {
-			workload: Workload {
-				uid: strng::format!("standalone-backend-{idx}"),
-				name: strng::format!("standalone-backend-{idx}"),
-				namespace: "default".into(),
-				workload_ips: vec!["127.0.0.1".parse().unwrap()],
-				..Default::default()
-			},
-			services: HashMap::from([(
-				STANDALONE_SERVICE_REF.to_string(),
-				HashMap::from([(STANDALONE_SERVICE_PORT, *port)]),
-			)]),
-		})
-		.collect();
 
 	t.pi
 		.stores
 		.discovery
-		.sync_local(vec![service], workloads, Default::default())
+		.sync_local(vec![service], vec![], Default::default())
 		.unwrap();
 }
 
 async fn setup_inference_routing_mock(
-	endpoint_ports: &[u16],
 	target: SocketAddr,
 	request_headers_seen: Arc<AtomicUsize>,
 ) -> (MockInstance, TestBind, Client<MemoryConnector, Body>) {
@@ -391,7 +390,7 @@ async fn setup_inference_routing_mock(
 	.await;
 
 	let mut t = setup_proxy_test("{}").unwrap().with_bind(simple_bind());
-	configure_standalone_service_endpoints(&t, endpoint_ports);
+	configure_standalone_service(&t);
 	t.attach_route(json!({
 		"name": "standalone-epp",
 		"backends": [
@@ -416,16 +415,12 @@ async fn setup_inference_routing_mock(
 }
 
 #[tokio::test]
-async fn standalone_inference_routing_uses_epp_selected_service_endpoint() {
+async fn standalone_inference_routing_uses_epp_selected_destination_without_local_endpoints() {
 	let backend_a = named_backend("backend-a").await;
 	let backend_b = named_backend("backend-b").await;
 	let request_headers_seen = Arc::new(AtomicUsize::new(0));
-	let (_ext_proc, _bind, io) = setup_inference_routing_mock(
-		&[backend_a.address().port(), backend_b.address().port()],
-		*backend_b.address(),
-		request_headers_seen.clone(),
-	)
-	.await;
+	let (_ext_proc, _bind, io) =
+		setup_inference_routing_mock(*backend_b.address(), request_headers_seen.clone()).await;
 
 	let res = send_request(io, Method::GET, "http://lo").await;
 	assert_eq!(res.status(), 200);
@@ -457,15 +452,37 @@ async fn standalone_inference_routing_uses_epp_selected_service_endpoint() {
 }
 
 #[tokio::test]
-async fn standalone_inference_routing_rejects_endpoint_outside_service() {
-	let backend = named_backend("backend-a").await;
+async fn standalone_inference_routing_requires_epp_selected_destination() {
 	let request_headers_seen = Arc::new(AtomicUsize::new(0));
-	let (_ext_proc, _bind, io) = setup_inference_routing_mock(
-		&[backend.address().port()],
-		"127.0.0.1:65535".parse().unwrap(),
-		request_headers_seen.clone(),
-	)
+	let request_headers_seen_for_handler = request_headers_seen.clone();
+	let ext_proc = ExtProcMock::new(move || NoDestinationInferenceRouter {
+		request_headers_seen: request_headers_seen_for_handler.clone(),
+	})
+	.spawn()
 	.await;
+
+	let mut t = setup_proxy_test("{}").unwrap().with_bind(simple_bind());
+	configure_standalone_service(&t);
+	t.attach_route(json!({
+		"name": "standalone-epp",
+		"backends": [
+			{
+				"service": {
+					"name": STANDALONE_SERVICE_REF,
+					"port": STANDALONE_SERVICE_PORT,
+				},
+				"policies": {
+					"inferenceRouting": {
+						"endpointPicker": {
+							"host": ext_proc.address.to_string(),
+						},
+					},
+				},
+			}
+		],
+	}))
+	.await;
+	let io = t.serve_http(BIND_KEY);
 
 	let res = send_request(io, Method::GET, "http://lo").await;
 	assert_eq!(res.status(), 503);
@@ -473,15 +490,6 @@ async fn standalone_inference_routing_rejects_endpoint_outside_service() {
 		request_headers_seen.load(Ordering::SeqCst),
 		1,
 		"gateway should consult EPP before rejecting the request",
-	);
-	assert_eq!(
-		backend
-			.received_requests()
-			.await
-			.expect("backend recording should be enabled")
-			.len(),
-		0,
-		"gateway should not forward traffic to a non-selected endpoint",
 	);
 }
 

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -21,7 +21,7 @@ use types::discovery::*;
 use crate::cel::{BackendContext, RequestTime};
 use crate::client::{ApplicationTransport, Transport};
 use crate::http::backendtls::BackendTLS;
-use crate::http::ext_proc::ExtProcRequest;
+use crate::http::ext_proc::{ExtProcRequest, InferenceRoutingDestinationMode};
 use crate::http::filters::{AutoHostname, BackendRequestTimeout};
 use crate::http::transformation_cel::Transformation;
 use crate::http::{
@@ -1397,6 +1397,11 @@ async fn make_backend_call(
 	// In practice, these don't conflict: inference is for AI backends, MCP pinning is for MCP backends.
 	let service_override = ServiceCallOverride {
 		destination: inference_result.destination.or(policies.override_dest),
+		destination_passthrough: inference_result.destination.is_some()
+			&& matches!(
+				inference_result.destination_mode,
+				InferenceRoutingDestinationMode::Passthrough
+			),
 		inference_failed_open: inference_result.failed_open,
 	};
 
@@ -1809,7 +1814,9 @@ pub fn build_service_call(
 	} else {
 		None
 	};
-	if let Some(destination) = service_override.destination {
+	if let Some(destination) = service_override.destination
+		&& service_override.destination_passthrough
+	{
 		return Ok(BackendCall {
 			target: Target::Address(destination),
 			http_version_override,
@@ -1822,13 +1829,14 @@ pub fn build_service_call(
 	let workloads = &inputs.stores.read_discovery().workloads;
 	let (ep, handle, wl) = svc
 		.endpoints
-		.select_endpoint(workloads, svc.as_ref(), port, None)
+		.select_endpoint(workloads, svc.as_ref(), port, service_override.destination)
 		.ok_or(ProxyError::NoHealthyEndpoints)?;
 
 	let target_port = select_service_target_port(
 		ep.as_ref(),
 		svc.as_ref(),
 		port,
+		service_override.destination,
 		service_override.inference_failed_open,
 	)
 	.ok_or(ProxyError::NoHealthyEndpoints)?;
@@ -1916,9 +1924,14 @@ fn select_service_target_port(
 	ep: &Endpoint,
 	svc: &Service,
 	svc_port: u16,
+	override_dest: Option<SocketAddr>,
 	inference_failed_open: bool,
 ) -> Option<u16> {
 	let svc_target_port = svc.ports.get(&svc_port).copied().unwrap_or_default();
+	if let Some(ov) = override_dest {
+		// Use the explicit override. select_endpoint ensures this is actually in the endpoint.
+		return Some(ov.port());
+	}
 	if inference_failed_open
 		&& let Some(target_port) = ep.port.values().choose(&mut rand::rng()).copied()
 	{
@@ -1975,6 +1988,7 @@ fn should_retry(res: &Result<Response, SnapshottedProxyResponse>, pol: &retry::P
 #[cfg(test)]
 mod tests {
 	use std::collections::{HashMap, HashSet};
+	use std::net::SocketAddr;
 
 	use super::{hop_by_hop_headers, resolved_workload_target_hostname, select_service_target_port};
 	use crate::http;
@@ -2037,6 +2051,22 @@ mod tests {
 	}
 
 	#[tokio::test]
+	async fn select_service_target_port_uses_override_destination_when_present() {
+		let endpoint = Endpoint {
+			workload_uid: "wl-1".into(),
+			port: HashMap::from([(8000, 8000), (8001, 8001)]),
+			status: HealthStatus::Healthy,
+		};
+		let service = multi_port_inference_service();
+		let override_dest = SocketAddr::from(([10, 0, 0, 1], 8001));
+
+		assert_eq!(
+			select_service_target_port(&endpoint, &service, 8000, Some(override_dest), true),
+			Some(8001)
+		);
+	}
+
+	#[tokio::test]
 	async fn select_service_target_port_uses_canonical_port_without_inference_fail_open() {
 		let endpoint = Endpoint {
 			workload_uid: "wl-1".into(),
@@ -2046,7 +2076,7 @@ mod tests {
 		let service = multi_port_inference_service();
 
 		assert_eq!(
-			select_service_target_port(&endpoint, &service, 8000, false),
+			select_service_target_port(&endpoint, &service, 8000, None, false),
 			Some(8000)
 		);
 	}
@@ -2062,7 +2092,7 @@ mod tests {
 		let mut seen = HashSet::new();
 
 		for _ in 0..64 {
-			let target_port = select_service_target_port(&endpoint, &service, 8000, true)
+			let target_port = select_service_target_port(&endpoint, &service, 8000, None, true)
 				.expect("expected a target port");
 			seen.insert(target_port);
 			if seen.len() == 2 {
@@ -2279,6 +2309,7 @@ pub struct BackendCall {
 #[derive(Debug, Clone, Copy, Default)]
 pub struct ServiceCallOverride {
 	pub destination: Option<SocketAddr>,
+	pub destination_passthrough: bool,
 	pub inference_failed_open: bool,
 }
 

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -1802,21 +1802,6 @@ pub fn build_service_call(
 	request_host: Option<&str>,
 ) -> Result<BackendCall, ProxyError> {
 	let port = *port;
-	let workloads = &inputs.stores.read_discovery().workloads;
-	let (ep, handle, wl) = svc
-		.endpoints
-		.select_endpoint(workloads, svc.as_ref(), port, service_override.destination)
-		.ok_or(ProxyError::NoHealthyEndpoints)?;
-
-	let target_port = select_service_target_port(
-		ep.as_ref(),
-		svc.as_ref(),
-		port,
-		service_override.destination,
-		service_override.inference_failed_open,
-	)
-	.ok_or(ProxyError::NoHealthyEndpoints)?;
-
 	let http_version_override = if svc.port_is_http2(port) {
 		Some(::http::Version::HTTP_2)
 	} else if svc.port_is_http1(port) {
@@ -1824,6 +1809,29 @@ pub fn build_service_call(
 	} else {
 		None
 	};
+	if let Some(destination) = service_override.destination {
+		return Ok(BackendCall {
+			target: Target::Address(destination),
+			http_version_override,
+			transport_override: None,
+			network_gateway: None,
+			backend_policies,
+		});
+	}
+
+	let workloads = &inputs.stores.read_discovery().workloads;
+	let (ep, handle, wl) = svc
+		.endpoints
+		.select_endpoint(workloads, svc.as_ref(), port, None)
+		.ok_or(ProxyError::NoHealthyEndpoints)?;
+
+	let target_port = select_service_target_port(
+		ep.as_ref(),
+		svc.as_ref(),
+		port,
+		service_override.inference_failed_open,
+	)
+	.ok_or(ProxyError::NoHealthyEndpoints)?;
 
 	log.add(move |l| l.request_handle = Some(handle));
 
@@ -1908,14 +1916,9 @@ fn select_service_target_port(
 	ep: &Endpoint,
 	svc: &Service,
 	svc_port: u16,
-	override_dest: Option<SocketAddr>,
 	inference_failed_open: bool,
 ) -> Option<u16> {
 	let svc_target_port = svc.ports.get(&svc_port).copied().unwrap_or_default();
-	if let Some(ov) = override_dest {
-		// use the explicit override. select_endpoint ensures this is actually in the endpoint
-		return Some(ov.port());
-	}
 	if inference_failed_open
 		&& let Some(target_port) = ep.port.values().choose(&mut rand::rng()).copied()
 	{
@@ -1972,7 +1975,6 @@ fn should_retry(res: &Result<Response, SnapshottedProxyResponse>, pol: &retry::P
 #[cfg(test)]
 mod tests {
 	use std::collections::{HashMap, HashSet};
-	use std::net::SocketAddr;
 
 	use super::{hop_by_hop_headers, resolved_workload_target_hostname, select_service_target_port};
 	use crate::http;
@@ -2035,22 +2037,6 @@ mod tests {
 	}
 
 	#[tokio::test]
-	async fn select_service_target_port_uses_override_destination_when_present() {
-		let endpoint = Endpoint {
-			workload_uid: "wl-1".into(),
-			port: HashMap::from([(8000, 8000), (8001, 8001)]),
-			status: HealthStatus::Healthy,
-		};
-		let service = multi_port_inference_service();
-		let override_dest = SocketAddr::from(([10, 0, 0, 1], 8001));
-
-		assert_eq!(
-			select_service_target_port(&endpoint, &service, 8000, Some(override_dest), true),
-			Some(8001)
-		);
-	}
-
-	#[tokio::test]
 	async fn select_service_target_port_uses_canonical_port_without_inference_fail_open() {
 		let endpoint = Endpoint {
 			workload_uid: "wl-1".into(),
@@ -2060,7 +2046,7 @@ mod tests {
 		let service = multi_port_inference_service();
 
 		assert_eq!(
-			select_service_target_port(&endpoint, &service, 8000, None, false),
+			select_service_target_port(&endpoint, &service, 8000, false),
 			Some(8000)
 		);
 	}
@@ -2076,7 +2062,7 @@ mod tests {
 		let mut seen = HashSet::new();
 
 		for _ in 0..64 {
-			let target_port = select_service_target_port(&endpoint, &service, 8000, None, true)
+			let target_port = select_service_target_port(&endpoint, &service, 8000, true)
 				.expect("expected a target port");
 			seen.insert(target_port);
 			if seen.len() == 2 {

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -1276,6 +1276,7 @@ fn backend_policy_from_proto(
 			};
 			BackendPolicy::InferenceRouting(http::ext_proc::InferenceRouting {
 				target: Arc::new(resolve_simple_reference(ir.endpoint_picker.as_ref())),
+				destination_mode: http::ext_proc::InferenceRoutingDestinationMode::Validated,
 				failure_mode,
 			})
 		},

--- a/crates/agentgateway/src/types/local_tests.rs
+++ b/crates/agentgateway/src/types/local_tests.rs
@@ -244,6 +244,7 @@ binds:
           inferenceRouting:
             endpointPicker:
               host: 127.0.0.1:9002
+            destinationMode: passthrough
 "#;
 
 	normalize_test_config(input)

--- a/examples/standalone-epp/README.md
+++ b/examples/standalone-epp/README.md
@@ -7,6 +7,14 @@ on Kubernetes.
 ### Config shape
 
 ```yaml
+services:
+- name: my-model
+  namespace: default
+  hostname: my-model
+  vips: []
+  ports:
+    8000: 8000
+
 binds:
 - port: 8081
   listeners:
@@ -24,15 +32,19 @@ binds:
 ### What it does
 
 * `agentgateway` listens on port `8081`.
-* The route forwards requests to the Kubernetes `Service` `default/my-model:8000`.
+* The top-level `services` entry defines the logical backend `Service`
+  `default/my-model:8000`.
 * Before choosing an upstream endpoint, `agentgateway` calls the local EPP over
   ext-proc at `127.0.0.1:9002`.
-* EPP returns the selected backend `ip:port`, and `agentgateway` uses that
-  endpoint for the request.
+* EPP returns the selected backend `ip:port`, and `agentgateway` forwards
+  directly to that destination without requiring matching local workload
+  endpoint entries.
 
 ### Current v1 constraints
 
 * `inferenceRouting` is only supported on `service` route backends.
+* Standalone routing requires a top-level logical `services` entry, but does
+  not require matching top-level `workloads` endpoint discovery data.
 * Standalone local config is fail-closed for now. If EPP is unavailable, the
   request fails instead of falling back to direct service endpoint balancing.
 * This example is meant to be mounted into the `agentgateway` sidecar in a

--- a/examples/standalone-epp/README.md
+++ b/examples/standalone-epp/README.md
@@ -27,6 +27,7 @@ binds:
           inferenceRouting:
             endpointPicker:
               host: 127.0.0.1:9002
+            destinationMode: passthrough
 ```
 
 ### What it does
@@ -38,13 +39,16 @@ binds:
   ext-proc at `127.0.0.1:9002`.
 * EPP returns the selected backend `ip:port`, and `agentgateway` forwards
   directly to that destination without requiring matching local workload
-  endpoint entries.
+  endpoint entries because `destinationMode` is set to `passthrough`.
 
 ### Current v1 constraints
 
 * `inferenceRouting` is only supported on `service` route backends.
 * Standalone routing requires a top-level logical `services` entry, but does
   not require matching top-level `workloads` endpoint discovery data.
+* `destinationMode: passthrough` is required when EPP owns endpoint discovery.
+  Without it, EPP-selected destinations must match agentgateway's local service
+  endpoint data.
 * Standalone local config is fail-closed for now. If EPP is unavailable, the
   request fails instead of falling back to direct service endpoint balancing.
 * This example is meant to be mounted into the `agentgateway` sidecar in a

--- a/examples/standalone-epp/config.yaml
+++ b/examples/standalone-epp/config.yaml
@@ -25,3 +25,4 @@ binds:
           inferenceRouting:
             endpointPicker:
               host: 127.0.0.1:9002
+            destinationMode: passthrough

--- a/examples/standalone-epp/config.yaml
+++ b/examples/standalone-epp/config.yaml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../schema/local.json
+services:
+- name: my-model
+  namespace: default
+  hostname: my-model
+  vips: []
+  ports:
+    8000: 8000
+
 binds:
 - port: 8081
   listeners:

--- a/schema/config.json
+++ b/schema/config.json
@@ -5257,11 +5257,29 @@
       "properties": {
         "endpointPicker": {
           "$ref": "#/$defs/SimpleLocalBackend"
+        },
+        "destinationMode": {
+          "$ref": "#/$defs/InferenceRoutingDestinationMode"
         }
       },
       "additionalProperties": false,
       "required": [
         "endpointPicker"
+      ]
+    },
+    "InferenceRoutingDestinationMode": {
+      "description": "Controls how an endpoint-picker-selected destination is used.",
+      "oneOf": [
+        {
+          "description": "Require the selected destination to match agentgateway's local service endpoints.",
+          "type": "string",
+          "const": "validated"
+        },
+        {
+          "description": "Trust the selected destination directly without local endpoint validation.",
+          "type": "string",
+          "const": "passthrough"
+        }
       ]
     },
     "LocalAIProviders": {

--- a/schema/config.md
+++ b/schema/config.md
@@ -1706,6 +1706,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.inferenceRouting.endpointPicker.service.port`|integer||
 |`binds[].listeners[].routes[].backends[].ai.policies.inferenceRouting.endpointPicker.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.policies.inferenceRouting.endpointPicker.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].ai.policies.inferenceRouting.destinationMode`|enum|Controls how an endpoint-picker-selected destination is used.<br>Possible values: `validated`, `passthrough`.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai`|object|Mark this as LLM traffic to enable LLM processing.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard`|object||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request`|[]object||
@@ -2614,6 +2615,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.inferenceRouting.endpointPicker.service.port`|integer||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.inferenceRouting.endpointPicker.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.inferenceRouting.endpointPicker.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.inferenceRouting.destinationMode`|enum|Controls how an endpoint-picker-selected destination is used.<br>Possible values: `validated`, `passthrough`.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai`|object|Mark this as LLM traffic to enable LLM processing.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard`|object||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request`|[]object||
@@ -3499,6 +3501,7 @@
 |`binds[].listeners[].routes[].backends[].policies.inferenceRouting.endpointPicker.service.port`|integer||
 |`binds[].listeners[].routes[].backends[].policies.inferenceRouting.endpointPicker.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].policies.inferenceRouting.endpointPicker.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].policies.inferenceRouting.destinationMode`|enum|Controls how an endpoint-picker-selected destination is used.<br>Possible values: `validated`, `passthrough`.|
 |`binds[].listeners[].routes[].backends[].policies.ai`|object|Mark this as LLM traffic to enable LLM processing.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard`|object||
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request`|[]object||
@@ -6473,6 +6476,7 @@
 |`backends[].ai.policies.inferenceRouting.endpointPicker.service.port`|integer||
 |`backends[].ai.policies.inferenceRouting.endpointPicker.host`|string|Hostname or IP address|
 |`backends[].ai.policies.inferenceRouting.endpointPicker.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].ai.policies.inferenceRouting.destinationMode`|enum|Controls how an endpoint-picker-selected destination is used.<br>Possible values: `validated`, `passthrough`.|
 |`backends[].ai.policies.ai`|object|Mark this as LLM traffic to enable LLM processing.|
 |`backends[].ai.policies.ai.promptGuard`|object||
 |`backends[].ai.policies.ai.promptGuard.request`|[]object||
@@ -7381,6 +7385,7 @@
 |`backends[].ai.groups[].providers[].policies.inferenceRouting.endpointPicker.service.port`|integer||
 |`backends[].ai.groups[].providers[].policies.inferenceRouting.endpointPicker.host`|string|Hostname or IP address|
 |`backends[].ai.groups[].providers[].policies.inferenceRouting.endpointPicker.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].ai.groups[].providers[].policies.inferenceRouting.destinationMode`|enum|Controls how an endpoint-picker-selected destination is used.<br>Possible values: `validated`, `passthrough`.|
 |`backends[].ai.groups[].providers[].policies.ai`|object|Mark this as LLM traffic to enable LLM processing.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard`|object||
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request`|[]object||
@@ -8265,6 +8270,7 @@
 |`backends[].policies.inferenceRouting.endpointPicker.service.port`|integer||
 |`backends[].policies.inferenceRouting.endpointPicker.host`|string|Hostname or IP address|
 |`backends[].policies.inferenceRouting.endpointPicker.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].policies.inferenceRouting.destinationMode`|enum|Controls how an endpoint-picker-selected destination is used.<br>Possible values: `validated`, `passthrough`.|
 |`backends[].policies.ai`|object|Mark this as LLM traffic to enable LLM processing.|
 |`backends[].policies.ai.promptGuard`|object||
 |`backends[].policies.ai.promptGuard.request`|[]object||
@@ -10647,6 +10653,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.inferenceRouting.endpointPicker.service.port`|integer||
 |`routeGroups[].routes[].backends[].ai.policies.inferenceRouting.endpointPicker.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.policies.inferenceRouting.endpointPicker.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].ai.policies.inferenceRouting.destinationMode`|enum|Controls how an endpoint-picker-selected destination is used.<br>Possible values: `validated`, `passthrough`.|
 |`routeGroups[].routes[].backends[].ai.policies.ai`|object|Mark this as LLM traffic to enable LLM processing.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard`|object||
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request`|[]object||
@@ -11555,6 +11562,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.inferenceRouting.endpointPicker.service.port`|integer||
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.inferenceRouting.endpointPicker.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.inferenceRouting.endpointPicker.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.inferenceRouting.destinationMode`|enum|Controls how an endpoint-picker-selected destination is used.<br>Possible values: `validated`, `passthrough`.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai`|object|Mark this as LLM traffic to enable LLM processing.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard`|object||
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request`|[]object||
@@ -12440,6 +12448,7 @@
 |`routeGroups[].routes[].backends[].policies.inferenceRouting.endpointPicker.service.port`|integer||
 |`routeGroups[].routes[].backends[].policies.inferenceRouting.endpointPicker.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].policies.inferenceRouting.endpointPicker.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].policies.inferenceRouting.destinationMode`|enum|Controls how an endpoint-picker-selected destination is used.<br>Possible values: `validated`, `passthrough`.|
 |`routeGroups[].routes[].backends[].policies.ai`|object|Mark this as LLM traffic to enable LLM processing.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard`|object||
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request`|[]object||


### PR DESCRIPTION
## Summary
- Use EPP-selected destinations directly for inferenceRouting service backends when `destinationMode: passthrough` is configured.
- Keep the default destination mode endpoint-validated so existing configs retain local endpoint-derived behavior.
- Keep the logical service metadata requirement without requiring mirrored local workload endpoints in passthrough mode.
- Update the standalone EPP example to opt into the passthrough flow.

## Testing
- cargo fmt --check
- cargo test -p agentgateway inference_routing
- cargo test -p agentgateway --test validate_examples
- cargo clippy -p agentgateway --all-targets -- -D warnings
- cargo run -p xtask -- schema

Fixes: #620