### PR TITLE
Finalize backend eviction with retries 

### DIFF
--- a/crates/agentgateway/src/http/health.rs
+++ b/crates/agentgateway/src/http/health.rs
@@ -8,7 +8,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::cel::Expression;
+use crate::cel::{ContextBuilder, Expression};
 use crate::{serde_dur_option, *};
 
 /// Eviction sub-policy: how long to remove a backend from the active set after an unhealthy response.
@@ -63,6 +63,12 @@ pub struct Policy {
 const DEFAULT_EVICTION_SECS: u64 = 3;
 
 impl Policy {
+	pub fn register_expressions(&self, ctx: &mut ContextBuilder) {
+		if let Some(expr) = self.unhealthy_expression.as_ref() {
+			ctx.register_expression(expr.as_ref());
+		}
+	}
+
 	/// Returns the configured base eviction duration, if any.
 	pub fn eviction_duration(&self) -> Option<Duration> {
 		self.eviction.as_ref().and_then(|e| e.duration)

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -1665,6 +1665,16 @@ async fn make_backend_call(
 		},
 		Backend::Invalid => return Err(ProxyResponse::from(ProxyError::BackendDoesNotExist)),
 	};
+	log.add(|l| l.health_policy = backend_call.backend_policies.health.clone());
+	if let Some(log) = log.as_mut()
+		&& let Some(expr) = backend_call
+			.backend_policies
+			.health
+			.as_ref()
+			.and_then(|policy| policy.unhealthy_expression.as_ref())
+	{
+		log.cel.ctx().register_expression(expr.as_ref());
+	}
 	// Apply auth before LLM request setup, so the providers can assume auth is in standardized header
 	// Apply auth as early as possible so any ext_proc or transformations won't be repeated on retries in case it fails.
 	let backend_info = auth::BackendInfo {
@@ -2326,20 +2336,8 @@ fn finalize_retryable_attempt(
 	let mcp = log.mcp_status.take();
 	log.llm_response.store(llm_response.clone());
 	log.mcp_status.store(mcp.clone());
-	let request_handle = log.request_handle.take();
 	let llm_response = llm_response.map(Into::into);
-	let cel_end_time = cel::RequestTime(end_time.as_datetime());
-	let cel_exec = log.cel.build(crate::telemetry::log::CelLoggingBuildInputs {
-		req: log.request_snapshot.as_deref(),
-		resp: log.response_snapshot.as_ref(),
-		llm_response: llm_response.as_ref(),
-		mcp: mcp.as_ref().filter(|m| !m.is_empty()),
-		end_time: &cel_end_time,
-		source_context: log.source_context.as_ref(),
-	});
-	if let Some(rh) = request_handle {
-		log.finalize_request_handle(rh, end_time, &cel_exec);
-	}
+	log.finalize_request_handle(end_time, llm_response.as_ref(), mcp.as_ref());
 }
 
 fn should_retry(res: &Result<Response, SnapshottedProxyResponse>, pol: &retry::Policy) -> bool {

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -2319,9 +2319,27 @@ fn finalize_retryable_attempt(
 		},
 	}
 	let end_time = agent_core::Timestamp::now();
-	let llm_response = log.llm_response.take().map(Into::into);
+	// Retryable attempts may finalize backend health before the overall request completes.
+	// So we snapshot async log fields for CEL eviction here without consuming them, so the final access logs
+	// and metrics still have the LLM/MCP data.
+	let llm_response = log.llm_response.take();
 	let mcp = log.mcp_status.take();
-	log.finalize_request_handle(end_time, llm_response.as_ref(), mcp.as_ref());
+	log.llm_response.store(llm_response.clone());
+	log.mcp_status.store(mcp.clone());
+	let request_handle = log.request_handle.take();
+	let llm_response = llm_response.map(Into::into);
+	let cel_end_time = cel::RequestTime(end_time.as_datetime());
+	let cel_exec = log.cel.build(crate::telemetry::log::CelLoggingBuildInputs {
+		req: log.request_snapshot.as_deref(),
+		resp: log.response_snapshot.as_ref(),
+		llm_response: llm_response.as_ref(),
+		mcp: mcp.as_ref().filter(|m| !m.is_empty()),
+		end_time: &cel_end_time,
+		source_context: log.source_context.as_ref(),
+	});
+	if let Some(rh) = request_handle {
+		log.finalize_request_handle(rh, end_time, &cel_exec);
+	}
 }
 
 fn should_retry(res: &Result<Response, SnapshottedProxyResponse>, pol: &retry::Policy) -> bool {

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -2319,7 +2319,7 @@ fn finalize_attempt_for_retry(
 		Err(SnapshottedProxyResponse(_)) => (None, None, None),
 	};
 	let end_time = agent_core::Timestamp::now();
-	let llm_response = log.llm_response.load_clone();
+	let llm_response = log.llm_response.load_clone().map(Into::into);
 	let mcp = log.mcp_status.load_clone();
 	let llm_response = llm_response.map(Into::into);
 	log.finalize_request_handle_for_attempt(

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -570,12 +570,7 @@ impl HTTPProxy {
 
 		// Pass the log into the body so it finishes once the stream is entirely complete.
 		// We will also record trailer info there.
-		log.with(|l| {
-			l.status = Some(resp.status());
-			l.reason = Some(reason);
-			l.retry_after = http::outlierdetection::retry_after(resp.status(), resp.headers());
-			l.response_snapshot = l.cel.cel_context.maybe_snapshot_response(&mut resp);
-		});
+		log.with(|l| set_final_response_fields(l, &reason, &mut resp));
 
 		if resp.status() == StatusCode::SWITCHING_PROTOCOLS {
 			let Some(req_upgrade) = resp.extensions_mut().remove::<RequestUpgrade>() else {
@@ -770,11 +765,6 @@ impl HTTPProxy {
 		backend_policies.register_cel_expressions(log.cel.ctx());
 		log.cel.ctx().maybe_buffer_request_body(&mut req).await;
 		log.health_policy = backend_policies.health.clone();
-		if let Some(ev) = &backend_policies.health
-			&& let Some(expr) = &ev.unhealthy_expression
-		{
-			log.cel.ctx().register_expression(expr.as_ref());
-		}
 		log.backend_info = Some(selected_backend.backend.backend.backend_info());
 		if let Some(bp) = selected_backend.backend.backend.backend_protocol() {
 			log.backend_protocol = Some(bp)
@@ -874,7 +864,7 @@ impl HTTPProxy {
 				);
 			}
 			let req = Request::from_parts(head, http::Body::new(this));
-			let res = self
+			let mut res = self
 				.attempt_upstream(
 					log,
 					&mut req_upgrade,
@@ -897,8 +887,7 @@ impl HTTPProxy {
 				res.is_err(),
 				res.as_ref().map(|r| r.status())
 			);
-			let mut res = res;
-			finalize_retryable_attempt(log, &mut res);
+			finalize_attempt_for_retry(log, &mut res);
 			last_res = Some(res);
 			if let Some(bo) = retry_backoff {
 				let fut = if let Some(request_timeout) = request_timeout {
@@ -1666,14 +1655,10 @@ async fn make_backend_call(
 		Backend::Invalid => return Err(ProxyResponse::from(ProxyError::BackendDoesNotExist)),
 	};
 	log.add(|l| l.health_policy = backend_call.backend_policies.health.clone());
-	if let Some(log) = log.as_mut()
-		&& let Some(expr) = backend_call
+	if let Some(log) = log.as_mut() {
+		backend_call
 			.backend_policies
-			.health
-			.as_ref()
-			.and_then(|policy| policy.unhealthy_expression.as_ref())
-	{
-		log.cel.ctx().register_expression(expr.as_ref());
+			.register_cel_expressions(log.cel.ctx());
 	}
 	// Apply auth before LLM request setup, so the providers can assume auth is in standardized header
 	// Apply auth as early as possible so any ext_proc or transformations won't be repeated on retries in case it fails.
@@ -2310,34 +2295,41 @@ fn resolved_workload_target_hostname<'a>(
 	}
 }
 
-fn finalize_retryable_attempt(
+fn set_final_response_fields(
+	log: &mut RequestLog,
+	reason: &ProxyResponseReason,
+	resp: &mut Response,
+) {
+	log.status = Some(resp.status());
+	log.reason = Some(*reason);
+	log.retry_after = http::outlierdetection::retry_after(resp.status(), resp.headers());
+	log.response_snapshot = log.cel.cel_context.maybe_snapshot_response(resp);
+}
+
+fn finalize_attempt_for_retry(
 	log: &mut RequestLog,
 	res: &mut Result<Response, SnapshottedProxyResponse>,
 ) {
-	match res {
-		Ok(resp) => {
-			log.status = Some(resp.status());
-			log.reason = Some(ProxyResponseReason::Upstream);
-			log.retry_after = http::outlierdetection::retry_after(resp.status(), resp.headers());
-			log.response_snapshot = log.cel.cel_context.maybe_snapshot_response(resp);
-		},
-		Err(SnapshottedProxyResponse(proxy_response)) => {
-			log.status = None;
-			log.reason = Some(proxy_response.as_reason());
-			log.retry_after = None;
-			log.response_snapshot = None;
-		},
-	}
+	let (status, retry_after, response_snapshot) = match res {
+		Ok(resp) => (
+			Some(resp.status()),
+			http::outlierdetection::retry_after(resp.status(), resp.headers()),
+			log.cel.cel_context.maybe_snapshot_response(resp),
+		),
+		Err(SnapshottedProxyResponse(_)) => (None, None, None),
+	};
 	let end_time = agent_core::Timestamp::now();
-	// Retryable attempts may finalize backend health before the overall request completes.
-	// So we snapshot async log fields for CEL eviction here without consuming them, so the final access logs
-	// and metrics still have the LLM/MCP data.
-	let llm_response = log.llm_response.take();
-	let mcp = log.mcp_status.take();
-	log.llm_response.store(llm_response.clone());
-	log.mcp_status.store(mcp.clone());
+	let llm_response = log.llm_response.load_clone();
+	let mcp = log.mcp_status.load_clone();
 	let llm_response = llm_response.map(Into::into);
-	log.finalize_request_handle(end_time, llm_response.as_ref(), mcp.as_ref());
+	log.finalize_request_handle_for_attempt(
+		end_time,
+		status,
+		retry_after,
+		response_snapshot.as_ref(),
+		llm_response.as_ref(),
+		mcp.as_ref(),
+	);
 }
 
 fn should_retry(res: &Result<Response, SnapshottedProxyResponse>, pol: &retry::Policy) -> bool {

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -2319,9 +2319,9 @@ fn finalize_attempt_for_retry(
 		Err(SnapshottedProxyResponse(_)) => (None, None, None),
 	};
 	let end_time = agent_core::Timestamp::now();
+	// This is an intermediate retry snapshot, so a best-effort clone is fine here.
 	let llm_response = log.llm_response.load_clone().map(Into::into);
 	let mcp = log.mcp_status.load_clone();
-	let llm_response = llm_response.map(Into::into);
 	log.finalize_request_handle_for_attempt(
 		end_time,
 		status,
@@ -2625,7 +2625,7 @@ mod tests {
 			.attach_route_policy(json!({
 				"retry": {
 					"attempts": 1,
-					"backoff": "10s",
+					"backoff": "10ms",
 					"codes": [429]
 				},
 				"ai": {

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -897,6 +897,8 @@ impl HTTPProxy {
 				res.is_err(),
 				res.as_ref().map(|r| r.status())
 			);
+			let mut res = res;
+			finalize_retryable_attempt(log, &mut res);
 			last_res = Some(res);
 			if let Some(bo) = retry_backoff {
 				let fut = if let Some(request_timeout) = request_timeout {
@@ -2298,6 +2300,30 @@ fn resolved_workload_target_hostname<'a>(
 	}
 }
 
+fn finalize_retryable_attempt(
+	log: &mut RequestLog,
+	res: &mut Result<Response, SnapshottedProxyResponse>,
+) {
+	match res {
+		Ok(resp) => {
+			log.status = Some(resp.status());
+			log.reason = Some(ProxyResponseReason::Upstream);
+			log.retry_after = http::outlierdetection::retry_after(resp.status(), resp.headers());
+			log.response_snapshot = log.cel.cel_context.maybe_snapshot_response(resp);
+		},
+		Err(SnapshottedProxyResponse(proxy_response)) => {
+			log.status = None;
+			log.reason = Some(proxy_response.as_reason());
+			log.retry_after = None;
+			log.response_snapshot = None;
+		},
+	}
+	let end_time = agent_core::Timestamp::now();
+	let llm_response = log.llm_response.take().map(Into::into);
+	let mcp = log.mcp_status.take();
+	log.finalize_request_handle(end_time, llm_response.as_ref(), mcp.as_ref());
+}
+
 fn should_retry(res: &Result<Response, SnapshottedProxyResponse>, pol: &retry::Policy) -> bool {
 	match res {
 		Ok(resp) => pol.codes.contains(&resp.status()),
@@ -2311,14 +2337,20 @@ mod tests {
 	use std::collections::{HashMap, HashSet};
 	use std::net::SocketAddr;
 
+	use ::http::Method;
+	use serde_json::json;
+	use wiremock::{Mock, ResponseTemplate};
+
 	use super::{
 		apply_auto_hostname, hop_by_hop_headers, resolved_workload_target_hostname,
 		select_service_target_port,
 	};
 	use crate::http;
 	use crate::http::filters::AutoHostname;
-	use crate::types::agent::Target;
+	use crate::test_helpers::proxymock;
+	use crate::types::agent::{Backend, ResourceName, Target};
 	use crate::types::discovery::{AppProtocol, Endpoint, HealthStatus, Service};
+	use crate::types::local::LocalAIBackend;
 
 	#[test]
 	fn apply_auto_hostname_rewrites_authority_when_enabled() {
@@ -2516,6 +2548,115 @@ mod tests {
 			Some("trailers")
 		);
 		assert!(!req.headers().contains_key("x-original-url"));
+	}
+
+	#[tokio::test]
+	async fn llm_retry_evicts_failed_priority_group_before_next_attempt() {
+		let primary = wiremock::MockServer::start().await;
+		Mock::given(wiremock::matchers::any())
+			.respond_with(ResponseTemplate::new(429))
+			.mount(&primary)
+			.await;
+
+		let fallback = wiremock::MockServer::start().await;
+		Mock::given(wiremock::matchers::any())
+			.respond_with(ResponseTemplate::new(200).set_body_raw(
+				include_bytes!("../llm/tests/response/completions/basic.json").to_vec(),
+				"application/json",
+			))
+			.mount(&fallback)
+			.await;
+
+		let mut bind = proxymock::setup_proxy_test("{}").expect("proxy test harness");
+		let local_backend: LocalAIBackend = serde_json::from_value(json!({
+			"groups": [
+				{
+					"providers": [{
+						"name": "primary",
+						"hostOverride": primary.address().to_string(),
+						"provider": {
+							"openAI": {
+								"model": null
+							}
+						},
+						"policies": {
+							"health": {
+								"unhealthyExpression": "response.code == 429"
+							}
+						}
+					}]
+				},
+				{
+					"providers": [{
+						"name": "fallback",
+						"hostOverride": fallback.address().to_string(),
+						"provider": {
+							"openAI": {
+								"model": null
+							}
+						}
+					}]
+				}
+			]
+		}))
+		.expect("local AI backend");
+		let backend = Backend::AI(
+			ResourceName::new("llm".into(), "".into()),
+			local_backend.translate().expect("translated backend"),
+		);
+		bind
+			.pi
+			.stores
+			.binds
+			.write()
+			.insert_backend(backend.name(), backend.into());
+		bind = bind
+			.with_bind(proxymock::simple_bind())
+			.with_route(proxymock::basic_named_route("/llm".into()));
+		bind
+			.attach_route_policy(json!({
+				"retry": {
+					"attempts": 1,
+					"backoff": "10s",
+					"codes": [429]
+				},
+				"ai": {
+					"routes": {
+						"/v1/chat/completions": "completions"
+					}
+				}
+			}))
+			.await;
+		let io = bind.serve_http(proxymock::BIND_KEY);
+
+		let res = proxymock::send_request_body(
+			io,
+			Method::POST,
+			"http://lo/v1/chat/completions",
+			include_bytes!("../llm/tests/requests/completions/basic.json"),
+		)
+		.await;
+
+		assert_eq!(res.status(), 200);
+
+		let primary_requests = primary
+			.received_requests()
+			.await
+			.expect("primary request recording");
+		assert_eq!(primary_requests.len(), 1);
+
+		let fallback_requests = fallback
+			.received_requests()
+			.await
+			.expect("fallback request recording");
+		assert_eq!(fallback_requests.len(), 1);
+		assert_eq!(
+			fallback_requests[0]
+				.headers
+				.get("x-retry-attempt")
+				.and_then(|v| v.to_str().ok()),
+			Some("1")
+		);
 	}
 }
 

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -285,6 +285,9 @@ impl BackendPolicies {
 	pub fn register_cel_expressions(&self, ctx: &mut ContextBuilder) {
 		self.ext_authz.register_expressions(ctx);
 		self.transformation.register_expressions(ctx);
+		if let Some(health) = self.health.as_ref() {
+			health.register_expressions(ctx);
+		}
 	}
 }
 

--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -51,6 +51,14 @@ use crate::{cel, llm, mcp};
 #[derive(Clone)]
 pub struct AsyncLog<T>(Arc<AtomicCell<Option<T>>>);
 
+impl<T: Clone> AsyncLog<T> {
+	pub fn load_clone(&self) -> Option<T> {
+		let cur = self.0.take();
+		self.0.store(cur.clone());
+		cur
+	}
+}
+
 impl<T> AsyncLog<T> {
 	// non_atomic_mutate is a racey method to modify the current value.
 	// If there is no current value, a default is used.
@@ -460,12 +468,23 @@ impl DropOnLog {
 	/// When no CEL expression is set, the default treats 5xx, connection failures, or non-zero
 	/// gRPC status as unhealthy.
 	fn default_unhealthy(log: &RequestLog) -> bool {
-		log.status.is_none_or(|s| s.is_server_error())
+		Self::default_unhealthy_for_status(log, log.status)
+	}
+
+	fn default_unhealthy_for_status(
+		log: &RequestLog,
+		status: Option<crate::http::StatusCode>,
+	) -> bool {
+		status.is_none_or(|s| s.is_server_error())
 			|| log.grpc_status.load().is_some_and(|status| status != 0)
 	}
 
-	fn eviction_unhealthy(log: &RequestLog, cel_exec: &CelLoggingExecutor<'_>) -> bool {
-		let default_unhealthy = Self::default_unhealthy(log);
+	fn eviction_unhealthy(
+		log: &RequestLog,
+		status: Option<crate::http::StatusCode>,
+		cel_exec: &CelLoggingExecutor<'_>,
+	) -> bool {
+		let default_unhealthy = Self::default_unhealthy_for_status(log, status);
 		let Some(policy) = &log.health_policy else {
 			return default_unhealthy;
 		};
@@ -477,17 +496,19 @@ impl DropOnLog {
 
 	/// Returns (health, eviction_duration, restore_health).
 	fn eviction_decision(
-		log: &RequestLog,
+		health_policy: &Option<health::Policy>,
+		retry_backoff: Option<Duration>,
+		retry_after: Option<Duration>,
 		current_health: f64,
 		consecutive_failure_count: u64,
 		times_ejected: u64,
 		unhealthy: bool,
 	) -> (bool, Option<Duration>, Option<f64>) {
-		let Some(policy) = &log.health_policy else {
+		let Some(policy) = health_policy else {
 			let health = !unhealthy;
 			return (health, None, None);
 		};
-		let fallback_duration = log.retry_after.or(log.retry_backoff);
+		let fallback_duration = retry_after.or(retry_backoff);
 		policy.eviction_decision(
 			current_health,
 			consecutive_failure_count,
@@ -669,9 +690,22 @@ impl RequestLog {
 		end_time: Timestamp,
 		cel_exec: &CelLoggingExecutor<'_>,
 	) {
-		let unhealthy = DropOnLog::eviction_unhealthy(self, cel_exec);
+		self.finish_request_handle_with_attempt(rh, end_time, self.status, self.retry_after, cel_exec);
+	}
+
+	fn finish_request_handle_with_attempt(
+		&self,
+		rh: ActiveHandle,
+		end_time: Timestamp,
+		status: Option<crate::http::StatusCode>,
+		retry_after: Option<Duration>,
+		cel_exec: &CelLoggingExecutor<'_>,
+	) {
+		let unhealthy = DropOnLog::eviction_unhealthy(self, status, cel_exec);
 		let (health, eviction_duration, restore_health) = DropOnLog::eviction_decision(
-			self,
+			&self.health_policy,
+			self.retry_backoff,
+			retry_after,
 			rh.health_score(),
 			rh.consecutive_failures(),
 			rh.times_ejected(),
@@ -706,6 +740,30 @@ impl RequestLog {
 			return;
 		};
 		self.finish_request_handle(rh, end_time, &cel_exec);
+	}
+
+	pub(crate) fn finalize_request_handle_for_attempt(
+		&mut self,
+		end_time: Timestamp,
+		status: Option<crate::http::StatusCode>,
+		retry_after: Option<Duration>,
+		response_snapshot: Option<&cel::ResponseSnapshot>,
+		llm_response: Option<&LLMContext>,
+		mcp: Option<&MCPInfo>,
+	) {
+		let cel_end_time = cel::RequestTime(end_time.as_datetime());
+		let cel_exec = self.cel.build(CelLoggingBuildInputs {
+			req: self.request_snapshot.as_deref(),
+			resp: response_snapshot,
+			llm_response,
+			mcp: mcp.filter(|m| !m.is_empty()),
+			end_time: &cel_end_time,
+			source_context: self.source_context.as_ref(),
+		});
+		let Some(rh) = self.request_handle.take() else {
+			return;
+		};
+		self.finish_request_handle_with_attempt(rh, end_time, status, retry_after, &cel_exec);
 	}
 }
 

--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -662,6 +662,42 @@ impl RequestLog {
 			inner: self.trace_spans.clone(),
 		})
 	}
+
+	/// Finalizes the current backend health state.
+	/// Retry loops can call this early to evict a failed target before the next attempt.
+	pub(crate) fn finalize_request_handle(
+		&mut self,
+		end_time: Timestamp,
+		llm_response: Option<&LLMContext>,
+		mcp: Option<&MCPInfo>,
+	) {
+		let cel_end_time = cel::RequestTime(end_time.as_datetime());
+		let cel_exec = self.cel.build(CelLoggingBuildInputs {
+			req: self.request_snapshot.as_deref(),
+			resp: self.response_snapshot.as_ref(),
+			llm_response,
+			mcp: mcp.filter(|m| !m.is_empty()),
+			end_time: &cel_end_time,
+			source_context: self.source_context.as_ref(),
+		});
+		let Some(rh) = self.request_handle.take() else {
+			return;
+		};
+		let unhealthy = DropOnLog::eviction_unhealthy(self, &cel_exec);
+		let (health, eviction_duration, restore_health) = DropOnLog::eviction_decision(
+			self,
+			rh.health_score(),
+			rh.consecutive_failures(),
+			rh.times_ejected(),
+			unhealthy,
+		);
+		rh.finish_request(
+			health,
+			end_time.duration_since(&self.start),
+			eviction_duration,
+			restore_health,
+		);
+	}
 }
 
 #[derive(Debug)]
@@ -784,32 +820,17 @@ impl Drop for DropOnLog {
 		let enable_trace = log.tracer.is_some();
 
 		let llm_response = log.llm_response.take().map(Into::into);
-
 		let mcp = log.mcp_status.take();
-		let mcp_cel = mcp.as_ref().filter(|m| !m.is_empty());
+		log.finalize_request_handle(end_time, llm_response.as_ref(), mcp.as_ref());
 		let cel_end_time = cel::RequestTime(end_time.as_datetime());
 		let cel_exec = log.cel.build(CelLoggingBuildInputs {
 			req: log.request_snapshot.as_deref(),
 			resp: log.response_snapshot.as_ref(),
 			llm_response: llm_response.as_ref(),
-			mcp: mcp_cel,
+			mcp: mcp.as_ref().filter(|m| !m.is_empty()),
 			end_time: &cel_end_time,
 			source_context: log.source_context.as_ref(),
 		});
-		if let Some(rh) = log.request_handle.take() {
-			let current_health = rh.health_score();
-			let consecutive_failures = rh.consecutive_failures();
-			let times_ejected = rh.times_ejected();
-			let unhealthy = Self::eviction_unhealthy(&log, &cel_exec);
-			let (health, eviction_duration, restore_health) = Self::eviction_decision(
-				&log,
-				current_health,
-				consecutive_failures,
-				times_ejected,
-				unhealthy,
-			);
-			rh.finish_request(health, duration, eviction_duration, restore_health);
-		}
 
 		let custom_metric_fields = CustomField::new(
 			// For metrics, keep empty values which will become 'unknown'

--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -719,29 +719,6 @@ impl RequestLog {
 		);
 	}
 
-	/// Finalizes the current backend health state.
-	/// Retry loops can call this early to evict a failed target before the next attempt.
-	pub(crate) fn finalize_request_handle(
-		&mut self,
-		end_time: Timestamp,
-		llm_response: Option<&LLMContext>,
-		mcp: Option<&MCPInfo>,
-	) {
-		let cel_end_time = cel::RequestTime(end_time.as_datetime());
-		let cel_exec = self.cel.build(CelLoggingBuildInputs {
-			req: self.request_snapshot.as_deref(),
-			resp: self.response_snapshot.as_ref(),
-			llm_response,
-			mcp: mcp.filter(|m| !m.is_empty()),
-			end_time: &cel_end_time,
-			source_context: self.source_context.as_ref(),
-		});
-		let Some(rh) = self.request_handle.take() else {
-			return;
-		};
-		self.finish_request_handle(rh, end_time, &cel_exec);
-	}
-
 	pub(crate) fn finalize_request_handle_for_attempt(
 		&mut self,
 		end_time: Timestamp,

--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -52,6 +52,9 @@ use crate::{cel, llm, mcp};
 pub struct AsyncLog<T>(Arc<AtomicCell<Option<T>>>);
 
 impl<T: Clone> AsyncLog<T> {
+	// load_clone is only a best-effort snapshot. It temporarily removes the value so it can clone it,
+	// then stores the clone back. A concurrent store/non_atomic_mutate between those operations can be
+	// lost when we restore `cur`, so callers must not rely on this as an atomic read.
 	pub fn load_clone(&self) -> Option<T> {
 		let cur = self.0.take();
 		self.0.store(cur.clone());
@@ -467,6 +470,7 @@ impl DropOnLog {
 	/// `unhealthy` should already be evaluated (preferably with the shared CEL executor when available).
 	/// When no CEL expression is set, the default treats 5xx, connection failures, or non-zero
 	/// gRPC status as unhealthy.
+	#[cfg(test)]
 	fn default_unhealthy(log: &RequestLog) -> bool {
 		Self::default_unhealthy_for_status(log, log.status)
 	}

--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -666,24 +666,12 @@ impl RequestLog {
 	/// Finalizes the current backend health state.
 	/// Retry loops can call this early to evict a failed target before the next attempt.
 	pub(crate) fn finalize_request_handle(
-		&mut self,
+		&self,
+		rh: ActiveHandle,
 		end_time: Timestamp,
-		llm_response: Option<&LLMContext>,
-		mcp: Option<&MCPInfo>,
+		cel_exec: &CelLoggingExecutor<'_>,
 	) {
-		let cel_end_time = cel::RequestTime(end_time.as_datetime());
-		let cel_exec = self.cel.build(CelLoggingBuildInputs {
-			req: self.request_snapshot.as_deref(),
-			resp: self.response_snapshot.as_ref(),
-			llm_response,
-			mcp: mcp.filter(|m| !m.is_empty()),
-			end_time: &cel_end_time,
-			source_context: self.source_context.as_ref(),
-		});
-		let Some(rh) = self.request_handle.take() else {
-			return;
-		};
-		let unhealthy = DropOnLog::eviction_unhealthy(self, &cel_exec);
+		let unhealthy = DropOnLog::eviction_unhealthy(self, cel_exec);
 		let (health, eviction_duration, restore_health) = DropOnLog::eviction_decision(
 			self,
 			rh.health_score(),
@@ -821,7 +809,7 @@ impl Drop for DropOnLog {
 
 		let llm_response = log.llm_response.take().map(Into::into);
 		let mcp = log.mcp_status.take();
-		log.finalize_request_handle(end_time, llm_response.as_ref(), mcp.as_ref());
+		let request_handle = log.request_handle.take();
 		let cel_end_time = cel::RequestTime(end_time.as_datetime());
 		let cel_exec = log.cel.build(CelLoggingBuildInputs {
 			req: log.request_snapshot.as_deref(),
@@ -831,6 +819,9 @@ impl Drop for DropOnLog {
 			end_time: &cel_end_time,
 			source_context: log.source_context.as_ref(),
 		});
+		if let Some(rh) = request_handle {
+			log.finalize_request_handle(rh, end_time, &cel_exec);
+		}
 
 		let custom_metric_fields = CustomField::new(
 			// For metrics, keep empty values which will become 'unknown'

--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -663,9 +663,7 @@ impl RequestLog {
 		})
 	}
 
-	/// Finalizes the current backend health state.
-	/// Retry loops can call this early to evict a failed target before the next attempt.
-	pub(crate) fn finalize_request_handle(
+	fn finish_request_handle(
 		&self,
 		rh: ActiveHandle,
 		end_time: Timestamp,
@@ -685,6 +683,29 @@ impl RequestLog {
 			eviction_duration,
 			restore_health,
 		);
+	}
+
+	/// Finalizes the current backend health state.
+	/// Retry loops can call this early to evict a failed target before the next attempt.
+	pub(crate) fn finalize_request_handle(
+		&mut self,
+		end_time: Timestamp,
+		llm_response: Option<&LLMContext>,
+		mcp: Option<&MCPInfo>,
+	) {
+		let cel_end_time = cel::RequestTime(end_time.as_datetime());
+		let cel_exec = self.cel.build(CelLoggingBuildInputs {
+			req: self.request_snapshot.as_deref(),
+			resp: self.response_snapshot.as_ref(),
+			llm_response,
+			mcp: mcp.filter(|m| !m.is_empty()),
+			end_time: &cel_end_time,
+			source_context: self.source_context.as_ref(),
+		});
+		let Some(rh) = self.request_handle.take() else {
+			return;
+		};
+		self.finish_request_handle(rh, end_time, &cel_exec);
 	}
 }
 
@@ -820,7 +841,7 @@ impl Drop for DropOnLog {
 			source_context: log.source_context.as_ref(),
 		});
 		if let Some(rh) = request_handle {
-			log.finalize_request_handle(rh, end_time, &cel_exec);
+			log.finish_request_handle(rh, end_time, &cel_exec);
 		}
 
 		let custom_metric_fields = CustomField::new(


### PR DESCRIPTION
Requests that would previously fail after a 429 can now succeed on the retry by failing over to the fallback provider within the same request. This improves the UX because users see fewer transient failures and less need to retry manually. 

In order to get this behavior, backend health is updated in the retry loop so that the retry target selection uses current health instead of stale health.

Tested locally and this is the new behavior:

1. fake providers + eviction policy config:
```
 apiVersion: v1
  kind: ConfigMap
  metadata:
    name: mock-llm-primary-nginx
    namespace: default
  data:
    nginx.conf: |
      events {}
      http {
        server {
          listen 9234;
          location = /v1/chat/completions {
            default_type application/json;
            return 429 '{"error":{"message":"rate limited","type":"rate_limit_error"}}';
          }
          location / {
            return 404;
          }
        }
      }
  ---
  apiVersion: apps/v1
  kind: Deployment
  metadata:
    name: mock-llm-primary
    namespace: default
  spec:
    replicas: 1
    selector:
      matchLabels:
        app: mock-llm-primary
    template:
      metadata:
        labels:
          app: mock-llm-primary
      spec:
        containers:
        - name: nginx
          image: nginx:1.27-alpine
          ports:
          - containerPort: 9234
          volumeMounts:
          - name: nginx-conf
            mountPath: /etc/nginx/nginx.conf
            subPath: nginx.conf
        volumes:
        - name: nginx-conf
          configMap:
            name: mock-llm-primary-nginx
  ---
  apiVersion: v1
  kind: Service
  metadata:
    name: mock-llm-primary
    namespace: default
  spec:
    selector:
      app: mock-llm-primary
    ports:
    - name: http
      port: 9234
      targetPort: 9234
  ---
  apiVersion: v1
  kind: ConfigMap
  metadata:
    name: mock-llm-fallback-nginx
    namespace: default
  data:
    nginx.conf: |
      events {}
      http {
        server {
          listen 9234;
          location = /v1/chat/completions {
            default_type application/json;
            return 200 '{"id":"chatcmpl-fallback","object":"chat.completion","created":1710000000,"model":"gpt-4o-mini","choices":[{"index":0,"message":{"role":"assistant","content":"fallback
  worked"},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":2,"total_tokens":7}}';
          }
          location / {
            return 404;
          }
        }
      }
  ---
  apiVersion: apps/v1
  kind: Deployment
  metadata:
    name: mock-llm-fallback
    namespace: default
  spec:
    replicas: 1
    selector:
      matchLabels:
        app: mock-llm-fallback
    template:
      metadata:
        labels:
          app: mock-llm-fallback
      spec:
        containers:
        - name: nginx
          image: nginx:1.27-alpine
          ports:
          - containerPort: 9234
          volumeMounts:
          - name: nginx-conf
            mountPath: /etc/nginx/nginx.conf
            subPath: nginx.conf
        volumes:
        - name: nginx-conf
          configMap:
            name: mock-llm-fallback-nginx
  ---
  apiVersion: v1
  kind: Service
  metadata:
    name: mock-llm-fallback
    namespace: default
  spec:
    selector:
      app: mock-llm-fallback
    ports:
    - name: http
      port: 9234
      targetPort: 9234
  ---
  apiVersion: gateway.networking.k8s.io/v1
  kind: Gateway
  metadata:
    name: gateway
    namespace: agentgateway-system
  spec:
    gatewayClassName: agentgateway
    listeners:
    - name: http
      protocol: HTTP
      port: 8080
      allowedRoutes:
        namespaces:
          from: All
  ---
  apiVersion: gateway.networking.k8s.io/v1
  kind: HTTPRoute
  metadata:
    name: mock-ratelimit-failover
    namespace: default
  spec:
    parentRefs:
    - group: gateway.networking.k8s.io
      kind: Gateway
      name: gateway
      namespace: agentgateway-system
    rules:
    - backendRefs:
      - group: agentgateway.dev
        kind: AgentgatewayBackend
        name: mock-ratelimit-failover
      matches:
      - path:
          type: PathPrefix
          value: /v1/chat/completions
        headers:
        - type: Exact
          name: x-test-failover
          value: "1"
  ---
  apiVersion: agentgateway.dev/v1alpha1
  kind: AgentgatewayBackend
  metadata:
    name: mock-ratelimit-failover
    namespace: default
  spec:
    ai:
      groups:
      - providers:
        - name: primary
          openai:
            model: gpt-4o-mini
          host: mock-llm-primary.default.svc.cluster.local
          port: 9234
      - providers:
        - name: fallback
          openai:
            model: gpt-4o-mini
          host: mock-llm-fallback.default.svc.cluster.local
          port: 9234
    policies:
      auth:
        key: dummy-key
  ---
  apiVersion: agentgateway.dev/v1alpha1
  kind: AgentgatewayPolicy
  metadata:
    name: retry-policy
    namespace: default
  spec:
    targetRefs:
    - group: gateway.networking.k8s.io
      kind: HTTPRoute
      name: mock-ratelimit-failover
    traffic:
      retry:
        attempts: 1
        backoff: 50ms
        codes:
        - 429
    backend:
      health:
        unhealthyCondition: "response.code == 429"
        eviction:
          duration: 120s
          consecutiveFailures: 1
          restoreHealth: 0
```

2. Send a curl, you should get a 200 OK immediately:
```
❯ curl -si http://127.0.0.1:8080/v1/chat/completions \
    -H 'content-type: application/json' \
    -H 'x-test-failover: 1' \
    -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"say hi"}]}'
HTTP/1.1 200 OK
server: nginx/1.27.5
date: Wed, 20 May 2026 19:04:59 GMT
content-type: application/json
connection: keep-alive
content-length: 269

{"model":"gpt-4o-mini","usage":{"prompt_tokens":5,"completion_tokens":2,"total_tokens":7},"choices":[{"message":{"content":"fallback worked","role":"assistant"},"index":0,"finish_reason":"stop"}],"id":"chatcmpl-fallback","object":"chat.completion","created":1710000000}%   
```

The old behavior had `http.status=429` returned and logs would show the final request ending on the primary, not fallback.

3. Look at logs to check backends are both getting hit:


```
❯  kubectl -n default logs deploy/mock-llm-primary --since=10m
10.244.0.9 - - [20/May/2026:19:04:55 +0000] "POST /v1/chat/completions HTTP/1.1" 429 62 "-" "curl/8.13.0"
```

```
❯  kubectl -n default logs deploy/mock-llm-fallback --since=10m
10.244.0.9 - - [20/May/2026:19:04:55 +0000] "POST /v1/chat/completions HTTP/1.1" 200 269 "-" "curl/8.13.0"
10.244.0.9 - - [20/May/2026:19:04:59 +0000] "POST /v1/chat/completions HTTP/1.1" 200 269 "-" "curl/8.13.0"
```

 gateway’s final log shows retry.attempt=1:
```
2026-05-20T19:04:55.252812Z     info    request gateway=agentgateway-system/gateway listener=http route=default/mock-ratelimit-failover endpoint=mock-llm-fallback.default.svc.cluster.local:9234 src.addr=127.0.0.1:47846 http.method=POST http.host=127.0.0.1 http.path=/v1/chat/completions http.version=HTTP/1.1 http.status=200 protocol=llm gen_ai.operation.name=chat gen_ai.provider.name=openai gen_ai.request.model=gpt-4o-mini gen_ai.response.model=gpt-4o-mini gen_ai.usage.input_tokens=5 gen_ai.usage.output_tokens=2 retry.attempt=1 duration=72ms
2026-05-20T19:04:59.793919Z     info    request gateway=agentgateway-system/gateway listener=http route=default/mock-ratelimit-failover endpoint=mock-llm-fallback.default.svc.cluster.local:9234 src.addr=127.0.0.1:47948 http.method=POST http.host=127.0.0.1 http.path=/v1/chat/completions http.version=HTTP/1.1 http.status=200 protocol=llm gen_ai.operation.name=chat gen_ai.provider.name=openai gen_ai.request.model=gpt-4o-mini gen_ai.response.model=gpt-4o-mini gen_ai.usage.input_tokens=5 gen_ai.usage.output_tokens=2 duration=0ms
```