### PR TITLE
llm: add per model authorization

### DIFF
--- a/crates/agentgateway/src/http/filters.rs
+++ b/crates/agentgateway/src/http/filters.rs
@@ -275,6 +275,53 @@ impl crate::store::RequestPolicyTrait for UrlRewrite {
 	}
 }
 
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct AuthorizationFilteredModelList {
+	pub entries: Arc<Vec<AuthorizationFilteredModelListEntry>>,
+}
+
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct AuthorizationFilteredModelListEntry {
+	pub id: String,
+	pub created: u64,
+	pub authorization: Option<crate::types::agent::Authorization>,
+}
+
+impl AuthorizationFilteredModelList {
+	fn body(&self, req: &Request) -> Result<Bytes, Error> {
+		let data = self
+			.entries
+			.iter()
+			.filter(|entry| {
+				entry.authorization.as_ref().is_none_or(|authorization| {
+					crate::http::authorization::HTTPAuthorizationSet::new(
+						crate::http::authorization::RuleSets::from_arcs(vec![authorization.0.clone()]),
+					)
+					.apply(req)
+					.is_ok()
+				})
+			})
+			.map(|entry| {
+				serde_json::json!({
+					"id": entry.id,
+					"object": "model",
+					"created": entry.created,
+					"owned_by": "openai",
+				})
+			})
+			.collect::<Vec<_>>();
+		serde_json::to_vec(&serde_json::json!({
+			"data": data,
+			"object": "list",
+		}))
+		.map(Bytes::from)
+		.map_err(|e| Error::InvalidFilterConfiguration(e.to_string()))
+	}
+}
+
+// DirectResponse is user-configurable, but not every field on it is. Internal
+// helpers may serialize for dumps/debugging, but must stay skipped from
+// deserialization and schema so users cannot set them in config.
 #[apply(schema!)]
 pub struct DirectResponse {
 	/// Static response body, encoded as bytes.
@@ -292,6 +339,12 @@ pub struct DirectResponse {
 	#[serde(with = "http_serde::status_code")]
 	#[cfg_attr(feature = "schema", schemars(with = "std::num::NonZeroU16"))]
 	pub status: StatusCode,
+	// Internal-only hook for the generated local LLM `/v1/models` response.
+	// This serializes for dumps/debugging, but is deliberately not deserialized
+	// or included in the public schema.
+	#[serde(default, skip_serializing_if = "Option::is_none", skip_deserializing)]
+	#[cfg_attr(feature = "schema", schemars(skip))]
+	pub authorization_filtered_model_list: Option<AuthorizationFilteredModelList>,
 }
 
 impl DirectResponse {
@@ -302,7 +355,17 @@ impl DirectResponse {
 			Apply,
 			"applied direct response"
 		);
-		let body = if let Some(expr) = &self.body_expression {
+		let body = if let Some(model_list) = &self.authorization_filtered_model_list {
+			// This branch is only reachable for DirectResponse values constructed
+			// internally by local LLM config normalization.
+			if !self.body.is_empty() || self.body_expression.is_some() {
+				return Err(Error::InvalidFilterConfiguration(
+					"body, bodyExpression, and authorizationFilteredModelList are mutually exclusive"
+						.to_string(),
+				));
+			}
+			model_list.body(req)?
+		} else if let Some(expr) = &self.body_expression {
 			if !self.body.is_empty() {
 				return Err(Error::InvalidFilterConfiguration(
 					"body and bodyExpression may not both be set".to_string(),

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -2135,6 +2135,7 @@ fn traffic_policy_from_proto(
 					})
 					.collect::<Result<_, ProtoError>>()?,
 				status: StatusCode::from_u16(dr.status as u16)?,
+				authorization_filtered_model_list: None,
 			}))
 		},
 		Some(tps::Kind::Cors(c)) => TrafficPolicy::CORS(RequestPolicy::single(

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -501,6 +501,9 @@ pub struct LocalLLMModels {
 	/// In this mode, requests must be sent in the native format of the provider.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	passthrough: Option<LocalLLMPassthrough>,
+	/// authorization configures HTTP authorization rules for requests to this model.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	authorization: Option<Authorization>,
 
 	// Policies
 	/// defaults allows setting default values for the request. If these are not present in the request body, they will be set.
@@ -2446,10 +2449,13 @@ request.path.endsWith(":streamRawPredict") || request.path.endsWith(":rawPredict
 			})
 			.collect::<anyhow::Result<Vec<_>>>()?;
 
-		let model_route_inline_policies = vec![TrafficPolicy::AI(Arc::new(crate::llm::Policy {
+		let mut model_route_inline_policies = vec![TrafficPolicy::AI(Arc::new(crate::llm::Policy {
 			routes: llm_routes.into_iter().collect(),
 			..Default::default()
 		}))];
+		if let Some(p) = model_config.authorization.clone() {
+			model_route_inline_policies.push(TrafficPolicy::Authorization(p));
+		}
 
 		let model_route = Route {
 			key: route_key.clone(),

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -2159,19 +2159,16 @@ request.path.endsWith(":streamRawPredict") || request.path.endsWith(":rawPredict
 	});
 
 	// Create model list route
-	let model_list_body = serde_json::json!({
-		"data": models
+	let model_list_entries = Arc::new(
+		models
 			.iter()
-			.map(|m| serde_json::json!({
-				"id": m.name,
-				"object": "model",
-				"created": startup_timestamp,
-				"owned_by": "openai"
-			}))
+			.map(|model| filters::AuthorizationFilteredModelListEntry {
+				id: model.name.clone(),
+				created: startup_timestamp,
+				authorization: model.authorization.clone(),
+			})
 			.collect::<Vec<_>>(),
-		"object": "list"
-	})
-	.to_string();
+	);
 
 	let model_list_inline_policies = vec![
 		TrafficPolicy::ResponseHeaderModifier(RequestPolicy::single(
@@ -2182,10 +2179,13 @@ request.path.endsWith(":streamRawPredict") || request.path.endsWith(":rawPredict
 			},
 		)),
 		TrafficPolicy::DirectResponse(RequestPolicy::single(filters::DirectResponse {
-			body: Bytes::copy_from_slice(model_list_body.as_bytes()),
+			body: Bytes::new(),
 			body_expression: None,
 			headers: Vec::new(),
 			status: ::http::StatusCode::OK,
+			authorization_filtered_model_list: Some(filters::AuthorizationFilteredModelList {
+				entries: model_list_entries,
+			}),
 		})),
 	];
 	let model_list_route = Route {
@@ -2510,6 +2510,7 @@ request.path.endsWith(":streamRawPredict") || request.path.endsWith(":rawPredict
 			)?)),
 			headers: Vec::new(),
 			status: ::http::StatusCode::NOT_FOUND,
+			authorization_filtered_model_list: None,
 		})),
 	];
 	routes.push(Route {

--- a/crates/agentgateway/src/types/local_tests/llm_simple_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/llm_simple_normalized.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/agentgateway/src/types/local_tests.rs
-assertion_line: 184
 description: "Config normalization test for llm_simple: YAML -> LocalConfig -> NormalizedLocalConfig -> YAML"
 ---
 binds:
@@ -23,8 +22,21 @@ listener_routes:
               set:
                 Content-Type: application/json
           - directResponse:
-              body: eyJkYXRhIjpbeyJpZCI6ImNsYXVkZS0zLWhhaWt1Iiwib2JqZWN0IjoibW9kZWwiLCJjcmVhdGVkIjowLCJvd25lZF9ieSI6Im9wZW5haSJ9LHsiaWQiOiIqIiwib2JqZWN0IjoibW9kZWwiLCJjcmVhdGVkIjowLCJvd25lZF9ieSI6Im9wZW5haSJ9LHsiaWQiOiJncHQtNy1tYXgiLCJvYmplY3QiOiJtb2RlbCIsImNyZWF0ZWQiOjAsIm93bmVkX2J5Ijoib3BlbmFpIn0seyJpZCI6ImdwdC0zLjUtdHVyYm8iLCJvYmplY3QiOiJtb2RlbCIsImNyZWF0ZWQiOjAsIm93bmVkX2J5Ijoib3BlbmFpIn1dLCJvYmplY3QiOiJsaXN0In0=
               status: 200
+              authorizationFilteredModelList:
+                entries:
+                  - id: claude-3-haiku
+                    created: 0
+                    authorization: ~
+                  - id: "*"
+                    created: 0
+                    authorization: ~
+                  - id: gpt-7-max
+                    created: 0
+                    authorization: ~
+                  - id: gpt-3.5-turbo
+                    created: 0
+                    authorization: ~
         key: "llm:admin:model-list"
         matches:
           - path:

--- a/schema/config.json
+++ b/schema/config.json
@@ -8065,6 +8065,17 @@
             }
           ]
         },
+        "authorization": {
+          "description": "authorization configures HTTP authorization rules for requests to this model.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Authorization"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "defaults": {
           "description": "defaults allows setting default values for the request. If these are not present in the request body, they will be set.\nTo override even when set, use `overrides`.",
           "type": [

--- a/schema/config.md
+++ b/schema/config.md
@@ -17168,6 +17168,8 @@
 |`llm.models[].provider.custom.formats[].type`|enum|Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `realtime`, `rerank`.|
 |`llm.models[].provider.custom.formats[].path`|string||
 |`llm.models[].passthrough`|enum|passthrough controls how requests are handled.<br>By default, requests will be parsed and translated as needed.<br>With passthrough, they will be unmodified and optionally inspected (with `detect`).<br>In this mode, requests must be sent in the native format of the provider.<br>Possible values: `detect`, `opaque`.|
+|`llm.models[].authorization`|object|authorization configures HTTP authorization rules for requests to this model.|
+|`llm.models[].authorization.rules`|[]string|CEL authorization rules to evaluate for a request.|
 |`llm.models[].defaults`|object|defaults allows setting default values for the request. If these are not present in the request body, they will be set.<br>To override even when set, use `overrides`.|
 |`llm.models[].overrides`|object|overrides allows setting values for the request, overriding any existing values|
 |`llm.models[].transformation`|object|transformation allows setting values from CEL expressions for the request, overriding any existing values.|


### PR DESCRIPTION
This adds a new field on each model (easy 1 liner) and then also makes /v1/models actually run the filter.

Now the last part is debatable... for example, a policy could be `json(request.body).temperature == 0.7`...... that would not be applied on /v1/models obviously.

That being said I think this prob makes sense...