### PR TITLE
fix(ui): guard null policy name and handle gateway targets on policies page

### DIFF
--- a/ui/src/app/policies/page.tsx
+++ b/ui/src/app/policies/page.tsx
@@ -207,24 +207,29 @@ export default function PoliciesPage() {
           ) : (
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               {appliedPolicies.map((p: AppliedPolicy) => {
-                const isService = !!p.target?.backend?.service;
-                const isBackend = !!p.target?.backend?.backend;
-                const targetLabel = isService
-                  ? `${p.target!.backend!.service!.namespace}/${p.target!.backend!.service!.hostname}`
-                  : isBackend
-                    ? `${p.target!.backend!.backend!.namespace}/${p.target!.backend!.backend!.name}`
-                    : "Unknown target";
+                const service = p.target?.backend?.service;
+                const backend = p.target?.backend?.backend;
+                const gateway = p.target?.gateway;
+                const target = service
+                  ? { kind: "Service", label: `${service.namespace}/${service.hostname}` }
+                  : backend
+                    ? { kind: "Backend", label: `${backend.namespace}/${backend.name}` }
+                    : gateway
+                      ? { kind: "Gateway", label: `${gateway.namespace}/${gateway.name}` }
+                      : { kind: "Unknown", label: "Unknown target" };
+                // Synthetic policies (e.g. frontend/tracing) have a null name; fall back to the key.
+                const policyLabel = p.name
+                  ? `${p.name.kind} ${p.name.namespace}/${p.name.name}`
+                  : p.key;
                 return (
                   <Card key={p.key}>
                     <CardHeader className="pb-2">
                       <div className="flex items-center justify-between">
-                        <div className="font-medium">
-                          {p.name.kind} {p.name.namespace}/{p.name.name}
-                        </div>
-                        <Badge variant="outline">{isService ? "Service" : "Backend"}</Badge>
+                        <div className="font-medium">{policyLabel}</div>
+                        <Badge variant="outline">{target.kind}</Badge>
                       </div>
                       <div className="text-xs text-muted-foreground mt-1">
-                        Target: {targetLabel}
+                        Target: {target.label}
                       </div>
                     </CardHeader>
                     <CardContent>

--- a/ui/src/app/policies/page.tsx
+++ b/ui/src/app/policies/page.tsx
@@ -210,13 +210,16 @@ export default function PoliciesPage() {
                 const service = p.target?.backend?.service;
                 const backend = p.target?.backend?.backend;
                 const gateway = p.target?.gateway;
+                const route = p.target?.route;
                 const target = service
                   ? { kind: "Service", label: `${service.namespace}/${service.hostname}` }
                   : backend
                     ? { kind: "Backend", label: `${backend.namespace}/${backend.name}` }
                     : gateway
                       ? { kind: "Gateway", label: `${gateway.namespace}/${gateway.name}` }
-                      : { kind: "Unknown", label: "Unknown target" };
+                      : route
+                        ? { kind: "Route", label: `${route.namespace}/${route.name}` }
+                        : { kind: "Unknown", label: "Unknown target" };
                 // Synthetic policies (e.g. frontend/tracing) have a null name; fall back to the key.
                 const policyLabel = p.name
                   ? `${p.name.kind} ${p.name.namespace}/${p.name.name}`

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -121,17 +121,19 @@ export interface Policies {
 // Top-level applied policy entries from config dump
 export interface AppliedPolicy {
   key: string;
+  // Synthetic policies (e.g. frontend/tracing) are emitted with a null name.
   name: {
     kind: string;
     name: string;
     namespace: string;
-  };
+  } | null;
   target: {
     backend?: {
       backend?: { name: string; namespace: string };
       service?: { hostname: string; namespace: string };
     };
     route?: { name: string; namespace: string };
+    gateway?: { name: string; namespace: string };
   };
   // Keep flexible to match varying shapes in dump; narrow types over time
   policy: {


### PR DESCRIPTION
Fixes #1786.

The Applied policies page (XDS mode) crashed with `TypeError: Cannot read
properties of null (reading 'kind')` whenever a synthetic policy was in
the config dump. The `frontend/tracing` policy emitted for
`AgentgatewayParameters.rawConfig.config.tracing` has `name: null` and a
`target: { gateway: ... }`, neither of which the page handled.

## Changes
- `AppliedPolicy.name` is now nullable, and `target` gains a `gateway`
  branch, matching the actual config-dump shape.
- The card renders the policy `key` when `name` is null, and resolves the
  gateway target into a `Gateway` badge and `namespace/name` label.

## Test
- `tsc --noEmit` and `next lint` pass.
- Verified label/kind resolution for service, backend, and the synthetic
  null-name gateway policy from the issue (no longer throws; renders
  `frontend/tracing` / `Gateway` / `agentgateway-system/agw-data`).
