### PR TITLE
oidc: recover stale callback transactions

### DIFF
--- a/crates/agentgateway/src/http/oidc/callback.rs
+++ b/crates/agentgateway/src/http/oidc/callback.rs
@@ -96,6 +96,24 @@ pub(super) fn start_login(
 	Ok(crate::http::PolicyResponse::default().with_response(response))
 }
 
+pub(super) fn restart_login_clearing_transaction(
+	policy: &OidcPolicy,
+	req: &Request,
+	transaction_cookie_name: &str,
+) -> Result<crate::http::PolicyResponse, Error> {
+	let mut response = start_login(policy, req)?;
+	if let Some(direct_response) = response.direct_response.as_mut() {
+		let clear_transaction = policy
+			.session
+			.clear_cookie(transaction_cookie_name, policy.redirect_uri.https);
+		direct_response.headers_mut().append(
+			::http::header::SET_COOKIE,
+			clear_transaction.parse().map_err(anyhow::Error::from)?,
+		);
+	}
+	Ok(response)
+}
+
 pub(super) async fn handle_callback(
 	policy: &OidcPolicy,
 	context: CallbackRequestContext,

--- a/crates/agentgateway/src/http/oidc/mod.rs
+++ b/crates/agentgateway/src/http/oidc/mod.rs
@@ -253,24 +253,41 @@ impl OidcPolicy {
 		let transaction_cookie_name = self
 			.session
 			.transaction_cookie_name(&callback_state.transaction_id);
-		let transaction_cookie = crate::http::read_request_cookie(req, &transaction_cookie_name)
-			.ok_or(Error::MissingTransaction)?
-			.to_string();
+		let transaction_cookie = match crate::http::read_request_cookie(req, &transaction_cookie_name) {
+			Some(cookie) => cookie.to_string(),
+			None => {
+				return Ok(Some(callback::restart_login_clearing_transaction(
+					self,
+					req,
+					&transaction_cookie_name,
+				)?));
+			},
+		};
 		if let Some(error) = query.error {
 			return Err(Error::ProviderCallback(error));
 		}
 		let code = query.code.ok_or(Error::InvalidCallback)?;
-		let response = callback::handle_callback(
+		let response = match callback::handle_callback(
 			self,
 			callback::CallbackRequestContext {
 				code,
 				callback_state,
-				transaction_cookie_name,
+				transaction_cookie_name: transaction_cookie_name.clone(),
 				transaction_cookie,
 			},
 			client,
 		)
-		.await?;
+		.await
+		{
+			Ok(response) => response,
+			Err(
+				Error::InvalidTransaction
+				| Error::PolicyMismatch
+				| Error::CsrfMismatch
+				| Error::NonceMismatch,
+			) => callback::restart_login_clearing_transaction(self, req, &transaction_cookie_name)?,
+			Err(err) => return Err(err),
+		};
 		Ok(Some(response))
 	}
 }

--- a/crates/agentgateway/src/http/oidc/tests.rs
+++ b/crates/agentgateway/src/http/oidc/tests.rs
@@ -14,7 +14,6 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use super::*;
 use crate::http::jwt;
-use crate::proxy::ProxyError;
 use crate::serdes::FileInlineOrRemote;
 use crate::test_helpers::proxymock::setup_proxy_test;
 use crate::{client, test_helpers};
@@ -613,25 +612,18 @@ async fn token_exchange_bounds_transport_failures() {
 }
 
 #[tokio::test]
-async fn callback_rejects_invalid_transaction_state() {
+async fn callback_recovers_from_invalid_transaction_state() {
 	let cases = [
-		(
-			"missing transaction",
-			None,
-			"tx-1",
-			"test-state",
-			Error::MissingTransaction,
-		),
+		("missing transaction", None, "tx-1", "test-state"),
 		(
 			"csrf mismatch",
 			Some(("expected-state", TEST_NONCE, "/protected")),
 			"tx-1",
 			"wrong-state",
-			Error::CsrfMismatch,
 		),
 	];
 
-	for (name, transaction, transaction_id, callback_csrf_state, expected_error) in cases {
+	for (name, transaction, transaction_id, callback_csrf_state) in cases {
 		let policy = test_policy();
 		let callback_state = encoded_callback_state(transaction_id, callback_csrf_state);
 		let uri =
@@ -655,21 +647,41 @@ async fn callback_rejects_invalid_transaction_state() {
 			);
 		}
 
-		let err = test_helpers::test_policy(&policy, &mut req)
+		let response = test_helpers::test_policy(&policy, &mut req)
 			.await
-			.expect_err(name)
-			.downcast();
-		match expected_error {
-			Error::MissingTransaction => assert!(
-				matches!(err, ProxyError::OidcFailure(Error::MissingTransaction)),
-				"{name}"
-			),
-			Error::CsrfMismatch => assert!(
-				matches!(err, ProxyError::OidcFailure(Error::CsrfMismatch)),
-				"{name}"
-			),
-			_ => unreachable!("unexpected test error"),
-		}
+			.expect(name)
+			.direct_response
+			.expect("login redirect");
+		assert_eq!(response.status(), ::http::StatusCode::FOUND, "{name}");
+		let location = response
+			.headers()
+			.get(header::LOCATION)
+			.expect("location header")
+			.to_str()
+			.expect("location utf8");
+		assert!(
+			location.starts_with("https://issuer.example.com/authorize?"),
+			"{name}"
+		);
+		let transaction_cookie_name = policy.session.transaction_cookie_name(transaction_id);
+		let set_cookies = response
+			.headers()
+			.get_all(header::SET_COOKIE)
+			.iter()
+			.filter_map(|value| value.to_str().ok())
+			.collect::<Vec<_>>();
+		assert!(
+			set_cookies
+				.iter()
+				.any(|cookie| cookie.starts_with(&format!("{transaction_cookie_name}=;"))),
+			"{name}: stale transaction cookie should be cleared"
+		);
+		assert!(
+			set_cookies
+				.iter()
+				.any(|cookie| cookie.starts_with(&format!("{}.", policy.session.transaction_cookie_prefix))),
+			"{name}: fresh transaction cookie should be set"
+		);
 	}
 }
 


### PR DESCRIPTION
Recover stale OIDC callback transactions by restarting login instead of returning a hard callback error.

When the callback points at a missing or mismatched transaction, the response now starts a fresh authorization flow and clears the stale transaction cookie name from the callback state. Other callback and token validation failures still fail normally.