### PR TITLE
fix: populate cache_creation_input_tokens in non-streaming responses

### DIFF
--- a/crates/agentgateway/src/llm/conversion/completions.rs
+++ b/crates/agentgateway/src/llm/conversion/completions.rs
@@ -986,6 +986,7 @@ pub fn passthrough_stream(
 									.prompt_tokens_details
 									.as_ref()
 									.and_then(|d| d.cached_tokens);
+								r.response.cache_creation_input_tokens = u.cache_creation_input_tokens;
 								r.response.reasoning_tokens = u
 									.completion_tokens_details
 									.as_ref()


### PR DESCRIPTION
Fixes #1991

## What

While building cost tracking for prompt caching, I found that `gen_ai.usage.cache_creation.input_tokens` was always absent from access logs on non-streaming requests, even though the Bedrock response body
correctly contained `cache_write_input_tokens`.

Traced it to `llm/types/completions.rs` — the outer `Usage` struct was missing the `cache_creation_input_tokens` field entirely, so it got dropped on deserialization. `to_llm_response()` also hardcoded it to `None`.

## Testing

Tested manually against AWS Bedrock (`us.anthropic.claude-sonnet-4-6`) with `promptCaching` enabled. Verified both cache write and cache read appear correctly in access logs for both streaming and non-streaming paths.

Before:
```
gen_ai.usage.input_tokens=9  gen_ai.usage.cache_read.input_tokens=0
```

After (cache write):
```
gen_ai.usage.input_tokens=9  gen_ai.usage.cache_creation.input_tokens=3153  gen_ai.usage.cache_read.input_tokens=0
```

After (cache read):
```
gen_ai.usage.input_tokens=9  gen_ai.usage.cache_creation.input_tokens=0  gen_ai.usage.cache_read.input_tokens=3153
```

*AI tooling was used to assist in code exploration and debugging.*