### PR TITLE
controller: xds tls plaintext mode

### DIFF
--- a/controller/pkg/setup/xds_tls.go
+++ b/controller/pkg/setup/xds_tls.go
@@ -173,6 +173,9 @@ func (m *xdsTLSMaterial) GetCertificate(_ *tls.ClientHelloInfo) (*tls.Certificat
 }
 
 func (m *xdsTLSMaterial) RegisterCallback(callback func(tls.Certificate)) {
+	if m == nil { // as this fulfills CertificateWatcher via pointers it is possible and even probable that this might be hit given a higher order nil versus typed nil check
+		return
+	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.currentCert != nil {

--- a/controller/test/e2e/features/tlsplaintext/suite.go
+++ b/controller/test/e2e/features/tlsplaintext/suite.go
@@ -1,0 +1,75 @@
+//go:build e2e
+
+package tlsplaintext
+
+import (
+	"context"
+	"net/http"
+	"path/filepath"
+
+	"github.com/onsi/gomega"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/agentgateway/agentgateway/controller/pkg/utils/fsutils"
+	"github.com/agentgateway/agentgateway/controller/pkg/utils/kubeutils"
+	"github.com/agentgateway/agentgateway/controller/pkg/utils/requestutils/curl"
+	"github.com/agentgateway/agentgateway/controller/test/e2e"
+	testdefaults "github.com/agentgateway/agentgateway/controller/test/e2e/defaults"
+	"github.com/agentgateway/agentgateway/controller/test/e2e/tests/base"
+	"github.com/agentgateway/agentgateway/controller/test/gomega/matchers"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+var _ e2e.NewSuiteFunc = NewTestingSuite
+
+type testingSuite struct {
+	*base.BaseTestingSuite
+}
+
+var (
+	basicGatewayManifest = filepath.Join(fsutils.MustGetThisDir(), "testdata", "gw.yaml")
+
+	gateway = &gwv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gw",
+			Namespace: "default",
+		},
+	}
+)
+
+func NewTestingSuite(ctx context.Context, testInst *e2e.TestInstallation) suite.TestingSuite {
+	setup := base.TestCase{
+		Manifests: []string{},
+	}
+	testCases := map[string]*base.TestCase{
+		"TestTLSControlPlaneBasicFunctionality": {
+			Manifests: []string{
+				basicGatewayManifest,
+			},
+		},
+	}
+	return &testingSuite{
+		base.NewBaseTestingSuite(ctx, testInst, setup, testCases),
+	}
+}
+
+// TestTLSControlPlaneBasicFunctionality validates that the control plane with plaintext mode
+// can successfully configure a basic Gateway and route traffic.
+func (s *testingSuite) TestTLSControlPlaneBasicFunctionality() {
+	s.TestInstallation.AssertionsT(s.T()).AssertEventualCurlResponse(
+		s.Ctx,
+		testdefaults.CurlPodExecOpt,
+		[]curl.Option{
+			curl.WithHost(kubeutils.ServiceFQDN(gateway.ObjectMeta)),
+			curl.WithHostHeader("test.example.com"),
+			curl.WithPort(8080),
+			curl.WithPath("/headers"),
+			curl.WithScheme("http"),
+		},
+		&matchers.HttpResponse{
+			StatusCode: http.StatusOK,
+			Body:       gomega.ContainSubstring("test.example.com"),
+		},
+	)
+}

--- a/controller/test/e2e/features/tlsplaintext/suite.go
+++ b/controller/test/e2e/features/tlsplaintext/suite.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/onsi/gomega"
 	"github.com/stretchr/testify/suite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/agentgateway/agentgateway/controller/pkg/utils/fsutils"
 	"github.com/agentgateway/agentgateway/controller/pkg/utils/kubeutils"
@@ -17,8 +19,6 @@ import (
 	testdefaults "github.com/agentgateway/agentgateway/controller/test/e2e/defaults"
 	"github.com/agentgateway/agentgateway/controller/test/e2e/tests/base"
 	"github.com/agentgateway/agentgateway/controller/test/gomega/matchers"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 var _ e2e.NewSuiteFunc = NewTestingSuite

--- a/controller/test/e2e/features/tlsplaintext/testdata/gw.yaml
+++ b/controller/test/e2e/features/tlsplaintext/testdata/gw.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gw
+spec:
+  gatewayClassName: agentgateway
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 8080
+      allowedRoutes:
+        namespaces:
+          from: Same
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: example-route
+spec:
+  parentRefs:
+    - name: gw
+  hostnames:
+    - "test.example.com"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: httpbin
+          port: 8000

--- a/controller/test/e2e/file.go
+++ b/controller/test/e2e/file.go
@@ -14,6 +14,8 @@ var (
 	// rely entirely on the values provided by the "profile". In those cases, the test supplies this reference
 	EmptyValuesManifestPath = ManifestPath("empty-values.yaml")
 
+	// ControlPlaneTLSPlaintextManifestPath returns the path to a manifest with plaintext mode for xDS communication
+	ControlPlaneTLSPlaintextManifestPath = ManifestPath("controlplane-plaintext-helm.yaml")
 	// ControlPlaneTLSManifestPath returns the path to a manifest with TLS enabled for xDS communication
 	ControlPlaneTLSManifestPath = ManifestPath("controlplane-tls-helm.yaml")
 )

--- a/controller/test/e2e/tests/manifests/controlplane-plaintext-helm.yaml
+++ b/controller/test/e2e/tests/manifests/controlplane-plaintext-helm.yaml
@@ -1,0 +1,3 @@
+controller:
+  xds:
+    mode: plaintext

--- a/controller/test/e2e/tests/manifests/controlplane-tls-helm.yaml
+++ b/controller/test/e2e/tests/manifests/controlplane-tls-helm.yaml
@@ -1,4 +1,3 @@
 controller:
   xds:
-    tls:
-      enabled: true
+    mode: tls

--- a/controller/test/e2e/tests/tls_plaintext_test.go
+++ b/controller/test/e2e/tests/tls_plaintext_test.go
@@ -1,0 +1,54 @@
+//go:build e2e
+
+package tests_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/agentgateway/agentgateway/controller/pkg/utils/envutils"
+	"github.com/agentgateway/agentgateway/controller/test/e2e"
+	. "github.com/agentgateway/agentgateway/controller/test/e2e/tests"
+	"github.com/agentgateway/agentgateway/controller/test/e2e/testutils/install"
+	"github.com/agentgateway/agentgateway/controller/test/testutils"
+)
+
+// TestControlPlaneTLSPlaintext tests the plaintext control plane integration functionality.
+func TestControlPlaneTLSPlaintext(t *testing.T) {
+	cleanupCtx := context.Background()
+	installNs, nsEnvPredefined := envutils.LookupOrDefault(testutils.InstallNamespace, "agentgateway-tls-plaintext-test")
+
+	testInstallation := e2e.CreateTestInstallation(
+		t,
+		&install.Context{
+			InstallNamespace:          installNs,
+			ProfileValuesManifestFile: e2e.EmptyValuesManifestPath,
+			ValuesManifestFile:        e2e.ControlPlaneTLSPlaintextManifestPath,
+			ExtraHelmArgs: []string{
+				"--set", "controller.extraEnv.KGW_GLOBAL_POLICY_NAMESPACE=" + installNs,
+			},
+		},
+	)
+	if !nsEnvPredefined {
+		os.Setenv(testutils.InstallNamespace, installNs)
+	}
+	testutils.Cleanup(t, func() {
+		if !nsEnvPredefined {
+			os.Unsetenv(testutils.InstallNamespace)
+		}
+		testInstallation.Uninstall(cleanupCtx, t)
+	})
+	testInstallation.InstallFromLocalChart(t.Context(), t)
+
+	TLSPlaintextSuiteRunner().Run(t.Context(), t, testInstallation)
+}
+
+func nsManifestPlaintext(ns string) string {
+	return fmt.Sprintf(`apiVersion: v1
+kind: Namespace
+metadata:
+  name: %s
+`, ns)
+}

--- a/controller/test/e2e/tests/tls_plaintext_test.go
+++ b/controller/test/e2e/tests/tls_plaintext_test.go
@@ -4,7 +4,6 @@ package tests_test
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"testing"
 
@@ -34,6 +33,7 @@ func TestControlPlaneTLSPlaintext(t *testing.T) {
 	if !nsEnvPredefined {
 		os.Setenv(testutils.InstallNamespace, installNs)
 	}
+
 	testutils.Cleanup(t, func() {
 		if !nsEnvPredefined {
 			os.Unsetenv(testutils.InstallNamespace)
@@ -43,12 +43,4 @@ func TestControlPlaneTLSPlaintext(t *testing.T) {
 	testInstallation.InstallFromLocalChart(t.Context(), t)
 
 	TLSPlaintextSuiteRunner().Run(t.Context(), t, testInstallation)
-}
-
-func nsManifestPlaintext(ns string) string {
-	return fmt.Sprintf(`apiVersion: v1
-kind: Namespace
-metadata:
-  name: %s
-`, ns)
 }

--- a/controller/test/e2e/tests/tls_tests.go
+++ b/controller/test/e2e/tests/tls_tests.go
@@ -5,10 +5,17 @@ package tests
 import (
 	"github.com/agentgateway/agentgateway/controller/test/e2e"
 	"github.com/agentgateway/agentgateway/controller/test/e2e/features/tls"
+	"github.com/agentgateway/agentgateway/controller/test/e2e/features/tlsplaintext"
 )
 
 func TLSSuiteRunner() e2e.SuiteRunner {
 	tlsSuiteRunner := e2e.NewSuiteRunner(false)
 	tlsSuiteRunner.Register("ControlPlaneTLS", tls.NewTestingSuite)
 	return tlsSuiteRunner
+}
+
+func TLSPlaintextSuiteRunner() e2e.SuiteRunner {
+	tlsPlaintextSuiteRunner := e2e.NewSuiteRunner(false)
+	tlsPlaintextSuiteRunner.Register("ControlPlaneTLSPlaintext", tlsplaintext.NewTestingSuite)
+	return tlsPlaintextSuiteRunner
 }

--- a/controller/test/e2e/testutils/assertions/gateway_install_assertions.go
+++ b/controller/test/e2e/testutils/assertions/gateway_install_assertions.go
@@ -12,7 +12,6 @@ const agentgatewayLabelSelector = "app.kubernetes.io/name=agentgateway"
 
 func (p *Provider) EventuallyGatewayInstallSucceeded(ctx context.Context) {
 	p.expectInstallContextDefined()
-
 	p.EventuallyPodsRunning(ctx, p.installContext.InstallNamespace,
 		metav1.ListOptions{
 			LabelSelector: agentgatewayLabelSelector,


### PR DESCRIPTION
The new test wont run under ci for now as its meant to be a companion to the tls test that doesnt run in ci.

However its easy to test the desired functionality locally with the helm value controller.xds.tls.mode=plaintext

The actual fix is in controller/pkg/setup/xds_tls.go where we do another nil check, previously we had an issue with controller/pkg/controller/gw_controller.go whereby in setupTLSCertificateWatch we did a nil check on something that could be a typed nil such what we do in setup.go with var certWatcher *xdsTLSMaterial