### PR TITLE
Add Istio ambient identification headers to outbound CONNECTs

### DIFF
--- a/crates/agentgateway/src/client/hbone_tunnel.rs
+++ b/crates/agentgateway/src/client/hbone_tunnel.rs
@@ -21,10 +21,11 @@ static BAGGAGE: http::HeaderName = http::HeaderName::from_static("baggage");
 /// `baggage` header is added (only set on the inner / terminating CONNECT).
 fn apply_hbone_headers(req: &mut ::http::Request<()>, headers: &HboneHeaders, inner: bool) {
 	let h = req.headers_mut();
-	if let Some(role) = headers.source
-		&& let Ok(v) = ::http::HeaderValue::from_str(role.as_header_value())
-	{
-		h.insert(X_ISTIO_SOURCE.clone(), v);
+	if let Some(role) = headers.source {
+		h.insert(
+			X_ISTIO_SOURCE.clone(),
+			http::HeaderValue::from_static(role.as_header_value()),
+		);
 	}
 	if !headers.forwarded_network.is_empty()
 		&& let Ok(v) = ::http::HeaderValue::from_str(&headers.forwarded_network)

--- a/crates/agentgateway/src/client/hbone_tunnel.rs
+++ b/crates/agentgateway/src/client/hbone_tunnel.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use http::Uri;
 use http::uri::Scheme;
 
+use crate::client::HboneHeaders;
 use crate::http::Error;
 use crate::transport::hbone::WorkloadKey;
 use crate::transport::stream::Socket;
@@ -11,10 +12,38 @@ use crate::transport::{hbone, stream};
 use crate::types::agent::Target;
 use crate::types::discovery::Identity;
 
+static X_ISTIO_SOURCE: http::HeaderName = http::HeaderName::from_static("x-istio-source");
+static X_FORWARDED_NETWORK: http::HeaderName = http::HeaderName::from_static("x-forwarded-network");
+static BAGGAGE: http::HeaderName = http::HeaderName::from_static("baggage");
+
+/// Apply identification headers used by Istio's ambient multi-network plumbing
+/// to a CONNECT request. `inner` controls whether the workload-identifying
+/// `baggage` header is added (only set on the inner / terminating CONNECT).
+fn apply_hbone_headers(req: &mut ::http::Request<()>, headers: &HboneHeaders, inner: bool) {
+	let h = req.headers_mut();
+	if let Some(role) = headers.source
+		&& let Ok(v) = ::http::HeaderValue::from_str(role.as_header_value())
+	{
+		h.insert(X_ISTIO_SOURCE.clone(), v);
+	}
+	if !headers.forwarded_network.is_empty()
+		&& let Ok(v) = ::http::HeaderValue::from_str(&headers.forwarded_network)
+	{
+		h.insert(X_FORWARDED_NETWORK.clone(), v);
+	}
+	if inner
+		&& let Some(b) = headers.baggage.as_deref()
+		&& let Ok(v) = ::http::HeaderValue::from_str(b)
+	{
+		h.insert(BAGGAGE.clone(), v);
+	}
+}
+
 pub async fn handshake(
 	mut hbone_pool: agent_hbone::pool::WorkloadHBONEPool<hbone::WorkloadKey>,
 	ep: SocketAddr,
 	identities: Vec<Identity>,
+	headers: HboneHeaders,
 ) -> Result<Socket, Error> {
 	let uri = Uri::builder()
 		.scheme(Scheme::HTTPS)
@@ -23,12 +52,13 @@ pub async fn handshake(
 		.build()
 		.expect("static builder must be accepted");
 	tracing::debug!("will use HBONE");
-	let req = ::http::Request::builder()
+	let mut req = ::http::Request::builder()
 		.uri(uri)
 		.method(hyper::Method::CONNECT)
 		.version(hyper::Version::HTTP_2)
 		.body(())
 		.expect("builder with known status code should not fail");
+	apply_hbone_headers(&mut req, &headers, true);
 
 	let pool_key = Box::new(WorkloadKey {
 		dst_id: identities,
@@ -57,6 +87,7 @@ pub async fn handshake_double(
 	gateway_address: SocketAddr,
 	gateway_identity: Identity,
 	waypoint_identities: Vec<Identity>,
+	headers: HboneHeaders,
 ) -> Result<Socket, Error> {
 	tracing::debug!(
 		"will use DOUBLE HBONE: gateway {} -> workload {}",
@@ -80,12 +111,13 @@ pub async fn handshake_double(
 		.path_and_query("/")
 		.build()
 		.expect("uri build should not fail");
-	let outer_req = ::http::Request::builder()
+	let mut outer_req = ::http::Request::builder()
 		.uri(outer_uri)
 		.method(hyper::Method::CONNECT)
 		.version(hyper::Version::HTTP_2)
 		.body(())
 		.expect("builder with known status code should not fail");
+	apply_hbone_headers(&mut outer_req, &headers, false);
 
 	// Connect to the network gateway at its HBONE port
 	let outer_pool_key = Box::new(WorkloadKey {
@@ -155,12 +187,13 @@ pub async fn handshake_double(
 		.path_and_query("/")
 		.build()
 		.expect("uri build should not fail");
-	let inner_req = ::http::Request::builder()
+	let mut inner_req = ::http::Request::builder()
 		.uri(inner_uri)
 		.method(hyper::Method::CONNECT)
 		.version(hyper::Version::HTTP_2)
 		.body(())
 		.expect("builder with known status code should not fail");
+	apply_hbone_headers(&mut inner_req, &headers, true);
 
 	let inner_upgraded = sender
 		.send_request(inner_req)

--- a/crates/agentgateway/src/client/mod.rs
+++ b/crates/agentgateway/src/client/mod.rs
@@ -78,16 +78,54 @@ pub struct TunnelConfig {
 	pub token: Option<HeaderValue>,
 }
 
+/// The role this agentgateway is acting as when originating an HBONE CONNECT.
+/// Will be used as the `x-istio-source` header value.
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, serde::Serialize)]
+#[non_exhaustive]
+pub enum HboneSourceRole {
+	Waypoint,
+}
+
+impl HboneSourceRole {
+	pub fn as_header_value(self) -> &'static str {
+		match self {
+			HboneSourceRole::Waypoint => "waypoint",
+		}
+	}
+
+	/// Map an originating bind's tunnel protocol to the role it identifies as on
+	/// outbound HBONE CONNECTs. Returns `None` when no source role applies.
+	pub fn from_tunnel(tp: types::agent::TunnelProtocol) -> Option<Self> {
+		use types::agent::TunnelProtocol;
+		match tp {
+			TunnelProtocol::HboneWaypoint => Some(HboneSourceRole::Waypoint),
+			TunnelProtocol::Direct | TunnelProtocol::HboneGateway | TunnelProtocol::Proxy => None,
+		}
+	}
+}
+
+/// Headers added to outbound HBONE CONNECT requests so that downstream Istio
+/// components can identify the originator.
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub struct HboneHeaders {
+	pub source: Option<HboneSourceRole>,
+	pub forwarded_network: Strng,
+	/// Baggage describing the originating workload (cluster/namespace/etc.).
+	/// Only emitted on the inner CONNECT.
+	pub baggage: Option<Strng>,
+}
+
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub enum Transport {
 	Plain(ApplicationTransport),
 	Tunnel(ApplicationTransport, TunnelConfig),
-	Hbone(ApplicationTransport, Vec<Identity>),
+	Hbone(ApplicationTransport, Vec<Identity>, HboneHeaders),
 	DoubleHbone {
 		gateway_address: SocketAddr, // Address of network gateway to connect to
 		gateway_identity: Identity,  // Identity of network gateway
 		waypoint_identities: Vec<Identity>, // Identities of waypoint/workload (workload + service SANs)
 		inner: ApplicationTransport,
+		headers: HboneHeaders,
 	},
 }
 
@@ -108,7 +146,7 @@ impl Transport {
 		match self {
 			Transport::Plain(inner) => inner,
 			Transport::Tunnel(inner, _) => inner,
-			Transport::Hbone(inner, _) => inner,
+			Transport::Hbone(inner, _, _) => inner,
 			Transport::DoubleHbone { inner, .. } => inner,
 		}
 	}
@@ -125,8 +163,8 @@ impl Transport {
 
 	pub fn name(&self) -> &'static str {
 		match self {
-			Transport::Hbone(ApplicationTransport::Plaintext, _) => "hbone",
-			Transport::Hbone(ApplicationTransport::Tls(_), _) => "hbone-tls",
+			Transport::Hbone(ApplicationTransport::Plaintext, _, _) => "hbone",
+			Transport::Hbone(ApplicationTransport::Tls(_), _, _) => "hbone-tls",
 			Transport::Plain(ApplicationTransport::Plaintext) => "plaintext",
 			Transport::Plain(ApplicationTransport::Tls(_)) => "tls",
 			Transport::Tunnel(ApplicationTransport::Plaintext, _) => "tunnel",
@@ -281,12 +319,12 @@ impl Connector {
 				socket.ext_mut().insert(stream::HttpProxy);
 				socket
 			},
-			Transport::Hbone(_, identities) => {
+			Transport::Hbone(_, identities, headers) => {
 				let pool = self
 					.hbone_pool
 					.clone()
 					.ok_or_else(|| crate::http::Error::new(anyhow::anyhow!("hbone pool disabled")))?;
-				hbone_tunnel::handshake(pool, ep, identities).await?
+				hbone_tunnel::handshake(pool, ep, identities, headers).await?
 			},
 
 			Transport::DoubleHbone {
@@ -294,6 +332,7 @@ impl Connector {
 				gateway_identity,
 				waypoint_identities,
 				inner: _,
+				headers,
 			} => {
 				let pool = self
 					.hbone_pool
@@ -306,6 +345,7 @@ impl Connector {
 					gateway_address,
 					gateway_identity,
 					waypoint_identities,
+					headers,
 				)
 				.await?
 			},
@@ -623,5 +663,34 @@ impl Client {
 			.insert(transport::BufferLimit::new(buffer_limit));
 		resp.extensions_mut().insert(ResolvedDestination(dest));
 		Ok(resp)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::types::agent::TunnelProtocol;
+
+	#[test]
+	fn waypoint_bind_renders_as_waypoint() {
+		assert_eq!(
+			HboneSourceRole::from_tunnel(TunnelProtocol::HboneWaypoint).map(|r| r.as_header_value()),
+			Some("waypoint"),
+		);
+	}
+
+	#[test]
+	fn non_waypoint_tunnel_protocols_have_no_source_role() {
+		for tp in [
+			TunnelProtocol::Direct,
+			TunnelProtocol::HboneGateway,
+			TunnelProtocol::Proxy,
+		] {
+			assert_eq!(
+				HboneSourceRole::from_tunnel(tp),
+				None,
+				"tunnel protocol {tp:?} should map to no source role",
+			);
+		}
 	}
 }

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -19,7 +19,7 @@ use types::agent::*;
 use types::discovery::*;
 
 use crate::cel::{BackendContext, RequestTime};
-use crate::client::{ApplicationTransport, Transport};
+use crate::client::{ApplicationTransport, HboneHeaders, HboneSourceRole, Transport};
 use crate::http::backendtls::BackendTLS;
 use crate::http::ext_proc::{ExtProcRequest, InferenceRoutingDestinationMode};
 use crate::http::filters::{AutoHostname, BackendRequestTimeout};
@@ -1072,6 +1072,7 @@ impl HTTPProxy {
 		let start = log.start;
 		let call = make_backend_call(
 			self.inputs.clone(),
+			hbone_source_for_bind(&self.inputs, &self.bind_name),
 			route_policies.clone(),
 			&selected_backend.backend.backend,
 			backend_policies,
@@ -1193,9 +1194,53 @@ async fn handle_upgrade(
 	Ok(resp)
 }
 
+/// Resolve a bind to the HBONE source role it should advertise on outbound
+/// CONNECTs. Returns `None` if the bind is unknown or its tunnel protocol has
+/// no associated role.
+pub(crate) fn hbone_source_for_bind(
+	inputs: &ProxyInputs,
+	bind_name: &BindKey,
+) -> Option<HboneSourceRole> {
+	let binds = inputs.stores.read_binds();
+	let tp = binds
+		.bind(bind_name)
+		.map(|b| b.tunnel_protocol)
+		.unwrap_or(TunnelProtocol::Direct);
+	HboneSourceRole::from_tunnel(tp)
+}
+
+/// Build the `x-istio-source` / `x-forwarded-network` / `baggage` headers added
+/// to outbound HBONE CONNECTs.
+pub(crate) fn build_hbone_headers(
+	inputs: &ProxyInputs,
+	source: Option<HboneSourceRole>,
+) -> HboneHeaders {
+	let baggage = inputs
+		.stores
+		.read_discovery()
+		.self_workload
+		.get()
+		.map(format_baggage)
+		.map(strng::new);
+	HboneHeaders {
+		source,
+		forwarded_network: inputs.cfg.network.clone(),
+		baggage,
+	}
+}
+
+/// Format matches Istio's `baggageFormat`.
+fn format_baggage(w: &Workload) -> String {
+	format!(
+		"k8s.cluster.name={},k8s.namespace.name={},k8s.deployment.name={},service.name={},service.version={}",
+		w.cluster_id, w.namespace, w.workload_name, w.canonical_name, w.canonical_revision,
+	)
+}
+
 pub async fn build_transport(
 	inputs: &ProxyInputs,
 	backend_call: &BackendCall,
+	hbone_source: Option<HboneSourceRole>,
 	backend_tls: Option<BackendTLS>,
 	backend_tunnel: Option<&backend::Tunnel>,
 	backend_http_version_override: Option<::http::Version>,
@@ -1217,6 +1262,7 @@ pub async fn build_transport(
 		let transport = Box::pin(build_transport(
 			inputs,
 			&call,
+			hbone_source,
 			tunnel_backend_tls,
 			None,
 			// Currently we only support HTTP/1.1
@@ -1269,6 +1315,7 @@ pub async fn build_transport(
 				gateway_identity: gw_identity.clone(),
 				waypoint_identities: waypoint_identities.clone(),
 				inner: app_transport,
+				headers: build_hbone_headers(inputs, hbone_source),
 			});
 		} else {
 			warn!("wanted double hbone but CA is not available");
@@ -1295,7 +1342,11 @@ pub async fn build_transport(
 		},
 		(Some((InboundProtocol::HBONE, idents)), Some(ca)) => {
 			if ca.get_identity().await.is_ok() {
-				Transport::Hbone(app_transport, idents.clone())
+				Transport::Hbone(
+					app_transport,
+					idents.clone(),
+					build_hbone_headers(inputs, hbone_source),
+				)
 			} else {
 				warn!("wanted TLS but CA is not available");
 				app_transport.into()
@@ -1373,8 +1424,10 @@ impl DerefMut for MustSnapshot<'_> {
 	}
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn make_backend_call(
 	inputs: Arc<ProxyInputs>,
+	hbone_source: Option<HboneSourceRole>,
 	route_policies: Arc<store::LLMRequestPolicies>,
 	backend: &Backend,
 	base_policies: BackendPolicies,
@@ -1564,7 +1617,6 @@ async fn make_backend_call(
 		},
 		Backend::Invalid => return Err(ProxyResponse::from(ProxyError::BackendDoesNotExist)),
 	};
-
 	// Apply auth before LLM request setup, so the providers can assume auth is in standardized header
 	// Apply auth as early as possible so any ext_proc or transformations won't be repeated on retries in case it fails.
 	let backend_info = auth::BackendInfo {
@@ -1765,6 +1817,7 @@ async fn make_backend_call(
 	let transport = build_transport(
 		&inputs,
 		&backend_call,
+		hbone_source,
 		backend_call.backend_policies.backend_tls.clone(),
 		backend_call.backend_policies.tunnel.as_ref(),
 		backend_call
@@ -2543,6 +2596,7 @@ impl PolicyClient {
 		Box::pin(async move {
 			make_backend_call(
 				self.inputs.clone(),
+				None,
 				Arc::new(LLMRequestPolicies::default()),
 				&backend,
 				pols,

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -1072,7 +1072,6 @@ impl HTTPProxy {
 		let start = log.start;
 		let call = make_backend_call(
 			self.inputs.clone(),
-			hbone_source_for_bind(&self.inputs, &self.bind_name),
 			route_policies.clone(),
 			&selected_backend.backend.backend,
 			backend_policies,
@@ -1192,21 +1191,6 @@ async fn handle_upgrade(
 		drop(log);
 	});
 	Ok(resp)
-}
-
-/// Resolve a bind to the HBONE source role it should advertise on outbound
-/// CONNECTs. Returns `None` if the bind is unknown or its tunnel protocol has
-/// no associated role.
-pub(crate) fn hbone_source_for_bind(
-	inputs: &ProxyInputs,
-	bind_name: &BindKey,
-) -> Option<HboneSourceRole> {
-	let binds = inputs.stores.read_binds();
-	let tp = binds
-		.bind(bind_name)
-		.map(|b| b.tunnel_protocol)
-		.unwrap_or(TunnelProtocol::Direct);
-	HboneSourceRole::from_tunnel(tp)
 }
 
 /// Build the `x-istio-source` / `x-forwarded-network` / `baggage` headers added
@@ -1427,7 +1411,6 @@ impl DerefMut for MustSnapshot<'_> {
 #[allow(clippy::too_many_arguments)]
 async fn make_backend_call(
 	inputs: Arc<ProxyInputs>,
-	hbone_source: Option<HboneSourceRole>,
 	route_policies: Arc<store::LLMRequestPolicies>,
 	backend: &Backend,
 	base_policies: BackendPolicies,
@@ -1438,6 +1421,11 @@ async fn make_backend_call(
 	let policy_client = PolicyClient {
 		inputs: inputs.clone(),
 	};
+	let hbone_source = req
+		.extensions()
+		.get::<WaypointService>()
+		.is_some()
+		.then_some(HboneSourceRole::Waypoint);
 
 	// The MCP backend aggregates multiple backends into a single backend.
 	// In some cases, we want to treat this as a normal backend, so we swap it out.
@@ -2596,7 +2584,6 @@ impl PolicyClient {
 		Box::pin(async move {
 			make_backend_call(
 				self.inputs.clone(),
-				None,
 				Arc::new(LLMRequestPolicies::default()),
 				&backend,
 				pols,

--- a/crates/agentgateway/src/proxy/tcpproxy.rs
+++ b/crates/agentgateway/src/proxy/tcpproxy.rs
@@ -178,6 +178,7 @@ impl TCPProxy {
 			&selected_backend.backend.backend,
 			backend_policies,
 		)?;
+		let hbone_source = crate::proxy::httpproxy::hbone_source_for_bind(&inputs, &bind_name);
 
 		let bi = selected_backend.backend.backend.backend_info();
 		log.endpoint = Some(backend_call.target.clone());
@@ -186,6 +187,7 @@ impl TCPProxy {
 		let transport = crate::proxy::httpproxy::build_transport(
 			&inputs,
 			&backend_call,
+			hbone_source,
 			backend_call.backend_policies.backend_tls.clone(),
 			backend_call.backend_policies.tunnel.as_ref(),
 			// TODO: for TCP we should actually probably do something here: telling it to not use ALPN at all?

--- a/crates/agentgateway/src/proxy/tcpproxy.rs
+++ b/crates/agentgateway/src/proxy/tcpproxy.rs
@@ -178,7 +178,10 @@ impl TCPProxy {
 			&selected_backend.backend.backend,
 			backend_policies,
 		)?;
-		let hbone_source = crate::proxy::httpproxy::hbone_source_for_bind(&inputs, &bind_name);
+		let hbone_source = connection
+			.ext::<WaypointService>()
+			.is_some()
+			.then_some(crate::client::HboneSourceRole::Waypoint);
 
 		let bi = selected_backend.backend.backend.backend_info();
 		log.endpoint = Some(backend_call.target.clone());

--- a/crates/agentgateway/tests/common/hbone_server.rs
+++ b/crates/agentgateway/tests/common/hbone_server.rs
@@ -7,6 +7,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use bytes::Bytes;
+use http::HeaderMap;
 use http_body_util::Full;
 use hyper::Response;
 use hyper::server::conn::http2;
@@ -15,6 +16,7 @@ use hyper_util::rt::TokioIo;
 use rand::Rng;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::net::TcpListener;
+use tokio::sync::mpsc;
 use tracing::{debug, error, info};
 
 #[allow(dead_code)]
@@ -34,6 +36,7 @@ pub struct HboneTestServer {
 	name: String,
 	waypoint_message: Vec<u8>, // Prefix to write before echoing data
 	port: u16,                 // The actual bound port
+	header_tx: Option<mpsc::UnboundedSender<HeaderMap>>,
 }
 
 impl HboneTestServer {
@@ -51,7 +54,16 @@ impl HboneTestServer {
 			name: name.to_string(),
 			waypoint_message,
 			port: actual_port,
+			header_tx: None,
 		}
+	}
+
+	/// Forward each accepted CONNECT's request headers on `tx`. Used by tests
+	/// to assert ambient identification headers (`x-istio-source`, etc.) are
+	/// set on outbound CONNECTs.
+	#[allow(dead_code)]
+	pub fn capture_headers(&mut self, tx: mpsc::UnboundedSender<HeaderMap>) {
+		self.header_tx = Some(tx);
 	}
 
 	/// Returns the port this server is bound to
@@ -98,6 +110,7 @@ impl HboneTestServer {
 			let mode = self.mode.clone();
 			let waypoint_message = self.waypoint_message.clone();
 			let name = self.name.clone();
+			let header_tx = self.header_tx.clone();
 
 			tokio::spawn(async move {
 				if let Err(err) = http2::Builder::new(hyper_util::rt::TokioExecutor::new())
@@ -107,8 +120,12 @@ impl HboneTestServer {
 							let waypoint_message = waypoint_message.clone();
 							let mode = mode.clone();
 							let name = name.clone();
+							let header_tx = header_tx.clone();
 							async move {
 								info!("{}: received request", name);
+								if let Some(tx) = header_tx.as_ref() {
+									let _ = tx.send(req.headers().clone());
+								}
 								tokio::task::spawn(async move {
 									match hyper::upgrade::on(req).await {
 										Ok(upgraded) => {

--- a/crates/agentgateway/tests/tests/hbone.rs
+++ b/crates/agentgateway/tests/tests/hbone.rs
@@ -16,7 +16,7 @@ async fn test_hbone() -> anyhow::Result<()> {
 	// Start the HBONE server in ReadWrite (echo) mode on the standard HBONE port 15008
 	// It will prefix all echoed data with "waypoint:" to prove the connection went through it
 	// Note: The HBONE client in agentgateway hardcodes port 15008 for HBONE connections
-	let _hbone_port = start_hbone_server(15008, "test-server", WAYPOINT_PREFIX.to_vec()).await;
+	let _hbone_port = start_hbone_server(15008, "test-server", WAYPOINT_PREFIX.to_vec(), None).await;
 
 	// Configure agentgateway with CA and a workload that uses HBONE protocol
 	// The workload's protocol: HBONE tells AGW to connect via HBONE to port 15008
@@ -122,12 +122,12 @@ async fn test_double_hbone() -> anyhow::Result<()> {
 	// Start the waypoint HBONE server (the final destination) on an OS-assigned port
 	// It echoes back data with "waypoint:" prefix
 	// The waypoint must have the identity of the remote-server workload
-	let waypoint_port = start_hbone_server(0, "remote-server", WAYPOINT_PREFIX.to_vec()).await;
+	let waypoint_port = start_hbone_server(0, "remote-server", WAYPOINT_PREFIX.to_vec(), None).await;
 
 	// Start the E/W gateway HBONE server on an OS-assigned port
 	// It forwards connections to the waypoint's HBONE port
 	let waypoint_addr: SocketAddr = format!("127.0.0.1:{}", waypoint_port).parse().unwrap();
-	let gateway_port = start_hbone_forward_server(0, "ew-gateway", waypoint_addr).await;
+	let gateway_port = start_hbone_forward_server(0, "ew-gateway", waypoint_addr, None).await;
 
 	// Configure agentgateway with:
 	// 1. AGW itself is on network "" (default)
@@ -252,12 +252,12 @@ async fn test_double_hbone_with_hostname() -> anyhow::Result<()> {
 	// Start the waypoint HBONE server (the final destination) on an OS-assigned port
 	// It echoes back data with "waypoint:" prefix
 	// The waypoint must have the identity of the remote-server workload
-	let waypoint_port = start_hbone_server(0, "remote-server", WAYPOINT_PREFIX.to_vec()).await;
+	let waypoint_port = start_hbone_server(0, "remote-server", WAYPOINT_PREFIX.to_vec(), None).await;
 
 	// Start the E/W gateway HBONE server on an OS-assigned port
 	// It forwards connections to the waypoint's HBONE port
 	let waypoint_addr: SocketAddr = format!("127.0.0.1:{}", waypoint_port).parse().unwrap();
-	let gateway_port = start_hbone_forward_server(0, "ew-gateway", waypoint_addr).await;
+	let gateway_port = start_hbone_forward_server(0, "ew-gateway", waypoint_addr, None).await;
 
 	// Configure agentgateway with:
 	// 1. AGW itself is on network "" (default)
@@ -474,9 +474,131 @@ binds:
 	Ok(())
 }
 
-async fn start_hbone_server(port: u16, name: &str, waypoint_message: Vec<u8>) -> u16 {
+/// Verifies that outbound HBONE CONNECT requests carry Istio's ambient
+/// identification headers (`x-istio-source` / `x-forwarded-network`)
+/// according to the originating bind's role.
+#[tokio::test]
+async fn test_hbone_carries_istio_source_headers() -> anyhow::Result<()> {
+	agent_core::telemetry::testing::setup_test_logging();
+
+	let ca_addr = start_mock_ca_server().await?;
+
+	let (waypoint_tx, mut waypoint_rx) = tokio::sync::mpsc::unbounded_channel::<http::HeaderMap>();
+	let waypoint_port =
+		start_hbone_server(0, "remote-server", b"waypoint:".to_vec(), Some(waypoint_tx)).await;
+
+	let (gateway_tx, mut gateway_rx) = tokio::sync::mpsc::unbounded_channel::<http::HeaderMap>();
+	let waypoint_addr: SocketAddr = format!("127.0.0.1:{}", waypoint_port).parse().unwrap();
+	let gateway_port =
+		start_hbone_forward_server(0, "ew-gateway", waypoint_addr, Some(gateway_tx)).await;
+
+	let gw_config = format!(
+		r#"config:
+  network: "network-1"
+  namespace: default
+  serviceAccount: default
+  trustDomain: cluster.local
+  caAddress: "http://{ca_addr}"
+workloads:
+  - uid: "ew-gateway"
+    name: "ew-gateway"
+    namespace: "default"
+    serviceAccount: "ew-gateway"
+    trustDomain: "cluster.local"
+    workloadIps: ["127.0.0.1"]
+    network: "remote"
+    protocol: HBONE
+    services: {{}}
+  - uid: "remote-workload"
+    name: "remote-server"
+    namespace: "default"
+    serviceAccount: "remote-server"
+    trustDomain: "cluster.local"
+    workloadIps: ["127.0.0.2"]
+    network: "remote"
+    protocol: HBONE
+    networkGateway:
+      destination: "remote/127.0.0.1"
+      hboneMtlsPort: {gateway_port}
+    services:
+      default/remote-service.default.svc.cluster.local:
+        "8080": 8080
+services:
+  - name: "remote-service"
+    namespace: "default"
+    hostname: "remote-service.default.svc.cluster.local"
+    vips:
+      - "/127.0.0.2"
+    ports:
+      "8080": 8080
+binds:
+- port: $PORT
+  listeners:
+  - name: default
+    protocol: TCP
+    tcpRoutes:
+    - name: default
+      backends:
+        - service:
+            name: default/remote-service.default.svc.cluster.local
+            port: 8080
+"#
+	);
+
+	let gw = AgentGateway::new(gw_config).await?;
+
+	use tokio::io::AsyncWriteExt;
+	use tokio::net::TcpStream;
+	let mut stream = TcpStream::connect(("127.0.0.1", gw.port()))
+		.await
+		.expect("connect to gw");
+	stream.write_all(b"hi").await.expect("write");
+	stream.shutdown().await.expect("shutdown");
+
+	let assert_headers = |label: &'static str, headers: http::HeaderMap| {
+		assert!(
+			headers.get("x-istio-source").is_none(),
+			"{label}: expected no x-istio-source for non-waypoint bind, got: {:?}",
+			headers,
+		);
+		assert_eq!(
+			headers
+				.get("x-forwarded-network")
+				.map(|v| v.to_str().unwrap_or("").to_string()),
+			Some("network-1".to_string()),
+			"{label}: expected x-forwarded-network: network-1, got: {:?}",
+			headers,
+		);
+	};
+
+	let outer = tokio::time::timeout(std::time::Duration::from_secs(5), gateway_rx.recv())
+		.await
+		.expect("timeout waiting for outer CONNECT headers")
+		.expect("gateway closed without forwarding headers");
+	assert_headers("outer (e/w gateway)", outer);
+
+	let inner = tokio::time::timeout(std::time::Duration::from_secs(5), waypoint_rx.recv())
+		.await
+		.expect("timeout waiting for inner CONNECT headers")
+		.expect("waypoint closed without forwarding headers");
+	assert_headers("inner (waypoint)", inner);
+
+	drop(stream);
+	gw.shutdown().await;
+	Ok(())
+}
+
+async fn start_hbone_server(
+	port: u16,
+	name: &str,
+	waypoint_message: Vec<u8>,
+	header_tx: Option<tokio::sync::mpsc::UnboundedSender<http::HeaderMap>>,
+) -> u16 {
 	let name = name.to_string();
-	let server = HboneTestServer::new(Mode::ReadWrite, &name, waypoint_message, port).await;
+	let mut server = HboneTestServer::new(Mode::ReadWrite, &name, waypoint_message, port).await;
+	if let Some(tx) = header_tx {
+		server.capture_headers(tx);
+	}
 	let actual_port = server.port();
 	tokio::spawn(async move {
 		server.run().await;
@@ -484,9 +606,17 @@ async fn start_hbone_server(port: u16, name: &str, waypoint_message: Vec<u8>) ->
 	actual_port
 }
 
-async fn start_hbone_forward_server(port: u16, name: &str, forward_to: SocketAddr) -> u16 {
+async fn start_hbone_forward_server(
+	port: u16,
+	name: &str,
+	forward_to: SocketAddr,
+	header_tx: Option<tokio::sync::mpsc::UnboundedSender<http::HeaderMap>>,
+) -> u16 {
 	let name = name.to_string();
-	let server = HboneTestServer::new(Mode::Forward(forward_to), &name, vec![], port).await;
+	let mut server = HboneTestServer::new(Mode::Forward(forward_to), &name, vec![], port).await;
+	if let Some(tx) = header_tx {
+		server.capture_headers(tx);
+	}
 	let actual_port = server.port();
 	tokio::spawn(async move {
 		server.run().await;

--- a/crates/agentgateway/tests/tests/hbone.rs
+++ b/crates/agentgateway/tests/tests/hbone.rs
@@ -474,11 +474,13 @@ binds:
 	Ok(())
 }
 
-/// Verifies that outbound HBONE CONNECT requests carry Istio's ambient
-/// identification headers (`x-istio-source` / `x-forwarded-network`)
-/// according to the originating bind's role.
+/// Verifies that outbound double-HBONE CONNECTs carry `x-forwarded-network`
+/// and `baggage` (inner only). The bind uses the default `Direct` tunnel
+/// protocol, so `x-istio-source` is absent; the waypoint role mapping
+/// (`HboneWaypoint → "waypoint"`) is covered by the unit tests in
+/// `client::tests`.
 #[tokio::test]
-async fn test_hbone_carries_istio_source_headers() -> anyhow::Result<()> {
+async fn test_hbone_carries_istio_headers() -> anyhow::Result<()> {
 	agent_core::telemetry::testing::setup_test_logging();
 
 	let ca_addr = start_mock_ca_server().await?;
@@ -555,33 +557,46 @@ binds:
 	stream.write_all(b"hi").await.expect("write");
 	stream.shutdown().await.expect("shutdown");
 
-	let assert_headers = |label: &'static str, headers: http::HeaderMap| {
-		assert!(
-			headers.get("x-istio-source").is_none(),
-			"{label}: expected no x-istio-source for non-waypoint bind, got: {:?}",
-			headers,
-		);
-		assert_eq!(
-			headers
-				.get("x-forwarded-network")
-				.map(|v| v.to_str().unwrap_or("").to_string()),
-			Some("network-1".to_string()),
-			"{label}: expected x-forwarded-network: network-1, got: {:?}",
-			headers,
-		);
-	};
-
 	let outer = tokio::time::timeout(std::time::Duration::from_secs(5), gateway_rx.recv())
 		.await
 		.expect("timeout waiting for outer CONNECT headers")
 		.expect("gateway closed without forwarding headers");
-	assert_headers("outer (e/w gateway)", outer);
+	assert!(
+		outer.get("x-istio-source").is_none(),
+		"outer: Direct bind should not set x-istio-source",
+	);
+	assert_eq!(
+		outer
+			.get("x-forwarded-network")
+			.map(|v| v.to_str().unwrap()),
+		Some("network-1"),
+		"outer: expected x-forwarded-network: network-1",
+	);
+	assert!(
+		outer.get("baggage").is_none(),
+		"outer: baggage must only appear on the inner CONNECT",
+	);
 
+	// --- inner CONNECT (to waypoint / workload): no x-istio-source, has x-forwarded-network + baggage ---
 	let inner = tokio::time::timeout(std::time::Duration::from_secs(5), waypoint_rx.recv())
 		.await
 		.expect("timeout waiting for inner CONNECT headers")
 		.expect("waypoint closed without forwarding headers");
-	assert_headers("inner (waypoint)", inner);
+	assert!(
+		inner.get("x-istio-source").is_none(),
+		"inner: Direct bind should not set x-istio-source",
+	);
+	assert_eq!(
+		inner
+			.get("x-forwarded-network")
+			.map(|v| v.to_str().unwrap()),
+		Some("network-1"),
+		"inner: expected x-forwarded-network: network-1",
+	);
+	assert!(
+		inner.get("baggage").is_some(),
+		"inner: expected baggage header on inner CONNECT",
+	);
 
 	drop(stream);
 	gw.shutdown().await;


### PR DESCRIPTION
Adds `x-istio-source`, `x-forwarded-network`, and `baggage` headers to outbound HBONE CONNECT requests.

- `x-istio-source` reflects the originating bind's role (Currently only `waypoint` or None).
- `x-forwarded-network` carries the gateway's configured network name.
- `baggage` encodes workload identity metadata and is only sent on inner CONNECTs.

Extends `HboneTestServer` with header capture support and adds an integration test (`test_hbone_carries_istio_source_headers`) verifying headers on both legs of a double-HBONE connection.
