### PR TITLE
controller/api: reduce extauth cost

### DIFF
--- a/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
+++ b/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
@@ -283,7 +283,7 @@ type SNI = string
 // ByteSize is a byte quantity that must fit in a uint32 dataplane field.
 // +kubebuilder:validation:XIntOrString
 // +kubebuilder:validation:MaxLength=32
-// +kubebuilder:validation:XValidation:rule="quantity(string(self)).asInteger() >= 1",message="value must be at least 1 byte"
+// +kubebuilder:validation:XValidation:rule="!quantity(string(self)).isLessThan(quantity('1'))",message="value must be at least 1 byte"
 // +kubebuilder:validation:XValidation:rule="quantity(string(self)).asInteger() <= 4294967295",message="value must fit within uint32"
 type ByteSize resource.Quantity
 

--- a/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
+++ b/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
@@ -283,8 +283,8 @@ type SNI = string
 // ByteSize is a byte quantity that must fit in a uint32 dataplane field.
 // +kubebuilder:validation:XIntOrString
 // +kubebuilder:validation:MaxLength=32
-// +kubebuilder:validation:XValidation:rule="!quantity(string(self)).isLessThan(quantity('1'))",message="value must be at least 1 byte"
-// +kubebuilder:validation:XValidation:rule="!quantity(string(self)).isGreaterThan(quantity('4294967295'))",message="value must fit within uint32"
+// +kubebuilder:validation:XValidation:rule="quantity(string(self)).asInteger() >= 1",message="value must be at least 1 byte"
+// +kubebuilder:validation:XValidation:rule="quantity(string(self)).asInteger() <= 4294967295",message="value must fit within uint32"
 type ByteSize resource.Quantity
 
 func (b ByteSize) Value() int64 {
@@ -1631,7 +1631,7 @@ type ExtAuthOrConditional struct {
 	// in case no conditions are met.
 	// +optional
 	// +kubebuilder:validation:MinItems=1
-	// +kubebuilder:validation:MaxItems=16
+	// +kubebuilder:validation:MaxItems=12
 	// +kubebuilder:validation:XValidation:message="conditional entries without condition must be last",rule="self.filter(e, !has(e.condition)).size() <= 1 && (!self.exists(e, !has(e.condition)) || !has(self[size(self) - 1].condition))"
 	Conditional []ExtAuthConditional `json:"conditional,omitempty"`
 }

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
@@ -9705,7 +9705,7 @@ spec:
                             x-kubernetes-int-or-string: true
                             x-kubernetes-validations:
                             - message: value must be at least 1 byte
-                              rule: quantity(string(self)).asInteger() >= 1
+                              rule: '!quantity(string(self)).isLessThan(quantity(''1''))'
                             - message: value must fit within uint32
                               rule: quantity(string(self)).asInteger() <= 4294967295
                         required:

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
@@ -9705,9 +9705,9 @@ spec:
                             x-kubernetes-int-or-string: true
                             x-kubernetes-validations:
                             - message: value must be at least 1 byte
-                              rule: '!quantity(string(self)).isLessThan(quantity(''1''))'
+                              rule: quantity(string(self)).asInteger() >= 1
                             - message: value must fit within uint32
-                              rule: '!quantity(string(self)).isGreaterThan(quantity(''4294967295''))'
+                              rule: quantity(string(self)).asInteger() <= 4294967295
                         required:
                         - maxSize
                         type: object

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
@@ -3854,7 +3854,7 @@ spec:
                             x-kubernetes-int-or-string: true
                             x-kubernetes-validations:
                             - message: value must be at least 1 byte
-                              rule: quantity(string(self)).asInteger() >= 1
+                              rule: '!quantity(string(self)).isLessThan(quantity(''1''))'
                             - message: value must fit within uint32
                               rule: quantity(string(self)).asInteger() <= 4294967295
                         required:
@@ -4995,7 +4995,7 @@ spec:
                         x-kubernetes-int-or-string: true
                         x-kubernetes-validations:
                         - message: value must be at least 1 byte
-                          rule: quantity(string(self)).asInteger() >= 1
+                          rule: '!quantity(string(self)).isLessThan(quantity(''1''))'
                         - message: value must fit within uint32
                           rule: quantity(string(self)).asInteger() <= 4294967295
                       http2FrameSize:
@@ -5014,7 +5014,7 @@ spec:
                         - message: http2FrameSize must be at most 1677215 bytes
                           rule: '!quantity(string(self)).isGreaterThan(quantity(''1677215''))'
                         - message: value must be at least 1 byte
-                          rule: quantity(string(self)).asInteger() >= 1
+                          rule: '!quantity(string(self)).isLessThan(quantity(''1''))'
                         - message: value must fit within uint32
                           rule: quantity(string(self)).asInteger() <= 4294967295
                       http2KeepaliveInterval:
@@ -5044,7 +5044,7 @@ spec:
                         x-kubernetes-int-or-string: true
                         x-kubernetes-validations:
                         - message: value must be at least 1 byte
-                          rule: quantity(string(self)).asInteger() >= 1
+                          rule: '!quantity(string(self)).isLessThan(quantity(''1''))'
                         - message: value must fit within uint32
                           rule: quantity(string(self)).asInteger() <= 4294967295
                       http2WindowSize:
@@ -5059,7 +5059,7 @@ spec:
                         x-kubernetes-int-or-string: true
                         x-kubernetes-validations:
                         - message: value must be at least 1 byte
-                          rule: quantity(string(self)).asInteger() >= 1
+                          rule: '!quantity(string(self)).isLessThan(quantity(''1''))'
                         - message: value must fit within uint32
                           rule: quantity(string(self)).asInteger() <= 4294967295
                       maxBufferSize:
@@ -5076,7 +5076,7 @@ spec:
                         x-kubernetes-int-or-string: true
                         x-kubernetes-validations:
                         - message: value must be at least 1 byte
-                          rule: quantity(string(self)).asInteger() >= 1
+                          rule: '!quantity(string(self)).isLessThan(quantity(''1''))'
                         - message: value must fit within uint32
                           rule: quantity(string(self)).asInteger() <= 4294967295
                       maxConnectionDuration:
@@ -6564,8 +6564,7 @@ spec:
                                       x-kubernetes-int-or-string: true
                                       x-kubernetes-validations:
                                       - message: value must be at least 1 byte
-                                        rule: quantity(string(self)).asInteger() >=
-                                          1
+                                        rule: '!quantity(string(self)).isLessThan(quantity(''1''))'
                                       - message: value must fit within uint32
                                         rule: quantity(string(self)).asInteger() <=
                                           4294967295
@@ -6723,7 +6722,7 @@ spec:
                             x-kubernetes-int-or-string: true
                             x-kubernetes-validations:
                             - message: value must be at least 1 byte
-                              rule: quantity(string(self)).asInteger() >= 1
+                              rule: '!quantity(string(self)).isLessThan(quantity(''1''))'
                             - message: value must fit within uint32
                               rule: quantity(string(self)).asInteger() <= 4294967295
                         required:

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
@@ -3854,9 +3854,9 @@ spec:
                             x-kubernetes-int-or-string: true
                             x-kubernetes-validations:
                             - message: value must be at least 1 byte
-                              rule: '!quantity(string(self)).isLessThan(quantity(''1''))'
+                              rule: quantity(string(self)).asInteger() >= 1
                             - message: value must fit within uint32
-                              rule: '!quantity(string(self)).isGreaterThan(quantity(''4294967295''))'
+                              rule: quantity(string(self)).asInteger() <= 4294967295
                         required:
                         - maxSize
                         type: object
@@ -4995,9 +4995,9 @@ spec:
                         x-kubernetes-int-or-string: true
                         x-kubernetes-validations:
                         - message: value must be at least 1 byte
-                          rule: '!quantity(string(self)).isLessThan(quantity(''1''))'
+                          rule: quantity(string(self)).asInteger() >= 1
                         - message: value must fit within uint32
-                          rule: '!quantity(string(self)).isGreaterThan(quantity(''4294967295''))'
+                          rule: quantity(string(self)).asInteger() <= 4294967295
                       http2FrameSize:
                         anyOf:
                         - type: integer
@@ -5014,9 +5014,9 @@ spec:
                         - message: http2FrameSize must be at most 1677215 bytes
                           rule: '!quantity(string(self)).isGreaterThan(quantity(''1677215''))'
                         - message: value must be at least 1 byte
-                          rule: '!quantity(string(self)).isLessThan(quantity(''1''))'
+                          rule: quantity(string(self)).asInteger() >= 1
                         - message: value must fit within uint32
-                          rule: '!quantity(string(self)).isGreaterThan(quantity(''4294967295''))'
+                          rule: quantity(string(self)).asInteger() <= 4294967295
                       http2KeepaliveInterval:
                         type: string
                         x-kubernetes-validations:
@@ -5044,9 +5044,9 @@ spec:
                         x-kubernetes-int-or-string: true
                         x-kubernetes-validations:
                         - message: value must be at least 1 byte
-                          rule: '!quantity(string(self)).isLessThan(quantity(''1''))'
+                          rule: quantity(string(self)).asInteger() >= 1
                         - message: value must fit within uint32
-                          rule: '!quantity(string(self)).isGreaterThan(quantity(''4294967295''))'
+                          rule: quantity(string(self)).asInteger() <= 4294967295
                       http2WindowSize:
                         anyOf:
                         - type: integer
@@ -5059,9 +5059,9 @@ spec:
                         x-kubernetes-int-or-string: true
                         x-kubernetes-validations:
                         - message: value must be at least 1 byte
-                          rule: '!quantity(string(self)).isLessThan(quantity(''1''))'
+                          rule: quantity(string(self)).asInteger() >= 1
                         - message: value must fit within uint32
-                          rule: '!quantity(string(self)).isGreaterThan(quantity(''4294967295''))'
+                          rule: quantity(string(self)).asInteger() <= 4294967295
                       maxBufferSize:
                         anyOf:
                         - type: integer
@@ -5076,9 +5076,9 @@ spec:
                         x-kubernetes-int-or-string: true
                         x-kubernetes-validations:
                         - message: value must be at least 1 byte
-                          rule: '!quantity(string(self)).isLessThan(quantity(''1''))'
+                          rule: quantity(string(self)).asInteger() >= 1
                         - message: value must fit within uint32
-                          rule: '!quantity(string(self)).isGreaterThan(quantity(''4294967295''))'
+                          rule: quantity(string(self)).asInteger() <= 4294967295
                       maxConnectionDuration:
                         description: |-
                           `maxConnectionDuration` specifies the maximum time a connection is allowed to remain open.
@@ -6564,9 +6564,11 @@ spec:
                                       x-kubernetes-int-or-string: true
                                       x-kubernetes-validations:
                                       - message: value must be at least 1 byte
-                                        rule: '!quantity(string(self)).isLessThan(quantity(''1''))'
+                                        rule: quantity(string(self)).asInteger() >=
+                                          1
                                       - message: value must fit within uint32
-                                        rule: '!quantity(string(self)).isGreaterThan(quantity(''4294967295''))'
+                                        rule: quantity(string(self)).asInteger() <=
+                                          4294967295
                                   required:
                                   - maxSize
                                   type: object
@@ -6687,7 +6689,7 @@ spec:
                           required:
                           - policy
                           type: object
-                        maxItems: 16
+                        maxItems: 12
                         minItems: 1
                         type: array
                         x-kubernetes-validations:
@@ -6721,9 +6723,9 @@ spec:
                             x-kubernetes-int-or-string: true
                             x-kubernetes-validations:
                             - message: value must be at least 1 byte
-                              rule: '!quantity(string(self)).isLessThan(quantity(''1''))'
+                              rule: quantity(string(self)).asInteger() >= 1
                             - message: value must fit within uint32
-                              rule: '!quantity(string(self)).isGreaterThan(quantity(''4294967295''))'
+                              rule: quantity(string(self)).asInteger() <= 4294967295
                         required:
                         - maxSize
                         type: object


### PR DESCRIPTION
Reduce the cost of extauth cel validation logic to get it under budget for k8s 1.33

Note that this does break if you somehow had 16 conditions on extauth but its a fairly new change so this feels safe.


