### PR TITLE
fix(llm): preserve all text blocks in non-streaming completions conversion (#2007)

### DIFF
--- a/crates/agentgateway/src/llm/conversion/bedrock.rs
+++ b/crates/agentgateway/src/llm/conversion/bedrock.rs
@@ -2758,7 +2758,9 @@ impl ConverseResponseAdapter {
 		for block in &self.message.content {
 			match block {
 				bedrock::ContentBlock::Text(text) => {
-					content = Some(text.clone());
+					// A message may contain multiple text blocks (e.g. text split around
+					// citations); concatenate them into the single OpenAI `content` field.
+					content.get_or_insert_with(String::new).push_str(text);
 				},
 				bedrock::ContentBlock::ReasoningContent(reasoning) => {
 					// Extract text from either format

--- a/crates/agentgateway/src/llm/conversion/bedrock_tests.rs
+++ b/crates/agentgateway/src/llm/conversion/bedrock_tests.rs
@@ -1443,37 +1443,3 @@ fn test_insert_cache_point_empty_messages_noop() {
 	helpers::insert_message_cache_point(&mut msgs, 0);
 	assert!(msgs.is_empty());
 }
-
-// When a Converse response message contains more than one text block (e.g. when
-// Anthropic splits text around citations), all of them must be preserved in the
-// single OpenAI `content` string instead of keeping only the last block.
-#[test]
-fn test_completions_response_concatenates_multiple_text_blocks() {
-	let model = "anthropic.claude-3-5-sonnet-20241022-v2:0";
-	let bedrock_resp = json!({
-		"output": {
-			"message": {
-				"role": "assistant",
-				"content": [
-					{"text": "Hello, "},
-					{"text": "world!"}
-				]
-			}
-		},
-		"stopReason": "end_turn",
-		"usage": {"inputTokens": 1, "outputTokens": 2, "totalTokens": 3}
-	});
-	let bytes = Bytes::from(serde_json::to_vec(&bedrock_resp).unwrap());
-
-	let translated = from_completions::translate_response(&bytes, model).unwrap();
-	let resp = translated
-		.serialize()
-		.and_then(|b| serde_json::from_slice::<types::completions::Response>(&b))
-		.unwrap();
-
-	assert_eq!(
-		resp.choices[0].message.content.as_deref(),
-		Some("Hello, world!"),
-		"all text blocks must be concatenated, not overwritten by the last one"
-	);
-}

--- a/crates/agentgateway/src/llm/conversion/bedrock_tests.rs
+++ b/crates/agentgateway/src/llm/conversion/bedrock_tests.rs
@@ -1443,3 +1443,37 @@ fn test_insert_cache_point_empty_messages_noop() {
 	helpers::insert_message_cache_point(&mut msgs, 0);
 	assert!(msgs.is_empty());
 }
+
+// When a Converse response message contains more than one text block (e.g. when
+// Anthropic splits text around citations), all of them must be preserved in the
+// single OpenAI `content` string instead of keeping only the last block.
+#[test]
+fn test_completions_response_concatenates_multiple_text_blocks() {
+	let model = "anthropic.claude-3-5-sonnet-20241022-v2:0";
+	let bedrock_resp = json!({
+		"output": {
+			"message": {
+				"role": "assistant",
+				"content": [
+					{"text": "Hello, "},
+					{"text": "world!"}
+				]
+			}
+		},
+		"stopReason": "end_turn",
+		"usage": {"inputTokens": 1, "outputTokens": 2, "totalTokens": 3}
+	});
+	let bytes = Bytes::from(serde_json::to_vec(&bedrock_resp).unwrap());
+
+	let translated = from_completions::translate_response(&bytes, model).unwrap();
+	let resp = translated
+		.serialize()
+		.and_then(|b| serde_json::from_slice::<types::completions::Response>(&b))
+		.unwrap();
+
+	assert_eq!(
+		resp.choices[0].message.content.as_deref(),
+		Some("Hello, world!"),
+		"all text blocks must be concatenated, not overwritten by the last one"
+	);
+}

--- a/crates/agentgateway/src/llm/conversion/messages.rs
+++ b/crates/agentgateway/src/llm/conversion/messages.rs
@@ -426,7 +426,9 @@ pub mod from_completions {
 		for block in resp.content {
 			match block {
 				messages::ContentBlock::Text(messages::ContentTextBlock { text, .. }) => {
-					content = Some(text.clone())
+					// A message may contain multiple text blocks (e.g. text split around
+					// citations); concatenate them into the single OpenAI `content` field.
+					content.get_or_insert_with(String::new).push_str(&text)
 				},
 				messages::ContentBlock::ToolUse {
 					id, name, input, ..

--- a/crates/agentgateway/src/llm/tests.rs
+++ b/crates/agentgateway/src/llm/tests.rs
@@ -495,6 +495,7 @@ mod response {
 		("basic", ALL_ANTHROPIC),
 		("tool", ALL_ANTHROPIC),
 		("thinking", ALL_ANTHROPIC),
+		("multiple_text_blocks", ALL_ANTHROPIC),
 	];
 	const ANTHROPIC_STREAM_RESPONSES: &[(&str, &[&str])] = &[
 		("stream_basic", ALL_ANTHROPIC),

--- a/crates/agentgateway/src/llm/tests/response/anthropic/multiple_text_blocks.json
+++ b/crates/agentgateway/src/llm/tests/response/anthropic/multiple_text_blocks.json
@@ -1,0 +1,37 @@
+{
+  "id": "msg_012JYtNYb8sv6Hb67TcGT7xW",
+  "type": "message",
+  "role": "assistant",
+  "model": "claude-haiku-4-5-20251001",
+  "content": [
+    {
+      "type": "text",
+      "text": "The sky is "
+    },
+    {
+      "type": "text",
+      "text": "blue during the day",
+      "citations": [
+        {
+          "type": "char_location",
+          "cited_text": "the sky appears blue",
+          "document_index": 0,
+          "document_title": "Sky Facts",
+          "start_char_index": 0,
+          "end_char_index": 20
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "text": "."
+    }
+  ],
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
+  "usage": {
+    "input_tokens": 15,
+    "output_tokens": 21,
+    "service_tier": "standard"
+  }
+}

--- a/crates/agentgateway/src/llm/tests/response/anthropic/multiple_text_blocks.messages-completions.snap
+++ b/crates/agentgateway/src/llm/tests/response/anthropic/multiple_text_blocks.messages-completions.snap
@@ -1,0 +1,60 @@
+---
+source: crates/agentgateway/src/llm/tests.rs
+description: src/llm/tests/response/anthropic/multiple_text_blocks.json
+info:
+  id: msg_012JYtNYb8sv6Hb67TcGT7xW
+  type: message
+  role: assistant
+  model: claude-haiku-4-5-20251001
+  content:
+    - type: text
+      text: "The sky is "
+    - type: text
+      text: blue during the day
+      citations:
+        - type: char_location
+          cited_text: the sky appears blue
+          document_index: 0
+          document_title: Sky Facts
+          start_char_index: 0
+          end_char_index: 20
+    - type: text
+      text: "."
+  stop_reason: end_turn
+  stop_sequence: ~
+  usage:
+    input_tokens: 15
+    output_tokens: 21
+    service_tier: standard
+---
+{
+  "response": {
+    "model": "claude-haiku-4-5-20251001",
+    "service_tier": "standard",
+    "usage": {
+      "prompt_tokens": 15,
+      "completion_tokens": 21,
+      "total_tokens": 36
+    },
+    "choices": [
+      {
+        "message": {
+          "content": "The sky is blue during the day.",
+          "role": "assistant"
+        },
+        "index": 0,
+        "finish_reason": "stop"
+      }
+    ],
+    "id": "[id]",
+    "created": "[date]",
+    "object": "chat.completion"
+  },
+  "parsed": {
+    "input_tokens": 15,
+    "output_tokens": 21,
+    "total_tokens": 36,
+    "service_tier": "standard",
+    "provider_model": "claude-haiku-4-5-20251001"
+  }
+}

--- a/crates/agentgateway/src/llm/tests/response/anthropic/multiple_text_blocks.messages-detect.snap
+++ b/crates/agentgateway/src/llm/tests/response/anthropic/multiple_text_blocks.messages-detect.snap
@@ -1,0 +1,75 @@
+---
+source: crates/agentgateway/src/llm/tests.rs
+description: src/llm/tests/response/anthropic/multiple_text_blocks.json
+info:
+  id: msg_012JYtNYb8sv6Hb67TcGT7xW
+  type: message
+  role: assistant
+  model: claude-haiku-4-5-20251001
+  content:
+    - type: text
+      text: "The sky is "
+    - type: text
+      text: blue during the day
+      citations:
+        - type: char_location
+          cited_text: the sky appears blue
+          document_index: 0
+          document_title: Sky Facts
+          start_char_index: 0
+          end_char_index: 20
+    - type: text
+      text: "."
+  stop_reason: end_turn
+  stop_sequence: ~
+  usage:
+    input_tokens: 15
+    output_tokens: 21
+    service_tier: standard
+---
+{
+  "response": {
+    "id": "[id]",
+    "type": "message",
+    "role": "assistant",
+    "model": "claude-haiku-4-5-20251001",
+    "content": [
+      {
+        "type": "text",
+        "text": "The sky is "
+      },
+      {
+        "type": "text",
+        "text": "blue during the day",
+        "citations": [
+          {
+            "type": "char_location",
+            "cited_text": "the sky appears blue",
+            "document_index": 0,
+            "document_title": "Sky Facts",
+            "start_char_index": 0,
+            "end_char_index": 20
+          }
+        ]
+      },
+      {
+        "type": "text",
+        "text": "."
+      }
+    ],
+    "stop_reason": "end_turn",
+    "stop_sequence": null,
+    "usage": {
+      "input_tokens": 15,
+      "output_tokens": 21,
+      "service_tier": "standard"
+    }
+  },
+  "parsed": {
+    "input_tokens": 15,
+    "output_tokens": 21,
+    "total_tokens": 36,
+    "service_tier": "standard",
+    "provider_model": "claude-haiku-4-5-20251001"
+  }
+}

--- a/crates/agentgateway/src/llm/tests/response/anthropic/multiple_text_blocks.messages-messages.snap
+++ b/crates/agentgateway/src/llm/tests/response/anthropic/multiple_text_blocks.messages-messages.snap
@@ -1,0 +1,75 @@
+---
+source: crates/agentgateway/src/llm/tests.rs
+description: src/llm/tests/response/anthropic/multiple_text_blocks.json
+info:
+  id: msg_012JYtNYb8sv6Hb67TcGT7xW
+  type: message
+  role: assistant
+  model: claude-haiku-4-5-20251001
+  content:
+    - type: text
+      text: "The sky is "
+    - type: text
+      text: blue during the day
+      citations:
+        - type: char_location
+          cited_text: the sky appears blue
+          document_index: 0
+          document_title: Sky Facts
+          start_char_index: 0
+          end_char_index: 20
+    - type: text
+      text: "."
+  stop_reason: end_turn
+  stop_sequence: ~
+  usage:
+    input_tokens: 15
+    output_tokens: 21
+    service_tier: standard
+---
+{
+  "response": {
+    "id": "[id]",
+    "type": "message",
+    "role": "assistant",
+    "model": "claude-haiku-4-5-20251001",
+    "stop_reason": "end_turn",
+    "stop_sequence": null,
+    "usage": {
+      "input_tokens": 15,
+      "output_tokens": 21,
+      "service_tier": "standard"
+    },
+    "content": [
+      {
+        "text": "The sky is ",
+        "type": "text"
+      },
+      {
+        "text": "blue during the day",
+        "type": "text",
+        "citations": [
+          {
+            "type": "char_location",
+            "cited_text": "the sky appears blue",
+            "document_index": 0,
+            "document_title": "Sky Facts",
+            "start_char_index": 0,
+            "end_char_index": 20
+          }
+        ]
+      },
+      {
+        "text": ".",
+        "type": "text"
+      }
+    ]
+  },
+  "parsed": {
+    "input_tokens": 15,
+    "output_tokens": 21,
+    "total_tokens": 36,
+    "service_tier": "standard",
+    "provider_model": "claude-haiku-4-5-20251001"
+  }
+}


### PR DESCRIPTION
Fixes #2007

Multiple text blocks in a non-streaming response were collapsed to the last
one when converting to the Completions format (Anthropic/Bedrock split text
into multiple blocks when citations are enabled). Concatenate them verbatim
instead — matching the streaming path and the sibling `to_responses_typed`,
which already accumulates all blocks.

Adds a unit test and an Anthropic fixture.