### PR TITLE
api: more strict quantity validation

### DIFF
--- a/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
+++ b/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
@@ -8,7 +8,6 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/agentgateway/agentgateway/controller/api/v1alpha1/shared"
@@ -300,12 +299,12 @@ func (b *ByteSize) ClampedValue() *uint32 {
 	}
 	v := b.Value.Value()
 	if v < 0 {
-		return ptr.To[uint32](0)
+		return new(uint32(0))
 	}
 	if v > math.MaxUint32 {
-		return ptr.To[uint32](math.MaxUint32)
+		return new(uint32(math.MaxUint32))
 	}
-	return ptr.To(uint32(v))
+	return new(uint32(v))
 }
 
 func (b ByteSize) MarshalJSON() ([]byte, error) {

--- a/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
+++ b/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
@@ -283,7 +283,6 @@ type LongString = string
 type SNI = string
 
 // ByteSize is a byte quantity that must fit in a uint32 dataplane field.
-// +kubebuilder:validation:Type=string
 // +kubebuilder:validation:XIntOrString
 // +kubebuilder:validation:MaxLength=32
 // +kubebuilder:validation:MinLength=1

--- a/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
+++ b/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
@@ -8,6 +8,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/agentgateway/agentgateway/controller/api/v1alpha1/shared"
@@ -282,41 +283,56 @@ type LongString = string
 type SNI = string
 
 // ByteSize is a byte quantity that must fit in a uint32 dataplane field.
+// +kubebuilder:validation:Type=string
 // +kubebuilder:validation:XIntOrString
 // +kubebuilder:validation:MaxLength=32
 // +kubebuilder:validation:MinLength=1
+// +kubebuilder:validation:Pattern=`^[+-]?([0-9]+(\.[0-9]*)?|\.[0-9]+)(([KMGTPE]i)|[numkMGTPE]|[eE](\+?0*([0-9]|1[0-8])|-0*[0-9]))?$`
 // +kubebuilder:validation:XValidation:rule="(self >= 1 && self <= 4294967295) || self.size() > 0",message="value must be at least 1 byte and fit within uint32"
-type ByteSize resource.Quantity
+type ByteSize struct {
+	Value *resource.Quantity `json:"-"`
+}
 
-// ClampedValue returns the quantity as a uint32, clamping values to 0..MaxUint32
-func (b ByteSize) ClampedValue() uint32 {
-	q := resource.Quantity(b)
-	v := q.Value()
+// ClampedValue returns the quantity as a uint32, clamping values to 0..MaxUint32.
+func (b *ByteSize) ClampedValue() *uint32 {
+	if b == nil || b.Value == nil {
+		return nil
+	}
+	v := b.Value.Value()
 	if v < 0 {
-		return 0
+		return ptr.To[uint32](0)
 	}
 	if v > math.MaxUint32 {
-		return math.MaxUint32
+		return ptr.To[uint32](math.MaxUint32)
 	}
-	return uint32(v)
+	return ptr.To(uint32(v))
 }
 
 func (b ByteSize) MarshalJSON() ([]byte, error) {
-	q := resource.Quantity(b)
-	return q.MarshalJSON()
+	if b.Value == nil {
+		return []byte("null"), nil
+	}
+	return b.Value.MarshalJSON()
 }
 
 func (b *ByteSize) UnmarshalJSON(data []byte) error {
 	var q resource.Quantity
 	if err := q.UnmarshalJSON(data); err != nil {
-		return err
+		// Invalid byte sizes must not block informer decoding. CEL cannot validate
+		// this safely until the quantity cost bug is fixed, so treat it as unset.
+		b.Value = nil
+		return nil
 	}
-	*b = ByteSize(q)
+	b.Value = &q
 	return nil
 }
 
 func (b ByteSize) DeepCopy() ByteSize {
-	return ByteSize(resource.Quantity(b).DeepCopy())
+	if b.Value == nil {
+		return ByteSize{}
+	}
+	q := b.Value.DeepCopy()
+	return ByteSize{Value: &q}
 }
 
 type InsecureTLSMode string
@@ -511,8 +527,6 @@ type FrontendHTTP struct {
 	HTTP2ConnectionWindowSize *ByteSize `json:"http2ConnectionWindowSize,omitempty"`
 	// `http2FrameSize` sets the maximum frame size to use.
 	// If unset, this defaults to `16kb`.
-	// +kubebuilder:validation:XValidation:rule="!quantity(string(self)).isLessThan(quantity('16384'))",message="http2FrameSize must be at least 16384 bytes"
-	// +kubebuilder:validation:XValidation:rule="!quantity(string(self)).isGreaterThan(quantity('1677215'))",message="http2FrameSize must be at most 1677215 bytes"
 	// +optional
 	HTTP2FrameSize *ByteSize `json:"http2FrameSize,omitempty"`
 	// `http2MaxHeaderSize` sets the maximum aggregate size of decoded HTTP/2

--- a/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
+++ b/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
@@ -2,6 +2,7 @@ package agentgateway
 
 import (
 	"iter"
+	"log/slog"
 	"math"
 
 	corev1 "k8s.io/api/core/v1"
@@ -319,6 +320,7 @@ func (b *ByteSize) UnmarshalJSON(data []byte) error {
 	if err := q.UnmarshalJSON(data); err != nil {
 		// Invalid byte sizes must not block informer decoding. CEL cannot validate
 		// this safely until the quantity cost bug is fixed, so treat it as unset.
+		slog.Warn("failed to unmarshal quantity, ignoring", "value", string(data), "error", err)
 		b.Value = nil
 		return nil
 	}
@@ -526,6 +528,8 @@ type FrontendHTTP struct {
 	HTTP2ConnectionWindowSize *ByteSize `json:"http2ConnectionWindowSize,omitempty"`
 	// `http2FrameSize` sets the maximum frame size to use.
 	// If unset, this defaults to `16kb`.
+	// +kubebuilder:validation:XValidation:rule="!quantity(string(self)).isLessThan(quantity('16384'))",message="http2FrameSize must be at least 16384 bytes"
+	// +kubebuilder:validation:XValidation:rule="!quantity(string(self)).isGreaterThan(quantity('1677215'))",message="http2FrameSize must be at most 1677215 bytes"
 	// +optional
 	HTTP2FrameSize *ByteSize `json:"http2FrameSize,omitempty"`
 	// `http2MaxHeaderSize` sets the maximum aggregate size of decoded HTTP/2

--- a/controller/api/v1alpha1/agentgateway/agentgateway_policy_types_test.go
+++ b/controller/api/v1alpha1/agentgateway/agentgateway_policy_types_test.go
@@ -1,0 +1,112 @@
+package agentgateway
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+
+	"istio.io/istio/pkg/ptr"
+	"sigs.k8s.io/yaml"
+)
+
+func TestByteSizeInvalidJSONDecodesAsUnset(t *testing.T) {
+	var b ByteSize
+	if err := json.Unmarshal([]byte(`"not-a-quantity"`), &b); err != nil {
+		t.Fatalf("UnmarshalJSON() error = %v", err)
+	}
+	if b.Value != nil {
+		t.Fatalf("Value = %v, want nil", b.Value)
+	}
+	if got := b.ClampedValue(); got != nil {
+		t.Fatalf("ByteSize = %v, want nil", got)
+	}
+}
+
+func TestFrontendHTTPInvalidByteSizeDecodesAsUnsetValue(t *testing.T) {
+	var http FrontendHTTP
+	if err := json.Unmarshal([]byte(`{
+		"maxBufferSize": "not-a-quantity",
+		"http2WindowSize": "64Ki"
+	}`), &http); err != nil {
+		t.Fatalf("UnmarshalJSON() error = %v", err)
+	}
+
+	if http.MaxBufferSize == nil {
+		t.Fatal("MaxBufferSize pointer = nil, want allocated ByteSize")
+	}
+	if http.MaxBufferSize.Value != nil {
+		t.Fatalf("MaxBufferSize.Value = %v, want nil", http.MaxBufferSize.Value)
+	}
+	if http.MaxBufferSize.ClampedValue() != nil {
+		t.Fatalf("MaxBufferSize.ClampedValue() = %v, want nil", http.MaxBufferSize.Value)
+	}
+	if http.HTTP2WindowSize == nil || http.HTTP2WindowSize.Value == nil {
+		t.Fatal("HTTP2WindowSize = unset, want parsed quantity")
+	}
+	got := http.HTTP2WindowSize.ClampedValue()
+	if got == nil || *got != 65536 {
+		t.Fatalf("HTTP2WindowSize = %v, want 65536", got)
+	}
+}
+
+func TestByteSizeYAMLDecodeClampedValue(t *testing.T) {
+	type holder struct {
+		Size *ByteSize `json:"size,omitempty"`
+	}
+
+	tests := []struct {
+		name string
+		in   string
+		want *uint32
+	}{
+		{
+			name: "missing",
+			in:   `{}`,
+			want: nil,
+		},
+		{
+			name: "null",
+			in:   `size: null`,
+			want: nil,
+		},
+		{
+			name: "invalid",
+			in:   `size: not-a-quantity`,
+			want: nil,
+		},
+		{
+			name: "quantity string",
+			in:   `size: 64Ki`,
+			want: new(uint32(65536)),
+		},
+		{
+			name: "integer",
+			in:   `size: 1024`,
+			want: new(uint32(1024)),
+		},
+		{
+			name: "negative",
+			in:   `size: -1`,
+			want: new(uint32(0)),
+		},
+		{
+			name: "too large",
+			in:   `size: 5Gi`,
+			want: new(uint32(math.MaxUint32)),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var h holder
+			if err := yaml.Unmarshal([]byte(tt.in), &h); err != nil {
+				t.Fatalf("Unmarshal() error = %v", err)
+			}
+
+			got := h.Size.ClampedValue()
+			if !ptr.Equal(got, tt.want) {
+				t.Fatalf("ClampedValue() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/controller/hack/crdgen/main.go
+++ b/controller/hack/crdgen/main.go
@@ -181,6 +181,7 @@ func generateCRDs(paths []string, outputDir string, maxDescLen int, crdVersion s
 		if !ok {
 			return fmt.Errorf("unexpected converted type %T", converted)
 		}
+		fixIntOrStringSchemas(crdV1)
 		removeDescriptionFromMetadata(crdV1)
 
 		out, err := marshalCRD(crdV1)
@@ -201,6 +202,48 @@ func generateCRDs(paths []string, outputDir string, maxDescLen int, crdVersion s
 	}
 
 	return nil
+}
+
+func fixIntOrStringSchemas(crdObj *apiextensionsv1.CustomResourceDefinition) {
+	for i := range crdObj.Spec.Versions {
+		version := &crdObj.Spec.Versions[i]
+		if version.Schema == nil || version.Schema.OpenAPIV3Schema == nil {
+			continue
+		}
+		crd.EditSchema(version.Schema.OpenAPIV3Schema, intOrStringSchemaFixer{})
+	}
+}
+
+type intOrStringSchemaFixer struct{}
+
+func (intOrStringSchemaFixer) Visit(schema *apiextensionsv1.JSONSchemaProps) crd.SchemaVisitor {
+	if schema == nil {
+		return nil
+	}
+	if schema.XIntOrString && schema.Type == "object" {
+		schema.Type = ""
+		if !hasIntegerAndStringAnyOf(schema.AnyOf) {
+			schema.AnyOf = append(schema.AnyOf,
+				apiextensionsv1.JSONSchemaProps{Type: "integer"},
+				apiextensionsv1.JSONSchemaProps{Type: "string"},
+			)
+		}
+	}
+	return intOrStringSchemaFixer{}
+}
+
+func hasIntegerAndStringAnyOf(anyOf []apiextensionsv1.JSONSchemaProps) bool {
+	hasInteger := false
+	hasString := false
+	for _, schema := range anyOf {
+		switch schema.Type {
+		case "integer":
+			hasInteger = true
+		case "string":
+			hasString = true
+		}
+	}
+	return hasInteger && hasString
 }
 
 func registerCustomMarkers(registry *markers.Registry) error {

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
@@ -9693,6 +9693,9 @@ spec:
                           If enabled, the request body will be buffered.
                         properties:
                           maxSize:
+                            anyOf:
+                            - type: integer
+                            - type: string
                             description: |-
                               `maxSize` specifies, in bytes, the largest body that will be buffered
                               and sent to the authorization server. If the body size is larger than
@@ -9700,7 +9703,6 @@ spec:
                             maxLength: 32
                             minLength: 1
                             pattern: ^[+-]?([0-9]+(\.[0-9]*)?|\.[0-9]+)(([KMGTPE]i)|[numkMGTPE]|[eE](\+?0*([0-9]|1[0-8])|-0*[0-9]))?$
-                            type: string
                             x-kubernetes-int-or-string: true
                             x-kubernetes-validations:
                             - message: value must be at least 1 byte and fit within

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
@@ -9693,16 +9693,14 @@ spec:
                           If enabled, the request body will be buffered.
                         properties:
                           maxSize:
-                            anyOf:
-                            - type: integer
-                            - type: string
                             description: |-
                               `maxSize` specifies, in bytes, the largest body that will be buffered
                               and sent to the authorization server. If the body size is larger than
                               `maxSize`, then the request will be rejected with a response.
                             maxLength: 32
                             minLength: 1
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            pattern: ^[+-]?([0-9]+(\.[0-9]*)?|\.[0-9]+)(([KMGTPE]i)|[numkMGTPE]|[eE](\+?0*([0-9]|1[0-8])|-0*[0-9]))?$
+                            type: string
                             x-kubernetes-int-or-string: true
                             x-kubernetes-validations:
                             - message: value must be at least 1 byte and fit within

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
@@ -3842,16 +3842,14 @@ spec:
                           If enabled, the request body will be buffered.
                         properties:
                           maxSize:
-                            anyOf:
-                            - type: integer
-                            - type: string
                             description: |-
                               `maxSize` specifies, in bytes, the largest body that will be buffered
                               and sent to the authorization server. If the body size is larger than
                               `maxSize`, then the request will be rejected with a response.
                             maxLength: 32
                             minLength: 1
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            pattern: ^[+-]?([0-9]+(\.[0-9]*)?|\.[0-9]+)(([KMGTPE]i)|[numkMGTPE]|[eE](\+?0*([0-9]|1[0-8])|-0*[0-9]))?$
+                            type: string
                             x-kubernetes-int-or-string: true
                             x-kubernetes-validations:
                             - message: value must be at least 1 byte and fit within
@@ -4985,36 +4983,28 @@ spec:
                         minimum: 1
                         type: integer
                       http2ConnectionWindowSize:
-                        anyOf:
-                        - type: integer
-                        - type: string
                         description: |-
                           `http2ConnectionWindowSize` indicates the initial window size for
                           connection-level flow control for received data.
                         maxLength: 32
                         minLength: 1
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        pattern: ^[+-]?([0-9]+(\.[0-9]*)?|\.[0-9]+)(([KMGTPE]i)|[numkMGTPE]|[eE](\+?0*([0-9]|1[0-8])|-0*[0-9]))?$
+                        type: string
                         x-kubernetes-int-or-string: true
                         x-kubernetes-validations:
                         - message: value must be at least 1 byte and fit within uint32
                           rule: (self >= 1 && self <= 4294967295) || self.size() >
                             0
                       http2FrameSize:
-                        anyOf:
-                        - type: integer
-                        - type: string
                         description: |-
                           `http2FrameSize` sets the maximum frame size to use.
                           If unset, this defaults to `16kb`.
                         maxLength: 32
                         minLength: 1
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        pattern: ^[+-]?([0-9]+(\.[0-9]*)?|\.[0-9]+)(([KMGTPE]i)|[numkMGTPE]|[eE](\+?0*([0-9]|1[0-8])|-0*[0-9]))?$
+                        type: string
                         x-kubernetes-int-or-string: true
                         x-kubernetes-validations:
-                        - message: http2FrameSize must be at least 16384 bytes
-                          rule: '!quantity(string(self)).isLessThan(quantity(''16384''))'
-                        - message: http2FrameSize must be at most 1677215 bytes
-                          rule: '!quantity(string(self)).isGreaterThan(quantity(''1677215''))'
                         - message: value must be at least 1 byte and fit within uint32
                           rule: (self >= 1 && self <= 4294967295) || self.size() >
                             0
@@ -5033,40 +5023,33 @@ spec:
                         - message: http2KeepaliveTimeout must be at least 1 second
                           rule: duration(self) >= duration('1s')
                       http2MaxHeaderSize:
-                        anyOf:
-                        - type: integer
-                        - type: string
                         description: |-
                           `http2MaxHeaderSize` sets the maximum aggregate size of decoded HTTP/2
                           request headers.
                           If unset, this defaults to `16Ki`.
                         maxLength: 32
                         minLength: 1
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        pattern: ^[+-]?([0-9]+(\.[0-9]*)?|\.[0-9]+)(([KMGTPE]i)|[numkMGTPE]|[eE](\+?0*([0-9]|1[0-8])|-0*[0-9]))?$
+                        type: string
                         x-kubernetes-int-or-string: true
                         x-kubernetes-validations:
                         - message: value must be at least 1 byte and fit within uint32
                           rule: (self >= 1 && self <= 4294967295) || self.size() >
                             0
                       http2WindowSize:
-                        anyOf:
-                        - type: integer
-                        - type: string
                         description: |-
                           `http2WindowSize` indicates the initial window size for stream-level flow
                           control for received data.
                         maxLength: 32
                         minLength: 1
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        pattern: ^[+-]?([0-9]+(\.[0-9]*)?|\.[0-9]+)(([KMGTPE]i)|[numkMGTPE]|[eE](\+?0*([0-9]|1[0-8])|-0*[0-9]))?$
+                        type: string
                         x-kubernetes-int-or-string: true
                         x-kubernetes-validations:
                         - message: value must be at least 1 byte and fit within uint32
                           rule: (self >= 1 && self <= 4294967295) || self.size() >
                             0
                       maxBufferSize:
-                        anyOf:
-                        - type: integer
-                        - type: string
                         description: |-
                           `maxBufferSize` defines the maximum HTTP body size that will be buffered
                           into memory.
@@ -5074,7 +5057,8 @@ spec:
                           If unset, this defaults to `2mb`.
                         maxLength: 32
                         minLength: 1
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        pattern: ^[+-]?([0-9]+(\.[0-9]*)?|\.[0-9]+)(([KMGTPE]i)|[numkMGTPE]|[eE](\+?0*([0-9]|1[0-8])|-0*[0-9]))?$
+                        type: string
                         x-kubernetes-int-or-string: true
                         x-kubernetes-validations:
                         - message: value must be at least 1 byte and fit within uint32
@@ -6573,16 +6557,14 @@ spec:
                                     If enabled, the request body will be buffered.
                                   properties:
                                     maxSize:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
                                       description: |-
                                         `maxSize` specifies, in bytes, the largest body that will be buffered
                                         and sent to the authorization server. If the body size is larger than
                                         `maxSize`, then the request will be rejected with a response.
                                       maxLength: 32
                                       minLength: 1
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      pattern: ^[+-]?([0-9]+(\.[0-9]*)?|\.[0-9]+)(([KMGTPE]i)|[numkMGTPE]|[eE](\+?0*([0-9]|1[0-8])|-0*[0-9]))?$
+                                      type: string
                                       x-kubernetes-int-or-string: true
                                       x-kubernetes-validations:
                                       - message: value must be at least 1 byte and
@@ -6731,16 +6713,14 @@ spec:
                           If enabled, the request body will be buffered.
                         properties:
                           maxSize:
-                            anyOf:
-                            - type: integer
-                            - type: string
                             description: |-
                               `maxSize` specifies, in bytes, the largest body that will be buffered
                               and sent to the authorization server. If the body size is larger than
                               `maxSize`, then the request will be rejected with a response.
                             maxLength: 32
                             minLength: 1
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            pattern: ^[+-]?([0-9]+(\.[0-9]*)?|\.[0-9]+)(([KMGTPE]i)|[numkMGTPE]|[eE](\+?0*([0-9]|1[0-8])|-0*[0-9]))?$
+                            type: string
                             x-kubernetes-int-or-string: true
                             x-kubernetes-validations:
                             - message: value must be at least 1 byte and fit within

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
@@ -3842,6 +3842,9 @@ spec:
                           If enabled, the request body will be buffered.
                         properties:
                           maxSize:
+                            anyOf:
+                            - type: integer
+                            - type: string
                             description: |-
                               `maxSize` specifies, in bytes, the largest body that will be buffered
                               and sent to the authorization server. If the body size is larger than
@@ -3849,7 +3852,6 @@ spec:
                             maxLength: 32
                             minLength: 1
                             pattern: ^[+-]?([0-9]+(\.[0-9]*)?|\.[0-9]+)(([KMGTPE]i)|[numkMGTPE]|[eE](\+?0*([0-9]|1[0-8])|-0*[0-9]))?$
-                            type: string
                             x-kubernetes-int-or-string: true
                             x-kubernetes-validations:
                             - message: value must be at least 1 byte and fit within
@@ -4983,26 +4985,30 @@ spec:
                         minimum: 1
                         type: integer
                       http2ConnectionWindowSize:
+                        anyOf:
+                        - type: integer
+                        - type: string
                         description: |-
                           `http2ConnectionWindowSize` indicates the initial window size for
                           connection-level flow control for received data.
                         maxLength: 32
                         minLength: 1
                         pattern: ^[+-]?([0-9]+(\.[0-9]*)?|\.[0-9]+)(([KMGTPE]i)|[numkMGTPE]|[eE](\+?0*([0-9]|1[0-8])|-0*[0-9]))?$
-                        type: string
                         x-kubernetes-int-or-string: true
                         x-kubernetes-validations:
                         - message: value must be at least 1 byte and fit within uint32
                           rule: (self >= 1 && self <= 4294967295) || self.size() >
                             0
                       http2FrameSize:
+                        anyOf:
+                        - type: integer
+                        - type: string
                         description: |-
                           `http2FrameSize` sets the maximum frame size to use.
                           If unset, this defaults to `16kb`.
                         maxLength: 32
                         minLength: 1
                         pattern: ^[+-]?([0-9]+(\.[0-9]*)?|\.[0-9]+)(([KMGTPE]i)|[numkMGTPE]|[eE](\+?0*([0-9]|1[0-8])|-0*[0-9]))?$
-                        type: string
                         x-kubernetes-int-or-string: true
                         x-kubernetes-validations:
                         - message: http2FrameSize must be at least 16384 bytes
@@ -5027,6 +5033,9 @@ spec:
                         - message: http2KeepaliveTimeout must be at least 1 second
                           rule: duration(self) >= duration('1s')
                       http2MaxHeaderSize:
+                        anyOf:
+                        - type: integer
+                        - type: string
                         description: |-
                           `http2MaxHeaderSize` sets the maximum aggregate size of decoded HTTP/2
                           request headers.
@@ -5034,26 +5043,30 @@ spec:
                         maxLength: 32
                         minLength: 1
                         pattern: ^[+-]?([0-9]+(\.[0-9]*)?|\.[0-9]+)(([KMGTPE]i)|[numkMGTPE]|[eE](\+?0*([0-9]|1[0-8])|-0*[0-9]))?$
-                        type: string
                         x-kubernetes-int-or-string: true
                         x-kubernetes-validations:
                         - message: value must be at least 1 byte and fit within uint32
                           rule: (self >= 1 && self <= 4294967295) || self.size() >
                             0
                       http2WindowSize:
+                        anyOf:
+                        - type: integer
+                        - type: string
                         description: |-
                           `http2WindowSize` indicates the initial window size for stream-level flow
                           control for received data.
                         maxLength: 32
                         minLength: 1
                         pattern: ^[+-]?([0-9]+(\.[0-9]*)?|\.[0-9]+)(([KMGTPE]i)|[numkMGTPE]|[eE](\+?0*([0-9]|1[0-8])|-0*[0-9]))?$
-                        type: string
                         x-kubernetes-int-or-string: true
                         x-kubernetes-validations:
                         - message: value must be at least 1 byte and fit within uint32
                           rule: (self >= 1 && self <= 4294967295) || self.size() >
                             0
                       maxBufferSize:
+                        anyOf:
+                        - type: integer
+                        - type: string
                         description: |-
                           `maxBufferSize` defines the maximum HTTP body size that will be buffered
                           into memory.
@@ -5062,7 +5075,6 @@ spec:
                         maxLength: 32
                         minLength: 1
                         pattern: ^[+-]?([0-9]+(\.[0-9]*)?|\.[0-9]+)(([KMGTPE]i)|[numkMGTPE]|[eE](\+?0*([0-9]|1[0-8])|-0*[0-9]))?$
-                        type: string
                         x-kubernetes-int-or-string: true
                         x-kubernetes-validations:
                         - message: value must be at least 1 byte and fit within uint32
@@ -6561,6 +6573,9 @@ spec:
                                     If enabled, the request body will be buffered.
                                   properties:
                                     maxSize:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
                                       description: |-
                                         `maxSize` specifies, in bytes, the largest body that will be buffered
                                         and sent to the authorization server. If the body size is larger than
@@ -6568,7 +6583,6 @@ spec:
                                       maxLength: 32
                                       minLength: 1
                                       pattern: ^[+-]?([0-9]+(\.[0-9]*)?|\.[0-9]+)(([KMGTPE]i)|[numkMGTPE]|[eE](\+?0*([0-9]|1[0-8])|-0*[0-9]))?$
-                                      type: string
                                       x-kubernetes-int-or-string: true
                                       x-kubernetes-validations:
                                       - message: value must be at least 1 byte and
@@ -6717,6 +6731,9 @@ spec:
                           If enabled, the request body will be buffered.
                         properties:
                           maxSize:
+                            anyOf:
+                            - type: integer
+                            - type: string
                             description: |-
                               `maxSize` specifies, in bytes, the largest body that will be buffered
                               and sent to the authorization server. If the body size is larger than
@@ -6724,7 +6741,6 @@ spec:
                             maxLength: 32
                             minLength: 1
                             pattern: ^[+-]?([0-9]+(\.[0-9]*)?|\.[0-9]+)(([KMGTPE]i)|[numkMGTPE]|[eE](\+?0*([0-9]|1[0-8])|-0*[0-9]))?$
-                            type: string
                             x-kubernetes-int-or-string: true
                             x-kubernetes-validations:
                             - message: value must be at least 1 byte and fit within

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
@@ -5005,6 +5005,10 @@ spec:
                         type: string
                         x-kubernetes-int-or-string: true
                         x-kubernetes-validations:
+                        - message: http2FrameSize must be at least 16384 bytes
+                          rule: '!quantity(string(self)).isLessThan(quantity(''16384''))'
+                        - message: http2FrameSize must be at most 1677215 bytes
+                          rule: '!quantity(string(self)).isGreaterThan(quantity(''1677215''))'
                         - message: value must be at least 1 byte and fit within uint32
                           rule: (self >= 1 && self <= 4294967295) || self.size() >
                             0

--- a/controller/pkg/agentgateway/plugins/frontend_policies.go
+++ b/controller/pkg/agentgateway/plugins/frontend_policies.go
@@ -371,7 +371,7 @@ func castUint32[T ~int32](ka *T) *uint32 {
 }
 
 func quantityUint32(ka *agentgateway.ByteSize) *uint32 {
-	return new((*ka).ClampedValue())
+	return ka.ClampedValue()
 }
 
 func translateFrontendTLS(policy *agentgateway.AgentgatewayPolicy, name string) *api.Policy {

--- a/controller/pkg/agentgateway/plugins/traffic_plugin.go
+++ b/controller/pkg/agentgateway/plugins/traffic_plugin.go
@@ -1079,8 +1079,12 @@ func buildExtAuthSpec(
 		}
 	}
 	if b := extAuth.ForwardBody; b != nil {
+		maxRequestBytes := uint32(0)
+		if v := b.MaxSize.ClampedValue(); v != nil {
+			maxRequestBytes = *v
+		}
 		spec.IncludeRequestBody = &api.TrafficPolicySpec_ExternalAuth_BodyOptions{
-			MaxRequestBytes: b.MaxSize.ClampedValue(),
+			MaxRequestBytes: maxRequestBytes,
 			// Currently the default, see https://github.com/kubernetes-sigs/gateway-api/issues/4198
 			AllowPartialMessage: true,
 			// TODO: should we allow config?

--- a/controller/pkg/agentgateway/plugins/traffic_plugin.go
+++ b/controller/pkg/agentgateway/plugins/traffic_plugin.go
@@ -1079,7 +1079,7 @@ func buildExtAuthSpec(
 		}
 	}
 	if b := extAuth.ForwardBody; b != nil {
-		maxRequestBytes := uint32(0)
+		maxRequestBytes := uint32(8192)
 		if v := b.MaxSize.ClampedValue(); v != nil {
 			maxRequestBytes = *v
 		}

--- a/controller/test/e2e/features/agentgateway/suite.go
+++ b/controller/test/e2e/features/agentgateway/suite.go
@@ -4,6 +4,7 @@ package agentgateway
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/stretchr/testify/suite"
@@ -120,4 +121,65 @@ func (s *testingSuite) TestAgentgatewayHTTPRoute() {
 		curl.WithHostHeader("www.example.com"),
 		curl.WithPath("/status/200"),
 	)
+}
+
+func (s *testingSuite) TestAgentgatewayPolicyQuantityApply() {
+	tests := []struct {
+		name      string
+		quantity  string
+		wantApply bool
+	}{
+		{
+			name:      "invalid-int",
+			quantity:  "0",
+			wantApply: false,
+		},
+		{
+			name:      "invalid-string",
+			quantity:  "not-a-quantity",
+			wantApply: false,
+		},
+		{
+			name:      "valid-int",
+			quantity:  "1024",
+			wantApply: true,
+		},
+		{
+			name:      "valid-string",
+			quantity:  "64Ki",
+			wantApply: true,
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			manifest := quantityPolicyManifest(tt.name, tt.quantity)
+			err := s.TestInstallation.Actions.Kubectl().Apply(s.Ctx, []byte(manifest))
+			if tt.wantApply {
+				s.Require().NoError(err)
+				s.T().Cleanup(func() {
+					_ = s.TestInstallation.Actions.Kubectl().Delete(s.Ctx, []byte(manifest))
+				})
+				return
+			}
+			s.Require().Error(err)
+		})
+	}
+}
+
+func quantityPolicyManifest(name, quantity string) string {
+	return fmt.Sprintf(`apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: quantity-%s
+  namespace: agentgateway-base
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: gateway
+  frontend:
+    http:
+      maxBufferSize: %s
+`, name, quantity)
 }

--- a/controller/test/e2e/features/agentgateway/suite.go
+++ b/controller/test/e2e/features/agentgateway/suite.go
@@ -17,6 +17,7 @@ import (
 	"github.com/agentgateway/agentgateway/controller/test/e2e/common"
 	"github.com/agentgateway/agentgateway/controller/test/e2e/tests/base"
 	"github.com/agentgateway/agentgateway/controller/test/gomega/matchers"
+	"github.com/agentgateway/agentgateway/controller/test/testutils"
 )
 
 type testingSuite struct {
@@ -157,7 +158,8 @@ func (s *testingSuite) TestAgentgatewayPolicyQuantityApply() {
 			err := s.TestInstallation.Actions.Kubectl().Apply(s.Ctx, []byte(manifest))
 			if tt.wantApply {
 				s.Require().NoError(err)
-				s.T().Cleanup(func() {
+
+				testutils.Cleanup(s.T(), func() {
 					_ = s.TestInstallation.Actions.Kubectl().Delete(s.Ctx, []byte(manifest))
 				})
 				return


### PR DESCRIPTION
Before Before: we use quantity(), perfect validation
Before this PR: we drop quantity() due to CEL cost bug; we can have json.Unmarshal fail on ByteSize

Now: we harden validation with a stricter regex (regex does not suffer
from CEL cost). If the regex somehow misses a case that is failing
unmarshal, we treat it as unset in the controller. I have fuzzed this
regex and not found any cases where this is possible.

However, there are a few cases of previously "valid" values that ARE now
rejected: these are so niche I think this is not a problem:

```
+
-
.
+.
-.
m
Ki
Ti
e1
.e1
1e19
1e9223372036854775807
```

Signed-off-by: John Howard <john.howard@solo.io>
