### PR TITLE
controller: fix HTTPRoute --> AGBE cross namespace

### DIFF
--- a/controller/pkg/agentgateway/plugins/reference_indexes.go
+++ b/controller/pkg/agentgateway/plugins/reference_indexes.go
@@ -28,6 +28,13 @@ type ResolvedPolicySelectorTarget struct {
 }
 
 type ReferenceTypes struct {
+	// KnownFromReferences is the set of GroupKinds this controller understands
+	// as ReferenceGrant from entries.
+	KnownFromReferences sets.Set[schema.GroupKind]
+	// KnownToReferences is the set of GroupKinds this controller understands as
+	// ReferenceGrant to entries. Extension authors must add their kinds here
+	// when they need ReferenceGrant permission checks to recognize those targets.
+	KnownToReferences       sets.Set[schema.GroupKind]
 	PolicyTargets           func(krtctx krt.HandlerContext, namespace string, name gwv1.ObjectName, gk schema.GroupKind, sectionName *gwv1.SectionName) ([]*api.PolicyTarget, bool)
 	PolicyTargetsBySelector func(krtctx krt.HandlerContext, policyNamespace string, selector shared.LocalPolicyTargetSelectorWithSectionName) []ResolvedPolicySelectorTarget
 	PolicyBackend           func(krtctx krt.HandlerContext, defaultNamespace string, gk schema.GroupKind, name gwv1.ObjectName, namespace *gwv1.Namespace, port *gwv1.PortNumber) (*api.BackendReference, error)
@@ -63,6 +70,19 @@ func (e *BackendReferenceError) Error() string {
 
 func DefaultReferenceTypes(agw *AgwCollections) ReferenceTypes {
 	return ReferenceTypes{
+		KnownFromReferences: sets.New(
+			wellknown.GatewayGVK.GroupKind(),
+			wellknown.HTTPRouteGVK.GroupKind(),
+			wellknown.GRPCRouteGVK.GroupKind(),
+			wellknown.TCPRouteGVK.GroupKind(),
+			wellknown.TLSRouteGVK.GroupKind(),
+			wellknown.ListenerSetGVK.GroupKind(),
+		),
+		KnownToReferences: sets.New(
+			wellknown.ServiceGVK.GroupKind(),
+			wellknown.SecretGVK.GroupKind(),
+			wellknown.AgentgatewayBackendGVK.GroupKind(),
+		),
 		// AgentgatewayPolicy targets
 		PolicyTargets: func(krtctx krt.HandlerContext, namespace string, name gwv1.ObjectName, gk schema.GroupKind, sectionName *gwv1.SectionName) ([]*api.PolicyTarget, bool) {
 			key := namespace + "/" + string(name)

--- a/controller/pkg/agentgateway/translator/conversion.go
+++ b/controller/pkg/agentgateway/translator/conversion.go
@@ -578,8 +578,8 @@ func buildAgwHTTPDestination(
 	var res []*api.RouteBackend
 	for _, fwd := range forwardTo {
 		// Handle HTTPRoute backend refs as delegation (route group) references
-		ref := NormalizeReference(fwd.Group, fwd.Kind, wellknown.ServiceGVK)
-		if ref == wellknown.HTTPRouteGVK {
+		ref := NormalizeReference(fwd.Group, fwd.Kind, wellknown.ServiceGVK.GroupKind())
+		if ref == wellknown.HTTPRouteGVK.GroupKind() {
 			weight := int32(1)
 			if fwd.Weight != nil {
 				weight = *fwd.Weight
@@ -630,7 +630,7 @@ func buildAgwDestination(
 	rb := &api.RouteBackend{
 		Weight: weight,
 	}
-	ref := NormalizeReference(to.Group, to.Kind, wellknown.ServiceGVK)
+	ref := NormalizeReference(to.Group, to.Kind, wellknown.ServiceGVK.GroupKind())
 	// check if the reference is allowed
 	if toNs := to.Namespace; toNs != nil && string(*toNs) != ns {
 		if !ctx.Grants.BackendAllowed(ctx.Krt, k, to.Name, *toNs, ns, ref) {
@@ -642,7 +642,7 @@ func buildAgwDestination(
 			}
 		}
 	}
-	backendRef, err := ctx.References.RouteBackend(ctx.Krt, ns, ref.GroupKind(), to.Name, to.Namespace, to.Port)
+	backendRef, err := ctx.References.RouteBackend(ctx.Krt, ns, ref, to.Name, to.Namespace, to.Port)
 	// Even in the error case, we still populate a partial backend
 	rb.Backend = backendRef
 	if err != nil {
@@ -682,26 +682,18 @@ func buildAgwDestination(
 	return rb, nil
 }
 
-var knownReferences = sets.New(
-	wellknown.GatewayGVK,
-	wellknown.ListenerSetGVK,
-	wellknown.ServiceGVK,
-	wellknown.ServiceEntryGVK,
-	wellknown.SecretGVK,
-	wellknown.ConfigMapGVK,
-)
 var allowedParentReferences = sets.New(
-	wellknown.GatewayGVK,
-	wellknown.ListenerSetGVK,
-	wellknown.ServiceGVK,
-	wellknown.ServiceEntryGVK,
+	wellknown.GatewayGVK.GroupKind(),
+	wellknown.ListenerSetGVK.GroupKind(),
+	wellknown.ServiceGVK.GroupKind(),
+	wellknown.ServiceEntryGVK.GroupKind(),
 )
 
-// NormalizeReference normalizes group and kind references to a standard GVK format.
-// If group or kind are nil/empty, it uses the default GVK's group/kind.
+// NormalizeReference applies Gateway API group/kind defaulting.
+// If group or kind are nil/empty, it uses the default GroupKind's group/kind.
 // Empty group is treated as "core" API group.
-func NormalizeReference(group *gwv1.Group, kind *gwv1.Kind, defaultGVK schema.GroupVersionKind) schema.GroupVersionKind {
-	result := defaultGVK
+func NormalizeReference(group *gwv1.Group, kind *gwv1.Kind, defaultGK schema.GroupKind) schema.GroupKind {
+	result := defaultGK
 
 	if kind != nil && *kind != "" {
 		result.Kind = string(*kind)
@@ -716,18 +708,13 @@ func NormalizeReference(group *gwv1.Group, kind *gwv1.Kind, defaultGVK schema.Gr
 			result.Group = groupStr
 		}
 	}
-	for wk := range knownReferences {
-		if wk.Group == result.Group && wk.Kind == result.Kind {
-			return wk
-		}
-	}
 
 	return result
 }
 
 // ToInternalParentReference converts a gwv1.ParentReference to a TypedNamespacedName.
 func ToInternalParentReference(p gwv1.ParentReference, localNamespace string) (utils.TypedNamespacedName, error) {
-	ref := NormalizeReference(p.Group, p.Kind, wellknown.GatewayGVK)
+	ref := NormalizeReference(p.Group, p.Kind, wellknown.GatewayGVK.GroupKind())
 	if !allowedParentReferences.Contains(ref) {
 		return utils.TypedNamespacedName{}, fmt.Errorf("unsupported Parent: %v/%v", p.Group, p.Kind)
 	}
@@ -1365,8 +1352,8 @@ func buildCaCertificateReference(
 		Info: TLSInfo{},
 	}
 
-	switch NormalizeReference(&ref.Group, &ref.Kind, schema.GroupVersionKind{}) {
-	case wellknown.ConfigMapGVK:
+	switch NormalizeReference(&ref.Group, &ref.Kind, schema.GroupKind{}) {
+	case wellknown.ConfigMapGVK.GroupKind():
 		res.Kind = wellknown.ConfigMapGVK.Kind
 		cm := ptr.Flatten(krt.FetchOne(ctx, configMaps, krt.FilterObjectName(res.Source)))
 		if cm == nil {
@@ -1383,7 +1370,7 @@ func buildCaCertificateReference(
 			}
 		}
 		res.Info.CaCert = certInfo.Cert
-	case wellknown.SecretGVK:
+	case wellknown.SecretGVK.GroupKind():
 		res.Kind = wellknown.SecretGVK.Kind
 		scrt := ptr.Flatten(krt.FetchOne(ctx, secrets, krt.FilterObjectName(res.Source)))
 		if scrt == nil {
@@ -1422,7 +1409,7 @@ func buildSecretReference(
 	gw controllers.Object,
 	secrets krt.Collection[*corev1.Secret],
 ) (*SecretReference, *ConfigError) {
-	if NormalizeReference(ref.Group, ref.Kind, wellknown.SecretGVK) != wellknown.SecretGVK {
+	if NormalizeReference(ref.Group, ref.Kind, wellknown.SecretGVK.GroupKind()) != wellknown.SecretGVK.GroupKind() {
 		return nil, &ConfigError{Reason: InvalidTLS, Message: fmt.Sprintf("invalid certificate reference %v, only secret is allowed", objectReferenceString(ref))}
 	}
 

--- a/controller/pkg/agentgateway/translator/gateway_collection.go
+++ b/controller/pkg/agentgateway/translator/gateway_collection.go
@@ -450,7 +450,7 @@ func ListenerSetBuilder(
 	status := obj.Status.DeepCopy()
 
 	p := ls.ParentRef
-	if NormalizeReference(p.Group, p.Kind, wellknown.GatewayGVK) != wellknown.GatewayGVK {
+	if NormalizeReference(p.Group, p.Kind, wellknown.GatewayGVK.GroupKind()) != wellknown.GatewayGVK.GroupKind() {
 		// Cannot report status since we don't know if it is for us
 		return nil, nil
 	}

--- a/controller/pkg/agentgateway/translator/references_collection.go
+++ b/controller/pkg/agentgateway/translator/references_collection.go
@@ -5,6 +5,7 @@ import (
 
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/kube/krt"
+	"istio.io/istio/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	gwv1b1 "sigs.k8s.io/gateway-api/apis/v1beta1"
@@ -13,9 +14,9 @@ import (
 	"github.com/agentgateway/agentgateway/controller/pkg/wellknown"
 )
 
-// Reference stores a reference to a namespaced GVK, as used by ReferencePolicy
+// Reference stores a reference to a namespaced GroupKind, as used by ReferenceGrant.
 type Reference struct {
-	Kind      schema.GroupVersionKind
+	Kind      schema.GroupKind
 	Namespace gwv1b1.Namespace
 }
 
@@ -37,41 +38,34 @@ type ReferenceGrants struct {
 }
 
 // ReferenceGrantsCollection creates a collection of ReferenceGrant objects from a collection of ReferenceGrant objects.
-func ReferenceGrantsCollection(referenceGrants krt.Collection[*gwv1b1.ReferenceGrant], krtopts krtutil.KrtOptions) krt.Collection[ReferenceGrant] {
+func ReferenceGrantsCollection(
+	referenceGrants krt.Collection[*gwv1b1.ReferenceGrant],
+	knownFromReferences sets.Set[schema.GroupKind],
+	knownToReferences sets.Set[schema.GroupKind],
+	krtopts krtutil.KrtOptions,
+) krt.Collection[ReferenceGrant] {
 	return krt.NewManyCollection(referenceGrants, func(ctx krt.HandlerContext, obj *gwv1b1.ReferenceGrant) []ReferenceGrant {
 		rp := obj.Spec
 		results := make([]ReferenceGrant, 0, len(rp.From)*len(rp.To))
 		for _, from := range rp.From {
-			fromKey := Reference{
-				Namespace: from.Namespace,
-			}
-			if string(from.Group) == wellknown.GatewayGVK.Group && string(from.Kind) == wellknown.GatewayKind {
-				fromKey.Kind = wellknown.GatewayGVK
-			} else if string(from.Group) == wellknown.HTTPRouteGVK.Group && string(from.Kind) == wellknown.HTTPRouteKind {
-				fromKey.Kind = wellknown.HTTPRouteGVK
-			} else if string(from.Group) == wellknown.GRPCRouteGVK.Group && string(from.Kind) == wellknown.GRPCRouteKind {
-				fromKey.Kind = wellknown.GRPCRouteGVK
-			} else if string(from.Group) == wellknown.TLSRouteGVK.Group && string(from.Kind) == wellknown.TLSRouteKind {
-				fromKey.Kind = wellknown.TLSRouteGVK
-			} else if string(from.Group) == wellknown.TCPRouteGVK.Group && string(from.Kind) == wellknown.TCPRouteKind {
-				fromKey.Kind = wellknown.TCPRouteGVK
-			} else if string(from.Group) == wellknown.ListenerSetGVK.Group && string(from.Kind) == wellknown.ListenerSetKind {
-				fromKey.Kind = wellknown.ListenerSetGVK
-			} else {
-				// Not supported type. Not an error; may be for another controller
+			fromGK := schema.GroupKind{Group: string(from.Group), Kind: string(from.Kind)}
+			if !knownFromReferences.Contains(fromGK) {
+				// Not supported type. Not an error; may be for another controller.
 				continue
 			}
+			fromKey := Reference{
+				Kind:      fromGK,
+				Namespace: from.Namespace,
+			}
 			for _, to := range rp.To {
-				toKey := Reference{
-					Namespace: gwv1b1.Namespace(obj.Namespace),
-				}
-				if to.Group == "" && string(to.Kind) == wellknown.SecretGVK.Kind {
-					toKey.Kind = wellknown.SecretGVK
-				} else if to.Group == "" && string(to.Kind) == wellknown.ServiceKind {
-					toKey.Kind = wellknown.ServiceGVK
-				} else {
-					// Not supported type. Not an error; may be for another controller
+				toGK := schema.GroupKind{Group: string(to.Group), Kind: string(to.Kind)}
+				if !knownToReferences.Contains(toGK) {
+					// Not supported type. Not an error; may be for another controller.
 					continue
+				}
+				toKey := Reference{
+					Kind:      toGK,
+					Namespace: gwv1b1.Namespace(obj.Namespace),
 				}
 				rg := ReferenceGrant{
 					Source:      config.NamespacedName(obj),
@@ -125,8 +119,8 @@ func (g ReferenceGrant) ResourceName() string {
 
 // SecretAllowed checks if a secret is allowed to be used by a gateway
 func (refs ReferenceGrants) SecretAllowed(ctx krt.HandlerContext, kind schema.GroupVersionKind, secret types.NamespacedName, namespace string) bool {
-	from := Reference{Kind: kind, Namespace: gwv1b1.Namespace(namespace)}
-	to := Reference{Kind: wellknown.SecretGVK, Namespace: gwv1b1.Namespace(secret.Namespace)}
+	from := Reference{Kind: kind.GroupKind(), Namespace: gwv1b1.Namespace(namespace)}
+	to := Reference{Kind: wellknown.SecretGVK.GroupKind(), Namespace: gwv1b1.Namespace(secret.Namespace)}
 	pair := ReferencePair{From: from, To: to}
 	grants := krt.Fetch(ctx, refs.collection, krt.FilterIndex(refs.index, pair))
 	for _, g := range grants {
@@ -144,13 +138,13 @@ func (refs ReferenceGrants) BackendAllowed(
 	backendName gwv1b1.ObjectName,
 	backendNamespace gwv1b1.Namespace,
 	routeNamespace string,
-	refKind schema.GroupVersionKind,
+	refKind schema.GroupKind,
 ) bool {
-	if refKind == wellknown.HTTPRouteGVK {
+	if refKind == wellknown.HTTPRouteGVK.GroupKind() {
 		// ReferenceGrant not required for route delegation
 		return true
 	}
-	from := Reference{Kind: k, Namespace: gwv1b1.Namespace(routeNamespace)}
+	from := Reference{Kind: k.GroupKind(), Namespace: gwv1b1.Namespace(routeNamespace)}
 	to := Reference{Kind: refKind, Namespace: backendNamespace}
 	pair := ReferencePair{From: from, To: to}
 	grants := krt.Fetch(ctx, refs.collection, krt.FilterIndex(refs.index, pair))

--- a/controller/pkg/agentgateway/translator/route_collections.go
+++ b/controller/pkg/agentgateway/translator/route_collections.go
@@ -119,7 +119,7 @@ func isDelegatedChildHTTPRoute(obj *gwv1.HTTPRoute) bool {
 }
 func childAllowsParent(obj *gwv1.HTTPRoute, parentRef resolvedBinding) bool {
 	allowedParents := slices.MapFilter(obj.Spec.ParentRefs, func(ref gwv1.ParentReference) *types.NamespacedName {
-		if NormalizeReference(ref.Group, ref.Kind, wellknown.GatewayGVK) != wellknown.HTTPRouteGVK {
+		if NormalizeReference(ref.Group, ref.Kind, wellknown.GatewayGVK.GroupKind()) != wellknown.HTTPRouteGVK.GroupKind() {
 			return nil
 		}
 		return new(types.NamespacedName{
@@ -136,8 +136,8 @@ func childAllowsParent(obj *gwv1.HTTPRoute, parentRef resolvedBinding) bool {
 func extractHTTPRouteGroupRefs(rule gwv1.HTTPRouteRule, routeNamespace string) []routeGroupBindingKey {
 	var res []routeGroupBindingKey
 	for _, backend := range rule.BackendRefs {
-		ref := NormalizeReference(backend.Group, backend.Kind, wellknown.ServiceGVK)
-		if ref != wellknown.HTTPRouteGVK {
+		ref := NormalizeReference(backend.Group, backend.Kind, wellknown.ServiceGVK.GroupKind())
+		if ref != wellknown.HTTPRouteGVK.GroupKind() {
 			continue
 		}
 		namespace := routeNamespace
@@ -340,7 +340,7 @@ func buildDelegatedHTTPRoutes(
 		for _, rule := range obj.Spec.Rules {
 			for _, backend := range rule.BackendRefs {
 				ref, refNs, refName := GetBackendRef(backend)
-				if ref == wellknown.HTTPRouteGVK {
+				if ref == wellknown.HTTPRouteGVK.GroupKind() {
 					continue
 				}
 				backends.Insert(utils.TypedNamespacedName{
@@ -1067,7 +1067,7 @@ func extractAncestorBackends[T controllers.Object, RT, BT any](ctx RouteContext,
 	for _, r := range rules {
 		for _, b := range extract(r) {
 			ref, refNs, refName := GetBackendRef(b)
-			if ref == wellknown.HTTPRouteGVK {
+			if ref == wellknown.HTTPRouteGVK.GroupKind() {
 				continue
 			}
 			be := utils.TypedNamespacedName{
@@ -1095,16 +1095,16 @@ func extractAncestorBackends[T controllers.Object, RT, BT any](ctx RouteContext,
 	return res
 }
 
-func GetBackendRef[I any](spec I) (schema.GroupVersionKind, *gwv1.Namespace, gwv1.ObjectName) {
+func GetBackendRef[I any](spec I) (schema.GroupKind, *gwv1.Namespace, gwv1.ObjectName) {
 	switch t := any(spec).(type) {
 	case gwv1.HTTPBackendRef:
-		return NormalizeReference(t.Group, t.Kind, wellknown.ServiceGVK), t.Namespace, t.Name
+		return NormalizeReference(t.Group, t.Kind, wellknown.ServiceGVK.GroupKind()), t.Namespace, t.Name
 	case gwv1.GRPCBackendRef:
-		return NormalizeReference(t.Group, t.Kind, wellknown.ServiceGVK), t.Namespace, t.Name
+		return NormalizeReference(t.Group, t.Kind, wellknown.ServiceGVK.GroupKind()), t.Namespace, t.Name
 	case gwv1.BackendRef:
-		return NormalizeReference(t.Group, t.Kind, wellknown.ServiceGVK), t.Namespace, t.Name
+		return NormalizeReference(t.Group, t.Kind, wellknown.ServiceGVK.GroupKind()), t.Namespace, t.Name
 	default:
 		log.Fatalf("unknown GetBackendRef type %T", t)
-		return schema.GroupVersionKind{}, nil, ""
+		return schema.GroupKind{}, nil, ""
 	}
 }

--- a/controller/pkg/agentgateway/translator/testdata/routes/httproute-cross-namespace-backends.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/routes/httproute-cross-namespace-backends.yaml
@@ -1,0 +1,192 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cross-ns-with-grant
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cross-ns-without-grant
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: cross-ns-with-refgrant
+  namespace: default
+spec:
+  parentRefs:
+    - name: test-gateway
+  rules:
+    - backendRefs:
+        - name: cross-ns-service-with-grant
+          namespace: cross-ns-with-grant
+          port: 8080
+        - name: cross-ns-backend-with-grant
+          namespace: cross-ns-with-grant
+          group: agentgateway.dev
+          kind: AgentgatewayBackend
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: cross-ns-without-refgrant
+  namespace: default
+spec:
+  parentRefs:
+    - name: test-gateway
+  rules:
+    - backendRefs:
+        - name: cross-ns-service-without-grant
+          namespace: cross-ns-without-grant
+          port: 8080
+        - name: cross-ns-backend-without-grant
+          namespace: cross-ns-without-grant
+          group: agentgateway.dev
+          kind: AgentgatewayBackend
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cross-ns-service-with-grant
+  namespace: cross-ns-with-grant
+spec:
+  ports:
+    - port: 8080
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayBackend
+metadata:
+  name: cross-ns-backend-with-grant
+  namespace: cross-ns-with-grant
+spec:
+  static:
+    host: with-grant.example.com
+    port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: allow-default-httproute
+  namespace: cross-ns-with-grant
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: default
+  to:
+    - group: ""
+      kind: Service
+      name: cross-ns-service-with-grant
+    - group: agentgateway.dev
+      kind: AgentgatewayBackend
+      name: cross-ns-backend-with-grant
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cross-ns-service-without-grant
+  namespace: cross-ns-without-grant
+spec:
+  ports:
+    - port: 8080
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayBackend
+metadata:
+  name: cross-ns-backend-without-grant
+  namespace: cross-ns-without-grant
+spec:
+  static:
+    host: without-grant.example.com
+    port: 80
+
+---
+# Output
+output:
+- gateway:
+    Name: test-gateway
+    Namespace: default
+  resource:
+    route:
+      backends:
+      - backend:
+          port: 8080
+          service:
+            hostname: cross-ns-service-with-grant.cross-ns-with-grant.svc.cluster.local
+            namespace: cross-ns-with-grant
+        weight: 1
+      - backend:
+          backend: cross-ns-with-grant/cross-ns-backend-with-grant
+        weight: 1
+      key: default/cross-ns-with-refgrant.00.http
+      listenerKey: default/test-gateway.http
+      name:
+        kind: HTTPRoute
+        name: cross-ns-with-refgrant
+        namespace: default
+- gateway:
+    Name: test-gateway
+    Namespace: default
+  resource:
+    route:
+      backends:
+      - weight: 1
+      - weight: 1
+      key: default/cross-ns-without-refgrant.00.http
+      listenerKey: default/test-gateway.http
+      name:
+        kind: HTTPRoute
+        name: cross-ns-without-refgrant
+        namespace: default
+status:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    name: cross-ns-with-refgrant
+    namespace: default
+  spec: null
+  status:
+    parents:
+    - conditions:
+      - lastTransitionTime: fake
+        message: ""
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: ""
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      controllerName: agentgateway.dev/agentgateway
+      parentRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: test-gateway
+        namespace: default
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    name: cross-ns-without-refgrant
+    namespace: default
+  spec: null
+  status:
+    parents:
+    - conditions:
+      - lastTransitionTime: fake
+        message: ""
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: backendRef cross-ns-backend-without-grant/cross-ns-without-grant
+          not accessible to a HTTPRoute in namespace "default" (missing a ReferenceGrant?)
+        reason: RefNotPermitted
+        status: "False"
+        type: ResolvedRefs
+      controllerName: agentgateway.dev/agentgateway
+      parentRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: test-gateway
+        namespace: default

--- a/controller/pkg/syncer/syncer.go
+++ b/controller/pkg/syncer/syncer.go
@@ -138,8 +138,17 @@ type CustomResourceCollectionsConfig struct {
 
 func (s *Syncer) buildResourceCollections(krtopts krtutil.KrtOptions) {
 	// Build core collections for irs
+	referenceTypes := plugins.DefaultReferenceTypes(s.agwCollections)
+	if s.buildReferenceTypesFunc != nil {
+		referenceTypes = s.buildReferenceTypesFunc(s.agwCollections, referenceTypes)
+	}
 	gatewayClasses := translator.GatewayClassesCollection(s.agwCollections.GatewayClasses, krtopts)
-	refGrants := translator.BuildReferenceGrants(translator.ReferenceGrantsCollection(s.agwCollections.ReferenceGrants, krtopts))
+	refGrants := translator.BuildReferenceGrants(translator.ReferenceGrantsCollection(
+		s.agwCollections.ReferenceGrants,
+		referenceTypes.KnownFromReferences,
+		referenceTypes.KnownToReferences,
+		krtopts,
+	))
 	listenerSetInitialStatus, listenerSets := s.buildListenerSetCollection(gatewayClasses, refGrants, krtopts)
 	if s.customResourceCollections != nil {
 		s.customResourceCollections(CustomResourceCollectionsConfig{
@@ -159,7 +168,7 @@ func (s *Syncer) buildResourceCollections(krtopts krtutil.KrtOptions) {
 	gatewayInitialStatus, gateways := s.buildGatewayCollection(gatewayClasses, listenerSets, refGrants, krtopts)
 
 	// Build Agw resources for gateway
-	agwResources, routeAttachments, ancestorCollection := s.buildAgwResources(gateways, listenerSets, refGrants, krtopts)
+	agwResources, routeAttachments, ancestorCollection := s.buildAgwResources(gateways, listenerSets, refGrants, referenceTypes, krtopts)
 
 	gatewayFinalStatus := s.buildFinalGatewayStatus(gatewayInitialStatus, routeAttachments, krtopts)
 	status.RegisterStatus(s.statusCollections, gatewayFinalStatus, translator.GetStatus)
@@ -403,6 +412,7 @@ func (s *Syncer) buildAgwResources(
 	gateways krt.Collection[*translator.GatewayListener],
 	listenerSets krt.Collection[translator.ListenerSet],
 	refGrants translator.ReferenceGrants,
+	referenceTypes plugins.ReferenceTypes,
 	krtopts krtutil.KrtOptions,
 ) (krt.Collection[agwir.AgwResource], krt.Collection[*plugins.RouteAttachment], plugins.ReferenceIndex) {
 	// filter gateway collections to only include gateways which use a built-in gateway class
@@ -477,11 +487,6 @@ func (s *Syncer) buildAgwResources(
 			}
 		}
 		routeParents = &translator.CompositeParentResolver{Resolvers: resolvers}
-	}
-
-	referenceTypes := plugins.DefaultReferenceTypes(s.agwCollections)
-	if s.buildReferenceTypesFunc != nil {
-		referenceTypes = s.buildReferenceTypesFunc(s.agwCollections, referenceTypes)
 	}
 
 	routeInputs := translator.RouteContextInputs{


### PR DESCRIPTION
This before was impossible to use; always failed. Not allowed with
RefGrant.

Before the RefGrant type list was hardcoded and didn't permit this

Signed-off-by: John Howard <john.howard@solo.io>
