### PR TITLE
fix(llm): capture completion content in Messages and Responses API streaming paths

### DIFF
--- a/crates/agentgateway/src/llm/conversion/messages.rs
+++ b/crates/agentgateway/src/llm/conversion/messages.rs
@@ -746,12 +746,28 @@ fn translate_stop_reason(resp: &messages::StopReason) -> completions::FinishReas
 	}
 }
 
-pub fn passthrough_stream(b: Body, buffer_limit: usize, log: AmendOnDrop) -> Body {
+pub fn passthrough_stream(
+	b: Body,
+	buffer_limit: usize,
+	log: AmendOnDrop,
+	include_completion_in_log: bool,
+) -> Body {
 	let mut saw_token = false;
+	let mut completion = include_completion_in_log.then(String::new);
 	// https://platform.claude.com/docs/en/build-with-claude/streaming
 	parse::sse::json_passthrough::<messages::MessagesStreamEvent>(b, buffer_limit, move |f| {
 		// ignore errors... what else can we do?
-		let Some(Ok(f)) = f else { return };
+		let Some(Ok(f)) = f else {
+			// Stream ended ([DONE]): flush completion if not already set via MessageDelta
+			if f.is_none() {
+				log.non_atomic_mutate(|r| {
+					if let Some(c) = completion.take() {
+						r.response.completion = Some(vec![c]);
+					}
+				});
+			}
+			return;
+		};
 
 		// Extract info we need
 		match f {
@@ -766,12 +782,17 @@ pub fn passthrough_stream(b: Body, buffer_limit: usize, log: AmendOnDrop) -> Bod
 					r.response.provider_model = Some(strng::new(&message.model))
 				});
 			},
-			messages::MessagesStreamEvent::ContentBlockDelta { .. } => {
+			messages::MessagesStreamEvent::ContentBlockDelta { delta, .. } => {
 				if !saw_token {
 					saw_token = true;
 					log.non_atomic_mutate(|r| {
 						r.response.first_token = Some(Instant::now());
 					});
+				}
+				if let Some(c) = completion.as_mut()
+					&& let messages::ContentBlockDelta::TextDelta { text } = &delta
+				{
+					c.push_str(text);
 				}
 			},
 			messages::MessagesStreamEvent::MessageDelta { usage, delta: _ } => {
@@ -789,6 +810,9 @@ pub fn passthrough_stream(b: Body, buffer_limit: usize, log: AmendOnDrop) -> Bod
 						&& let Some(o) = r.response.output_tokens
 					{
 						r.response.total_tokens = Some(inp + o)
+					}
+					if let Some(c) = completion.take() {
+						r.response.completion = Some(vec![c]);
 					}
 				});
 			},

--- a/crates/agentgateway/src/llm/conversion/responses.rs
+++ b/crates/agentgateway/src/llm/conversion/responses.rs
@@ -6,13 +6,27 @@ use crate::http::Body;
 use crate::llm::{AmendOnDrop, types};
 use crate::parse;
 
-pub fn passthrough_stream(b: Body, buffer_limit: usize, log: AmendOnDrop) -> Body {
+pub fn passthrough_stream(
+	b: Body,
+	buffer_limit: usize,
+	log: AmendOnDrop,
+	include_completion_in_log: bool,
+) -> Body {
 	let mut saw_token = false;
+	let mut completion = include_completion_in_log.then(String::new);
 	parse::sse::json_passthrough::<types::responses::typed::ResponseStreamEvent>(
 		b,
 		buffer_limit,
 		move |event| {
 			let Some(Ok(event)) = event else {
+				// Stream ended ([DONE]): flush completion if not already set via ResponseCompleted
+				if event.is_none() {
+					log.non_atomic_mutate(|r| {
+						if let Some(c) = completion.take() {
+							r.response.completion = Some(vec![c]);
+						}
+					});
+				}
 				return;
 			};
 
@@ -36,11 +50,16 @@ pub fn passthrough_stream(b: Body, buffer_limit: usize, log: AmendOnDrop) -> Bod
 						}
 					});
 				},
-				types::responses::typed::ResponseStreamEvent::ResponseOutputTextDelta(_) if !saw_token => {
-					saw_token = true;
-					log.non_atomic_mutate(|r| {
-						r.response.first_token = Some(Instant::now());
-					});
+				types::responses::typed::ResponseStreamEvent::ResponseOutputTextDelta(ref delta) => {
+					if !saw_token {
+						saw_token = true;
+						log.non_atomic_mutate(|r| {
+							r.response.first_token = Some(Instant::now());
+						});
+					}
+					if let Some(c) = completion.as_mut() {
+						c.push_str(&delta.delta);
+					}
 				},
 				types::responses::typed::ResponseStreamEvent::ResponseCompleted(completed) => {
 					log.non_atomic_mutate(|r| {
@@ -58,6 +77,9 @@ pub fn passthrough_stream(b: Body, buffer_limit: usize, log: AmendOnDrop) -> Bod
 								Some(usage.input_tokens_details.cached_tokens as u64);
 							r.response.reasoning_tokens =
 								Some(usage.output_tokens_details.reasoning_tokens as u64);
+						}
+						if let Some(c) = completion.take() {
+							r.response.completion = Some(vec![c]);
 						}
 					});
 				},

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -1449,13 +1449,17 @@ impl AIProvider {
 				resp.map(|b| conversion::messages::from_completions::translate_stream(b, buffer, logger))
 			},
 			(AIProvider::Custom(_), InputFormat::Messages, Some(custom::ProviderFormat::Messages)) => {
-				resp.map(|b| conversion::messages::passthrough_stream(b, buffer, logger))
+				resp.map(|b| {
+					conversion::messages::passthrough_stream(b, buffer, logger, include_completion_in_log)
+				})
 			},
 			(AIProvider::Custom(_), InputFormat::Messages, Some(custom::ProviderFormat::Completions)) => {
 				resp.map(|b| conversion::completions::from_messages::translate_stream(b, buffer, logger))
 			},
 			(AIProvider::Custom(_), InputFormat::Responses, Some(custom::ProviderFormat::Responses)) => {
-				resp.map(|b| conversion::responses::passthrough_stream(b, buffer, logger))
+				resp.map(|b| {
+					conversion::responses::passthrough_stream(b, buffer, logger, include_completion_in_log)
+				})
 			},
 			(
 				AIProvider::Custom(_),
@@ -1492,21 +1496,23 @@ impl AIProvider {
 				| AIProvider::Vertex(_),
 				InputFormat::Responses,
 				_,
-			) => resp.map(|b| conversion::responses::passthrough_stream(b, buffer, logger)),
+			) => resp.map(|b| {
+				conversion::responses::passthrough_stream(b, buffer, logger, include_completion_in_log)
+			}),
 			(AIProvider::Gemini(_), InputFormat::Responses, _) => {
 				resp.map(|b| conversion::openai_compat::to_responses::translate_stream(b, buffer, logger))
 			},
 			// Vertex messages: passthrough only for Anthropic models, otherwise translate from completions
-			(AIProvider::Vertex(_), InputFormat::Messages, _) if is_vertex_anthropic => {
-				resp.map(|b| conversion::messages::passthrough_stream(b, buffer, logger))
-			},
+			(AIProvider::Vertex(_), InputFormat::Messages, _) if is_vertex_anthropic => resp.map(|b| {
+				conversion::messages::passthrough_stream(b, buffer, logger, include_completion_in_log)
+			}),
 			(AIProvider::Vertex(_), InputFormat::Messages, _) => {
 				resp.map(|b| conversion::completions::from_messages::translate_stream(b, buffer, logger))
 			},
 			// Anthropic messages: passthrough
-			(AIProvider::Anthropic(_), InputFormat::Messages, _) => {
-				resp.map(|b| conversion::messages::passthrough_stream(b, buffer, logger))
-			},
+			(AIProvider::Anthropic(_), InputFormat::Messages, _) => resp.map(|b| {
+				conversion::messages::passthrough_stream(b, buffer, logger, include_completion_in_log)
+			}),
 			// OpenAI/Gemini/Azure messages: translate from chat completions
 			(
 				AIProvider::OpenAI(_)

--- a/crates/agentgateway/src/llm/tests.rs
+++ b/crates/agentgateway/src/llm/tests.rs
@@ -1531,3 +1531,145 @@ fn completions_response_missing_message_and_usage_fields() {
 	assert_eq!(usage.completion_tokens, 0);
 	assert_eq!(usage.total_tokens, 12);
 }
+
+#[tokio::test]
+async fn messages_passthrough_stream_captures_completion() {
+	let input_path = fixture_path("response/anthropic/stream_basic.json");
+	let input_bytes = fs::read(&input_path).expect("Failed to read fixture");
+	let body = Body::from(input_bytes);
+	let log = AsyncLog::default();
+	let log2 = log.clone();
+	let llmresp = LLMInfo {
+		request: LLMRequest {
+			input_tokens: None,
+			input_format: InputFormat::Messages,
+			native_format: Some(custom::ProviderFormat::Messages),
+			request_model: "claude-haiku-4-5-20251001".into(),
+			provider: "anthropic".into(),
+			streaming: true,
+			params: Default::default(),
+			prompt: None,
+		},
+		response: LLMResponse::default(),
+	};
+	log.store(Some(llmresp));
+	let logger = AmendOnDrop::new(log, LLMResponsePolicies::default(), None);
+	let buffer_limit = 1024 * 1024;
+	let body = conversion::messages::passthrough_stream(body, buffer_limit, logger, true);
+	// Consume the body to drive the stream to completion
+	let _ = body.collect().await.unwrap();
+	let info = log2
+		.take()
+		.expect("log should have LLMInfo after stream completes");
+	let completion = info
+		.response
+		.completion
+		.expect("completion should be set for messages streaming");
+	assert_eq!(
+		completion.join(""),
+		"Hi there! How are you doing today? Is there anything I can help you with?"
+	);
+}
+
+#[tokio::test]
+async fn messages_passthrough_stream_skips_completion_when_disabled() {
+	let input_path = fixture_path("response/anthropic/stream_basic.json");
+	let input_bytes = fs::read(&input_path).expect("Failed to read fixture");
+	let body = Body::from(input_bytes);
+	let log = AsyncLog::default();
+	let log2 = log.clone();
+	let llmresp = LLMInfo {
+		request: LLMRequest {
+			input_tokens: None,
+			input_format: InputFormat::Messages,
+			native_format: Some(custom::ProviderFormat::Messages),
+			request_model: "claude-haiku-4-5-20251001".into(),
+			provider: "anthropic".into(),
+			streaming: true,
+			params: Default::default(),
+			prompt: None,
+		},
+		response: LLMResponse::default(),
+	};
+	log.store(Some(llmresp));
+	let logger = AmendOnDrop::new(log, LLMResponsePolicies::default(), None);
+	let buffer_limit = 1024 * 1024;
+	let body = conversion::messages::passthrough_stream(body, buffer_limit, logger, false);
+	let _ = body.collect().await.unwrap();
+	let info = log2
+		.take()
+		.expect("log should have LLMInfo after stream completes");
+	assert!(
+		info.response.completion.is_none(),
+		"completion should not be set when include_completion_in_log is false"
+	);
+}
+
+#[tokio::test]
+async fn responses_passthrough_stream_captures_completion() {
+	let input_path = fixture_path("response/responses/stream.json");
+	let input_bytes = fs::read(&input_path).expect("Failed to read fixture");
+	let body = Body::from(input_bytes);
+	let log = AsyncLog::default();
+	let log2 = log.clone();
+	let llmresp = LLMInfo {
+		request: LLMRequest {
+			input_tokens: None,
+			input_format: InputFormat::Responses,
+			native_format: Some(custom::ProviderFormat::Responses),
+			request_model: "gpt-4.1-mini".into(),
+			provider: "openai".into(),
+			streaming: true,
+			params: Default::default(),
+			prompt: None,
+		},
+		response: LLMResponse::default(),
+	};
+	log.store(Some(llmresp));
+	let logger = AmendOnDrop::new(log, LLMResponsePolicies::default(), None);
+	let buffer_limit = 1024 * 1024;
+	let body = conversion::responses::passthrough_stream(body, buffer_limit, logger, true);
+	let _ = body.collect().await.unwrap();
+	let info = log2
+		.take()
+		.expect("log should have LLMInfo after stream completes");
+	let completion = info
+		.response
+		.completion
+		.expect("completion should be set for responses streaming");
+	assert_eq!(completion.join(""), "Hello");
+}
+
+#[tokio::test]
+async fn responses_passthrough_stream_skips_completion_when_disabled() {
+	let input_path = fixture_path("response/responses/stream.json");
+	let input_bytes = fs::read(&input_path).expect("Failed to read fixture");
+	let body = Body::from(input_bytes);
+	let log = AsyncLog::default();
+	let log2 = log.clone();
+	let llmresp = LLMInfo {
+		request: LLMRequest {
+			input_tokens: None,
+			input_format: InputFormat::Responses,
+			native_format: Some(custom::ProviderFormat::Responses),
+			request_model: "gpt-4.1-mini".into(),
+			provider: "openai".into(),
+			streaming: true,
+			params: Default::default(),
+			prompt: None,
+		},
+		response: LLMResponse::default(),
+	};
+	log.store(Some(llmresp));
+	let logger = AmendOnDrop::new(log, LLMResponsePolicies::default(), None);
+	let buffer_limit = 1024 * 1024;
+	let body = conversion::responses::passthrough_stream(body, buffer_limit, logger, false);
+	let _ = body.collect().await.unwrap();
+	let info = log2
+		.take()
+		.expect("log should have LLMInfo after stream completes");
+	assert!(
+		info.response.completion.is_none(),
+		"completion should not be set when include_completion_in_log is false"
+	);
+}


### PR DESCRIPTION
## Summary

The Messages API (Anthropic) and Responses API (OpenAI) streaming paths did not accumulate completion text during streaming, causing OTEL telemetry consumers (e.g., Langfuse) that reference `llm.completion` via CEL `add` fields to receive empty output for streaming requests. Non-streaming requests worked correctly.

## Changes

Follows the existing convention from `completions::passthrough_stream`:

- **`conversion/messages.rs`**: Add `include_completion_in_log` parameter, accumulate `TextDelta` content, flush to `r.response.completion` at `MessageDelta` (with `[DONE]` fallback)
- **`conversion/responses.rs`**: Same pattern — accumulate `ResponseOutputTextDelta`, flush at `ResponseCompleted` (with `[DONE]` fallback)
- **`mod.rs`**: Pass `include_completion_in_log` to both passthrough call sites
- **`tests.rs`**: 4 new tests covering both paths with enabled/disabled states

## Testing

- All existing tests pass (993 unit + 85 integration)
- 4 new targeted tests verify completion capture and gating
- Manually verified with Anthropic streaming backend → Langfuse showing correct output

Fixes #1900