### PR TITLE
Add form body helpers for OAuth device flow transformations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 .run
 .DS_Store
 .venv
+.env
+.env.*
 *.local
 var/
 controller/_output

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,7 @@ dependencies = [
  "base64",
  "cel",
  "divan",
+ "hashbrown 0.17.0",
  "hex",
  "ipnet",
  "md-5 0.11.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,7 @@ dependencies = [
  "serde_regex",
  "sha1 0.11.0",
  "sha2 0.11.0",
+ "url",
  "uuid",
  "vector-map",
 ]

--- a/crates/agentgateway/src/http/transformation_cel_tests.rs
+++ b/crates/agentgateway/src/http/transformation_cel_tests.rs
@@ -58,6 +58,137 @@ async fn test_transformation_body() {
 	assert_eq!(b.as_ref(), b"helloGET");
 }
 
+#[tokio::test]
+async fn test_transformation_form_urlencoded_body_merge() {
+	let mut req = ::http::Request::builder()
+		.method("POST")
+		.uri("https://gateway.example.com/oauth/devicecode")
+		.header("content-type", "application/x-www-form-urlencoded")
+		.header("content-length", "0")
+		.body(crate::http::Body::empty())
+		.unwrap();
+	req
+		.extensions_mut()
+		.insert(crate::cel::BufferedBody(bytes::Bytes::new()));
+
+	let c = super::LocalTransformationConfig {
+		request: Some(super::LocalTransform {
+			body: Some(
+				r#"
+request.path == "/oauth/devicecode" ?
+	form.encode(form.decode(request.body).merge({
+		"client_id": "app-id",
+		"scope": "openid profile api://app-id/access_as_user"
+	})) :
+request.path == "/oauth/token" ?
+	form.encode(form.decode(request.body).merge({"client_id": "app-id"})) :
+request.body
+"#
+				.into(),
+			),
+			..Default::default()
+		}),
+		response: None,
+	};
+	let xfm = Transformation::try_from_local_config(c, true).unwrap();
+
+	xfm.apply_request(&mut req);
+
+	assert!(req.headers().get(::http::header::CONTENT_LENGTH).is_none());
+	let body = crate::http::read_body_with_limit(req.into_body(), 1000)
+		.await
+		.unwrap();
+	let fields = url::form_urlencoded::parse(body.as_ref())
+		.into_owned()
+		.collect::<std::collections::HashMap<_, _>>();
+	assert_eq!(fields.get("client_id").unwrap(), "app-id");
+	assert_eq!(
+		fields.get("scope").unwrap(),
+		"openid profile api://app-id/access_as_user"
+	);
+
+	let mut req = ::http::Request::builder()
+		.method("POST")
+		.uri("https://gateway.example.com/oauth/token")
+		.header("content-type", "application/x-www-form-urlencoded")
+		.header("content-length", "0")
+		.body(crate::http::Body::empty())
+		.unwrap();
+	req
+		.extensions_mut()
+		.insert(crate::cel::BufferedBody(bytes::Bytes::from_static(
+			b"grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Adevice_code&device_code=abc",
+		)));
+
+	xfm.apply_request(&mut req);
+
+	let body = crate::http::read_body_with_limit(req.into_body(), 1000)
+		.await
+		.unwrap();
+	let fields = url::form_urlencoded::parse(body.as_ref())
+		.into_owned()
+		.collect::<std::collections::HashMap<_, _>>();
+	assert_eq!(fields.get("client_id").unwrap(), "app-id");
+	assert_eq!(fields.get("device_code").unwrap(), "abc");
+	assert_eq!(
+		fields.get("grant_type").unwrap(),
+		"urn:ietf:params:oauth:grant-type:device_code"
+	);
+	assert!(!fields.contains_key("scope"));
+}
+
+#[tokio::test]
+async fn test_transformation_response_json_body_rewrite() {
+	let mut req = ::http::Request::builder()
+		.method("POST")
+		.uri("https://gateway.example.com/oauth/devicecode")
+		.body(crate::http::Body::empty())
+		.unwrap();
+	let c = super::LocalTransformationConfig {
+		request: None,
+		response: Some(super::LocalTransform {
+			body: Some(
+				r#"
+json(response.body).merge({
+	"verification_uri": "https://gateway.example.com/oauth/verify",
+	"verification_uri_complete": "https://gateway.example.com/oauth/verify?user_code=" + json(response.body).user_code
+})
+"#
+					.into(),
+			),
+			..Default::default()
+		}),
+	};
+	let xfm = Transformation::try_from_local_config(c, true).unwrap();
+	let mut resp = ::http::Response::builder()
+		.status(200)
+		.header("content-type", "application/json")
+		.body(crate::http::Body::from(
+			r#"{"verification_uri":"https://login.microsoft.com/device","verification_uri_complete":"https://login.microsoft.com/device?user_code=ABCDEFGH","user_code":"ABCDEFGH"}"#,
+		))
+		.unwrap();
+	resp.extensions_mut().insert(crate::cel::BufferedBody(
+		bytes::Bytes::from_static(
+			br#"{"verification_uri":"https://login.microsoft.com/device","verification_uri_complete":"https://login.microsoft.com/device?user_code=ABCDEFGH","user_code":"ABCDEFGH"}"#,
+		),
+	));
+
+	let snap = cel::snapshot_request(&mut req, true);
+	xfm.apply_response(&mut resp, Some(&snap));
+	let body = crate::http::read_body_with_limit(resp.into_body(), 1000)
+		.await
+		.unwrap();
+	let rewritten: serde_json::Value = serde_json::from_slice(body.as_ref()).unwrap();
+	assert_eq!(
+		rewritten["verification_uri"],
+		"https://gateway.example.com/oauth/verify"
+	);
+	assert_eq!(
+		rewritten["verification_uri_complete"],
+		"https://gateway.example.com/oauth/verify?user_code=ABCDEFGH"
+	);
+}
+
 #[test]
 fn test_transformation_pseudoheader() {
 	let mut req = ::http::Request::builder()

--- a/crates/agentgateway/src/http/transformation_cel_tests.rs
+++ b/crates/agentgateway/src/http/transformation_cel_tests.rs
@@ -149,13 +149,15 @@ async fn test_transformation_response_json_body_rewrite() {
 		response: Some(super::LocalTransform {
 			body: Some(
 				r#"
-json(response.body).merge({
-	"verification_uri": "https://gateway.example.com/oauth/verify",
-	"verification_uri_complete": "https://gateway.example.com/oauth/verify?user_code=" + json(response.body).user_code
-})
-"#
+json(response.body).with(body,
+	body.merge({
+		"verification_uri": "https://gateway.example.com/oauth/verify",
+		"verification_uri_complete": "https://gateway.example.com/oauth/verify?user_code=" + body.user_code
+	})
+)
+	"#
 					.into(),
-			),
+				),
 			..Default::default()
 		}),
 	};

--- a/crates/celx/Cargo.toml
+++ b/crates/celx/Cargo.toml
@@ -21,6 +21,7 @@ cel.workspace = true
 rand.workspace = true
 base64.workspace = true
 hex.workspace = true
+hashbrown.workspace = true
 ipnet.workspace = true
 regex.workspace = true
 serde_json.workspace = true

--- a/crates/celx/Cargo.toml
+++ b/crates/celx/Cargo.toml
@@ -29,6 +29,7 @@ md-5.workspace = true
 sha1.workspace = true
 sha2.workspace = true
 uuid.workspace = true
+url.workspace = true
 serde_regex.workspace = true
 vector-map.workspace = true
 divan = { workspace = true, optional = true }

--- a/crates/celx/src/function_tests.rs
+++ b/crates/celx/src/function_tests.rs
@@ -132,6 +132,42 @@ fn base64() {
 }
 
 #[test]
+fn form() {
+	assert(
+		json!({"client_id": "abc", "scope": "openid profile"}),
+		r#"form.decode("client_id=abc&scope=openid+profile")"#,
+	);
+	assert(json!({"a": ["1", "2"]}), r#"form.decode("a=1&a=2")"#);
+	assert(
+		json!("scope=openid+profile"),
+		r#"form.encode({"scope": "openid profile"})"#,
+	);
+	assert(
+		json!({"client_id": "app id", "scope": "openid profile"}),
+		r#"form.decode(form.encode({"client_id": "app id", "scope": "openid profile"}))"#,
+	);
+	assert(
+		json!({
+			"client_id": "app-id",
+			"scope": "openid profile api://app-id/access_as_user",
+		}),
+		r#"form.decode(form.encode(form.decode("").merge({"client_id": "app-id", "scope": "openid profile api://app-id/access_as_user"})))"#,
+	);
+	assert(
+		json!({
+			"client_id": "app-id",
+			"device_code": "abc",
+			"grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+		}),
+		r#"form.decode(form.encode(form.decode("grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Adevice_code&device_code=abc").merge({"client_id": "app-id"})))"#,
+	);
+
+	assert_fails(r#"form.decode({})"#);
+	assert_fails(r#"form.encode([])"#);
+	assert_fails(r#"form.encode({"bad": {}})"#);
+}
+
+#[test]
 fn hashes() {
 	assert(
 		json!("aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d"),

--- a/crates/celx/src/general.rs
+++ b/crates/celx/src/general.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use ::cel::extractors::{Argument, This};
-use ::cel::objects::{MapValue, StringValue, ValueType};
+use ::cel::objects::{ListValue, MapValue, StringValue, ValueType};
 use ::cel::{Context, FunctionContext, ResolveResult, Value};
 use base64::alphabet;
 use base64::engine::{DecodePaddingMode, GeneralPurpose, GeneralPurposeConfig};
@@ -14,6 +14,7 @@ use serde::Deserializer;
 use sha1::Sha1;
 use sha2::Sha256;
 use sha2::digest::Digest;
+use url::form_urlencoded;
 use uuid::Uuid;
 
 pub fn insert_all(ctx: &mut Context) {
@@ -35,12 +36,16 @@ pub fn insert_all(ctx: &mut Context) {
 	ctx.add_function("regexReplace", regex_replace);
 	ctx.add_function("fail", fail);
 	ctx.add_function("uuid", uuid_generate);
+	ctx.add_function("formDecode", form_decode);
+	ctx.add_function("formEncode", form_encode);
 
 	// Support legacy and modern name
 	ctx.add_function("base64Encode", base64_encode);
 	ctx.add_function("base64Decode", base64_decode);
 	ctx.add_qualified_function("base64", "encode", base64_encode);
 	ctx.add_qualified_function("base64", "decode", base64_decode);
+	ctx.add_qualified_function("form", "decode", form_decode);
+	ctx.add_qualified_function("form", "encode", form_encode);
 	ctx.add_qualified_function("sha1", "encode", sha1_encode);
 	ctx.add_qualified_function("sha256", "encode", sha256_encode);
 	ctx.add_qualified_function("md5", "encode", md5_encode);
@@ -98,6 +103,70 @@ pub fn sha1_encode<'a>(ftx: &mut FunctionContext<'a, '_>, v: Argument) -> Resolv
 
 pub fn md5_encode<'a>(ftx: &mut FunctionContext<'a, '_>, v: Argument) -> ResolveResult<'a> {
 	hash_encode::<Md5>(ftx, v)
+}
+
+pub fn form_decode<'a>(ftx: &mut FunctionContext<'a, '_>, v: Argument) -> ResolveResult<'a> {
+	let v = v.load(ftx)?.always_materialize_owned();
+	let bytes = v.as_bytes_pre_materialized()?;
+	let pairs = form_urlencoded::parse(bytes);
+	let mut values = std::collections::HashMap::<String, Vec<String>>::new();
+	for (key, value) in pairs {
+		values
+			.entry(key.into_owned())
+			.or_default()
+			.push(value.into_owned());
+	}
+
+	let map = values
+		.into_iter()
+		.map(|(key, values)| {
+			let value = if values.len() == 1 {
+				Value::from(values.into_iter().next().unwrap())
+			} else {
+				Value::List(ListValue::Owned(
+					values
+						.into_iter()
+						.map(Value::from)
+						.collect::<Vec<_>>()
+						.into(),
+				))
+			};
+			(key, value)
+		})
+		.collect::<std::collections::HashMap<_, _>>();
+	Ok(Value::Map(MapValue::from(map)))
+}
+
+pub fn form_encode<'a>(ftx: &mut FunctionContext<'a, '_>, v: Argument) -> ResolveResult<'a> {
+	let v = v.load_value(ftx)?;
+	let map = must_map(v)?;
+	let mut fields = map
+		.iter_owned()
+		.map(|(key, value)| (key.to_string(), value.always_materialize_owned()))
+		.collect::<Vec<_>>();
+	fields.sort_by(|(left, _), (right, _)| left.cmp(right));
+
+	let mut serializer = form_urlencoded::Serializer::new(String::new());
+	for (key, value) in fields {
+		match value {
+			Value::List(values) => {
+				for value in values.as_ref() {
+					let value = value
+						.as_str()
+						.map_err(|e| ftx.error(format!("invalid form value for key {key}: {e}")))?;
+					serializer.append_pair(&key, value.as_ref());
+				}
+			},
+			Value::Null => {},
+			value => {
+				let value = value
+					.as_str()
+					.map_err(|e| ftx.error(format!("invalid form value for key {key}: {e}")))?;
+				serializer.append_pair(&key, value.as_ref());
+			},
+		}
+	}
+	Ok(serializer.finish().into())
 }
 
 fn with<'a, 'rf, 'b>(

--- a/crates/celx/src/general.rs
+++ b/crates/celx/src/general.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use ::cel::extractors::{Argument, This};
-use ::cel::objects::{ListValue, MapValue, StringValue, ValueType};
+use ::cel::objects::{Key, MapValue, StringValue, ValueType};
 use ::cel::{Context, FunctionContext, ResolveResult, Value};
 use base64::alphabet;
 use base64::engine::{DecodePaddingMode, GeneralPurpose, GeneralPurposeConfig};
@@ -109,32 +109,29 @@ pub fn form_decode<'a>(ftx: &mut FunctionContext<'a, '_>, v: Argument) -> Resolv
 	let v = v.load(ftx)?.always_materialize_owned();
 	let bytes = v.as_bytes_pre_materialized()?;
 	let pairs = form_urlencoded::parse(bytes);
-	let mut values = std::collections::HashMap::<String, Vec<String>>::new();
+	let mut map = hashbrown::HashMap::<Key, Value<'static>>::new();
 	for (key, value) in pairs {
-		values
-			.entry(key.into_owned())
-			.or_default()
-			.push(value.into_owned());
+		let key = Key::from(key.into_owned());
+		let value = Value::from(value.into_owned());
+		match map.entry(key) {
+			hashbrown::hash_map::Entry::Vacant(entry) => {
+				entry.insert(value);
+			},
+			hashbrown::hash_map::Entry::Occupied(mut entry) => match entry.get_mut() {
+				Value::List(values) => {
+					let mut values = values.as_ref().to_vec();
+					values.push(value);
+					entry.insert(Value::from(values));
+				},
+				existing => {
+					let first = std::mem::replace(existing, Value::Null);
+					entry.insert(Value::from(vec![first, value]));
+				},
+			},
+		}
 	}
 
-	let map = values
-		.into_iter()
-		.map(|(key, values)| {
-			let value = if values.len() == 1 {
-				Value::from(values.into_iter().next().unwrap())
-			} else {
-				Value::List(ListValue::Owned(
-					values
-						.into_iter()
-						.map(Value::from)
-						.collect::<Vec<_>>()
-						.into(),
-				))
-			};
-			(key, value)
-		})
-		.collect::<std::collections::HashMap<_, _>>();
-	Ok(Value::Map(MapValue::from(map)))
+	Ok(Value::Map(MapValue::Owned(Arc::new(map))))
 }
 
 pub fn form_encode<'a>(ftx: &mut FunctionContext<'a, '_>, v: Argument) -> ResolveResult<'a> {

--- a/crates/celx/src/general.rs
+++ b/crates/celx/src/general.rs
@@ -36,8 +36,6 @@ pub fn insert_all(ctx: &mut Context) {
 	ctx.add_function("regexReplace", regex_replace);
 	ctx.add_function("fail", fail);
 	ctx.add_function("uuid", uuid_generate);
-	ctx.add_function("formDecode", form_decode);
-	ctx.add_function("formEncode", form_encode);
 
 	// Support legacy and modern name
 	ctx.add_function("base64Encode", base64_encode);

--- a/examples/oauth2-proxy/README.md
+++ b/examples/oauth2-proxy/README.md
@@ -34,8 +34,8 @@ Requests to `http://localhost:3000` should automatically redirect to a GitHub si
 Some OAuth 2.0 Device Authorization Grant clients send empty
 `application/x-www-form-urlencoded` POST bodies and expect the gateway to add
 public-client fields before forwarding to the identity provider. A
-`transformation` policy can now parse the existing form body, merge required
-fields, and re-encode it with `form.decode` and `form.encode`.
+`transformation` policy can parse the existing form body, merge required fields,
+and re-encode it with `form.decode` and `form.encode`.
 
 ```yaml
 policies:

--- a/examples/oauth2-proxy/README.md
+++ b/examples/oauth2-proxy/README.md
@@ -28,3 +28,40 @@ cargo run -- -f examples/oauth2-proxy/config.yaml
 ```
 
 Requests to `http://localhost:3000` should automatically redirect to a GitHub sign-in page.
+
+### Device authorization grant transforms
+
+Some OAuth 2.0 Device Authorization Grant clients send empty
+`application/x-www-form-urlencoded` POST bodies and expect the gateway to add
+public-client fields before forwarding to the identity provider. A
+`transformation` policy can now parse the existing form body, merge required
+fields, and re-encode it with `form.decode` and `form.encode`.
+
+```yaml
+policies:
+  transformation:
+    request:
+      body: |
+        request.path == "/oauth/devicecode" ?
+          form.encode(form.decode(request.body).merge({
+            "client_id": "00000000-0000-0000-0000-000000000000",
+            "scope": "openid profile api://00000000-0000-0000-0000-000000000000/access_as_user"
+          })) :
+        request.path == "/oauth/token" ?
+          form.encode(form.decode(request.body).merge({
+            "client_id": "00000000-0000-0000-0000-000000000000"
+          })) :
+        request.body
+    response:
+      body: |
+        request.path == "/oauth/devicecode" ?
+          json(response.body).merge({
+            "verification_uri": "https://gateway.example.com/oauth/verify",
+            "verification_uri_complete": "https://gateway.example.com/oauth/verify?user_code=" + json(response.body).user_code
+          }) :
+        response.body
+```
+
+This pairs with the existing route, `urlRewrite`, `directResponse`, or
+`requestRedirect` policies used to proxy the authorization server metadata and
+serve the gateway-origin verification URL.

--- a/examples/oauth2-proxy/README.md
+++ b/examples/oauth2-proxy/README.md
@@ -39,7 +39,7 @@ fields, and re-encode it with `form.decode` and `form.encode`.
 
 ```yaml
 policies:
-  transformation:
+  transformations:
     request:
       body: |
         request.path == "/oauth/devicecode" ?

--- a/examples/oauth2-proxy/README.md
+++ b/examples/oauth2-proxy/README.md
@@ -55,10 +55,12 @@ policies:
     response:
       body: |
         request.path == "/oauth/devicecode" ?
-          json(response.body).merge({
-            "verification_uri": "https://gateway.example.com/oauth/verify",
-            "verification_uri_complete": "https://gateway.example.com/oauth/verify?user_code=" + json(response.body).user_code
-          }) :
+          json(response.body).with(body,
+            body.merge({
+              "verification_uri": "https://gateway.example.com/oauth/verify",
+              "verification_uri_complete": "https://gateway.example.com/oauth/verify?user_code=" + body.user_code
+            })
+          ) :
         response.body
 ```
 


### PR DESCRIPTION
Fixes #1736

## Summary
- add CEL `form.decode` / `form.encode` helpers for `application/x-www-form-urlencoded` request body transformations
- preserve repeated form fields as CEL lists and encode list values as repeated form fields
- document the OAuth device authorization grant transformation pattern, including `verification_uri` JSON response rewrites
- add coverage for `/oauth/devicecode`, `/oauth/token`, and response JSON body rewrite transformations

## Testing
- `CARGO_INCREMENTAL=0 RUSTFLAGS=''-Cdebuginfo=0'' cargo test -p agent-celx`\n- `CARGO_INCREMENTAL=0 RUSTFLAGS=\'-Cdebuginfo=0\' cargo test -p agentgateway transformation_cel`