### PR TITLE
docs: use 0.0.0-dev placeholder and add comment to Chart.yaml appVersion

### DIFF
--- a/controller/install/helm/agentgateway-crds/Chart.yaml
+++ b/controller/install/helm/agentgateway-crds/Chart.yaml
@@ -4,5 +4,8 @@ description: A Helm chart for the agentgateway project CRDs
 icon: https://raw.githubusercontent.com/agentgateway/website/refs/heads/main/static/favicon.svg
 type: application
 version: "0.0.2"
-appVersion: "0.0.1"
+# appVersion is a placeholder. The real version is injected at release time by the
+# Makefile release-charts target via --app-version $(HELM_CHART_VERSION_V).
+# Using 0.0.0-dev makes it clear this is not a real release version.
+appVersion: "0.0.0-dev"
 

--- a/controller/install/helm/agentgateway/Chart.yaml
+++ b/controller/install/helm/agentgateway/Chart.yaml
@@ -4,5 +4,8 @@ description: A Helm chart for the agentgateway project
 icon: https://raw.githubusercontent.com/agentgateway/website/refs/heads/main/static/favicon.svg
 type: application
 version: "0.0.2"
-appVersion: "0.0.1"
+# appVersion is a placeholder. The real version is injected at release time by the
+# Makefile release-charts target via --app-version $(HELM_CHART_VERSION_V).
+# Using 0.0.0-dev makes it clear this is not a real release version.
+appVersion: "0.0.0-dev"
 

--- a/controller/test/helm/helm_version_test.go
+++ b/controller/test/helm/helm_version_test.go
@@ -37,8 +37,8 @@ func TestImageTagVPrefix(t *testing.T) {
 	}{
 		{
 			name:        "default AppVersion without v prefix gets v added",
-			setValues:   nil, // Uses Chart.AppVersion which is "0.0.1"
-			expectedTag: "v0.0.1",
+			setValues:   nil, // Uses Chart.AppVersion which is "0.0.0-dev"
+			expectedTag: "v0.0.0-dev",
 		},
 		{
 			name:        "explicit tag with v prefix is not doubled",
@@ -54,13 +54,13 @@ func TestImageTagVPrefix(t *testing.T) {
 			name:           "controller-specific tag with v prefix is not doubled",
 			setValues:      []string{"controller.image.tag=v3.0.0"},
 			expectedTag:    "v3.0.0",
-			expectedEnvTag: "v0.0.1", // KGW_DEFAULT_IMAGE_TAG falls back to AppVersion
+			expectedEnvTag: "v0.0.0-dev", // KGW_DEFAULT_IMAGE_TAG falls back to AppVersion
 		},
 		{
 			name:           "controller-specific tag without v prefix gets v added",
 			setValues:      []string{"controller.image.tag=3.0.0"},
 			expectedTag:    "v3.0.0",
-			expectedEnvTag: "v0.0.1", // KGW_DEFAULT_IMAGE_TAG falls back to AppVersion
+			expectedEnvTag: "v0.0.0-dev", // KGW_DEFAULT_IMAGE_TAG falls back to AppVersion
 		},
 		{
 			name:        "latest tag is not modified",

--- a/controller/test/helm/testdata/agentgateway/additional-labels.golden
+++ b/controller/test/helm/testdata/agentgateway/additional-labels.golden
@@ -10,7 +10,7 @@ metadata:
     agentgateway: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/instance: test-release
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"
     app.kubernetes.io/managed-by: Helm
     another-label: "true"
     extra-label-key: extra-label-value
@@ -234,7 +234,7 @@ metadata:
     agentgateway: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/instance: test-release
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"
     app.kubernetes.io/managed-by: Helm
     another-label: "true"
     extra-label-key: extra-label-value
@@ -269,7 +269,7 @@ metadata:
     agentgateway: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/instance: test-release
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"
     app.kubernetes.io/managed-by: Helm
     another-label: "true"
     extra-label-key: extra-label-value
@@ -301,7 +301,7 @@ spec:
             capabilities:
               drop:
               - ALL
-          image: "cr.agentgateway.dev/controller:v0.0.1"
+          image: "cr.agentgateway.dev/controller:v0.0.0-dev"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9978

--- a/controller/test/helm/testdata/agentgateway/default.golden
+++ b/controller/test/helm/testdata/agentgateway/default.golden
@@ -10,7 +10,7 @@ metadata:
     agentgateway: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/instance: test-release
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: agentgateway/templates/role.yaml
@@ -232,7 +232,7 @@ metadata:
     agentgateway: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/instance: test-release
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -265,7 +265,7 @@ metadata:
     agentgateway: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/instance: test-release
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -295,7 +295,7 @@ spec:
             capabilities:
               drop:
               - ALL
-          image: "cr.agentgateway.dev/controller:v0.0.1"
+          image: "cr.agentgateway.dev/controller:v0.0.0-dev"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9978

--- a/controller/test/helm/testdata/agentgateway/extra-env.golden
+++ b/controller/test/helm/testdata/agentgateway/extra-env.golden
@@ -10,7 +10,7 @@ metadata:
     agentgateway: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/instance: test-release
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: agentgateway/templates/role.yaml
@@ -232,7 +232,7 @@ metadata:
     agentgateway: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/instance: test-release
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -265,7 +265,7 @@ metadata:
     agentgateway: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/instance: test-release
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -295,7 +295,7 @@ spec:
             capabilities:
               drop:
               - ALL
-          image: "cr.agentgateway.dev/controller:v0.0.1"
+          image: "cr.agentgateway.dev/controller:v0.0.0-dev"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9978

--- a/controller/test/helm/testdata/agentgateway/extra-volumes.golden
+++ b/controller/test/helm/testdata/agentgateway/extra-volumes.golden
@@ -10,7 +10,7 @@ metadata:
     agentgateway: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/instance: test-release
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: agentgateway/templates/role.yaml
@@ -232,7 +232,7 @@ metadata:
     agentgateway: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/instance: test-release
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -265,7 +265,7 @@ metadata:
     agentgateway: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/instance: test-release
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -295,7 +295,7 @@ spec:
             capabilities:
               drop:
               - ALL
-          image: "cr.agentgateway.dev/controller:v0.0.1"
+          image: "cr.agentgateway.dev/controller:v0.0.0-dev"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9978

--- a/controller/test/helm/testdata/agentgateway/hpa-and-vpa.golden
+++ b/controller/test/helm/testdata/agentgateway/hpa-and-vpa.golden
@@ -10,7 +10,7 @@ metadata:
     agentgateway: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/instance: test-release
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: agentgateway/templates/role.yaml
@@ -232,7 +232,7 @@ metadata:
     agentgateway: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/instance: test-release
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -265,7 +265,7 @@ metadata:
     agentgateway: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/instance: test-release
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -295,7 +295,7 @@ spec:
             capabilities:
               drop:
               - ALL
-          image: "cr.agentgateway.dev/controller:v0.0.1"
+          image: "cr.agentgateway.dev/controller:v0.0.0-dev"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9978
@@ -369,7 +369,7 @@ metadata:
     agentgateway: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/instance: test-release
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"
     app.kubernetes.io/managed-by: Helm
 spec:
   scaleTargetRef:
@@ -397,7 +397,7 @@ metadata:
     agentgateway: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/instance: test-release
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"
     app.kubernetes.io/managed-by: Helm
 spec:
   targetRef:

--- a/controller/test/helm/testdata/agentgateway/monitoring-custom-proxy-namespace-selector.golden
+++ b/controller/test/helm/testdata/agentgateway/monitoring-custom-proxy-namespace-selector.golden
@@ -10,7 +10,7 @@ metadata:
     agentgateway: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/instance: test-release
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: agentgateway/templates/role.yaml
@@ -232,7 +232,7 @@ metadata:
     agentgateway: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/instance: test-release
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -265,7 +265,7 @@ metadata:
     agentgateway: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/instance: test-release
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -295,7 +295,7 @@ spec:
             capabilities:
               drop:
               - ALL
-          image: "cr.agentgateway.dev/controller:v0.0.1"
+          image: "cr.agentgateway.dev/controller:v0.0.0-dev"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9978
@@ -369,7 +369,7 @@ metadata:
     agentgateway: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/instance: test-release
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -393,7 +393,7 @@ metadata:
     agentgateway: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/instance: test-release
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:

--- a/controller/test/helm/testdata/agentgateway/monitoring-enabled-no-dashboard.golden
+++ b/controller/test/helm/testdata/agentgateway/monitoring-enabled-no-dashboard.golden
@@ -10,7 +10,7 @@ metadata:
     agentgateway: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/instance: test-release
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: agentgateway/templates/role.yaml
@@ -232,7 +232,7 @@ metadata:
     agentgateway: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/instance: test-release
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -265,7 +265,7 @@ metadata:
     agentgateway: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/instance: test-release
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -295,7 +295,7 @@ spec:
             capabilities:
               drop:
               - ALL
-          image: "cr.agentgateway.dev/controller:v0.0.1"
+          image: "cr.agentgateway.dev/controller:v0.0.0-dev"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9978
@@ -369,7 +369,7 @@ metadata:
     agentgateway: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/instance: test-release
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -391,7 +391,7 @@ metadata:
     agentgateway: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/instance: test-release
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:

--- a/controller/test/helm/testdata/agentgateway/monitoring-enabled-no-service-monitor.golden
+++ b/controller/test/helm/testdata/agentgateway/monitoring-enabled-no-service-monitor.golden
@@ -10,7 +10,7 @@ metadata:
     agentgateway: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/instance: test-release
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: agentgateway/templates/role.yaml
@@ -232,7 +232,7 @@ metadata:
     agentgateway: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/instance: test-release
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -265,7 +265,7 @@ metadata:
     agentgateway: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/instance: test-release
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -295,7 +295,7 @@ spec:
             capabilities:
               drop:
               - ALL
-          image: "cr.agentgateway.dev/controller:v0.0.1"
+          image: "cr.agentgateway.dev/controller:v0.0.0-dev"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9978

--- a/controller/test/helm/testdata/agentgateway/monitoring-enabled.golden
+++ b/controller/test/helm/testdata/agentgateway/monitoring-enabled.golden
@@ -10,7 +10,7 @@ metadata:
     agentgateway: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/instance: test-release
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: agentgateway/templates/role.yaml
@@ -232,7 +232,7 @@ metadata:
     agentgateway: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/instance: test-release
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -265,7 +265,7 @@ metadata:
     agentgateway: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/instance: test-release
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -295,7 +295,7 @@ spec:
             capabilities:
               drop:
               - ALL
-          image: "cr.agentgateway.dev/controller:v0.0.1"
+          image: "cr.agentgateway.dev/controller:v0.0.0-dev"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9978
@@ -369,7 +369,7 @@ metadata:
     agentgateway: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/instance: test-release
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"
     app.kubernetes.io/managed-by: Helm
     release: prometheus
 spec:
@@ -395,7 +395,7 @@ metadata:
     agentgateway: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/instance: test-release
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"
     app.kubernetes.io/managed-by: Helm
     release: prometheus
 spec:

--- a/controller/test/helm/testdata/agentgateway/pdb-max-unavailable.golden
+++ b/controller/test/helm/testdata/agentgateway/pdb-max-unavailable.golden
@@ -10,7 +10,7 @@ metadata:
     agentgateway: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/instance: test-release
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -31,7 +31,7 @@ metadata:
     agentgateway: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/instance: test-release
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: agentgateway/templates/role.yaml
@@ -253,7 +253,7 @@ metadata:
     agentgateway: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/instance: test-release
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -286,7 +286,7 @@ metadata:
     agentgateway: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/instance: test-release
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -316,7 +316,7 @@ spec:
             capabilities:
               drop:
               - ALL
-          image: "cr.agentgateway.dev/controller:v0.0.1"
+          image: "cr.agentgateway.dev/controller:v0.0.0-dev"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9978

--- a/controller/test/helm/testdata/agentgateway/pdb-min-available.golden
+++ b/controller/test/helm/testdata/agentgateway/pdb-min-available.golden
@@ -10,7 +10,7 @@ metadata:
     agentgateway: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/instance: test-release
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -31,7 +31,7 @@ metadata:
     agentgateway: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/instance: test-release
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: agentgateway/templates/role.yaml
@@ -253,7 +253,7 @@ metadata:
     agentgateway: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/instance: test-release
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -286,7 +286,7 @@ metadata:
     agentgateway: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/instance: test-release
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -316,7 +316,7 @@ spec:
             capabilities:
               drop:
               - ALL
-          image: "cr.agentgateway.dev/controller:v0.0.1"
+          image: "cr.agentgateway.dev/controller:v0.0.0-dev"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9978

--- a/controller/test/helm/testdata/agentgateway/priority-class-name.golden
+++ b/controller/test/helm/testdata/agentgateway/priority-class-name.golden
@@ -10,7 +10,7 @@ metadata:
     agentgateway: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/instance: test-release
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: agentgateway/templates/role.yaml
@@ -232,7 +232,7 @@ metadata:
     agentgateway: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/instance: test-release
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -265,7 +265,7 @@ metadata:
     agentgateway: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/instance: test-release
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -296,7 +296,7 @@ spec:
             capabilities:
               drop:
               - ALL
-          image: "cr.agentgateway.dev/controller:v0.0.1"
+          image: "cr.agentgateway.dev/controller:v0.0.0-dev"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9978

--- a/controller/test/helm/testdata/agentgateway/service-full-config.golden
+++ b/controller/test/helm/testdata/agentgateway/service-full-config.golden
@@ -10,7 +10,7 @@ metadata:
     agentgateway: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/instance: test-release
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: agentgateway/templates/role.yaml
@@ -232,7 +232,7 @@ metadata:
     agentgateway: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/instance: test-release
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"
     app.kubernetes.io/managed-by: Helm
     custom-label: custom-value
     environment: test
@@ -293,7 +293,7 @@ metadata:
     agentgateway: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/instance: test-release
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -323,7 +323,7 @@ spec:
             capabilities:
               drop:
               - ALL
-          image: "cr.agentgateway.dev/controller:v0.0.1"
+          image: "cr.agentgateway.dev/controller:v0.0.0-dev"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9978

--- a/controller/test/helm/testdata/agentgateway/xds-tls-enabled.golden
+++ b/controller/test/helm/testdata/agentgateway/xds-tls-enabled.golden
@@ -10,7 +10,7 @@ metadata:
     agentgateway: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/instance: test-release
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: agentgateway/templates/role.yaml
@@ -232,7 +232,7 @@ metadata:
     agentgateway: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/instance: test-release
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -265,7 +265,7 @@ metadata:
     agentgateway: agentgateway
     app.kubernetes.io/name: agentgateway
     app.kubernetes.io/instance: test-release
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -295,7 +295,7 @@ spec:
             capabilities:
               drop:
               - ALL
-          image: "cr.agentgateway.dev/controller:v0.0.1"
+          image: "cr.agentgateway.dev/controller:v0.0.0-dev"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9978

--- a/controller/test/helm/testdata/helm-version-output.golden
+++ b/controller/test/helm/testdata/helm-version-output.golden
@@ -2,16 +2,16 @@
     helm.sh/chart: kgateway-0.0.2
 --
     app.kubernetes.io/instance: foobar
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"
 --
   labels:
     helm.sh/chart: kgateway-0.0.2
 --
     app.kubernetes.io/instance: foobar
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"
 --
   labels:
     helm.sh/chart: kgateway-0.0.2
 --
     app.kubernetes.io/instance: foobar
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/version: "0.0.0-dev"


### PR DESCRIPTION
Fixes #1964

## What's changed

Both `controller/install/helm/agentgateway/Chart.yaml` and `controller/install/helm/agentgateway-crds/Chart.yaml` had `appVersion: "0.0.1"` which looks like a real old release version. This is confusing for contributors who install the chart locally from source and see that version show up in `helm list`.

The `release-charts` Makefile target already overrides `appVersion` at packaging time via `--app-version $(HELM_CHART_VERSION_V)`, so the in-repo value is just a placeholder — it was just missing any indication of that.

## Changes

- Changed `appVersion` from `"0.0.1"` → `"0.0.0-dev"` in both charts to make it obvious it's not a real release
- Added a short comment above each `appVersion` field pointing to the Makefile override, so contributors don't have to go digging to understand why the version looks wrong

## Testing

No functional change — `appVersion` in the source `Chart.yaml` is always overridden at release time. This only affects local dev installs where someone uses the chart directly from the repo.