### PR TITLE
fix(proxy): always set x-istio-source when sending HBONE

### DIFF
--- a/crates/agentgateway/src/client/mod.rs
+++ b/crates/agentgateway/src/client/mod.rs
@@ -84,12 +84,14 @@ pub struct TunnelConfig {
 #[non_exhaustive]
 pub enum HboneSourceRole {
 	Waypoint,
+	Gateway,
 }
 
 impl HboneSourceRole {
 	pub fn as_header_value(self) -> &'static str {
 		match self {
 			HboneSourceRole::Waypoint => "waypoint",
+			HboneSourceRole::Gateway => "gateway",
 		}
 	}
 
@@ -99,7 +101,8 @@ impl HboneSourceRole {
 		use types::agent::TunnelProtocol;
 		match tp {
 			TunnelProtocol::HboneWaypoint => Some(HboneSourceRole::Waypoint),
-			TunnelProtocol::Direct | TunnelProtocol::HboneGateway | TunnelProtocol::Proxy => None,
+			TunnelProtocol::HboneGateway => Some(HboneSourceRole::Gateway),
+			TunnelProtocol::Direct | TunnelProtocol::Proxy => None,
 		}
 	}
 }
@@ -709,12 +712,16 @@ mod tests {
 	}
 
 	#[test]
-	fn non_waypoint_tunnel_protocols_have_no_source_role() {
-		for tp in [
-			TunnelProtocol::Direct,
-			TunnelProtocol::HboneGateway,
-			TunnelProtocol::Proxy,
-		] {
+	fn gateway_bind_renders_as_gateway() {
+		assert_eq!(
+			HboneSourceRole::from_tunnel(TunnelProtocol::HboneGateway).map(|r| r.as_header_value()),
+			Some("gateway"),
+		);
+	}
+
+	#[test]
+	fn non_role_tunnel_protocols_have_no_source_role() {
+		for tp in [TunnelProtocol::Direct, TunnelProtocol::Proxy] {
 			assert_eq!(
 				HboneSourceRole::from_tunnel(tp),
 				None,

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -1461,8 +1461,8 @@ async fn make_backend_call(
 	let hbone_source = req
 		.extensions()
 		.get::<WaypointService>()
-		.is_some()
-		.then_some(HboneSourceRole::Waypoint);
+		.map(|_| HboneSourceRole::Waypoint)
+		.or_else(|| Some(HboneSourceRole::Gateway));
 
 	// The MCP backend aggregates multiple backends into a single backend.
 	// In some cases, we want to treat this as a normal backend, so we swap it out.

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -2036,7 +2036,7 @@ pub fn build_service_call(
 	// When set, route traffic through the waypoint instead of directly to the workload.
 	// Skip when we are acting as a waypoint: ingress_use_waypoint should only affect
 	// ingress gateways, never waypoint-to-waypoint traffic.
-	let waypoint = if svc.ingress_use_waypoint && hbone_source.is_none() {
+	let waypoint = if svc.ingress_use_waypoint && hbone_source != Some(HboneSourceRole::Waypoint) {
 		if let Some(wp) = &svc.waypoint {
 			let discovery = inputs.stores.read_discovery();
 			let wp_ip = match &wp.destination {

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -1462,7 +1462,7 @@ async fn make_backend_call(
 		.extensions()
 		.get::<WaypointService>()
 		.map(|_| HboneSourceRole::Waypoint)
-		.or_else(|| Some(HboneSourceRole::Gateway));
+		.or(Some(HboneSourceRole::Gateway));
 
 	// The MCP backend aggregates multiple backends into a single backend.
 	// In some cases, we want to treat this as a normal backend, so we swap it out.

--- a/crates/agentgateway/src/proxy/tcpproxy.rs
+++ b/crates/agentgateway/src/proxy/tcpproxy.rs
@@ -6,7 +6,7 @@ use rand::prelude::IndexedRandom;
 
 use crate::cel::SourceContext;
 use crate::proxy::httpproxy::BackendCall;
-use crate::proxy::{httpproxy, ProxyError, WaypointService};
+use crate::proxy::{ProxyError, WaypointService, httpproxy};
 use crate::store::{BackendPolicies, FrontendPolices, RoutePath};
 use crate::telemetry::log;
 use crate::telemetry::log::{DropOnLog, RequestLog};
@@ -850,7 +850,7 @@ mod tests {
 		use prometheus_client::registry::Registry;
 
 		use crate::client::Client;
-		use crate::{client, BackendConfig};
+		use crate::{BackendConfig, client};
 
 		let config = crate::config::parse_config("{}".to_string(), None).unwrap();
 		let encoder = config.session_encoder.clone();

--- a/crates/agentgateway/src/proxy/tcpproxy.rs
+++ b/crates/agentgateway/src/proxy/tcpproxy.rs
@@ -6,7 +6,7 @@ use rand::prelude::IndexedRandom;
 
 use crate::cel::SourceContext;
 use crate::proxy::httpproxy::BackendCall;
-use crate::proxy::{ProxyError, WaypointService, httpproxy};
+use crate::proxy::{httpproxy, ProxyError, WaypointService};
 use crate::store::{BackendPolicies, FrontendPolices, RoutePath};
 use crate::telemetry::log;
 use crate::telemetry::log::{DropOnLog, RequestLog};
@@ -173,8 +173,8 @@ impl TCPProxy {
 
 		let hbone_source = connection
 			.ext::<WaypointService>()
-			.is_some()
-			.then_some(crate::client::HboneSourceRole::Waypoint);
+			.map(|_| crate::client::HboneSourceRole::Waypoint)
+			.or(Some(crate::client::HboneSourceRole::Gateway));
 		let backend_call = Self::build_backend_call(
 			&mut Some(log),
 			sni,
@@ -850,7 +850,7 @@ mod tests {
 		use prometheus_client::registry::Registry;
 
 		use crate::client::Client;
-		use crate::{BackendConfig, client};
+		use crate::{client, BackendConfig};
 
 		let config = crate::config::parse_config("{}".to_string(), None).unwrap();
 		let encoder = config.session_encoder.clone();

--- a/crates/agentgateway/tests/tests/hbone.rs
+++ b/crates/agentgateway/tests/tests/hbone.rs
@@ -474,11 +474,9 @@ binds:
 	Ok(())
 }
 
-/// Verifies that outbound double-HBONE CONNECTs carry `x-forwarded-network`
-/// and `baggage` (inner only). The bind uses the default `Direct` tunnel
-/// protocol, so `x-istio-source` is absent; the waypoint role mapping
-/// (`HboneWaypoint → "waypoint"`) is covered by the unit tests in
-/// `client::tests`.
+/// Verifies that outbound double-HBONE CONNECTs carry `x-istio-source: gateway`,
+/// `x-forwarded-network`, and `baggage` (inner only). The waypoint role mapping
+/// (`HboneWaypoint → "waypoint"`) is covered by the unit tests in `client::tests`.
 #[tokio::test]
 async fn test_hbone_carries_istio_headers() -> anyhow::Result<()> {
 	agent_core::telemetry::testing::setup_test_logging();
@@ -561,9 +559,10 @@ binds:
 		.await
 		.expect("timeout waiting for outer CONNECT headers")
 		.expect("gateway closed without forwarding headers");
-	assert!(
-		outer.get("x-istio-source").is_none(),
-		"outer: Direct bind should not set x-istio-source",
+	assert_eq!(
+		outer.get("x-istio-source").map(|v| v.to_str().unwrap()),
+		Some("gateway"),
+		"outer: expected x-istio-source: gateway",
 	);
 	assert_eq!(
 		outer
@@ -577,14 +576,15 @@ binds:
 		"outer: baggage must only appear on the inner CONNECT",
 	);
 
-	// --- inner CONNECT (to waypoint / workload): no x-istio-source, has x-forwarded-network + baggage ---
+	// --- inner CONNECT (to waypoint / workload): x-istio-source: gateway, x-forwarded-network + baggage ---
 	let inner = tokio::time::timeout(std::time::Duration::from_secs(5), waypoint_rx.recv())
 		.await
 		.expect("timeout waiting for inner CONNECT headers")
 		.expect("waypoint closed without forwarding headers");
-	assert!(
-		inner.get("x-istio-source").is_none(),
-		"inner: Direct bind should not set x-istio-source",
+	assert_eq!(
+		inner.get("x-istio-source").map(|v| v.to_str().unwrap()),
+		Some("gateway"),
+		"inner: expected x-istio-source: gateway",
 	);
 	assert_eq!(
 		inner


### PR DESCRIPTION
#1740 added ingress-use-waypoint support. This PR makes it so an ingress sending to an eastwest gateway can tell that eastwest gateway to respect ingress-use-waypoint by sending "gateway" in the "x-istio-source"

See https://github.com/istio/istio/pull/60162