### PR TITLE
fix(llm): apply pathPrefix for passthrough routes on custom-host backends

### DIFF
--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -369,6 +369,14 @@ impl AIProvider {
 				.unwrap_or(custom::Provider::NAME),
 		}
 	}
+	fn default_base_path(&self) -> Option<&'static str> {
+		match self {
+			AIProvider::OpenAI(_) | AIProvider::Copilot(_) => Some(openai::DEFAULT_BASE_PATH),
+			AIProvider::Anthropic(_) => Some(anthropic::DEFAULT_BASE_PATH),
+			_ => None,
+		}
+	}
+
 	pub fn override_model(&self) -> Option<Strng> {
 		match self {
 			AIProvider::OpenAI(p) => p.model.clone(),
@@ -491,6 +499,35 @@ impl AIProvider {
 		has_host_override: bool,
 	) -> anyhow::Result<()> {
 		if matches!(route_type, RouteType::Passthrough | RouteType::Detect) {
+			if let Some(prefix) = path_prefix {
+				http::modify_req(req, |req| {
+					http::modify_uri(req, |uri| {
+						let current = uri
+							.path_and_query
+							.as_ref()
+							.map(|pq| pq.path())
+							.unwrap_or("/");
+						let new_path = match self.default_base_path() {
+							// For providers with a default base path (e.g. /v1), strip it so
+							// that pathPrefix replaces it — consistent with non-passthrough routes.
+							// If the path doesn't start with the default base, still apply
+							// pathPrefix so it is never silently dropped.
+							Some(base) => {
+								let rest = current
+									.strip_prefix(base)
+									.filter(|rest| rest.is_empty() || rest.starts_with('/'))
+									.unwrap_or(current);
+								format!("{}{}", prefix.trim_end_matches('/'), rest)
+							},
+							// For other providers, pathPrefix is prepended to the full path,
+							// consistent with with_path_prefix used in their non-passthrough code.
+							None => format!("{}{}", prefix.trim_end_matches('/'), current),
+						};
+						Self::set_path_and_query(uri, &new_path)?;
+						Ok(())
+					})
+				})?;
+			}
 			return Ok(());
 		}
 

--- a/crates/agentgateway/src/proxy/gateway_test.rs
+++ b/crates/agentgateway/src/proxy/gateway_test.rs
@@ -32,7 +32,7 @@ use x509_parser::nom::AsBytes;
 
 use crate::http::tests_common::*;
 use crate::http::{Body, Response, ext_proc};
-use crate::llm::{AIProvider, custom, openai};
+use crate::llm::{AIProvider, custom, gemini, openai};
 use crate::proxy::request_builder::RequestBuilder;
 use crate::test_helpers::proxymock::*;
 use crate::test_helpers::{extauthmock, oteltracemock, ratelimitmock};
@@ -1928,6 +1928,102 @@ async fn llm_openai_messages_translation_with_host_override_path_behavior(
 	let upstream = &requests[0];
 	assert_eq!(
 		&upstream.url[Position::BeforePath..Position::AfterQuery],
+		expected_url
+	);
+}
+
+#[rstest::rstest]
+#[case::preserves_path(None, "/v1/models", "/v1/models")]
+#[case::path_prefix(Some("/openai/v1"), "/v1/models", "/openai/v1/models")]
+#[case::path_prefix_with_query(
+	Some("/openai/v1"),
+	"/v1/models?foo=bar",
+	"/openai/v1/models?foo=bar"
+)]
+#[case::path_prefix_non_default_path(Some("/openai/v1"), "/foo", "/openai/v1/foo")]
+#[tokio::test]
+async fn llm_openai_passthrough_applies_path_prefix(
+	#[case] path_prefix: Option<&str>,
+	#[case] request_path: &str,
+	#[case] expected_url: &str,
+) {
+	let mock = body_mock(b"{}").await;
+	let provider = crate::test_helpers::proxymock::llm_named_provider(
+		&mock,
+		AIProvider::OpenAI(openai::Provider { model: None }),
+		false,
+	);
+	let provider = crate::types::local::LocalNamedAIProvider {
+		path_prefix: path_prefix.map(strng::new),
+		..provider
+	};
+	let (mock, mut bind, io) = setup_llm_named_provider_mock(mock, provider, "{}");
+	bind
+		.attach_route_policy(json!({
+			"ai": {
+				"routes": {
+					"*": "passthrough"
+				}
+			}
+		}))
+		.await;
+
+	let res = send_request(io, Method::GET, &format!("http://lo{request_path}")).await;
+
+	assert_eq!(res.status(), 200);
+	let requests = mock
+		.received_requests()
+		.await
+		.expect("request recording should be enabled");
+	assert_eq!(requests.len(), 1);
+	assert_eq!(
+		&requests[0].url[Position::BeforePath..Position::AfterQuery],
+		expected_url
+	);
+}
+
+// Providers without a DEFAULT_BASE_PATH (e.g. Gemini) prepend pathPrefix to the
+// full incoming path rather than replacing /v1.
+#[rstest::rstest]
+#[case::preserves_path(None, "/some/path", "/some/path")]
+#[case::path_prefix(Some("/my/prefix"), "/some/path", "/my/prefix/some/path")]
+#[tokio::test]
+async fn llm_non_openai_passthrough_prepends_path_prefix(
+	#[case] path_prefix: Option<&str>,
+	#[case] request_path: &str,
+	#[case] expected_url: &str,
+) {
+	let mock = body_mock(b"{}").await;
+	let provider = crate::test_helpers::proxymock::llm_named_provider(
+		&mock,
+		AIProvider::Gemini(gemini::Provider { model: None }),
+		false,
+	);
+	let provider = crate::types::local::LocalNamedAIProvider {
+		path_prefix: path_prefix.map(strng::new),
+		..provider
+	};
+	let (mock, mut bind, io) = setup_llm_named_provider_mock(mock, provider, "{}");
+	bind
+		.attach_route_policy(json!({
+			"ai": {
+				"routes": {
+					"/some/path": "passthrough"
+				}
+			}
+		}))
+		.await;
+
+	let res = send_request(io, Method::GET, &format!("http://lo{request_path}")).await;
+
+	assert_eq!(res.status(), 200);
+	let requests = mock
+		.received_requests()
+		.await
+		.expect("request recording should be enabled");
+	assert_eq!(requests.len(), 1);
+	assert_eq!(
+		&requests[0].url[Position::BeforePath..Position::AfterQuery],
 		expected_url
 	);
 }


### PR DESCRIPTION
When an `AgentgatewayBackend` has a custom `host` and `pathPrefix` configured, passthrough routes (e.g. `/v1/models`) were forwarded to the upstream with the original path unchanged, ignoring `pathPrefix`. This caused `404`s on backends whose API root differs from the standard `/v1` (e.g. kubeai at `/openai/v1/`).

Fix `set_default_path` to substitute the default base path prefix with the configured `pathPrefix` before returning early for passthrough routes.

Fixes #2150