### PR TITLE
mcp: set Host header from target URL on upstream requests

### DIFF
--- a/crates/agentgateway/src/mcp/upstream/sse.rs
+++ b/crates/agentgateway/src/mcp/upstream/sse.rs
@@ -90,6 +90,7 @@ impl ClientCore {
 			.body(body.into())
 			.map_err(ClientError::new)?;
 
+		req.extensions_mut().insert(crate::http::filters::AutoHostname());
 		ctx.apply(&mut req);
 
 		let resp = self.http_client.call(req).await.map_err(ClientError::new)?;
@@ -113,6 +114,7 @@ impl ClientCore {
 			.body(http::Body::empty())
 			.map_err(ClientError::new)?;
 
+		req.extensions_mut().insert(crate::http::filters::AutoHostname());
 		ctx.apply(&mut req);
 
 		let resp = self.http_client.call(req).await?;

--- a/crates/agentgateway/src/mcp/upstream/streamablehttp.rs
+++ b/crates/agentgateway/src/mcp/upstream/streamablehttp.rs
@@ -90,6 +90,7 @@ impl Client {
 			.body(body.into())
 			.map_err(ClientError::new)?;
 
+		req.extensions_mut().insert(crate::http::filters::AutoHostname());
 		self.maybe_insert_session_id(&mut req)?;
 
 		ctx.apply(&mut req);
@@ -157,6 +158,7 @@ impl Client {
 			.body(crate::http::Body::empty())
 			.map_err(ClientError::new)?;
 
+		req.extensions_mut().insert(crate::http::filters::AutoHostname());
 		self.maybe_insert_session_id(&mut req)?;
 
 		ctx.apply(&mut req);
@@ -179,6 +181,7 @@ impl Client {
 			.body(crate::http::Body::empty())
 			.map_err(ClientError::new)?;
 
+		req.extensions_mut().insert(crate::http::filters::AutoHostname());
 		self.maybe_insert_session_id(&mut req)?;
 
 		ctx.apply(&mut req);


### PR DESCRIPTION
## Summary

The MCP upstream path doesn't participate in the `hostRewrite` policy mechanism that the HTTP proxy path uses. This causes two related issues:

1. **#1851**: For k8s Service backends, the incoming public `Host` header leaks through to backends via `IncomingRequestContext::apply()`, triggering Python MCP SDK DNS rebinding protection (421)
2. **#1860**: For k8s Service backends with `hostRewrite.mode: None`, the original public Host is not preserved — backends always see the internal service hostname

Both stem from the same root cause: the MCP upstream path doesn't read or apply the `hostRewrite` policy, and doesn't set `AutoHostname()` in request extensions like the HTTP path does.

## Current State

This PR currently inserts `AutoHostname()` unconditionally in MCP upstream requests. This fixes #1851 but would make #1860 worse.

## Proposed Direction

The proper fix should wire up `hostRewrite` policy support for MCP targets so:
- `Auto` (default for hostname backends): rewrite Host to backend hostname — fixes #1851
- `None` (default for k8s Service backends): preserve original public Host — fixes #1860

Happy to rework this PR to implement that if you can point me to where the MCP handler should read the route/backend policies.

Refs: #1851, #1860