### PR TITLE
Fix Tilt-based workflow

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -43,3 +43,30 @@ Run the agentgateway binary:
 ```
 Open your browser and navigate to `http://localhost:15000/ui` to see the agentgateway UI.
 
+## Local Development with Tilt (Kubernetes)
+
+For developing against a local Kind cluster with live reloading:
+
+Requirements (in addition to the above):
+- [Kind](https://kind.sigs.k8s.io/)
+- [Tilt](https://tilt.dev/)
+- [ctlptl](https://github.com/tilt-dev/ctlptl) - used to create a Kind cluster with a local registry
+- [cross](https://github.com/cross-rs/cross) - required for ensuring the Rust backend compiles (or cross-compiles) for Linux
+- Docker (or Podman) — required by both Kind and `cross`
+- Go 1.22+ (for the controller)
+
+>NOTE: On Apple Silicon Macs, Tilt runs the `cross` build container as `linux/amd64` because the
+>default `cross` image for `aarch64-unknown-linux-gnu` does not publish a `linux/arm64` manifest.
+>This still produces the Linux arm64 dataplane binary used by Kind.
+
+Create the local Kind cluster and registry if they do not already exist:
+
+```bash
+ctlptl create cluster kind --name kind-kind --registry=ctlptl-registry
+```
+
+Run:
+
+```bash
+tilt up
+```

--- a/Tiltfile
+++ b/Tiltfile
@@ -57,9 +57,13 @@ docker_build_with_restart(
     image_registry + '/agentgateway-controller',
     context='./tools/tilt/',
     entrypoint='/usr/local/bin/agentgateway-controller',
+    # Run as non-root while ensuring Tilt can do in-place updates of the Go binary
     dockerfile_contents="""
 FROM ubuntu:24.04
-COPY agentgateway-controller /usr/local/bin/agentgateway-controller
+RUN useradd -r -U -u 65532 -s /usr/sbin/nologin agentgateway
+RUN chown agentgateway:agentgateway /usr/local/bin
+COPY --chown=agentgateway:agentgateway agentgateway-controller /usr/local/bin/agentgateway-controller
+USER 65532
 ENTRYPOINT /usr/local/bin/agentgateway-controller
     """,
     # Live update: sync Go binaries

--- a/Tiltfile
+++ b/Tiltfile
@@ -9,6 +9,21 @@ cluster_name = 'kind'
 install_namespace = k8s_namespace()
 image_registry = 'localhost:5000'
 
+# Detect host architecture for cross-compilation
+host_os = str(local('uname -s', quiet=True)).strip()
+host_arch = str(local('uname -m', quiet=True)).strip()
+if host_arch in ['arm64', 'aarch64']:
+    rust_target = 'aarch64-unknown-linux-gnu'
+else:
+    rust_target = 'x86_64-unknown-linux-gnu'
+
+cross_env = ''
+if host_os == 'Darwin' and host_arch in ['arm64', 'aarch64']:
+  cross_env = 'CROSS_CONTAINER_OPTS="${CROSS_CONTAINER_OPTS:+$CROSS_CONTAINER_OPTS }--platform linux/amd64" '
+
+if str(local('command -v cross >/dev/null 2>&1; echo $?', quiet=True)).strip() != '0':
+    fail('cross is required for Tilt dataplane builds. Install it with: cargo install cross')
+
 # Ensure Kind cluster exists
 allow_k8s_contexts('kind-' + cluster_name)
 
@@ -107,9 +122,13 @@ k8s_resource('agentgateway',
 # Data Plane (Rust-based proxy)
 # =============================================================================
 
+# Use cross to consistently build a Linux binary (which can run on Kind)
+# regardless of whether the local machine is Linux or macOS
 local_resource(
   'rust-compile-dataplane',
-  'cargo build && if [ -f "./tools/tilt/agentgateway" ]; then rm "./tools/tilt/agentgateway"; fi && mv ./target/debug/agentgateway ./tools/tilt/agentgateway',
+  cross_env + 'cross build --target ' + rust_target +
+    ' && if [ -f "./tools/tilt/agentgateway" ]; then rm "./tools/tilt/agentgateway"; fi' +
+    ' && mv ./target/' + rust_target + '/debug/agentgateway ./tools/tilt/agentgateway',
   deps=['./crates',
         './Cargo.toml',
         './Cargo.lock',

--- a/controller/hack/helm/dev.yaml
+++ b/controller/hack/helm/dev.yaml
@@ -8,3 +8,11 @@ controller:
     # rollingUpdate:
     #   maxSurge: 100%
     #   maxUnavailable: 100%
+securityContext:
+  allowPrivilegeEscalation: false
+  # Ensure Tilt can update binaries
+  readOnlyRootFilesystem: false
+  runAsNonRoot: true
+  capabilities:
+    drop:
+    - ALL


### PR DESCRIPTION
Ensure the Tilt-based workflow works and can be used cross-platform.

Fixes #2066.
Fixes #2068.