### PR TITLE
Fix tool-use stream conversion for empty content deltas

### DIFF
--- a/crates/agentgateway/src/llm/conversion/completions.rs
+++ b/crates/agentgateway/src/llm/conversion/completions.rs
@@ -493,7 +493,12 @@ pub mod from_messages {
 					}
 
 					if let Some(choice) = f.choices.first() {
-						if let Some(content) = &choice.delta.content {
+						if let Some(content) = choice
+							.delta
+							.content
+							.as_ref()
+							.filter(|content| !content.is_empty())
+						{
 							let index = open_text_block(&mut state, &mut events);
 							maybe_set_first_token(&mut state, &log);
 							push_event(

--- a/crates/agentgateway/src/llm/conversion/completions.rs
+++ b/crates/agentgateway/src/llm/conversion/completions.rs
@@ -493,12 +493,7 @@ pub mod from_messages {
 					}
 
 					if let Some(choice) = f.choices.first() {
-						if let Some(content) = choice
-							.delta
-							.content
-							.as_ref()
-							.filter(|content| !content.is_empty())
-						{
+						if let Some(content) = choice.delta.content.as_deref().filter(|s| !s.is_empty()) {
 							let index = open_text_block(&mut state, &mut events);
 							maybe_set_first_token(&mut state, &log);
 							push_event(
@@ -506,7 +501,7 @@ pub mod from_messages {
 								messages::MessagesStreamEvent::ContentBlockDelta {
 									index,
 									delta: messages::ContentBlockDelta::TextDelta {
-										text: content.clone(),
+										text: content.to_string(),
 									},
 								},
 							);

--- a/crates/agentgateway/src/llm/tests.rs
+++ b/crates/agentgateway/src/llm/tests.rs
@@ -563,7 +563,10 @@ mod response {
 		("gemini_zero_completion_tokens", ALL_COMPLETIONS),
 		("gemini_with_completion_tokens", ALL_COMPLETIONS),
 	];
-	const COMPLETIONS_STREAM_RESPONSES: &[(&str, &[&str])] = &[("stream", ALL_COMPLETIONS)];
+	const COMPLETIONS_STREAM_RESPONSES: &[(&str, &[&str])] = &[
+		("stream", ALL_COMPLETIONS),
+		("stream_tool_empty_content", &[COMPLETIONS_TO_MESSAGES]),
+	];
 
 	const EMBEDDING_RESPONSES: &[(&str, &[&str])] = &[
 		("response/bedrock-titan/embeddings.json", &[BEDROCK_TITAN]),

--- a/crates/agentgateway/src/llm/tests/response/completions/stream.completions-messages-streaming.snap
+++ b/crates/agentgateway/src/llm/tests/response/completions/stream.completions-messages-streaming.snap
@@ -9,9 +9,6 @@ event: content_block_start
 data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
 
 event: content_block_delta
-data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":""}}
-
-event: content_block_delta
 data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}
 
 event: content_block_delta

--- a/crates/agentgateway/src/llm/tests/response/completions/stream_tool_empty_content.completions-messages-streaming.snap
+++ b/crates/agentgateway/src/llm/tests/response/completions/stream_tool_empty_content.completions-messages-streaming.snap
@@ -1,0 +1,33 @@
+---
+source: crates/agentgateway/src/llm/tests.rs
+description: src/llm/tests/response/completions/stream_tool_empty_content.json
+---
+event: message_start
+data: {"type":"message_start","message":{"id":"chatcmpl-tool-empty-content","type":"message","role":"assistant","content":[],"model":"claude-opus-4-8","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":0,"output_tokens":0}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_empty_content","name":"Bash","input":{}}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"com"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"mand\":\"pwd\"}"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":12,"output_tokens":8}}
+
+event: message_stop
+data: {"type":"message_stop"}
+
+
+
+{
+  "input_tokens": 12,
+  "output_tokens": 8,
+  "total_tokens": 20,
+  "provider_model": "claude-opus-4-8"
+}

--- a/crates/agentgateway/src/llm/tests/response/completions/stream_tool_empty_content.json
+++ b/crates/agentgateway/src/llm/tests/response/completions/stream_tool_empty_content.json
@@ -4,11 +4,11 @@ data: {"id":"chatcmpl-tool-empty-content","object":"chat.completion.chunk","crea
 
 data: {"id":"chatcmpl-tool-empty-content","object":"chat.completion.chunk","created":1772656915,"model":"claude-opus-4-8","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":""},"finish_reason":null}],"usage":null}
 
-data: {"id":"chatcmpl-tool-empty-content","object":"chat.completion.chunk","created":1772656915,"model":"claude-opus-4-8","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":null,"type":null,"function":{"arguments":"{\"com"}}]},"finish_reason":null}],"usage":null}
+data: {"id":"chatcmpl-tool-empty-content","object":"chat.completion.chunk","created":1772656915,"model":"claude-opus-4-8","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"com"}}]},"finish_reason":null}],"usage":null}
 
 data: {"id":"chatcmpl-tool-empty-content","object":"chat.completion.chunk","created":1772656915,"model":"claude-opus-4-8","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":""},"finish_reason":null}],"usage":null}
 
-data: {"id":"chatcmpl-tool-empty-content","object":"chat.completion.chunk","created":1772656915,"model":"claude-opus-4-8","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":null,"type":null,"function":{"arguments":"mand\":\"pwd\"}"}}]},"finish_reason":null}],"usage":null}
+data: {"id":"chatcmpl-tool-empty-content","object":"chat.completion.chunk","created":1772656915,"model":"claude-opus-4-8","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"mand\":\"pwd\"}"}}]},"finish_reason":null}],"usage":null}
 
 data: {"id":"chatcmpl-tool-empty-content","object":"chat.completion.chunk","created":1772656915,"model":"claude-opus-4-8","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":""},"finish_reason":null}],"usage":null}
 

--- a/crates/agentgateway/src/llm/tests/response/completions/stream_tool_empty_content.json
+++ b/crates/agentgateway/src/llm/tests/response/completions/stream_tool_empty_content.json
@@ -1,0 +1,20 @@
+data: {"id":"chatcmpl-tool-empty-content","object":"chat.completion.chunk","created":1772656915,"model":"claude-opus-4-8","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}],"usage":null}
+
+data: {"id":"chatcmpl-tool-empty-content","object":"chat.completion.chunk","created":1772656915,"model":"claude-opus-4-8","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"toolu_empty_content","type":"function","function":{"name":"Bash"}}]},"finish_reason":null}],"usage":null}
+
+data: {"id":"chatcmpl-tool-empty-content","object":"chat.completion.chunk","created":1772656915,"model":"claude-opus-4-8","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":""},"finish_reason":null}],"usage":null}
+
+data: {"id":"chatcmpl-tool-empty-content","object":"chat.completion.chunk","created":1772656915,"model":"claude-opus-4-8","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":null,"type":null,"function":{"arguments":"{\"com"}}]},"finish_reason":null}],"usage":null}
+
+data: {"id":"chatcmpl-tool-empty-content","object":"chat.completion.chunk","created":1772656915,"model":"claude-opus-4-8","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":""},"finish_reason":null}],"usage":null}
+
+data: {"id":"chatcmpl-tool-empty-content","object":"chat.completion.chunk","created":1772656915,"model":"claude-opus-4-8","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":null,"type":null,"function":{"arguments":"mand\":\"pwd\"}"}}]},"finish_reason":null}],"usage":null}
+
+data: {"id":"chatcmpl-tool-empty-content","object":"chat.completion.chunk","created":1772656915,"model":"claude-opus-4-8","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":""},"finish_reason":null}],"usage":null}
+
+data: {"id":"chatcmpl-tool-empty-content","object":"chat.completion.chunk","created":1772656915,"model":"claude-opus-4-8","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":null},"finish_reason":"tool_calls"}],"usage":null}
+
+data: {"id":"chatcmpl-tool-empty-content","object":"chat.completion.chunk","created":1772656915,"model":"claude-opus-4-8","service_tier":"default","system_fingerprint":null,"choices":[],"usage":{"prompt_tokens":12,"completion_tokens":8,"total_tokens":20}}
+
+data: [DONE]
+


### PR DESCRIPTION
## Summary
- Treat empty streamed content deltas as no-ops when translating completions streams to Messages SSE.
- Add a golden fixture covering empty content deltas interleaved with tool call argument chunks.
- Update the existing Messages stream snapshot to drop the no-op empty text delta.

Fixes #2147.

## Testing
- `cargo fmt --all --check`
- `cargo test -p agentgateway llm::tests::response::from_completions -- --exact --nocapture`
- `cargo test -p agentgateway llm::tests::response -- --nocapture`
- `cargo test -p agentgateway`
- `cargo clippy -p agentgateway --all-targets -- -D warnings`