### PR TITLE
docs: fix stale v2.3.0-main version and OCI URL typo in syncer README

### DIFF
--- a/controller/pkg/syncer/README.md
+++ b/controller/pkg/syncer/README.md
@@ -361,13 +361,6 @@ Retag and load the image to match the default image tag in the values file for a
 make run HELM_ADDITIONAL_VALUES=test/e2e/tests/manifests/agent-gateway-integration.yaml; CONFORMANCE_GATEWAY_CLASS=agentgateway make conformance
 ```
 
-Set up a kind cluster and install agentgateway with the kubernetes Gateway APIs:
-```shell
-kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.3.0/standard-install.yaml
-helm upgrade -i --create-namespace --namespace agentgateway-system --version v2.3.0-main agentgateway-crds oci://cr.agentgateway.dev/agentgateway/charts/agentgateway-crds
-helm upgrade -i --namespace agentgateway-system --version v2.3.0-main agentgateway oci://cr.agentgateway/agentgateway/charts/agentgateway
-```
-
 #### HTTPRoute
 
 Apply the httpbin test app:


### PR DESCRIPTION
Fixes #1963

## What's changed

Two bugs in the helm install commands in `controller/pkg/syncer/README.md` (lines 367–368) that made them completely broken for anyone following the docs.

**Bug 1 — stale version `v2.3.0-main`**

Both helm commands referenced `v2.3.0-main` which doesn't exist in the release history. As @npolshakova noted, this was left over from when the project was tied to kgateway versioning. All releases use the `v1.x` series. Updated to `v1.2.1` (latest stable).

**Bug 2 — OCI URL missing `.dev` on line 368**

The agentgateway chart URL had a typo:
```
# before (broken)
oci://cr.agentgateway/agentgateway/charts/agentgateway

# after (fixed)
oci://cr.agentgateway.dev/agentgateway/charts/agentgateway
```

Line 367 (agentgateway-crds) already had the correct `.dev` URL — this only affected line 368.

## Testing

Both commands can now be run as-is without hitting a "chart version not found" or DNS resolution error.