### PR TITLE
fix(ui): ensure binds defaults to empty array when config lacks binds field

### DIFF
--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -53,6 +53,14 @@ export async function fetchConfig(): Promise<LocalConfig> {
       throw new Error(`Failed to fetch config: ${r.status}`);
     }
     const raw = await r.json();
+    // The simplified `mcp:`/`llm:` top-level config formats are expanded into
+    // binds/listeners/routes/backends by the backend at runtime, but `/config`
+    // returns the raw file which has no `binds` in that case. Fall back to
+    // `/config_dump`, which returns the fully expanded representation (the same
+    // path used in XDS mode), so the UI doesn't render an empty config.
+    if (!raw.binds && (raw.mcp || raw.llm)) {
+      return fetchViaDump();
+    }
     return { ...raw, binds: raw.binds || [] } as LocalConfig;
   }
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -52,7 +52,8 @@ export async function fetchConfig(): Promise<LocalConfig> {
       }
       throw new Error(`Failed to fetch config: ${r.status}`);
     }
-    return (await r.json()) as LocalConfig;
+    const raw = await r.json();
+    return { ...raw, binds: raw.binds || [] } as LocalConfig;
   }
 }
 


### PR DESCRIPTION
## Problem

When agent gateway is deployed in LLM proxy mode (without explicit `binds` in the config), the `/config` API endpoint returns raw config JSON that lacks a `binds` field.

The UI expects `binds` to always be present (as `binds: Bind[]` per the `LocalConfig` interface), causing `config.binds.forEach()` to crash with:

> Cannot read properties of undefined (reading 'forEach')

This breaks every UI page (home, listeners, routes, backends, policies).

## Fix

Ensure `binds` defaults to an empty array in `fetchViaConfig()` so the UI gracefully handles configs without binds.

**Fixes #1958**