### PR TITLE
mcp: advertise prompts and resources list_changed capabilities

### DIFF
--- a/crates/agentgateway/src/mcp/handler.rs
+++ b/crates/agentgateway/src/mcp/handler.rs
@@ -643,7 +643,9 @@ impl Relay {
 				.enable_tools()
 				.enable_tool_list_changed()
 				.enable_prompts()
-				.enable_resources();
+				.enable_prompts_list_changed()
+				.enable_resources()
+				.enable_resources_list_changed();
 			if resource_subscribe {
 				builder = builder.enable_resources_subscribe();
 			}

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -251,6 +251,8 @@ async fn multiplex_advertises_tool_and_resource_subscribe_capabilities() {
 	let client = mcp_streamable_client(io).await;
 	let caps = &client.peer_info().unwrap().capabilities;
 	assert_eq!(caps.tools.as_ref().unwrap().list_changed, Some(true));
+	assert_eq!(caps.prompts.as_ref().unwrap().list_changed, Some(true));
+	assert_eq!(caps.resources.as_ref().unwrap().list_changed, Some(true));
 	assert_eq!(caps.resources.as_ref().unwrap().subscribe, Some(true));
 }
 


### PR DESCRIPTION
When multiplexing MCP backends, the gateway already forwards upstream
`list_changed` notifications to clients over the GET stream, but the
initialize response only advertised `tools.listChanged`. Clients had no
way to know prompt or resource sets could change, so they never re-listed.

This advertises `prompts.listChanged` and `resources.listChanged` in the
server capabilities. The notification plumbing is unchanged; only the
capability flags are added.

Follow-up to #1850.

## Test
- Extended `multiplex_advertises_tool_and_resource_subscribe_capabilities`
  to assert both new flags.
- `cargo test -p agentgateway --lib mcp::` passes.
