### PR TITLE
performance: optimize allocators and enable visibility

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,5 +5,10 @@ xtask = "run --package xtask --"
 # Not supported for non-linux
 [target.'cfg(target_os = "linux")']
 rustflags = [
-    "--cfg", "tokio_unstable"
+    "--cfg", "tokio_unstable",
+    "-C", "force-frame-pointers",
 ]
+
+[env]
+CXXFLAGS = "-fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"
+CFLAGS = "-fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,7 +129,7 @@ dependencies = [
  "futures",
  "http 1.4.0",
  "prometheus-client",
- "prost",
+ "prost 0.14.3",
  "prost-wkt-types",
  "protos",
  "serde",
@@ -196,6 +196,7 @@ dependencies = [
  "http-body-util",
  "http-serde",
  "httpdate",
+ "human_bytes",
  "hyper",
  "hyper-util",
  "include_dir",
@@ -208,6 +209,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "macro_rules_attribute",
+ "mimalloc",
  "notify",
  "notify-debouncer-full",
  "num_cpus",
@@ -224,8 +226,9 @@ dependencies = [
  "pin-project-lite",
  "ppp",
  "pprof",
+ "pprof-alloc",
  "prometheus-client",
- "prost",
+ "prost 0.14.3",
  "prost-types",
  "prost-wkt-types",
  "protos",
@@ -290,6 +293,8 @@ dependencies = [
  "clap",
  "fs-err",
  "libc",
+ "mimalloc",
+ "pprof-alloc",
  "tikv-jemallocator",
  "tokio",
  "tracing",
@@ -303,6 +308,7 @@ checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
  "const-random",
+ "getrandom 0.3.4",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -1901,6 +1907,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cty"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2002,6 +2014,20 @@ dependencies = [
  "darling_core 0.23.0",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -2785,6 +2811,12 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -3065,6 +3097,12 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "human_bytes"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91f255a4535024abf7640cb288260811fc14794f62b063652ed349f9a6c2348e"
 
 [[package]]
 name = "hybrid-array"
@@ -3630,6 +3668,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
+dependencies = [
+ "cc",
+ "cty",
+ "libc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3875,6 +3924,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -4273,7 +4331,7 @@ dependencies = [
  "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
- "prost",
+ "prost 0.14.3",
  "thiserror 2.0.18",
  "tokio",
  "tonic",
@@ -4290,7 +4348,7 @@ dependencies = [
  "const-hex",
  "opentelemetry",
  "opentelemetry_sdk",
- "prost",
+ "prost 0.14.3",
  "serde",
  "serde_json",
  "tonic",
@@ -4619,6 +4677,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "pprof-alloc"
+version = "0.1.0"
+dependencies = [
+ "ahash",
+ "anyhow",
+ "backtrace",
+ "dashmap",
+ "errno",
+ "flate2",
+ "itertools 0.14.0",
+ "lazy_static",
+ "libc",
+ "libmimalloc-sys",
+ "num",
+ "once_cell",
+ "paste",
+ "prometheus-client",
+ "prost 0.13.5",
+ "quick-xml",
+ "regex",
+ "serde",
+ "smallvec",
+ "thiserror 1.0.69",
+ "tikv-jemalloc-ctl",
+ "tracing",
+]
+
+[[package]]
 name = "pprof_util"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4629,7 +4715,7 @@ dependencies = [
  "flate2",
  "num",
  "paste",
- "prost",
+ "prost 0.14.3",
 ]
 
 [[package]]
@@ -4755,12 +4841,22 @@ dependencies = [
 
 [[package]]
 name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive 0.13.5",
+]
+
+[[package]]
+name = "prost"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.14.3",
 ]
 
 [[package]]
@@ -4775,13 +4871,26 @@ dependencies = [
  "multimap",
  "petgraph",
  "prettyplease",
- "prost",
+ "prost 0.14.3",
  "prost-types",
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "regex",
  "syn",
  "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -4805,7 +4914,7 @@ checksum = "b89455ef41ed200cafc47c76c552ee7792370ac420497e551f16123a9135f76e"
 dependencies = [
  "logos",
  "miette 7.6.0",
- "prost",
+ "prost 0.14.3",
  "prost-types",
 ]
 
@@ -4815,7 +4924,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
- "prost",
+ "prost 0.14.3",
 ]
 
 [[package]]
@@ -4826,7 +4935,7 @@ checksum = "cd3de5e9c9e84fcb5efa204b8e283d23e615a8bc8c777bf1d6622bb01dc61445"
 dependencies = [
  "chrono",
  "inventory",
- "prost",
+ "prost 0.14.3",
  "serde",
  "serde_derive",
  "serde_json",
@@ -4840,7 +4949,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe500dc80e757a75e1e8fb7290e448d62dfba3105ece1d058579cb00b58151cd"
 dependencies = [
  "heck",
- "prost",
+ "prost 0.14.3",
  "prost-build",
  "prost-types",
  "quote",
@@ -4853,7 +4962,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13807eaa7e15833d06e899008371926201cdcd11d74b6d490f49130cdb3f415e"
 dependencies = [
  "chrono",
- "prost",
+ "prost 0.14.3",
  "prost-build",
  "prost-types",
  "prost-wkt",
@@ -4921,7 +5030,7 @@ name = "protos"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "prost",
+ "prost 0.14.3",
  "prost-build",
  "prost-types",
  "prost-wkt-build",
@@ -4940,7 +5049,7 @@ checksum = "4f25a07a73c6717f0b9bbbd685918f5df9815f7efba450b83d9c9dea41f0e3a1"
 dependencies = [
  "bytes",
  "miette 7.6.0",
- "prost",
+ "prost 0.14.3",
  "prost-reflect",
  "prost-types",
  "protox-parse",
@@ -5011,6 +5120,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
 dependencies = [
  "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -6819,7 +6929,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
 dependencies = [
  "bytes",
- "prost",
+ "prost 0.14.3",
  "tonic",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,7 +196,6 @@ dependencies = [
  "http-body-util",
  "http-serde",
  "httpdate",
- "human_bytes",
  "hyper",
  "hyper-util",
  "include_dir",
@@ -3099,12 +3098,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
-name = "human_bytes"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91f255a4535024abf7640cb288260811fc14794f62b063652ed349f9a6c2348e"
-
-[[package]]
 name = "hybrid-array"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4679,6 +4672,8 @@ dependencies = [
 [[package]]
 name = "pprof-alloc"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af3132568d642696e1cafb08d33944e2a0a40e19799fccffab951629aa87391f"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,6 +131,7 @@ phonenumber = "0.3"
 pin-project-lite = "0.2"
 pingora-pool = "0.8"
 ppp = "2.3"
+pprof-alloc = "0.1"
 pprof = { version = "0.15", features = [
     "protobuf",
     "protobuf-codec",
@@ -153,6 +154,7 @@ reqwest = { version = "0.13", default-features = false, features = [
     "rustls",
 ] }
 rstest = "0.26"
+mimalloc = { version = "0.1", features = ["v3", "no_thp"] }
 rustc_version = "0.4"
 rustls = { version = "0.23", default-features = false, features = ["tls12", "aws_lc_rs"] }
 rustls-native-certs = "0.8"
@@ -243,6 +245,10 @@ heck = "0.5"
 macro_rules_attribute = "0.2"
 
 # Release optimized but without as many dependencies, suitable for incremental development
+[profile.quick-release-debug]
+inherits = "quick-release"
+debug = true
+
 [profile.quick-release]
 inherits = "release"
 codegen-units = 16

--- a/crates/agentgateway-app/Cargo.toml
+++ b/crates/agentgateway-app/Cargo.toml
@@ -11,17 +11,23 @@ path = "src/main.rs"
 bench = false
 
 [features]
-default = []
+# Jemalloc has been found to have the highest throughput and best ability to return memory to the system
+# This comes at the small cost of a few mb memory overhead relative to others (most notable in an empty setup).
+default = ["jemalloc"]
+glibc = ["agentgateway/glibc"]
 jemalloc = ["dep:tikv-jemallocator", "agentgateway/jemalloc"]
+mimalloc = ["dep:mimalloc", "agentgateway/mimalloc"]
 schema = ["agentgateway/schema"]
 
 [dependencies]
+pprof-alloc.workspace = true
 agent-core.workspace = true
 agentgateway.workspace = true
 anyhow.workspace = true
 clap.workspace = true
 fs-err = { workspace = true, features = ["tokio"] }
 libc.workspace = true
+mimalloc = { workspace = true, optional = true }
 tokio.workspace = true
 tracing.workspace = true
 tikv-jemallocator = {workspace = true, optional = true}

--- a/crates/agentgateway-app/Cargo.toml
+++ b/crates/agentgateway-app/Cargo.toml
@@ -30,7 +30,9 @@ libc.workspace = true
 mimalloc = { workspace = true, optional = true }
 tokio.workspace = true
 tracing.workspace = true
-tikv-jemallocator = {workspace = true, optional = true}
+
+[target.'cfg(target_os = "linux")'.dependencies]
+tikv-jemallocator = { workspace = true, optional = true }
 
 [lints.clippy]
 # This rule makes code more confusing

--- a/crates/agentgateway-app/src/lib.rs
+++ b/crates/agentgateway-app/src/lib.rs
@@ -6,16 +6,52 @@ use clap::{Args as ClapArgs, Parser, Subcommand};
 
 mod commands;
 
+#[cfg(not(any(feature = "glibc", feature = "jemalloc", feature = "mimalloc",)))]
+compile_error!("exactly one allocator feature must be enabled: glibc, jemalloc, or mimalloc");
+
+#[cfg(any(
+	all(feature = "glibc", feature = "jemalloc"),
+	all(feature = "glibc", feature = "mimalloc"),
+	all(feature = "jemalloc", feature = "mimalloc"),
+))]
+compile_error!(
+	"allocator features are mutually exclusive; enable exactly one of glibc, jemalloc, or mimalloc"
+);
+
+#[cfg(feature = "glibc")]
+#[global_allocator]
+static GLOBAL: pprof_alloc::PprofAlloc<std::alloc::System> =
+	pprof_alloc::PprofAlloc::from_allocator(std::alloc::System)
+		.with_pprof_sample_rate_from_env(pprof_alloc::DEFAULT_PPROF_SAMPLE_RATE)
+		.with_stats();
+
+#[cfg(feature = "glibc")]
+pprof_alloc::declare_allocator_kind!(pprof_alloc::allocator::AllocatorKind::Glibc);
+
 #[cfg(feature = "jemalloc")]
 #[global_allocator]
-static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+static GLOBAL: pprof_alloc::PprofAlloc<tikv_jemallocator::Jemalloc> =
+	pprof_alloc::PprofAlloc::from_allocator(tikv_jemallocator::Jemalloc)
+		.with_pprof_sample_rate_from_env(pprof_alloc::DEFAULT_PPROF_SAMPLE_RATE)
+		.with_stats();
 
-// Enable profiling, unless on musl due to https://github.com/tikv/jemallocator/issues/146
-#[cfg(not(target_env = "musl"))]
+#[cfg(feature = "jemalloc")]
+pprof_alloc::declare_allocator_kind!(pprof_alloc::allocator::AllocatorKind::Jemalloc);
+
+#[cfg(feature = "mimalloc")]
+#[global_allocator]
+static GLOBAL: pprof_alloc::PprofAlloc<mimalloc::MiMalloc> =
+	pprof_alloc::PprofAlloc::from_allocator(mimalloc::MiMalloc)
+		.with_pprof_sample_rate_from_env(pprof_alloc::DEFAULT_PPROF_SAMPLE_RATE)
+		.with_stats();
+
+#[cfg(feature = "mimalloc")]
+pprof_alloc::declare_allocator_kind!(pprof_alloc::allocator::AllocatorKind::Mimalloc);
+
 #[cfg(feature = "jemalloc")]
 #[allow(non_upper_case_globals)]
 #[unsafe(export_name = "malloc_conf")]
-pub static malloc_conf: &[u8] = b"prof:true,prof_active:true,lg_prof_sample:19\0";
+pub static malloc_conf: &[u8] = b"thp:never,background_thread:true,dirty_decay_ms:5000,muzzy_decay_ms:5000\0";
 
 #[derive(ClapArgs, Debug, Clone)]
 pub(crate) struct ConfigArgs {

--- a/crates/agentgateway-app/src/lib.rs
+++ b/crates/agentgateway-app/src/lib.rs
@@ -51,7 +51,8 @@ pprof_alloc::declare_allocator_kind!(pprof_alloc::allocator::AllocatorKind::Mima
 #[cfg(all(feature = "jemalloc", target_os = "linux"))]
 #[allow(non_upper_case_globals)]
 #[unsafe(export_name = "malloc_conf")]
-pub static malloc_conf: &[u8] = b"thp:never,background_thread:true,dirty_decay_ms:5000,muzzy_decay_ms:5000\0";
+pub static malloc_conf: &[u8] =
+	b"thp:never,background_thread:true,dirty_decay_ms:5000,muzzy_decay_ms:5000\0";
 
 #[derive(ClapArgs, Debug, Clone)]
 pub(crate) struct ConfigArgs {

--- a/crates/agentgateway-app/src/lib.rs
+++ b/crates/agentgateway-app/src/lib.rs
@@ -18,24 +18,24 @@ compile_error!(
 	"allocator features are mutually exclusive; enable exactly one of glibc, jemalloc, or mimalloc"
 );
 
-#[cfg(feature = "glibc")]
+#[cfg(any(feature = "glibc", all(feature = "jemalloc", not(target_os = "linux"))))]
 #[global_allocator]
 static GLOBAL: pprof_alloc::PprofAlloc<std::alloc::System> =
 	pprof_alloc::PprofAlloc::from_allocator(std::alloc::System)
 		.with_pprof_sample_rate_from_env(pprof_alloc::DEFAULT_PPROF_SAMPLE_RATE)
 		.with_stats();
 
-#[cfg(feature = "glibc")]
+#[cfg(any(feature = "glibc", all(feature = "jemalloc", not(target_os = "linux"))))]
 pprof_alloc::declare_allocator_kind!(pprof_alloc::allocator::AllocatorKind::Glibc);
 
-#[cfg(feature = "jemalloc")]
+#[cfg(all(feature = "jemalloc", target_os = "linux"))]
 #[global_allocator]
 static GLOBAL: pprof_alloc::PprofAlloc<tikv_jemallocator::Jemalloc> =
 	pprof_alloc::PprofAlloc::from_allocator(tikv_jemallocator::Jemalloc)
 		.with_pprof_sample_rate_from_env(pprof_alloc::DEFAULT_PPROF_SAMPLE_RATE)
 		.with_stats();
 
-#[cfg(feature = "jemalloc")]
+#[cfg(all(feature = "jemalloc", target_os = "linux"))]
 pprof_alloc::declare_allocator_kind!(pprof_alloc::allocator::AllocatorKind::Jemalloc);
 
 #[cfg(feature = "mimalloc")]
@@ -48,7 +48,7 @@ static GLOBAL: pprof_alloc::PprofAlloc<mimalloc::MiMalloc> =
 #[cfg(feature = "mimalloc")]
 pprof_alloc::declare_allocator_kind!(pprof_alloc::allocator::AllocatorKind::Mimalloc);
 
-#[cfg(feature = "jemalloc")]
+#[cfg(all(feature = "jemalloc", target_os = "linux"))]
 #[allow(non_upper_case_globals)]
 #[unsafe(export_name = "malloc_conf")]
 pub static malloc_conf: &[u8] = b"thp:never,background_thread:true,dirty_decay_ms:5000,muzzy_decay_ms:5000\0";

--- a/crates/agentgateway/Cargo.toml
+++ b/crates/agentgateway/Cargo.toml
@@ -11,14 +11,13 @@ path = "src/lib.rs"
 [features]
 default = []
 glibc = []
-jemalloc = ["pprof-alloc/allocator-jemalloc", "dep:tikv-jemallocator", "dep:jemalloc_pprof"]
+jemalloc = ["dep:tikv-jemallocator", "dep:jemalloc_pprof"]
 mimalloc = ["pprof-alloc/allocator-mimalloc", "dep:mimalloc"]
 ui = []
 schema = ["schemars"]
 internal_benches = ["divan"]
 
 [dependencies]
-pprof-alloc.workspace = true
 agent-core.workspace = true
 agent-celx.workspace = true
 agent-hbone.workspace = true
@@ -157,11 +156,13 @@ pprof.workspace = true
 which.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
+pprof-alloc = { workspace = true, features = ["allocator-jemalloc"] }
 tokio = { workspace = true, features = ["taskdump"] }
 tikv-jemallocator = { workspace = true, optional = true }
 jemalloc_pprof = { workspace = true, optional = true }
 
 [target.'cfg(not(target_os = "linux"))'.dependencies]
+pprof-alloc.workspace = true
 tokio = { workspace = true }
 
 [dev-dependencies]

--- a/crates/agentgateway/Cargo.toml
+++ b/crates/agentgateway/Cargo.toml
@@ -10,12 +10,15 @@ path = "src/lib.rs"
 
 [features]
 default = []
-jemalloc = ["dep:tikv-jemallocator", "dep:jemalloc_pprof"]
+glibc = []
+jemalloc = ["pprof-alloc/allocator-jemalloc", "dep:tikv-jemallocator", "dep:jemalloc_pprof"]
+mimalloc = ["pprof-alloc/allocator-mimalloc", "dep:mimalloc"]
 ui = []
 schema = ["schemars"]
 internal_benches = ["divan"]
 
 [dependencies]
+pprof-alloc.workspace = true
 agent-core.workspace = true
 agent-celx.workspace = true
 agent-hbone.workspace = true
@@ -126,6 +129,7 @@ sse-stream.workspace = true
 thiserror.workspace = true
 tiktoken-rs.workspace = true
 tikv-jemallocator = { workspace = true, optional = true }
+mimalloc = { workspace = true, optional = true }
 tokio-rustls.workspace = true
 tokio-stream.workspace = true
 tokio-util.workspace = true

--- a/crates/agentgateway/Cargo.toml
+++ b/crates/agentgateway/Cargo.toml
@@ -73,7 +73,6 @@ include_dir.workspace = true
 indexmap = { workspace = true }
 ipnet.workspace = true
 itertools.workspace = true
-jemalloc_pprof = { workspace = true, optional = true }
 jsonwebtoken.workspace = true
 lazy_static.workspace = true
 macro_rules_attribute.workspace = true
@@ -128,7 +127,6 @@ socket2.workspace = true
 sse-stream.workspace = true
 thiserror.workspace = true
 tiktoken-rs.workspace = true
-tikv-jemallocator = { workspace = true, optional = true }
 mimalloc = { workspace = true, optional = true }
 tokio-rustls.workspace = true
 tokio-stream.workspace = true
@@ -160,6 +158,8 @@ which.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 tokio = { workspace = true, features = ["taskdump"] }
+tikv-jemallocator = { workspace = true, optional = true }
+jemalloc_pprof = { workspace = true, optional = true }
 
 [target.'cfg(not(target_os = "linux"))'.dependencies]
 tokio = { workspace = true }

--- a/crates/agentgateway/src/app.rs
+++ b/crates/agentgateway/src/app.rs
@@ -49,6 +49,8 @@ pub async fn run(config: Arc<Config>) -> anyhow::Result<Bound> {
 	let sub_registry = metrics::sub_registry(&mut registry);
 	let xds_metrics = agent_xds::Metrics::new(sub_registry);
 	agent_core::metrics::TokioCollector::register(sub_registry, &data_plane_handle);
+	pprof_alloc::stats::cgroups::PrometheusCollector::register(sub_registry);
+	pprof_alloc::stats::smaps::PrometheusCollector::register(sub_registry);
 
 	// TODO: use for XDS
 	let control_client = client::Client::new(&config.dns, None, config.backend.clone(), None);

--- a/crates/agentgateway/src/management/admin.rs
+++ b/crates/agentgateway/src/management/admin.rs
@@ -133,8 +133,8 @@ impl Service {
 			match req.uri().path() {
 				#[cfg(target_os = "linux")]
 				"/debug/pprof/profile" => handle_pprof(req).await,
-				#[cfg(target_os = "linux")]
-				"/debug/pprof/heap" => handle_jemalloc_pprof_heapgen(req).await,
+				"/debug/pprof/heap" => handle_heap_pprof().await,
+				"/memory" => handle_memory().await,
 				"/quitquitquit" => Ok(
 					handle_server_shutdown(
 						state.shutdown_trigger.clone(),
@@ -179,8 +179,9 @@ async fn handle_dashboard(_req: Request<Incoming>) -> Response {
 		),
 		(
 			"debug/pprof/heap",
-			"collect heap profiling data (if supported, requires jmalloc)",
+			"collect heap profiling data (if supported)",
 		),
+		("memory", "dump allocator and process memory statistics"),
 		("quitquitquit", "shut down the server"),
 		("config_dump", "dump the current agentgateway configuration"),
 		("logging", "query/changing logging levels"),
@@ -469,26 +470,8 @@ fn change_log_level(reset: bool, level: &str) -> Response {
 	}
 }
 
-#[cfg(all(feature = "jemalloc", target_os = "linux"))]
-async fn handle_jemalloc_pprof_heapgen(_req: Request<Incoming>) -> anyhow::Result<Response> {
-	let Some(prof_ctrl) = jemalloc_pprof::PROF_CTL.as_ref() else {
-		return Ok(
-			::http::Response::builder()
-				.status(hyper::StatusCode::INTERNAL_SERVER_ERROR)
-				.body("jemalloc profiling is not enabled".into())
-				.expect("builder with known status code should not fail"),
-		);
-	};
-	let mut prof_ctl = prof_ctrl.lock().await;
-	if !prof_ctl.activated() {
-		return Ok(
-			::http::Response::builder()
-				.status(hyper::StatusCode::INTERNAL_SERVER_ERROR)
-				.body("jemalloc not enabled".into())
-				.expect("builder with known status code should not fail"),
-		);
-	}
-	let pprof = prof_ctl.dump_pprof()?;
+pub async fn handle_heap_pprof() -> anyhow::Result<Response> {
+	let pprof = pprof_alloc::generate_pprof()?;
 	Ok(
 		::http::Response::builder()
 			.status(hyper::StatusCode::OK)
@@ -497,12 +480,14 @@ async fn handle_jemalloc_pprof_heapgen(_req: Request<Incoming>) -> anyhow::Resul
 	)
 }
 
-#[cfg(all(not(feature = "jemalloc"), target_os = "linux"))]
-async fn handle_jemalloc_pprof_heapgen(_req: Request<Incoming>) -> anyhow::Result<Response> {
+pub async fn handle_memory() -> anyhow::Result<Response> {
+	let snap = pprof_alloc::snapshot();
+	let body = serde_json::to_string_pretty(&snap)?;
 	Ok(
 		::http::Response::builder()
-			.status(hyper::StatusCode::INTERNAL_SERVER_ERROR)
-			.body("jemalloc not enabled".into())
+			.status(hyper::StatusCode::OK)
+			.header(hyper::header::CONTENT_TYPE, "application/json")
+			.body(body.into())
 			.expect("builder with known status code should not fail"),
 	)
 }


### PR DESCRIPTION
Right now, we have no visibility into memory. We cannot get a pprof, we do not expose any info etc. We can opt into jemalloc but at the cost of absurd memory usage (like 100mb at rest on a big machine).

This PR flips this. We add the `pproc-alloc` crate, which gives increased visibility (stats for allocations, pprof support, cgroup/smaps reading, and prometheus export). Pprof is enabled by default with a sampling rate mirroring Golang's; I didn't see any performance overhead from this.

New debug endpoints: /debug/pprof/heap and /memory. The heap profile is a standard heap profile and includes inuse and allocs (like Go; unlike any other Rust ones). /memory is just a dump of all the memory we can extract.

Jemalloc is tuned. Profiling is disabled (as we no longer need it with our own profiling), and THP is disabled (which is shown to have massive impact on memory).

Benchmarking shows jemalloc dominating:
```
DEST           THROUGHPUT
istio-large    112031.37qps
jemalloc-large 142020.09qps # <--
glibc-large    114349.46qps
mimalloc-large 116839.96qps

istio-small    67772.52qps
jemalloc-small 96266.13qps  # <--
glibc-small    87639.24qps
mimalloc-small 88187.87qps

DEST           P50      P90      P99
istio-small    0.101ms  0.289ms  0.483ms
jemalloc-small 0.038ms  0.057ms  0.152ms # <--
glibc-small    0.041ms  0.190ms  0.395ms
mimalloc-small 0.039ms  0.083ms  0.227ms

istio-large    0.083ms  0.148ms  0.274ms
jemalloc-large 0.047ms  0.076ms  0.135ms # <--
glibc-large    0.049ms  0.085ms  0.153ms
mimalloc-large 0.048ms  0.082ms  0.138ms
```
(small: 2 core; large: 8 core).

Additionally, we see a marginal amount of increased memory in some cases, but substantially better ability to free memory. Note mimalloc is also pretty decent at freeing memory, but I found the performance inconsistent in ways that didn't make me feel comfortable making it a default (despite it being what I was biased towards).

**At rest** jemalloc uses slightly more memory than others but not too bad
<img width="1879" height="766" alt="2026-04-29_14-52-13" src="https://github.com/user-attachments/assets/b7ea1751-6897-4fb9-b563-5a5c10707494" />

---

**After load** jemalloc recovers memory quite a bit better
<img width="1864" height="742" alt="2026-04-29_14-51-54" src="https://github.com/user-attachments/assets/e64832cc-5922-4fb9-922f-81794775a4c5" />


---

**After super high load** this is more exaggerated. Here I added Istio in as well; you can see neither Istio nor AGW (before this PR) free any memory at all
<img width="1873" height="772" alt="2026-04-29_14-51-31" src="https://github.com/user-attachments/assets/94c9e0d8-1a52-43f4-bf0f-9218739264f0" />
