### PR TITLE
crds: let chart consumers set CRD annotations via .Values.crds.annotations

### DIFF
--- a/controller/hack/crdgen/main.go
+++ b/controller/hack/crdgen/main.go
@@ -189,6 +189,11 @@ func generateCRDs(paths []string, outputDir string, maxDescLen int, crdVersion s
 			return fmt.Errorf("marshal CRD %s/%s: %w", groupKind.Group, groupKind.Kind, err)
 		}
 
+		out, err = injectHelmCRDAnnotations(out)
+		if err != nil {
+			return fmt.Errorf("inject Helm annotations into CRD %s/%s: %w", groupKind.Group, groupKind.Kind, err)
+		}
+
 		fileName := fmt.Sprintf("%s_%s.yaml", crdRaw.Spec.Group, crdRaw.Spec.Names.Plural)
 		filePath := filepath.Join(outputDir, fileName)
 		// nolint:gosec // G306: not relevant here
@@ -956,6 +961,41 @@ func addAttribution(crd *apiextensionsv1.CustomResourceDefinition) {
 		crd.ObjectMeta.Annotations = map[string]string{}
 	}
 	crd.ObjectMeta.Annotations["controller-gen.kubebuilder.io/version"] = controllerGenVersion
+}
+
+// helmAnnotationsBlock is a Helm templating snippet that merges the chart's
+// .Values.crds.annotations into a CRD's metadata.annotations. It is inserted as
+// raw lines into the already-marshaled YAML because typed YAML marshaling cannot
+// emit Helm directives. The indentation matches the annotations map (4 spaces),
+// and nindent 4 keeps the merged values aligned with the sibling keys.
+const helmAnnotationsBlock = "    {{- with .Values.crds.annotations }}\n" +
+	"    {{- toYaml . | nindent 4 }}\n" +
+	"    {{- end }}"
+
+// injectHelmCRDAnnotations rewrites the marshaled CRD YAML so chart consumers can
+// merge custom annotations (e.g. helm.sh/resource-policy: keep) onto every CRD via
+// .Values.crds.annotations. It anchors on the controller-gen version annotation,
+// which addAttribution guarantees is always present, and inserts the Helm block
+// immediately after it.
+func injectHelmCRDAnnotations(crdYAML []byte) ([]byte, error) {
+	anchor := []byte("    controller-gen.kubebuilder.io/version:")
+	idx := bytes.Index(crdYAML, anchor)
+	if idx < 0 {
+		return nil, fmt.Errorf("anchor %q not found in marshaled CRD", anchor)
+	}
+	rel := bytes.IndexByte(crdYAML[idx:], '\n')
+	if rel < 0 {
+		return nil, fmt.Errorf("no newline after anchor %q in marshaled CRD", anchor)
+	}
+	insertAt := idx + rel + 1
+
+	var buf bytes.Buffer
+	buf.Grow(len(crdYAML) + len(helmAnnotationsBlock) + 1)
+	buf.Write(crdYAML[:insertAt])
+	buf.WriteString(helmAnnotationsBlock)
+	buf.WriteByte('\n')
+	buf.Write(crdYAML[insertAt:])
+	return buf.Bytes(), nil
 }
 
 func removeDescriptionFromMetadata(crd *apiextensionsv1.CustomResourceDefinition) {

--- a/controller/hack/crdgen/main_test.go
+++ b/controller/hack/crdgen/main_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-tools/pkg/crd"
 	"sigs.k8s.io/controller-tools/pkg/loader"
 	"sigs.k8s.io/controller-tools/pkg/markers"
@@ -135,6 +136,76 @@ func TestOverrideXValidationErrorsWithoutExactSingleMatch(t *testing.T) {
 		})
 		require.EqualError(t, err, "OverrideXValidation matched 2 rules for messageContains \"phase PreRouting only\", expected exactly 1")
 	})
+}
+
+func TestInjectHelmCRDAnnotations(t *testing.T) {
+	in := `---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.0
+  labels:
+    app: agentgateway
+  name: agentgatewayparameters.agentgateway.dev
+spec:
+  group: agentgateway.dev
+`
+
+	out, err := injectHelmCRDAnnotations([]byte(in))
+	require.NoError(t, err)
+
+	want := `---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.0
+    {{- with .Values.crds.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  labels:
+    app: agentgateway
+  name: agentgatewayparameters.agentgateway.dev
+spec:
+  group: agentgateway.dev
+`
+	require.Equal(t, want, string(out))
+}
+
+func TestInjectHelmCRDAnnotationsErrorsWithoutAnchor(t *testing.T) {
+	_, err := injectHelmCRDAnnotations([]byte("metadata:\n  name: foo\n"))
+	require.Error(t, err)
+}
+
+// TestInjectHelmCRDAnnotationsOnMarshaledCRD guards the load-bearing invariant:
+// the anchor injectHelmCRDAnnotations relies on must actually appear, at the
+// expected 4-space indent, in real marshalCRD output. If a future controller-gen
+// or YAML-marshaling change moved or renamed the controller-gen annotation, this
+// fails at the root cause rather than silently producing broken templates.
+func TestInjectHelmCRDAnnotationsOnMarshaledCRD(t *testing.T) {
+	crdObj := &apiextensionsv1.CustomResourceDefinition{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apiextensions.k8s.io/v1",
+			Kind:       "CustomResourceDefinition",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "agentgatewayparameters.agentgateway.dev",
+		},
+	}
+	addAttribution(crdObj)
+
+	marshaled, err := marshalCRD(crdObj)
+	require.NoError(t, err)
+	require.Contains(t, string(marshaled), "\n    controller-gen.kubebuilder.io/version: "+controllerGenVersion+"\n")
+
+	out, err := injectHelmCRDAnnotations(marshaled)
+	require.NoError(t, err)
+	require.Contains(t, string(out),
+		"    controller-gen.kubebuilder.io/version: "+controllerGenVersion+"\n"+
+			"    {{- with .Values.crds.annotations }}\n"+
+			"    {{- toYaml . | nindent 4 }}\n"+
+			"    {{- end }}\n")
 }
 
 func TestApplyConditionalPolicyUsesVisibleSchemaFields(t *testing.T) {

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
@@ -4,6 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.20.0
+    {{- with .Values.crds.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   labels:
     app: agentgateway
     app.kubernetes.io/name: agentgateway

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewayparameters.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewayparameters.yaml
@@ -4,6 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.20.0
+    {{- with .Values.crds.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   labels:
     app: agentgateway
     app.kubernetes.io/name: agentgateway

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
@@ -4,6 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.20.0
+    {{- with .Values.crds.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   labels:
     app: agentgateway
     app.kubernetes.io/name: agentgateway

--- a/controller/install/helm/agentgateway-crds/values.yaml
+++ b/controller/install/helm/agentgateway-crds/values.yaml
@@ -1,0 +1,10 @@
+# Configuration for the CustomResourceDefinitions shipped by this chart.
+crds:
+  # annotations are merged into metadata.annotations of every CRD.
+  # For example, to stop Helm from deleting the CRDs (and every agentgateway
+  # custom resource cluster-wide) when the release is uninstalled:
+  #
+  #   crds:
+  #     annotations:
+  #       helm.sh/resource-policy: keep
+  annotations: {}


### PR DESCRIPTION
## What

Let consumers of the `agentgateway-crds` chart set annotations on the generated
CRDs via `.Values.crds.annotations`. The generator now injects a Helm merge block
into each CRD's `metadata.annotations`, and the chart's `values.yaml` defaults
`crds.annotations` to `{}`.

## Why

Any Helm operation that removes the release also cascade-deletes the CRDs — and
with them every agentgateway custom resource in the cluster. That makes otherwise
routine, sometimes unavoidable lifecycle operations (moving the release to another
namespace, restructuring releases, running the chart as a sub-chart) destructive.
There is currently no way to set `helm.sh/resource-policy: keep` (or any other
annotation) on these CRDs, and hand edits don't survive regeneration. Closes #1977.

Usage:

```yaml
crds:
  annotations:
    helm.sh/resource-policy: keep
```

## How

- `controller/hack/crdgen`: after a CRD is marshaled, `injectHelmCRDAnnotations`
  inserts a `{{- with .Values.crds.annotations }}` / `{{- toYaml . | nindent 4 }}`
  block immediately after the `controller-gen.kubebuilder.io/version` annotation
  (guaranteed present by `addAttribution`). Typed YAML marshaling can't emit Helm
  directives, so this is a targeted string insertion; it errors loudly if the
  anchor is missing rather than emitting a broken template.
- `controller/install/helm/agentgateway-crds/values.yaml`: document and default
  `crds.annotations: {}`.
- Regenerated the three CRD templates.

This mirrors how External Secrets Operator and prometheus-operator-crds expose
`crds.annotations` on their generated CRDs (same `with`/`toYaml`/`nindent` block).

## Testing

- `go test ./controller/hack/crdgen/...` — added `TestInjectHelmCRDAnnotations`,
  `TestInjectHelmCRDAnnotationsErrorsWithoutAnchor`, and
  `TestInjectHelmCRDAnnotationsOnMarshaledCRD` (the last asserts the anchor
  invariant against real `marshalCRD` output, so a future controller-gen/marshaling
  change is caught at the root cause).
- `go build` / `go vet` / `gofmt` clean.
- `helm lint` passes; `helm template` renders nothing extra by default and merges
  `helm.sh/resource-policy: keep` (and arbitrary keys) correctly when set.
- CRD regeneration is deterministic — re-running `generate.sh` reproduces the
  committed templates byte-for-byte, so the `make verify` clean-repo gate stays green.
