### PR TITLE
mcp: advertise tools.listChanged in multiplexing mode

### DIFF
--- a/crates/agentgateway/src/mcp/handler.rs
+++ b/crates/agentgateway/src/mcp/handler.rs
@@ -606,6 +606,7 @@ impl Relay {
 			// Resources are supported with multiplexing using service+scheme:// URI prefixing.
 			ServerCapabilities::builder()
 				.enable_tools()
+				.enable_tool_list_changed()
 				.enable_prompts()
 				.enable_resources()
 				.build()

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -234,6 +234,25 @@ async fn stream_to_multiplex_resources() {
 }
 
 #[tokio::test]
+async fn multiplex_advertises_tool_list_changed() {
+	let mock_a = mock_streamable_http_server(true).await;
+	let mock_b = mock_streamable_http_server(true).await;
+	let t = setup_proxy_test("{}")
+		.unwrap()
+		.with_multiplex_mcp_backend(
+			"mcp",
+			vec![("a", mock_a.addr, false), ("b", mock_b.addr, false)],
+			true,
+		)
+		.with_bind(simple_bind())
+		.with_route(basic_named_route(strng::new("/mcp")));
+	let io = t.serve_real_listener(strng::new("bind")).await;
+	let client = mcp_streamable_client(io).await;
+	let caps = &client.peer_info().unwrap().capabilities;
+	assert_eq!(caps.tools.as_ref().unwrap().list_changed, Some(true));
+}
+
+#[tokio::test]
 async fn stateless_multiplex_tool_call_initializes_only_target() {
 	let mock_a = mock_streamable_http_server(true).await;
 	let mock_b = mock_streamable_http_server(true).await;


### PR DESCRIPTION
Upstream notifications are forwarded to the client, but the capabilities the gateway builds for multiplexing never declared `tools.listChanged`, so spec-compliant clients discard forwarded `notifications/tools/list_changed` instead of refetching `tools/list`. Single-target mode is unaffected: the upstream's own capabilities pass through verbatim.

Advertising unconditionally (rather than only when some upstream advertises it) is deliberate: the merged tool list of a multiplexed backend can change mid-session even when individual upstreams are static, e.g. when a target is skipped under `failOpen`.

`prompts`/`resources` `listChanged` have the same gap and can be added similarly if desired; `resources.subscribe` requires real subscription routing and stays out of scope.

Includes an integration test asserting the client-visible `InitializeResult` advertises the capability in multiplexing mode.