### PR TITLE
Preserve per-test e2e bug reports

### DIFF
--- a/controller/test/e2e/test.go
+++ b/controller/test/e2e/test.go
@@ -270,7 +270,7 @@ func (i *TestInstallation) UninstallAgentgatewayCRDs(ctx context.Context, t *tes
 
 // PreFailHandler is the function that is invoked if a test in the given TestInstallation fails
 func (i *TestInstallation) PreFailHandler(ctx context.Context, t *testing.T) {
-	i.preFailHandler(ctx, t, i.GeneratedFiles.FailureDir)
+	i.preFailHandler(ctx, t, filepath.Join(i.GeneratedFiles.FailureDir, t.Name()))
 }
 
 // PerTestPreFailHandler is the function that is invoked if a test in the given TestInstallation fails


### PR DESCRIPTION
The e2e harness writes a focused dump under bug_report/<cluster>/<test> when an individual suite test fails, but the top-level test cleanup also dumps into bug_report/<cluster>. The dump helper clears its target directory before writing, so the later cleanup dump deleted the more useful per-test directory before CI uploaded the artifact.

Write the cleanup dump under the top-level Go test name instead. This keeps the final cluster snapshot while preserving per-test dumps such as TestDynamicMCPAdminRouting in the uploaded bug-report artifact.

Signed-off-by: John Howard <john.howard@solo.io>
