### PR TITLE
fix(proxy): hostname NetworkGateway references

### DIFF
--- a/crates/agentgateway/src/proxy/gateway_test.rs
+++ b/crates/agentgateway/src/proxy/gateway_test.rs
@@ -3256,3 +3256,136 @@ async fn ingress_use_waypoint_build_transport_falls_back_without_ca() {
 	// Without CA, it falls back to Plain
 	assert_eq!(transport.name(), "plaintext");
 }
+
+#[tokio::test]
+async fn network_gateway_hostname_resolves_via_service_endpoint() {
+	use crate::proxy::httpproxy;
+	use crate::store::LocalWorkload;
+	use crate::types::discovery::gatewayaddress::Destination;
+	use crate::types::discovery::{
+		GatewayAddress, Identity, NamespacedHostname, NetworkAddress, Service, Workload,
+	};
+
+	let mock = simple_mock().await;
+	let gw_ip: std::net::IpAddr = "192.168.1.10".parse().unwrap();
+	let remote_network = strng::literal!("network-3");
+	let gateway_namespace = strng::literal!("gateway-ns");
+	let gateway_hostname = strng::literal!("gateway.example.internal");
+	let svc_port: u16 = 15008;
+	let gw_target_port: u16 = 31234;
+
+	let t = setup_proxy_test("{}").unwrap();
+
+	let app_svc = Service {
+		name: strng::literal!("my-svc"),
+		namespace: strng::literal!("default"),
+		hostname: strng::literal!("my-svc.default.svc.cluster.local"),
+		vips: vec![NetworkAddress {
+			network: strng::EMPTY,
+			address: "10.0.0.1".parse().unwrap(),
+		}],
+		ports: std::collections::HashMap::from([(80, mock.address().port())]),
+		..Default::default()
+	};
+	let remote_wl = LocalWorkload {
+		workload: Workload {
+			uid: strng::literal!("remote-wl-uid"),
+			name: strng::literal!("remote-wl"),
+			namespace: strng::literal!("default"),
+			service_account: strng::literal!("remote-sa"),
+			network: remote_network.clone(),
+			workload_ips: vec!["10.244.0.5".parse().unwrap()],
+			network_gateway: Some(GatewayAddress {
+				destination: Destination::Hostname(NamespacedHostname {
+					namespace: gateway_namespace.clone(),
+					hostname: gateway_hostname.clone(),
+				}),
+				hbone_mtls_port: svc_port,
+			}),
+			..Default::default()
+		},
+		services: std::collections::HashMap::from([(
+			"default/my-svc.default.svc.cluster.local".to_string(),
+			std::collections::HashMap::from([(80, mock.address().port())]),
+		)]),
+	};
+
+	// gateway service with port mapping
+	let gw_svc = Service {
+		name: strng::literal!("gateway-svc"),
+		namespace: gateway_namespace.clone(),
+		hostname: gateway_hostname.clone(),
+		vips: vec![],
+		ports: std::collections::HashMap::from([(svc_port, gw_target_port)]),
+		..Default::default()
+	};
+	let gw_wl = LocalWorkload {
+		workload: Workload {
+			uid: strng::literal!("gw-wl-uid"),
+			name: strng::literal!("gw-1"),
+			namespace: gateway_namespace.clone(),
+			service_account: strng::literal!("gateway-sa"),
+			network: remote_network.clone(),
+			workload_ips: vec![gw_ip],
+			..Default::default()
+		},
+		services: std::collections::HashMap::from([(
+			format!("{}/{}", gateway_namespace, gateway_hostname),
+			std::collections::HashMap::from([(svc_port, gw_target_port)]),
+		)]),
+	};
+
+	t.pi
+		.stores
+		.discovery
+		.sync_local(
+			vec![app_svc, gw_svc],
+			vec![remote_wl, gw_wl],
+			Default::default(),
+		)
+		.unwrap();
+
+	let svc = t
+		.pi
+		.stores
+		.read_discovery()
+		.services
+		.get_by_namespaced_host(&NamespacedHostname {
+			namespace: strng::literal!("default"),
+			hostname: strng::literal!("my-svc.default.svc.cluster.local"),
+		})
+		.expect("app service must exist");
+
+	let backend_call = httpproxy::build_service_call(
+		&t.pi,
+		Default::default(),
+		&mut None,
+		Default::default(),
+		&svc,
+		&80,
+		None,
+		None,
+	)
+	.expect("build_service_call should succeed");
+
+	let (resolved_gw, gw_identity) = backend_call
+		.network_gateway
+		.expect("network_gateway must be resolved for hostname-form destination");
+
+	assert_matches!(resolved_gw.destination, Destination::Address(addr) => {
+		assert_eq!(addr.address, gw_ip, "should resolve to the gateway endpoint IP");
+		assert_eq!(addr.network, remote_network, "network should be the gateway workload's network");
+	});
+	assert_eq!(
+		resolved_gw.hbone_mtls_port, gw_target_port,
+		"port should be the endpoint target port, not the service port"
+	);
+	assert_eq!(
+		gw_identity,
+		Identity::Spiffe {
+			trust_domain: strng::EMPTY,
+			namespace: gateway_namespace.clone(),
+			service_account: strng::literal!("gateway-sa"),
+		},
+	);
+}

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -1996,7 +1996,8 @@ pub fn build_service_call(
 		});
 	}
 
-	let workloads = &inputs.stores.read_discovery().workloads;
+	let discovery = inputs.stores.read_discovery();
+	let workloads = &discovery.workloads;
 	let (ep, handle, wl) = svc
 		.endpoints
 		.select_endpoint(workloads, svc.as_ref(), port, service_override.destination)
@@ -2016,33 +2017,78 @@ pub fn build_service_call(
 	// Check if we need double hbone (workload on remote network with gateway)
 	let network_gateway = if wl.network != inputs.cfg.network {
 		if let Some(gw_addr) = &wl.network_gateway {
-			// Look up the gateway workload to get its identity
-			let gateway_workload = match &gw_addr.destination {
+			match &gw_addr.destination {
 				types::discovery::gatewayaddress::Destination::Address(net_addr) => {
-					workloads.find_address(net_addr)
+					if let Some(gw_wl) = workloads.find_address(net_addr) {
+						let resolved_gw_addr = gw_addr.clone();
+						tracing::debug!(
+							source_network = %inputs.cfg.network,
+							dest_network = %wl.network,
+							gateway = ?resolved_gw_addr,
+							"picked workload on remote network, using double hbone"
+						);
+						Some((resolved_gw_addr, gw_wl.identity()))
+					} else {
+						tracing::warn!(
+							gateway_address = ?net_addr,
+							"network gateway address not found in workload store for remote workload"
+						);
+						None
+					}
 				},
-				types::discovery::gatewayaddress::Destination::Hostname(_hostname) => {
-					// TODO: Implement hostname resolution for gateway
-					// For now, we don't support hostname-based gateways
-					tracing::warn!("hostname-based network gateways not yet supported");
-					None
+				types::discovery::gatewayaddress::Destination::Hostname(hostname) => {
+					// TODO we could support looking up workloads by hostname too
+					let resolved = discovery
+						.services
+						.get_by_namespaced_host(&NamespacedHostname {
+							namespace: hostname.namespace.clone(),
+							hostname: hostname.hostname.clone(),
+						})
+						.and_then(|gw_svc| {
+							let (gw_ep, _gw_handle, gw_wl) = gw_svc.endpoints.select_endpoint(
+								&discovery.workloads,
+								gw_svc.as_ref(),
+								gw_addr.hbone_mtls_port,
+								None,
+							)?;
+							let resolved_port = select_service_target_port(
+								gw_ep.as_ref(),
+								gw_svc.as_ref(),
+								gw_addr.hbone_mtls_port,
+								None,
+								false,
+							)?;
+							let ip = *gw_wl.workload_ips.first()?;
+							Some((
+								GatewayAddress {
+									destination: types::discovery::gatewayaddress::Destination::Address(
+										NetworkAddress {
+											network: gw_wl.network.clone(),
+											address: ip,
+										},
+									),
+									hbone_mtls_port: resolved_port,
+								},
+								gw_wl.identity(),
+							))
+						});
+					if let Some((resolved_gw_addr, gw_identity)) = resolved {
+						tracing::debug!(
+							source_network = %inputs.cfg.network,
+							dest_network = %wl.network,
+							gateway = ?resolved_gw_addr,
+							"picked workload on remote network, using double hbone"
+						);
+						// TODO:wire the gw_handle through to handshake_double to track per-conn health/latency
+						Some((resolved_gw_addr, gw_identity))
+					} else {
+						tracing::warn!(
+							gateway_hostname = ?hostname,
+							"no service / endpoint / IP for hostname-based network gateway"
+						);
+						None
+					}
 				},
-			};
-
-			if let Some(gw_wl) = gateway_workload {
-				tracing::debug!(
-					source_network = % inputs.cfg.network,
-					dest_network = % wl.network,
-					gateway = ? gw_addr,
-					"picked workload on remote network, using double hbone"
-				);
-				Some((gw_addr.clone(), gw_wl.identity()))
-			} else {
-				tracing::warn!(
-					"network gateway {:?} not found for remote workload",
-					gw_addr
-				);
-				None
 			}
 		} else {
 			tracing::warn ! (
@@ -2062,7 +2108,6 @@ pub fn build_service_call(
 	// ingress gateways, never waypoint-to-waypoint traffic.
 	let waypoint = if svc.ingress_use_waypoint && hbone_source != Some(HboneSourceRole::Waypoint) {
 		if let Some(wp) = &svc.waypoint {
-			let discovery = inputs.stores.read_discovery();
 			let wp_ip = match &wp.destination {
 				types::discovery::gatewayaddress::Destination::Address(net_addr) => Some(net_addr.address),
 				types::discovery::gatewayaddress::Destination::Hostname(nh) => {
@@ -2105,7 +2150,6 @@ pub fn build_service_call(
 				};
 				identity.map(|id| (ip, id))
 			});
-			drop(discovery);
 			match waypoint_info {
 				Some((ip, identity)) => {
 					let wp_port = if wp.hbone_mtls_port > 0 {


### PR DESCRIPTION
allow the networkgateway reference to be hostname based

this does mean we go hostname -> services -> lb, but we don't track anything on the picked endpoint so we don't benefit from health/ewma/eviction, which would require a bunch more plumbing to be handled in a follow up. 