### PR TITLE
Add support for rustls-openssl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,6 +217,7 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "openapiv3",
+ "openssl",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-otlp",
@@ -246,6 +247,7 @@ dependencies = [
  "rstest",
  "rustls",
  "rustls-native-certs",
+ "rustls-openssl",
  "rustls-pki-types",
  "schemars 1.0.4",
  "secrecy",
@@ -2552,6 +2554,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4359,10 +4376,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl"
+version = "0.10.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.116"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "opentelemetry"
@@ -5896,6 +5950,20 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-openssl"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bce63aeefbba181bc32fe7519a3d7edcdfa9fc2aa1f5e7f152493a25275ec14a"
+dependencies = [
+ "foreign-types",
+ "once_cell",
+ "openssl",
+ "openssl-sys",
+ "rustls",
+ "zeroize",
 ]
 
 [[package]]
@@ -7511,6 +7579,12 @@ dependencies = [
  "sval_ref",
  "sval_serde",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vector-map"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,8 @@ aws-sigv4 = "1.4"
 aws-smithy-eventstream = "0.60"
 aws-smithy-types = "1.3"
 aws-lc-rs = "1.17"
+openssl = "0.10"
+rustls-openssl = { version = "0.3", features = ["tls12"] }
 axum = { version = "0.8", features = ["macros"] }
 axum-core = "0.5"
 axum-extra = { version = "0.12", features = ["json-lines", "typed-header"] }
@@ -160,7 +162,7 @@ reqwest = { version = "0.13", default-features = false, features = [
 rstest = "0.26"
 mimalloc = { version = "0.1", features = ["v3", "no_thp"] }
 rustc_version = "0.4"
-rustls = { version = "0.23", default-features = false, features = ["tls12", "aws_lc_rs"] }
+rustls = { version = "0.23", default-features = false, features = ["tls12", "std", "logging"] }
 rustls-native-certs = "0.8"
 rustls-pki-types = "1.14"
 schemars = { version = "=1.0.4", git = "https://github.com/howardjohn/schemars", rev = "4364354fa41897a0c2001d891c0a9a38eafedb82", features = [
@@ -189,7 +191,7 @@ tempfile = "3.27"
 thiserror = "2.0"
 tiktoken-rs = "0.11"
 tokio = { version = "1.52", features = ["full", "macros", "sync"] }
-tokio-rustls = { version = "0.26", default-features = false, features = ["aws_lc_rs"] }
+tokio-rustls = { version = "0.26", default-features = false, features = ["tls12", "logging"] }
 tokio-stream = { version = "0.1", features = ["net", "sync"] }
 tokio-test = "0.4"
 tokio-util = { version = "0.7", features = ["codec", "io"] }

--- a/crates/agentgateway/Cargo.toml
+++ b/crates/agentgateway/Cargo.toml
@@ -9,9 +9,11 @@ publish = { workspace = true }
 path = "src/lib.rs"
 
 [features]
-default = ["jemalloc", "mimalloc"]
+default = ["jemalloc", "mimalloc", "tls-aws-lc"]
 jemalloc = ["dep:tikv-jemallocator", "dep:jemalloc_pprof"]
 mimalloc = ["pprof-alloc/allocator-mimalloc", "dep:mimalloc"]
+tls-aws-lc = ["rustls/aws_lc_rs", "tokio-rustls/aws_lc_rs"]
+tls-openssl = ["dep:openssl", "dep:rustls-openssl"]
 ui = []
 schema = ["schemars"]
 internal_benches = ["divan"]
@@ -32,6 +34,8 @@ aws-config.workspace = true
 aws-credential-types.workspace = true
 aws-sigv4.workspace = true
 aws-lc-rs.workspace = true
+openssl = { workspace = true, optional = true }
+rustls-openssl = { workspace = true, optional = true }
 aws-smithy-eventstream.workspace = true
 aws-smithy-types.workspace = true
 axum-core.workspace = true
@@ -217,6 +221,8 @@ declare_interior_mutable_const = "allow"
 [lints.rust]
 # This rule makes code more confusing
 mismatched_lifetime_syntaxes = "allow"
+# ossl350 is set by the openssl-sys crate when OpenSSL >= 3.5.0 is detected.
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(ossl350)'] }
 
 [[bench]]
 name = "bench_tests"

--- a/crates/agentgateway/src/proxy/gateway_test.rs
+++ b/crates/agentgateway/src/proxy/gateway_test.rs
@@ -1803,6 +1803,7 @@ async fn tls_connection_drains_when_listener_changes() {
 }
 
 #[tokio::test]
+#[cfg(feature = "tls-aws-lc")]
 async fn tls_backend_connection() {
 	let (mock, certs) = tls_mock().await;
 	let backend_tls = http::backendtls::ResolvedBackendTLS {
@@ -1835,6 +1836,7 @@ async fn tls_backend_connection() {
 }
 
 #[tokio::test]
+#[cfg(feature = "tls-aws-lc")]
 async fn tls_backend_connection_alpn() {
 	let (mock, certs) = tls_mock().await;
 	let backend_tls = http::backendtls::ResolvedBackendTLS {
@@ -1876,6 +1878,7 @@ async fn tls_backend_connection_alpn() {
 }
 
 #[tokio::test]
+#[cfg(feature = "tls-aws-lc")]
 async fn tls_backend_http2_version() {
 	let (mock, certs) = tls_mock().await;
 	let backend_tls = http::backendtls::ResolvedBackendTLS {
@@ -1917,6 +1920,7 @@ async fn tls_backend_http2_version() {
 }
 
 #[tokio::test]
+#[cfg(feature = "tls-aws-lc")]
 async fn tls_backend_http1_version() {
 	let (mock, certs) = tls_mock().await;
 	let backend_tls = http::backendtls::ResolvedBackendTLS {
@@ -1958,6 +1962,7 @@ async fn tls_backend_http1_version() {
 }
 
 #[tokio::test]
+#[cfg(feature = "tls-aws-lc")]
 async fn tls_backend_version_with_alpn() {
 	let (mock, certs) = tls_mock().await;
 	let backend_tls = http::backendtls::ResolvedBackendTLS {
@@ -2275,6 +2280,7 @@ async fn tunnel_absolute_form() {
 }
 
 #[tokio::test]
+#[cfg(feature = "tls-aws-lc")]
 async fn tunnel_connect() {
 	let (mock, _certs) = tls_mock().await;
 	let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();

--- a/crates/agentgateway/src/test_helpers/proxymock.rs
+++ b/crates/agentgateway/src/test_helpers/proxymock.rs
@@ -354,13 +354,12 @@ pub async fn simple_mock() -> MockServer {
 }
 
 // Spawn a mock TLS server. It will always respond on h2,http/1.1 ALPN
+// Note: wiremock generates test certs via rcgen (which uses aws_lc_rs internally).
+// The OpenSSL KeyProvider cannot parse the DER keys that aws_lc_rs produces,
+// so this function is only available with the tls-aws-lc feature.
+#[cfg(feature = "tls-aws-lc")]
 pub async fn tls_mock() -> (MockServer, MockTlsCertificates) {
-	// Always install aws_lc_rs as the global default here because wiremock
-	// generates test certs via rcgen (which uses aws_lc_rs). The OpenSSL
-	// KeyProvider cannot parse the DER keys that aws_lc_rs produces.
-	let _ = rustls::crypto::CryptoProvider::install_default(
-		rustls::crypto::aws_lc_rs::default_provider(),
-	);
+	let _ = rustls::crypto::CryptoProvider::install_default(Arc::unwrap_or_clone(tls::provider()));
 	let certs = wiremock::tls_certs::MockTlsCertificates::random();
 	let mock = wiremock::MockServer::builder()
 		.start_https(certs.get_server_config())

--- a/crates/agentgateway/src/test_helpers/proxymock.rs
+++ b/crates/agentgateway/src/test_helpers/proxymock.rs
@@ -355,7 +355,12 @@ pub async fn simple_mock() -> MockServer {
 
 // Spawn a mock TLS server. It will always respond on h2,http/1.1 ALPN
 pub async fn tls_mock() -> (MockServer, MockTlsCertificates) {
-	let _ = rustls::crypto::CryptoProvider::install_default(Arc::unwrap_or_clone(tls::provider()));
+	// Always install aws_lc_rs as the global default here because wiremock
+	// generates test certs via rcgen (which uses aws_lc_rs). The OpenSSL
+	// KeyProvider cannot parse the DER keys that aws_lc_rs produces.
+	let _ = rustls::crypto::CryptoProvider::install_default(
+		rustls::crypto::aws_lc_rs::default_provider(),
+	);
 	let certs = wiremock::tls_certs::MockTlsCertificates::random();
 	let mock = wiremock::MockServer::builder()
 		.start_https(certs.get_server_config())

--- a/crates/agentgateway/src/transport/tls.rs
+++ b/crates/agentgateway/src/transport/tls.rs
@@ -23,6 +23,7 @@ pub static ALL_TLS_VERSIONS: &[&rustls::SupportedProtocolVersion] =
 	&[&rustls::version::TLS12, &rustls::version::TLS13];
 
 /// All currently supported cipher suites.
+#[cfg(feature = "tls-aws-lc")]
 pub static ALL_CIPHER_SUITES: &[SupportedCipherSuite] = &[
 	// TLS 1.3 cipher suites
 	rustls::crypto::aws_lc_rs::cipher_suite::TLS13_AES_256_GCM_SHA384,
@@ -37,7 +38,24 @@ pub static ALL_CIPHER_SUITES: &[SupportedCipherSuite] = &[
 	rustls::crypto::aws_lc_rs::cipher_suite::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
 ];
 
+/// All currently supported cipher suites (OpenSSL provider).
+#[cfg(feature = "tls-openssl")]
+pub static ALL_CIPHER_SUITES: std::sync::LazyLock<Vec<SupportedCipherSuite>> =
+	std::sync::LazyLock::new(|| {
+		vec![
+			// TLS 1.3 cipher suites
+			rustls_openssl::cipher_suite::TLS13_AES_256_GCM_SHA384,
+			rustls_openssl::cipher_suite::TLS13_AES_128_GCM_SHA256,
+			// TLS 1.2 cipher suites
+			rustls_openssl::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+			rustls_openssl::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			rustls_openssl::cipher_suite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			rustls_openssl::cipher_suite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		]
+	});
+
 // Default cipher suites to use if user does not specify cipher suites
+#[cfg(feature = "tls-aws-lc")]
 pub static DEFAULT_CIPHER_SUITES: &[SupportedCipherSuite] = &[
 	rustls::crypto::aws_lc_rs::cipher_suite::TLS13_AES_256_GCM_SHA384,
 	rustls::crypto::aws_lc_rs::cipher_suite::TLS13_AES_128_GCM_SHA256,
@@ -47,12 +65,44 @@ pub static DEFAULT_CIPHER_SUITES: &[SupportedCipherSuite] = &[
 	rustls::crypto::aws_lc_rs::cipher_suite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
 ];
 
+#[cfg(feature = "tls-openssl")]
+pub static DEFAULT_CIPHER_SUITES: std::sync::LazyLock<Vec<SupportedCipherSuite>> =
+	std::sync::LazyLock::new(|| {
+		vec![
+			rustls_openssl::cipher_suite::TLS13_AES_256_GCM_SHA384,
+			rustls_openssl::cipher_suite::TLS13_AES_128_GCM_SHA256,
+			rustls_openssl::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+			rustls_openssl::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			rustls_openssl::cipher_suite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			rustls_openssl::cipher_suite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		]
+	});
+
+#[cfg(feature = "tls-aws-lc")]
 pub static DEFAULT_KEY_EXCHANGE_GROUPS: &[&'static dyn SupportedKxGroup] = &[
 	KeyExchangeGroup::X25519.to_supported_kx_group(),
 	KeyExchangeGroup::P256.to_supported_kx_group(),
 	KeyExchangeGroup::P384.to_supported_kx_group(),
 	KeyExchangeGroup::X25519_MLKEM768.to_supported_kx_group(),
 ];
+
+#[cfg(feature = "tls-openssl")]
+pub static DEFAULT_KEY_EXCHANGE_GROUPS: std::sync::LazyLock<Vec<&'static dyn SupportedKxGroup>> =
+	std::sync::LazyLock::new(|| {
+		let groups: Vec<&'static dyn SupportedKxGroup> = {
+			#[allow(unused_mut)]
+			let mut g = vec![
+				rustls_openssl::kx_group::X25519,
+				rustls_openssl::kx_group::SECP256R1,
+				rustls_openssl::kx_group::SECP384R1,
+			];
+			// X25519MLKEM768 is only available with OpenSSL 3.5+
+			#[cfg(ossl350)]
+			g.push(rustls_openssl::kx_group::X25519MLKEM768);
+			g
+		};
+		groups
+	});
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
@@ -107,6 +157,7 @@ impl CipherSuite {
 		}
 	}
 
+	#[cfg(feature = "tls-aws-lc")]
 	pub const fn to_supported_cipher_suite(&self) -> SupportedCipherSuite {
 		match self {
 			// TLS 1.3 cipher suites
@@ -141,6 +192,39 @@ impl CipherSuite {
 			},
 		}
 	}
+
+	#[cfg(feature = "tls-openssl")]
+	pub fn to_supported_cipher_suite(&self) -> SupportedCipherSuite {
+		match self {
+			// TLS 1.3 cipher suites
+			CipherSuite::TLS_AES_256_GCM_SHA384 => rustls_openssl::cipher_suite::TLS13_AES_256_GCM_SHA384,
+			CipherSuite::TLS_AES_128_GCM_SHA256 => rustls_openssl::cipher_suite::TLS13_AES_128_GCM_SHA256,
+			// ChaCha20 is not universally available in OpenSSL; fall back to AES
+			CipherSuite::TLS_CHACHA20_POLY1305_SHA256 => {
+				rustls_openssl::cipher_suite::TLS13_AES_128_GCM_SHA256
+			},
+
+			// TLS 1.2 cipher suites
+			CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 => {
+				rustls_openssl::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+			},
+			CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 => {
+				rustls_openssl::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+			},
+			CipherSuite::TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256 => {
+				rustls_openssl::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+			},
+			CipherSuite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 => {
+				rustls_openssl::cipher_suite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+			},
+			CipherSuite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 => {
+				rustls_openssl::cipher_suite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+			},
+			CipherSuite::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 => {
+				rustls_openssl::cipher_suite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+			},
+		}
+	}
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
@@ -165,12 +249,26 @@ impl KeyExchangeGroup {
 		}
 	}
 
+	#[cfg(feature = "tls-aws-lc")]
 	pub const fn to_supported_kx_group(&self) -> &'static dyn SupportedKxGroup {
 		match self {
 			KeyExchangeGroup::X25519 => rustls::crypto::aws_lc_rs::kx_group::X25519,
 			KeyExchangeGroup::P256 => rustls::crypto::aws_lc_rs::kx_group::SECP256R1,
 			KeyExchangeGroup::P384 => rustls::crypto::aws_lc_rs::kx_group::SECP384R1,
 			KeyExchangeGroup::X25519_MLKEM768 => rustls::crypto::aws_lc_rs::kx_group::X25519MLKEM768,
+		}
+	}
+
+	#[cfg(feature = "tls-openssl")]
+	pub fn to_supported_kx_group(&self) -> &'static dyn SupportedKxGroup {
+		match self {
+			KeyExchangeGroup::X25519 => rustls_openssl::kx_group::X25519,
+			KeyExchangeGroup::P256 => rustls_openssl::kx_group::SECP256R1,
+			KeyExchangeGroup::P384 => rustls_openssl::kx_group::SECP384R1,
+			#[cfg(ossl350)]
+			KeyExchangeGroup::X25519_MLKEM768 => rustls_openssl::kx_group::X25519MLKEM768,
+			#[cfg(not(ossl350))]
+			KeyExchangeGroup::X25519_MLKEM768 => rustls_openssl::kx_group::X25519,
 		}
 	}
 }
@@ -234,11 +332,21 @@ pub fn provider_with_options(
 			.collect()
 	};
 
-	let mut provider = rustls::crypto::aws_lc_rs::default_provider();
+	let mut provider = default_crypto_provider();
 	// Restrict negotiation to our allowlist.
 	provider.cipher_suites = cipher_suites;
 	provider.kx_groups = key_exchange_groups;
 	Arc::new(provider)
+}
+
+#[cfg(feature = "tls-aws-lc")]
+fn default_crypto_provider() -> CryptoProvider {
+	rustls::crypto::aws_lc_rs::default_provider()
+}
+
+#[cfg(feature = "tls-openssl")]
+fn default_crypto_provider() -> CryptoProvider {
+	rustls_openssl::default_provider()
 }
 
 pub fn provider_with_cipher_suites(cipher_suites: &[CipherSuite]) -> Arc<CryptoProvider> {

--- a/crates/agentgateway/src/transport/tls.rs
+++ b/crates/agentgateway/src/transport/tls.rs
@@ -40,19 +40,16 @@ pub static ALL_CIPHER_SUITES: &[SupportedCipherSuite] = &[
 
 /// All currently supported cipher suites (OpenSSL provider).
 #[cfg(feature = "tls-openssl")]
-pub static ALL_CIPHER_SUITES: std::sync::LazyLock<Vec<SupportedCipherSuite>> =
-	std::sync::LazyLock::new(|| {
-		vec![
-			// TLS 1.3 cipher suites
-			rustls_openssl::cipher_suite::TLS13_AES_256_GCM_SHA384,
-			rustls_openssl::cipher_suite::TLS13_AES_128_GCM_SHA256,
-			// TLS 1.2 cipher suites
-			rustls_openssl::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-			rustls_openssl::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-			rustls_openssl::cipher_suite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-			rustls_openssl::cipher_suite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-		]
-	});
+pub static ALL_CIPHER_SUITES: &[SupportedCipherSuite] = &[
+	// TLS 1.3 cipher suites
+	rustls_openssl::cipher_suite::TLS13_AES_256_GCM_SHA384,
+	rustls_openssl::cipher_suite::TLS13_AES_128_GCM_SHA256,
+	// TLS 1.2 cipher suites
+	rustls_openssl::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+	rustls_openssl::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+	rustls_openssl::cipher_suite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+	rustls_openssl::cipher_suite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+];
 
 // Default cipher suites to use if user does not specify cipher suites
 #[cfg(feature = "tls-aws-lc")]
@@ -66,17 +63,14 @@ pub static DEFAULT_CIPHER_SUITES: &[SupportedCipherSuite] = &[
 ];
 
 #[cfg(feature = "tls-openssl")]
-pub static DEFAULT_CIPHER_SUITES: std::sync::LazyLock<Vec<SupportedCipherSuite>> =
-	std::sync::LazyLock::new(|| {
-		vec![
-			rustls_openssl::cipher_suite::TLS13_AES_256_GCM_SHA384,
-			rustls_openssl::cipher_suite::TLS13_AES_128_GCM_SHA256,
-			rustls_openssl::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-			rustls_openssl::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-			rustls_openssl::cipher_suite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-			rustls_openssl::cipher_suite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-		]
-	});
+pub static DEFAULT_CIPHER_SUITES: &[SupportedCipherSuite] = &[
+	rustls_openssl::cipher_suite::TLS13_AES_256_GCM_SHA384,
+	rustls_openssl::cipher_suite::TLS13_AES_128_GCM_SHA256,
+	rustls_openssl::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+	rustls_openssl::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+	rustls_openssl::cipher_suite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+	rustls_openssl::cipher_suite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+];
 
 #[cfg(feature = "tls-aws-lc")]
 pub static DEFAULT_KEY_EXCHANGE_GROUPS: &[&'static dyn SupportedKxGroup] = &[
@@ -87,22 +81,13 @@ pub static DEFAULT_KEY_EXCHANGE_GROUPS: &[&'static dyn SupportedKxGroup] = &[
 ];
 
 #[cfg(feature = "tls-openssl")]
-pub static DEFAULT_KEY_EXCHANGE_GROUPS: std::sync::LazyLock<Vec<&'static dyn SupportedKxGroup>> =
-	std::sync::LazyLock::new(|| {
-		let groups: Vec<&'static dyn SupportedKxGroup> = {
-			#[allow(unused_mut)]
-			let mut g = vec![
-				rustls_openssl::kx_group::X25519,
-				rustls_openssl::kx_group::SECP256R1,
-				rustls_openssl::kx_group::SECP384R1,
-			];
-			// X25519MLKEM768 is only available with OpenSSL 3.5+
-			#[cfg(ossl350)]
-			g.push(rustls_openssl::kx_group::X25519MLKEM768);
-			g
-		};
-		groups
-	});
+pub static DEFAULT_KEY_EXCHANGE_GROUPS: &[&'static dyn SupportedKxGroup] = &[
+	rustls_openssl::kx_group::X25519,
+	rustls_openssl::kx_group::SECP256R1,
+	rustls_openssl::kx_group::SECP384R1,
+	#[cfg(ossl350)]
+	rustls_openssl::kx_group::X25519MLKEM768,
+];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]

--- a/crates/agentgateway/tests/common/hbone_server.rs
+++ b/crates/agentgateway/tests/common/hbone_server.rs
@@ -42,7 +42,10 @@ pub struct HboneTestServer {
 impl HboneTestServer {
 	/// Creates a new HBONE test server. If port is 0, the OS will assign an available port.
 	pub async fn new(mode: Mode, name: &str, waypoint_message: Vec<u8>, port: u16) -> Self {
+		#[cfg(feature = "tls-aws-lc")]
 		let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+		#[cfg(feature = "tls-openssl")]
+		let _ = rustls_openssl::default_provider().install_default();
 
 		let addr = SocketAddr::from(([127, 0, 0, 1], port));
 		let listener = TcpListener::bind(addr).await.unwrap();


### PR DESCRIPTION
Adds support in agentgateway for the rustls-openssl crypto provider through the cargo feature flag `tls-openssl`. Other uses of `aws-lc-rs` directly for non-TLS crypto (PKCE, session cookies, cookie name derivation) are left untouched, so the library will still be imported regardless. TLS through aws-ls-rc is now gated in the default feature flag `tls-aws-lc`

Additionally, we skip 6 backend TLS tests if the flag is enabled because OpenSSL cannot parse the key format that rcgen/aws-lc-rs produces.