### PR TITLE
loosen waypoint self check

### DIFF
--- a/crates/agentgateway/src/proxy/gateway.rs
+++ b/crates/agentgateway/src/proxy/gateway.rs
@@ -1272,14 +1272,11 @@ impl Gateway {
 			anyhow::bail!("self_id required for waypoint");
 		};
 		let is_ours = match &wp.destination {
-			Destination::Address(addr) => self_id.matches_address(addr, |ns, hostname| {
-				let self_svc = discovery.services.get_by_namespaced_host(
-					&crate::types::discovery::NamespacedHostname {
-						namespace: ns.clone(),
-						hostname: hostname.clone(),
-					},
-				)?;
-				Some(self_svc.vips.clone())
+			Destination::Address(addr) => self_id.matches_address(addr, |a| {
+				discovery
+					.services
+					.get_by_vip(a)
+					.map(|s| (s.name.clone(), s.namespace.clone()))
 			}),
 			Destination::Hostname(n) => self_id.matches_hostname(n),
 		};

--- a/crates/agentgateway/src/proxy/tcpproxy.rs
+++ b/crates/agentgateway/src/proxy/tcpproxy.rs
@@ -377,15 +377,12 @@ fn resolve_waypoint_service(
 	let is_ours = match &wp.destination {
 		Destination::Address(addr) => {
 			let stores_ref = stores.clone();
-			self_id.matches_address(addr, |ns, hostname| {
+			self_id.matches_address(addr, |a| {
 				let discovery = stores_ref.read_discovery();
-				let self_svc = discovery.services.get_by_namespaced_host(
-					&crate::types::discovery::NamespacedHostname {
-						namespace: ns.clone(),
-						hostname: hostname.clone(),
-					},
-				)?;
-				Some(self_svc.vips.clone())
+				discovery
+					.services
+					.get_by_vip(a)
+					.map(|s| (s.name.clone(), s.namespace.clone()))
 			})
 		},
 		Destination::Hostname(n) => self_id.matches_hostname(n),
@@ -601,6 +598,38 @@ mod tests {
 			route.is_none(),
 			"should reject service bound to different waypoint"
 		);
+	}
+
+	#[tokio::test]
+	async fn test_waypoint_default_tcp_route_custom_cluster_domain() {
+		let svc = make_service(
+			"mysql-db",
+			"default",
+			"mysql-db.default.custom.local",
+			"10.0.0.50",
+			"network",
+			Some(GatewayAddress {
+				destination: Destination::Hostname(NamespacedHostname {
+					namespace: strng::new("istio-system"),
+					hostname: strng::new("my-waypoint.istio-system.custom.local"),
+				}),
+				hbone_mtls_port: 15008,
+			}),
+		);
+		let stores = stores_with_services(vec![svc]);
+		let network = strng::literal!("network");
+		let dst = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 50)), 3306);
+		let self_addr = make_self_addr("my-waypoint", "istio-system");
+
+		let route = super::select_best_route(
+			None,
+			hbone_listener(),
+			&stores,
+			&network,
+			dst,
+			Some(&self_addr),
+		);
+		assert!(route.is_some());
 	}
 
 	#[tokio::test]

--- a/crates/agentgateway/src/types/discovery.rs
+++ b/crates/agentgateway/src/types/discovery.rs
@@ -103,7 +103,8 @@ pub struct WaypointIdentity {
 }
 
 impl WaypointIdentity {
-	/// Returns the full Kubernetes FQDN for this waypoint.
+	/// Returns the default full Kubernetes FQDN for this waypoint.
+	/// TODO: we don't know the cluster domain, so we potentially return the wrong hostname for this waypoint.
 	pub fn hostname(&self) -> Strng {
 		strng::format!("{}.{}.svc.cluster.local", self.gateway, self.namespace)
 	}
@@ -122,16 +123,23 @@ impl WaypointIdentity {
 	}
 
 	/// Checks whether this waypoint identity matches an Address-based waypoint destination
-	/// by looking up this waypoint's own service VIPs.
+	/// by resolving the service at `addr` and comparing its (name, namespace) to this waypoint's
+	/// (gateway, namespace).
 	pub fn matches_address(
 		&self,
 		addr: &NetworkAddress,
 		get_service_at: impl FnOnce(&NetworkAddress) -> Option<(Strng, Strng)>,
 	) -> bool {
-		matches!(
-			get_service_at(addr),
-			Some((name, ns)) if name == self.gateway && ns == self.namespace
-		)
+		match get_service_at(addr) {
+			Some((name, ns)) => name == self.gateway && ns == self.namespace,
+			None => {
+				warn!(
+					"waypoint {}.{} cannot resolve service at {} for address verification",
+					self.gateway, self.namespace, addr
+				);
+				false
+			},
+		}
 	}
 }
 

--- a/crates/agentgateway/src/types/discovery.rs
+++ b/crates/agentgateway/src/types/discovery.rs
@@ -109,9 +109,16 @@ impl WaypointIdentity {
 	}
 
 	/// Checks whether this waypoint identity matches a NamespacedHostname waypoint destination.
-	/// The hostname from xDS is always a FQDN (e.g., "waypoint.ns.svc.cluster.local").
+	/// Assumes the hostname from xDS always starts with `{gateway name}.{namespace}` but the suffix
+	/// may be customized.
 	pub fn matches_hostname(&self, nh: &NamespacedHostname) -> bool {
-		nh.hostname == self.hostname()
+		nh.namespace == self.namespace
+			&& nh
+				.hostname
+				.strip_prefix(self.gateway.as_str())
+				.and_then(|s| s.strip_prefix('.'))
+				.and_then(|s| s.strip_prefix(self.namespace.as_str()))
+				.is_some_and(|s| s.starts_with('.') && s.len() > 1)
 	}
 
 	/// Checks whether this waypoint identity matches an Address-based waypoint destination
@@ -119,18 +126,12 @@ impl WaypointIdentity {
 	pub fn matches_address(
 		&self,
 		addr: &NetworkAddress,
-		get_self_vips: impl FnOnce(&Strng, &Strng) -> Option<Vec<NetworkAddress>>,
+		get_service_at: impl FnOnce(&NetworkAddress) -> Option<(Strng, Strng)>,
 	) -> bool {
-		match get_self_vips(&self.namespace, &self.hostname()) {
-			Some(vips) => vips.contains(addr),
-			None => {
-				warn!(
-					"waypoint {}.{} cannot find own service for address verification",
-					self.gateway, self.namespace
-				);
-				false
-			},
-		}
+		matches!(
+			get_service_at(addr),
+			Some((name, ns)) if name == self.gateway && ns == self.namespace
+		)
 	}
 }
 


### PR DESCRIPTION
We should not hardcode `.svc.cluster.local`, which prevents using a custom domain. 