### PR TITLE
Sanitize Bedrock request metadata

### DIFF
--- a/crates/agentgateway/src/llm/conversion/bedrock.rs
+++ b/crates/agentgateway/src/llm/conversion/bedrock.rs
@@ -443,6 +443,7 @@ pub mod from_completions {
 			metadata.extend(header_metadata);
 		}
 
+		let metadata = helpers::sanitize_request_metadata(metadata);
 		let metadata = if metadata.is_empty() {
 			None
 		} else {
@@ -1266,14 +1267,19 @@ pub mod from_messages {
 			None
 		};
 
-		// Build metadata from request field and x-bedrock-metadata header
-		let mut metadata = req.metadata.map(|m| m.fields).unwrap_or_default();
-
-		// Extract metadata from x-bedrock-metadata header (set by ExtAuthz or transformation policy)
-		if let Some(header_metadata) = helpers::extract_metadata_from_headers(headers) {
-			metadata.extend(header_metadata);
+		if let Some(metadata) = req.metadata.map(|m| m.fields)
+			&& !metadata.is_empty()
+		{
+			// Anthropic metadata is opaque to Bedrock requestMetadata validation. Preserve it
+			// in the Anthropic model request envelope instead of dropping provider-specific data.
+			upsert_additional_field("metadata", serde_json::json!(metadata));
 		}
 
+		// Extract Bedrock-native metadata from x-bedrock-metadata header (set by ExtAuthz or
+		// transformation policy). This is separate from Anthropic's model-specific metadata.
+		let metadata = helpers::sanitize_request_metadata(
+			helpers::extract_metadata_from_headers(headers).unwrap_or_default(),
+		);
 		let metadata = if metadata.is_empty() {
 			None
 		} else {
@@ -2025,6 +2031,7 @@ pub mod from_responses {
 			metadata.extend(header_metadata);
 		}
 
+		let metadata = sanitize_request_metadata(metadata);
 		let metadata = if metadata.is_empty() {
 			None
 		} else {
@@ -2577,6 +2584,9 @@ mod helpers {
 	use crate::llm::AIError;
 	use crate::llm::types::bedrock;
 
+	const BEDROCK_REQUEST_METADATA_MAX_ENTRIES: usize = 16;
+	const BEDROCK_REQUEST_METADATA_MAX_LEN: usize = 256;
+
 	pub fn create_cache_point() -> bedrock::CachePointBlock {
 		bedrock::CachePointBlock {
 			r#type: bedrock::CachePointType::Default,
@@ -2681,6 +2691,36 @@ mod helpers {
 		}
 
 		metadata
+	}
+
+	/// Bedrock Converse requestMetadata only accepts short strings from a restricted
+	/// character set. Keep compatible entries unchanged and drop incompatible ones.
+	pub fn sanitize_request_metadata(metadata: HashMap<String, String>) -> HashMap<String, String> {
+		metadata
+			.into_iter()
+			.filter(|(key, value)| {
+				is_valid_request_metadata_key(key) && is_valid_request_metadata_value(value)
+			})
+			.take(BEDROCK_REQUEST_METADATA_MAX_ENTRIES)
+			.collect()
+	}
+
+	fn is_valid_request_metadata_key(value: &str) -> bool {
+		!value.is_empty() && is_valid_request_metadata_value(value)
+	}
+
+	fn is_valid_request_metadata_value(value: &str) -> bool {
+		value.len() <= BEDROCK_REQUEST_METADATA_MAX_LEN
+			&& value.chars().all(is_valid_request_metadata_char)
+	}
+
+	fn is_valid_request_metadata_char(c: char) -> bool {
+		c.is_ascii_alphanumeric()
+			|| c.is_ascii_whitespace()
+			|| matches!(
+				c,
+				':' | '_' | '@' | '$' | '#' | '=' | '/' | '+' | ',' | '-' | '.'
+			)
 	}
 
 	pub fn extract_beta_headers(

--- a/crates/agentgateway/src/llm/conversion/bedrock.rs
+++ b/crates/agentgateway/src/llm/conversion/bedrock.rs
@@ -420,10 +420,9 @@ pub mod from_completions {
 			None
 		};
 
-		// Build metadata from:
+		// Build gateway-generated metadata from:
 		// - OpenAI `user` field (normalized as user_id)
 		// - OpenAI `metadata` field (agentgateway uses this to carry guardrail/model-armor knobs through Messages→Completions)
-		// - x-bedrock-metadata header (set by ExtAuthz or transformation policy)
 		let mut metadata = req
 			.user
 			.map(|user| HashMap::from([("user_id".to_string(), user)]))
@@ -438,12 +437,14 @@ pub mod from_completions {
 			}
 		}
 
-		// Extract metadata from x-bedrock-metadata header (set by ExtAuthz or transformation policy)
+		let mut metadata = helpers::sanitize_request_metadata(metadata);
+
+		// x-bedrock-metadata is an explicit Bedrock requestMetadata escape hatch. Forward it
+		// unchanged so Bedrock, not the gateway, rejects operator-supplied invalid values.
 		if let Some(header_metadata) = super::helpers::extract_metadata_from_headers(headers) {
 			metadata.extend(header_metadata);
 		}
 
-		let metadata = helpers::sanitize_request_metadata(metadata);
 		let metadata = if metadata.is_empty() {
 			None
 		} else {
@@ -1275,11 +1276,9 @@ pub mod from_messages {
 			upsert_additional_field("metadata", serde_json::json!(metadata));
 		}
 
-		// Extract Bedrock-native metadata from x-bedrock-metadata header (set by ExtAuthz or
-		// transformation policy). This is separate from Anthropic's model-specific metadata.
-		let metadata = helpers::sanitize_request_metadata(
-			helpers::extract_metadata_from_headers(headers).unwrap_or_default(),
-		);
+		// x-bedrock-metadata is an explicit Bedrock requestMetadata escape hatch. Forward it
+		// unchanged so Bedrock, not the gateway, rejects operator-supplied invalid values.
+		let metadata = helpers::extract_metadata_from_headers(headers).unwrap_or_default();
 		let metadata = if metadata.is_empty() {
 			None
 		} else {
@@ -2024,14 +2023,16 @@ pub mod from_responses {
 			None
 		};
 
-		// Extract metadata from request body and merge with headers (consistent with Messages/Completions)
-		let mut metadata = req.metadata.unwrap_or_default();
+		// Sanitize gateway-generated/request-body metadata before merging explicit Bedrock
+		// metadata from headers.
+		let mut metadata = sanitize_request_metadata(req.metadata.unwrap_or_default());
 
+		// x-bedrock-metadata is an explicit Bedrock requestMetadata escape hatch. Forward it
+		// unchanged so Bedrock, not the gateway, rejects operator-supplied invalid values.
 		if let Some(header_metadata) = extract_metadata_from_headers(headers) {
 			metadata.extend(header_metadata);
 		}
 
-		let metadata = sanitize_request_metadata(metadata);
 		let metadata = if metadata.is_empty() {
 			None
 		} else {

--- a/crates/agentgateway/src/llm/conversion/bedrock.rs
+++ b/crates/agentgateway/src/llm/conversion/bedrock.rs
@@ -420,31 +420,9 @@ pub mod from_completions {
 			None
 		};
 
-		// Build gateway-generated metadata from:
-		// - OpenAI `user` field (normalized as user_id)
-		// - OpenAI `metadata` field (agentgateway uses this to carry guardrail/model-armor knobs through Messages→Completions)
-		let mut metadata = req
-			.user
-			.map(|user| HashMap::from([("user_id".to_string(), user)]))
-			.unwrap_or_default();
-
-		// Merge OpenAI request `metadata` when it is an object of string values
-		if let Some(serde_json::Value::Object(obj)) = &req.metadata {
-			for (k, v) in obj {
-				if let serde_json::Value::String(s) = v {
-					metadata.insert(k.clone(), s.clone());
-				}
-			}
-		}
-
-		let mut metadata = helpers::sanitize_request_metadata(metadata);
-
 		// x-bedrock-metadata is an explicit Bedrock requestMetadata escape hatch. Forward it
 		// unchanged so Bedrock, not the gateway, rejects operator-supplied invalid values.
-		if let Some(header_metadata) = super::helpers::extract_metadata_from_headers(headers) {
-			metadata.extend(header_metadata);
-		}
-
+		let metadata = super::helpers::extract_metadata_from_headers(headers).unwrap_or_default();
 		let metadata = if metadata.is_empty() {
 			None
 		} else {
@@ -2023,16 +2001,9 @@ pub mod from_responses {
 			None
 		};
 
-		// Sanitize gateway-generated/request-body metadata before merging explicit Bedrock
-		// metadata from headers.
-		let mut metadata = sanitize_request_metadata(req.metadata.unwrap_or_default());
-
 		// x-bedrock-metadata is an explicit Bedrock requestMetadata escape hatch. Forward it
 		// unchanged so Bedrock, not the gateway, rejects operator-supplied invalid values.
-		if let Some(header_metadata) = extract_metadata_from_headers(headers) {
-			metadata.extend(header_metadata);
-		}
-
+		let metadata = extract_metadata_from_headers(headers).unwrap_or_default();
 		let metadata = if metadata.is_empty() {
 			None
 		} else {
@@ -2585,9 +2556,6 @@ mod helpers {
 	use crate::llm::AIError;
 	use crate::llm::types::bedrock;
 
-	const BEDROCK_REQUEST_METADATA_MAX_ENTRIES: usize = 16;
-	const BEDROCK_REQUEST_METADATA_MAX_LEN: usize = 256;
-
 	pub fn create_cache_point() -> bedrock::CachePointBlock {
 		bedrock::CachePointBlock {
 			r#type: bedrock::CachePointType::Default,
@@ -2692,36 +2660,6 @@ mod helpers {
 		}
 
 		metadata
-	}
-
-	/// Bedrock Converse requestMetadata only accepts short strings from a restricted
-	/// character set. Keep compatible entries unchanged and drop incompatible ones.
-	pub fn sanitize_request_metadata(metadata: HashMap<String, String>) -> HashMap<String, String> {
-		metadata
-			.into_iter()
-			.filter(|(key, value)| {
-				is_valid_request_metadata_key(key) && is_valid_request_metadata_value(value)
-			})
-			.take(BEDROCK_REQUEST_METADATA_MAX_ENTRIES)
-			.collect()
-	}
-
-	fn is_valid_request_metadata_key(value: &str) -> bool {
-		!value.is_empty() && is_valid_request_metadata_value(value)
-	}
-
-	fn is_valid_request_metadata_value(value: &str) -> bool {
-		value.len() <= BEDROCK_REQUEST_METADATA_MAX_LEN
-			&& value.chars().all(is_valid_request_metadata_char)
-	}
-
-	fn is_valid_request_metadata_char(c: char) -> bool {
-		c.is_ascii_alphanumeric()
-			|| c.is_ascii_whitespace()
-			|| matches!(
-				c,
-				':' | '_' | '@' | '$' | '#' | '=' | '/' | '+' | ',' | '-' | '.'
-			)
 	}
 
 	pub fn extract_beta_headers(

--- a/crates/agentgateway/src/llm/conversion/bedrock_tests.rs
+++ b/crates/agentgateway/src/llm/conversion/bedrock_tests.rs
@@ -114,7 +114,7 @@ fn test_metadata_from_header() {
 	let mut headers = HeaderMap::new();
 	headers.insert(
 		"x-bedrock-metadata",
-		r#"{"user_id": "user123", "department": "engineering"}"#
+		r#"{"user_id": "user123", "department": "engineering", "json_user": "{\"device_id\":\"abc\"}", "bad?key": "bad{}"}"#
 			.parse()
 			.unwrap(),
 	);
@@ -150,6 +150,11 @@ fn test_metadata_from_header() {
 
 	assert_eq!(metadata.get("user_id"), Some(&"user123".to_string()));
 	assert_eq!(metadata.get("department"), Some(&"engineering".to_string()));
+	assert_eq!(
+		metadata.get("json_user"),
+		Some(&r#"{"device_id":"abc"}"#.to_string())
+	);
+	assert_eq!(metadata.get("bad?key"), Some(&"bad{}".to_string()));
 }
 
 #[test]
@@ -668,6 +673,7 @@ fn test_metadata_from_completions_metadata_field() {
 		metadata: Some(json!({
 			"user_id": "user123",
 			"department": "engineering",
+			"json_user": r#"{"device_id":"from-body"}"#,
 			// Non-string values should be ignored by the Bedrock metadata bridge
 			"nonstr": 123
 		})),
@@ -679,12 +685,19 @@ fn test_metadata_from_completions_metadata_field() {
 		store: None,
 		reasoning_effort: None,
 	};
+	let mut headers = HeaderMap::new();
+	headers.insert(
+		"x-bedrock-metadata",
+		r#"{"json_user": "{\"device_id\":\"from-header\"}", "bad?key": "bad{}"}"#
+			.parse()
+			.unwrap(),
+	);
 
 	let out = super::from_completions::translate_internal(
 		req,
 		"anthropic.claude-3-sonnet".to_string(),
 		&provider,
-		None,
+		Some(&headers),
 		None,
 	);
 	let md = out.request_metadata.unwrap();
@@ -692,6 +705,11 @@ fn test_metadata_from_completions_metadata_field() {
 	// `metadata.user_id` should win over the `user`-derived value.
 	assert_eq!(md.get("user_id"), Some(&"user123".to_string()));
 	assert_eq!(md.get("department"), Some(&"engineering".to_string()));
+	assert_eq!(
+		md.get("json_user"),
+		Some(&r#"{"device_id":"from-header"}"#.to_string())
+	);
+	assert_eq!(md.get("bad?key"), Some(&"bad{}".to_string()));
 	assert!(!md.contains_key("nonstr"));
 }
 
@@ -989,6 +1007,45 @@ fn test_responses_json_schema_text_format_maps_to_converse_output_config() {
 		translated["outputConfig"]["textFormat"]["structure"]["jsonSchema"]["schema"],
 		serde_json::to_string(&schema).unwrap()
 	);
+}
+
+#[test]
+fn test_responses_metadata_from_header_is_forwarded_without_sanitizing() {
+	let provider = Provider {
+		model: None,
+		region: strng::new("us-east-1"),
+		guardrail_identifier: None,
+		guardrail_version: None,
+	};
+
+	let req: types::responses::Request = serde_json::from_value(json!({
+		"model": "gpt-4o",
+		"max_output_tokens": 16,
+		"input": "Hello",
+		"metadata": {
+			"safe": "ok",
+			"json_user": "{\"device_id\":\"from-body\"}"
+		}
+	}))
+	.expect("valid responses request");
+
+	let mut headers = HeaderMap::new();
+	headers.insert(
+		"x-bedrock-metadata",
+		r#"{"json_user": "{\"device_id\":\"from-header\"}", "bad?key": "bad{}"}"#
+			.parse()
+			.unwrap(),
+	);
+
+	let translated = super::from_responses::translate(&req, &provider, Some(&headers), None).unwrap();
+	let translated: serde_json::Value = serde_json::from_slice(&translated).unwrap();
+
+	assert_eq!(translated["requestMetadata"]["safe"], "ok");
+	assert_eq!(
+		translated["requestMetadata"]["json_user"],
+		r#"{"device_id":"from-header"}"#
+	);
+	assert_eq!(translated["requestMetadata"]["bad?key"], "bad{}");
 }
 
 #[test]

--- a/crates/agentgateway/src/llm/conversion/bedrock_tests.rs
+++ b/crates/agentgateway/src/llm/conversion/bedrock_tests.rs
@@ -153,6 +153,56 @@ fn test_metadata_from_header() {
 }
 
 #[test]
+fn test_messages_metadata_is_preserved_in_additional_model_request_fields() {
+	let provider = Provider {
+		model: None,
+		region: strng::new("us-east-1"),
+		guardrail_identifier: None,
+		guardrail_version: None,
+	};
+
+	let json_encoded_user_id = r#"{"device_id":"704cb53c2074e9","account_uuid":"","session_id":"180423cd-fe24-4f48-bbde-b4ab5bfd36e7"}"#;
+	let req = messages::typed::Request {
+		model: "anthropic.claude-3-sonnet".to_string(),
+		messages: vec![messages::typed::Message {
+			role: messages::typed::Role::User,
+			content: vec![messages::typed::ContentBlock::Text(
+				messages::typed::ContentTextBlock {
+					text: "Hello".to_string(),
+					citations: None,
+					cache_control: None,
+				},
+			)],
+		}],
+		max_tokens: 100,
+		metadata: Some(messages::typed::Metadata {
+			fields: std::collections::HashMap::from([
+				("user_id".to_string(), json_encoded_user_id.to_string()),
+				("department".to_string(), "engineering".to_string()),
+			]),
+		}),
+		system: None,
+		stop_sequences: vec![],
+		stream: false,
+		temperature: None,
+		top_k: None,
+		top_p: None,
+		tools: None,
+		tool_choice: None,
+		thinking: None,
+		output_config: None,
+	};
+
+	let out = super::from_messages::translate_internal(req, &provider, None).unwrap();
+	let additional_fields = out.additional_model_request_fields.unwrap();
+	let metadata = additional_fields.get("metadata").unwrap();
+
+	assert!(out.request_metadata.is_none());
+	assert_eq!(metadata["user_id"], json_encoded_user_id);
+	assert_eq!(metadata["department"], "engineering");
+}
+
+#[test]
 fn test_output_config_effort_without_thinking_is_passed_through() {
 	let provider = Provider {
 		model: None,

--- a/crates/agentgateway/src/llm/conversion/bedrock_tests.rs
+++ b/crates/agentgateway/src/llm/conversion/bedrock_tests.rs
@@ -628,7 +628,7 @@ fn test_messages_image_url_to_bedrock_returns_error() {
 }
 
 #[test]
-fn test_metadata_from_completions_metadata_field() {
+fn test_completions_request_metadata_only_uses_bedrock_header() {
 	let provider = Provider {
 		model: None,
 		region: strng::new("us-east-1"),
@@ -636,7 +636,6 @@ fn test_metadata_from_completions_metadata_field() {
 		guardrail_version: None,
 	};
 
-	// OpenAI-style request metadata (agentgateway uses this to carry request-scoped guardrail knobs)
 	let req = types::completions::typed::Request {
 		model: Some("anthropic.claude-3-sonnet".to_string()),
 		messages: vec![types::completions::typed::RequestMessage::User(
@@ -674,7 +673,6 @@ fn test_metadata_from_completions_metadata_field() {
 			"user_id": "user123",
 			"department": "engineering",
 			"json_user": r#"{"device_id":"from-body"}"#,
-			// Non-string values should be ignored by the Bedrock metadata bridge
 			"nonstr": 123
 		})),
 		#[allow(deprecated)]
@@ -702,9 +700,8 @@ fn test_metadata_from_completions_metadata_field() {
 	);
 	let md = out.request_metadata.unwrap();
 
-	// `metadata.user_id` should win over the `user`-derived value.
-	assert_eq!(md.get("user_id"), Some(&"user123".to_string()));
-	assert_eq!(md.get("department"), Some(&"engineering".to_string()));
+	assert!(!md.contains_key("user_id"));
+	assert!(!md.contains_key("department"));
 	assert_eq!(
 		md.get("json_user"),
 		Some(&r#"{"device_id":"from-header"}"#.to_string())
@@ -1010,7 +1007,7 @@ fn test_responses_json_schema_text_format_maps_to_converse_output_config() {
 }
 
 #[test]
-fn test_responses_metadata_from_header_is_forwarded_without_sanitizing() {
+fn test_responses_request_metadata_only_uses_bedrock_header() {
 	let provider = Provider {
 		model: None,
 		region: strng::new("us-east-1"),
@@ -1039,8 +1036,11 @@ fn test_responses_metadata_from_header_is_forwarded_without_sanitizing() {
 
 	let translated = super::from_responses::translate(&req, &provider, Some(&headers), None).unwrap();
 	let translated: serde_json::Value = serde_json::from_slice(&translated).unwrap();
+	let metadata = translated["requestMetadata"]
+		.as_object()
+		.expect("requestMetadata object");
 
-	assert_eq!(translated["requestMetadata"]["safe"], "ok");
+	assert!(!metadata.contains_key("safe"));
 	assert_eq!(
 		translated["requestMetadata"]["json_user"],
 		r#"{"device_id":"from-header"}"#

--- a/crates/agentgateway/src/llm/tests/requests/completions/full.bedrock.snap
+++ b/crates/agentgateway/src/llm/tests/requests/completions/full.bedrock.snap
@@ -160,8 +160,5 @@ info:
         "name": "my_function"
       }
     }
-  },
-  "requestMetadata": {
-    "user_id": "user_12345"
   }
 }


### PR DESCRIPTION
## Summary

- sanitize Bedrock Converse requestMetadata keys and values before forwarding
- preserve Bedrock-compatible metadata unchanged
- hash incompatible or too-long metadata components as deterministic `sha256:<hex>` strings
- add a regression test for JSON-encoded Anthropic `metadata.user_id` from gateway-mode Claude Desktop requests

Fixes #1739

## Testing

- `cargo fmt`
- `cargo test -p agentgateway test_messages_metadata_invalid_user_id_is_bedrock_safe`
- `cargo test -p agentgateway llm::conversion::bedrock::tests::`