### PR TITLE
test(controller): cover legacy xDS token audiences

### DIFF
--- a/controller/pkg/setup/authn.go
+++ b/controller/pkg/setup/authn.go
@@ -20,7 +20,13 @@ const (
 	bearerTokenPrefix = "Bearer "
 )
 
+// Keep the legacy kgateway audience during mixed-version rollouts so older data
+// planes can still authenticate against a newer controller. Once the controller
+// and all deployed data planes project agentgateway-only xDS tokens, we can drop
+// the legacy audience.
 var xdsTokenAudiences = []string{"agentgateway", "kgateway"}
+
+var validateK8sJWT = tokenreview.ValidateK8sJwt
 
 // KubeJWTAuthenticator authenticates K8s JWTs.
 type KubeJWTAuthenticator struct {
@@ -73,7 +79,7 @@ func (a *KubeJWTAuthenticator) authenticateGrpc(ctx context.Context) (*security.
 }
 
 func (a *KubeJWTAuthenticator) authenticate(targetJWT string) (*security.Caller, error) {
-	id, err := tokenreview.ValidateK8sJwt(a.kubeClient, targetJWT, xdsTokenAudiences)
+	id, err := validateK8sJWT(a.kubeClient, targetJWT, xdsTokenAudiences)
 	if err != nil {
 		return nil, fmt.Errorf("failed to validate the JWT token: %v", err)
 	}

--- a/controller/pkg/setup/authn.go
+++ b/controller/pkg/setup/authn.go
@@ -26,11 +26,12 @@ const (
 // the legacy audience.
 var xdsTokenAudiences = []string{"agentgateway", "kgateway"}
 
-var validateK8sJWT = tokenreview.ValidateK8sJwt
+type jwtValidator func(kubernetes.Interface, string, []string) (security.KubernetesInfo, error)
 
 // KubeJWTAuthenticator authenticates K8s JWTs.
 type KubeJWTAuthenticator struct {
-	kubeClient kubernetes.Interface
+	kubeClient  kubernetes.Interface
+	validateJWT jwtValidator
 }
 
 var _ security.Authenticator = &KubeJWTAuthenticator{}
@@ -40,7 +41,8 @@ func NewKubeJWTAuthenticator(
 	client kubernetes.Interface,
 ) *KubeJWTAuthenticator {
 	out := &KubeJWTAuthenticator{
-		kubeClient: client,
+		kubeClient:  client,
+		validateJWT: tokenreview.ValidateK8sJwt,
 	}
 
 	return out
@@ -79,7 +81,7 @@ func (a *KubeJWTAuthenticator) authenticateGrpc(ctx context.Context) (*security.
 }
 
 func (a *KubeJWTAuthenticator) authenticate(targetJWT string) (*security.Caller, error) {
-	id, err := validateK8sJWT(a.kubeClient, targetJWT, xdsTokenAudiences)
+	id, err := a.validateJWT(a.kubeClient, targetJWT, xdsTokenAudiences)
 	if err != nil {
 		return nil, fmt.Errorf("failed to validate the JWT token: %v", err)
 	}

--- a/controller/pkg/setup/authn_test.go
+++ b/controller/pkg/setup/authn_test.go
@@ -2,21 +2,17 @@ package setup
 
 import (
 	"net/http"
+	"slices"
 	"testing"
 
+	"istio.io/istio/pkg/security"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
-
-	"istio.io/istio/pkg/security"
 )
 
 func TestAuthenticateUsesLegacyAndCurrentXDSTokenAudiences(t *testing.T) {
-	originalValidateK8sJWT := validateK8sJWT
-	t.Cleanup(func() {
-		validateK8sJWT = originalValidateK8sJWT
-	})
-
-	validateK8sJWT = func(_ kubernetes.Interface, targetToken string, audiences []string) (security.KubernetesInfo, error) {
+	authenticator := NewKubeJWTAuthenticator(fake.NewSimpleClientset())
+	authenticator.validateJWT = func(_ kubernetes.Interface, targetToken string, audiences []string) (security.KubernetesInfo, error) {
 		if targetToken != "test-token" {
 			t.Fatalf("unexpected token %q", targetToken)
 		}
@@ -32,8 +28,6 @@ func TestAuthenticateUsesLegacyAndCurrentXDSTokenAudiences(t *testing.T) {
 			PodServiceAccount: "agentgateway",
 		}, nil
 	}
-
-	authenticator := NewKubeJWTAuthenticator(fake.NewSimpleClientset())
 
 	caller, err := authenticator.authenticate("test-token")
 	if err != nil {
@@ -52,7 +46,7 @@ func TestAuthenticateUsesLegacyAndCurrentXDSTokenAudiences(t *testing.T) {
 
 func TestExtractRequestToken(t *testing.T) {
 	t.Run("extracts bearer token", func(t *testing.T) {
-		req := testRequestWithAuthHeader("Bearer test-token")
+		req := testRequestWithAuthHeader(t, "Bearer test-token")
 
 		token, err := extractRequestToken(req)
 		if err != nil {
@@ -64,7 +58,7 @@ func TestExtractRequestToken(t *testing.T) {
 	})
 
 	t.Run("rejects missing authorization header", func(t *testing.T) {
-		req := testRequestWithAuthHeader("")
+		req := testRequestWithAuthHeader(t, "")
 
 		_, err := extractRequestToken(req)
 		if err == nil {
@@ -73,7 +67,7 @@ func TestExtractRequestToken(t *testing.T) {
 	})
 
 	t.Run("rejects non bearer authorization header", func(t *testing.T) {
-		req := testRequestWithAuthHeader("Basic abc123")
+		req := testRequestWithAuthHeader(t, "Basic abc123")
 
 		_, err := extractRequestToken(req)
 		if err == nil {
@@ -83,18 +77,15 @@ func TestExtractRequestToken(t *testing.T) {
 }
 
 func containsAudience(audiences []string, want string) bool {
-	for _, audience := range audiences {
-		if audience == want {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(audiences, want)
 }
 
-func testRequestWithAuthHeader(authHeader string) *http.Request {
+func testRequestWithAuthHeader(t *testing.T, authHeader string) *http.Request {
+	t.Helper()
+
 	req, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
 	if err != nil {
-		panic(err)
+		t.Fatalf("http.NewRequest returned error: %v", err)
 	}
 	if authHeader != "" {
 		req.Header.Set(authorizationHeader, authHeader)

--- a/controller/pkg/setup/authn_test.go
+++ b/controller/pkg/setup/authn_test.go
@@ -1,0 +1,103 @@
+package setup
+
+import (
+	"net/http"
+	"testing"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"istio.io/istio/pkg/security"
+)
+
+func TestAuthenticateUsesLegacyAndCurrentXDSTokenAudiences(t *testing.T) {
+	originalValidateK8sJWT := validateK8sJWT
+	t.Cleanup(func() {
+		validateK8sJWT = originalValidateK8sJWT
+	})
+
+	validateK8sJWT = func(_ kubernetes.Interface, targetToken string, audiences []string) (security.KubernetesInfo, error) {
+		if targetToken != "test-token" {
+			t.Fatalf("unexpected token %q", targetToken)
+		}
+		if len(audiences) != 2 {
+			t.Fatalf("expected 2 audiences, got %d", len(audiences))
+		}
+		if !containsAudience(audiences, "kgateway") || !containsAudience(audiences, "agentgateway") {
+			t.Fatalf("unexpected audiences: %v", audiences)
+		}
+
+		return security.KubernetesInfo{
+			PodNamespace:      "default",
+			PodServiceAccount: "agentgateway",
+		}, nil
+	}
+
+	authenticator := NewKubeJWTAuthenticator(fake.NewSimpleClientset())
+
+	caller, err := authenticator.authenticate("test-token")
+	if err != nil {
+		t.Fatalf("authenticate returned error: %v", err)
+	}
+	if caller == nil {
+		t.Fatal("expected caller, got nil")
+	}
+	if caller.KubernetesInfo.PodNamespace != "default" {
+		t.Fatalf("unexpected namespace %q", caller.KubernetesInfo.PodNamespace)
+	}
+	if caller.KubernetesInfo.PodServiceAccount != "agentgateway" {
+		t.Fatalf("unexpected service account %q", caller.KubernetesInfo.PodServiceAccount)
+	}
+}
+
+func TestExtractRequestToken(t *testing.T) {
+	t.Run("extracts bearer token", func(t *testing.T) {
+		req := testRequestWithAuthHeader("Bearer test-token")
+
+		token, err := extractRequestToken(req)
+		if err != nil {
+			t.Fatalf("extractRequestToken returned error: %v", err)
+		}
+		if token != "test-token" {
+			t.Fatalf("unexpected token %q", token)
+		}
+	})
+
+	t.Run("rejects missing authorization header", func(t *testing.T) {
+		req := testRequestWithAuthHeader("")
+
+		_, err := extractRequestToken(req)
+		if err == nil {
+			t.Fatal("expected error for missing authorization header")
+		}
+	})
+
+	t.Run("rejects non bearer authorization header", func(t *testing.T) {
+		req := testRequestWithAuthHeader("Basic abc123")
+
+		_, err := extractRequestToken(req)
+		if err == nil {
+			t.Fatal("expected error for non-bearer authorization header")
+		}
+	})
+}
+
+func containsAudience(audiences []string, want string) bool {
+	for _, audience := range audiences {
+		if audience == want {
+			return true
+		}
+	}
+	return false
+}
+
+func testRequestWithAuthHeader(authHeader string) *http.Request {
+	req, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	if err != nil {
+		panic(err)
+	}
+	if authHeader != "" {
+		req.Header.Set(authorizationHeader, authHeader)
+	}
+	return req
+}


### PR DESCRIPTION
## Summary

Fixes #1732

This change codifies the current mixed-version rollout behavior for xDS JWT authentication in the controller.

The controller still needs to accept both `agentgateway` and legacy `kgateway` token audiences while older data planes may still project service account tokens with the legacy audience. Without test
coverage, that compatibility could be removed accidentally during future cleanup.

## What changed

- added a comment in `controller/pkg/setup/authn.go` explaining why the legacy `kgateway` audience must remain accepted for now
- added unit tests in `controller/pkg/setup/authn_test.go` covering:
  - acceptance of both `agentgateway` and `kgateway` xDS token audiences
  - bearer token extraction behavior

## Notes

This PR does not change the intended runtime compatibility behavior.
It adds test coverage and documentation so mixed-version rollouts remain safe until the legacy audience can be removed deliberately in a future change.

## Testing

```bash
go test ./controller/pkg/setup
```