### PR TITLE
openapi mcp response error handling status cleanup

### DIFF
--- a/crates/agentgateway/src/mcp/session.rs
+++ b/crates/agentgateway/src/mcp/session.rs
@@ -226,6 +226,14 @@ impl Session {
 			}) if req_id.is_some() => {
 				Err(mcp::Error::Authorization(req_id.unwrap(), resource_type, resource_name).into())
 			},
+			Err(UpstreamError::OpenAPIHttpError { status, body, tool: _ }) => {
+				let resp = ::http::Response::builder()
+					.status(status)
+					.header(::http::header::CONTENT_TYPE, "application/json")
+					.body(bytes::Bytes::from(body))
+					.map_err(|e| ProxyError::Processing(anyhow!("failed to build OpenAPI error response: {e}")))?;
+				Err(mcp::Error::UpstreamError(Box::new(http::SendDirectResponse(resp))).into())
+			},
 			// TODO: this is too broad. We have a big tangle of errors to untangle though
 			Err(e) => Err(mcp::Error::SendError(req_id, e.to_string()).into()),
 		}
@@ -772,4 +780,53 @@ fn get_client_info() -> ClientInfo {
 	client_info.client_info =
 		Implementation::new("agentgateway", BuildInfo::new().version.to_string());
 	client_info
+}
+
+#[cfg(test)]
+mod tests {
+	use ::http::StatusCode;
+	use rstest::rstest;
+
+	use super::*;
+	use crate::mcp;
+	use crate::mcp::upstream::{ UpstreamError};
+	use crate::proxy::ProxyError;
+
+	#[rstest]
+	#[case::not_found(StatusCode::NOT_FOUND)]
+	#[case::internal_server_error(StatusCode::INTERNAL_SERVER_ERROR)]
+	#[case::bad_request(StatusCode::BAD_REQUEST)]
+	#[tokio::test]
+	async fn test_handle_openapi_http_error(#[case] status: StatusCode) {
+		let err = UpstreamError::OpenAPIHttpError {
+			status,
+			body: r#"{"error":"upstream error"}"#.to_string(),
+			tool: "my_tool".to_string(),
+		};
+		let ProxyError::MCP(mcp::Error::UpstreamError(resp)) =
+			Session::handle_error(None, Err(err)).await.unwrap_err()
+		else {
+			panic!("impl err, this test needs to be reevaled");
+		};
+		assert_eq!(resp.status(), status);
+	}
+
+	#[rstest]
+	#[case::not_found(StatusCode::NOT_FOUND)]
+	#[case::internal_server_error(StatusCode::INTERNAL_SERVER_ERROR)]
+	#[tokio::test]
+	async fn test_handle_http_error_status(#[case] status: StatusCode) {
+		let base_resp = ::http::Response::builder()
+			.status(status)
+			.body(crate::http::Body::empty())
+			.unwrap();
+		let err = UpstreamError::Http(mcp::ClientError::Status(Box::new(base_resp)));
+		let ProxyError::MCP(mcp::Error::UpstreamError(resp)) =
+			Session::handle_error(None, Err(err)).await.unwrap_err()
+		else {
+			panic!("impl err, this test needs to be reevaled");
+		};
+		assert_eq!(resp.status(), status);
+	}
+
 }

--- a/crates/agentgateway/src/mcp/upstream/mod.rs
+++ b/crates/agentgateway/src/mcp/upstream/mod.rs
@@ -75,6 +75,12 @@ pub enum UpstreamError {
 	Http(#[from] mcp::ClientError),
 	#[error("openapi upstream error: {0}")]
 	OpenAPIError(#[from] anyhow::Error),
+	#[error("openapi upstream send error: Upstream API call for tool '{tool}' failed with status {status}: {body}")]
+	OpenAPIHttpError {
+		status: ::http::StatusCode,
+		body: String,
+		tool: String,
+	},
 	#[error("{0}")]
 	Proxy(#[from] ProxyError),
 	#[error("stdio upstream error: {0}")]

--- a/crates/agentgateway/src/mcp/upstream/openapi/mod.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/mod.rs
@@ -940,12 +940,11 @@ impl Handler {
 					.to_vec(),
 			)
 			.map_err(|e| UpstreamError::OpenAPIError(e.into()))?;
-			Err(UpstreamError::OpenAPIError(anyhow::anyhow!(
-				"Upstream API call for tool '{}' failed with status {}: {}",
-				name,
+			Err(UpstreamError::OpenAPIHttpError {
 				status,
-				body
-			)))
+				body,
+				tool: name.to_string(),
+			})
 		}
 	}
 


### PR DESCRIPTION

Right now we dont have an amazing way of standardizing handle_error in sessions.rs
Because of this the behavior of an mcp server hitting a 404 is not consistent if you are using a standard or an openapi setup. To some degree the verbage being different seems fine but the status codes minimally should be cleaner.

Therefore in this pr we introduce a new error such that we propagate the status back to the user rather than always setting a 500 code which hopefully will allow callers to resolve issues more easily in cases where things like a tool call gets a 404.

Thoughts:
1. I dont love the way its tested but dont have a better idea right now other than this minimal test so that we can continue to iterate without too large of chnages
2. I considered changing the existing openapi test and or changing it to an enum more like http upstream error, however it felt like there are 2 classes of errors on openapi as some fail before and some fail due to subsequent calls hence the change.

Note the implementor has not done much rust so any and all suggestions are requested.