### PR TITLE
install: select latest stable release and report download failures honestly

### DIFF
--- a/tools/get-agentgateway
+++ b/tools/get-agentgateway
@@ -99,8 +99,8 @@ verifySupported() {
 # checkDesiredVersion checks if the desired version is available.
 checkDesiredVersion() {
   if [ "x$DESIRED_VERSION" == "x" ]; then
-    # Pick the latest stable tag (vX.Y.Z, no suffix); releases are not flagged
-    # as pre-release on GitHub. Use --version to install a pre-release.
+    # Pick the highest stable tag (vX.Y.Z, no suffix), skipping drafts and
+    # pre-releases. Use --version to install a pre-release.
     local latest_release_url="https://api.github.com/repos/agentgateway/agentgateway/releases?per_page=100"
     local latest_release_response=""
     if [ "${HAS_CURL}" == "true" ]; then
@@ -108,7 +108,7 @@ checkDesiredVersion() {
     elif [ "${HAS_WGET}" == "true" ]; then
       latest_release_response=$( wget "$latest_release_url" -q -O - 2>&1 || true )
     fi
-    TAG=$( echo "$latest_release_response" | jq -r '[.[] | select(.draft == false) | .tag_name | select(test("^v[0-9]+\\.[0-9]+\\.[0-9]+$"))] | .[0] // empty' )
+    TAG=$( echo "$latest_release_response" | jq -r '[.[] | select(.draft == false and .prerelease == false) | .tag_name | select(test("^v[0-9]+\\.[0-9]+\\.[0-9]+$"))] | sort_by(ltrimstr("v") | split(".") | map(tonumber)) | last // empty' )
     if [ "x$TAG" == "x" ]; then
       printf "Could not retrieve the latest stable release tag information from %s: %s\n" "${latest_release_url}" "${latest_release_response}"
       exit 1
@@ -190,7 +190,7 @@ downloadToFile() {
   if [ "${HAS_CURL}" == "true" ]; then
     curl -SsL --fail "$url" -o "$dest"
   else
-    wget -q -O "$dest" "$url"
+    wget -nv -O "$dest" "$url"
   fi
 }
 

--- a/tools/get-agentgateway
+++ b/tools/get-agentgateway
@@ -99,17 +99,18 @@ verifySupported() {
 # checkDesiredVersion checks if the desired version is available.
 checkDesiredVersion() {
   if [ "x$DESIRED_VERSION" == "x" ]; then
-    # Get tag from release URL
-    local latest_release_url="https://api.github.com/repos/agentgateway/agentgateway/releases/latest"
+    # Pick the latest stable tag (vX.Y.Z, no suffix); releases are not flagged
+    # as pre-release on GitHub. Use --version to install a pre-release.
+    local latest_release_url="https://api.github.com/repos/agentgateway/agentgateway/releases?per_page=100"
     local latest_release_response=""
     if [ "${HAS_CURL}" == "true" ]; then
       latest_release_response=$( curl -L --silent --show-error --fail "$latest_release_url" 2>&1 || true )
     elif [ "${HAS_WGET}" == "true" ]; then
       latest_release_response=$( wget "$latest_release_url" -q -O - 2>&1 || true )
     fi
-    TAG=$( echo "$latest_release_response" | jq -r .tag_name | grep '^v[0-9]' )
+    TAG=$( echo "$latest_release_response" | jq -r '[.[] | select(.draft == false) | .tag_name | select(test("^v[0-9]+\\.[0-9]+\\.[0-9]+$"))] | .[0] // empty' )
     if [ "x$TAG" == "x" ]; then
-      printf "Could not retrieve the latest release tag information from %s: %s\n" "${latest_release_url}" "${latest_release_response}"
+      printf "Could not retrieve the latest stable release tag information from %s: %s\n" "${latest_release_url}" "${latest_release_response}"
       exit 1
     fi
   else
@@ -171,12 +172,25 @@ downloadFile() {
   AGENTGATEWAY_TMP_FILE="$AGENTGATEWAY_TMP_ROOT/$AGENTGATEWAY_DIST"
   AGENTGATEWAY_SUM_FILE="$AGENTGATEWAY_TMP_ROOT/$AGENTGATEWAY_DIST.sha256"
   echo "Downloading $DOWNLOAD_URL"
+  # Fail on HTTP errors so a missing asset (404) is not mistaken for a bad checksum.
+  if ! downloadToFile "$DOWNLOAD_URL" "$AGENTGATEWAY_TMP_FILE"; then
+    echo "Failed to download ${DOWNLOAD_URL}."
+    echo "Release ${TAG} may not ship a ${OS}-${ARCH} binary. See https://github.com/agentgateway/agentgateway/releases"
+    exit 1
+  fi
+  if ! downloadToFile "$CHECKSUM_URL" "$AGENTGATEWAY_SUM_FILE"; then
+    echo "Failed to download checksum ${CHECKSUM_URL}."
+    exit 1
+  fi
+}
+
+# downloadToFile fetches a URL to a path, failing on HTTP errors.
+downloadToFile() {
+  local url="$1" dest="$2"
   if [ "${HAS_CURL}" == "true" ]; then
-    curl -SsL "$CHECKSUM_URL" -o "$AGENTGATEWAY_SUM_FILE"
-    curl -SsL "$DOWNLOAD_URL" -o "$AGENTGATEWAY_TMP_FILE"
-  elif [ "${HAS_WGET}" == "true" ]; then
-    wget -q -O "$AGENTGATEWAY_SUM_FILE" "$CHECKSUM_URL"
-    wget -q -O "$AGENTGATEWAY_TMP_FILE" "$DOWNLOAD_URL"
+    curl -SsL --fail "$url" -o "$dest"
+  else
+    wget -q -O "$dest" "$url"
   fi
 }
 


### PR DESCRIPTION
Fixes #2091.

The install script auto-upgraded users to pre-release builds and, when an
arch-specific asset was missing, reported a misleading checksum mismatch
(the real cause was a 404).

## Changes
- `checkDesiredVersion`: pick the latest stable tag. Releases are not
  flagged as pre-release on GitHub, so `/releases/latest` returns
  alpha/beta/rc tags; selection is now by tag shape (`vX.Y.Z`, no suffix).
  `--version` still installs a specific or pre-release build.
- `downloadFile`: fail on HTTP errors (`curl --fail`) and report a missing
  os-arch binary with a link to the releases page, instead of letting a
  404 body fall through to a bogus checksum error.

Whether to restore the darwin-amd64 build (the other suggestion in the
issue) is a release decision and is left to maintainers; the script now
fails clearly when an asset is absent.

## Test
- Verified against the live API: stable selection returns v1.2.1, not
  v1.3.0-alpha.1.
- End-to-end install on darwin-arm64 downloads, verifies checksum, and
  installs a working binary.
- Missing-asset path now prints the real download failure and exits.
