### PR TITLE
support SSLKEYLOGFILE env var

### DIFF
--- a/crates/agentgateway/src/app.rs
+++ b/crates/agentgateway/src/app.rs
@@ -12,6 +12,7 @@ use crate::telemetry::trc;
 use crate::{Config, ProxyInputs, client, mcp, proxy, state_manager};
 
 pub async fn run(config: Arc<Config>) -> anyhow::Result<Bound> {
+	crate::transport::tls::warn_if_key_log_enabled();
 	let (data_plane_handle, data_plane_pool) = new_data_plane_pool(config.num_worker_threads);
 
 	// Initialize OpenTelemetry resource defaults from gateway + proxy metadata

--- a/crates/agentgateway/src/control/caclient.rs
+++ b/crates/agentgateway/src/control/caclient.rs
@@ -165,6 +165,7 @@ impl WorkloadCertificate {
 				self.chain.iter().map(|c| c.der.clone()).collect(),
 				self.private_key.clone_key(),
 			)?;
+		cc.key_log = transport::tls::key_log();
 		cc.alpn_protocols = vec![b"istio".into()];
 		cc.resumption = Resumption::disabled();
 		// cc.enable_sni = false;
@@ -186,6 +187,7 @@ impl WorkloadCertificate {
 				self.chain.iter().map(|c| c.der.clone()).collect(),
 				self.private_key.clone_key(),
 			)?;
+		cc.key_log = transport::tls::key_log();
 		cc.alpn_protocols = vec![b"h2".into()];
 		cc.resumption = Resumption::disabled();
 		cc.enable_sni = false;
@@ -233,6 +235,7 @@ impl WorkloadCertificate {
 			self.chain.iter().map(|c| c.der.clone()).collect(),
 			self.private_key.clone_key(),
 		)?;
+		sc.key_log = transport::tls::key_log();
 		sc.alpn_protocols = alpns;
 		Ok(sc)
 	}

--- a/crates/agentgateway/src/control/mod.rs
+++ b/crates/agentgateway/src/control/mod.rs
@@ -52,6 +52,7 @@ impl RootCert {
 			.with_protocol_versions(transport::tls::ALL_TLS_VERSIONS)?
 			.with_root_certificates(roots)
 			.with_no_client_auth();
+		ccb.key_log = transport::tls::key_log();
 		ccb.alpn_protocols = vec![b"h2".to_vec()];
 		Ok(BackendTLS {
 			hostname_override: None,

--- a/crates/agentgateway/src/http/backendtls.rs
+++ b/crates/agentgateway/src/http/backendtls.rs
@@ -209,6 +209,7 @@ impl ResolvedBackendTLS {
 					roots, sans,
 				)));
 		}
+		cc.key_log = transport::tls::key_log();
 		let allow_custom_alpn = self.alpn.is_none();
 		if let Some(a) = self.alpn {
 			cc.alpn_protocols = a.into_iter().map(|b| b.as_bytes().to_vec()).collect();

--- a/crates/agentgateway/src/transport/tls.rs
+++ b/crates/agentgateway/src/transport/tls.rs
@@ -179,6 +179,38 @@ pub fn provider() -> Arc<CryptoProvider> {
 	provider_with_options(&[], &[])
 }
 
+/// Returns a shared rustls `KeyLog` backed by `rustls::KeyLogFile`, which honors
+/// the `SSLKEYLOGFILE` environment variable. If the env var is unset, returns NoKeyLog.
+pub fn key_log() -> Arc<dyn rustls::KeyLog> {
+	static KEY_LOG: std::sync::LazyLock<Arc<dyn rustls::KeyLog>> = std::sync::LazyLock::new(|| {
+		// if SSLKEYLOGFILE is set use key log file.
+		// Note - in theory, KeyLogFile is a no-op if SSLKEYLOGFILE is not set,
+		// but it does use an internal mutex even if no file is set. so check it here
+		// and return the default (NoKeyLog) if not set. This guarantees that we are not
+		// introducing new overhead when SSLKEYLOGFILE is not set.
+		if std::env::var("SSLKEYLOGFILE").is_ok() {
+			Arc::new(rustls::KeyLogFile::new())
+		} else {
+			Arc::new(rustls::NoKeyLog)
+		}
+	});
+	let key_log = &*KEY_LOG;
+	key_log.clone()
+}
+
+/// Emits a startup warning if `SSLKEYLOGFILE` is set, since secret logging is
+/// enabled and traffic can be decrypted by anyone who reads the file.
+pub fn warn_if_key_log_enabled() {
+	if let Ok(path) = std::env::var("SSLKEYLOGFILE")
+		&& !path.is_empty()
+	{
+		warn!(
+			"SSLKEYLOGFILE is set ({path}); TLS session secrets will be written to disk. \
+				 This is intended for debugging only — do not enable in production."
+		);
+	}
+}
+
 pub fn provider_with_options(
 	cipher_suites: &[CipherSuite],
 	key_exchange_groups: &[KeyExchangeGroup],

--- a/crates/agentgateway/src/transport/tls.rs
+++ b/crates/agentgateway/src/transport/tls.rs
@@ -179,35 +179,36 @@ pub fn provider() -> Arc<CryptoProvider> {
 	provider_with_options(&[], &[])
 }
 
-/// Returns a shared rustls `KeyLog` backed by `rustls::KeyLogFile`, which honors
-/// the `SSLKEYLOGFILE` environment variable. If the env var is unset, returns NoKeyLog.
+/// Returns a shared rustls `KeyLog`. On release builds this always returns
+/// `NoKeyLog` so TLS session secrets can never be logged in production. On
+/// debug builds, honors `SSLKEYLOGFILE` (NSS keylog format) for use with
+/// Wireshark/tcpdump decryption.
+#[cfg(debug_assertions)]
 pub fn key_log() -> Arc<dyn rustls::KeyLog> {
 	static KEY_LOG: std::sync::LazyLock<Arc<dyn rustls::KeyLog>> = std::sync::LazyLock::new(|| {
-		// if SSLKEYLOGFILE is set use key log file.
-		// Note - in theory, KeyLogFile is a no-op if SSLKEYLOGFILE is not set,
-		// but it does use an internal mutex even if no file is set. so check it here
-		// and return the default (NoKeyLog) if not set. This guarantees that we are not
-		// introducing new overhead when SSLKEYLOGFILE is not set.
+		// KeyLogFile uses an internal mutex even when SSLKEYLOGFILE is unset, so
+		// guard the env check to avoid any overhead when the user is not using it.
 		if std::env::var("SSLKEYLOGFILE").is_ok() {
 			Arc::new(rustls::KeyLogFile::new())
 		} else {
 			Arc::new(rustls::NoKeyLog)
 		}
 	});
-	let key_log = &*KEY_LOG;
-	key_log.clone()
+	(*KEY_LOG).clone()
 }
 
-/// Emits a startup warning if `SSLKEYLOGFILE` is set, since secret logging is
-/// enabled and traffic can be decrypted by anyone who reads the file.
+#[cfg(not(debug_assertions))]
+pub fn key_log() -> Arc<dyn rustls::KeyLog> {
+	Arc::new(rustls::NoKeyLog)
+}
+
+/// Startup warning when SSLKEYLOGFILE is honored (debug builds only).
 pub fn warn_if_key_log_enabled() {
+	#[cfg(debug_assertions)]
 	if let Ok(path) = std::env::var("SSLKEYLOGFILE")
 		&& !path.is_empty()
 	{
-		warn!(
-			"SSLKEYLOGFILE is set ({path}); TLS session secrets will be written to disk. \
-				 This is intended for debugging only — do not enable in production."
-		);
+		warn!("SSLKEYLOGFILE={path}; TLS session secrets will be written to disk (debug build only).");
 	}
 }
 

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -432,6 +432,7 @@ impl ServerTLSConfig {
 		let cert_chain = parse_cert(&inputs.cert_pem)?;
 		let private_key = parse_key(&inputs.key_pem)?;
 		let mut sc = scb.with_single_cert(cert_chain, private_key)?;
+		sc.key_log = crate::transport::tls::key_log();
 		sc.alpn_protocols = alpns
 			.map(|a| a.to_vec())
 			.unwrap_or_else(|| inputs.default_alpns.clone());


### PR DESCRIPTION
Allows to read SSL traffic for debugging.
Tested manually.
If there are concerns can feature gate this, though I do think it is a useful feature to have.