### PR TITLE
bedrock: url encode model

### DIFF
--- a/crates/agentgateway/src/llm/bedrock.rs
+++ b/crates/agentgateway/src/llm/bedrock.rs
@@ -43,6 +43,9 @@ impl Provider {
 		model: &str,
 	) -> Strng {
 		let model = self.model.as_deref().unwrap_or(model);
+		const MODEL_SEGMENT: &percent_encoding::AsciiSet =
+			&percent_encoding::CONTROLS.add(b'/').add(b'%');
+		let model = percent_encoding::utf8_percent_encode(model, MODEL_SEGMENT);
 		match route_type {
 			super::RouteType::AnthropicTokenCount => strng::format!("/model/{model}/count-tokens"),
 			super::RouteType::Embeddings => strng::format!("/model/{model}/invoke"),


### PR DESCRIPTION
This allows models like
`arn:aws:bedrock:us-west-2:123456789:inference-profile/global.amazon.nova-2-lite-v1:0`
Signed-off-by: John Howard <john.howard@solo.io>
