### PR TITLE
policies: add InferencePool targetRef support to AgentgatewayPolicy

### DIFF
--- a/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
+++ b/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
@@ -57,8 +57,8 @@ type AgentgatewayPolicyList struct {
 // +kubebuilder:validation:XValidation:rule="!(has(self.traffic) && has(self.traffic.jwtAuthentication) && has(self.backend) && has(self.backend.mcp) && has(self.backend.mcp.authentication))",message="traffic.jwtAuthentication may not be used with backend.mcp.authentication in the same policy"
 // +kubebuilder:validation:XValidation:rule="has(self.frontend) && has(self.targetRefs) ? self.targetRefs.all(t, t.kind == 'Gateway' && !has(t.sectionName)) : true",message="the 'frontend' field can only target a Gateway"
 // +kubebuilder:validation:XValidation:rule="has(self.frontend) && has(self.targetSelectors) ? self.targetSelectors.all(t, t.kind == 'Gateway' && !has(t.sectionName)) : true",message="the 'frontend' field can only target a Gateway"
-// +kubebuilder:validation:XValidation:rule="has(self.traffic) && has(self.targetRefs) ? self.targetRefs.all(t, t.kind in ['Gateway', 'HTTPRoute', 'GRPCRoute', 'ListenerSet']) : true",message="the 'traffic' field can only target a Gateway, ListenerSet, GRPCRoute, or HTTPRoute"
-// +kubebuilder:validation:XValidation:rule="has(self.traffic) && has(self.targetSelectors) ? self.targetSelectors.all(t, t.kind in ['Gateway', 'HTTPRoute', 'GRPCRoute', 'ListenerSet']) : true",message="the 'traffic' field can only target a Gateway, ListenerSet, GRPCRoute, or HTTPRoute"
+// +kubebuilder:validation:XValidation:rule="has(self.traffic) && has(self.targetRefs) ? self.targetRefs.all(t, t.kind in ['Gateway', 'HTTPRoute', 'GRPCRoute', 'ListenerSet', 'InferencePool']) : true",message="the 'traffic' field can only target a Gateway, ListenerSet, GRPCRoute, HTTPRoute, or InferencePool"
+// +kubebuilder:validation:XValidation:rule="has(self.traffic) && has(self.targetSelectors) ? self.targetSelectors.all(t, t.kind in ['Gateway', 'HTTPRoute', 'GRPCRoute', 'ListenerSet', 'InferencePool']) : true",message="the 'traffic' field can only target a Gateway, ListenerSet, GRPCRoute, HTTPRoute, or InferencePool"
 // +kubebuilder:validation:XValidation:rule="has(self.targetRefs) && has(self.traffic) && has(self.traffic.phase) && self.traffic.phase == 'PreRouting' ? self.targetRefs.all(t, t.kind in ['Gateway', 'ListenerSet']) : true",message="the 'traffic.phase=PreRouting' field can only target a Gateway or ListenerSet"
 // +kubebuilder:validation:XValidation:rule="has(self.targetSelectors) && has(self.traffic) && has(self.traffic.phase) && self.traffic.phase == 'PreRouting' ? self.targetSelectors.all(t, t.kind in ['Gateway', 'ListenerSet']) : true",message="the 'traffic.phase=PreRouting' field can only target a Gateway or ListenerSet"
 type AgentgatewayPolicySpec struct {
@@ -68,7 +68,7 @@ type AgentgatewayPolicySpec struct {
 	// +listType=atomic
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=16
-	// +kubebuilder:validation:XValidation:rule="self.all(r, (r.kind == 'Service' && r.group == '') || (r.kind == 'AgentgatewayBackend' && r.group == 'agentgateway.dev') || (r.kind in ['Gateway', 'HTTPRoute', 'GRPCRoute'] && r.group == 'gateway.networking.k8s.io') || (r.kind == 'ListenerSet' && r.group == 'gateway.networking.k8s.io'))",message="targetRefs may only reference Gateway, HTTPRoute, GRPCRoute, ListenerSet, Service, or AgentgatewayBackend resources"
+	// +kubebuilder:validation:XValidation:rule="self.all(r, (r.kind == 'Service' && r.group == '') || (r.kind == 'AgentgatewayBackend' && r.group == 'agentgateway.dev') || (r.kind in ['Gateway', 'HTTPRoute', 'GRPCRoute'] && r.group == 'gateway.networking.k8s.io') || (r.kind == 'ListenerSet' && r.group == 'gateway.networking.k8s.io') || (r.kind == 'InferencePool' && r.group == 'inference.networking.k8s.io'))",message="targetRefs may only reference Gateway, HTTPRoute, GRPCRoute, ListenerSet, Service, AgentgatewayBackend, or InferencePool resources"
 	// +kubebuilder:validation:XValidation:message="Only one Kind of targetRef can be set on one policy",rule="self.all(l1, !self.exists(l2, l1.kind != l2.kind))"
 	// +optional
 	TargetRefs []shared.LocalPolicyTargetReferenceWithSectionName `json:"targetRefs,omitempty"`
@@ -77,7 +77,7 @@ type AgentgatewayPolicySpec struct {
 	// to attach the policy to.
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=16
-	// +kubebuilder:validation:XValidation:rule="self.all(r, (r.kind == 'Service' && r.group == '') || (r.kind == 'AgentgatewayBackend' && r.group == 'agentgateway.dev') || (r.kind in ['Gateway', 'HTTPRoute', 'GRPCRoute'] && r.group == 'gateway.networking.k8s.io') || (r.kind == 'ListenerSet' && r.group == 'gateway.networking.k8s.io'))",message="targetRefs may only reference Gateway, HTTPRoute, GRPCRoute, ListenerSet, Service, or AgentgatewayBackend resources"
+	// +kubebuilder:validation:XValidation:rule="self.all(r, (r.kind == 'Service' && r.group == '') || (r.kind == 'AgentgatewayBackend' && r.group == 'agentgateway.dev') || (r.kind in ['Gateway', 'HTTPRoute', 'GRPCRoute'] && r.group == 'gateway.networking.k8s.io') || (r.kind == 'ListenerSet' && r.group == 'gateway.networking.k8s.io') || (r.kind == 'InferencePool' && r.group == 'inference.networking.k8s.io'))",message="targetRefs may only reference Gateway, HTTPRoute, GRPCRoute, ListenerSet, Service, AgentgatewayBackend, or InferencePool resources"
 	// +kubebuilder:validation:XValidation:message="Only one Kind of targetRef can be set on one policy",rule="self.all(l1, !self.exists(l2, l1.kind != l2.kind))"
 	// +optional
 	TargetSelectors []shared.LocalPolicyTargetSelectorWithSectionName `json:"targetSelectors,omitempty"`

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
@@ -5316,12 +5316,13 @@ spec:
                 x-kubernetes-list-type: atomic
                 x-kubernetes-validations:
                 - message: targetRefs may only reference Gateway, HTTPRoute, GRPCRoute,
-                    ListenerSet, Service, or AgentgatewayBackend resources
+                    ListenerSet, Service, AgentgatewayBackend, or InferencePool resources
                   rule: self.all(r, (r.kind == 'Service' && r.group == '') || (r.kind
                     == 'AgentgatewayBackend' && r.group == 'agentgateway.dev') ||
                     (r.kind in ['Gateway', 'HTTPRoute', 'GRPCRoute'] && r.group ==
                     'gateway.networking.k8s.io') || (r.kind == 'ListenerSet' && r.group
-                    == 'gateway.networking.k8s.io'))
+                    == 'gateway.networking.k8s.io') || (r.kind == 'InferencePool'
+                    && r.group == 'inference.networking.k8s.io'))
                 - message: Only one Kind of targetRef can be set on one policy
                   rule: self.all(l1, !self.exists(l2, l1.kind != l2.kind))
               targetSelectors:
@@ -5374,12 +5375,13 @@ spec:
                 type: array
                 x-kubernetes-validations:
                 - message: targetRefs may only reference Gateway, HTTPRoute, GRPCRoute,
-                    ListenerSet, Service, or AgentgatewayBackend resources
+                    ListenerSet, Service, AgentgatewayBackend, or InferencePool resources
                   rule: self.all(r, (r.kind == 'Service' && r.group == '') || (r.kind
                     == 'AgentgatewayBackend' && r.group == 'agentgateway.dev') ||
                     (r.kind in ['Gateway', 'HTTPRoute', 'GRPCRoute'] && r.group ==
                     'gateway.networking.k8s.io') || (r.kind == 'ListenerSet' && r.group
-                    == 'gateway.networking.k8s.io'))
+                    == 'gateway.networking.k8s.io') || (r.kind == 'InferencePool'
+                    && r.group == 'inference.networking.k8s.io'))
                 - message: Only one Kind of targetRef can be set on one policy
                   rule: self.all(l1, !self.exists(l2, l1.kind != l2.kind))
               traffic:
@@ -7758,15 +7760,15 @@ spec:
               rule: 'has(self.frontend) && has(self.targetSelectors) ? self.targetSelectors.all(t,
                 t.kind == ''Gateway'' && !has(t.sectionName)) : true'
             - message: the 'traffic' field can only target a Gateway, ListenerSet,
-                GRPCRoute, or HTTPRoute
+                GRPCRoute, HTTPRoute, or InferencePool
               rule: 'has(self.traffic) && has(self.targetRefs) ? self.targetRefs.all(t,
-                t.kind in [''Gateway'', ''HTTPRoute'', ''GRPCRoute'', ''ListenerSet''])
-                : true'
+                t.kind in [''Gateway'', ''HTTPRoute'', ''GRPCRoute'', ''ListenerSet'',
+                ''InferencePool'']) : true'
             - message: the 'traffic' field can only target a Gateway, ListenerSet,
-                GRPCRoute, or HTTPRoute
+                GRPCRoute, HTTPRoute, or InferencePool
               rule: 'has(self.traffic) && has(self.targetSelectors) ? self.targetSelectors.all(t,
-                t.kind in [''Gateway'', ''HTTPRoute'', ''GRPCRoute'', ''ListenerSet''])
-                : true'
+                t.kind in [''Gateway'', ''HTTPRoute'', ''GRPCRoute'', ''ListenerSet'',
+                ''InferencePool'']) : true'
             - message: the 'traffic.phase=PreRouting' field can only target a Gateway
                 or ListenerSet
               rule: 'has(self.targetRefs) && has(self.traffic) && has(self.traffic.phase)

--- a/controller/pkg/agentgateway/plugins/collection.go
+++ b/controller/pkg/agentgateway/plugins/collection.go
@@ -64,7 +64,8 @@ type AgwCollections struct {
 	ListenerSetsByNamespace krt.Index[string, *gwv1.ListenerSet]
 
 	// Extended resources
-	InferencePools krt.Collection[*inf.InferencePool]
+	InferencePools            krt.Collection[*inf.InferencePool]
+	InferencePoolsByNamespace krt.Index[string, *inf.InferencePool]
 
 	// agentgateway resources
 	Backends             krt.Collection[*agentgateway.AgentgatewayBackend]
@@ -203,6 +204,7 @@ func (c *AgwCollections) SetupIndexes() {
 	c.GRPCRoutesByNamespace = krt.NewNamespaceIndex(c.GRPCRoutes)
 	c.ListenerSetsByNamespace = krt.NewNamespaceIndex(c.ListenerSets)
 	c.BackendsByNamespace = krt.NewNamespaceIndex(c.Backends)
+	c.InferencePoolsByNamespace = krt.NewNamespaceIndex(c.InferencePools)
 }
 
 func (c *AgwCollections) HasSynced() bool {

--- a/controller/pkg/agentgateway/plugins/reference_indexes.go
+++ b/controller/pkg/agentgateway/plugins/reference_indexes.go
@@ -91,6 +91,11 @@ func DefaultReferenceTypes(agw *AgwCollections) ReferenceTypes {
 				return []*api.PolicyTarget{{
 					Kind: utils.ListenerSetTarget(namespace, string(name), sectionName),
 				}}, ResourceExists(krtctx, agw.ListenerSets, key)
+			case wellknown.InferencePoolGVK.GroupKind():
+				hostname := kubeutils.GetInferenceServiceHostname(string(name), namespace)
+				return []*api.PolicyTarget{{
+					Kind: utils.ServiceTargetWithHostname(namespace, hostname, nil),
+				}}, ResourceExists(krtctx, agw.InferencePools, key)
 			}
 			return nil, false
 		},

--- a/controller/pkg/agentgateway/plugins/reference_indexes.go
+++ b/controller/pkg/agentgateway/plugins/reference_indexes.go
@@ -147,6 +147,14 @@ func DefaultReferenceTypes(agw *AgwCollections) ReferenceTypes {
 					}}
 					targets = append(targets, ResolvedPolicySelectorTarget{Name: gwv1.ObjectName(svc.Name), Namespace: svc.Namespace, PolicyTargets: policyTargets})
 				}
+			case wellknown.InferencePoolGVK.GroupKind():
+				for _, pool := range krt.Fetch(krtctx, agw.InferencePools, krt.FilterLabel(selector.MatchLabels), krt.FilterIndex(agw.InferencePoolsByNamespace, policyNamespace)) {
+					hostname := kubeutils.GetInferenceServiceHostname(pool.Name, pool.Namespace)
+					policyTargets := []*api.PolicyTarget{{
+						Kind: utils.ServiceTargetWithHostname(pool.Namespace, hostname, nil),
+					}}
+					targets = append(targets, ResolvedPolicySelectorTarget{Name: gwv1.ObjectName(pool.Name), Namespace: pool.Namespace, PolicyTargets: policyTargets})
+				}
 			}
 
 			slices.SortFunc(targets, func(a, b ResolvedPolicySelectorTarget) int {

--- a/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/inferencepool-policy-selector.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/inferencepool-policy-selector.yaml
@@ -32,6 +32,20 @@ spec:
   selector:
     app: gateway
 ---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: inference-route
+  namespace: default
+spec:
+  parentRefs:
+    - name: test
+  rules:
+    - backendRefs:
+        - group: inference.networking.k8s.io
+          kind: InferencePool
+          name: gateway-pool
+---
 apiVersion: agentgateway.dev/v1alpha1
 kind: AgentgatewayPolicy
 metadata:
@@ -52,7 +66,66 @@ spec:
 
 ---
 # Output
-output: []
+output:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
+    policy:
+      backend:
+        inferenceRouting:
+          endpointPicker:
+            port: 9002
+            service:
+              hostname: gateway-pool-endpoint-picker.default.svc.cluster.local
+              namespace: default
+          failureMode: FAIL_CLOSED
+      key: default/gateway-pool:inference
+      name:
+        kind: InferencePool
+        name: gateway-pool
+        namespace: default
+      target:
+        service:
+          hostname: gateway-pool.default.inference.cluster.local
+          namespace: default
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
+    policy:
+      backend:
+        backendTls:
+          verification: INSECURE_ALL
+      key: default/gateway-pool:inferencetls
+      name:
+        kind: InferencePool
+        name: gateway-pool
+        namespace: default
+      target:
+        service:
+          hostname: gateway-pool-endpoint-picker.default.svc.cluster.local
+          namespace: default
+          port: 9002
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
+    policy:
+      key: traffic/default/pool-rl-policy:rl-local:default/gateway-pool.default.inference.cluster.local
+      name:
+        kind: AgentgatewayPolicy
+        name: pool-rl-policy
+        namespace: default
+      target:
+        service:
+          hostname: gateway-pool.default.inference.cluster.local
+          namespace: default
+      traffic:
+        localRateLimit:
+          fillInterval: 60s
+          maxTokens: "110"
+          tokensPerFill: "100"
 status:
 - apiVersion: agentgateway.dev/v1alpha1
   kind: AgentgatewayPolicy
@@ -63,8 +136,10 @@ status:
   status:
     ancestors:
     - ancestorRef:
-        group: agentgateway.dev
-        name: StatusSummary
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: test
+        namespace: default
       conditions:
       - lastTransitionTime: fake
         message: Policy accepted
@@ -72,9 +147,8 @@ status:
         status: "True"
         type: Accepted
       - lastTransitionTime: fake
-        message: 'Policy is not attached: InferencePool default/gateway-pool is not
-          attached to any Gateway'
-        reason: Pending
-        status: "False"
+        message: Attached to all targets
+        reason: Attached
+        status: "True"
         type: Attached
       controllerName: agentgateway.dev/agentgateway

--- a/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/inferencepool-policy-selector.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/inferencepool-policy-selector.yaml
@@ -1,0 +1,80 @@
+apiVersion: inference.networking.k8s.io/v1
+kind: InferencePool
+metadata:
+  name: gateway-pool
+  namespace: default
+  labels:
+    app: gateway-pool
+spec:
+  appProtocol: kubernetes.io/h2c
+  endpointPickerRef:
+    failureMode: FailClose
+    group: ""
+    kind: Service
+    name: gateway-pool-endpoint-picker
+    port:
+      number: 9002
+  selector:
+    matchLabels:
+      app: gateway
+  targetPorts:
+    - number: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gateway-pool-endpoint-picker
+  namespace: default
+spec:
+  ports:
+    - port: 9002
+      protocol: TCP
+  selector:
+    app: gateway
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: pool-rl-policy
+  namespace: default
+spec:
+  targetSelectors:
+  - group: inference.networking.k8s.io
+    kind: InferencePool
+    matchLabels:
+      app: gateway-pool
+  traffic:
+    rateLimit:
+      local:
+        - requests: 100
+          unit: Minutes
+          burst: 10
+
+---
+# Output
+output: []
+status:
+- apiVersion: agentgateway.dev/v1alpha1
+  kind: AgentgatewayPolicy
+  metadata:
+    name: pool-rl-policy
+    namespace: default
+  spec: null
+  status:
+    ancestors:
+    - ancestorRef:
+        group: agentgateway.dev
+        name: StatusSummary
+      conditions:
+      - lastTransitionTime: fake
+        message: Policy accepted
+        reason: Valid
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: 'Policy is not attached: InferencePool default/gateway-pool is not
+          attached to any Gateway'
+        reason: Pending
+        status: "False"
+        type: Attached
+      controllerName: agentgateway.dev/agentgateway

--- a/controller/pkg/agentgateway/translator/testdata/backends/inferencepool-policy.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/backends/inferencepool-policy.yaml
@@ -1,0 +1,150 @@
+apiVersion: inference.networking.k8s.io/v1
+kind: InferencePool
+metadata:
+  name: gateway-pool
+  namespace: default
+spec:
+  appProtocol: kubernetes.io/h2c
+  endpointPickerRef:
+    failureMode: FailClose
+    group: ""
+    kind: Service
+    name: gateway-pool-endpoint-picker
+    port:
+      number: 9002
+  selector:
+    matchLabels:
+      app: gateway
+  targetPorts:
+    - number: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gateway-pool-endpoint-picker
+  namespace: default
+spec:
+  ports:
+    - port: 9002
+      protocol: TCP
+  selector:
+    app: gateway
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: pool-rl-policy
+  namespace: default
+spec:
+  targetRefs:
+  - group: inference.networking.k8s.io
+    kind: InferencePool
+    name: gateway-pool
+  traffic:
+    rateLimit:
+      local:
+        - requests: 100
+          unit: Minutes
+          burst: 10
+
+---
+# Output
+output:
+- gateway:
+    Name: basic
+    Namespace: default
+  resource:
+    policy:
+      backend:
+        inferenceRouting:
+          endpointPicker:
+            port: 9002
+            service:
+              hostname: gateway-pool-endpoint-picker.default.svc.cluster.local
+              namespace: default
+          failureMode: FAIL_CLOSED
+      key: default/gateway-pool:inference
+      name:
+        kind: InferencePool
+        name: gateway-pool
+        namespace: default
+      target:
+        service:
+          hostname: gateway-pool.default.inference.cluster.local
+          namespace: default
+- gateway:
+    Name: basic
+    Namespace: default
+  resource:
+    policy:
+      backend:
+        backendTls:
+          verification: INSECURE_ALL
+      key: default/gateway-pool:inferencetls
+      name:
+        kind: InferencePool
+        name: gateway-pool
+        namespace: default
+      target:
+        service:
+          hostname: gateway-pool-endpoint-picker.default.svc.cluster.local
+          namespace: default
+          port: 9002
+- gateway:
+    Name: basic
+    Namespace: default
+  resource:
+    policy:
+      key: traffic/default/pool-rl-policy:rl-local:default/gateway-pool.default.inference.cluster.local
+      name:
+        kind: AgentgatewayPolicy
+        name: pool-rl-policy
+        namespace: default
+      target:
+        service:
+          hostname: gateway-pool.default.inference.cluster.local
+          namespace: default
+      traffic:
+        localRateLimit:
+          fillInterval: 60s
+          maxTokens: "110"
+          tokensPerFill: "100"
+- canonical: true
+  hostname: gateway-pool-endpoint-picker.default.svc.cluster.local
+  name: gateway-pool-endpoint-picker
+  namespace: default
+  ports:
+  - servicePort: 9002
+- hostname: gateway-pool.default.inference.cluster.local
+  name: gateway-pool
+  namespace: default
+  ports:
+  - appProtocol: HTTP2
+    servicePort: 8080
+    targetPort: 8080
+status:
+- apiVersion: inference.networking.k8s.io/v1
+  kind: InferencePool
+  metadata:
+    name: gateway-pool
+    namespace: default
+  spec: null
+  status:
+    parents:
+    - conditions:
+      - lastTransitionTime: fake
+        message: InferencePool has been accepted by controller agentgateway.dev/agentgateway
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: All InferencePool references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      controllerName: agentgateway.dev/agentgateway
+      parentRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: basic
+        namespace: default


### PR DESCRIPTION
Fixes #1714

## Changes

### Problem
`AgentgatewayPolicy.targetRefs` could not target `InferencePool` resources due to two separate blockers:

1. **CEL validation (API server level)**: The kubebuilder marker in `agentgateway_policy_types.go` generated a CEL rule that whitelisted only `Service`, `Gateway`, `HTTPRoute`, `GRPCRoute`, `ListenerSet`, and `AgentgatewayBackend`. Applying a policy targeting `InferencePool` was rejected by the API server before the controller ever saw it.

2. **Missing switch case (controller level)**: `reference_indexes.go` had no `InferencePool` case in the `PolicyTargets` switch, so even if CEL were fixed, the controller would fall through to `return nil, false` and silently ignore the policy.

### Fix

- Add `InferencePool` (`inference.networking.k8s.io`) to the CEL validation whitelist in `agentgateway_policy_types.go` for both `targetRefs` and `targetSelectors`, including the `traffic` field restriction rule
- Add `InferencePool` case to `PolicyTargets` switch in `reference_indexes.go`, reusing `utils.ServiceTargetWithHostname` with the synthetic hostname (`pool.namespace.inference.cluster.local`) — same pattern used by `inference_plugin.go`
- Regenerate CRD YAML via `make generate`
- Add golden test to verify InferencePool policy attachment works end-to-end

## Testing

Golden test added at `controller/pkg/agentgateway/translator/testdata/backends/inferencepool-policy.yaml` and passes:

```
--- PASS: TestBackends/inferencepool-policy.yaml
```