### PR TITLE
.golangci: add formatting linter revive

### DIFF
--- a/controller/.golangci.yaml
+++ b/controller/.golangci.yaml
@@ -12,6 +12,7 @@ linters:
   default: none
   enable:
     - bodyclose
+    - revive
     - copyloopvar
     - forbidigo
     - ginkgolinter
@@ -61,6 +62,16 @@ linters:
               isFirstField: Ignore
               useProtobuf: Forbid
               usePatchStrategy: Ignore
+    revive:
+      rules:
+        - name: var-naming
+          disabled: false
+        - name: unused-parameter
+          disabled: true
+        - name: dot-imports
+          disabled: true
+        - name: package-comments
+          disabled: true
     forbidigo:
       forbid:
         - pattern: anypb.New
@@ -181,7 +192,67 @@ linters:
       - path-except: "^api/v1alpha1"
         linters:
           - kubeapilinter
-issues:
+
+      # Revive catches legacy exported names with issues
+      - path: "agentgateway_parameters_types.go"
+        linters:
+          - revive
+        text: 'LoggingJson'
+      - path: "agentgateway_policy_types.go"
+        linters:
+          - revive
+        text: 'GcpAuthTypeIdToken|OTLPProtocolHttp'
+      - path: "settings.go"
+        linters:
+          - revive
+        text: 'DnsLookupFamily'
+      - path: "pkg/utils/kubeutils/rest_config.go"
+        linters:
+          - revive
+        text: 'Qps'
+      
+      # Exclude var-naming for TLS cipher suite constants - these must match IANA/standard names
+      - path: "agentgateway_policy_types.go"
+        linters:
+          - revive
+        text: 'CipherSuite'
+      - path: "ai_policy.go"
+        linters:
+          - revive
+        text: 'ALL_CAPS'
+      - linters:
+          - revive
+        text: 'avoid meaningless package names' # shared, common etc
+      - path: "agentgateway_backend_types.go"
+        linters:
+          - revive
+        text: 'ApiVersion|ProjectId'
+
+      - path: "test/"
+        linters:
+          - revive
+      - path: "pkg/admin"
+        linters:
+          - revive
+        text: 'Json'
+      - path: "pkg/agentgateway/jwks/fetcher.go"
+        linters:
+          - revive
+        text: 'HttpClient'
+      - path: "pkg/deployer/values.go"
+        linters:
+          - revive
+        text: 'Tls'
+      - path: "pkg/deployer/deployer.go"
+        linters:
+          - revive
+        text: 'XdsTls'
+      - path: "pkg/syncer/"
+        linters:
+          - revive
+        text: 'TypeUrl|TargetType.*Url'
+
+  issues:
   max-same-issues: 0
   uniq-by-line: true
 formatters:

--- a/controller/pkg/agentgateway/plugins/backend_policies.go
+++ b/controller/pkg/agentgateway/plugins/backend_policies.go
@@ -26,12 +26,12 @@ import (
 
 const (
 	aiPolicySuffix                = ":ai"
-	backendTlsPolicySuffix        = ":backend-tls"
+	backendTLSPolicySuffix        = ":backend-tls"
 	backendTunnelPolicySuffix     = ":backend-tunnel"
 	backendauthPolicySuffix       = ":backend-auth"
 	backendTransformationSuffix   = ":backend-transformation"
 	tlsPolicySuffix               = ":tls"
-	backendHttpPolicySuffix       = ":backend-http"
+	backendHTTPPolicySuffix       = ":backend-http"
 	mcpAuthorizationPolicySuffix  = ":mcp-authorization"
 	mcpAuthenticationPolicySuffix = ":mcp-authentication"
 	healthPolicySuffix            = ":health"
@@ -364,7 +364,7 @@ func translateBackendHTTP(policy *agentgateway.AgentgatewayPolicy) *api.Policy {
 		p.RequestTimeout = durationpb.New(rt.Duration)
 	}
 	tp := &api.Policy{
-		Key:  policy.Namespace + "/" + policy.Name + backendHttpPolicySuffix,
+		Key:  policy.Namespace + "/" + policy.Name + backendHTTPPolicySuffix,
 		Name: TypedResourceName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
 		Kind: &api.Policy_Backend{
 			Backend: &api.BackendPolicySpec{
@@ -809,7 +809,7 @@ func buildAwsAuthPolicy(krtctx krt.HandlerContext, auth *agentgateway.AwsAuth, s
 		return nil, nil
 	}
 
-	var accessKeyId, secretAccessKey string
+	var accessKeyID, secretAccessKey string
 	var sessionToken *string
 
 	// Get secret using the SecretIndex
@@ -821,7 +821,7 @@ func buildAwsAuthPolicy(krtctx krt.HandlerContext, auth *agentgateway.AwsAuth, s
 		if value, exists := kubeutils.GetSecretValue(secret, wellknown.AccessKey); !exists {
 			errs = append(errs, errors.New("accessKey is missing or not a valid string"))
 		} else {
-			accessKeyId = value
+			accessKeyID = value
 		}
 
 		// Extract secret key
@@ -844,7 +844,7 @@ func buildAwsAuthPolicy(krtctx krt.HandlerContext, auth *agentgateway.AwsAuth, s
 			Aws: &api.Aws{
 				Kind: &api.Aws_ExplicitConfig{
 					ExplicitConfig: &api.AwsExplicitConfig{
-						AccessKeyId:     accessKeyId,
+						AccessKeyId:     accessKeyID,
 						SecretAccessKey: secretAccessKey,
 						SessionToken:    sessionToken,
 						Region:          "",

--- a/controller/pkg/agentgateway/plugins/backend_tls_plugin.go
+++ b/controller/pkg/agentgateway/plugins/backend_tls_plugin.go
@@ -219,7 +219,7 @@ func translatePoliciesForBackendTLS(
 		}
 
 		policy := &api.Policy{
-			Key:    btls.Namespace + "/" + btls.Name + backendTlsPolicySuffix + attachmentName(policyTarget),
+			Key:    btls.Namespace + "/" + btls.Name + backendTLSPolicySuffix + attachmentName(policyTarget),
 			Name:   TypedResourceName(wellknown.BackendTLSPolicyKind, btls),
 			Target: policyTarget,
 			Kind: &api.Policy_Backend{

--- a/controller/pkg/agentgateway/plugins/frontend_policies.go
+++ b/controller/pkg/agentgateway/plugins/frontend_policies.go
@@ -14,10 +14,10 @@ import (
 )
 
 const (
-	frontendTcpPolicySuffix     = ":frontend-tcp"
+	frontendTCPPolicySuffix     = ":frontend-tcp"
 	frontendNetworkAuthzSuffix  = ":frontend-network-authz"
-	frontendTlsPolicySuffix     = ":frontend-tls"
-	frontendHttpPolicySuffix    = ":frontend-http"
+	frontendTLSPolicySuffix     = ":frontend-tls"
+	frontendHTTPPolicySuffix    = ":frontend-http"
 	frontendProxyPolicySuffix   = ":frontend-proxy"
 	frontendLoggingPolicySuffix = ":frontend-logging"
 	frontendTracingPolicySuffix = ":frontend-tracing"
@@ -263,7 +263,7 @@ func translateFrontendTCP(policy *agentgateway.AgentgatewayPolicy, name string) 
 	}
 
 	tcpPolicy := &api.Policy{
-		Key:  name + frontendTcpPolicySuffix,
+		Key:  name + frontendTCPPolicySuffix,
 		Name: TypedResourceName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
 		Kind: &api.Policy_Frontend{
 			Frontend: &api.FrontendPolicySpec{
@@ -431,7 +431,7 @@ func translateFrontendTLS(policy *agentgateway.AgentgatewayPolicy, name string) 
 	}
 
 	tlsPolicy := &api.Policy{
-		Key:  name + frontendTlsPolicySuffix,
+		Key:  name + frontendTLSPolicySuffix,
 		Name: TypedResourceName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
 		Kind: &api.Policy_Frontend{
 			Frontend: &api.FrontendPolicySpec{
@@ -481,7 +481,7 @@ func translateFrontendHTTP(policy *agentgateway.AgentgatewayPolicy, name string)
 	}
 
 	httpPolicy := &api.Policy{
-		Key:  name + frontendHttpPolicySuffix,
+		Key:  name + frontendHTTPPolicySuffix,
 		Name: TypedResourceName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
 		Kind: &api.Policy_Frontend{
 			Frontend: &api.FrontendPolicySpec{

--- a/controller/pkg/agentgateway/plugins/tls.go
+++ b/controller/pkg/agentgateway/plugins/tls.go
@@ -10,9 +10,9 @@ import (
 )
 
 var (
-	ErrInvalidTlsSecret = errors.New("invalid TLS secret")
+	ErrInvalidTlsSecret = errors.New("invalid TLS secret") //revive:disable-line
 
-	InvalidTlsSecretError = func(n, ns string, err error) error {
+	InvalidTlsSecretError = func(n, ns string, err error) error { //revive:disable-line
 		return fmt.Errorf("%w %s/%s: %v", ErrInvalidTlsSecret, ns, n, err)
 	}
 
@@ -23,7 +23,7 @@ var (
 	}
 )
 
-func ValidateTlsSecretData(n, ns string, sslSecretData map[string][]byte) (cleanedCertChain string, err error) {
+func ValidateTlsSecretData(n, ns string, sslSecretData map[string][]byte) (cleanedCertChain string, err error) { //revive:disable-line
 	certChain := string(sslSecretData[corev1.TLSCertKey])
 	privateKey := string(sslSecretData[corev1.TLSPrivateKeyKey])
 	rootCa := string(sslSecretData[corev1.ServiceAccountRootCAKey])

--- a/controller/pkg/agentgateway/translator/conversion.go
+++ b/controller/pkg/agentgateway/translator/conversion.go
@@ -1200,8 +1200,8 @@ func listenerProtocolToAgw(p gwv1.ProtocolType) (string, error) {
 	return "", fmt.Errorf("protocol %q is unsupported", p)
 }
 
-// dummyTls is a sentinel value to send to agentgateway to signal that it should reject TLS connects due to invalid config
-var dummyTls = &TLSInfo{
+// dummyTLS is a sentinel value to send to agentgateway to signal that it should reject TLS connects due to invalid config
+var dummyTLS = &TLSInfo{
 	Cert: []byte("invalid"),
 	Key:  []byte("invalid"),
 }
@@ -1246,17 +1246,17 @@ func buildTLS(
 		// Important: all failures MUST include dummyTls, as this is the signal to the dataplane to actually do TLS (but fail)
 		if len(tls.CertificateRefs) != 1 {
 			// This is required in the API, should be rejected in validation
-			return dummyTls, &ConfigError{Reason: InvalidTLS, Message: "exactly 1 certificateRefs should be present for TLS termination"}
+			return dummyTLS, &ConfigError{Reason: InvalidTLS, Message: "exactly 1 certificateRefs should be present for TLS termination"}
 		}
 		tlsRes, err := buildSecretReference(ctx, tls.CertificateRefs[0], gw, secrets)
 		if err != nil {
-			return dummyTls, err
+			return dummyTLS, err
 		}
 		// If we are going to send a cert, validate we can access it
 		sameNamespace := tlsRes.Source.Namespace == namespace
 		objectKind := GvkFromObject(gw)
 		if !sameNamespace && !grants.SecretAllowed(ctx, objectKind, tlsRes.Source, namespace) {
-			return dummyTls, &ConfigError{
+			return dummyTLS, &ConfigError{
 				Reason: InvalidListenerRefNotPermitted,
 				Message: fmt.Sprintf(
 					"certificateRef %v/%v not accessible to a Gateway in namespace %q (missing a ReferenceGrant?)",
@@ -1268,7 +1268,7 @@ func buildTLS(
 		if gatewayTLS != nil && gatewayTLS.Validation != nil && len(gatewayTLS.Validation.CACertificateRefs) > 0 {
 			// TODO: add 'Mode'
 			if len(gatewayTLS.Validation.CACertificateRefs) > 1 {
-				return dummyTls, &ConfigError{
+				return dummyTLS, &ConfigError{
 					Reason:  InvalidTLS,
 					Message: "only one caCertificateRef is supported",
 				}
@@ -1276,11 +1276,11 @@ func buildTLS(
 			caCertRef := gatewayTLS.Validation.CACertificateRefs[0]
 			cred, err := buildCaCertificateReference(ctx, caCertRef, gw, configMaps, secrets)
 			if err != nil {
-				return dummyTls, err
+				return dummyTLS, err
 			}
 			sameNamespace := cred.Source.Namespace == namespace
 			if !sameNamespace && !grants.SecretAllowed(ctx, GvkFromObject(gw), cred.Source, namespace) {
-				return dummyTls, &ConfigError{
+				return dummyTLS, &ConfigError{
 					Reason: InvalidListenerRefNotPermitted,
 					Message: fmt.Sprintf(
 						"caCertificateRef %v/%v not accessible to a Gateway in namespace %q (missing a ReferenceGrant?)",

--- a/controller/pkg/deployer/deployer.go
+++ b/controller/pkg/deployer/deployer.go
@@ -113,7 +113,7 @@ func applyPatch(client apiclient.Client, fieldManager string, gvr schema.GroupVe
 	return err
 }
 
-func JsonConvert(in *HelmConfig, out any) error {
+func JsonConvert(in *HelmConfig, out any) error { //revive:disable-line
 	b, err := json.Marshal(in)
 	if err != nil {
 		return err

--- a/controller/pkg/syncer/krtxds/xds.go
+++ b/controller/pkg/syncer/krtxds/xds.go
@@ -873,9 +873,9 @@ func (s *DiscoveryServer) initConnection(node *envoycorev3.Node, con *Connection
 
 	// Authorize xds clients
 	if id != nil {
-		reqId := AgentgatewayID(con.node)
-		if reqId != *id {
-			return fmt.Errorf("requested gateway %v but authenticated as %v", reqId, *id)
+		reqID := AgentgatewayID(con.node)
+		if reqID != *id {
+			return fmt.Errorf("requested gateway %v but authenticated as %v", reqID, *id)
 		}
 	}
 

--- a/controller/pkg/syncer/syncer.go
+++ b/controller/pkg/syncer/syncer.go
@@ -618,14 +618,14 @@ func (s *Syncer) getBindProtocol(obj *translator.GatewayListener) api.Bind_Proto
 // using the istio ambient builder. It can be passed via WithBuildAddressCollections to the syncer.
 func defaultBuildAddressCollections(cols *plugins.AgwCollections, krtopts krtutil.KrtOptions) (krt.Collection[Address], func() bool) {
 	opts := krtopts.ToIstio()
-	clusterId := cluster.ID(cols.ClusterID)
+	clusterID := cluster.ID(cols.ClusterID)
 	Networks := ambient.BuildNetworkCollections(cols.Namespaces, cols.Gateways, ambient.Options{
 		SystemNamespace: cols.IstioNamespace,
-		ClusterID:       clusterId,
+		ClusterID:       clusterID,
 	}, opts)
 	builder := ambient.Builder{
 		DomainSuffix: kubeutils.GetClusterDomainName(),
-		ClusterID:    clusterId,
+		ClusterID:    clusterID,
 		Networks:     Networks,
 		Flags: ambient.FeatureFlags{
 			EnableK8SServiceSelectWorkloadEntries: true,
@@ -644,9 +644,9 @@ func defaultBuildAddressCollections(cols *plugins.AgwCollections, krtopts krtuti
 		return &ambient.MeshConfig{MeshConfig: mesh.DefaultMeshConfig()}
 	}, krtopts.ToOptions("IstioMeshConfig")...)
 
-	waypoints := builder.WaypointsCollection(clusterId, cols.Gateways, cols.GatewayClasses, cols.Pods, opts)
+	waypoints := builder.WaypointsCollection(clusterID, cols.Gateways, cols.GatewayClasses, cols.Pods, opts)
 	services := builder.ServicesCollection(
-		clusterId,
+		clusterID,
 		cols.Services,
 		cols.ServiceEntries,
 		waypoints,

--- a/controller/pkg/utils/helmutils/client.go
+++ b/controller/pkg/utils/helmutils/client.go
@@ -88,12 +88,12 @@ func (c *Client) Delete(ctx context.Context, extraArgs ...string) error {
 	return c.RunCommand(ctx, args...)
 }
 
-func (c *Client) AddRepository(ctx context.Context, chartName string, chartUrl string, extraArgs ...string) error {
+func (c *Client) AddRepository(ctx context.Context, chartName string, chartURL string, extraArgs ...string) error {
 	args := append([]string{
 		"repo",
 		"add",
 		chartName,
-		chartUrl,
+		chartURL,
 	}, extraArgs...)
 	return c.RunCommand(ctx, args...)
 }

--- a/controller/pkg/utils/kubeutils/rest_config.go
+++ b/controller/pkg/utils/kubeutils/rest_config.go
@@ -25,7 +25,7 @@ func GetRestConfigWithKubeContext(kubeContext string) (*rest.Config, error) {
 		return nil, err
 	}
 
-	if err = setClientQpsOrError(restConfig); err != nil {
+	if err = setClientQPSOrError(restConfig); err != nil {
 		return nil, err
 	}
 	if err = setClientBurstOrError(restConfig); err != nil {
@@ -35,14 +35,14 @@ func GetRestConfigWithKubeContext(kubeContext string) (*rest.Config, error) {
 	return restConfig, nil
 }
 
-func setClientQpsOrError(restConfig *rest.Config) error {
+func setClientQPSOrError(restConfig *rest.Config) error {
 	restConfig.QPS = K8sClientQpsDefault
-	clientQpsOverride := os.Getenv(K8sClientQpsEnv)
-	if clientQpsOverride == "" {
+	clientQPSOverride := os.Getenv(K8sClientQpsEnv)
+	if clientQPSOverride == "" {
 		return nil
 	}
 
-	qps, err := strconv.ParseFloat(clientQpsOverride, 32)
+	qps, err := strconv.ParseFloat(clientQPSOverride, 32)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
revive is kinda nice to keep consistency 

That being said it can be overbearing so if we dont want it thats fine too.


In this setup we illustrate skipping both by file and by line comment to avoid changing exported non-compliant stuff.