### PR TITLE
agctl: add get, describe, and analyze commands

### DIFF
--- a/controller/pkg/cli/resource/cmd/analyze.go
+++ b/controller/pkg/cli/resource/cmd/analyze.go
@@ -1,0 +1,254 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	agwv1a1 "github.com/agentgateway/agentgateway/controller/api/v1alpha1/agentgateway"
+	"github.com/agentgateway/agentgateway/controller/pkg/cli/resource"
+)
+
+type analyzeFlags struct {
+	namespace     string
+	allNamespaces bool
+}
+
+// BuildAnalyzeCmd returns the `agctl analyze` cobra command.
+// It performs pure read-only validation of resources against the cluster state.
+func BuildAnalyzeCmd() *cobra.Command {
+	f := &analyzeFlags{}
+
+	cmd := &cobra.Command{
+		Use:   "analyze",
+		Short: "Validate resources for broken references and misconfigurations",
+		Long: `Validate Agentgateway resources by reading cluster state.
+
+Checks performed:
+  - HTTPRoute parent refs resolve to existing Gateways
+  - AgentgatewayPolicy targetRefs point at existing resources
+  - AgentgatewayBackend static host/port sanity
+
+No cluster-side execution; pure Kubernetes API reads.`,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runAnalyze(cmd.Context(), f, cmd)
+		},
+	}
+
+	cmd.Flags().StringVarP(&f.namespace, "namespace", "n", "", "Kubernetes namespace (default: current context namespace)")
+	cmd.Flags().BoolVarP(&f.allNamespaces, "all-namespaces", "A", false, "Analyze resources across all namespaces")
+	return cmd
+}
+
+type finding struct {
+	kind      string
+	namespace string
+	name      string
+	message   string
+}
+
+func runAnalyze(ctx context.Context, f *analyzeFlags, cmd *cobra.Command) error {
+	c, err := resource.NewClient()
+	if err != nil {
+		return err
+	}
+
+	namespace := f.namespace
+	if !f.allNamespaces && namespace == "" {
+		namespace, err = resolveNamespace()
+		if err != nil {
+			return err
+		}
+	}
+
+	var findings []finding
+
+	findings = append(findings, analyzeHTTPRoutes(ctx, c, namespace)...)
+	findings = append(findings, analyzeAgentgatewayPolicies(ctx, c, namespace)...)
+	findings = append(findings, analyzeAgentgatewayBackends(ctx, c, namespace)...)
+
+	if len(findings) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "No issues found.")
+		return nil
+	}
+
+	for _, f := range findings {
+		ns := f.namespace
+		if ns != "" {
+			fmt.Fprintf(cmd.OutOrStdout(), "[%s] %s/%s: %s\n", f.kind, ns, f.name, f.message)
+		} else {
+			fmt.Fprintf(cmd.OutOrStdout(), "[%s] %s: %s\n", f.kind, f.name, f.message)
+		}
+	}
+	return fmt.Errorf("%d issue(s) found", len(findings))
+}
+
+func analyzeHTTPRoutes(ctx context.Context, c client.Client, namespace string) []finding {
+	var routes gwv1.HTTPRouteList
+	var opts []client.ListOption
+	if namespace != "" {
+		opts = append(opts, client.InNamespace(namespace))
+	}
+	if err := c.List(ctx, &routes, opts...); err != nil {
+		return []finding{{kind: "HTTPRoute", message: fmt.Sprintf("failed to list: %v", err)}}
+	}
+
+	// Cache gateway existence checks to avoid N+1 API calls when multiple
+	// routes reference the same parent gateway. Only cache definitive results
+	// (found or not-found); transient errors are not cached so retries are possible.
+	type gwResult struct{ missing bool; err error }
+	gwCache := map[client.ObjectKey]gwResult{}
+
+	var out []finding
+	for _, route := range routes.Items {
+		for _, ref := range route.Spec.ParentRefs {
+			gwNamespace := route.Namespace
+			if ref.Namespace != nil {
+				gwNamespace = string(*ref.Namespace)
+			}
+			key := client.ObjectKey{Namespace: gwNamespace, Name: string(ref.Name)}
+
+			result, cached := gwCache[key]
+			if !cached {
+				var gw gwv1.Gateway
+				err := c.Get(ctx, key, &gw)
+				result = gwResult{missing: apierrors.IsNotFound(err)}
+				if !apierrors.IsNotFound(err) {
+					result.err = err
+				}
+				// Only cache definitive outcomes; transient errors are left uncached.
+				if err == nil || apierrors.IsNotFound(err) {
+					gwCache[key] = result
+				}
+			}
+
+			if result.missing {
+				out = append(out, finding{
+					kind:      "HTTPRoute",
+					namespace: route.Namespace,
+					name:      route.Name,
+					message:   fmt.Sprintf("parentRef Gateway %s/%s not found", gwNamespace, ref.Name),
+				})
+			} else if result.err != nil {
+				out = append(out, finding{
+					kind:      "HTTPRoute",
+					namespace: route.Namespace,
+					name:      route.Name,
+					message:   fmt.Sprintf("error checking parentRef Gateway %s/%s: %v", gwNamespace, ref.Name, result.err),
+				})
+			}
+		}
+	}
+	return out
+}
+
+func analyzeAgentgatewayPolicies(ctx context.Context, c client.Client, namespace string) []finding {
+	var policies agwv1a1.AgentgatewayPolicyList
+	var opts []client.ListOption
+	if namespace != "" {
+		opts = append(opts, client.InNamespace(namespace))
+	}
+	if err := c.List(ctx, &policies, opts...); err != nil {
+		return []finding{{kind: "AgentgatewayPolicy", message: fmt.Sprintf("failed to list: %v", err)}}
+	}
+
+	var out []finding
+	for _, pol := range policies.Items {
+		for _, ref := range pol.Spec.TargetRefs {
+			targetName := string(ref.Name)
+			targetKind := string(ref.Kind)
+			targetGroup := string(ref.Group)
+
+			if err := checkTargetExists(ctx, c, targetGroup, targetKind, pol.Namespace, targetName); err != nil {
+				out = append(out, finding{
+					kind:      "AgentgatewayPolicy",
+					namespace: pol.Namespace,
+					name:      pol.Name,
+					message:   fmt.Sprintf("targetRef %s/%s %q: %v", targetGroup, targetKind, targetName, err),
+				})
+			}
+		}
+		for _, sel := range pol.Spec.TargetSelectors {
+			targetKind := string(sel.Kind)
+			targetGroup := string(sel.Group)
+			if !isSupportedTargetKind(targetKind) {
+				out = append(out, finding{
+					kind:      "AgentgatewayPolicy",
+					namespace: pol.Namespace,
+					name:      pol.Name,
+					message:   fmt.Sprintf("targetSelector %s/%s: unknown kind — cannot verify target existence", targetGroup, targetKind),
+				})
+			}
+		}
+	}
+	return out
+}
+
+func analyzeAgentgatewayBackends(ctx context.Context, c client.Client, namespace string) []finding {
+	var backends agwv1a1.AgentgatewayBackendList
+	var opts []client.ListOption
+	if namespace != "" {
+		opts = append(opts, client.InNamespace(namespace))
+	}
+	if err := c.List(ctx, &backends, opts...); err != nil {
+		return []finding{{kind: "AgentgatewayBackend", message: fmt.Sprintf("failed to list: %v", err)}}
+	}
+
+	var out []finding
+	for _, be := range backends.Items {
+		if be.Spec.Static != nil {
+			if be.Spec.Static.Host == "" && be.Spec.Static.UnixPath == nil {
+				out = append(out, finding{
+					kind:      "AgentgatewayBackend",
+					namespace: be.Namespace,
+					name:      be.Name,
+					message:   "static backend must specify host+port or unixPath",
+				})
+			}
+		}
+	}
+	return out
+}
+
+// isSupportedTargetKind reports whether the given kind is one that
+// checkTargetExists can verify.
+func isSupportedTargetKind(kind string) bool {
+	switch kind {
+	case "Gateway", "HTTPRoute", "AgentgatewayBackend":
+		return true
+	default:
+		return false
+	}
+}
+
+// checkTargetExists verifies that a referenced resource exists.
+// Supports Gateway, HTTPRoute, and AgentgatewayBackend.
+// Returns an error for unknown kinds so callers can surface a warning finding.
+func checkTargetExists(ctx context.Context, c client.Client, _, kind, namespace, name string) error {
+	key := client.ObjectKey{Namespace: namespace, Name: name}
+	var obj client.Object
+
+	switch kind {
+	case "Gateway":
+		obj = &gwv1.Gateway{}
+	case "HTTPRoute":
+		obj = &gwv1.HTTPRoute{}
+	case "AgentgatewayBackend":
+		obj = &agwv1a1.AgentgatewayBackend{}
+	default:
+		return fmt.Errorf("unknown kind %q — cannot verify target existence", kind)
+	}
+
+	if err := c.Get(ctx, key, obj); err != nil {
+		if apierrors.IsNotFound(err) {
+			return fmt.Errorf("not found")
+		}
+		return err
+	}
+	return nil
+}

--- a/controller/pkg/cli/resource/cmd/describe.go
+++ b/controller/pkg/cli/resource/cmd/describe.go
@@ -1,0 +1,71 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/agentgateway/agentgateway/controller/pkg/cli/resource"
+)
+
+type describeFlags struct {
+	namespace string
+}
+
+// BuildDescribeCmd returns the `agctl describe` cobra command.
+func BuildDescribeCmd() *cobra.Command {
+	f := &describeFlags{}
+
+	cmd := &cobra.Command{
+		Use:          "describe <resource> <name>",
+		Short:        "Show detailed information about a resource",
+		Aliases:      []string{"desc"},
+		Args:         cobra.ExactArgs(2),
+		ValidArgs:    collectAliases(),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDescribe(cmd.Context(), f, args, cmd)
+		},
+	}
+
+	cmd.Flags().StringVarP(&f.namespace, "namespace", "n", "", "Kubernetes namespace")
+	return cmd
+}
+
+func runDescribe(ctx context.Context, f *describeFlags, args []string, cmd *cobra.Command) error {
+	resourceType := args[0]
+	name := args[1]
+
+	h, err := resource.Lookup(resourceType)
+	if err != nil {
+		return err
+	}
+
+	c, err := resource.NewClient()
+	if err != nil {
+		return err
+	}
+
+	namespace := f.namespace
+	if namespace == "" {
+		namespace, err = resolveNamespace()
+		if err != nil {
+			return err
+		}
+	}
+
+	gvk := h.Mapping().GroupVersionKind
+	gvr := h.Mapping().Resource
+	obj, err := getOne(ctx, c, gvk, gvr, namespace, name)
+	if err != nil {
+		return err
+	}
+
+	sections, err := h.DescribeExtra(obj)
+	if err != nil {
+		return fmt.Errorf("describe: %w", err)
+	}
+
+	return resource.PrintDescribe(cmd.OutOrStdout(), obj, sections)
+}

--- a/controller/pkg/cli/resource/cmd/get.go
+++ b/controller/pkg/cli/resource/cmd/get.go
@@ -1,0 +1,258 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/agentgateway/agentgateway/controller/pkg/cli/kubeutil"
+	"github.com/agentgateway/agentgateway/controller/pkg/cli/printer"
+	"github.com/agentgateway/agentgateway/controller/pkg/cli/resource"
+)
+
+type getFlags struct {
+	namespace     string
+	allNamespaces bool
+	selector      string
+	output        string
+}
+
+// BuildGetCmd returns the `agctl get` cobra command built dynamically
+// from registered resource handlers.
+func BuildGetCmd() *cobra.Command {
+	f := &getFlags{}
+
+	cmd := &cobra.Command{
+		Use:       "get <resource> [name]",
+		Short:     "List or get Agentgateway resources",
+		Long:      buildGetLong(),
+		Aliases:   []string{"g"},
+		Args:      cobra.RangeArgs(1, 2),
+		ValidArgs: collectAliases(),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runGet(cmd.Context(), f, args)
+		},
+		SilenceUsage: true,
+	}
+
+	cmd.Flags().StringVarP(&f.namespace, "namespace", "n", "", "Kubernetes namespace")
+	cmd.Flags().BoolVarP(&f.allNamespaces, "all-namespaces", "A", false, "List across all namespaces")
+	cmd.Flags().StringVarP(&f.selector, "selector", "l", "", "Label selector filter")
+	cmd.Flags().StringVarP(&f.output, "output", "o", "short", "Output format: short|wide|json|yaml")
+
+	return cmd
+}
+
+func runGet(ctx context.Context, f *getFlags, args []string) error {
+	resourceType := args[0]
+	var resourceName string
+	if len(args) == 2 {
+		resourceName = args[1]
+	}
+
+	h, err := resource.Lookup(resourceType)
+	if err != nil {
+		return err
+	}
+
+	switch f.output {
+	case "short", "wide", "json", "yaml":
+	default:
+		return fmt.Errorf("unsupported output format %q; use short, wide, json, or yaml", f.output)
+	}
+
+	c, err := resource.NewClient()
+	if err != nil {
+		return err
+	}
+
+	namespace := f.namespace
+	if f.allNamespaces {
+		namespace = ""
+	} else if namespace == "" {
+		namespace, err = kubeutil.LoadNamespace("")
+		if err != nil {
+			return err
+		}
+	}
+
+	gvk := h.Mapping().GroupVersionKind
+	gvr := h.Mapping().Resource
+
+	if resourceName != "" {
+		obj, err := getOne(ctx, c, gvk, gvr, namespace, resourceName)
+		if err != nil {
+			return err
+		}
+		return printObject(f.output, h, []client.Object{obj})
+	}
+
+	objs, err := listAll(ctx, c, gvk, gvr, namespace, f.selector)
+	if err != nil {
+		return err
+	}
+	if len(objs) == 0 {
+		if namespace != "" {
+			fmt.Fprintf(os.Stdout, "No resources found in %s namespace.\n", namespace)
+		} else {
+			fmt.Fprintln(os.Stdout, "No resources found.")
+		}
+		return nil
+	}
+	return printObject(f.output, h, objs)
+}
+
+func getOne(ctx context.Context, c client.Client, gvk schema.GroupVersionKind, _ schema.GroupVersionResource, namespace, name string) (client.Object, error) {
+	obj, err := newObjectForGVK(gvk)
+	if err != nil {
+		return nil, err
+	}
+	key := client.ObjectKey{Namespace: namespace, Name: name}
+	if err := c.Get(ctx, key, obj); err != nil {
+		return nil, fmt.Errorf("failed to get %s/%s: %w", gvk.Kind, name, err)
+	}
+	// controller-runtime clears TypeMeta on typed Get responses; re-stamp it so
+	// callers (e.g. PrintDescribe, json/yaml output) see the correct Kind/Group.
+	obj.GetObjectKind().SetGroupVersionKind(gvk)
+	return obj, nil
+}
+
+func listAll(ctx context.Context, c client.Client, gvk schema.GroupVersionKind, _ schema.GroupVersionResource, namespace, selector string) ([]client.Object, error) {
+	listGVK := schema.GroupVersionKind{Group: gvk.Group, Version: gvk.Version, Kind: gvk.Kind + "List"}
+	listObj, err := newListObjectForGVK(listGVK)
+	if err != nil {
+		return nil, err
+	}
+
+	var opts []client.ListOption
+	if namespace != "" {
+		opts = append(opts, client.InNamespace(namespace))
+	}
+	if selector != "" {
+		sel, err := labels.Parse(selector)
+		if err != nil {
+			return nil, fmt.Errorf("invalid label selector %q: %w", selector, err)
+		}
+		opts = append(opts, client.MatchingLabelsSelector{Selector: sel})
+	}
+
+	if err := c.List(ctx, listObj, opts...); err != nil {
+		return nil, fmt.Errorf("failed to list %s: %w", gvk.Kind, err)
+	}
+
+	return extractListItems(listObj)
+}
+
+func printObject(format string, h resource.ResourceHandler, objs []client.Object) error {
+	switch format {
+	case "json", "yaml":
+		p, _ := printer.New(format)
+		if len(objs) == 1 {
+			return p.Print(os.Stdout, objs[0])
+		}
+		return p.Print(os.Stdout, objs)
+	default:
+		return resource.PrintTable(os.Stdout, h.Columns(), objs, format == "wide")
+	}
+}
+
+func newObjectForGVK(gvk schema.GroupVersionKind) (client.Object, error) {
+	obj, err := resource.SchemeForClient().New(gvk)
+	if err != nil {
+		return nil, fmt.Errorf("unrecognized resource type %s/%s: %w", gvk.Group, gvk.Kind, err)
+	}
+	co, ok := obj.(client.Object)
+	if !ok {
+		return nil, fmt.Errorf("type %T does not implement client.Object", obj)
+	}
+	return co, nil
+}
+
+func newListObjectForGVK(gvk schema.GroupVersionKind) (client.ObjectList, error) {
+	obj, err := resource.SchemeForClient().New(gvk)
+	if err != nil {
+		return nil, fmt.Errorf("unrecognized list type %s/%s: %w", gvk.Group, gvk.Kind, err)
+	}
+	lo, ok := obj.(client.ObjectList)
+	if !ok {
+		return nil, fmt.Errorf("type %T does not implement client.ObjectList", obj)
+	}
+	return lo, nil
+}
+
+func extractListItems(listObj client.ObjectList) ([]client.Object, error) {
+	scheme := resource.SchemeForClient()
+	// Resolve item GVK once, outside the loop.
+	gvks, _, err := scheme.ObjectKinds(listObj)
+	if err != nil || len(gvks) == 0 {
+		return nil, fmt.Errorf("failed to determine GVK for list object: %w", err)
+	}
+	// Item GVK is the list GVK without the "List" suffix.
+	itemKind := strings.TrimSuffix(gvks[0].Kind, "List")
+	if itemKind == gvks[0].Kind {
+		return nil, fmt.Errorf("list GVK kind %q does not end in \"List\"", gvks[0].Kind)
+	}
+	itemGVK := schema.GroupVersionKind{
+		Group:   gvks[0].Group,
+		Version: gvks[0].Version,
+		Kind:    itemKind,
+	}
+
+	raw, err := runtime.DefaultUnstructuredConverter.ToUnstructured(listObj)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract list items: %w", err)
+	}
+	rawItems, _ := raw["items"].([]any)
+	result := make([]client.Object, 0, len(rawItems))
+	for i, item := range rawItems {
+		m, ok := item.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("item %d in list is not a map", i)
+		}
+		obj, err := scheme.New(itemGVK)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create object for %s: %w", itemGVK.Kind, err)
+		}
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(m, obj); err != nil {
+			return nil, fmt.Errorf("failed to decode item %d (%s): %w", i, itemGVK.Kind, err)
+		}
+		co, ok := obj.(client.Object)
+		if !ok {
+			return nil, fmt.Errorf("type %T does not implement client.Object", obj)
+		}
+		co.GetObjectKind().SetGroupVersionKind(itemGVK)
+		result = append(result, co)
+	}
+	return result, nil
+}
+
+func resolveNamespace() (string, error) {
+	return kubeutil.LoadNamespace("")
+}
+
+func collectAliases() []string {
+	var all []string
+	for _, h := range resource.All() {
+		all = append(all, h.Aliases()...)
+	}
+	return all
+}
+
+func buildGetLong() string {
+	var b strings.Builder
+	b.WriteString("List or get Agentgateway resources.\n\nAvailable resources:")
+	for _, h := range resource.All() {
+		aliases := h.Aliases()
+		if len(aliases) > 0 {
+			fmt.Fprintf(&b, "\n  %-35s (%s)", aliases[0], strings.Join(aliases[1:], ", "))
+		}
+	}
+	return b.String()
+}

--- a/controller/pkg/cli/resource/handlers/agentgateway.go
+++ b/controller/pkg/cli/resource/handlers/agentgateway.go
@@ -1,0 +1,238 @@
+package handlers
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	agwv1a1 "github.com/agentgateway/agentgateway/controller/api/v1alpha1/agentgateway"
+	"github.com/agentgateway/agentgateway/controller/pkg/cli/resource"
+)
+
+func init() {
+	resource.Register(&agentgatewayPolicyHandler{})
+	resource.Register(&agentgatewayParametersHandler{})
+	resource.Register(&agentgatewayBackendHandler{})
+}
+
+// ─── AgentgatewayPolicy ──────────────────────────────────────────────────────
+
+type agentgatewayPolicyHandler struct{}
+
+func (h *agentgatewayPolicyHandler) Mapping() meta.RESTMapping {
+	return resource.Mapping(resource.GVR("agentgateway.dev", "v1alpha1", "agentgatewaypolicies"), "AgentgatewayPolicy")
+}
+
+func (h *agentgatewayPolicyHandler) Aliases() []string {
+	return []string{"agentgatewaypolicies", "agentgatewaypolicy", "agpol"}
+}
+
+func (h *agentgatewayPolicyHandler) Columns() []resource.Column {
+	return []resource.Column{
+		{Header: "NAMESPACE", Field: func(obj client.Object) string { return obj.GetNamespace() }},
+		{Header: "NAME", Field: func(obj client.Object) string { return obj.GetName() }},
+		{Header: "ACCEPTED", Field: func(obj client.Object) string {
+			if p, ok := obj.(*agwv1a1.AgentgatewayPolicy); ok {
+				return policyAccepted(p.Status)
+			}
+			return ""
+		}},
+		{Header: "ATTACHED", Field: func(obj client.Object) string {
+			if p, ok := obj.(*agwv1a1.AgentgatewayPolicy); ok {
+				return policyAttached(p.Status)
+			}
+			return ""
+		}},
+		{Header: "AGE", Field: func(obj client.Object) string { return age(obj.GetCreationTimestamp()) }},
+		{Header: "TARGET", Wide: true, Field: func(obj client.Object) string {
+			if p, ok := obj.(*agwv1a1.AgentgatewayPolicy); ok {
+				return policyTargets(p)
+			}
+			return ""
+		}},
+	}
+}
+
+func (h *agentgatewayPolicyHandler) DescribeExtra(obj client.Object) ([]resource.Section, error) {
+	p, ok := obj.(*agwv1a1.AgentgatewayPolicy)
+	if !ok {
+		return nil, nil
+	}
+	var sections []resource.Section
+
+	if len(p.Spec.TargetRefs) > 0 {
+		var b strings.Builder
+		for _, t := range p.Spec.TargetRefs {
+			fmt.Fprintf(&b, "group=%s kind=%s name=%s\n", t.Group, t.Kind, t.Name)
+		}
+		sections = append(sections, resource.Section{Title: "Target References", Body: b.String()})
+	}
+
+	if len(p.Status.Ancestors) > 0 {
+		var b strings.Builder
+		for _, a := range p.Status.Ancestors {
+			kind := "Gateway"
+			if a.AncestorRef.Kind != nil {
+				kind = string(*a.AncestorRef.Kind)
+			}
+			fmt.Fprintf(&b, "%s/%s:\n", kind, a.AncestorRef.Name)
+			for _, c := range a.Conditions {
+				fmt.Fprintf(&b, "  %-20s %s  %s\n", c.Type, c.Status, c.Message)
+			}
+		}
+		sections = append(sections, resource.Section{Title: "Status", Body: b.String()})
+	}
+
+	return sections, nil
+}
+
+// ─── AgentgatewayParameters ──────────────────────────────────────────────────
+
+type agentgatewayParametersHandler struct{}
+
+func (h *agentgatewayParametersHandler) Mapping() meta.RESTMapping {
+	return resource.Mapping(resource.GVR("agentgateway.dev", "v1alpha1", "agentgatewayparameters"), "AgentgatewayParameters")
+}
+
+func (h *agentgatewayParametersHandler) Aliases() []string {
+	return []string{"agentgatewayparameters", "agentgatewayparameter", "agpar"}
+}
+
+func (h *agentgatewayParametersHandler) Columns() []resource.Column {
+	return []resource.Column{
+		{Header: "NAMESPACE", Field: func(obj client.Object) string { return obj.GetNamespace() }},
+		{Header: "NAME", Field: func(obj client.Object) string { return obj.GetName() }},
+		{Header: "AGE", Field: func(obj client.Object) string { return age(obj.GetCreationTimestamp()) }},
+	}
+}
+
+func (h *agentgatewayParametersHandler) DescribeExtra(obj client.Object) ([]resource.Section, error) {
+	_, ok := obj.(*agwv1a1.AgentgatewayParameters)
+	if !ok {
+		return nil, nil
+	}
+	return []resource.Section{
+		{Title: "Spec", Body: "Use -o yaml for full parameters spec"},
+	}, nil
+}
+
+// ─── AgentgatewayBackend ─────────────────────────────────────────────────────
+
+type agentgatewayBackendHandler struct{}
+
+func (h *agentgatewayBackendHandler) Mapping() meta.RESTMapping {
+	return resource.Mapping(resource.GVR("agentgateway.dev", "v1alpha1", "agentgatewaybackends"), "AgentgatewayBackend")
+}
+
+func (h *agentgatewayBackendHandler) Aliases() []string {
+	return []string{"agentgatewaybackends", "agentgatewaybackend", "agbe"}
+}
+
+func (h *agentgatewayBackendHandler) Columns() []resource.Column {
+	return []resource.Column{
+		{Header: "NAMESPACE", Field: func(obj client.Object) string { return obj.GetNamespace() }},
+		{Header: "NAME", Field: func(obj client.Object) string { return obj.GetName() }},
+		{Header: "TYPE", Field: func(obj client.Object) string {
+			if b, ok := obj.(*agwv1a1.AgentgatewayBackend); ok {
+				return backendType(b)
+			}
+			return ""
+		}},
+		{Header: "ACCEPTED", Field: func(obj client.Object) string {
+			if b, ok := obj.(*agwv1a1.AgentgatewayBackend); ok {
+				return backendAccepted(b)
+			}
+			return ""
+		}},
+		{Header: "AGE", Field: func(obj client.Object) string { return age(obj.GetCreationTimestamp()) }},
+	}
+}
+
+func (h *agentgatewayBackendHandler) DescribeExtra(obj client.Object) ([]resource.Section, error) {
+	b, ok := obj.(*agwv1a1.AgentgatewayBackend)
+	if !ok {
+		return nil, nil
+	}
+	var sections []resource.Section
+
+	sections = append(sections, resource.Section{
+		Title: "Type",
+		Body:  backendType(b),
+	})
+
+	if len(b.Status.Conditions) > 0 {
+		var buf strings.Builder
+		for _, c := range b.Status.Conditions {
+			fmt.Fprintf(&buf, "%-20s %-8s %s\n", c.Type, c.Status, c.Message)
+		}
+		sections = append(sections, resource.Section{Title: "Conditions", Body: buf.String()})
+	}
+
+	return sections, nil
+}
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+func policyAccepted(status gwv1.PolicyStatus) string {
+	return findPolicyCondition(status, "Accepted")
+}
+
+func policyAttached(status gwv1.PolicyStatus) string {
+	if s := findPolicyCondition(status, "Attached"); s != "Unknown" {
+		return s
+	}
+	return findPolicyCondition(status, "ResolvedRefs")
+}
+
+func findPolicyCondition(status gwv1.PolicyStatus, condType string) string {
+	for _, a := range status.Ancestors {
+		for _, c := range a.Conditions {
+			if c.Type == condType {
+				return string(c.Status)
+			}
+		}
+	}
+	return "Unknown"
+}
+
+func policyTargets(p *agwv1a1.AgentgatewayPolicy) string {
+	var parts []string
+	for _, t := range p.Spec.TargetRefs {
+		parts = append(parts, string(t.Kind)+"/"+string(t.Name))
+	}
+	for _, t := range p.Spec.TargetSelectors {
+		parts = append(parts, string(t.Kind)+"[selector]")
+	}
+	return strings.Join(parts, ",")
+}
+
+func backendType(b *agwv1a1.AgentgatewayBackend) string {
+	switch {
+	case b.Spec.Static != nil:
+		return "static"
+	case b.Spec.AI != nil:
+		return "ai"
+	case b.Spec.MCP != nil:
+		return "mcp"
+	case b.Spec.A2A != nil:
+		return "a2a"
+	case b.Spec.DynamicForwardProxy != nil:
+		return "dynamic-forward-proxy"
+	case b.Spec.Aws != nil:
+		return "aws"
+	default:
+		return "unknown"
+	}
+}
+
+func backendAccepted(b *agwv1a1.AgentgatewayBackend) string {
+	for _, c := range b.Status.Conditions {
+		if c.Type == "Accepted" {
+			return string(c.Status)
+		}
+	}
+	return "Unknown"
+}

--- a/controller/pkg/cli/resource/handlers/gateway_api.go
+++ b/controller/pkg/cli/resource/handlers/gateway_api.go
@@ -1,0 +1,406 @@
+package handlers
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gwv1b1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	"github.com/agentgateway/agentgateway/controller/pkg/cli/resource"
+)
+
+func init() {
+	resource.Register(&gatewayClassHandler{})
+	resource.Register(&gatewayHandler{})
+	resource.Register(&httpRouteHandler{})
+	resource.Register(&referenceGrantHandler{})
+}
+
+// ─── GatewayClass ────────────────────────────────────────────────────────────
+
+type gatewayClassHandler struct{}
+
+func (h *gatewayClassHandler) Mapping() meta.RESTMapping {
+	return resource.Mapping(resource.GVR("gateway.networking.k8s.io", "v1", "gatewayclasses"), "GatewayClass")
+}
+
+func (h *gatewayClassHandler) Aliases() []string {
+	return []string{"gatewayclasses", "gatewayclass"}
+}
+
+func (h *gatewayClassHandler) Columns() []resource.Column {
+	return []resource.Column{
+		{Header: "NAME", Field: func(obj client.Object) string { return obj.GetName() }},
+		{Header: "CONTROLLER", Field: func(obj client.Object) string {
+			if gc, ok := obj.(*gwv1.GatewayClass); ok {
+				return string(gc.Spec.ControllerName)
+			}
+			return ""
+		}},
+		{Header: "ACCEPTED", Field: func(obj client.Object) string {
+			if gc, ok := obj.(*gwv1.GatewayClass); ok {
+				return conditionStatus(gc.Status.Conditions, "Accepted")
+			}
+			return ""
+		}},
+		{Header: "AGE", Field: func(obj client.Object) string { return age(obj.GetCreationTimestamp()) }},
+		{Header: "DESCRIPTION", Wide: true, Field: func(obj client.Object) string {
+			if gc, ok := obj.(*gwv1.GatewayClass); ok && gc.Spec.Description != nil {
+				return *gc.Spec.Description
+			}
+			return ""
+		}},
+	}
+}
+
+func (h *gatewayClassHandler) DescribeExtra(obj client.Object) ([]resource.Section, error) {
+	gc, ok := obj.(*gwv1.GatewayClass)
+	if !ok {
+		return nil, nil
+	}
+	var sections []resource.Section
+
+	sections = append(sections, resource.Section{
+		Title: "Controller",
+		Body:  string(gc.Spec.ControllerName),
+	})
+
+	if len(gc.Status.Conditions) > 0 {
+		sections = append(sections, resource.Section{
+			Title: "Conditions",
+			Body:  formatConditions(gc.Status.Conditions),
+		})
+	}
+
+	return sections, nil
+}
+
+// ─── Gateway ──────────────────────────────────────────────────────────────────
+
+type gatewayHandler struct{}
+
+func (h *gatewayHandler) Mapping() meta.RESTMapping {
+	return resource.Mapping(resource.GVR("gateway.networking.k8s.io", "v1", "gateways"), "Gateway")
+}
+
+func (h *gatewayHandler) Aliases() []string {
+	return []string{"gateways", "gateway"}
+}
+
+func (h *gatewayHandler) Columns() []resource.Column {
+	return []resource.Column{
+		{Header: "NAMESPACE", Field: func(obj client.Object) string { return obj.GetNamespace() }},
+		{Header: "NAME", Field: func(obj client.Object) string { return obj.GetName() }},
+		{Header: "CLASS", Field: func(obj client.Object) string {
+			if gw, ok := obj.(*gwv1.Gateway); ok {
+				return string(gw.Spec.GatewayClassName)
+			}
+			return ""
+		}},
+		{Header: "ADDRESS", Field: func(obj client.Object) string {
+			if gw, ok := obj.(*gwv1.Gateway); ok {
+				return gatewayAddress(gw)
+			}
+			return ""
+		}},
+		{Header: "PROGRAMMED", Field: func(obj client.Object) string {
+			if gw, ok := obj.(*gwv1.Gateway); ok {
+				return conditionStatus(gw.Status.Conditions, "Programmed")
+			}
+			return ""
+		}},
+		{Header: "AGE", Field: func(obj client.Object) string { return age(obj.GetCreationTimestamp()) }},
+		{Header: "ROUTES", Wide: true, Field: func(obj client.Object) string {
+			if gw, ok := obj.(*gwv1.Gateway); ok {
+				return fmt.Sprintf("%d", gatewayRouteCount(gw))
+			}
+			return ""
+		}},
+	}
+}
+
+func (h *gatewayHandler) DescribeExtra(obj client.Object) ([]resource.Section, error) {
+	gw, ok := obj.(*gwv1.Gateway)
+	if !ok {
+		return nil, nil
+	}
+	var sections []resource.Section
+
+	sections = append(sections, resource.Section{
+		Title: "GatewayClass",
+		Body:  string(gw.Spec.GatewayClassName),
+	})
+
+	if len(gw.Spec.Listeners) > 0 {
+		var b strings.Builder
+		for _, l := range gw.Spec.Listeners {
+			fmt.Fprintf(&b, "%s  port=%d  protocol=%s", l.Name, l.Port, l.Protocol)
+			if l.Hostname != nil {
+				fmt.Fprintf(&b, "  hostname=%s", *l.Hostname)
+			}
+			b.WriteByte('\n')
+		}
+		sections = append(sections, resource.Section{Title: "Listeners", Body: b.String()})
+	}
+
+	if len(gw.Status.Conditions) > 0 {
+		sections = append(sections, resource.Section{
+			Title: "Conditions",
+			Body:  formatConditions(gw.Status.Conditions),
+		})
+	}
+
+	return sections, nil
+}
+
+// ─── HTTPRoute ────────────────────────────────────────────────────────────────
+
+type httpRouteHandler struct{}
+
+func (h *httpRouteHandler) Mapping() meta.RESTMapping {
+	return resource.Mapping(resource.GVR("gateway.networking.k8s.io", "v1", "httproutes"), "HTTPRoute")
+}
+
+func (h *httpRouteHandler) Aliases() []string {
+	return []string{"httproutes", "httproute"}
+}
+
+func (h *httpRouteHandler) Columns() []resource.Column {
+	return []resource.Column{
+		{Header: "NAMESPACE", Field: func(obj client.Object) string { return obj.GetNamespace() }},
+		{Header: "NAME", Field: func(obj client.Object) string { return obj.GetName() }},
+		{Header: "HOSTNAMES", Field: func(obj client.Object) string {
+			if r, ok := obj.(*gwv1.HTTPRoute); ok {
+				return httpRouteHostnames(r)
+			}
+			return ""
+		}},
+		{Header: "PARENT", Field: func(obj client.Object) string {
+			if r, ok := obj.(*gwv1.HTTPRoute); ok {
+				return httpRouteParents(r)
+			}
+			return ""
+		}},
+		{Header: "AGE", Field: func(obj client.Object) string { return age(obj.GetCreationTimestamp()) }},
+	}
+}
+
+func (h *httpRouteHandler) DescribeExtra(obj client.Object) ([]resource.Section, error) {
+	r, ok := obj.(*gwv1.HTTPRoute)
+	if !ok {
+		return nil, nil
+	}
+	var sections []resource.Section
+
+	if len(r.Spec.Hostnames) > 0 {
+		var hostnames []string
+		for _, h := range r.Spec.Hostnames {
+			hostnames = append(hostnames, string(h))
+		}
+		sections = append(sections, resource.Section{Title: "Hostnames", Body: strings.Join(hostnames, "\n")})
+	}
+
+	if len(r.Spec.ParentRefs) > 0 {
+		var b strings.Builder
+		for _, p := range r.Spec.ParentRefs {
+			ns := ""
+			if p.Namespace != nil {
+				ns = string(*p.Namespace) + "/"
+			}
+			fmt.Fprintf(&b, "%s%s\n", ns, p.Name)
+		}
+		sections = append(sections, resource.Section{Title: "Parent References", Body: b.String()})
+	}
+
+	if len(r.Status.RouteStatus.Parents) > 0 {
+		var b strings.Builder
+		for _, ps := range r.Status.RouteStatus.Parents {
+			fmt.Fprintf(&b, "%s: %s\n", ps.ParentRef.Name, conditionStatus(ps.Conditions, "Accepted"))
+		}
+		sections = append(sections, resource.Section{Title: "Parent Status", Body: b.String()})
+	}
+
+	if len(r.Spec.Rules) > 0 {
+		var b strings.Builder
+		for i, rule := range r.Spec.Rules {
+			fmt.Fprintf(&b, "Rule %d:\n", i+1)
+			for _, m := range rule.Matches {
+				if m.Path != nil && m.Path.Value != nil {
+					fmt.Fprintf(&b, "  path: %s\n", *m.Path.Value)
+				}
+			}
+			for _, be := range rule.BackendRefs {
+				portStr := ""
+				if be.Port != nil {
+					portStr = fmt.Sprintf(":%d", *be.Port)
+				}
+				fmt.Fprintf(&b, "  backend: %s%s\n", be.Name, portStr)
+			}
+		}
+		sections = append(sections, resource.Section{Title: "Rules", Body: b.String()})
+	}
+
+	return sections, nil
+}
+
+// ─── ReferenceGrant ──────────────────────────────────────────────────────────
+
+type referenceGrantHandler struct{}
+
+func (h *referenceGrantHandler) Mapping() meta.RESTMapping {
+	return resource.Mapping(resource.GVR("gateway.networking.k8s.io", "v1beta1", "referencegrants"), "ReferenceGrant")
+}
+
+func (h *referenceGrantHandler) Aliases() []string {
+	return []string{"referencegrants", "referencegrant"}
+}
+
+func (h *referenceGrantHandler) Columns() []resource.Column {
+	return []resource.Column{
+		{Header: "NAMESPACE", Field: func(obj client.Object) string { return obj.GetNamespace() }},
+		{Header: "NAME", Field: func(obj client.Object) string { return obj.GetName() }},
+		{Header: "FROM", Field: func(obj client.Object) string {
+			if rg, ok := obj.(*gwv1b1.ReferenceGrant); ok {
+				return referenceGrantFrom(rg)
+			}
+			return ""
+		}},
+		{Header: "TO", Field: func(obj client.Object) string {
+			if rg, ok := obj.(*gwv1b1.ReferenceGrant); ok {
+				return referenceGrantTo(rg)
+			}
+			return ""
+		}},
+		{Header: "AGE", Field: func(obj client.Object) string { return age(obj.GetCreationTimestamp()) }},
+	}
+}
+
+func (h *referenceGrantHandler) DescribeExtra(obj client.Object) ([]resource.Section, error) {
+	rg, ok := obj.(*gwv1b1.ReferenceGrant)
+	if !ok {
+		return nil, nil
+	}
+	var sections []resource.Section
+
+	var from strings.Builder
+	for _, f := range rg.Spec.From {
+		fmt.Fprintf(&from, "group=%s kind=%s namespace=%s\n", f.Group, f.Kind, f.Namespace)
+	}
+	sections = append(sections, resource.Section{Title: "From", Body: from.String()})
+
+	var to strings.Builder
+	for _, t := range rg.Spec.To {
+		fmt.Fprintf(&to, "group=%s kind=%s", t.Group, t.Kind)
+		if t.Name != nil {
+			fmt.Fprintf(&to, " name=%s", *t.Name)
+		}
+		to.WriteByte('\n')
+	}
+	sections = append(sections, resource.Section{Title: "To", Body: to.String()})
+
+	return sections, nil
+}
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+func conditionStatus(conditions []metav1.Condition, condType string) string {
+	for _, c := range conditions {
+		if c.Type == condType {
+			return string(c.Status)
+		}
+	}
+	return "Unknown"
+}
+
+func age(t metav1.Time) string {
+	if t.IsZero() {
+		return "<unknown>"
+	}
+	d := metav1.Now().Sub(t.Time)
+	switch {
+	case d.Hours() >= 24*365:
+		return fmt.Sprintf("%dy", int(d.Hours()/(24*365)))
+	case d.Hours() >= 24:
+		return fmt.Sprintf("%dd", int(d.Hours()/24))
+	case d.Hours() >= 1:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	case d.Minutes() >= 1:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	default:
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+}
+
+func formatConditions(conditions []metav1.Condition) string {
+	var b strings.Builder
+	for _, c := range conditions {
+		fmt.Fprintf(&b, "%-20s %-8s %s\n", c.Type, c.Status, c.Message)
+	}
+	return b.String()
+}
+
+func gatewayAddress(gw *gwv1.Gateway) string {
+	var addrs []string
+	for _, a := range gw.Status.Addresses {
+		addrs = append(addrs, a.Value)
+	}
+	if len(addrs) == 0 {
+		return "<none>"
+	}
+	return strings.Join(addrs, ",")
+}
+
+func gatewayRouteCount(gw *gwv1.Gateway) int {
+	count := 0
+	for _, l := range gw.Status.Listeners {
+		count += int(l.AttachedRoutes)
+	}
+	return count
+}
+
+func httpRouteHostnames(r *gwv1.HTTPRoute) string {
+	if len(r.Spec.Hostnames) == 0 {
+		return "*"
+	}
+	var h []string
+	for _, hn := range r.Spec.Hostnames {
+		h = append(h, string(hn))
+	}
+	return strings.Join(h, ",")
+}
+
+func httpRouteParents(r *gwv1.HTTPRoute) string {
+	var parents []string
+	for _, p := range r.Spec.ParentRefs {
+		ns := r.Namespace
+		if p.Namespace != nil {
+			ns = string(*p.Namespace)
+		}
+		parents = append(parents, ns+"/"+string(p.Name))
+	}
+	return strings.Join(parents, ",")
+}
+
+func referenceGrantFrom(rg *gwv1b1.ReferenceGrant) string {
+	var parts []string
+	for _, f := range rg.Spec.From {
+		parts = append(parts, string(f.Kind)+"/"+string(f.Namespace))
+	}
+	return strings.Join(parts, ",")
+}
+
+func referenceGrantTo(rg *gwv1b1.ReferenceGrant) string {
+	var parts []string
+	for _, t := range rg.Spec.To {
+		name := "*"
+		if t.Name != nil {
+			name = string(*t.Name)
+		}
+		parts = append(parts, string(t.Kind)+"/"+name)
+	}
+	return strings.Join(parts, ",")
+}

--- a/controller/pkg/cli/resource/kube.go
+++ b/controller/pkg/cli/resource/kube.go
@@ -1,0 +1,53 @@
+package resource
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/agentgateway/agentgateway/controller/pkg/cli/flag"
+	"github.com/agentgateway/agentgateway/controller/pkg/schemes"
+)
+
+// NewClient builds a controller-runtime client with all agentgateway types registered.
+func NewClient() (client.Client, error) {
+	restConfig, err := buildRestConfig()
+	if err != nil {
+		return nil, err
+	}
+	scheme := schemes.DefaultScheme()
+	return client.New(restConfig, client.Options{Scheme: scheme})
+}
+
+// NewDynamicClient builds a dynamic Kubernetes client for unstructured operations.
+func NewDynamicClient() (dynamic.Interface, error) {
+	restConfig, err := buildRestConfig()
+	if err != nil {
+		return nil, err
+	}
+	return dynamic.NewForConfig(restConfig)
+}
+
+// SchemeForClient returns the scheme used by agentgateway clients.
+func SchemeForClient() *runtime.Scheme {
+	return schemes.DefaultScheme()
+}
+
+func buildRestConfig() (*rest.Config, error) {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	if kc := flag.Kubeconfig(); kc != "" {
+		loadingRules.ExplicitPath = kc
+	}
+	cfg := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, &clientcmd.ConfigOverrides{})
+	restConfig, err := cfg.ClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build Kubernetes client config: %w", err)
+	}
+	restConfig.QPS = 50
+	restConfig.Burst = 100
+	return restConfig, nil
+}

--- a/controller/pkg/cli/resource/registry.go
+++ b/controller/pkg/cli/resource/registry.go
@@ -1,0 +1,110 @@
+package resource
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Column describes one column in short or wide table output.
+type Column struct {
+	Header string
+	Wide   bool // if true, only shown with -o wide
+	// Field returns the string value for the column from the given object.
+	Field func(obj client.Object) string
+}
+
+// Section is a named block of text shown in describe output.
+type Section struct {
+	Title string
+	Body  string
+}
+
+// ResourceHandler is implemented once per resource type.
+// OSS handlers are registered via init(); enterprise handlers are registered
+// from enterprise binary startup before Execute() is called.
+type ResourceHandler interface {
+	// Mapping returns the GroupVersionResource and Kind for this resource type.
+	Mapping() meta.RESTMapping
+	// Aliases returns all names that identify this resource (plural, singular, short names).
+	Aliases() []string
+	// Columns returns the columns for table output. Wide-only columns are included in the slice
+	// but have Wide=true set; callers filter based on the selected output format.
+	Columns() []Column
+	// DescribeExtra returns additional sections shown in `agctl describe` output
+	// that are specific to this resource type (e.g. attached policies, resolved refs).
+	DescribeExtra(obj client.Object) ([]Section, error)
+}
+
+var (
+	// handlers is the registry of ResourceHandler implementations keyed by canonical plural name.
+	handlers = map[string]ResourceHandler{}
+	// aliasMap maps every alias (plural, singular, short name) to the canonical plural name.
+	aliasMap = map[string]string{}
+)
+
+// Register adds a handler to the global registry.
+// It is safe to call from init() in each resource-specific file
+// or from enterprise code at startup before Execute().
+func Register(h ResourceHandler) {
+	canonical := canonicalName(h.Mapping().Resource.Resource)
+	if _, exists := handlers[canonical]; exists {
+		panic(fmt.Sprintf("resource handler already registered for %q", canonical))
+	}
+	handlers[canonical] = h
+	for _, alias := range h.Aliases() {
+		lower := strings.ToLower(alias)
+		if existing, conflict := aliasMap[lower]; conflict && existing != canonical {
+			panic(fmt.Sprintf("alias %q already registered for %q, cannot register for %q", lower, existing, canonical))
+		}
+		aliasMap[lower] = canonical
+	}
+}
+
+// Lookup finds a handler by any alias (case-insensitive).
+func Lookup(name string) (ResourceHandler, error) {
+	canonical, ok := aliasMap[strings.ToLower(name)]
+	if !ok {
+		return nil, fmt.Errorf("unknown resource type %q; run `agctl get --help` to see available resources", name)
+	}
+	h, ok := handlers[canonical]
+	if !ok {
+		return nil, fmt.Errorf("internal error: handler for %q not found", canonical)
+	}
+	return h, nil
+}
+
+// All returns all registered handlers in stable order (sorted by canonical plural name).
+func All() []ResourceHandler {
+	names := make([]string, 0, len(handlers))
+	for k := range handlers {
+		names = append(names, k)
+	}
+	slices.Sort(names)
+	result := make([]ResourceHandler, 0, len(names))
+	for _, n := range names {
+		result = append(result, handlers[n])
+	}
+	return result
+}
+
+// GVR is a convenience constructor for schema.GroupVersionResource.
+func GVR(group, version, resource string) schema.GroupVersionResource {
+	return schema.GroupVersionResource{Group: group, Version: version, Resource: resource}
+}
+
+// Mapping constructs a RESTMapping from a GVR and kind.
+func Mapping(gvr schema.GroupVersionResource, kind string) meta.RESTMapping {
+	return meta.RESTMapping{
+		Resource:         gvr,
+		GroupVersionKind: schema.GroupVersionKind{Group: gvr.Group, Version: gvr.Version, Kind: kind},
+	}
+}
+
+func canonicalName(s string) string {
+	return strings.ToLower(s)
+}

--- a/controller/pkg/cli/resource/registry.go
+++ b/controller/pkg/cli/resource/registry.go
@@ -25,8 +25,8 @@ type Section struct {
 }
 
 // ResourceHandler is implemented once per resource type.
-// OSS handlers are registered via init(); enterprise handlers are registered
-// from enterprise binary startup before Execute() is called.
+// AgentGateway handlers are registered via init(); out-of-tree handlers are registered
+// from out-of-tree binary startup before Execute() is called.
 type ResourceHandler interface {
 	// Mapping returns the GroupVersionResource and Kind for this resource type.
 	Mapping() meta.RESTMapping
@@ -49,7 +49,7 @@ var (
 
 // Register adds a handler to the global registry.
 // It is safe to call from init() in each resource-specific file
-// or from enterprise code at startup before Execute().
+// or from out-of-tree code at startup before Execute().
 func Register(h ResourceHandler) {
 	canonical := canonicalName(h.Mapping().Resource.Resource)
 	if _, exists := handlers[canonical]; exists {

--- a/controller/pkg/cli/resource/table.go
+++ b/controller/pkg/cli/resource/table.go
@@ -1,0 +1,78 @@
+package resource
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// PrintTable writes objects as a tab-aligned table to w using the provided columns.
+// If wide is true, columns with Wide=true are included.
+func PrintTable(w io.Writer, cols []Column, objs []client.Object, wide bool) error {
+	tw := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
+
+	// Header
+	var headers []string
+	for _, c := range cols {
+		if !c.Wide || wide {
+			headers = append(headers, c.Header)
+		}
+	}
+	fmt.Fprintln(tw, strings.Join(headers, "\t"))
+
+	// Rows
+	for _, obj := range objs {
+		var cells []string
+		for _, c := range cols {
+			if !c.Wide || wide {
+				cells = append(cells, c.Field(obj))
+			}
+		}
+		fmt.Fprintln(tw, strings.Join(cells, "\t"))
+	}
+
+	return tw.Flush()
+}
+
+// PrintDescribe writes a describe-style output for a single object.
+func PrintDescribe(w io.Writer, obj client.Object, sections []Section) error {
+	gvk := obj.GetObjectKind().GroupVersionKind()
+	fmt.Fprintf(w, "Name:       %s\n", obj.GetName())
+	fmt.Fprintf(w, "Namespace:  %s\n", obj.GetNamespace())
+	fmt.Fprintf(w, "Kind:       %s\n", gvk.Kind)
+	if gvk.Group != "" {
+		fmt.Fprintf(w, "Group:      %s\n", gvk.Group)
+	}
+
+	labels := obj.GetLabels()
+	if len(labels) > 0 {
+		fmt.Fprintf(w, "Labels:\n")
+		for k, v := range labels {
+			fmt.Fprintf(w, "  %s=%s\n", k, v)
+		}
+	}
+
+	annotations := obj.GetAnnotations()
+	if len(annotations) > 0 {
+		fmt.Fprintf(w, "Annotations:\n")
+		for k, v := range annotations {
+			fmt.Fprintf(w, "  %s=%s\n", k, v)
+		}
+	}
+
+	for _, s := range sections {
+		fmt.Fprintf(w, "\n%s:\n", s.Title)
+		if s.Body == "" {
+			fmt.Fprintf(w, "  <none>\n")
+		} else {
+			for _, line := range strings.Split(strings.TrimRight(s.Body, "\n"), "\n") {
+				fmt.Fprintf(w, "  %s\n", line)
+			}
+		}
+	}
+
+	return nil
+}

--- a/controller/pkg/cli/root.go
+++ b/controller/pkg/cli/root.go
@@ -7,8 +7,12 @@ import (
 
 	"github.com/agentgateway/agentgateway/controller/pkg/cli/config"
 	"github.com/agentgateway/agentgateway/controller/pkg/cli/flag"
+	resourcecmd "github.com/agentgateway/agentgateway/controller/pkg/cli/resource/cmd"
 	"github.com/agentgateway/agentgateway/controller/pkg/cli/trace"
 	cliversion "github.com/agentgateway/agentgateway/controller/pkg/cli/version"
+
+	// Import handlers so their init() functions register resource handlers.
+	_ "github.com/agentgateway/agentgateway/controller/pkg/cli/resource/handlers"
 )
 
 func NewRootCmd() *cobra.Command {
@@ -21,6 +25,11 @@ func NewRootCmd() *cobra.Command {
 	rootCmd.AddCommand(flag.BuildCobra(cliversion.Command))
 	rootCmd.AddCommand(flag.BuildCobra(config.Command))
 	rootCmd.AddCommand(flag.BuildCobra(trace.Command))
+
+	// Resource-oriented commands (gwctl-compatible UX).
+	rootCmd.AddCommand(resourcecmd.BuildGetCmd())
+	rootCmd.AddCommand(resourcecmd.BuildDescribeCmd())
+	rootCmd.AddCommand(resourcecmd.BuildAnalyzeCmd())
 
 	return rootCmd
 }


### PR DESCRIPTION
## Summary

- Adds read-only `agctl get`, `agctl describe`, and `agctl analyze` commands for Gateway API and agentgateway CRD resources
- Introduces a `ResourceHandler` plugin registry so out-of-tree packages can register additional resource types without modifying this package
- No write operations — mutations are deferred to kubectl, following istioctl precedent

## What's included

**New commands**

| Command | Description |
|---|---|
| `agctl get <resource> [name]` | List or fetch a single resource; supports `-n`, `-A`, `-l`, `-o short\|wide\|json\|yaml` |
| `agctl describe <resource> <name>` | Detailed view with type-specific sections (status conditions, target refs) |
| `agctl analyze` | Read-only cross-reference validation across the cluster |

**Built-in resource handlers**

Gateway API: `GatewayClass`, `Gateway`, `HTTPRoute`, `ReferenceGrant`

Agentgateway CRDs: `AgentgatewayPolicy` (`agpol`), `AgentgatewayParameters` (`agpar`), `AgentgatewayBackend` (`agbe`)

**`analyze` checks**
- HTTPRoute `parentRefs` → existing Gateway (with per-run cache to avoid N+1 API calls; transient errors not cached)
- AgentgatewayPolicy `targetRefs` → existing resource (Gateway, HTTPRoute, AgentgatewayBackend)
- AgentgatewayPolicy `targetSelectors` → warns on unverifiable/unknown kinds
- AgentgatewayBackend static spec → host+port or unixPath required

## Architecture

```
controller/pkg/cli/resource/
  registry.go       # ResourceHandler interface + Register/Lookup/All
  table.go          # PrintTable / PrintDescribe
  kube.go           # NewClient (controller-runtime) + SchemeForClient
  handlers/
    gateway_api.go  # GatewayClass, Gateway, HTTPRoute, ReferenceGrant (init())
    agentgateway.go # AgentgatewayPolicy, Parameters, Backend (init())
  cmd/
    get.go
    describe.go
    analyze.go
```

The `handlers` package uses `init()` for self-registration; a blank import in `root.go` triggers it. Out-of-tree packages can call `resource.Register()` before `Execute()` to add resource types.

## Test plan

- [ ] `agctl get gateway -A` lists gateways across all namespaces
- [ ] `agctl get agpol -n default` lists policies in the default namespace
- [ ] `agctl describe httproute my-route` shows parentRef and conditions sections
- [ ] `agctl get gateway my-gw -o json` emits JSON with correct `kind`/`apiVersion`
- [ ] `agctl analyze` reports missing gateway parentRefs and unknown targetRef kinds
- [ ] `agctl analyze` exits 0 when no issues found, non-zero when issues exist
- [ ] `agctl get unknownresource` returns a clear error message

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
