### PR TITLE
Remove AgwRouteGroup in controller

### DIFF
--- a/controller/pkg/agentgateway/translator/gateway_collection.go
+++ b/controller/pkg/agentgateway/translator/gateway_collection.go
@@ -43,8 +43,6 @@ func ToAgwResource(t any) *api.Resource {
 		return &api.Resource{Kind: &api.Resource_Listener{Listener: tt.Listener}}
 	case AgwRoute:
 		return &api.Resource{Kind: &api.Resource_Route{Route: tt.Route}}
-	case AgwRouteGroup:
-		return &api.Resource{Kind: &api.Resource_RouteGroup{RouteGroup: tt.RouteGroup}}
 	case AgwTCPRoute:
 		return &api.Resource{Kind: &api.Resource_TcpRoute{TcpRoute: tt.TCPRoute}}
 	case AgwPolicy:
@@ -120,18 +118,6 @@ func (g AgwRoute) ResourceName() string {
 }
 
 func (g AgwRoute) Equals(other AgwRoute) bool {
-	return protoconv.Equals(g, other)
-}
-
-type AgwRouteGroup struct {
-	*api.RouteGroup
-}
-
-func (g AgwRouteGroup) ResourceName() string {
-	return g.Key
-}
-
-func (g AgwRouteGroup) Equals(other AgwRouteGroup) bool {
 	return protoconv.Equals(g, other)
 }
 

--- a/controller/pkg/agentgateway/translator/route_collections.go
+++ b/controller/pkg/agentgateway/translator/route_collections.go
@@ -197,20 +197,9 @@ func buildHTTPRouteGroupBindings(
 	return raw
 }
 
-func buildHTTPRouteGroupResources(
-	bindings krt.Collection[routeGroupBindingKey],
-	krtopts krtutil.KrtOptions,
-) krt.Collection[agwir.AgwResource] {
-	return krt.NewCollection(bindings, func(krtctx krt.HandlerContext, binding routeGroupBindingKey) *agwir.AgwResource {
-		return ptr.Of(ToResourceForGateway(binding.GatewayNN(), AgwRouteGroup{
-			RouteGroup: &api.RouteGroup{
-				Key:       utils.InternalRouteGroupKey(binding.Namespace, binding.Name),
-				Namespace: binding.Namespace,
-				Name:      binding.Name,
-			},
-		}))
-	}, krtopts.ToOptions("HTTPRouteGroups")...)
-}
+// NOTE: We intentionally do not send RouteGroup resources over xDS. The data plane has no use for
+// them today (routes already carry route_group_key). If RouteGroup gains meaningful fields in the
+// future, re-add this and handle XdsKind::RouteGroup in the data plane's insert_xds().
 
 func buildDelegatedHTTPRoutes(
 	httpRouteCol krt.Collection[*gwv1.HTTPRoute],
@@ -446,7 +435,6 @@ func AgwRouteCollection(
 		},
 	)
 	status.RegisterStatus(queue, httpRouteStatus, GetStatus)
-	httpRouteGroups := buildHTTPRouteGroupResources(httpRouteGroupBindings, krtopts)
 	delegatedHTTPRoutes, delegatedHTTPAncestors := buildDelegatedHTTPRoutes(httpRouteCol, httpRouteGroupBindings, inputs, krtopts)
 
 	grpcRouteStatus, grpcRoutes := createRouteCollectionGeneric(grpcRouteCol, inputs, krtopts, "GRPCRoutes",
@@ -503,7 +491,6 @@ func AgwRouteCollection(
 	routes := krt.JoinCollection(
 		[]krt.Collection[agwir.AgwResource]{
 			httpRoutes,
-			httpRouteGroups,
 			delegatedHTTPRoutes,
 			grpcRoutes,
 			tcpRoutes,


### PR DESCRIPTION
Fixes initialization issue with route delegation:
```
Control plane: ADS: ACK ERROR … route_group/<ns>/<name>: unknown resource type
Data plane: agent_xds::client … type=Nack error="route_group/… unknown resource type"
```

In the future, we can support it in insert_xds, but currently, we're not doing anything with them. 