### PR TITLE
fix: defer Backend::Dynamic target resolution until after transformat…

### DIFF
--- a/crates/agentgateway/src/llm/policy/azure_content_safety.rs
+++ b/crates/agentgateway/src/llm/policy/azure_content_safety.rs
@@ -8,7 +8,7 @@ use crate::http::jwt::Claims;
 use crate::llm::RequestType;
 use crate::llm::policy::{AnalyzeTextConfig, AzureContentSafety, DetectJailbreakConfig};
 use crate::proxy::httpproxy::PolicyClient;
-use crate::types::agent::{BackendTrafficPolicy, ResourceName, SimpleBackend, Target};
+use crate::types::agent::{Backend, BackendTrafficPolicy, ResourceName};
 
 // ---------------------------------------------------------------------------
 // Analyze Text types
@@ -234,12 +234,12 @@ async fn send_content_safety_request<Req: Serialize, Resp: serde::de::Deserializ
 
 	let req = rb.body(crate::http::Body::from(serde_json::to_vec(body)?))?;
 
-	let mock_be = SimpleBackend::Opaque(
+	let mock_be = Backend::Dynamic(
 		ResourceName::new(
 			strng::literal!("_azure-content-safety"),
 			strng::literal!(""),
 		),
-		Target::Hostname(host, 443),
+		(),
 	);
 
 	let resp = client

--- a/crates/agentgateway/src/llm/policy/bedrock_guardrails.rs
+++ b/crates/agentgateway/src/llm/policy/bedrock_guardrails.rs
@@ -8,7 +8,7 @@ use crate::llm::RequestType;
 use crate::llm::bedrock::AwsRegion;
 use crate::llm::policy::BedrockGuardrails;
 use crate::proxy::httpproxy::PolicyClient;
-use crate::types::agent::{BackendTrafficPolicy, ResourceName, SimpleBackend, Target};
+use crate::types::agent::{Backend, BackendTrafficPolicy, ResourceName};
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
@@ -215,9 +215,9 @@ async fn send_guardrail_request(
 
 	let req = rb.body(crate::http::Body::from(serde_json::to_vec(&request_body)?))?;
 
-	let mock_be = SimpleBackend::Opaque(
+	let mock_be = Backend::Dynamic(
 		ResourceName::new(strng::literal!("_bedrock-guardrails"), strng::literal!("")),
-		Target::Hostname(host, 443),
+		(),
 	);
 
 	let resp = client

--- a/crates/agentgateway/src/llm/policy/google_model_armor.rs
+++ b/crates/agentgateway/src/llm/policy/google_model_armor.rs
@@ -15,7 +15,7 @@ use crate::json;
 use crate::llm::RequestType;
 use crate::llm::policy::GoogleModelArmor;
 use crate::proxy::httpproxy::PolicyClient;
-use crate::types::agent::{BackendTrafficPolicy, ResourceName, SimpleBackend, Target};
+use crate::types::agent::{Backend, BackendTrafficPolicy, ResourceName};
 
 /// User prompt data for sanitization
 #[derive(Debug, Clone, Serialize)]
@@ -368,9 +368,9 @@ async fn send_model_armor_request<T: Serialize>(
 
 	let req = rb.body(crate::http::Body::from(serde_json::to_vec(request_body)?))?;
 
-	let mock_be = SimpleBackend::Opaque(
+	let mock_be = Backend::Dynamic(
 		ResourceName::new(strng::literal!("_google-model-armor"), strng::literal!("")),
-		Target::Hostname(host, 443),
+		(),
 	);
 
 	let resp = client

--- a/crates/agentgateway/src/llm/policy/moderation.rs
+++ b/crates/agentgateway/src/llm/policy/moderation.rs
@@ -6,7 +6,7 @@ use crate::json;
 use crate::llm::RequestType;
 use crate::llm::policy::Moderation;
 use crate::proxy::httpproxy::PolicyClient;
-use crate::types::agent::{BackendTrafficPolicy, ResourceName, SimpleBackend, Target};
+use crate::types::agent::{Backend, BackendTrafficPolicy, ResourceName};
 
 pub async fn send_request(
 	req: &mut dyn RequestType,
@@ -41,9 +41,9 @@ pub async fn send_request(
 			"model": model,
 		}),
 	)?))?;
-	let mock_be = SimpleBackend::Opaque(
+	let mock_be = Backend::Dynamic(
 		ResourceName::new(strng::literal!("_openai-moderation"), strng::literal!("")),
-		Target::Hostname(strng::literal!("api.openai.com"), 443),
+		(),
 	);
 	let resp = client
 		.call_with_explicit_policies_list(req, mock_be, pols)

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -1522,7 +1522,7 @@ async fn make_backend_call(
 		inference_failed_open: inference_result.failed_open,
 	};
 
-	let backend_call = match backend {
+	let mut backend_call = match backend {
 		Backend::AI(n, ai) => {
 			let (provider, handle) = ai.select_provider().ok_or(ProxyError::NoHealthyEndpoints)?;
 			log.add(move |l| l.request_handle = Some(handle));
@@ -1622,6 +1622,9 @@ async fn make_backend_call(
 			}
 		},
 		Backend::Dynamic(_, _) => {
+			// Use a preliminary target from the current request URI.
+			// This will be re-resolved after transformations are applied,
+			// so that policies like `:authority` overrides take effect.
 			let host = http::get_host(&req)?;
 			let port = req
 				.uri()
@@ -1677,6 +1680,21 @@ async fn make_backend_call(
 		response_policies,
 	)
 	.await?;
+
+	// For Dynamic backends, re-resolve the target from the (now potentially transformed)
+	// request URI. This allows policies like `:authority` overrides (e.g., VPC endpoint
+	// routing) to take effect on the actual upstream connection target.
+	if matches!(backend, Backend::Dynamic(_, _)) {
+		let host = http::get_host(&req)?;
+		let port = req
+			.uri()
+			.port_u16()
+			.unwrap_or_else(|| match req.uri().scheme() {
+				Some(s) if *s == Scheme::HTTPS => 443,
+				_ => 80,
+			});
+		backend_call.target = Target::from((host, port));
+	}
 
 	log.add(|l| {
 		l.endpoint = Some(backend_call.target.clone());
@@ -2847,10 +2865,9 @@ impl PolicyClient {
 	pub async fn call_with_explicit_policies_list(
 		&self,
 		req: Request,
-		backend: SimpleBackend,
+		backend: Backend,
 		policies: Vec<BackendTrafficPolicy>,
 	) -> Result<Response, ProxyError> {
-		let backend = Backend::from(backend);
 		let pols = self
 			.inputs
 			.stores

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -1449,6 +1449,18 @@ impl DerefMut for MustSnapshot<'_> {
 	}
 }
 
+fn target_from_request(req: &Request) -> Result<Target, ProxyError> {
+	let host = http::get_host(req)?;
+	let port = req
+		.uri()
+		.port_u16()
+		.unwrap_or_else(|| match req.uri().scheme() {
+			Some(s) if *s == Scheme::HTTPS => 443,
+			_ => 80,
+		});
+	Ok(Target::from((host, port)))
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn make_backend_call(
 	inputs: Arc<ProxyInputs>,
@@ -1625,17 +1637,8 @@ async fn make_backend_call(
 			// Use a preliminary target from the current request URI.
 			// This will be re-resolved after transformations are applied,
 			// so that policies like `:authority` overrides take effect.
-			let host = http::get_host(&req)?;
-			let port = req
-				.uri()
-				.port_u16()
-				.unwrap_or_else(|| match req.uri().scheme() {
-					Some(s) if *s == Scheme::HTTPS => 443,
-					_ => 80,
-				});
-			let target = Target::from((host, port));
 			BackendCall {
-				target,
+				target: target_from_request(&req)?,
 				http_version_override: None,
 				transport_override: None,
 				network_gateway: None,
@@ -1685,15 +1688,7 @@ async fn make_backend_call(
 	// request URI. This allows policies like `:authority` overrides (e.g., VPC endpoint
 	// routing) to take effect on the actual upstream connection target.
 	if matches!(backend, Backend::Dynamic(_, _)) {
-		let host = http::get_host(&req)?;
-		let port = req
-			.uri()
-			.port_u16()
-			.unwrap_or_else(|| match req.uri().scheme() {
-				Some(s) if *s == Scheme::HTTPS => 443,
-				_ => 80,
-			});
-		backend_call.target = Target::from((host, port));
+		backend_call.target = target_from_request(&req)?;
 	}
 
 	log.add(|l| {


### PR DESCRIPTION
Previously, Backend::Dynamic resolved the upstream connection target from req.uri().host() before apply_backend_policies ran transformations. This meant that :authority overrides (e.g., for VPC endpoint routing) modified the request headers but had no effect on the actual TCP/TLS connection target.

This change:
- Makes backend_call mutable in make_backend_call
- After apply_backend_policies runs (which applies transformations), re-resolves the target from the now-transformed req.uri() for Dynamic backends
- Changes call_with_explicit_policies_list to accept Backend directly
- Updates all 4 LLM policy files (bedrock_guardrails, azure_content_safety, google_model_armor, moderation) to use Backend::Dynamic instead of SimpleBackend::Opaque with a hardcoded Target::Hostname

Fixes #1885