### PR TITLE
do not drop anthropic-beta from local

### DIFF
--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -2005,22 +2005,16 @@ async fn convert_llm_config(
 		LocalTransformationConfig {
 			request: Some(http::transformation_cel::LocalTransform {
 				metadata: Vec::new(),
-				set: vec![
-					(
-						strng::new("x-gateway-model-name"),
-						strng::new(
-							r#"
+				set: vec![(
+					strng::new("x-gateway-model-name"),
+					strng::new(
+						r#"
 request.path.endsWith(":streamRawPredict") || request.path.endsWith(":rawPredict") ?
 request.path.regexReplace("^.*/publishers/anthropic/models/(.+?):.*", "${1}") :
 json(request.body).model
 "#,
-						),
 					),
-					(
-						strng::new("anthropic-beta"),
-						strng::new("request.headers['anthropic-beta'].split(',').filter(v, v.trim() in [])"),
-					),
-				],
+				)],
 				add: vec![],
 				remove: vec![],
 				body: None,

--- a/crates/agentgateway/src/types/local_tests/llm_simple_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/llm_simple_normalized.snap
@@ -213,8 +213,6 @@ policies:
             set:
               - - x-gateway-model-name
                 - "\nrequest.path.endsWith(\":streamRawPredict\") || request.path.endsWith(\":rawPredict\") ?\nrequest.path.regexReplace(\"^.*/publishers/anthropic/models/(.+?):.*\", \"${1}\") :\njson(request.body).model\n"
-              - - anthropic-beta
-                - "request.headers['anthropic-beta'].split(',').filter(v, v.trim() in [])"
           response: {}
   - key: frontend/accessLog
     name: ~


### PR DESCRIPTION
Fixes https://github.com/agentgateway/agentgateway/issues/1777

> [!WARNING]
> This could introduce a regression on people relying on this implicit drop. we could add an optional (temporary) override on vertex/bedrock to keep current behavior while users switch

A user can still restrict beta headers to a few ones (or as mentioned on the issue above, via claude env vars `CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS`)
```yaml
llm:
       models:
         - name: claude-vertex
           provider: vertex
           requestHeaders:
             set:
               - name: anthropic-beta
                 value: "interleaved-thinking-2025-05-14,output-128k-2025-02-19,context-management-2025-06-27,compact-2026-01-12,advanced-tool-use-2025-11-20,context-1m-2025-08-07,prompt-caching-scope-2026-01-05"
```

**NOTE**:
litellm has a comprehensive list at https://github.com/BerriAI/litellm/blob/litellm_internal_staging/litellm/anthropic_beta_headers_config.json 