### PR TITLE
[codex] fix Anthropic Messages system role normalization

### DIFF
--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -684,9 +684,10 @@ impl AIProvider {
 		tokenize: bool,
 		log: &mut Option<&mut RequestLog>,
 	) -> Result<RequestResult, AIError> {
-		let (parts, req) = self
+		let (parts, mut req) = self
 			.read_body_and_default_model::<types::messages::Request>(policies, req, log)
 			.await?;
+		req.normalize_system_role_messages();
 
 		self
 			.process_request(

--- a/crates/agentgateway/src/llm/tests.rs
+++ b/crates/agentgateway/src/llm/tests.rs
@@ -890,6 +890,272 @@ async fn openai_provider_preserves_max_tokens_for_non_gpt_models() {
 	assert_eq!(llm_request.params.max_tokens, Some(1024));
 }
 
+fn messages_backend_info() -> crate::http::auth::BackendInfo {
+	use crate::test_helpers::proxymock::setup_proxy_test;
+	use crate::types::agent::BackendTarget;
+
+	let inputs = setup_proxy_test("{}").unwrap().pi;
+	crate::http::auth::BackendInfo {
+		target: BackendTarget::Invalid,
+		call_target: Target::from(("localhost", 443)),
+		inputs,
+	}
+}
+
+async fn process_messages_json(
+	provider: AIProvider,
+	uri: &str,
+	body: Value,
+) -> (::http::Uri, Value, LLMRequest) {
+	let req = ::http::Request::builder()
+		.method("POST")
+		.uri(uri)
+		.header(::http::header::CONTENT_TYPE, "application/json")
+		.body(Body::from(serde_json::to_vec(&body).unwrap()))
+		.unwrap();
+
+	let RequestResult::Success(forwarded, llm_request) = provider
+		.process_messages_request(&messages_backend_info(), None, req, false, &mut None)
+		.await
+		.expect("messages request should process")
+	else {
+		panic!("expected forwarded request");
+	};
+
+	let uri = forwarded.uri().clone();
+	let forwarded_body = forwarded.collect().await.unwrap().to_bytes();
+	let forwarded_json: Value =
+		serde_json::from_slice(&forwarded_body).expect("forwarded request should be JSON");
+
+	(uri, forwarded_json, llm_request)
+}
+
+#[tokio::test]
+async fn anthropic_messages_lifts_system_role_message() {
+	let provider = AIProvider::Anthropic(anthropic::Provider { model: None });
+	let (uri, forwarded_json, _) = process_messages_json(
+		provider,
+		"/v1/messages?beta=true",
+		json!({
+			"model": "claude-sonnet-4-6",
+			"max_tokens": 128,
+			"messages": [
+				{"role": "system", "content": "You are helpful."},
+				{"role": "user", "content": "Say hi"}
+			],
+			"metadata": {"user_id": "test-user"}
+		}),
+	)
+	.await;
+
+	assert_eq!(
+		uri.path_and_query().unwrap().as_str(),
+		"/v1/messages?beta=true"
+	);
+	assert_eq!(forwarded_json["system"], json!("You are helpful."));
+	assert_eq!(
+		forwarded_json["messages"],
+		json!([
+			{"role": "user", "content": "Say hi"}
+		])
+	);
+	assert_eq!(forwarded_json["metadata"], json!({"user_id": "test-user"}));
+}
+
+#[tokio::test]
+async fn anthropic_messages_appends_lifted_system_to_existing_system() {
+	let provider = AIProvider::Anthropic(anthropic::Provider { model: None });
+	let (_, forwarded_json, _) = process_messages_json(
+		provider,
+		"/v1/messages",
+		json!({
+			"model": "claude-sonnet-4-6",
+			"max_tokens": 128,
+			"system": "Existing system.",
+			"messages": [
+				{"role": "system", "content": "Lifted system."},
+				{"role": "user", "content": "Say hi"}
+			]
+		}),
+	)
+	.await;
+
+	assert_eq!(
+		forwarded_json["system"],
+		json!([
+			{"type": "text", "text": "Existing system."},
+			{"type": "text", "text": "Lifted system."}
+		])
+	);
+	assert_eq!(
+		forwarded_json["messages"],
+		json!([
+			{"role": "user", "content": "Say hi"}
+		])
+	);
+}
+
+#[tokio::test]
+async fn anthropic_messages_lifts_multiple_system_role_messages_in_order() {
+	let provider = AIProvider::Anthropic(anthropic::Provider { model: None });
+	let (_, forwarded_json, _) = process_messages_json(
+		provider,
+		"/v1/messages",
+		json!({
+			"model": "claude-sonnet-4-6",
+			"max_tokens": 128,
+			"messages": [
+				{"role": "system", "content": "First system."},
+				{"role": "system", "content": "Second system."},
+				{"role": "user", "content": "Say hi"}
+			]
+		}),
+	)
+	.await;
+
+	assert_eq!(
+		forwarded_json["system"],
+		json!([
+			{"type": "text", "text": "First system."},
+			{"type": "text", "text": "Second system."}
+		])
+	);
+	assert_eq!(
+		forwarded_json["messages"],
+		json!([
+			{"role": "user", "content": "Say hi"}
+		])
+	);
+}
+
+#[tokio::test]
+async fn anthropic_messages_lifts_non_leading_system_role_message() {
+	let provider = AIProvider::Anthropic(anthropic::Provider { model: None });
+	let (_, forwarded_json, _) = process_messages_json(
+		provider,
+		"/v1/messages",
+		json!({
+			"model": "claude-sonnet-4-6",
+			"max_tokens": 128,
+			"messages": [
+				{"role": "user", "content": "First user."},
+				{"role": "system", "content": "Middle system."},
+				{"role": "assistant", "content": "Assistant reply."}
+			]
+		}),
+	)
+	.await;
+
+	assert_eq!(forwarded_json["system"], json!("Middle system."));
+	assert_eq!(
+		forwarded_json["messages"],
+		json!([
+			{"role": "user", "content": "First user."},
+			{"role": "assistant", "content": "Assistant reply."}
+		])
+	);
+}
+
+#[tokio::test]
+async fn anthropic_messages_lifts_content_block_system_message() {
+	let provider = AIProvider::Anthropic(anthropic::Provider { model: None });
+	let (_, forwarded_json, _) = process_messages_json(
+		provider,
+		"/v1/messages",
+		json!({
+			"model": "claude-sonnet-4-6",
+			"max_tokens": 128,
+			"messages": [
+				{
+					"role": "system",
+					"content": [
+						{
+							"type": "text",
+							"text": "Block system.",
+							"cache_control": {"type": "ephemeral"}
+						}
+					]
+				},
+				{"role": "user", "content": "Say hi"}
+			]
+		}),
+	)
+	.await;
+
+	assert_eq!(
+		forwarded_json["system"],
+		json!([
+			{
+				"type": "text",
+				"text": "Block system.",
+				"cache_control": {"type": "ephemeral"}
+			}
+		])
+	);
+	assert_eq!(
+		forwarded_json["messages"],
+		json!([
+			{"role": "user", "content": "Say hi"}
+		])
+	);
+}
+
+#[tokio::test]
+async fn anthropic_messages_without_system_role_messages_remain_unchanged() {
+	let provider = AIProvider::Anthropic(anthropic::Provider { model: None });
+	let input = json!({
+		"model": "claude-sonnet-4-6",
+		"max_tokens": 128,
+		"system": "Existing system.",
+		"messages": [
+			{"role": "user", "content": "Say hi"},
+			{"role": "assistant", "content": "Hi"}
+		],
+		"temperature": 0.2
+	});
+	let (_, forwarded_json, _) = process_messages_json(provider, "/v1/messages", input.clone()).await;
+
+	assert_eq!(forwarded_json, input);
+}
+
+#[tokio::test]
+async fn bedrock_messages_accepts_system_role_message_after_normalization() {
+	let provider = AIProvider::Bedrock(bedrock::Provider {
+		model: Some(strng::new("anthropic.claude-3-5-sonnet-20241022-v2:0")),
+		region: strng::new("us-west-2"),
+		guardrail_identifier: None,
+		guardrail_version: None,
+		source_credentials_cache: Default::default(),
+		assume_role_cache: Default::default(),
+	});
+	let (_, forwarded_json, _) = process_messages_json(
+		provider,
+		"/v1/messages",
+		json!({
+			"model": "anthropic.claude-3-5-sonnet-20241022-v2:0",
+			"max_tokens": 128,
+			"messages": [
+				{"role": "system", "content": "You are helpful."},
+				{"role": "user", "content": "Say hi"}
+			]
+		}),
+	)
+	.await;
+
+	assert_eq!(
+		forwarded_json["system"],
+		json!([
+			{"text": "You are helpful."}
+		])
+	);
+	assert_eq!(
+		forwarded_json["messages"],
+		json!([
+			{"role": "user", "content": [{"text": "Say hi"}]}
+		])
+	);
+}
+
 #[test]
 fn openai_token_limit_normalization_keeps_explicit_max_completion_tokens() {
 	let mut request: types::completions::Request = serde_json::from_value(json!({

--- a/crates/agentgateway/src/llm/types/messages.rs
+++ b/crates/agentgateway/src/llm/types/messages.rs
@@ -73,6 +73,63 @@ pub enum TextPart {
 	Unknown(serde_json::Value),
 }
 
+impl From<ContentPart> for TextPart {
+	fn from(part: ContentPart) -> Self {
+		match part {
+			ContentPart::Text { r#type, text, rest } => TextPart::Text { r#type, text, rest },
+			ContentPart::Unknown(value) => TextPart::Unknown(value),
+		}
+	}
+}
+
+impl From<ContentBlock> for TextBlock {
+	fn from(content: ContentBlock) -> Self {
+		match content {
+			ContentBlock::Text(text) => TextBlock::Text(text),
+			ContentBlock::Array(parts) => {
+				TextBlock::Array(parts.into_iter().map(TextPart::from).collect())
+			},
+		}
+	}
+}
+
+fn text_part(text: String) -> TextPart {
+	TextPart::Text {
+		r#type: "text".to_string(),
+		text,
+		rest: Default::default(),
+	}
+}
+
+fn text_block_into_parts(block: TextBlock) -> Vec<TextPart> {
+	match block {
+		TextBlock::Text(text) => vec![text_part(text)],
+		TextBlock::Array(parts) => parts,
+	}
+}
+
+fn append_lifted_system_content(system: &mut Option<TextBlock>, lifted: Vec<TextBlock>) {
+	if lifted.is_empty() {
+		return;
+	}
+
+	if system.is_none() && lifted.len() == 1 {
+		*system = lifted.into_iter().next();
+		return;
+	}
+
+	let mut parts = match std::mem::take(system) {
+		Some(existing) => text_block_into_parts(existing),
+		None => Vec::new(),
+	};
+
+	for block in lifted {
+		parts.extend(text_block_into_parts(block));
+	}
+
+	*system = Some(TextBlock::Array(parts));
+}
+
 #[derive(Debug, Deserialize, Clone, Serialize)]
 pub struct Response {
 	pub id: String,
@@ -177,6 +234,26 @@ pub fn get_messages_helper(
 		}
 	}));
 	out
+}
+
+impl Request {
+	pub(crate) fn normalize_system_role_messages(&mut self) {
+		let mut lifted_system = Vec::new();
+		let mut messages = Vec::with_capacity(self.messages.len());
+
+		for message in std::mem::take(&mut self.messages) {
+			if message.role == "system" {
+				if let Some(content) = message.content {
+					lifted_system.push(TextBlock::from(content));
+				}
+			} else {
+				messages.push(message);
+			}
+		}
+
+		self.messages = messages;
+		append_lifted_system_content(&mut self.system, lifted_system);
+	}
 }
 
 impl RequestType for Request {
@@ -289,21 +366,15 @@ pub fn prepend_prompts_helper(
 	if !system_prompts.is_empty() {
 		let mut items: Vec<TextPart> = match std::mem::take(system) {
 			Some(TextBlock::Array(existing)) => existing,
-			Some(TextBlock::Text(text)) => vec![TextPart::Text {
-				r#type: "text".to_string(),
-				text,
-				rest: Default::default(),
-			}],
+			Some(TextBlock::Text(text)) => vec![text_part(text)],
 			None => Vec::new(),
 		};
 
 		items.splice(
 			0..0,
-			system_prompts.into_iter().map(|p| TextPart::Text {
-				r#type: "text".to_string(),
-				text: p.content.to_string(),
-				rest: Default::default(),
-			}),
+			system_prompts
+				.into_iter()
+				.map(|p| text_part(p.content.to_string())),
 		);
 
 		*system = Some(TextBlock::Array(items));
@@ -325,20 +396,16 @@ pub fn append_prompts_helper(
 
 	if !system_prompts.is_empty() {
 		let mut items: Vec<TextPart> = match std::mem::take(system) {
-			Some(TextBlock::Text(text)) => vec![TextPart::Text {
-				r#type: "text".to_string(),
-				text,
-				rest: Default::default(),
-			}],
+			Some(TextBlock::Text(text)) => vec![text_part(text)],
 			Some(TextBlock::Array(existing)) => existing,
 			None => Vec::new(),
 		};
 
-		items.extend(system_prompts.into_iter().map(|p| TextPart::Text {
-			r#type: "text".to_string(),
-			text: p.content.to_string(),
-			rest: Default::default(),
-		}));
+		items.extend(
+			system_prompts
+				.into_iter()
+				.map(|p| text_part(p.content.to_string())),
+		);
 
 		*system = Some(TextBlock::Array(items));
 	}


### PR DESCRIPTION
## Summary

Fixes https://github.com/agentgateway/agentgateway/issues/2065.

Adds a narrow Anthropic Messages request normalization step for `/v1/messages` payloads that include `messages[].role == "system"` from Claude Code/Cowork gateway mode. System-role message content is lifted into top-level `system`, those entries are removed from `messages`, non-system messages keep their original order, and existing top-level system content is appended deterministically before lifted content.

## Changes

- Normalize Anthropic Messages requests immediately after parsing and before policy/log/provider conversion handling.
- Preserve single lifted string system prompts as a top-level string; merge existing/lifted system content as ordered text blocks when both are present.
- Preserve content-block style system text metadata such as `cache_control`.
- Add regression tests for Anthropic passthrough, existing-system merge, multiple lifted system messages, non-leading system messages, content-block system content, unchanged valid requests, and Bedrock strict role parsing.

## Validation

- Before the Copilot follow-up commit: `cargo test -p agentgateway anthropic_messages_ -- --nocapture` passed.
- Before the Copilot follow-up commit: `cargo test -p agentgateway bedrock_messages_accepts_system_role_message_after_normalization -- --nocapture` passed.
- Before the Copilot follow-up commit: `cargo test -p agentgateway` passed.
- Current commit: `cargo fmt --check` passed.
- Current commit: `git diff --check` passed.
- Current commit: `cargo test -p agentgateway anthropic_messages_ -- --nocapture` could not complete locally because the host volume is full (`No space left on device` while linking in `target`).
- `cargo clippy -p agentgateway --all-targets -- -D warnings` could not complete locally because the host volume was full (`No space left on device` while compiling dependencies in `target` and the system temp dir).