### PR TITLE
fix: A2A policy path matching for agents hosted under a sub-path

### DIFF
--- a/crates/agentgateway/src/a2a/mod.rs
+++ b/crates/agentgateway/src/a2a/mod.rs
@@ -20,7 +20,11 @@ async fn classify_request(req: &mut Request<Body>) -> RequestType {
 	match (req.method(), req.uri().path()) {
 		// agent-card.json: v0.3.0+
 		// agent.json: older versions
-		(m, "/.well-known/agent.json" | "/.well-known/agent-card.json") if m == http::Method::GET => {
+		(m, path)
+			if m == http::Method::GET
+				&& (path.ends_with("/.well-known/agent.json")
+					|| path.ends_with("/.well-known/agent-card.json")) =>
+		{
 			// In case of rewrite, use the original so we know where to send them back to
 			let uri = req
 				.extensions()

--- a/crates/agentgateway/src/a2a/tests.rs
+++ b/crates/agentgateway/src/a2a/tests.rs
@@ -99,6 +99,28 @@ async fn test_classify_request_uses_original_url_for_agent_card() {
 }
 
 #[tokio::test]
+async fn test_classify_request_uses_original_url_for_agent_card_with_subpath() {
+	let original: Uri = "https://example.com/api/.well-known/agent-card.json"
+		.parse()
+		.unwrap();
+	let mut req = ::http::Request::builder()
+		.method(Method::GET)
+		.uri("http://backend.internal/sub/path/.well-known/agent-card.json")
+		.body(http::Body::empty())
+		.unwrap();
+	req
+		.extensions_mut()
+		.insert(crate::http::filters::OriginalUrl(original.clone()));
+
+	let ty = classify_request(&mut req).await;
+
+	match ty {
+		RequestType::AgentCard(uri) => assert_eq!(uri, original),
+		other => panic!("expected agent card request, got {other:?}"),
+	}
+}
+
+#[tokio::test]
 async fn test_classify_request_uses_x_forwarded_proto_for_agent_card() {
 	let original: Uri = "http://example.com/api/.well-known/agent-card.json"
 		.parse()


### PR DESCRIPTION
## Fix A2A policy path matching for agents hosted under a sub-path

### Problem

The A2A policy request classifier matched the agent card path with exact equality:

```rust
(m, "/.well-known/agent.json" | "/.well-known/agent-card.json") if m == http::Method::GET => { ... }
```

This only fires when `req.uri().path()` is exactly `/.well-known/agent.json`. It works in this specific configuration: the backend agent serves at the root (e.g. `http://internal.backend`; no sub-path), and the gateway route rewrites the prefix away (e.g. `/agent1/*` → `/*`) so the classifier sees the bare well-known path. It breaks as soon as the backend agent lives under its own sub-path. 

Example: 
Agent lives under `http://internal.backend/agents/agent1/`, registered in AgentGateway with route `/agent1/*` rewritten to `/agents/agent1/*` on backend internal.backend. 
After the rewrite, `req.uri().path()` is `/agents/agent1/.well-known/agent.json`, therefore the classifier returns Unknown, the response rewrite is skipped, and the card returned to the client still advertises the internal backend URL in its url field.
As far as I can tell, this case is unfixable through route configuration. To make the classifier match, you'd have to rewrite the path down to bare `/.well-known/agent.json` before forwarding, but then the backend (which expects its own sub-path) 404s. No rewrite satisfies both the classifier and the backend simultaneously.

### Fix

Match on suffix instead of exact equality:

```rust
(m, path)
    if m == http::Method::GET
        && (path.ends_with("/.well-known/agent.json")
            || path.ends_with("/.well-known/agent-card.json")) => { ... }
```