### PR TITLE
Add LLM usage event export

### DIFF
--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -948,6 +948,16 @@ impl HTTPProxy {
 				});
 		}
 
+		if let Some(uep) = frontend_policies.usage_export.as_deref() {
+			log.usage_exporter = uep
+				.get_or_init(self.policy_client())
+				.map(|e| Some(e.clone()))
+				.unwrap_or_else(|e| {
+					warn!("failed to initialize usage event exporter: {e}");
+					None
+				});
+		}
+
 		let mut sampler = TraceSampler::default();
 		if let Some(tp) = frontend_policies.tracing.as_deref() {
 			// Apply sampling overrides if present

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -129,6 +129,7 @@ pub struct FrontendPolices {
 	pub access_log: Option<frontend::LoggingPolicy>,
 	pub tracing: Option<Arc<crate::types::agent::TracingPolicy>>,
 	pub access_log_otlp: Option<Arc<crate::types::agent::AccessLogPolicy>>,
+	pub usage_export: Option<Arc<crate::types::agent::UsageExportPolicy>>,
 	pub metrics_fields: Option<frontend::MetricsFieldsPolicy>,
 }
 
@@ -163,6 +164,9 @@ impl FrontendPolices {
 			FrontendPolicy::Tracing(p) => {
 				self.tracing.get_or_insert_with(|| p.clone());
 			},
+			FrontendPolicy::UsageExport(p) => {
+				self.usage_export.get_or_insert_with(|| p.clone());
+			},
 			FrontendPolicy::Metrics(p) => {
 				self.metrics_fields.get_or_insert_with(|| p.clone());
 			},
@@ -186,6 +190,11 @@ impl FrontendPolices {
 		}
 		if let Some(mf) = &self.metrics_fields {
 			for (_, v) in mf.add.iter() {
+				ctx.register_log_expression(v)
+			}
+		}
+		if let Some(ue) = &self.usage_export {
+			for (_, v) in ue.config.add.iter() {
 				ctx.register_log_expression(v)
 			}
 		}
@@ -1036,6 +1045,7 @@ impl Store {
 						}
 					}) as ShutdownPolicy)
 				},
+				FrontendPolicy::UsageExport(_) => None,
 				_ => None,
 			})
 			.collect_vec()

--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 use std::fmt::Debug;
 use std::net::SocketAddr;
 use std::pin::Pin;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll, ready};
 use std::time::{Duration, SystemTime};
@@ -14,6 +15,7 @@ use bytes::Buf;
 use crossbeam::atomic::AtomicCell;
 use frozen_collections::FzHashSet;
 use http_body::{Body, Frame, SizeHint};
+use http_body_util::BodyExt;
 use indexmap::IndexMap;
 use itertools::Itertools;
 use opentelemetry::logs::{AnyValue, LogRecord as _, Logger, LoggerProvider as _, Severity};
@@ -28,7 +30,7 @@ use serde::de::DeserializeOwned;
 use serde::ser::SerializeMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
-use tracing::{Level, trace};
+use tracing::{Level, trace, warn};
 
 use crate::cel::{ContextBuilder, Expression, LLMContext};
 use crate::http::{Request, health};
@@ -436,6 +438,383 @@ pub struct CelLoggingBuildInputs<'a> {
 	pub source_context: Option<&'a cel::SourceContext>,
 }
 
+static USAGE_EVENT_SEQUENCE: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Clone, Debug)]
+pub struct UsageEventExporter {
+	policy_client: crate::proxy::httpproxy::PolicyClient,
+	backend_ref: crate::types::agent::SimpleBackendReference,
+	policies: Vec<crate::types::agent::BackendTrafficPolicy>,
+	path: String,
+	max_attempts: u32,
+	retry_backoff: Duration,
+	add: Arc<OrderedStringMap<Arc<cel::Expression>>>,
+	runtime: tokio::runtime::Handle,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct UsageEvent {
+	schema_version: &'static str,
+	event_id: String,
+	start_time: String,
+	end_time: String,
+	duration_ms: u64,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	trace_id: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	span_id: Option<String>,
+	http: UsageHttp,
+	route: UsageRoute,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	backend: Option<UsageBackend>,
+	llm: UsageLlm,
+	tokens: UsageTokens,
+	#[serde(skip_serializing_if = "serde_json::Map::is_empty")]
+	attributes: serde_json::Map<String, Value>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct UsageHttp {
+	#[serde(skip_serializing_if = "Option::is_none")]
+	method: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	host: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	path: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	status: Option<u16>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct UsageRoute {
+	#[serde(skip_serializing_if = "Option::is_none")]
+	gateway: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	listener: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	route: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	route_rule: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct UsageBackend {
+	backend_type: cel::BackendType,
+	backend_name: String,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	protocol: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	endpoint: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct UsageLlm {
+	operation: &'static str,
+	provider: String,
+	request_model: String,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	response_model: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	service_tier: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct UsageTokens {
+	#[serde(skip_serializing_if = "Option::is_none")]
+	input: Option<u64>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	input_text: Option<u64>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	input_image: Option<u64>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	input_audio: Option<u64>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	cache_read_input: Option<u64>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	cache_creation_input: Option<u64>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	output: Option<u64>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	output_text: Option<u64>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	output_image: Option<u64>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	output_audio: Option<u64>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	reasoning: Option<u64>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	total: Option<u64>,
+}
+
+impl UsageTokens {
+	fn from_llm(llm: &LLMContext) -> Self {
+		Self {
+			input: llm.input_tokens,
+			input_text: llm.input_text_tokens,
+			input_image: llm.input_image_tokens,
+			input_audio: llm.input_audio_tokens,
+			cache_read_input: llm.cached_input_tokens,
+			cache_creation_input: llm.cache_creation_input_tokens,
+			output: llm.output_tokens,
+			output_text: llm.output_text_tokens,
+			output_image: llm.output_image_tokens,
+			output_audio: llm.output_audio_tokens,
+			reasoning: llm.reasoning_tokens,
+			total: llm.total_tokens,
+		}
+	}
+
+	fn has_usage(&self) -> bool {
+		self.input.is_some()
+			|| self.input_text.is_some()
+			|| self.input_image.is_some()
+			|| self.input_audio.is_some()
+			|| self.cache_read_input.is_some()
+			|| self.cache_creation_input.is_some()
+			|| self.output.is_some()
+			|| self.output_text.is_some()
+			|| self.output_image.is_some()
+			|| self.output_audio.is_some()
+			|| self.reasoning.is_some()
+			|| self.total.is_some()
+	}
+}
+
+impl UsageEventExporter {
+	pub fn new(
+		policy_client: crate::proxy::httpproxy::PolicyClient,
+		backend_ref: crate::types::agent::SimpleBackendReference,
+		policies: Vec<crate::types::agent::BackendTrafficPolicy>,
+		path: String,
+		max_attempts: u32,
+		retry_backoff: Duration,
+		add: Arc<OrderedStringMap<Arc<cel::Expression>>>,
+	) -> Self {
+		let runtime = policy_client
+			.inputs
+			.cfg
+			.admin_runtime_handle
+			.clone()
+			.unwrap_or_else(tokio::runtime::Handle::current);
+		Self {
+			policy_client,
+			backend_ref,
+			policies,
+			path,
+			max_attempts: max_attempts.max(1),
+			retry_backoff,
+			add,
+			runtime,
+		}
+	}
+
+	pub fn emit(
+		&self,
+		log: &RequestLog,
+		route_identifier: &RouteIdentifier,
+		end_time: Timestamp,
+		duration: Duration,
+		llm_response: Option<&LLMContext>,
+		cel_exec: &CelLoggingExecutor<'_>,
+	) {
+		let Some(event) = build_usage_event(
+			&self.add,
+			log,
+			route_identifier,
+			end_time,
+			duration,
+			llm_response,
+			cel_exec,
+		) else {
+			return;
+		};
+
+		let client = self.policy_client.clone();
+		let backend_ref = self.backend_ref.clone();
+		let policies = self.policies.clone();
+		let path = self.path.clone();
+		let max_attempts = self.max_attempts;
+		let retry_backoff = self.retry_backoff;
+		let event_id = event.event_id.clone();
+		self.runtime.spawn(async move {
+			for attempt in 1..=max_attempts {
+				let req = match build_usage_request(&path, &event) {
+					Ok(req) => req,
+					Err(err) => {
+						warn!(error=%err, %event_id, "failed to build usage event export request");
+						return;
+					},
+				};
+				match client
+					.call_reference_with_policies(req, &backend_ref, &policies)
+					.await
+				{
+					Ok(resp) => {
+						let status = resp.status();
+						if let Err(err) = resp.into_body().collect().await {
+							warn!(
+								error=%err,
+								%event_id,
+								attempt,
+								max_attempts,
+								"failed to drain usage event export response body"
+							);
+						}
+						if status.is_success() {
+							return;
+						}
+						warn!(
+							status=%status,
+							%event_id,
+							attempt,
+							max_attempts,
+							"usage event export returned non-success status"
+						);
+						if attempt == max_attempts {
+							return;
+						}
+					},
+					Err(err) => {
+						warn!(
+							error=%err,
+							%event_id,
+							attempt,
+							max_attempts,
+							"usage event export failed"
+						);
+						if attempt == max_attempts {
+							return;
+						}
+					},
+				}
+				tokio::time::sleep(retry_backoff).await;
+			}
+		});
+	}
+}
+
+fn build_usage_event(
+	add: &OrderedStringMap<Arc<cel::Expression>>,
+	log: &RequestLog,
+	route_identifier: &RouteIdentifier,
+	end_time: Timestamp,
+	duration: Duration,
+	llm_response: Option<&LLMContext>,
+	cel_exec: &CelLoggingExecutor<'_>,
+) -> Option<UsageEvent> {
+	let llm_response = llm_response?;
+	let tokens = UsageTokens::from_llm(llm_response);
+	if !tokens.has_usage() {
+		return None;
+	}
+	let trace_id = log
+		.outgoing_span
+		.as_ref()
+		.map(|id| id.trace_id().to_string());
+	let span_id = log
+		.outgoing_span
+		.as_ref()
+		.map(|id| id.span_id().to_string());
+	let event_id = match (&trace_id, &span_id) {
+		(Some(trace_id), Some(span_id)) => format!("{trace_id}:{span_id}"),
+		_ => fallback_usage_event_id(log),
+	};
+	let attributes = cel_exec
+		.eval(add)
+		.into_iter()
+		.filter_map(|(k, v)| v.map(|v| (k.into_owned(), v)))
+		.collect();
+	Some(UsageEvent {
+		schema_version: "agentgateway.llm.usage.v1",
+		event_id,
+		start_time: log.start.as_datetime().to_rfc3339(),
+		end_time: end_time.as_datetime().to_rfc3339(),
+		duration_ms: duration.as_millis().try_into().unwrap_or(u64::MAX),
+		trace_id,
+		span_id,
+		http: UsageHttp {
+			method: log.method.as_ref().map(ToString::to_string),
+			host: log.host.clone(),
+			path: log.path.clone(),
+			status: log.status.as_ref().map(|s| s.as_u16()),
+		},
+		route: UsageRoute {
+			gateway: route_identifier.gateway.as_deref().map(ToString::to_string),
+			listener: route_identifier
+				.listener
+				.as_deref()
+				.map(ToString::to_string),
+			route: route_identifier.route.as_deref().map(ToString::to_string),
+			route_rule: route_identifier
+				.route_rule
+				.as_deref()
+				.map(ToString::to_string),
+		},
+		backend: log.backend_info.as_ref().map(|backend| UsageBackend {
+			backend_type: backend.backend_type,
+			backend_name: backend.backend_name.to_string(),
+			protocol: log.backend_protocol.as_ref().map(|p| format!("{p:?}")),
+			endpoint: log.endpoint.as_ref().map(ToString::to_string),
+		}),
+		llm: UsageLlm {
+			operation: if log
+				.llm_request
+				.as_ref()
+				.is_some_and(|r| r.input_format == InputFormat::Embeddings)
+			{
+				"embeddings"
+			} else {
+				"chat"
+			},
+			provider: llm_response.provider.to_string(),
+			request_model: llm_response.request_model.to_string(),
+			response_model: llm_response
+				.response_model
+				.as_ref()
+				.map(ToString::to_string),
+			service_tier: llm_response.service_tier.as_ref().map(ToString::to_string),
+		},
+		tokens,
+		attributes,
+	})
+}
+
+fn build_usage_request(path: &str, event: &UsageEvent) -> anyhow::Result<Request> {
+	let body = serde_json::to_vec(event)?;
+	let path = if path.starts_with('/') {
+		path.to_string()
+	} else {
+		format!("/{path}")
+	};
+	Ok(
+		::http::Request::builder()
+			.uri(path)
+			.method(::http::Method::POST)
+			.header(
+				::http::header::CONTENT_TYPE,
+				::http::HeaderValue::from_static("application/json"),
+			)
+			.body(crate::http::Body::from(body))?,
+	)
+}
+
+fn fallback_usage_event_id(log: &RequestLog) -> String {
+	let started = log
+		.start
+		.as_system_time()
+		.duration_since(SystemTime::UNIX_EPOCH)
+		.map(|d| d.as_nanos())
+		.unwrap_or_default();
+	let sequence = USAGE_EVENT_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+	format!("{started}:{sequence}")
+}
+
 #[derive(Debug)]
 pub struct DropOnLog {
 	log: Option<RequestLog>,
@@ -602,6 +981,7 @@ impl RequestLog {
 			tracer: None,
 			trace_spans: Arc::new(Mutex::new(Default::default())),
 			otel_logger: None,
+			usage_exporter: None,
 			endpoint: None,
 			bind_name: None,
 			listener_name: None,
@@ -671,6 +1051,8 @@ pub struct RequestLog {
 
 	// Set only if OTLP logging is configured
 	pub otel_logger: Option<std::sync::Arc<OtelAccessLogger>>,
+	// Set only if usage export is configured.
+	pub usage_exporter: Option<std::sync::Arc<UsageEventExporter>>,
 
 	pub endpoint: Option<Target>,
 
@@ -847,6 +1229,16 @@ impl Drop for DropOnLog {
 			llm_response.as_ref(),
 			&custom_metric_fields,
 		);
+		if let Some(exporter) = &log.usage_exporter {
+			exporter.emit(
+				&log,
+				&route_identifier,
+				end_time,
+				duration,
+				llm_response.as_ref(),
+				&cel_exec,
+			);
+		}
 		if let Some(mcp) = &mcp
 			&& mcp.method_name.is_some()
 		{
@@ -1571,12 +1963,15 @@ mod tests {
 	use std::sync::{Arc, Mutex};
 	use std::time::Instant;
 
+	use http_body_util::BodyExt;
 	use opentelemetry::trace::{SpanKind, TracerProvider};
 	use opentelemetry_sdk::error::OTelSdkResult;
 	use opentelemetry_sdk::trace::{SimpleSpanProcessor, SpanData, SpanExporter};
 	use prometheus_client::registry::Registry;
+	use serde_json::json;
 
 	use super::*;
+	use crate::http::jwt;
 	use crate::telemetry::metrics::Metrics;
 	use crate::telemetry::trc;
 	use crate::transport::stream::TCPConnectionInfo;
@@ -1638,6 +2033,229 @@ mod tests {
 				raw_peer_addr: None,
 			},
 		)
+	}
+
+	fn test_llm_response() -> LLMContext {
+		LLMContext {
+			streaming: false,
+			request_model: "gpt-4".into(),
+			response_model: Some("gpt-4".into()),
+			provider: "openai".into(),
+			input_tokens: Some(100),
+			input_image_tokens: None,
+			input_text_tokens: Some(90),
+			input_audio_tokens: None,
+			cached_input_tokens: Some(20),
+			cache_creation_input_tokens: Some(10),
+			output_tokens: Some(50),
+			output_image_tokens: None,
+			output_text_tokens: Some(45),
+			output_audio_tokens: None,
+			reasoning_tokens: Some(5),
+			total_tokens: Some(150),
+			service_tier: Some("default".into()),
+			first_token: None,
+			count_tokens: None,
+			prompt: None,
+			completion: None,
+			params: llm::LLMRequestParams::default(),
+		}
+	}
+
+	#[test]
+	fn usage_event_includes_custom_oid_attribute() {
+		let mut request = test_request_log();
+		let mut req = ::http::Request::builder()
+			.method(::http::Method::POST)
+			.uri("http://example.com/v1/chat/completions")
+			.body(crate::http::Body::empty())
+			.unwrap();
+		let serde_json::Value::Object(claims) = json!({
+			"oid": "366ad564-ff40-4220-8bba-1a0aeed3e4f4"
+		}) else {
+			unreachable!()
+		};
+		req.extensions_mut().insert(jwt::Claims {
+			inner: claims,
+			jwt: Default::default(),
+		});
+		request.request_snapshot = Some(Arc::new(cel::snapshot_request(&mut req, true)));
+
+		let add =
+			OrderedStringMap::from_iter([("oid", Arc::new(Expression::new_strict("jwt.oid").unwrap()))]);
+		let llm_response = test_llm_response();
+		let end_time = Timestamp::now();
+		let cel_end_time = cel::RequestTime(end_time.as_datetime());
+		let cel_exec = request.cel.build(CelLoggingBuildInputs {
+			req: request.request_snapshot.as_deref(),
+			resp: None,
+			llm_response: Some(&llm_response),
+			mcp: None,
+			end_time: &cel_end_time,
+			source_context: None,
+		});
+
+		let event = build_usage_event(
+			&add,
+			&request,
+			&RouteIdentifier::default(),
+			end_time,
+			Duration::from_millis(10),
+			Some(&llm_response),
+			&cel_exec,
+		)
+		.expect("usage event should be built");
+
+		assert_eq!(
+			event.attributes.get("oid"),
+			Some(&json!("366ad564-ff40-4220-8bba-1a0aeed3e4f4"))
+		);
+		assert_eq!(event.tokens.input, Some(100));
+		assert_eq!(event.tokens.output, Some(50));
+	}
+
+	#[test]
+	fn usage_event_uses_trace_span_as_event_id_and_preserves_token_fields() {
+		let mut request = test_request_log();
+		let mut outgoing = trc::TraceParent::new();
+		outgoing.flags = 1;
+		request.outgoing_span = Some(outgoing.clone());
+		let llm_response = test_llm_response();
+		let end_time = Timestamp::now();
+		let cel_end_time = cel::RequestTime(end_time.as_datetime());
+		let cel_exec = request.cel.build(CelLoggingBuildInputs {
+			req: None,
+			resp: None,
+			llm_response: Some(&llm_response),
+			mcp: None,
+			end_time: &cel_end_time,
+			source_context: None,
+		});
+
+		let event = build_usage_event(
+			&OrderedStringMap::default(),
+			&request,
+			&RouteIdentifier::default(),
+			end_time,
+			Duration::from_millis(42),
+			Some(&llm_response),
+			&cel_exec,
+		)
+		.expect("usage event should be built");
+
+		assert_eq!(
+			event.event_id,
+			format!("{}:{}", outgoing.trace_id(), outgoing.span_id())
+		);
+		assert_eq!(event.trace_id, Some(outgoing.trace_id().to_string()));
+		assert_eq!(event.span_id, Some(outgoing.span_id().to_string()));
+		assert_eq!(event.duration_ms, 42);
+		assert_eq!(event.llm.provider, "openai");
+		assert_eq!(event.llm.request_model, "gpt-4");
+		assert_eq!(event.llm.service_tier.as_deref(), Some("default"));
+		assert_eq!(event.tokens.input, Some(100));
+		assert_eq!(event.tokens.input_text, Some(90));
+		assert_eq!(event.tokens.cache_read_input, Some(20));
+		assert_eq!(event.tokens.cache_creation_input, Some(10));
+		assert_eq!(event.tokens.output, Some(50));
+		assert_eq!(event.tokens.output_text, Some(45));
+		assert_eq!(event.tokens.reasoning, Some(5));
+		assert_eq!(event.tokens.total, Some(150));
+	}
+
+	#[test]
+	fn usage_event_is_not_built_without_llm_usage() {
+		let request = test_request_log();
+		let mut llm_response = test_llm_response();
+		llm_response.input_tokens = None;
+		llm_response.input_text_tokens = None;
+		llm_response.cached_input_tokens = None;
+		llm_response.cache_creation_input_tokens = None;
+		llm_response.output_tokens = None;
+		llm_response.output_text_tokens = None;
+		llm_response.reasoning_tokens = None;
+		llm_response.total_tokens = None;
+		let end_time = Timestamp::now();
+		let cel_end_time = cel::RequestTime(end_time.as_datetime());
+		let cel_exec = request.cel.build(CelLoggingBuildInputs {
+			req: None,
+			resp: None,
+			llm_response: Some(&llm_response),
+			mcp: None,
+			end_time: &cel_end_time,
+			source_context: None,
+		});
+
+		assert!(
+			build_usage_event(
+				&OrderedStringMap::default(),
+				&request,
+				&RouteIdentifier::default(),
+				end_time,
+				Duration::from_millis(1),
+				None,
+				&cel_exec,
+			)
+			.is_none()
+		);
+		assert!(
+			build_usage_event(
+				&OrderedStringMap::default(),
+				&request,
+				&RouteIdentifier::default(),
+				end_time,
+				Duration::from_millis(1),
+				Some(&llm_response),
+				&cel_exec,
+			)
+			.is_none()
+		);
+	}
+
+	#[tokio::test]
+	async fn usage_request_serializes_json_post_with_normalized_path() {
+		let request = test_request_log();
+		let llm_response = test_llm_response();
+		let end_time = Timestamp::now();
+		let cel_end_time = cel::RequestTime(end_time.as_datetime());
+		let cel_exec = request.cel.build(CelLoggingBuildInputs {
+			req: None,
+			resp: None,
+			llm_response: Some(&llm_response),
+			mcp: None,
+			end_time: &cel_end_time,
+			source_context: None,
+		});
+		let event = build_usage_event(
+			&OrderedStringMap::from_iter([(
+				"oid",
+				Arc::new(Expression::new_strict("'user-oid'").unwrap()),
+			)]),
+			&request,
+			&RouteIdentifier::default(),
+			end_time,
+			Duration::from_millis(10),
+			Some(&llm_response),
+			&cel_exec,
+		)
+		.expect("usage event should be built");
+
+		let req = build_usage_request("v1/usage", &event).unwrap();
+		assert_eq!(req.method(), ::http::Method::POST);
+		assert_eq!(req.uri().path(), "/v1/usage");
+		assert_eq!(
+			req.headers().get(::http::header::CONTENT_TYPE).unwrap(),
+			"application/json"
+		);
+
+		let body = req.into_body().collect().await.unwrap().to_bytes();
+		let value: serde_json::Value = serde_json::from_slice(&body).unwrap();
+		assert_eq!(value["schemaVersion"], "agentgateway.llm.usage.v1");
+		assert_eq!(value["attributes"]["oid"], "user-oid");
+		assert_eq!(value["tokens"]["input"], 100);
+		assert_eq!(value["tokens"]["cacheReadInput"], 20);
+		assert_eq!(value["tokens"]["cacheCreationInput"], 10);
+		assert_eq!(value["tokens"]["output"], 50);
 	}
 
 	#[test]

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -2113,6 +2113,40 @@ impl serde::Serialize for AccessLogPolicy {
 	}
 }
 
+#[derive(Clone, Debug)]
+pub struct UsageExportPolicy {
+	pub config: crate::types::frontend::UsageExportConfig,
+	pub exporter: once_cell::sync::OnceCell<Arc<crate::telemetry::log::UsageEventExporter>>,
+}
+
+impl UsageExportPolicy {
+	pub fn get_or_init(
+		&self,
+		policy_client: crate::proxy::httpproxy::PolicyClient,
+	) -> anyhow::Result<&Arc<crate::telemetry::log::UsageEventExporter>> {
+		self.exporter.get_or_try_init(|| {
+			Ok(Arc::new(crate::telemetry::log::UsageEventExporter::new(
+				policy_client,
+				self.config.provider_backend.clone(),
+				self.config.policies.clone(),
+				self.config.path.clone(),
+				self.config.max_attempts.get(),
+				self.config.retry_backoff,
+				self.config.add.clone(),
+			)))
+		})
+	}
+}
+
+impl serde::Serialize for UsageExportPolicy {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: serde::Serializer,
+	{
+		self.config.serialize(serializer)
+	}
+}
+
 impl From<BackendTrafficPolicy> for PolicyType {
 	fn from(value: BackendTrafficPolicy) -> Self {
 		Self::Backend(value)
@@ -2280,6 +2314,7 @@ pub enum FrontendPolicy {
 	Proxy(frontend::Proxy),
 	AccessLog(frontend::LoggingPolicy),
 	Tracing(Arc<TracingPolicy>),
+	UsageExport(Arc<UsageExportPolicy>),
 	Metrics(frontend::MetricsFieldsPolicy),
 }
 

--- a/crates/agentgateway/src/types/frontend.rs
+++ b/crates/agentgateway/src/types/frontend.rs
@@ -1,3 +1,4 @@
+use std::num::NonZeroU32;
 use std::time::Duration;
 
 use frozen_collections::{FzHashSet, Len};
@@ -249,4 +250,70 @@ fn default_logs_path() -> String {
 
 fn is_default_logs_path(path: &str) -> bool {
 	path == "/v1/logs"
+}
+
+#[apply(schema!)]
+pub struct UsageExportConfig {
+	/// Backend reference that receives usage events.
+	#[serde(flatten)]
+	pub provider_backend: super::agent::SimpleBackendReference,
+	/// Backend policies applied when sending usage events, such as backend auth or TLS.
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	#[serde(deserialize_with = "crate::types::local::de_from_local_backend_policy")]
+	#[cfg_attr(
+		feature = "schema",
+		schemars(with = "Option<crate::types::local::SimpleLocalBackendPolicies>")
+	)]
+	pub policies: Vec<super::agent::BackendTrafficPolicy>,
+	/// Request path for usage event POSTs. Defaults to `/usage`.
+	#[serde(
+		default = "default_usage_export_path",
+		skip_serializing_if = "is_default_usage_export_path"
+	)]
+	pub path: String,
+	/// Maximum send attempts for each usage event. Attempts are best effort and are not persisted across process restarts.
+	#[serde(
+		default = "default_usage_export_max_attempts",
+		skip_serializing_if = "is_default_usage_export_max_attempts"
+	)]
+	pub max_attempts: NonZeroU32,
+	/// Delay between failed send attempts.
+	#[serde(with = "serde_dur")]
+	#[cfg_attr(feature = "schema", schemars(with = "String"))]
+	#[serde(
+		default = "default_usage_export_retry_backoff",
+		skip_serializing_if = "is_default_usage_export_retry_backoff"
+	)]
+	pub retry_backoff: Duration,
+	/// CEL expressions evaluated at request completion and emitted under the event `attributes` object, for example `oid: jwt.oid`.
+	#[serde(default, skip_serializing_if = "OrderedStringMap::is_empty")]
+	#[cfg_attr(
+		feature = "schema",
+		schemars(with = "std::collections::HashMap<String, String>")
+	)]
+	pub add: Arc<OrderedStringMap<Arc<cel::Expression>>>,
+}
+
+fn default_usage_export_path() -> String {
+	"/usage".to_string()
+}
+
+fn is_default_usage_export_path(path: &str) -> bool {
+	path == "/usage"
+}
+
+fn default_usage_export_max_attempts() -> NonZeroU32 {
+	NonZeroU32::new(3).unwrap()
+}
+
+fn is_default_usage_export_max_attempts(max_attempts: &NonZeroU32) -> bool {
+	*max_attempts == default_usage_export_max_attempts()
+}
+
+fn default_usage_export_retry_backoff() -> Duration {
+	Duration::from_millis(200)
+}
+
+fn is_default_usage_export_retry_backoff(retry_backoff: &Duration) -> bool {
+	*retry_backoff == default_usage_export_retry_backoff()
 }

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -1629,6 +1629,9 @@ struct LocalFrontendPolicies {
 	/// Settings for request access logs.
 	#[serde(default, alias = "logging")]
 	pub access_log: Option<frontend::LoggingPolicy>,
+	/// Export one JSON usage event for each completed LLM request with token usage.
+	#[serde(default)]
+	pub usage_export: Option<frontend::UsageExportConfig>,
 	#[serde(default)]
 	pub tracing: Option<TracingConfig>,
 }
@@ -2745,6 +2748,7 @@ async fn split_frontend_policies(
 		network_authorization,
 		proxy_protocol,
 		access_log,
+		usage_export,
 		tracing,
 	} = pol;
 	if let Some(p) = http {
@@ -2768,6 +2772,15 @@ async fn split_frontend_policies(
 	if let Some(mut p) = access_log {
 		p.init_access_log_policy();
 		add(FrontendPolicy::AccessLog(p), "accessLog");
+	}
+	if let Some(p) = usage_export {
+		add(
+			FrontendPolicy::UsageExport(Arc::new(crate::types::agent::UsageExportPolicy {
+				config: p,
+				exporter: once_cell::sync::OnceCell::new(),
+			})),
+			"usageExport",
+		);
 	}
 	if let Some(tracing_config) = tracing {
 		// Build logging fields from attributes for lazy tracer creation

--- a/crates/agentgateway/src/types/local_tests.rs
+++ b/crates/agentgateway/src/types/local_tests.rs
@@ -388,6 +388,46 @@ binds:
 }
 
 #[tokio::test]
+async fn test_local_frontend_usage_export_policy_custom_oid() {
+	let input = r#"
+frontendPolicies:
+  usageExport:
+    host: 127.0.0.1:9000
+    path: /v1/usage
+    maxAttempts: 4
+    retryBackoff: 100ms
+    add:
+      oid: "has(jwt.oid) ? jwt.oid : 'unknown'"
+binds:
+- port: 3000
+  listeners:
+  - routes:
+    - backends:
+      - host: 127.0.0.1:8000
+"#;
+
+	let normalized = normalize_test_yaml(input).await.unwrap();
+	let usage_export = normalized
+		.policies
+		.iter()
+		.find_map(|policy| match &policy.policy {
+			PolicyType::Frontend(crate::types::agent::FrontendPolicy::UsageExport(policy)) => {
+				Some(policy)
+			},
+			_ => None,
+		})
+		.expect("expected usageExport frontend policy");
+
+	assert_eq!(usage_export.config.path, "/v1/usage");
+	assert_eq!(usage_export.config.max_attempts.get(), 4);
+	assert_eq!(
+		usage_export.config.retry_backoff,
+		std::time::Duration::from_millis(100)
+	);
+	assert!(usage_export.config.add.contains_key("oid"));
+}
+
+#[tokio::test]
 async fn test_local_ext_authz_conditional_fallback_must_be_last() {
 	let input = r#"
 binds:

--- a/schema/config.json
+++ b/schema/config.json
@@ -6397,6 +6397,18 @@
           ],
           "default": null
         },
+        "usageExport": {
+          "description": "Export one JSON usage event for each completed LLM request with token usage.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/UsageExportConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "tracing": {
           "anyOf": [
             {
@@ -6732,6 +6744,105 @@
       "enum": [
         "grpc",
         "http"
+      ]
+    },
+    "UsageExportConfig": {
+      "type": "object",
+      "properties": {
+        "policies": {
+          "description": "Backend policies applied when sending usage events, such as backend auth or TLS.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SimpleLocalBackendPolicies"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "path": {
+          "description": "Request path for usage event POSTs. Defaults to `/usage`.",
+          "type": "string"
+        },
+        "maxAttempts": {
+          "description": "Maximum send attempts for each usage event. Attempts are best effort and are not persisted across process restarts.",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 1
+        },
+        "retryBackoff": {
+          "description": "Delay between failed send attempts.",
+          "type": "string"
+        },
+        "add": {
+          "description": "CEL expressions evaluated at request completion and emitted under the event `attributes` object, for example `oid: jwt.oid`.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "unevaluatedProperties": false,
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "invalid"
+          ]
+        },
+        {
+          "description": "Service reference. Service must be defined in the top level services list.",
+          "type": "object",
+          "properties": {
+            "service": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "$ref": "#/$defs/NamespacedHostname"
+                },
+                "port": {
+                  "type": "integer",
+                  "format": "uint16",
+                  "minimum": 0,
+                  "maximum": 65535
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "name",
+                "port"
+              ]
+            }
+          },
+          "required": [
+            "service"
+          ]
+        },
+        {
+          "description": "Hostname or IP address",
+          "type": "object",
+          "properties": {
+            "host": {
+              "description": "Hostname or IP address",
+              "type": "string"
+            }
+          },
+          "required": [
+            "host"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "backend": {
+              "description": "Explicit backend reference. Backend must be defined in the top level backends list",
+              "type": "string"
+            }
+          },
+          "required": [
+            "backend"
+          ]
+        }
       ]
     },
     "TracingConfig": {

--- a/schema/config.md
+++ b/schema/config.md
@@ -5934,6 +5934,115 @@
 |`frontendPolicies.accessLog.otlp.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
 |`frontendPolicies.accessLog.otlp.protocol`|enum|Possible values: `grpc`, `http`.|
 |`frontendPolicies.accessLog.otlp.path`|string||
+|`frontendPolicies.usageExport`|object|Export one JSON usage event for each completed LLM request with token usage.|
+|`frontendPolicies.usageExport.service`|object||
+|`frontendPolicies.usageExport.service.name`|object||
+|`frontendPolicies.usageExport.service.name.namespace`|string||
+|`frontendPolicies.usageExport.service.name.hostname`|string||
+|`frontendPolicies.usageExport.service.port`|integer||
+|`frontendPolicies.usageExport.host`|string|Hostname or IP address|
+|`frontendPolicies.usageExport.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`frontendPolicies.usageExport.policies`|object|Backend policies applied when sending usage events, such as backend auth or TLS.|
+|`frontendPolicies.usageExport.policies.requestHeaderModifier`|object|Headers to be modified in the request.|
+|`frontendPolicies.usageExport.policies.requestHeaderModifier.add`|object||
+|`frontendPolicies.usageExport.policies.requestHeaderModifier.set`|object||
+|`frontendPolicies.usageExport.policies.requestHeaderModifier.remove`|[]string||
+|`frontendPolicies.usageExport.policies.transformations`|object|Modify requests and responses sent to and from the backend.|
+|`frontendPolicies.usageExport.policies.transformations.request`|object||
+|`frontendPolicies.usageExport.policies.transformations.request.add`|object||
+|`frontendPolicies.usageExport.policies.transformations.request.set`|object||
+|`frontendPolicies.usageExport.policies.transformations.request.remove`|[]string||
+|`frontendPolicies.usageExport.policies.transformations.request.body`|string||
+|`frontendPolicies.usageExport.policies.transformations.request.metadata`|object||
+|`frontendPolicies.usageExport.policies.transformations.response`|object||
+|`frontendPolicies.usageExport.policies.transformations.response.add`|object||
+|`frontendPolicies.usageExport.policies.transformations.response.set`|object||
+|`frontendPolicies.usageExport.policies.transformations.response.remove`|[]string||
+|`frontendPolicies.usageExport.policies.transformations.response.body`|string||
+|`frontendPolicies.usageExport.policies.transformations.response.metadata`|object||
+|`frontendPolicies.usageExport.policies.backendTLS`|object|Send TLS to the backend.|
+|`frontendPolicies.usageExport.policies.backendTLS.cert`|string||
+|`frontendPolicies.usageExport.policies.backendTLS.key`|string||
+|`frontendPolicies.usageExport.policies.backendTLS.root`|string||
+|`frontendPolicies.usageExport.policies.backendTLS.hostname`|string||
+|`frontendPolicies.usageExport.policies.backendTLS.insecure`|boolean||
+|`frontendPolicies.usageExport.policies.backendTLS.insecureHost`|boolean||
+|`frontendPolicies.usageExport.policies.backendTLS.alpn`|[]string||
+|`frontendPolicies.usageExport.policies.backendTLS.subjectAltNames`|[]string||
+|`frontendPolicies.usageExport.policies.backendTLS.keyExchangeGroups`|[]enum|Key exchange groups allowed for negotiating TLS.<br>Possible values: `X25519`, `P-256`, `P-384`, `X25519_MLKEM768`.|
+|`frontendPolicies.usageExport.policies.backendAuth`|object|Authenticate to the backend.|
+|`frontendPolicies.usageExport.policies.backendAuth.passthrough`|object||
+|`frontendPolicies.usageExport.policies.backendAuth.passthrough.location`|object||
+|`frontendPolicies.usageExport.policies.backendAuth.passthrough.location.header`|object||
+|`frontendPolicies.usageExport.policies.backendAuth.passthrough.location.header.name`|string||
+|`frontendPolicies.usageExport.policies.backendAuth.passthrough.location.header.prefix`|string||
+|`frontendPolicies.usageExport.policies.backendAuth.passthrough.location.queryParameter`|object||
+|`frontendPolicies.usageExport.policies.backendAuth.passthrough.location.queryParameter.name`|string||
+|`frontendPolicies.usageExport.policies.backendAuth.passthrough.location.cookie`|object||
+|`frontendPolicies.usageExport.policies.backendAuth.passthrough.location.cookie.name`|string||
+|`frontendPolicies.usageExport.policies.backendAuth.key`|object||
+|`frontendPolicies.usageExport.policies.backendAuth.key.value`|object||
+|`frontendPolicies.usageExport.policies.backendAuth.key.value.file`|string||
+|`frontendPolicies.usageExport.policies.backendAuth.key.location`|object||
+|`frontendPolicies.usageExport.policies.backendAuth.key.location.header`|object||
+|`frontendPolicies.usageExport.policies.backendAuth.key.location.header.name`|string||
+|`frontendPolicies.usageExport.policies.backendAuth.key.location.header.prefix`|string||
+|`frontendPolicies.usageExport.policies.backendAuth.key.location.queryParameter`|object||
+|`frontendPolicies.usageExport.policies.backendAuth.key.location.queryParameter.name`|string||
+|`frontendPolicies.usageExport.policies.backendAuth.key.location.cookie`|object||
+|`frontendPolicies.usageExport.policies.backendAuth.key.location.cookie.name`|string||
+|`frontendPolicies.usageExport.policies.backendAuth.gcp`|object||
+|`frontendPolicies.usageExport.policies.backendAuth.gcp.type`|enum|Possible values: `idToken`.|
+|`frontendPolicies.usageExport.policies.backendAuth.gcp.audience`|string|Audience for the token. If not set, the destination host will be used.|
+|`frontendPolicies.usageExport.policies.backendAuth.gcp.credential`|object|ADC-compatible Google credential JSON. If not set, ambient credentials are used.|
+|`frontendPolicies.usageExport.policies.backendAuth.gcp.credential.file`|string||
+|`frontendPolicies.usageExport.policies.backendAuth.gcp.type`|enum|Possible values: `accessToken`, `null`.|
+|`frontendPolicies.usageExport.policies.backendAuth.gcp.credential`|object|ADC-compatible Google credential JSON. If not set, ambient credentials are used.|
+|`frontendPolicies.usageExport.policies.backendAuth.gcp.credential.file`|string||
+|`frontendPolicies.usageExport.policies.backendAuth.aws`|object||
+|`frontendPolicies.usageExport.policies.backendAuth.aws.accessKeyId`|string||
+|`frontendPolicies.usageExport.policies.backendAuth.aws.secretAccessKey`|string||
+|`frontendPolicies.usageExport.policies.backendAuth.aws.region`|string||
+|`frontendPolicies.usageExport.policies.backendAuth.aws.sessionToken`|string||
+|`frontendPolicies.usageExport.policies.backendAuth.azure`|object|Exactly one of explicitConfig, developerImplicit, or implicit may be set.|
+|`frontendPolicies.usageExport.policies.backendAuth.azure.explicitConfig`|object|Exactly one of clientSecret, managedIdentity, or workloadIdentity may be set.|
+|`frontendPolicies.usageExport.policies.backendAuth.azure.explicitConfig.clientSecret`|object||
+|`frontendPolicies.usageExport.policies.backendAuth.azure.explicitConfig.clientSecret.tenant_id`|string||
+|`frontendPolicies.usageExport.policies.backendAuth.azure.explicitConfig.clientSecret.client_id`|string||
+|`frontendPolicies.usageExport.policies.backendAuth.azure.explicitConfig.clientSecret.client_secret`|string||
+|`frontendPolicies.usageExport.policies.backendAuth.azure.explicitConfig.managedIdentity`|object||
+|`frontendPolicies.usageExport.policies.backendAuth.azure.explicitConfig.managedIdentity.userAssignedIdentity`|object||
+|`frontendPolicies.usageExport.policies.backendAuth.azure.explicitConfig.managedIdentity.userAssignedIdentity.clientId`|string||
+|`frontendPolicies.usageExport.policies.backendAuth.azure.explicitConfig.managedIdentity.userAssignedIdentity.objectId`|string||
+|`frontendPolicies.usageExport.policies.backendAuth.azure.explicitConfig.managedIdentity.userAssignedIdentity.resourceId`|string||
+|`frontendPolicies.usageExport.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
+|`frontendPolicies.usageExport.policies.backendAuth.azure.developerImplicit`|object||
+|`frontendPolicies.usageExport.policies.backendAuth.azure.implicit`|object||
+|`frontendPolicies.usageExport.policies.http`|object|Specify HTTP settings for the backend|
+|`frontendPolicies.usageExport.policies.http.version`|string||
+|`frontendPolicies.usageExport.policies.http.requestTimeout`|string||
+|`frontendPolicies.usageExport.policies.tcp`|object|Specify TCP settings for the backend|
+|`frontendPolicies.usageExport.policies.tcp.keepalives`|object||
+|`frontendPolicies.usageExport.policies.tcp.keepalives.enabled`|boolean||
+|`frontendPolicies.usageExport.policies.tcp.keepalives.time`|string||
+|`frontendPolicies.usageExport.policies.tcp.keepalives.interval`|string||
+|`frontendPolicies.usageExport.policies.tcp.keepalives.retries`|integer||
+|`frontendPolicies.usageExport.policies.tcp.connectTimeout`|object||
+|`frontendPolicies.usageExport.policies.tcp.connectTimeout.secs`|integer||
+|`frontendPolicies.usageExport.policies.tcp.connectTimeout.nanos`|integer||
+|`frontendPolicies.usageExport.policies.backendTunnel`|object|Specify a tunnel to use when connecting to the backend|
+|`frontendPolicies.usageExport.policies.backendTunnel.proxy`|object|Reference to the proxy address<br>Exactly one of service, host, or backend may be set.|
+|`frontendPolicies.usageExport.policies.backendTunnel.proxy.service`|object||
+|`frontendPolicies.usageExport.policies.backendTunnel.proxy.service.name`|object||
+|`frontendPolicies.usageExport.policies.backendTunnel.proxy.service.name.namespace`|string||
+|`frontendPolicies.usageExport.policies.backendTunnel.proxy.service.name.hostname`|string||
+|`frontendPolicies.usageExport.policies.backendTunnel.proxy.service.port`|integer||
+|`frontendPolicies.usageExport.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
+|`frontendPolicies.usageExport.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`frontendPolicies.usageExport.path`|string|Request path for usage event POSTs. Defaults to `/usage`.|
+|`frontendPolicies.usageExport.maxAttempts`|integer|Maximum send attempts for each usage event. Attempts are best effort and are not persisted across process restarts.|
+|`frontendPolicies.usageExport.retryBackoff`|string|Delay between failed send attempts.|
+|`frontendPolicies.usageExport.add`|object|CEL expressions evaluated at request completion and emitted under the event `attributes` object, for example `oid: jwt.oid`.|
 |`frontendPolicies.tracing`|object||
 |`frontendPolicies.tracing.service`|object||
 |`frontendPolicies.tracing.service.name`|object||


### PR DESCRIPTION
## Summary

Adds `frontendPolicies.usageExport` for request-level LLM usage event export.

- emits one JSON event after an LLM request completes with token usage
- sends events to a configured backend/reference and path
- supports backend policies for auth/TLS/header mutation
- includes provider, model, status, route, token, and cache-token fields
- supports custom CEL attributes under `attributes`, for example `oid: jwt.oid`
- retries failed sends with configurable `maxAttempts` and `retryBackoff`

Fixes #1805

## Tests

- `cargo fmt --all --check`
- `cargo check -p agentgateway`
- `cargo test -p agentgateway usage_event_`
- `cargo test -p agentgateway usage_request_serializes_json_post_with_normalized_path`
- `cargo test -p agentgateway test_local_frontend_usage_export_policy_custom_oid`
- `cargo xtask schema`