### PR TITLE
ext-authz: preserve invalid header values

### DIFF
--- a/crates/agentgateway/src/http/ext_authz.rs
+++ b/crates/agentgateway/src/http/ext_authz.rs
@@ -219,8 +219,7 @@ impl ExtAuthz {
 			.headers()
 			.get_all(name)
 			.iter()
-			.filter_map(|v| v.to_str().ok())
-			.map(|s| s.to_string())
+			.map(|v| String::from_utf8_lossy(v.as_bytes()).into_owned())
 			.collect();
 
 		if !values.is_empty() {

--- a/crates/agentgateway/src/http/ext_authz_tests.rs
+++ b/crates/agentgateway/src/http/ext_authz_tests.rs
@@ -470,6 +470,26 @@ fn test_include_request_headers_empty_includes_all() {
 }
 
 #[test]
+fn test_get_header_values_sanitizes_non_utf8_values() {
+	use ::http::{HeaderName, HeaderValue, Request};
+
+	let mut req = Request::builder().body(http::Body::empty()).unwrap();
+	req.headers_mut().append(
+		"x-raw",
+		HeaderValue::from_bytes(b"ok-\xff").expect("obs-text should be accepted"),
+	);
+	req
+		.headers_mut()
+		.append("x-raw", HeaderValue::from_static("second"));
+
+	let ext_authz = ExtAuthz::default();
+	let mut headers = std::collections::HashMap::new();
+	ext_authz.get_header_values(&req, &HeaderName::from_static("x-raw"), &mut headers);
+
+	assert_eq!(headers.get("x-raw").unwrap(), "ok-\u{fffd}, second");
+}
+
+#[test]
 fn test_host_header_protection() {
 	// Test that host header cannot be added through upstream headers
 	let header_options = vec![


### PR DESCRIPTION
Forward configured request headers to the authorization service even when a value is not valid UTF-8. HTTP header values can carry opaque bytes, and dropping those values changes what ext-authz sees when making a decision.