### PR TITLE
proxy: do not leak error info to clients

### DIFF
--- a/crates/agentgateway/src/http/ext_authz.rs
+++ b/crates/agentgateway/src/http/ext_authz.rs
@@ -317,7 +317,7 @@ impl ExtAuthz {
 	}
 
 	/// Handle authorization failure with FailureMode configuration
-	fn handle_auth_failure(&self, error_msg: &str) -> Result<PolicyResponse, ProxyError> {
+	fn handle_auth_failure(&self) -> Result<PolicyResponse, ProxyError> {
 		match &self.failure_mode {
 			FailureMode::Allow => {
 				dtrace::pol_event!(
@@ -331,7 +331,9 @@ impl ExtAuthz {
 				let status = StatusCode::from_u16(*status_code).unwrap_or(StatusCode::FORBIDDEN);
 				let resp = ::http::Response::builder()
 					.status(status)
-					.body(http::Body::from(error_msg.to_string()))
+					.body(http::Body::from(
+						ProxyError::ExternalAuthorizationFailed(None).external_message(),
+					))
 					.map_err(|e| ProxyError::Processing(e.into()))?;
 				Ok(PolicyResponse {
 					direct_response: Some(resp),
@@ -578,7 +580,7 @@ impl ExtAuthz {
 			Ok(response) => response,
 			Err(e) => {
 				warn!("ext_authz request failed: {}", e);
-				return self.handle_auth_failure("Authorization service unavailable");
+				return self.handle_auth_failure();
 			},
 		};
 		let cr = cr.into_inner();
@@ -866,7 +868,7 @@ impl ExtAuthz {
 			Ok(r) => r,
 			Err(e) => {
 				trace!("ext_authz failed {e}");
-				return self.handle_auth_failure(&e.to_string());
+				return self.handle_auth_failure();
 			},
 		};
 		if resp.status().is_success() {

--- a/crates/agentgateway/src/http/ext_proc_tests.rs
+++ b/crates/agentgateway/src/http/ext_proc_tests.rs
@@ -269,11 +269,7 @@ mod body_modes {
 		let res = send_request_body(io, Method::POST, "http://lo", b"request body").await;
 		assert_eq!(res.status(), 500);
 		let body = read_body_raw(res.into_body()).await;
-		assert!(
-			body
-				.as_ref()
-				.starts_with(b"ext_proc failed: invalid body mutation:")
-		);
+		assert_eq!(body.as_ref(), b"external processing failed");
 	}
 
 	#[tokio::test]
@@ -606,11 +602,7 @@ mod body_modes {
 		let res = send_request(io, Method::GET, "http://lo").await;
 		assert_eq!(res.status(), 500);
 		let body = read_body_raw(res.into_body()).await;
-		assert!(
-			body
-				.as_ref()
-				.starts_with(b"ext_proc failed: invalid body mutation:")
-		);
+		assert_eq!(body.as_ref(), b"external processing failed");
 	}
 
 	#[tokio::test]
@@ -1672,7 +1664,7 @@ mod immediate_and_failure {
 		let res = send_request_body(io, Method::POST, "http://lo", b"request").await;
 		assert_eq!(res.status(), 500);
 		let body = read_body_raw(res.into_body()).await;
-		assert!(body.as_ref().starts_with(b"ext_proc failed:"));
+		assert_eq!(body.as_ref(), b"external processing failed");
 	}
 
 	#[tokio::test]
@@ -1757,7 +1749,7 @@ mod immediate_and_failure {
 		let res = send_request_body(io, Method::POST, "http://lo", b"request").await;
 		assert_eq!(res.status(), 500);
 		let body = read_body_raw(res.into_body()).await;
-		assert!(body.as_ref().starts_with(b"ext_proc failed:"));
+		assert_eq!(body.as_ref(), b"external processing failed");
 	}
 
 	#[tokio::test]
@@ -2127,11 +2119,7 @@ mod dynamic_backend_target {
 		.unwrap();
 		assert_eq!(res.status(), 503);
 		let body = read_body_raw(res.into_body()).await;
-		assert!(
-			body
-				.as_ref()
-				.starts_with(b"processing failed: dynamic backend target expression must evaluate")
-		);
+		assert_eq!(body.as_ref(), b"internal error");
 	}
 
 	#[tokio::test]
@@ -2158,9 +2146,7 @@ mod dynamic_backend_target {
 		.unwrap();
 		assert_eq!(res.status(), 503);
 		let body = read_body_raw(res.into_body()).await;
-		assert!(body.as_ref().starts_with(
-			b"processing failed: dynamic backend target \"not-a-hostport\": invalid host:port"
-		));
+		assert_eq!(body.as_ref(), b"internal error");
 	}
 }
 

--- a/crates/agentgateway/src/mcp/guardrails/client.rs
+++ b/crates/agentgateway/src/mcp/guardrails/client.rs
@@ -361,7 +361,7 @@ fn on_grpc_error<T>(
 		FailureMode::FailOpen => Outcome::Pass,
 		FailureMode::FailClosed => Outcome::Reject(ErrorData::new(
 			ErrorCode::INTERNAL_ERROR,
-			format!("mcpGuardrails {rpc} failed: {}", status.message()),
+			"guardrail check failed",
 			None,
 		)),
 	}
@@ -383,7 +383,7 @@ fn on_protocol_violation<T>(
 		FailureMode::FailOpen => Outcome::Pass,
 		FailureMode::FailClosed => Outcome::Reject(ErrorData::new(
 			ErrorCode::INTERNAL_ERROR,
-			format!("mcpGuardrails protocol violation: {reason}"),
+			"guardrail check failed",
 			None,
 		)),
 	}

--- a/crates/agentgateway/src/mcp/handler.rs
+++ b/crates/agentgateway/src/mcp/handler.rs
@@ -1733,6 +1733,7 @@ fn into_sse_stream(
 						Some(rpc)
 					},
 					Err(e) => {
+						warn!(error = %e, "upstream MCP stream failed");
 						*errored = true;
 						if *terminal_seen {
 							None
@@ -1742,7 +1743,11 @@ fn into_sse_stream(
 								Some(request_id.clone()),
 							);
 							*terminal_seen = capture_terminal_mcp_payload(mcp_log.as_ref(), &request_id, &msg);
-							Some(msg)
+							// Capture the diagnostic detail before building the client response.
+							Some(ServerJsonRpcMessage::error(
+								ErrorData::internal_error("upstream stream failed", None),
+								Some(request_id.clone()),
+							))
 						}
 					},
 				};
@@ -1920,7 +1925,7 @@ async fn apply_guardrails_response_intercept(
 			// matching the request side's handling of serialize failures.
 			tracing::warn!(error = %e, "mcpGuardrails: failed to serialize result for inspection");
 			return Some(ServerJsonRpcMessage::error(
-				ErrorData::internal_error(format!("mcpGuardrails: serialize result: {e}"), None),
+				ErrorData::internal_error("guardrail check failed", None),
 				Some(resp.id.clone()),
 			));
 		},
@@ -2220,7 +2225,9 @@ mod tests {
 		assert_eq!(messages.len(), 1, "the transport error must end the stream");
 		assert!(matches!(
 			messages[0].message.as_ref(),
-			ServerJsonRpcMessage::Error(error) if error.id == Some(RequestId::Number(7))
+			ServerJsonRpcMessage::Error(error)
+				if error.id == Some(RequestId::Number(7))
+					&& error.error.message == "upstream stream failed"
 		));
 
 		let info = log.take().unwrap();

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -1548,7 +1548,7 @@ async fn task_methods_respect_mcp_authorization_deny_policy() {
 	)
 	.await;
 	assert_eq!(get["error"]["code"], -32602);
-	assert_eq!(get["error"]["message"], "Unknown task: task-abc");
+	assert_eq!(get["error"]["message"], "unknown resource");
 }
 
 /// Test that a policy keyed on mcp.methodName sees the right method for each
@@ -1736,7 +1736,7 @@ async fn streamable_http_validates_protocol_version_header() {
 			"id": 3,
 			"error": {
 				"code": -32601,
-				"message": "method not found: initialize"
+				"message": "method not found"
 			}
 		})
 	);
@@ -7614,7 +7614,7 @@ async fn mcp_guardrails_fail_closed_on_grpc_error() {
 		"gRPC failure should map to internal error"
 	);
 	assert!(
-		e.message.contains("mcpGuardrails checkRequest failed"),
+		e.message == "guardrail check failed",
 		"unexpected message: {}",
 		e.message
 	);
@@ -7720,7 +7720,7 @@ async fn mcp_guardrails_protocol_violation_fails_closed() {
 		"protocol violation should map to internal error"
 	);
 	assert!(
-		e.message.contains("protocol violation"),
+		e.message == "guardrail check failed",
 		"unexpected message: {}",
 		e.message
 	);
@@ -7765,7 +7765,7 @@ async fn mcp_guardrails_non_object_mutation_is_protocol_violation() {
 		panic!("expected McpError, got {err:?}");
 	};
 	assert!(
-		e.message.contains("protocol violation"),
+		e.message == "guardrail check failed",
 		"unexpected message: {}",
 		e.message
 	);

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -2720,7 +2720,7 @@ async fn stream_to_stream_single_tls() {
 }
 
 /// Test that calling a tool denied by MCP authorization policy returns proper JSON-RPC error
-/// with INVALID_PARAMS error code (-32602) and message "Unknown tool: {tool_name}"
+/// with INVALID_PARAMS error code (-32602) and message "unknown resource"
 #[tokio::test]
 async fn authorization_denied_returns_unknown_tool_error() {
 	let mock = mock_streamable_http_server(true).await;
@@ -2743,7 +2743,7 @@ async fn authorization_denied_returns_unknown_tool_error() {
 
 	let client = mcp_streamable_client(io).await;
 
-	// Attempt to call a tool - should fail with "Unknown tool" error
+	// Attempt to call a tool - should fail with "unknown resource" error
 	let result = client
 		.call_tool(
 			rmcp::model::CallToolRequestParams::new("echo").with_arguments(
@@ -2777,8 +2777,8 @@ async fn authorization_denied_returns_unknown_tool_error() {
 	);
 	assert_eq!(
 		mcp_error.message.as_ref(),
-		"Unknown tool: echo",
-		"Expected error message 'Unknown tool: echo', got: {}",
+		"unknown resource",
+		"Expected error message 'unknown resource', got: {}",
 		mcp_error.message
 	);
 }
@@ -2917,7 +2917,7 @@ async fn stateful_session_cannot_cross_mcp_backends() {
 }
 
 /// Test that getting a prompt denied by MCP authorization policy returns proper JSON-RPC error
-/// with INVALID_PARAMS error code (-32602) and message "Unknown prompt: {prompt_name}"
+/// with INVALID_PARAMS error code (-32602) and message "unknown resource"
 #[tokio::test]
 async fn authorization_denied_returns_unknown_prompt_error() {
 	let mock = mock_streamable_http_server(true).await;
@@ -2962,8 +2962,8 @@ async fn authorization_denied_returns_unknown_prompt_error() {
 			);
 			assert_eq!(
 				mcp_error.message.as_ref(),
-				"Unknown prompt: example_prompt",
-				"Expected error message 'Unknown prompt: example_prompt', got: {}",
+				"unknown resource",
+				"Expected error message 'unknown resource', got: {}",
 				mcp_error.message
 			);
 		},
@@ -3015,7 +3015,7 @@ async fn authorization_by_method_name_allows_prompts_list_denies_prompts_get() {
 }
 
 /// Test that reading a resource denied by MCP authorization policy returns proper JSON-RPC error
-/// with INVALID_PARAMS error code (-32602) and message "Unknown resource: {resource_uri}"
+/// with INVALID_PARAMS error code (-32602) and message "unknown resource"
 #[tokio::test]
 async fn authorization_denied_returns_unknown_resource_error() {
 	let mock = mock_streamable_http_server(true).await;
@@ -3062,8 +3062,8 @@ async fn authorization_denied_returns_unknown_resource_error() {
 			);
 			assert_eq!(
 				mcp_error.message.as_ref(),
-				"Unknown resource: memo://insights",
-				"Expected error message 'Unknown resource: memo://insights', got: {}",
+				"unknown resource",
+				"Expected error message 'unknown resource', got: {}",
 				mcp_error.message
 			);
 		},
@@ -7284,7 +7284,7 @@ async fn mcp_guardrails_metadata_consumed_by_authz() {
 		panic!("expected McpError, got {err:?}");
 	};
 	assert_eq!(e.code.0, -32602, "authz denial maps to INVALID_PARAMS");
-	assert_eq!(e.message.as_ref(), "Unknown tool: echo");
+	assert_eq!(e.message.as_ref(), "unknown resource");
 }
 
 // Simiilar to mcp_guardrails_metadata_consumed_by_authz but for the fanout path.

--- a/crates/agentgateway/src/mcp/mod.rs
+++ b/crates/agentgateway/src/mcp/mod.rs
@@ -281,7 +281,12 @@ impl Error {
 					id,
 					ErrorData {
 						code,
-						message: self.to_string().into(),
+						message: match self {
+							Error::SendError(_, _) => "failed to send message".into(),
+							Error::Unavailable(_, _) => "service unavailable".into(),
+							Error::Authorization(_, _, _) => "unknown resource".into(),
+							_ => self.to_string().into(),
+						},
 						data: None,
 					},
 				)

--- a/crates/agentgateway/src/mcp/mod.rs
+++ b/crates/agentgateway/src/mcp/mod.rs
@@ -223,18 +223,60 @@ pub enum Error {
 }
 
 impl Error {
+	/// A client-safe message; Display retains the internal diagnostic details.
+	pub fn external_message(&self) -> &'static str {
+		match self {
+			Error::GetStreamNotSupported => "GET event stream is not supported",
+			Error::UnsupportedVersion { .. } => "unsupported MCP protocol version",
+			Error::VersionMismatch(_) => "MCP protocol version header/body mismatch",
+			Error::HeaderBodyMismatch(_, _) => "header/body mismatch",
+			Error::InvalidRoutingHeader(_, _) => "invalid MCP routing header",
+			Error::MethodNotFound(_, _) => "method not found",
+			Error::InvalidParams(_, _) => "invalid request parameters",
+			Error::Unavailable(_, _) => "service unavailable",
+			Error::McpGuardrails(_, _) => "request rejected by guardrail",
+			Error::RateLimited { .. } => "rate limit exceeded",
+			Error::MethodNotAllowed => "method not allowed",
+			Error::InvalidAccept => "invalid accept header",
+			Error::InvalidAcceptGet => "invalid accept header",
+			Error::InvalidContentType => "invalid content type",
+			Error::Deserialize(_) => "invalid request body",
+			Error::StartSession(_) => "failed to create session",
+			Error::UnknownSession => "session not found",
+			Error::MissingSessionHeader => "session header is required",
+			Error::SessionIdRequired => "session id is required",
+			Error::InvalidSessionIdHeader => "invalid session id header",
+			Error::InvalidProtocolVersion => "invalid protocol version",
+			Error::Stdio(_) => "failed to start stdio server",
+			Error::SendError(_, _) => "failed to send message",
+			Error::Authorization(_, _, _) => "unknown resource",
+			Error::InvalidSessionIdQuery => "invalid session id query",
+			Error::EstablishGetStream(_) => "failed to establish stream",
+			Error::ForwardLegacySse(_) => "failed to forward message",
+			Error::CreateSseUrl(_) => "failed to create sse url",
+			Error::OpenAPI(_) => "failed to parse openapi",
+			Error::UpstreamError(_) => "upstream error",
+			Error::NoBackends => "no backends available",
+		}
+	}
+
 	pub fn jsonrpc_error_body(&self) -> Option<String> {
 		let (id, error) = match self {
+			// Policy rejections are explicit client responses; retain their message and data.
 			Error::McpGuardrails(id, rejection) => (id.clone(), rejection.clone()),
 			Error::RateLimited {
 				request_id: id,
 				status,
+				message,
 				..
 			} => (
 				id.clone(),
 				ErrorData {
 					code: RESOURCE_EXHAUSTED,
-					message: self.to_string().into(),
+					message: message
+						.clone()
+						.unwrap_or_else(|| self.external_message().to_owned())
+						.into(),
 					data: status.map(|s| {
 						serde_json::json!({
 							"limit": s.limit,
@@ -252,7 +294,7 @@ impl Error {
 				id.clone(),
 				ErrorData {
 					code: ErrorCode::UNSUPPORTED_PROTOCOL_VERSION,
-					message: self.to_string().into(),
+					message: self.external_message().into(),
 					// This gate runs before backend selection, so it reports the gateway set.
 					// With single-server discover passthrough, SEP-2575's supported/discover
 					// correlation holds only when the upstream advertises a superset of this list.
@@ -281,12 +323,7 @@ impl Error {
 					id,
 					ErrorData {
 						code,
-						message: match self {
-							Error::SendError(_, _) => "failed to send message".into(),
-							Error::Unavailable(_, _) => "service unavailable".into(),
-							Error::Authorization(_, _, _) => "unknown resource".into(),
-							_ => self.to_string().into(),
-						},
+						message: self.external_message().into(),
 						data: None,
 					},
 				)

--- a/crates/agentgateway/src/mcp/subscriptions.rs
+++ b/crates/agentgateway/src/mcp/subscriptions.rs
@@ -623,13 +623,11 @@ mod tests {
 			"the ack must echo the granted filter"
 		);
 		assert_eq!(frames[1]["method"], "notifications/tools/list_changed");
-		assert!(
-			frames[2]["error"]["message"]
-				.as_str()
-				.unwrap()
-				.contains("ended"),
+		assert_eq!(
+			frames[2]["error"]["message"], "upstream stream failed",
 			"a premature EOF under FailClosed must send a terminal error"
 		);
+		assert_eq!(frames[2]["error"]["code"], -32603);
 	}
 
 	#[tokio::test]

--- a/crates/agentgateway/src/proxy/mod.rs
+++ b/crates/agentgateway/src/proxy/mod.rs
@@ -228,8 +228,68 @@ impl ProxyError {
 			_ => false,
 		}
 	}
+
+	pub fn external_message(&self) -> &'static str {
+		match self {
+			ProxyError::BindNotFound => "bind not found",
+			ProxyError::ListenerNotFound => "listener not found",
+			ProxyError::RouteNotFound => "route not found",
+			ProxyError::RouteCycleDetected => "route cycle detected",
+			ProxyError::MisdirectedRequest => "misdirected request",
+			ProxyError::NoValidBackends
+			| ProxyError::NoHealthyEndpoints
+			| ProxyError::BackendDoesNotExist
+			| ProxyError::ServiceNotFound
+			| ProxyError::InvalidBackendType
+			| ProxyError::MCP(mcp::Error::NoBackends) => "no backends available",
+			ProxyError::DnsResolution => "dns resolution failed",
+			ProxyError::FilterError(_) => "filter failed",
+			ProxyError::BackendUnsupportedMirror | ProxyError::Processing(_) | ProxyError::ProcessingString(_) => "internal error",
+			ProxyError::APIKeyAuthenticationFailure(_)
+			| ProxyError::BasicAuthenticationFailure(_)
+			| ProxyError::OidcFailure(_)
+			| ProxyError::JwtAuthenticationFailure(_)
+			| ProxyError::McpJwtAuthenticationFailure(_, _) => "authentication failed",
+			ProxyError::CsrfValidationFailed => "csrf validation failed",
+			ProxyError::ExternalAuthorizationFailed(_) | ProxyError::AuthorizationFailed => "authorization failed",
+			ProxyError::BackendAuthenticationFailed(_) => "backend authentication failed",
+			ProxyError::Body(_) => "request body error",
+			ProxyError::UpstreamCallFailed(e) => external_upstream_message(e),
+			ProxyError::UpstreamCallTimeout | ProxyError::RequestTimeout => "request timeout",
+			ProxyError::UpstreamTCPCallFailed(e) => external_upstream_message(e),
+			ProxyError::UpstreamTCPProxy(_) => "upstream connection failed",
+			ProxyError::Http(_) => "invalid http",
+			ProxyError::ExtProc(_) => "external processing failed",
+			ProxyError::RateLimitExceeded { .. } => "rate limit exceeded",
+			ProxyError::RateLimitFailed => "rate limit failed",
+			ProxyError::InvalidRequest => "invalid request",
+			ProxyError::UpgradeFailed(_, _) => "request upgrade failed",
+			ProxyError::MethodNotAllowed => "method not allowed",
+			ProxyError::MCP(mcp::Error::MethodNotAllowed) => "method not allowed",
+			ProxyError::MCP(mcp::Error::InvalidAccept) => "invalid accept header",
+			ProxyError::MCP(mcp::Error::InvalidAcceptGet) => "invalid accept header",
+			ProxyError::MCP(mcp::Error::InvalidContentType) => "invalid content type",
+			ProxyError::MCP(mcp::Error::Deserialize(_)) => "invalid request body",
+			ProxyError::MCP(mcp::Error::StartSession(_)) => "failed to create session",
+			ProxyError::MCP(mcp::Error::UnknownSession) => "session not found",
+			ProxyError::MCP(mcp::Error::MissingSessionHeader) => "session header is required",
+			ProxyError::MCP(mcp::Error::SessionIdRequired) => "session id is required",
+			ProxyError::MCP(mcp::Error::InvalidSessionIdHeader) => "invalid session id header",
+			ProxyError::MCP(mcp::Error::InvalidProtocolVersion) => "invalid protocol version",
+			ProxyError::MCP(mcp::Error::Stdio(_)) => "failed to start stdio server",
+			ProxyError::MCP(mcp::Error::SendError(_, _)) => "failed to send message",
+			ProxyError::MCP(mcp::Error::Authorization(_, _, _)) => "unknown resource",
+			ProxyError::MCP(mcp::Error::InvalidSessionIdQuery) => "invalid session id query",
+			ProxyError::MCP(mcp::Error::EstablishGetStream(_)) => "failed to establish stream",
+			ProxyError::MCP(mcp::Error::ForwardLegacySse(_)) => "failed to forward message",
+			ProxyError::MCP(mcp::Error::CreateSseUrl(_)) => "failed to create sse url",
+			ProxyError::MCP(mcp::Error::OpenAPI(_)) => "failed to parse openapi",
+			ProxyError::MCP(mcp::Error::UpstreamError(_)) => "upstream error",
+		}
+	}
+
 	pub fn into_response_with_grpc(self, is_grpc_request: bool) -> Response {
-		let msg = self.to_string();
+		let msg = self.external_message();
 		let code = match self {
 			ProxyError::BindNotFound => StatusCode::NOT_FOUND,
 			ProxyError::ListenerNotFound => StatusCode::NOT_FOUND,
@@ -376,14 +436,14 @@ impl ProxyError {
 				)))
 				.unwrap();
 		}
-		if let ProxyError::MCP(ref e @ mcp::Error::SendError(ref id, _)) = self {
+		if let ProxyError::MCP(mcp::Error::SendError(ref id, _)) = self {
 			let err = if let Some(req_id) = id {
 				serde_json::to_string(&JsonRpcError {
 					jsonrpc: Default::default(),
 					id: req_id.clone(),
 					error: ErrorData {
 						code: ErrorCode::INTERNAL_ERROR,
-						message: format!("failed to send message: {e}",).into(),
+						message: msg.into(),
 						data: None,
 					},
 				})
@@ -391,19 +451,19 @@ impl ProxyError {
 			} else {
 				None
 			};
-			let msg = err.unwrap_or_else(|| format!("failed to send message: {e}"));
+			let msg = err.unwrap_or_else(|| msg.to_string());
 			return rb
 				.header("content-type", "application/json")
 				.body(http::Body::from(msg))
 				.unwrap();
 		}
-		if let ProxyError::MCP(ref e @ mcp::Error::Authorization(ref req_id, _, _)) = self {
+		if let ProxyError::MCP(mcp::Error::Authorization(ref req_id, _, _)) = self {
 			let msg = serde_json::to_string(&JsonRpcError {
 				jsonrpc: Default::default(),
 				id: req_id.clone(),
 				error: ErrorData {
 					code: ErrorCode::INVALID_PARAMS,
-					message: e.to_string().into(),
+					message: msg.into(),
 					data: None,
 				},
 			})
@@ -418,6 +478,23 @@ impl ProxyError {
 			.body(http::Body::from(msg))
 			.unwrap()
 	}
+}
+
+fn external_upstream_message(error: &(dyn std::error::Error + 'static)) -> &'static str {
+	let mut current = Some(error);
+	while let Some(error) = current {
+		if let Some(io_error) = error.downcast_ref::<std::io::Error>() {
+			return match io_error.kind() {
+				std::io::ErrorKind::ConnectionRefused => "connection refused",
+				std::io::ErrorKind::ConnectionReset => "connection reset",
+				std::io::ErrorKind::ConnectionAborted => "connection aborted",
+				std::io::ErrorKind::TimedOut => "connection timed out",
+				_ => "upstream connection failed",
+			};
+		}
+		current = error.source();
+	}
+	"upstream call failed"
 }
 
 fn proxy_error_to_grpc_status(error: &ProxyError, http_status: StatusCode) -> Code {
@@ -559,7 +636,7 @@ mod tests {
 		);
 		assert_eq!(
 			response.headers().get("grpc-message").unwrap(),
-			"no%20healthy%20backends"
+			"no%20backends%20available"
 		);
 	}
 
@@ -602,5 +679,47 @@ mod tests {
 			grpc.headers().get("grpc-status").unwrap(),
 			&i32::from(Code::Unavailable).to_string()
 		);
+	}
+
+	#[test]
+	fn display_keeps_internal_error_detail() {
+		let err = ProxyError::ProcessingString("secret backend detail".to_string());
+
+		assert_eq!(err.to_string(), "processing failed: secret backend detail");
+		assert_eq!(err.external_message(), "processing failed");
+	}
+
+	#[tokio::test]
+	async fn http_error_response_uses_external_message() {
+		let response = ProxyError::ProcessingString("secret backend detail".to_string())
+			.into_response_with_grpc(false);
+
+		assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+		let body = crate::http::read_body_with_limit(response.into_body(), 100)
+			.await
+			.unwrap();
+		assert_eq!(body.as_ref(), b"processing failed");
+	}
+
+	#[test]
+	fn grpc_error_response_uses_external_message() {
+		let response = ProxyError::ProcessingString("secret backend detail".to_string())
+			.into_response_with_grpc(true);
+
+		assert_eq!(response.status(), StatusCode::OK);
+		assert_eq!(
+			response.headers().get("grpc-message").unwrap(),
+			"processing%20failed"
+		);
+	}
+
+	#[test]
+	fn external_message_preserves_safe_io_error_kind() {
+		let err = ProxyError::UpstreamTCPCallFailed(crate::http::Error::new(std::io::Error::from(
+			std::io::ErrorKind::ConnectionRefused,
+		)));
+
+		assert_eq!(err.external_message(), "connection refused");
+		assert!(err.to_string().contains("connection refused"));
 	}
 }

--- a/crates/agentgateway/src/proxy/mod.rs
+++ b/crates/agentgateway/src/proxy/mod.rs
@@ -375,8 +375,10 @@ impl ProxyError {
 		}
 	}
 
+	/// A client-safe message. Keep Display and Debug for logs and diagnostics.
 	pub fn external_message(&self) -> &'static str {
 		match self {
+			ProxyError::MCP(e) => e.external_message(),
 			ProxyError::StaleAssignment => "service unavailable",
 			ProxyError::AIRequest(_) => "failed to process LLM request",
 			ProxyError::AIResponse(_) => "failed to process LLM response",
@@ -387,18 +389,6 @@ impl ProxyError {
 			ProxyError::GuardrailRejected { .. } => "request rejected by guardrail",
 			ProxyError::BudgetExceeded(_) => "budget exceeded",
 			ProxyError::RemoteRateLimitExceeded { .. } => "rate limit exceeded",
-			ProxyError::MCP(mcp::Error::GetStreamNotSupported) => "GET event stream is not supported",
-			ProxyError::MCP(mcp::Error::UnsupportedVersion { .. }) => "unsupported MCP protocol version",
-			ProxyError::MCP(mcp::Error::VersionMismatch(_)) => {
-				"MCP protocol version header/body mismatch"
-			},
-			ProxyError::MCP(mcp::Error::HeaderBodyMismatch(_, _)) => "header/body mismatch",
-			ProxyError::MCP(mcp::Error::InvalidRoutingHeader(_, _)) => "invalid MCP routing header",
-			ProxyError::MCP(mcp::Error::MethodNotFound(_, _)) => "method not found",
-			ProxyError::MCP(mcp::Error::InvalidParams(_, _)) => "invalid request parameters",
-			ProxyError::MCP(mcp::Error::Unavailable(_, _)) => "service unavailable",
-			ProxyError::MCP(mcp::Error::McpGuardrails(_, _)) => "request rejected by guardrail",
-			ProxyError::MCP(mcp::Error::RateLimited { .. }) => "rate limit exceeded",
 			ProxyError::BindNotFound => "bind not found",
 			ProxyError::ListenerNotFound => "listener not found",
 			ProxyError::RouteNotFound => "route not found",
@@ -408,8 +398,7 @@ impl ProxyError {
 			| ProxyError::NoHealthyEndpoints
 			| ProxyError::BackendDoesNotExist
 			| ProxyError::ServiceNotFound
-			| ProxyError::InvalidBackendType
-			| ProxyError::MCP(mcp::Error::NoBackends) => "no backends available",
+			| ProxyError::InvalidBackendType => "no backends available",
 			ProxyError::DnsResolution => "dns resolution failed",
 			ProxyError::FilterError(_) => "filter failed",
 			ProxyError::BackendUnsupportedMirror
@@ -437,26 +426,6 @@ impl ProxyError {
 			ProxyError::InvalidRequest => "invalid request",
 			ProxyError::UpgradeFailed(_, _) => "request upgrade failed",
 			ProxyError::MethodNotAllowed => "method not allowed",
-			ProxyError::MCP(mcp::Error::MethodNotAllowed) => "method not allowed",
-			ProxyError::MCP(mcp::Error::InvalidAccept) => "invalid accept header",
-			ProxyError::MCP(mcp::Error::InvalidAcceptGet) => "invalid accept header",
-			ProxyError::MCP(mcp::Error::InvalidContentType) => "invalid content type",
-			ProxyError::MCP(mcp::Error::Deserialize(_)) => "invalid request body",
-			ProxyError::MCP(mcp::Error::StartSession(_)) => "failed to create session",
-			ProxyError::MCP(mcp::Error::UnknownSession) => "session not found",
-			ProxyError::MCP(mcp::Error::MissingSessionHeader) => "session header is required",
-			ProxyError::MCP(mcp::Error::SessionIdRequired) => "session id is required",
-			ProxyError::MCP(mcp::Error::InvalidSessionIdHeader) => "invalid session id header",
-			ProxyError::MCP(mcp::Error::InvalidProtocolVersion) => "invalid protocol version",
-			ProxyError::MCP(mcp::Error::Stdio(_)) => "failed to start stdio server",
-			ProxyError::MCP(mcp::Error::SendError(_, _)) => "failed to send message",
-			ProxyError::MCP(mcp::Error::Authorization(_, _, _)) => "unknown resource",
-			ProxyError::MCP(mcp::Error::InvalidSessionIdQuery) => "invalid session id query",
-			ProxyError::MCP(mcp::Error::EstablishGetStream(_)) => "failed to establish stream",
-			ProxyError::MCP(mcp::Error::ForwardLegacySse(_)) => "failed to forward message",
-			ProxyError::MCP(mcp::Error::CreateSseUrl(_)) => "failed to create sse url",
-			ProxyError::MCP(mcp::Error::OpenAPI(_)) => "failed to parse openapi",
-			ProxyError::MCP(mcp::Error::UpstreamError(_)) => "upstream error",
 		}
 	}
 
@@ -641,7 +610,7 @@ impl ProxyError {
 				.header("grpc-status", i32::from(grpc_status).to_string())
 				.header(
 					"grpc-message",
-					utf8_percent_encode(&msg, GRPC_MESSAGE_ENCODE_SET).to_string(),
+					utf8_percent_encode(msg, GRPC_MESSAGE_ENCODE_SET).to_string(),
 				)
 				.body(http::Body::empty())
 				.unwrap();
@@ -654,7 +623,7 @@ impl ProxyError {
 				.body(http::Body::from(
 					serde_json::json!({
 						"error": {
-							"message": exceeded.to_string(),
+							"message": msg,
 							"type": "rate_limit_error",
 							"code": "budget_exceeded",
 						}
@@ -1062,36 +1031,68 @@ mod tests {
 		);
 	}
 
-	#[test]
-	fn display_keeps_internal_error_detail() {
-		let err = ProxyError::ProcessingString("secret backend detail".to_string());
-
-		assert_eq!(err.to_string(), "processing failed: secret backend detail");
-		assert_eq!(err.external_message(), "internal error");
-	}
-
 	#[tokio::test]
-	async fn http_error_response_uses_external_message() {
-		let response = ProxyError::ProcessingString("secret backend detail".to_string())
-			.into_response_with_grpc(false);
+	async fn error_responses_keep_details_internal() {
+		use rmcp::model::RequestId;
 
-		assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
-		let body = crate::http::read_body_with_limit(response.into_body(), 100)
-			.await
-			.unwrap();
-		assert_eq!(body.as_ref(), b"internal error");
-	}
-
-	#[test]
-	fn grpc_error_response_uses_external_message() {
-		let response = ProxyError::ProcessingString("secret backend detail".to_string())
-			.into_response_with_grpc(true);
-
-		assert_eq!(response.status(), StatusCode::OK);
-		assert_eq!(
-			response.headers().get("grpc-message").unwrap(),
-			"internal%20error"
-		);
+		for grpc in [false, true] {
+			for error in [
+				ProxyError::ProcessingString("secret backend detail".into()),
+				ProxyError::Processing(anyhow::anyhow!("secret backend detail")),
+				ProxyError::Body(http::Error::new(std::io::Error::other(
+					"secret backend detail",
+				))),
+				ProxyError::UpstreamTCPCallFailed(http::Error::new(std::io::Error::other(
+					"secret backend detail",
+				))),
+				ProxyError::SubstrateIngressFailed(StatusCode::BAD_GATEWAY, "secret backend detail".into()),
+				ProxyError::SubstrateEgressDenied("secret backend detail".into()),
+				ProxyError::MCP(mcp::Error::SendError(None, "secret backend detail".into())),
+				ProxyError::MCP(mcp::Error::SendError(
+					Some(RequestId::Number(7)),
+					"secret backend detail".into(),
+				)),
+				ProxyError::MCP(mcp::Error::Unavailable(
+					Some(RequestId::Number(7)),
+					"secret backend detail".into(),
+				)),
+				ProxyError::MCP(mcp::Error::InvalidParams(
+					Some(RequestId::Number(7)),
+					"secret backend detail".into(),
+				)),
+				ProxyError::MCP(mcp::Error::Authorization(
+					RequestId::Number(7),
+					"tool".into(),
+					"secret backend detail".into(),
+				)),
+			] {
+				assert!(error.to_string().contains("secret backend detail"));
+				let external = error.external_message();
+				assert!(!external.contains("secret"));
+				let response = error.into_response_with_grpc(grpc);
+				if grpc {
+					assert_eq!(response.status(), StatusCode::OK);
+					assert_eq!(
+						response.headers()["grpc-message"],
+						utf8_percent_encode(external, GRPC_MESSAGE_ENCODE_SET).to_string()
+					);
+					assert!(http::read_resp_body(response).await.unwrap().is_empty());
+				} else {
+					assert!(response.status().is_client_error() || response.status().is_server_error());
+					let json = response.headers()[hyper::header::CONTENT_TYPE] == "application/json";
+					let body = http::read_resp_body(response).await.unwrap();
+					if json {
+						let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+						assert_eq!(body["jsonrpc"], "2.0");
+						assert_eq!(body["id"], 7);
+						assert_eq!(body["error"]["message"], external);
+						assert!(body["error"].get("data").is_none());
+					} else {
+						assert_eq!(body.as_ref(), external.as_bytes());
+					}
+				}
+			}
+		}
 	}
 
 	#[test]

--- a/crates/agentgateway/src/proxy/mod.rs
+++ b/crates/agentgateway/src/proxy/mod.rs
@@ -374,8 +374,94 @@ impl ProxyError {
 			_ => false,
 		}
 	}
+
+	pub fn external_message(&self) -> &'static str {
+		match self {
+			ProxyError::StaleAssignment => "service unavailable",
+			ProxyError::AIRequest(_) => "failed to process LLM request",
+			ProxyError::AIResponse(_) => "failed to process LLM response",
+			ProxyError::SubstrateIngressFailed(_, _) => "ingress failed",
+			ProxyError::SubstrateEgressDenied(_) => "authorization failed",
+			ProxyError::SubstrateEgressUnavailable(_) => "service unavailable",
+			ProxyError::RequestLimitExceeded => "request limit exceeded",
+			ProxyError::GuardrailRejected { .. } => "request rejected by guardrail",
+			ProxyError::BudgetExceeded(_) => "budget exceeded",
+			ProxyError::RemoteRateLimitExceeded { .. } => "rate limit exceeded",
+			ProxyError::MCP(mcp::Error::GetStreamNotSupported) => "GET event stream is not supported",
+			ProxyError::MCP(mcp::Error::UnsupportedVersion { .. }) => "unsupported MCP protocol version",
+			ProxyError::MCP(mcp::Error::VersionMismatch(_)) => {
+				"MCP protocol version header/body mismatch"
+			},
+			ProxyError::MCP(mcp::Error::HeaderBodyMismatch(_, _)) => "header/body mismatch",
+			ProxyError::MCP(mcp::Error::InvalidRoutingHeader(_, _)) => "invalid MCP routing header",
+			ProxyError::MCP(mcp::Error::MethodNotFound(_, _)) => "method not found",
+			ProxyError::MCP(mcp::Error::InvalidParams(_, _)) => "invalid request parameters",
+			ProxyError::MCP(mcp::Error::Unavailable(_, _)) => "service unavailable",
+			ProxyError::MCP(mcp::Error::McpGuardrails(_, _)) => "request rejected by guardrail",
+			ProxyError::MCP(mcp::Error::RateLimited { .. }) => "rate limit exceeded",
+			ProxyError::BindNotFound => "bind not found",
+			ProxyError::ListenerNotFound => "listener not found",
+			ProxyError::RouteNotFound => "route not found",
+			ProxyError::RouteCycleDetected => "route cycle detected",
+			ProxyError::MisdirectedRequest => "misdirected request",
+			ProxyError::NoValidBackends
+			| ProxyError::NoHealthyEndpoints
+			| ProxyError::BackendDoesNotExist
+			| ProxyError::ServiceNotFound
+			| ProxyError::InvalidBackendType
+			| ProxyError::MCP(mcp::Error::NoBackends) => "no backends available",
+			ProxyError::DnsResolution => "dns resolution failed",
+			ProxyError::FilterError(_) => "filter failed",
+			ProxyError::BackendUnsupportedMirror
+			| ProxyError::Processing(_)
+			| ProxyError::ProcessingString(_) => "internal error",
+			ProxyError::APIKeyAuthenticationFailure(_)
+			| ProxyError::BasicAuthenticationFailure(_)
+			| ProxyError::OidcFailure(_)
+			| ProxyError::JwtAuthenticationFailure(_)
+			| ProxyError::McpJwtAuthenticationFailure(_, _) => "authentication failed",
+			ProxyError::CsrfValidationFailed => "csrf validation failed",
+			ProxyError::ExternalAuthorizationFailed(_) | ProxyError::AuthorizationFailed => {
+				"authorization failed"
+			},
+			ProxyError::BackendAuthenticationFailed(_) => "backend authentication failed",
+			ProxyError::Body(_) => "request body error",
+			ProxyError::UpstreamCallFailed(e) => external_upstream_message(e),
+			ProxyError::UpstreamCallTimeout | ProxyError::RequestTimeout => "request timeout",
+			ProxyError::UpstreamTCPCallFailed(e) => external_upstream_message(e),
+			ProxyError::UpstreamTCPProxy(_) => "upstream connection failed",
+			ProxyError::Http(_) => "invalid http",
+			ProxyError::ExtProc(_) => "external processing failed",
+			ProxyError::RateLimitExceeded { .. } => "rate limit exceeded",
+			ProxyError::RateLimitFailed => "rate limit failed",
+			ProxyError::InvalidRequest => "invalid request",
+			ProxyError::UpgradeFailed(_, _) => "request upgrade failed",
+			ProxyError::MethodNotAllowed => "method not allowed",
+			ProxyError::MCP(mcp::Error::MethodNotAllowed) => "method not allowed",
+			ProxyError::MCP(mcp::Error::InvalidAccept) => "invalid accept header",
+			ProxyError::MCP(mcp::Error::InvalidAcceptGet) => "invalid accept header",
+			ProxyError::MCP(mcp::Error::InvalidContentType) => "invalid content type",
+			ProxyError::MCP(mcp::Error::Deserialize(_)) => "invalid request body",
+			ProxyError::MCP(mcp::Error::StartSession(_)) => "failed to create session",
+			ProxyError::MCP(mcp::Error::UnknownSession) => "session not found",
+			ProxyError::MCP(mcp::Error::MissingSessionHeader) => "session header is required",
+			ProxyError::MCP(mcp::Error::SessionIdRequired) => "session id is required",
+			ProxyError::MCP(mcp::Error::InvalidSessionIdHeader) => "invalid session id header",
+			ProxyError::MCP(mcp::Error::InvalidProtocolVersion) => "invalid protocol version",
+			ProxyError::MCP(mcp::Error::Stdio(_)) => "failed to start stdio server",
+			ProxyError::MCP(mcp::Error::SendError(_, _)) => "failed to send message",
+			ProxyError::MCP(mcp::Error::Authorization(_, _, _)) => "unknown resource",
+			ProxyError::MCP(mcp::Error::InvalidSessionIdQuery) => "invalid session id query",
+			ProxyError::MCP(mcp::Error::EstablishGetStream(_)) => "failed to establish stream",
+			ProxyError::MCP(mcp::Error::ForwardLegacySse(_)) => "failed to forward message",
+			ProxyError::MCP(mcp::Error::CreateSseUrl(_)) => "failed to create sse url",
+			ProxyError::MCP(mcp::Error::OpenAPI(_)) => "failed to parse openapi",
+			ProxyError::MCP(mcp::Error::UpstreamError(_)) => "upstream error",
+		}
+	}
+
 	pub fn into_response_with_grpc(self, is_grpc_request: bool) -> Response {
-		let msg = self.to_string();
+		let msg = self.external_message();
 		let code = match self {
 			ProxyError::BindNotFound => StatusCode::NOT_FOUND,
 			ProxyError::ListenerNotFound => StatusCode::NOT_FOUND,
@@ -603,6 +689,23 @@ impl ProxyError {
 			.body(http::Body::from(msg))
 			.unwrap()
 	}
+}
+
+fn external_upstream_message(error: &(dyn std::error::Error + 'static)) -> &'static str {
+	let mut current = Some(error);
+	while let Some(error) = current {
+		if let Some(io_error) = error.downcast_ref::<std::io::Error>() {
+			return match io_error.kind() {
+				std::io::ErrorKind::ConnectionRefused => "connection refused",
+				std::io::ErrorKind::ConnectionReset => "connection reset",
+				std::io::ErrorKind::ConnectionAborted => "connection aborted",
+				std::io::ErrorKind::TimedOut => "connection timed out",
+				_ => "upstream connection failed",
+			};
+		}
+		current = error.source();
+	}
+	"upstream call failed"
 }
 
 fn proxy_error_to_grpc_status(error: &ProxyError, http_status: StatusCode) -> Code {
@@ -914,7 +1017,7 @@ mod tests {
 		);
 		assert_eq!(
 			response.headers().get("grpc-message").unwrap(),
-			"no%20healthy%20backends"
+			"no%20backends%20available"
 		);
 	}
 
@@ -957,5 +1060,47 @@ mod tests {
 			grpc.headers().get("grpc-status").unwrap(),
 			&i32::from(Code::Unavailable).to_string()
 		);
+	}
+
+	#[test]
+	fn display_keeps_internal_error_detail() {
+		let err = ProxyError::ProcessingString("secret backend detail".to_string());
+
+		assert_eq!(err.to_string(), "processing failed: secret backend detail");
+		assert_eq!(err.external_message(), "internal error");
+	}
+
+	#[tokio::test]
+	async fn http_error_response_uses_external_message() {
+		let response = ProxyError::ProcessingString("secret backend detail".to_string())
+			.into_response_with_grpc(false);
+
+		assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+		let body = crate::http::read_body_with_limit(response.into_body(), 100)
+			.await
+			.unwrap();
+		assert_eq!(body.as_ref(), b"internal error");
+	}
+
+	#[test]
+	fn grpc_error_response_uses_external_message() {
+		let response = ProxyError::ProcessingString("secret backend detail".to_string())
+			.into_response_with_grpc(true);
+
+		assert_eq!(response.status(), StatusCode::OK);
+		assert_eq!(
+			response.headers().get("grpc-message").unwrap(),
+			"internal%20error"
+		);
+	}
+
+	#[test]
+	fn external_message_preserves_safe_io_error_kind() {
+		let err = ProxyError::UpstreamTCPCallFailed(crate::http::Error::new(std::io::Error::from(
+			std::io::ErrorKind::ConnectionRefused,
+		)));
+
+		assert_eq!(err.external_message(), "connection refused");
+		assert!(err.to_string().contains("connection refused"));
 	}
 }

--- a/crates/agentgateway/tests/tests/dfp.rs
+++ b/crates/agentgateway/tests/tests/dfp.rs
@@ -99,10 +99,7 @@ async fn dfp_rejects_inference_routing() {
 	let res = send_request(io, Method::GET, "http://example.com/dynamic").await;
 	assert_eq!(res.status(), StatusCode::SERVICE_UNAVAILABLE);
 	let body = res.into_body().collect().await.unwrap().to_bytes();
-	assert_eq!(
-		String::from_utf8_lossy(&body),
-		"processing failed: inferenceRouting is not supported with dynamic backends"
-	);
+	assert_eq!(String::from_utf8_lossy(&body), "internal error");
 }
 
 /// DFP resolves the destination from the request's Host/URI authority, including the port.

--- a/crates/agentgateway/tests/tests/llm.rs
+++ b/crates/agentgateway/tests/tests/llm.rs
@@ -1016,12 +1016,7 @@ async fn llm_custom_provider_rejects_unsupported_format_before_upstream_call() {
 	let res = send_completions_with_model(io, "replaceme", &[]).await;
 	assert_eq!(res.status(), 400);
 	let body = read_body_raw(res.into_body()).await;
-	assert!(
-		String::from_utf8_lossy(&body)
-			.contains("unsupported conversion: from Completions to provider custom"),
-		"unexpected response body: {}",
-		String::from_utf8_lossy(&body)
-	);
+	assert_eq!(body.as_ref(), b"failed to process LLM request");
 
 	let requests = mock
 		.received_requests()

--- a/crates/agentgateway/tests/tests/policy.rs
+++ b/crates/agentgateway/tests/tests/policy.rs
@@ -55,7 +55,7 @@ async fn response_policy_short_circuit() {
 	// Each type of response modifier should NOT run since the ext_authz short-circuits the req
 	assert_eq!(res.hdr("x-filter"), "");
 	assert_eq!(res.hdr("x-xfm"), "");
-	assert_eq!(read_body!(res).as_ref(), b"external authorization failed");
+	assert_eq!(read_body!(res).as_ref(), b"authorization failed");
 }
 
 #[tokio::test]
@@ -527,6 +527,8 @@ async fn response_transformation_can_read_gateway_error() {
 			.hdr("x-error-message")
 			.starts_with("upstream call failed:")
 	);
+	// Operators can explicitly expose diagnostics through CEL, but the default body stays safe.
+	assert_eq!(read_body!(res).as_ref(), b"connection refused");
 }
 
 #[tokio::test]


### PR DESCRIPTION
Today we have 1 representation of errors. This puts us in a dilemma - we cannot expose useful info since it gets exposed to clients, but then we cannot see useful info in debugging logs.

This splits the errors to have two representations: and internal and external one. The external ones are pretty opaque - more opaque than envoy though perhaps less opaque than nginx. 

This opens us up to being more descriptive in our errors but I didn't do so.

