### PR TITLE
deps: bump async-openai 0.38 -> 0.40.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -551,9 +551,9 @@ dependencies = [
 
 [[package]]
 name = "async-openai"
-version = "0.38.2"
+version = "0.40.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bb666d696156a8da537278ecb3195806d885edf25a573ce23ceec4dee2b0eee"
+checksum = "278af84d3d19995d440ea7b401a4b121c780c8d37f5eb6e883d987c17b523aa4"
 dependencies = [
  "bytes",
  "derive_builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ anyhow = "1.0"
 arc-swap = "1.9"
 arcstr = { version = "1.2", features = ["serde"] }
 assert_matches = "1.5.0"
-async-openai = { version = "0.38", default-features = false, features = ["chat-completion-types", "moderation-types", "response-types", "realtime-types"] }
+async-openai = { version = "0.40", default-features = false, features = ["chat-completion-types", "moderation-types", "response-types", "realtime-types"] }
 async-stream = "0.3"
 async-trait = "0.1"
 aws-config = { version = "1.8", default-features = false, features = ["default-https-client", "rt-tokio", "sso"] }

--- a/crates/agentgateway/src/llm/conversion/bedrock.rs
+++ b/crates/agentgateway/src/llm/conversion/bedrock.rs
@@ -580,19 +580,11 @@ pub mod from_completions {
 					serde_json::json!({ "type": "object", "additionalProperties": true }),
 				),
 			),
-			completions::ResponseFormat::JsonSchema { json_schema } => {
-				let Some(schema) = json_schema.schema.as_ref() else {
-					tracing::warn!(
-						"Dropping response_format.json_schema for Bedrock conversion because schema is missing"
-					);
-					return None;
-				};
-				(
-					Some(json_schema.name.clone()),
-					json_schema.description.clone(),
-					std::borrow::Cow::Borrowed(schema),
-				)
-			},
+			completions::ResponseFormat::JsonSchema { json_schema } => (
+				Some(json_schema.name.clone()),
+				json_schema.description.clone(),
+				std::borrow::Cow::Borrowed(&json_schema.schema),
+			),
 		};
 
 		let Ok(schema_json) = serde_json::to_string(schema.as_ref()) else {
@@ -2095,19 +2087,11 @@ pub mod from_responses {
 					serde_json::json!({ "type": "object", "additionalProperties": true }),
 				),
 			),
-			responses::TextResponseFormatConfiguration::JsonSchema(json_schema) => {
-				let Some(schema) = json_schema.schema.as_ref() else {
-					tracing::warn!(
-						"Dropping text.format.json_schema for Bedrock conversion because schema is missing"
-					);
-					return None;
-				};
-				(
-					Some(json_schema.name.clone()),
-					json_schema.description.clone(),
-					std::borrow::Cow::Borrowed(schema),
-				)
-			},
+			responses::TextResponseFormatConfiguration::JsonSchema(json_schema) => (
+				Some(json_schema.name.clone()),
+				json_schema.description.clone(),
+				std::borrow::Cow::Borrowed(&json_schema.schema),
+			),
 		};
 
 		let Ok(schema_json) = serde_json::to_string(schema.as_ref()) else {

--- a/crates/agentgateway/src/llm/conversion/bedrock_tests.rs
+++ b/crates/agentgateway/src/llm/conversion/bedrock_tests.rs
@@ -761,7 +761,7 @@ fn test_completions_json_schema_response_format_maps_to_converse_output_config()
 			json_schema: types::completions::typed::ResponseFormatJsonSchema {
 				description: Some("Structured summary".to_string()),
 				name: "summary_schema".to_string(),
-				schema: Some(schema.clone()),
+				schema: schema.clone(),
 				strict: Some(true),
 			},
 		}),

--- a/crates/agentgateway/src/llm/conversion/completions.rs
+++ b/crates/agentgateway/src/llm/conversion/completions.rs
@@ -670,7 +670,7 @@ pub mod from_messages {
 					json_schema: completions::ResponseFormatJsonSchema {
 						description: None,
 						name: "structured_output".to_string(),
-						schema: Some(schema.clone()),
+						schema: schema.clone(),
 						strict: None,
 					},
 				},

--- a/crates/agentgateway/src/llm/conversion/messages.rs
+++ b/crates/agentgateway/src/llm/conversion/messages.rs
@@ -359,9 +359,11 @@ pub mod from_completions {
 		};
 
 		let response_format = match req.response_format {
-			Some(completions::ResponseFormat::JsonSchema { json_schema }) => json_schema
-				.schema
-				.map(|schema| messages::OutputFormat::JsonSchema { schema }),
+			Some(completions::ResponseFormat::JsonSchema { json_schema }) => {
+				Some(messages::OutputFormat::JsonSchema {
+					schema: json_schema.schema,
+				})
+			},
 			Some(completions::ResponseFormat::JsonObject) => Some(messages::OutputFormat::JsonSchema {
 				schema: serde_json::json!({
 					"type": "object",

--- a/crates/agentgateway/src/llm/tests/response/bedrock/tool.bedrock-completions-streaming.snap
+++ b/crates/agentgateway/src/llm/tests/response/bedrock/tool.bedrock-completions-streaming.snap
@@ -1,18 +1,19 @@
 ---
 source: crates/agentgateway/src/llm/tests.rs
+assertion_line: 205
 description: src/llm/tests/response/bedrock/tool.bin
 ---
 data: {"id":"request_id","choices":[{"index":0,"delta":{"content":null,"role":"assistant"}}],"created":123,"model":"input-model","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
 
-data: {"id":"request_id","choices":[{"index":0,"delta":{"content":null,"tool_calls":[{"index":0,"id":"tooluse_kZJMlvQmRJ6eAyJE5GIl7Q","type":"function","function":{"name":"top_song","arguments":null}}]}}],"created":123,"model":"input-model","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
+data: {"id":"request_id","choices":[{"index":0,"delta":{"content":null,"tool_calls":[{"index":0,"id":"tooluse_kZJMlvQmRJ6eAyJE5GIl7Q","type":"function","function":{"name":"top_song"}}]}}],"created":123,"model":"input-model","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
 
-data: {"id":"request_id","choices":[{"index":0,"delta":{"content":null,"tool_calls":[{"index":0,"id":null,"type":null,"function":{"name":null,"arguments":"{\"sign\":"}}]}}],"created":123,"model":"input-model","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
+data: {"id":"request_id","choices":[{"index":0,"delta":{"content":null,"tool_calls":[{"index":0,"id":null,"type":null,"function":{"arguments":"{\"sign\":"}}]}}],"created":123,"model":"input-model","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
 
-data: {"id":"request_id","choices":[{"index":0,"delta":{"content":null,"tool_calls":[{"index":0,"id":null,"type":null,"function":{"name":null,"arguments":"\"WZPZ\"}"}}]}}],"created":123,"model":"input-model","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
+data: {"id":"request_id","choices":[{"index":0,"delta":{"content":null,"tool_calls":[{"index":0,"id":null,"type":null,"function":{"arguments":"\"WZPZ\"}"}}]}}],"created":123,"model":"input-model","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
 
-data: {"id":"request_id","choices":[{"index":0,"delta":{"content":null,"tool_calls":[{"index":1,"id":"tooluse_kZJMlvQmRJ6eAyxxx","type":"function","function":{"name":"hello","arguments":null}}]}}],"created":123,"model":"input-model","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
+data: {"id":"request_id","choices":[{"index":0,"delta":{"content":null,"tool_calls":[{"index":1,"id":"tooluse_kZJMlvQmRJ6eAyxxx","type":"function","function":{"name":"hello"}}]}}],"created":123,"model":"input-model","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
 
-data: {"id":"request_id","choices":[{"index":0,"delta":{"content":null,"tool_calls":[{"index":1,"id":null,"type":null,"function":{"name":null,"arguments":"{\"sign\":\"world\"}"}}]}}],"created":123,"model":"input-model","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
+data: {"id":"request_id","choices":[{"index":0,"delta":{"content":null,"tool_calls":[{"index":1,"id":null,"type":null,"function":{"arguments":"{\"sign\":\"world\"}"}}]}}],"created":123,"model":"input-model","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
 
 data: {"id":"request_id","choices":[{"index":0,"delta":{"content":null},"finish_reason":"tool_calls"}],"created":123,"model":"input-model","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
 


### PR DESCRIPTION
Bumps `async-openai` to v0.40.3 to pick up [64bit/async-openai#561](https://github.com/64bit/async-openai/pull/561) (shipped in [v0.40.3](https://crates.io/crates/async-openai/0.40.3)). Streaming `tool_call` deltas no longer emit `function.name` / `function.arguments` as JSON `null` when `None` — they're omitted, which matches the [OpenAI spec](https://developers.openai.com/api/reference/resources/chat/subresources/completions/streaming-events) (both declared as non-nullable optional strings).

Resolves #1988. Supersedes #1989, closed in favour of fixing the root cause upstream.

## Changes
- `Cargo.toml` / `Cargo.lock`: `async-openai 0.38 -> 0.40.3`.
- 5 call sites adapted for the 0.40 breaking change in `ResponseFormatJsonSchema::schema` (`Option<Value> -> Value`, per [64bit/async-openai#555](https://github.com/64bit/async-openai/pull/555)): `bedrock.rs` (2 sites), `completions.rs`, `messages.rs`, `bedrock_tests.rs`.
- `tests/response/bedrock/tool.bedrock-completions-streaming.snap`: refreshed to the new wire shape (absent fields where the pre-bump output emitted `null`).

## Behavior notes
The only behavioral delta beyond the wire-shape fix: a missing `schema` field in a `ResponseFormatJsonSchema` request now fails at deserialization rather than being silently dropped. This follows from async-openai 0.40 making the field required to match the OpenAI spec ([64bit/async-openai#555](https://github.com/64bit/async-openai/pull/555)). Requests that explicitly send `"schema": null` are passed through identically before and after — the old `let Some(...) else { ... }` guard only matched `Option::None` (field absent), not `Value::Null`.

## Verification
- `cargo check --workspace --all-features --all-targets`: clean.
- `make lint` (CI command): clean.
- `make test`: **1344 / 1344 passed**, 0 failed, 5 ignored (pre-existing).
- End-to-end validated in a local docker-compose stack: Bedrock Claude 4.5 + MCP tool calls (aws-docs) work cleanly, no `TypeError: object of type 'NoneType' has no len()` on the strict-string client side that originally triggered #1988.

---
*AI-assisted change. Author reviewed, ran the full lint + test pipeline, and verified the fix end-to-end before submission.*