### PR TITLE
cors: allow preRouting phase

### DIFF
--- a/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
+++ b/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
@@ -758,7 +758,7 @@ const (
 	PolicyPhasePostRouting PolicyPhase = "PostRouting"
 )
 
-// +kubebuilder:validation:IfThenOnlyFields:if="has(self.phase) && self.phase == 'PreRouting'",fields=phase;transformation;extProc;extAuth;jwtAuthentication;basicAuthentication;apiKeyAuthentication,message="phase PreRouting only supports extAuth, transformation, extProc, jwtAuthentication, basicAuthentication and apiKeyAuthentication"
+// +kubebuilder:validation:IfThenOnlyFields:if="has(self.phase) && self.phase == 'PreRouting'",fields=phase;transformation;extProc;extAuth;jwtAuthentication;basicAuthentication;apiKeyAuthentication;cors,message="phase PreRouting only supports extAuth, transformation, extProc, jwtAuthentication, basicAuthentication, apiKeyAuthentication and cors"
 type Traffic struct {
 	// The phase to apply the traffic policy to. If the phase is `PreRouting`,
 	// the `targetRef` must be a `Gateway` or a `Listener`. `PreRouting` is

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
@@ -9953,8 +9953,9 @@ spec:
                 type: object
                 x-kubernetes-validations:
                 - message: phase PreRouting only supports extAuth, transformation,
-                    extProc, jwtAuthentication, basicAuthentication and apiKeyAuthentication
-                  rule: 'has(self.phase) && self.phase == ''PreRouting'' ? [has(self.authorization),has(self.buffer),has(self.cors),has(self.csrf),has(self.directResponse),has(self.headerModifiers),has(self.hostRewrite),has(self.rateLimit),has(self.retry),has(self.timeouts)].filter(x,x==true).size()
+                    extProc, jwtAuthentication, basicAuthentication, apiKeyAuthentication
+                    and cors
+                  rule: 'has(self.phase) && self.phase == ''PreRouting'' ? [has(self.authorization),has(self.buffer),has(self.csrf),has(self.directResponse),has(self.headerModifiers),has(self.hostRewrite),has(self.rateLimit),has(self.retry),has(self.timeouts)].filter(x,x==true).size()
                     == 0 : true'
             type: object
             x-kubernetes-validations:

--- a/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/cors-pre-routing.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/cors-pre-routing.yaml
@@ -1,0 +1,68 @@
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: cors-pre-routing
+  namespace: default
+spec:
+  targetRefs:
+  - kind: Gateway
+    name: test
+    group: gateway.networking.k8s.io
+  traffic:
+    phase: PreRouting
+    cors:
+      allowOrigins:
+      - "https://example.com"
+      allowMethods:
+      - GET
+---
+# Output
+output:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
+    policy:
+      key: traffic/default/cors-pre-routing:cors:default/test
+      name:
+        kind: AgentgatewayPolicy
+        name: cors-pre-routing
+        namespace: default
+      target:
+        gateway:
+          name: test
+          namespace: default
+      traffic:
+        cors:
+          allowMethods:
+          - GET
+          allowOrigins:
+          - https://example.com
+          maxAge: 0s
+        phase: GATEWAY
+status:
+- apiVersion: agentgateway.dev/v1alpha1
+  kind: AgentgatewayPolicy
+  metadata:
+    name: cors-pre-routing
+    namespace: default
+  spec: null
+  status:
+    ancestors:
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: test
+        namespace: default
+      conditions:
+      - lastTransitionTime: fake
+        message: Policy accepted
+        reason: Valid
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: Attached to all targets
+        reason: Attached
+        status: "True"
+        type: Attached
+      controllerName: agentgateway.dev/agentgateway

--- a/controller/pkg/agentgateway/plugins/traffic_plugin.go
+++ b/controller/pkg/agentgateway/plugins/traffic_plugin.go
@@ -517,7 +517,7 @@ func translateTrafficPolicyToAgw(
 	}
 
 	if traffic.Cors != nil {
-		appendPolicy("cors")(processCorsPolicy(traffic.Cors, basePolicyName, policyName), nil)
+		appendPolicy("cors")(processCorsPolicy(traffic.Cors, traffic.Phase, basePolicyName, policyName), nil)
 	}
 
 	if traffic.HeaderModifiers != nil {
@@ -1024,12 +1024,13 @@ func processHeaderModifierPolicy(headerModifier *shared.HeaderModifiers, basePol
 	return policies
 }
 
-func processCorsPolicy(cors *agentgateway.CORS, basePolicyName string, policy types.NamespacedName) *api.Policy {
+func processCorsPolicy(cors *agentgateway.CORS, policyPhase *agentgateway.PolicyPhase, basePolicyName string, policy types.NamespacedName) *api.Policy {
 	corsPolicy := &api.Policy{
 		Key:  basePolicyName + corsPolicySuffix,
 		Name: TypedResourceFromName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
 		Kind: &api.Policy_Traffic{
 			Traffic: &api.TrafficPolicySpec{
+				Phase: phase(policyPhase),
 				Kind: &api.TrafficPolicySpec_Cors{Cors: &api.CORS{
 					AllowCredentials: ptr.OrEmpty(cors.AllowCredentials),
 					AllowHeaders:     slices.Map(cors.AllowHeaders, func(h gwv1.HTTPHeaderName) string { return string(h) }),

--- a/crates/agentgateway/src/proxy/gateway_test.rs
+++ b/crates/agentgateway/src/proxy/gateway_test.rs
@@ -831,6 +831,36 @@ async fn gateway_phase_oidc_bypasses_cors_preflight_requests() {
 }
 
 #[tokio::test]
+async fn gateway_phase_cors_handles_preflight_before_route_selection() {
+	let (_mock, mut bind, io) = basic_setup().await;
+	bind
+		.attach_gateway_policy(json!({
+			"cors": {
+				"allowCredentials": false,
+				"allowHeaders": ["*"],
+				"allowMethods": ["GET", "POST"],
+				"allowOrigins": ["http://example.com"],
+				"exposeHeaders": [],
+			},
+		}))
+		.await;
+
+	let res = send_request_headers(
+		io,
+		Method::OPTIONS,
+		"http://lo/no-route-needed",
+		&[
+			("origin", "http://example.com"),
+			("access-control-request-method", "GET"),
+		],
+	)
+	.await;
+
+	assert_eq!(res.status(), 200);
+	assert_eq!(res.hdr("access-control-allow-origin"), "http://example.com");
+}
+
+#[tokio::test]
 async fn network_authorization_allow() {
 	let (_mock, mut bind, io) = basic_setup().await;
 	bind

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -341,6 +341,13 @@ async fn apply_gateway_policies(
 ) -> Result<(), ProxyResponse> {
 	let c = &client;
 
+	// CORS must run before authentication so preflight requests can short-circuit
+	// and rejected browser requests still receive the configured response headers.
+	policies
+		.cors
+		.apply_without_response("gateway cors", c, l, req, response_policies.headers())
+		.await?;
+
 	policies
 		.oidc
 		.apply_without_response("gateway oidc", c, l, req, response_policies.headers())

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -331,6 +331,7 @@ pub struct RoutePolicies {
 #[derive(Debug, Default, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GatewayPolicies {
+	pub cors: RequestPolicy<http::cors::Cors>,
 	pub ext_proc: RequestPolicy<ext_proc::ExtProc>,
 	pub oidc: RequestPolicy<oidc::OidcPolicy>,
 	pub jwt: RequestPolicy<JwtAuthentication>,
@@ -344,6 +345,7 @@ pub struct GatewayPolicies {
 impl GatewayPolicies {
 	pub fn iter(&self) -> impl Iterator<Item = &dyn PolicyExpressions> {
 		[
+			&self.cors as &dyn PolicyExpressions,
 			&self.ext_proc as &dyn PolicyExpressions,
 			&self.oidc as &dyn PolicyExpressions,
 			&self.jwt as &dyn PolicyExpressions,
@@ -914,6 +916,9 @@ impl Store {
 		let mut pol = GatewayPolicies::default();
 		for rule in rules {
 			match rule {
+				TrafficPolicy::CORS(p) => {
+					pol.cors.set_if_unset(p);
+				},
 				TrafficPolicy::Oidc(p) => {
 					pol.oidc.set_if_unset(p);
 				},

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -1416,9 +1416,6 @@ struct LocalLLMPolicy {
 	/// Authorization policies for HTTP access.
 	#[serde(default)]
 	authorization: Option<Authorization>,
-	/// Handle CORS preflight requests and append configured CORS headers to applicable requests.
-	#[serde(default)]
-	cors: Option<http::cors::Cors>,
 	/// Rate limit incoming requests. State is kept local.
 	#[serde(default)]
 	local_rate_limit: Vec<crate::http::localratelimit::RateLimit>,
@@ -1442,6 +1439,9 @@ struct LocalGatewayPolicy {
 	/// Extend agentgateway with an external processor
 	#[serde(default)]
 	ext_proc: Option<LocalExtProcPolicy>,
+	/// Handle CORS preflight requests and append configured CORS headers to applicable requests.
+	#[serde(default)]
+	cors: Option<http::cors::Cors>,
 	/// Modify requests and responses
 	#[serde(default)]
 	#[cfg_attr(
@@ -1464,6 +1464,7 @@ impl From<LocalGatewayPolicy> for FilterOrPolicy {
 			jwt_auth,
 			ext_authz,
 			ext_proc,
+			cors,
 			transformations,
 			basic_auth,
 			api_key,
@@ -1473,6 +1474,7 @@ impl From<LocalGatewayPolicy> for FilterOrPolicy {
 			jwt_auth,
 			ext_authz,
 			ext_proc,
+			cors,
 			transformations,
 			basic_auth,
 			api_key,
@@ -2047,12 +2049,6 @@ fn llm_model_match_specificity(model_name: &str) -> usize {
 	model_name.chars().filter(|c| *c != '*').count()
 }
 
-fn add_llm_cors_policy(inline_policies: &mut Vec<TrafficPolicy>, cors: &Option<http::cors::Cors>) {
-	if let Some(cors) = cors.clone() {
-		inline_policies.push(TrafficPolicy::CORS(RequestPolicy::single(cors)));
-	}
-}
-
 #[allow(deprecated)]
 async fn convert_llm_config(
 	client: client::Client,
@@ -2078,11 +2074,10 @@ async fn convert_llm_config(
 	let mut all_policies = vec![];
 	let mut all_backends = vec![];
 	let mut routes = Vec::new();
-	let (llm_cors, listener_gateway_policies, listener_route_policies) = if let Some(pol) = policies {
+	let (listener_gateway_policies, listener_route_policies) = if let Some(pol) = policies {
 		let LocalLLMPolicy {
 			gateway,
 			authorization,
-			cors,
 			local_rate_limit,
 			remote_rate_limit,
 		} = pol;
@@ -2106,12 +2101,11 @@ async fn convert_llm_config(
 		)
 		.await?;
 		(
-			cors,
 			gateway_policies.route_policies,
 			route_policies.route_policies,
 		)
 	} else {
-		(None, vec![], vec![])
+		(vec![], vec![])
 	};
 
 	// Create transformation policy to set x-gateway-model-name header from request body
@@ -2163,7 +2157,7 @@ request.path.endsWith(":streamRawPredict") || request.path.endsWith(":rawPredict
 	})
 	.to_string();
 
-	let mut model_list_inline_policies = vec![
+	let model_list_inline_policies = vec![
 		TrafficPolicy::ResponseHeaderModifier(RequestPolicy::single(
 			crate::http::filters::HeaderModifier {
 				set: vec![(strng::new("Content-Type"), strng::new("application/json"))],
@@ -2178,8 +2172,6 @@ request.path.endsWith(":streamRawPredict") || request.path.endsWith(":rawPredict
 			status: ::http::StatusCode::OK,
 		})),
 	];
-	add_llm_cors_policy(&mut model_list_inline_policies, &llm_cors);
-
 	let model_list_route = Route {
 		key: strng::new("llm:admin:model-list"),
 		service_key: None,
@@ -2439,11 +2431,10 @@ request.path.endsWith(":streamRawPredict") || request.path.endsWith(":rawPredict
 			})
 			.collect::<anyhow::Result<Vec<_>>>()?;
 
-		let mut model_route_inline_policies = vec![TrafficPolicy::AI(Arc::new(crate::llm::Policy {
+		let model_route_inline_policies = vec![TrafficPolicy::AI(Arc::new(crate::llm::Policy {
 			routes: llm_routes.into_iter().collect(),
 			..Default::default()
 		}))];
-		add_llm_cors_policy(&mut model_route_inline_policies, &llm_cors);
 
 		let model_route = Route {
 			key: route_key.clone(),
@@ -2467,7 +2458,7 @@ request.path.endsWith(":streamRawPredict") || request.path.endsWith(":rawPredict
 		routes.push(model_route);
 	}
 
-	let mut fallback_inline_policies = vec![
+	let fallback_inline_policies = vec![
 		TrafficPolicy::ResponseHeaderModifier(RequestPolicy::single(
 			crate::http::filters::HeaderModifier {
 				set: vec![(strng::new("Content-Type"), strng::new("application/json"))],
@@ -2500,8 +2491,6 @@ request.path.endsWith(":streamRawPredict") || request.path.endsWith(":rawPredict
 			status: ::http::StatusCode::NOT_FOUND,
 		})),
 	];
-	add_llm_cors_policy(&mut fallback_inline_policies, &llm_cors);
-
 	routes.push(Route {
 		key: strng::new("llm:model:fallback"),
 		service_key: None,

--- a/crates/agentgateway/src/types/local_tests/llm_simple_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/llm_simple_normalized.snap
@@ -24,11 +24,6 @@ listener_routes:
           - directResponse:
               body: eyJkYXRhIjpbeyJpZCI6ImNsYXVkZS0zLWhhaWt1Iiwib2JqZWN0IjoibW9kZWwiLCJjcmVhdGVkIjowLCJvd25lZF9ieSI6Im9wZW5haSJ9LHsiaWQiOiIqIiwib2JqZWN0IjoibW9kZWwiLCJjcmVhdGVkIjowLCJvd25lZF9ieSI6Im9wZW5haSJ9LHsiaWQiOiJncHQtNy1tYXgiLCJvYmplY3QiOiJtb2RlbCIsImNyZWF0ZWQiOjAsIm93bmVkX2J5Ijoib3BlbmFpIn0seyJpZCI6ImdwdC0zLjUtdHVyYm8iLCJvYmplY3QiOiJtb2RlbCIsImNyZWF0ZWQiOjAsIm93bmVkX2J5Ijoib3BlbmFpIn1dLCJvYmplY3QiOiJsaXN0In0=
               status: 200
-          - cors:
-              allowCredentials: false
-              allowOrigins:
-                - "http://localhost:15000"
-              maxAge: ~
         key: "llm:admin:model-list"
         matches:
           - path:
@@ -54,11 +49,6 @@ listener_routes:
                 /v1/responses/compact: detect
                 ":rawPredict": messages
                 ":streamRawPredict": messages
-          - cors:
-              allowCredentials: false
-              allowOrigins:
-                - "http://localhost:15000"
-              maxAge: ~
         key: "llm:model:000000:claude-3-haiku"
         matches:
           - headers:
@@ -89,11 +79,6 @@ listener_routes:
                 /v1/responses/compact: detect
                 ":rawPredict": messages
                 ":streamRawPredict": messages
-          - cors:
-              allowCredentials: false
-              allowOrigins:
-                - "http://localhost:15000"
-              maxAge: ~
         key: "llm:model:000001:gpt-3.5-turbo"
         matches:
           - headers:
@@ -121,11 +106,6 @@ listener_routes:
                 /v1/responses/compact: detect
                 ":rawPredict": messages
                 ":streamRawPredict": messages
-          - cors:
-              allowCredentials: false
-              allowOrigins:
-                - "http://localhost:15000"
-              maxAge: ~
         key: "llm:model:000002:gpt-7-max"
         matches:
           - headers:
@@ -153,11 +133,6 @@ listener_routes:
                 /v1/responses/compact: detect
                 ":rawPredict": messages
                 ":streamRawPredict": messages
-          - cors:
-              allowCredentials: false
-              allowOrigins:
-                - "http://localhost:15000"
-              maxAge: ~
         key: "llm:model:000003:*"
         matches:
           - headers:
@@ -175,11 +150,6 @@ listener_routes:
           - directResponse:
               bodyExpression: "\n\"x-gateway-model-name\" in request.headers ?\n\t{\n\t\t\"error\": {\n\t\t\t\"message\": \"Model \" + request.headers[\"x-gateway-model-name\"] + \" not found\",\n\t\t\t\"type\": \"invalid_request_error\",\n\t\t\t\"code\": \"model_not_found\"\n\t\t}\n\t} :\n\t{\n\t\t\"error\": {\n\t\t\t\"message\": \"No model set\",\n\t\t\t\"type\": \"invalid_request_error\",\n\t\t\t\"code\": \"model_not_found\"\n\t\t}\n\t}\n"
               status: 404
-          - cors:
-              allowCredentials: false
-              allowOrigins:
-                - "http://localhost:15000"
-              maxAge: ~
         key: "llm:model:fallback"
         matches:
           - path:
@@ -199,6 +169,21 @@ policies:
         listenerName: llm
     policy:
       traffic:
+        cors:
+          allowCredentials: false
+          allowOrigins:
+            - "http://localhost:15000"
+          maxAge: ~
+        phase: gateway
+  - key: listener/1
+    name: ~
+    target:
+      gateway:
+        gatewayName: name
+        gatewayNamespace: ns
+        listenerName: llm
+    policy:
+      traffic:
         jwtAuth:
           location:
             header:
@@ -209,7 +194,7 @@ policies:
             - issuer: agentgateway.dev
               keys: []
         phase: gateway
-  - key: listener/1
+  - key: listener/2
     name: ~
     target:
       gateway:
@@ -223,7 +208,7 @@ policies:
             allow:
               - "jwt.email.endsWith(\"@example.com\")"
         phase: route
-  - key: listener/2
+  - key: listener/3
     name: ~
     target:
       gateway:

--- a/schema/config.json
+++ b/schema/config.json
@@ -6659,6 +6659,18 @@
             }
           ]
         },
+        "cors": {
+          "description": "Handle CORS preflight requests and append configured CORS headers to applicable requests.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CorsSerde"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "transformations": {
           "description": "Modify requests and responses",
           "anyOf": [
@@ -8062,6 +8074,18 @@
             }
           ]
         },
+        "cors": {
+          "description": "Handle CORS preflight requests and append configured CORS headers to applicable requests.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CorsSerde"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "transformations": {
           "description": "Modify requests and responses",
           "anyOf": [
@@ -8100,18 +8124,6 @@
           "anyOf": [
             {
               "$ref": "#/$defs/Authorization"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "cors": {
-          "description": "Handle CORS preflight requests and append configured CORS headers to applicable requests.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/CorsSerde"
             },
             {
               "type": "null"

--- a/schema/config.md
+++ b/schema/config.md
@@ -6050,6 +6050,13 @@
 |`binds[].listeners[].policies.extProc.processingOptions.requestTrailerMode`|enum|Possible values: `send`, `skip`.|
 |`binds[].listeners[].policies.extProc.processingOptions.responseTrailerMode`|enum|Possible values: `send`, `skip`.|
 |`binds[].listeners[].policies.extProc.processingOptions.allowModeOverride`|boolean|Allow ext_proc `mode_override` values from matching headers responses to update<br>subsequent request/response processing phases for this exchange.|
+|`binds[].listeners[].policies.cors`|object|Handle CORS preflight requests and append configured CORS headers to applicable requests.|
+|`binds[].listeners[].policies.cors.allowCredentials`|boolean||
+|`binds[].listeners[].policies.cors.allowHeaders`|[]string||
+|`binds[].listeners[].policies.cors.allowMethods`|[]string||
+|`binds[].listeners[].policies.cors.allowOrigins`|[]string||
+|`binds[].listeners[].policies.cors.exposeHeaders`|[]string||
+|`binds[].listeners[].policies.cors.maxAge`|string||
 |`binds[].listeners[].policies.transformations`|object|Modify requests and responses|
 |`binds[].listeners[].policies.transformations.conditional`|[]object|conditional policy entries. An entry without a condition must be the final fallback.|
 |`binds[].listeners[].policies.transformations.conditional[].condition`|string|condition must evaluate to true for this policy to execute. If unset, the policy is the fallback.|
@@ -18619,6 +18626,13 @@
 |`llm.policies.extProc.processingOptions.requestTrailerMode`|enum|Possible values: `send`, `skip`.|
 |`llm.policies.extProc.processingOptions.responseTrailerMode`|enum|Possible values: `send`, `skip`.|
 |`llm.policies.extProc.processingOptions.allowModeOverride`|boolean|Allow ext_proc `mode_override` values from matching headers responses to update<br>subsequent request/response processing phases for this exchange.|
+|`llm.policies.cors`|object|Handle CORS preflight requests and append configured CORS headers to applicable requests.|
+|`llm.policies.cors.allowCredentials`|boolean||
+|`llm.policies.cors.allowHeaders`|[]string||
+|`llm.policies.cors.allowMethods`|[]string||
+|`llm.policies.cors.allowOrigins`|[]string||
+|`llm.policies.cors.exposeHeaders`|[]string||
+|`llm.policies.cors.maxAge`|string||
 |`llm.policies.transformations`|object|Modify requests and responses|
 |`llm.policies.transformations.conditional`|[]object|conditional policy entries. An entry without a condition must be the final fallback.|
 |`llm.policies.transformations.conditional[].condition`|string|condition must evaluate to true for this policy to execute. If unset, the policy is the fallback.|
@@ -18678,13 +18692,6 @@
 |`llm.policies.apiKey.location.expression.expression`|string||
 |`llm.policies.authorization`|object|Authorization policies for HTTP access.|
 |`llm.policies.authorization.rules`|[]string||
-|`llm.policies.cors`|object|Handle CORS preflight requests and append configured CORS headers to applicable requests.|
-|`llm.policies.cors.allowCredentials`|boolean||
-|`llm.policies.cors.allowHeaders`|[]string||
-|`llm.policies.cors.allowMethods`|[]string||
-|`llm.policies.cors.allowOrigins`|[]string||
-|`llm.policies.cors.exposeHeaders`|[]string||
-|`llm.policies.cors.maxAge`|string||
 |`llm.policies.localRateLimit`|[]object|Rate limit incoming requests. State is kept local.|
 |`llm.policies.localRateLimit[].maxTokens`|integer||
 |`llm.policies.localRateLimit[].tokensPerFill`|integer||


### PR DESCRIPTION
PreRouting phase has, so far, been reserved for things that impact
routing.

However, if you need auth pre-routing and CORS, its broken since the
auth will reject before we get to CORS.

Signed-off-by: John Howard <john.howard@solo.io>
