### PR TITLE
fix(ext_proc): return ImmediateResponse from the request body phase to the client

### DIFF
--- a/crates/agentgateway/src/http/ext_proc.rs
+++ b/crates/agentgateway/src/http/ext_proc.rs
@@ -352,7 +352,8 @@ impl ExtProcRequest {
 	}
 
 	pub fn take_body_immediate_response(&self) -> Option<http::Response> {
-		self.ext_proc
+		self
+			.ext_proc
 			.as_ref()?
 			.request_body_immediate_response
 			.lock()

--- a/crates/agentgateway/src/http/ext_proc.rs
+++ b/crates/agentgateway/src/http/ext_proc.rs
@@ -1,4 +1,5 @@
 use std::convert::Infallible;
+use std::sync::Mutex;
 
 use anyhow::anyhow;
 use bytes::Bytes;
@@ -349,6 +350,15 @@ impl ExtProcRequest {
 		);
 		Ok(pr)
 	}
+
+	pub fn take_body_immediate_response(&self) -> Option<http::Response> {
+		self.ext_proc
+			.as_ref()?
+			.request_body_immediate_response
+			.lock()
+			.unwrap()
+			.take()
+	}
 }
 
 // Very experimental support for ext_proc
@@ -356,6 +366,7 @@ impl ExtProcRequest {
 struct ExtProcInstance {
 	failure_mode: FailureMode,
 	skipped: bool,
+	request_body_immediate_response: Arc<Mutex<Option<http::Response>>>,
 	protocol_config_sent: bool,
 	mode_state: ModeStateMachine,
 	tx_req: Sender<ProcessingRequest>,
@@ -432,6 +443,7 @@ impl ExtProcInstance {
 		});
 		Self {
 			skipped: Default::default(),
+			request_body_immediate_response: Arc::new(Mutex::new(None)),
 			failure_mode,
 			protocol_config_sent: false,
 			mode_state: processing_options.into(),
@@ -1091,6 +1103,7 @@ impl ExtProcInstance {
 				if !step.eos && request_fsm.body_path != BodyPath::BufferedPartial {
 					request_fsm.enter_streaming_continuation();
 					trace!("spawn body!");
+					let immediate_response = self.request_body_immediate_response.clone();
 					// Move remaining body response handling to an async task so we can return
 					// the request to the caller while body chunks continue to flow.
 					tokio::task::spawn(async move {
@@ -1099,6 +1112,11 @@ impl ExtProcInstance {
 								trace!("done receiving request");
 								return;
 							};
+							if let Some(resp) = to_immediate_response(&presp) {
+								trace!("got immediate response during request body streaming");
+								*immediate_response.lock().unwrap() = resp.direct_response;
+								return;
+							}
 							let response = handle_response_for_request_mutation(
 								request_fsm.expect_body_response,
 								send_request_headers,

--- a/crates/agentgateway/src/http/ext_proc_tests.rs
+++ b/crates/agentgateway/src/http/ext_proc_tests.rs
@@ -1517,8 +1517,11 @@ mod immediate_and_failure {
 		assert_eq!(body.as_ref(), b"immediate");
 	}
 
+	// An ImmediateResponse sent during the request body phase (after a headers `Continue`) must
+	// be returned to the client instead of the upstream response.  The body channel is dropped so
+	// the upstream may see an empty/truncated body, but the client receives the ext_proc response.
 	#[tokio::test]
-	async fn immediate_response_request_body_is_deferred_to_response() {
+	async fn immediate_response_request_body_short_circuits() {
 		let mock = simple_mock().await;
 		let processing_options = json!({
 			"requestBodyMode": "fullDuplexStreamed",
@@ -1540,6 +1543,35 @@ mod immediate_and_failure {
 		assert_eq!(res.status(), 403);
 		let body = read_body_raw(res.into_body()).await;
 		assert_eq!(body.as_ref(), b"Access denied");
+	}
+
+	// Regression guard: a normal full-duplex request body (no ImmediateResponse) must stream
+	// through unchanged and reach the upstream.
+	#[tokio::test]
+	async fn full_duplex_request_body_passthrough_not_aborted() {
+		let mock = simple_mock().await;
+		let processing_options = json!({
+			"requestBodyMode": "fullDuplexStreamed",
+			"responseBodyMode": "fullDuplexStreamed",
+			"requestHeaderMode": "send",
+			"responseHeaderMode": "send",
+			"requestTrailerMode": "send",
+			"responseTrailerMode": "send",
+		});
+		let (mock, _ext_proc, _bind, io) = setup_ext_proc_mock_with_processing_options(
+			mock,
+			ext_proc::FailureMode::FailClosed,
+			ExtProcMock::new(|| BBRExtProc::new(false)),
+			"{}",
+			Some(processing_options),
+		)
+		.await;
+		let res = send_request_body(io, Method::POST, "http://lo", b"request").await;
+		assert_eq!(res.status(), 200);
+		let dumped = read_body(res.into_body()).await;
+		assert_eq!(dumped.body.as_ref(), b"request");
+		let upstream_requests = mock.received_requests().await.unwrap_or_default();
+		assert_eq!(upstream_requests.len(), 1, "upstream should be contacted exactly once");
 	}
 
 	#[tokio::test]

--- a/crates/agentgateway/src/http/ext_proc_tests.rs
+++ b/crates/agentgateway/src/http/ext_proc_tests.rs
@@ -1571,7 +1571,11 @@ mod immediate_and_failure {
 		let dumped = read_body(res.into_body()).await;
 		assert_eq!(dumped.body.as_ref(), b"request");
 		let upstream_requests = mock.received_requests().await.unwrap_or_default();
-		assert_eq!(upstream_requests.len(), 1, "upstream should be contacted exactly once");
+		assert_eq!(
+			upstream_requests.len(),
+			1,
+			"upstream should be contacted exactly once"
+		);
 	}
 
 	#[tokio::test]

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -2914,11 +2914,12 @@ impl ResponsePolicies {
 	}
 
 	fn take_ext_proc_body_immediate_response(&self) -> Option<http::Response> {
-		for ep in [&self.ext_proc, &self.gateway_ext_proc] {
-			if let Some(ep) = ep {
-				if let Some(resp) = ep.take_body_immediate_response() {
-					return Some(resp);
-				}
+		for ep in [&self.ext_proc, &self.gateway_ext_proc]
+			.into_iter()
+			.flatten()
+		{
+			if let Some(resp) = ep.take_body_immediate_response() {
+				return Some(resp);
 			}
 		}
 		None

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -1094,6 +1094,14 @@ impl HTTPProxy {
 			Ok(call.await)
 		};
 
+		// If ext_proc returned an ImmediateResponse during the request body phase, it stored
+		// the response and dropped the body channel.  Return it regardless of whether the
+		// upstream call succeeded (with empty body) or failed (body parse error).
+		if let Some(resp) = response_policies.take_ext_proc_body_immediate_response() {
+			return Err(ProxyResponse::DirectResponse(Box::new(resp)))
+				.maybe_snapshot_on_err(log, &mut req_opt);
+		}
+
 		// Run the actual call
 		let mut resp = match call_result {
 			Ok(Ok(resp)) => resp,
@@ -2903,6 +2911,17 @@ struct ResponsePolicies {
 impl ResponsePolicies {
 	pub fn headers(&mut self) -> &mut HeaderMap {
 		&mut self.response_headers
+	}
+
+	fn take_ext_proc_body_immediate_response(&self) -> Option<http::Response> {
+		for ep in [&self.ext_proc, &self.gateway_ext_proc] {
+			if let Some(ep) = ep {
+				if let Some(resp) = ep.take_body_immediate_response() {
+					return Some(resp);
+				}
+			}
+		}
+		None
 	}
 
 	pub async fn apply(


### PR DESCRIPTION
related to issue #2009 

When an ext_proc server returns an ImmediateResponse during the request body phase (after replying Continue to the headers), agentgateway lost it: for FullDuplexStreamed bodies, mutate_request returns the request early and a detached task forwards body responses, so the immediate response landed in that task, was only logged, and tx_chunk was dropped -> the request was forwarded upstream with an empty body. Body-sensitive upstreams (the LLM route) then failed parsing with "EOF while parsing a value" and the client got a 503 instead of the ext_proc response.

Fix: make the body propagate the error semantics directly.  When the streaming continuation task receives an ImmediateResponse, it stores the response in shared state (Arc<Mutex>) and returns, dropping tx_chunk.  After the upstream call completes (whether it succeeded with an empty body or failed with a parse error), attempt_upstream checks the shared state and, if present, returns the stored response as a DirectResponse.

The existing "defer to response" path (mutate_response reads the response-side channel) is preserved as a fallback for the rare case where the ImmediateResponse arrives after the upstream call finishes.

