### PR TITLE
fix(controller): Apply DiscoveryNamespaceSelectors

### DIFF
--- a/controller/pkg/setup/setup.go
+++ b/controller/pkg/setup/setup.go
@@ -8,9 +8,12 @@ import (
 	"sync"
 
 	"github.com/go-logr/logr"
+	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/kube/kclient"
 	"istio.io/istio/pkg/kube/krt"
 	"istio.io/istio/pkg/security"
 	"istio.io/istio/pkg/util/sets"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/rest"
@@ -34,6 +37,7 @@ import (
 	"github.com/agentgateway/agentgateway/controller/pkg/logging"
 	"github.com/agentgateway/agentgateway/controller/pkg/metrics"
 	"github.com/agentgateway/agentgateway/controller/pkg/pluginsdk"
+	pluginsdkcol "github.com/agentgateway/agentgateway/controller/pkg/pluginsdk/collections"
 	"github.com/agentgateway/agentgateway/controller/pkg/pluginsdk/krtutil"
 	"github.com/agentgateway/agentgateway/controller/pkg/schemes"
 	"github.com/agentgateway/agentgateway/controller/pkg/syncer"
@@ -203,6 +207,10 @@ func (s *setup) Start(ctx context.Context) error {
 		CertWatcher:    certWatcher,
 	}
 
+	if err := initDiscoveryNSFilter(ctx, s.APIClient, s.GlobalSettings.DiscoveryNamespaceSelectors); err != nil {
+		return err
+	}
+
 	slog.Info("creating krt collections")
 	krtOpts := krtutil.NewKrtOptions(ctx.Done(), setupOpts.KrtDebugger)
 
@@ -358,6 +366,23 @@ func SetupLogging(levelStr string) {
 		klogLogger := logr.FromSlogHandler(logging.New("klog").Handler())
 		klog.SetLogger(klogLogger)
 	})
+}
+
+func initDiscoveryNSFilter(
+	ctx context.Context,
+	cli apiclient.Client,
+	discoveryNamespaceSetting string,
+) error {
+	// NOTE: Do not apply an ObjectFilter to namespaces as the discovery namespace ObjectFilter for other clients
+	// requires all namespaces to be watched
+	nsClient := kclient.New[*corev1.Namespace](cli) //nolint:forbidigo // okay to use non-filtered client
+	// Initialize discovery namespace filter
+	discoveryNamespacesFilter, err := pluginsdkcol.NewDiscoveryNamespacesFilter(nsClient, discoveryNamespaceSetting, ctx.Done())
+	if err != nil {
+		return fmt.Errorf("error creating discovery namespace filter: %w", err)
+	}
+	kube.SetObjectFilter(cli.Core(), discoveryNamespacesFilter)
+	return nil
 }
 
 func buildJwksStore(

--- a/controller/test/e2e/features/agentgateway/discoverynsfilter/suite.go
+++ b/controller/test/e2e/features/agentgateway/discoverynsfilter/suite.go
@@ -1,0 +1,84 @@
+//go:build e2e
+
+package discoverynsfilter
+
+import (
+	"context"
+	"time"
+
+	"github.com/onsi/gomega"
+	"github.com/stretchr/testify/suite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/agentgateway/agentgateway/controller/test/e2e"
+	"github.com/agentgateway/agentgateway/controller/test/e2e/tests/base"
+)
+
+func NewTestingSuite(ctx context.Context, testInst *e2e.TestInstallation) suite.TestingSuite {
+	routeSelected := &base.TestCase{
+		Manifests: []string{routeSelectedManifest},
+	}
+	routeUnselected := &base.TestCase{
+		Manifests: []string{routeUnselectedManifest},
+	}
+
+	return &testingSuite{
+		BaseTestingSuite: base.NewBaseTestingSuite(ctx, testInst, setup, map[string]*base.TestCase{
+			"TestRouteInSelectedNamespaceIsReconciled": routeSelected,
+			"TestDynamicLabelAddEnablesDiscovery":      routeUnselected,
+		}),
+	}
+}
+
+func (s *testingSuite) TestRouteInSelectedNamespaceIsReconciled() {
+	s.assertRouteReconciled("route-selected", nsSelected)
+}
+
+func (s *testingSuite) TestDynamicLabelAddEnablesDiscovery() {
+	kubectl := s.TestInstallation.Actions.Kubectl()
+	s.assertRouteNotReconciled("route-unselected", nsUnselected, 10*time.Second)
+
+	s.Require().NoError(
+		kubectl.SetLabel(s.Ctx, "namespace", nsUnselected, "", DiscoveryLabel, "enabled"),
+	)
+	defer func() {
+		_ = kubectl.UnsetLabel(s.Ctx, "namespace", nsUnselected, "", DiscoveryLabel)
+	}()
+
+	s.assertRouteReconciled("route-unselected", nsUnselected)
+}
+
+func (s *testingSuite) assertRouteReconciled(routeName, namespace string) {
+	assertions := s.TestInstallation.AssertionsT(s.T())
+	assertions.EventuallyHTTPRouteCondition(
+		s.Ctx,
+		routeName,
+		namespace,
+		gwv1.RouteConditionAccepted,
+		metav1.ConditionTrue,
+	)
+	assertions.EventuallyHTTPRouteCondition(
+		s.Ctx,
+		routeName,
+		namespace,
+		gwv1.RouteConditionResolvedRefs,
+		metav1.ConditionTrue,
+	)
+}
+
+func (s *testingSuite) assertRouteNotReconciled(routeName, namespace string, duration time.Duration) {
+	assertions := s.TestInstallation.AssertionsT(s.T())
+	assertions.Gomega.Consistently(func(g gomega.Gomega) {
+		route := &gwv1.HTTPRoute{}
+		err := s.TestInstallation.ClusterContext.Client.Get(
+			s.Ctx,
+			types.NamespacedName{Name: routeName, Namespace: namespace},
+			route,
+		)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		g.Expect(route.Status.Parents).To(gomega.BeEmpty(),
+			"route should not be reconciled before namespace discovery is enabled")
+	}, duration, 2*time.Second).Should(gomega.Succeed())
+}

--- a/controller/test/e2e/features/agentgateway/discoverynsfilter/testdata/route-selected.yaml
+++ b/controller/test/e2e/features/agentgateway/discoverynsfilter/testdata/route-selected.yaml
@@ -1,0 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route-selected
+  namespace: discoveryns-selected
+spec:
+  parentRefs:
+    - name: gateway
+      namespace: discoveryns-selected
+  hostnames:
+    - "selected.example.com"
+  rules:
+    - backendRefs:
+        - name: backend
+          port: 80

--- a/controller/test/e2e/features/agentgateway/discoverynsfilter/testdata/route-unselected.yaml
+++ b/controller/test/e2e/features/agentgateway/discoverynsfilter/testdata/route-unselected.yaml
@@ -1,0 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route-unselected
+  namespace: discoveryns-unselected
+spec:
+  parentRefs:
+    - name: gateway
+      namespace: discoveryns-selected
+  hostnames:
+    - "unselected.example.com"
+  rules:
+    - backendRefs:
+        - name: backend
+          port: 80

--- a/controller/test/e2e/features/agentgateway/discoverynsfilter/testdata/setup.yaml
+++ b/controller/test/e2e/features/agentgateway/discoverynsfilter/testdata/setup.yaml
@@ -1,0 +1,50 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: discoveryns-selected
+  labels:
+    agentgateway.dev/discovery: enabled
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: discoveryns-unselected
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway
+  namespace: discoveryns-selected
+spec:
+  gatewayClassName: agentgateway
+  listeners:
+    - protocol: HTTP
+      port: 80
+      name: http
+      allowedRoutes:
+        namespaces:
+          from: All
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend
+  namespace: discoveryns-selected
+spec:
+  ports:
+    - name: http
+      port: 80
+  selector:
+    app.kubernetes.io/name: testbox
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend
+  namespace: discoveryns-unselected
+spec:
+  ports:
+    - name: http
+      port: 80
+  selector:
+    app.kubernetes.io/name: testbox

--- a/controller/test/e2e/features/agentgateway/discoverynsfilter/types.go
+++ b/controller/test/e2e/features/agentgateway/discoverynsfilter/types.go
@@ -1,0 +1,35 @@
+//go:build e2e
+
+package discoverynsfilter
+
+import (
+	"path/filepath"
+
+	"github.com/agentgateway/agentgateway/controller/pkg/utils/fsutils"
+	"github.com/agentgateway/agentgateway/controller/test/e2e"
+	"github.com/agentgateway/agentgateway/controller/test/e2e/tests/base"
+)
+
+type testingSuite struct {
+	*base.BaseTestingSuite
+}
+
+const (
+	// DiscoveryLabel is the label key used to enable namespace discovery.
+	DiscoveryLabel = "agentgateway.dev/discovery"
+
+	nsSelected   = "discoveryns-selected"
+	nsUnselected = "discoveryns-unselected"
+)
+
+var (
+	_ e2e.NewSuiteFunc = NewTestingSuite
+
+	setupManifest           = filepath.Join(fsutils.MustGetThisDir(), "testdata", "setup.yaml")
+	routeSelectedManifest   = filepath.Join(fsutils.MustGetThisDir(), "testdata", "route-selected.yaml")
+	routeUnselectedManifest = filepath.Join(fsutils.MustGetThisDir(), "testdata", "route-unselected.yaml")
+
+	setup = base.TestCase{
+		Manifests: []string{setupManifest},
+	}
+)

--- a/controller/test/e2e/tests/agent_gateway_test.go
+++ b/controller/test/e2e/tests/agent_gateway_test.go
@@ -37,7 +37,7 @@ func TestAgentgatewayIntegration(t *testing.T) {
 	}
 
 	// We register the cleanup function _before_ we actually perform the installation.
-	// This allows us to uninstall kgateway, in case the original installation only completed partially
+	// This allows us to uninstall agentgateway, in case the original installation only completed partially
 	testutils.Cleanup(t, func() {
 		if !nsEnvPredefined {
 			os.Unsetenv(testutils.InstallNamespace)
@@ -49,7 +49,7 @@ func TestAgentgatewayIntegration(t *testing.T) {
 		testInstallation.Uninstall(ctx, t)
 	})
 
-	// Install kgateway
+	// Install agentgateway
 	testInstallation.InstallFromLocalChart(ctx, t)
 
 	common.SetupBaseConfig(ctx, t, testInstallation, filepath.Join("manifests", "agent-gateway-base.yaml"))

--- a/controller/test/e2e/tests/discovery_ns_filter_test.go
+++ b/controller/test/e2e/tests/discovery_ns_filter_test.go
@@ -1,0 +1,94 @@
+//go:build e2e
+
+package tests_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/agentgateway/agentgateway/controller/pkg/utils/envutils"
+	"github.com/agentgateway/agentgateway/controller/test/e2e"
+	"github.com/agentgateway/agentgateway/controller/test/e2e/features/agentgateway/discoverynsfilter"
+	. "github.com/agentgateway/agentgateway/controller/test/e2e/tests"
+	"github.com/agentgateway/agentgateway/controller/test/e2e/testutils/install"
+	"github.com/agentgateway/agentgateway/controller/test/testutils"
+)
+
+// TestDiscoveryNSFilter tests that the AGW_DISCOVERY_NAMESPACE_SELECTORS setting restricts
+// the controller to only watch resources in namespaces matching the configured label selector,
+// and that the filter responds dynamically to namespace label changes.
+func TestDiscoveryNSFilter(t *testing.T) {
+	cleanupCtx := context.Background()
+	installNs, nsEnvPredefined := envutils.LookupOrDefault(testutils.InstallNamespace, "agentgateway-discoveryns")
+
+	testInstallation := e2e.CreateTestInstallation(
+		t,
+		&install.Context{
+			InstallNamespace:          installNs,
+			ChartType:                 "agentgateway",
+			ProfileValuesManifestFile: e2e.EmptyValuesManifestPath,
+			ValuesManifestFile:        e2e.ManifestPath("discovery-ns-filter-helm.yaml"),
+		},
+	)
+
+	if !nsEnvPredefined {
+		os.Setenv(testutils.InstallNamespace, installNs)
+	}
+
+	testutils.Cleanup(t, func() {
+		if !nsEnvPredefined {
+			os.Unsetenv(testutils.InstallNamespace)
+		}
+		if t.Failed() {
+			testInstallation.PreFailHandler(cleanupCtx, t)
+		}
+		testInstallation.Uninstall(cleanupCtx, t)
+	})
+
+	ensureDiscoveryNamespaceLabel(cleanupCtx, t, testInstallation, installNs)
+
+	testInstallation.InstallFromLocalChart(t.Context(), t)
+
+	DiscoveryNSFilterSuiteRunner().Run(t.Context(), t, testInstallation)
+}
+
+func ensureDiscoveryNamespaceLabel(
+	ctx context.Context,
+	t *testing.T,
+	testInstallation *e2e.TestInstallation,
+	namespace string,
+) {
+	t.Helper()
+
+	key := client.ObjectKey{Name: namespace}
+	ns := &corev1.Namespace{}
+	err := testInstallation.ClusterContext.Client.Get(ctx, key, ns)
+	switch {
+	case apierrors.IsNotFound(err):
+		ns.ObjectMeta = metav1.ObjectMeta{
+			Name:   namespace,
+			Labels: map[string]string{discoverynsfilter.DiscoveryLabel: "enabled"},
+		}
+		if err := testInstallation.ClusterContext.Client.Create(ctx, ns); err != nil {
+			t.Fatalf("failed to create namespace %s: %v", namespace, err)
+		}
+	case err != nil:
+		t.Fatalf("failed to get namespace %s: %v", namespace, err)
+	default:
+		if ns.Labels == nil {
+			ns.Labels = make(map[string]string)
+		}
+		if ns.Labels[discoverynsfilter.DiscoveryLabel] != "enabled" {
+			ns.Labels[discoverynsfilter.DiscoveryLabel] = "enabled"
+			if err := testInstallation.ClusterContext.Client.Update(ctx, ns); err != nil {
+				t.Fatalf("failed to label namespace %s: %v", namespace, err)
+			}
+		}
+	}
+}

--- a/controller/test/e2e/tests/discovery_ns_filter_tests.go
+++ b/controller/test/e2e/tests/discovery_ns_filter_tests.go
@@ -1,0 +1,14 @@
+//go:build e2e
+
+package tests
+
+import (
+	"github.com/agentgateway/agentgateway/controller/test/e2e"
+	"github.com/agentgateway/agentgateway/controller/test/e2e/features/agentgateway/discoverynsfilter"
+)
+
+func DiscoveryNSFilterSuiteRunner() e2e.SuiteRunner {
+	runner := e2e.NewSuiteRunner(false)
+	runner.Register("DiscoveryNamespaceFilter", discoverynsfilter.NewTestingSuite)
+	return runner
+}

--- a/controller/test/e2e/tests/manifests/discovery-ns-filter-helm.yaml
+++ b/controller/test/e2e/tests/manifests/discovery-ns-filter-helm.yaml
@@ -1,0 +1,3 @@
+controller:
+  extraEnv:
+    AGW_DISCOVERY_NAMESPACE_SELECTORS: '[{"matchLabels":{"agentgateway.dev/discovery":"enabled"}}]'


### PR DESCRIPTION
Wire up the `DiscoveryNamespaceSelectors` controller in setup so namespace filtering is actually applied at runtime, and add E2E tests that verify routes in selected namespaces are accessible while routes in unselected namespaces are not.