### PR TITLE
feat(metrics): Configuration synchronisation metric

### DIFF
--- a/crates/agentgateway/src/app.rs
+++ b/crates/agentgateway/src/app.rs
@@ -83,8 +83,7 @@ pub async fn run(config: Arc<Config>) -> anyhow::Result<Bound> {
 	let state_mgr = state_manager::StateManager::new(
 		config.clone(),
 		control_client.clone(),
-		xds_metrics,
-		metrics_handle.clone(),
+		Arc::new(xds_metrics),
 		xds_tx,
 	)
 	.await?;

--- a/crates/agentgateway/src/app.rs
+++ b/crates/agentgateway/src/app.rs
@@ -81,7 +81,7 @@ pub async fn run(config: Arc<Config>) -> anyhow::Result<Bound> {
 
 	let (xds_tx, xds_rx) = tokio::sync::watch::channel(());
 	let state_mgr =
-		state_manager::StateManager::new(config.clone(), control_client.clone(), xds_metrics, xds_tx)
+		state_manager::StateManager::new(config.clone(), control_client.clone(), xds_metrics, metrics_handle.clone(), xds_tx)
 			.await?;
 	let stores = state_mgr.stores();
 

--- a/crates/agentgateway/src/app.rs
+++ b/crates/agentgateway/src/app.rs
@@ -80,9 +80,14 @@ pub async fn run(config: Arc<Config>) -> anyhow::Result<Bound> {
 	);
 
 	let (xds_tx, xds_rx) = tokio::sync::watch::channel(());
-	let state_mgr =
-		state_manager::StateManager::new(config.clone(), control_client.clone(), xds_metrics, metrics_handle.clone(), xds_tx)
-			.await?;
+	let state_mgr = state_manager::StateManager::new(
+		config.clone(),
+		control_client.clone(),
+		xds_metrics,
+		metrics_handle.clone(),
+		xds_tx,
+	)
+	.await?;
 	let stores = state_mgr.stores();
 
 	state_manager::start_self_workload_resolution(&config, stores.clone(), &ready);

--- a/crates/agentgateway/src/state_manager.rs
+++ b/crates/agentgateway/src/state_manager.rs
@@ -8,7 +8,6 @@ use tokio::fs;
 
 use crate::client::Client;
 use crate::store::Stores;
-use crate::telemetry::metrics;
 use crate::types::agent::ListenerTarget;
 use crate::types::discovery::SelfIdentitySource;
 use crate::types::proto::agent::Resource as ADPResource;
@@ -34,8 +33,7 @@ impl StateManager {
 	pub async fn new(
 		config: Arc<crate::Config>,
 		client: client::Client,
-		xds_metrics: agent_xds::Metrics,
-		metrics: Arc<metrics::Metrics>,
+		config_metrics: Arc<agent_xds::Metrics>,
 		awaiting_ready: tokio::sync::watch::Sender<()>,
 	) -> anyhow::Result<Self> {
 		let xds = &config.xds;
@@ -58,7 +56,7 @@ impl StateManager {
 				.with_watched_handler::<XdsAddress>(ADDRESS_TYPE, stores.clone().discovery.clone())
 				.with_watched_handler::<ADPResource>(ADP_TYPE, stores.clone().binds.clone())
 				// .with_watched_handler::<XdsAuthorization>(AUTHORIZATION_TYPE, state)
-				.build(xds_metrics, awaiting_ready),
+				.build(config_metrics.clone(), awaiting_ready),
 			)
 		} else {
 			None
@@ -75,7 +73,7 @@ impl StateManager {
 					listener_name: None,
 					port: None,
 				},
-				metrics,
+				metrics: config_metrics,
 			};
 			Box::pin(local_client.run()).await?;
 		}
@@ -102,7 +100,7 @@ pub struct LocalClient {
 	pub stores: Stores,
 	pub client: Client,
 	pub gateway: ListenerTarget,
-	pub metrics: Arc<metrics::Metrics>,
+	pub metrics: Arc<agent_xds::Metrics>,
 }
 
 impl LocalClient {

--- a/crates/agentgateway/src/state_manager.rs
+++ b/crates/agentgateway/src/state_manager.rs
@@ -259,7 +259,6 @@ fn should_reload_config(
 	current_config_path: Option<&Path>,
 	previous_config_path: Option<&Path>,
 ) -> bool {
-    println!("Event: {:?}", event);
 	let target_changed = current_config_path.is_some() && current_config_path != previous_config_path;
 	if target_changed {
 		return true;

--- a/crates/agentgateway/src/state_manager.rs
+++ b/crates/agentgateway/src/state_manager.rs
@@ -35,7 +35,7 @@ impl StateManager {
 		config: Arc<crate::Config>,
 		client: client::Client,
 		xds_metrics: agent_xds::Metrics,
-        metrics: Arc<metrics::Metrics>,
+		metrics: Arc<metrics::Metrics>,
 		awaiting_ready: tokio::sync::watch::Sender<()>,
 	) -> anyhow::Result<Self> {
 		let xds = &config.xds;
@@ -75,7 +75,7 @@ impl StateManager {
 					listener_name: None,
 					port: None,
 				},
-                metrics
+				metrics,
 			};
 			Box::pin(local_client.run()).await?;
 		}
@@ -102,7 +102,7 @@ pub struct LocalClient {
 	pub stores: Stores,
 	pub client: Client,
 	pub gateway: ListenerTarget,
-    pub metrics: Arc<metrics::Metrics>,
+	pub metrics: Arc<metrics::Metrics>,
 }
 
 impl LocalClient {
@@ -188,11 +188,11 @@ impl LocalClient {
 					match lc.reload_config(next_state.clone()).await {
 						Ok(nxt) => {
 							next_state = nxt;
-                            lc.metrics.config_synchronized.set(1);
+							lc.metrics.config_synchronized.set(1);
 							debug!("Config reloaded successfully")
 						},
 						Err(e) => {
-                            lc.metrics.config_synchronized.set(0);
+							lc.metrics.config_synchronized.set(0);
 							error!("Failed to reload config: {}", e)
 						},
 					}

--- a/crates/agentgateway/src/state_manager.rs
+++ b/crates/agentgateway/src/state_manager.rs
@@ -8,6 +8,7 @@ use tokio::fs;
 
 use crate::client::Client;
 use crate::store::Stores;
+use crate::telemetry::metrics;
 use crate::types::agent::ListenerTarget;
 use crate::types::discovery::SelfIdentitySource;
 use crate::types::proto::agent::Resource as ADPResource;
@@ -34,6 +35,7 @@ impl StateManager {
 		config: Arc<crate::Config>,
 		client: client::Client,
 		xds_metrics: agent_xds::Metrics,
+        metrics: Arc<metrics::Metrics>,
 		awaiting_ready: tokio::sync::watch::Sender<()>,
 	) -> anyhow::Result<Self> {
 		let xds = &config.xds;
@@ -73,6 +75,7 @@ impl StateManager {
 					listener_name: None,
 					port: None,
 				},
+                metrics
 			};
 			Box::pin(local_client.run()).await?;
 		}
@@ -99,6 +102,7 @@ pub struct LocalClient {
 	pub stores: Stores,
 	pub client: Client,
 	pub gateway: ListenerTarget,
+    pub metrics: Arc<metrics::Metrics>,
 }
 
 impl LocalClient {
@@ -184,9 +188,11 @@ impl LocalClient {
 					match lc.reload_config(next_state.clone()).await {
 						Ok(nxt) => {
 							next_state = nxt;
+                            lc.metrics.config_synchronized.set(1);
 							debug!("Config reloaded successfully")
 						},
 						Err(e) => {
+                            lc.metrics.config_synchronized.set(0);
 							error!("Failed to reload config: {}", e)
 						},
 					}
@@ -253,6 +259,7 @@ fn should_reload_config(
 	current_config_path: Option<&Path>,
 	previous_config_path: Option<&Path>,
 ) -> bool {
+    println!("Event: {:?}", event);
 	let target_changed = current_config_path.is_some() && current_config_path != previous_config_path;
 	if target_changed {
 		return true;

--- a/crates/agentgateway/src/telemetry/metrics.rs
+++ b/crates/agentgateway/src/telemetry/metrics.rs
@@ -152,7 +152,7 @@ pub struct Metrics {
 	// metrics for request retries
 	pub retries: Counter,
 
-    pub config_synchronized: prometheus_client::metrics::gauge::Gauge,
+	pub config_synchronized: prometheus_client::metrics::gauge::Gauge,
 }
 
 // FilteredRegistry is a wrapper around Registry that allows to filter out certain metrics.
@@ -373,16 +373,16 @@ impl Metrics {
 				"retries",
 				"The total number of request retries",
 			),
-            config_synchronized: {
-                let m = prometheus_client::metrics::gauge::Gauge::default();
-                m.set(1);
-                registry.register(
+			config_synchronized: {
+				let m = prometheus_client::metrics::gauge::Gauge::default();
+				m.set(1);
+				registry.register(
                     "config_synchronized",
                     "Whether the last configuration load/reload was successful or not, being synchronized with the on-disk configuration",
                     m.clone()
                 );
-                m
-            },
+				m
+			},
 		}
 	}
 }

--- a/crates/agentgateway/src/telemetry/metrics.rs
+++ b/crates/agentgateway/src/telemetry/metrics.rs
@@ -151,6 +151,8 @@ pub struct Metrics {
 
 	// metrics for request retries
 	pub retries: Counter,
+
+    pub config_synchronized: prometheus_client::metrics::gauge::Gauge,
 }
 
 // FilteredRegistry is a wrapper around Registry that allows to filter out certain metrics.
@@ -371,6 +373,16 @@ impl Metrics {
 				"retries",
 				"The total number of request retries",
 			),
+            config_synchronized: {
+                let m = prometheus_client::metrics::gauge::Gauge::default();
+                m.set(1);
+                registry.register(
+                    "config_synchronized",
+                    "Whether the last configuration load/reload was successful or not, being synchronized with the on-disk configuration",
+                    m.clone()
+                );
+                m
+            },
 		}
 	}
 }

--- a/crates/agentgateway/src/telemetry/metrics.rs
+++ b/crates/agentgateway/src/telemetry/metrics.rs
@@ -151,8 +151,6 @@ pub struct Metrics {
 
 	// metrics for request retries
 	pub retries: Counter,
-
-	pub config_synchronized: prometheus_client::metrics::gauge::Gauge,
 }
 
 // FilteredRegistry is a wrapper around Registry that allows to filter out certain metrics.
@@ -373,16 +371,6 @@ impl Metrics {
 				"retries",
 				"The total number of request retries",
 			),
-			config_synchronized: {
-				let m = prometheus_client::metrics::gauge::Gauge::default();
-				m.set(1);
-				registry.register(
-                    "config_synchronized",
-                    "Whether the last configuration load/reload was successful or not, being synchronized with the on-disk configuration",
-                    m.clone()
-                );
-				m
-			},
 		}
 	}
 }

--- a/crates/xds/src/client.rs
+++ b/crates/xds/src/client.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::fmt::{Debug, Display, Formatter};
 use std::future::Future;
 use std::pin::Pin;
+use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::Duration;
 use std::{fmt, mem};
@@ -409,7 +410,11 @@ impl Config {
 		}
 	}
 
-	pub fn build(self, metrics: Metrics, block_ready: tokio::sync::watch::Sender<()>) -> AdsClient {
+	pub fn build(
+		self,
+		metrics: Arc<Metrics>,
+		block_ready: tokio::sync::watch::Sender<()>,
+	) -> AdsClient {
 		AdsClient::new(self, metrics, block_ready)
 	}
 }
@@ -427,7 +432,7 @@ pub struct AdsClient {
 
 	state: State,
 
-	pub(crate) metrics: Metrics,
+	pub(crate) metrics: Arc<Metrics>,
 	block_ready: Option<tokio::sync::watch::Sender<()>>,
 
 	connection_id: u32,
@@ -453,7 +458,11 @@ const INITIAL_BACKOFF: Duration = Duration::from_millis(10);
 const MAX_BACKOFF: Duration = Duration::from_secs(15);
 
 impl AdsClient {
-	fn new(config: Config, metrics: Metrics, block_ready: tokio::sync::watch::Sender<()>) -> Self {
+	fn new(
+		config: Config,
+		metrics: Arc<Metrics>,
+		block_ready: tokio::sync::watch::Sender<()>,
+	) -> Self {
 		let state = State {
 			known_resources: Default::default(),
 		};

--- a/crates/xds/src/metrics.rs
+++ b/crates/xds/src/metrics.rs
@@ -2,14 +2,17 @@ use agent_core::metrics::Recorder;
 use prometheus_client::encoding::{EncodeLabelSet, EncodeLabelValue};
 use prometheus_client::metrics::counter::Counter;
 use prometheus_client::metrics::family::Family;
+use prometheus_client::metrics::gauge::Gauge;
 use prometheus_client::registry::{Registry, Unit};
 
 use super::service::discovery::v3::DeltaDiscoveryResponse;
 
+#[derive(Debug)]
 pub struct Metrics {
 	pub connection_terminations: Family<ConnectionTermination, Counter>,
 	pub message_types: Family<TypeUrl, Counter>,
 	pub total_messages_size: Family<TypeUrl, Counter>,
+	pub config_synchronized: Gauge,
 }
 
 #[derive(Clone, Hash, Debug, PartialEq, Eq, EncodeLabelSet)]
@@ -56,10 +59,19 @@ impl Metrics {
 			total_messages_size.clone(),
 		);
 
+		let config_synchronized = Gauge::default();
+		config_synchronized.set(1);
+		registry.register(
+            "config_synchronized",
+            "Whether the last configuration load/reload was successful or not, being synchronized with the on-disk configuration",
+            config_synchronized.clone()
+        );
+
 		Self {
 			connection_terminations,
 			message_types: message_count,
 			total_messages_size,
+			config_synchronized,
 		}
 	}
 }


### PR DESCRIPTION
This addresses the need for a programmatic way to identify whether a configuration load/reload succeeded or not (#2057).

This PR publishes a new metric updated by the `StateManager` on each config update:

```
# HELP agentgateway_config_synchronized Whether the last configuration load/reload was successful or not, being synchronized with the on-disk configuration.
# TYPE agentgateway_config_synchronized gauge
agentgateway_config_synchronized 0
```