### PR TITLE
fix(ui): show XDS route path prefixes

### DIFF
--- a/ui/src/lib/configMapper.ts
+++ b/ui/src/lib/configMapper.ts
@@ -219,14 +219,15 @@ function mapToMatches(matchesData: any): Match[] {
     }
 
     if (matchData.path) {
-      if (matchData.path.exact) {
-        match.path.exact = matchData.path.exact;
-      } else if (matchData.path.pathPrefix) {
-        match.path.pathPrefix = matchData.path.pathPrefix;
-      } else if (matchData.path.prefix) {
-        match.path.pathPrefix = matchData.path.prefix;
-      } else if (matchData.path.regex) {
-        match.path.regex = matchData.path.regex;
+      const pathData = matchData.path;
+      if (typeof pathData.exact === "string") {
+        match.path.exact = pathData.exact;
+      } else if (typeof pathData.pathPrefix === "string") {
+        match.path.pathPrefix = pathData.pathPrefix;
+      } else if (typeof pathData.prefix === "string") {
+        match.path.pathPrefix = pathData.prefix;
+      } else if (typeof pathData.regex === "string") {
+        match.path.regex = pathData.regex;
       }
     }
 

--- a/ui/src/lib/configMapper.ts
+++ b/ui/src/lib/configMapper.ts
@@ -221,6 +221,8 @@ function mapToMatches(matchesData: any): Match[] {
     if (matchData.path) {
       if (matchData.path.exact) {
         match.path.exact = matchData.path.exact;
+      } else if (matchData.path.pathPrefix) {
+        match.path.pathPrefix = matchData.path.pathPrefix;
       } else if (matchData.path.prefix) {
         match.path.pathPrefix = matchData.path.prefix;
       } else if (matchData.path.regex) {


### PR DESCRIPTION
## Summary

Fixes #1370.

The admin UI routes page was showing `/` for every HTTPRoute in XDS/Kubernetes mode because `configMapper.ts` only checked `matchData.path.prefix`.

The `/config_dump` response uses `pathPrefix`, so the path was not mapped into the UI route model and the display helper fell back to `/`.

## Changes

- Read `matchData.path.pathPrefix` when mapping route matches from `/config_dump`
- Keep `matchData.path.prefix` as a fallback for compatibility with any older/internal shape

## Testing

```bash
git diff --check
npm run lint -- --file src/lib/configMapper.ts
npm run lint
./node_modules/.bin/next build
```

Note: full UI lint/build still reports two unrelated existing warnings in ui/src/app/cel/page.tsx.