### PR TITLE
bug: do not evict when health is configured without eviction

### DIFF
--- a/crates/agentgateway/src/http/health.rs
+++ b/crates/agentgateway/src/http/health.rs
@@ -92,10 +92,17 @@ impl Policy {
 		let health = !unhealthy;
 		let ev = self.eviction.as_ref();
 		let eviction_duration = if unhealthy {
-			let base_duration = self
-				.eviction_duration()
-				.or(fallback_duration)
-				.or(Some(Duration::from_secs(DEFAULT_EVICTION_SECS)));
+			let base_duration =
+				self
+					.eviction_duration()
+					.or(fallback_duration)
+					.or(if self.eviction.is_some() {
+						// If we have eviction, but no duration set, use the default
+						Some(Duration::from_secs(DEFAULT_EVICTION_SECS))
+					} else {
+						// Else there is no eviction
+						None
+					});
 			let health_threshold = ev.and_then(|e| e.health_threshold);
 			let consecutive_failures = ev.and_then(|e| e.consecutive_failures);
 			// +1 because the current failure hasn't been recorded yet.
@@ -264,7 +271,7 @@ mod tests {
 	fn unhealthy_default_eviction_duration() {
 		let policy = Policy::default();
 		let (_, eviction, _) = policy.eviction_decision(1.0, 0, 0, true, None);
-		assert_eq!(eviction, Some(Duration::from_secs(DEFAULT_EVICTION_SECS)));
+		assert_eq!(eviction, None);
 	}
 
 	// --- health_threshold only ---


### PR DESCRIPTION
```
// When unset, any 5xx response, or a connection failure, is treated as unhealthy.
	// This default lowers the backend's health score but does not trigger eviction on its own.
	//
	// +optional
	UnhealthyCondition *shared.CELExpression `json:"unhealthyCondition,omitempty"`
```

But we did not respect this; we turned on eviction when only this was
set.

This fixes it and updates the test case that encodes the bad behavior.

Manually verified + changed the test to capture this.

Signed-off-by: John Howard <john.howard@solo.io>
