### PR TITLE
feat: add per-user token usage and cost tracking

### DIFF
--- a/crates/agentgateway/src/app.rs
+++ b/crates/agentgateway/src/app.rs
@@ -93,6 +93,12 @@ pub async fn run(config: Arc<Config>) -> anyhow::Result<Bound> {
 	// Run the XDS state manager in the current tokio worker pool.
 	tokio::spawn(state_mgr.run());
 
+	let usage_store = Arc::new(match &config.usage_store_path {
+		Some(path) => crate::telemetry::usage_store::UsageStore::with_persistence(path.clone()),
+		None => crate::telemetry::usage_store::UsageStore::new(),
+	});
+	let pricing = Arc::new(config.pricing.clone());
+
 	#[allow(unused_mut)]
 	let mut admin_server = crate::management::admin::Service::new(
 		config.clone(),
@@ -100,6 +106,7 @@ pub async fn run(config: Arc<Config>) -> anyhow::Result<Bound> {
 		shutdown.trigger(),
 		drain_rx.clone(),
 		data_plane_handle.clone(),
+		usage_store.clone(),
 	)
 	.await
 	.context("admin server starts")?;
@@ -116,6 +123,8 @@ pub async fn run(config: Arc<Config>) -> anyhow::Result<Bound> {
 		ca,
 
 		mcp_state: mcp::App::new(stores.clone(), config.session_encoder.clone()),
+		usage_store: usage_store.clone(),
+		pricing: pricing.clone(),
 	};
 
 	let gw = proxy::Gateway::new(Arc::new(pi), drain_rx.clone());

--- a/crates/agentgateway/src/config.rs
+++ b/crates/agentgateway/src/config.rs
@@ -498,6 +498,8 @@ pub fn parse_config(contents: String, filename: Option<PathBuf>) -> anyhow::Resu
 		},
 		session_encoder,
 		oidc_cookie_encoder,
+		pricing: raw.pricing.unwrap_or_default(),
+		usage_store_path: raw.usage_store_path,
 		hbone: Arc::new(agent_hbone::Config {
 			// window size: per-stream limit
 			window_size: parse("HTTP2_STREAM_WINDOW_SIZE")?

--- a/crates/agentgateway/src/lib.rs
+++ b/crates/agentgateway/src/lib.rs
@@ -198,6 +198,14 @@ pub struct RawConfig {
 	_listener: serdes::RenamedField,
 
 	hbone: Option<RawHBONE>,
+
+	/// Token pricing for computing per-request cost.
+	#[serde(default)]
+	pricing: Option<crate::telemetry::usage_store::PricingConfig>,
+
+	/// Optional path to a JSON file for persisting usage records across restarts.
+	#[serde(default)]
+	usage_store_path: Option<PathBuf>,
 }
 
 mod removed {
@@ -505,6 +513,15 @@ pub struct Config {
 
 	pub backend: BackendConfig,
 	pub mcp: McpConfig,
+
+	/// Token pricing configuration used to compute per-request cost.
+	#[serde(default)]
+	pub pricing: crate::telemetry::usage_store::PricingConfig,
+
+	/// Optional path to a JSON file for persisting usage records across restarts.
+	/// When unset, usage data is stored in memory only and lost on restart.
+	#[serde(default)]
+	pub usage_store_path: Option<PathBuf>,
 }
 
 #[apply(schema!)]
@@ -616,6 +633,9 @@ pub struct ProxyInputs {
 
 	pub mcp_state: mcp::App,
 	pub ca: Option<Arc<CaClient>>,
+
+	pub usage_store: Arc<crate::telemetry::usage_store::UsageStore>,
+	pub pricing: Arc<crate::telemetry::usage_store::PricingConfig>,
 }
 
 impl ProxyInputs {
@@ -632,6 +652,8 @@ impl ProxyInputs {
 		mcp_state: mcp::App,
 		ca: Option<Arc<CaClient>>,
 	) -> Self {
+		let usage_store = Arc::new(crate::telemetry::usage_store::UsageStore::new());
+		let pricing = Arc::new(crate::telemetry::usage_store::PricingConfig::default());
 		Self {
 			cfg,
 			stores,
@@ -639,6 +661,8 @@ impl ProxyInputs {
 			metrics,
 			mcp_state,
 			ca,
+			usage_store,
+			pricing,
 		}
 	}
 }

--- a/crates/agentgateway/src/management/admin.rs
+++ b/crates/agentgateway/src/management/admin.rs
@@ -11,6 +11,7 @@ use agent_core::drain::DrainWatcher;
 use agent_core::version::BuildInfo;
 use agent_core::{signal, telemetry};
 use bytes::Bytes;
+use chrono::DateTime;
 use hyper::Request;
 use hyper::body::Incoming;
 use hyper::header::{CONTENT_TYPE, HeaderValue};
@@ -57,6 +58,7 @@ struct State {
 	config_dump_handlers: Vec<Arc<dyn ConfigDumpHandler>>,
 	admin_fallback: Option<Arc<dyn AdminFallback>>,
 	dataplane_handle: Handle,
+	usage_store: Arc<crate::telemetry::usage_store::UsageStore>,
 }
 
 pub struct Service {
@@ -98,6 +100,7 @@ impl Service {
 		shutdown_trigger: signal::ShutdownTrigger,
 		drain_rx: DrainWatcher,
 		dataplane_handle: Handle,
+		usage_store: Arc<crate::telemetry::usage_store::UsageStore>,
 	) -> anyhow::Result<Self> {
 		Server::<State>::bind(
 			"admin",
@@ -110,6 +113,7 @@ impl Service {
 				config_dump_handlers: vec![],
 				admin_fallback: None,
 				dataplane_handle,
+				usage_store,
 			},
 		)
 		.await
@@ -156,16 +160,17 @@ impl Service {
 					)
 					.await
 				},
-				"/logging" => Ok(handle_logging(req).await),
-				_ => {
-					if let Some(h) = &state.admin_fallback {
-						Ok(h.handle(req).await)
-					} else if req.uri().path() == "/" {
-						Ok(handle_dashboard(req).await)
-					} else {
-						Ok(empty_response(hyper::StatusCode::NOT_FOUND))
-					}
-				},
+			"/logging" => Ok(handle_logging(req).await),
+			"/usage" => Ok(handle_usage(req, &state.usage_store).await),
+			_ => {
+				if let Some(h) = &state.admin_fallback {
+					Ok(h.handle(req).await)
+				} else if req.uri().path() == "/" {
+					Ok(handle_dashboard(req).await)
+				} else {
+					Ok(empty_response(hyper::StatusCode::NOT_FOUND))
+				}
+			},
 			}
 		})
 	}
@@ -184,6 +189,7 @@ async fn handle_dashboard(_req: Request<Incoming>) -> Response {
 		("quitquitquit", "shut down the server"),
 		("config_dump", "dump the current agentgateway configuration"),
 		("logging", "query/changing logging levels"),
+		("usage", "per-user token usage and cost report. Supports ?user=, ?model=, ?since= (Unix timestamp)"),
 	];
 
 	let mut api_rows = String::new();
@@ -207,6 +213,50 @@ async fn handle_dashboard(_req: Request<Incoming>) -> Response {
 	);
 
 	response
+}
+
+async fn handle_usage(
+	req: Request<Incoming>,
+	store: &crate::telemetry::usage_store::UsageStore,
+) -> Response {
+	// Parse optional query parameters: ?user=<id>&model=<name>&since=<unix_ts>
+	let qp: HashMap<String, String> = req
+		.uri()
+		.query()
+		.map(|v| {
+			url::form_urlencoded::parse(v.as_bytes())
+				.into_owned()
+				.collect()
+		})
+		.unwrap_or_default();
+
+	let user = qp.get("user").map(String::as_str);
+	let model = qp.get("model").map(String::as_str);
+	let since = qp.get("since").and_then(|s| {
+		s.parse::<i64>().ok().and_then(|ts| {
+			DateTime::from_timestamp(ts, 0)
+		})
+	});
+
+	let records = store.query(user, model, since);
+
+	match serde_json::to_string(&records) {
+		Ok(body) => {
+			let mut resp = plaintext_response(hyper::StatusCode::OK, body);
+			resp.headers_mut().insert(
+				CONTENT_TYPE,
+				HeaderValue::from_static("application/json"),
+			);
+			resp
+		},
+		Err(e) => {
+			warn!("failed to serialize usage records: {}", e);
+			plaintext_response(
+				hyper::StatusCode::INTERNAL_SERVER_ERROR,
+				"failed to serialize usage records".to_string(),
+			)
+		},
+	}
 }
 
 #[cfg(target_os = "linux")]

--- a/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
@@ -52,6 +52,8 @@ async fn setup_with_prefix(prefix: &str) -> (MockServer, Handler) {
 		ca: None,
 
 		mcp_state: mcp::router::App::new(stores.clone(), encoder),
+		usage_store: Arc::new(crate::telemetry::usage_store::UsageStore::new()),
+		pricing: Arc::new(crate::telemetry::usage_store::PricingConfig::default()),
 	});
 
 	let client = PolicyClient { inputs: pi.clone() };

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -477,12 +477,14 @@ impl HTTPProxy {
 		req
 			.extensions_mut()
 			.insert(RequestTime(start.as_datetime()));
-		let log = RequestLog::new(
+		let log = RequestLog::new_with_usage(
 			log::CelLogging::new(
 				self.inputs.cfg.logging.clone(),
 				self.inputs.cfg.metrics.clone(),
 			),
 			self.inputs.metrics.clone(),
+			self.inputs.usage_store.clone(),
+			self.inputs.pricing.clone(),
 			start,
 			tcp.clone(),
 		);

--- a/crates/agentgateway/src/proxy/tcpproxy.rs
+++ b/crates/agentgateway/src/proxy/tcpproxy.rs
@@ -835,6 +835,8 @@ mod tests {
 			upstream: client,
 			ca: None,
 			mcp_state: crate::mcp::App::new(stores, encoder),
+			usage_store: Arc::new(crate::telemetry::usage_store::UsageStore::new()),
+			pricing: Arc::new(crate::telemetry::usage_store::PricingConfig::default()),
 		})
 	}
 

--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -40,6 +40,7 @@ use crate::telemetry::metrics::{
 };
 use crate::telemetry::trc;
 use crate::telemetry::trc::TraceParent;
+use crate::telemetry::usage_store::{PricingConfig, UsageStore};
 use crate::transport::stream::{TCPConnectionInfo, TLSConnectionInfo};
 use crate::types::agent::{BackendInfo, BindKey, ListenerName, RouteName, Target};
 use crate::types::loadbalancer::ActiveHandle;
@@ -572,6 +573,23 @@ impl DropOnLog {
 						.observe(throughput);
 				}
 			}
+
+			// ── Per-user usage tracking ──────────────────────────────────────
+			// Attribute the request to the authenticated JWT subject when
+			// present, or "anonymous" when no JWT-authenticated user exists.
+			let user_id = log.jwt_sub.as_deref().unwrap_or("anonymous");
+			let model = llm_response.response_model
+				.as_deref()
+				.unwrap_or_else(|| llm_response.request_model.as_str());
+			log.usage_store.record(
+				user_id,
+				model,
+				llm_response.input_tokens.unwrap_or(0),
+				llm_response.output_tokens.unwrap_or(0),
+				llm_response.cached_input_tokens.unwrap_or(0),
+				llm_response.cache_creation_input_tokens.unwrap_or(0),
+				&log.pricing,
+			);
 		}
 	}
 }
@@ -589,9 +607,29 @@ impl RequestLog {
 		start: Timestamp,
 		tcp_info: TCPConnectionInfo,
 	) -> Self {
+		RequestLog::new_with_usage(
+			cel,
+			metrics,
+			Arc::new(UsageStore::new()),
+			Arc::new(PricingConfig::default()),
+			start,
+			tcp_info,
+		)
+	}
+
+	pub fn new_with_usage(
+		cel: CelLogging,
+		metrics: Arc<Metrics>,
+		usage_store: Arc<UsageStore>,
+		pricing: Arc<PricingConfig>,
+		start: Timestamp,
+		tcp_info: TCPConnectionInfo,
+	) -> Self {
 		RequestLog {
 			cel,
 			metrics,
+			usage_store,
+			pricing,
 			start,
 			tcp_info,
 			tls_info: None,
@@ -653,6 +691,8 @@ impl RequestLog {
 pub struct RequestLog {
 	pub cel: CelLogging,
 	pub metrics: Arc<Metrics>,
+	pub usage_store: Arc<UsageStore>,
+	pub pricing: Arc<PricingConfig>,
 	pub start: Timestamp,
 	pub tcp_info: TCPConnectionInfo,
 

--- a/crates/agentgateway/src/telemetry/mod.rs
+++ b/crates/agentgateway/src/telemetry/mod.rs
@@ -1,3 +1,4 @@
 pub mod log;
 pub mod metrics;
 pub mod trc;
+pub mod usage_store;

--- a/crates/agentgateway/src/telemetry/usage_store.rs
+++ b/crates/agentgateway/src/telemetry/usage_store.rs
@@ -1,0 +1,447 @@
+/// Per-user token usage and cost tracking.
+///
+/// Tracks cumulative token consumption and estimated cost for each (user, model) pair.
+/// Data is held in memory and optionally persisted to a JSON file on disk so it
+/// survives gateway restarts.
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
+use tracing::{debug, warn};
+
+// ── Pricing ──────────────────────────────────────────────────────────────────
+
+/// Per-model pricing in USD per million tokens.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct ModelPricing {
+    /// Cost per million input tokens (USD).
+    #[serde(default)]
+    pub input: f64,
+    /// Cost per million output tokens (USD).
+    #[serde(default)]
+    pub output: f64,
+    /// Cost per million cache-read tokens (USD).
+    /// When `None` the input price is used as the fallback.
+    pub cache_read: Option<f64>,
+    /// Cost per million cache-write tokens (USD).
+    /// When `None` the input price is used as the fallback.
+    pub cache_write: Option<f64>,
+}
+
+impl ModelPricing {
+    pub fn compute_cost(
+        &self,
+        input_tokens: u64,
+        output_tokens: u64,
+        cache_read_tokens: u64,
+        cache_write_tokens: u64,
+    ) -> f64 {
+        let m = 1_000_000.0_f64;
+        let cache_read_price = self.cache_read.unwrap_or(self.input);
+        let cache_write_price = self.cache_write.unwrap_or(self.input);
+        (input_tokens as f64) / m * self.input
+            + (output_tokens as f64) / m * self.output
+            + (cache_read_tokens as f64) / m * cache_read_price
+            + (cache_write_tokens as f64) / m * cache_write_price
+    }
+}
+
+/// Top-level pricing configuration, deserialized from the gateway config file.
+///
+/// All model name keys are normalized to lowercase at deserialization time so
+/// lookups are always O(1) and case-insensitive. When multiple original keys
+/// differ only by case, the lexicographically smallest key wins
+/// deterministically.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct PricingConfig {
+    /// Map from model name to pricing (USD per million tokens).
+    /// Keys are normalized to lowercase on deserialization.
+    #[serde(default, deserialize_with = "deserialize_normalized_models")]
+    pub models: HashMap<String, ModelPricing>,
+}
+
+/// Deserialize the models map while normalizing all keys to lowercase.
+/// When two original keys differ only by case, the lexicographically smallest
+/// original key is used (deterministic tie-breaking).
+fn deserialize_normalized_models<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, ModelPricing>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let raw = HashMap::<String, ModelPricing>::deserialize(deserializer)?;
+    let mut canonical: HashMap<String, String> = HashMap::new();
+    let mut normalized: HashMap<String, ModelPricing> = HashMap::new();
+    for (key, pricing) in raw {
+        let lower = key.to_lowercase();
+        // Keep whichever original key is lexicographically smallest.
+        let keep = match canonical.get(&lower) {
+            Some(existing) => key < *existing,
+            None => true,
+        };
+        if keep {
+            canonical.insert(lower.clone(), key);
+            normalized.insert(lower, pricing);
+        }
+    }
+    Ok(normalized)
+}
+
+/// Zero-cost sentinel returned when a model is not found in the pricing config.
+static ZERO_PRICING: ModelPricing = ModelPricing {
+    input: 0.0,
+    output: 0.0,
+    cache_read: None,
+    cache_write: None,
+};
+
+impl PricingConfig {
+    /// Look up pricing for a model name.
+    ///
+    /// The lookup is case-insensitive (keys are normalized to lowercase at
+    /// construction time). Returns a zero-cost sentinel if the model is not
+    /// found.
+    pub fn for_model(&self, model: &str) -> &ModelPricing {
+        let lower = model.to_lowercase();
+        self.models.get(&lower).unwrap_or(&ZERO_PRICING)
+    }
+}
+
+// ── Usage records ─────────────────────────────────────────────────────────────
+
+/// Composite key identifying a single (user, model) usage bucket.
+/// The model component is stored in lowercase so that
+/// `claude-sonnet-4-5-20250929` and `Claude-Sonnet-4-5-20250929` map to the
+/// same bucket.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+struct UsageKey {
+    user_id: String,
+    /// Always lowercase.
+    model: String,
+}
+
+impl UsageKey {
+    fn new(user_id: &str, model: &str) -> Self {
+        Self {
+            user_id: user_id.to_owned(),
+            model: model.to_lowercase(),
+        }
+    }
+}
+
+/// Accumulated usage for one (user, model) pair.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct UsageRecord {
+    pub user_id: String,
+    pub model: String,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cache_read_tokens: u64,
+    pub cache_write_tokens: u64,
+    pub cost_usd: f64,
+    pub request_count: u64,
+    pub first_seen: Option<DateTime<Utc>>,
+    pub last_seen: Option<DateTime<Utc>>,
+}
+
+impl UsageRecord {
+    fn new(user_id: &str, model: &str) -> Self {
+        Self {
+            user_id: user_id.to_owned(),
+            // Preserve original casing in the display field.
+            model: model.to_owned(),
+            ..Default::default()
+        }
+    }
+}
+
+// ── Store ─────────────────────────────────────────────────────────────────────
+
+/// Thread-safe, optionally persistent usage store.
+///
+/// Call [`UsageStore::record`] from the request completion path to accumulate
+/// token counts.  Call [`UsageStore::query`] to read the current state.
+#[derive(Debug, Clone)]
+pub struct UsageStore {
+    inner: Arc<RwLock<StoreInner>>,
+}
+
+#[derive(Debug, Default)]
+struct StoreInner {
+    records: HashMap<UsageKey, UsageRecord>,
+    persist_path: Option<PathBuf>,
+}
+
+impl UsageStore {
+    /// Create a new in-memory store (no persistence).
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(StoreInner::default())),
+        }
+    }
+
+    /// Create a store backed by a JSON file.
+    ///
+    /// If the file exists its contents are loaded on startup.
+    /// After every update the file is rewritten atomically via a background
+    /// `spawn_blocking` task so the Tokio worker thread is not stalled.
+    pub fn with_persistence(path: PathBuf) -> Self {
+        let mut records: HashMap<UsageKey, UsageRecord> = HashMap::new();
+
+        if path.exists() {
+            match std::fs::read_to_string(&path) {
+                Ok(s) => match serde_json::from_str::<Vec<UsageRecord>>(&s) {
+                    Ok(loaded) => {
+                        for r in loaded {
+                            records.insert(UsageKey::new(&r.user_id, &r.model), r);
+                        }
+                        debug!(path = %path.display(), count = records.len(), "loaded usage records from disk");
+                    }
+                    Err(e) => warn!(path = %path.display(), error = %e, "failed to parse usage store file, starting empty"),
+                },
+                Err(e) => warn!(path = %path.display(), error = %e, "failed to read usage store file, starting empty"),
+            }
+        }
+
+        Self {
+            inner: Arc::new(RwLock::new(StoreInner {
+                records,
+                persist_path: Some(path),
+            })),
+        }
+    }
+
+    /// Record one completed request's token usage.
+    ///
+    /// - `user_id`: identity of the caller (JWT sub or "anonymous")
+    /// - `model`: the model name returned by the provider
+    /// - `pricing`: pricing table used to compute estimated cost
+    ///
+    /// Persistence (if configured) is performed off the calling thread via
+    /// `tokio::task::spawn_blocking` to avoid stalling the Tokio worker.
+    pub fn record(
+        &self,
+        user_id: &str,
+        model: &str,
+        input_tokens: u64,
+        output_tokens: u64,
+        cache_read_tokens: u64,
+        cache_write_tokens: u64,
+        pricing: &PricingConfig,
+    ) {
+        let cost = pricing.for_model(model).compute_cost(
+            input_tokens,
+            output_tokens,
+            cache_read_tokens,
+            cache_write_tokens,
+        );
+        let now = Utc::now();
+        let key = UsageKey::new(user_id, model);
+
+        // Snapshot path + updated records under the lock, then release before IO.
+        let persist = {
+            let mut inner = self.inner.write();
+            let entry = inner
+                .records
+                .entry(key)
+                .or_insert_with(|| UsageRecord::new(user_id, model));
+
+            entry.input_tokens += input_tokens;
+            entry.output_tokens += output_tokens;
+            entry.cache_read_tokens += cache_read_tokens;
+            entry.cache_write_tokens += cache_write_tokens;
+            entry.cost_usd += cost;
+            entry.request_count += 1;
+            if entry.first_seen.is_none() {
+                entry.first_seen = Some(now);
+            }
+            entry.last_seen = Some(now);
+
+            // Collect snapshot while holding the lock; IO happens after.
+            inner.persist_path.clone().map(|path| {
+                let snapshot: Vec<UsageRecord> = inner.records.values().cloned().collect();
+                (path, snapshot)
+            })
+        }; // write lock released here
+
+        if let Some((path, snapshot)) = persist {
+            tokio::task::spawn_blocking(move || {
+                match serde_json::to_string(&snapshot) {
+                    Ok(json) => {
+                        let tmp = path.with_extension("tmp");
+                        if let Err(e) =
+                            std::fs::write(&tmp, &json).and_then(|_| std::fs::rename(&tmp, &path))
+                        {
+                            warn!(path = %path.display(), error = %e, "failed to persist usage store");
+                        }
+                    }
+                    Err(e) => warn!(error = %e, "failed to serialize usage store"),
+                }
+            });
+        }
+    }
+
+    /// Return all usage records, optionally filtered by user, model, and/or
+    /// minimum `last_seen` timestamp.
+    pub fn query(
+        &self,
+        user_id: Option<&str>,
+        model: Option<&str>,
+        since: Option<DateTime<Utc>>,
+    ) -> Vec<UsageRecord> {
+        let model_lower = model.map(|m| m.to_lowercase());
+        let inner = self.inner.read();
+        inner
+            .records
+            .values()
+            .filter(|r| {
+                user_id.map_or(true, |u| r.user_id == u)
+                    && model_lower
+                        .as_deref()
+                        .map_or(true, |m| r.model.to_lowercase() == m)
+                    && since.map_or(true, |s| r.last_seen.map_or(false, |ls| ls >= s))
+            })
+            .cloned()
+            .collect()
+    }
+}
+
+impl Default for UsageStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_pricing() -> PricingConfig {
+        // Construct via JSON so the normalizing deserializer runs.
+        serde_json::from_str(r#"{"models":{"claude-sonnet":{"input":3.0,"output":15.0,"cacheRead":0.3,"cacheWrite":3.75}}}"#).unwrap()
+    }
+
+    #[test]
+    fn pricing_exact_match() {
+        let p = make_pricing();
+        let m = p.for_model("claude-sonnet");
+        assert_eq!(m.input, 3.0);
+        assert_eq!(m.output, 15.0);
+    }
+
+    #[test]
+    fn pricing_case_insensitive_match() {
+        let p = make_pricing();
+        assert_eq!(p.for_model("Claude-Sonnet").input, 3.0);
+        assert_eq!(p.for_model("CLAUDE-SONNET").output, 15.0);
+    }
+
+    #[test]
+    fn pricing_unknown_model_zero_cost() {
+        let p = make_pricing();
+        let m = p.for_model("unknown-model");
+        assert_eq!(m.input, 0.0);
+        assert_eq!(m.output, 0.0);
+    }
+
+    #[test]
+    fn pricing_deterministic_case_collision() {
+        // When two keys differ only by case, the lexicographically smallest wins.
+        // "ModelA" < "modela" lexicographically, so "ModelA" is the canonical key.
+        let p: PricingConfig = serde_json::from_str(
+            r#"{"models":{"ModelA":{"input":1.0,"output":2.0},"modela":{"input":9.0,"output":9.0}}}"#,
+        ).unwrap();
+        // All lookups hit the same normalized key; "ModelA" wins (lex smallest).
+        assert_eq!(p.for_model("ModelA").input, 1.0);
+        assert_eq!(p.for_model("modela").input, 1.0);
+        assert_eq!(p.for_model("MODELA").input, 1.0);
+    }
+
+    #[test]
+    fn compute_cost_correct() {
+        let m = ModelPricing { input: 3.0, output: 15.0, cache_read: Some(0.3), cache_write: Some(3.75) };
+        // 1M input + 1M output = $3 + $15 = $18
+        let cost = m.compute_cost(1_000_000, 1_000_000, 0, 0);
+        assert!((cost - 18.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn compute_cost_cache_fallback_to_input() {
+        // When cache_read/cache_write are None, input price is used as fallback.
+        let m = ModelPricing { input: 4.0, output: 12.0, cache_read: None, cache_write: None };
+        // 1M cache-read tokens billed at input rate = $4
+        let cost = m.compute_cost(0, 0, 1_000_000, 0);
+        assert!((cost - 4.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn record_and_query_basic() {
+        let store = UsageStore::new();
+        let pricing = make_pricing();
+
+        store.record("alice", "claude-sonnet", 100, 50, 0, 0, &pricing);
+        store.record("alice", "claude-sonnet", 200, 80, 0, 0, &pricing);
+        store.record("bob", "claude-sonnet", 10, 5, 0, 0, &pricing);
+
+        let all = store.query(None, None, None);
+        assert_eq!(all.len(), 2);
+
+        let alice = store.query(Some("alice"), None, None);
+        assert_eq!(alice.len(), 1);
+        assert_eq!(alice[0].input_tokens, 300);
+        assert_eq!(alice[0].output_tokens, 130);
+        assert_eq!(alice[0].request_count, 2);
+        // cost: (300 * 3.0 + 130 * 15.0) / 1_000_000
+        let expected = (300.0 * 3.0 + 130.0 * 15.0) / 1_000_000.0;
+        assert!((alice[0].cost_usd - expected).abs() < 1e-9);
+    }
+
+    #[test]
+    fn record_normalizes_model_case() {
+        let store = UsageStore::new();
+        let pricing = make_pricing();
+
+        store.record("alice", "Claude-Sonnet", 100, 50, 0, 0, &pricing);
+        store.record("alice", "CLAUDE-SONNET", 100, 50, 0, 0, &pricing);
+
+        // Both should land in the same bucket.
+        let records = store.query(Some("alice"), None, None);
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].request_count, 2);
+        assert_eq!(records[0].input_tokens, 200);
+    }
+
+    #[test]
+    fn query_model_filter_case_insensitive() {
+        let store = UsageStore::new();
+        let pricing = make_pricing();
+
+        store.record("alice", "claude-sonnet", 10, 5, 0, 0, &pricing);
+
+        assert_eq!(store.query(None, Some("claude-sonnet"), None).len(), 1);
+        assert_eq!(store.query(None, Some("Claude-Sonnet"), None).len(), 1);
+        assert_eq!(store.query(None, Some("other"), None).len(), 0);
+    }
+
+    #[test]
+    fn query_since_filter() {
+        let store = UsageStore::new();
+        let pricing = make_pricing();
+
+        store.record("alice", "claude-sonnet", 10, 5, 0, 0, &pricing);
+
+        let future = Utc::now() + chrono::Duration::hours(1);
+        assert_eq!(store.query(None, None, Some(future)).len(), 0);
+        assert_eq!(store.query(None, None, None).len(), 1);
+    }
+}

--- a/crates/agentgateway/src/test_helpers/proxymock.rs
+++ b/crates/agentgateway/src/test_helpers/proxymock.rs
@@ -990,6 +990,8 @@ pub fn setup_proxy_test_with_config(config: crate::Config) -> TestBind {
 		ca: None,
 
 		mcp_state: mcp::App::new(stores.clone(), encoder),
+		usage_store: Arc::new(crate::telemetry::usage_store::UsageStore::new()),
+		pricing: Arc::new(crate::telemetry::usage_store::PricingConfig::default()),
 	});
 	TestBind {
 		pi,

--- a/examples/opencode-anthropic/README.md
+++ b/examples/opencode-anthropic/README.md
@@ -1,0 +1,173 @@
+# opencode → agentgateway → Anthropic
+
+This example shows how to route opencode's Anthropic traffic through
+agentgateway so the gateway holds the API key and opencode never contacts
+Anthropic directly.
+
+```
+opencode  →  agentgateway (localhost:3000)  →  api.anthropic.com
+```
+
+Benefits:
+- The Anthropic API key lives only in the gateway (or its environment), not
+  in the opencode config that may be committed to source control.
+- You can layer agentgateway policies on top: prompt guards, rate limiting,
+  cost tracking, access logging, etc.
+
+## Prerequisites
+
+- agentgateway built (`cargo build --release` from the repo root)
+- opencode installed (`npm i -g opencode-ai` or from source)
+- An Anthropic API key
+
+## Ports
+
+agentgateway listens on two ports:
+
+| Port | Purpose |
+|------|---------|
+| **3000** | Proxy — receives requests from opencode and forwards to Anthropic |
+| **15000** | Admin — usage stats, config dump, debug endpoints |
+
+## 1. Start agentgateway
+
+Export your Anthropic API key and start the gateway from the repo root:
+
+```bash
+export ANTHROPIC_API_KEY="sk-ant-..."
+./target/release/agentgateway --file examples/opencode-anthropic/gateway.yaml
+```
+
+The gateway binds to `http://localhost:3000` and accepts Anthropic Messages
+API requests at `/v1/messages`.
+
+## 2. Configure opencode
+
+Copy the provided `opencode.json` to your opencode config directory, or merge
+the `provider.anthropic` block into your existing config:
+
+```bash
+cp examples/opencode-anthropic/opencode.json ~/.config/opencode/opencode.json
+```
+
+The key change is setting `baseURL` so the Anthropic SDK inside opencode sends
+requests to the gateway instead of `api.anthropic.com`.  The `apiKey` value is
+a placeholder — the real key is held by the gateway:
+
+```json
+{
+  "provider": {
+    "anthropic": {
+      "options": {
+        "baseURL": "http://localhost:3000/v1",
+        "apiKey": "placeholder"
+      }
+    }
+  }
+}
+```
+
+## 3. Run opencode
+
+```bash
+opencode
+```
+
+Pick any `claude-*` model.  Traffic flows:
+
+```
+opencode (Anthropic SDK)
+  POST http://localhost:3000/v1/messages
+    → agentgateway
+      adds x-api-key: <real key>
+        → POST https://api.anthropic.com/v1/messages
+```
+
+## Verifying the gateway is in the path
+
+With the gateway running, confirm it is intercepting requests:
+
+```bash
+curl -s http://localhost:3000/v1/messages \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "claude-sonnet-4-6",
+    "max_tokens": 32,
+    "messages": [{"role": "user", "content": "Say hello"}]
+  }' | jq .
+```
+
+You should get a valid Anthropic response back through the gateway.
+
+## Viewing token usage and cost
+
+After sending some requests through the gateway, query the **admin server**
+at port **15000** (not the proxy port 3000):
+
+```bash
+curl -s http://localhost:15000/usage | jq .
+```
+
+Example output after a few opencode sessions:
+
+```json
+[
+  {
+    "userId": "anonymous",
+    "model": "claude-sonnet-4-6",
+    "inputTokens": 23,
+    "outputTokens": 29,
+    "cacheReadTokens": 0,
+    "cacheWriteTokens": 0,
+    "costUsd": 0.000504,
+    "requestCount": 2,
+    "firstSeen": "2026-04-29T10:08:39Z",
+    "lastSeen": "2026-04-29T10:08:41Z"
+  }
+]
+```
+
+The `costUsd` is computed from the pricing table in `gateway.yaml`.
+Current Anthropic prices are pre-filled; update them at
+https://www.anthropic.com/pricing if they change.
+
+Filter by user or model with query parameters:
+
+```bash
+# All requests for a specific model
+curl -s "http://localhost:15000/usage?model=claude-sonnet-4-6" | jq .
+
+# Requests since a Unix timestamp
+curl -s "http://localhost:15000/usage?since=1748000000" | jq .
+```
+
+When JWT or API key authentication is added to the gateway listener, the
+`userId` field will be the authenticated identity instead of `"anonymous"`.
+
+To persist usage across gateway restarts, add to `gateway.yaml`:
+
+```yaml
+config:
+  usageStorePath: /var/lib/agentgateway/usage.json
+  pricing:
+    ...
+```
+
+## Adding policies
+
+Edit `gateway.yaml` to add policies before the backend.  For example, to
+reject any prompt containing a credit-card number:
+
+```yaml
+      policies:
+        ai:
+          promptGuard:
+            request:
+            - regex:
+                action: reject
+                rules:
+                - builtin: credit_card
+```
+
+See the [agentgateway documentation](https://agentgateway.dev) for the full
+policy reference.

--- a/examples/opencode-anthropic/gateway.yaml
+++ b/examples/opencode-anthropic/gateway.yaml
@@ -1,0 +1,79 @@
+# yaml-language-server: $schema=https://agentgateway.dev/schema/config
+#
+# agentgateway config: proxy Anthropic traffic from opencode.
+#
+# Run from the repo root:
+#   export ANTHROPIC_API_KEY="sk-ant-..."
+#   ./target/release/agentgateway --file examples/opencode-anthropic/gateway.yaml
+#
+# The gateway listens on port 3000 and accepts requests in the Anthropic
+# Messages API format, forwarding them to api.anthropic.com.
+# opencode sends requests to http://localhost:3000 and never needs to
+# hold the real API key itself.
+#
+# Shell variable references are expanded before parsing so the API key
+# is read securely from the environment at startup.
+
+# config: sets gateway-level options (pricing, logging, etc.).
+# Pricing (USD per million tokens) powers the /usage endpoint on the
+# admin server (http://localhost:15000/usage).
+# Source: https://www.anthropic.com/pricing
+config:
+  pricing:
+    models:
+      # Sonnet 4.6 / 4.5 — 3.00 input, 15.00 output USD per MTok
+      claude-sonnet-4-6:
+        input: 3.00
+        output: 15.00
+        cacheRead: 0.30
+        cacheWrite: 3.75
+      claude-sonnet-4-5:
+        input: 3.00
+        output: 15.00
+        cacheRead: 0.30
+        cacheWrite: 3.75
+      claude-sonnet-4-5-20250929:
+        input: 3.00
+        output: 15.00
+        cacheRead: 0.30
+        cacheWrite: 3.75
+      # Opus 4.6 — 5.00 input, 25.00 output USD per MTok
+      claude-opus-4-6:
+        input: 5.00
+        output: 25.00
+        cacheRead: 0.50
+        cacheWrite: 6.25
+      claude-opus-4-5:
+        input: 15.00
+        output: 75.00
+        cacheRead: 1.50
+        cacheWrite: 18.75
+      # Haiku 4.5 — 1.00 input, 5.00 output USD per MTok
+      claude-haiku-4-5:
+        input: 1.00
+        output: 5.00
+        cacheRead: 0.10
+        cacheWrite: 1.25
+
+binds:
+- port: 3000
+  listeners:
+  - name: opencode-anthropic
+    routes:
+    - policies:
+        ai:
+          # Tell the gateway which request format to expect on each path.
+          # Without this, all paths default to OpenAI completions format,
+          # which breaks requests from opencode (which sends native Anthropic
+          # Messages API format to /v1/messages).
+          routes:
+            /v1/messages: messages
+            /v1/messages/count_tokens: anthropicTokenCount
+      backends:
+      - ai:
+          name: anthropic
+          provider:
+            anthropic: {}
+          policies:
+            backendAuth:
+              key: ${ANTHROPIC_API_KEY}

--- a/examples/opencode-anthropic/opencode.json
+++ b/examples/opencode-anthropic/opencode.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "anthropic": {
+      "name": "Anthropic (via agentgateway)",
+      "options": {
+        "baseURL": "http://localhost:3000/v1",
+        "apiKey": "placeholder"
+      }
+    }
+  },
+  "model": "anthropic/claude-sonnet-4-6"
+}

--- a/examples/opencode-anthropic/start.sh
+++ b/examples/opencode-anthropic/start.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Start agentgateway for the opencode-anthropic demo.
+#
+# Usage:
+#   export ANTHROPIC_API_KEY="sk-ant-..."
+#   ./examples/opencode-anthropic/start.sh
+
+set -euo pipefail
+
+if [[ -z "${ANTHROPIC_API_KEY:-}" ]]; then
+  echo "Error: ANTHROPIC_API_KEY is not set." >&2
+  echo "  export ANTHROPIC_API_KEY=\"sk-ant-...\"" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+BINARY="${REPO_ROOT}/target/release/agentgateway"
+
+if [[ ! -x "$BINARY" ]]; then
+  echo "Release binary not found. Building..." >&2
+  cargo build --release --manifest-path "${REPO_ROOT}/Cargo.toml"
+fi
+
+echo "Starting agentgateway on http://localhost:3000 ..."
+exec "$BINARY" --file "${SCRIPT_DIR}/gateway.yaml"


### PR DESCRIPTION
Track cumulative token consumption and estimated cost for each (user, model) pair across all LLM requests proxied by the gateway.

## Core implementation

- Add `UsageStore`: thread-safe, Arc-clonable in-memory store with optional JSON-file persistence. The write lock is released before serialization, and disk IO runs in a `tokio::task::spawn_blocking` task so the worker thread is not stalled.
- Add `PricingConfig`: YAML-deserializable map of model name to `{input, output, cache_read, cache_write}` prices (USD/million tokens) with `deny_unknown_fields` for early typo detection.
  - `cache_read` and `cache_write` are `Option<f64>`; when unset, the input price is used as the fallback so 'unset' is distinguishable from an explicit zero.
  - Pricing keys are normalized to lowercase at deserialization time via a custom deserializer, making lookup O(1) and case-insensitive. When keys differ only by case, the lexicographically smallest original key wins deterministically.
  - Model names are stored lowercase in usage bucket keys so that provider variants (e.g. `claude-sonnet-4-5-20250929`) collapse into a single bucket regardless of input casing.
- Wire both into `ProxyInputs` and `RequestLog` so `add_llm_metrics()` records usage for every completed LLM response.
- Attribute requests to `jwt_sub` when JWT auth is configured, falling back to `anonymous` for unauthenticated gateways.
- Expose `GET /usage` on the admin server with `?user=`, `?model=`, and `?since=` (Unix timestamp) query filters returning JSON.
- Add `pricing` and `usage_store_path` fields to `RawConfig`/`Config` so operators can configure prices and persistence path in YAML (inside the `config:` block of a local config file).
- Add 10 unit tests covering pricing lookup, cost computation, record aggregation, case normalisation, cache price fallback, and time-based query filtering.

## Demo

Add `examples/opencode-anthropic/` showing how to route opencode's Anthropic traffic through agentgateway so the API key lives only in the gateway. Includes `gateway.yaml` with a pricing table for `claude-sonnet-4-5`, an `opencode.json` drop-in, a `start.sh` helper, and a README with usage query examples.