### PR TITLE
cel: expose grpc status on response

### DIFF
--- a/crates/agentgateway/src/cel/types.rs
+++ b/crates/agentgateway/src/cel/types.rs
@@ -601,6 +601,7 @@ pub fn snapshot_request(req: &mut crate::http::Request, clear: bool) -> RequestS
 pub fn snapshot_response(resp: &mut crate::http::Response) -> ResponseSnapshot {
 	ResponseSnapshot {
 		code: resp.status(),
+		grpc_status: crate::proxy::httpproxy::parse_grpc_status(resp.headers()),
 		headers: resp.headers().clone(),
 		body: resp.extensions_mut().remove::<BufferedBody>(),
 		recorded_body: resp.extensions_mut().remove::<RecordedBodyHandle>(),
@@ -690,6 +691,7 @@ pub struct RequestRef<'a> {
 #[derive(Debug, Clone)]
 pub struct ResponseSnapshot {
 	pub code: http::StatusCode,
+	pub grpc_status: Option<u8>,
 	pub headers: http::HeaderMap,
 	pub body: Option<BufferedBody>,
 	pub recorded_body: Option<RecordedBodyHandle>,
@@ -700,6 +702,11 @@ pub struct ResponseSnapshot {
 pub struct ResponseRef<'a> {
 	/// The HTTP status code of the response.
 	pub code: u16,
+
+	/// The gRPC status code of the response, when present.
+	#[serde(rename = "grpcStatus", skip_serializing_if = "Option::is_none")]
+	#[dynamic(rename = "grpcStatus")]
+	pub grpc_status: Option<u8>,
 
 	/// The headers of the response.
 	pub headers: Headers<'a>,
@@ -712,6 +719,7 @@ impl<'a> From<&'a ResponseSnapshot> for ResponseRef<'a> {
 	fn from(value: &'a ResponseSnapshot) -> Self {
 		Self {
 			code: value.code.as_u16(),
+			grpc_status: value.grpc_status,
 			headers: Headers::new(&value.headers),
 			body: BodyExtensionOrDirect::Direct {
 				buffered: value.body.as_ref(),
@@ -784,6 +792,14 @@ pub struct ResponseRefSerde {
 	#[serde(default)]
 	pub code: u16,
 
+	/// The gRPC status code of the response, when present.
+	#[serde(
+		default,
+		rename = "grpcStatus",
+		skip_serializing_if = "Option::is_none"
+	)]
+	pub grpc_status: Option<u8>,
+
 	/// The headers of the response.
 	#[serde(default, with = "http_serde::header_map")]
 	#[cfg_attr(
@@ -840,6 +856,7 @@ impl<'a> From<&'a crate::http::Response> for ResponseRef<'a> {
 	fn from(resp: &'a crate::http::Response) -> Self {
 		Self {
 			code: resp.status().as_u16(),
+			grpc_status: crate::proxy::httpproxy::parse_grpc_status(resp.headers()),
 			headers: Headers::new(resp.headers()),
 			body: BodyExtensionOrDirect::Extension(resp.extensions()),
 		}
@@ -1661,6 +1678,7 @@ impl ExecutorSerde {
 		if let Some(resp) = &self.response {
 			exec.response = Some(ResponseRef {
 				code: resp.code,
+				grpc_status: resp.grpc_status,
 				headers: Headers::new(&resp.headers),
 				body: BodyExtensionOrDirect::Direct {
 					buffered: resp.body.as_ref(),
@@ -1714,6 +1732,7 @@ pub fn full_example_executor() -> ExecutorSerde {
 		}),
 		response: Some(ResponseRefSerde {
 			code: 200,
+			grpc_status: None,
 			headers: resp_headers,
 			body: Some(BufferedBody(Bytes::from(r#"{"ok": true}"#))),
 		}),

--- a/crates/agentgateway/src/proxy/gateway_test.rs
+++ b/crates/agentgateway/src/proxy/gateway_test.rs
@@ -1,14 +1,17 @@
+use std::convert::Infallible;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};
 use std::time::Duration;
 
-use ::http::{Method, StatusCode, Version, header};
+use ::http::{HeaderMap, Method, StatusCode, Version, header};
 use agent_core::strng;
 use assert_matches::assert_matches;
-use http_body_util::BodyExt;
+use http_body::Frame;
+use http_body_util::{BodyExt, StreamBody};
 use hyper::client::conn::http1;
+use hyper::service::service_fn;
 use hyper_util::client::legacy::Client;
-use hyper_util::rt::TokioIo;
+use hyper_util::rt::{TokioExecutor, TokioIo};
 use jsonwebtoken::jwk::JwkSet;
 use jsonwebtoken::{Algorithm, EncodingKey, Header};
 use ppp::v2::{
@@ -526,6 +529,78 @@ async fn basic_http2() {
 		.unwrap();
 	assert_eq!(res.status(), 200);
 	assert_eq!(read_body(res.into_body()).await.version, Version::HTTP_2);
+}
+
+async fn grpc_trailer_backend(status: &'static str) -> std::net::SocketAddr {
+	let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+	let addr = listener.local_addr().unwrap();
+	tokio::spawn(async move {
+		loop {
+			let Ok((stream, _)) = listener.accept().await else {
+				return;
+			};
+			tokio::spawn(async move {
+				let svc = service_fn(move |_| async move {
+					let mut trailers = HeaderMap::new();
+					trailers.insert("grpc-status", status.parse().unwrap());
+					let body = StreamBody::new(tokio_stream::iter([
+						Ok::<_, Infallible>(Frame::data(bytes::Bytes::new())),
+						Ok(Frame::trailers(trailers)),
+					]));
+					Ok::<_, Infallible>(
+						::http::Response::builder()
+							.status(200)
+							.header(header::CONTENT_TYPE, "application/grpc")
+							.body(body)
+							.unwrap(),
+					)
+				});
+				let _ = hyper::server::conn::http2::Builder::new(TokioExecutor::new())
+					.serve_connection(TokioIo::new(stream), svc)
+					.await;
+			});
+		}
+	});
+	addr
+}
+
+#[tokio::test]
+async fn grpc_status_trailer_is_available_to_access_log_cel() {
+	let backend = grpc_trailer_backend("13").await;
+	let path = format!("/grpc-{}", rand::rng().random::<u128>());
+	let t = setup_proxy_test(
+		r#"{"config":{"logging":{"fields":{"add":{"cel_grpc_status":"response.grpcStatus"}}}}}"#,
+	)
+	.unwrap()
+	.with_raw_backend(BackendWithPolicies {
+		backend: Backend::Opaque(
+			ResourceName::new(strng::format!("{}", backend), "".into()),
+			Target::Address(backend),
+		),
+		inline_policies: vec![BackendTrafficPolicy::HTTP(backend::HTTP {
+			version: Some(Version::HTTP_2),
+			..Default::default()
+		})],
+	})
+	.with_bind(simple_bind())
+	.with_route(basic_route(backend));
+	let io = t.serve_http2(strng::new("bind"));
+	let res = RequestBuilder::new(Method::POST, &format!("http://lo{path}"))
+		.version(Version::HTTP_2)
+		.header(header::CONTENT_TYPE, "application/grpc")
+		.body(Body::empty())
+		.send(io)
+		.await
+		.unwrap();
+	assert_eq!(res.status(), 200);
+	read_body_raw(res.into_body()).await;
+
+	let log =
+		agent_core::telemetry::testing::eventually_find(&[("scope", "request"), ("http.path", &path)])
+			.await
+			.unwrap();
+	assert_eq!(log["grpc.status"].as_u64(), Some(13));
+	assert_eq!(log["cel_grpc_status"].as_u64(), Some(13));
 }
 
 #[tokio::test]

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -2822,12 +2822,16 @@ mod tests {
 }
 
 pub fn maybe_set_grpc_status(status: &AsyncLog<u8>, headers: &HeaderMap) {
-	if let Some(s) = headers.get("grpc-status") {
-		let parsed = std::str::from_utf8(s.as_bytes())
-			.ok()
-			.and_then(|s| s.parse::<u8>().ok());
-		status.store(parsed);
+	if let Some(parsed) = parse_grpc_status(headers) {
+		status.store(Some(parsed));
 	}
+}
+
+pub fn parse_grpc_status(headers: &HeaderMap) -> Option<u8> {
+	headers
+		.get("grpc-status")
+		.and_then(|status| std::str::from_utf8(status.as_bytes()).ok())
+		.and_then(|status| status.parse().ok())
 }
 
 async fn send_mirror(

--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -874,6 +874,14 @@ impl Drop for DropOnLog {
 			let mcp = log.mcp_status.take();
 			let request_handle = log.request_handle.take();
 			let cel_end_time = cel::RequestTime(end_time.as_datetime());
+			// The response snapshot is captured before the response body is drained, so
+			// trailer-only grpc-status values are learned later by LogBody. Copy the final
+			// value back into the snapshot before evaluating access-log CEL fields.
+			if let Some(grpc_status) = log.grpc_status.load()
+				&& let Some(resp) = log.response_snapshot.as_mut()
+			{
+				resp.grpc_status = Some(grpc_status);
+			}
 			let cel_exec = log.cel.build(CelLoggingBuildInputs {
 				req: log.request_snapshot.as_deref(),
 				resp: log.response_snapshot.as_ref(),

--- a/schema/cel.json
+++ b/schema/cel.json
@@ -99,6 +99,16 @@
           "maximum": 65535,
           "default": 0
         },
+        "grpcStatus": {
+          "description": "The gRPC status code of the response, when present.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint8",
+          "minimum": 0,
+          "maximum": 255
+        },
         "headers": {
           "description": "The headers of the response.",
           "type": "object",

--- a/schema/cel.md
+++ b/schema/cel.md
@@ -16,6 +16,7 @@
 |`request.endTime`|string|The time the request completed|
 |`response`|object|`response` contains attributes about the HTTP response|
 |`response.code`|integer|The HTTP status code of the response.|
+|`response.grpcStatus`|integer|The gRPC status code of the response, when present.|
 |`response.headers`|object|The headers of the response.|
 |`response.body`|string|The body of the response. Warning: accessing the body will cause the body to be buffered.|
 |`env`|object|`env` contains selected process environment attributes exposed to CEL.<br>This does NOT expose raw environment variables, but rather a subset of well-known variables.|


### PR DESCRIPTION
Expose grpc-status on the CEL response object as response.grpcStatus.

The value is parsed from response headers when present and copied from the final logged grpc status before access-log CEL fields are evaluated, so trailer-only gRPC statuses are available too.