### PR TITLE
update tracing endpoint support for grpc

### DIFF
--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -212,14 +212,17 @@ fn merge_deprecated_frontend_policies(
 			Vec::new()
 		};
 		if let Some(ep) = endpoint {
-			// Strip the scheme (http:// or https://) from the endpoint URL to get host:port
+			// Strip the scheme (http://, https://), or grpc://) from the endpoint URL to get host:port
 			let host_port = ep
 				.strip_prefix("http://")
 				.or_else(|| ep.strip_prefix("https://"))
 				.or_else(|| ep.strip_prefix("grpc://"))
 				.unwrap_or(&ep);
 			frontend_policies.tracing = Some(TracingConfig {
-				provider_backend: SimpleBackendReference::InlineBackend(Target::try_from(host_port).with_context(|| format!("failed parsing tracing endpoint: {}", ep))?),
+				provider_backend: SimpleBackendReference::InlineBackend(
+					Target::try_from(host_port)
+						.with_context(|| format!("failed parsing tracing endpoint: {}", ep))?,
+				),
 				policies,
 				attributes: Arc::unwrap_or_clone(fields.add),
 				resources: Default::default(), // Not supported in the old config

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use ::http::Uri;
 use agent_core::prelude::Strng;
-use anyhow::{Error, anyhow, bail};
+use anyhow::{Context, Error, anyhow, bail};
 use bytes::Bytes;
 use frozen_collections::Len;
 use itertools::Itertools;
@@ -216,9 +216,10 @@ fn merge_deprecated_frontend_policies(
 			let host_port = ep
 				.strip_prefix("http://")
 				.or_else(|| ep.strip_prefix("https://"))
+				.or_else(|| ep.strip_prefix("grpc://"))
 				.unwrap_or(&ep);
 			frontend_policies.tracing = Some(TracingConfig {
-				provider_backend: SimpleBackendReference::InlineBackend(Target::try_from(host_port)?),
+				provider_backend: SimpleBackendReference::InlineBackend(Target::try_from(host_port).with_context(|| format!("failed parsing tracing endpoint: {}", ep))?),
 				policies,
 				attributes: Arc::unwrap_or_clone(fields.add),
 				resources: Default::default(), // Not supported in the old config

--- a/crates/agentgateway/src/types/local_tests.rs
+++ b/crates/agentgateway/src/types/local_tests.rs
@@ -420,6 +420,30 @@ config:
 	assert_eq!(tracing.get("protocol").unwrap(), "http");
 }
 
+#[rstest::rstest]
+#[case::https_scheme("https://tracing.example.com:4318", "http", "tracing.example.com:4318")]
+#[case::http_scheme("http://tracing.example.com:4318", "http", "tracing.example.com:4318")]
+#[case::grpc_scheme("grpc://tracing.example.com:4317", "grpc", "tracing.example.com:4317")]
+#[case::no_scheme("tracing.example.com:4317", "grpc", "tracing.example.com:4317")]
+fn test_deprecated_tracing_endpoint_schemes(#[case] endpoint: &str, #[case] protocol: &str, #[case] expected: &str) {
+	let input = format!("config:\n  tracing:\n    otlpEndpoint: {endpoint}\n    otlpProtocol: {protocol}\n");
+	let out = super::migrate_deprecated_local_config(&input).unwrap();
+	let v: serde_json::Value = crate::serdes::yamlviajson::from_str(&out).unwrap();
+	let tracing = v.get("frontendPolicies").unwrap().get("tracing").unwrap();
+	assert_eq!(tracing.get("inlineBackend").unwrap(), expected);
+}
+
+
+#[rstest::rstest]
+#[case::unrecognized_scheme("nateisgreat://tracing.example.com:4317")]
+fn test_deprecated_tracing_endpoint_unrecognized_scheme_error(#[case] endpoint: &str) {
+	let input = format!("config:\n  tracing:\n    otlpEndpoint: {endpoint}\n    otlpProtocol: grpc\n");
+	let err = super::migrate_deprecated_local_config(&input).unwrap_err().to_string();
+	assert!(err.contains("tracing"), "error message should mention 'tracing': {err}");
+	assert!(err.contains("failed"), "error message should mention 'failed': {err}");
+	assert!(err.contains(endpoint), "error message should include the invalid endpoint: {err}");
+}
+
 #[tokio::test]
 async fn test_targeted_gateway_phase_oidc_accepts_gateway_and_listener_targets() {
 	for target in [

--- a/crates/agentgateway/src/types/local_tests.rs
+++ b/crates/agentgateway/src/types/local_tests.rs
@@ -425,23 +425,39 @@ config:
 #[case::http_scheme("http://tracing.example.com:4318", "http", "tracing.example.com:4318")]
 #[case::grpc_scheme("grpc://tracing.example.com:4317", "grpc", "tracing.example.com:4317")]
 #[case::no_scheme("tracing.example.com:4317", "grpc", "tracing.example.com:4317")]
-fn test_deprecated_tracing_endpoint_schemes(#[case] endpoint: &str, #[case] protocol: &str, #[case] expected: &str) {
-	let input = format!("config:\n  tracing:\n    otlpEndpoint: {endpoint}\n    otlpProtocol: {protocol}\n");
+fn test_deprecated_tracing_endpoint_schemes(
+	#[case] endpoint: &str,
+	#[case] protocol: &str,
+	#[case] expected: &str,
+) {
+	let input =
+		format!("config:\n  tracing:\n    otlpEndpoint: {endpoint}\n    otlpProtocol: {protocol}\n");
 	let out = super::migrate_deprecated_local_config(&input).unwrap();
 	let v: serde_json::Value = crate::serdes::yamlviajson::from_str(&out).unwrap();
 	let tracing = v.get("frontendPolicies").unwrap().get("tracing").unwrap();
 	assert_eq!(tracing.get("inlineBackend").unwrap(), expected);
 }
 
-
 #[rstest::rstest]
 #[case::unrecognized_scheme("nateisgreat://tracing.example.com:4317")]
 fn test_deprecated_tracing_endpoint_unrecognized_scheme_error(#[case] endpoint: &str) {
-	let input = format!("config:\n  tracing:\n    otlpEndpoint: {endpoint}\n    otlpProtocol: grpc\n");
-	let err = super::migrate_deprecated_local_config(&input).unwrap_err().to_string();
-	assert!(err.contains("tracing"), "error message should mention 'tracing': {err}");
-	assert!(err.contains("failed"), "error message should mention 'failed': {err}");
-	assert!(err.contains(endpoint), "error message should include the invalid endpoint: {err}");
+	let input =
+		format!("config:\n  tracing:\n    otlpEndpoint: {endpoint}\n    otlpProtocol: grpc\n");
+	let err = super::migrate_deprecated_local_config(&input)
+		.unwrap_err()
+		.to_string();
+	assert!(
+		err.contains("tracing"),
+		"error message should mention 'tracing': {err}"
+	);
+	assert!(
+		err.contains("failed"),
+		"error message should mention 'failed': {err}"
+	);
+	assert!(
+		err.contains(endpoint),
+		"error message should include the invalid endpoint: {err}"
+	);
 }
 
 #[tokio::test]


### PR DESCRIPTION
We had a problem with grpc:// as a start to a tracing endpoint
workaround was to just remove that but keep the protocol

Now we support this prefix and have slightly more informative errors for other unsupported starts.

Note this is an attempt to keep the change as small as possible and to use rstest as much as makes sense.