### PR TITLE
Add Dominion Observatory trust scoring example

### DIFF
--- a/examples/dominion-observatory-trust-scoring/Dockerfile
+++ b/examples/dominion-observatory-trust-scoring/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+WORKDIR /app
+RUN pip install --no-cache-dir flask httpx
+COPY authz-service.py .
+CMD ["python", "authz-service.py"]

--- a/examples/dominion-observatory-trust-scoring/README.md
+++ b/examples/dominion-observatory-trust-scoring/README.md
@@ -1,0 +1,39 @@
+# AgentGateway + Dominion Observatory Trust Scoring
+
+External authorization example that verifies MCP server trust scores before routing tool calls through AgentGateway.
+
+## How It Works
+
+1. Agent sends MCP tool call to AgentGateway
+2. AgentGateway calls the Observatory authz service (ext-authz)
+3. Authz service checks the target server's trust score via Observatory API
+4. If score >= threshold: request is routed to the upstream MCP server
+5. If score < threshold: request is denied with 403
+
+## Quick Start
+
+```bash
+docker-compose up
+```
+
+Or run the authz service standalone:
+
+```bash
+pip install flask httpx
+TRUST_THRESHOLD=70 python authz-service.py
+```
+
+## Configuration
+
+| Environment Variable | Default | Description |
+|---------------------|---------|-------------|
+| `TRUST_THRESHOLD` | 60 | Minimum trust score (0-100) |
+| `OBSERVATORY_URL` | https://dominionobservatory.com | Observatory API base URL |
+| `CACHE_TTL` | 300 | Trust score cache TTL in seconds |
+| `PORT` | 8080 | Authz service port |
+
+## Links
+
+- [Dominion Observatory](https://dominionobservatory.com) - Behavioral trust scoring for 14,800+ MCP servers
+- [AgentGateway ext-authz docs](https://agentgateway.dev/docs/policies/ext-authz)
+- [Observatory API](https://dominionobservatory.com/api/trust?url=example)

--- a/examples/dominion-observatory-trust-scoring/authz-service.py
+++ b/examples/dominion-observatory-trust-scoring/authz-service.py
@@ -1,0 +1,109 @@
+"""
+Dominion Observatory External Authorization Service for AgentGateway.
+
+This lightweight HTTP service implements the ext-authz protocol.
+AgentGateway calls this service before routing each MCP request.
+The service checks the target server's trust score via Observatory
+and returns allow/deny.
+
+Usage:
+    pip install flask httpx
+    python authz-service.py
+
+Configuration via environment variables:
+    TRUST_THRESHOLD  - Minimum trust score (0-100). Default: 60
+    OBSERVATORY_URL  - Observatory base URL. Default: https://dominionobservatory.com
+    CACHE_TTL        - Score cache TTL in seconds. Default: 300
+    PORT             - Service port. Default: 8080
+"""
+
+import os
+import time
+import logging
+import json
+from flask import Flask, request, jsonify
+import httpx
+
+app = Flask(__name__)
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+TRUST_THRESHOLD = float(os.environ.get("TRUST_THRESHOLD", "60"))
+OBSERVATORY_URL = os.environ.get("OBSERVATORY_URL", "https://dominionobservatory.com")
+CACHE_TTL = float(os.environ.get("CACHE_TTL", "300"))
+
+# In-memory trust score cache
+_cache: dict[str, tuple[float, dict]] = {}
+
+
+def check_trust(server_url: str) -> dict:
+    """Query Observatory trust API with caching."""
+    now = time.time()
+
+    if server_url in _cache:
+        cached_time, cached_data = _cache[server_url]
+        if now - cached_time < CACHE_TTL:
+            return cached_data
+
+    try:
+        resp = httpx.get(
+            f"{OBSERVATORY_URL}/api/trust",
+            params={"url": server_url},
+            timeout=10.0,
+        )
+        data = resp.json()
+        _cache[server_url] = (now, data)
+        return data
+    except Exception as e:
+        logger.warning(f"Observatory check failed: {e}")
+        # Fail open — allow on API error
+        return {"found": False, "trust_score": None, "error": str(e)}
+
+
+@app.route("/authorize", methods=["GET", "POST"])
+def authorize():
+    """External authorization endpoint called by AgentGateway.
+
+    Checks the X-MCP-Server-URL header against Observatory's trust scores.
+    Returns 200 to allow, 403 to deny.
+    """
+    server_url = request.headers.get("X-MCP-Server-URL", "")
+
+    if not server_url:
+        # No server URL in request — allow (non-MCP traffic)
+        return "", 200
+
+    trust_data = check_trust(server_url)
+    score = trust_data.get("trust_score")
+
+    if score is None:
+        # Server not tracked — allow (fail open)
+        logger.info(f"ALLOW (untracked): {server_url}")
+        return "", 200
+
+    if score >= TRUST_THRESHOLD:
+        logger.info(f"ALLOW: {server_url} (score={score})")
+        return "", 200
+    else:
+        logger.warning(f"DENY: {server_url} (score={score} < {TRUST_THRESHOLD})")
+        return jsonify({
+            "error": "MCP server trust check failed",
+            "server_url": server_url,
+            "trust_score": score,
+            "threshold": TRUST_THRESHOLD,
+            "details_url": f"{OBSERVATORY_URL}/api/trust?url={server_url}",
+        }), 403
+
+
+@app.route("/health", methods=["GET"])
+def health():
+    """Health check endpoint."""
+    return jsonify({"status": "ok", "threshold": TRUST_THRESHOLD})
+
+
+if __name__ == "__main__":
+    port = int(os.environ.get("PORT", "8080"))
+    logger.info(f"Starting Observatory authz service on port {port}")
+    logger.info(f"Trust threshold: {TRUST_THRESHOLD}")
+    logger.info(f"Observatory URL: {OBSERVATORY_URL}")
+    app.run(host="0.0.0.0", port=port)

--- a/examples/dominion-observatory-trust-scoring/config.yaml
+++ b/examples/dominion-observatory-trust-scoring/config.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://agentgateway.dev/schema/config
+#
+# AgentGateway + Dominion Observatory Trust Scoring
+#
+# Routes MCP traffic through AgentGateway with external authorization
+# powered by Dominion Observatory's behavioral trust scores.
+#
+# Trust scores are checked before each tool call. Servers with scores
+# below the threshold are blocked automatically.
+
+binds:
+- port: 3000
+  listeners:
+  - routes:
+    - policies:
+        extAuthz:
+          conditional:
+          - host: observatory-authz
+            port: 8080
+            protocol: http
+            path: '"/authorize"'
+            headers:
+              - authorization
+              - x-mcp-server-url
+      backends:
+      - mcp:
+          targets:
+          - name: upstream-mcp-server
+            host: upstream-server
+            port: 8080

--- a/examples/dominion-observatory-trust-scoring/docker-compose.yaml
+++ b/examples/dominion-observatory-trust-scoring/docker-compose.yaml
@@ -1,0 +1,23 @@
+version: "3.8"
+
+services:
+  # Dominion Observatory authorization service
+  observatory-authz:
+    build: .
+    ports:
+      - "8080:8080"
+    environment:
+      TRUST_THRESHOLD: "60"
+      OBSERVATORY_URL: "https://dominionobservatory.com"
+      CACHE_TTL: "300"
+      PORT: "8080"
+
+  # AgentGateway with external authorization
+  agentgateway:
+    image: ghcr.io/agentgateway/agentgateway:latest
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./config.yaml:/etc/agentgateway/config.yaml
+    depends_on:
+      - observatory-authz


### PR DESCRIPTION
## Summary

Adds a new ext-authz example that integrates [Dominion Observatory](https://dominionobservatory.com) behavioral trust scoring with AgentGateway. Before routing each MCP tool call, the authorization service checks the target server's trust score and blocks servers below a configurable threshold.

- Lightweight Flask-based ext-authz service with in-memory caching
- Docker Compose setup for one-command deployment (`docker-compose up`)
- AgentGateway config with external authorization policy
- Covers 14,800+ MCP servers tracked by Observatory

### Files

| File | Purpose |
|------|---------|
| `config.yaml` | AgentGateway config with ext-authz policy |
| `authz-service.py` | HTTP authorization service (Observatory API client) |
| `docker-compose.yaml` | Service orchestration |
| `Dockerfile` | Authz service container |
| `README.md` | Setup and configuration docs |

### How it works

1. Agent sends MCP tool call to AgentGateway
2. AgentGateway calls the Observatory authz service (ext-authz)
3. Authz service checks the target server's trust score via Observatory API
4. Score >= threshold → request routed to upstream MCP server
5. Score < threshold → request denied with 403

### Related

- [Dominion Observatory](https://dominionobservatory.com) — Behavioral trust scoring for MCP servers
- [Observatory API](https://dominionobservatory.com/api/trust?url=example) — Trust score lookup
- Issue #1927 — Original feature discussion