### PR TITLE
authz policy: do not clone rule sets

### DIFF
--- a/crates/agentgateway/src/http/authorization.rs
+++ b/crates/agentgateway/src/http/authorization.rs
@@ -68,7 +68,7 @@ impl NetworkAuthorizationSet {
 	}
 
 	pub fn merge_rule_set(&mut self, rule_set: RuleSet) {
-		self.0.0.push(rule_set);
+		self.0.0.push(Arc::new(rule_set));
 	}
 }
 
@@ -183,10 +183,16 @@ where
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
-pub struct RuleSets(Vec<RuleSet>);
+pub struct RuleSets(Vec<Arc<RuleSet>>);
 
 impl From<Vec<RuleSet>> for RuleSets {
 	fn from(value: Vec<RuleSet>) -> Self {
+		Self(value.into_iter().map(Arc::new).collect())
+	}
+}
+
+impl RuleSets {
+	pub fn from_arcs(value: Vec<Arc<RuleSet>>) -> Self {
 		Self(value)
 	}
 }

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -777,7 +777,9 @@ impl Store {
 			}
 		}
 		if !authz.is_empty() {
-			pol.authorization = RequestPolicy::single(HTTPAuthorizationSet::new(authz.into()));
+			pol.authorization = RequestPolicy::single(HTTPAuthorizationSet::new(
+				crate::http::authorization::RuleSets::from_arcs(authz),
+			));
 		}
 		dtrace::trace(|t| {
 			let s = serde_json::to_value(&pol).unwrap_or_default();

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -2345,7 +2345,7 @@ pub enum BackendTrafficPolicy {
 pub struct A2aPolicy {}
 
 #[apply(schema!)]
-pub struct Authorization(pub RuleSet);
+pub struct Authorization(pub Arc<RuleSet>);
 
 // Do not use schema! as it will reject the `extra` field
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -1330,7 +1330,7 @@ fn authorization_from_proto(
 
 	// Create PolicySet using the same pattern as in de_policies function
 	let policy_set = authorization::PolicySet::new(allow_exprs, deny_exprs, require_exprs);
-	Authorization(authorization::RuleSet::new(policy_set))
+	Authorization(Arc::new(authorization::RuleSet::new(policy_set)))
 }
 
 fn transformation_from_proto(


### PR DESCRIPTION
This makes things about 25% faster with 1000 policies

Signed-off-by: John Howard <john.howard@solo.io>
