### PR TITLE
connect: replay bytes after tunnel response headers

### DIFF
--- a/crates/agentgateway/src/client/connect_tunnel.rs
+++ b/crates/agentgateway/src/client/connect_tunnel.rs
@@ -4,10 +4,12 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use crate::transport::stream::Socket;
 
 pub async fn handshake(
-	conn: &mut Socket,
+	conn: Socket,
 	dest: &str,
 	auth: Option<HeaderValue>,
-) -> Result<(), anyhow::Error> {
+) -> Result<Socket, anyhow::Error> {
+	let (ext, metrics, inner) = conn.into_parts();
+	let mut conn = Socket::new_rewind(inner);
 	// While the raw HTTP/1 usage here looks pretty sketchy, hyper itself is doing this so its probably sufficient
 	// for our simple needs here.
 	// If we need to add TLS (which implies ALPN negotiation, etc) then we will want to make this more robust.
@@ -40,19 +42,79 @@ pub async fn handshake(
 		}
 		pos += n;
 
-		let recvd = &buf[..pos];
-		if recvd.starts_with(b"HTTP/1.1 200") || recvd.starts_with(b"HTTP/1.0 200") {
-			if recvd.ends_with(b"\r\n\r\n") {
-				return Ok(());
+		if let Some(end) = header_end(&buf[..pos]) {
+			let recvd = &buf[..pos];
+			if recvd.starts_with(b"HTTP/1.1 200") || recvd.starts_with(b"HTTP/1.0 200") {
+				let conn = conn.keep_after(end);
+				return Ok(Socket::from_rewind(ext, metrics, conn));
+			} else if recvd.starts_with(b"HTTP/1.1 407") || recvd.starts_with(b"HTTP/1.0 407") {
+				return Err(anyhow::anyhow!("tunnel required auth"));
+			} else {
+				return Err(anyhow::anyhow!("tunnel failed"));
 			}
-			if pos == buf.len() {
-				return Err(anyhow::anyhow!("headers too long"));
-			}
-		// else read more
-		} else if recvd.starts_with(b"HTTP/1.1 407") {
-			return Err(anyhow::anyhow!("tunnel required auth"));
-		} else {
-			return Err(anyhow::anyhow!("tunnel failed"));
 		}
+		if pos == buf.len() {
+			return Err(anyhow::anyhow!("headers too long"));
+		}
+	}
+}
+
+fn header_end(buf: &[u8]) -> Option<usize> {
+	buf
+		.windows(4)
+		.position(|w| w == b"\r\n\r\n")
+		.map(|pos| pos + 4)
+}
+
+#[cfg(test)]
+mod tests {
+	use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+	use std::time::Instant;
+
+	use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+	use super::*;
+	use crate::transport::stream::TCPConnectionInfo;
+
+	fn memory_socket(stream: tokio::io::DuplexStream) -> Socket {
+		Socket::from_memory(
+			stream,
+			TCPConnectionInfo {
+				peer_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 1234),
+				local_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 4321),
+				start: Instant::now(),
+				raw_peer_addr: None,
+			},
+		)
+	}
+
+	#[tokio::test]
+	async fn handshake_replays_bytes_after_connect_headers() {
+		let (client, mut server) = tokio::io::duplex(1024);
+		let server_task = tokio::spawn(async move {
+			let mut request = vec![0; 256];
+			let n = server.read(&mut request).await.expect("read request");
+			assert!(
+				std::str::from_utf8(&request[..n])
+					.unwrap()
+					.starts_with("CONNECT dest:443 ")
+			);
+			server
+				.write_all(b"HTTP/1.1 200 OK\r\n\r\nhello")
+				.await
+				.expect("write response");
+		});
+
+		let mut tunneled = handshake(memory_socket(client), "dest:443", None)
+			.await
+			.expect("handshake should succeed");
+		let mut first_bytes = [0; 5];
+		tunneled
+			.read_exact(&mut first_bytes)
+			.await
+			.expect("read replayed bytes");
+
+		assert_eq!(&first_bytes, b"hello");
+		server_task.await.expect("server task");
 	}
 }

--- a/crates/agentgateway/src/client/mod.rs
+++ b/crates/agentgateway/src/client/mod.rs
@@ -313,10 +313,9 @@ impl Connector {
 					.map_err(crate::http::Error::new)?;
 				let dest = target.to_string();
 				// This is recursive but bounded: we cannot even tunnel to a tunnel
-				let mut con =
-					Box::pin(self.connect(tcfg.target, proxy_dst, *tcfg.transport, false)).await?;
+				let con = Box::pin(self.connect(tcfg.target, proxy_dst, *tcfg.transport, false)).await?;
 
-				connect_tunnel::handshake(&mut con, &dest, tcfg.token)
+				let con = connect_tunnel::handshake(con, &dest, tcfg.token)
 					.await
 					.map_err(crate::http::Error::new)?;
 				debug!(%dest, "connected to tunnel proxy (CONNECT)");


### PR DESCRIPTION
Preserve bytes that arrive after the CONNECT response headers in the same read.

The tunnel handshake now returns the rewound socket so any already-buffered tunneled data is still visible to the caller instead of being consumed while parsing the proxy response.