### PR TITLE
agctl: restructure CLI and add proxy/controller log commands

### DIFF
--- a/controller/pkg/cli/config/cmd.go
+++ b/controller/pkg/cli/config/cmd.go
@@ -11,13 +11,13 @@ import (
 
 	"github.com/agentgateway/agentgateway/controller/pkg/cli/flag"
 	"github.com/agentgateway/agentgateway/controller/pkg/cli/kubeutil"
+	"github.com/agentgateway/agentgateway/controller/pkg/wellknown"
 )
 
 const (
-	defaultProxyAdminPort = 15000
-	shortOutput           = "short"
-	jsonOutput            = "json"
-	yamlOutput            = "yaml"
+	shortOutput = "short"
+	jsonOutput  = "json"
+	yamlOutput  = "yaml"
 )
 
 type commonFlags struct {
@@ -37,7 +37,7 @@ type configDumpSource struct {
 
 func Command() flag.Command {
 	common := &commonFlags{
-		proxyAdminPort: defaultProxyAdminPort,
+		proxyAdminPort: wellknown.ProxyAdminPort,
 		outputFormat:   shortOutput,
 	}
 

--- a/controller/pkg/cli/controller/cmd.go
+++ b/controller/pkg/cli/controller/cmd.go
@@ -1,0 +1,19 @@
+package controller
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/agentgateway/agentgateway/controller/pkg/cli/controller/log"
+)
+
+func Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "controller",
+		Short: "Inspect and manage the Agentgateway controller",
+		Long:  "Inspect and manage the Agentgateway controller admin API.",
+	}
+
+	cmd.AddCommand(log.Command())
+
+	return cmd
+}

--- a/controller/pkg/cli/controller/log/cmd.go
+++ b/controller/pkg/cli/controller/log/cmd.go
@@ -1,0 +1,132 @@
+package log
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/agentgateway/agentgateway/controller/pkg/cli/kubeutil"
+	"github.com/agentgateway/agentgateway/controller/pkg/utils/namespaces"
+	"github.com/agentgateway/agentgateway/controller/pkg/wellknown"
+)
+
+type flags struct {
+	namespace           string
+	controllerAdminPort int
+	level               string
+	set                 []string
+}
+
+func Command() *cobra.Command {
+	f := &flags{controllerAdminPort: int(wellknown.AdminPort)}
+
+	cmd := &cobra.Command{
+		Use:   "log",
+		Short: "Get or set controller log levels",
+		Long: `Get or set log levels on the Agentgateway controller.
+
+With no flags, prints the current log level for each component.
+
+Examples:
+  agctl controller log                               # show current levels
+  agctl controller log --level debug                 # set all components to debug
+  agctl controller log --set reconciler=debug        # set a single component
+  agctl controller log --set reconciler=debug --set xds=info  # set multiple
+
+When multiple controller pods are running, all are targeted and output
+is prefixed per pod. All pods are attempted even if one fails.`,
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return run(cmd, f)
+		},
+	}
+
+	cmd.Flags().StringVarP(&f.namespace, "namespace", "n", namespaces.DefaultNamespace, "Namespace where the controller is running")
+	cmd.Flags().IntVar(&f.controllerAdminPort, "controller-admin-port", f.controllerAdminPort, "Controller admin port")
+	cmd.Flags().StringVar(&f.level, "level", "", "Set log level for all components (error|warn|info|debug|trace)")
+	cmd.Flags().StringArrayVar(&f.set, "set", nil, "Set a component log level: component=level (may be repeated)")
+
+	return cmd
+}
+
+func run(cmd *cobra.Command, f *flags) error {
+	if f.level != "" && len(f.set) > 0 {
+		return fmt.Errorf("--level and --set are mutually exclusive")
+	}
+
+	kubeClient, err := kubeutil.NewCLIClient()
+	if err != nil {
+		return err
+	}
+
+	pods, err := kubeutil.ResolveControllerPods(cmd.Context(), kubeClient, f.namespace)
+	if err != nil {
+		return err
+	}
+
+	path, err := buildPath(f)
+	if err != nil {
+		return err
+	}
+
+	// The controller /logging handler requires POST or PUT even for reads;
+	// sending POST with no query params returns the current levels.
+	return kubeutil.ForEachPod(cmd.Context(), pods, cmd.OutOrStdout(), func(ctx context.Context, pod kubeutil.Pod) (string, error) {
+		out, err := kubeClient.EnvoyDoWithPort(ctx, pod.Name, pod.Namespace, "POST", path, f.controllerAdminPort)
+		if err != nil {
+			return "", err
+		}
+		return string(out), nil
+	})
+}
+
+// buildPath constructs the request path for the controller /logging endpoint.
+// The controller accepts POST/PUT with:
+//   - no params: returns current log levels
+//   - ?level=<level>: sets all components to level
+//   - ?<component>=<level>&...: sets specific components
+func buildPath(f *flags) (string, error) {
+	if f.level != "" {
+		if err := validateLevel(f.level); err != nil {
+			return "", err
+		}
+		return "logging?level=" + url.QueryEscape(f.level), nil
+	}
+
+	if len(f.set) == 0 {
+		return "logging", nil
+	}
+
+	params := url.Values{}
+	for _, s := range f.set {
+		for _, part := range strings.Split(s, ",") {
+			part = strings.TrimSpace(part)
+			if part == "" {
+				continue
+			}
+			kv := strings.SplitN(part, "=", 2)
+			if len(kv) != 2 || kv[0] == "" {
+				return "", fmt.Errorf("invalid --set value %q: expected component=level", part)
+			}
+			if err := validateLevel(kv[1]); err != nil {
+				return "", fmt.Errorf("--set %s: %w", kv[0], err)
+			}
+			params.Set(kv[0], kv[1])
+		}
+	}
+
+	return "logging?" + params.Encode(), nil
+}
+
+func validateLevel(level string) error {
+	switch strings.ToLower(level) {
+	case "error", "warn", "info", "debug", "trace":
+		return nil
+	default:
+		return fmt.Errorf("unknown level %q; must be one of error|warn|info|debug|trace", level)
+	}
+}

--- a/controller/pkg/cli/controller/log/cmd.go
+++ b/controller/pkg/cli/controller/log/cmd.go
@@ -46,7 +46,7 @@ is prefixed per pod. All pods are attempted even if one fails.`,
 	}
 
 	cmd.Flags().StringVarP(&f.namespace, "namespace", "n", namespaces.DefaultNamespace, "Namespace where the controller is running")
-	cmd.Flags().IntVar(&f.controllerAdminPort, "controller-admin-port", f.controllerAdminPort, "Controller admin port")
+	cmd.Flags().IntVarP(&f.controllerAdminPort, "controller-admin-port", "p", f.controllerAdminPort, "Controller admin port")
 	cmd.Flags().StringVar(&f.level, "level", "", "Set log level for all components (error|warn|info|debug|trace)")
 	cmd.Flags().StringArrayVar(&f.set, "set", nil, "Set a component log level: component=level (may be repeated)")
 

--- a/controller/pkg/cli/controller/log/cmd.go
+++ b/controller/pkg/cli/controller/log/cmd.go
@@ -103,7 +103,7 @@ func buildPath(f *flags) (string, error) {
 
 	params := url.Values{}
 	for _, s := range f.set {
-		for _, part := range strings.Split(s, ",") {
+		for part := range strings.SplitSeq(s, ",") {
 			part = strings.TrimSpace(part)
 			if part == "" {
 				continue

--- a/controller/pkg/cli/kubeutil/kube.go
+++ b/controller/pkg/cli/kubeutil/kube.go
@@ -99,7 +99,7 @@ func ResolvePodsForResource(kubeClient kube.CLIClient, resourceName, namespace s
 // ResolveControllerPods returns all controller pods in namespace, identified
 // by the app.kubernetes.io/name=agentgateway label, sorted by name.
 func ResolveControllerPods(ctx context.Context, kubeClient kube.CLIClient, namespace string) ([]Pod, error) {
-	selector := fmt.Sprintf("%s=%s", wellknown.KubernetesAppNameLabel, wellknown.KubernetesAppNameValue)
+	selector := fmt.Sprintf("%s=%s", wellknown.AgentgatewayLabel, wellknown.AgentgatewayLabelValue)
 	list, err := kubeClient.Kube().CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: selector,
 	})

--- a/controller/pkg/cli/kubeutil/kube.go
+++ b/controller/pkg/cli/kubeutil/kube.go
@@ -3,17 +3,25 @@ package kubeutil
 import (
 	"context"
 	"fmt"
+	"io"
 	"slices"
 
 	istiocli "istio.io/istio/istioctl/pkg/cli"
 	"istio.io/istio/istioctl/pkg/util/handlers"
 	"istio.io/istio/pkg/kube"
+	"k8s.io/apimachinery/pkg/util/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/agentgateway/agentgateway/controller/pkg/cli/flag"
 )
+
+// Pod identifies a single Kubernetes pod by name and namespace.
+type Pod struct {
+	Name      string
+	Namespace string
+}
 
 func LoadNamespace(namespaceOverride string) (string, error) {
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
@@ -52,17 +60,88 @@ func ResolveResourceName(ctx context.Context, kubeClient kube.CLIClient, namespa
 	return inferSingleGatewayResourceName(ctx, kubeClient, namespace)
 }
 
+// ResolvePodForResource returns the first (alphabetically) pod backing the
+// named resource. Use this only for commands that inherently target a single
+// pod (e.g. opening a streaming connection). For commands that should reach
+// all pods, use ResolvePodsForResource with ForEachPod.
 func ResolvePodForResource(kubeClient kube.CLIClient, resourceName, namespace string) (string, string, error) {
-	factory := istiocli.MakeKubeFactory(kubeClient)
-	pods, podNamespace, err := handlers.InferPodsFromTypedResource(resourceName, namespace, factory)
+	pods, err := ResolvePodsForResource(kubeClient, resourceName, namespace)
 	if err != nil {
 		return "", "", err
 	}
-	if len(pods) == 0 {
-		return "", "", fmt.Errorf("no pods found for resource %q", resourceName)
+	return pods[0].Name, pods[0].Namespace, nil
+}
+
+// ResolvePodsForResource returns all pods backing the named resource, sorted
+// by name for deterministic ordering.
+func ResolvePodsForResource(kubeClient kube.CLIClient, resourceName, namespace string) ([]Pod, error) {
+	factory := istiocli.MakeKubeFactory(kubeClient)
+	names, podNamespace, err := handlers.InferPodsFromTypedResource(resourceName, namespace, factory)
+	if err != nil {
+		return nil, err
 	}
-	slices.Sort(pods)
-	return pods[0], podNamespace, nil
+	if len(names) == 0 {
+		return nil, fmt.Errorf("no pods found for resource %q", resourceName)
+	}
+	slices.Sort(names)
+	pods := make([]Pod, len(names))
+	for i, n := range names {
+		pods[i] = Pod{Name: n, Namespace: podNamespace}
+	}
+	return pods, nil
+}
+
+// ResolveControllerPods returns all controller pods in namespace, identified
+// by the app.kubernetes.io/name=agentgateway label, sorted by name.
+func ResolveControllerPods(ctx context.Context, kubeClient kube.CLIClient, namespace string) ([]Pod, error) {
+	list, err := kubeClient.Kube().CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "app.kubernetes.io/name=agentgateway",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list controller pods in namespace %q: %w", namespace, err)
+	}
+	if len(list.Items) == 0 {
+		return nil, fmt.Errorf("no controller pods found in namespace %q (label app.kubernetes.io/name=agentgateway)", namespace)
+	}
+	pods := make([]Pod, len(list.Items))
+	for i, p := range list.Items {
+		pods[i] = Pod{Name: p.Name, Namespace: p.Namespace}
+	}
+	slices.SortFunc(pods, func(a, b Pod) int {
+		if a.Name < b.Name {
+			return -1
+		}
+		if a.Name > b.Name {
+			return 1
+		}
+		return 0
+	})
+	return pods, nil
+}
+
+// ForEachPod calls fn for every pod in pods, writes prefixed output to w, and
+// returns a combined error for any pods that failed. All pods are attempted
+// regardless of individual failures.
+//
+// Output format per pod:
+//
+//	<name>.<namespace>:
+//	<fn output>
+func ForEachPod(ctx context.Context, pods []Pod, w io.Writer, fn func(ctx context.Context, pod Pod) (string, error)) error {
+	prefix := len(pods) > 1
+	var errs []error
+	for _, pod := range pods {
+		out, err := fn(ctx, pod)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("%s.%s: %w", pod.Name, pod.Namespace, err))
+			continue
+		}
+		if prefix {
+			fmt.Fprintf(w, "%s.%s:\n", pod.Name, pod.Namespace)
+		}
+		fmt.Fprint(w, out)
+	}
+	return errors.NewAggregate(errs)
 }
 
 func inferSingleGatewayResourceName(ctx context.Context, kubeClient kube.CLIClient, namespace string) (string, error) {

--- a/controller/pkg/cli/kubeutil/kube.go
+++ b/controller/pkg/cli/kubeutil/kube.go
@@ -9,12 +9,13 @@ import (
 	istiocli "istio.io/istio/istioctl/pkg/cli"
 	"istio.io/istio/istioctl/pkg/util/handlers"
 	"istio.io/istio/pkg/kube"
-	"k8s.io/apimachinery/pkg/util/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/tools/clientcmd"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/agentgateway/agentgateway/controller/pkg/cli/flag"
+	"github.com/agentgateway/agentgateway/controller/pkg/wellknown"
 )
 
 // Pod identifies a single Kubernetes pod by name and namespace.
@@ -66,6 +67,10 @@ func ResolveResourceName(ctx context.Context, kubeClient kube.CLIClient, namespa
 // all pods, use ResolvePodsForResource with ForEachPod.
 func ResolvePodForResource(kubeClient kube.CLIClient, resourceName, namespace string) (string, string, error) {
 	pods, err := ResolvePodsForResource(kubeClient, resourceName, namespace)
+	// ResolvePodsForResource errors on empty, but guard explicitly in case that changes.
+	if len(pods) == 0 {
+		return "", "", fmt.Errorf("no pods found for resource %q", resourceName)
+	}
 	if err != nil {
 		return "", "", err
 	}
@@ -94,14 +99,15 @@ func ResolvePodsForResource(kubeClient kube.CLIClient, resourceName, namespace s
 // ResolveControllerPods returns all controller pods in namespace, identified
 // by the app.kubernetes.io/name=agentgateway label, sorted by name.
 func ResolveControllerPods(ctx context.Context, kubeClient kube.CLIClient, namespace string) ([]Pod, error) {
+	selector := fmt.Sprintf("%s=%s", wellknown.KubernetesAppNameLabel, wellknown.KubernetesAppNameValue)
 	list, err := kubeClient.Kube().CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
-		LabelSelector: "app.kubernetes.io/name=agentgateway",
+		LabelSelector: selector,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to list controller pods in namespace %q: %w", namespace, err)
 	}
 	if len(list.Items) == 0 {
-		return nil, fmt.Errorf("no controller pods found in namespace %q (label app.kubernetes.io/name=agentgateway)", namespace)
+		return nil, fmt.Errorf("no controller pods found in namespace %q (label %s)", namespace, selector)
 	}
 	pods := make([]Pod, len(list.Items))
 	for i, p := range list.Items {

--- a/controller/pkg/cli/proxy/cmd.go
+++ b/controller/pkg/cli/proxy/cmd.go
@@ -1,0 +1,24 @@
+package proxy
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/agentgateway/agentgateway/controller/pkg/cli/config"
+	"github.com/agentgateway/agentgateway/controller/pkg/cli/flag"
+	"github.com/agentgateway/agentgateway/controller/pkg/cli/proxy/log"
+	"github.com/agentgateway/agentgateway/controller/pkg/cli/trace"
+)
+
+func Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "proxy",
+		Short: "Inspect and manage the Agentgateway proxy",
+		Long:  "Inspect and manage the Agentgateway proxy admin API.",
+	}
+
+	cmd.AddCommand(flag.BuildCobra(config.Command))
+	cmd.AddCommand(flag.BuildCobra(trace.Command))
+	cmd.AddCommand(log.Command())
+
+	return cmd
+}

--- a/controller/pkg/cli/proxy/log/cmd.go
+++ b/controller/pkg/cli/proxy/log/cmd.go
@@ -9,9 +9,8 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/agentgateway/agentgateway/controller/pkg/cli/kubeutil"
+	"github.com/agentgateway/agentgateway/controller/pkg/wellknown"
 )
-
-const defaultProxyAdminPort = 15000
 
 type flags struct {
 	namespace      string
@@ -21,7 +20,7 @@ type flags struct {
 }
 
 func Command() *cobra.Command {
-	f := &flags{proxyAdminPort: defaultProxyAdminPort}
+	f := &flags{proxyAdminPort: wellknown.ProxyAdminPort}
 
 	cmd := &cobra.Command{
 		Use:   "log [resource]",
@@ -52,7 +51,7 @@ prefixed per pod. All pods are attempted even if one fails.`,
 	}
 
 	cmd.Flags().StringVarP(&f.namespace, "namespace", "n", "", "Namespace for proxy pod resolution")
-	cmd.Flags().IntVar(&f.proxyAdminPort, "proxy-admin-port", f.proxyAdminPort, "Proxy admin port")
+	cmd.Flags().IntVarP(&f.proxyAdminPort, "proxy-admin-port", "p", f.proxyAdminPort, "Proxy admin port")
 	cmd.Flags().StringVar(&f.level, "level", "", "Set global log level (error|warn|info|debug|trace|off)")
 	cmd.Flags().StringArrayVar(&f.set, "set", nil, "Set module log level: module=level (may be repeated or comma-separated)")
 

--- a/controller/pkg/cli/proxy/log/cmd.go
+++ b/controller/pkg/cli/proxy/log/cmd.go
@@ -116,7 +116,7 @@ func buildPath(f *flags) (string, error) {
 
 	var directives []string
 	for _, s := range f.set {
-		for _, part := range strings.Split(s, ",") {
+		for part := range strings.SplitSeq(s, ",") {
 			part = strings.TrimSpace(part)
 			if part == "" {
 				continue

--- a/controller/pkg/cli/proxy/log/cmd.go
+++ b/controller/pkg/cli/proxy/log/cmd.go
@@ -1,0 +1,151 @@
+package log
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/agentgateway/agentgateway/controller/pkg/cli/kubeutil"
+)
+
+const defaultProxyAdminPort = 15000
+
+type flags struct {
+	namespace      string
+	proxyAdminPort int
+	level          string
+	set            []string
+}
+
+func Command() *cobra.Command {
+	f := &flags{proxyAdminPort: defaultProxyAdminPort}
+
+	cmd := &cobra.Command{
+		Use:   "log [resource]",
+		Short: "Get or set proxy log levels",
+		Long: `Get or set log levels on the Agentgateway proxy.
+
+With no flags, prints the current active log filter directive.
+
+The proxy uses Rust tracing-subscriber filter directives. Module names are
+Rust crate paths (e.g. agentgateway::proxy). See the Agentgateway docs for
+the full list of valid module paths. Level changes via --set are additive:
+they append to the current directive rather than replacing it. Use --level
+to reset to a clean global level.
+
+Examples:
+  agctl proxy log                                      # show current directive
+  agctl proxy log --level debug                        # set global level
+  agctl proxy log --set agentgateway::proxy=debug      # set a single module
+  agctl proxy log --set agentgateway::proxy=debug,agentgateway::http=info
+
+When multiple pods back a resource, all are targeted and output is
+prefixed per pod. All pods are attempted even if one fails.`,
+		Args:         cobra.MaximumNArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return run(cmd, f, args)
+		},
+	}
+
+	cmd.Flags().StringVarP(&f.namespace, "namespace", "n", "", "Namespace for proxy pod resolution")
+	cmd.Flags().IntVar(&f.proxyAdminPort, "proxy-admin-port", f.proxyAdminPort, "Proxy admin port")
+	cmd.Flags().StringVar(&f.level, "level", "", "Set global log level (error|warn|info|debug|trace|off)")
+	cmd.Flags().StringArrayVar(&f.set, "set", nil, "Set module log level: module=level (may be repeated or comma-separated)")
+
+	return cmd
+}
+
+func run(cmd *cobra.Command, f *flags, args []string) error {
+	if f.level != "" && len(f.set) > 0 {
+		return fmt.Errorf("--level and --set are mutually exclusive")
+	}
+
+	namespace, err := kubeutil.LoadNamespace(f.namespace)
+	if err != nil {
+		return err
+	}
+
+	kubeClient, err := kubeutil.NewCLIClient()
+	if err != nil {
+		return err
+	}
+
+	resourceName, err := kubeutil.ResolveResourceName(cmd.Context(), kubeClient, namespace, args)
+	if err != nil {
+		return err
+	}
+
+	pods, err := kubeutil.ResolvePodsForResource(kubeClient, resourceName, namespace)
+	if err != nil {
+		return err
+	}
+
+	path, err := buildPath(f)
+	if err != nil {
+		return err
+	}
+
+	return kubeutil.ForEachPod(cmd.Context(), pods, cmd.OutOrStdout(), func(ctx context.Context, pod kubeutil.Pod) (string, error) {
+		out, err := kubeClient.EnvoyDoWithPort(ctx, pod.Name, pod.Namespace, "POST", path, f.proxyAdminPort)
+		if err != nil {
+			return "", err
+		}
+		return string(out), nil
+	})
+}
+
+// buildPath constructs the request path for the proxy /logging endpoint.
+// The proxy accepts:
+//   - no params: returns current level
+//   - ?level=<level>: sets global level
+//   - ?level=mod1:lvl1,mod2:lvl2: sets per-module levels (Rust tracing directive)
+func buildPath(f *flags) (string, error) {
+	if f.level != "" {
+		if err := validateLevel(f.level); err != nil {
+			return "", err
+		}
+		return "logging?level=" + url.QueryEscape(f.level), nil
+	}
+
+	if len(f.set) == 0 {
+		return "logging", nil
+	}
+
+	var directives []string
+	for _, s := range f.set {
+		for _, part := range strings.Split(s, ",") {
+			part = strings.TrimSpace(part)
+			if part == "" {
+				continue
+			}
+			if !strings.Contains(part, "=") {
+				return "", fmt.Errorf("invalid --set value %q: expected module=level", part)
+			}
+			kv := strings.SplitN(part, "=", 2)
+			if err := validateLevel(kv[1]); err != nil {
+				return "", fmt.Errorf("--set %s: %w", kv[0], err)
+			}
+			// Proxy directive format uses colon separator: module:level
+			directives = append(directives, kv[0]+":"+kv[1])
+		}
+	}
+
+	if len(directives) == 0 {
+		return "logging", nil
+	}
+
+	return "logging?level=" + url.QueryEscape(strings.Join(directives, ",")), nil
+}
+
+func validateLevel(level string) error {
+	switch strings.ToLower(level) {
+	case "error", "warn", "info", "debug", "trace", "off":
+		return nil
+	default:
+		return fmt.Errorf("unknown level %q; must be one of error|warn|info|debug|trace|off", level)
+	}
+}

--- a/controller/pkg/cli/root.go
+++ b/controller/pkg/cli/root.go
@@ -1,12 +1,15 @@
 package cli
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
 
 	"github.com/agentgateway/agentgateway/controller/pkg/cli/config"
+	controllercmd "github.com/agentgateway/agentgateway/controller/pkg/cli/controller"
 	"github.com/agentgateway/agentgateway/controller/pkg/cli/flag"
+	proxycmd "github.com/agentgateway/agentgateway/controller/pkg/cli/proxy"
 	"github.com/agentgateway/agentgateway/controller/pkg/cli/trace"
 	cliversion "github.com/agentgateway/agentgateway/controller/pkg/cli/version"
 )
@@ -19,10 +22,23 @@ func NewRootCmd() *cobra.Command {
 
 	flag.AttachGlobalFlags(rootCmd)
 	rootCmd.AddCommand(flag.BuildCobra(cliversion.Command))
-	rootCmd.AddCommand(flag.BuildCobra(config.Command))
-	rootCmd.AddCommand(flag.BuildCobra(trace.Command))
+	rootCmd.AddCommand(proxycmd.Command())
+	rootCmd.AddCommand(controllercmd.Command())
+
+	// Deprecated top-level aliases — delegate to the canonical subcommands.
+	rootCmd.AddCommand(deprecatedAlias("config", "agctl proxy config", flag.BuildCobra(config.Command)))
+	rootCmd.AddCommand(deprecatedAlias("trace", "agctl proxy trace", flag.BuildCobra(trace.Command)))
 
 	return rootCmd
+}
+
+// deprecatedAlias wraps cmd so that running it prints a deprecation notice and
+// then executes the same underlying logic.
+func deprecatedAlias(use, canonical string, cmd *cobra.Command) *cobra.Command {
+	cmd.Use = use
+	cmd.Deprecated = fmt.Sprintf("use \"%s\" instead", canonical)
+	cmd.Hidden = true
+	return cmd
 }
 
 func Execute() {

--- a/controller/pkg/cli/trace/cmd.go
+++ b/controller/pkg/cli/trace/cmd.go
@@ -6,9 +6,8 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/agentgateway/agentgateway/controller/pkg/cli/flag"
+	"github.com/agentgateway/agentgateway/controller/pkg/wellknown"
 )
-
-const defaultProxyAdminPort = 15000
 
 type traceFlags struct {
 	namespace      string
@@ -22,7 +21,7 @@ type traceFlags struct {
 
 func Command() flag.Command {
 	flags := &traceFlags{
-		proxyAdminPort: defaultProxyAdminPort,
+		proxyAdminPort: wellknown.ProxyAdminPort,
 	}
 
 	return flag.Command{

--- a/controller/pkg/wellknown/labels.go
+++ b/controller/pkg/wellknown/labels.go
@@ -1,0 +1,6 @@
+package wellknown
+
+const (
+	KubernetesAppNameLabel = "app.kubernetes.io/name"
+	KubernetesAppNameValue = "agentgateway"
+)

--- a/controller/pkg/wellknown/labels.go
+++ b/controller/pkg/wellknown/labels.go
@@ -1,6 +1,6 @@
 package wellknown
 
 const (
-	KubernetesAppNameLabel = "app.kubernetes.io/name"
-	KubernetesAppNameValue = "agentgateway"
+	AgentgatewayLabel      = "agentgateway"
+	AgentgatewayLabelValue = "agentgateway"
 )

--- a/controller/pkg/wellknown/ports.go
+++ b/controller/pkg/wellknown/ports.go
@@ -1,4 +1,7 @@
 package wellknown
 
-// AdminPort is the admin server port
+// AdminPort is the controller admin server port
 var AdminPort uint32 = 9095
+
+// ProxyAdminPort is the proxy admin server port
+const ProxyAdminPort = 15000


### PR DESCRIPTION
## Summary

- Restructures `agctl` around `agctl proxy` and `agctl controller` subcommand groups; existing `config` and `trace` commands move under `agctl proxy` with deprecated top-level aliases
- Adds `agctl proxy log` to read and set log levels on the proxy admin API
- Adds `agctl controller log` to read and set log levels on the controller admin API

## Commands

```
agctl proxy log [resource]                                        # show current filter directive
agctl proxy log --level debug                                     # set global level (resets directive)
agctl proxy log --set agentgateway::proxy=debug                   # append a module directive
agctl proxy log --set agentgateway::proxy=debug,agentgateway::http=info

agctl controller log                                              # show current component levels
agctl controller log --level debug                                # set all components to debug
agctl controller log --set reconciler=debug                       # set a single component
```

Both commands use `kubectl port-forward` to the target pod via the existing `EnvoyDoWithPort` mechanism. No new cluster-side changes are required; both `/logging` endpoints already exist.

The proxy command uses Rust tracing-subscriber filter directives (`module:level`). Module names are Rust crate paths (e.g. `agentgateway::proxy`); see the Agentgateway docs for the full list of valid module paths. `--set` is additive — it appends to the current directive rather than replacing it. Use `--level` to reset to a clean global level.

The controller command uses Go slog component names (`?component=level`). Valid component names are self-enumerating: running `agctl controller log` with no flags prints every registered component and its current level.

When multiple pods back a resource (scaled proxy, HA controller), all pods are targeted via `kubeutil.ForEachPod`. Output is prefixed per pod; all pods are attempted before any error is returned. Reads similarly fan out to all pods — log levels are process-local state and may differ across replicas.

## Deprecation

`agctl config` and `agctl trace` remain functional at the top level and print:

```
Command "config" is deprecated, use "agctl proxy config" instead
```

## Test plan

- [x] `agctl proxy log` prints the current tracing-subscriber filter directive
- [ ] `agctl proxy log --level debug` sets the global proxy log level
- [ ] `agctl proxy log --set agentgateway::proxy=debug` appends a module-level directive
- [ ] `agctl proxy log --set` followed by a second `--set` correctly appends both directives
- [ ] `agctl controller log` prints current component levels
- [ ] `agctl controller log --level debug` sets all controller components
- [ ] `agctl config` prints the deprecation notice and behaves identically to `agctl proxy config`
- [ ] `agctl trace` prints the deprecation notice and behaves identically to `agctl proxy trace`
- [ ] `agctl proxy log --level x --set y=z` returns an error

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
