### PR TITLE
fix(llm): use correct Azure AI Foundry hostname format

### DIFF
--- a/controller/api/v1alpha1/agentgateway/agentgateway_backend_types.go
+++ b/controller/api/v1alpha1/agentgateway/agentgateway_backend_types.go
@@ -307,7 +307,7 @@ type AzureResourceType string
 const (
 	// AzureResourceTypeOpenAI uses the Azure OpenAI endpoint: {resourceName}.openai.azure.com
 	AzureResourceTypeOpenAI AzureResourceType = "OpenAI"
-	// AzureResourceTypeFoundry uses the Azure AI Foundry endpoint: {resourceName}-resource.services.ai.azure.com
+	// AzureResourceTypeFoundry uses the Azure AI Foundry endpoint: {resourceName}.services.ai.azure.com
 	AzureResourceTypeFoundry AzureResourceType = "Foundry"
 )
 
@@ -316,7 +316,11 @@ const (
 type AzureConfig struct {
 	// The Azure resource name used to construct the endpoint host.
 	// For OpenAI: {resourceName}.openai.azure.com
-	// For Foundry: {resourceName}-resource.services.ai.azure.com
+	// For Foundry: {resourceName}.services.ai.azure.com
+	// Note: when the Azure portal "Foundry legacy" template was used, the
+	// generated resource name may end in "-resource" (e.g. "myproject-resource");
+	// that suffix is part of the resource name as the user configured it, not
+	// part of the hostname suffix agentgateway should append.
 	// +required
 	ResourceName ShortString `json:"resourceName"`
 

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
@@ -137,7 +137,11 @@ spec:
                                     description: |-
                                       The Azure resource name used to construct the endpoint host.
                                       For OpenAI: {resourceName}.openai.azure.com
-                                      For Foundry: {resourceName}-resource.services.ai.azure.com
+                                      For Foundry: {resourceName}.services.ai.azure.com
+                                      Note: when the Azure portal "Foundry legacy" template was used, the
+                                      generated resource name may end in "-resource" (e.g. "myproject-resource");
+                                      that suffix is part of the resource name as the user configured it, not
+                                      part of the hostname suffix agentgateway should append.
                                     maxLength: 256
                                     minLength: 1
                                     type: string
@@ -5028,7 +5032,11 @@ spec:
                             description: |-
                               The Azure resource name used to construct the endpoint host.
                               For OpenAI: {resourceName}.openai.azure.com
-                              For Foundry: {resourceName}-resource.services.ai.azure.com
+                              For Foundry: {resourceName}.services.ai.azure.com
+                              Note: when the Azure portal "Foundry legacy" template was used, the
+                              generated resource name may end in "-resource" (e.g. "myproject-resource");
+                              that suffix is part of the resource name as the user configured it, not
+                              part of the hostname suffix agentgateway should append.
                             maxLength: 256
                             minLength: 1
                             type: string

--- a/controller/pkg/syncer/backend/backend_plugin.go
+++ b/controller/pkg/syncer/backend/backend_plugin.go
@@ -564,12 +564,16 @@ func toMCPProtocol(appProtocol string) api.MCPTarget_Protocol {
 
 // parseAzureEndpoint extracts the resource name and resource type from a full
 // Azure endpoint host string (e.g. "my-resource.openai.azure.com").
+//
+// For Foundry endpoints the host is "{resourceName}.services.ai.azure.com".
+// The Azure portal's legacy template generates resource names that end in
+// "-resource" (e.g. "myproject-resource"), which is part of the user's
+// resource name — NOT part of the hostname suffix. This parser must not
+// strip "-resource", or round-trip parsing would lose the suffix the user
+// configured.
 func parseAzureEndpoint(endpoint string) (string, api.AIBackend_AzureResourceType) {
 	if name, ok := strings.CutSuffix(endpoint, ".openai.azure.com"); ok {
 		return name, api.AIBackend_OPEN_AI
-	}
-	if name, ok := strings.CutSuffix(endpoint, "-resource.services.ai.azure.com"); ok {
-		return name, api.AIBackend_FOUNDRY
 	}
 	if name, ok := strings.CutSuffix(endpoint, ".services.ai.azure.com"); ok {
 		return name, api.AIBackend_FOUNDRY

--- a/controller/pkg/syncer/backend/backend_plugin_internal_test.go
+++ b/controller/pkg/syncer/backend/backend_plugin_internal_test.go
@@ -1,0 +1,57 @@
+package agentgatewaybackend
+
+import (
+	"testing"
+
+	"github.com/agentgateway/agentgateway/api"
+)
+
+func TestParseAzureEndpoint(t *testing.T) {
+	tests := []struct {
+		name             string
+		endpoint         string
+		wantName         string
+		wantResourceType api.AIBackend_AzureResourceType
+	}{
+		{
+			name:             "openai endpoint",
+			endpoint:         "my-resource.openai.azure.com",
+			wantName:         "my-resource",
+			wantResourceType: api.AIBackend_OPEN_AI,
+		},
+		{
+			name:             "foundry endpoint without -resource suffix",
+			endpoint:         "myproject.services.ai.azure.com",
+			wantName:         "myproject",
+			wantResourceType: api.AIBackend_FOUNDRY,
+		},
+		{
+			// Azure portal's "Foundry legacy" template generates resource
+			// names that end in "-resource". That suffix is part of the
+			// user's resource name, NOT part of the hostname suffix the
+			// parser should strip.
+			name:             "foundry endpoint with legacy -resource resource name preserved",
+			endpoint:         "myproject-resource.services.ai.azure.com",
+			wantName:         "myproject-resource",
+			wantResourceType: api.AIBackend_FOUNDRY,
+		},
+		{
+			name:             "unknown suffix falls back to whole endpoint with OpenAI type",
+			endpoint:         "something.example.com",
+			wantName:         "something.example.com",
+			wantResourceType: api.AIBackend_OPEN_AI,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotName, gotResourceType := parseAzureEndpoint(tt.endpoint)
+			if gotName != tt.wantName {
+				t.Errorf("parseAzureEndpoint(%q) name = %q, want %q", tt.endpoint, gotName, tt.wantName)
+			}
+			if gotResourceType != tt.wantResourceType {
+				t.Errorf("parseAzureEndpoint(%q) resourceType = %v, want %v", tt.endpoint, gotResourceType, tt.wantResourceType)
+			}
+		})
+	}
+}

--- a/crates/agentgateway/src/llm/azure.rs
+++ b/crates/agentgateway/src/llm/azure.rs
@@ -10,7 +10,7 @@ use crate::*;
 pub enum AzureResourceType {
 	/// Azure OpenAI Service endpoint: `{resourceName}.openai.azure.com`
 	OpenAI,
-	/// Azure AI Foundry (project) endpoint: `{resourceName}-resource.services.ai.azure.com`
+	/// Azure AI Foundry (project) endpoint: `{resourceName}.services.ai.azure.com`
 	/// Requires `project_name` to construct paths like `/api/projects/{project}/openai/v1/...`
 	#[serde(alias = "aiServices")]
 	Foundry,
@@ -82,12 +82,36 @@ impl Provider {
 				strng::format!("{}.openai.azure.com", self.resource_name)
 			},
 			AzureResourceType::Foundry => {
-				strng::format!("{}-resource.services.ai.azure.com", self.resource_name)
+				strng::format!("{}.services.ai.azure.com", self.resource_name)
 			},
 		}
 	}
 
 	fn api_version(&self) -> &str {
 		self.api_version.as_deref().unwrap_or("v1")
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn make_provider(resource_name: &str, resource_type: AzureResourceType) -> Provider {
+		Provider {
+			model: None,
+			resource_name: strng::new(resource_name),
+			resource_type,
+			api_version: None,
+			project_name: None,
+			cached_cred: AzureCredentialCache::default(),
+		}
+	}
+
+	#[rstest::rstest]
+	#[case::openai(AzureResourceType::OpenAI, "my-resource.openai.azure.com")]
+	#[case::foundry(AzureResourceType::Foundry, "my-resource.services.ai.azure.com")]
+	fn test_get_host(#[case] resource_type: AzureResourceType, #[case] expected: &str) {
+		let p = make_provider("my-resource", resource_type);
+		assert_eq!(p.get_host().as_str(), expected);
 	}
 }

--- a/schema/config.json
+++ b/schema/config.json
@@ -5755,7 +5755,7 @@
           "const": "openAI"
         },
         {
-          "description": "Azure AI Foundry (project) endpoint: `{resourceName}-resource.services.ai.azure.com`\nRequires `project_name` to construct paths like `/api/projects/{project}/openai/v1/...`",
+          "description": "Azure AI Foundry (project) endpoint: `{resourceName}.services.ai.azure.com`\nRequires `project_name` to construct paths like `/api/projects/{project}/openai/v1/...`",
           "type": "string",
           "const": "foundry"
         }


### PR DESCRIPTION
Closes #1892

## What

`crates/agentgateway/src/llm/azure.rs::get_host()` for `AzureResourceType::Foundry` constructed:

```text
{resourceName}-resource.services.ai.azure.com
```

Per Microsoft's documented format (cited by the issue reporter):

```text
{resourceName}.services.ai.azure.com
```

References:

- [Foundry REST API docs](https://learn.microsoft.com/en-us/rest/api/aifoundry/aiproject)
- [Foundry SDK overview](https://learn.microsoft.com/en-us/azure/foundry/how-to/develop/sdk-overview)

Bug was introduced in #1456 when the Foundry resource type was added.

## How

1. Drop the `-resource` suffix in the `Foundry` arm of `get_host()`.
2. Update the doc comment on the `Foundry` variant so the docs and code agree.
3. Add a `#[cfg(test)]` test module with `rstest` cases covering both `OpenAI` and `Foundry` host formatting. Pattern mirrors the existing `crates/agentgateway/src/llm/vertex.rs::test_get_host`.

## Verification

Run under the project-pinned toolchain (Rust 1.95 via `rust-toolchain.toml`):

| Command | Result |
| --- | --- |
| `cargo check -p agentgateway` | clean |
| `cargo test -p agentgateway --lib llm::azure` | 2 / 2 passed (`test_get_host::case_1_openai`, `test_get_host::case_2_foundry`) |
| `cargo clippy -p agentgateway --lib -- -D warnings` | clean |
| `cargo fmt --all --check` | clean |

## Backward-compatibility note

This is a behavior change for any deployment that worked around the bug by provisioning an Azure resource whose name already contains `-resource` (e.g., `myfoundry-resource`). The Azure docs have never documented the `-resource` suffix, so the realistic blast radius should be small — flagging anyway for the release notes.