### PR TITLE
Compose multiple AI backend policies

### DIFF
--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -405,35 +405,60 @@ impl LLMRequestPolicies {
 			return Arc::new(route_policies);
 		};
 
-		// Backend aliases replace route aliases entirely (consistent with defaults/overrides)
-		let (merged_aliases, merged_wildcard_patterns) = if be.model_aliases.is_empty() {
-			(re.model_aliases.clone(), Arc::clone(&re.wildcard_patterns))
+		route_policies.llm = Some(Self::merge_llm_policies(&be, &re));
+		Arc::new(route_policies)
+	}
+
+	fn merge_llm_policies(
+		preferred: &Arc<llm::Policy>,
+		fallback: &Arc<llm::Policy>,
+	) -> Arc<llm::Policy> {
+		// Preferred aliases replace fallback aliases entirely (consistent with defaults/overrides).
+		let (merged_aliases, merged_wildcard_patterns) = if preferred.model_aliases.is_empty() {
+			(
+				fallback.model_aliases.clone(),
+				Arc::clone(&fallback.wildcard_patterns),
+			)
 		} else {
-			(be.model_aliases.clone(), Arc::clone(&be.wildcard_patterns))
+			(
+				preferred.model_aliases.clone(),
+				Arc::clone(&preferred.wildcard_patterns),
+			)
 		};
 
-		route_policies.llm = Some(Arc::new(llm::Policy {
-			prompt_guard: be.prompt_guard.clone().or_else(|| re.prompt_guard.clone()),
-			defaults: be.defaults.clone().or_else(|| re.defaults.clone()),
-			overrides: be.overrides.clone().or_else(|| re.overrides.clone()),
-			transformations: be
+		Arc::new(llm::Policy {
+			prompt_guard: preferred
+				.prompt_guard
+				.clone()
+				.or_else(|| fallback.prompt_guard.clone()),
+			defaults: preferred
+				.defaults
+				.clone()
+				.or_else(|| fallback.defaults.clone()),
+			overrides: preferred
+				.overrides
+				.clone()
+				.or_else(|| fallback.overrides.clone()),
+			transformations: preferred
 				.transformations
 				.clone()
-				.or_else(|| re.transformations.clone()),
-			prompts: be.prompts.clone().or_else(|| re.prompts.clone()),
+				.or_else(|| fallback.transformations.clone()),
+			prompts: preferred
+				.prompts
+				.clone()
+				.or_else(|| fallback.prompts.clone()),
 			model_aliases: merged_aliases,
 			wildcard_patterns: merged_wildcard_patterns,
-			prompt_caching: be
+			prompt_caching: preferred
 				.prompt_caching
 				.clone()
-				.or_else(|| re.prompt_caching.clone()),
-			routes: if be.routes.is_empty() {
-				re.routes.clone()
+				.or_else(|| fallback.prompt_caching.clone()),
+			routes: if preferred.routes.is_empty() {
+				fallback.routes.clone()
 			} else {
-				be.routes.clone()
+				preferred.routes.clone()
 			},
-		}));
-		Arc::new(route_policies)
+		})
 	}
 }
 
@@ -987,7 +1012,10 @@ impl Store {
 					pol.ext_authz.set_if_unset(p);
 				},
 				BackendTrafficPolicy::AI(p) => {
-					pol.llm.get_or_insert_with(|| p.clone());
+					pol.llm = Some(match pol.llm.take() {
+						Some(existing) => LLMRequestPolicies::merge_llm_policies(&existing, p),
+						None => p.clone(),
+					});
 				},
 
 				BackendTrafficPolicy::HTTP(p) => {
@@ -2533,6 +2561,57 @@ mod tests {
 			(strng::new("x-foo"), strng::new("bar3")),
 			"Section attached policy (bar3) should win over backend attached policy (bar)"
 		);
+	}
+
+	#[test]
+	fn backend_ai_policy_merge_preserves_routes_and_prompt_guard() {
+		use crate::llm::policy::{
+			PromptGuard, RegexRule, RegexRules, RequestGuard, RequestGuardKind, SortedRoutes,
+		};
+		use crate::llm::{self, RouteType};
+
+		let mut routes = SortedRoutes::default();
+		routes.insert(strng::new("/v1/messages"), RouteType::Messages);
+		routes.insert(strng::new("*"), RouteType::Passthrough);
+
+		let routes_policy = BackendTrafficPolicy::AI(Arc::new(llm::Policy {
+			routes,
+			..Default::default()
+		}));
+		let prompt_guard_policy = BackendTrafficPolicy::AI(Arc::new(llm::Policy {
+			prompt_guard: Some(PromptGuard {
+				request: vec![RequestGuard {
+					rejection: Default::default(),
+					kind: RequestGuardKind::Regex(RegexRules {
+						action: Default::default(),
+						rules: vec![RegexRule::Regex {
+							pattern: regex::Regex::new("secret").unwrap(),
+						}],
+					}),
+				}],
+				response: vec![],
+			}),
+			..Default::default()
+		}));
+
+		let inline_policies = vec![prompt_guard_policy, routes_policy];
+		let policies = Store::default().backend_policies(
+			BackendTargetRef::Backend {
+				name: "test-backend",
+				namespace: "test-ns",
+				section: None,
+			},
+			&[&inline_policies],
+			None,
+		);
+		let policy = policies.llm.expect("expected merged AI policy");
+
+		assert!(
+			policy.prompt_guard.is_some(),
+			"prompt guard config should be preserved"
+		);
+		assert_eq!(policy.resolve_route("/v1/messages"), RouteType::Messages);
+		assert_eq!(policy.resolve_route("/v1/models"), RouteType::Passthrough);
 	}
 
 	#[test]


### PR DESCRIPTION
- Reuse the existing AI policy field-wise merge logic when collecting multiple applicable backend AI policies.
- Preserve configured route maps when a separate promptguard-only AI policy also applies.
- Add regression coverage for prompt guard plus `/v1/messages` and wildcard route resolution.