### PR TITLE
ci: verify controller CRD generation in pull_request.yml

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -137,8 +137,9 @@ jobs:
         go mod tidy
         git diff --exit-code go.mod go.sum
     - name: Gen
-      # TODO: the rest of codegen
-      run: make generate-apis check-clean-repo
+      run: |
+        make generate-apis check-clean-repo
+        make -C controller verify
 
   controller-e2e:
     runs-on: blacksmith-4vcpu-ubuntu-2404


### PR DESCRIPTION
Fixes #1939

**Description**
In PR #1831, generated CRD changes were missed because the CI did not verify the controller's code generation (`make -C controller generated-code`). The `controller-lint` job only executed `make generate-apis`, which solely handles protobuf generation.

This PR adds `make -C controller verify` to the `controller-lint` Gen step in `pull_request.yml`. The `verify` target ensures that all generated CRDs, deepcopy files, and OpenAPI specs are up to date and fails the build if there is a diff.

**Reproduction Log:**
(Added a dummy field to `AgentgatewayBackendSpec` locally to simulate a missed generation scenario):
```diff
--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
@@ -5242,6 +5242,9 @@ spec:
                 x-kubernetes-validations:
                 - message: exactly one of the fields in [agentCore] must be set
                   rule: '[has(self.agentCore)].filter(x,x==true).size() == 1'
+              dummy:
+                description: dummy is a fake field for CI testing.
+                type: string
               dynamicForwardProxy:
                 description: |-
                   dynamicForwardProxy configures the proxy to dynamically send requests to the destination based on the incoming
make: *** [verify] Error 1
```
