### PR TITLE
controller/test/e2e: test switching between mcp types

### DIFF
--- a/controller/test/e2e/features/agentgateway/mcp/suite.go
+++ b/controller/test/e2e/features/agentgateway/mcp/suite.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/onsi/gomega"
 	"github.com/stretchr/testify/suite"
@@ -23,8 +24,9 @@ func NewTestingSuite(ctx context.Context, testInst *e2e.TestInstallation) suite.
 	return &testingSuite{
 		BaseTestingSuite: base.NewBaseTestingSuite(ctx, testInst, setup, map[string]*base.TestCase{
 			// Static tests
-			"TestMCPWorkflow": &staticSetup,
-			"TestSSEEndpoint": &staticSetup,
+			"TestMCPWorkflow":           &staticSetup,
+			"TestSSEEndpoint":           &staticSetup,
+			"TestMCPSeamlessSwitchover": &switchSetup,
 			// Dynamic tests
 			"TestDynamicMCPAdminRouting":     &dynamicSetup,
 			"TestDynamicMCPUserRouting":      &dynamicSetup,
@@ -173,6 +175,35 @@ func (s *testingSuite) TestSSEEndpoint() {
 	}, headers, initBody)
 
 	_ = s.initializeSession(initBody, headers, "sse")
+}
+
+func (s *testingSuite) TestMCPSeamlessSwitchover() {
+	s.waitStaticReady()
+
+	initRequest := buildInitializeRequest("switch-client", 1)
+	headers := mcpHeaders(nil)
+
+	resp, body, err := s.execCurlMCP(headers, initRequest)
+	s.Require().NoError(err, "baseline initialize request failed")
+	s.Require().Equal(http.StatusOK, resp.StatusCode, "baseline initialize should return 200, got %d: %s", resp.StatusCode, body)
+	resp.Body.Close()
+	s.ApplyManifests(&base.TestCase{Manifests: []string{switchStaticUpdateManifest}})
+
+	host := strings.TrimSpace(s.GetKubectlOutput(
+		"get", "agentgatewaybackend", "mcp-backend",
+		"-n", "default",
+		"-o", "jsonpath={.spec.mcp.targets[0].static.host}",
+	))
+	s.Require().Equal("127.0.0.1", host, "expected static host to be applied to backend spec")
+
+	s.Require().Eventually(func() bool {
+		resp, _, err := s.execCurlMCP(headers, initRequest)
+		resp.Body.Close()
+		if err != nil {
+			return false
+		}
+		return resp.StatusCode != http.StatusOK
+	}, 90*time.Second, 2*time.Second, "expected selector changed to static backend update to take effect without restart")
 }
 
 func (s *testingSuite) TestDynamicMCPAdminRouting() {

--- a/controller/test/e2e/features/agentgateway/mcp/testdata/switch-static-update.yaml
+++ b/controller/test/e2e/features/agentgateway/mcp/testdata/switch-static-update.yaml
@@ -1,0 +1,13 @@
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayBackend
+metadata:
+  name: mcp-backend
+  namespace: default
+spec:
+  mcp:
+    targets:
+    - name: switch-target
+      static:
+        host: 127.0.0.1
+        port: 9
+        protocol: StreamableHTTP

--- a/controller/test/e2e/features/agentgateway/mcp/testdata/switch.yaml
+++ b/controller/test/e2e/features/agentgateway/mcp/testdata/switch.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mcp-switch-upstream
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mcp-switch-upstream
+  template:
+    metadata:
+      labels:
+        app: mcp-switch-upstream
+        app.kubernetes.io/name: mcp-switch-upstream
+    spec:
+      containers:
+      - image: ghcr.io/agentgateway/testbox:0.0.1
+        imagePullPolicy: IfNotPresent
+        name: testbox
+        env:
+        - name: INSTANCE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mcp-switch-upstream
+  namespace: default
+  labels:
+    app: mcp-switch-upstream
+spec:
+  selector:
+    app.kubernetes.io/name: mcp-switch-upstream
+  ports:
+  - name: mcp
+    port: 80
+    targetPort: 8000
+    appProtocol: kgateway.dev/mcp
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayBackend
+metadata:
+  name: mcp-backend
+  namespace: default
+spec:
+  mcp:
+    targets:
+    - name: switch-target
+      selector:
+        services:
+          matchLabels:
+            app: mcp-switch-upstream
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mcp-route
+  namespace: default
+spec:
+  parentRefs:
+  - name: gateway
+    namespace: agentgateway-base
+  rules:
+  - backendRefs:
+    - name: mcp-backend
+      kind: AgentgatewayBackend
+      group: agentgateway.dev

--- a/controller/test/e2e/features/agentgateway/mcp/types.go
+++ b/controller/test/e2e/features/agentgateway/mcp/types.go
@@ -78,10 +78,12 @@ var (
 	gatewayNamespace = "agentgateway-base"
 
 	// manifests
-	staticSetupManifest      = filepath.Join(fsutils.MustGetThisDir(), "testdata", "static.yaml")
-	dynamicSetupManifest     = filepath.Join(fsutils.MustGetThisDir(), "testdata", "dynamic.yaml")
-	authnPolicyManifest      = filepath.Join(fsutils.MustGetThisDir(), "testdata", "remote-authn-auth0.yaml")
-	routeAuthnPolicyManifest = filepath.Join(fsutils.MustGetThisDir(), "testdata", "remote-route-authn-auth0.yaml")
+	staticSetupManifest        = filepath.Join(fsutils.MustGetThisDir(), "testdata", "static.yaml")
+	dynamicSetupManifest       = filepath.Join(fsutils.MustGetThisDir(), "testdata", "dynamic.yaml")
+	switchSetupManifest        = filepath.Join(fsutils.MustGetThisDir(), "testdata", "switch.yaml")
+	switchStaticUpdateManifest = filepath.Join(fsutils.MustGetThisDir(), "testdata", "switch-static-update.yaml")
+	authnPolicyManifest        = filepath.Join(fsutils.MustGetThisDir(), "testdata", "remote-authn-auth0.yaml")
+	routeAuthnPolicyManifest   = filepath.Join(fsutils.MustGetThisDir(), "testdata", "remote-route-authn-auth0.yaml")
 
 	// Base test setup - common resources
 	setup = base.TestCase{
@@ -96,6 +98,11 @@ var (
 	// Static test setup (resources needed for non-dynamic tests)
 	staticSetup = base.TestCase{
 		Manifests: []string{staticSetupManifest},
+	}
+
+	// Switch test setup (selector-based backend that is updated to static at runtime)
+	switchSetup = base.TestCase{
+		Manifests: []string{switchSetupManifest},
 	}
 
 	// MCP authn keycloak test setup (resources needed for non-dynamic tests)


### PR DESCRIPTION
I had thought that this wasnt working earlier so made this test to show that switching the mcp backend type will correctly update and resolve itself.