### PR TITLE
fix(proxy): capacity weighted loadbalancing

### DIFF
--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -74,7 +74,7 @@ impl AIBackend {
 		let best = [a, b]
 			.into_iter()
 			.map(|idx| {
-				let (_, EndpointWithInfo { endpoint, info }) =
+				let (_, EndpointWithInfo { endpoint, info, .. }) =
 					index.get_index(idx).expect("index already checked");
 				(endpoint.clone(), info)
 			})

--- a/crates/agentgateway/src/proxy/locality_test.rs
+++ b/crates/agentgateway/src/proxy/locality_test.rs
@@ -45,18 +45,21 @@ async fn prefer_same_zone_pins_to_local_zone() {
 						svc: "app",
 						loc: ("r1", "z1", "node-a"),
 						healthy: true,
+						cap: 1,
 					},
 					Ep {
 						label: "other-zone",
 						svc: "app",
 						loc: ("r1", "z2", "node-b"),
 						healthy: true,
+						cap: 1,
 					},
 					Ep {
 						label: "other-region",
 						svc: "app",
 						loc: ("r2", "z1", "node-c"),
 						healthy: true,
+						cap: 1,
 					},
 				],
 			},
@@ -89,12 +92,14 @@ async fn failover_spills_to_next_tier_when_local_missing() {
 						svc: "app",
 						loc: ("r1", "z2", "node-b"),
 						healthy: true,
+						cap: 1,
 					},
 					Ep {
 						label: "other-region",
 						svc: "app",
 						loc: ("r2", "z1", "node-c"),
 						healthy: true,
+						cap: 1,
 					},
 				],
 			},
@@ -126,12 +131,14 @@ async fn prefer_same_node_pins_to_local_node() {
 						svc: "app",
 						loc: ("r1", "z1", "node-a"),
 						healthy: true,
+						cap: 1,
 					},
 					Ep {
 						label: "same-zone",
 						svc: "app",
 						loc: ("r1", "z1", "node-b"),
 						healthy: true,
+						cap: 1,
 					},
 				],
 			},
@@ -164,12 +171,14 @@ async fn strict_mode_drops_non_matching_endpoints() {
 						svc: "app",
 						loc: ("r1", "z2", "node-b"),
 						healthy: true,
+						cap: 1,
 					},
 					Ep {
 						label: "other-region",
 						svc: "app",
 						loc: ("r2", "z1", "node-c"),
 						healthy: true,
+						cap: 1,
 					},
 				],
 			},
@@ -201,12 +210,14 @@ async fn strict_mode_keeps_full_matches() {
 						svc: "app",
 						loc: ("r1", "z1", "node-a"),
 						healthy: true,
+						cap: 1,
 					},
 					Ep {
 						label: "drop",
 						svc: "app",
 						loc: ("r1", "z2", "node-b"),
 						healthy: true,
+						cap: 1,
 					},
 				],
 			},
@@ -239,18 +250,21 @@ async fn standard_mode_ignores_locality() {
 						svc: "app",
 						loc: ("r1", "z1", "node-a"),
 						healthy: true,
+						cap: 1,
 					},
 					Ep {
 						label: "z2",
 						svc: "app",
 						loc: ("r1", "z2", "node-b"),
 						healthy: true,
+						cap: 1,
 					},
 					Ep {
 						label: "z3",
 						svc: "app",
 						loc: ("r1", "z3", "node-c"),
 						healthy: true,
+						cap: 1,
 					},
 				],
 			},
@@ -258,6 +272,52 @@ async fn standard_mode_ignores_locality() {
 				hits: 30,
 				want_status: StatusCode::OK,
 				want: Expect::Spread(vec!["z1", "z2", "z3"]),
+			},
+		],
+	})
+	.await;
+}
+
+// test capacity weighted p2c but with a large tolerance
+// to avoid tet flakes, and account for ewma also amplifying
+// the split
+#[tokio::test]
+async fn capacity_weighted_p2c_splits_traffic_by_weight() {
+	run(Case {
+		self_loc: Some(("r1", "z1", "node-a")),
+		steps: vec![
+			Step::Sync {
+				services: vec![Svc {
+					name: "app",
+					mode: Standard,
+					scopes: vec![],
+				}],
+				endpoints: vec![
+					Ep {
+						label: "heavy",
+						svc: "app",
+						loc: ("r1", "z1", "node-a"),
+						cap: 3,
+						..Default::default()
+					},
+					Ep {
+						label: "light",
+						svc: "app",
+						loc: ("r1", "z1", "node-a"),
+						cap: 1,
+						..Default::default()
+					},
+				],
+			},
+			Step::Hit {
+				hits: 4000,
+				want_status: StatusCode::OK,
+				// Window [0.60, 0.90] for heavy: rejects uniform (broken, 0.50) but tolerates
+				// the score-dynamic amplification above the pure-sampler 0.75.
+				want: Expect::Ratio {
+					shares: vec![("heavy", 0.75), ("light", 0.25)],
+					tolerance: 0.15,
+				},
 			},
 		],
 	})
@@ -284,12 +344,14 @@ async fn missing_self_identity_keeps_all_endpoints_reachable() {
 							svc: "app",
 							loc: ("r1", "z1", "node-a"),
 							healthy: true,
+							cap: 1,
 						},
 						Ep {
 							label: "b",
 							svc: "app",
 							loc: ("r1", "z2", "node-b"),
 							healthy: true,
+							cap: 1,
 						},
 					],
 				},
@@ -323,12 +385,14 @@ async fn unhealthy_local_zone_falls_back_to_next_tier() {
 						svc: "app",
 						loc: ("r1", "z1", "node-a"),
 						healthy: false,
+						cap: 1,
 					},
 					Ep {
 						label: "same-region",
 						svc: "app",
 						loc: ("r1", "z2", "node-b"),
 						healthy: true,
+						cap: 1,
 					},
 				],
 			},
@@ -360,18 +424,21 @@ async fn shared_bucket_splits_within_and_skips_lower_tier() {
 						svc: "app",
 						loc: ("r1", "z1", "node-a"),
 						healthy: true,
+						cap: 1,
 					},
 					Ep {
 						label: "b",
 						svc: "app",
 						loc: ("r1", "z1", "node-b"),
 						healthy: true,
+						cap: 1,
 					},
 					Ep {
 						label: "c",
 						svc: "app",
 						loc: ("r1", "z2", "node-c"),
 						healthy: true,
+						cap: 1,
 					},
 				],
 			},
@@ -404,18 +471,21 @@ async fn shared_bucket_with_one_unhealthy_stays_in_bucket() {
 						svc: "app",
 						loc: ("r1", "z1", "node-a"),
 						healthy: false,
+						cap: 1,
 					},
 					Ep {
 						label: "b",
 						svc: "app",
 						loc: ("r1", "z1", "node-b"),
 						healthy: true,
+						cap: 1,
 					},
 					Ep {
 						label: "c",
 						svc: "app",
 						loc: ("r1", "z2", "node-c"),
 						healthy: true,
+						cap: 1,
 					},
 				],
 			},
@@ -441,12 +511,14 @@ async fn service_arrives_after_workloads() {
 			svc: "app",
 			loc: ("r1", "z1", "node-a"),
 			healthy: true,
+			cap: 1,
 		},
 		Ep {
 			label: "other-zone",
 			svc: "app",
 			loc: ("r1", "z2", "node-b"),
 			healthy: true,
+			cap: 1,
 		},
 	];
 	run(Case {
@@ -493,18 +565,21 @@ async fn service_lb_preference_change_rebuckets() {
 			svc: "app",
 			loc: ("r1", "z1", "node-a"),
 			healthy: true,
+			cap: 1,
 		},
 		Ep {
 			label: "same-zone",
 			svc: "app",
 			loc: ("r1", "z1", "node-b"),
 			healthy: true,
+			cap: 1,
 		},
 		Ep {
 			label: "same-region",
 			svc: "app",
 			loc: ("r1", "z2", "node-c"),
 			healthy: true,
+			cap: 1,
 		},
 	];
 	run(Case {
@@ -557,12 +632,14 @@ async fn strict_then_failover_recovers_dropped_endpoints() {
 			svc: "app",
 			loc: ("r1", "z2", "node-b"),
 			healthy: true,
+			cap: 1,
 		},
 		Ep {
 			label: "other-zone-2",
 			svc: "app",
 			loc: ("r1", "z3", "node-c"),
 			healthy: true,
+			cap: 1,
 		},
 	];
 	run(Case {
@@ -626,12 +703,14 @@ async fn late_self_identity_rebuckets() {
 			svc: "app",
 			loc: ("r1", "z1", "node-a"),
 			healthy: true,
+			cap: 1,
 		},
 		Ep {
 			label: "other-zone",
 			svc: "app",
 			loc: ("r1", "z2", "node-b"),
 			healthy: true,
+			cap: 1,
 		},
 	];
 	run(Case {
@@ -746,6 +825,19 @@ struct Ep {
 	svc: &'static str,
 	loc: Loc,
 	healthy: bool,
+	cap: u32,
+}
+
+impl Default for Ep {
+	fn default() -> Self {
+		Self {
+			label: "",
+			svc: "",
+			loc: ("", "", ""),
+			healthy: true,
+			cap: 1,
+		}
+	}
 }
 
 enum Expect {
@@ -753,6 +845,13 @@ enum Expect {
 	Exact(Vec<(&'static str, usize)>),
 	/// Every listed label must receive ≥1 request this step; counts must sum to `hits`.
 	Spread(Vec<&'static str>),
+	/// Per-label expected share of `hits` (fractions, sum should be 1.0). Asserts each label's
+	/// observed share is within `tolerance` of its expected share. Use for stochastic
+	/// distributions (e.g. capacity-weighted P2C).
+	Ratio {
+		shares: Vec<(&'static str, f64)>,
+		tolerance: f64,
+	},
 }
 
 enum Step {
@@ -823,6 +922,7 @@ fn build_workload(
 	node: &str,
 	svc: &str,
 	status: HealthStatus,
+	capacity: u32,
 ) -> LocalWorkload {
 	LocalWorkload {
 		workload: Workload {
@@ -833,6 +933,7 @@ fn build_workload(
 			locality: loc,
 			node: node.into(),
 			status,
+			capacity,
 			..Default::default()
 		},
 		services: HashMap::from([(svc_key(svc), HashMap::from([(SVC_PORT, addr.port())]))]),
@@ -892,6 +993,7 @@ async fn apply_sync(h: &mut Harness, services: Vec<Svc>, endpoints: Vec<Ep>) {
 			n,
 			ep.svc,
 			status,
+			ep.cap,
 		));
 	}
 	let svcs: Vec<Service> = services.iter().map(build_service).collect();
@@ -942,6 +1044,15 @@ async fn apply_hit(h: &mut Harness, hits: usize, want_status: StatusCode, want: 
 				total += got;
 			}
 			assert_eq!(total, hits, "total hits");
+		},
+		Expect::Ratio { shares, tolerance } => {
+			for (label, want_share) in &shares {
+				let got_share = delta(label) as f64 / hits as f64;
+				assert!(
+					(got_share - want_share).abs() <= tolerance,
+					"label={label} share={got_share} want={want_share} ±{tolerance}",
+				);
+			}
 		},
 	}
 	h.baseline = snapshot;

--- a/crates/agentgateway/src/types/discovery.rs
+++ b/crates/agentgateway/src/types/discovery.rs
@@ -17,7 +17,7 @@ use crate::types::proto::workload::{
 	GatewayAddress as XdsGatewayAddress, Port, PortList, Service as XdsService,
 	Workload as XdsWorkload,
 };
-use crate::types::proto::{workload, ProtoError};
+use crate::types::proto::{ProtoError, workload};
 use crate::*;
 
 #[derive(Debug, Eq, PartialEq, Hash, Clone)]

--- a/crates/agentgateway/src/types/discovery.rs
+++ b/crates/agentgateway/src/types/discovery.rs
@@ -17,7 +17,7 @@ use crate::types::proto::workload::{
 	GatewayAddress as XdsGatewayAddress, Port, PortList, Service as XdsService,
 	Workload as XdsWorkload,
 };
-use crate::types::proto::{ProtoError, workload};
+use crate::types::proto::{workload, ProtoError};
 use crate::*;
 
 #[derive(Debug, Eq, PartialEq, Hash, Clone)]
@@ -224,7 +224,7 @@ pub enum SelfIdentitySource {
 	},
 }
 
-#[derive(Debug, Default, Eq, PartialEq, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Eq, PartialEq, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct Workload {
 	pub workload_ips: Vec<IpAddr>,
@@ -285,8 +285,40 @@ pub struct Workload {
 	pub capacity: u32,
 }
 
-fn default_capacity() -> u32 {
+pub fn default_capacity() -> u32 {
 	1
+}
+
+impl Default for Workload {
+	fn default() -> Self {
+		Self {
+			workload_ips: Default::default(),
+			waypoint: Default::default(),
+			network_gateway: Default::default(),
+			protocol: Default::default(),
+			network_mode: Default::default(),
+			uid: Default::default(),
+			name: Default::default(),
+			namespace: Default::default(),
+			trust_domain: Default::default(),
+			service_account: Default::default(),
+			network: Default::default(),
+			workload_name: Default::default(),
+			workload_type: Default::default(),
+			canonical_name: Default::default(),
+			canonical_revision: Default::default(),
+			hostname: Default::default(),
+			node: Default::default(),
+			authorization_policies: Default::default(),
+			status: Default::default(),
+			cluster_id: Default::default(),
+			locality: Default::default(),
+			services: Default::default(),
+
+			// default capacity to 1, as 0 means this workload should not receive traffic
+			capacity: default_capacity(),
+		}
+	}
 }
 
 impl Workload {

--- a/crates/agentgateway/src/types/loadbalancer.rs
+++ b/crates/agentgateway/src/types/loadbalancer.rs
@@ -8,6 +8,8 @@ use futures_util::SinkExt;
 use indexmap::IndexMap;
 use itertools::Itertools;
 use rand::RngExt;
+use rand::distr::Distribution;
+use rand::distr::weighted::WeightedIndex;
 use serde::ser::SerializeSeq;
 use tokio::time::sleep_until;
 
@@ -39,14 +41,14 @@ impl<T> EndpointWithInfo<T> {
 	}
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub enum Sampler {
 	/// All endpoints have the same nonzero capacity. No need for weighted sampling.
 	/// Stores the common capacity for quick checks that we're still uniform after
 	/// new endpoints are added incrementally.
 	Uniform(u32),
-	// Weighted sampling by capacity via expansion table.
-	Weighted(Vec<u32>),
+	/// Weighted sampling by capacity via a cached prefix sum.
+	Weighted(WeightedIndex<u64>),
 	/// At least one endpoint is present, but total capacity is zero — every
 	/// active endpoint is drained. Distinct from the zero-endpoints case,
 	/// which keeps the default `Uniform(1)` sampler.
@@ -63,19 +65,6 @@ impl Sampler {
 	pub fn is_drained(&self) -> bool {
 		matches!(self, Sampler::Drained)
 	}
-}
-
-// cap the size of the expansion table to avoid excessive memory
-// usage in pathological cases for capacity values.
-const MAX_EXPANSION: usize = 4096;
-
-fn gcd_u32(mut a: u32, mut b: u32) -> u32 {
-	while b != 0 {
-		let t = b;
-		b = a % b;
-		a = t;
-	}
-	a
 }
 
 fn build_sampler<T>(active: &IndexMap<EndpointKey, EndpointWithInfo<T>>) -> Sampler {
@@ -100,41 +89,9 @@ fn build_sampler<T>(active: &IndexMap<EndpointKey, EndpointWithInfo<T>>) -> Samp
 		return Sampler::Uniform(first_cap);
 	}
 
-	let g = active
-		.values()
-		.map(|e| e.capacity)
-		.filter(|&c| c > 0)
-		// reduce expansion size by normalizing capacity weights
-		.reduce(gcd_u32)
-		.unwrap_or(1)
-		.max(1);
-	let mut reduced: Vec<u32> = active.values().map(|e| e.capacity / g).collect();
-
-	// if the expansion would be very large due to no common divisor with
-	// large values for capacity, iteratively shrink all capacities which
-	// reduces precision but keeps memory usage sane
-	let mut total: u64 = reduced.iter().map(|&c| c as u64).sum();
-	while total as usize > MAX_EXPANSION {
-		let mut changed = false;
-		for c in reduced.iter_mut() {
-			if *c > 1 {
-				*c = c.div_ceil(2);
-				changed = true;
-			}
-		}
-		if !changed {
-			break;
-		}
-		total = reduced.iter().map(|&c| c as u64).sum();
-	}
-
-	let mut table = Vec::with_capacity(total as usize);
-	for (i, &c) in reduced.iter().enumerate() {
-		for _ in 0..c {
-			table.push(i as u32);
-		}
-	}
-	Sampler::Weighted(table)
+	let dist = WeightedIndex::new(active.values().map(|e| e.capacity as u64))
+		.expect("non-empty, non-all-zero u64 weights cannot fail WeightedIndex::new");
+	Sampler::Weighted(dist)
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -275,13 +232,7 @@ impl EndpointSet<Endpoint> {
 		let mut rng = rand::rng();
 		let (a, b) = match iter.sampler() {
 			Some(Sampler::Drained) => return None,
-			Some(Sampler::Weighted(table)) => {
-				let tl = table.len();
-				(
-					table[rng.random_range(0..tl)] as usize,
-					table[rng.random_range(0..tl)] as usize,
-				)
-			},
+			Some(Sampler::Weighted(dist)) => (dist.sample(&mut rng), dist.sample(&mut rng)),
 			Some(Sampler::Uniform(_)) | None => {
 				let len = index.len();
 				(rng.random_range(0..len), rng.random_range(0..len))
@@ -352,16 +303,14 @@ fn viable(
 	if target_port == 0 && !endpoint.port.contains_key(&svc_port) {
 		trace!(
 			"filter endpoint {}, no service port {}",
-			endpoint.workload_uid,
-			svc_port
+			endpoint.workload_uid, svc_port
 		);
 		return None;
 	}
 	if wl.capacity == 0 {
 		trace!(
 			"filter endpoint {}, workload {} capacity is 0",
-			endpoint.workload_uid,
-			wl.name
+			endpoint.workload_uid, wl.name
 		);
 		return None;
 	}
@@ -612,11 +561,7 @@ impl<T: Clone + Sync + Send + 'static> EndpointSet<T> {
 			.iter()
 			.find_map(|x| {
 				let b = x.load_full();
-				if !b.active.is_empty() {
-					Some(b)
-				} else {
-					None
-				}
+				if !b.active.is_empty() { Some(b) } else { None }
 			})
 			// TODO: allow selecting across multiple buckets.
 			.unwrap_or_else(|| self.buckets[0].load_full())
@@ -1613,13 +1558,13 @@ mod tests {
 	#[test]
 	fn sampler_all_default_capacity_is_uniform() {
 		let active = make_active(&[1, 1, 1, 1]);
-		assert_eq!(build_sampler(&active), Sampler::Uniform(1));
+		assert!(matches!(build_sampler(&active), Sampler::Uniform(1)));
 	}
 
 	#[test]
 	fn sampler_all_equal_nonzero_is_uniform() {
 		let active = make_active(&[5, 5, 5]);
-		assert_eq!(build_sampler(&active), Sampler::Uniform(5));
+		assert!(matches!(build_sampler(&active), Sampler::Uniform(5)));
 	}
 
 	#[test]
@@ -1639,16 +1584,16 @@ mod tests {
 	fn sampler_weighted_3_1_distribution() {
 		let active = make_active(&[3, 1]);
 		let sampler = build_sampler(&active);
-		let Sampler::Weighted(table) = &sampler else {
+		let Sampler::Weighted(dist) = &sampler else {
 			panic!("expected Weighted, got {sampler:?}");
 		};
-		assert_eq!(table.len(), 4);
+		assert_eq!(dist.weights().collect::<Vec<_>>(), vec![3u64, 1]);
 
 		let mut rng = rand::rng();
 		let mut counts = [0u32; 2];
 		let n = 100_000u32;
 		for _ in 0..n {
-			let idx = table[rng.random_range(0..table.len())] as usize;
+			let idx = dist.sample(&mut rng);
 			counts[idx] += 1;
 		}
 		// Expect ~75/25; ±2% is comfortable for n=100k.
@@ -1660,60 +1605,21 @@ mod tests {
 	}
 
 	#[test]
-	fn sampler_gcd_reduces_round_capacities() {
-		// 100, 200, 300 → after gcd=100, table size is 1+2+3 = 6, not 600.
-		let active = make_active(&[100, 200, 300]);
-		let sampler = build_sampler(&active);
-		let Sampler::Weighted(table) = &sampler else {
-			panic!("expected Weighted, got {sampler:?}");
-		};
-		assert_eq!(table.len(), 6, "gcd reduction should yield 1+2+3");
-		let zero = table.iter().filter(|&&i| i == 0).count();
-		let one = table.iter().filter(|&&i| i == 1).count();
-		let two = table.iter().filter(|&&i| i == 2).count();
-		assert_eq!((zero, one, two), (1, 2, 3));
-	}
-
-	#[test]
-	fn sampler_zero_cap_excluded_from_weighted_table() {
-		// Mixed 0 and nonzero — the 0-cap index must never appear in samples.
+	fn sampler_zero_cap_endpoint_is_never_sampled() {
+		// Mixed 0 and nonzero — the 0-cap index must never be returned.
 		let active = make_active(&[0, 1, 1]);
 		let sampler = build_sampler(&active);
-		let Sampler::Weighted(table) = &sampler else {
+		let Sampler::Weighted(dist) = &sampler else {
 			panic!("expected Weighted, got {sampler:?}");
 		};
-		assert_eq!(table.len(), 2);
-		for &i in table {
-			assert_ne!(i, 0, "cap=0 endpoint must not appear in expansion table");
+		let mut rng = rand::rng();
+		for _ in 0..1_000 {
+			assert_ne!(
+				dist.sample(&mut rng),
+				0,
+				"cap=0 endpoint must never be sampled"
+			);
 		}
-	}
-
-	#[test]
-	fn sampler_clamps_pathological_large_capacity() {
-		// gcd(10_000, 1) = 1 → naive expansion would be 10_001 entries.
-		// The clamp must bound the table without zeroing out the small cap.
-		let active = make_active(&[10_000, 1]);
-		let sampler = build_sampler(&active);
-		let Sampler::Weighted(table) = &sampler else {
-			panic!("expected Weighted, got {sampler:?}");
-		};
-		assert!(
-			table.len() <= MAX_EXPANSION,
-			"table.len()={} exceeds MAX_EXPANSION={}",
-			table.len(),
-			MAX_EXPANSION
-		);
-		let zero = table.iter().filter(|&&i| i == 0).count();
-		let one = table.iter().filter(|&&i| i == 1).count();
-		assert!(
-			one >= 1,
-			"small-capacity endpoint must remain reachable post-clamp (zero={zero}, one={one})"
-		);
-		// Ratio should still strongly favor the large-capacity endpoint.
-		assert!(
-			zero > one * 100,
-			"expected strong skew toward index 0, got zero={zero}, one={one}"
-		);
 	}
 
 	/// Test helper: equivalent to the inlined `sampler = build_sampler(&active)`
@@ -1733,17 +1639,17 @@ mod tests {
 			.active
 			.insert("b".into(), EndpointWithInfo::with_capacity((), 1));
 		rebuild_sampler(&mut group);
-		assert_eq!(group.sampler, Sampler::Uniform(1));
+		assert!(matches!(group.sampler, Sampler::Uniform(1)));
 
 		// Replace "a" with cap=3 — now mixed, should become Weighted.
 		group
 			.active
 			.insert("a".into(), EndpointWithInfo::with_capacity((), 3));
 		rebuild_sampler(&mut group);
-		let Sampler::Weighted(table) = &group.sampler else {
+		let Sampler::Weighted(dist) = &group.sampler else {
 			panic!("expected Weighted, got {:?}", group.sampler);
 		};
-		assert_eq!(table.len(), 4); // 3 + 1
+		assert_eq!(dist.weights().collect::<Vec<_>>(), vec![3u64, 1]);
 
 		// Drain everything — should become Drained.
 		group
@@ -1765,17 +1671,17 @@ mod tests {
 			.active
 			.insert("a".into(), EndpointWithInfo::with_capacity((), 1));
 		rebuild_sampler(&mut group);
-		assert_eq!(group.sampler, Sampler::Uniform(1));
+		assert!(matches!(group.sampler, Sampler::Uniform(1)));
 
 		group
 			.active
 			.insert("b".into(), EndpointWithInfo::with_capacity((), 1));
 		group.update_sampler(Some(1));
-		assert_eq!(group.sampler, Sampler::Uniform(1));
+		assert!(matches!(group.sampler, Sampler::Uniform(1)));
 
 		group.active.swap_remove(&Strng::from("b"));
 		group.update_sampler(None);
-		assert_eq!(group.sampler, Sampler::Uniform(1));
+		assert!(matches!(group.sampler, Sampler::Uniform(1)));
 	}
 
 	#[test]
@@ -1786,7 +1692,7 @@ mod tests {
 			.active
 			.insert("a".into(), EndpointWithInfo::with_capacity((), 1));
 		rebuild_sampler(&mut group);
-		assert_eq!(group.sampler, Sampler::Uniform(1));
+		assert!(matches!(group.sampler, Sampler::Uniform(1)));
 
 		group
 			.active
@@ -1802,13 +1708,13 @@ mod tests {
 			.active
 			.insert("a".into(), EndpointWithInfo::with_capacity((), 0));
 		rebuild_sampler(&mut group);
-		assert_eq!(group.sampler, Sampler::Drained);
+		assert!(matches!(group.sampler, Sampler::Drained));
 
 		group
 			.active
 			.insert("b".into(), EndpointWithInfo::with_capacity((), 0));
 		group.update_sampler(Some(0));
-		assert_eq!(group.sampler, Sampler::Drained);
+		assert!(matches!(group.sampler, Sampler::Drained));
 	}
 
 	#[test]
@@ -1838,7 +1744,7 @@ mod tests {
 			.active
 			.insert("a".into(), EndpointWithInfo::with_capacity((), 0));
 		rebuild_sampler(&mut group);
-		assert_eq!(group.sampler, Sampler::Drained);
+		assert!(matches!(group.sampler, Sampler::Drained));
 
 		group.active.swap_remove(&Strng::from("a"));
 		group.update_sampler(None);
@@ -1847,15 +1753,6 @@ mod tests {
 			"sampler stayed drained after removing the last cap=0 endpoint; \
 			 select_fallback would now skip this bucket's rejected pool"
 		);
-	}
-
-	#[test]
-	fn gcd_basic() {
-		assert_eq!(gcd_u32(12, 18), 6);
-		assert_eq!(gcd_u32(7, 11), 1);
-		assert_eq!(gcd_u32(100, 0), 100);
-		assert_eq!(gcd_u32(0, 100), 100);
-		assert_eq!(gcd_u32(0, 0), 0);
 	}
 
 	#[test]

--- a/crates/agentgateway/src/types/loadbalancer.rs
+++ b/crates/agentgateway/src/types/loadbalancer.rs
@@ -44,8 +44,6 @@ impl<T> EndpointWithInfo<T> {
 #[derive(Debug, Clone)]
 pub enum Sampler {
 	/// Every endpoint has the default capacity of 1. No need for weighted sampling.
-	/// Other uniform-cap configurations (e.g. all-5) fall through to Weighted —
-	/// correct, just slightly less efficient than this fast path.
 	Uniform,
 	/// Weighted sampling by capacity via a cached prefix sum.
 	Weighted(WeightedIndex<u64>),
@@ -102,6 +100,52 @@ pub struct EndpointGroup<T> {
 }
 
 impl<T> EndpointGroup<T> {
+	fn from_pools(
+		active: IndexMap<EndpointKey, EndpointWithInfo<T>>,
+		rejected: IndexMap<EndpointKey, EndpointWithInfo<T>>,
+	) -> Self {
+		let sampler = build_sampler(&active);
+		Self {
+			active,
+			rejected,
+			sampler,
+		}
+	}
+
+	/// Promote an endpoint to active, removing any prior rejected entry under the same key.
+	fn add(&mut self, key: EndpointKey, ep: EndpointWithInfo<T>) {
+		self.rejected.swap_remove(&key);
+		let cap = ep.capacity;
+		self.active.insert(key, ep);
+		self.update_sampler(Some(cap));
+	}
+
+	/// Remove an endpoint from both pools.
+	fn remove(&mut self, key: &EndpointKey) {
+		if self.active.swap_remove(key).is_some() || self.rejected.swap_remove(key).is_some() {
+			self.update_sampler(None);
+		}
+	}
+
+	/// Move an endpoint from active -> rejected (eviction). No-op if not active.
+	fn evict(&mut self, key: EndpointKey) {
+		if let Some(ep) = self.active.swap_remove(&key) {
+			self.rejected.insert(key, ep);
+			self.update_sampler(None);
+		}
+	}
+
+	/// Move an endpoint from rejected -> active (uneviction). The closure mutates
+	/// the endpoint info before re-insertion. No-op if not rejected.
+	fn unevict(&mut self, key: EndpointKey, edit: impl FnOnce(&EndpointWithInfo<T>)) {
+		if let Some(ep) = self.rejected.swap_remove(&key) {
+			edit(&ep);
+			let cap = ep.capacity;
+			self.active.insert(key, ep);
+			self.update_sampler(Some(cap));
+		}
+	}
+
 	// rebuilds the sampler, unless the change is guaranteed to preserve the same distribution
 	fn update_sampler(&mut self, added_ep_cap: Option<u32>) {
 		let preserved = match (&self.sampler, added_ep_cap) {
@@ -486,17 +530,12 @@ impl<T: Clone + Sync + Send + 'static> EndpointSet<T> {
 		let buckets = initial_set
 			.into_iter()
 			.map(|items| {
-				// All EWIs created via `new` get cap=1, so the default Uniform(1)
-				// sampler is already correct — no rebuild needed.
-				let eg = EndpointGroup {
-					active: IndexMap::from_iter(
-						items
-							.into_iter()
-							.map(|(k, v)| (k, EndpointWithInfo::new(v))),
-					),
-					rejected: Default::default(),
-					sampler: Sampler::default(),
-				};
+				let active = IndexMap::from_iter(
+					items
+						.into_iter()
+						.map(|(k, v)| (k, EndpointWithInfo::new(v))),
+				);
+				let eg = EndpointGroup::from_pools(active, IndexMap::new());
 				Arc::new(ArcSwap::new(Arc::new(eg)))
 			})
 			.collect_vec();
@@ -646,11 +685,17 @@ impl<T: Clone + Sync + Send + 'static> EndpointSet<T> {
 		let _mu = self.action_mutex.lock();
 		let n = self.buckets.len();
 
-		let mut new_groups: Vec<EndpointGroup<T>> = (0..n).map(|_| EndpointGroup::default()).collect();
+		let mut new_active: Vec<IndexMap<EndpointKey, EndpointWithInfo<T>>> =
+			(0..n).map(|_| IndexMap::new()).collect();
+		let mut new_rejected: Vec<IndexMap<EndpointKey, EndpointWithInfo<T>>> =
+			(0..n).map(|_| IndexMap::new()).collect();
 
 		for bucket in &self.buckets {
 			let g = bucket.load_full();
-			for (entries, rejected) in [(&g.active, false), (&g.rejected, true)] {
+			for (entries, into) in [
+				(&g.active, &mut new_active),
+				(&g.rejected, &mut new_rejected),
+			] {
 				for (key, ep) in entries {
 					let Some(b) = ranker(ep.endpoint.as_ref()) else {
 						continue;
@@ -658,21 +703,15 @@ impl<T: Clone + Sync + Send + 'static> EndpointSet<T> {
 					if b >= n {
 						continue;
 					}
-					let target = if rejected {
-						&mut new_groups[b].rejected
-					} else {
-						&mut new_groups[b].active
-					};
-					target.insert(key.clone(), ep.clone());
+					into[b].insert(key.clone(), ep.clone());
 				}
 			}
 		}
 
-		for (i, mut group) in new_groups.into_iter().enumerate() {
+		for (i, (active, rejected)) in new_active.into_iter().zip(new_rejected).enumerate() {
 			// Redistributed EWIs may have any capacity, so derive the sampler
 			// from scratch — no trusted prior to incrementally update from.
-			group.sampler = build_sampler(&group.active);
-			self.buckets[i].store(Arc::new(group));
+			self.buckets[i].store(Arc::new(EndpointGroup::from_pools(active, rejected)));
 		}
 	}
 
@@ -692,10 +731,7 @@ impl<T: Clone + Sync + Send + 'static> EndpointSet<T> {
 					return;
 				};
 				let mut eps = Arc::unwrap_or_clone(slot.load_full());
-				eps.rejected.swap_remove(&key);
-				let cap = ep.capacity;
-				eps.active.insert(key, ep);
-				eps.update_sampler(Some(cap));
+				eps.add(key, ep);
 				slot.store(Arc::new(eps));
 			},
 			EndpointEvent::Delete(key) => {
@@ -703,9 +739,7 @@ impl<T: Clone + Sync + Send + 'static> EndpointSet<T> {
 					return;
 				};
 				let mut eps = Arc::unwrap_or_clone(bucket.load_full());
-				if eps.active.swap_remove(&key).is_some() || eps.rejected.swap_remove(&key).is_some() {
-					eps.update_sampler(None);
-				}
+				eps.remove(&key);
 				bucket.store(Arc::new(eps));
 			},
 		}
@@ -729,16 +763,13 @@ impl<T: Clone + Sync + Send + 'static> EndpointSet<T> {
 					return;
 				};
 				let mut eps = Arc::unwrap_or_clone(bucket.load_full());
-				if let Some(ep) = eps.rejected.swap_remove(&key) {
+				eps.unevict(key, |ep| {
 					ep.info.evicted_until.store(None);
 					if let Some(h) = restore_health {
 						// Health scoring assumes normalized values in [0.0, 1.0].
 						ep.info.health.set(h.clamp(0.0, 1.0));
 					}
-					let cap = ep.capacity;
-					eps.active.insert(key, ep);
-					eps.update_sampler(Some(cap));
-				}
+				});
 				bucket.store(Arc::new(eps));
 			};
 			let handle_recv_evict = |uneviction_heap: &mut BinaryHeap<UnevictEntry>,
@@ -756,10 +787,7 @@ impl<T: Clone + Sync + Send + 'static> EndpointSet<T> {
 				let mut eps = Arc::unwrap_or_clone(bucket.load_full());
 
 				uneviction_heap.push(UnevictEntry(until, key.clone(), restore_health));
-				if let Some(ep) = eps.active.swap_remove(&key) {
-					eps.rejected.insert(key, ep);
-					eps.update_sampler(None);
-				}
+				eps.evict(key);
 				bucket.store(Arc::new(eps));
 			};
 			loop {
@@ -1310,16 +1338,15 @@ mod tests {
 		active: &[&'static str],
 		rejected: &[&'static str],
 	) -> EndpointGroup<&'static str> {
-		let mut group = EndpointGroup::default();
-		for v in active {
-			group.active.insert((*v).into(), EndpointWithInfo::new(*v));
-		}
-		for v in rejected {
-			group
-				.rejected
-				.insert((*v).into(), EndpointWithInfo::new(*v));
-		}
-		group
+		let active_map = active
+			.iter()
+			.map(|v| ((*v).into(), EndpointWithInfo::new(*v)))
+			.collect();
+		let rejected_map = rejected
+			.iter()
+			.map(|v| ((*v).into(), EndpointWithInfo::new(*v)))
+			.collect();
+		EndpointGroup::from_pools(active_map, rejected_map)
 	}
 
 	fn install(eps: &EndpointSet<&'static str>, idx: usize, g: EndpointGroup<&'static str>) {
@@ -1623,65 +1650,38 @@ mod tests {
 		}
 	}
 
-	/// Test helper: equivalent to the inlined `sampler = build_sampler(&active)`
-	/// used by EndpointSet::new / rebucket — lets tests set up a known starting
-	/// sampler before exercising `update_sampler`.
-	fn rebuild_sampler<T>(group: &mut EndpointGroup<T>) {
-		group.sampler = build_sampler(&group.active);
-	}
-
 	#[test]
 	fn build_sampler_reflects_active_state() {
 		let mut group = EndpointGroup::<()>::default();
-		group
-			.active
-			.insert("a".into(), EndpointWithInfo::with_capacity((), 1));
-		group
-			.active
-			.insert("b".into(), EndpointWithInfo::with_capacity((), 1));
-		rebuild_sampler(&mut group);
+		group.add("a".into(), EndpointWithInfo::with_capacity((), 1));
+		group.add("b".into(), EndpointWithInfo::with_capacity((), 1));
 		assert!(matches!(group.sampler, Sampler::Uniform));
 
 		// Replace "a" with cap=3 — now mixed, should become Weighted.
-		group
-			.active
-			.insert("a".into(), EndpointWithInfo::with_capacity((), 3));
-		rebuild_sampler(&mut group);
+		group.add("a".into(), EndpointWithInfo::with_capacity((), 3));
 		let Sampler::Weighted(dist) = &group.sampler else {
 			panic!("expected Weighted, got {:?}", group.sampler);
 		};
 		assert_eq!(dist.weights().collect::<Vec<_>>(), vec![3u64, 1]);
 
 		// Drain everything — should become Drained.
-		group
-			.active
-			.insert("a".into(), EndpointWithInfo::with_capacity((), 0));
-		group
-			.active
-			.insert("b".into(), EndpointWithInfo::with_capacity((), 0));
-		rebuild_sampler(&mut group);
+		group.add("a".into(), EndpointWithInfo::with_capacity((), 0));
+		group.add("b".into(), EndpointWithInfo::with_capacity((), 0));
 		assert!(group.sampler.is_drained());
 	}
 
 	#[test]
 	fn update_sampler_preserves_uniform_when_cap_matches() {
 		// Common XDS case: all endpoints share the default cap=1. Adds and
-		// deletes should leave the sampler instance untouched, not rebuild.
+		// deletes should leave the sampler as Uniform.
 		let mut group = EndpointGroup::<()>::default();
-		group
-			.active
-			.insert("a".into(), EndpointWithInfo::with_capacity((), 1));
-		rebuild_sampler(&mut group);
+		group.add("a".into(), EndpointWithInfo::with_capacity((), 1));
 		assert!(matches!(group.sampler, Sampler::Uniform));
 
-		group
-			.active
-			.insert("b".into(), EndpointWithInfo::with_capacity((), 1));
-		group.update_sampler(Some(1));
+		group.add("b".into(), EndpointWithInfo::with_capacity((), 1));
 		assert!(matches!(group.sampler, Sampler::Uniform));
 
-		group.active.swap_remove(&Strng::from("b"));
-		group.update_sampler(None);
+		group.remove(&Strng::from("b"));
 		assert!(matches!(group.sampler, Sampler::Uniform));
 	}
 
@@ -1689,32 +1689,20 @@ mod tests {
 	fn update_sampler_rebuilds_on_cap_mismatch() {
 		// Adding a cap=2 endpoint to a Uniform group must transition to Weighted.
 		let mut group = EndpointGroup::<()>::default();
-		group
-			.active
-			.insert("a".into(), EndpointWithInfo::with_capacity((), 1));
-		rebuild_sampler(&mut group);
+		group.add("a".into(), EndpointWithInfo::with_capacity((), 1));
 		assert!(matches!(group.sampler, Sampler::Uniform));
 
-		group
-			.active
-			.insert("b".into(), EndpointWithInfo::with_capacity((), 2));
-		group.update_sampler(Some(2));
+		group.add("b".into(), EndpointWithInfo::with_capacity((), 2));
 		assert!(matches!(group.sampler, Sampler::Weighted(_)));
 	}
 
 	#[test]
 	fn update_sampler_drained_stays_drained_on_zero_cap_add() {
 		let mut group = EndpointGroup::<()>::default();
-		group
-			.active
-			.insert("a".into(), EndpointWithInfo::with_capacity((), 0));
-		rebuild_sampler(&mut group);
+		group.add("a".into(), EndpointWithInfo::with_capacity((), 0));
 		assert!(matches!(group.sampler, Sampler::Drained));
 
-		group
-			.active
-			.insert("b".into(), EndpointWithInfo::with_capacity((), 0));
-		group.update_sampler(Some(0));
+		group.add("b".into(), EndpointWithInfo::with_capacity((), 0));
 		assert!(matches!(group.sampler, Sampler::Drained));
 	}
 
@@ -1722,13 +1710,9 @@ mod tests {
 	fn update_sampler_remove_last_uniform_stays_uniform() {
 		// Deleting the last active entry leaves the sampler as Uniform
 		let mut group = EndpointGroup::<()>::default();
-		group
-			.active
-			.insert("a".into(), EndpointWithInfo::with_capacity((), 1));
-		rebuild_sampler(&mut group);
+		group.add("a".into(), EndpointWithInfo::with_capacity((), 1));
 
-		group.active.swap_remove(&Strng::from("a"));
-		group.update_sampler(None);
+		group.remove(&Strng::from("a"));
 		assert!(matches!(group.sampler, Sampler::Uniform));
 		assert!(!group.sampler.is_drained());
 	}
@@ -1741,14 +1725,10 @@ mod tests {
 		// select_fallback to skip the whole bucket, which would also skip
 		// the rejected pool — the wrong behavior when active is empty.
 		let mut group = EndpointGroup::<()>::default();
-		group
-			.active
-			.insert("a".into(), EndpointWithInfo::with_capacity((), 0));
-		rebuild_sampler(&mut group);
+		group.add("a".into(), EndpointWithInfo::with_capacity((), 0));
 		assert!(matches!(group.sampler, Sampler::Drained));
 
-		group.active.swap_remove(&Strng::from("a"));
-		group.update_sampler(None);
+		group.remove(&Strng::from("a"));
 		assert!(
 			!group.sampler.is_drained(),
 			"sampler stayed drained after removing the last cap=0 endpoint; \

--- a/crates/agentgateway/src/types/loadbalancer.rs
+++ b/crates/agentgateway/src/types/loadbalancer.rs
@@ -43,21 +43,21 @@ impl<T> EndpointWithInfo<T> {
 
 #[derive(Debug, Clone)]
 pub enum Sampler {
-	/// All endpoints have the same nonzero capacity. No need for weighted sampling.
-	/// Stores the common capacity for quick checks that we're still uniform after
-	/// new endpoints are added incrementally.
-	Uniform(u32),
+	/// Every endpoint has the default capacity of 1. No need for weighted sampling.
+	/// Other uniform-cap configurations (e.g. all-5) fall through to Weighted —
+	/// correct, just slightly less efficient than this fast path.
+	Uniform,
 	/// Weighted sampling by capacity via a cached prefix sum.
 	Weighted(WeightedIndex<u64>),
 	/// At least one endpoint is present, but total capacity is zero — every
 	/// active endpoint is drained. Distinct from the zero-endpoints case,
-	/// which keeps the default `Uniform(1)` sampler.
+	/// which keeps the default `Uniform` sampler.
 	Drained,
 }
 
 impl Default for Sampler {
 	fn default() -> Self {
-		Sampler::Uniform(1)
+		Sampler::Uniform
 	}
 }
 
@@ -68,25 +68,24 @@ impl Sampler {
 }
 
 fn build_sampler<T>(active: &IndexMap<EndpointKey, EndpointWithInfo<T>>) -> Sampler {
-	let mut iter = active.values();
-	let Some(first_cap) = iter.next().map(|e| e.capacity) else {
+	if active.is_empty() {
 		return Sampler::default();
-	};
-	let mut all_equal = true;
-	let mut any_nonzero = first_cap != 0;
-	for ewi in iter {
+	}
+	let mut all_ones = true;
+	let mut any_nonzero = false;
+	for ewi in active.values() {
 		if ewi.capacity != 0 {
 			any_nonzero = true;
 		}
-		if ewi.capacity != first_cap {
-			all_equal = false;
+		if ewi.capacity != 1 {
+			all_ones = false;
 		}
 	}
 	if !any_nonzero {
 		return Sampler::Drained;
 	}
-	if all_equal {
-		return Sampler::Uniform(first_cap);
+	if all_ones {
+		return Sampler::Uniform;
 	}
 
 	let dist = WeightedIndex::new(active.values().map(|e| e.capacity as u64))
@@ -108,8 +107,8 @@ impl<T> EndpointGroup<T> {
 		let preserved = match (&self.sampler, added_ep_cap) {
 			// change doesn't modify any capacity, still Uniform
 			// this is the common case for unweighted EndpointGroups
-			(Sampler::Uniform(c), Some(new_c)) if *c == new_c && new_c > 0 => true,
-			(Sampler::Uniform(_), None) => true,
+			(Sampler::Uniform, Some(1)) => true,
+			(Sampler::Uniform, None) => true,
 			(Sampler::Drained, Some(0)) => true,
 			(Sampler::Drained, None) if !self.active.is_empty() => true,
 
@@ -233,7 +232,7 @@ impl EndpointSet<Endpoint> {
 		let (a, b) = match iter.sampler() {
 			Some(Sampler::Drained) => return None,
 			Some(Sampler::Weighted(dist)) => (dist.sample(&mut rng), dist.sample(&mut rng)),
-			Some(Sampler::Uniform(_)) | None => {
+			Some(Sampler::Uniform) | None => {
 				let len = index.len();
 				(rng.random_range(0..len), rng.random_range(0..len))
 			},
@@ -1552,19 +1551,21 @@ mod tests {
 	fn sampler_empty_map_is_uniform() {
 		// Vacuously uniform; the empty-len check in callers prevents sampling.
 		let active = make_active(&[]);
-		assert!(matches!(build_sampler(&active), Sampler::Uniform(_)));
+		assert!(matches!(build_sampler(&active), Sampler::Uniform));
 	}
 
 	#[test]
 	fn sampler_all_default_capacity_is_uniform() {
 		let active = make_active(&[1, 1, 1, 1]);
-		assert!(matches!(build_sampler(&active), Sampler::Uniform(1)));
+		assert!(matches!(build_sampler(&active), Sampler::Uniform));
 	}
 
 	#[test]
-	fn sampler_all_equal_nonzero_is_uniform() {
+	fn sampler_all_equal_nonone_is_weighted() {
+		// Uniform fast path only fires for the default cap=1. All-equal non-1
+		// caps fall through to Weighted — correct, just not optimized.
 		let active = make_active(&[5, 5, 5]);
-		assert!(matches!(build_sampler(&active), Sampler::Uniform(5)));
+		assert!(matches!(build_sampler(&active), Sampler::Weighted(_)));
 	}
 
 	#[test]
@@ -1639,7 +1640,7 @@ mod tests {
 			.active
 			.insert("b".into(), EndpointWithInfo::with_capacity((), 1));
 		rebuild_sampler(&mut group);
-		assert!(matches!(group.sampler, Sampler::Uniform(1)));
+		assert!(matches!(group.sampler, Sampler::Uniform));
 
 		// Replace "a" with cap=3 — now mixed, should become Weighted.
 		group
@@ -1671,28 +1672,28 @@ mod tests {
 			.active
 			.insert("a".into(), EndpointWithInfo::with_capacity((), 1));
 		rebuild_sampler(&mut group);
-		assert!(matches!(group.sampler, Sampler::Uniform(1)));
+		assert!(matches!(group.sampler, Sampler::Uniform));
 
 		group
 			.active
 			.insert("b".into(), EndpointWithInfo::with_capacity((), 1));
 		group.update_sampler(Some(1));
-		assert!(matches!(group.sampler, Sampler::Uniform(1)));
+		assert!(matches!(group.sampler, Sampler::Uniform));
 
 		group.active.swap_remove(&Strng::from("b"));
 		group.update_sampler(None);
-		assert!(matches!(group.sampler, Sampler::Uniform(1)));
+		assert!(matches!(group.sampler, Sampler::Uniform));
 	}
 
 	#[test]
 	fn update_sampler_rebuilds_on_cap_mismatch() {
-		// Adding a cap=2 endpoint to a Uniform(1) group must transition to Weighted.
+		// Adding a cap=2 endpoint to a Uniform group must transition to Weighted.
 		let mut group = EndpointGroup::<()>::default();
 		group
 			.active
 			.insert("a".into(), EndpointWithInfo::with_capacity((), 1));
 		rebuild_sampler(&mut group);
-		assert!(matches!(group.sampler, Sampler::Uniform(1)));
+		assert!(matches!(group.sampler, Sampler::Uniform));
 
 		group
 			.active
@@ -1728,7 +1729,7 @@ mod tests {
 
 		group.active.swap_remove(&Strng::from("a"));
 		group.update_sampler(None);
-		assert!(matches!(group.sampler, Sampler::Uniform(_)));
+		assert!(matches!(group.sampler, Sampler::Uniform));
 		assert!(!group.sampler.is_drained());
 	}
 

--- a/crates/agentgateway/src/types/loadbalancer.rs
+++ b/crates/agentgateway/src/types/loadbalancer.rs
@@ -22,21 +22,147 @@ type EndpointKey = Strng;
 pub struct EndpointWithInfo<T> {
 	pub endpoint: Arc<T>,
 	pub info: Arc<EndpointInfo>,
+	pub capacity: u32,
 }
 
 impl<T> EndpointWithInfo<T> {
 	pub fn new(ep: T) -> Self {
+		Self::with_capacity(ep, 1)
+	}
+
+	pub fn with_capacity(ep: T, capacity: u32) -> Self {
 		Self {
 			endpoint: Arc::new(ep),
 			info: Default::default(),
+			capacity,
 		}
 	}
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Sampler {
+	/// All endpoints have the same nonzero capacity. No need for weighted sampling.
+	/// Stores the common capacity for quick checks that we're still uniform after
+	/// new endpoints are added incrementally.
+	Uniform(u32),
+	// Weighted sampling by capacity via expansion table.
+	Weighted(Vec<u32>),
+	/// At least one endpoint is present, but total capacity is zero — every
+	/// active endpoint is drained. Distinct from the zero-endpoints case,
+	/// which keeps the default `Uniform(1)` sampler.
+	Drained,
+}
+
+impl Default for Sampler {
+	fn default() -> Self {
+		Sampler::Uniform(1)
+	}
+}
+
+impl Sampler {
+	pub fn is_drained(&self) -> bool {
+		matches!(self, Sampler::Drained)
+	}
+}
+
+// cap the size of the expansion table to avoid excessive memory
+// usage in pathological cases for capacity values.
+const MAX_EXPANSION: usize = 4096;
+
+fn gcd_u32(mut a: u32, mut b: u32) -> u32 {
+	while b != 0 {
+		let t = b;
+		b = a % b;
+		a = t;
+	}
+	a
+}
+
+fn build_sampler<T>(active: &IndexMap<EndpointKey, EndpointWithInfo<T>>) -> Sampler {
+	let mut iter = active.values();
+	let Some(first_cap) = iter.next().map(|e| e.capacity) else {
+		return Sampler::default();
+	};
+	let mut all_equal = true;
+	let mut any_nonzero = first_cap != 0;
+	for ewi in iter {
+		if ewi.capacity != 0 {
+			any_nonzero = true;
+		}
+		if ewi.capacity != first_cap {
+			all_equal = false;
+		}
+	}
+	if !any_nonzero {
+		return Sampler::Drained;
+	}
+	if all_equal {
+		return Sampler::Uniform(first_cap);
+	}
+
+	let g = active
+		.values()
+		.map(|e| e.capacity)
+		.filter(|&c| c > 0)
+		// reduce expansion size by normalizing capacity weights
+		.reduce(gcd_u32)
+		.unwrap_or(1)
+		.max(1);
+	let mut reduced: Vec<u32> = active.values().map(|e| e.capacity / g).collect();
+
+	// if the expansion would be very large due to no common divisor with
+	// large values for capacity, iteratively shrink all capacities which
+	// reduces precision but keeps memory usage sane
+	let mut total: u64 = reduced.iter().map(|&c| c as u64).sum();
+	while total as usize > MAX_EXPANSION {
+		let mut changed = false;
+		for c in reduced.iter_mut() {
+			if *c > 1 {
+				*c = c.div_ceil(2);
+				changed = true;
+			}
+		}
+		if !changed {
+			break;
+		}
+		total = reduced.iter().map(|&c| c as u64).sum();
+	}
+
+	let mut table = Vec::with_capacity(total as usize);
+	for (i, &c) in reduced.iter().enumerate() {
+		for _ in 0..c {
+			table.push(i as u32);
+		}
+	}
+	Sampler::Weighted(table)
 }
 
 #[derive(Debug, Clone, Serialize)]
 pub struct EndpointGroup<T> {
 	active: IndexMap<EndpointKey, EndpointWithInfo<T>>,
 	rejected: IndexMap<EndpointKey, EndpointWithInfo<T>>,
+	#[serde(skip)]
+	sampler: Sampler,
+}
+
+impl<T> EndpointGroup<T> {
+	// rebuilds the sampler, unless the change is guaranteed to preserve the same distribution
+	fn update_sampler(&mut self, added_ep_cap: Option<u32>) {
+		let preserved = match (&self.sampler, added_ep_cap) {
+			// change doesn't modify any capacity, still Uniform
+			// this is the common case for unweighted EndpointGroups
+			(Sampler::Uniform(c), Some(new_c)) if *c == new_c && new_c > 0 => true,
+			(Sampler::Uniform(_), None) => true,
+			(Sampler::Drained, Some(0)) => true,
+			(Sampler::Drained, None) if !self.active.is_empty() => true,
+
+			// must rebuild
+			_ => false,
+		};
+		if !preserved {
+			self.sampler = build_sampler(&self.active);
+		}
+	}
 }
 
 impl<T> Default for EndpointGroup<T> {
@@ -44,6 +170,7 @@ impl<T> Default for EndpointGroup<T> {
 		EndpointGroup::<T> {
 			active: IndexMap::new(),
 			rejected: IndexMap::new(),
+			sampler: Sampler::default(),
 		}
 	}
 }
@@ -75,7 +202,9 @@ impl EndpointSet<Endpoint> {
 			Some(b) => b,
 			None => return, // Strict mode mismatch — drop
 		};
-		self.insert_key(ep.workload_uid.clone(), ep, bucket)
+		let key = ep.workload_uid.clone();
+		let ewi = EndpointWithInfo::with_capacity(ep, dest_workload.capacity);
+		self.event(EndpointEvent::Add(key, ewi, bucket))
 	}
 
 	pub fn select_endpoint(
@@ -128,6 +257,9 @@ impl EndpointSet<Endpoint> {
 	/// P2C: pick two random endpoints from the best non-empty bucket, return the
 	/// higher-scored one. Sampling with replacement (vs `rand::seq::index::sample`)
 	/// keeps the worst endpoint reachable instead of starving it of traffic.
+	///
+	/// sets of endpoints that define non-uniform capacity will use weighted sampling
+	/// when making the random picks.
 	fn select_p2c(
 		&self,
 		workloads: &store::WorkloadStore,
@@ -141,8 +273,20 @@ impl EndpointSet<Endpoint> {
 			return None;
 		}
 		let mut rng = rand::rng();
-		let a = rng.random_range(0..index.len());
-		let b = rng.random_range(0..index.len());
+		let (a, b) = match iter.sampler() {
+			Some(Sampler::Drained) => return None,
+			Some(Sampler::Weighted(table)) => {
+				let tl = table.len();
+				(
+					table[rng.random_range(0..tl)] as usize,
+					table[rng.random_range(0..tl)] as usize,
+				)
+			},
+			Some(Sampler::Uniform(_)) | None => {
+				let len = index.len();
+				(rng.random_range(0..len), rng.random_range(0..len))
+			},
+		};
 		[a, b]
 			.into_iter()
 			.filter_map(|idx| {
@@ -160,6 +304,10 @@ impl EndpointSet<Endpoint> {
 	/// Slow fallback when P2C finds nothing viable: scan buckets in locality order
 	/// and take the best-scored match in the first bucket that yields any.
 	/// Per-bucket: prefer active, fall back to rejected when active is empty.
+	/// Fully-drained buckets (`sampler.is_drained()` — every active endpoint at
+	/// capacity=0) are skipped entirely: the operator's drain signal supersedes
+	/// the rejected-set fallback. Partially-drained buckets are scanned, but
+	/// individual cap=0 endpoints are filtered out.
 	fn select_fallback(
 		&self,
 		workloads: &store::WorkloadStore,
@@ -168,6 +316,9 @@ impl EndpointSet<Endpoint> {
 	) -> Option<Candidate> {
 		self.buckets.iter().find_map(|bucket| {
 			let group = bucket.load_full();
+			if group.sampler.is_drained() {
+				return None;
+			}
 			let map = if !group.active.is_empty() {
 				&group.active
 			} else {
@@ -201,7 +352,16 @@ fn viable(
 	if target_port == 0 && !endpoint.port.contains_key(&svc_port) {
 		trace!(
 			"filter endpoint {}, no service port {}",
-			endpoint.workload_uid, svc_port
+			endpoint.workload_uid,
+			svc_port
+		);
+		return None;
+	}
+	if wl.capacity == 0 {
+		trace!(
+			"filter endpoint {}, workload {} capacity is 0",
+			endpoint.workload_uid,
+			wl.name
 		);
 		return None;
 	}
@@ -378,6 +538,8 @@ impl<T: Clone + Sync + Send + 'static> EndpointSet<T> {
 		let buckets = initial_set
 			.into_iter()
 			.map(|items| {
+				// All EWIs created via `new` get cap=1, so the default Uniform(1)
+				// sampler is already correct — no rebuild needed.
 				let eg = EndpointGroup {
 					active: IndexMap::from_iter(
 						items
@@ -385,6 +547,7 @@ impl<T: Clone + Sync + Send + 'static> EndpointSet<T> {
 							.map(|(k, v)| (k, EndpointWithInfo::new(v))),
 					),
 					rejected: Default::default(),
+					sampler: Sampler::default(),
 				};
 				Arc::new(ArcSwap::new(Arc::new(eg)))
 			})
@@ -449,7 +612,11 @@ impl<T: Clone + Sync + Send + 'static> EndpointSet<T> {
 			.iter()
 			.find_map(|x| {
 				let b = x.load_full();
-				if !b.active.is_empty() { Some(b) } else { None }
+				if !b.active.is_empty() {
+					Some(b)
+				} else {
+					None
+				}
 			})
 			// TODO: allow selecting across multiple buckets.
 			.unwrap_or_else(|| self.buckets[0].load_full())
@@ -557,7 +724,10 @@ impl<T: Clone + Sync + Send + 'static> EndpointSet<T> {
 			}
 		}
 
-		for (i, group) in new_groups.into_iter().enumerate() {
+		for (i, mut group) in new_groups.into_iter().enumerate() {
+			// Redistributed EWIs may have any capacity, so derive the sampler
+			// from scratch — no trusted prior to incrementally update from.
+			group.sampler = build_sampler(&group.active);
 			self.buckets[i].store(Arc::new(group));
 		}
 	}
@@ -579,7 +749,9 @@ impl<T: Clone + Sync + Send + 'static> EndpointSet<T> {
 				};
 				let mut eps = Arc::unwrap_or_clone(slot.load_full());
 				eps.rejected.swap_remove(&key);
+				let cap = ep.capacity;
 				eps.active.insert(key, ep);
+				eps.update_sampler(Some(cap));
 				slot.store(Arc::new(eps));
 			},
 			EndpointEvent::Delete(key) => {
@@ -587,8 +759,9 @@ impl<T: Clone + Sync + Send + 'static> EndpointSet<T> {
 					return;
 				};
 				let mut eps = Arc::unwrap_or_clone(bucket.load_full());
-				eps.active.swap_remove(&key);
-				eps.rejected.swap_remove(&key);
+				if eps.active.swap_remove(&key).is_some() || eps.rejected.swap_remove(&key).is_some() {
+					eps.update_sampler(None);
+				}
 				bucket.store(Arc::new(eps));
 			},
 		}
@@ -618,7 +791,9 @@ impl<T: Clone + Sync + Send + 'static> EndpointSet<T> {
 						// Health scoring assumes normalized values in [0.0, 1.0].
 						ep.info.health.set(h.clamp(0.0, 1.0));
 					}
+					let cap = ep.capacity;
 					eps.active.insert(key, ep);
+					eps.update_sampler(Some(cap));
 				}
 				bucket.store(Arc::new(eps));
 			};
@@ -639,6 +814,7 @@ impl<T: Clone + Sync + Send + 'static> EndpointSet<T> {
 				uneviction_heap.push(UnevictEntry(until, key.clone(), restore_health));
 				if let Some(ep) = eps.active.swap_remove(&key) {
 					eps.rejected.insert(key, ep);
+					eps.update_sampler(None);
 				}
 				bucket.store(Arc::new(eps));
 			};
@@ -911,12 +1087,20 @@ impl<T> ActiveEndpointsIter<T> {
 		self.index().iter().map(|(_k, v)| (&v.endpoint, &v.info))
 	}
 	pub fn index(&self) -> &IndexMap<EndpointKey, EndpointWithInfo<T>> {
-		if self.0.active.is_empty() {
+		if self.is_active_phase() {
+			&self.0.active
+		} else {
 			// If we have no active endpoints, return the rejected ones
 			&self.0.rejected
-		} else {
-			&self.0.active
 		}
+	}
+	pub fn is_active_phase(&self) -> bool {
+		!self.0.active.is_empty()
+	}
+	/// The sampler for the active pool. `None` in the rejected-fallback phase,
+	/// where capacity weighting doesn't apply.
+	pub fn sampler(&self) -> Option<&Sampler> {
+		self.is_active_phase().then_some(&self.0.sampler)
 	}
 }
 
@@ -1406,6 +1590,272 @@ mod tests {
 		assert_eq!(r.rank(&wl("n1", "_", "z1", "_", "_")), Some(2));
 		assert_eq!(r.rank(&wl("n1", "_", "z2", "_", "_")), None);
 		assert_eq!(r.rank(&wl("n2", "_", "z1", "_", "_")), None);
+	}
+
+	// --- Sampler / capacity weighting ---
+
+	fn make_active(caps: &[u32]) -> IndexMap<EndpointKey, EndpointWithInfo<()>> {
+		let mut map = IndexMap::new();
+		for (i, &cap) in caps.iter().enumerate() {
+			let key: Strng = format!("ep{i}").into();
+			map.insert(key, EndpointWithInfo::with_capacity((), cap));
+		}
+		map
+	}
+
+	#[test]
+	fn sampler_empty_map_is_uniform() {
+		// Vacuously uniform; the empty-len check in callers prevents sampling.
+		let active = make_active(&[]);
+		assert!(matches!(build_sampler(&active), Sampler::Uniform(_)));
+	}
+
+	#[test]
+	fn sampler_all_default_capacity_is_uniform() {
+		let active = make_active(&[1, 1, 1, 1]);
+		assert_eq!(build_sampler(&active), Sampler::Uniform(1));
+	}
+
+	#[test]
+	fn sampler_all_equal_nonzero_is_uniform() {
+		let active = make_active(&[5, 5, 5]);
+		assert_eq!(build_sampler(&active), Sampler::Uniform(5));
+	}
+
+	#[test]
+	fn sampler_all_zero_is_drained() {
+		let active = make_active(&[0, 0, 0]);
+		assert!(matches!(build_sampler(&active), Sampler::Drained));
+		assert!(build_sampler(&active).is_drained());
+	}
+
+	#[test]
+	fn sampler_single_zero_is_drained() {
+		let active = make_active(&[0]);
+		assert!(matches!(build_sampler(&active), Sampler::Drained));
+	}
+
+	#[test]
+	fn sampler_weighted_3_1_distribution() {
+		let active = make_active(&[3, 1]);
+		let sampler = build_sampler(&active);
+		let Sampler::Weighted(table) = &sampler else {
+			panic!("expected Weighted, got {sampler:?}");
+		};
+		assert_eq!(table.len(), 4);
+
+		let mut rng = rand::rng();
+		let mut counts = [0u32; 2];
+		let n = 100_000u32;
+		for _ in 0..n {
+			let idx = table[rng.random_range(0..table.len())] as usize;
+			counts[idx] += 1;
+		}
+		// Expect ~75/25; ±2% is comfortable for n=100k.
+		let ratio0 = counts[0] as f64 / n as f64;
+		assert!(
+			(ratio0 - 0.75).abs() < 0.02,
+			"index 0 share = {ratio0} (counts={counts:?})"
+		);
+	}
+
+	#[test]
+	fn sampler_gcd_reduces_round_capacities() {
+		// 100, 200, 300 → after gcd=100, table size is 1+2+3 = 6, not 600.
+		let active = make_active(&[100, 200, 300]);
+		let sampler = build_sampler(&active);
+		let Sampler::Weighted(table) = &sampler else {
+			panic!("expected Weighted, got {sampler:?}");
+		};
+		assert_eq!(table.len(), 6, "gcd reduction should yield 1+2+3");
+		let zero = table.iter().filter(|&&i| i == 0).count();
+		let one = table.iter().filter(|&&i| i == 1).count();
+		let two = table.iter().filter(|&&i| i == 2).count();
+		assert_eq!((zero, one, two), (1, 2, 3));
+	}
+
+	#[test]
+	fn sampler_zero_cap_excluded_from_weighted_table() {
+		// Mixed 0 and nonzero — the 0-cap index must never appear in samples.
+		let active = make_active(&[0, 1, 1]);
+		let sampler = build_sampler(&active);
+		let Sampler::Weighted(table) = &sampler else {
+			panic!("expected Weighted, got {sampler:?}");
+		};
+		assert_eq!(table.len(), 2);
+		for &i in table {
+			assert_ne!(i, 0, "cap=0 endpoint must not appear in expansion table");
+		}
+	}
+
+	#[test]
+	fn sampler_clamps_pathological_large_capacity() {
+		// gcd(10_000, 1) = 1 → naive expansion would be 10_001 entries.
+		// The clamp must bound the table without zeroing out the small cap.
+		let active = make_active(&[10_000, 1]);
+		let sampler = build_sampler(&active);
+		let Sampler::Weighted(table) = &sampler else {
+			panic!("expected Weighted, got {sampler:?}");
+		};
+		assert!(
+			table.len() <= MAX_EXPANSION,
+			"table.len()={} exceeds MAX_EXPANSION={}",
+			table.len(),
+			MAX_EXPANSION
+		);
+		let zero = table.iter().filter(|&&i| i == 0).count();
+		let one = table.iter().filter(|&&i| i == 1).count();
+		assert!(
+			one >= 1,
+			"small-capacity endpoint must remain reachable post-clamp (zero={zero}, one={one})"
+		);
+		// Ratio should still strongly favor the large-capacity endpoint.
+		assert!(
+			zero > one * 100,
+			"expected strong skew toward index 0, got zero={zero}, one={one}"
+		);
+	}
+
+	/// Test helper: equivalent to the inlined `sampler = build_sampler(&active)`
+	/// used by EndpointSet::new / rebucket — lets tests set up a known starting
+	/// sampler before exercising `update_sampler`.
+	fn rebuild_sampler<T>(group: &mut EndpointGroup<T>) {
+		group.sampler = build_sampler(&group.active);
+	}
+
+	#[test]
+	fn build_sampler_reflects_active_state() {
+		let mut group = EndpointGroup::<()>::default();
+		group
+			.active
+			.insert("a".into(), EndpointWithInfo::with_capacity((), 1));
+		group
+			.active
+			.insert("b".into(), EndpointWithInfo::with_capacity((), 1));
+		rebuild_sampler(&mut group);
+		assert_eq!(group.sampler, Sampler::Uniform(1));
+
+		// Replace "a" with cap=3 — now mixed, should become Weighted.
+		group
+			.active
+			.insert("a".into(), EndpointWithInfo::with_capacity((), 3));
+		rebuild_sampler(&mut group);
+		let Sampler::Weighted(table) = &group.sampler else {
+			panic!("expected Weighted, got {:?}", group.sampler);
+		};
+		assert_eq!(table.len(), 4); // 3 + 1
+
+		// Drain everything — should become Drained.
+		group
+			.active
+			.insert("a".into(), EndpointWithInfo::with_capacity((), 0));
+		group
+			.active
+			.insert("b".into(), EndpointWithInfo::with_capacity((), 0));
+		rebuild_sampler(&mut group);
+		assert!(group.sampler.is_drained());
+	}
+
+	#[test]
+	fn update_sampler_preserves_uniform_when_cap_matches() {
+		// Common XDS case: all endpoints share the default cap=1. Adds and
+		// deletes should leave the sampler instance untouched, not rebuild.
+		let mut group = EndpointGroup::<()>::default();
+		group
+			.active
+			.insert("a".into(), EndpointWithInfo::with_capacity((), 1));
+		rebuild_sampler(&mut group);
+		assert_eq!(group.sampler, Sampler::Uniform(1));
+
+		group
+			.active
+			.insert("b".into(), EndpointWithInfo::with_capacity((), 1));
+		group.update_sampler(Some(1));
+		assert_eq!(group.sampler, Sampler::Uniform(1));
+
+		group.active.swap_remove(&Strng::from("b"));
+		group.update_sampler(None);
+		assert_eq!(group.sampler, Sampler::Uniform(1));
+	}
+
+	#[test]
+	fn update_sampler_rebuilds_on_cap_mismatch() {
+		// Adding a cap=2 endpoint to a Uniform(1) group must transition to Weighted.
+		let mut group = EndpointGroup::<()>::default();
+		group
+			.active
+			.insert("a".into(), EndpointWithInfo::with_capacity((), 1));
+		rebuild_sampler(&mut group);
+		assert_eq!(group.sampler, Sampler::Uniform(1));
+
+		group
+			.active
+			.insert("b".into(), EndpointWithInfo::with_capacity((), 2));
+		group.update_sampler(Some(2));
+		assert!(matches!(group.sampler, Sampler::Weighted(_)));
+	}
+
+	#[test]
+	fn update_sampler_drained_stays_drained_on_zero_cap_add() {
+		let mut group = EndpointGroup::<()>::default();
+		group
+			.active
+			.insert("a".into(), EndpointWithInfo::with_capacity((), 0));
+		rebuild_sampler(&mut group);
+		assert_eq!(group.sampler, Sampler::Drained);
+
+		group
+			.active
+			.insert("b".into(), EndpointWithInfo::with_capacity((), 0));
+		group.update_sampler(Some(0));
+		assert_eq!(group.sampler, Sampler::Drained);
+	}
+
+	#[test]
+	fn update_sampler_remove_last_uniform_stays_uniform() {
+		// Deleting the last active entry leaves the sampler as Uniform
+		let mut group = EndpointGroup::<()>::default();
+		group
+			.active
+			.insert("a".into(), EndpointWithInfo::with_capacity((), 1));
+		rebuild_sampler(&mut group);
+
+		group.active.swap_remove(&Strng::from("a"));
+		group.update_sampler(None);
+		assert!(matches!(group.sampler, Sampler::Uniform(_)));
+		assert!(!group.sampler.is_drained());
+	}
+
+	#[test]
+	fn update_sampler_drops_drained_state_when_active_becomes_empty() {
+		// Setup: one cap=0 endpoint → sampler is Drained.
+		// Action: remove that endpoint.
+		// Expect: sampler must NOT stay Drained. A drained sampler tells
+		// select_fallback to skip the whole bucket, which would also skip
+		// the rejected pool — the wrong behavior when active is empty.
+		let mut group = EndpointGroup::<()>::default();
+		group
+			.active
+			.insert("a".into(), EndpointWithInfo::with_capacity((), 0));
+		rebuild_sampler(&mut group);
+		assert_eq!(group.sampler, Sampler::Drained);
+
+		group.active.swap_remove(&Strng::from("a"));
+		group.update_sampler(None);
+		assert!(
+			!group.sampler.is_drained(),
+			"sampler stayed drained after removing the last cap=0 endpoint; \
+			 select_fallback would now skip this bucket's rejected pool"
+		);
+	}
+
+	#[test]
+	fn gcd_basic() {
+		assert_eq!(gcd_u32(12, 18), 6);
+		assert_eq!(gcd_u32(7, 11), 1);
+		assert_eq!(gcd_u32(100, 0), 100);
+		assert_eq!(gcd_u32(0, 100), 100);
+		assert_eq!(gcd_u32(0, 0), 0);
 	}
 
 	#[test]

--- a/crates/agentgateway/src/types/loadbalancer.rs
+++ b/crates/agentgateway/src/types/loadbalancer.rs
@@ -41,9 +41,10 @@ impl<T> EndpointWithInfo<T> {
 	}
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub enum Sampler {
 	/// Every endpoint has the default capacity of 1. No need for weighted sampling.
+	#[default]
 	Uniform,
 	/// Weighted sampling by capacity via a cached prefix sum.
 	Weighted(WeightedIndex<u64>),
@@ -51,12 +52,6 @@ pub enum Sampler {
 	/// active endpoint is drained. Distinct from the zero-endpoints case,
 	/// which keeps the default `Uniform` sampler.
 	Drained,
-}
-
-impl Default for Sampler {
-	fn default() -> Self {
-		Sampler::Uniform
-	}
 }
 
 impl Sampler {

--- a/crates/agentgateway/src/types/local_tests/llm_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/llm_normalized.snap
@@ -55,6 +55,7 @@ backends:
                     consecutiveFailures: 0
                     timesEjected: 0
                     evictedUntil: ~
+                  capacity: 1
               rejected: {}
             - active:
                 openai:
@@ -74,6 +75,7 @@ backends:
                     consecutiveFailures: 0
                     timesEjected: 0
                     evictedUntil: ~
+                  capacity: 1
                 overrides:
                   endpoint:
                     name: overrides
@@ -97,6 +99,7 @@ backends:
                     consecutiveFailures: 0
                     timesEjected: 0
                     evictedUntil: ~
+                  capacity: 1
               rejected: {}
 route_groups: []
 workloads: []

--- a/crates/agentgateway/src/types/local_tests/llm_simple_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/llm_simple_normalized.snap
@@ -256,6 +256,7 @@ backends:
                     consecutiveFailures: 0
                     timesEjected: 0
                     evictedUntil: ~
+                  capacity: 1
               rejected: {}
     inlinePolicies:
       - backendTLS: ~
@@ -301,6 +302,7 @@ backends:
                     consecutiveFailures: 0
                     timesEjected: 0
                     evictedUntil: ~
+                  capacity: 1
               rejected: {}
     inlinePolicies:
       - requestHeaderModifier:
@@ -335,6 +337,7 @@ backends:
                     consecutiveFailures: 0
                     timesEjected: 0
                     evictedUntil: ~
+                  capacity: 1
               rejected: {}
     inlinePolicies:
       - requestHeaderModifier:
@@ -365,6 +368,7 @@ backends:
                     consecutiveFailures: 0
                     timesEjected: 0
                     evictedUntil: ~
+                  capacity: 1
               rejected: {}
     inlinePolicies:
       - requestHeaderModifier:


### PR DESCRIPTION
WDS already sends us a capacity field, but we were ignoring it. This switches to a weighted sample during the p2c only when we have non-uniform capacity values within an endpoint group.

The cost is mostly on the xds load side, but on that side we will avoid doing any of the work to build the weighted distribution unless we actually need it. 