### PR TITLE
release: attach VEX policy to supress CVE false positives

### DIFF
--- a/.github/vex/openvex.json
+++ b/.github/vex/openvex.json
@@ -1,0 +1,69 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/agentgateway/agentgateway/.github/vex/openvex.json",
+  "author": "agentgateway",
+  "timestamp": "2026-05-14T00:00:00Z",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2019-14993"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/istio.io/istio"
+        }
+      ],
+      "status": "fixed",
+      "impact_statement": "Scanner version matching is incorrect for this pseudo-version; the vendored dependency code is already patched."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2021-39155"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/istio.io/istio"
+        }
+      ],
+      "status": "fixed",
+      "impact_statement": "Scanner version matching is incorrect for this pseudo-version; the vendored dependency code is already patched."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2021-39156"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/istio.io/istio"
+        }
+      ],
+      "status": "fixed",
+      "impact_statement": "Scanner version matching is incorrect for this pseudo-version; the vendored dependency code is already patched."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2022-23635"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/istio.io/istio"
+        }
+      ],
+      "status": "fixed",
+      "impact_statement": "Scanner version matching is incorrect for this pseudo-version; the vendored dependency code is already patched."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2022-31045"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/istio.io/istio"
+        }
+      ],
+      "status": "fixed",
+      "impact_statement": "Scanner version matching is incorrect for this pseudo-version; the vendored dependency code is already patched."
+    }
+  ]
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,7 @@ env:
   GO_VERSION: "1.26.2"
   REGISTRY_IMAGE: ghcr.io/${{ github.repository_owner }}/agentgateway
   CONTROLLER_REGISTRY_IMAGE: ghcr.io/${{ github.repository_owner }}/controller
+  VEX_FILE: .github/vex/openvex.json
   # Note: /charts is added to this
   CHART_REGISTRY_IMAGE_BASE: ghcr.io/${{ github.repository_owner }}
 
@@ -437,6 +438,10 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.9.1
 
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - name: Download digests
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
@@ -482,6 +487,14 @@ jobs:
       - name: Sign the extra tag
         if: ${{ inputs.extra_tag != '' }}
         run: cosign sign --yes ${{ env.CONTROLLER_REGISTRY_IMAGE }}:${{ inputs.extra_tag }}
+
+      - name: Attach VEX attestation
+        run: |
+          cosign attest \
+            --predicate "${{ env.VEX_FILE }}" \
+            --type openvex \
+            --yes \
+            ${{ env.CONTROLLER_REGISTRY_IMAGE }}:v${{ env.VERSION }}
 
       - name: Inspect image
         run: |


### PR DESCRIPTION
`trivy image --vex oci` picks this up