### PR TITLE
dtrace: fix test flake

### DIFF
--- a/crates/agentgateway/src/proxy/dtrace.rs
+++ b/crates/agentgateway/src/proxy/dtrace.rs
@@ -794,17 +794,18 @@ mod tests {
 		})
 		.await;
 
-		let msg = tokio::time::timeout(Duration::from_secs(1), trace_rx.recv())
-			.await
-			.expect("trace event should be emitted")
-			.expect("trace receiver should still be open");
-		match msg.message {
-			MessageType::Cel { expr, result, .. } => {
-				assert_eq!(expr, "request.path");
-				assert_eq!(result, serde_json::json!("/test"));
-			},
-			other => panic!("expected CEL trace event, got {other:?}"),
-		}
+		tokio::time::timeout(Duration::from_secs(1), async {
+			while let Some(msg) = trace_rx.recv().await {
+				if let MessageType::Cel { expr, result, .. } = msg.message {
+					assert_eq!(expr, "request.path");
+					assert_eq!(result, serde_json::json!("/test"));
+					return;
+				}
+			}
+			panic!("trace receiver closed before CEL trace event was emitted");
+		})
+		.await
+		.expect("trace event should be emitted");
 	}
 
 	#[tokio::test]


### PR DESCRIPTION
DebugTracer::maybe_scope can emit normal lifecycle events like RequestStarted before the CEL event.