### PR TITLE
fix: implement AgentgatewayPolicy targeting for ListenerSet

### DIFF
--- a/controller/pkg/agentgateway/plugins/reference_indexes.go
+++ b/controller/pkg/agentgateway/plugins/reference_indexes.go
@@ -79,6 +79,16 @@ func DefaultReferenceTypes(agw *AgwCollections) ReferenceTypes {
 				return []*api.PolicyTarget{{
 					Kind: utils.RouteTarget(namespace, string(name), wellknown.GRPCRouteGVK.Kind, sectionName),
 				}}, ResourceExists(krtctx, agw.GRPCRoutes, key)
+			case wellknown.ListenerSetGVK.GroupKind():
+				ls := ptr.Flatten(krt.FetchOne(krtctx, agw.ListenerSets, krt.FilterKey(key)))
+				if ls == nil {
+					return nil, false
+				}
+				parentNs := string(ptr.OrDefault(ls.Spec.ParentRef.Namespace, gwv1.Namespace(ls.Namespace)))
+				parentName := string(ls.Spec.ParentRef.Name)
+				return []*api.PolicyTarget{{
+					Kind: utils.GatewayTarget(parentNs, parentName, sectionName),
+				}}, true
 			case wellknown.AgentgatewayBackendGVK.GroupKind():
 				return []*api.PolicyTarget{{
 					Kind: utils.BackendTarget(namespace, string(name), sectionName),
@@ -119,7 +129,12 @@ func DefaultReferenceTypes(agw *AgwCollections) ReferenceTypes {
 				}
 			case wellknown.ListenerSetGVK.GroupKind():
 				for _, ls := range krt.Fetch(krtctx, agw.ListenerSets, krt.FilterLabel(selector.MatchLabels), krt.FilterIndex(agw.ListenerSetsByNamespace, policyNamespace)) {
-					targets = append(targets, ResolvedPolicySelectorTarget{Name: gwv1.ObjectName(ls.Name), Namespace: ls.Namespace})
+					parentNs := string(ptr.OrDefault(ls.Spec.ParentRef.Namespace, gwv1.Namespace(ls.Namespace)))
+					parentName := string(ls.Spec.ParentRef.Name)
+					policyTargets := []*api.PolicyTarget{{
+						Kind: utils.GatewayTarget(parentNs, parentName, sectionName),
+					}}
+					targets = append(targets, ResolvedPolicySelectorTarget{Name: gwv1.ObjectName(ls.Name), Namespace: ls.Namespace, PolicyTargets: policyTargets})
 				}
 			case wellknown.AgentgatewayBackendGVK.GroupKind():
 				for _, backend := range krt.Fetch(krtctx, agw.Backends, krt.FilterLabel(selector.MatchLabels), krt.FilterIndex(agw.BackendsByNamespace, policyNamespace)) {
@@ -345,8 +360,9 @@ type ReferenceIndex struct {
 	PolicyAttachments krt.IndexCollection[utils.TypedNamespacedName, *PolicyAttachment]
 	// Route --> Gateway
 	attachments krt.IndexCollection[utils.TypedNamespacedName, *RouteAttachment]
+	// ListenerSet --> Gateway
+	listenerSetAttachments krt.IndexCollection[utils.TypedNamespacedName, *RouteAttachment]
 	// Gateway --> Gateway: trivial, no collection needed
-	// ListenerSet --> Gateway: NOT present; ListenerSet attachment not implemented (but really should be!) in AgentgatewayPolicy anyways
 
 	explicitReferences ReferenceTypes
 }
@@ -356,6 +372,14 @@ func (p ReferenceIndex) LookupGatewaysForTarget(ctx krt.HandlerContext, object u
 	case wellknown.GatewayGVK.Kind:
 		// Trivial case
 		return sets.New(object.NamespacedName)
+	case wellknown.ListenerSetGVK.Kind:
+		gateways := sets.New[types.NamespacedName]()
+		if p.listenerSetAttachments != nil {
+			for _, attachment := range krtutil.FetchIndexObjects(ctx, p.listenerSetAttachments, object) {
+				gateways.Insert(attachment.Gateway)
+			}
+		}
+		return gateways
 	case wellknown.HTTPRouteGVK.Kind, wellknown.GRPCRouteGVK.Kind, wellknown.TCPRouteGVK.Kind, wellknown.TLSRouteGVK.Kind:
 		gateways := sets.New[types.NamespacedName]()
 		for _, ancestor := range krtutil.FetchIndexObjects(ctx, p.attachments, object) {
@@ -407,6 +431,11 @@ func (p ReferenceIndex) LookupGatewaysForPolicyTarget(ctx krt.HandlerContext, ob
 
 func (p ReferenceIndex) WithPolicyAttachments(references krt.IndexCollection[utils.TypedNamespacedName, *PolicyAttachment]) ReferenceIndex {
 	p.PolicyAttachments = references
+	return p
+}
+
+func (p ReferenceIndex) WithListenerSetAttachments(lsa krt.IndexCollection[utils.TypedNamespacedName, *RouteAttachment]) ReferenceIndex {
+	p.listenerSetAttachments = lsa
 	return p
 }
 

--- a/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/listenerset-selector.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/listenerset-selector.yaml
@@ -1,0 +1,49 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: selector-gw
+  namespace: default
+spec:
+  gatewayClassName: agentgateway
+  allowedListeners:
+    namespaces:
+      from: All
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: labeled-ls
+  namespace: default
+  labels:
+    env: staging
+spec:
+  parentRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: selector-gw
+  listeners:
+  - name: extra
+    protocol: HTTP
+    port: 9090
+    allowedRoutes:
+      namespaces:
+        from: All
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: ls-selector-policy
+  namespace: default
+spec:
+  targetSelectors:
+  - kind: ListenerSet
+    group: gateway.networking.k8s.io
+    matchLabels:
+      env: staging
+  traffic:
+    timeouts:
+      request: 30s

--- a/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/listenerset-selector.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/listenerset-selector.yaml
@@ -47,3 +47,50 @@ spec:
   traffic:
     timeouts:
       request: 30s
+
+---
+# Output
+output:
+- gateway:
+    Name: selector-gw
+    Namespace: default
+  resource:
+    policy:
+      key: traffic/default/ls-selector-policy:timeout:default/selector-gw
+      name:
+        kind: AgentgatewayPolicy
+        name: ls-selector-policy
+        namespace: default
+      target:
+        gateway:
+          name: selector-gw
+          namespace: default
+      traffic:
+        timeout:
+          request: 30s
+status:
+- apiVersion: agentgateway.dev/v1alpha1
+  kind: AgentgatewayPolicy
+  metadata:
+    name: ls-selector-policy
+    namespace: default
+  spec: null
+  status:
+    ancestors:
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: selector-gw
+        namespace: default
+      conditions:
+      - lastTransitionTime: fake
+        message: Policy accepted
+        reason: Valid
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: Attached to all targets
+        reason: Attached
+        status: "True"
+        type: Attached
+      controllerName: agentgateway.dev/agentgateway

--- a/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/listenerset-targetref.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/listenerset-targetref.yaml
@@ -1,0 +1,46 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: listenerset-gw
+  namespace: default
+spec:
+  gatewayClassName: agentgateway
+  allowedListeners:
+    namespaces:
+      from: All
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: my-listenerset
+  namespace: default
+spec:
+  parentRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: listenerset-gw
+  listeners:
+  - name: extra
+    protocol: HTTP
+    port: 9090
+    allowedRoutes:
+      namespaces:
+        from: All
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: ls-targetref-policy
+  namespace: default
+spec:
+  targetRefs:
+  - kind: ListenerSet
+    group: gateway.networking.k8s.io
+    name: my-listenerset
+  traffic:
+    timeouts:
+      request: 15s

--- a/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/listenerset-targetref.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/listenerset-targetref.yaml
@@ -44,3 +44,50 @@ spec:
   traffic:
     timeouts:
       request: 15s
+
+---
+# Output
+output:
+- gateway:
+    Name: listenerset-gw
+    Namespace: default
+  resource:
+    policy:
+      key: traffic/default/ls-targetref-policy:timeout:default/listenerset-gw
+      name:
+        kind: AgentgatewayPolicy
+        name: ls-targetref-policy
+        namespace: default
+      target:
+        gateway:
+          name: listenerset-gw
+          namespace: default
+      traffic:
+        timeout:
+          request: 15s
+status:
+- apiVersion: agentgateway.dev/v1alpha1
+  kind: AgentgatewayPolicy
+  metadata:
+    name: ls-targetref-policy
+    namespace: default
+  spec: null
+  status:
+    ancestors:
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: listenerset-gw
+        namespace: default
+      conditions:
+      - lastTransitionTime: fake
+        message: Policy accepted
+        reason: Valid
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: Attached to all targets
+        reason: Attached
+        status: "True"
+        type: Attached
+      controllerName: agentgateway.dev/agentgateway

--- a/controller/pkg/syncer/syncer.go
+++ b/controller/pkg/syncer/syncer.go
@@ -507,6 +507,26 @@ func (s *Syncer) buildAgwResources(gateways krt.Collection[*translator.GatewayLi
 
 	referenceIndex := plugins.BuildReferenceIndex(ancestorCollection, routeAttachmentsIndex, referenceTypes)
 
+	lsAttachments := krt.NewManyCollection(s.agwCollections.ListenerSets, func(_ krt.HandlerContext, ls *gwv1.ListenerSet) []*plugins.RouteAttachment {
+		parentNs := string(ptr.OrDefault(ls.Spec.ParentRef.Namespace, gwv1.Namespace(ls.Namespace)))
+		gw := types.NamespacedName{Namespace: parentNs, Name: string(ls.Spec.ParentRef.Name)}
+		return []*plugins.RouteAttachment{{
+			From: utils.TypedNamespacedName{
+				Kind:           wellknown.ListenerSetGVK.Kind,
+				NamespacedName: types.NamespacedName{Namespace: ls.GetNamespace(), Name: ls.GetName()},
+			},
+			To: utils.TypedNamespacedName{
+				Kind:           wellknown.GatewayGVK.Kind,
+				NamespacedName: gw,
+			},
+			Gateway: gw,
+		}}
+	}, krtopts.ToOptions("ListenerSetAttachmentsSource")...)
+	lsAttachmentsIdx := krt.NewIndex(lsAttachments, "ls-from", func(o *plugins.RouteAttachment) []utils.TypedNamespacedName {
+		return []utils.TypedNamespacedName{o.From}
+	}).AsCollection(append(krtopts.ToOptions("ListenerSetAttachments"), utils.TypedNamespacedNameIndexCollectionFunc)...)
+	referenceIndex = referenceIndex.WithListenerSetAttachments(lsAttachmentsIdx)
+
 	// Phase 1: Collect policy references (e.g. ext_proc backendRefs) BEFORE building
 	// policies. This ensures BackendTLSPolicy can look up gateways for backends that
 	// are only reachable via PolicyAttachments (like ext_proc processor Services).


### PR DESCRIPTION
Fixes #1701

## Summary

- Add `ListenerSet` case to `PolicyTargets` closure in `DefaultReferenceTypes` — resolves a `targetRef` to a ListenerSet by reading `spec.parentRef` and returning a `GatewayTarget` for the parent Gateway
- Fix `PolicyTargetsBySelector` ListenerSet case — was appending an empty `PolicyTargets` slice, causing the policy to be silently dropped; now populates it with the parent `GatewayTarget`
- Add `listenerSetAttachments` index field to `ReferenceIndex` + `WithListenerSetAttachments` method + `ListenerSet` case in `LookupGatewaysForTarget` (with nil guard matching the existing `PolicyAttachments` pattern)
- Build a krt reactive collection in `syncer.go` over `agwCollections.ListenerSets` mapping each ListenerSet to its parent Gateway, indexed by the ListenerSet's `TypedNamespacedName`, and wire it into `referenceIndex`

A `ListenerSet` has no independent data-plane identity — it delegates to a parent Gateway via `spec.parentRef`. The fix resolves this delegation at policy-attachment time so the policy is correctly applied to the parent Gateway.

## Test Plan

- [ ] Two new golden tests added: `testdata/trafficpolicy/listenerset-targetref.yaml` (explicit `targetRefs`) and `testdata/trafficpolicy/listenerset-selector.yaml` (`targetSelectors` with label matching)
- [ ] Both tests confirm the policy resolves to the parent Gateway (not the ListenerSet) with `Accepted: True` and `Attached: True` status
- [ ] All existing `TestTrafficPolicies` golden tests continue to pass