### PR TITLE
fix: make service parents work with delegation

### DIFF
--- a/controller/pkg/agentgateway/translator/route_collections.go
+++ b/controller/pkg/agentgateway/translator/route_collections.go
@@ -37,9 +37,10 @@ import (
 )
 
 type resolvedBinding struct {
-	Gateway types.NamespacedName
-	Parent  types.NamespacedName
-	Target  types.NamespacedName
+	Gateway    types.NamespacedName
+	Parent     types.NamespacedName
+	Target     types.NamespacedName
+	ServiceKey *types.NamespacedName
 }
 
 func (b resolvedBinding) RouteGroupKey() string {
@@ -47,14 +48,15 @@ func (b resolvedBinding) RouteGroupKey() string {
 }
 
 type routeGroupBindingKey struct {
-	Gateway   *types.NamespacedName // +noKrtEquals
-	Source    types.NamespacedName
-	Namespace string
-	Name      string
+	Gateway    *types.NamespacedName // +noKrtEquals
+	Source     types.NamespacedName
+	Namespace  string
+	Name       string
+	ServiceKey *types.NamespacedName // +noKrtEquals
 }
 
 func (k routeGroupBindingKey) String() string {
-	return strings.Join([]string{k.gatewayKey(), k.Source.String(), k.Namespace, k.Name}, "/")
+	return strings.Join([]string{k.gatewayKey(), k.serviceKey(), k.Source.String(), k.Namespace, k.Name}, "/")
 }
 
 func (b routeGroupBindingKey) ResourceName() string {
@@ -65,7 +67,8 @@ func (b routeGroupBindingKey) Equals(other routeGroupBindingKey) bool {
 	return b.Source == other.Source &&
 		b.Namespace == other.Namespace &&
 		b.Name == other.Name &&
-		b.GatewayNN() == other.GatewayNN()
+		b.GatewayNN() == other.GatewayNN() &&
+		b.ServiceKeyNN() == other.ServiceKeyNN()
 }
 
 func (b routeGroupBindingKey) GatewayNN() types.NamespacedName {
@@ -75,11 +78,25 @@ func (b routeGroupBindingKey) GatewayNN() types.NamespacedName {
 	return *b.Gateway
 }
 
+func (b routeGroupBindingKey) ServiceKeyNN() types.NamespacedName {
+	if b.ServiceKey == nil {
+		return types.NamespacedName{}
+	}
+	return *b.ServiceKey
+}
+
 func (b routeGroupBindingKey) gatewayKey() string {
 	if b.Gateway == nil {
 		return ""
 	}
 	return b.Gateway.String()
+}
+
+func (b routeGroupBindingKey) serviceKey() string {
+	if b.ServiceKey == nil {
+		return ""
+	}
+	return b.ServiceKey.String()
 }
 
 // isDelegatedChildHTTPRoute returns true for routes that may be delegated children:
@@ -184,6 +201,9 @@ func buildHTTPRouteGroupBindings(
 					if parent.ParentGateway != (types.NamespacedName{}) {
 						binding.Gateway = ptr.Of(parent.ParentGateway)
 					}
+					if parent.ServiceKey != nil {
+						binding.ServiceKey = parent.ServiceKey
+					}
 					if seen.InsertContains(binding.ResourceName()) {
 						continue
 					}
@@ -245,11 +265,16 @@ func buildDelegatedHTTPRoutes(
 			}
 			for _, gateway := range resolveGateways(krtctx, c, sets.New[string]()) {
 				resolvedBinding := resolvedBinding{
-					Gateway: gateway,
-					Parent:  c.Source,
-					Target:  target,
+					Gateway:    gateway,
+					Parent:     c.Source,
+					Target:     target,
+					ServiceKey: c.ServiceKey,
 				}
-				if seen.InsertContains(resolvedBinding.Gateway.String() + "/" + resolvedBinding.RouteGroupKey()) {
+				dedupeKey := resolvedBinding.Gateway.String() + "/" + resolvedBinding.RouteGroupKey()
+				if c.ServiceKey != nil {
+					dedupeKey += "/" + c.ServiceKey.String()
+				}
+				if seen.InsertContains(dedupeKey) {
 					continue
 				}
 				resolved = append(resolved, resolvedBinding)
@@ -277,6 +302,13 @@ func buildDelegatedHTTPRoutes(
 				route.ListenerKey = ""
 				route.RouteGroupKey = ptr.Of(binding.RouteGroupKey())
 				route.Key = delegatedRouteKey(route.GetKey(), binding.RouteGroupKey())
+				if binding.ServiceKey != nil {
+					route.ServiceKey = &workloadapi.NamespacedHostname{
+						Namespace: binding.ServiceKey.Namespace,
+						Hostname:  binding.ServiceKey.Name,
+					}
+					route.Hostnames = nil
+				}
 				resources = append(resources, ToResourceForGateway(binding.Gateway, AgwRoute{Route: route}))
 			}
 		}

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -1416,10 +1416,11 @@ impl Store {
 		diagnostics: &mut Diagnostics,
 	) -> anyhow::Result<()> {
 		let (route, listener_name, rgk) = Route::from_xds(&raw, diagnostics)?;
-		if let Some(sk) = route.service_key.clone() {
-			self.insert_service_route(route, sk);
-		} else if let Some(rgk) = rgk {
+		if let Some(rgk) = rgk {
+			// use group over service key here, the leaf route has a service key for policy
 			self.insert_route_into_group(route, rgk);
+		} else if let Some(sk) = route.service_key.clone() {
+			self.insert_service_route(route, sk);
 		} else {
 			self.insert_route(route, listener_name);
 		}
@@ -1853,6 +1854,103 @@ mod tests {
 				.routes
 				.as_ref()
 				.is_some_and(|routes| routes.contains(&strng::literal!("route")))
+		);
+	}
+
+	#[test]
+	fn delegated_child_dispatches_to_group_and_inherits_service_policies() {
+		use crate::types::proto::agent::RouteName as XdsRouteName;
+		use crate::types::proto::workload::NamespacedHostname as XdsNamespacedHostname;
+
+		let updater = StoreUpdater::new(Arc::new(RwLock::new(Store::with_ipv6_enabled(true))));
+		let listener = listener();
+		let svc = NamespacedHostname {
+			namespace: strng::literal!("ns"),
+			hostname: strng::literal!("svc-a.ns.svc.cluster.local"),
+		};
+		let rgk: RouteGroupKey = strng::literal!("ns/svc-a-children");
+
+		// Service-targeted timeout policy on svc-a. Service targets are stored
+		// as Backend(Service { ... }) — the same view NamespacedHostname uses
+		// in as_policy_target_ref().
+		let svc_policy_key: PolicyKey = strng::literal!("svc-a-timeout");
+		let svc_policy_target = PolicyTarget::Backend(BackendTarget::Service {
+			hostname: svc.hostname.clone(),
+			namespace: svc.namespace.clone(),
+			port: None,
+		});
+		let svc_timeout = timeout::Policy {
+			request_timeout: Some(Duration::from_secs(7)),
+			backend_request_timeout: None,
+		};
+
+		let xds_route = XdsRoute {
+			key: "child-route".to_string(),
+			listener_key: String::new(),
+			service_key: Some(XdsNamespacedHostname {
+				namespace: svc.namespace.to_string(),
+				hostname: svc.hostname.to_string(),
+			}),
+			route_group_key: Some(rgk.to_string()),
+			name: Some(XdsRouteName {
+				kind: "HTTPRoute".to_string(),
+				name: "child".to_string(),
+				namespace: "ns".to_string(),
+				rule_name: None,
+			}),
+			hostnames: vec![],
+			matches: vec![],
+			backends: vec![],
+			traffic_policies: vec![],
+		};
+
+		{
+			let mut store = updater.write();
+			store.policies_by_key.insert(
+				svc_policy_key.clone(),
+				Arc::new(TargetedPolicy {
+					key: svc_policy_key.clone(),
+					name: None,
+					target: svc_policy_target.clone(),
+					policy: TrafficPolicy::Timeout(svc_timeout.clone()).into(),
+				}),
+			);
+			store
+				.policies_by_target
+				.entry(svc_policy_target)
+				.or_default()
+				.insert(svc_policy_key);
+			store
+				.insert_xds_route(xds_route, &mut Diagnostics::default())
+				.expect("insert_xds_route should succeed");
+		}
+
+		let store = updater.read();
+
+		let group = store
+			.lookup_route_group(&rgk)
+			.expect("route should be in the route group");
+		let in_group = group
+			.iter()
+			.find(|r| r.key == strng::literal!("child-route"))
+			.expect("delegated child should be in the group");
+		assert!(
+			store.get_service_routes(&svc).is_none(),
+			"route with route_group_key must not also live in service-keyed routes",
+		);
+
+		let pols = store.route_policies(
+			&RoutePath {
+				listener: &listener,
+				service: in_group.service_key.as_ref(),
+				routes: vec![&in_group.name],
+			},
+			&[],
+		);
+		assert_eq!(
+			pols.timeout,
+			Some(svc_timeout),
+			"Service-targeted policy on svc-a must apply when traffic reaches the delegated child",
 		);
 	}
 

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -892,7 +892,10 @@ impl Route {
 		Ok((
 			r,
 			strng::new(&s.listener_key),
-			s.route_group_key.as_ref().map(strng::new),
+			s.route_group_key
+				.as_ref()
+				.filter(|k| !k.is_empty())
+				.map(strng::new),
 		))
 	}
 }


### PR DESCRIPTION
* thread service key from parent routes to child routes through the route group
* prefer the route group key over service key, we'll still get the service key at the end, but otherwise we'd never follow the delegation path