### PR TITLE
Implement concurrent handling of upstream requests in Relay

### DIFF
--- a/crates/agentgateway/src/mcp/handler.rs
+++ b/crates/agentgateway/src/mcp/handler.rs
@@ -543,12 +543,7 @@ impl Relay {
 			.map(|(name, con)| {
 				let notification = r.notification.clone();
 				let ctx = &ctx;
-				async move {
-					(
-						name,
-						con.generic_notification(notification, ctx).await,
-					)
-				}
+				async move { (name, con.generic_notification(notification, ctx).await) }
 			})
 			.collect();
 

--- a/crates/agentgateway/src/mcp/handler.rs
+++ b/crates/agentgateway/src/mcp/handler.rs
@@ -403,8 +403,19 @@ impl Relay {
 		&self,
 		ctx: IncomingRequestContext,
 	) -> Result<Response, UpstreamError> {
-		for (name, con) in self.upstreams.iter_named() {
-			match con.delete(&ctx).await {
+		let futs: Vec<_> = self
+			.upstreams
+			.iter_named()
+			.map(|(name, con)| {
+				let ctx = ctx.clone();
+				async move { (name, con.delete(&ctx).await) }
+			})
+			.collect();
+
+		let fut_results = futures::future::join_all(futs).await;
+
+		for (name, result) in fut_results {
+			match result {
 				Ok(_) => {},
 				Err(e) => {
 					if self.upstreams.failure_mode == FailureMode::FailOpen {
@@ -425,8 +436,20 @@ impl Relay {
 		ctx: IncomingRequestContext,
 	) -> Result<Response, UpstreamError> {
 		let mut streams = Vec::new();
-		for (name, con) in self.upstreams.iter_named() {
-			match con.get_event_stream(&ctx).await {
+
+		let futs: Vec<_> = self
+			.upstreams
+			.iter_named()
+			.map(|(name, con)| {
+				let ctx = ctx.clone();
+				async move { (name, con.get_event_stream(&ctx).await) }
+			})
+			.collect();
+
+		let fut_results = futures::future::join_all(futs).await;
+
+		for (name, result) in fut_results {
+			match result {
 				Ok(s) => streams.push((name, s)),
 				Err(e) => {
 					if self.upstreams.failure_mode == FailureMode::FailOpen {
@@ -460,6 +483,7 @@ impl Relay {
 		let ms = mergestream::MergeStream::new_without_merge(streams, self.upstreams.failure_mode);
 		messages_to_response(RequestId::Number(0), ms, None)
 	}
+
 	pub async fn send_fanout(
 		&self,
 		r: JsonRpcRequest<ClientRequest>,
@@ -468,8 +492,21 @@ impl Relay {
 	) -> Result<Response, UpstreamError> {
 		let id = r.id.clone();
 		let mut streams = Vec::new();
-		for (name, con) in self.upstreams.iter_named() {
-			match con.generic_stream(r.clone(), &ctx).await {
+
+		let futs: Vec<_> = self
+			.upstreams
+			.iter_named()
+			.map(|(name, con)| {
+				let r = r.clone();
+				let ctx = ctx.clone();
+				async move { (name, con.generic_stream(r, &ctx).await) }
+			})
+			.collect();
+
+		let fut_results = futures::future::join_all(futs).await;
+
+		for (name, result) in fut_results {
+			match result {
 				Ok(s) => streams.push((name, s)),
 				Err(e) => {
 					if self.upstreams.failure_mode == FailureMode::FailOpen {
@@ -500,8 +537,25 @@ impl Relay {
 		r: JsonRpcNotification<ClientNotification>,
 		ctx: IncomingRequestContext,
 	) -> Result<Response, UpstreamError> {
-		for (name, con) in self.upstreams.iter_named() {
-			match con.generic_notification(r.notification.clone(), &ctx).await {
+		let futs: Vec<_> = self
+			.upstreams
+			.iter_named()
+			.map(|(name, con)| {
+				let r = r.clone();
+				let ctx = ctx.clone();
+				async move {
+					(
+						name,
+						con.generic_notification(r.notification.clone(), &ctx).await,
+					)
+				}
+			})
+			.collect();
+
+		let fut_results = futures::future::join_all(futs).await;
+
+		for (name, result) in fut_results {
+			match result {
 				Ok(_) => {},
 				Err(e) => {
 					if self.upstreams.failure_mode == FailureMode::FailOpen {

--- a/crates/agentgateway/src/mcp/handler.rs
+++ b/crates/agentgateway/src/mcp/handler.rs
@@ -407,8 +407,8 @@ impl Relay {
 			.upstreams
 			.iter_named()
 			.map(|(name, con)| {
-				let ctx = ctx.clone();
-				async move { (name, con.delete(&ctx).await) }
+				let ctx = &ctx;
+				async move { (name, con.delete(ctx).await) }
 			})
 			.collect();
 
@@ -441,8 +441,8 @@ impl Relay {
 			.upstreams
 			.iter_named()
 			.map(|(name, con)| {
-				let ctx = ctx.clone();
-				async move { (name, con.get_event_stream(&ctx).await) }
+				let ctx = &ctx;
+				async move { (name, con.get_event_stream(ctx).await) }
 			})
 			.collect();
 
@@ -498,8 +498,8 @@ impl Relay {
 			.iter_named()
 			.map(|(name, con)| {
 				let r = r.clone();
-				let ctx = ctx.clone();
-				async move { (name, con.generic_stream(r, &ctx).await) }
+				let ctx = &ctx;
+				async move { (name, con.generic_stream(r, ctx).await) }
 			})
 			.collect();
 
@@ -541,12 +541,12 @@ impl Relay {
 			.upstreams
 			.iter_named()
 			.map(|(name, con)| {
-				let r = r.clone();
-				let ctx = ctx.clone();
+				let notification = r.notification.clone();
+				let ctx = &ctx;
 				async move {
 					(
 						name,
-						con.generic_notification(r.notification.clone(), &ctx).await,
+						con.generic_notification(notification, ctx).await,
 					)
 				}
 			})


### PR DESCRIPTION
Closes #1506

## Summary
Replace the sequential fanout loop in `send_fanout`, `send_get_streams`, `send_delete`, and `send_notification` with concurrent execution using `futures::future::join_all`, reducing fanout latency from O(sum of latencies) to O(max latency).

## Changes
- Refactored `send_fanout` in `handler.rs` to issue all upstream requests concurrently
- Applied the same pattern to `send_get_streams`, `send_delete`, and `send_notification`
- Preserved existing `FailOpen`/`FailClosed` error handling semantics across concurrent futures