### PR TITLE
Fall back to config_dump for simplified mcp/llm configs

### DIFF
--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -52,7 +52,15 @@ export async function fetchConfig(): Promise<LocalConfig> {
       }
       throw new Error(`Failed to fetch config: ${r.status}`);
     }
-    return (await r.json()) as LocalConfig;
+    const config = (await r.json()) as any;
+    // The simplified mcp/llm top-level config formats are expanded into binds/listeners/routes/backends
+    // by the backend at runtime. The raw config file won't have binds in that case, so fall back
+    // to config_dump which returns the fully expanded representation.
+    if (!config.binds && (config.mcp || config.llm)) {
+      return fetchViaDump();
+    }
+    config.binds = config.binds ?? [];
+    return config as LocalConfig;
   }
 }
 


### PR DESCRIPTION
When using the simplified `mcp:` or `llm:` top-level config format, the UI shows 0 listeners, 0 routes and 0 backends.

The `/config` endpoint returns the raw config file as JSON. When the simplified format is used, this JSON has `mcp` or `llm` top-level keys but no `binds`. The UI exclusively reads from `config.binds` to populate listeners, routes, and backends — so it sees an empty configuration.

The backend correctly expands the simplified format into the full bind/listener/route/backend model at runtime (confirmed via `/config_dump`), but the UI never consults that expanded representation.

This breaks the primary onboarding path: the [MCP quickstart guide](https://agentgateway.dev/docs/standalone/latest/quickstart/mcp/) uses the simplified `mcp:` format, and the [configuration overview](https://agentgateway.dev/docs/standalone/latest/configuration/overview/) recommends it as the default for MCP and LLM use cases.

The fix: In `fetchViaConfig()`, detect when the response uses the simplified format (`mcp` or `llm` keys present, no `binds`) and fall back to the `/config_dump` endpoint which returns the fully expanded internal representation. This reuses the existing `configDumpToLocalConfig()` mapper — the same code path already used in XDS mode.

Fixes #1958.