### PR TITLE
Fix MCP request CEL context in response phase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .cursor
+.claude
+.codex
 /target
 .vscode
 .idea

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -667,6 +667,74 @@ async fn authorization_deny_with_request_header_filters_per_agent() {
 	);
 }
 
+#[tokio::test]
+async fn mcp_authentication_early_response_transformation_has_request_context() {
+	let mock = mock_streamable_http_server(true).await;
+	let authn = crate::types::agent::McpAuthentication {
+		issuer: "https://issuer.example.com".to_string(),
+		audiences: vec!["mcp".to_string()],
+		provider: None,
+		resource_metadata: crate::types::agent::ResourceMetadata {
+			extra: Default::default(),
+		},
+		jwt_validator: Arc::new(crate::http::jwt::Jwt::from_providers(
+			vec![],
+			crate::http::jwt::Mode::Strict,
+			crate::http::auth::AuthorizationLocation::bearer_header(),
+		)),
+		mode: crate::types::agent::McpAuthenticationMode::Strict,
+	};
+
+	let mut t = setup_proxy_test("{}")
+		.unwrap()
+		.with_mcp_backend_policies(
+			mock.addr,
+			true,
+			false,
+			vec![BackendTrafficPolicy::McpAuthentication(authn)],
+		)
+		.with_bind(simple_bind())
+		.with_route(basic_route(mock.addr));
+
+	t.attach_route_policy(serde_json::json!({
+		"transformations": {
+			"response": {
+				"set": {
+					"x-request-id-from-cel": "request.headers[\"x-regression-id\"]",
+					"x-request-path-from-cel": "request.path"
+				}
+			}
+		}
+	}))
+	.await;
+
+	let io = t.serve_real_listener(BIND_KEY).await;
+	let resp = reqwest::Client::new()
+		.get(format!(
+			"http://{io}/.well-known/oauth-protected-resource/mcp"
+		))
+		.header("x-regression-id", "mcp-authn-snapshot")
+		.send()
+		.await
+		.expect("metadata request should complete");
+
+	assert_eq!(resp.status(), reqwest::StatusCode::OK);
+	assert_eq!(
+		resp
+			.headers()
+			.get("x-request-id-from-cel")
+			.and_then(|v| v.to_str().ok()),
+		Some("mcp-authn-snapshot")
+	);
+	assert_eq!(
+		resp
+			.headers()
+			.get("x-request-path-from-cel")
+			.and_then(|v| v.to_str().ok()),
+		Some("/.well-known/oauth-protected-resource/mcp")
+	);
+}
+
 async fn standard_assertions(client: RunningService<RoleClient, InitializeRequestParams>) {
 	let tools = client.list_tools(None).await.unwrap();
 	let t = tools

--- a/crates/agentgateway/src/mcp/router.rs
+++ b/crates/agentgateway/src/mcp/router.rs
@@ -126,12 +126,13 @@ impl App {
 		// MCP context is added later. The context is inserted after
 		// authentication so it can include verified claims
 
+		// Take a request snapshot before authentication can mutate or partially consume the
+		// request. If authentication lets the request continue, the normal snapshot below
+		// replaces this with the post-authentication request state.
+		Self::snapshot_request_without_clearing_extensions(&mut req, log);
 		if let Some(auth) = authn.as_ref()
 			&& let Some(resp) = auth::enforce_authentication(&mut req, auth, &client).await?
 		{
-			// Take a request snapshot so that response transformations can access request data
-			// even after a direct response/early return from authn.
-			Self::snapshot_request_for_early_response(&mut req, log);
 			return Ok(resp);
 		}
 
@@ -169,7 +170,10 @@ impl App {
 		}
 	}
 
-	fn snapshot_request_for_early_response(req: &mut MustSnapshot<'_>, log: &mut RequestLog) {
+	fn snapshot_request_without_clearing_extensions(
+		req: &mut MustSnapshot<'_>,
+		log: &mut RequestLog,
+	) {
 		log.request_snapshot = log
 			.cel
 			.cel_context

--- a/crates/agentgateway/src/mcp/router.rs
+++ b/crates/agentgateway/src/mcp/router.rs
@@ -129,6 +129,9 @@ impl App {
 		if let Some(auth) = authn.as_ref()
 			&& let Some(resp) = auth::enforce_authentication(&mut req, auth, &client).await?
 		{
+			// Take a request snapshot so that response transformations can access request data
+			// even after a direct response/early return from authn.
+			Self::snapshot_request_for_early_response(&mut req, log);
 			return Ok(resp);
 		}
 
@@ -164,6 +167,14 @@ impl App {
 			))
 			.await
 		}
+	}
+
+	fn snapshot_request_for_early_response(req: &mut MustSnapshot<'_>, log: &mut RequestLog) {
+		log.request_snapshot = log
+			.cel
+			.cel_context
+			.maybe_snapshot_request(req, false)
+			.map(Arc::new);
 	}
 }
 


### PR DESCRIPTION
Agentgateway does a direct response/early return in the MCP router when the request is to a well known path (e.g. during an oauth flow). This early return skips request snapshotting and results in the `request` CEL context field being unavailable which could lead to empty responses if a response-phase transformation access `request` unguarded.