### PR TITLE
docs: add AgentID pre-tool authorization example

### DIFF
--- a/examples/authorization/README.md
+++ b/examples/authorization/README.md
@@ -77,3 +77,37 @@ This is because our third policy allows access `when { context.claims.nested.key
 
 When the policy doesn't allow the connecting user to access a tool, it is automatically filtered from the tools list.
 If the user does still attempt to call the tool, it is also denied.
+
+### External agent authority checks
+
+Some deployments also need an agent-specific authority contract in addition to
+JWT authentication and CEL authorization. For example, a team may want to allow
+a support agent to read a customer record, but require human approval and a
+short-lived grant before the same agent can update that record during a
+particular support case.
+
+One way to model that is to run an external authorization service before
+forwarding selected MCP `tools/call` requests:
+
+```text
+MCP client -> agentgateway -> external authorization check -> MCP server
+```
+
+The external check should complement, not replace, agentgateway's existing
+authorization policy. A typical request includes the authenticated user or
+agent identity, MCP tool name, action, resource, job or case identifier, and any
+approval or just-in-time grant metadata. The service returns an allow or deny
+decision, and the gateway forwards the call only when both the local
+`mcpAuthorization` policy and the external check allow it.
+
+AgentID is one open-source example of this pattern. It defines a manifest for
+agent tool-call authority and exposes an `/authorize` endpoint that can be used
+as an external pre-tool-call check:
+
+- AgentID: <https://github.com/dinpd/AgentID>
+- Reference MCP gateway adapter: <https://github.com/dinpd/AgentID/tree/main/mcp-gateway-adapter>
+- Demo walkthrough: <https://github.com/dinpd/AgentID/blob/main/docs/mcp-gateway-demo.md>
+
+This pattern keeps downstream MCP servers unchanged while giving platform teams
+a place to enforce job boundaries, approval requirements, just-in-time grants,
+and structured decision logging for sensitive agent tool calls.

--- a/examples/mcp-authorization/README.md
+++ b/examples/mcp-authorization/README.md
@@ -83,3 +83,37 @@ This is because our third policy allows access when `jwt.nested.key == "value"`,
 
 When the policy doesn't allow the connecting user to access a tool, it is automatically filtered from the tools list.
 If the user does still attempt to call the tool, it is also denied.
+
+### External agent authority checks
+
+Some deployments also need an agent-specific authority contract in addition to
+JWT authentication and CEL authorization. For example, a team may want to allow
+a support agent to read a customer record, but require human approval and a
+short-lived grant before the same agent can update that record during a
+particular support case.
+
+One way to model that is to run an external authorization service before
+forwarding selected MCP `tools/call` requests:
+
+```text
+MCP client -> agentgateway -> external authorization check -> MCP server
+```
+
+The external check should complement, not replace, agentgateway's existing
+authorization policy. A typical request includes the authenticated user or
+agent identity, MCP tool name, action, resource, job or case identifier, and any
+approval or just-in-time grant metadata. The service returns an allow or deny
+decision, and the gateway forwards the call only when both the local
+`mcpAuthorization` policy and the external check allow it.
+
+AgentID is one open-source example of this pattern. It defines a manifest for
+agent tool-call authority and exposes an `/authorize` endpoint that can be used
+as an external pre-tool-call check:
+
+- AgentID: <https://github.com/dinpd/AgentID>
+- Reference MCP gateway adapter: <https://github.com/dinpd/AgentID/tree/main/mcp-gateway-adapter>
+- Demo walkthrough: <https://github.com/dinpd/AgentID/blob/main/docs/mcp-gateway-demo.md>
+
+This pattern keeps downstream MCP servers unchanged while giving platform teams
+a place to enforce job boundaries, approval requirements, just-in-time grants,
+and structured decision logging for sensitive agent tool calls.


### PR DESCRIPTION
## Summary

Adds a documentation example for using AgentID as an external pre-tool-call authorization checkpoint with agentgateway MCP authorization.

The example is intentionally optional and docs-only. It does not add AgentID as a dependency or change agentgateway's built-in JWT, CEL, RBAC, or MCP authorization behavior.

## Why

Agentgateway already provides MCP-native authorization, tool filtering, and policy-based governance. AgentID can complement that model for teams that want an agent-specific authority contract covering job boundaries, tool/action eligibility, approval/JIT requirements, and structured decision logs before forwarding sensitive MCP `tools/call` requests.

## Links

AgentID:
https://github.com/dinpd/AgentID

Reference adapter:
https://github.com/dinpd/AgentID/tree/main/mcp-gateway-adapter

Demo walkthrough:
https://github.com/dinpd/AgentID/blob/main/docs/mcp-gateway-demo.md

## Checks

- [x] Docs-only change
- [x] No runtime dependency added
- [x] Existing authorization docs remain accurate
