### PR TITLE
cel: sneak response llm information

### DIFF
--- a/controller/test/e2e/features/agentgateway/aibackend/suite.go
+++ b/controller/test/e2e/features/agentgateway/aibackend/suite.go
@@ -37,8 +37,9 @@ const (
 	// Ref: https://github.com/solo-io/gloo-gateway-use-cases/blob/76e6cec2f0b41eda7a93ac87a1b0f41ddb17503c/ai-guardrail-webhook-server/main.py#L112
 	maskedPatternResponse = "****ing"
 
-	dockerBridgeIfaceIP = "172.17.0.1"
-
+	// TODO(nfuden): This shoudlnt be in this specific file, it should either be an overarching replacement or a special env variable as we see in some other projects
+	// Mac causes a lot of problems but we should be able to support it in general
+	dockerBridgeIfaceIP   = "172.17.0.1"
 	macOSDockerBridgeHost = "host.docker.internal"
 )
 

--- a/controller/test/e2e/features/agentgateway/aibackend/suite.go
+++ b/controller/test/e2e/features/agentgateway/aibackend/suite.go
@@ -65,7 +65,14 @@ var (
 	}
 	testCases = map[string]*base.TestCase{
 		"TestFailover": {
-			Manifests: []string{failoverEvictionManifest},
+			ManifestsWithTransform: map[string]func(string) string{
+				failoverEvictionManifest: func(original string) string {
+					if runtime.GOOS == "darwin" {
+						return strings.ReplaceAll(original, dockerBridgeIfaceIP, macOSDockerBridgeHost)
+					}
+					return original
+				},
+			},
 		},
 	}
 )
@@ -225,6 +232,7 @@ func (s *testingSuite) TestFailover() {
 		&testmatchers.HttpResponse{
 			StatusCode: http.StatusOK,
 			Body:       gomega.ContainSubstring(expectedResponse),
+			Headers:    map[string]any{"x-backend-model": "gpt-4o-mini", "x-model-swapped": "true"},
 		},
 		curl.WithPath("/v1/chat/completions"),
 		curl.WithPostBody(`{"messages": [{"role": "user", "content": "What is the name of this project?"}]}`),

--- a/controller/test/e2e/features/agentgateway/aibackend/suite.go
+++ b/controller/test/e2e/features/agentgateway/aibackend/suite.go
@@ -37,7 +37,7 @@ const (
 	// Ref: https://github.com/solo-io/gloo-gateway-use-cases/blob/76e6cec2f0b41eda7a93ac87a1b0f41ddb17503c/ai-guardrail-webhook-server/main.py#L112
 	maskedPatternResponse = "****ing"
 
-	// TODO(nfuden): This shoudlnt be in this specific file, it should either be an overarching replacement or a special env variable as we see in some other projects
+	// TODO(nfuden): This shouldnt be in this specific file, it should either be an overarching replacement or a special env variable as we see in some other projects
 	// Mac causes a lot of problems but we should be able to support it in general
 	dockerBridgeIfaceIP   = "172.17.0.1"
 	macOSDockerBridgeHost = "host.docker.internal"

--- a/controller/test/e2e/features/agentgateway/aibackend/testdata/failover_eviction.yaml
+++ b/controller/test/e2e/features/agentgateway/aibackend/testdata/failover_eviction.yaml
@@ -59,6 +59,25 @@ spec:
         value: "1"
 ---
 apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: model-header-transformation
+  namespace: default
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: llm-failover
+  traffic:
+    transformation:
+      response:
+        add:
+          - name: x-backend-model
+            value: 'default(llm.responseModel, "not-set")'
+          - name: x-model-swapped
+            value: 'string(default(llm.responseModel, "")==default(llm.requestModel, ""))'
+---
+apiVersion: agentgateway.dev/v1alpha1
 kind: AgentgatewayBackend
 metadata:
   name: openai-failover

--- a/crates/agentgateway/src/cel/mod.rs
+++ b/crates/agentgateway/src/cel/mod.rs
@@ -257,6 +257,10 @@ impl ContextBuilder {
 		}
 	}
 
+	pub fn needs_llm(&self) -> bool {
+		self.any_has(Attributes::Llm)
+	}
+
 	pub fn needs_llm_prompt(&self) -> bool {
 		self.any_has(Attributes::LlmPrompt)
 	}

--- a/crates/agentgateway/src/cel/types.rs
+++ b/crates/agentgateway/src/cel/types.rs
@@ -359,6 +359,9 @@ impl<'a> Executor<'a> {
 	}
 	fn set_response(&mut self, resp: &'a crate::http::Response) {
 		self.response = Some(resp.into());
+		if resp.extensions().get::<LLMContext>().is_some() {
+			self.llm = ExtensionOrDirect::Extension(resp.extensions());
+		}
 	}
 	fn set_response_snapshot(&mut self, resp: &'a ResponseSnapshot) {
 		self.response = Some(resp.into());

--- a/crates/agentgateway/src/cel/types.rs
+++ b/crates/agentgateway/src/cel/types.rs
@@ -359,8 +359,8 @@ impl<'a> Executor<'a> {
 	}
 	fn set_response(&mut self, resp: &'a crate::http::Response) {
 		self.response = Some(resp.into());
-		if resp.extensions().get::<LLMContext>().is_some() {
-			self.llm = ExtensionOrDirect::Extension(resp.extensions());
+		if let Some(llm) = resp.extensions().get::<LLMContext>() {
+			self.llm = ExtensionOrDirect::Direct(Some(llm));
 		}
 	}
 	fn set_response_snapshot(&mut self, resp: &'a ResponseSnapshot) {

--- a/crates/agentgateway/src/cel/types.rs
+++ b/crates/agentgateway/src/cel/types.rs
@@ -967,7 +967,7 @@ impl PartialEq for RequestRef<'_> {
 #[apply(schema!)]
 #[derive(Eq, PartialEq, cel::DynamicType)]
 pub struct LLMContext {
-	/// Whether the LLM response is streamed.
+	/// Whether the LLM response is streamed. If it is streamed some fields may be inconsistent based on when accessed during the response flow.
 	pub streaming: bool,
 	/// The model requested for the LLM request. This may differ from the actual model used.
 	#[dynamic(rename = "requestModel")]

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -988,12 +988,15 @@ impl AIProvider {
 			};
 
 			parts.headers.remove(header::CONTENT_LENGTH);
-			let resp = Response::from_parts(parts, bytes.into());
+			let mut resp = Response::from_parts(parts, bytes.into());
 			let llm_resp = LLMResponse {
 				count_tokens: Some(count),
 				..Default::default()
 			};
 			let llm_info = LLMInfo::new(req, llm_resp);
+			resp
+				.extensions_mut()
+				.insert(crate::cel::LLMContext::from(llm_info.clone()));
 			log.store(Some(llm_info));
 			return Ok(resp);
 		}
@@ -1003,8 +1006,11 @@ impl AIProvider {
 			if !parts.status.is_success() {
 				let body = self.process_error(&req, parts.status, &bytes)?;
 				parts.headers.remove(header::CONTENT_LENGTH);
-				let resp = Response::from_parts(parts, body.into());
+				let mut resp = Response::from_parts(parts, body.into());
 				let llm_info = LLMInfo::new(req, LLMResponse::default());
+				resp
+					.extensions_mut()
+					.insert(crate::cel::LLMContext::from(llm_info.clone()));
 				log.store(Some(llm_info));
 				return Ok(resp);
 			}
@@ -1012,8 +1018,11 @@ impl AIProvider {
 			let (llm_resp, bytes) = self.process_embeddings_response(&req, &parts.headers, bytes)?;
 
 			parts.headers.remove(header::CONTENT_LENGTH);
-			let resp = Response::from_parts(parts, bytes.into());
+			let mut resp = Response::from_parts(parts, bytes.into());
 			let llm_info = LLMInfo::new(req, llm_resp);
+			resp
+				.extensions_mut()
+				.insert(crate::cel::LLMContext::from(llm_info.clone()));
 			log.store(Some(llm_info));
 			return Ok(resp);
 		}
@@ -1057,12 +1066,15 @@ impl AIProvider {
 			Body::from(body)
 		};
 		parts.headers.remove(header::CONTENT_LENGTH);
-		let resp = Response::from_parts(parts, body);
+		let mut resp = Response::from_parts(parts, body);
 
 		let llm_info = LLMInfo::new(req, llm_resp);
 		// In the initial request, we subtracted the approximate request tokens.
 		// Now we should have the real request tokens and the response tokens
 		amend_tokens(rate_limit, &llm_info);
+		resp
+			.extensions_mut()
+			.insert(crate::cel::LLMContext::from(llm_info.clone()));
 		log.store(Some(llm_info));
 		Ok(resp)
 	}

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -988,41 +988,38 @@ impl AIProvider {
 			};
 
 			parts.headers.remove(header::CONTENT_LENGTH);
-			let mut resp = Response::from_parts(parts, bytes.into());
 			let llm_resp = LLMResponse {
 				count_tokens: Some(count),
 				..Default::default()
 			};
 			let llm_info = LLMInfo::new(req, llm_resp);
-			resp
-				.extensions_mut()
+			parts
+				.extensions
 				.insert(crate::cel::LLMContext::from(llm_info.clone()));
+			let resp = Response::from_parts(parts, bytes.into());
 			log.store(Some(llm_info));
 			return Ok(resp);
 		}
 
 		// embeddings has simplified response handling
 		if req.input_format == InputFormat::Embeddings {
+			parts.headers.remove(header::CONTENT_LENGTH);
 			if !parts.status.is_success() {
 				let body = self.process_error(&req, parts.status, &bytes)?;
-				parts.headers.remove(header::CONTENT_LENGTH);
-				let mut resp = Response::from_parts(parts, body.into());
 				let llm_info = LLMInfo::new(req, LLMResponse::default());
-				resp
-					.extensions_mut()
+				parts
+					.extensions
 					.insert(crate::cel::LLMContext::from(llm_info.clone()));
+				let resp = Response::from_parts(parts, body.into());
 				log.store(Some(llm_info));
 				return Ok(resp);
 			}
-
 			let (llm_resp, bytes) = self.process_embeddings_response(&req, &parts.headers, bytes)?;
-
-			parts.headers.remove(header::CONTENT_LENGTH);
-			let mut resp = Response::from_parts(parts, bytes.into());
 			let llm_info = LLMInfo::new(req, llm_resp);
-			resp
-				.extensions_mut()
+			parts
+				.extensions
 				.insert(crate::cel::LLMContext::from(llm_info.clone()));
+			let resp = Response::from_parts(parts, bytes.into());
 			log.store(Some(llm_info));
 			return Ok(resp);
 		}
@@ -1066,15 +1063,15 @@ impl AIProvider {
 			Body::from(body)
 		};
 		parts.headers.remove(header::CONTENT_LENGTH);
-		let mut resp = Response::from_parts(parts, body);
-
 		let llm_info = LLMInfo::new(req, llm_resp);
+		parts
+			.extensions
+			.insert(crate::cel::LLMContext::from(llm_info.clone()));
+		let resp = Response::from_parts(parts, body);
+
 		// In the initial request, we subtracted the approximate request tokens.
 		// Now we should have the real request tokens and the response tokens
 		amend_tokens(rate_limit, &llm_info);
-		resp
-			.extensions_mut()
-			.insert(crate::cel::LLMContext::from(llm_info.clone()));
 		log.store(Some(llm_info));
 		Ok(resp)
 	}

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -2399,11 +2399,6 @@ impl ResponsePolicies {
 	) -> Result<(), ProxyResponse> {
 		let rh = &mut self.response_headers;
 
-		if let Some(llm_info) = l.llm_response.take() {
-			let llm_ctx = crate::cel::LLMContext::from(llm_info);
-			resp.extensions_mut().insert(llm_ctx);
-		}
-
 		self
 			.route_response_header
 			.apply("response header modifier", l, resp, rh)

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -2399,6 +2399,11 @@ impl ResponsePolicies {
 	) -> Result<(), ProxyResponse> {
 		let rh = &mut self.response_headers;
 
+		if let Some(llm_info) = l.llm_response.take() {
+			let llm_ctx = crate::cel::LLMContext::from(llm_info);
+			resp.extensions_mut().insert(llm_ctx);
+		}
+
 		self
 			.route_response_header
 			.apply("response header modifier", l, resp, rh)

--- a/schema/cel.json
+++ b/schema/cel.json
@@ -196,7 +196,7 @@
       ],
       "properties": {
         "streaming": {
-          "description": "Whether the LLM response is streamed.",
+          "description": "Whether the LLM response is streamed. If it is streamed some fields may be inconsistent based on when accessed during the response flow.",
           "type": "boolean"
         },
         "requestModel": {

--- a/schema/cel.md
+++ b/schema/cel.md
@@ -28,7 +28,7 @@
 |`basicAuth`|object|`basicAuth` contains the claims from a verified basic authentication Key. This is only present if the Basic authentication policy is enabled.|
 |`basicAuth.username`|string||
 |`llm`|object|`llm` contains attributes about an LLM request or response. This is only present when using an `ai` backend.|
-|`llm.streaming`|boolean|Whether the LLM response is streamed.|
+|`llm.streaming`|boolean|Whether the LLM response is streamed. If it is streamed some fields may be inconsistent based on when accessed during the response flow.|
 |`llm.requestModel`|string|The model requested for the LLM request. This may differ from the actual model used.|
 |`llm.responseModel`|string|The model that actually served the LLM response.|
 |`llm.provider`|string|The provider of the LLM.|


### PR DESCRIPTION
This feels somewhat wrong but partial information for transformations seems powerful.

Today we do a lot of pushing things off to log but some meta information may be desired earlier so this attempts to do that. 

Considered alternatives such as pushing transformations to have the responsibility for grabbing llm_info

We dont seem to smuggle too much in the resp mutable extensions but we do it currently for buffeered body so it seemed safe enough as a mechanism for passing the llm info.


Basically this means we can get a mediocre sense of what llm response info is at transformation time so we can emit headers like 'string(default(llm.responseModel, "")==default(llm.requestModel, ""))'


Calls out the risk of streamed bodies and transformations in https://github.com/agentgateway/website/pull/478 and also makes some updates to the cel json information to call out the inconsistencies based on call time.