### PR TITLE
mcp: allow explicit service selector target name

### DIFF
--- a/controller/api/annotations/agentgateway.go
+++ b/controller/api/annotations/agentgateway.go
@@ -7,4 +7,5 @@ const LegacyMCPServiceHTTPPath = "kgateway.dev/mcp-path"
 const MCPServiceHTTPPath = "agentgateway.dev/mcp-path"
 
 // MCPServiceTargetName is the annotation used to specify the target name for the MCP service.
+// The value must be a valid Gateway API SectionName.
 const MCPServiceTargetName = "agentgateway.dev/mcp-target-name"

--- a/controller/api/annotations/agentgateway.go
+++ b/controller/api/annotations/agentgateway.go
@@ -5,3 +5,6 @@ const LegacyMCPServiceHTTPPath = "kgateway.dev/mcp-path"
 
 // MCPServiceHTTPPath is the annotation used to specify the HTTP path for the MCP service
 const MCPServiceHTTPPath = "agentgateway.dev/mcp-path"
+
+// MCPServiceTargetName is the annotation used to specify the target name for the MCP service.
+const MCPServiceTargetName = "agentgateway.dev/mcp-target-name"

--- a/controller/pkg/syncer/backend/backend_plugin_test.go
+++ b/controller/pkg/syncer/backend/backend_plugin_test.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/agentgateway/agentgateway/api"
+	apiannotations "github.com/agentgateway/agentgateway/controller/api/annotations"
 	"github.com/agentgateway/agentgateway/controller/api/v1alpha1/agentgateway"
 	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/plugins"
 	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/testutils"
@@ -181,6 +182,31 @@ func TestBuildMCP(t *testing.T) {
 				},
 			},
 			inputs: []any{createMockMCPServiceWithBothAnnotations("test-ns", "mcp-service-both", "app=mcp-server-both", "/new/path", "/legacy/path")},
+		},
+		{
+			name: "Service selector MCPBackend backend - target name annotation",
+			backend: &agentgateway.AgentgatewayBackend{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "service-mcp-backend-target-name",
+					Namespace: "test-ns",
+				},
+				Spec: agentgateway.AgentgatewayBackendSpec{
+					MCP: &agentgateway.MCPBackend{
+						Targets: []agentgateway.McpTargetSelector{
+							{
+								Selector: &agentgateway.McpSelector{
+									Service: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app": "mcp-server-target-name",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			inputs: []any{createMockMCPServiceWithTargetNameAnnotation("test-ns", "mcp-service-target-name", "custom-mcp-target")},
 		},
 		{
 			name: "Service backendRef MCPBackend backend - same namespace",
@@ -837,6 +863,28 @@ func TestGetSecretValue(t *testing.T) {
 				t.Errorf("value = %v, expected %v", val, tt.expectedVal)
 			}
 		})
+	}
+}
+
+func createMockMCPServiceWithTargetNameAnnotation(namespace, serviceName, targetName string) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      serviceName,
+			Namespace: namespace,
+			Labels:    map[string]string{"app": "mcp-server-target-name"},
+			Annotations: map[string]string{
+				apiannotations.MCPServiceTargetName: targetName,
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Name:        "mcp",
+					Port:        8080,
+					AppProtocol: new("agentgateway.dev/mcp"),
+				},
+			},
+		},
 	}
 }
 

--- a/controller/pkg/syncer/backend/backend_plugin_test.go
+++ b/controller/pkg/syncer/backend/backend_plugin_test.go
@@ -2,6 +2,7 @@ package agentgatewaybackend_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"google.golang.org/protobuf/proto"
@@ -24,10 +25,11 @@ import (
 
 func TestBuildMCP(t *testing.T) {
 	tests := []struct {
-		name        string
-		backend     *agentgateway.AgentgatewayBackend
-		expectError bool
-		inputs      []any
+		name          string
+		backend       *agentgateway.AgentgatewayBackend
+		expectError   bool
+		errorContains string
+		inputs        []any
 	}{
 		{
 			name: "Static MCPBackend target backend",
@@ -209,6 +211,33 @@ func TestBuildMCP(t *testing.T) {
 			inputs: []any{createMockMCPServiceWithTargetNameAnnotation("test-ns", "mcp-service-target-name", "custom-mcp-target")},
 		},
 		{
+			name: "Service selector MCPBackend backend - invalid target name annotation",
+			backend: &agentgateway.AgentgatewayBackend{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "service-mcp-backend-invalid-target-name",
+					Namespace: "test-ns",
+				},
+				Spec: agentgateway.AgentgatewayBackendSpec{
+					MCP: &agentgateway.MCPBackend{
+						Targets: []agentgateway.McpTargetSelector{
+							{
+								Selector: &agentgateway.McpSelector{
+									Service: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app": "mcp-server-target-name",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectError:   true,
+			errorContains: `invalid Service test-ns/mcp-service-invalid-target-name annotation agentgateway.dev/mcp-target-name value "invalid_target"`,
+			inputs:        []any{createMockMCPServiceWithTargetNameAnnotation("test-ns", "mcp-service-invalid-target-name", "invalid_target")},
+		},
+		{
 			name: "Service backendRef MCPBackend backend - same namespace",
 			backend: &agentgateway.AgentgatewayBackend{
 				ObjectMeta: metav1.ObjectMeta{
@@ -270,6 +299,9 @@ func TestBuildMCP(t *testing.T) {
 			result, err := agentgatewaybackend.BuildAgwBackend(ctx, tt.backend)
 			if tt.expectError {
 				assert.Error(t, err)
+				if tt.errorContains != "" && !strings.Contains(err.Error(), tt.errorContains) {
+					t.Fatalf("expected error to contain %q, got %v", tt.errorContains, err)
+				}
 				return
 			} else {
 				assert.NoError(t, err)

--- a/controller/pkg/syncer/backend/mcp.go
+++ b/controller/pkg/syncer/backend/mcp.go
@@ -98,9 +98,12 @@ func TranslateMCPSelectorTargets(
 				appProtocol != mcpProtocolLegacy && appProtocol != mcpProtocolSSELegacy {
 				continue
 			}
-			targetName := service.Name + fmt.Sprintf("-%d", port.Port)
-			if port.Name != "" {
-				targetName = service.Name + "-" + port.Name
+			targetName := service.Annotations[apiannotations.MCPServiceTargetName]
+			if targetName == "" {
+				targetName = service.Name + fmt.Sprintf("-%d", port.Port)
+				if port.Name != "" {
+					targetName = service.Name + "-" + port.Name
+				}
 			}
 
 			path := service.Annotations[apiannotations.MCPServiceHTTPPath]

--- a/controller/pkg/syncer/backend/mcp.go
+++ b/controller/pkg/syncer/backend/mcp.go
@@ -2,12 +2,14 @@ package agentgatewaybackend
 
 import (
 	"fmt"
+	"strings"
 
 	"istio.io/istio/pkg/kube/krt"
 	"istio.io/istio/pkg/ptr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/validation"
 
 	"github.com/agentgateway/agentgateway/api"
 	apiannotations "github.com/agentgateway/agentgateway/controller/api/annotations"
@@ -104,6 +106,15 @@ func TranslateMCPSelectorTargets(
 				if port.Name != "" {
 					targetName = service.Name + "-" + port.Name
 				}
+			} else if errs := validation.IsDNS1123Subdomain(targetName); len(errs) > 0 {
+				return nil, fmt.Errorf(
+					"invalid Service %s/%s annotation %s value %q: must be a valid Gateway API SectionName: %s",
+					service.Namespace,
+					service.Name,
+					apiannotations.MCPServiceTargetName,
+					targetName,
+					strings.Join(errs, "; "),
+				)
 			}
 
 			path := service.Annotations[apiannotations.MCPServiceHTTPPath]

--- a/controller/pkg/syncer/backend/testdata/Service_selector_MCPBackend_backend_-_target_name_annotation.yaml
+++ b/controller/pkg/syncer/backend/testdata/Service_selector_MCPBackend_backend_-_target_name_annotation.yaml
@@ -1,0 +1,13 @@
+- key: test-ns/service-mcp-backend-target-name
+  mcp:
+    targets:
+    - backend:
+        port: 8080
+        service:
+          hostname: mcp-service-target-name.test-ns.svc.cluster.local
+          namespace: test-ns
+      name: custom-mcp-target
+      protocol: STREAMABLE_HTTP
+  name:
+    name: service-mcp-backend-target-name
+    namespace: test-ns


### PR DESCRIPTION
Otherwise users may be exposing internal service names and ports they do
not want

Signed-off-by: John Howard <john.howard@solo.io>
