### PR TITLE
include mcp-session-id in cors request header to make the basic tutor…

### DIFF
--- a/examples/basic/config.yaml
+++ b/examples/basic/config.yaml
@@ -11,6 +11,7 @@ binds:
           - mcp-protocol-version
           - content-type
           - cache-control
+          - mcp-session-id
           exposeHeaders:
           - "Mcp-Session-Id"
       backends:


### PR DESCRIPTION
…ial example work with the agentgateway ui playground

elaboration..
basically if you work through the basic tutorial:
https://agentgateway.dev/docs/standalone/latest/tutorials/basic/

one cannot connect from the agentgateway ui playground to the mcp server.  it's because of the missing allowHeaders: mcp-session-id header.  this PR adds the header to the list (for cors).