### PR TITLE
Add per mcp backend oauth passthrough

### DIFF
--- a/api/resource.pb.go
+++ b/api/resource.pb.go
@@ -7106,10 +7106,14 @@ type MCPBackend struct {
 	// to mix stateful and stateless targets in the same backend.
 	StatefulMode MCPBackend_StatefulMode `protobuf:"varint,3,opt,name=stateful_mode,json=statefulMode,proto3,enum=agentgateway.dev.resource.MCPBackend_StatefulMode" json:"stateful_mode,omitempty"`
 	// Whether to always prefix the tool name using the target name
-	PrefixMode    MCPBackend_PrefixMode  `protobuf:"varint,4,opt,name=prefix_mode,json=prefixMode,proto3,enum=agentgateway.dev.resource.MCPBackend_PrefixMode" json:"prefix_mode,omitempty"`
-	FailureMode   MCPBackend_FailureMode `protobuf:"varint,5,opt,name=failure_mode,json=failureMode,proto3,enum=agentgateway.dev.resource.MCPBackend_FailureMode" json:"failure_mode,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	PrefixMode  MCPBackend_PrefixMode  `protobuf:"varint,4,opt,name=prefix_mode,json=prefixMode,proto3,enum=agentgateway.dev.resource.MCPBackend_PrefixMode" json:"prefix_mode,omitempty"`
+	FailureMode MCPBackend_FailureMode `protobuf:"varint,5,opt,name=failure_mode,json=failureMode,proto3,enum=agentgateway.dev.resource.MCPBackend_FailureMode" json:"failure_mode,omitempty"`
+	// When true, .well-known/ OAuth discovery requests are forwarded to the backend
+	// MCP server instead of being handled by the gateway. This enables hosting MCP servers
+	// that have their own OAuth flow behind the gateway while preserving observability.
+	OauthPassthrough bool `protobuf:"varint,6,opt,name=oauth_passthrough,json=oauthPassthrough,proto3" json:"oauth_passthrough,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *MCPBackend) Reset() {
@@ -7168,6 +7172,13 @@ func (x *MCPBackend) GetFailureMode() MCPBackend_FailureMode {
 		return x.FailureMode
 	}
 	return MCPBackend_FAIL_CLOSED
+}
+
+func (x *MCPBackend) GetOauthPassthrough() bool {
+	if x != nil {
+		return x.OauthPassthrough
+	}
+	return false
 }
 
 type MCPTarget struct {
@@ -14505,14 +14516,15 @@ const file_resource_proto_rawDesc = "" +
 	"\n" +
 	"EMBEDDINGS\x10\x04\x12\x19\n" +
 	"\x15ANTHROPIC_TOKEN_COUNT\x10\x05\x12\f\n" +
-	"\bREALTIME\x10\x06\"\xd5\x03\n" +
+	"\bREALTIME\x10\x06\"\x82\x04\n" +
 	"\n" +
 	"MCPBackend\x12>\n" +
 	"\atargets\x18\x02 \x03(\v2$.agentgateway.dev.resource.MCPTargetR\atargets\x12W\n" +
 	"\rstateful_mode\x18\x03 \x01(\x0e22.agentgateway.dev.resource.MCPBackend.StatefulModeR\fstatefulMode\x12Q\n" +
 	"\vprefix_mode\x18\x04 \x01(\x0e20.agentgateway.dev.resource.MCPBackend.PrefixModeR\n" +
 	"prefixMode\x12T\n" +
-	"\ffailure_mode\x18\x05 \x01(\x0e21.agentgateway.dev.resource.MCPBackend.FailureModeR\vfailureMode\"+\n" +
+	"\ffailure_mode\x18\x05 \x01(\x0e21.agentgateway.dev.resource.MCPBackend.FailureModeR\vfailureMode\x12+\n" +
+	"\x11oauth_passthrough\x18\x06 \x01(\bR\x10oauthPassthrough\"+\n" +
 	"\fStatefulMode\x12\f\n" +
 	"\bSTATEFUL\x10\x00\x12\r\n" +
 	"\tSTATELESS\x10\x01\")\n" +

--- a/controller/api/v1alpha1/agentgateway/agentgateway_backend_types.go
+++ b/controller/api/v1alpha1/agentgateway/agentgateway_backend_types.go
@@ -509,6 +509,13 @@ type MCPBackend struct {
 	// entire session if any target fails.
 	// +optional
 	FailureMode FailureMode `json:"failureMode,omitempty"`
+
+	// `oauthPassthrough` when true, forwards `.well-known/` OAuth discovery
+	// requests to the backend MCP server instead of handling them at the gateway.
+	// Use this when the target MCP server has its own OAuth flow.
+	// Defaults to false.
+	// +optional
+	OauthPassthrough bool `json:"oauthPassthrough,omitempty"`
 }
 
 const (

--- a/controller/pkg/syncer/backend/backend_plugin.go
+++ b/controller/pkg/syncer/backend/backend_plugin.go
@@ -349,9 +349,10 @@ func TranslateMCPBackends(ctx plugins.PolicyCtx, be *agentgateway.AgentgatewayBa
 		Name: plugins.ResourceName(be),
 		Kind: &api.Backend_Mcp{
 			Mcp: &api.MCPBackend{
-				Targets:      mcpTargets,
-				StatefulMode: sessionRouting,
-				FailureMode:  failureMode,
+				Targets:          mcpTargets,
+				StatefulMode:     sessionRouting,
+				FailureMode:      failureMode,
+				OauthPassthrough: mcp.OauthPassthrough,
 			},
 		},
 		InlinePolicies: inlinePolicies,

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -996,6 +996,97 @@ async fn mcp_authentication_early_response_transformation_has_request_context() 
 	);
 }
 
+#[tokio::test]
+async fn mcp_oauth_passthrough_forwards_well_known_to_backend() {
+	// Start a simple HTTP server that responds to .well-known requests with a custom header
+	// to prove the request was forwarded rather than handled by the gateway.
+	let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+	let addr = listener.local_addr().unwrap();
+	let _server = tokio::spawn(async move {
+		loop {
+			let (stream, _) = listener.accept().await.unwrap();
+			tokio::spawn(async move {
+				let io = hyper_util::rt::TokioIo::new(stream);
+				let service =
+					hyper::service::service_fn(|req: hyper::Request<hyper::body::Incoming>| async move {
+						if req.uri().path().contains("/.well-known/") {
+							Ok::<_, std::convert::Infallible>(
+								hyper::Response::builder()
+									.status(200)
+									.header("content-type", "application/json")
+									.header("x-oauth-source", "backend-mcp")
+									.body(http_body_util::Full::new(bytes::Bytes::from(
+										r#"{"resource":"https://backend-mcp.example.com"}"#,
+									)))
+									.unwrap(),
+							)
+						} else {
+							Ok(
+								hyper::Response::builder()
+									.status(404)
+									.body(http_body_util::Full::new(bytes::Bytes::new()))
+									.unwrap(),
+							)
+						}
+					});
+				let _ = hyper::server::conn::http1::Builder::new()
+					.serve_connection(io, service)
+					.await;
+			});
+		}
+	});
+
+	let authn = crate::types::agent::McpAuthentication {
+		issuer: "https://issuer.example.com".to_string(),
+		audiences: vec!["mcp".to_string()],
+		provider: None,
+		resource_metadata: crate::types::agent::ResourceMetadata {
+			extra: Default::default(),
+		},
+		jwt_validator: Arc::new(crate::http::jwt::Jwt::from_providers(
+			vec![],
+			crate::http::jwt::Mode::Strict,
+			crate::http::auth::AuthorizationLocation::bearer_header(),
+		)),
+		mode: crate::types::agent::McpAuthenticationMode::Strict,
+		client_id: None,
+	};
+
+	let t = setup_proxy_test("{}")
+		.unwrap()
+		.with_mcp_backend_oauth_passthrough(
+			addr,
+			true,
+			false,
+			vec![BackendTrafficPolicy::McpAuthentication(authn)],
+		)
+		.with_bind(simple_bind())
+		.with_route(basic_route(addr));
+
+	let io = t.serve_real_listener(BIND_KEY).await;
+
+	// With oauth_passthrough=true, .well-known/ requests should be forwarded to the backend
+	// instead of being intercepted by the gateway's OAuth handler.
+	let resp = reqwest::Client::new()
+		.get(format!(
+			"http://{io}/.well-known/oauth-protected-resource/mcp"
+		))
+		.send()
+		.await
+		.expect("metadata request should complete");
+
+	assert_eq!(resp.status(), reqwest::StatusCode::OK);
+	// The backend's custom header proves the request was forwarded, not handled locally
+	assert_eq!(
+		resp
+			.headers()
+			.get("x-oauth-source")
+			.and_then(|v| v.to_str().ok()),
+		Some("backend-mcp"),
+		"request should have been forwarded to the backend MCP server"
+	);
+}
+
 async fn standard_assertions(client: RunningService<RoleClient, InitializeRequestParams>) {
 	let tools = client.list_tools(None).await.unwrap();
 	let t = tools

--- a/crates/agentgateway/src/mcp/router.rs
+++ b/crates/agentgateway/src/mcp/router.rs
@@ -43,7 +43,7 @@ impl App {
 			return None;
 		}
 
-		if backend_policies.mcp_authentication.is_some() {
+		if backend_policies.mcp_authentication.is_some() && !backend.oauth_passthrough {
 			return None;
 		}
 		if !req.uri().path().contains("/.well-known/") {

--- a/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
@@ -1473,6 +1473,7 @@ async fn test_openapi_from_url() {
 		stateful_mode: McpStatefulMode::Stateful,
 		prefix_mode: None,
 		failure_mode: None,
+		oauth_passthrough: false,
 	});
 
 	// Convert to runtime backends

--- a/crates/agentgateway/src/test_helpers/proxymock.rs
+++ b/crates/agentgateway/src/test_helpers/proxymock.rs
@@ -648,6 +648,56 @@ impl TestBind {
 		self.with_mcp_backend_policies(b, stateful, legacy_sse, Default::default())
 	}
 
+	pub fn with_mcp_backend_oauth_passthrough(
+		self,
+		b: SocketAddr,
+		stateful: bool,
+		legacy_sse: bool,
+		policies: Vec<BackendTrafficPolicy>,
+	) -> Self {
+		let opb = Backend::Opaque(
+			ResourceName::new(strng::format!("basic-{}", b), "".into()),
+			Target::Address(b),
+		);
+		let sb = SimpleBackendReference::Backend(strng::format!("/basic-{}", b));
+		let b = Backend::MCP(
+			ResourceName::new(strng::format!("{}", b), "".into()),
+			McpBackend {
+				targets: vec![Arc::new(McpTarget {
+					name: "mcp".into(),
+					spec: if !legacy_sse {
+						McpTargetSpec::Mcp(StreamableHTTPTargetSpec {
+							backend: sb,
+							path: "/mcp".to_string(),
+						})
+					} else {
+						McpTargetSpec::Sse(SseTargetSpec {
+							backend: sb,
+							path: "/sse".to_string(),
+						})
+					},
+				})],
+				stateful,
+				always_use_prefix: false,
+				failure_mode: FailureMode::FailClosed,
+				session_idle_ttl: crate::mcp::DEFAULT_SESSION_IDLE_TTL,
+				oauth_passthrough: true,
+			},
+		);
+		{
+			let mut bw = self.pi.stores.binds.write();
+			bw.insert_backend(opb.name(), opb.into());
+			bw.insert_backend(
+				b.name(),
+				BackendWithPolicies {
+					backend: b,
+					inline_policies: policies,
+				},
+			);
+		}
+		self
+	}
+
 	pub fn with_mcp_backend_policies(
 		self,
 		b: SocketAddr,
@@ -681,6 +731,7 @@ impl TestBind {
 				always_use_prefix: false,
 				failure_mode: FailureMode::FailClosed,
 				session_idle_ttl: crate::mcp::DEFAULT_SESSION_IDLE_TTL,
+				oauth_passthrough: false,
 			},
 		);
 		{
@@ -730,6 +781,7 @@ impl TestBind {
 				always_use_prefix: false,
 				failure_mode: FailureMode::FailClosed,
 				session_idle_ttl: crate::mcp::DEFAULT_SESSION_IDLE_TTL,
+				oauth_passthrough: false,
 			},
 		);
 		{

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -1393,6 +1393,10 @@ pub struct McpBackend {
 	#[serde(with = "crate::serdes::serde_dur")]
 	#[cfg_attr(feature = "schema", schemars(with = "String"))]
 	pub session_idle_ttl: Duration,
+	/// When true, `.well-known/` OAuth discovery requests are forwarded to the backend
+	/// MCP server instead of being handled by the gateway. This enables hosting MCP servers
+	/// that have their own OAuth flow behind the gateway while preserving observability.
+	pub oauth_passthrough: bool,
 }
 
 impl McpBackend {

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -1293,6 +1293,7 @@ pub(crate) fn backend_with_policies_from_proto(
 					proto::agent::mcp_backend::FailureMode::FailClosed => FailureMode::FailClosed,
 				},
 				session_idle_ttl: crate::mcp::DEFAULT_SESSION_IDLE_TTL,
+				oauth_passthrough: m.oauth_passthrough,
 			},
 		),
 		None => {

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -1044,6 +1044,7 @@ impl LocalBackend {
 					}),
 					failure_mode: tgt.failure_mode.unwrap_or_default(),
 					session_idle_ttl: mcp_session_ttl,
+					oauth_passthrough: tgt.oauth_passthrough,
 				};
 				backends.push(Backend::MCP(name, m).into());
 				backends
@@ -1115,6 +1116,11 @@ pub struct LocalMcpBackend {
 	/// Defaults to `failClosed`.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub failure_mode: Option<FailureMode>,
+	/// When true, `.well-known/` OAuth discovery requests are forwarded to the backend
+	/// MCP server instead of being handled by the gateway. Use this when the target MCP
+	/// server has its own OAuth flow.
+	#[serde(default)]
+	pub oauth_passthrough: bool,
 }
 
 #[apply(schema_de!)]

--- a/crates/protos/proto/resource.proto
+++ b/crates/protos/proto/resource.proto
@@ -1506,6 +1506,11 @@ message MCPBackend {
     FAIL_OPEN = 1;
   }
   FailureMode failure_mode = 5;
+
+  // When true, .well-known/ OAuth discovery requests are forwarded to the backend
+  // MCP server instead of being handled by the gateway. This enables hosting MCP servers
+  // that have their own OAuth flow behind the gateway while preserving observability.
+  bool oauth_passthrough = 6;
 }
 
 message MCPTarget {

--- a/schema/config.json
+++ b/schema/config.json
@@ -5341,6 +5341,11 @@
               "type": "null"
             }
           ]
+        },
+        "oauthPassthrough": {
+          "description": "When true, `.well-known/` OAuth discovery requests are forwarded to the backend\nMCP server instead of being handled by the gateway. Use this when the target MCP\nserver has its own OAuth flow.",
+          "type": "boolean",
+          "default": false
         }
       },
       "additionalProperties": false,
@@ -8054,6 +8059,11 @@
               "type": "null"
             }
           ]
+        },
+        "oauthPassthrough": {
+          "description": "When true, `.well-known/` OAuth discovery requests are forwarded to the backend\nMCP server instead of being handled by the gateway. Use this when the target MCP\nserver has its own OAuth flow.",
+          "type": "boolean",
+          "default": false
         },
         "policies": {
           "anyOf": [

--- a/schema/config.md
+++ b/schema/config.md
@@ -2091,6 +2091,7 @@
 |`binds[].listeners[].routes[].backends[].mcp.statefulMode`|enum|Possible values: `stateless`, `stateful`.|
 |`binds[].listeners[].routes[].backends[].mcp.prefixMode`|enum|Possible values: `always`, `conditional`, `null`.|
 |`binds[].listeners[].routes[].backends[].mcp.failureMode`|enum|Behavior when one or more MCP targets fail to initialize or fail during fanout.<br>Defaults to `failClosed`.<br>Possible values: `failClosed`, `failOpen`.|
+|`binds[].listeners[].routes[].backends[].mcp.oauthPassthrough`|boolean|When true, `.well-known/` OAuth discovery requests are forwarded to the backend<br>MCP server instead of being handled by the gateway. Use this when the target MCP<br>server has its own OAuth flow.|
 |`binds[].listeners[].routes[].backends[].ai`|object||
 |`binds[].listeners[].routes[].backends[].ai.name`|string||
 |`binds[].listeners[].routes[].backends[].ai.provider`|object|Exactly one of openAI, gemini, vertex, anthropic, bedrock, azure, copilot, or custom may be set.|
@@ -8374,6 +8375,7 @@
 |`backends[].mcp.statefulMode`|enum|Possible values: `stateless`, `stateful`.|
 |`backends[].mcp.prefixMode`|enum|Possible values: `always`, `conditional`, `null`.|
 |`backends[].mcp.failureMode`|enum|Behavior when one or more MCP targets fail to initialize or fail during fanout.<br>Defaults to `failClosed`.<br>Possible values: `failClosed`, `failOpen`.|
+|`backends[].mcp.oauthPassthrough`|boolean|When true, `.well-known/` OAuth discovery requests are forwarded to the backend<br>MCP server instead of being handled by the gateway. Use this when the target MCP<br>server has its own OAuth flow.|
 |`backends[].ai`|object||
 |`backends[].ai.name`|string||
 |`backends[].ai.provider`|object|Exactly one of openAI, gemini, vertex, anthropic, bedrock, azure, copilot, or custom may be set.|
@@ -13735,6 +13737,7 @@
 |`routeGroups[].routes[].backends[].mcp.statefulMode`|enum|Possible values: `stateless`, `stateful`.|
 |`routeGroups[].routes[].backends[].mcp.prefixMode`|enum|Possible values: `always`, `conditional`, `null`.|
 |`routeGroups[].routes[].backends[].mcp.failureMode`|enum|Behavior when one or more MCP targets fail to initialize or fail during fanout.<br>Defaults to `failClosed`.<br>Possible values: `failClosed`, `failOpen`.|
+|`routeGroups[].routes[].backends[].mcp.oauthPassthrough`|boolean|When true, `.well-known/` OAuth discovery requests are forwarded to the backend<br>MCP server instead of being handled by the gateway. Use this when the target MCP<br>server has its own OAuth flow.|
 |`routeGroups[].routes[].backends[].ai`|object||
 |`routeGroups[].routes[].backends[].ai.name`|string||
 |`routeGroups[].routes[].backends[].ai.provider`|object|Exactly one of openAI, gemini, vertex, anthropic, bedrock, azure, copilot, or custom may be set.|
@@ -18880,6 +18883,7 @@
 |`mcp.statefulMode`|enum|Possible values: `stateless`, `stateful`.|
 |`mcp.prefixMode`|enum|Possible values: `always`, `conditional`, `null`.|
 |`mcp.failureMode`|enum|Behavior when one or more MCP targets fail to initialize or fail during fanout.<br>Defaults to `failClosed`.<br>Possible values: `failClosed`, `failOpen`.|
+|`mcp.oauthPassthrough`|boolean|When true, `.well-known/` OAuth discovery requests are forwarded to the backend<br>MCP server instead of being handled by the gateway. Use this when the target MCP<br>server has its own OAuth flow.|
 |`mcp.policies`|object||
 |`mcp.policies.requestHeaderModifier`|object|Headers to be modified in the request.|
 |`mcp.policies.requestHeaderModifier.add`|object||


### PR DESCRIPTION
This PR adds a per mcp backend oauth passthrough flag so some  MCP servers can handle their own Oauth while others use the gateway.