### PR TITLE
Fix jwk fetch stale

### DIFF
--- a/controller/pkg/agentgateway/jwks/fetcher.go
+++ b/controller/pkg/agentgateway/jwks/fetcher.go
@@ -313,9 +313,13 @@ func (f *Fetcher) maybeFetchJwks(ctx context.Context) {
 		updates.Insert(fetch.RequestKey)
 	}
 
-	if !updates.IsEmpty() {
-		f.notifySubscribers(updates)
+	if updates.IsEmpty() {
+		return
 	}
+
+	swept := f.sweepRetiredCache()
+	updates.Merge(swept)
+	f.notifySubscribers(updates)
 }
 
 func (f *Fetcher) SubscribeToUpdates() <-chan sets.Set[remotehttp.FetchKey] {
@@ -413,6 +417,39 @@ func (f *Fetcher) RemoveKeyset(requestKey remotehttp.FetchKey) {
 	if hadRequest {
 		signalWake(f.wake)
 	}
+}
+
+// RetireKeyset stops fetching requestKey but keeps its cache entry alive so
+// that JWT validation can continue using the old keys until the next
+// successful fetch sweeps the orphaned entry.
+func (f *Fetcher) RetireKeyset(requestKey remotehttp.FetchKey) {
+	f.mu.Lock()
+	_, hadRequest := f.requests[requestKey]
+	if hadRequest {
+		delete(f.requests, requestKey)
+		f.schedule.Remove(requestKey)
+	}
+	f.mu.Unlock()
+
+	if hadRequest {
+		signalWake(f.wake)
+	}
+}
+
+// sweepRetiredCache removes cache entries that have no corresponding live
+// request. Called after a successful fetch batch so that retired entries
+// linger until a replacement is available.
+func (f *Fetcher) sweepRetiredCache() sets.Set[remotehttp.FetchKey] {
+	f.mu.Lock()
+	swept := sets.New[remotehttp.FetchKey]()
+	for _, key := range f.cache.Keys() {
+		if _, ok := f.requests[key]; !ok {
+			swept.Insert(key)
+			f.cache.deleteJwks(key)
+		}
+	}
+	f.mu.Unlock()
+	return swept
 }
 
 func (f *Fetcher) fetchJwks(ctx context.Context, source JwksSource) (string, jose.JSONWebKeySet, error) {

--- a/controller/pkg/agentgateway/jwks/fetcher_test.go
+++ b/controller/pkg/agentgateway/jwks/fetcher_test.go
@@ -79,6 +79,56 @@ func TestRemoveKeysetClearsCacheEvenWithoutRequest(t *testing.T) {
 	assert.False(t, ok, "cache should be cleared even when request was not tracked")
 }
 
+func TestRetireKeysetKeepsCacheThenSweptOnSuccessfulFetch(t *testing.T) {
+	ctx := t.Context()
+	oldSource := testSourceWithURL("https://test/old-jwks")
+	newSource := testSourceWithURL("https://test/new-jwks")
+
+	f := NewFetcher(NewCache())
+	assert.NoError(t, f.AddOrUpdateKeyset(oldSource))
+	seedJwksCacheForTest(f.cache, oldSource.RequestKey, oldSource.Target.URL)
+
+	// Retire removes from requests/schedule but keeps cache.
+	f.RetireKeyset(oldSource.RequestKey)
+
+	f.mu.Lock()
+	_, inRequests := f.requests[oldSource.RequestKey]
+	schedLen := f.schedule.Len()
+	f.mu.Unlock()
+	assert.False(t, inRequests, "retired key should be removed from requests")
+	assert.Equal(t, 0, schedLen, "retired key should be removed from schedule")
+	_, inCache := f.cache.GetJwks(oldSource.RequestKey)
+	assert.True(t, inCache, "retired key should remain in cache")
+
+	// A successful fetch of a new key sweeps the retired entry.
+	expectedJwks := jose.JSONWebKeySet{}
+	assert.NoError(t, json.Unmarshal([]byte(sampleJWKS), &expectedJwks))
+	f.defaultJwksClient = stubJwksClient{
+		t:           t,
+		expectedReq: newSource.Target,
+		result:      expectedJwks,
+	}
+	assert.NoError(t, f.AddOrUpdateKeyset(newSource))
+
+	updates := f.SubscribeToUpdates()
+	go f.maybeFetchJwks(ctx)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		select {
+		case update := <-updates:
+			assert.True(c, update.Contains(newSource.RequestKey), "new key should be in updates")
+			assert.True(c, update.Contains(oldSource.RequestKey), "swept old key should be in updates")
+		default:
+			assert.Fail(c, "no updates yet")
+		}
+	}, testEventuallyTimeout, testEventuallyPoll)
+
+	_, inCache = f.cache.GetJwks(oldSource.RequestKey)
+	assert.False(t, inCache, "retired key should be swept after successful fetch")
+	_, inCache = f.cache.GetJwks(newSource.RequestKey)
+	assert.True(t, inCache, "new key should be in cache")
+}
+
 func TestAddOrUpdateKeysetReplacesExistingScheduleEntry(t *testing.T) {
 	f := NewFetcher(NewCache())
 	source := testSource()

--- a/controller/pkg/agentgateway/jwks/store.go
+++ b/controller/pkg/agentgateway/jwks/store.go
@@ -67,6 +67,12 @@ func (s *Store) Start(ctx context.Context) error {
 			if event.New == nil {
 				return
 			}
+			if event.Event == controllers.EventUpdate && event.Old != nil && event.Old.RequestKey != event.New.RequestKey {
+				// Defensively drop the previous key when a shared request retargets.
+				// Some update paths can surface as an update without a distinct delete event.
+				logger.Debug("removing stale keyset after request key change", "old_request_key", event.Old.RequestKey, "new_request_key", event.New.RequestKey)
+				s.jwksFetcher.RemoveKeyset(event.Old.RequestKey)
+			}
 
 			request := event.New.JwksSource()
 			logger.Debug("updating keyset", "request_key", request.RequestKey, "config_map", JwksConfigMapName(s.storePrefix, request.RequestKey))

--- a/controller/pkg/agentgateway/jwks/store.go
+++ b/controller/pkg/agentgateway/jwks/store.go
@@ -68,10 +68,11 @@ func (s *Store) Start(ctx context.Context) error {
 				return
 			}
 			if event.Event == controllers.EventUpdate && event.Old != nil && event.Old.RequestKey != event.New.RequestKey {
-				// Defensively drop the previous key when a shared request retargets.
-				// Some update paths can surface as an update without a distinct delete event.
-				logger.Debug("removing stale keyset after request key change", "old_request_key", event.Old.RequestKey, "new_request_key", event.New.RequestKey)
-				s.jwksFetcher.RemoveKeyset(event.Old.RequestKey)
+				// Retire the old keyset: stop fetching it but keep the cache
+				// entry so JWT validation continues working until the next
+				// successful fetch sweeps the orphaned entry.
+				logger.Debug("retiring stale keyset after request key change", "old_request_key", event.Old.RequestKey, "new_request_key", event.New.RequestKey)
+				s.jwksFetcher.RetireKeyset(event.Old.RequestKey)
 			}
 
 			request := event.New.JwksSource()

--- a/controller/pkg/agentgateway/jwks/store_test.go
+++ b/controller/pkg/agentgateway/jwks/store_test.go
@@ -131,6 +131,49 @@ func TestStoreTracksSharedRequestCollectionLifecycle(t *testing.T) {
 	awaitNoJwksFetchState(t, store.jwksFetcher, remotehttp.FetchTarget{URL: "https://issuer.example/b"}.Key())
 }
 
+func TestStoreDropsOldFetchStateWhenPolicyRetargets(t *testing.T) {
+	krtOpts := testKrtOptions(t)
+	policies := dynamicRemotePolicies(t, []*agentgateway.AgentgatewayPolicy{
+		testRemotePolicy("one", "https://issuer.example/v1", 5*time.Minute),
+	}, krtOpts)
+
+	collections := NewCollections(CollectionInputs{
+		AgentgatewayPolicies: policies,
+		Backends:             krt.NewStaticCollection[*agentgateway.AgentgatewayBackend](alwaysSynced{}, nil),
+		Resolver: jwksResolverFunc(func(owner RemoteJwksOwner) (*ResolvedJwksRequest, error) {
+			return resolvedJwksRequest(owner, owner.Remote.JwksPath), nil
+		}),
+		KrtOpts: krtOpts,
+	})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	persisted := NewPersistedEntriesFromCollection(
+		krt.NewStaticCollection[*corev1.ConfigMap](alwaysSynced{}, nil),
+		DefaultJwksStorePrefix,
+		"agentgateway-system",
+	)
+	store := NewStore(collections.SharedRequests, persisted, DefaultJwksStorePrefix)
+	store.jwksFetcher.defaultJwksClient = offlineStubJwksClient{}
+	go func() {
+		_ = store.Start(ctx)
+	}()
+
+	oldKey := remotehttp.FetchTarget{URL: "https://issuer.example/v1"}.Key()
+	newKey := remotehttp.FetchTarget{URL: "https://issuer.example/v2"}.Key()
+
+	assert.Eventually(t, store.HasSynced, testEventuallyTimeout, testEventuallyPoll)
+	awaitJwksFetchState(t, store.jwksFetcher, oldKey)
+
+	policies.Reset([]*agentgateway.AgentgatewayPolicy{
+		testRemotePolicy("one", "https://issuer.example/v2", 5*time.Minute),
+	})
+
+	awaitNoJwksFetchState(t, store.jwksFetcher, oldKey)
+	awaitJwksFetchState(t, store.jwksFetcher, newKey)
+}
+
 func TestStoreLoadsPersistedKeysetsBeforeServing(t *testing.T) {
 	target := remotehttp.FetchTarget{URL: "https://issuer.example/jwks"}
 	keyset := Keyset{


### PR DESCRIPTION
On an EventUpdate where RequestKey changed, calls RemoveKeyset on the old key before adding the new one. This fixes stale fetcher entry from surviving on changes to things like jwksPath. 