### PR TITLE
mcp: support resource subscribe

### DIFF
--- a/crates/agentgateway/src/mcp/handler.rs
+++ b/crates/agentgateway/src/mcp/handler.rs
@@ -11,7 +11,8 @@ use rmcp::ErrorData;
 use rmcp::model::{
 	ClientNotification, ClientRequest, Implementation, JsonRpcNotification, JsonRpcRequest,
 	ListPromptsResult, ListResourceTemplatesResult, ListResourcesResult, ListToolsResult,
-	ProtocolVersion, RequestId, ServerCapabilities, ServerInfo, ServerJsonRpcMessage, ServerResult,
+	ProtocolVersion, RequestId, ServerCapabilities, ServerInfo, ServerJsonRpcMessage,
+	ServerNotification, ServerResult,
 };
 use tracing::{debug, warn};
 
@@ -53,6 +54,24 @@ fn resource_uri(default_target_name: Option<&String>, target: &str, uri: &str) -
 	}
 }
 
+fn rewrite_resource_update_message(
+	default_target_name: Option<&String>,
+	target: &str,
+	mut message: ServerJsonRpcMessage,
+) -> ServerJsonRpcMessage {
+	if let ServerJsonRpcMessage::Notification(notification) = &mut message
+		&& let ServerNotification::ResourceUpdatedNotification(resource_updated) =
+			&mut notification.notification
+	{
+		resource_updated.params.uri = resource_uri(
+			default_target_name,
+			target,
+			resource_updated.params.uri.as_str(),
+		);
+	}
+	message
+}
+
 #[derive(Debug, Clone)]
 pub struct Relay {
 	upstreams: Arc<upstream::UpstreamGroup>,
@@ -87,6 +106,14 @@ impl Relay {
 			upstreams: self.upstreams.clone(),
 			policies,
 		}
+	}
+
+	fn rewrite_outbound_server_messages(&self, target: &str, stream: Messages) -> Messages {
+		let target = target.to_string();
+		let default_target_name = self.upstreams.default_target_name.clone();
+		stream.map_server_messages(move |message| {
+			rewrite_resource_update_message(default_target_name.as_ref(), &target, message)
+		})
 	}
 
 	pub fn parse_resource_name<'a, 'b: 'a>(
@@ -232,6 +259,7 @@ impl Relay {
 	}
 
 	pub fn merge_initialize(&self, pv: ProtocolVersion, multiplexing: bool) -> Box<MergeFn> {
+		let resource_subscribe = self.upstreams.stateful();
 		Box::new(move |s| {
 			if !multiplexing {
 				// Happy case: we can forward everything
@@ -244,7 +272,7 @@ impl Relay {
 				}
 				// If we got here in FailOpen mode, it means the only target failed.
 				// Return a default info response to keep the client session alive.
-				return Ok(Self::get_info(pv, multiplexing, Vec::new()).into());
+				return Ok(Self::get_info(pv, resource_subscribe, Vec::new()).into());
 			}
 
 			// Multiplexing is more complex. We need to find the lowest protocol version
@@ -265,7 +293,7 @@ impl Relay {
 				}
 			}
 
-			Ok(Self::get_info(lowest_version, multiplexing, upstream_instructions).into())
+			Ok(Self::get_info(lowest_version, resource_subscribe, upstream_instructions).into())
 		})
 	}
 
@@ -408,7 +436,8 @@ impl Relay {
 				"unknown service {service_name}"
 			)));
 		};
-		let stream = us.generic_stream(r, &ctx).await?;
+		let stream =
+			self.rewrite_outbound_server_messages(service_name, us.generic_stream(r, &ctx).await?);
 
 		messages_to_response(id, stream, mcp_log)
 	}
@@ -463,7 +492,10 @@ impl Relay {
 
 		for (name, result) in fut_results {
 			match result {
-				Ok(s) => streams.push((name, s)),
+				Ok(s) => {
+					let s = self.rewrite_outbound_server_messages(name.as_str(), s);
+					streams.push((name, s));
+				},
 				Err(e) => {
 					if self.upstreams.failure_mode == FailureMode::FailOpen {
 						let is_405 = if let UpstreamError::Http(ClientError::Status(ref r)) = e
@@ -520,7 +552,10 @@ impl Relay {
 
 		for (name, result) in fut_results {
 			match result {
-				Ok(s) => streams.push((name, s)),
+				Ok(s) => {
+					let s = self.rewrite_outbound_server_messages(name.as_str(), s);
+					streams.push((name, s));
+				},
 				Err(e) => {
 					if self.upstreams.failure_mode == FailureMode::FailOpen {
 						warn!("upstream '{}' failed during fanout, skipping: {}", name, e);
@@ -598,24 +633,21 @@ impl Relay {
 
 	fn get_info(
 		pv: ProtocolVersion,
-		multiplexing: bool,
+		resource_subscribe: bool,
 		upstream_instructions: Vec<(String, String)>,
 	) -> ServerInfo {
-		let capabilities = if multiplexing {
+		let capabilities = {
 			// Prompts are supported with multiplexing using proxy-prefixed names.
 			// Resources are supported with multiplexing using service+scheme:// URI prefixing.
-			ServerCapabilities::builder()
+			let mut builder = ServerCapabilities::builder()
 				.enable_tools()
 				.enable_tool_list_changed()
 				.enable_prompts()
-				.enable_resources()
-				.build()
-		} else {
-			ServerCapabilities::builder()
-				.enable_tools()
-				.enable_prompts()
-				.enable_resources()
-				.build()
+				.enable_resources();
+			if resource_subscribe {
+				builder = builder.enable_resources_subscribe();
+			}
+			builder.build()
 		};
 		let gateway_preamble = "This server is a gateway to a set of mcp servers. It is responsible for routing requests to the correct server and aggregating the results.";
 		let instructions = if upstream_instructions.is_empty() {

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -1,4 +1,5 @@
 use std::net::SocketAddr;
+use std::sync::Arc;
 
 use agent_core::strng;
 use itertools::Itertools;
@@ -234,7 +235,7 @@ async fn stream_to_multiplex_resources() {
 }
 
 #[tokio::test]
-async fn multiplex_advertises_tool_list_changed() {
+async fn multiplex_advertises_tool_and_resource_subscribe_capabilities() {
 	let mock_a = mock_streamable_http_server(true).await;
 	let mock_b = mock_streamable_http_server(true).await;
 	let t = setup_proxy_test("{}")
@@ -250,6 +251,26 @@ async fn multiplex_advertises_tool_list_changed() {
 	let client = mcp_streamable_client(io).await;
 	let caps = &client.peer_info().unwrap().capabilities;
 	assert_eq!(caps.tools.as_ref().unwrap().list_changed, Some(true));
+	assert_eq!(caps.resources.as_ref().unwrap().subscribe, Some(true));
+}
+
+#[tokio::test]
+async fn stateless_multiplex_does_not_advertise_resource_subscribe() {
+	let mock_a = mock_streamable_http_server(true).await;
+	let mock_b = mock_streamable_http_server(true).await;
+	let t = setup_proxy_test("{}")
+		.unwrap()
+		.with_multiplex_mcp_backend(
+			"mcp",
+			vec![("a", mock_a.addr, false), ("b", mock_b.addr, false)],
+			false,
+		)
+		.with_bind(simple_bind())
+		.with_route(basic_named_route(strng::new("/mcp")));
+	let io = t.serve_real_listener(strng::new("bind")).await;
+	let client = mcp_streamable_client(io).await;
+	let caps = &client.peer_info().unwrap().capabilities;
+	assert_ne!(caps.resources.as_ref().unwrap().subscribe, Some(true));
 }
 
 #[tokio::test]
@@ -764,6 +785,93 @@ async fn resource_subscribe_and_unsubscribe_forward_to_single_backend() {
 		))
 		.await
 		.unwrap();
+}
+
+#[tokio::test]
+async fn multiplex_resource_subscribe_and_unsubscribe_route_to_target() {
+	let mock_a = mock_streamable_http_server(true).await;
+	let mock_b = mock_streamable_http_server(true).await;
+	let t = setup_proxy_test("{}")
+		.unwrap()
+		.with_multiplex_mcp_backend(
+			"mcp",
+			vec![("a", mock_a.addr, false), ("b", mock_b.addr, false)],
+			true,
+		)
+		.with_bind(simple_bind())
+		.with_route(basic_named_route(strng::new("/mcp")));
+	let io = t.serve_real_listener(strng::new("bind")).await;
+	let client = mcp_streamable_client(io).await;
+
+	client
+		.subscribe(rmcp::model::SubscribeRequestParams::new(
+			"a+memo://insights",
+		))
+		.await
+		.unwrap();
+	client
+		.unsubscribe(rmcp::model::UnsubscribeRequestParams::new(
+			"a+memo://insights",
+		))
+		.await
+		.unwrap();
+
+	assert!(
+		client
+			.subscribe(rmcp::model::SubscribeRequestParams::new("memo://insights"))
+			.await
+			.is_err(),
+		"expected unprefixed multiplex resource subscribe to fail"
+	);
+}
+
+#[tokio::test]
+async fn multiplex_resource_updated_notification_is_prefixed() {
+	let mock_a = mock_streamable_http_server(true).await;
+	let mock_b = mock_streamable_http_server(true).await;
+	let t = setup_proxy_test("{}")
+		.unwrap()
+		.with_multiplex_mcp_backend(
+			"mcp",
+			vec![("a", mock_a.addr, false), ("b", mock_b.addr, false)],
+			true,
+		)
+		.with_bind(simple_bind())
+		.with_route(basic_named_route(strng::new("/mcp")));
+	let io = t.serve_real_listener(strng::new("bind")).await;
+	let (client, updated_uri, notify) = mcp_streamable_client_capture_resource_updates(io).await;
+
+	client
+		.subscribe(rmcp::model::SubscribeRequestParams::new(
+			"a+memo://insights",
+		))
+		.await
+		.unwrap();
+	tokio::time::timeout(std::time::Duration::from_secs(5), notify.notified())
+		.await
+		.unwrap();
+
+	assert_eq!(
+		updated_uri.lock().await.as_deref(),
+		Some("a+memo://insights")
+	);
+}
+
+#[tokio::test]
+async fn single_resource_updated_notification_is_not_prefixed() {
+	let mock = mock_streamable_http_server(true).await;
+	let (_bind, io) = setup_proxy(&mock, true, false).await;
+	let (client, updated_uri, notify) = mcp_streamable_client_capture_resource_updates(io).await;
+
+	client
+		.subscribe(rmcp::model::SubscribeRequestParams::new("memo://insights"))
+		.await
+		.unwrap();
+	tokio::time::timeout(std::time::Duration::from_secs(5), notify.notified())
+		.await
+		.unwrap();
+
+	assert_eq!(updated_uri.lock().await.as_deref(), Some("memo://insights"));
 }
 
 /// Test that a deny policy targeting a specific tool filters only that tool from list_tools,
@@ -1360,6 +1468,48 @@ pub async fn mcp_streamable_client(
 		.unwrap()
 }
 
+#[derive(Clone)]
+struct ResourceUpdateClient {
+	updated_uri: Arc<tokio::sync::Mutex<Option<String>>>,
+	notify: Arc<tokio::sync::Notify>,
+}
+
+impl rmcp::ClientHandler for ResourceUpdateClient {
+	async fn on_resource_updated(
+		&self,
+		params: rmcp::model::ResourceUpdatedNotificationParam,
+		_: rmcp::service::NotificationContext<RoleClient>,
+	) {
+		*self.updated_uri.lock().await = Some(params.uri);
+		self.notify.notify_one();
+	}
+}
+
+async fn mcp_streamable_client_capture_resource_updates(
+	s: SocketAddr,
+) -> (
+	RunningService<RoleClient, ResourceUpdateClient>,
+	Arc<tokio::sync::Mutex<Option<String>>>,
+	Arc<tokio::sync::Notify>,
+) {
+	use rmcp::ServiceExt;
+	use rmcp::transport::StreamableHttpClientTransport;
+	let transport =
+		StreamableHttpClientTransport::<reqwest::Client>::from_uri(format!("http://{s}/mcp"));
+	let updated_uri = Arc::new(tokio::sync::Mutex::new(None));
+	let notify = Arc::new(tokio::sync::Notify::new());
+	let client = ResourceUpdateClient {
+		updated_uri: updated_uri.clone(),
+		notify: notify.clone(),
+	};
+
+	(
+		Box::pin(client.serve(transport)).await.unwrap(),
+		updated_uri,
+		notify,
+	)
+}
+
 type LegacyService = legacy_rmcp::service::RunningService<
 	legacy_rmcp::RoleClient,
 	legacy_rmcp::model::InitializeRequestParam,
@@ -1708,10 +1858,19 @@ mod mockserver {
 		async fn subscribe(
 			&self,
 			SubscribeRequestParams { uri, .. }: SubscribeRequestParams,
-			_: RequestContext<RoleServer>,
+			ctx: RequestContext<RoleServer>,
 		) -> Result<(), McpError> {
 			match uri.as_str() {
-				"str:////Users/to/some/path/" | "memo://insights" => Ok(()),
+				"str:////Users/to/some/path/" | "memo://insights" => {
+					let peer = ctx.peer;
+					let notify_uri = uri.clone();
+					tokio::spawn(async move {
+						let _ = peer
+							.notify_resource_updated(ResourceUpdatedNotificationParam::new(notify_uri))
+							.await;
+					});
+					Ok(())
+				},
 				_ => Err(McpError::resource_not_found(
 					"resource_not_found",
 					Some(json!({

--- a/crates/agentgateway/src/mcp/mergestream.rs
+++ b/crates/agentgateway/src/mcp/mergestream.rs
@@ -25,6 +25,21 @@ impl Messages {
 	pub fn from_result<T: Into<ServerResult>>(id: RequestId, result: T) -> Self {
 		Self::from(ServerJsonRpcMessage::response(result.into(), id))
 	}
+
+	pub fn map_server_messages(
+		self,
+		mut f: impl FnMut(ServerJsonRpcMessage) -> ServerJsonRpcMessage + Send + 'static,
+	) -> Self {
+		Messages(
+			self
+				.0
+				.map(move |message| match message {
+					Ok(message) => Ok(f(message)),
+					Err(err) => Err(err),
+				})
+				.boxed(),
+		)
+	}
 }
 
 impl Stream for Messages {

--- a/crates/agentgateway/src/mcp/upstream/mod.rs
+++ b/crates/agentgateway/src/mcp/upstream/mod.rs
@@ -313,6 +313,10 @@ impl UpstreamGroup {
 		self.by_name.get_key_value(name).map(|(k, _)| k.as_str())
 	}
 
+	pub(crate) fn stateful(&self) -> bool {
+		self.backend.stateful
+	}
+
 	fn setup_upstream(&self, target: &McpTarget) -> Result<upstream::Upstream, mcp::Error> {
 		trace!("connecting to target: {}", target.name);
 		let target = match &target.spec {


### PR DESCRIPTION
This adds support for the resource subscribe method. The only trick here is we need to watch the GET stream and transform the name with multiplexing.