### PR TITLE
fix(bedrock): emit empty string for initial tool_call arguments delta

### DIFF
--- a/crates/agentgateway/src/llm/conversion/bedrock.rs
+++ b/crates/agentgateway/src/llm/conversion/bedrock.rs
@@ -692,7 +692,7 @@ pub mod from_completions {
 								r#type: Some(completions::FunctionType::Function),
 								function: Some(completions::FunctionCallStream {
 									name: Some(tu.name),
-									arguments: None,
+									arguments: Some(String::new()),
 								}),
 							}]),
 							..Default::default()

--- a/crates/agentgateway/src/llm/tests/response/bedrock/tool.bedrock-completions-streaming.snap
+++ b/crates/agentgateway/src/llm/tests/response/bedrock/tool.bedrock-completions-streaming.snap
@@ -1,16 +1,17 @@
 ---
 source: crates/agentgateway/src/llm/tests.rs
+assertion_line: 205
 description: src/llm/tests/response/bedrock/tool.bin
 ---
 data: {"id":"request_id","choices":[{"index":0,"delta":{"content":null,"role":"assistant"}}],"created":123,"model":"input-model","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
 
-data: {"id":"request_id","choices":[{"index":0,"delta":{"content":null,"tool_calls":[{"index":0,"id":"tooluse_kZJMlvQmRJ6eAyJE5GIl7Q","type":"function","function":{"name":"top_song","arguments":null}}]}}],"created":123,"model":"input-model","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
+data: {"id":"request_id","choices":[{"index":0,"delta":{"content":null,"tool_calls":[{"index":0,"id":"tooluse_kZJMlvQmRJ6eAyJE5GIl7Q","type":"function","function":{"name":"top_song","arguments":""}}]}}],"created":123,"model":"input-model","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
 
 data: {"id":"request_id","choices":[{"index":0,"delta":{"content":null,"tool_calls":[{"index":0,"id":null,"type":null,"function":{"name":null,"arguments":"{\"sign\":"}}]}}],"created":123,"model":"input-model","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
 
 data: {"id":"request_id","choices":[{"index":0,"delta":{"content":null,"tool_calls":[{"index":0,"id":null,"type":null,"function":{"name":null,"arguments":"\"WZPZ\"}"}}]}}],"created":123,"model":"input-model","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
 
-data: {"id":"request_id","choices":[{"index":0,"delta":{"content":null,"tool_calls":[{"index":1,"id":"tooluse_kZJMlvQmRJ6eAyxxx","type":"function","function":{"name":"hello","arguments":null}}]}}],"created":123,"model":"input-model","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
+data: {"id":"request_id","choices":[{"index":0,"delta":{"content":null,"tool_calls":[{"index":1,"id":"tooluse_kZJMlvQmRJ6eAyxxx","type":"function","function":{"name":"hello","arguments":""}}]}}],"created":123,"model":"input-model","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
 
 data: {"id":"request_id","choices":[{"index":0,"delta":{"content":null,"tool_calls":[{"index":1,"id":null,"type":null,"function":{"name":null,"arguments":"{\"sign\":\"world\"}"}}]}}],"created":123,"model":"input-model","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
 


### PR DESCRIPTION
Fixes #1988.

The streaming `ContentBlockStart::ToolUse` branch was emitting `function.arguments` as `None`, which serializes to JSON `null`. The OpenAI streaming spec requires `arguments` to be a string. Emit `Some(String::new())` on the first chunk so downstream string-typed accumulators stay correct.

No behavior change for subsequent deltas: `ContentBlockDelta::ToolUse` continues to emit the accumulated input as a string.

## Changes
- `bedrock.rs`: one line — `arguments: None` → `arguments: Some(String::new())` in the `ContentBlockStart::ToolUse` branch.
- `tool.bedrock-completions-streaming.snap`: existing snapshot test updated to the corrected wire shape (only the two tool_use start chunks change `null` → `""`; subsequent JSON-content chunks unchanged). This snapshot serves as the regression test, covering the streaming pipeline end-to-end.

## Verification
- `make lint` clean.
- `make test` green: 1341 tests across 15 binaries, all passing. The previously failing `bedrock-completions-streaming` snapshot now matches.
- Manually verified end-to-end with a Bedrock `claude-sonnet-4-6` request that triggers an MCP tool call through OpenWebUI — the pre-fix `TypeError: object of type 'NoneType' has no len()` on the client side is gone and the tool round-trip completes.

---
*AI-assisted change. Author reviewed, ran the full test suite, and verified the fix end-to-end before submission.*