### PR TITLE
fix(controller): avoid nil pointer panic when InferencePool EndpointPickerRef is invalid

### DIFF
--- a/controller/pkg/agentgateway/plugins/inference_plugin.go
+++ b/controller/pkg/agentgateway/plugins/inference_plugin.go
@@ -57,6 +57,14 @@ func translatePoliciesForInferencePool(
 	attachedGateways := inferencePoolAttachedGateways(krtctx, references, pool)
 	status := buildInferencePoolStatus(pool, controllerName, attachedGateways, validationErr)
 
+	// If the EndpointPickerRef failed validation (e.g. nil Port, wrong Kind, or
+	// missing referenced Service) we cannot safely build downstream policies:
+	// dereferencing fields like epr.Port.Number would panic. Surface the error
+	// via status and skip policy generation for this pool.
+	if validationErr != nil {
+		return status, infPolicies
+	}
+
 	// 'service/{namespace}/{hostname}:{port}'
 	hostname := kubeutils.GetInferenceServiceHostname(pool.Name, pool.Namespace)
 	eppPort := epr.Port.Number


### PR DESCRIPTION
Fixes #1719.

`translatePoliciesForInferencePool` calls `validateInferencePoolEndpointPickerRef` but discards the returned error and continues to dereference `epr.Port.Number` at `inference_plugin.go:62`. When the `InferencePool` spec omits `endpointPickerRef.port` (or sets a non-Service `kind`), `epr.Port` is nil and the controller panics, crashing into `CrashLoopBackOff`.

Return early with the populated status (which already encodes the validation failure) and no policies when validation fails, so the bad InferencePool is surfaced via status conditions instead of killing the controller.