### PR TITLE
fix builds for agentgateway-app

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -217,7 +217,7 @@ jobs:
           - platform: linux/arm64
             os: blacksmith-4vcpu-ubuntu-2404-arm
             # arm64 musl fails with jemalloc: https://github.com/tikv/jemallocator/issues/146
-            cargo_features: agentgateway/ui,agentgateway-app/mimalloc
+            cargo_features: agentgateway/ui,agentgateway-app/mimalloc,agentgateway-app/tls-aws-lc
             cargo_no_default_features: true
     env:
       VERSION: ${{ needs.setup.outputs.version }}
@@ -549,7 +549,7 @@ jobs:
           - os: blacksmith-4vcpu-ubuntu-2404-arm
             target: aarch64-unknown-linux-musl
             # arm64 musl fails with jemalloc: https://github.com/tikv/jemallocator/issues/146
-            extra_cargo_args: "--no-default-features --features agentgateway-app/mimalloc"
+            extra_cargo_args: "--no-default-features --features agentgateway-app/mimalloc,agentgateway-app/tls-aws-lc"
             name: linux-arm
           - os: macos-26
             target: aarch64-apple-darwin

--- a/crates/agentgateway-app/Cargo.toml
+++ b/crates/agentgateway-app/Cargo.toml
@@ -13,9 +13,14 @@ bench = false
 [features]
 # Jemalloc has been found to have the highest throughput and best ability to return memory to the system
 # This comes at the small cost of a few mb memory overhead relative to others (most notable in an empty setup).
-default = ["jemalloc", "mimalloc"]
+default = ["jemalloc", "mimalloc", "tls-aws-lc"]
 jemalloc = ["dep:tikv-jemallocator", "agentgateway/jemalloc"]
 mimalloc = ["dep:mimalloc", "agentgateway/mimalloc"]
+# TLS crypto provider passthroughs. A provider must be selected; `tls-aws-lc` is the default.
+# Builds that pass `--no-default-features` (e.g. arm64 musl, which drops jemalloc) MUST re-add one
+# of these, otherwise the agentgateway TLS code will fail to compile.
+tls-aws-lc = ["agentgateway/tls-aws-lc"]
+tls-openssl = ["agentgateway/tls-openssl"]
 schema = ["agentgateway/schema"]
 
 [dependencies]


### PR DESCRIPTION
https://github.com/agentgateway/agentgateway/pull/2076 created a bug by gating tls with aws-lc-rs through a default feature. Building `agentgateway-app` failed because it pulls the `agentgateway` crate as a dependency with no default features. This broke arm64 musl releases too because they set `--no-default-features`, so I've explicitly added the feature to the cargo args.