### PR TITLE
fix(proxy): allow route-level OIDC by removing premature cookie stripping in gateway

### DIFF
--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -334,7 +334,6 @@ async fn apply_gateway_policies(
 		.oidc
 		.apply_without_response("gateway oidc", c, l, req, response_policies.headers())
 		.await?;
-	http::strip_request_cookies_by_prefix(req, http::oidc::RESERVED_COOKIE_PREFIX);
 
 	policies
 		.jwt


### PR DESCRIPTION
**Description**

This PR fixes a bug where OIDC authentication fails with `oidc failure: missing transaction` when the OIDC policy is configured at the Route level.

I ran into this while trying out the `examples/oidc` example and consistently hit the error on the authentication callback.

**The Problem**

`apply_gateway_policies` was unconditionally stripping cookies via `strip_request_cookies_by_prefix`, regardless of whether OIDC was configured at the gateway level. Since gateway policies always execute before route policies, this destroyed the transaction cookie before the route-level OIDC policy could read it during the callback, causing the `missing transaction` error.

**The Fix**

Remove the `strip_request_cookies_by_prefix` call from `apply_gateway_policies` entirely.

**Why this is safe**

Looking at `proxy_internal`, the request flow is strictly linear and unconditional:

```
apply_gateway_policies()
apply_request_policies()   ← strip happens here
attempt_upstream()         ← backend
```

There is no code path where a request reaches the backend without going through `apply_request_policies`. The strip in `apply_request_policies` is therefore sufficient to guarantee OIDC cookies are never forwarded to the upstream backend.