### PR TITLE
Fix hostRewrite for MCP and Services

### DIFF
--- a/controller/test/e2e/features/agentgateway/hostrewrite/suite.go
+++ b/controller/test/e2e/features/agentgateway/hostrewrite/suite.go
@@ -1,0 +1,53 @@
+//go:build e2e
+
+package hostrewrite
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/onsi/gomega"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/agentgateway/agentgateway/controller/pkg/utils/requestutils/curl"
+	"github.com/agentgateway/agentgateway/controller/test/e2e"
+	"github.com/agentgateway/agentgateway/controller/test/e2e/common"
+	"github.com/agentgateway/agentgateway/controller/test/e2e/tests/base"
+	"github.com/agentgateway/agentgateway/controller/test/gomega/matchers"
+)
+
+var _ e2e.NewSuiteFunc = NewTestingSuite
+
+type testingSuite struct {
+	*base.BaseTestingSuite
+}
+
+func NewTestingSuite(ctx context.Context, testInst *e2e.TestInstallation) suite.TestingSuite {
+	return &testingSuite{
+		BaseTestingSuite: base.NewBaseTestingSuite(ctx, testInst, setup, testCases),
+	}
+}
+
+func (s *testingSuite) TestServiceBackendHostRewrite() {
+	s.assertHostRewrite(svcDefaultHost, svcDefaultHost)
+	s.assertHostRewrite(svcNoneHost, svcNoneHost)
+	s.assertHostRewrite(svcAutoHost, backendHost)
+}
+
+func (s *testingSuite) TestAgentgatewayBackendHostRewrite() {
+	s.assertHostRewrite(agbeDefaultHost, backendHost)
+	s.assertHostRewrite(agbeNoneHost, agbeNoneHost)
+	s.assertHostRewrite(agbeAutoHost, backendHost)
+}
+
+func (s *testingSuite) assertHostRewrite(routeHost string, expectedUpstreamHost string) {
+	common.BaseGateway.Send(
+		s.T(),
+		&matchers.HttpResponse{
+			StatusCode: http.StatusOK,
+			Body:       gomega.ContainSubstring("Host=" + expectedUpstreamHost),
+		},
+		curl.WithHostHeader(routeHost),
+		curl.WithPath("/"),
+	)
+}

--- a/controller/test/e2e/features/agentgateway/hostrewrite/testdata/agbe-routes.yaml
+++ b/controller/test/e2e/features/agentgateway/hostrewrite/testdata/agbe-routes.yaml
@@ -1,0 +1,85 @@
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayBackend
+metadata:
+  name: hostrewrite-static-backend
+  namespace: agentgateway-base
+spec:
+  static:
+    host: backend.agentgateway-base.svc.cluster.local
+    port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: hostrewrite-agbe-default
+  namespace: agentgateway-base
+spec:
+  parentRefs:
+    - name: gateway
+  hostnames:
+    - "agbe-default.hostrewrite.test"
+  rules:
+    - backendRefs:
+        - group: agentgateway.dev
+          kind: AgentgatewayBackend
+          name: hostrewrite-static-backend
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: hostrewrite-agbe-none
+  namespace: agentgateway-base
+spec:
+  parentRefs:
+    - name: gateway
+  hostnames:
+    - "agbe-none.hostrewrite.test"
+  rules:
+    - backendRefs:
+        - group: agentgateway.dev
+          kind: AgentgatewayBackend
+          name: hostrewrite-static-backend
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: hostrewrite-agbe-none
+  namespace: agentgateway-base
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: hostrewrite-agbe-none
+  traffic:
+    hostRewrite:
+      mode: None
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: hostrewrite-agbe-auto
+  namespace: agentgateway-base
+spec:
+  parentRefs:
+    - name: gateway
+  hostnames:
+    - "agbe-auto.hostrewrite.test"
+  rules:
+    - backendRefs:
+        - group: agentgateway.dev
+          kind: AgentgatewayBackend
+          name: hostrewrite-static-backend
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: hostrewrite-agbe-auto
+  namespace: agentgateway-base
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: hostrewrite-agbe-auto
+  traffic:
+    hostRewrite:
+      mode: Auto

--- a/controller/test/e2e/features/agentgateway/hostrewrite/testdata/service-routes.yaml
+++ b/controller/test/e2e/features/agentgateway/hostrewrite/testdata/service-routes.yaml
@@ -1,0 +1,72 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: hostrewrite-svc-default
+  namespace: agentgateway-base
+spec:
+  parentRefs:
+    - name: gateway
+  hostnames:
+    - "svc-default.hostrewrite.test"
+  rules:
+    - backendRefs:
+        - name: backend
+          port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: hostrewrite-svc-none
+  namespace: agentgateway-base
+spec:
+  parentRefs:
+    - name: gateway
+  hostnames:
+    - "svc-none.hostrewrite.test"
+  rules:
+    - backendRefs:
+        - name: backend
+          port: 80
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: hostrewrite-svc-none
+  namespace: agentgateway-base
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: hostrewrite-svc-none
+  traffic:
+    hostRewrite:
+      mode: None
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: hostrewrite-svc-auto
+  namespace: agentgateway-base
+spec:
+  parentRefs:
+    - name: gateway
+  hostnames:
+    - "svc-auto.hostrewrite.test"
+  rules:
+    - backendRefs:
+        - name: backend
+          port: 80
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: hostrewrite-svc-auto
+  namespace: agentgateway-base
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: hostrewrite-svc-auto
+  traffic:
+    hostRewrite:
+      mode: Auto

--- a/controller/test/e2e/features/agentgateway/hostrewrite/types.go
+++ b/controller/test/e2e/features/agentgateway/hostrewrite/types.go
@@ -1,0 +1,40 @@
+//go:build e2e
+
+package hostrewrite
+
+import (
+	"path/filepath"
+
+	"github.com/agentgateway/agentgateway/controller/pkg/utils/fsutils"
+	"github.com/agentgateway/agentgateway/controller/test/e2e/tests/base"
+)
+
+const (
+	backendHost     = "backend.agentgateway-base.svc.cluster.local"
+	svcDefaultHost  = "svc-default.hostrewrite.test"
+	svcNoneHost     = "svc-none.hostrewrite.test"
+	svcAutoHost     = "svc-auto.hostrewrite.test"
+	agbeDefaultHost = "agbe-default.hostrewrite.test"
+	agbeNoneHost    = "agbe-none.hostrewrite.test"
+	agbeAutoHost    = "agbe-auto.hostrewrite.test"
+)
+
+var (
+	serviceRoutesManifest = getTestFile("service-routes.yaml")
+	agbeRoutesManifest    = getTestFile("agbe-routes.yaml")
+
+	setup = base.TestCase{}
+
+	testCases = map[string]*base.TestCase{
+		"TestServiceBackendHostRewrite": {
+			Manifests: []string{serviceRoutesManifest},
+		},
+		"TestAgentgatewayBackendHostRewrite": {
+			Manifests: []string{agbeRoutesManifest},
+		},
+	}
+)
+
+func getTestFile(filename string) string {
+	return filepath.Join(fsutils.MustGetThisDir(), "testdata", filename)
+}

--- a/controller/test/e2e/tests/agent_gateway_tests.go
+++ b/controller/test/e2e/tests/agent_gateway_tests.go
@@ -14,6 +14,7 @@ import (
 	"github.com/agentgateway/agentgateway/controller/test/e2e/features/agentgateway/delegation"
 	"github.com/agentgateway/agentgateway/controller/test/e2e/features/agentgateway/extauth"
 	"github.com/agentgateway/agentgateway/controller/test/e2e/features/agentgateway/extproc"
+	"github.com/agentgateway/agentgateway/controller/test/e2e/features/agentgateway/hostrewrite"
 	"github.com/agentgateway/agentgateway/controller/test/e2e/features/agentgateway/jwtauth"
 	"github.com/agentgateway/agentgateway/controller/test/e2e/features/agentgateway/locality"
 	"github.com/agentgateway/agentgateway/controller/test/e2e/features/agentgateway/mcp"
@@ -40,6 +41,7 @@ func AgentgatewaySuiteRunner() e2e.SuiteRunner {
 	agentgatewaySuiteRunner.Register("Delegation", delegation.NewTestingSuite)
 	agentgatewaySuiteRunner.Register("Extauth", extauth.NewTestingSuite)
 	agentgatewaySuiteRunner.Register("Extproc", extproc.NewTestingSuite)
+	agentgatewaySuiteRunner.Register("HostRewrite", hostrewrite.NewTestingSuite)
 	agentgatewaySuiteRunner.Register("LocalRateLimit", local_rate_limit.NewTestingSuite)
 	agentgatewaySuiteRunner.Register("GlobalRateLimit", global_rate_limit.NewTestingSuite)
 	agentgatewaySuiteRunner.Register("RBAC", rbac.NewTestingSuite)

--- a/crates/agentgateway/src/client/mod.rs
+++ b/crates/agentgateway/src/client/mod.rs
@@ -599,9 +599,14 @@ impl Client {
 			.connector
 			.resolve_target(transport.skip_dns_resolution(), &target)
 			.await?;
-		let auto_host = req.extensions().get::<filters::AutoHostname>().is_some();
+		let auto_host_authority =
+			auto_hostname_authority(&req, &target).map_err(ProxyError::Processing)?;
 		http::modify_req_uri(&mut req, |uri| {
 			let scheme = transport.scheme();
+			if let Some(authority) = auto_host_authority.clone() {
+				uri.authority = Some(authority);
+			}
+
 			// Strip the port from the hostname if its the default already
 			// The hyper client does this for HTTP/1.1 but not for HTTP2
 			if let Some(a) = uri.authority.as_mut()
@@ -612,15 +617,12 @@ impl Client {
 			}
 			uri.scheme = Some(scheme);
 
-			if let Target::Hostname(h, _) = &target
-				&& auto_host
-				&& let Some(a) = uri.authority.as_mut()
-			{
-				*a = Authority::from_str(h)?
-			}
 			Ok(())
 		})
 		.map_err(ProxyError::Processing)?;
+		if req.extensions().get::<filters::AutoHostname>().is_some() {
+			req.headers_mut().remove(::http::header::HOST);
+		}
 		let version = req.version();
 		let transport_name = transport.name();
 		// We are going to do a HTTP absolute form tunnel request. For CONNECT this is handled
@@ -698,9 +700,30 @@ impl Client {
 	}
 }
 
+fn auto_hostname_authority(
+	req: &http::Request,
+	target: &Target,
+) -> anyhow::Result<Option<Authority>> {
+	if req.extensions().get::<filters::AutoHostname>().is_none() {
+		return Ok(None);
+	}
+	if let Some(h) = req
+		.extensions()
+		.get::<filters::AutoHostname>()
+		.and_then(|auto| auto.target.as_ref())
+	{
+		return Ok(Some(Authority::from_str(h)?));
+	}
+	if let Target::Hostname(h, _) = target {
+		return Ok(Some(Authority::from_str(h)?));
+	}
+	Ok(None)
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use crate::http::filters::AutoHostname;
 	use crate::types::agent::TunnelProtocol;
 
 	#[test]
@@ -728,5 +751,60 @@ mod tests {
 				"tunnel protocol {tp:?} should map to no source role",
 			);
 		}
+	}
+
+	#[test]
+	fn auto_hostname_uses_explicit_target_for_address_backend() {
+		let mut req = ::http::Request::builder()
+			.uri("http://original.example/")
+			.body(http::Body::empty())
+			.unwrap();
+		req.extensions_mut().insert(AutoHostname {
+			explicit: true,
+			target: Some(strng::literal!("svc.default.svc.cluster.local")),
+		});
+		let target = Target::Address("127.0.0.1:8080".parse().unwrap());
+
+		assert_eq!(
+			auto_hostname_authority(&req, &target)
+				.unwrap()
+				.map(|a| a.to_string()),
+			Some("svc.default.svc.cluster.local".to_string())
+		);
+	}
+
+	#[test]
+	fn auto_hostname_uses_hostname_backend_without_explicit_target() {
+		let mut req = ::http::Request::builder()
+			.uri("http://original.example/")
+			.body(http::Body::empty())
+			.unwrap();
+		req.extensions_mut().insert(AutoHostname {
+			explicit: false,
+			target: None,
+		});
+		let target = Target::Hostname(strng::literal!("backend.example"), 8080);
+
+		assert_eq!(
+			auto_hostname_authority(&req, &target)
+				.unwrap()
+				.map(|a| a.to_string()),
+			Some("backend.example".to_string())
+		);
+	}
+
+	#[test]
+	fn auto_hostname_does_not_rewrite_address_backend_without_explicit_target() {
+		let mut req = ::http::Request::builder()
+			.uri("http://original.example/")
+			.body(http::Body::empty())
+			.unwrap();
+		req.extensions_mut().insert(AutoHostname {
+			explicit: false,
+			target: None,
+		});
+		let target = Target::Address("127.0.0.1:8080".parse().unwrap());
+
+		assert!(auto_hostname_authority(&req, &target).unwrap().is_none());
 	}
 }

--- a/crates/agentgateway/src/http/filters.rs
+++ b/crates/agentgateway/src/http/filters.rs
@@ -201,9 +201,15 @@ pub struct UrlRewrite {
 #[derive(Debug, Clone)]
 pub struct OriginalUrl(pub Uri);
 
-/// AutoHostname is an HTTP Extension that signals that auto-hostname rewrite should be used
+/// AutoHostname is an HTTP Extension that signals that auto-hostname rewrite should be used.
 #[derive(Debug, Clone)]
-pub struct AutoHostname();
+pub struct AutoHostname {
+	/// True when auto-hostname rewrite was explicitly configured, rather than only applied as the
+	/// default.
+	pub explicit: bool,
+	/// Hostname to use when the network target is not itself hostname-based.
+	pub target: Option<Strng>,
+}
 
 /// BackendRequestTimeout is an HTTP Extension that signals the backend request timeout to use for backend calls.
 #[derive(Debug, Clone)]

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -238,7 +238,7 @@ async fn stateless_multiplex_delete_session_skips_uninitialized_targets() {
 	let mut session = session_manager.create_stateless_session(relay);
 	let parts = ::http::Request::<()>::builder()
 		.method(http::Method::POST)
-		.uri("http://example.test/mcp")
+		.uri("http://localhost/mcp")
 		.body(())
 		.unwrap()
 		.into_parts()

--- a/crates/agentgateway/src/mcp/upstream/mod.rs
+++ b/crates/agentgateway/src/mcp/upstream/mod.rs
@@ -26,6 +26,7 @@ use crate::*;
 pub struct IncomingRequestContext {
 	headers: http::HeaderMap,
 	ext: ::http::Extensions,
+	authority: Option<::http::uri::Authority>,
 }
 
 impl IncomingRequestContext {
@@ -34,15 +35,33 @@ impl IncomingRequestContext {
 		Self {
 			headers: http::HeaderMap::new(),
 			ext: ::http::Extensions::new(),
+			authority: None,
 		}
 	}
 	pub fn new(parts: &::http::request::Parts) -> Self {
 		Self {
 			headers: parts.headers.clone(),
 			ext: parts.extensions.clone(),
+			authority: parts.uri.authority().cloned(),
 		}
 	}
-	pub fn apply(&self, req: &mut http::Request) {
+	pub fn apply(&self, req: &mut http::Request) -> anyhow::Result<()> {
+		req.extensions_mut().extend(self.ext.clone());
+		let explicit_auto_hostname = req
+			.extensions()
+			.get::<crate::http::filters::AutoHostname>()
+			.is_some_and(|auto| auto.explicit);
+		if explicit_auto_hostname {
+			let authority = req.uri().authority().map(|a| strng::new(a.as_str()));
+			if let Some(authority) = authority
+				&& let Some(auto) = req
+					.extensions_mut()
+					.get_mut::<crate::http::filters::AutoHostname>()
+				&& auto.target.is_none()
+			{
+				auto.target = Some(authority);
+			}
+		}
 		for (k, v) in &self.headers {
 			// Remove headers we do not want to propagate to the backend
 			if k == http::header::CONTENT_ENCODING || k == http::header::CONTENT_LENGTH {
@@ -52,7 +71,13 @@ impl IncomingRequestContext {
 				req.headers_mut().insert(k.clone(), v.clone());
 			}
 		}
-		req.extensions_mut().extend(self.ext.clone());
+		let Some(authority) = self.authority.clone() else {
+			return Ok(());
+		};
+		http::modify_req_uri(req, |uri| {
+			uri.authority = Some(authority);
+			Ok(())
+		})
 	}
 }
 
@@ -383,5 +408,34 @@ impl UpstreamGroup {
 		};
 
 		Ok(target)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn incoming_request_context_applies_original_authority() {
+		let parts = ::http::Request::builder()
+			.uri("http://original.example/mcp")
+			.body(())
+			.unwrap()
+			.into_parts()
+			.0;
+		let ctx = IncomingRequestContext::new(&parts);
+		let mut req = ::http::Request::builder()
+			.uri("http://svc.default.svc.cluster.local:80/mcp")
+			.body(crate::http::Body::empty())
+			.unwrap();
+
+		ctx.apply(&mut req).unwrap();
+
+		assert_eq!(
+			req.uri().authority().map(|a| a.as_str()),
+			Some("original.example")
+		);
+		assert_eq!(req.headers().get(http::header::HOST), None);
+		assert_eq!(req.uri().path(), "/mcp");
 	}
 }

--- a/crates/agentgateway/src/mcp/upstream/openapi/mod.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/mod.rs
@@ -853,7 +853,7 @@ impl Handler {
 			.body(body.into())
 			.map_err(|e| anyhow::anyhow!("Failed to build request: {}", e))?;
 
-		ctx.apply(&mut request);
+		ctx.apply(&mut request)?;
 
 		// First header set wins including headers set by ctx.apply or the gateway
 		for (key, value) in &header_params {

--- a/crates/agentgateway/src/mcp/upstream/sse.rs
+++ b/crates/agentgateway/src/mcp/upstream/sse.rs
@@ -90,7 +90,7 @@ impl ClientCore {
 			.body(body.into())
 			.map_err(ClientError::new)?;
 
-		ctx.apply(&mut req);
+		ctx.apply(&mut req).map_err(ClientError::new)?;
 
 		let resp = self.http_client.call(req).await.map_err(ClientError::new)?;
 
@@ -113,7 +113,7 @@ impl ClientCore {
 			.body(http::Body::empty())
 			.map_err(ClientError::new)?;
 
-		ctx.apply(&mut req);
+		ctx.apply(&mut req).map_err(ClientError::new)?;
 
 		let resp = self.http_client.call(req).await?;
 

--- a/crates/agentgateway/src/mcp/upstream/streamablehttp.rs
+++ b/crates/agentgateway/src/mcp/upstream/streamablehttp.rs
@@ -92,7 +92,7 @@ impl Client {
 
 		self.maybe_insert_session_id(&mut req)?;
 
-		ctx.apply(&mut req);
+		ctx.apply(&mut req).map_err(ClientError::new)?;
 
 		let resp = self.http_client.call(req).await?;
 
@@ -159,7 +159,7 @@ impl Client {
 
 		self.maybe_insert_session_id(&mut req)?;
 
-		ctx.apply(&mut req);
+		ctx.apply(&mut req).map_err(ClientError::new)?;
 
 		let resp = self.http_client.call(req).await?;
 
@@ -181,7 +181,7 @@ impl Client {
 
 		self.maybe_insert_session_id(&mut req)?;
 
-		ctx.apply(&mut req);
+		ctx.apply(&mut req).map_err(ClientError::new)?;
 
 		let resp = self.http_client.call(req).await?;
 

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -207,7 +207,10 @@ async fn apply_request_policies(
 	// Enable Auto Hostname rewrite by default. This may be disabled by a URL Rewrite, or explicitly
 	// setting hostname_rewrite = None
 	if pol.hostname_rewrite.unwrap_or(HostRedirectOverride::Auto) == HostRedirectOverride::Auto {
-		req.extensions_mut().insert(AutoHostname());
+		req.extensions_mut().insert(AutoHostname {
+			explicit: pol.hostname_rewrite == Some(HostRedirectOverride::Auto),
+			target: None,
+		});
 	}
 	pol
 		.url_rewrite
@@ -1561,16 +1564,25 @@ async fn make_backend_call(
 				waypoint: None,
 			}
 		},
-		Backend::Service(svc, port) => build_service_call(
-			&inputs,
-			policies,
-			&mut log,
-			service_override,
-			svc,
-			port,
-			req.uri().host(),
-			hbone_source,
-		)?,
+		Backend::Service(svc, port) => {
+			// If user explicitly set auto hostname, we support it for Service.
+			// Otherwise, the implicit default only applies to AgentgatewayBackend.
+			if let Some(auto) = req.extensions_mut().get_mut::<AutoHostname>()
+				&& auto.explicit
+			{
+				auto.target = Some(svc.hostname.clone());
+			}
+			build_service_call(
+				&inputs,
+				policies,
+				&mut log,
+				service_override,
+				svc,
+				port,
+				req.uri().host(),
+				hbone_source,
+			)?
+		},
 		Backend::Opaque(_, target) => BackendCall {
 			target: target.clone(),
 			http_version_override: None,


### PR DESCRIPTION
Fix explicit `hostRewrite.mode: Auto` for MCP upstreams so Service-backed MCP targets use the Kubernetes Service hostname as upstream authority, even when endpoint selection routes to a concrete pod IP.

**Details**

- Preserve the intended MCP upstream authority by carrying it through `AutoHostname.target`.
- Avoid restoring downstream authority for explicit Auto in MCP synthetic upstream requests.
- Remove stale downstream `Host` when Auto hostname rewrite is active so the lowest HTTP client layer derives `Host` from the final URI authority.
- Extend Auto handling so explicit Auto can rewrite address-backed Service calls to the Service hostname without affecting implicit/default Auto behavior.

Signed-off-by: John Howard <john.howard@solo.io>
