### PR TITLE
Handle invalid InferencePool EPP refs

### DIFF
--- a/controller/pkg/agentgateway/plugins/inference_plugin.go
+++ b/controller/pkg/agentgateway/plugins/inference_plugin.go
@@ -59,8 +59,22 @@ func translatePoliciesForInferencePool(
 
 	// 'service/{namespace}/{hostname}:{port}'
 	hostname := kubeutils.GetInferenceServiceHostname(pool.Name, pool.Namespace)
-	eppPort := epr.Port.Number
-	eppSvc := kubeutils.GetServiceHostname(string(epr.Name), pool.Namespace)
+	eppPort := int32(0)
+	eppSvc := ""
+	endpointPicker := &api.BackendReference{}
+	if validationErr == nil {
+		eppPort = int32(epr.Port.Number)
+		eppSvc = kubeutils.GetServiceHostname(string(epr.Name), pool.Namespace)
+		endpointPicker = &api.BackendReference{
+			Kind: &api.BackendReference_Service_{
+				Service: &api.BackendReference_Service{
+					Hostname:  eppSvc,
+					Namespace: pool.Namespace,
+				},
+			},
+			Port: uint32(eppPort), //nolint:gosec // G115: eppPort is derived from validated port numbers
+		}
+	}
 
 	failureMode := api.BackendPolicySpec_InferenceRouting_FAIL_CLOSED
 	if epr.FailureMode == inf.EndpointPickerFailOpen {
@@ -76,16 +90,8 @@ func translatePoliciesForInferencePool(
 			Backend: &api.BackendPolicySpec{
 				Kind: &api.BackendPolicySpec_InferenceRouting_{
 					InferenceRouting: &api.BackendPolicySpec_InferenceRouting{
-						EndpointPicker: &api.BackendReference{
-							Kind: &api.BackendReference_Service_{
-								Service: &api.BackendReference_Service{
-									Hostname:  eppSvc,
-									Namespace: pool.Namespace,
-								},
-							},
-							Port: uint32(eppPort), //nolint:gosec // G115: eppPort is derived from validated port numbers
-						},
-						FailureMode: failureMode,
+						EndpointPicker: endpointPicker,
+						FailureMode:    failureMode,
 					},
 				},
 			},
@@ -96,6 +102,14 @@ func translatePoliciesForInferencePool(
 		gatewayTargets = append(gatewayTargets, gatewayTarget)
 	}
 	infPolicies = appendPolicyForGateways(infPolicies, gatewayTargets, inferencePolicy)
+
+	if validationErr != nil {
+		logger.Debug("generated invalid inference pool policy",
+			"pool", pool.Name,
+			"namespace", pool.Namespace,
+			"inference_policy", inferencePolicy.Name)
+		return status, infPolicies
+	}
 
 	// Create the TLS policy for the endpoint picker
 	// TODO: we would want some way if they explicitly set a BackendTLSPolicy for the EPP to respect that

--- a/controller/pkg/agentgateway/translator/testdata/routes/inferencepool-invalid-endpoint-picker-ref-fail-open.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/routes/inferencepool-invalid-endpoint-picker-ref-fail-open.yaml
@@ -1,0 +1,123 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: invalid-epp-fail-open-route
+  namespace: default
+spec:
+  parentRefs:
+    - name: test-gateway
+  rules:
+    - backendRefs:
+        - name: invalid-epp-fail-open-pool
+          kind: InferencePool
+          group: inference.networking.k8s.io
+---
+apiVersion: inference.networking.k8s.io/v1
+kind: InferencePool
+metadata:
+  name: invalid-epp-fail-open-pool
+  namespace: default
+spec:
+  endpointPickerRef:
+    failureMode: FailOpen
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: test-gateway
+  selector:
+    matchLabels:
+      app: gateway
+  targetPorts:
+    - number: 8080
+
+---
+# Output
+output:
+- gateway:
+    Name: test-gateway
+    Namespace: default
+  resource:
+    policy:
+      backend:
+        inferenceRouting:
+          endpointPicker: {}
+          failureMode: FAIL_OPEN
+      key: default/invalid-epp-fail-open-pool:inference
+      name:
+        kind: InferencePool
+        name: invalid-epp-fail-open-pool
+        namespace: default
+      target:
+        service:
+          hostname: invalid-epp-fail-open-pool.default.inference.cluster.local
+          namespace: default
+- gateway:
+    Name: test-gateway
+    Namespace: default
+  resource:
+    route:
+      backends:
+      - backend:
+          port: 8080
+          service:
+            hostname: invalid-epp-fail-open-pool.default.inference.cluster.local
+            namespace: default
+        weight: 1
+      key: default/invalid-epp-fail-open-route.00.http
+      listenerKey: default/test-gateway.http
+      name:
+        kind: HTTPRoute
+        name: invalid-epp-fail-open-route
+        namespace: default
+status:
+- apiVersion: inference.networking.k8s.io/v1
+  kind: InferencePool
+  metadata:
+    name: invalid-epp-fail-open-pool
+    namespace: default
+  spec: null
+  status:
+    parents:
+    - conditions:
+      - lastTransitionTime: fake
+        message: InferencePool has been accepted by controller agentgateway.dev/agentgateway
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: 'error: endpointPickerRef.group must be empty, got "gateway.networking.k8s.io";
+          endpointPickerRef.kind must be "Service", got "Gateway"; endpointPickerRef.port
+          must be specified'
+        reason: InvalidExtensionRef
+        status: "False"
+        type: ResolvedRefs
+      controllerName: agentgateway.dev/agentgateway
+      parentRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: test-gateway
+        namespace: default
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    name: invalid-epp-fail-open-route
+    namespace: default
+  spec: null
+  status:
+    parents:
+    - conditions:
+      - lastTransitionTime: fake
+        message: ""
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: ""
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      controllerName: agentgateway.dev/agentgateway
+      parentRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: test-gateway
+        namespace: default

--- a/controller/pkg/agentgateway/translator/testdata/routes/inferencepool-invalid-endpoint-picker-ref.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/routes/inferencepool-invalid-endpoint-picker-ref.yaml
@@ -1,0 +1,122 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: invalid-epp-route
+  namespace: default
+spec:
+  parentRefs:
+    - name: test-gateway
+  rules:
+    - backendRefs:
+        - name: invalid-epp-pool
+          kind: InferencePool
+          group: inference.networking.k8s.io
+---
+apiVersion: inference.networking.k8s.io/v1
+kind: InferencePool
+metadata:
+  name: invalid-epp-pool
+  namespace: default
+spec:
+  endpointPickerRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: test-gateway
+  selector:
+    matchLabels:
+      app: gateway
+  targetPorts:
+    - number: 8080
+
+---
+# Output
+output:
+- gateway:
+    Name: test-gateway
+    Namespace: default
+  resource:
+    policy:
+      backend:
+        inferenceRouting:
+          endpointPicker: {}
+          failureMode: FAIL_CLOSED
+      key: default/invalid-epp-pool:inference
+      name:
+        kind: InferencePool
+        name: invalid-epp-pool
+        namespace: default
+      target:
+        service:
+          hostname: invalid-epp-pool.default.inference.cluster.local
+          namespace: default
+- gateway:
+    Name: test-gateway
+    Namespace: default
+  resource:
+    route:
+      backends:
+      - backend:
+          port: 8080
+          service:
+            hostname: invalid-epp-pool.default.inference.cluster.local
+            namespace: default
+        weight: 1
+      key: default/invalid-epp-route.00.http
+      listenerKey: default/test-gateway.http
+      name:
+        kind: HTTPRoute
+        name: invalid-epp-route
+        namespace: default
+status:
+- apiVersion: inference.networking.k8s.io/v1
+  kind: InferencePool
+  metadata:
+    name: invalid-epp-pool
+    namespace: default
+  spec: null
+  status:
+    parents:
+    - conditions:
+      - lastTransitionTime: fake
+        message: InferencePool has been accepted by controller agentgateway.dev/agentgateway
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: 'error: endpointPickerRef.group must be empty, got "gateway.networking.k8s.io";
+          endpointPickerRef.kind must be "Service", got "Gateway"; endpointPickerRef.port
+          must be specified'
+        reason: InvalidExtensionRef
+        status: "False"
+        type: ResolvedRefs
+      controllerName: agentgateway.dev/agentgateway
+      parentRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: test-gateway
+        namespace: default
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    name: invalid-epp-route
+    namespace: default
+  spec: null
+  status:
+    parents:
+    - conditions:
+      - lastTransitionTime: fake
+        message: ""
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: ""
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      controllerName: agentgateway.dev/agentgateway
+      parentRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: test-gateway
+        namespace: default


### PR DESCRIPTION
- Return ResolvedRefs=False for invalid InferencePool endpointPickerRef values.
- Preserve fail-closed behavior by emitting an invalid endpoint-picker backend reference.
- Add temporary local coverage until GAIE conformance covers the case.

Upstream conformance gap: https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/2915

Fixes: #1719