### PR TITLE
refactor(mcp): add helper has_rules on McpAuthorizationSet and make CelExecWrapper cloneable

### DIFF
--- a/crates/agentgateway/src/http/authorization.rs
+++ b/crates/agentgateway/src/http/authorization.rs
@@ -208,9 +208,12 @@ impl RuleSets {
 				.map(|rule| rule.as_ref())
 		})
 	}
+	pub(crate) fn has_rules(&self) -> bool {
+		self.0.iter().any(|r| r.has_rules())
+	}
 	pub fn validate(&self, exec: &Executor) -> bool {
 		let rule_sets = &self.0;
-		let has_rules = rule_sets.iter().any(|r| r.has_rules());
+		let has_rules = self.has_rules();
 		// If there are no rule sets, everyone has access
 		#[allow(clippy::if_same_then_else)] // This is intentional to make things explicit.
 		let allowed = if !has_rules {

--- a/crates/agentgateway/src/mcp/rbac.rs
+++ b/crates/agentgateway/src/mcp/rbac.rs
@@ -162,15 +162,15 @@ mod tests {
 
 	#[test]
 	fn test_mcp_authorization_empty_rules_short_circuits() {
-		let authz = McpAuthorizationSet::new(RuleSets::from(vec![RuleSet::new(PolicySet::new(
-			vec![],
-			vec![],
-			vec![],
-		))]));
-		let req = req_without_claims();
 		let res = tool_resource("server", "increment");
 
-		assert!(authz.validate(&res, &CelExecWrapper::new(req)));
+		let no_rule_sets = McpAuthorizationSet::new(RuleSets::from(vec![]));
+		assert!(no_rule_sets.validate(&res, &CelExecWrapper::new(req_without_claims())));
+
+		let empty_rule_set = McpAuthorizationSet::new(RuleSets::from(vec![RuleSet::new(
+			PolicySet::new(vec![], vec![], vec![]),
+		)]));
+		assert!(empty_rule_set.validate(&res, &CelExecWrapper::new(req_without_claims())));
 	}
 
 	#[test]

--- a/crates/agentgateway/src/mcp/rbac.rs
+++ b/crates/agentgateway/src/mcp/rbac.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use ::cel::Value;
 use ::cel::objects::{KeyRef, MapValue};
 use serde::{Deserialize, Serialize};
@@ -20,11 +22,13 @@ impl McpAuthorization {
 	}
 }
 
-pub struct CelExecWrapper(::http::Request<()>);
+/// Cheap clone via Arc; this API treats the request as read-only after construction.
+#[derive(Clone)]
+pub struct CelExecWrapper(Arc<::http::Request<()>>);
 
 impl CelExecWrapper {
 	pub fn new(req: ::http::Request<()>) -> CelExecWrapper {
-		CelExecWrapper(req)
+		CelExecWrapper(Arc::new(req))
 	}
 }
 #[derive(Clone, Debug)]
@@ -35,9 +39,12 @@ impl McpAuthorizationSet {
 		Self(rs)
 	}
 	pub fn validate(&self, res: &ResourceType, cel: &CelExecWrapper) -> bool {
+		if !self.0.has_rules() {
+			return true;
+		}
 		tracing::debug!("Checking RBAC for resource: {:?}", res);
 		let mcp = crate::mcp::MCPInfo::from(res);
-		let exec = crate::cel::Executor::new_mcp_request(&cel.0, &mcp);
+		let exec = crate::cel::Executor::new_mcp_request(cel.0.as_ref(), &mcp);
 		self.0.validate(&exec)
 	}
 
@@ -151,6 +158,19 @@ mod tests {
 			vec![],
 		);
 		McpAuthorizationSet::new(RuleSets::from(vec![RuleSet::new(policies)]))
+	}
+
+	#[test]
+	fn test_mcp_authorization_empty_rules_short_circuits() {
+		let authz = McpAuthorizationSet::new(RuleSets::from(vec![RuleSet::new(PolicySet::new(
+			vec![],
+			vec![],
+			vec![],
+		))]));
+		let req = req_without_claims();
+		let res = tool_resource("server", "increment");
+
+		assert!(authz.validate(&res, &CelExecWrapper::new(req)));
 	}
 
 	#[test]


### PR DESCRIPTION
Small MCP RBAC helpers to make authorization checks cheaper and easier
  to reuse from callers that evaluate multiple resources per request.