### PR TITLE
openapi mcp protocol and non-compliant response handling update

### DIFF
--- a/crates/agentgateway/src/mcp/upstream/openapi/mod.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/mod.rs
@@ -911,8 +911,8 @@ impl Handler {
 
 		// Read response body
 		let status = response.status();
-		
-		// per https://modelcontextprotocol.io/specification/2025-11-25/server/tools 
+
+		// per https://modelcontextprotocol.io/specification/2025-11-25/server/tools
 		// Clients MAY provide protocol errors to language models which are mainly caught up higher.
 		// However we contend that server errors on the tool call should also count as protocol
 		// Everything else should be treated as a success from an http perspective and wrapped in the json-rpc format.

--- a/crates/agentgateway/src/mcp/upstream/openapi/mod.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/mod.rs
@@ -911,8 +911,12 @@ impl Handler {
 
 		// Read response body
 		let status = response.status();
-		// Check if the request was successful
-		if status.is_success() {
+		
+		// per https://modelcontextprotocol.io/specification/2025-11-25/server/tools 
+		// Clients MAY provide protocol errors to language models which are mainly caught up higher.
+		// However we contend that server errors on the tool call should also count as protocol
+		// Everything else should be treated as a success from an http perspective and wrapped in the json-rpc format.
+		if !status.is_server_error() {
 			let lim = crate::http::response_buffer_limit(&response);
 			let content_encoding = response.headers().typed_get::<headers::ContentEncoding>();
 			let body_bytes = crate::http::compression::to_bytes_with_decompression(
@@ -923,14 +927,17 @@ impl Handler {
 			.await
 			.map_err(|e| UpstreamError::OpenAPIError(e.into()))?
 			.1;
-
-			// Wrap responses that are not structuredContent compliant in object
-			Ok(json!({ "data":
-				match serde_json::from_slice::<serde_json::Value>(&body_bytes).map_err(|e| UpstreamError::OpenAPIError(e.into()))? {
-					Value::Object(obj) => return Ok(Value::Object(obj)),
-					Value::Null => return Ok(Value::Null),
-					data => data,
-			}}))
+			match serde_json::from_slice::<serde_json::Value>(&body_bytes) {
+				Ok(Value::Object(obj)) => Ok(Value::Object(obj)),
+				Ok(Value::Null) => Ok(Value::Null),
+				Ok(data) => Ok(json!({ "data": data })),
+				Err(_) => {
+					// We should probably record a metric here as this means despite requesting json we got back non-json
+					// This would be fine if it was a 5XX but its not so we help a little.
+					// There is a consideration that we could put is_error in here based on the status but dont know if that makes sense for now
+					Ok(json!({ "code": status.as_u16(), "message": String::from_utf8_lossy(&body_bytes) }))
+				},
+			}
 		} else {
 			let lim = crate::http::response_buffer_limit(&response);
 			let body = String::from_utf8(

--- a/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
@@ -427,9 +427,41 @@ async fn test_call_tool_upstream_error() {
 		)
 		.await;
 
+	assert!(result.is_ok());
+	assert_eq!(result.unwrap(), error_response);
+}
+
+#[tokio::test]
+async fn test_call_tool_upstream_internal_error() {
+	let (server, handler) = setup().await;
+
+	let user_id = "error-user";
+	let error_response = json!({ "error": "Something went wrong accessing Github :unicorn:" });
+
+	Mock::given(method("GET"))
+		.and(path(format!("/users/{user_id}")))
+		.respond_with(ResponseTemplate::new(500).set_body_json(&error_response))
+		.mount(&server)
+		.await;
+
+	let args = json!({ "path": { "user_id": user_id } });
+	let result = handler
+		.call_tool(
+			"get_user",
+			Some(args.as_object().unwrap().clone()),
+			&IncomingRequestContext::empty(),
+		)
+		.await;
+
 	assert!(result.is_err());
 	let err = result.unwrap_err();
-	assert!(err.to_string().contains("failed with status 404 Not Found"));
+	assert!(
+		err
+			.to_string()
+			.contains("failed with status 500 Internal Server Error"),
+		"error was {}",
+		err.to_string()
+	);
 	assert!(err.to_string().contains(&error_response.to_string()));
 }
 
@@ -524,16 +556,13 @@ async fn test_call_tool_invalid_path_param_value() {
 
 	// Depending on server behavior for the literal path, this might be Ok or Err.
 	// If server returns 404 for the literal path:
-	assert!(result.is_err());
-	assert!(
-		result
-			.as_ref()
-			.unwrap_err()
-			.to_string()
-			.contains("failed with status 404 Not Found"),
-		"{}",
-		result.unwrap_err().to_string()
-	);
+	assert!(result.is_ok());
+	// assert!(
+	// 	result.unwrap()
+	// 		.contains("failed with status 404 Not Found"),
+	// 	"{}",
+	// 	result.unwrap_err().to_string()
+	// );
 
 	// If the request *itself* failed before sending (e.g., invalid URL formed),
 	// the error might be different.

--- a/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
@@ -579,26 +579,32 @@ async fn test_call_tool_with_compressed_response() {
 async fn test_call_tool_response_wrapping() {
 	let (server, handler) = setup().await;
 
-	let test_cases = [
-		(false, Value::Null),
+	// (wrapped, raw_body_bytes, expected_parsed_value)
+	let test_cases: &[(bool, &[u8], Value)] = &[
+		(false, b"null", Value::Null),
 		(
 			false,
+			br#"{"id":"123","name":"Test User","email":"test@example.com"}"#,
 			json!({ "id": "123", "name": "Test User", "email": "test@example.com" }),
 		),
 		(
 			true,
+			br#"[{"id":1,"name":"1"},{"id":2,"name":"2"},{"id":3,"name":"3"}]"#,
 			json!([ { "id": 1, "name": "1" }, { "id": 2, "name": "2" }, { "id": 3, "name": "3" }]),
 		),
-		(true, json!("plain text response")),
-		(true, json!(42)),
-		(true, json!(true)),
+		(false, b"plain text response", json!({"code": 200, "message": "plain text response"})),
+		(true, b"42", json!(42)),
+		(true, b"true", json!(true)),
 	];
 
-	for (i, (wrapped, response)) in test_cases.iter().enumerate() {
+	for (i, (wrapped, body, response)) in test_cases.iter().enumerate() {
 		let user_id = format!("{}", i);
 		Mock::given(method("GET"))
 			.and(path(format!("/users/{}", user_id)))
-			.respond_with(ResponseTemplate::new(200).set_body_json(response))
+			.respond_with(
+				ResponseTemplate::new(200)
+					.set_body_bytes(body.to_vec()),
+			)
 			.expect(1)
 			.mount(&server)
 			.await;
@@ -611,7 +617,8 @@ async fn test_call_tool_response_wrapping() {
 				&IncomingRequestContext::empty(),
 			)
 			.await;
-		assert!(result.is_ok());
+
+		assert!(result.is_ok(), "result {:?}", result);
 
 		// Spec requires an object https://modelcontextprotocol.io/specification/2025-06-18/schema#calltoolresult
 		let expected = if *wrapped {
@@ -622,6 +629,7 @@ async fn test_call_tool_response_wrapping() {
 		assert_eq!(result.unwrap(), expected);
 	}
 }
+
 #[tokio::test]
 async fn test_normalize_url_path_empty_prefix() {
 	// Test the fix for double slash issue when prefix is empty (host/port config)
@@ -1516,3 +1524,4 @@ async fn test_openapi_from_url() {
 		}
 	}
 }
+

--- a/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
@@ -460,7 +460,7 @@ async fn test_call_tool_upstream_internal_error() {
 			.to_string()
 			.contains("failed with status 500 Internal Server Error"),
 		"error was {}",
-		err.to_string()
+		err
 	);
 	assert!(err.to_string().contains(&error_response.to_string()));
 }

--- a/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
@@ -592,7 +592,11 @@ async fn test_call_tool_response_wrapping() {
 			br#"[{"id":1,"name":"1"},{"id":2,"name":"2"},{"id":3,"name":"3"}]"#,
 			json!([ { "id": 1, "name": "1" }, { "id": 2, "name": "2" }, { "id": 3, "name": "3" }]),
 		),
-		(false, b"plain text response", json!({"code": 200, "message": "plain text response"})),
+		(
+			false,
+			b"plain text response",
+			json!({"code": 200, "message": "plain text response"}),
+		),
 		(true, b"42", json!(42)),
 		(true, b"true", json!(true)),
 	];
@@ -601,10 +605,7 @@ async fn test_call_tool_response_wrapping() {
 		let user_id = format!("{}", i);
 		Mock::given(method("GET"))
 			.and(path(format!("/users/{}", user_id)))
-			.respond_with(
-				ResponseTemplate::new(200)
-					.set_body_bytes(body.to_vec()),
-			)
+			.respond_with(ResponseTemplate::new(200).set_body_bytes(body.to_vec()))
 			.expect(1)
 			.mount(&server)
 			.await;
@@ -1524,4 +1525,3 @@ async fn test_openapi_from_url() {
 		}
 	}
 }
-


### PR DESCRIPTION

Our openapi mcp response handling had what seems to be 2 places where we could benefit from some updates, namely non-protocol error handling and graceful handling of non-compliant response bodies (not json). 

A version of this was attempted [here](https://github.com/agentgateway/agentgateway/pull/1673) but that assumed that calling a valid tool that complained returned a valid model instruction about a missing endpoint such as a 404 looking for a non-existant id on a valid path was a protocol error.
Since our setup is mainly wrapping the json-rpc spec per mcp specification I dug a bit into how statuses are supposed to be reported for html wrapped json-rpc.
Whats a little annoying here is that while json-rpc v1 has a spec for being wrapped with http which has an error mapping strategy to expose the internal errors sort of like what the customer is expecting.
Json-rpc v2 html wrapping does NOT have an explicit spec for response codes as far as I could find.
There seems to be 2 schools of thought, of which both are fairly similar for our implementation specifics and pretty much boil down to always returning a 200 if we get valid json-rpc responses even if those have errors. See this proposal from 2013 that hasnt been picked up but seems to be the main proposal linked across searches. https://www.simple-is-better.org/json-rpc/transport_http.html

Given all this the PR does 2 things:
1. downscopes what we consider protocol errors from being true protocol errors plus non-2xx statuses from our tool calls to being just true protocol errors plus 5xx statuses from our tool calls.
2. makes us more generous with regards to non-json responses from tool calls which would previously always return an error straight from our json parser of `mcp: send error: openapi upstream error: expected value at line 1 column 1`


/kind fix