### PR TITLE
fix(llm): set service_port on local fallback route

### DIFF
--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -2487,6 +2487,7 @@ request.path.endsWith(":streamRawPredict") || request.path.endsWith(":rawPredict
 	routes.push(Route {
 		key: strng::new("llm:model:fallback"),
 		service_key: None,
+		service_port: 0,
 		name: RouteName {
 			name: strng::new("model:fallback"),
 			namespace: strng::new("internal"),


### PR DESCRIPTION
## Problem

`upstream/main` does not compile:

```
error[E0063]: missing field `service_port` in initializer of `types::agent::Route`
  --> crates/agentgateway/src/types/local.rs
error: could not compile `agentgateway` (lib)
```

## Cause

A merge skew between two independently-green PRs:

- **#2121** added the `llm:model:fallback` route literal in `convert_llm_config` (before `service_port` existed).
- **#2108** added `service_port` as a required field on `Route` and updated the literals it knew about — but it was branched before #2121, so it couldn't update #2121's new literal.

Merged together, the fallback literal is missing the now-required field, so the lib fails to build.

## Fix

Set `service_port: 0` on the fallback route, matching every other local route literal. `cargo check -p agentgateway` passes.
