### PR TITLE
feat: EPP ordered destination-endpoint fallback

### DIFF
--- a/crates/agentgateway/src/http/ext_proc.rs
+++ b/crates/agentgateway/src/http/ext_proc.rs
@@ -1,6 +1,6 @@
 use std::convert::Infallible;
 
-use anyhow::anyhow;
+
 use bytes::Bytes;
 use http_body::{Body, Frame};
 use http_body_util::BodyStream;
@@ -136,7 +136,7 @@ pub struct InferencePoolRouter {
 
 #[derive(Debug, Default)]
 pub struct InferenceRequestResult {
-	pub destination: Option<SocketAddr>,
+	pub destinations: Vec<SocketAddr>,
 	pub destination_mode: InferenceRoutingDestinationMode,
 	pub policy_response: PolicyResponse,
 	pub failed_open: bool,
@@ -171,15 +171,19 @@ impl InferencePoolRouter {
 		let (new_req, pr) = ext_proc.mutate_request(r).await?;
 		let failed_open = ext_proc.did_fail_open();
 		*req = new_req;
-		let dest = req
-			.headers()
-			.get(HeaderName::from_static("x-gateway-destination-endpoint"))
-			.and_then(|v| v.to_str().ok())
-			.map(|v| v.parse::<SocketAddr>())
-			.transpose()
-			.map_err(|e| ProxyError::Processing(anyhow!("EPP returned invalid address: {e}")))?;
+		let destinations = req
+    		.headers()
+    		.get(HeaderName::from_static("x-gateway-destination-endpoint"))
+    		.and_then(|v| v.to_str().ok())
+    		.map(|v| {
+        		v.split(',')
+            		.map(str::trim)
+            		.filter_map(|s| s.parse::<SocketAddr>().ok())
+            		.collect::<Vec<_>>()
+    		})
+    		.unwrap_or_default();
 		Ok(InferenceRequestResult {
-			destination: dest,
+			destinations,
 			destination_mode: self.destination_mode,
 			policy_response: pr.unwrap_or_default(),
 			failed_open,

--- a/crates/agentgateway/src/http/ext_proc.rs
+++ b/crates/agentgateway/src/http/ext_proc.rs
@@ -1,6 +1,5 @@
 use std::convert::Infallible;
 
-
 use bytes::Bytes;
 use http_body::{Body, Frame};
 use http_body_util::BodyStream;
@@ -172,16 +171,16 @@ impl InferencePoolRouter {
 		let failed_open = ext_proc.did_fail_open();
 		*req = new_req;
 		let destinations = req
-    		.headers()
-    		.get(HeaderName::from_static("x-gateway-destination-endpoint"))
-    		.and_then(|v| v.to_str().ok())
-    		.map(|v| {
-        		v.split(',')
-            		.map(str::trim)
-            		.filter_map(|s| s.parse::<SocketAddr>().ok())
-            		.collect::<Vec<_>>()
-    		})
-    		.unwrap_or_default();
+			.headers()
+			.get(HeaderName::from_static("x-gateway-destination-endpoint"))
+			.and_then(|v| v.to_str().ok())
+			.map(|v| {
+				v.split(',')
+					.map(str::trim)
+					.filter_map(|s| s.parse::<SocketAddr>().ok())
+					.collect::<Vec<_>>()
+			})
+			.unwrap_or_default();
 		Ok(InferenceRequestResult {
 			destinations,
 			destination_mode: self.destination_mode,

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -784,15 +784,17 @@ impl HTTPProxy {
 		}
 
 		// Run EPP once before retry loop — parse ordered destination list
-        let policy_client = self.policy_client();
-        let mut maybe_inference = backend_policies.build_inference(policy_client.clone());
-        let inference_result = maybe_inference.mutate_request(&mut req).await
-            .snapshot_on_err(log, &mut req)?;
-        inference_result
-            .policy_response
-            .apply(response_policies.headers())
+		let policy_client = self.policy_client();
+		let mut maybe_inference = backend_policies.build_inference(policy_client.clone());
+		let inference_result = maybe_inference
+			.mutate_request(&mut req)
+			.await
+			.snapshot_on_err(log, &mut req)?;
+		inference_result
+			.policy_response
+			.apply(response_policies.headers())
 			.map_err(SnapshottedProxyResponse)?;
-        log.inference_pool = inference_result.destinations.first().copied();
+		log.inference_pool = inference_result.destinations.first().copied();
 
 		let (head, body) = req.into_parts();
 		for mirror in route_policies
@@ -853,7 +855,10 @@ impl HTTPProxy {
 				// no retries at all, just send the request as normal
 				let req = Request::from_parts(head, http::Body::new(body));
 				let service_override = ServiceCallOverride {
-					destination: inference_result.destinations.first().copied()
+					destination: inference_result
+						.destinations
+						.first()
+						.copied()
 						.or(backend_policies.override_dest),
 					destination_passthrough: !inference_result.destinations.is_empty()
 						&& matches!(
@@ -904,13 +909,16 @@ impl HTTPProxy {
 			}
 			let req = Request::from_parts(head, http::Body::new(this));
 			let service_override = ServiceCallOverride {
-				destination: inference_result.destinations.get(n as usize).copied()
+				destination: inference_result
+					.destinations
+					.get(n as usize)
+					.copied()
 					.or(backend_policies.override_dest),
 				destination_passthrough: inference_result.destinations.get(n as usize).is_some()
 					&& matches!(
 						inference_result.destination_mode,
 						InferenceRoutingDestinationMode::Passthrough
-						),
+					),
 				inference_failed_open: inference_result.failed_open,
 			};
 			let mut res = self
@@ -1109,7 +1117,7 @@ impl HTTPProxy {
 		route_policies: Arc<store::LLMRequestPolicies>,
 		selected_backend: &RouteBackend,
 		backend_policies: BackendPolicies,
-		service_override: ServiceCallOverride,   
+		service_override: ServiceCallOverride,
 		response_policies: &mut ResponsePolicies,
 		mut req: Request,
 	) -> Result<Response, SnapshottedProxyResponse> {
@@ -1133,7 +1141,7 @@ impl HTTPProxy {
 			route_policies.clone(),
 			&selected_backend.backend.backend,
 			backend_policies,
-			service_override,          
+			service_override,
 			MustSnapshot::new(&mut req_opt),
 			Some(log),
 			response_policies,
@@ -1477,7 +1485,7 @@ async fn make_backend_call(
 	route_policies: Arc<store::LLMRequestPolicies>,
 	backend: &Backend,
 	base_policies: BackendPolicies,
-	service_override: ServiceCallOverride,   
+	service_override: ServiceCallOverride,
 	mut req: MustSnapshot<'_>,
 	mut log: Option<&mut RequestLog>,
 	response_policies: &mut ResponsePolicies,
@@ -1525,7 +1533,6 @@ async fn make_backend_call(
 			l.backend_protocol = Some(bp)
 		}
 	});
-
 
 	let backend_call = match backend {
 		Backend::AI(n, ai) => {
@@ -2636,7 +2643,7 @@ impl PolicyClient {
 				Arc::new(LLMRequestPolicies::default()),
 				&backend,
 				pols,
-				ServiceCallOverride::default(),  
+				ServiceCallOverride::default(),
 				MustSnapshot::new(&mut req),
 				// Here we don't have a log to pass. MCP and LLM flows expect there to always be a log.
 				// As such, we ensure we ONLY call this with Simple backend type which cannot be MCP/LLM

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -783,6 +783,17 @@ impl HTTPProxy {
 			log.backend_protocol = Some(bp)
 		}
 
+		// Run EPP once before retry loop — parse ordered destination list
+        let policy_client = self.policy_client();
+        let mut maybe_inference = backend_policies.build_inference(policy_client.clone());
+        let inference_result = maybe_inference.mutate_request(&mut req).await
+            .snapshot_on_err(log, &mut req)?;
+        inference_result
+            .policy_response
+            .apply(response_policies.headers())
+			.map_err(SnapshottedProxyResponse)?;
+        log.inference_pool = inference_result.destinations.first().copied();
+
 		let (head, body) = req.into_parts();
 		for mirror in route_policies
 			.request_mirror
@@ -841,17 +852,32 @@ impl HTTPProxy {
 				trace!("no retries");
 				// no retries at all, just send the request as normal
 				let req = Request::from_parts(head, http::Body::new(body));
-				return self
+				let service_override = ServiceCallOverride {
+					destination: inference_result.destinations.first().copied()
+						.or(backend_policies.override_dest),
+					destination_passthrough: !inference_result.destinations.is_empty()
+						&& matches!(
+							inference_result.destination_mode,
+							InferenceRoutingDestinationMode::Passthrough
+						),
+					inference_failed_open: inference_result.failed_open,
+				};
+				let mut res = self
 					.attempt_upstream(
 						log,
 						&mut req_upgrade,
 						llm_request_policies,
 						&selected_backend,
 						backend_policies,
+						service_override,
 						response_policies,
 						req,
 					)
 					.await;
+				if let Ok(ref mut resp) = res {
+					let _ = maybe_inference.mutate_response(resp).await;
+				}
+				return res;
 			},
 		};
 		let mut last_res: Option<Result<Response, SnapshottedProxyResponse>> = None;
@@ -877,13 +903,24 @@ impl HTTPProxy {
 				);
 			}
 			let req = Request::from_parts(head, http::Body::new(this));
-			let res = self
+			let service_override = ServiceCallOverride {
+				destination: inference_result.destinations.get(n as usize).copied()
+					.or(backend_policies.override_dest),
+				destination_passthrough: inference_result.destinations.get(n as usize).is_some()
+					&& matches!(
+						inference_result.destination_mode,
+						InferenceRoutingDestinationMode::Passthrough
+						),
+				inference_failed_open: inference_result.failed_open,
+			};
+			let mut res = self
 				.attempt_upstream(
 					log,
 					&mut req_upgrade,
 					llm_request_policies.clone(),
 					&selected_backend,
 					backend_policies.clone(),
+					service_override,
 					response_policies,
 					req,
 				)
@@ -891,6 +928,9 @@ impl HTTPProxy {
 			if last || !should_retry(&res, retries.as_ref().unwrap()) {
 				if !last {
 					debug!("response not retry-able");
+				}
+				if let Ok(ref mut resp) = res {
+					let _ = maybe_inference.mutate_response(resp).await;
 				}
 				return res;
 			}
@@ -1069,6 +1109,7 @@ impl HTTPProxy {
 		route_policies: Arc<store::LLMRequestPolicies>,
 		selected_backend: &RouteBackend,
 		backend_policies: BackendPolicies,
+		service_override: ServiceCallOverride,   
 		response_policies: &mut ResponsePolicies,
 		mut req: Request,
 	) -> Result<Response, SnapshottedProxyResponse> {
@@ -1092,6 +1133,7 @@ impl HTTPProxy {
 			route_policies.clone(),
 			&selected_backend.backend.backend,
 			backend_policies,
+			service_override,          
 			MustSnapshot::new(&mut req_opt),
 			Some(log),
 			response_policies,
@@ -1435,6 +1477,7 @@ async fn make_backend_call(
 	route_policies: Arc<store::LLMRequestPolicies>,
 	backend: &Backend,
 	base_policies: BackendPolicies,
+	service_override: ServiceCallOverride,   
 	mut req: MustSnapshot<'_>,
 	mut log: Option<&mut RequestLog>,
 	response_policies: &mut ResponsePolicies,
@@ -1483,24 +1526,6 @@ async fn make_backend_call(
 		}
 	});
 
-	let mut maybe_inference = policies.build_inference(policy_client.clone());
-	let inference_result = maybe_inference.mutate_request(&mut req).await?;
-	inference_result
-		.policy_response
-		.apply(response_policies.headers())?;
-	log.add(|l| l.inference_pool = inference_result.destination);
-
-	// Use inference override if present, otherwise check for stateful MCP pinning.
-	// In practice, these don't conflict: inference is for AI backends, MCP pinning is for MCP backends.
-	let service_override = ServiceCallOverride {
-		destination: inference_result.destination.or(policies.override_dest),
-		destination_passthrough: inference_result.destination.is_some()
-			&& matches!(
-				inference_result.destination_mode,
-				InferenceRoutingDestinationMode::Passthrough
-			),
-		inference_failed_open: inference_result.failed_open,
-	};
 
 	let backend_call = match backend {
 		Backend::AI(n, ai) => {
@@ -1879,7 +1904,7 @@ async fn make_backend_call(
 	)
 	.await
 	.map_err(ProxyError::Processing)?;
-	let mut resp = if let (Some(llm), Some(llm_request)) =
+	let resp = if let (Some(llm), Some(llm_request)) =
 		(backend_call.backend_policies.llm_provider, llm_request)
 	{
 		llm
@@ -1899,7 +1924,6 @@ async fn make_backend_call(
 		resp
 	};
 	// TODO: we currently do not support ImmediateResponse from inference router
-	let _ = maybe_inference.mutate_response(&mut resp).await?;
 	if let Some(log) = log.as_ref() {
 		dtrace::snapshot!(Response, "backend response ready", log, &resp);
 	}
@@ -2612,6 +2636,7 @@ impl PolicyClient {
 				Arc::new(LLMRequestPolicies::default()),
 				&backend,
 				pols,
+				ServiceCallOverride::default(),  
 				MustSnapshot::new(&mut req),
 				// Here we don't have a log to pass. MCP and LLM flows expect there to always be a log.
 				// As such, we ensure we ONLY call this with Simple backend type which cannot be MCP/LLM


### PR DESCRIPTION
## Summary

Fixes #1444

This PR adds ordered fallback support for the EPP `x-gateway-destination-endpoint` header.

Right now the header is parsed as a single `SocketAddr`, so only one endpoint is ever used. With this change:

- The header is parsed as a comma-separated list into a `Vec<SocketAddr>`. Any invalid entries are silently skipped instead of failing the whole request
- The EPP call (`mutate_request`) is moved before the retry loop so it only runs once per request, not once per attempt
- Each retry attempt gets its own `ServiceCallOverride` pointing to the next endpoint in the list (`destinations[n]`)
- If there are fewer endpoints than retry attempts, we handle that gracefully — no panics, no out-of-bounds indexing
- `destination_mode` (Validated vs Passthrough) is respected on each attempt
- `maybe_inference` is kept alive past the retry loop so `mutate_response` can set `x-gateway-destination-endpoint-served` to the endpoint that actually handled the final response

## Files changed

- `ext_proc.rs` — switched to `filter_map` for parsing the comma-separated header
- `httpproxy.rs` — moved EPP call before retry loop, added per-attempt `ServiceCallOverride`, added `mutate_response` on final response

## Tests I'm planning to add

- [ ] Single endpoint override
- [ ] Multi-endpoint ordered fallback (first endpoint fails → retry picks up the second)
- [ ] Same IP, different ports
- [ ] Different IPs, different ports
- [ ] `x-gateway-destination-endpoint-served` in the response matches the endpoint that actually served the request

Wanted to share the approach first before writing tests — happy to adjust based on feedback.

/cc @danehans