### PR TITLE
quantity: only expose uint32

### DIFF
--- a/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
+++ b/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
@@ -2,6 +2,7 @@ package agentgateway
 
 import (
 	"iter"
+	"math"
 
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -287,9 +288,17 @@ type SNI = string
 // +kubebuilder:validation:XValidation:rule="(self >= 1 && self <= 4294967295) || self.size() > 0",message="value must be at least 1 byte and fit within uint32"
 type ByteSize resource.Quantity
 
-func (b ByteSize) Value() int64 {
+// ClampedValue returns the quantity as a uint32, clamping values to 0..MaxUint32
+func (b ByteSize) ClampedValue() uint32 {
 	q := resource.Quantity(b)
-	return q.Value()
+	v := q.Value()
+	if v < 0 {
+		return 0
+	}
+	if v > math.MaxUint32 {
+		return math.MaxUint32
+	}
+	return uint32(v)
 }
 
 func (b ByteSize) MarshalJSON() ([]byte, error) {

--- a/controller/pkg/agentgateway/plugins/frontend_policies.go
+++ b/controller/pkg/agentgateway/plugins/frontend_policies.go
@@ -3,7 +3,6 @@ package plugins
 import (
 	"errors"
 	"fmt"
-	"math"
 
 	"google.golang.org/protobuf/types/known/durationpb"
 	"istio.io/istio/pkg/ptr"
@@ -372,19 +371,7 @@ func castUint32[T ~int32](ka *T) *uint32 {
 }
 
 func quantityUint32(ka *agentgateway.ByteSize) *uint32 {
-	return new(requiredQuantityUint32(*ka))
-}
-
-func requiredQuantityUint32(ka agentgateway.ByteSize) uint32 {
-	// TODO: just cast as uint32 once k8s 1.33 is no longer supported and we can place validation via quantity without blowing up cel
-	v := ka.Value()
-	if v < 0 {
-		return 0
-	}
-	if v > math.MaxUint32 {
-		return math.MaxUint32
-	}
-	return uint32(v)
+	return new((*ka).ClampedValue())
 }
 
 func translateFrontendTLS(policy *agentgateway.AgentgatewayPolicy, name string) *api.Policy {

--- a/controller/pkg/agentgateway/plugins/traffic_plugin.go
+++ b/controller/pkg/agentgateway/plugins/traffic_plugin.go
@@ -1071,7 +1071,7 @@ func buildExtAuthSpec(
 	}
 	if b := extAuth.ForwardBody; b != nil {
 		spec.IncludeRequestBody = &api.TrafficPolicySpec_ExternalAuth_BodyOptions{
-			MaxRequestBytes: requiredQuantityUint32(b.MaxSize),
+			MaxRequestBytes: b.MaxSize.ClampedValue(),
 			// Currently the default, see https://github.com/kubernetes-sigs/gateway-api/issues/4198
 			AllowPartialMessage: true,
 			// TODO: should we allow config?


### PR DESCRIPTION
This avoids the ability to use it in ways we don't currently intend
Minor refactor, no behavioral change
