### PR TITLE
Retain agentcore default servicename

### DIFF
--- a/crates/agentgateway/src/http/auth/aws.rs
+++ b/crates/agentgateway/src/http/auth/aws.rs
@@ -15,6 +15,9 @@ use tokio::sync::{Mutex, OnceCell};
 use crate::llm::bedrock::AwsRegion;
 use crate::*;
 
+#[derive(Clone, Debug)]
+pub struct DefaultAwsServiceName(pub String);
+
 #[apply(schema!)]
 #[serde(untagged)]
 pub enum AwsAuth {
@@ -116,6 +119,18 @@ impl AwsAuth {
 	}
 }
 
+fn signing_service_name<'a>(req: &'a http::Request, aws_auth: &'a AwsAuth) -> &'a str {
+	aws_auth
+		.service_name()
+		.or_else(|| {
+			req
+				.extensions()
+				.get::<DefaultAwsServiceName>()
+				.map(|default| default.0.as_str())
+		})
+		.unwrap_or("bedrock")
+}
+
 pub(super) async fn sign_request(
 	req: &mut http::Request,
 	aws_auth: &AwsAuth,
@@ -143,7 +158,7 @@ pub(super) async fn sign_request(
 	};
 	let creds = load_credentials(aws_auth, region).await?.into();
 
-	let service = aws_auth.service_name().unwrap_or("bedrock");
+	let service = signing_service_name(req, aws_auth);
 	trace!("AWS signing with region: {}, service: {}", region, service);
 
 	// Sign the request

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -1716,6 +1716,12 @@ async fn build_simple_backend_call(
 				region: config.region().to_string(),
 			});
 
+			req
+				.extensions_mut()
+				.insert(auth::aws::DefaultAwsServiceName(
+					config.service_name().to_string(),
+				));
+
 			let default_policies = BackendPolicies {
 				backend_tls: Some(http::backendtls::SYSTEM_TRUST.clone()),
 				backend_auth: Some(auth::BackendAuth::Aws(auth::AwsAuth::Implicit {

--- a/crates/agentgateway/src/proxy/tcpproxy.rs
+++ b/crates/agentgateway/src/proxy/tcpproxy.rs
@@ -955,7 +955,10 @@ mod tests {
 		assert!(
 			matches!(
 				&result.backend_policies.backend_auth,
-				Some(BackendAuth::Aws(AwsAuth::ExplicitConfig { .. }))
+				Some(BackendAuth::Aws(AwsAuth::ExplicitConfig {
+					service_name: None,
+					..
+				}))
 			),
 			"user-provided auth should override default implicit auth"
 		);


### PR DESCRIPTION
This fixes a regression in #1881 where if a user explicitly sets aws auth but does not default serviceName, our default-serviceName for agentcore is dropped