### PR TITLE
test(llm): cover Bedrock Converse reasoning_signature replay from Messages

### DIFF
--- a/crates/agentgateway/src/llm/tests.rs
+++ b/crates/agentgateway/src/llm/tests.rs
@@ -282,6 +282,10 @@ mod requests {
 		("system_message", &[COMPLETIONS, BEDROCK, VERTEX]),
 		("tools", &[COMPLETIONS, BEDROCK, VERTEX]),
 		("reasoning", &[COMPLETIONS, BEDROCK, VERTEX]),
+		// Replaying a prior assistant `thinking` block to Bedrock Converse must preserve its
+		// cryptographic `signature` (mapped to reasoningContent.reasoningText.signature) so
+		// Bedrock can validate the replayed thinking.
+		("reasoning_replay", &[BEDROCK]),
 	];
 	const RESPONSES_REQUESTS: &[(&str, &[&str])] = &[
 		("basic", &[BEDROCK, GEMINI]),

--- a/crates/agentgateway/src/llm/tests/requests/messages/reasoning_replay.bedrock.snap
+++ b/crates/agentgateway/src/llm/tests/requests/messages/reasoning_replay.bedrock.snap
@@ -1,0 +1,63 @@
+---
+source: crates/agentgateway/src/llm/tests.rs
+description: src/llm/tests/requests/messages/reasoning_replay.json
+info:
+  model: "claude-3-7-sonnet-20250219-v1:0"
+  max_tokens: 1024
+  messages:
+    - role: user
+      content:
+        - type: text
+          text: What is 2+2?
+    - role: assistant
+      content:
+        - type: thinking
+          thinking: Two plus two.
+          signature: SIG-replay==
+        - type: text
+          text: "4"
+    - role: user
+      content:
+        - type: text
+          text: And 3+3?
+---
+{
+  "modelId": "claude-3-7-sonnet-20250219-v1:0",
+  "messages": [
+    {
+      "role": "user",
+      "content": [
+        {
+          "text": "What is 2+2?"
+        }
+      ]
+    },
+    {
+      "role": "assistant",
+      "content": [
+        {
+          "reasoningContent": {
+            "reasoningText": {
+              "text": "Two plus two.",
+              "signature": "SIG-replay=="
+            }
+          }
+        },
+        {
+          "text": "4"
+        }
+      ]
+    },
+    {
+      "role": "user",
+      "content": [
+        {
+          "text": "And 3+3?"
+        }
+      ]
+    }
+  ],
+  "inferenceConfig": {
+    "maxTokens": 1024
+  }
+}

--- a/crates/agentgateway/src/llm/tests/requests/messages/reasoning_replay.json
+++ b/crates/agentgateway/src/llm/tests/requests/messages/reasoning_replay.json
@@ -1,0 +1,25 @@
+{
+  "model": "claude-3-7-sonnet-20250219-v1:0",
+  "max_tokens": 1024,
+  "messages": [
+    {
+      "role": "user",
+      "content": [{ "type": "text", "text": "What is 2+2?" }]
+    },
+    {
+      "role": "assistant",
+      "content": [
+        {
+          "type": "thinking",
+          "thinking": "Two plus two.",
+          "signature": "SIG-replay=="
+        },
+        { "type": "text", "text": "4" }
+      ]
+    },
+    {
+      "role": "user",
+      "content": [{ "type": "text", "text": "And 3+3?" }]
+    }
+  ]
+}


### PR DESCRIPTION
## What

Adds golden-file coverage for **Messages → Bedrock Converse `reasoning_signature` replay**.

The Anthropic Messages API models a thinking block's signature as a first-class `thinking.signature` field, and the Converse request translation already maps a replayed `thinking` block to a `reasoningContent` block carrying that signature (so Bedrock can validate the replayed thinking). The behavior is correct but was untested — a future refactor of the `from_messages` content-block mapping could silently drop the signature without failing CI.

## Change

- `requests/messages/reasoning_replay.json`: an assistant turn with a signed `thinking` block, replayed alongside a follow-up user turn.
- Wired into `MESSAGES_REQUESTS` (→ `BEDROCK`). The snapshot pins that the assistant message translates to a `reasoningContent.reasoningText` block with the original `signature` preserved, ahead of the text block.

Test-only; no production code changes. The reverse direction (Converse → Messages, streaming + non-streaming) is covered separately by the fixtures in #2018.
