### PR TITLE
local rate limit: allow simplified config

### DIFF
--- a/crates/agentgateway/src/http/localratelimit.rs
+++ b/crates/agentgateway/src/http/localratelimit.rs
@@ -1,4 +1,5 @@
 use serde::de::Error;
+use std::num::NonZeroU64;
 
 use crate::llm::LLMRequest;
 use crate::proxy::ProxyError;
@@ -6,7 +7,7 @@ use crate::*;
 
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
-#[cfg_attr(feature = "schema", schemars(with = "RateLimitSpec"))]
+#[cfg_attr(feature = "schema", schemars(with = "RateLimitConfig"))]
 #[derive(serde::Serialize)]
 pub struct RateLimit {
 	#[serde(skip_serializing)]
@@ -25,7 +26,7 @@ impl<'de> serde::Deserialize<'de> for RateLimit {
 	}
 }
 
-#[apply(schema!)]
+#[apply(schema_ser_schema!)]
 pub struct RateLimitSpec {
 	/// Maximum number of tokens that can accumulate in the local bucket.
 	#[serde(default)]
@@ -41,6 +42,154 @@ pub struct RateLimitSpec {
 	#[serde(default)]
 	#[serde(rename = "type")]
 	pub limit_type: RateLimitType,
+}
+
+impl<'de> serde::Deserialize<'de> for RateLimitSpec {
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: serde::Deserializer<'de>,
+	{
+		<RateLimitConfig as serde::Deserialize>::deserialize(deserializer)?
+			.try_into()
+			.map_err(D::Error::custom)
+	}
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(untagged)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[cfg_attr(feature = "schema", schemars(untagged, deny_unknown_fields))]
+enum RateLimitConfig {
+	Explicit(ExplicitRateLimitSpec),
+	Simple(SimpleRateLimitSpec),
+}
+
+// Flattening `RateLimitConfig` into a conditional policy produces an invalid schema:
+// `condition` is then an additional property of both variants below. Model the two
+// complete conditional shapes explicitly for schema generation instead.
+#[cfg(feature = "schema")]
+#[allow(dead_code)]
+#[derive(JsonSchema)]
+#[schemars(untagged, deny_unknown_fields)]
+pub(crate) enum ConditionalRateLimitConfig {
+	Explicit(ConditionalExplicitRateLimitSpec),
+	Simple(ConditionalSimpleRateLimitSpec),
+}
+
+#[cfg(feature = "schema")]
+#[allow(dead_code)]
+#[derive(JsonSchema)]
+#[schemars(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct ConditionalExplicitRateLimitSpec {
+	/// condition must evaluate to true for this policy to execute. If unset, the policy is the fallback.
+	condition: Option<Arc<crate::cel::Expression>>,
+	/// Maximum number of tokens that can accumulate in the local bucket.
+	#[schemars(default)]
+	max_tokens: u64,
+	/// Number of tokens added to the local bucket each fill interval.
+	#[schemars(default)]
+	tokens_per_fill: u64,
+	/// How often the local bucket is refilled.
+	#[schemars(with = "String")]
+	fill_interval: Duration,
+	/// Whether this limit counts requests or LLM tokens.
+	#[schemars(default, rename = "type")]
+	limit_type: RateLimitType,
+}
+
+#[cfg(feature = "schema")]
+#[allow(dead_code)]
+#[derive(JsonSchema)]
+#[schemars(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct ConditionalSimpleRateLimitSpec {
+	/// condition must evaluate to true for this policy to execute. If unset, the policy is the fallback.
+	condition: Option<Arc<crate::cel::Expression>>,
+	/// Whether this limit counts requests or LLM tokens.
+	#[schemars(rename = "type")]
+	limit_type: RateLimitType,
+	/// Sustained request or token allowance per unit.
+	limit: NonZeroU64,
+	/// Unit of time for the limit.
+	unit: RateLimitUnit,
+	/// Additional bucket capacity above the sustained limit.
+	#[schemars(default)]
+	burst: u64,
+}
+
+#[apply(schema!)]
+struct ExplicitRateLimitSpec {
+	/// Maximum number of tokens that can accumulate in the local bucket.
+	#[serde(default)]
+	max_tokens: u64,
+	/// Number of tokens added to the local bucket each fill interval.
+	#[serde(default)]
+	tokens_per_fill: u64,
+	/// How often the local bucket is refilled.
+	#[serde(with = "serde_dur")]
+	#[cfg_attr(feature = "schema", schemars(with = "String"))]
+	fill_interval: Duration,
+	/// Whether this limit counts requests or LLM tokens.
+	#[serde(default)]
+	#[serde(rename = "type")]
+	limit_type: RateLimitType,
+}
+
+#[apply(schema!)]
+struct SimpleRateLimitSpec {
+	/// Whether this limit counts requests or LLM tokens.
+	#[serde(rename = "type")]
+	limit_type: RateLimitType,
+	/// Sustained request or token allowance per unit.
+	limit: NonZeroU64,
+	/// Unit of time for the limit.
+	unit: RateLimitUnit,
+	/// Additional bucket capacity above the sustained limit.
+	#[serde(default)]
+	burst: u64,
+}
+
+#[apply(schema!)]
+#[derive(Eq, PartialEq)]
+enum RateLimitUnit {
+	/// Per second.
+	Seconds,
+	/// Per minute.
+	Minutes,
+	/// Per hour.
+	Hours,
+}
+
+impl TryFrom<RateLimitConfig> for RateLimitSpec {
+	type Error = String;
+
+	fn try_from(value: RateLimitConfig) -> Result<Self, Self::Error> {
+		match value {
+			RateLimitConfig::Explicit(value) => Ok(RateLimitSpec {
+				max_tokens: value.max_tokens,
+				tokens_per_fill: value.tokens_per_fill,
+				fill_interval: value.fill_interval,
+				limit_type: value.limit_type,
+			}),
+			RateLimitConfig::Simple(value) => {
+				let limit = value.limit.get();
+				let max_tokens = value
+					.limit
+					.get()
+					.checked_add(value.burst)
+					.ok_or_else(|| "limit plus burst exceeds uint64".to_string())?;
+				Ok(RateLimitSpec {
+					max_tokens,
+					tokens_per_fill: limit,
+					fill_interval: match value.unit {
+						RateLimitUnit::Seconds => Duration::from_secs(1),
+						RateLimitUnit::Minutes => Duration::from_secs(60),
+						RateLimitUnit::Hours => Duration::from_secs(60 * 60),
+					},
+					limit_type: value.limit_type,
+				})
+			},
+		}
+	}
 }
 
 #[apply(schema!)]
@@ -138,6 +287,98 @@ impl crate::store::RequestPolicyTrait for Vec<RateLimit> {
 			rate_limit.check_request()?;
 		}
 		Ok(http::PolicyResponse::default())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn simple_requests_rate_limit_deserializes() {
+		let spec: RateLimitSpec = serde_yaml::from_str(
+			r#"
+type: requests
+limit: 50
+unit: seconds
+"#,
+		)
+		.unwrap();
+
+		assert_eq!(spec.limit_type, RateLimitType::Requests);
+		assert_eq!(spec.max_tokens, 50);
+		assert_eq!(spec.tokens_per_fill, 50);
+		assert_eq!(spec.fill_interval, Duration::from_secs(1));
+	}
+
+	#[test]
+	fn simple_rate_limit_burst_only_increases_capacity() {
+		let spec: RateLimitSpec = serde_yaml::from_str(
+			r#"
+type: requests
+limit: 50
+unit: seconds
+burst: 10
+"#,
+		)
+		.unwrap();
+
+		assert_eq!(spec.limit_type, RateLimitType::Requests);
+		assert_eq!(spec.max_tokens, 60);
+		assert_eq!(spec.tokens_per_fill, 50);
+		assert_eq!(spec.fill_interval, Duration::from_secs(1));
+	}
+
+	#[test]
+	fn simple_tokens_rate_limit_deserializes() {
+		let spec: RateLimitSpec = serde_yaml::from_str(
+			r#"
+type: tokens
+limit: 1000
+unit: minutes
+"#,
+		)
+		.unwrap();
+
+		assert_eq!(spec.limit_type, RateLimitType::Tokens);
+		assert_eq!(spec.max_tokens, 1000);
+		assert_eq!(spec.tokens_per_fill, 1000);
+		assert_eq!(spec.fill_interval, Duration::from_secs(60));
+	}
+
+	#[test]
+	fn simple_rate_limit_rejects_invalid_shapes() {
+		for yaml in [
+			r#"
+type: requests
+unit: seconds
+"#,
+			r#"
+type: requests
+limit: 50
+"#,
+			r#"
+type: requests
+limit: 50
+unit: days
+"#,
+			r#"
+type: requests
+limit: 0
+unit: seconds
+"#,
+			r#"
+type: requests
+limit: 50
+unit: seconds
+maxTokens: 50
+"#,
+		] {
+			assert!(
+				serde_yaml::from_str::<RateLimitSpec>(yaml).is_err(),
+				"expected invalid rate limit config: {yaml}"
+			);
+		}
 	}
 }
 

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -700,10 +700,28 @@ impl LocalExplicitOrConditional<LocalTransformationConfig> {
 #[derive(Debug, Clone, serde::Deserialize)]
 #[serde(untagged)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-#[cfg_attr(feature = "schema", schemars(untagged, deny_unknown_fields))]
+#[cfg_attr(feature = "schema", schemars(with = "LocalRateLimitPolicySchema"))]
 enum LocalRateLimitPolicy {
 	Conditional(LocalConditionalPolicies<crate::http::localratelimit::RateLimit>),
 	Explicit(Vec<crate::http::localratelimit::RateLimit>),
+}
+
+#[cfg(feature = "schema")]
+#[allow(dead_code)]
+#[derive(schemars::JsonSchema)]
+#[schemars(untagged, deny_unknown_fields)]
+enum LocalRateLimitPolicySchema {
+	Conditional(LocalConditionalRateLimitPoliciesSchema),
+	Explicit(Vec<crate::http::localratelimit::RateLimit>),
+}
+
+#[cfg(feature = "schema")]
+#[allow(dead_code)]
+#[derive(schemars::JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct LocalConditionalRateLimitPoliciesSchema {
+	/// conditional policy entries. An entry without a condition must be the final fallback.
+	conditional: Vec<crate::http::localratelimit::ConditionalRateLimitConfig>,
 }
 
 impl LocalRateLimitPolicy {
@@ -2232,7 +2250,7 @@ struct LocalLLMPolicy {
 	/// Guardrails to apply to every configured model.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	guardrails: Option<PromptGuard>,
-	/// Local rate limits for incoming requests.
+	/// Local rate limits for incoming requests. Each entry must use either the simplified `limit`/`unit`/`burst` fields or the explicit `maxTokens`/`tokensPerFill`/`fillInterval` fields; the two forms cannot be mixed.
 	#[serde(default)]
 	local_rate_limit: Vec<crate::http::localratelimit::RateLimit>,
 	/// Remote rate limit checks for incoming requests.
@@ -2712,7 +2730,7 @@ pub struct FilterOrPolicy {
 	#[serde(default, deserialize_with = "de_backend_auth")]
 	#[cfg_attr(feature = "schema", schemars(with = "Option<BackendAuthCompat>"))]
 	backend_auth: Option<BackendAuth>,
-	/// Local rate limits for incoming requests.
+	/// Local rate limits for incoming requests. Each entry must use either the simplified `limit`/`unit`/`burst` fields or the explicit `maxTokens`/`tokensPerFill`/`fillInterval` fields; the two forms cannot be mixed.
 	#[serde(default)]
 	local_rate_limit: Option<LocalRateLimitPolicy>,
 	/// Remote rate limit checks for incoming requests.

--- a/crates/agentgateway/src/types/local_tests.rs
+++ b/crates/agentgateway/src/types/local_tests.rs
@@ -1387,12 +1387,13 @@ binds:
         localRateLimit:
           conditional:
           - condition: request.path == "/local-limit"
-            maxTokens: 10
-            tokensPerFill: 1
-            fillInterval: 1s
-          - maxTokens: 1
-            tokensPerFill: 1
-            fillInterval: 60s
+            type: requests
+            limit: 1
+            unit: seconds
+            burst: 9
+          - type: requests
+            limit: 1
+            unit: minutes
         remoteRateLimit:
           conditional:
           - condition: request.path == "/remote-limit"
@@ -1445,6 +1446,15 @@ binds:
 				},
 				("localRateLimit", TrafficPolicy::LocalRateLimit(p)) => {
 					let entries = p.iter().collect::<Vec<_>>();
+					assert_eq!(entries[0].pol[0].spec.max_tokens, 10);
+					assert_eq!(entries[0].pol[0].spec.tokens_per_fill, 1);
+					assert_eq!(entries[0].pol[0].spec.fill_interval, Duration::from_secs(1));
+					assert_eq!(entries[1].pol[0].spec.max_tokens, 1);
+					assert_eq!(entries[1].pol[0].spec.tokens_per_fill, 1);
+					assert_eq!(
+						entries[1].pol[0].spec.fill_interval,
+						Duration::from_secs(60)
+					);
 					Some((entries.len(), entries[1].condition.is_none()))
 				},
 				("remoteRateLimit", TrafficPolicy::RemoteRateLimit(p)) => {

--- a/examples/traffic-ratelimiting-local/README.md
+++ b/examples/traffic-ratelimiting-local/README.md
@@ -22,14 +22,14 @@ Send requests through the gateway:
 curl http://localhost:3000/
 ```
 
-The `localRateLimit` policy allows 10 requests per minute:
+The `localRateLimit` policy allows 50 requests per second:
 
 ```yaml
 policies:
   localRateLimit:
-  - maxTokens: 10
-    tokensPerFill: 1
-    fillInterval: 60s
+  - type: requests
+    limit: 50
+    unit: seconds
 ```
 
-Increase `maxTokens`, `tokensPerFill`, or shorten `fillInterval` in `config.yaml` to change the allowed request rate.
+Change `limit` or `unit` in `config.yaml` to adjust the allowed request rate.

--- a/examples/traffic-ratelimiting-local/config.yaml
+++ b/examples/traffic-ratelimiting-local/config.yaml
@@ -10,8 +10,8 @@ binds:
     routes:
     - policies:
         localRateLimit:
-        - maxTokens: 10
-          tokensPerFill: 1
-          fillInterval: 60s
+        - type: requests
+          limit: 50
+          unit: seconds
       backends:
       - host: localhost:8080

--- a/schema/config.json
+++ b/schema/config.json
@@ -1740,10 +1740,10 @@
           "default": null
         },
         "localRateLimit": {
-          "description": "Local rate limits for incoming requests.",
+          "description": "Local rate limits for incoming requests. Each entry must use either the simplified `limit`/`unit`/`burst` fields or the explicit `maxTokens`/`tokensPerFill`/`fillInterval` fields; the two forms cannot be mixed.",
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalRateLimitPolicy"
+              "$ref": "#/$defs/LocalRateLimitPolicySchema"
             },
             {
               "type": "null"
@@ -5012,36 +5012,45 @@
         }
       ]
     },
-    "LocalRateLimitPolicy": {
+    "LocalRateLimitPolicySchema": {
       "anyOf": [
         {
-          "$ref": "#/$defs/LocalConditionalPolicies_RateLimitSpec"
+          "$ref": "#/$defs/LocalConditionalRateLimitPoliciesSchema"
         },
         {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/RateLimitSpec"
+            "$ref": "#/$defs/RateLimitConfig"
           }
         }
       ]
     },
-    "LocalConditionalPolicies_RateLimitSpec": {
+    "LocalConditionalRateLimitPoliciesSchema": {
       "type": "object",
       "properties": {
         "conditional": {
           "description": "conditional policy entries. An entry without a condition must be the final fallback.",
           "type": "array",
           "items": {
-            "$ref": "#/$defs/LocalConditionalPolicy_RateLimitSpec"
+            "$ref": "#/$defs/ConditionalRateLimitConfig"
           }
         }
       },
-      "additionalProperties": false,
       "required": [
         "conditional"
       ]
     },
-    "LocalConditionalPolicy_RateLimitSpec": {
+    "ConditionalRateLimitConfig": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ConditionalExplicitRateLimitSpec"
+        },
+        {
+          "$ref": "#/$defs/ConditionalSimpleRateLimitSpec"
+        }
+      ]
+    },
+    "ConditionalExplicitRateLimitSpec": {
       "type": "object",
       "properties": {
         "condition": {
@@ -5053,24 +5062,23 @@
             {
               "type": "null"
             }
-          ],
-          "default": null
+          ]
         },
-        "maxTokens": {
+        "max_tokens": {
           "description": "Maximum number of tokens that can accumulate in the local bucket.",
           "type": "integer",
           "format": "uint64",
           "minimum": 0,
           "default": 0
         },
-        "tokensPerFill": {
+        "tokens_per_fill": {
           "description": "Number of tokens added to the local bucket each fill interval.",
           "type": "integer",
           "format": "uint64",
           "minimum": 0,
           "default": 0
         },
-        "fillInterval": {
+        "fill_interval": {
           "description": "How often the local bucket is refilled.",
           "type": "string"
         },
@@ -5081,7 +5089,7 @@
         }
       },
       "required": [
-        "fillInterval"
+        "fill_interval"
       ]
     },
     "RateLimitType": {
@@ -5098,7 +5106,78 @@
         }
       ]
     },
-    "RateLimitSpec": {
+    "ConditionalSimpleRateLimitSpec": {
+      "type": "object",
+      "properties": {
+        "condition": {
+          "description": "condition must evaluate to true for this policy to execute. If unset, the policy is the fallback.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Expression"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "type": {
+          "description": "Whether this limit counts requests or LLM tokens.",
+          "$ref": "#/$defs/RateLimitType"
+        },
+        "limit": {
+          "description": "Sustained request or token allowance per unit.",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 1
+        },
+        "unit": {
+          "description": "Unit of time for the limit.",
+          "$ref": "#/$defs/RateLimitUnit"
+        },
+        "burst": {
+          "description": "Additional bucket capacity above the sustained limit.",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0,
+          "default": 0
+        }
+      },
+      "required": [
+        "type",
+        "limit",
+        "unit"
+      ]
+    },
+    "RateLimitUnit": {
+      "oneOf": [
+        {
+          "description": "Per second.",
+          "type": "string",
+          "const": "seconds"
+        },
+        {
+          "description": "Per minute.",
+          "type": "string",
+          "const": "minutes"
+        },
+        {
+          "description": "Per hour.",
+          "type": "string",
+          "const": "hours"
+        }
+      ]
+    },
+    "RateLimitConfig": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ExplicitRateLimitSpec"
+        },
+        {
+          "$ref": "#/$defs/SimpleRateLimitSpec"
+        }
+      ]
+    },
+    "ExplicitRateLimitSpec": {
       "type": "object",
       "properties": {
         "maxTokens": {
@@ -5128,6 +5207,38 @@
       "additionalProperties": false,
       "required": [
         "fillInterval"
+      ]
+    },
+    "SimpleRateLimitSpec": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "Whether this limit counts requests or LLM tokens.",
+          "$ref": "#/$defs/RateLimitType"
+        },
+        "limit": {
+          "description": "Sustained request or token allowance per unit.",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 1
+        },
+        "unit": {
+          "description": "Unit of time for the limit.",
+          "$ref": "#/$defs/RateLimitUnit"
+        },
+        "burst": {
+          "description": "Additional bucket capacity above the sustained limit.",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0,
+          "default": 0
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "limit",
+        "unit"
       ]
     },
     "LocalExplicitOrConditional_RemoteRateLimit": {
@@ -11119,7 +11230,7 @@
           "description": "Local rate limits for incoming requests.",
           "type": "array",
           "items": {
-            "$ref": "#/$defs/RateLimitSpec"
+            "$ref": "#/$defs/RateLimitConfig"
           },
           "default": []
         },


### PR DESCRIPTION
This mirrors k8s and lets users think in high level terms rather than token buckets leaking the implementation