### PR TITLE
Fix deserialization

### DIFF
--- a/crates/agentgateway/src/mcp/upstream/streamablehttp.rs
+++ b/crates/agentgateway/src/mcp/upstream/streamablehttp.rs
@@ -133,9 +133,12 @@ impl Client {
 				.await
 				.map_err(ClientError::new)?
 				.1;
-				let message =
-					serde_json::from_slice::<ServerJsonRpcMessage>(&body_bytes).map_err(ClientError::new)?;
-				Ok(StreamableHttpPostResponse::Json(message, session_id))
+				let message: Option<ServerJsonRpcMessage> =
+					serde_json::from_slice(&body_bytes).map_err(ClientError::new)?;
+				match message {
+					Some(msg) => Ok(StreamableHttpPostResponse::Json(msg, session_id)),
+					None => Ok(StreamableHttpPostResponse::Accepted),
+				}
 			},
 			_ => Err(ClientError::new(anyhow!(
 				"unexpected content type: {:?}",


### PR DESCRIPTION
Fixes https://github.com/agentgateway/agentgateway/issues/1623 

```
❯ curl -X POST http://localhost:3001/mcp -v \
  -H "Content-Type: application/json" \
  -H "Accept: application/json, text/event-stream" \
  -H "mcp-protocol-version: 2025-03-26" \
  -H "Mcp-Session-Id: <id>" \
  --data-raw '{"jsonrpc":"2.0","method":"notifications/initialized"}'
Note: Unnecessary use of -X or --request, POST is already inferred.
* Host localhost:3001 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:3001...
* Connected to localhost (::1) port 3001
* using HTTP/1.x
> POST /mcp HTTP/1.1
> Host: localhost:3001
> User-Agent: curl/8.13.0
> Content-Type: application/json
> Accept: application/json, text/event-stream
> mcp-protocol-version: 2025-03-26
> Mcp-Session-Id: <id>
> Content-Length: 54
> 
* upload completely sent off: 54 bytes
< HTTP/1.1 202 Accepted
< content-length: 0
< date: Mon, 27 Apr 2026 18:51:45 GMT
< 
* Connection #0 to host localhost left intact
```