### PR TITLE
backendtls: fail closed on invalid backend client cert refs

### DIFF
--- a/controller/pkg/agentgateway/plugins/backend_tls_plugin.go
+++ b/controller/pkg/agentgateway/plugins/backend_tls_plugin.go
@@ -189,14 +189,17 @@ func translatePoliciesForBackendTLS(
 			if mtlsClientRef.Namespace != nil {
 				// TODO Implement this later
 				logger.Warn("ignoring Gateway.spec.tls.backend; cross namespace not permitted")
+				invalidBackendClientCertificate(conds, "Gateway.spec.tls.backend.clientCertificateRef cross namespace reference is not permitted")
 				skip = true
 			}
 			if mtlsClientRef.Kind != nil && *mtlsClientRef.Kind != wellknown.SecretKind {
 				logger.Warn("ignoring Gateway.spec.tls.backend; only Secret is allowed")
+				invalidBackendClientCertificate(conds, "Gateway.spec.tls.backend.clientCertificateRef must refer to a Secret")
 				skip = true
 			}
 			if mtlsClientRef.Group != nil && string(*mtlsClientRef.Group) != wellknown.SecretGVK.Group {
 				logger.Warn("ignoring Gateway.spec.tls.backend; only core is allowed")
+				invalidBackendClientCertificate(conds, "Gateway.spec.tls.backend.clientCertificateRef must use the core API group")
 				skip = true
 			}
 			if !skip {
@@ -207,14 +210,20 @@ func translatePoliciesForBackendTLS(
 				scrt := ptr.Flatten(krt.FetchOne(krtctx, secrets, krt.FilterObjectName(nn)))
 				if scrt == nil {
 					logger.Warn("ignoring Gateway.spec.tls.backend; secret not found")
+					invalidBackendClientCertificate(conds, "Gateway.spec.tls.backend.clientCertificateRef Secret not found")
 				} else {
 					if _, err := ValidateTlsSecretData(nn.Name, nn.Namespace, scrt.Data); err != nil {
-						logger.Warn("ignoring Gateway.spec.tls.backend; secret not found")
+						logger.Warn("ignoring Gateway.spec.tls.backend; secret invalid")
+						invalidBackendClientCertificate(conds, "Gateway.spec.tls.backend.clientCertificateRef Secret invalid: "+err.Error())
 					} else {
 						res.Cert = scrt.Data[corev1.TLSCertKey]
 						res.Key = scrt.Data[corev1.TLSPrivateKeyKey]
 					}
 				}
+			}
+			if res.Cert == nil || res.Key == nil {
+				res.Cert = dummyClientCert
+				res.Key = dummyClientCert
 			}
 		}
 
@@ -281,6 +290,14 @@ func targetEqual(a, b gwv1.LocalPolicyTargetReferenceWithSectionName) bool {
 
 // a sentinel value to send to agentgateway to signal that it should reject TLS connects due to invalid config
 var dummyCaCert = []byte("invalid")
+var dummyClientCert = []byte("invalid")
+
+func invalidBackendClientCertificate(conds map[string]*Condition, message string) {
+	conds[string(gwv1.PolicyConditionAccepted)].Error = &ConfigError{
+		Reason:  string(gwv1.PolicyReasonInvalid),
+		Message: message,
+	}
+}
 
 func getBackendTLSCACert(
 	krtctx krt.HandlerContext,

--- a/controller/pkg/agentgateway/translator/testdata/backends/backendtlspolicy-invalid-client-cert.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/backends/backendtlspolicy-invalid-client-cert.yaml
@@ -1,0 +1,97 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: basic
+  namespace: default
+spec:
+  gatewayClassName: agentgateway
+  tls:
+    backend:
+      clientCertificateRef:
+        group: ""
+        kind: Secret
+        name: missing-client-cert
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: infra-backend
+  namespace: default
+spec:
+  ports:
+    - name: https
+      port: 443
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: BackendTLSPolicy
+metadata:
+  name: invalid-client-cert
+  namespace: default
+spec:
+  targetRefs:
+    - name: infra-backend
+      kind: Service
+      group: ""
+      sectionName: https
+  validation:
+    hostname: example.com
+    wellKnownCACertificates: System
+---
+# Output
+output:
+- gateway:
+    Name: basic
+    Namespace: default
+  resource:
+    policy:
+      backend:
+        backendTls:
+          cert: aW52YWxpZA==
+          hostname: example.com
+          key: aW52YWxpZA==
+      key: default/invalid-client-cert:backend-tls:default/infra-backend.default.svc.cluster.local/443
+      name:
+        kind: BackendTLSPolicy
+        name: invalid-client-cert
+        namespace: default
+      target:
+        service:
+          hostname: infra-backend.default.svc.cluster.local
+          namespace: default
+          port: 443
+- canonical: true
+  hostname: infra-backend.default.svc.cluster.local
+  name: infra-backend
+  namespace: default
+  ports:
+  - appProtocol: TLS
+    servicePort: 443
+status:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: BackendTLSPolicy
+  metadata:
+    name: invalid-client-cert
+    namespace: default
+  spec: null
+  status:
+    ancestors:
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: basic
+      conditions:
+      - lastTransitionTime: fake
+        message: Gateway.spec.tls.backend.clientCertificateRef Secret not found
+        reason: Invalid
+        status: "False"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: Configuration is valid
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      controllerName: agentgateway.dev/agentgateway


### PR DESCRIPTION
When a selected Gateway backend client certificate ref is invalid, send an invalid client cert/key sentinel instead of silently omitting client certificate material. This keeps invalid mTLS configuration from degrading into a less strict upstream TLS connection.