### PR TITLE
api: allow validation on older k8s versions

### DIFF
--- a/controller/api/tests/testdata/agentgateway_policy_invalid.yaml
+++ b/controller/api/tests/testdata/agentgateway_policy_invalid.yaml
@@ -127,6 +127,10 @@ kind: AgentgatewayPolicy
 metadata:
   name: frontend-http-buffer-small
 spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: dummy
   frontend:
     http:
       maxBufferSize: 0
@@ -167,9 +171,55 @@ kind: AgentgatewayPolicy
 metadata:
   name: frontend-http2-window-small
 spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: dummy
   frontend:
     http:
       http2WindowSize: 0
+---
+_err: 'http.maxBufferSize'
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: frontend-http-buffer-empty
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: dummy
+  frontend:
+    http:
+      maxBufferSize: ""
+---
+_err: 'http.maxBufferSize'
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: frontend-http-buffer-negative
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: dummy
+  frontend:
+    http:
+      maxBufferSize: -1
+---
+_err: 'http.maxBufferSize'
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: frontend-http-buffer-too-large
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: dummy
+  frontend:
+    http:
+      maxBufferSize: 4294967296
 ---
 _err: 'keepalive.retries'
 apiVersion: agentgateway.dev/v1alpha1
@@ -181,17 +231,6 @@ spec:
     tcp:
       keepalive:
         retries: 0
----
-_err: 'backendRef: Required'
-apiVersion: agentgateway.dev/v1alpha1
-kind: AgentgatewayPolicy
-metadata:
-  name: traffic-extauth-no-backend
-spec:
-  traffic:
-    extAuth:
-      forwardBody:
-        maxSize: 1024
 ---
 _err: 'backendRef: Required'
 apiVersion: agentgateway.dev/v1alpha1

--- a/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
+++ b/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
@@ -283,8 +283,8 @@ type SNI = string
 // ByteSize is a byte quantity that must fit in a uint32 dataplane field.
 // +kubebuilder:validation:XIntOrString
 // +kubebuilder:validation:MaxLength=32
-// +kubebuilder:validation:XValidation:rule="!quantity(string(self)).isLessThan(quantity('1'))",message="value must be at least 1 byte"
-// +kubebuilder:validation:XValidation:rule="!quantity(string(self)).isGreaterThan(quantity('4294967295'))",message="value must fit within uint32"
+// +kubebuilder:validation:MinLength=1
+// +kubebuilder:validation:XValidation:rule="(self >= 1 && self <= 4294967295) || self.size() > 0",message="value must be at least 1 byte and fit within uint32"
 type ByteSize resource.Quantity
 
 func (b ByteSize) Value() int64 {

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
@@ -9701,13 +9701,14 @@ spec:
                               and sent to the authorization server. If the body size is larger than
                               `maxSize`, then the request will be rejected with a response.
                             maxLength: 32
+                            minLength: 1
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
                             x-kubernetes-validations:
-                            - message: value must be at least 1 byte
-                              rule: '!quantity(string(self)).isLessThan(quantity(''1''))'
-                            - message: value must fit within uint32
-                              rule: '!quantity(string(self)).isGreaterThan(quantity(''4294967295''))'
+                            - message: value must be at least 1 byte and fit within
+                                uint32
+                              rule: (self >= 1 && self <= 4294967295) || self.size()
+                                > 0
                         required:
                         - maxSize
                         type: object

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
@@ -3850,13 +3850,14 @@ spec:
                               and sent to the authorization server. If the body size is larger than
                               `maxSize`, then the request will be rejected with a response.
                             maxLength: 32
+                            minLength: 1
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
                             x-kubernetes-validations:
-                            - message: value must be at least 1 byte
-                              rule: '!quantity(string(self)).isLessThan(quantity(''1''))'
-                            - message: value must fit within uint32
-                              rule: '!quantity(string(self)).isGreaterThan(quantity(''4294967295''))'
+                            - message: value must be at least 1 byte and fit within
+                                uint32
+                              rule: (self >= 1 && self <= 4294967295) || self.size()
+                                > 0
                         required:
                         - maxSize
                         type: object
@@ -4991,13 +4992,13 @@ spec:
                           `http2ConnectionWindowSize` indicates the initial window size for
                           connection-level flow control for received data.
                         maxLength: 32
+                        minLength: 1
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                         x-kubernetes-validations:
-                        - message: value must be at least 1 byte
-                          rule: '!quantity(string(self)).isLessThan(quantity(''1''))'
-                        - message: value must fit within uint32
-                          rule: '!quantity(string(self)).isGreaterThan(quantity(''4294967295''))'
+                        - message: value must be at least 1 byte and fit within uint32
+                          rule: (self >= 1 && self <= 4294967295) || self.size() >
+                            0
                       http2FrameSize:
                         anyOf:
                         - type: integer
@@ -5006,6 +5007,7 @@ spec:
                           `http2FrameSize` sets the maximum frame size to use.
                           If unset, this defaults to `16kb`.
                         maxLength: 32
+                        minLength: 1
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                         x-kubernetes-validations:
@@ -5013,10 +5015,9 @@ spec:
                           rule: '!quantity(string(self)).isLessThan(quantity(''16384''))'
                         - message: http2FrameSize must be at most 1677215 bytes
                           rule: '!quantity(string(self)).isGreaterThan(quantity(''1677215''))'
-                        - message: value must be at least 1 byte
-                          rule: '!quantity(string(self)).isLessThan(quantity(''1''))'
-                        - message: value must fit within uint32
-                          rule: '!quantity(string(self)).isGreaterThan(quantity(''4294967295''))'
+                        - message: value must be at least 1 byte and fit within uint32
+                          rule: (self >= 1 && self <= 4294967295) || self.size() >
+                            0
                       http2KeepaliveInterval:
                         type: string
                         x-kubernetes-validations:
@@ -5040,13 +5041,13 @@ spec:
                           request headers.
                           If unset, this defaults to `16Ki`.
                         maxLength: 32
+                        minLength: 1
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                         x-kubernetes-validations:
-                        - message: value must be at least 1 byte
-                          rule: '!quantity(string(self)).isLessThan(quantity(''1''))'
-                        - message: value must fit within uint32
-                          rule: '!quantity(string(self)).isGreaterThan(quantity(''4294967295''))'
+                        - message: value must be at least 1 byte and fit within uint32
+                          rule: (self >= 1 && self <= 4294967295) || self.size() >
+                            0
                       http2WindowSize:
                         anyOf:
                         - type: integer
@@ -5055,13 +5056,13 @@ spec:
                           `http2WindowSize` indicates the initial window size for stream-level flow
                           control for received data.
                         maxLength: 32
+                        minLength: 1
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                         x-kubernetes-validations:
-                        - message: value must be at least 1 byte
-                          rule: '!quantity(string(self)).isLessThan(quantity(''1''))'
-                        - message: value must fit within uint32
-                          rule: '!quantity(string(self)).isGreaterThan(quantity(''4294967295''))'
+                        - message: value must be at least 1 byte and fit within uint32
+                          rule: (self >= 1 && self <= 4294967295) || self.size() >
+                            0
                       maxBufferSize:
                         anyOf:
                         - type: integer
@@ -5072,13 +5073,13 @@ spec:
                           Bodies will only be buffered for policies which require buffering.
                           If unset, this defaults to `2mb`.
                         maxLength: 32
+                        minLength: 1
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                         x-kubernetes-validations:
-                        - message: value must be at least 1 byte
-                          rule: '!quantity(string(self)).isLessThan(quantity(''1''))'
-                        - message: value must fit within uint32
-                          rule: '!quantity(string(self)).isGreaterThan(quantity(''4294967295''))'
+                        - message: value must be at least 1 byte and fit within uint32
+                          rule: (self >= 1 && self <= 4294967295) || self.size() >
+                            0
                       maxConnectionDuration:
                         description: |-
                           `maxConnectionDuration` specifies the maximum time a connection is allowed to remain open.
@@ -6560,13 +6561,14 @@ spec:
                                         and sent to the authorization server. If the body size is larger than
                                         `maxSize`, then the request will be rejected with a response.
                                       maxLength: 32
+                                      minLength: 1
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                       x-kubernetes-validations:
-                                      - message: value must be at least 1 byte
-                                        rule: '!quantity(string(self)).isLessThan(quantity(''1''))'
-                                      - message: value must fit within uint32
-                                        rule: '!quantity(string(self)).isGreaterThan(quantity(''4294967295''))'
+                                      - message: value must be at least 1 byte and
+                                          fit within uint32
+                                        rule: (self >= 1 && self <= 4294967295) ||
+                                          self.size() > 0
                                   required:
                                   - maxSize
                                   type: object
@@ -6717,13 +6719,14 @@ spec:
                               and sent to the authorization server. If the body size is larger than
                               `maxSize`, then the request will be rejected with a response.
                             maxLength: 32
+                            minLength: 1
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
                             x-kubernetes-validations:
-                            - message: value must be at least 1 byte
-                              rule: '!quantity(string(self)).isLessThan(quantity(''1''))'
-                            - message: value must fit within uint32
-                              rule: '!quantity(string(self)).isGreaterThan(quantity(''4294967295''))'
+                            - message: value must be at least 1 byte and fit within
+                                uint32
+                              rule: (self >= 1 && self <= 4294967295) || self.size()
+                                > 0
                         required:
                         - maxSize
                         type: object

--- a/controller/pkg/agentgateway/plugins/frontend_policies.go
+++ b/controller/pkg/agentgateway/plugins/frontend_policies.go
@@ -3,6 +3,7 @@ package plugins
 import (
 	"errors"
 	"fmt"
+	"math"
 
 	"google.golang.org/protobuf/types/known/durationpb"
 	"istio.io/istio/pkg/ptr"
@@ -375,7 +376,15 @@ func quantityUint32(ka *agentgateway.ByteSize) *uint32 {
 }
 
 func requiredQuantityUint32(ka agentgateway.ByteSize) uint32 {
-	return uint32(ka.Value()) //nolint:gosec // G115: kubebuilder validation ensures safe for uint32
+	// TODO: just cast as uint32 once k8s 1.33 is no longer supported and we can place validation via quantity without blowing up cel
+	v := ka.Value()
+	if v < 0 {
+		return 0
+	}
+	if v > math.MaxUint32 {
+		return math.MaxUint32
+	}
+	return uint32(v)
 }
 
 func translateFrontendTLS(policy *agentgateway.AgentgatewayPolicy, name string) *api.Policy {


### PR DESCRIPTION
This drops the quanitity operations from 300k cost to 7 due to a bug in k8s 1.33 and older https://github.com/kubernetes/kubernetes/issues/132370