### PR TITLE
ext-authz: derive scheme from forwarded proto

### DIFF
--- a/crates/agentgateway/src/http/ext_authz.rs
+++ b/crates/agentgateway/src/http/ext_authz.rs
@@ -209,6 +209,15 @@ impl ExtAuthz {
 		}
 	}
 
+	fn request_scheme(req: &Request) -> String {
+		if let Some(scheme) = req.uri().scheme() {
+			return scheme.to_string();
+		}
+		http::x_headers::forwarded_scheme(req.headers())
+			.unwrap_or(http::uri::Scheme::HTTP)
+			.to_string()
+	}
+
 	fn get_header_values(
 		&self,
 		req: &Request,
@@ -344,11 +353,7 @@ impl ExtAuthz {
 					.map(|s| s.as_str())
 					.unwrap_or("")
 					.to_string(),
-				scheme: req
-					.uri()
-					.scheme()
-					.map(|s| s.to_string())
-					.unwrap_or_else(|| "http".to_string()),
+				scheme: Self::request_scheme(req),
 				protocol: http::version_str(&req.version()).to_string(),
 				// Always empty per spec
 				query: "".to_string(),

--- a/crates/agentgateway/src/http/ext_authz_tests.rs
+++ b/crates/agentgateway/src/http/ext_authz_tests.rs
@@ -349,6 +349,28 @@ fn test_pseudo_header_value_extraction() {
 }
 
 #[test]
+fn grpc_ext_authz_scheme_uses_forwarded_proto_when_uri_has_no_scheme() {
+	let req = ::http::Request::builder()
+		.uri("/api/test")
+		.header("x-forwarded-proto", "https")
+		.body(http::Body::empty())
+		.unwrap();
+
+	assert_eq!(ExtAuthz::request_scheme(&req), "https");
+}
+
+#[test]
+fn grpc_ext_authz_scheme_prefers_uri_scheme_over_forwarded_proto() {
+	let req = ::http::Request::builder()
+		.uri("http://example.com/api/test")
+		.header("x-forwarded-proto", "https")
+		.body(http::Body::empty())
+		.unwrap();
+
+	assert_eq!(ExtAuthz::request_scheme(&req), "http");
+}
+
+#[test]
 fn test_pseudo_header_authority_fallback() {
 	use ::http::{Method, Request};
 


### PR DESCRIPTION
Set the ext-authz request scheme from forwarded proto when the request URI does not already carry a scheme.

Absolute-form requests keep their URI scheme. Origin-form requests can use the existing forwarded proto helper so ext-authz sees the externally observed scheme instead of an empty value.