### PR TITLE
Add waypoint endpoint resolution for ingress-use-waypoint

### DIFF
--- a/crates/agentgateway/src/client/hbone_tunnel.rs
+++ b/crates/agentgateway/src/client/hbone_tunnel.rs
@@ -143,7 +143,7 @@ pub async fn handshake_double(
 	target: &Target,
 	ep: SocketAddr,
 	gateway_address: SocketAddr,
-	gateway_identity: Identity,
+	gateway_identities: Vec<Identity>,
 	waypoint_identities: Vec<Identity>,
 	headers: HboneHeaders,
 ) -> Result<Socket, Error> {
@@ -179,7 +179,7 @@ pub async fn handshake_double(
 
 	// Connect to the network gateway at its HBONE port
 	let outer_pool_key = Box::new(WorkloadKey {
-		dst_id: vec![gateway_identity.clone()],
+		dst_id: gateway_identities,
 		dst: gateway_address,
 	});
 	let mut pool_clone = pool.clone();

--- a/crates/agentgateway/src/client/mod.rs
+++ b/crates/agentgateway/src/client/mod.rs
@@ -125,7 +125,7 @@ pub enum Transport {
 	Hbone(ApplicationTransport, u16, Vec<Identity>, HboneHeaders),
 	DoubleHbone {
 		gateway_address: SocketAddr, // Address of network gateway to connect to
-		gateway_identity: Identity,  // Identity of network gateway
+		gateway_identities: Vec<Identity>, // Identities of network gateway (workload + service SANs)
 		waypoint_identities: Vec<Identity>, // Identities of waypoint/workload (workload + service SANs)
 		inner: ApplicationTransport,
 		headers: HboneHeaders,
@@ -348,7 +348,7 @@ impl Connector {
 
 			Transport::DoubleHbone {
 				gateway_address,
-				gateway_identity,
+				gateway_identities,
 				waypoint_identities,
 				inner: _,
 				headers,
@@ -362,7 +362,7 @@ impl Connector {
 					&target,
 					ep,
 					gateway_address,
-					gateway_identity,
+					gateway_identities,
 					waypoint_identities,
 					headers,
 				)

--- a/crates/agentgateway/src/proxy/gateway_test.rs
+++ b/crates/agentgateway/src/proxy/gateway_test.rs
@@ -3136,6 +3136,181 @@ async fn ingress_use_waypoint_false_no_waypoint() {
 }
 
 #[tokio::test]
+async fn ingress_use_waypoint_remote_waypoint_uses_network_gateway() {
+	use crate::proxy::httpproxy;
+	use crate::store::LocalWorkload;
+	use crate::types::discovery::gatewayaddress::Destination;
+	use crate::types::discovery::{
+		GatewayAddress, Identity, InboundProtocol, NamespacedHostname, NetworkAddress, Service,
+		Workload,
+	};
+
+	let mock = simple_mock().await;
+	let waypoint_vip: std::net::IpAddr = "240.240.0.5".parse().unwrap();
+	let waypoint_ip: std::net::IpAddr = "10.20.0.12".parse().unwrap();
+	let gateway_ip: std::net::IpAddr = "172.18.7.110".parse().unwrap();
+	let remote_network = strng::literal!("network-2");
+	let t = setup_proxy_test("{}").unwrap();
+
+	let svc = Service {
+		name: strng::literal!("my-svc"),
+		namespace: strng::literal!("default"),
+		hostname: strng::literal!("my-svc.default.svc.cluster.local"),
+		vips: vec![NetworkAddress {
+			network: strng::EMPTY,
+			address: "10.0.0.1".parse().unwrap(),
+		}],
+		ports: std::collections::HashMap::from([(80, mock.address().port())]),
+		waypoint: Some(GatewayAddress {
+			destination: Destination::Hostname(NamespacedHostname {
+				namespace: strng::literal!("default"),
+				hostname: strng::literal!("waypoint.default.svc.cluster.local"),
+			}),
+			hbone_mtls_port: 15008,
+		}),
+		ingress_use_waypoint: true,
+		..Default::default()
+	};
+	let wl = LocalWorkload {
+		workload: Workload {
+			uid: strng::literal!("test-wl-uid"),
+			name: strng::literal!("test-wl"),
+			namespace: strng::literal!("default"),
+			workload_ips: vec![mock.address().ip()],
+			..Default::default()
+		},
+		services: std::collections::HashMap::from([(
+			"default/my-svc.default.svc.cluster.local".to_string(),
+			std::collections::HashMap::from([(80, mock.address().port())]),
+		)]),
+	};
+	let wp_svc = Service {
+		name: strng::literal!("waypoint"),
+		namespace: strng::literal!("default"),
+		hostname: strng::literal!("waypoint.default.svc.cluster.local"),
+		vips: vec![NetworkAddress {
+			network: strng::EMPTY,
+			address: waypoint_vip,
+		}],
+		ports: std::collections::HashMap::from([(15008, 15008)]),
+		subject_alt_names: vec![Identity::Spiffe {
+			trust_domain: strng::literal!("td2"),
+			namespace: strng::literal!("default"),
+			service_account: strng::literal!("waypoint-san"),
+		}],
+		..Default::default()
+	};
+	let wp_wl = LocalWorkload {
+		workload: Workload {
+			uid: strng::literal!("test-waypoint-wl-uid"),
+			name: strng::literal!("test-waypoint-wl"),
+			namespace: strng::literal!("default"),
+			service_account: strng::literal!("waypoint"),
+			network: remote_network.clone(),
+			workload_ips: vec![waypoint_ip],
+			network_gateway: Some(GatewayAddress {
+				destination: Destination::Address(NetworkAddress {
+					network: remote_network.clone(),
+					address: gateway_ip,
+				}),
+				hbone_mtls_port: 15008,
+			}),
+			..Default::default()
+		},
+		services: std::collections::HashMap::from([(
+			"default/waypoint.default.svc.cluster.local".to_string(),
+			std::collections::HashMap::from([(15008, 15008)]),
+		)]),
+	};
+	let gw_wl = LocalWorkload {
+		workload: Workload {
+			uid: strng::literal!("test-gateway-wl-uid"),
+			name: strng::literal!("test-gateway-wl"),
+			namespace: strng::literal!("istio-gateways"),
+			service_account: strng::literal!("istio-eastwest"),
+			network: remote_network.clone(),
+			workload_ips: vec![gateway_ip],
+			..Default::default()
+		},
+		services: Default::default(),
+	};
+
+	t.pi
+		.stores
+		.discovery
+		.sync_local(
+			vec![svc, wp_svc],
+			vec![wl, wp_wl, gw_wl],
+			Default::default(),
+		)
+		.unwrap();
+
+	let svc = t
+		.pi
+		.stores
+		.read_discovery()
+		.services
+		.get_by_namespaced_host(&NamespacedHostname {
+			namespace: strng::literal!("default"),
+			hostname: strng::literal!("my-svc.default.svc.cluster.local"),
+		})
+		.expect("service must exist");
+
+	let backend_call = httpproxy::build_service_call(
+		&t.pi,
+		Default::default(),
+		&mut None,
+		Default::default(),
+		&svc,
+		&80,
+		None,
+		None,
+	)
+	.expect("build_service_call should succeed");
+
+	assert!(
+		backend_call.waypoint.is_none(),
+		"remote waypoint should be reached through double HBONE, not direct waypoint transport"
+	);
+	let (resolved_gw, gw_identities) = backend_call
+		.network_gateway
+		.expect("remote waypoint should resolve a network gateway");
+	assert_matches!(resolved_gw.destination, Destination::Address(addr) => {
+		assert_eq!(addr.address, gateway_ip);
+		assert_eq!(addr.network, remote_network);
+	});
+	assert_eq!(resolved_gw.hbone_mtls_port, 15008);
+	// Outer tunnel: gateway workload id (the gateway is referenced by address, so no SANs).
+	assert_eq!(
+		gw_identities,
+		vec![Identity::Spiffe {
+			trust_domain: strng::EMPTY,
+			namespace: strng::literal!("istio-gateways"),
+			service_account: strng::literal!("istio-eastwest"),
+		}]
+	);
+	// Inner tunnel: waypoint workload id + waypoint service SANs.
+	assert_matches!(backend_call.transport_override, Some((InboundProtocol::HBONE, identities)) => {
+		assert_eq!(identities, vec![
+			Identity::Spiffe {
+				trust_domain: strng::EMPTY,
+				namespace: strng::literal!("default"),
+				service_account: strng::literal!("waypoint"),
+			},
+			Identity::Spiffe {
+				trust_domain: strng::literal!("td2"),
+				namespace: strng::literal!("default"),
+				service_account: strng::literal!("waypoint-san"),
+			},
+		]);
+	});
+	assert_matches!(backend_call.target, Target::Hostname(host, port) => {
+		assert_eq!(host.as_str(), "my-svc.default.svc.cluster.local");
+		assert_eq!(port, 80);
+	});
+}
+
+#[tokio::test]
 async fn ingress_use_waypoint_ip_based_waypoint() {
 	use crate::proxy::httpproxy;
 	use crate::store::LocalWorkload;
@@ -3408,6 +3583,11 @@ async fn network_gateway_hostname_resolves_via_service_endpoint() {
 		hostname: gateway_hostname.clone(),
 		vips: vec![],
 		ports: std::collections::HashMap::from([(svc_port, gw_target_port)]),
+		subject_alt_names: vec![Identity::Spiffe {
+			trust_domain: strng::literal!("td-gw"),
+			namespace: gateway_namespace.clone(),
+			service_account: strng::literal!("gateway-san"),
+		}],
 		..Default::default()
 	};
 	let gw_wl = LocalWorkload {
@@ -3459,7 +3639,7 @@ async fn network_gateway_hostname_resolves_via_service_endpoint() {
 	)
 	.expect("build_service_call should succeed");
 
-	let (resolved_gw, gw_identity) = backend_call
+	let (resolved_gw, gw_identities) = backend_call
 		.network_gateway
 		.expect("network_gateway must be resolved for hostname-form destination");
 
@@ -3471,12 +3651,20 @@ async fn network_gateway_hostname_resolves_via_service_endpoint() {
 		resolved_gw.hbone_mtls_port, gw_target_port,
 		"port should be the endpoint target port, not the service port"
 	);
+	// Outer-tunnel identities match ztunnel: gateway workload id + gateway service SANs.
 	assert_eq!(
-		gw_identity,
-		Identity::Spiffe {
-			trust_domain: strng::EMPTY,
-			namespace: gateway_namespace.clone(),
-			service_account: strng::literal!("gateway-sa"),
-		},
+		gw_identities,
+		vec![
+			Identity::Spiffe {
+				trust_domain: strng::EMPTY,
+				namespace: gateway_namespace.clone(),
+				service_account: strng::literal!("gateway-sa"),
+			},
+			Identity::Spiffe {
+				trust_domain: strng::literal!("td-gw"),
+				namespace: gateway_namespace.clone(),
+				service_account: strng::literal!("gateway-san"),
+			},
+		]
 	);
 }

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -1290,7 +1290,7 @@ pub async fn build_transport(
 
 	// Check if we need double hbone
 	if let (
-		Some((gw_addr, gw_identity)),
+		Some((gw_addr, gw_identities)),
 		Some((InboundProtocol::HBONE, waypoint_identities)),
 		Some(ca),
 	) = (
@@ -1317,7 +1317,7 @@ pub async fn build_transport(
 			);
 			return Ok(Transport::DoubleHbone {
 				gateway_address: gateway_socket_addr,
-				gateway_identity: gw_identity.clone(),
+				gateway_identities: gw_identities.clone(),
 				waypoint_identities: waypoint_identities.clone(),
 				inner: app_transport,
 				headers: build_hbone_headers(inputs, hbone_source),
@@ -2024,92 +2024,17 @@ pub fn build_service_call(
 	log.add(move |l| l.request_handle = Some(handle));
 
 	// Check if we need double hbone (workload on remote network with gateway)
-	let network_gateway = if wl.network != inputs.cfg.network {
-		if let Some(gw_addr) = &wl.network_gateway {
-			match &gw_addr.destination {
-				types::discovery::gatewayaddress::Destination::Address(net_addr) => {
-					if let Some(gw_wl) = workloads.find_address(net_addr) {
-						let resolved_gw_addr = gw_addr.clone();
-						tracing::debug!(
-							source_network = %inputs.cfg.network,
-							dest_network = %wl.network,
-							gateway = ?resolved_gw_addr,
-							"picked workload on remote network, using double hbone"
-						);
-						Some((resolved_gw_addr, gw_wl.identity()))
-					} else {
-						tracing::warn!(
-							gateway_address = ?net_addr,
-							"network gateway address not found in workload store for remote workload"
-						);
-						None
-					}
-				},
-				types::discovery::gatewayaddress::Destination::Hostname(hostname) => {
-					// TODO we could support looking up workloads by hostname too
-					let resolved = discovery
-						.services
-						.get_by_namespaced_host(&NamespacedHostname {
-							namespace: hostname.namespace.clone(),
-							hostname: hostname.hostname.clone(),
-						})
-						.and_then(|gw_svc| {
-							let (gw_ep, _gw_handle, gw_wl) = gw_svc.endpoints.select_endpoint(
-								&discovery.workloads,
-								gw_svc.as_ref(),
-								gw_addr.hbone_mtls_port,
-								None,
-							)?;
-							let resolved_port = select_service_target_port(
-								gw_ep.as_ref(),
-								gw_svc.as_ref(),
-								gw_addr.hbone_mtls_port,
-								None,
-								false,
-							)?;
-							let ip = *gw_wl.workload_ips.first()?;
-							Some((
-								GatewayAddress {
-									destination: types::discovery::gatewayaddress::Destination::Address(
-										NetworkAddress {
-											network: gw_wl.network.clone(),
-											address: ip,
-										},
-									),
-									hbone_mtls_port: resolved_port,
-								},
-								gw_wl.identity(),
-							))
-						});
-					if let Some((resolved_gw_addr, gw_identity)) = resolved {
-						tracing::debug!(
-							source_network = %inputs.cfg.network,
-							dest_network = %wl.network,
-							gateway = ?resolved_gw_addr,
-							"picked workload on remote network, using double hbone"
-						);
-						// TODO:wire the gw_handle through to handshake_double to track per-conn health/latency
-						Some((resolved_gw_addr, gw_identity))
-					} else {
-						tracing::warn!(
-							gateway_hostname = ?hostname,
-							"no service / endpoint / IP for hostname-based network gateway"
-						);
-						None
-					}
-				},
-			}
-		} else {
-			tracing::warn ! (
-			source_network = % inputs.cfg.network,
-			dest_network = % wl.network,
-			"workload on remote network but no gateway configured"
-			);
-			None
-		}
+	let mut network_gateway = if wl.network != inputs.cfg.network {
+		resolve_network_gateway(
+			inputs,
+			&discovery,
+			wl.as_ref(),
+			"selected service workload is remote",
+		)
 	} else {
 		None
 	};
+	let mut transport_override = Some((wl.protocol, workload_and_service_sans(&wl, svc)));
 
 	// Check if the service has ingress_use_waypoint set and a waypoint configured.
 	// When set, route traffic through the waypoint instead of directly to the workload.
@@ -2117,68 +2042,75 @@ pub fn build_service_call(
 	// ingress gateways, never waypoint-to-waypoint traffic.
 	let waypoint = if svc.ingress_use_waypoint && hbone_source != Some(HboneSourceRole::Waypoint) {
 		if let Some(wp) = &svc.waypoint {
-			let wp_ip = match &wp.destination {
-				types::discovery::gatewayaddress::Destination::Address(net_addr) => Some(net_addr.address),
-				types::discovery::gatewayaddress::Destination::Hostname(nh) => {
-					// Resolve hostname-based waypoint via service discovery
-					discovery
-						.services
-						.get_by_namespaced_host(&NamespacedHostname {
-							namespace: nh.namespace.clone(),
-							hostname: nh.hostname.clone(),
-						})
-						.and_then(|wp_svc| {
-							wp_svc
-								.vips
-								.iter()
-								.find(|v| v.network == inputs.cfg.network)
-								.or_else(|| wp_svc.vips.first())
-								.map(|v| v.address)
-						})
-				},
+			let default_wp_port = if wp.hbone_mtls_port > 0 {
+				wp.hbone_mtls_port
+			} else {
+				agent_hbone::DEFAULT_HBONE_PORT
 			};
-			// Resolve the waypoint's own SPIFFE identity for mTLS verification.
-			let waypoint_info = wp_ip.and_then(|ip| {
-				let net_addr = types::discovery::NetworkAddress {
-					network: inputs.cfg.network.clone(),
-					address: ip,
-				};
-				let identity = if let Some(wp_wl) = discovery.workloads.find_address(&net_addr) {
-					// waypoint_ip is a pod IP — use the workload identity directly
-					Some(wp_wl.identity())
-				} else if let Some(wp_svc) = discovery.services.get_by_vip(&net_addr) {
-					// waypoint_ip is a service VIP — get identity from a backing workload
-					wp_svc.endpoints.iter().iter().find_map(|(ep, _)| {
-						discovery
-							.workloads
-							.find_uid(&ep.workload_uid)
-							.map(|wl| wl.identity())
-					})
-				} else {
-					None
-				};
-				identity.map(|id| (ip, id))
-			});
-			match waypoint_info {
-				Some((ip, identity)) => {
-					let wp_port = if wp.hbone_mtls_port > 0 {
-						wp.hbone_mtls_port
+			// Resolve the waypoint to a concrete backing workload so we know its IP (not the
+			// service VIP) and its network — the latter lets us detect a remote waypoint and
+			// route to it through the network gateway via double HBONE.
+			let waypoint_info = match &wp.destination {
+				types::discovery::gatewayaddress::Destination::Address(net_addr) => {
+					if let Some(wp_wl) = discovery.workloads.find_address(net_addr) {
+						// A pod IP: use the workload identity directly (no service SANs available).
+						Some((
+							SocketAddr::new(net_addr.address, default_wp_port),
+							vec![wp_wl.identity()],
+							wp_wl,
+						))
+					} else if let Some(wp_svc) = discovery.services.get_by_vip(net_addr) {
+						// A service VIP: resolve a backing endpoint to get a real workload IP.
+						resolve_service_endpoint(&discovery, &wp_svc, default_wp_port)
 					} else {
-						agent_hbone::DEFAULT_HBONE_PORT
-					};
-					tracing::debug!(
-						service = %svc.hostname,
-						waypoint = %ip,
-						waypoint_port = %wp_port,
-						"ingress_use_waypoint: routing through waypoint"
-					);
-					Some(WaypointTarget {
-						address: SocketAddr::new(ip, wp_port),
-						service_hostname: svc.hostname.clone(),
-						identities: vec![identity],
-					})
+						None
+					}
 				},
-				_ => {
+				types::discovery::gatewayaddress::Destination::Hostname(nh) => discovery
+					.services
+					.get_by_namespaced_host(&NamespacedHostname {
+						namespace: nh.namespace.clone(),
+						hostname: nh.hostname.clone(),
+					})
+					.and_then(|wp_svc| resolve_service_endpoint(&discovery, &wp_svc, default_wp_port)),
+			};
+			match waypoint_info {
+				Some((address, identities, wp_wl)) => {
+					if wp_wl.network != inputs.cfg.network {
+						// Remote waypoint: reach it through the network gateway via double HBONE.
+						// The inner HBONE identities are the waypoint's; the outer ones are the
+						// gateway's, resolved below.
+						if let Some(gw) = resolve_network_gateway(
+							inputs,
+							&discovery,
+							wp_wl.as_ref(),
+							"ingress_use_waypoint selected a remote waypoint workload",
+						) {
+							network_gateway = Some(gw);
+							transport_override = Some((InboundProtocol::HBONE, identities));
+							tracing::debug!(
+								service = %svc.hostname,
+								waypoint = %address.ip(),
+								waypoint_port = %address.port(),
+								"ingress_use_waypoint: routing to remote waypoint through network gateway"
+							);
+						}
+						None
+					} else {
+						tracing::debug!(
+							service = %svc.hostname,
+							waypoint = %address.ip(),
+							waypoint_port = %address.port(),
+							"ingress_use_waypoint: routing through waypoint"
+						);
+						Some(WaypointTarget {
+							address,
+							service_hostname: svc.hostname.clone(),
+							identities,
+						})
+					}
+				},
+				None => {
 					tracing::warn!(
 						service = %svc.hostname,
 						"ingress_use_waypoint set but waypoint could not be resolved"
@@ -2230,7 +2162,7 @@ pub fn build_service_call(
 	Ok(BackendCall {
 		target,
 		http_version_override,
-		transport_override: Some((wl.protocol, workload_and_service_sans(&wl, svc))),
+		transport_override,
 		hbone_port,
 		network_gateway,
 		waypoint,
@@ -2277,6 +2209,95 @@ fn workload_and_service_sans(wl: &Workload, svc: &Service) -> Vec<Identity> {
 		}
 	}
 	ids
+}
+
+/// Selects a healthy endpoint for `svc` on `port` and returns its reachable socket address
+/// (a real workload IP, not the service VIP), the accepted SPIFFE identities for mTLS
+/// verification (workload identity + service SANs, matching ztunnel), and the backing workload.
+fn resolve_service_endpoint(
+	discovery: &store::DiscoveryStore,
+	svc: &Service,
+	port: u16,
+) -> Option<(SocketAddr, Vec<Identity>, Arc<Workload>)> {
+	let (ep, _handle, wl) = svc
+		.endpoints
+		.select_endpoint(&discovery.workloads, svc, port, None)?;
+	// TODO: plumb `_handle` through the waypoint/gateway transports so endpoint selection
+	// keeps EWMA, eviction, and latency feedback.
+	let resolved_port = select_service_target_port(ep.as_ref(), svc, port, None, false)?;
+	let ip = *wl.workload_ips.first()?;
+	let identities = workload_and_service_sans(&wl, svc);
+	Some((SocketAddr::new(ip, resolved_port), identities, wl))
+}
+
+/// Resolves the network gateway used to reach `remote_wl` from the local network via double
+/// HBONE. Returns the gateway address and the accepted SPIFFE identities for the outer tunnel.
+fn resolve_network_gateway(
+	inputs: &ProxyInputs,
+	discovery: &store::DiscoveryStore,
+	remote_wl: &Workload,
+	reason: &'static str,
+) -> Option<(GatewayAddress, Vec<Identity>)> {
+	let Some(gw_addr) = &remote_wl.network_gateway else {
+		tracing::warn!(
+			source_network = %inputs.cfg.network,
+			dest_network = %remote_wl.network,
+			"workload on remote network but no gateway configured"
+		);
+		return None;
+	};
+	let resolved = match &gw_addr.destination {
+		types::discovery::gatewayaddress::Destination::Address(net_addr) => {
+			let Some(gw_wl) = discovery.workloads.find_address(net_addr) else {
+				tracing::warn!(
+					gateway_address = ?net_addr,
+					"network gateway address not found in workload store for remote workload"
+				);
+				return None;
+			};
+			// A direct gateway address gives us only the workload; no service SANs available.
+			Some((gw_addr.clone(), vec![gw_wl.identity()]))
+		},
+		types::discovery::gatewayaddress::Destination::Hostname(hostname) => {
+			let resolved = discovery
+				.services
+				.get_by_namespaced_host(&NamespacedHostname {
+					namespace: hostname.namespace.clone(),
+					hostname: hostname.hostname.clone(),
+				})
+				.and_then(|gw_svc| {
+					let (addr, identities, gw_wl) =
+						resolve_service_endpoint(discovery, &gw_svc, gw_addr.hbone_mtls_port)?;
+					Some((
+						GatewayAddress {
+							destination: types::discovery::gatewayaddress::Destination::Address(NetworkAddress {
+								network: gw_wl.network.clone(),
+								address: addr.ip(),
+							}),
+							hbone_mtls_port: addr.port(),
+						},
+						identities,
+					))
+				});
+			if resolved.is_none() {
+				tracing::warn!(
+					gateway_hostname = ?hostname,
+					"no service / endpoint / IP for hostname-based network gateway"
+				);
+			}
+			resolved
+		},
+	};
+	if let Some((resolved_gw_addr, _)) = &resolved {
+		tracing::debug!(
+			source_network = %inputs.cfg.network,
+			dest_network = %remote_wl.network,
+			gateway = ?resolved_gw_addr,
+			reason,
+			"picked workload on remote network, using double hbone"
+		);
+	}
+	resolved
 }
 
 fn resolved_workload_target_hostname<'a>(
@@ -2840,8 +2861,8 @@ pub struct BackendCall {
 	pub http_version_override: Option<::http::Version>,
 	pub transport_override: Option<(InboundProtocol, Vec<Identity>)>,
 	pub hbone_port: u16,
-	pub network_gateway: Option<(GatewayAddress, Identity)>, /* For double hbone: (gateway_address, gateway_identity) */
-	pub waypoint: Option<WaypointTarget>,                    // For ingress waypoint routing
+	pub network_gateway: Option<(GatewayAddress, Vec<Identity>)>, /* For double hbone: (gateway_address, gateway_identities) */
+	pub waypoint: Option<WaypointTarget>,                         // For ingress waypoint routing
 	pub backend_policies: BackendPolicies,
 }
 


### PR DESCRIPTION
Refactors ingress waypoint resolution to select backing waypoint endpoints instead of relying on waypoint VIPs, while preserving the original service hostname as the HBONE target.

Also adds test coverage for hostname/IP waypoint resolution, remote waypoint gateway routing, and hostname-based network gateway resolution.