### PR TITLE
fix krt snapshot for jwks policies

### DIFF
--- a/controller/pkg/agentgateway/jwks/types.go
+++ b/controller/pkg/agentgateway/jwks/types.go
@@ -2,6 +2,7 @@ package jwks
 
 import (
 	"crypto/tls"
+	"encoding/json"
 	"reflect"
 	"time"
 
@@ -39,6 +40,26 @@ func (s JwksSource) Equals(other JwksSource) bool {
 		s.TTL == other.TTL
 }
 
+func (s JwksSource) MarshalJSON() ([]byte, error) {
+	type jsonJwksSource struct {
+		OwnerKey          OwnerKey               `json:"ownerKey"`
+		RequestKey        remotehttp.FetchKey    `json:"requestKey"`
+		Target            remotehttp.FetchTarget `json:"target"`
+		HasTLSConfig      bool                   `json:"hasTLSConfig"`
+		HasProxyTLSConfig bool                   `json:"hasProxyTLSConfig"`
+		TTL               time.Duration          `json:"ttl"`
+	}
+
+	return json.Marshal(jsonJwksSource{
+		OwnerKey:          s.OwnerKey,
+		RequestKey:        s.RequestKey,
+		Target:            s.Target,
+		HasTLSConfig:      s.TLSConfig != nil,
+		HasProxyTLSConfig: s.ProxyTLSConfig != nil,
+		TTL:               s.TTL,
+	})
+}
+
 // SharedJwksRequest is the canonical JWKS request produced by KRT for a shared
 // fetch key. It is the unit the runtime Fetcher and persistence layer watch.
 type SharedJwksRequest struct {
@@ -59,6 +80,24 @@ func (r SharedJwksRequest) Equals(other SharedJwksRequest) bool {
 	return r.RequestKey == other.RequestKey &&
 		reflect.DeepEqual(r.Target, other.Target) &&
 		r.TTL == other.TTL
+}
+
+func (r SharedJwksRequest) MarshalJSON() ([]byte, error) {
+	type jsonSharedJwksRequest struct {
+		RequestKey        remotehttp.FetchKey    `json:"requestKey"`
+		Target            remotehttp.FetchTarget `json:"target"`
+		HasTLSConfig      bool                   `json:"hasTLSConfig"`
+		HasProxyTLSConfig bool                   `json:"hasProxyTLSConfig"`
+		TTL               time.Duration          `json:"ttl"`
+	}
+
+	return json.Marshal(jsonSharedJwksRequest{
+		RequestKey:        r.RequestKey,
+		Target:            r.Target,
+		HasTLSConfig:      r.TLSConfig != nil,
+		HasProxyTLSConfig: r.ProxyTLSConfig != nil,
+		TTL:               r.TTL,
+	})
 }
 
 // JwksSource returns the canonical runtime request consumed by the Fetcher.

--- a/controller/pkg/agentgateway/jwks/types.go
+++ b/controller/pkg/agentgateway/jwks/types.go
@@ -54,8 +54,8 @@ func (s JwksSource) MarshalJSON() ([]byte, error) {
 		OwnerKey:          s.OwnerKey,
 		RequestKey:        s.RequestKey,
 		Target:            s.Target,
-		HasTLSConfig:      s.TLSConfig != nil,
-		HasProxyTLSConfig: s.ProxyTLSConfig != nil,
+		HasTLSConfig:      s.TLSConfig != nil,      // the underlying tls.Config is not serializable, so we will just indicate its presence
+		HasProxyTLSConfig: s.ProxyTLSConfig != nil, // the underlying tls.Config is not serializable, so we will just indicate its presence
 		TTL:               s.TTL,
 	})
 }
@@ -94,8 +94,8 @@ func (r SharedJwksRequest) MarshalJSON() ([]byte, error) {
 	return json.Marshal(jsonSharedJwksRequest{
 		RequestKey:        r.RequestKey,
 		Target:            r.Target,
-		HasTLSConfig:      r.TLSConfig != nil,
-		HasProxyTLSConfig: r.ProxyTLSConfig != nil,
+		HasTLSConfig:      r.TLSConfig != nil,      // the underlying tls.Config is not serializable, so we will just indicate its presence
+		HasProxyTLSConfig: r.ProxyTLSConfig != nil, // the underlying tls.Config is not serializable, so we will just indicate its presence
 		TTL:               r.TTL,
 	})
 }

--- a/controller/pkg/agentgateway/jwks/types_json_test.go
+++ b/controller/pkg/agentgateway/jwks/types_json_test.go
@@ -1,0 +1,72 @@
+package jwks
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/remotehttp"
+)
+
+func TestJwksSourceMarshalJSONOmitsTLSConfigObjects(t *testing.T) {
+	source := JwksSource{
+		OwnerKey: JwksOwnerID{
+			Kind:      OwnerKindPolicy,
+			Namespace: "agentgateway-base",
+			Name:      "route-policy",
+			Path:      "spec.traffic.jwtAuthentication.providers[0].jwks.remote",
+		},
+		RequestKey:     remotehttp.FetchKey("request-key"),
+		Target:         remotehttp.FetchTarget{URL: "https://dummy-idp.default.svc/org-one/keys"},
+		TLSConfig:      &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+		ProxyTLSConfig: &tls.Config{ServerName: "proxy.internal"},
+		TTL:            5 * time.Minute,
+	}
+
+	payload, err := json.Marshal(source)
+	require.NoError(t, err)
+	require.JSONEq(t, `{
+		"ownerKey": {
+			"Kind": "AgentgatewayPolicy",
+			"Namespace": "agentgateway-base",
+			"Name": "route-policy",
+			"Path": "spec.traffic.jwtAuthentication.providers[0].jwks.remote"
+		},
+		"requestKey": "request-key",
+		"target": {
+			"url": "https://dummy-idp.default.svc/org-one/keys",
+			"transport": {},
+			"proxyTransport": {}
+		},
+		"hasTLSConfig": true,
+		"hasProxyTLSConfig": true,
+		"ttl": 300000000000
+	}`, string(payload))
+}
+
+func TestSharedJwksRequestMarshalJSONOmitsTLSConfigObjects(t *testing.T) {
+	request := SharedJwksRequest{
+		RequestKey:     remotehttp.FetchKey("request-key"),
+		Target:         remotehttp.FetchTarget{URL: "https://dummy-idp.default.svc/org-one/keys"},
+		TLSConfig:      &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+		ProxyTLSConfig: &tls.Config{ServerName: "proxy.internal"},
+		TTL:            5 * time.Minute,
+	}
+
+	payload, err := json.Marshal(request)
+	require.NoError(t, err)
+	require.JSONEq(t, `{
+		"requestKey": "request-key",
+		"target": {
+			"url": "https://dummy-idp.default.svc/org-one/keys",
+			"transport": {},
+			"proxyTransport": {}
+		},
+		"hasTLSConfig": true,
+		"hasProxyTLSConfig": true,
+		"ttl": 300000000000
+	}`, string(payload))
+}

--- a/controller/pkg/agentgateway/jwks/types_json_test.go
+++ b/controller/pkg/agentgateway/jwks/types_json_test.go
@@ -21,8 +21,8 @@ func TestJwksSourceMarshalJSONOmitsTLSConfigObjects(t *testing.T) {
 		},
 		RequestKey:     remotehttp.FetchKey("request-key"),
 		Target:         remotehttp.FetchTarget{URL: "https://dummy-idp.default.svc/org-one/keys"},
-		TLSConfig:      &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
-		ProxyTLSConfig: &tls.Config{ServerName: "proxy.internal"},
+		TLSConfig:      &tls.Config{InsecureSkipVerify: true},     //nolint:gosec // purely test data
+		ProxyTLSConfig: &tls.Config{ServerName: "proxy.internal"}, //nolint:gosec // purely test data
 		TTL:            5 * time.Minute,
 	}
 
@@ -51,8 +51,8 @@ func TestSharedJwksRequestMarshalJSONOmitsTLSConfigObjects(t *testing.T) {
 	request := SharedJwksRequest{
 		RequestKey:     remotehttp.FetchKey("request-key"),
 		Target:         remotehttp.FetchTarget{URL: "https://dummy-idp.default.svc/org-one/keys"},
-		TLSConfig:      &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
-		ProxyTLSConfig: &tls.Config{ServerName: "proxy.internal"},
+		TLSConfig:      &tls.Config{InsecureSkipVerify: true},     //nolint:gosec // purely test data
+		ProxyTLSConfig: &tls.Config{ServerName: "proxy.internal"}, //nolint:gosec // purely test data
 		TTL:            5 * time.Minute,
 	}
 


### PR DESCRIPTION
KRT snapshot page was attempting to JSON marshal raw `tls.Config` types, resulting in errors like:

```
json: error calling MarshalJSON for type *krt.DebugHandler: json: error calling MarshalJSON for type krt.DebugCollection: json: unsupported type: func() time.Time
```

This commit will explicitly avoid marshaling those fields (similar to how they are already excluded from the krt `Equals` computation)