### PR TITLE
flake: eviction test flake

### DIFF
--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -2610,7 +2610,10 @@ mod tests {
 						},
 						"policies": {
 							"health": {
-								"unhealthyExpression": "response.code == 429"
+								"unhealthyExpression": "response.code == 429",
+								"eviction": {
+									"duration": "1s"
+								}
 							}
 						}
 					}]


### PR DESCRIPTION
Root cause: the test’s health eviction duration was implicitly falling back to the retry backoff, and both were 10ms, so under stress the primary provider could be unevicted right as the retry selected the next provider.

Signed-off-by: John Howard <john.howard@solo.io>
