### PR TITLE
fix retry error semantics

### DIFF
--- a/crates/agentgateway/src/proxy/mod.rs
+++ b/crates/agentgateway/src/proxy/mod.rs
@@ -223,7 +223,7 @@ impl ProxyError {
 	pub fn is_retryable(&self) -> bool {
 		match self {
 			ProxyError::UpstreamCallFailed(_) => true,
-			ProxyError::RequestTimeout => true,
+			ProxyError::UpstreamCallTimeout => true,
 			ProxyError::DnsResolution => true,
 			_ => false,
 		}


### PR DESCRIPTION
Fix retry timeout classification so backend request timeouts are retryable, while overall request timeouts are terminal. This matches Gateway API semantics: backendRequest timeout applies to an individual upstream attempt and may be retried by an HTTPRoute retry policy, but request timeout is the total budget for the client request and must not start another attempt once exceeded.

Signed-off-by: John Howard <john.howard@solo.io>
