### PR TITLE
gateway: add test for invalid TLS route kind

### DIFF
--- a/controller/pkg/agentgateway/translator/testdata/routes/tlsroute-invalid-backend-kind.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/routes/tlsroute-invalid-backend-kind.yaml
@@ -1,0 +1,79 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: test-gateway
+  namespace: default
+spec:
+  gatewayClassName: agentgateway
+  listeners:
+  - name: tls
+    port: 443
+    protocol: TLS
+    allowedRoutes:
+      namespaces:
+        from: Same
+    tls:
+      mode: Passthrough
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: TLSRoute
+metadata:
+  name: invalid-backend-kind
+  namespace: default
+spec:
+  parentRefs:
+  - name: test-gateway
+  hostnames:
+  - example.com
+  rules:
+  - backendRefs:
+    - group: unknownkind.example.com
+      kind: NonExistent
+      name: tls-backend
+      port: 443
+---
+# Output
+output:
+- gateway:
+    Name: test-gateway
+    Namespace: default
+  resource:
+    tcpRoute:
+      backends:
+      - backend: {}
+        weight: 1
+      hostnames:
+      - example.com
+      key: default/invalid-backend-kind.00.tls.tls
+      listenerKey: default/test-gateway.tls
+      name:
+        kind: TLSRoute
+        name: invalid-backend-kind
+        namespace: default
+status:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: TLSRoute
+  metadata:
+    name: invalid-backend-kind
+    namespace: default
+  spec: null
+  status:
+    parents:
+    - conditions:
+      - lastTransitionTime: fake
+        message: ""
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: 'referencing unsupported backendRef: group "unknownkind.example.com"
+          kind "NonExistent"'
+        reason: InvalidKind
+        status: "False"
+        type: ResolvedRefs
+      controllerName: agentgateway.dev/agentgateway
+      parentRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: test-gateway
+        namespace: default


### PR DESCRIPTION
Was going to fix something but ended up not; test coverage gap is still
good to have

Signed-off-by: John Howard <john.howard@solo.io>
