### PR TITLE
use mkdirall for e2e test

### DIFF
--- a/controller/test/e2e/test.go
+++ b/controller/test/e2e/test.go
@@ -260,7 +260,7 @@ func (i *TestInstallation) preFailHandler(ctx context.Context, t *testing.T, dir
 	// The idea here is we want to accumulate ALL information about this TestInstallation into a single directory
 	// That way we can upload it in CI, or inspect it locally
 
-	err := os.Mkdir(dir, os.ModePerm)
+	err := os.MkdirAll(dir, os.ModePerm)
 	// We don't want to fail on the output directory already existing. This could occur
 	// if multiple tests running in the same cluster from the same installation namespace
 	// fail.


### PR DESCRIPTION
mkdir can cause problem when trying subtests as subfolders might not exists