### PR TITLE
proxy: translate errors into gRPC errors for gRPC requests

### DIFF
--- a/crates/agentgateway/src/http/mod.rs
+++ b/crates/agentgateway/src/http/mod.rs
@@ -720,6 +720,24 @@ pub fn classify_content_type(h: &HeaderMap) -> WellKnownContentTypes {
 	WellKnownContentTypes::Unknown
 }
 
+pub fn is_grpc_request<B>(req: &::http::Request<B>) -> bool {
+	!req.uri().path().is_empty() && is_grpc_content_type(req.headers())
+}
+
+pub fn is_grpc_content_type(headers: &HeaderMap) -> bool {
+	let Some(content_type) = headers.get(header::CONTENT_TYPE) else {
+		return false;
+	};
+	let Ok(content_type) = content_type.to_str() else {
+		return false;
+	};
+	let content_type = content_type.split(';').next().unwrap_or_default().trim();
+	content_type.eq_ignore_ascii_case("application/grpc")
+		|| content_type
+			.get(..17)
+			.is_some_and(|prefix| prefix.eq_ignore_ascii_case("application/grpc+"))
+}
+
 pub fn get_path_and_query(req: &Uri) -> &str {
 	req
 		.path_and_query()
@@ -1004,5 +1022,35 @@ mod tests {
 		modify_query_parameters(&mut uri, std::iter::empty::<(&str, &str)>(), ["remove"]).unwrap();
 
 		assert_eq!(uri.to_string(), "https://example.com/resource");
+	}
+
+	#[test]
+	fn detects_grpc_request_content_types() {
+		for content_type in [
+			"application/grpc",
+			"application/grpc+proto",
+			"application/grpc; charset=utf-8",
+		] {
+			let req = ::http::Request::builder()
+				.uri("/svc.Method/Call")
+				.header(header::CONTENT_TYPE, content_type)
+				.body(Body::empty())
+				.unwrap();
+
+			assert!(is_grpc_request(&req), "{content_type}");
+		}
+	}
+
+	#[test]
+	fn rejects_non_grpc_request_content_types() {
+		for content_type in ["application/json", "application/grpc-web"] {
+			let req = ::http::Request::builder()
+				.uri("/svc.Method/Call")
+				.header(header::CONTENT_TYPE, content_type)
+				.body(Body::empty())
+				.unwrap();
+
+			assert!(!is_grpc_request(&req), "{content_type}");
+		}
 	}
 }

--- a/crates/agentgateway/src/http/remoteratelimit_tests.rs
+++ b/crates/agentgateway/src/http/remoteratelimit_tests.rs
@@ -673,7 +673,7 @@ fn rate_limit_failed_maps_to_500() {
 	use ::http::StatusCode;
 
 	let err = ProxyError::RateLimitFailed;
-	let response = err.into_response();
+	let response = err.into_response_with_grpc(false);
 	assert_eq!(
 		response.status(),
 		StatusCode::INTERNAL_SERVER_ERROR,
@@ -690,7 +690,7 @@ fn rate_limit_exceeded_maps_to_429() {
 		remaining: 0,
 		reset_seconds: 60,
 	};
-	let response = err.into_response();
+	let response = err.into_response_with_grpc(false);
 	assert_eq!(
 		response.status(),
 		StatusCode::TOO_MANY_REQUESTS,

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -525,6 +525,7 @@ impl HTTPProxy {
 		// Setup ResponsePolicies outside of proxy_internal, so we have can unconditionally run them even on errors
 		// or direct responses
 		let mut response_policies = ResponsePolicies::default();
+		let is_grpc_request = http::is_grpc_request(&req);
 		let ret = self
 			.proxy_internal(req, log.as_mut().unwrap(), &mut response_policies)
 			.await
@@ -544,7 +545,7 @@ impl HTTPProxy {
 			Err(e) => e.as_reason(),
 		};
 		let mut resp = ret.unwrap_or_else(|err| match err {
-			ProxyResponse::Error(e) => e.into_response(),
+			ProxyResponse::Error(e) => e.into_response_with_grpc(is_grpc_request),
 			ProxyResponse::DirectResponse(dr) => *dr,
 		});
 
@@ -562,7 +563,7 @@ impl HTTPProxy {
 		{
 			Ok(_) => resp,
 			Err(e) => match e {
-				ProxyResponse::Error(e) => e.into_response(),
+				ProxyResponse::Error(e) => e.into_response_with_grpc(is_grpc_request),
 				ProxyResponse::DirectResponse(dr) => *dr,
 			},
 		};
@@ -581,11 +582,11 @@ impl HTTPProxy {
 
 		if resp.status() == StatusCode::SWITCHING_PROTOCOLS {
 			let Some(req_upgrade) = resp.extensions_mut().remove::<RequestUpgrade>() else {
-				return ProxyError::UpgradeFailed(None, None).into_response();
+				return ProxyError::UpgradeFailed(None, None).into_response_with_grpc(is_grpc_request);
 			};
 			handle_upgrade(req_upgrade, resp, log)
 				.await
-				.unwrap_or_else(|e| e.into_response())
+				.unwrap_or_else(|e| e.into_response_with_grpc(is_grpc_request))
 		} else {
 			resp.map(move |b| http::Body::new(LogBody::new(b, log)))
 		}

--- a/crates/agentgateway/src/proxy/mod.rs
+++ b/crates/agentgateway/src/proxy/mod.rs
@@ -9,8 +9,10 @@ use std::sync::Arc;
 
 use agent_pool::Error as HyperError;
 pub use gateway::Gateway;
+use percent_encoding::{AsciiSet, CONTROLS, utf8_percent_encode};
 use rmcp::ErrorData;
 use rmcp::model::{ErrorCode, JsonRpcError};
+use tonic::Code;
 
 use crate::http::{HeaderValue, Response, StatusCode, ext_proc};
 use crate::types::agent::{
@@ -19,6 +21,11 @@ use crate::types::agent::{
 };
 use crate::types::discovery::Service;
 use crate::*;
+
+// grpc-message is percent-encoded. At minimum, space, percent, and control
+// bytes must be escaped.
+// https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#responses
+const GRPC_MESSAGE_ENCODE_SET: &AsciiSet = &CONTROLS.add(b' ').add(b'%');
 
 #[derive(thiserror::Error, Debug)]
 pub enum ProxyResponse {
@@ -218,7 +225,7 @@ impl ProxyError {
 			_ => false,
 		}
 	}
-	pub fn into_response(self) -> Response {
+	pub fn into_response_with_grpc(self, is_grpc_request: bool) -> Response {
 		let msg = self.to_string();
 		let code = match self {
 			ProxyError::BindNotFound => StatusCode::NOT_FOUND,
@@ -306,6 +313,7 @@ impl ProxyError {
 			// Note: we do not return a 401/403 here, as the obscure that it was rejected due to auth
 			ProxyError::MCP(mcp::Error::Authorization(_, _, _)) => StatusCode::BAD_REQUEST,
 		};
+		let grpc_status = is_grpc_request.then(|| proxy_error_to_grpc_status(&self, code));
 		let mut rb = ::http::Response::builder().status(code);
 
 		// Apply per-error headers
@@ -336,6 +344,19 @@ impl ProxyError {
 			if let Ok(hv) = HeaderValue::try_from(auth_header) {
 				rb = rb.header(hyper::header::WWW_AUTHENTICATE, hv);
 			}
+		}
+
+		if let Some(grpc_status) = grpc_status {
+			return rb
+				.status(StatusCode::OK)
+				.header(hyper::header::CONTENT_TYPE, "application/grpc")
+				.header("grpc-status", i32::from(grpc_status).to_string())
+				.header(
+					"grpc-message",
+					utf8_percent_encode(&msg, GRPC_MESSAGE_ENCODE_SET).to_string(),
+				)
+				.body(http::Body::empty())
+				.unwrap();
 		}
 
 		// Add WWW-Authenticate header for MCP failures
@@ -394,6 +415,33 @@ impl ProxyError {
 	}
 }
 
+fn proxy_error_to_grpc_status(error: &ProxyError, http_status: StatusCode) -> Code {
+	match error {
+		// Gateway API requires invalid backend references to be HTTP 500 for HTTP
+		// requests, but gRPC callers should see the backend as unavailable.
+		ProxyError::NoValidBackends => Code::Unavailable,
+		_ => http_status_to_grpc_status(http_status),
+	}
+}
+
+fn http_status_to_grpc_status(status: StatusCode) -> Code {
+	// Keep in sync with the gRPC HTTP-to-status fallback table:
+	// https://grpc.github.io/grpc/core/md_doc_http-grpc-status-mapping.html
+	match status {
+		StatusCode::OK => Code::Ok,
+		StatusCode::BAD_REQUEST => Code::Internal,
+		StatusCode::UNAUTHORIZED => Code::Unauthenticated,
+		StatusCode::FORBIDDEN => Code::PermissionDenied,
+		// HTTP 404 maps to UNIMPLEMENTED, not gRPC NOT_FOUND.
+		StatusCode::NOT_FOUND => Code::Unimplemented,
+		StatusCode::TOO_MANY_REQUESTS
+		| StatusCode::BAD_GATEWAY
+		| StatusCode::SERVICE_UNAVAILABLE
+		| StatusCode::GATEWAY_TIMEOUT => Code::Unavailable,
+		_ => Code::Unknown,
+	}
+}
+
 #[derive(Clone, Debug)]
 pub struct WaypointService(pub Arc<Service>);
 
@@ -412,6 +460,7 @@ impl WaypointService {
 		})
 	}
 }
+
 pub fn resolve_backend(
 	b: &BackendReference,
 	pi: &ProxyInputs,
@@ -484,4 +533,69 @@ pub fn resolve_simple_backend_with_policies(
 		backend,
 		inline_policies,
 	})
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn grpc_error_response_maps_http_status_to_grpc_status() {
+		let response = ProxyError::NoHealthyEndpoints.into_response_with_grpc(true);
+
+		assert_eq!(response.status(), StatusCode::OK);
+		assert_eq!(
+			response.headers().get(hyper::header::CONTENT_TYPE).unwrap(),
+			"application/grpc"
+		);
+		assert_eq!(
+			response.headers().get("grpc-status").unwrap(),
+			&i32::from(Code::Unavailable).to_string()
+		);
+		assert_eq!(
+			response.headers().get("grpc-message").unwrap(),
+			"no%20healthy%20backends"
+		);
+	}
+
+	#[test]
+	fn http_error_response_keeps_http_status() {
+		let response = ProxyError::NoHealthyEndpoints.into_response_with_grpc(false);
+
+		assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+		assert_eq!(
+			response.headers().get(hyper::header::CONTENT_TYPE).unwrap(),
+			"text/plain"
+		);
+		assert!(response.headers().get("grpc-status").is_none());
+	}
+
+	#[test]
+	fn grpc_error_response_uses_standard_fallback_mapping() {
+		let not_found = ProxyError::RouteNotFound.into_response_with_grpc(true);
+		let forbidden = ProxyError::AuthorizationFailed.into_response_with_grpc(true);
+
+		assert_eq!(
+			not_found.headers().get("grpc-status").unwrap(),
+			&i32::from(Code::Unimplemented).to_string()
+		);
+		assert_eq!(
+			forbidden.headers().get("grpc-status").unwrap(),
+			&i32::from(Code::PermissionDenied).to_string()
+		);
+	}
+
+	#[test]
+	fn no_valid_backends_is_http_500_but_grpc_unavailable() {
+		let http = ProxyError::NoValidBackends.into_response_with_grpc(false);
+		let grpc = ProxyError::NoValidBackends.into_response_with_grpc(true);
+
+		assert_eq!(http.status(), StatusCode::INTERNAL_SERVER_ERROR);
+		assert!(http.headers().get("grpc-status").is_none());
+		assert_eq!(grpc.status(), StatusCode::OK);
+		assert_eq!(
+			grpc.headers().get("grpc-status").unwrap(),
+			&i32::from(Code::Unavailable).to_string()
+		);
+	}
 }

--- a/crates/agentgateway/src/types/backend.rs
+++ b/crates/agentgateway/src/types/backend.rs
@@ -38,7 +38,7 @@ impl HTTP {
 				let tls = req.extensions().get::<TLSConnectionInfo>();
 				if tls.is_some() {
 					// Do not trust the downstream, use HTTP/1.1
-					if is_grpc(req) {
+					if http::is_grpc_content_type(req.headers()) {
 						Some(::http::Version::HTTP_2)
 					} else {
 						Some(::http::Version::HTTP_11)
@@ -59,13 +59,6 @@ impl HTTP {
 			_ => {},
 		};
 	}
-}
-
-fn is_grpc(req: &http::Request) -> bool {
-	req
-		.headers()
-		.get(http::header::CONTENT_TYPE)
-		.is_some_and(|value| value.as_bytes().starts_with("application/grpc".as_bytes()))
 }
 
 #[apply(schema!)]


### PR DESCRIPTION
This gives more useful context to gRPC clients. This is only for internally generated errors. We fallback to standard gRPC mapping but can explicitly set the error type for specific errors too