### PR TITLE
Add Dominion Observatory trust verification example

### DIFF
--- a/examples/dominion-trust/README.md
+++ b/examples/dominion-trust/README.md
@@ -1,0 +1,52 @@
+# Dominion Observatory Trust Verification
+
+This example demonstrates how to use agentgateway's `extAuthz` policy to verify MCP server behavioral trust scores via [Dominion Observatory](https://dominion-observatory.sgdata.workers.dev) before allowing tool calls.
+
+## How it works
+
+1. An agent sends an MCP tool call through agentgateway
+2. Agentgateway's `extAuthz` policy sends a check request to the trust verification sidecar
+3. The sidecar queries the Dominion Observatory API: `GET /benchmark/{server_name}`
+4. If the server's trust score is below the threshold (default: 60), the request is denied with a 403
+5. If the server is trusted, the request proceeds to the MCP backend
+
+Trust scores are cached for 5 minutes to avoid excessive API calls.
+
+## Setup
+
+### 1. Start the trust verification sidecar
+
+```bash
+python trust-authz-server.py --port 8990 --threshold 60
+```
+
+Options:
+- `--port` - Port for the sidecar (default: 8990)
+- `--threshold` - Minimum trust score to allow requests (0-100, default: 60)
+- `--cache-ttl` - Cache duration in seconds (default: 300)
+
+### 2. Start your MCP server
+
+Start your MCP server on `localhost:3001` (or adjust `config.yaml` accordingly).
+
+### 3. Start agentgateway
+
+```bash
+agentgateway --config examples/dominion-trust/config.yaml
+```
+
+## API Reference
+
+Dominion Observatory provides behavioral trust scoring for 14,820+ MCP servers:
+
+```
+GET https://dominion-observatory.sgdata.workers.dev/benchmark/{server_name}
+
+Response: {"trust_score": 0-100, ...}
+```
+
+## Configuration
+
+Edit `config.yaml` to adjust:
+- MCP backend targets and ports
+- `failureMode`: `Deny` (default) blocks requests when the sidecar is unavailable; `Allow` lets them through

--- a/examples/dominion-trust/config.yaml
+++ b/examples/dominion-trust/config.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://agentgateway.dev/schema/config
+#
+# Dominion Observatory Trust Verification Example
+#
+# This example shows how to use agentgateway's extAuthz policy to verify
+# MCP server trust scores via Dominion Observatory before allowing tool calls.
+#
+# The ext_authz sidecar (trust-authz-server.py) checks trust scores against
+# https://dominion-observatory.sgdata.workers.dev and caches results for 5 minutes.
+#
+# Setup:
+#   1. Start the trust verification sidecar:
+#      python trust-authz-server.py
+#   2. Start your MCP server on localhost:3001
+#   3. Start agentgateway:
+#      agentgateway --config examples/dominion-trust/config.yaml
+
+binds:
+- port: 3000
+  listeners:
+  - name: mcp-with-trust-verification
+    routes:
+    - backends:
+      - mcp:
+          targets:
+          - name: my-mcp-server
+            mcp:
+              host: http://localhost:3001/mcp
+      policies:
+        extAuthz:
+          host: localhost:8990
+          protocol:
+            http:
+              # The sidecar expects the MCP server name as a query parameter.
+              # It returns 200 (allow) or 403 (deny) based on trust score.
+              path: '"/check-trust?server=" + mcp.target'
+          # Block requests when the trust verification service is unavailable
+          failureMode: Deny

--- a/examples/dominion-trust/test_trust_authz.py
+++ b/examples/dominion-trust/test_trust_authz.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""
+Tests for the Dominion Observatory trust-authz-server sidecar.
+
+Run with: python -m pytest test_trust_authz.py -v
+"""
+
+import json
+import threading
+import time
+import urllib.request
+import urllib.error
+from http.server import HTTPServer
+from unittest.mock import patch, MagicMock
+
+import sys
+import os
+
+# Add parent directory to path so we can import the server module
+sys.path.insert(0, os.path.dirname(__file__))
+
+# We need to import after path manipulation
+import importlib
+trust_authz = importlib.import_module("trust-authz-server")
+
+TrustAuthzHandler = trust_authz.TrustAuthzHandler
+get_trust_score = trust_authz.get_trust_score
+
+
+class TestGetTrustScore:
+    """Tests for the get_trust_score function."""
+
+    def setup_method(self):
+        """Clear the cache before each test."""
+        trust_authz._cache.clear()
+
+    @patch("trust-authz-server.urllib.request.urlopen")
+    def test_fetch_and_cache(self, mock_urlopen):
+        """Test fetching a score and caching the result."""
+        response_data = {"trust_score": 85}
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps(response_data).encode()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        score = get_trust_score("test-server", cache_ttl=300)
+        assert score == 85
+        assert mock_urlopen.call_count == 1
+
+        # Second call should use cache
+        score2 = get_trust_score("test-server", cache_ttl=300)
+        assert score2 == 85
+        assert mock_urlopen.call_count == 1  # No additional API call
+
+    @patch("trust-authz-server.urllib.request.urlopen")
+    def test_cache_expiry(self, mock_urlopen):
+        """Test that cache entries expire after TTL."""
+        response_data = {"trust_score": 70}
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps(response_data).encode()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        score = get_trust_score("expiry-server", cache_ttl=1)
+        assert score == 70
+
+        # Simulate cache expiry
+        trust_authz._cache["expiry-server"]["timestamp"] = time.monotonic() - 2
+
+        score2 = get_trust_score("expiry-server", cache_ttl=1)
+        assert score2 == 70
+        assert mock_urlopen.call_count == 2  # Had to fetch again
+
+    @patch("trust-authz-server.urllib.request.urlopen")
+    def test_api_error_returns_none(self, mock_urlopen):
+        """Test that API errors return None."""
+        mock_urlopen.side_effect = urllib.error.URLError("Connection refused")
+
+        score = get_trust_score("unreachable-server", cache_ttl=300)
+        assert score is None
+
+    @patch("trust-authz-server.urllib.request.urlopen")
+    def test_missing_trust_score_field(self, mock_urlopen):
+        """Test handling of API responses without trust_score."""
+        response_data = {"status": "unknown"}
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps(response_data).encode()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        score = get_trust_score("no-score-server", cache_ttl=300)
+        assert score is None
+
+
+class TestTrustAuthzServer:
+    """Integration tests for the ext_authz HTTP server."""
+
+    @classmethod
+    def setup_class(cls):
+        """Start the authz server in a background thread."""
+        cls.server = HTTPServer(("127.0.0.1", 0), TrustAuthzHandler)
+        cls.server.threshold = 60
+        cls.server.cache_ttl = 300
+        cls.port = cls.server.server_address[1]
+        cls.base_url = f"http://127.0.0.1:{cls.port}"
+        cls.thread = threading.Thread(target=cls.server.serve_forever, daemon=True)
+        cls.thread.start()
+
+    @classmethod
+    def teardown_class(cls):
+        """Stop the server."""
+        cls.server.shutdown()
+
+    def setup_method(self):
+        """Clear cache between tests."""
+        trust_authz._cache.clear()
+
+    def test_missing_server_param(self):
+        """Request without server parameter should return 400."""
+        req = urllib.request.Request(f"{self.base_url}/check-trust")
+        try:
+            urllib.request.urlopen(req)
+            assert False, "Should have raised HTTPError"
+        except urllib.error.HTTPError as e:
+            assert e.code == 400
+
+    def test_not_found_path(self):
+        """Unknown path should return 404."""
+        req = urllib.request.Request(f"{self.base_url}/unknown")
+        try:
+            urllib.request.urlopen(req)
+            assert False, "Should have raised HTTPError"
+        except urllib.error.HTTPError as e:
+            assert e.code == 404
+
+    @patch.object(trust_authz, "get_trust_score")
+    def test_trusted_server_allowed(self, mock_score):
+        """Trusted server should get 200 response."""
+        mock_score.return_value = 85
+        req = urllib.request.Request(
+            f"{self.base_url}/check-trust?server=trusted-server"
+        )
+        with urllib.request.urlopen(req) as resp:
+            assert resp.status == 200
+            data = json.loads(resp.read())
+            assert data["action"] == "allowed"
+            assert data["trust_score"] == 85
+
+    @patch.object(trust_authz, "get_trust_score")
+    def test_untrusted_server_denied(self, mock_score):
+        """Untrusted server should get 403 response."""
+        mock_score.return_value = 30
+        req = urllib.request.Request(
+            f"{self.base_url}/check-trust?server=untrusted-server"
+        )
+        try:
+            urllib.request.urlopen(req)
+            assert False, "Should have raised HTTPError"
+        except urllib.error.HTTPError as e:
+            assert e.code == 403
+            data = json.loads(e.read())
+            assert data["action"] == "denied"
+            assert data["trust_score"] == 30
+
+    @patch.object(trust_authz, "get_trust_score")
+    def test_api_unavailable_denied(self, mock_score):
+        """When API returns None, should deny with 403."""
+        mock_score.return_value = None
+        req = urllib.request.Request(
+            f"{self.base_url}/check-trust?server=unknown-server"
+        )
+        try:
+            urllib.request.urlopen(req)
+            assert False, "Should have raised HTTPError"
+        except urllib.error.HTTPError as e:
+            assert e.code == 403
+            data = json.loads(e.read())
+            assert data["action"] == "denied"

--- a/examples/dominion-trust/trust-authz-server.py
+++ b/examples/dominion-trust/trust-authz-server.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""
+Dominion Observatory Trust Verification - ext_authz sidecar for agentgateway.
+
+This lightweight HTTP server acts as an ext_authz backend for agentgateway.
+It checks MCP server behavioral trust scores via the Dominion Observatory API
+and returns allow/deny decisions.
+
+Usage:
+    python trust-authz-server.py [--port 8990] [--threshold 60] [--cache-ttl 300]
+
+API (Dominion Observatory):
+    GET https://dominion-observatory.sgdata.workers.dev/benchmark/{server_name}
+    Response: {"trust_score": 0-100, ...}
+"""
+
+import argparse
+import json
+import logging
+import time
+import urllib.request
+import urllib.error
+import urllib.parse
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger("dominion-trust-authz")
+
+# --- Configuration ---
+DOMINION_API_BASE = "https://dominion-observatory.sgdata.workers.dev"
+DEFAULT_THRESHOLD = 60
+DEFAULT_CACHE_TTL = 300  # 5 minutes
+DEFAULT_PORT = 8990
+REQUEST_TIMEOUT = 5
+
+# --- In-memory cache ---
+_cache = {}
+
+
+def get_trust_score(server_name, cache_ttl):
+    """Fetch trust score from Dominion Observatory with caching."""
+    now = time.monotonic()
+
+    # Check cache
+    if server_name in _cache:
+        entry = _cache[server_name]
+        if now - entry["timestamp"] < cache_ttl:
+            logger.debug(f"Cache hit for '{server_name}': score={entry['score']}")
+            return entry["score"]
+        else:
+            del _cache[server_name]
+
+    # Fetch from API
+    url = f"{DOMINION_API_BASE}/benchmark/{urllib.parse.quote(server_name, safe='')}"
+    logger.info(f"Fetching trust score for '{server_name}' from {url}")
+
+    try:
+        req = urllib.request.Request(
+            url,
+            headers={
+                "Accept": "application/json",
+                "User-Agent": "agentgateway-dominion-authz/1.0",
+            },
+        )
+        with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+
+        score = data.get("trust_score")
+        if score is not None:
+            _cache[server_name] = {"score": score, "timestamp": now}
+            logger.info(f"Trust score for '{server_name}': {score}")
+            return score
+        else:
+            logger.warning(f"No trust_score in response for '{server_name}': {data}")
+            return None
+
+    except urllib.error.HTTPError as e:
+        logger.warning(f"HTTP {e.code} from Dominion API for '{server_name}': {e.reason}")
+        return None
+    except urllib.error.URLError as e:
+        logger.error(f"Cannot reach Dominion API for '{server_name}': {e.reason}")
+        return None
+    except Exception as e:
+        logger.error(f"Error fetching trust score for '{server_name}': {e}")
+        return None
+
+
+class TrustAuthzHandler(BaseHTTPRequestHandler):
+    """HTTP handler for ext_authz trust verification requests."""
+
+    def do_GET(self):
+        """Handle ext_authz check requests from agentgateway."""
+        parsed = urllib.parse.urlparse(self.path)
+        params = urllib.parse.parse_qs(parsed.query)
+
+        if parsed.path != "/check-trust":
+            self.send_response(404)
+            self.end_headers()
+            self.wfile.write(b"Not found")
+            return
+
+        server_name = params.get("server", [None])[0]
+        if not server_name:
+            self.send_response(400)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps({
+                "error": "Missing 'server' query parameter"
+            }).encode())
+            return
+
+        score = get_trust_score(server_name, self.server.cache_ttl)
+
+        if score is None:
+            # API unreachable or invalid response - deny by default
+            self.send_response(403)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps({
+                "error": f"Trust score unavailable for server '{server_name}'",
+                "action": "denied",
+            }).encode())
+            return
+
+        if score < self.server.threshold:
+            # Trust score too low - deny
+            logger.warning(
+                f"DENIED: '{server_name}' has trust score {score} "
+                f"(threshold: {self.server.threshold})"
+            )
+            self.send_response(403)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps({
+                "error": f"Server '{server_name}' blocked: trust score {score} is below threshold {self.server.threshold}",
+                "trust_score": score,
+                "threshold": self.server.threshold,
+                "action": "denied",
+            }).encode())
+            return
+
+        # Trust score OK - allow
+        logger.info(
+            f"ALLOWED: '{server_name}' has trust score {score} "
+            f"(threshold: {self.server.threshold})"
+        )
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps({
+            "trust_score": score,
+            "threshold": self.server.threshold,
+            "action": "allowed",
+        }).encode())
+
+    def log_message(self, format, *args):
+        """Redirect HTTP server logs to our logger."""
+        logger.debug(f"{self.address_string()} - {format % args}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Dominion Observatory trust verification sidecar for agentgateway"
+    )
+    parser.add_argument(
+        "--port", type=int, default=DEFAULT_PORT,
+        help=f"Port to listen on (default: {DEFAULT_PORT})",
+    )
+    parser.add_argument(
+        "--threshold", type=int, default=DEFAULT_THRESHOLD,
+        help=f"Minimum trust score to allow requests (default: {DEFAULT_THRESHOLD})",
+    )
+    parser.add_argument(
+        "--cache-ttl", type=int, default=DEFAULT_CACHE_TTL,
+        help=f"Cache TTL in seconds (default: {DEFAULT_CACHE_TTL})",
+    )
+    args = parser.parse_args()
+
+    server = HTTPServer(("0.0.0.0", args.port), TrustAuthzHandler)
+    server.threshold = args.threshold
+    server.cache_ttl = args.cache_ttl
+
+    logger.info(
+        f"Dominion Observatory trust authz sidecar starting on port {args.port} "
+        f"(threshold: {args.threshold}, cache TTL: {args.cache_ttl}s)"
+    )
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        logger.info("Shutting down...")
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds a new example showing how to verify MCP server behavioral trust scores via [Dominion Observatory](https://dominion-observatory.sgdata.workers.dev) using agentgateway's existing `extAuthz` policy
- Includes a Python ext_authz sidecar that checks trust scores, caches results for 5 minutes, and returns allow/deny decisions
- Servers with scores below the threshold (default: 60) are blocked from receiving tool calls

## Details

This follows agentgateway's existing ext_authz pattern (similar to `oauth2-proxy` and `tailscale-auth` examples) to integrate external trust verification without modifying core Rust code.

**Files:**
- `examples/dominion-trust/config.yaml` - agentgateway config using `extAuthz` policy
- `examples/dominion-trust/trust-authz-server.py` - Python sidecar (ext_authz HTTP endpoint)
- `examples/dominion-trust/test_trust_authz.py` - Tests for the sidecar
- `examples/dominion-trust/README.md` - Setup and usage documentation

**How it works:**
1. Agent sends MCP tool call through agentgateway
2. `extAuthz` policy sends a check to the Python sidecar
3. Sidecar queries Dominion Observatory API: `GET /benchmark/{server_name}` -> `{trust_score: 0-100}`
4. Score below 60 returns 403 (deny); at or above 60 returns 200 (allow)

## Test plan
- [ ] Run `python -m pytest examples/dominion-trust/test_trust_authz.py -v`
- [ ] Start sidecar with `python trust-authz-server.py` and verify it responds on port 8990
- [ ] Verify trusted servers (score >= 60) get 200 and untrusted servers get 403
- [ ] Verify caching works (only one API call per server per 5-minute window)

🤖 Generated with [Claude Code](https://claude.com/claude-code)