### PR TITLE
fix: rate limit fails closed on misconfigured descriptor CEL

### DIFF
--- a/crates/agentgateway/src/cel/mod.rs
+++ b/crates/agentgateway/src/cel/mod.rs
@@ -31,6 +31,16 @@ pub enum Error {
 	JsonConvert,
 }
 
+impl Error {
+	// An undeclared reference is a static config error: the expression can never resolve for any input.
+	pub fn undeclared_reference(&self) -> Option<&str> {
+		match self {
+			Error::Resolve(ExecutionError::UndeclaredReference(name)) => Some(name.as_str()),
+			_ => None,
+		}
+	}
+}
+
 impl From<Box<dyn std::error::Error>> for Error {
 	fn from(value: Box<dyn std::error::Error>) -> Self {
 		Self::Variable(value.to_string())

--- a/crates/agentgateway/src/http/remoteratelimit.rs
+++ b/crates/agentgateway/src/http/remoteratelimit.rs
@@ -179,20 +179,33 @@ impl LLMResponseAmend {
 	}
 }
 
+// A descriptor whose CEL references an undeclared variable can never resolve; treated as a config error, not a skip.
+#[derive(Debug)]
+struct DescriptorConfigError {
+	key: String,
+	reference: String,
+}
+
+// The built gRPC request paired with each descriptor's optional cost expression (used for the token amend).
+type BuiltRateLimitRequest = (RateLimitRequest, Vec<Option<Arc<cel::Expression>>>);
+
 impl RemoteRateLimit {
 	/// Build a rate-limit request by evaluating all descriptor entries of the
 	/// given `limit_type` against the incoming HTTP request.
 	///
 	/// Individual descriptors whose CEL expressions fail to evaluate are
 	/// silently dropped (matching Envoy's per-descriptor "all-or-nothing"
-	/// semantics). Returns `None` only when **no** descriptor could be
+	/// semantics). Returns `Ok(None)` when **no** descriptor could be
 	/// successfully resolved, so the gRPC call is skipped entirely.
+	///
+	/// Returns `Err` when a descriptor references an undeclared variable, since
+	/// that expression can never resolve and the policy is misconfigured.
 	fn build_request(
 		&self,
 		req: &http::Request,
 		limit_type: RateLimitType,
 		default_cost: Option<u64>,
-	) -> Option<(RateLimitRequest, Vec<Option<Arc<cel::Expression>>>)> {
+	) -> Result<Option<BuiltRateLimitRequest>, DescriptorConfigError> {
 		let mut descriptors = Vec::with_capacity(self.descriptors.0.len());
 		let exec = Executor::new_request(req);
 		let candidate_count = self
@@ -213,7 +226,8 @@ impl RemoteRateLimit {
 			.iter()
 			.filter(|e| e.limit_type == limit_type)
 		{
-			if let Some(rl_entries) = Self::eval_descriptor(&exec, &desc_entry.entries) {
+			let rl_entries_opt = Self::eval_descriptor(&exec, &desc_entry.entries)?;
+			if let Some(rl_entries) = rl_entries_opt {
 				// Rate limit servers require each descriptor to have at least one entry.
 				if rl_entries.is_empty() {
 					trace!(
@@ -284,7 +298,7 @@ impl RemoteRateLimit {
 				"ratelimit all descriptors failed evaluation for domain={}, type={:?}, skipping rate-limit call",
 				self.domain, limit_type,
 			);
-			return None;
+			return Ok(None);
 		}
 
 		trace!(
@@ -294,7 +308,7 @@ impl RemoteRateLimit {
 			descriptors.len()
 		);
 
-		Some((
+		Ok(Some((
 			proto::RateLimitRequest {
 				domain: self.domain.clone(),
 				descriptors,
@@ -302,8 +316,30 @@ impl RemoteRateLimit {
 				hits_addend: 0,
 			},
 			descriptor_costs,
-		))
+		)))
 	}
+
+	// A misconfigured descriptor follows the configured failureMode, like a rate-limit service failure does.
+	fn on_config_error(&self, err: DescriptorConfigError) -> Result<(), ProxyError> {
+		let deny = self.failure_mode != FailureMode::FailOpen;
+		warn!(
+			"ratelimit descriptor '{}' references undeclared variable '{}' (domain: {}); {}",
+			err.key,
+			err.reference,
+			self.domain,
+			if deny {
+				"denying request (failure_mode: failClosed)"
+			} else {
+				"allowing request (failure_mode: failOpen)"
+			}
+		);
+		if deny {
+			Err(ProxyError::RateLimitFailed)
+		} else {
+			Ok(())
+		}
+	}
+
 	pub async fn check_llm(
 		&self,
 		client: PolicyClient,
@@ -327,11 +363,15 @@ impl RemoteRateLimit {
 		// If they have an explicit `cost` expression, it is specified to be on output; send only a '0' cost here.
 		// If they have tokenization enabled, we have an explicit cost to send, so we can send it.
 		// Else send '0'.
-		let Some((request, descriptor_costs)) =
-			self.build_request(req, RateLimitType::Tokens, Some(default_cost))
-		else {
-			return Ok((PolicyResponse::default(), None));
-		};
+		let (request, descriptor_costs) =
+			match self.build_request(req, RateLimitType::Tokens, Some(default_cost)) {
+				Ok(Some(v)) => v,
+				Ok(None) => return Ok((PolicyResponse::default(), None)),
+				Err(cfg) => {
+					self.on_config_error(cfg)?;
+					return Ok((PolicyResponse::default(), None));
+				},
+			};
 		let cr = self.check_internal(client.clone(), request.clone()).await;
 		let r = LLMResponseAmend {
 			base: self.clone(),
@@ -371,8 +411,13 @@ impl RemoteRateLimit {
 			);
 			return Ok(PolicyResponse::default());
 		}
-		let Some((request, _)) = self.build_request(req, RateLimitType::Requests, None) else {
-			return Ok(PolicyResponse::default());
+		let request = match self.build_request(req, RateLimitType::Requests, None) {
+			Ok(Some((request, _))) => request,
+			Ok(None) => return Ok(PolicyResponse::default()),
+			Err(cfg) => {
+				self.on_config_error(cfg)?;
+				return Ok(PolicyResponse::default());
+			},
 		};
 		match self.check_internal(client, request).await {
 			Ok(cr) => Self::apply(req, cr),
@@ -488,7 +533,10 @@ impl RemoteRateLimit {
 		}))
 	}
 
-	fn eval_descriptor(exec: &cel::Executor<'_>, entries: &Vec<Descriptor>) -> Option<Vec<Entry>> {
+	fn eval_descriptor(
+		exec: &cel::Executor<'_>,
+		entries: &Vec<Descriptor>,
+	) -> Result<Option<Vec<Entry>>, DescriptorConfigError> {
 		let mut rl_entries = Vec::with_capacity(entries.len());
 		for Descriptor(k, lookup) in entries {
 			// We drop the entire set if we cannot eval one; emit trace to aid debugging
@@ -499,7 +547,7 @@ impl RemoteRateLimit {
 							"ratelimit descriptor value not convertible to string: key={}, expr={:?}",
 							k, lookup
 						);
-						return None;
+						return Ok(None);
 					};
 					let entry = Entry {
 						key: k.clone(),
@@ -508,15 +556,21 @@ impl RemoteRateLimit {
 					rl_entries.push(entry);
 				},
 				Err(e) => {
+					if let Some(reference) = e.undeclared_reference() {
+						return Err(DescriptorConfigError {
+							key: k.clone(),
+							reference: reference.to_string(),
+						});
+					}
 					trace!(
 						"ratelimit failed to evaluate expression: key={}, expr={:?}, error={}",
 						k, lookup, e
 					);
-					return None;
+					return Ok(None);
 				},
 			}
 		}
-		Some(rl_entries)
+		Ok(Some(rl_entries))
 	}
 
 	pub fn expressions(&self) -> impl Iterator<Item = &Expression> {

--- a/crates/agentgateway/src/http/remoteratelimit_tests.rs
+++ b/crates/agentgateway/src/http/remoteratelimit_tests.rs
@@ -55,10 +55,12 @@ fn build_request_all_descriptors_evaluate_returns_some() {
 
 	let result = rl.build_request(&req, RateLimitType::Requests, None);
 	assert!(
-		result.is_some(),
+		matches!(&result, Ok(Some(_))),
 		"expected Some when all descriptors evaluate"
 	);
-	let request = result.unwrap().0;
+	let Ok(Some((request, _))) = result else {
+		unreachable!("asserted Ok(Some) above")
+	};
 	assert_eq!(request.descriptors.len(), 1);
 	assert_eq!(request.descriptors[0].entries.len(), 2);
 	assert_eq!(request.descriptors[0].entries[0].key, "user");
@@ -85,8 +87,10 @@ fn build_request_header_descriptor_evaluates() {
 		.unwrap();
 
 	let result = rl.build_request(&req, RateLimitType::Requests, None);
-	assert!(result.is_some());
-	let request = result.unwrap().0;
+	assert!(matches!(&result, Ok(Some(_))));
+	let Ok(Some((request, _))) = result else {
+		unreachable!("asserted Ok(Some) above")
+	};
 	assert_eq!(request.descriptors[0].entries[0].value, "my-client");
 }
 
@@ -109,7 +113,7 @@ fn build_request_missing_header_returns_none() {
 
 	let result = rl.build_request(&req, RateLimitType::Requests, None);
 	assert!(
-		result.is_none(),
+		matches!(result, Ok(None)),
 		"expected None when descriptor evaluation fails"
 	);
 }
@@ -134,10 +138,12 @@ fn build_request_second_descriptor_fails_sends_successful_only() {
 
 	let result = rl.build_request(&req, RateLimitType::Requests, None);
 	assert!(
-		result.is_some(),
+		matches!(&result, Ok(Some(_))),
 		"expected Some with the successful descriptor when only one fails"
 	);
-	let request = result.unwrap().0;
+	let Ok(Some((request, _))) = result else {
+		unreachable!("asserted Ok(Some) above")
+	};
 	assert_eq!(
 		request.descriptors.len(),
 		1,
@@ -167,10 +173,12 @@ fn build_request_first_descriptor_fails_sends_successful_only() {
 
 	let result = rl.build_request(&req, RateLimitType::Requests, None);
 	assert!(
-		result.is_some(),
+		matches!(&result, Ok(Some(_))),
 		"expected Some with the successful descriptor when only the first fails"
 	);
-	let request = result.unwrap().0;
+	let Ok(Some((request, _))) = result else {
+		unreachable!("asserted Ok(Some) above")
+	};
 	assert_eq!(
 		request.descriptors.len(),
 		1,
@@ -198,7 +206,7 @@ fn build_request_no_matching_type_returns_none() {
 	// Ask for Requests type -- no candidates
 	let result = rl.build_request(&req, RateLimitType::Requests, None);
 	assert!(
-		result.is_none(),
+		matches!(result, Ok(None)),
 		"expected None when no candidates match the requested type"
 	);
 }
@@ -215,10 +223,9 @@ fn build_request_cost_propagated_to_hits_addend() {
 		.body(crate::http::Body::empty())
 		.unwrap();
 
-	let result = rl
-		.build_request(&req, RateLimitType::Tokens, Some(42))
-		.unwrap()
-		.0;
+	let Ok(Some((result, _))) = rl.build_request(&req, RateLimitType::Tokens, Some(42)) else {
+		panic!("expected a built request");
+	};
 	assert_eq!(result.descriptors[0].hits_addend, Some(42));
 }
 
@@ -276,10 +283,9 @@ fn build_request_limit_override_evaluates() {
 		.body(crate::http::Body::empty())
 		.unwrap();
 
-	let result = rl
-		.build_request(&req, RateLimitType::Requests, None)
-		.unwrap()
-		.0;
+	let Ok(Some((result, _))) = rl.build_request(&req, RateLimitType::Requests, None) else {
+		panic!("expected a built request");
+	};
 	let limit = result.descriptors[0]
 		.limit
 		.as_ref()
@@ -310,7 +316,7 @@ fn build_request_delete_disconnect_skips_ratelimit() {
 
 	let result = rl.build_request(&req, RateLimitType::Requests, None);
 	assert!(
-		result.is_none(),
+		matches!(result, Ok(None)),
 		"expected None for DELETE disconnect with missing descriptor headers"
 	);
 }
@@ -331,8 +337,10 @@ fn build_request_multiple_entries_all_succeed() {
 		.unwrap();
 
 	let result = rl.build_request(&req, RateLimitType::Requests, None);
-	assert!(result.is_some());
-	let request = result.unwrap().0;
+	assert!(matches!(&result, Ok(Some(_))));
+	let Ok(Some((request, _))) = result else {
+		unreachable!("asserted Ok(Some) above")
+	};
 	assert_eq!(request.descriptors.len(), 3);
 	assert_eq!(request.descriptors[0].entries[0].value, "alice");
 	assert_eq!(request.descriptors[1].entries[0].value, "echo");
@@ -357,7 +365,7 @@ fn build_request_tokens_type_missing_header_returns_none() {
 
 	let result = rl.build_request(&req, RateLimitType::Tokens, Some(100));
 	assert!(
-		result.is_none(),
+		matches!(result, Ok(None)),
 		"expected None for Tokens type when descriptor fails"
 	);
 }
@@ -375,8 +383,10 @@ fn build_request_tokens_type_all_succeed() {
 		.unwrap();
 
 	let result = rl.build_request(&req, RateLimitType::Tokens, Some(50));
-	assert!(result.is_some());
-	let request = result.unwrap().0;
+	assert!(matches!(&result, Ok(Some(_))));
+	let Ok(Some((request, _))) = result else {
+		unreachable!("asserted Ok(Some) above")
+	};
 	assert_eq!(request.descriptors.len(), 1);
 	assert_eq!(request.descriptors[0].entries[0].value, "test-user");
 	assert_eq!(request.descriptors[0].hits_addend, Some(50));
@@ -404,7 +414,7 @@ fn build_request_all_descriptors_fail_returns_none() {
 
 	let result = rl.build_request(&req, RateLimitType::Requests, None);
 	assert!(
-		result.is_none(),
+		matches!(result, Ok(None)),
 		"expected None when all descriptor entries fail evaluation"
 	);
 }
@@ -457,8 +467,10 @@ fn build_request_two_descriptors_multi_entry_all_succeed() {
 		.unwrap();
 
 	let result = rl.build_request(&req, RateLimitType::Requests, None);
-	assert!(result.is_some());
-	let request = result.unwrap().0;
+	assert!(matches!(&result, Ok(Some(_))));
+	let Ok(Some((request, _))) = result else {
+		unreachable!("asserted Ok(Some) above")
+	};
 	assert_eq!(request.descriptors.len(), 2);
 	// First descriptor: path + remote_address
 	assert_eq!(request.descriptors[0].entries.len(), 2);
@@ -503,10 +515,12 @@ fn build_request_two_descriptors_first_partially_fails_sends_second() {
 
 	let result = rl.build_request(&req, RateLimitType::Requests, None);
 	assert!(
-		result.is_some(),
+		matches!(&result, Ok(Some(_))),
 		"expected Some — second descriptor should still be sent"
 	);
-	let request = result.unwrap().0;
+	let Ok(Some((request, _))) = result else {
+		unreachable!("asserted Ok(Some) above")
+	};
 	assert_eq!(
 		request.descriptors.len(),
 		1,
@@ -547,7 +561,7 @@ fn build_request_two_descriptors_both_partially_fail_returns_none() {
 
 	let result = rl.build_request(&req, RateLimitType::Requests, None);
 	assert!(
-		result.is_none(),
+		matches!(result, Ok(None)),
 		"expected None when all descriptors have at least one failing entry"
 	);
 }
@@ -569,9 +583,75 @@ fn build_request_non_string_cel_result_returns_none() {
 
 	let result = rl.build_request(&req, RateLimitType::Requests, None);
 	assert!(
-		result.is_none(),
+		matches!(result, Ok(None)),
 		"expected None when CEL result is not string-convertible"
 	);
+}
+
+// --- config error (undeclared variable) tests ---
+
+/// A descriptor value referencing an undeclared variable (`users` is parsed as a CEL
+/// identifier, not a literal) can never resolve, so `build_request` surfaces it as a
+/// config error instead of silently skipping like a missing-header (NoSuchKey) case.
+#[test]
+fn build_request_undeclared_variable_returns_config_error() {
+	let entry = make_descriptor_entry(vec![("database", "users")], RateLimitType::Requests);
+	let rl = make_rate_limit(vec![entry]);
+
+	let req = ::http::Request::builder()
+		.method(::http::Method::POST)
+		.uri("http://example.com/mcp")
+		.body(crate::http::Body::empty())
+		.unwrap();
+
+	let Err(err) = rl.build_request(&req, RateLimitType::Requests, None) else {
+		panic!("expected a config error for an undeclared variable");
+	};
+	assert_eq!(err.key, "database");
+	assert_eq!(err.reference, "users");
+}
+
+/// A config error in any descriptor is surfaced even when another descriptor would build.
+#[test]
+fn build_request_undeclared_variable_overrides_successful_descriptor() {
+	let good = make_descriptor_entry(vec![("user", r#""alice""#)], RateLimitType::Requests);
+	let bad = make_descriptor_entry(vec![("database", "users")], RateLimitType::Requests);
+	let rl = make_rate_limit(vec![good, bad]);
+
+	let req = ::http::Request::builder()
+		.method(::http::Method::POST)
+		.uri("http://example.com/mcp")
+		.body(crate::http::Body::empty())
+		.unwrap();
+
+	let result = rl.build_request(&req, RateLimitType::Requests, None);
+	assert!(result.is_err(), "config error should take precedence");
+}
+
+/// With failClosed (the default), a misconfigured descriptor denies the request (500).
+#[test]
+fn config_error_fails_closed_denies() {
+	let rl = make_rate_limit(vec![]);
+	let err = DescriptorConfigError {
+		key: "database".to_string(),
+		reference: "users".to_string(),
+	};
+	assert!(matches!(
+		rl.on_config_error(err),
+		Err(ProxyError::RateLimitFailed)
+	));
+}
+
+/// With failOpen, a misconfigured descriptor allows the request through.
+#[test]
+fn config_error_fails_open_allows() {
+	let mut rl = make_rate_limit(vec![]);
+	rl.failure_mode = FailureMode::FailOpen;
+	let err = DescriptorConfigError {
+		key: "database".to_string(),
+		reference: "users".to_string(),
+	};
+	assert!(rl.on_config_error(err).is_ok());
 }
 
 // --- FailureMode tests ---
@@ -810,10 +890,12 @@ fn build_request_jwt_sub_descriptor_evaluates_with_materialization() {
 
 	let result = rl.build_request(&req, RateLimitType::Requests, None);
 	assert!(
-		result.is_some(),
+		matches!(&result, Ok(Some(_))),
 		"expected Some when jwt.sub evaluates (with materialization) to a string"
 	);
-	let request = result.unwrap().0;
+	let Ok(Some((request, _))) = result else {
+		unreachable!("asserted Ok(Some) above")
+	};
 	assert_eq!(request.descriptors.len(), 1);
 	assert_eq!(request.descriptors[0].entries.len(), 1);
 	assert_eq!(request.descriptors[0].entries[0].key, "user");


### PR DESCRIPTION
A remote rate-limit descriptor whose CEL expression references an undeclared variable can never resolve for any input, so it is a static config error rather than a per-request evaluation failure. Previously such descriptors were silently dropped like a missing-header case, causing the request to be allowed through even when failClosed was configured.

Distinguish undeclared-reference errors from runtime evaluation failures (missing header, non-string result). Runtime failures keep Envoy's per-descriptor skip semantics; config errors now follow the configured failureMode, denying the request under failClosed.

Fixes #1994