### PR TITLE
fix flaky crdgen AtLeastOneFieldSet inference

### DIFF
--- a/controller/hack/crdgen/main.go
+++ b/controller/hack/crdgen/main.go
@@ -276,18 +276,16 @@ func populateInferredMarkerFields(parser *crd.Parser) error {
 			return fmt.Errorf("%s: %w", candidate.typ, err)
 		}
 
-		if markerVals, ok := candidate.info.Markers[atLeastOneFieldSetMarker]; ok {
-			for i, raw := range markerVals {
-				marker, err := asAtLeastOneFieldSet(raw)
-				if err != nil {
-					return fmt.Errorf("%s: %w", candidate.typ, err)
-				}
-				if len(marker.Fields) == 0 {
-					marker.Fields = append([]string(nil), inferredFields...)
-					markerVals[i] = marker
-				}
+		markerVals := candidate.info.Markers[atLeastOneFieldSetMarker]
+		for i, raw := range markerVals {
+			marker, err := asAtLeastOneFieldSet(raw)
+			if err != nil {
+				return fmt.Errorf("%s: %w", candidate.typ, err)
 			}
-			candidate.info.Markers[atLeastOneFieldSetMarker] = markerVals
+			if len(marker.Fields) == 0 {
+				marker.Fields = append([]string(nil), inferredFields...)
+				markerVals[i] = marker
+			}
 		}
 	}
 
@@ -299,6 +297,11 @@ type inferredMarkerCandidate struct {
 	info *markers.TypeInfo
 }
 
+// inferredMarkerCandidates returns types with AtLeastOneFieldSet markers that need field
+// inference. Snapshot before inference: walking inline embedded fields can call
+// parser.NeedPackage and mutate parser.Types. Late-loaded types must not join this pass by
+// map-iteration luck; markers left without inferred fields are resolved later from their
+// generated schema node in ApplyToSchema.
 func inferredMarkerCandidates(parser *crd.Parser) ([]inferredMarkerCandidate, error) {
 	candidates := make([]inferredMarkerCandidate, 0, len(parser.Types))
 	for typ, info := range parser.Types {
@@ -318,8 +321,7 @@ func inferredMarkerCandidates(parser *crd.Parser) ([]inferredMarkerCandidate, er
 		}
 	}
 
-	// Inference can load imported packages into parser.Types. Snapshot first so
-	// generated validation does not depend on Go map iteration over new entries.
+	// Sort so processing order (and which error surfaces first) is deterministic.
 	sort.Slice(candidates, func(i, j int) bool {
 		iPkg := loader.NonVendorPath(candidates[i].typ.Package.PkgPath)
 		jPkg := loader.NonVendorPath(candidates[j].typ.Package.PkgPath)

--- a/controller/hack/crdgen/main.go
+++ b/controller/hack/crdgen/main.go
@@ -265,43 +265,70 @@ func populateInferredMarkerFields(parser *crd.Parser) error {
 	fieldCache := make(map[crd.TypeIdent][]string)
 	inProgress := make(map[crd.TypeIdent]bool)
 
-	for typ, info := range parser.Types {
-		needInferredFields := false
-		for _, raw := range info.Markers[atLeastOneFieldSetMarker] {
-			marker, err := asAtLeastOneFieldSet(raw)
-			if err != nil {
-				return fmt.Errorf("%s: %w", typ, err)
-			}
-			if len(marker.Fields) == 0 {
-				needInferredFields = true
-				break
-			}
-		}
-		if !needInferredFields {
-			continue
-		}
+	candidates, err := inferredMarkerCandidates(parser)
+	if err != nil {
+		return err
+	}
 
-		inferredFields, err := allJSONFieldNamesForType(parser, typ, info, fieldCache, inProgress)
+	for _, candidate := range candidates {
+		inferredFields, err := allJSONFieldNamesForType(parser, candidate.typ, candidate.info, fieldCache, inProgress)
 		if err != nil {
-			return fmt.Errorf("%s: %w", typ, err)
+			return fmt.Errorf("%s: %w", candidate.typ, err)
 		}
 
-		if markerVals, ok := info.Markers[atLeastOneFieldSetMarker]; ok {
+		if markerVals, ok := candidate.info.Markers[atLeastOneFieldSetMarker]; ok {
 			for i, raw := range markerVals {
 				marker, err := asAtLeastOneFieldSet(raw)
 				if err != nil {
-					return fmt.Errorf("%s: %w", typ, err)
+					return fmt.Errorf("%s: %w", candidate.typ, err)
 				}
 				if len(marker.Fields) == 0 {
 					marker.Fields = append([]string(nil), inferredFields...)
 					markerVals[i] = marker
 				}
 			}
-			info.Markers[atLeastOneFieldSetMarker] = markerVals
+			candidate.info.Markers[atLeastOneFieldSetMarker] = markerVals
 		}
 	}
 
 	return nil
+}
+
+type inferredMarkerCandidate struct {
+	typ  crd.TypeIdent
+	info *markers.TypeInfo
+}
+
+func inferredMarkerCandidates(parser *crd.Parser) ([]inferredMarkerCandidate, error) {
+	candidates := make([]inferredMarkerCandidate, 0, len(parser.Types))
+	for typ, info := range parser.Types {
+		needInferredFields := false
+		for _, raw := range info.Markers[atLeastOneFieldSetMarker] {
+			marker, err := asAtLeastOneFieldSet(raw)
+			if err != nil {
+				return nil, fmt.Errorf("%s: %w", typ, err)
+			}
+			if len(marker.Fields) == 0 {
+				needInferredFields = true
+				break
+			}
+		}
+		if needInferredFields {
+			candidates = append(candidates, inferredMarkerCandidate{typ: typ, info: info})
+		}
+	}
+
+	// Inference can load imported packages into parser.Types. Snapshot first so
+	// generated validation does not depend on Go map iteration over new entries.
+	sort.Slice(candidates, func(i, j int) bool {
+		iPkg := loader.NonVendorPath(candidates[i].typ.Package.PkgPath)
+		jPkg := loader.NonVendorPath(candidates[j].typ.Package.PkgPath)
+		if iPkg != jPkg {
+			return iPkg < jPkg
+		}
+		return candidates[i].typ.Name < candidates[j].typ.Name
+	})
+	return candidates, nil
 }
 
 func asAtLeastOneFieldSet(raw any) (AtLeastOneFieldSet, error) {

--- a/controller/hack/crdgen/main_test.go
+++ b/controller/hack/crdgen/main_test.go
@@ -221,3 +221,36 @@ func TestApplyPostSchemaMarkersToCRDIfThenOnlyFieldsIncludesImportedInlineFields
 	require.Equal(t, "when baz is set only foo and baz may be set", trafficSchema.XValidations[0].Message)
 	require.Equal(t, "has(self.baz) ? [has(self.bar)].filter(x,x==true).size() == 0 : true", trafficSchema.XValidations[0].Rule)
 }
+
+func TestApplyPostSchemaMarkersToCRDOverrideXValidationMatchesSideEffectLoadedInlineType(t *testing.T) {
+	const rootPath = "github.com/agentgateway/agentgateway/controller/hack/crdgen/testdata/overrideembedded/api/v1"
+
+	roots, parser := newTestParser(t, rootPath)
+	require.NoError(t, populateInferredMarkerFields(parser))
+
+	metav1Pkg := crd.FindMetav1(roots)
+	require.NotNil(t, metav1Pkg)
+
+	kubeKinds := crd.FindKubeKinds(parser, metav1Pkg)
+	require.Len(t, kubeKinds, 1)
+
+	groupKind := kubeKinds[0]
+	maxDescLen := 0
+	parser.NeedCRDFor(groupKind, &maxDescLen)
+
+	crdObj := parser.CustomResourceDefinitions[groupKind]
+	require.NoError(t, applyPostSchemaMarkersToCRD(parser, &crdObj, groupKind))
+
+	require.Len(t, crdObj.Spec.Versions, 1)
+	rootSchema := crdObj.Spec.Versions[0].Schema.OpenAPIV3Schema
+	require.NotNil(t, rootSchema)
+
+	specSchema, ok := rootSchema.Properties["spec"]
+	require.True(t, ok)
+	policiesSchema, ok := specSchema.Properties["policies"]
+	require.True(t, ok)
+
+	require.Len(t, policiesSchema.XValidations, 1)
+	require.Equal(t, "at least one of the fields in [ai auth health http token] must be set", policiesSchema.XValidations[0].Message)
+	require.Equal(t, "[has(self.ai),has(self.auth),has(self.health),has(self.http),has(self.token)].filter(x,x==true).size() >= 1", policiesSchema.XValidations[0].Rule)
+}

--- a/controller/hack/crdgen/testdata/overrideembedded/api/v1/doc.go
+++ b/controller/hack/crdgen/testdata/overrideembedded/api/v1/doc.go
@@ -1,0 +1,2 @@
+// +groupName=testdata.agentgateway.dev
+package v1

--- a/controller/hack/crdgen/testdata/overrideembedded/api/v1/types.go
+++ b/controller/hack/crdgen/testdata/overrideembedded/api/v1/types.go
@@ -1,0 +1,28 @@
+package v1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/agentgateway/agentgateway/controller/hack/crdgen/testdata/overrideembedded/upstream"
+)
+
+// +kubebuilder:object:root=true
+// +kubebuilder:resource:path=widgets,scope=Namespaced
+type Widget struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec WidgetSpec `json:"spec,omitempty"`
+}
+
+type WidgetSpec struct {
+	Policies *LocalPolicies `json:"policies,omitempty"`
+}
+
+// +kubebuilder:validation:AtLeastOneFieldSet
+// +kubebuilder:validation:OverrideXValidation:messageContains="at least one of the fields in [ai health]"
+type LocalPolicies struct {
+	upstream.FullPolicy `json:",inline"`
+
+	Token *string `json:"token,omitempty"`
+}

--- a/controller/hack/crdgen/testdata/overrideembedded/upstream/types.go
+++ b/controller/hack/crdgen/testdata/overrideembedded/upstream/types.go
@@ -1,0 +1,14 @@
+package upstream
+
+type SimplePolicy struct {
+	Auth *string `json:"auth,omitempty"`
+	HTTP *string `json:"http,omitempty"`
+}
+
+// +kubebuilder:validation:AtLeastOneFieldSet
+type FullPolicy struct {
+	SimplePolicy `json:",inline"`
+
+	AI     *string `json:"ai,omitempty"`
+	Health *string `json:"health,omitempty"`
+}


### PR DESCRIPTION
This fixes a flaky CRD generation issue in our custom `AtLeastOneFieldSet` handling.

The bug was that `populateInferredMarkerFields` iterated `parser.Types` while the inference code could load imported packages and add more entries to that same map (in `allJSONFieldNamesForType`), in addition to the non-deterministic iteration in golang over maps