### PR TITLE
Add design document template

### DIFF
--- a/design/README.md
+++ b/design/README.md
@@ -1,0 +1,34 @@
+# Design Documents
+
+Design documents capture proposed changes that need more context than a GitHub issue or pull request can comfortably
+hold. They are point-in-time proposals, so the current implementation may differ after review or implementation.
+
+## Naming
+
+Use the following filename format:
+
+```text
+<number>-<kebab-case-title>.md
+```
+
+The number should be the related issue number. An issue must exist before adding a design document. For early
+drafts without a stable number, use `XXXX` and rename the file before merge.
+
+Examples:
+
+- `288-inferencepool-ai-policies.md`
+- `XXXX-new-routing-feature.md`
+
+## Template
+
+Start new design documents from [template.md](template.md). Keep the sections that help explain the proposal and remove
+sections that do not apply.
+
+At minimum, each design document should include:
+
+- A title that starts with `EP-<number>`.
+- Links to related issues or pull requests.
+- A status.
+- A date in `M/D/YYYY` format.
+- The standard note that the design may become outdated as implementation evolves.
+- A summary, goals, non-goals, design details, and test plan.

--- a/design/template.md
+++ b/design/template.md
@@ -1,0 +1,83 @@
+# EP-XXXX: Proposal Title
+
+- Issue: [#XXXX](https://github.com/agentgateway/agentgateway/issues/XXXX)
+- Related: N/A
+- Status: proposed
+- Date: M/D/YYYY
+
+> **Note:** This design reflects the proposal as of the date above. The current implementation may differ as the design
+> is implemented, reviewed, or revised.
+
+## Summary
+
+Briefly describe the problem and the proposed solution. Focus on what changes for users and maintainers.
+
+## Background
+
+Explain the current behavior, why it is insufficient, and any relevant prior work or related issues.
+
+## Goals
+
+- State the concrete outcomes this design is intended to deliver.
+- Prefer user or operator-based outcomes over implementation tasks.
+- Include enough detail that reviewers can tell whether the design solves the problem.
+
+## Non-Goals
+
+- List decisions that are intentionally out of scope.
+- Call out tempting follow-up work that should not block this proposal.
+- Be explicit about compatibility or migration work that is deferred.
+
+## API
+
+Describe user-facing API changes, configuration shape, validation rules, and examples.
+
+```yaml
+apiVersion: example.agentgateway.dev/v1alpha1
+kind: Example
+metadata:
+  name: example
+spec:
+  field: value
+```
+
+## Runtime Design
+
+Describe how the data plane, control plane, or both will implement the design.
+
+Include important internal types or pseudocode when it makes the design easier to review:
+
+```text
+request
+  -> select route
+  -> select backend
+  -> apply policy
+  -> call upstream
+```
+
+## Controller and xDS
+
+Describe controller translation, generated resources, xDS/proto changes, or schema changes. If none are needed, say so.
+
+## Policy Attachment
+
+Describe how policies attach to the new or changed resources. Include policy ordering if it matters.
+
+## Compatibility and Migration
+
+Explain how existing users are affected, whether behavior changes by default, and how users migrate to the new behavior.
+
+## Risks and Tradeoffs
+
+List known risks, implementation tradeoffs, and alternatives that were considered.
+
+## Test Plan
+
+- Add API validation tests for new fields or validation rules.
+- Add controller translation tests for generated resources.
+- Add data-plane tests for request and response behavior.
+- Add end-to-end tests for the primary user flow, when practical.
+
+## Open Questions
+
+- List unresolved questions that should be answered before implementation or merge.


### PR DESCRIPTION
- Added a `design/README.md` with naming guidance and usage expectations.
- Added a reusable `design/template.md` for new design proposals.

For context, this template is based on the InferencePool AI policies design work in https://github.com/agentgateway/agentgateway/pull/1734.
