### PR TITLE
controller/api: bytesize no longer validates instead rely on control plane clamping

### DIFF
--- a/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
+++ b/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
@@ -282,9 +282,8 @@ type SNI = string
 
 // ByteSize is a byte quantity that must fit in a uint32 dataplane field.
 // +kubebuilder:validation:XIntOrString
+// +kubebuilder:validation:MinLength=1
 // +kubebuilder:validation:MaxLength=32
-// +kubebuilder:validation:XValidation:rule="!quantity(string(self)).isLessThan(quantity('1'))",message="value must be at least 1 byte"
-// +kubebuilder:validation:XValidation:rule="!quantity(string(self)).isGreaterThan(quantity('4294967295'))",message="value must fit within uint32"
 type ByteSize resource.Quantity
 
 func (b ByteSize) Value() int64 {

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
@@ -9701,13 +9701,9 @@ spec:
                               and sent to the authorization server. If the body size is larger than
                               `maxSize`, then the request will be rejected with a response.
                             maxLength: 32
+                            minLength: 1
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                            x-kubernetes-validations:
-                            - message: value must be at least 1 byte
-                              rule: '!quantity(string(self)).isLessThan(quantity(''1''))'
-                            - message: value must fit within uint32
-                              rule: '!quantity(string(self)).isGreaterThan(quantity(''4294967295''))'
                         required:
                         - maxSize
                         type: object

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
@@ -3850,13 +3850,9 @@ spec:
                               and sent to the authorization server. If the body size is larger than
                               `maxSize`, then the request will be rejected with a response.
                             maxLength: 32
+                            minLength: 1
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                            x-kubernetes-validations:
-                            - message: value must be at least 1 byte
-                              rule: '!quantity(string(self)).isLessThan(quantity(''1''))'
-                            - message: value must fit within uint32
-                              rule: '!quantity(string(self)).isGreaterThan(quantity(''4294967295''))'
                         required:
                         - maxSize
                         type: object
@@ -4991,13 +4987,9 @@ spec:
                           `http2ConnectionWindowSize` indicates the initial window size for
                           connection-level flow control for received data.
                         maxLength: 32
+                        minLength: 1
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
-                        x-kubernetes-validations:
-                        - message: value must be at least 1 byte
-                          rule: '!quantity(string(self)).isLessThan(quantity(''1''))'
-                        - message: value must fit within uint32
-                          rule: '!quantity(string(self)).isGreaterThan(quantity(''4294967295''))'
                       http2FrameSize:
                         anyOf:
                         - type: integer
@@ -5006,6 +4998,7 @@ spec:
                           `http2FrameSize` sets the maximum frame size to use.
                           If unset, this defaults to `16kb`.
                         maxLength: 32
+                        minLength: 1
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                         x-kubernetes-validations:
@@ -5013,10 +5006,6 @@ spec:
                           rule: '!quantity(string(self)).isLessThan(quantity(''16384''))'
                         - message: http2FrameSize must be at most 1677215 bytes
                           rule: '!quantity(string(self)).isGreaterThan(quantity(''1677215''))'
-                        - message: value must be at least 1 byte
-                          rule: '!quantity(string(self)).isLessThan(quantity(''1''))'
-                        - message: value must fit within uint32
-                          rule: '!quantity(string(self)).isGreaterThan(quantity(''4294967295''))'
                       http2KeepaliveInterval:
                         type: string
                         x-kubernetes-validations:
@@ -5040,13 +5029,9 @@ spec:
                           request headers.
                           If unset, this defaults to `16Ki`.
                         maxLength: 32
+                        minLength: 1
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
-                        x-kubernetes-validations:
-                        - message: value must be at least 1 byte
-                          rule: '!quantity(string(self)).isLessThan(quantity(''1''))'
-                        - message: value must fit within uint32
-                          rule: '!quantity(string(self)).isGreaterThan(quantity(''4294967295''))'
                       http2WindowSize:
                         anyOf:
                         - type: integer
@@ -5055,13 +5040,9 @@ spec:
                           `http2WindowSize` indicates the initial window size for stream-level flow
                           control for received data.
                         maxLength: 32
+                        minLength: 1
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
-                        x-kubernetes-validations:
-                        - message: value must be at least 1 byte
-                          rule: '!quantity(string(self)).isLessThan(quantity(''1''))'
-                        - message: value must fit within uint32
-                          rule: '!quantity(string(self)).isGreaterThan(quantity(''4294967295''))'
                       maxBufferSize:
                         anyOf:
                         - type: integer
@@ -5072,13 +5053,9 @@ spec:
                           Bodies will only be buffered for policies which require buffering.
                           If unset, this defaults to `2mb`.
                         maxLength: 32
+                        minLength: 1
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
-                        x-kubernetes-validations:
-                        - message: value must be at least 1 byte
-                          rule: '!quantity(string(self)).isLessThan(quantity(''1''))'
-                        - message: value must fit within uint32
-                          rule: '!quantity(string(self)).isGreaterThan(quantity(''4294967295''))'
                       maxConnectionDuration:
                         description: |-
                           `maxConnectionDuration` specifies the maximum time a connection is allowed to remain open.
@@ -6560,13 +6537,9 @@ spec:
                                         and sent to the authorization server. If the body size is larger than
                                         `maxSize`, then the request will be rejected with a response.
                                       maxLength: 32
+                                      minLength: 1
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
-                                      x-kubernetes-validations:
-                                      - message: value must be at least 1 byte
-                                        rule: '!quantity(string(self)).isLessThan(quantity(''1''))'
-                                      - message: value must fit within uint32
-                                        rule: '!quantity(string(self)).isGreaterThan(quantity(''4294967295''))'
                                   required:
                                   - maxSize
                                   type: object
@@ -6717,13 +6690,9 @@ spec:
                               and sent to the authorization server. If the body size is larger than
                               `maxSize`, then the request will be rejected with a response.
                             maxLength: 32
+                            minLength: 1
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                            x-kubernetes-validations:
-                            - message: value must be at least 1 byte
-                              rule: '!quantity(string(self)).isLessThan(quantity(''1''))'
-                            - message: value must fit within uint32
-                              rule: '!quantity(string(self)).isGreaterThan(quantity(''4294967295''))'
                         required:
                         - maxSize
                         type: object

--- a/controller/pkg/agentgateway/plugins/frontend_policies.go
+++ b/controller/pkg/agentgateway/plugins/frontend_policies.go
@@ -3,6 +3,7 @@ package plugins
 import (
 	"errors"
 	"fmt"
+	"math"
 
 	"google.golang.org/protobuf/types/known/durationpb"
 	"istio.io/istio/pkg/ptr"
@@ -375,7 +376,15 @@ func quantityUint32(ka *agentgateway.ByteSize) *uint32 {
 }
 
 func requiredQuantityUint32(ka agentgateway.ByteSize) uint32 {
-	return uint32(ka.Value()) //nolint:gosec // G115: kubebuilder validation ensures safe for uint32
+	// TODO: just cast as uint32 once k8s 1.33 is no longer supported and we can place validation via quantity without blowing up cel
+	v := ka.Value()
+	if v < 0 {
+		return 0
+	}
+	if v > math.MaxUint32 {
+		return math.MaxUint32
+	}
+	return uint32(v)
 }
 
 func translateFrontendTLS(policy *agentgateway.AgentgatewayPolicy, name string) *api.Policy {


### PR DESCRIPTION
Other potential workaround for extauth cost https://github.com/agentgateway/agentgateway/pull/1835