### PR TITLE
fix(mcp): strip inbound Mcp-Session-Id from upstream requests

### DIFF
--- a/crates/agentgateway/src/mcp/upstream/mod.rs
+++ b/crates/agentgateway/src/mcp/upstream/mod.rs
@@ -10,6 +10,7 @@ pub(crate) use client::McpHttpClient;
 pub use openapi::ParseError as OpenAPIParseError;
 use rmcp::model::{ClientNotification, ClientRequest, JsonRpcRequest};
 use rmcp::transport::TokioChildProcess;
+use rmcp::transport::common::http_header::HEADER_SESSION_ID;
 use thiserror::Error;
 use tokio::process::Command;
 
@@ -64,7 +65,10 @@ impl IncomingRequestContext {
 		}
 		for (k, v) in &self.headers {
 			// Remove headers we do not want to propagate to the backend
-			if k == http::header::CONTENT_ENCODING || k == http::header::CONTENT_LENGTH {
+			if k == http::header::CONTENT_ENCODING
+				|| k == http::header::CONTENT_LENGTH
+				|| k.as_str().eq_ignore_ascii_case(HEADER_SESSION_ID)
+			{
 				continue;
 			}
 			if !req.headers().contains_key(k) {
@@ -440,5 +444,68 @@ mod tests {
 		);
 		assert_eq!(req.headers().get(http::header::HOST), None);
 		assert_eq!(req.uri().path(), "/mcp");
+	}
+
+	fn ctx_with_headers(headers: &[(&str, &str)]) -> IncomingRequestContext {
+		let mut builder = ::http::Request::builder()
+			.uri("http://example/")
+			.method("GET");
+		for (k, v) in headers {
+			builder = builder.header(*k, *v);
+		}
+		let parts = builder.body(()).unwrap().into_parts().0;
+		IncomingRequestContext::new(&parts)
+	}
+
+	fn empty_upstream_req() -> http::Request {
+		::http::Request::builder()
+			.uri("http://upstream/")
+			.body(http::Body::empty())
+			.unwrap()
+	}
+
+	#[test]
+	fn apply_strips_inbound_mcp_session_id() {
+		let ctx = ctx_with_headers(&[(HEADER_SESSION_ID, "client-sid"), ("x-trace", "abc")]);
+		let mut req = empty_upstream_req();
+		ctx.apply(&mut req).unwrap();
+		assert!(req.headers().get(HEADER_SESSION_ID).is_none());
+		assert_eq!(req.headers().get("x-trace").unwrap(), "abc");
+	}
+
+	#[test]
+	fn apply_preserves_upstream_session_id_when_already_set() {
+		let ctx = ctx_with_headers(&[(HEADER_SESSION_ID, "client-sid")]);
+		let mut req = empty_upstream_req();
+		req.headers_mut().insert(
+			::http::HeaderName::from_static("mcp-session-id"),
+			::http::HeaderValue::from_static("upstream-sid"),
+		);
+		ctx.apply(&mut req).unwrap();
+		assert_eq!(
+			req.headers().get(HEADER_SESSION_ID).unwrap(),
+			"upstream-sid"
+		);
+	}
+
+	#[test]
+	fn apply_strips_content_encoding_and_length() {
+		let ctx = ctx_with_headers(&[
+			(http::header::CONTENT_ENCODING.as_str(), "gzip"),
+			(http::header::CONTENT_LENGTH.as_str(), "42"),
+		]);
+		let mut req = empty_upstream_req();
+		ctx.apply(&mut req).unwrap();
+		assert!(req.headers().get(http::header::CONTENT_ENCODING).is_none());
+		assert!(req.headers().get(http::header::CONTENT_LENGTH).is_none());
+	}
+
+	#[test]
+	fn apply_propagates_other_headers() {
+		let ctx = ctx_with_headers(&[("authorization", "Bearer token"), ("x-request-id", "req-1")]);
+		let mut req = empty_upstream_req();
+		ctx.apply(&mut req).unwrap();
+		assert_eq!(req.headers().get("authorization").unwrap(), "Bearer token");
+		assert_eq!(req.headers().get("x-request-id").unwrap(), "req-1");
 	}
 }


### PR DESCRIPTION
## Problem

The `Mcp-Session-Id` header identifies the client/gateway session. It has no meaning on the gateway/upstream leg, but agentgateway was forwarding the client's value through to upstream MCP servers. An upstream that receives an unrecognized session-id can reject the request - most visibly an `initialize` call arriving mid-handshake carrying a session-id the upstream never issued.

The severity differs by transport:

- **Streamable HTTP:** every send calls `maybe_insert_session_id` before `ctx.apply`, and `apply` only copies an inbound header when the outbound request does not already have it. Once an upstream session-id is established it is inserted first, so the inbound value is dropped. The leak is therefore limited to the `initialize` request, before any upstream session-id exists.
- **SSE:** `ctx.apply` is called with no prior session-id insertion (the SSE client ignores `set_session_id` for the header entirely), so the outbound request never carries an upstream session-id and the inbound header leaks on every upstream call.

## Fix

Drop `Mcp-Session-Id` in `IncomingRequestContext::apply`, alongside the existing `Content-Encoding` / `Content-Length` stripping. The match is case-insensitive and uses rmcp's `HEADER_SESSION_ID` constant. Upstream-set session-ids are untouched.

## Tests

Added unit tests in `crates/agentgateway/src/mcp/upstream/mod.rs` covering:

- inbound `Mcp-Session-Id` is stripped while unrelated headers pass through
- an upstream-set session-id is preserved (not clobbered by the inbound one)
- `Content-Encoding` / `Content-Length` continue to be stripped
- other headers (e.g. `Authorization`, `x-request-id`) are propagated

`make lint` and `make test` pass.
