### PR TITLE
feat(jwt): expose canonical (iss, sub) identity as jwt.identity

### DIFF
--- a/crates/agentgateway/src/http/jwt.rs
+++ b/crates/agentgateway/src/http/jwt.rs
@@ -413,12 +413,27 @@ pub struct Claims {
 	pub jwt: SecretString,
 }
 
+impl Claims {
+	/// Canonical cross-issuer identity: the `(iss, sub)` pair (OIDC Core 1.0 §5.7).
+	/// `None` if either claim is absent or non-string.
+	pub fn canonical_identity(&self) -> Option<String> {
+		let iss = self.inner.get("iss")?.as_str()?;
+		let sub = self.inner.get("sub")?.as_str()?;
+		Some(format!("{iss}#{sub}"))
+	}
+}
+
 impl DynamicType for Claims {
 	fn materialize(&self) -> cel::Value<'_> {
 		self.inner.materialize()
 	}
 
 	fn field(&self, field: &str) -> Option<cel::Value<'_>> {
+		if field == "identity" {
+			return self
+				.canonical_identity()
+				.map(|id| cel::Value::String(id.into()));
+		}
 		self.inner.field(field)
 	}
 }
@@ -493,10 +508,11 @@ impl Jwt {
 			},
 		};
 
-		if let Some(serde_json::Value::String(sub)) = claims.inner.get("sub")
-			&& let Some(log) = log
-		{
-			log.jwt_sub = Some(sub.to_string());
+		if let Some(log) = log {
+			if let Some(serde_json::Value::String(sub)) = claims.inner.get("sub") {
+				log.jwt_sub = Some(sub.to_string());
+			}
+			log.jwt_identity = claims.canonical_identity();
 		};
 		// Remove the token.
 		self

--- a/crates/agentgateway/src/http/jwt_tests.rs
+++ b/crates/agentgateway/src/http/jwt_tests.rs
@@ -1022,3 +1022,27 @@ pub fn test_required_claims_with_nbf_rejects_missing_nbf() {
 		"required_claims with nbf should reject tokens missing nbf claim"
 	);
 }
+
+#[test]
+fn test_canonical_identity_combines_iss_and_sub() {
+	let claims = super::Claims {
+		inner: json!({ "iss": "https://idp-a/", "sub": "alice" })
+			.as_object()
+			.unwrap()
+			.clone(),
+		jwt: Default::default(),
+	};
+	assert_eq!(
+		claims.canonical_identity().as_deref(),
+		Some("https://idp-a/#alice")
+	);
+}
+
+#[test]
+fn test_canonical_identity_none_when_claim_missing() {
+	let claims = super::Claims {
+		inner: json!({ "sub": "alice" }).as_object().unwrap().clone(),
+		jwt: Default::default(),
+	};
+	assert_eq!(claims.canonical_identity(), None);
+}

--- a/crates/agentgateway/src/mcp/rbac.rs
+++ b/crates/agentgateway/src/mcp/rbac.rs
@@ -199,4 +199,19 @@ mod tests {
 
 		assert!(!authz.validate(&res, &CelExecWrapper::new(req)));
 	}
+
+	// `jwt.identity` keys on the (iss, sub) pair, so the same `sub` from a different issuer is a
+	// distinct identity (OIDC Core 1.0 §5.7).
+	#[test]
+	fn test_mcp_authorization_jwt_identity_disambiguates_issuers() {
+		let authz =
+			authorization_set(r#"mcp.tool.name == "increment" && jwt.identity == "https://idp-a/#alice""#);
+		let res = tool_resource("server", "increment");
+
+		let matching = req_with_claims(json!({ "iss": "https://idp-a/", "sub": "alice" }));
+		assert!(authz.validate(&res, &CelExecWrapper::new(matching)));
+
+		let other_issuer = req_with_claims(json!({ "iss": "https://idp-b/", "sub": "alice" }));
+		assert!(!authz.validate(&res, &CelExecWrapper::new(other_issuer)));
+	}
 }

--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -652,6 +652,7 @@ impl RequestLog {
 			health_policy: None,
 			retry_backoff: None,
 			jwt_sub: None,
+			jwt_identity: None,
 			retry_attempt: None,
 			error: None,
 			grpc_status: Default::default(),
@@ -792,6 +793,7 @@ pub struct RequestLog {
 	pub retry_backoff: Option<Duration>,
 
 	pub jwt_sub: Option<String>,
+	pub jwt_identity: Option<String>,
 
 	pub retry_attempt: Option<u8>,
 	pub error: Option<String>,
@@ -1042,6 +1044,7 @@ impl Drop for DropOnLog {
 			("trace.id", trace_id.display()),
 			("span.id", span_id.display()),
 			("jwt.sub", log.jwt_sub.display()),
+			("jwt.identity", log.jwt_identity.display()),
 			("protocol", log.backend_protocol.as_ref().map(debug)),
 			("a2a.method", log.a2a_method.display()),
 			(


### PR DESCRIPTION
A JWT sub is only unique within its issuer (OIDC Core 1.0 §5.7), so keying identity on sub alone is ambiguous when multiple JWT providers are configured.

Derive a canonical identity from the (iss, sub) pair and expose it to CEL as jwt.identity (formatted as "{iss}#{sub}") and to access logs, so authorization policies can distinguish the same sub coming from different issuers. It is null when either claim is absent, and is purely additive with no new config.

Closes #2019