### PR TITLE
fix: support path prefixes for all LLM providers

### DIFF
--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -380,14 +380,22 @@ impl AIProvider {
 	fn set_path_and_query(uri: &mut http::uri::Parts, path: &str) -> anyhow::Result<()> {
 		let query = uri.path_and_query.as_ref().and_then(|p| p.query());
 		if let Some(query) = query {
+			let separator = if path.contains('?') { "&" } else { "?" };
 			uri.path_and_query = Some(PathAndQuery::from_maybe_shared(format!(
-				"{}?{}",
-				path, query
+				"{}{}{}",
+				path, separator, query
 			))?);
 		} else {
 			uri.path_and_query = Some(PathAndQuery::try_from(path)?);
 		};
 		Ok(())
+	}
+
+	fn with_path_prefix(path: &str, path_prefix: Option<&str>) -> String {
+		match path_prefix {
+			Some(prefix) => format!("{}{}", prefix.trim_end_matches('/'), path),
+			None => path.to_string(),
+		}
 	}
 
 	pub fn set_default_path(
@@ -402,11 +410,7 @@ impl AIProvider {
 			return Ok(());
 		}
 
-		let supports_path_prefix = matches!(
-			self,
-			AIProvider::OpenAI(_) | AIProvider::Anthropic(_) | AIProvider::Copilot(_)
-		);
-		if has_host_override && !(supports_path_prefix && path_prefix.is_some()) {
+		if has_host_override && path_prefix.is_none() {
 			return Ok(());
 		}
 
@@ -453,7 +457,8 @@ impl AIProvider {
 			}),
 			AIProvider::Gemini(_) => http::modify_req(req, |req| {
 				http::modify_uri(req, |uri| {
-					Self::set_path_and_query(uri, gemini::path(route_type))?;
+					let path = Self::with_path_prefix(gemini::path(route_type), path_prefix);
+					Self::set_path_and_query(uri, &path)?;
 					Ok(())
 				})?;
 				Ok(())
@@ -464,7 +469,8 @@ impl AIProvider {
 				http::modify_req(req, |req| {
 					http::modify_uri(req, |uri| {
 						let path = provider.get_path_for_model(route_type, request_model, streaming);
-						uri.path_and_query = Some(PathAndQuery::from_str(&path)?);
+						let path = Self::with_path_prefix(&path, path_prefix);
+						Self::set_path_and_query(uri, &path)?;
 						Ok(())
 					})?;
 					Ok(())
@@ -475,7 +481,8 @@ impl AIProvider {
 					if let Some(l) = llm_request {
 						let path =
 							provider.get_path_for_route(route_type, l.streaming, l.request_model.as_str());
-						uri.path_and_query = Some(PathAndQuery::from_str(&path)?);
+						let path = Self::with_path_prefix(&path, path_prefix);
+						Self::set_path_and_query(uri, &path)?;
 					}
 					Ok(())
 				})?;
@@ -485,7 +492,8 @@ impl AIProvider {
 				http::modify_uri(req, |uri| {
 					if let Some(l) = llm_request {
 						let path = provider.get_path_for_model(route_type, l.request_model.as_str());
-						uri.path_and_query = Some(PathAndQuery::from_str(&path)?);
+						let path = Self::with_path_prefix(&path, path_prefix);
+						Self::set_path_and_query(uri, &path)?;
 					}
 					Ok(())
 				})?;

--- a/crates/agentgateway/src/llm/tests.rs
+++ b/crates/agentgateway/src/llm/tests.rs
@@ -1124,6 +1124,102 @@ fn setup_request_openai_normalizes_trailing_slash_in_path_prefix() {
 	assert_eq!(req.uri().query(), Some("trace=repro"));
 }
 
+fn llm_request_for_path(request_model: &str) -> LLMRequest {
+	LLMRequest {
+		input_tokens: None,
+		input_format: InputFormat::Messages,
+		request_model: request_model.into(),
+		provider: Default::default(),
+		streaming: false,
+		params: Default::default(),
+		prompt: None,
+	}
+}
+
+fn assert_prefixed_host_override_path(
+	provider: AIProvider,
+	request_model: &str,
+	expected_path: &str,
+	expected_query: Option<&str>,
+) {
+	let llm_request = llm_request_for_path(request_model);
+	let mut req = crate::http::tests_common::request(
+		"https://proxy.example.com/v1/messages?trace=repro",
+		http::Method::POST,
+		&[],
+	);
+
+	provider
+		.setup_request(
+			&mut req,
+			RouteType::Messages,
+			Some(&llm_request),
+			None,
+			Some("/proxy/"),
+			true,
+		)
+		.expect("setup_request should succeed");
+
+	assert_eq!(req.uri().path(), expected_path);
+	assert_eq!(req.uri().query(), expected_query);
+}
+
+#[test]
+fn setup_request_gemini_applies_path_prefix_with_host_override() {
+	assert_prefixed_host_override_path(
+		AIProvider::Gemini(gemini::Provider { model: None }),
+		"gemini-2.5-pro",
+		"/proxy/v1beta/openai/chat/completions",
+		Some("trace=repro"),
+	);
+}
+
+#[test]
+fn setup_request_vertex_applies_path_prefix_with_host_override() {
+	assert_prefixed_host_override_path(
+		AIProvider::Vertex(vertex::Provider {
+			model: None,
+			region: Some(strng::new("us-central1")),
+			project_id: strng::new("example-project"),
+		}),
+		"gemini-2.5-pro",
+		"/proxy/v1/projects/example-project/locations/us-central1/endpoints/openapi/chat/completions",
+		Some("trace=repro"),
+	);
+}
+
+#[test]
+fn setup_request_bedrock_applies_path_prefix_with_host_override() {
+	assert_prefixed_host_override_path(
+		AIProvider::Bedrock(bedrock::Provider {
+			model: None,
+			region: strng::new("us-east-1"),
+			guardrail_identifier: None,
+			guardrail_version: None,
+		}),
+		"anthropic.claude-3-5-sonnet-20241022-v2:0",
+		"/proxy/model/anthropic.claude-3-5-sonnet-20241022-v2:0/converse",
+		Some("trace=repro"),
+	);
+}
+
+#[test]
+fn setup_request_azure_applies_path_prefix_with_host_override() {
+	assert_prefixed_host_override_path(
+		AIProvider::Azure(azure::Provider {
+			model: None,
+			resource_name: strng::new("example"),
+			resource_type: azure::AzureResourceType::OpenAI,
+			api_version: Some(strng::new("2024-02-15-preview")),
+			project_name: None,
+			cached_cred: Default::default(),
+		}),
+		"gpt-4.1",
+		"/proxy/openai/deployments/gpt-4.1/chat/completions",
+		Some("api-version=2024-02-15-preview&trace=repro"),
+	);
+}
+
 #[test]
 fn completions_response_missing_message_and_usage_fields() {
 	// Gemini's OpenAI-compat endpoint can omit `message` from choices and


### PR DESCRIPTION
Fixes #1451.

## Summary
- allow `pathPrefix` to trigger provider path construction for custom-host LLM providers beyond OpenAI/Anthropic/Copilot
- prepend the configured prefix to Gemini, Vertex, Bedrock, and Azure provider-generated paths
- preserve existing OpenAI/Anthropic/Copilot path-prefix behavior and correctly append original request query params when generated paths already contain a query string

## Tests
- `CARGO_INCREMENTAL=0 RUSTFLAGS='-C debuginfo=0' cargo test -p agentgateway setup_request_ --lib`\n- `git diff --check`