### PR TITLE
fix(mcp): include RFC 7591 metadata in clientId mock DCR response

### DIFF
--- a/crates/agentgateway/src/mcp/auth.rs
+++ b/crates/agentgateway/src/mcp/auth.rs
@@ -338,25 +338,14 @@ pub(super) async fn client_registration(
 	Ok(upstream)
 }
 
+const MOCK_DCR_CLIENT_ID_ISSUED_AT: u64 = 0;
+
 /// Build the mock Dynamic Client Registration response used when
 /// `MCPAuthentication.clientId` is configured.
 ///
-/// RFC 7591 §3.2.1 (Client Information Response) requires the server to
-/// echo back the metadata the client registered, with the issued client_id
-/// appended. Strict MCP clients validate the response with a Zod schema
-/// (`OAuthClientInformationFullSchema`) that requires both `client_id` AND
-/// `redirect_uris` on the response. Returning only `{"client_id": "..."}`
-/// passes lax test clients but fails the MCP SDK used by Claude Code,
-/// MCP Inspector, and similar production clients.
-///
-/// We parse the client's submitted body, override `client_id` with the
-/// operator-configured value, and set `client_id_issued_at`. We do NOT
-/// mint a `client_secret` — operators using this path have a real
-/// pre-registered IdP app whose secret lives outside the gateway.
-///
-/// If the request body is empty or fails to parse as JSON, we fall back
-/// to a minimal `{"client_id": ...}` body so the function never fails on
-/// malformed input — same behavior as before for those cases.
+/// This path is for pre-registered IdP clients. The gateway is not creating
+/// a client upstream, so return deterministic registration metadata and carry
+/// forward only the requested redirect URIs that strict MCP clients validate.
 async fn build_mock_dcr_response(
 	req: &mut Request,
 	client_id: &str,
@@ -367,22 +356,19 @@ async fn build_mock_dcr_response(
 		.await
 		.map_err(ProxyError::Body)?;
 
-	let mut response_json: serde_json::Value =
-		serde_json::from_slice(&bytes).unwrap_or_else(|_| serde_json::json!({}));
-	// Ensure the response is a JSON object — if a client posted a non-object
-	// body (e.g. an array), default to an empty object so we don't return
-	// nonsense.
-	if !response_json.is_object() {
-		response_json = serde_json::json!({});
-	}
+	let redirect_uris = serde_json::from_slice::<serde_json::Value>(&bytes)
+		.ok()
+		.and_then(|json| json.get("redirect_uris").filter(|v| v.is_array()).cloned())
+		.unwrap_or_else(|| serde_json::json!([]));
 
-	response_json["client_id"] = serde_json::Value::String(client_id.to_string());
-	response_json["client_id_issued_at"] = serde_json::json!(
-		std::time::SystemTime::now()
-			.duration_since(std::time::UNIX_EPOCH)
-			.map(|d| d.as_secs())
-			.unwrap_or(0)
-	);
+	let response_json = serde_json::json!({
+		"client_id": client_id,
+		"client_id_issued_at": MOCK_DCR_CLIENT_ID_ISSUED_AT,
+		"token_endpoint_auth_method": "none",
+		"grant_types": ["authorization_code"],
+		"response_types": ["code"],
+		"redirect_uris": redirect_uris,
+	});
 
 	let body_bytes = bytes::Bytes::from(
 		serde_json::to_vec(&response_json).map_err(|e| ProxyError::ProcessingString(e.to_string()))?,
@@ -431,8 +417,6 @@ mod tests {
 
 	#[tokio::test]
 	async fn mock_dcr_echoes_redirect_uris_and_overrides_client_id() {
-		// RFC 7591 §3.2.1: response includes the metadata the client
-		// registered. MCP SDK's Zod schema requires redirect_uris.
 		let body = r#"{"redirect_uris":["http://localhost:33418/callback"],"grant_types":["authorization_code"],"client_name":"Claude Code"}"#;
 		let mut req = dcr_request(body);
 
@@ -451,8 +435,10 @@ mod tests {
 			json["grant_types"],
 			serde_json::json!(["authorization_code"])
 		);
-		assert_eq!(json["client_name"], "Claude Code");
-		assert!(json["client_id_issued_at"].is_number());
+		assert_eq!(json["response_types"], serde_json::json!(["code"]));
+		assert_eq!(json["token_endpoint_auth_method"], "none");
+		assert_eq!(json["client_id_issued_at"], MOCK_DCR_CLIENT_ID_ISSUED_AT);
+		assert!(json.get("client_name").is_none());
 	}
 
 	#[tokio::test]
@@ -477,8 +463,6 @@ mod tests {
 
 	#[tokio::test]
 	async fn mock_dcr_handles_empty_body() {
-		// Empty body — no metadata to echo. Response still has client_id
-		// + issued_at so the function never fails on minimal input.
 		let mut req = ::http::Request::builder()
 			.method(Method::POST)
 			.uri("https://gateway.example.com/client-registration")
@@ -491,13 +475,12 @@ mod tests {
 
 		let json = response_body_to_json(resp).await;
 		assert_eq!(json["client_id"], "operator-id");
-		assert!(json["client_id_issued_at"].is_number());
-		assert!(json.get("redirect_uris").is_none());
+		assert_eq!(json["client_id_issued_at"], MOCK_DCR_CLIENT_ID_ISSUED_AT);
+		assert_eq!(json["redirect_uris"], serde_json::json!([]));
 	}
 
 	#[tokio::test]
 	async fn mock_dcr_handles_malformed_json() {
-		// Garbage body — graceful fallback to minimal response, no 500.
 		let mut req = dcr_request("this is not json {{{");
 
 		let resp = build_mock_dcr_response(&mut req, "operator-id")
@@ -506,13 +489,11 @@ mod tests {
 
 		let json = response_body_to_json(resp).await;
 		assert_eq!(json["client_id"], "operator-id");
-		assert!(json["client_id_issued_at"].is_number());
+		assert_eq!(json["redirect_uris"], serde_json::json!([]));
 	}
 
 	#[tokio::test]
 	async fn mock_dcr_handles_non_object_body() {
-		// JSON array instead of object — we coerce to {} rather than
-		// trying to splice client_id into an array.
 		let mut req = dcr_request(r#"["not", "an", "object"]"#);
 
 		let resp = build_mock_dcr_response(&mut req, "operator-id")
@@ -522,5 +503,6 @@ mod tests {
 		let json = response_body_to_json(resp).await;
 		assert_eq!(json["client_id"], "operator-id");
 		assert!(json.is_object());
+		assert_eq!(json["redirect_uris"], serde_json::json!([]));
 	}
 }

--- a/crates/agentgateway/src/mcp/auth.rs
+++ b/crates/agentgateway/src/mcp/auth.rs
@@ -296,18 +296,7 @@ pub(super) async fn client_registration(
 	client: PolicyClient,
 ) -> Result<Response, ProxyError> {
 	if let Some(client_id) = &auth.client_id {
-		let body = serde_json::json!({
-			"client_id": client_id
-		});
-		let body = bytes::Bytes::from(
-			serde_json::to_vec(&body).map_err(|e| ProxyError::ProcessingString(e.to_string()))?,
-		);
-		return Ok(
-			Response::builder()
-				.status(::http::StatusCode::CREATED)
-				.header(::http::header::CONTENT_TYPE, "application/json")
-				.body(body.into())?,
-		);
+		return build_mock_dcr_response(req, client_id).await;
 	}
 
 	// Normalize issuer URL by removing trailing slashes to avoid double-slash in path
@@ -349,6 +338,63 @@ pub(super) async fn client_registration(
 	Ok(upstream)
 }
 
+/// Build the mock Dynamic Client Registration response used when
+/// `MCPAuthentication.clientId` is configured.
+///
+/// RFC 7591 §3.2.1 (Client Information Response) requires the server to
+/// echo back the metadata the client registered, with the issued client_id
+/// appended. Strict MCP clients validate the response with a Zod schema
+/// (`OAuthClientInformationFullSchema`) that requires both `client_id` AND
+/// `redirect_uris` on the response. Returning only `{"client_id": "..."}`
+/// passes lax test clients but fails the MCP SDK used by Claude Code,
+/// MCP Inspector, and similar production clients.
+///
+/// We parse the client's submitted body, override `client_id` with the
+/// operator-configured value, and set `client_id_issued_at`. We do NOT
+/// mint a `client_secret` — operators using this path have a real
+/// pre-registered IdP app whose secret lives outside the gateway.
+///
+/// If the request body is empty or fails to parse as JSON, we fall back
+/// to a minimal `{"client_id": ...}` body so the function never fails on
+/// malformed input — same behavior as before for those cases.
+async fn build_mock_dcr_response(
+	req: &mut Request,
+	client_id: &str,
+) -> Result<Response, ProxyError> {
+	let limit = crate::http::buffer_limit(req);
+	let body = std::mem::take(req.body_mut());
+	let bytes = crate::http::read_body_with_limit(body, limit)
+		.await
+		.map_err(ProxyError::Body)?;
+
+	let mut response_json: serde_json::Value =
+		serde_json::from_slice(&bytes).unwrap_or_else(|_| serde_json::json!({}));
+	// Ensure the response is a JSON object — if a client posted a non-object
+	// body (e.g. an array), default to an empty object so we don't return
+	// nonsense.
+	if !response_json.is_object() {
+		response_json = serde_json::json!({});
+	}
+
+	response_json["client_id"] = serde_json::Value::String(client_id.to_string());
+	response_json["client_id_issued_at"] = serde_json::json!(
+		std::time::SystemTime::now()
+			.duration_since(std::time::UNIX_EPOCH)
+			.map(|d| d.as_secs())
+			.unwrap_or(0)
+	);
+
+	let body_bytes = bytes::Bytes::from(
+		serde_json::to_vec(&response_json).map_err(|e| ProxyError::ProcessingString(e.to_string()))?,
+	);
+	Ok(
+		Response::builder()
+			.status(::http::StatusCode::CREATED)
+			.header(::http::header::CONTENT_TYPE, "application/json")
+			.body(body_bytes.into())?,
+	)
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
@@ -365,5 +411,116 @@ mod tests {
 			request_uri_for_oauth_metadata(&req).to_string(),
 			"https://example.com/.well-known/oauth-protected-resource/mcp"
 		);
+	}
+
+	async fn response_body_to_json(resp: Response) -> serde_json::Value {
+		let bytes = crate::http::read_resp_body(resp)
+			.await
+			.expect("response body should read");
+		serde_json::from_slice(&bytes).expect("response body should be JSON")
+	}
+
+	fn dcr_request(body: &'static str) -> Request {
+		::http::Request::builder()
+			.method(Method::POST)
+			.uri("https://gateway.example.com/client-registration")
+			.header(::http::header::CONTENT_TYPE, "application/json")
+			.body(Body::from(body))
+			.expect("request should build")
+	}
+
+	#[tokio::test]
+	async fn mock_dcr_echoes_redirect_uris_and_overrides_client_id() {
+		// RFC 7591 §3.2.1: response includes the metadata the client
+		// registered. MCP SDK's Zod schema requires redirect_uris.
+		let body = r#"{"redirect_uris":["http://localhost:33418/callback"],"grant_types":["authorization_code"],"client_name":"Claude Code"}"#;
+		let mut req = dcr_request(body);
+
+		let resp = build_mock_dcr_response(&mut req, "0oa1wcsu7sbWwq3Ht358")
+			.await
+			.expect("mock should build");
+
+		assert_eq!(resp.status(), ::http::StatusCode::CREATED);
+		let json = response_body_to_json(resp).await;
+		assert_eq!(json["client_id"], "0oa1wcsu7sbWwq3Ht358");
+		assert_eq!(
+			json["redirect_uris"],
+			serde_json::json!(["http://localhost:33418/callback"])
+		);
+		assert_eq!(
+			json["grant_types"],
+			serde_json::json!(["authorization_code"])
+		);
+		assert_eq!(json["client_name"], "Claude Code");
+		assert!(json["client_id_issued_at"].is_number());
+	}
+
+	#[tokio::test]
+	async fn mock_dcr_overrides_client_id_if_client_submitted_one() {
+		// If a client submitted its own client_id (unusual but possible),
+		// we override it with the operator-configured value rather than
+		// honoring what the client sent.
+		let body = r#"{"redirect_uris":["http://localhost:1234/cb"],"client_id":"client-supplied-id"}"#;
+		let mut req = dcr_request(body);
+
+		let resp = build_mock_dcr_response(&mut req, "operator-id")
+			.await
+			.expect("mock should build");
+
+		let json = response_body_to_json(resp).await;
+		assert_eq!(json["client_id"], "operator-id");
+		assert_eq!(
+			json["redirect_uris"],
+			serde_json::json!(["http://localhost:1234/cb"])
+		);
+	}
+
+	#[tokio::test]
+	async fn mock_dcr_handles_empty_body() {
+		// Empty body — no metadata to echo. Response still has client_id
+		// + issued_at so the function never fails on minimal input.
+		let mut req = ::http::Request::builder()
+			.method(Method::POST)
+			.uri("https://gateway.example.com/client-registration")
+			.body(Body::empty())
+			.expect("request should build");
+
+		let resp = build_mock_dcr_response(&mut req, "operator-id")
+			.await
+			.expect("mock should build for empty body");
+
+		let json = response_body_to_json(resp).await;
+		assert_eq!(json["client_id"], "operator-id");
+		assert!(json["client_id_issued_at"].is_number());
+		assert!(json.get("redirect_uris").is_none());
+	}
+
+	#[tokio::test]
+	async fn mock_dcr_handles_malformed_json() {
+		// Garbage body — graceful fallback to minimal response, no 500.
+		let mut req = dcr_request("this is not json {{{");
+
+		let resp = build_mock_dcr_response(&mut req, "operator-id")
+			.await
+			.expect("mock should build for invalid JSON");
+
+		let json = response_body_to_json(resp).await;
+		assert_eq!(json["client_id"], "operator-id");
+		assert!(json["client_id_issued_at"].is_number());
+	}
+
+	#[tokio::test]
+	async fn mock_dcr_handles_non_object_body() {
+		// JSON array instead of object — we coerce to {} rather than
+		// trying to splice client_id into an array.
+		let mut req = dcr_request(r#"["not", "an", "object"]"#);
+
+		let resp = build_mock_dcr_response(&mut req, "operator-id")
+			.await
+			.expect("mock should build for non-object body");
+
+		let json = response_body_to_json(resp).await;
+		assert_eq!(json["client_id"], "operator-id");
+		assert!(json.is_object());
 	}
 }


### PR DESCRIPTION
## Summary

Follow-up to #1831 and addressing [issue #1936](https://github.com/agentgateway/agentgateway/issues/1936). When `MCPAuthentication.clientId` is configured (the static-client short-circuit path), the gateway's mock DCR response contains only `{"client_id": "..."}` and omits every other RFC 7591 §3.2.1 Client Information Response field.

This breaks strict MCP clients. The official MCP SDK validates DCR responses with `OAuthClientInformationFullSchema`, which requires both `client_id` AND `redirect_uris`. Claude Code (and any other MCP client using the SDK) fails with:

```
"expected": "array", "path": ["redirect_uris"],
"message": "Invalid input: expected array, received undefined"
```

End-to-end effect: a production Okta integration following #1831's documentation gets all the way through the new Okta dispatch, hits the mock DCR, receives `{"client_id": "..."}`, fails Zod validation, and the OAuth flow stops. One missing field is currently blocking the entire MCP OAuth flow on a configuration that is otherwise green.

## Root cause

`crates/agentgateway/src/mcp/auth.rs`, the early-return path when `auth.client_id` is set, built a one-key JSON body and returned. RFC 7591 §3.2.1 expects the server to echo the metadata the client registered (notably `redirect_uris`) alongside the issued `client_id` so the client knows what was accepted.

## Fix

Extract the mock-response construction into a `build_mock_dcr_response` helper that:

1. Reads the incoming DCR request body (with the configured buffer limit).
2. Parses it as JSON, coerces non-object bodies to `{}`.
3. Overrides `client_id` with the operator-configured value and adds `client_id_issued_at`.
4. Returns the resulting JSON as the `201 Created` body.

Empty bodies, malformed JSON, and non-object bodies all fall back to a minimal `{"client_id", "client_id_issued_at"}` response — same fail-safe behavior as before for those cases. We deliberately do not mint a fake `client_secret`; operators using this path have a real pre-registered IdP app whose secret lives outside the gateway.

## Tests

Five new unit tests in `mod tests`:

- `mock_dcr_echoes_redirect_uris_and_overrides_client_id` — standard happy path: client posts `{redirect_uris, grant_types, client_name}`, response echoes all three and adds `client_id` + `client_id_issued_at`.
- `mock_dcr_overrides_client_id_if_client_submitted_one` — operator-configured `client_id` wins over a client-submitted one.
- `mock_dcr_handles_empty_body` — empty body returns minimal response, doesn't error.
- `mock_dcr_handles_malformed_json` — invalid JSON falls back gracefully, doesn't 500.
- `mock_dcr_handles_non_object_body` — JSON array body coerces to `{}` rather than splicing fields into an array.

`make lint` and `make test` both pass locally.

## Compatibility

No behavior change for the non-mock path (`auth.client_id` is `None`) — Auth0 and Keycloak DCR proxy flows are untouched. No CRD or config schema change. Existing tests continue to pass.

## Related

- Bug surfaced during a production Okta integration that had `provider: Okta` + `clientId` configured per #1831 documentation.
- Related discussion in #1831 review thread touched on shared-`client_id` semantics but framed it as an IdP-side config concern; this is a separate response-shape compliance issue on the gateway side.

cc @TwilightTechie @christian-posta @howardjohn