### PR TITLE
Fix: default jemalloc arm64 builds for 64KB page size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,6 +73,11 @@ RUN --mount=type=cache,target=/app/target \
     <<EOF
 export VERSION="${VERSION}"
 export GIT_REVISION="${GIT_REVISION}"
+# Build jemalloc for 64KB pages on arm64 so the image runs on hosts with any page
+# size <= 64KB (4KB/16KB/64KB).
+if [ "${TARGETARCH}" = "arm64" ]; then
+  export JEMALLOC_SYS_WITH_LG_PAGE=16
+fi
 if [ "${CARGO_NO_DEFAULT_FEATURES}" = "true" ]; then
   cargo build --no-default-features --features "${CARGO_FEATURES}" --target "$(cat /build/target)" --profile ${PROFILE} || exit 1
 else


### PR DESCRIPTION
## Fixes #2011

Build jemalloc for arm64 with a 64KB configured page by exporting
`JEMALLOC_SYS_WITH_LG_PAGE=16` during the arm64 build in the `Dockerfile`.
`tikv-jemalloc-sys` passes this through to jemalloc's `configure` as
`--with-lg-page=16`.

jemalloc only aborts when the runtime page size is **larger** than the compiled-in
page size. Building with the maximum arm64 page size (64KB) means every arm64 host
satisfies `os_page <= 65536`, so a single image runs everywhere:

| Host page size            | Result        |
|---------------------------|---------------|
| 4KB (Graviton)     | ✅ works       |
| 16KB                      | ✅ works       |
| 64KB (the reported crash) | ✅ works       |

(Linux arm64 supports only 4KB / 16KB / 64KB base pages, so 64KB is the ceiling —
there is no host where the runtime page size could exceed the compiled value.)

## Scope

- **arm64 only.** The change is guarded by `if [ "${TARGETARCH}" = "arm64" ]`, so
  amd64 is untouched and keeps the 4KB default.
- **Backwards compatible.** Existing 4KB-page arm64 deployments (the common case)
  continue to run unchanged.
- Unaffected artifacts: the `-musl` image and the `agentgateway-linux-arm64`
  release binary already use mimalloc; the macOS binary uses the system allocator.

## Trade-off

On 4KB-page arm64 hosts, jemalloc now manages memory in 64KB granularity, which
slightly increases baseline memory usage and makes memory return to the OS a bit
coarser (typically tens of MB, workload-dependent). This a trade-off of a
single image that runs across all page sizes, and it preserves jemalloc's
throughput and the `/debug/pprof/heap` memory profiling on arm64.

## Verification

Built the arm64 image and confirmed jemalloc's compiled page size via its own
statistics dump:

```bash
docker run --rm -e MALLOC_CONF=stats_print:true agw-arm64-test --version

<snip>
Page size: 65536
</snip>
```