### PR TITLE
http: ensure we only rewrite on proper pathPrefix match

### DIFF
--- a/crates/agentgateway/src/http/filters.rs
+++ b/crates/agentgateway/src/http/filters.rs
@@ -431,9 +431,11 @@ fn rewrite_path(
 					"prefix redirect requires prefix match".to_string(),
 				));
 			};
+			let match_pfx = match_pfx.trim_end_matches('/');
+			let Some(rest) = strip_segment_prefix(orig.path(), match_pfx) else {
+				return Err(Error::InvalidURI);
+			};
 			let mut new_path = r.to_string();
-			// path prefix ignores trailing / so trim those out
-			let (_, rest) = orig.path().split_at(match_pfx.trim_end_matches("/").len());
 			if !new_path.ends_with('/') && !rest.is_empty() && !rest.starts_with('/') {
 				new_path.push('/');
 			}
@@ -447,6 +449,15 @@ fn rewrite_path(
 			}
 			Ok(new_path.try_into()?)
 		},
+	}
+}
+
+fn strip_segment_prefix<'a>(path: &'a str, prefix: &str) -> Option<&'a str> {
+	let rest = path.strip_prefix(prefix)?;
+	if prefix.is_empty() || rest.is_empty() || rest.starts_with('/') {
+		Some(rest)
+	} else {
+		None
 	}
 }
 

--- a/crates/agentgateway/src/http/filters_test.rs
+++ b/crates/agentgateway/src/http/filters_test.rs
@@ -825,6 +825,24 @@ fn rewrite_test() {
 				uri: "http://test.com/v1".to_string(),
 			}),
 		),
+		(
+			"path_prefix_rewrite_rejects_partial_segment",
+			Input {
+				path: &match_api,
+				rewrite: &prefix_path_rewrite,
+				uri: "http://test.com/apiary",
+			},
+			None,
+		),
+		(
+			"path_prefix_rewrite_rejects_encoded_slash_boundary",
+			Input {
+				path: &match_api,
+				rewrite: &prefix_path_rewrite,
+				uri: "http://test.com/api%2Fv1",
+			},
+			None,
+		),
 		// Test hostname rewrite with HTTPS
 		(
 			"hostname_rewrite_https",

--- a/crates/agentgateway/src/http/route_test.rs
+++ b/crates/agentgateway/src/http/route_test.rs
@@ -199,6 +199,26 @@ fn test_path_matching() {
 			path: "/api/v1/users/123",
 			expected_route: Some("prefix-path"),
 		},
+		TestCase {
+			name: "prefix path exact segment match without trailing slash",
+			path: "/api",
+			expected_route: Some("prefix-path"),
+		},
+		TestCase {
+			name: "prefix path does not match partial segment",
+			path: "/apiary",
+			expected_route: Some("root-prefix"),
+		},
+		TestCase {
+			name: "prefix path does not match encoded slash as segment boundary",
+			path: "/api%2Fv1",
+			expected_route: Some("root-prefix"),
+		},
+		TestCase {
+			name: "prefix path matches raw double slash segment",
+			path: "/api//v1",
+			expected_route: Some("prefix-path"),
+		},
 		// Test regex path matching
 		TestCase {
 			name: "regex path match",


### PR DESCRIPTION
Signed-off-by: John Howard <john.howard@solo.io>
