### PR TITLE
fix(mcp): support resource multiplexing

### DIFF
--- a/crates/agentgateway/src/mcp/handler.rs
+++ b/crates/agentgateway/src/mcp/handler.rs
@@ -104,6 +104,32 @@ impl Relay {
 		}
 	}
 
+	/// Reverse of `resource_uri`: extracts the service name and original URI from a
+	/// multiplexed URI of the form `service+scheme://rest`.
+	pub fn parse_resource_uri<'a>(
+		&'a self,
+		uri: &str,
+	) -> Result<(&'a str, String), UpstreamError> {
+		if let Some(default) = self.upstreams.default_target_name.as_ref() {
+			Ok((default.as_str(), uri.to_string()))
+		} else {
+			// URI format: "service+scheme://rest"
+			let plus_pos = uri.find('+').ok_or_else(|| {
+				UpstreamError::InvalidRequest("invalid resource URI".to_string())
+			})?;
+			let service_name = &uri[..plus_pos];
+			let original_uri = &uri[plus_pos + 1..];
+			// Validate that the extracted service name corresponds to a known upstream
+			let validated_name = self
+				.upstreams
+				.get_name(service_name)
+				.ok_or_else(|| {
+					UpstreamError::InvalidRequest(format!("unknown service {service_name}"))
+				})?;
+			Ok((validated_name, original_uri.to_string()))
+		}
+	}
+
 	pub fn get_sessions(&self) -> Option<Vec<MCPSession>> {
 		let mut sessions = Vec::with_capacity(self.upstreams.size());
 		for (_, us) in self.upstreams.iter_named() {
@@ -162,9 +188,6 @@ impl Relay {
 	}
 	pub fn is_multiplexing(&self) -> bool {
 		self.upstreams.is_multiplexing
-	}
-	pub fn default_target_name(&self) -> Option<String> {
-		self.upstreams.default_target_name.clone()
 	}
 
 	pub fn merge_tools(&self, cel: CelExecWrapper) -> Box<MergeFn> {
@@ -332,6 +355,7 @@ impl Relay {
 	}
 	pub fn merge_resource_templates(&self, cel: CelExecWrapper) -> Box<MergeFn> {
 		let policies = self.policies.clone();
+		let default_target_name = self.upstreams.default_target_name.clone();
 		Box::new(move |streams| {
 			let resource_templates = streams
 				.into_iter()
@@ -351,8 +375,15 @@ impl Relay {
 								&cel,
 							)
 						})
-						// TODO(https://github.com/agentgateway/agentgateway/issues/404) map this to the service name,
-						// if we add support for multiple services.
+						// Prefix uri_template with service name when multiplexing
+						.map(|mut rt| {
+							rt.uri_template = resource_uri(
+								default_target_name.as_ref(),
+								server_name.as_str(),
+								&rt.uri_template,
+							);
+							rt
+						})
 						.collect_vec()
 				})
 				.collect_vec();
@@ -385,19 +416,6 @@ impl Relay {
 		let stream = us.generic_stream(r, &ctx).await?;
 
 		messages_to_response(id, stream, mcp_log)
-	}
-	// For some requests, we don't have a sane mapping of incoming requests to a specific
-	// downstream service when multiplexing. Only forward when we have only one backend.
-	pub async fn send_single_without_multiplexing(
-		&self,
-		r: JsonRpcRequest<ClientRequest>,
-		ctx: IncomingRequestContext,
-		mcp_log: Option<AsyncLog<MCPInfo>>,
-	) -> Result<Response, UpstreamError> {
-		let Some(service_name) = &self.upstreams.default_target_name else {
-			return Err(UpstreamError::InvalidMethod(r.request.method().to_string()));
-		};
-		self.send_single(r, ctx, service_name, mcp_log).await
 	}
 	pub async fn send_fanout_deletion(
 		&self,
@@ -590,10 +608,11 @@ impl Relay {
 	) -> ServerInfo {
 		let capabilities = if multiplexing {
 			// Prompts are supported with multiplexing using proxy-prefixed names.
-			// Resources can be listed, but read/templates/completion do not have reverse routing yet.
+			// Resources are supported with multiplexing using service+scheme:// URI prefixing.
 			ServerCapabilities::builder()
 				.enable_tools()
 				.enable_prompts()
+				.enable_resources()
 				.build()
 		} else {
 			ServerCapabilities::builder()

--- a/crates/agentgateway/src/mcp/handler.rs
+++ b/crates/agentgateway/src/mcp/handler.rs
@@ -106,26 +106,21 @@ impl Relay {
 
 	/// Reverse of `resource_uri`: extracts the service name and original URI from a
 	/// multiplexed URI of the form `service+scheme://rest`.
-	pub fn parse_resource_uri<'a>(
-		&'a self,
-		uri: &str,
-	) -> Result<(&'a str, String), UpstreamError> {
+	pub fn parse_resource_uri<'a>(&'a self, uri: &str) -> Result<(&'a str, String), UpstreamError> {
 		if let Some(default) = self.upstreams.default_target_name.as_ref() {
 			Ok((default.as_str(), uri.to_string()))
 		} else {
 			// URI format: "service+scheme://rest"
-			let plus_pos = uri.find('+').ok_or_else(|| {
-				UpstreamError::InvalidRequest("invalid resource URI".to_string())
-			})?;
+			let plus_pos = uri
+				.find('+')
+				.ok_or_else(|| UpstreamError::InvalidRequest("invalid resource URI".to_string()))?;
 			let service_name = &uri[..plus_pos];
 			let original_uri = &uri[plus_pos + 1..];
 			// Validate that the extracted service name corresponds to a known upstream
 			let validated_name = self
 				.upstreams
 				.get_name(service_name)
-				.ok_or_else(|| {
-					UpstreamError::InvalidRequest(format!("unknown service {service_name}"))
-				})?;
+				.ok_or_else(|| UpstreamError::InvalidRequest(format!("unknown service {service_name}")))?;
 			Ok((validated_name, original_uri.to_string()))
 		}
 	}

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -143,6 +143,97 @@ async fn stream_to_multiplex() {
 }
 
 #[tokio::test]
+async fn stream_to_multiplex_resources() {
+	let mock_a = mock_streamable_http_server(true).await;
+	let mock_b = mock_streamable_http_server(true).await;
+	let t = setup_proxy_test("{}")
+		.unwrap()
+		.with_multiplex_mcp_backend(
+			"mcp",
+			vec![("a", mock_a.addr, false), ("b", mock_b.addr, false)],
+			true,
+		)
+		.with_bind(simple_bind())
+		.with_route(basic_named_route(strng::new("/mcp")));
+	let io = t.serve_real_listener(strng::new("bind")).await;
+	let client = mcp_streamable_client(io).await;
+
+	// 1. list_resources should return resources from both backends with prefixed URIs
+	let resources = client.list_resources(None).await.unwrap();
+	let uris: Vec<String> = resources
+		.resources
+		.iter()
+		.map(|r| r.uri.clone())
+		.sorted()
+		.collect();
+	// Each mock provides "str:////Users/to/some/path/" and "memo://insights"
+	// With multiplexing these become "a+str:////Users/to/some/path/", "a+memo://insights", etc.
+	assert!(
+		uris.iter().any(|u| u == "a+memo://insights"),
+		"Expected 'a+memo://insights' in resources, got: {:?}",
+		uris
+	);
+	assert!(
+		uris.iter().any(|u| u == "b+memo://insights"),
+		"Expected 'b+memo://insights' in resources, got: {:?}",
+		uris
+	);
+
+	// 2. read_resource with prefixed URI should route to the correct backend
+	let result = client
+		.read_resource(rmcp::model::ReadResourceRequestParams::new(
+			"a+memo://insights",
+		))
+		.await
+		.unwrap();
+	assert!(
+		!result.contents.is_empty(),
+		"Expected non-empty resource contents"
+	);
+	let text = match &result.contents[0] {
+		rmcp::model::ResourceContents::TextResourceContents { text, .. } => text.clone(),
+		other => panic!("Expected text resource content, got: {:?}", other),
+	};
+	assert!(
+		text.contains("Business Intelligence Memo"),
+		"Expected memo content, got: {}",
+		text
+	);
+
+	// Also read from backend "b"
+	let result_b = client
+		.read_resource(rmcp::model::ReadResourceRequestParams::new(
+			"b+memo://insights",
+		))
+		.await
+		.unwrap();
+	assert!(
+		!result_b.contents.is_empty(),
+		"Expected non-empty resource contents from backend b"
+	);
+
+	// 3. list_resource_templates should not error (mock returns empty)
+	let templates = client.list_resource_templates(None).await.unwrap();
+	// Templates may be empty since mock server returns empty vec, but should not error
+	assert!(
+		templates.resource_templates.is_empty(),
+		"Expected empty resource templates from mock, got: {:?}",
+		templates.resource_templates
+	);
+
+	// 4. read_resource with unprefixed URI should fail
+	assert!(
+		client
+			.read_resource(rmcp::model::ReadResourceRequestParams::new(
+				"memo://insights",
+			))
+			.await
+			.is_err(),
+		"Expected error when reading resource without service prefix"
+	);
+}
+
+#[tokio::test]
 async fn stateless_multiplex_tool_call_initializes_only_target() {
 	let mock_a = mock_streamable_http_server(true).await;
 	let mock_b = mock_streamable_http_server(true).await;

--- a/crates/agentgateway/src/mcp/session.rs
+++ b/crates/agentgateway/src/mcp/session.rs
@@ -465,10 +465,7 @@ impl Session {
 							&cel,
 						)?;
 						rrr.params.uri = original_uri;
-						self
-							.relay
-							.send_single(r, ctx, service_name, None)
-							.await
+						self.relay.send_single(r, ctx, service_name, None).await
 					},
 					ClientRequest::SubscribeRequest(sr) => {
 						let uri = sr.params.uri.clone();
@@ -482,10 +479,7 @@ impl Session {
 							&cel,
 						)?;
 						sr.params.uri = original_uri;
-						self
-							.relay
-							.send_single(r, ctx, service_name, None)
-							.await
+						self.relay.send_single(r, ctx, service_name, None).await
 					},
 					ClientRequest::UnsubscribeRequest(ur) => {
 						let uri = ur.params.uri.clone();
@@ -499,10 +493,7 @@ impl Session {
 							&cel,
 						)?;
 						ur.params.uri = original_uri;
-						self
-							.relay
-							.send_single(r, ctx, service_name, None)
-							.await
+						self.relay.send_single(r, ctx, service_name, None).await
 					},
 
 					ClientRequest::ListTasksRequest(_)
@@ -513,31 +504,28 @@ impl Session {
 						// TODO(https://github.com/agentgateway/agentgateway/issues/404)
 						Err(UpstreamError::InvalidMethod(r.request.method().to_string()))
 					},
-					ClientRequest::CompleteRequest(cr) => {
-						match &cr.params.r#ref {
-							Reference::Prompt(prompt) => {
-								let name = prompt.name.clone();
-								let (service_name, prompt_name) =
-									self.authorize_prompt_request(&name, &method, &mut span, &log, &cel)?;
-								cr.params.r#ref = Reference::for_prompt(prompt_name.to_string());
-								self.relay.send_single(r, ctx, service_name, None).await
-							},
-							Reference::Resource(resource) => {
-								let uri = resource.uri.clone();
-								let (service_name, original_uri) =
-									self.relay.parse_resource_uri(&uri)?;
-								self.authorize_resource_request(
-									service_name,
-									&original_uri,
-									&method,
-									&mut span,
-									&log,
-									&cel,
-								)?;
-								cr.params.r#ref = Reference::for_resource(original_uri);
-								self.relay.send_single(r, ctx, service_name, None).await
-							},
-						}
+					ClientRequest::CompleteRequest(cr) => match &cr.params.r#ref {
+						Reference::Prompt(prompt) => {
+							let name = prompt.name.clone();
+							let (service_name, prompt_name) =
+								self.authorize_prompt_request(&name, &method, &mut span, &log, &cel)?;
+							cr.params.r#ref = Reference::for_prompt(prompt_name.to_string());
+							self.relay.send_single(r, ctx, service_name, None).await
+						},
+						Reference::Resource(resource) => {
+							let uri = resource.uri.clone();
+							let (service_name, original_uri) = self.relay.parse_resource_uri(&uri)?;
+							self.authorize_resource_request(
+								service_name,
+								&original_uri,
+								&method,
+								&mut span,
+								&log,
+								&cel,
+							)?;
+							cr.params.r#ref = Reference::for_resource(original_uri);
+							self.relay.send_single(r, ctx, service_name, None).await
+						},
 					},
 				}
 			},

--- a/crates/agentgateway/src/mcp/session.rs
+++ b/crates/agentgateway/src/mcp/session.rs
@@ -412,18 +412,10 @@ impl Session {
 							.await
 					},
 					ClientRequest::ListResourceTemplatesRequest(_) => {
-						if !self.relay.is_multiplexing() {
-							self
-								.relay
-								.send_fanout(r, ctx, self.relay.merge_resource_templates(cel))
-								.await
-						} else {
-							// TODO(https://github.com/agentgateway/agentgateway/issues/404)
-							// Find a mapping of URL
-							Err(UpstreamError::InvalidMethodWithMultiplexing(
-								r.request.method().to_string(),
-							))
-						}
+						self
+							.relay
+							.send_fanout(r, ctx, self.relay.merge_resource_templates(cel))
+							.await
 					},
 					ClientRequest::CallToolRequest(ctr) => {
 						let name = ctr.params.name.clone();
@@ -462,73 +454,55 @@ impl Session {
 						self.relay.send_single(r, ctx, service_name, None).await
 					},
 					ClientRequest::ReadResourceRequest(rrr) => {
-						if let Some(service_name) = self.relay.default_target_name() {
-							let uri = rrr.params.uri.clone();
-							self.authorize_resource_request(
-								&service_name,
-								&uri,
-								&method,
-								&mut span,
-								&log,
-								&cel,
-							)?;
-							self
-								.relay
-								.send_single_without_multiplexing(r, ctx, None)
-								.await
-						} else {
-							// TODO(https://github.com/agentgateway/agentgateway/issues/404)
-							// Find a mapping of URL
-							Err(UpstreamError::InvalidMethodWithMultiplexing(
-								r.request.method().to_string(),
-							))
-						}
+						let uri = rrr.params.uri.clone();
+						let (service_name, original_uri) = self.relay.parse_resource_uri(&uri)?;
+						self.authorize_resource_request(
+							service_name,
+							&original_uri,
+							&method,
+							&mut span,
+							&log,
+							&cel,
+						)?;
+						rrr.params.uri = original_uri;
+						self
+							.relay
+							.send_single(r, ctx, service_name, None)
+							.await
 					},
 					ClientRequest::SubscribeRequest(sr) => {
-						if let Some(service_name) = self.relay.default_target_name() {
-							let uri = sr.params.uri.clone();
-							self.authorize_resource_request(
-								&service_name,
-								&uri,
-								&method,
-								&mut span,
-								&log,
-								&cel,
-							)?;
-							self
-								.relay
-								.send_single_without_multiplexing(r, ctx, None)
-								.await
-						} else {
-							// TODO(https://github.com/agentgateway/agentgateway/issues/404)
-							// Find a mapping of URL
-							Err(UpstreamError::InvalidMethodWithMultiplexing(
-								r.request.method().to_string(),
-							))
-						}
+						let uri = sr.params.uri.clone();
+						let (service_name, original_uri) = self.relay.parse_resource_uri(&uri)?;
+						self.authorize_resource_request(
+							service_name,
+							&original_uri,
+							&method,
+							&mut span,
+							&log,
+							&cel,
+						)?;
+						sr.params.uri = original_uri;
+						self
+							.relay
+							.send_single(r, ctx, service_name, None)
+							.await
 					},
 					ClientRequest::UnsubscribeRequest(ur) => {
-						if let Some(service_name) = self.relay.default_target_name() {
-							let uri = ur.params.uri.clone();
-							self.authorize_resource_request(
-								&service_name,
-								&uri,
-								&method,
-								&mut span,
-								&log,
-								&cel,
-							)?;
-							self
-								.relay
-								.send_single_without_multiplexing(r, ctx, None)
-								.await
-						} else {
-							// TODO(https://github.com/agentgateway/agentgateway/issues/404)
-							// Find a mapping of URL
-							Err(UpstreamError::InvalidMethodWithMultiplexing(
-								r.request.method().to_string(),
-							))
-						}
+						let uri = ur.params.uri.clone();
+						let (service_name, original_uri) = self.relay.parse_resource_uri(&uri)?;
+						self.authorize_resource_request(
+							service_name,
+							&original_uri,
+							&method,
+							&mut span,
+							&log,
+							&cel,
+						)?;
+						ur.params.uri = original_uri;
+						self
+							.relay
+							.send_single(r, ctx, service_name, None)
+							.await
 					},
 
 					ClientRequest::ListTasksRequest(_)
@@ -549,27 +523,19 @@ impl Session {
 								self.relay.send_single(r, ctx, service_name, None).await
 							},
 							Reference::Resource(resource) => {
-								if let Some(service_name) = self.relay.default_target_name() {
-									let uri = resource.uri.clone();
-									self.authorize_resource_request(
-										&service_name,
-										&uri,
-										&method,
-										&mut span,
-										&log,
-										&cel,
-									)?;
-									self
-										.relay
-										.send_single_without_multiplexing(r, ctx, None)
-										.await
-								} else {
-									// TODO(https://github.com/agentgateway/agentgateway/issues/404)
-									// Find a mapping of URL
-									Err(UpstreamError::InvalidMethodWithMultiplexing(
-										r.request.method().to_string(),
-									))
-								}
+								let uri = resource.uri.clone();
+								let (service_name, original_uri) =
+									self.relay.parse_resource_uri(&uri)?;
+								self.authorize_resource_request(
+									service_name,
+									&original_uri,
+									&method,
+									&mut span,
+									&log,
+									&cel,
+								)?;
+								cr.params.r#ref = Reference::for_resource(original_uri);
+								self.relay.send_single(r, ctx, service_name, None).await
 							},
 						}
 					},

--- a/crates/agentgateway/src/mcp/upstream/mod.rs
+++ b/crates/agentgateway/src/mcp/upstream/mod.rs
@@ -92,8 +92,6 @@ pub enum UpstreamError {
 	InvalidRequest(String),
 	#[error("unsupported method: {0}")]
 	InvalidMethod(String),
-	#[error("method {0} is unsupported with multiplexing")]
-	InvalidMethodWithMultiplexing(String),
 	#[error("stdio upstream error: {0}")]
 	ServiceError(#[from] rmcp::ServiceError),
 	#[error("http upstream error: {0}")]
@@ -304,6 +302,11 @@ impl UpstreamGroup {
 			.get(name)
 			.map(|v| v.as_ref())
 			.ok_or_else(|| anyhow::anyhow!("requested target {name} is not initialized",))
+	}
+	/// Returns the stored name key if it exists in the upstream map.
+	/// Used by `parse_resource_uri` to get a stable `&str` reference.
+	pub(crate) fn get_name(&self, name: &str) -> Option<&str> {
+		self.by_name.get_key_value(name).map(|(k, _)| k.as_str())
 	}
 
 	fn setup_upstream(&self, target: &McpTarget) -> Result<upstream::Upstream, mcp::Error> {


### PR DESCRIPTION
This adds support for multiplexing resources, resolving issues where multiple targets behind a single route would cause resources/read, resources/templates/list, and other resource-related methods to fail with InvalidMethodWithMultiplexing.

Fixes #1858

Signed-off-by: Anup Sharma <anupnewsmail@gmail.com> 