### PR TITLE
fix: implement ListenerSet policy targeting via per-listener fan-out

### DIFF
--- a/controller/pkg/agentgateway/plugins/reference_indexes.go
+++ b/controller/pkg/agentgateway/plugins/reference_indexes.go
@@ -86,7 +86,7 @@ func DefaultReferenceTypes(agw *AgwCollections) ReferenceTypes {
 				}
 				parentNs := string(ptr.OrDefault(ls.Spec.ParentRef.Namespace, gwv1.Namespace(ls.Namespace)))
 				parentName := string(ls.Spec.ParentRef.Name)
-				if sectionName != nil {
+				if sectionName != nil && *sectionName != "" {
 					// Caller named a specific listener within the set.
 					return []*api.PolicyTarget{{
 						Kind: utils.GatewayTarget(parentNs, parentName, sectionName),
@@ -144,7 +144,7 @@ func DefaultReferenceTypes(agw *AgwCollections) ReferenceTypes {
 					parentNs := string(ptr.OrDefault(ls.Spec.ParentRef.Namespace, gwv1.Namespace(ls.Namespace)))
 					parentName := string(ls.Spec.ParentRef.Name)
 					var policyTargets []*api.PolicyTarget
-					if sectionName != nil {
+					if sectionName != nil && *sectionName != "" {
 						policyTargets = []*api.PolicyTarget{{
 							Kind: utils.GatewayTarget(parentNs, parentName, sectionName),
 						}}

--- a/controller/pkg/agentgateway/plugins/reference_indexes.go
+++ b/controller/pkg/agentgateway/plugins/reference_indexes.go
@@ -79,6 +79,28 @@ func DefaultReferenceTypes(agw *AgwCollections) ReferenceTypes {
 				return []*api.PolicyTarget{{
 					Kind: utils.RouteTarget(namespace, string(name), wellknown.GRPCRouteGVK.Kind, sectionName),
 				}}, ResourceExists(krtctx, agw.GRPCRoutes, key)
+			case wellknown.ListenerSetGVK.GroupKind():
+				ls := ptr.Flatten(krt.FetchOne(krtctx, agw.ListenerSets, krt.FilterKey(key)))
+				if ls == nil {
+					return nil, false
+				}
+				parentNs := string(ptr.OrDefault(ls.Spec.ParentRef.Namespace, gwv1.Namespace(ls.Namespace)))
+				parentName := string(ls.Spec.ParentRef.Name)
+				if sectionName != nil {
+					// Caller named a specific listener within the set.
+					return []*api.PolicyTarget{{
+						Kind: utils.GatewayTarget(parentNs, parentName, sectionName),
+					}}, true
+				}
+				// Fan out: one GatewayTarget per listener in the set.
+				var targets []*api.PolicyTarget
+				for _, l := range ls.Spec.Listeners {
+					ln := l.Name // copy to avoid loop-variable aliasing
+					targets = append(targets, &api.PolicyTarget{
+						Kind: utils.GatewayTarget(parentNs, parentName, &ln),
+					})
+				}
+				return targets, true
 			case wellknown.AgentgatewayBackendGVK.GroupKind():
 				return []*api.PolicyTarget{{
 					Kind: utils.BackendTarget(namespace, string(name), sectionName),
@@ -119,7 +141,26 @@ func DefaultReferenceTypes(agw *AgwCollections) ReferenceTypes {
 				}
 			case wellknown.ListenerSetGVK.GroupKind():
 				for _, ls := range krt.Fetch(krtctx, agw.ListenerSets, krt.FilterLabel(selector.MatchLabels), krt.FilterIndex(agw.ListenerSetsByNamespace, policyNamespace)) {
-					targets = append(targets, ResolvedPolicySelectorTarget{Name: gwv1.ObjectName(ls.Name), Namespace: ls.Namespace})
+					parentNs := string(ptr.OrDefault(ls.Spec.ParentRef.Namespace, gwv1.Namespace(ls.Namespace)))
+					parentName := string(ls.Spec.ParentRef.Name)
+					var policyTargets []*api.PolicyTarget
+					if sectionName != nil {
+						policyTargets = []*api.PolicyTarget{{
+							Kind: utils.GatewayTarget(parentNs, parentName, sectionName),
+						}}
+					} else {
+						for _, l := range ls.Spec.Listeners {
+							ln := l.Name
+							policyTargets = append(policyTargets, &api.PolicyTarget{
+								Kind: utils.GatewayTarget(parentNs, parentName, &ln),
+							})
+						}
+					}
+					targets = append(targets, ResolvedPolicySelectorTarget{
+						Name:          gwv1.ObjectName(ls.Name),
+						Namespace:     ls.Namespace,
+						PolicyTargets: policyTargets,
+					})
 				}
 			case wellknown.AgentgatewayBackendGVK.GroupKind():
 				for _, backend := range krt.Fetch(krtctx, agw.Backends, krt.FilterLabel(selector.MatchLabels), krt.FilterIndex(agw.BackendsByNamespace, policyNamespace)) {
@@ -345,8 +386,9 @@ type ReferenceIndex struct {
 	PolicyAttachments krt.IndexCollection[utils.TypedNamespacedName, *PolicyAttachment]
 	// Route --> Gateway
 	attachments krt.IndexCollection[utils.TypedNamespacedName, *RouteAttachment]
+	// ListenerSet --> Gateway
+	listenerSetAttachments krt.IndexCollection[utils.TypedNamespacedName, *RouteAttachment]
 	// Gateway --> Gateway: trivial, no collection needed
-	// ListenerSet --> Gateway: NOT present; ListenerSet attachment not implemented (but really should be!) in AgentgatewayPolicy anyways
 
 	explicitReferences ReferenceTypes
 }
@@ -356,6 +398,15 @@ func (p ReferenceIndex) LookupGatewaysForTarget(ctx krt.HandlerContext, object u
 	case wellknown.GatewayGVK.Kind:
 		// Trivial case
 		return sets.New(object.NamespacedName)
+	case wellknown.ListenerSetGVK.Kind:
+		if p.listenerSetAttachments == nil {
+			return sets.New[types.NamespacedName]()
+		}
+		gateways := sets.New[types.NamespacedName]()
+		for _, attachment := range krtutil.FetchIndexObjects(ctx, p.listenerSetAttachments, object) {
+			gateways.Insert(attachment.Gateway)
+		}
+		return gateways
 	case wellknown.HTTPRouteGVK.Kind, wellknown.GRPCRouteGVK.Kind, wellknown.TCPRouteGVK.Kind, wellknown.TLSRouteGVK.Kind:
 		gateways := sets.New[types.NamespacedName]()
 		for _, ancestor := range krtutil.FetchIndexObjects(ctx, p.attachments, object) {
@@ -407,6 +458,11 @@ func (p ReferenceIndex) LookupGatewaysForPolicyTarget(ctx krt.HandlerContext, ob
 
 func (p ReferenceIndex) WithPolicyAttachments(references krt.IndexCollection[utils.TypedNamespacedName, *PolicyAttachment]) ReferenceIndex {
 	p.PolicyAttachments = references
+	return p
+}
+
+func (p ReferenceIndex) WithListenerSetAttachments(lsa krt.IndexCollection[utils.TypedNamespacedName, *RouteAttachment]) ReferenceIndex {
+	p.listenerSetAttachments = lsa
 	return p
 }
 

--- a/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/listenerset-selector.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/listenerset-selector.yaml
@@ -1,0 +1,49 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: selector-gw
+  namespace: default
+spec:
+  gatewayClassName: agentgateway
+  allowedListeners:
+    namespaces:
+      from: All
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: labeled-ls
+  namespace: default
+  labels:
+    env: staging
+spec:
+  parentRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: selector-gw
+  listeners:
+  - name: extra
+    protocol: HTTP
+    port: 9090
+    allowedRoutes:
+      namespaces:
+        from: All
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: ls-selector-policy
+  namespace: default
+spec:
+  targetSelectors:
+  - kind: ListenerSet
+    group: gateway.networking.k8s.io
+    matchLabels:
+      env: staging
+  traffic:
+    timeouts:
+      request: 30s

--- a/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/listenerset-selector.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/listenerset-selector.yaml
@@ -47,3 +47,51 @@ spec:
   traffic:
     timeouts:
       request: 30s
+
+---
+# Output
+output:
+- gateway:
+    Name: selector-gw
+    Namespace: default
+  resource:
+    policy:
+      key: traffic/default/ls-selector-policy:timeout:default/selector-gw/extra
+      name:
+        kind: AgentgatewayPolicy
+        name: ls-selector-policy
+        namespace: default
+      target:
+        gateway:
+          listener: extra
+          name: selector-gw
+          namespace: default
+      traffic:
+        timeout:
+          request: 30s
+status:
+- apiVersion: agentgateway.dev/v1alpha1
+  kind: AgentgatewayPolicy
+  metadata:
+    name: ls-selector-policy
+    namespace: default
+  spec: null
+  status:
+    ancestors:
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: selector-gw
+        namespace: default
+      conditions:
+      - lastTransitionTime: fake
+        message: Policy accepted
+        reason: Valid
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: Attached to all targets
+        reason: Attached
+        status: "True"
+        type: Attached
+      controllerName: agentgateway.dev/agentgateway

--- a/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/listenerset-targetref.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/listenerset-targetref.yaml
@@ -1,0 +1,46 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: listenerset-gw
+  namespace: default
+spec:
+  gatewayClassName: agentgateway
+  allowedListeners:
+    namespaces:
+      from: All
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: my-listenerset
+  namespace: default
+spec:
+  parentRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: listenerset-gw
+  listeners:
+  - name: extra
+    protocol: HTTP
+    port: 9090
+    allowedRoutes:
+      namespaces:
+        from: All
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: ls-targetref-policy
+  namespace: default
+spec:
+  targetRefs:
+  - kind: ListenerSet
+    group: gateway.networking.k8s.io
+    name: my-listenerset
+  traffic:
+    timeouts:
+      request: 15s

--- a/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/listenerset-targetref.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/listenerset-targetref.yaml
@@ -44,3 +44,51 @@ spec:
   traffic:
     timeouts:
       request: 15s
+
+---
+# Output
+output:
+- gateway:
+    Name: listenerset-gw
+    Namespace: default
+  resource:
+    policy:
+      key: traffic/default/ls-targetref-policy:timeout:default/listenerset-gw/extra
+      name:
+        kind: AgentgatewayPolicy
+        name: ls-targetref-policy
+        namespace: default
+      target:
+        gateway:
+          listener: extra
+          name: listenerset-gw
+          namespace: default
+      traffic:
+        timeout:
+          request: 15s
+status:
+- apiVersion: agentgateway.dev/v1alpha1
+  kind: AgentgatewayPolicy
+  metadata:
+    name: ls-targetref-policy
+    namespace: default
+  spec: null
+  status:
+    ancestors:
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: listenerset-gw
+        namespace: default
+      conditions:
+      - lastTransitionTime: fake
+        message: Policy accepted
+        reason: Valid
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: Attached to all targets
+        reason: Attached
+        status: "True"
+        type: Attached
+      controllerName: agentgateway.dev/agentgateway

--- a/controller/pkg/syncer/syncer.go
+++ b/controller/pkg/syncer/syncer.go
@@ -507,6 +507,30 @@ func (s *Syncer) buildAgwResources(gateways krt.Collection[*translator.GatewayLi
 
 	referenceIndex := plugins.BuildReferenceIndex(ancestorCollection, routeAttachmentsIndex, referenceTypes)
 
+	// Build ListenerSet → Gateway index so policies targeting a ListenerSet can
+	// be delivered to the correct xDS Gateway.
+	// Use NewManyCollection (TransformationMulti) so the element type is *plugins.RouteAttachment,
+	// matching the IndexCollection[..., *RouteAttachment] expected by WithListenerSetAttachments.
+	lsAttachmentsSrc := krt.NewManyCollection(s.agwCollections.ListenerSets, func(_ krt.HandlerContext, ls *gwv1.ListenerSet) []*plugins.RouteAttachment {
+		parentNs := string(ptr.OrDefault(ls.Spec.ParentRef.Namespace, gwv1.Namespace(ls.Namespace)))
+		gw := types.NamespacedName{Namespace: parentNs, Name: string(ls.Spec.ParentRef.Name)}
+		return []*plugins.RouteAttachment{{
+			From: utils.TypedNamespacedName{
+				Kind:           wellknown.ListenerSetGVK.Kind,
+				NamespacedName: types.NamespacedName{Namespace: ls.GetNamespace(), Name: ls.GetName()},
+			},
+			To: utils.TypedNamespacedName{
+				Kind:           wellknown.GatewayGVK.Kind,
+				NamespacedName: gw,
+			},
+			Gateway: gw,
+		}}
+	}, krtopts.ToOptions("ListenerSetAttachmentsSrc")...)
+	lsAttachmentsIdx := krt.NewIndex(lsAttachmentsSrc, "ls-from", func(o *plugins.RouteAttachment) []utils.TypedNamespacedName {
+		return []utils.TypedNamespacedName{o.From}
+	}).AsCollection(append(krtopts.ToOptions("ListenerSetAttachments"), utils.TypedNamespacedNameIndexCollectionFunc)...)
+	referenceIndex = referenceIndex.WithListenerSetAttachments(lsAttachmentsIdx)
+
 	// Phase 1: Collect policy references (e.g. ext_proc backendRefs) BEFORE building
 	// policies. This ensures BackendTLSPolicy can look up gateways for backends that
 	// are only reachable via PolicyAttachments (like ext_proc processor Services).

--- a/controller/pkg/syncer/syncer.go
+++ b/controller/pkg/syncer/syncer.go
@@ -512,6 +512,15 @@ func (s *Syncer) buildAgwResources(gateways krt.Collection[*translator.GatewayLi
 	// Use NewManyCollection (TransformationMulti) so the element type is *plugins.RouteAttachment,
 	// matching the IndexCollection[..., *RouteAttachment] expected by WithListenerSetAttachments.
 	lsAttachmentsSrc := krt.NewManyCollection(s.agwCollections.ListenerSets, func(_ krt.HandlerContext, ls *gwv1.ListenerSet) []*plugins.RouteAttachment {
+		p := ls.Spec.ParentRef
+		// Only process ListenerSets whose ParentRef resolves to a Gateway.
+		// This mirrors the filter in translator.ListenerSetBuilder.
+		if translator.NormalizeReference(p.Group, p.Kind, wellknown.GatewayGVK) != wellknown.GatewayGVK {
+			return nil
+		}
+		if p.Name == "" {
+			return nil
+		}
 		parentNs := string(ptr.OrDefault(ls.Spec.ParentRef.Namespace, gwv1.Namespace(ls.Namespace)))
 		gw := types.NamespacedName{Namespace: parentNs, Name: string(ls.Spec.ParentRef.Name)}
 		return []*plugins.RouteAttachment{{


### PR DESCRIPTION
## Summary

Closes #1701

`AgentgatewayPolicy` `targetRefs` and `targetSelectors` silently ignored `ListenerSet` targets — the policy was never attached. This PR implements correct ListenerSet targeting using per-listener fan-out.

**What changes:**

- `PolicyTargets` (`reference_indexes.go`): adds a `ListenerSet` case that enumerates `ls.Spec.Listeners` and returns one `GatewayTarget{Listener: listenerName}` per listener. If `sectionName` is set (and non-empty), targets only that listener.
- `PolicyTargetsBySelector` (`reference_indexes.go`): replaces the existing stub (which appended an empty `PolicyTargets` slice) with the same per-listener fan-out.
- `ReferenceIndex` (`reference_indexes.go`): adds a `listenerSetAttachments` krt index (ListenerSet → Gateway) and a `ListenerSet` case in `LookupGatewaysForTarget` so that policy-to-xDS-gateway resolution works correctly.
- `syncer.go`: builds and wires the `listenerSetAttachments` krt collection. The transformer validates that `spec.parentRef` resolves to a Gateway (mirrors `translator.NormalizeReference`) and skips ListenerSets with an empty or non-Gateway parent ref.

**Why per-listener, not gateway-wide?**

A ListenerSet adds listeners to a parent Gateway, but resolving the target as the entire parent Gateway would apply the policy to _all_ listeners on that Gateway — including native Gateway listeners and listeners from other ListenerSets. The Rust data plane already supports listener-scoped `PolicyTargetRef::Gateway { listener_name: Some(...) }` entries; the controller just wasn't producing them for ListenerSet targets.

## Test Plan

- [ ] New golden test `listenerset-targetref.yaml`: policy targeting a ListenerSet via `targetRefs` produces a listener-scoped policy entry for each listener in the set (`listener: extra`), and does NOT attach to sibling listeners on the parent Gateway (`http`)
- [ ] New golden test `listenerset-selector.yaml`: policy targeting via `targetSelectors` with label match produces the same listener-scoped entries
- [ ] Full plugin test suite passes with no regressions (`go test ./controller/pkg/agentgateway/plugins/...`)