### PR TITLE
Make MCP work with simplified config

### DIFF
--- a/crates/agentgateway/src/http/cors.rs
+++ b/crates/agentgateway/src/http/cors.rs
@@ -118,6 +118,52 @@ pub struct CorsSerde {
 	pub max_age: Option<Duration>,
 }
 
+impl CorsSerde {
+	/// Default CORS policy that allows the admin UI (served on `admin_port`) to
+	/// reach a proxy port. Contains common headers shared by all simplified configs.
+	///
+	/// NOTE: Origins use `http://` because the admin server is plaintext-only.
+	/// If the admin UI is accessed behind a TLS-terminating reverse proxy,
+	/// users should configure an explicit CORS policy with the appropriate origins.
+	pub fn default_admin(admin_port: u16) -> Self {
+		Self {
+			allow_origins: vec![
+				format!("http://localhost:{admin_port}"),
+				format!("http://127.0.0.1:{admin_port}"),
+				format!("http://[::1]:{admin_port}"),
+			],
+			allow_methods: vec![
+				"GET".to_string(),
+				"POST".to_string(),
+				"DELETE".to_string(),
+				"OPTIONS".to_string(),
+			],
+			allow_headers: vec!["content-type".to_string(), "cache-control".to_string()],
+			expose_headers: vec![],
+			allow_credentials: false,
+			max_age: None,
+		}
+	}
+
+	/// Default CORS policy for the MCP simplified config. Extends [`Self::default_admin`]
+	/// with MCP-specific headers (`mcp-protocol-version`, `mcp-session-id`).
+	///
+	/// NOTE: Exposing `mcp-session-id` in CORS headers is required for the MCP Streamable
+	/// HTTP protocol to work cross-origin from the playground UI. This does not introduce
+	/// new server-side exposure — the MCP proxy port binds to `0.0.0.0` and any network
+	/// client can already read session IDs from HTTP responses directly. The CORS headers
+	/// only make them visible to browser JS running on the admin UI origin.
+	pub fn default_mcp_admin(admin_port: u16) -> Self {
+		let mut cors = Self::default_admin(admin_port);
+		cors.allow_headers.extend([
+			"mcp-protocol-version".to_string(),
+			"mcp-session-id".to_string(),
+		]);
+		cors.expose_headers.push("mcp-session-id".to_string());
+		cors
+	}
+}
+
 impl TryFrom<CorsSerde> for Cors {
 	type Error = anyhow::Error;
 	fn try_from(value: CorsSerde) -> Result<Self, Self::Error> {

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -2034,7 +2034,7 @@ async fn convert_llm_config(
 			local_rate_limit,
 			remote_rate_limit,
 		} = pol;
-		let route_policies = split_policies(
+		let mut route_policies = split_policies(
 			client.clone(),
 			FilterOrPolicy {
 				authorization,
@@ -2046,6 +2046,9 @@ async fn convert_llm_config(
 			None,
 		)
 		.await?;
+		route_policies.ensure_default_cors(http::cors::CorsSerde::default_admin(
+			config.admin_addr.port(),
+		))?;
 		let gateway_policies = split_policies(
 			client.clone(),
 			gateway.into(),
@@ -2057,7 +2060,11 @@ async fn convert_llm_config(
 			route_policies.route_policies,
 		)
 	} else {
-		(vec![], vec![])
+		let mut default = ResolvedPolicies::default();
+		default.ensure_default_cors(http::cors::CorsSerde::default_admin(
+			config.admin_addr.port(),
+		))?;
+		(vec![], default.route_policies)
 	};
 
 	// Create transformation policy to set x-gateway-model-name header from request body
@@ -2462,11 +2469,15 @@ async fn convert_mcp_config(
 	let port = port.unwrap_or(DEFAULT_MCP_PORT);
 	let route_key = strng::new("mcp:default");
 
-	let resolved_policies = if let Some(pol) = policies {
+	let mut resolved_policies = if let Some(pol) = policies {
 		split_policies(client.clone(), pol, config.as_policy_context(&route_key)).await?
 	} else {
 		ResolvedPolicies::default()
 	};
+
+	resolved_policies.ensure_default_cors(http::cors::CorsSerde::default_mcp_admin(
+		config.admin_addr.port(),
+	))?;
 
 	let mut routes = Vec::new();
 	let route = Route {
@@ -2783,6 +2794,28 @@ pub async fn convert_route(
 pub(crate) struct ResolvedPolicies {
 	pub(crate) backend_policies: Vec<BackendTrafficPolicy>,
 	pub(crate) route_policies: Vec<TrafficPolicy>,
+}
+
+impl ResolvedPolicies {
+	/// Inject a default CORS policy so the admin UI can reach the proxy port,
+	/// unless the user already specified one.
+	pub(crate) fn ensure_default_cors(
+		&mut self,
+		default_cors: http::cors::CorsSerde,
+	) -> anyhow::Result<()> {
+		let has_cors = self
+			.route_policies
+			.iter()
+			.any(|p| matches!(p, TrafficPolicy::CORS(_)));
+		if !has_cors {
+			self
+				.route_policies
+				.push(TrafficPolicy::CORS(RequestPolicy::single(
+					http::cors::Cors::try_from(default_cors)?,
+				)));
+		}
+		Ok(())
+	}
 }
 
 pub struct AttachedPolicyContext<'a> {

--- a/crates/agentgateway/src/types/local_tests/llm_simple_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/llm_simple_normalized.snap
@@ -195,6 +195,31 @@ policies:
             tokensPerFill: 10
             type: tokens
         phase: route
+  - key: listener/3
+    name: ~
+    target:
+      gateway:
+        gatewayName: name
+        gatewayNamespace: ns
+        listenerName: llm
+    policy:
+      traffic:
+        cors:
+          allowCredentials: false
+          allowHeaders:
+            - content-type
+            - cache-control
+          allowMethods:
+            - GET
+            - POST
+            - DELETE
+            - OPTIONS
+          allowOrigins:
+            - "http://localhost:15000"
+            - "http://127.0.0.1:15000"
+            - "http://[::1]:15000"
+          maxAge: ~
+        phase: route
   - key: "llm:transformation"
     name:
       kind: Local

--- a/crates/agentgateway/src/types/local_tests/mcp_simple_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/mcp_simple_normalized.snap
@@ -21,6 +21,26 @@ listener_routes:
     - - backends:
           - backend: /mcp
             weight: 1
+        inlinePolicies:
+          - cors:
+              allowCredentials: false
+              allowHeaders:
+                - content-type
+                - cache-control
+                - mcp-protocol-version
+                - mcp-session-id
+              allowMethods:
+                - GET
+                - POST
+                - DELETE
+                - OPTIONS
+              allowOrigins:
+                - "http://localhost:15000"
+                - "http://127.0.0.1:15000"
+                - "http://[::1]:15000"
+              exposeHeaders:
+                - mcp-session-id
+              maxAge: ~
         key: "mcp:default"
         matches:
           - path:

--- a/ui/src/app/playground/page.tsx
+++ b/ui/src/app/playground/page.tsx
@@ -51,6 +51,7 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { getBackendName } from "@/lib/backend-utils";
+import { getListenerHostname } from "@/lib/listener-utils";
 import { v4 as uuidv4 } from "uuid";
 
 import { CapabilitiesList } from "@/components/playground/CapabilitiesList";
@@ -274,7 +275,7 @@ export default function PlaygroundPage() {
         if (listener.routes) {
           listener.routes.forEach((route: Route, routeIndex: number) => {
             const protocol = listener.protocol === ListenerProtocol.HTTPS ? "https" : "http";
-            const hostname = listener.hostname || "localhost";
+            const hostname = getListenerHostname(listener.hostname);
             const port = bind.port; // Use the actual port from the bind configuration
             const baseEndpoint = `${protocol}://${hostname}:${port}`;
 
@@ -1082,9 +1083,7 @@ export default function PlaygroundPage() {
                     <span className="font-medium text-sm">Request URL</span>
                   </div>
                   <div className="font-mono text-sm break-all">
-                    {selectedRoute.protocol}://{selectedRoute.listener.hostname || "localhost"}:
-                    {selectedRoute.bindPort}
-                    {request.path}
+                    {`${selectedRoute.protocol}://${getListenerHostname(selectedRoute.listener.hostname)}:${selectedRoute.bindPort}${request.path}`}
                   </div>
                 </div>
 

--- a/ui/src/app/policies/page.tsx
+++ b/ui/src/app/policies/page.tsx
@@ -5,7 +5,7 @@ import { useServer } from "@/lib/server-context";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { AlertCircle, Shield } from "lucide-react";
 import { useState, useEffect, useCallback } from "react";
-import { fetchBinds, fetchConfig } from "@/lib/api";
+import { fetchBinds, fetchAppliedPolicies } from "@/lib/api";
 import { useXdsMode } from "@/hooks/use-xds-mode";
 import { AppliedPolicy } from "@/lib/types";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
@@ -114,8 +114,8 @@ export default function PoliciesPage() {
     setAppliedLoading(true);
     setAppliedError(null);
     try {
-      const cfg = await fetchConfig();
-      const nonRoute = (cfg.appliedPolicies || []).filter((p) => !p.target?.route);
+      const policies = await fetchAppliedPolicies();
+      const nonRoute = policies.filter((p) => !p.target?.route);
       setAppliedPolicies(nonRoute);
     } catch (e: any) {
       console.error("Error loading applied policies:", e);

--- a/ui/src/components/listener-config.tsx
+++ b/ui/src/components/listener-config.tsx
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Listener, ListenerProtocol, Bind } from "@/lib/types";
+import { getListenerHostname } from "@/lib/listener-utils";
 import {
   Trash2,
   Lock,
@@ -355,7 +356,7 @@ export function ListenerConfig({
   const getDisplayEndpoint = (listener: ListenerWithBackendsAndRoutes, port: number) => {
     const listenerProtocol = listener.protocol || ListenerProtocol.HTTP;
     const protocol = listenerProtocol === ListenerProtocol.HTTPS ? "https" : "http";
-    const hostname = listener.hostname || "localhost";
+    const hostname = getListenerHostname(listener.hostname);
     return `${protocol}://${hostname}:${port}`;
   };
 
@@ -513,7 +514,11 @@ export function ListenerConfig({
                                     {getProtocolString(listener.protocol)}
                                   </Badge>
                                 </TableCell>
-                                <TableCell>{listener.hostname || "localhost"}</TableCell>
+                                <TableCell>
+                                  {!listener.hostname || listener.hostname === "*"
+                                    ? "localhost"
+                                    : listener.hostname}
+                                </TableCell>
                                 <TableCell className="font-mono text-sm">
                                   {getDisplayEndpoint(
                                     {

--- a/ui/src/components/setup-wizard/ReviewStep.tsx
+++ b/ui/src/components/setup-wizard/ReviewStep.tsx
@@ -12,6 +12,7 @@ import {
 import { AgentgatewayLogo } from "@/components/agentgateway-logo";
 import { ArrowLeft, CheckCircle, Network, Route, Globe, Shield } from "lucide-react";
 import { LocalConfig } from "@/lib/types";
+import { getListenerHostname } from "@/lib/listener-utils";
 import { Badge } from "@/components/ui/badge";
 import { updateConfig } from "@/lib/api";
 
@@ -157,7 +158,7 @@ export function ReviewStep({ onNext, onPrevious, config }: ReviewStepProps) {
                           <Badge variant="outline">{listener.protocol}</Badge>
                           <span className="text-sm">{listener.name}</span>
                           <span className="text-xs text-muted-foreground">
-                            {listener.hostname || "localhost"}
+                            {getListenerHostname(listener.hostname)}
                           </span>
                         </div>
 

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -52,7 +52,16 @@ export async function fetchConfig(): Promise<LocalConfig> {
       }
       throw new Error(`Failed to fetch config: ${r.status}`);
     }
-    return (await r.json()) as LocalConfig;
+    const raw = await r.json();
+    // The simplified `mcp:`/`llm:` top-level config formats are expanded into
+    // binds/listeners/routes/backends by the backend at runtime, but `/config`
+    // returns the raw file which has no `binds` in that case. Fall back to
+    // `/config_dump`, which returns the fully expanded representation (the same
+    // path used in XDS mode), so the UI doesn't render an empty config.
+    if (!raw.binds && (raw.mcp || raw.llm)) {
+      return fetchViaDump();
+    }
+    return { ...raw, binds: raw.binds || [] } as LocalConfig;
   }
 }
 

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -101,7 +101,15 @@ function cleanupConfig(config: LocalConfig): LocalConfig {
           const cleanedRoute: any = {
             hostnames: route.hostnames,
             matches: route.matches,
-            backends: route.backends,
+            backends: route.backends.map((b) => {
+              // mcp.name is injected by config_dump (ResourceName flattening)
+              // but is not part of the write schema — strip it before POST.
+              if (b.mcp?.name) {
+                const { name: _, ...mcpRest } = b.mcp;
+                return { ...b, mcp: mcpRest };
+              }
+              return b;
+            }),
           };
 
           if (route.name) cleanedRoute.name = route.name;

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1,4 +1,13 @@
-import { Target, Listener, LocalConfig, Bind, Backend, Route, McpStatefulMode } from "./types";
+import {
+  Target,
+  Listener,
+  LocalConfig,
+  Bind,
+  Backend,
+  Route,
+  McpStatefulMode,
+  AppliedPolicy,
+} from "./types";
 
 // Mapping utilities are centralized in configMapper
 import { configDumpToLocalConfig } from "./configMapper";
@@ -159,6 +168,14 @@ export async function updateConfig(config: LocalConfig): Promise<void> {
     console.error("Error updating configuration:", error);
     throw error;
   }
+}
+
+/**
+ * Fetches applied policies from config_dump (XDS mode only).
+ */
+export async function fetchAppliedPolicies(): Promise<AppliedPolicy[]> {
+  const dumpJson = await fetchConfigDump(API_URL);
+  return (dumpJson.policies || []) as AppliedPolicy[];
 }
 
 /**

--- a/ui/src/lib/configMapper.ts
+++ b/ui/src/lib/configMapper.ts
@@ -26,7 +26,6 @@ export function configDumpToLocalConfig(configDump: any): LocalConfig {
     binds: [],
     workloads: configDump.workloads || [],
     services: configDump.services || [],
-    appliedPolicies: configDump.policies || [],
   };
 
   const backends = (configDump.backends || [])
@@ -221,8 +220,8 @@ function mapToMatches(matchesData: any): Match[] {
     if (matchData.path) {
       if (matchData.path.exact) {
         match.path.exact = matchData.path.exact;
-      } else if (matchData.path.prefix) {
-        match.path.pathPrefix = matchData.path.prefix;
+      } else if (matchData.path.pathPrefix != null || matchData.path.prefix != null) {
+        match.path.pathPrefix = matchData.path.pathPrefix ?? matchData.path.prefix;
       } else if (matchData.path.regex) {
         match.path.regex = matchData.path.regex;
       }
@@ -253,14 +252,27 @@ function mapToBackend(backendData: any): Backend | undefined {
 }
 
 function mapToRouteBackend(rb: any, backends: Backend[]): Backend | undefined {
+  let backend: Backend | undefined;
+
   // Route backend reference is a string in "namespace/name" format
   if (typeof rb.backend === "string") {
-    const found = backends.find((b) => getBackendName(b) === rb.backend);
-    if (found) return found;
+    backend = backends.find((b) => getBackendName(b) === rb.backend);
   }
 
   // Fallback: instantiate a backend in-place based on the route backend data
-  return mapToBackend(rb);
+  if (!backend) {
+    backend = mapToBackend(rb);
+  }
+
+  // mcp.name is injected by the server (ResourceName flattening) and used
+  // for lookup above, but is not part of the write schema. Return a clone
+  // without it so the backends array keeps names for future lookups.
+  if (backend?.mcp?.name) {
+    const { name: _, ...mcpRest } = backend.mcp;
+    return { ...backend, mcp: mcpRest as McpBackend };
+  }
+
+  return backend;
 }
 
 function getBackendName(backend: Backend): string {
@@ -314,9 +326,11 @@ function mapToServiceBackend(data: any): ServiceBackend | undefined {
 }
 
 function mapToHostBackend(data: any): HostBackend | undefined {
-  if (!data) return undefined;
-  // Include namespace in name to match route backend reference format "namespace/name"
-  const fullName = data.namespace && data.name ? `${data.namespace}/${data.name}` : data.name;
+  if (!data || typeof data.name !== "string") return undefined;
+  // Format as "namespace/name" to match route backend reference keys
+  // (mirrors Rust Display for ResourceName: "{namespace}/{name}").
+  const namespace = typeof data.namespace === "string" ? data.namespace : "";
+  const fullName = `${namespace}/${data.name}`;
   if (typeof data.target === "string") {
     const [host, portStr] = data.target.split(":");
     const port = Number(portStr);
@@ -337,8 +351,10 @@ function mapToHostBackend(data: any): HostBackend | undefined {
 function mapToMcpBackend(data: any): McpBackend | undefined {
   if (typeof data?.name !== "string" || !Array.isArray(data?.target?.targets)) return undefined;
   const targets = data.target.targets.map(mapToMcpTarget).filter(Boolean) as McpTarget[];
-  // Include namespace in name to match route backend reference format "namespace/name"
-  const fullName = data.namespace ? `${data.namespace}/${data.name}` : data.name;
+  // Format as "namespace/name" to match route backend reference keys
+  // (mirrors Rust Display for ResourceName: "{namespace}/{name}").
+  const namespace = typeof data.namespace === "string" ? data.namespace : "";
+  const fullName = `${namespace}/${data.name}`;
   return {
     name: fullName,
     targets, // Flat structure for UI and write path

--- a/ui/src/lib/configMapper.ts
+++ b/ui/src/lib/configMapper.ts
@@ -254,22 +254,20 @@ function mapToBackend(backendData: any): Backend | undefined {
 function mapToRouteBackend(rb: any, backends: Backend[]): Backend | undefined {
   let backend: Backend | undefined;
 
-  // Route backend reference is a string in "namespace/name" format
+  // Route backend reference is a string in "namespace/name" format.
+  // For empty namespaces the server emits "/name" while the UI stores
+  // just "name", so strip a leading slash before comparing.
   if (typeof rb.backend === "string") {
-    backend = backends.find((b) => getBackendName(b) === rb.backend);
+    const normalizedRef = rb.backend.startsWith("/") ? rb.backend.slice(1) : rb.backend;
+    backend = backends.find((b) => {
+      const name = getBackendName(b);
+      return name === normalizedRef || name === rb.backend;
+    });
   }
 
   // Fallback: instantiate a backend in-place based on the route backend data
   if (!backend) {
     backend = mapToBackend(rb);
-  }
-
-  // mcp.name is injected by the server (ResourceName flattening) and used
-  // for lookup above, but is not part of the write schema. Return a clone
-  // without it so the backends array keeps names for future lookups.
-  if (backend?.mcp?.name) {
-    const { name: _, ...mcpRest } = backend.mcp;
-    return { ...backend, mcp: mcpRest as McpBackend };
   }
 
   return backend;
@@ -327,10 +325,8 @@ function mapToServiceBackend(data: any): ServiceBackend | undefined {
 
 function mapToHostBackend(data: any): HostBackend | undefined {
   if (!data || typeof data.name !== "string") return undefined;
-  // Format as "namespace/name" to match route backend reference keys
-  // (mirrors Rust Display for ResourceName: "{namespace}/{name}").
-  const namespace = typeof data.namespace === "string" ? data.namespace : "";
-  const fullName = `${namespace}/${data.name}`;
+  // Include namespace in name to match route backend reference format "namespace/name"
+  const fullName = data.namespace ? `${data.namespace}/${data.name}` : data.name;
   if (typeof data.target === "string") {
     const [host, portStr] = data.target.split(":");
     const port = Number(portStr);
@@ -351,10 +347,8 @@ function mapToHostBackend(data: any): HostBackend | undefined {
 function mapToMcpBackend(data: any): McpBackend | undefined {
   if (typeof data?.name !== "string" || !Array.isArray(data?.target?.targets)) return undefined;
   const targets = data.target.targets.map(mapToMcpTarget).filter(Boolean) as McpTarget[];
-  // Format as "namespace/name" to match route backend reference keys
-  // (mirrors Rust Display for ResourceName: "{namespace}/{name}").
-  const namespace = typeof data.namespace === "string" ? data.namespace : "";
-  const fullName = `${namespace}/${data.name}`;
+  // Include namespace in name to match route backend reference format "namespace/name"
+  const fullName = data.namespace ? `${data.namespace}/${data.name}` : data.name;
   return {
     name: fullName,
     targets, // Flat structure for UI and write path

--- a/ui/src/lib/listener-utils.ts
+++ b/ui/src/lib/listener-utils.ts
@@ -1,0 +1,6 @@
+/**
+ * Returns the effective hostname for a listener, falling back to "localhost"
+ * when the hostname is unset or a wildcard.
+ */
+export const getListenerHostname = (hostname: string | null | undefined): string =>
+  !hostname || hostname === "*" ? "localhost" : hostname;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -5,7 +5,6 @@ export interface LocalConfig {
   binds: Bind[];
   workloads?: any[];
   services?: any[];
-  appliedPolicies?: AppliedPolicy[];
 }
 
 export interface Bind {


### PR DESCRIPTION
This PR fixes multiple UI-related problems I've stumbled upon when going through the standalone MCP [quickstart](https://agentgateway.dev/docs/standalone/latest/quickstart/mcp/).

One such problem is described in #1958. Others I haven't opened bugs for but if you simply try to do the quickstart using either `main` or the latest release, you'll encounter them one after the other.

I'm new to agentgateway so my initial assumption upon encountering the errors was that I've made some mistake, however after spending some hours on this I'm quite convinced that all the included fixes are necessary just to get the basic quickstart to work as written.

I've identified two obvious culprits:

1. The **simplified config format** introduced in #1007 is incompatible with the current state of the UI.
2. A **CORS config** is required for the playground UI to be able to talk to the MCP endpoint.

The rest of the fixes are smaller UI bugs which either break the MCP quickstart flow or show confusing data to the user.

I've done my best to include good commit messages and slice the change set in a way that makes sense.

**Please review carefully** as my confidence level about correctness is low, plus we have no UI-level testing at the moment AFAICT.

Fixes #1958. Supersedes #1966.

Co-authored with @yalindogusahin.