### PR TITLE
fix(controller): normalize version-derived proxy image tags

### DIFF
--- a/controller/pkg/controller/start.go
+++ b/controller/pkg/controller/start.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"maps"
 	"net/http"
+	"strings"
 
 	"istio.io/istio/pkg/kube/krt"
 	istiolog "istio.io/istio/pkg/log"
@@ -216,7 +217,7 @@ func (c *ControllerBuilder) Build() (*syncer.Syncer, error) {
 	if defaultTag == nil {
 		// Else, the binary is built with an explicit version
 		if version.Version != "" {
-			defaultTag = new("v" + version.Version)
+			defaultTag = new(normalizeProxyImageTag(version.Version))
 		} else {
 			// Else, detect automatically based on the build.
 			// TODO: probably what we really want here is to have a file in the repo that has a floating version like v1.0.0-dev
@@ -257,6 +258,10 @@ func (c *ControllerBuilder) Build() (*syncer.Syncer, error) {
 	}
 
 	return c.agwSyncer, nil
+}
+
+func normalizeProxyImageTag(tag string) string {
+	return "v" + strings.TrimPrefix(tag, "v")
 }
 
 func (c *ControllerBuilder) HasSynced() bool {

--- a/controller/pkg/controller/start_internal_test.go
+++ b/controller/pkg/controller/start_internal_test.go
@@ -1,0 +1,33 @@
+package controller
+
+import (
+	"testing"
+)
+
+func TestNormalizeProxyImageTag(t *testing.T) {
+	tests := []struct {
+		name string
+		tag  string
+		want string
+	}{
+		{
+			name: "adds v prefix",
+			tag:  "1.2.3",
+			want: "v1.2.3",
+		},
+		{
+			name: "preserves v-prefixed tag",
+			tag:  "v1.2.3",
+			want: "v1.2.3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeProxyImageTag(tt.tag)
+			if got != tt.want {
+				t.Fatalf("expected tag %q, got %q", tt.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

  Normalize controller-derived proxy image tags so build versions that already include a leading v do not produce
  vv... tags.

  fixes #1197.

  ## Testing

  - go test ./controller/pkg/controller -run TestNormalizeProxyImageTag -count=1
  - go test ./controller/pkg/controller -count=1