### PR TITLE
Doc updates for agctl commands

### DIFF
--- a/controller/pkg/cli/config/backends.go
+++ b/controller/pkg/cli/config/backends.go
@@ -80,8 +80,8 @@ func backendsCommand(common *commonFlags) flag.Command {
 	return flag.Command{
 		Use:     "backends",
 		Aliases: []string{"b", "be"},
-		Short:   "Retrieve Agentgateway backend endpoint status",
-		Long:    "Retrieve Agentgateway backend endpoint status.",
+		Short:   "Retrieve agentgateway backend endpoint status",
+		Long:    "Get the status of agentgateway backend endpoints.",
 		AddFlags: func(cmd *cobra.Command) {
 			cmd.Flags().BoolVar(&showAll, "all", false, "Show endpoints with zero requests")
 		},

--- a/controller/pkg/cli/config/cmd.go
+++ b/controller/pkg/cli/config/cmd.go
@@ -44,8 +44,8 @@ func Command() flag.Command {
 	return flag.Command{
 		Use:     "config",
 		Aliases: []string{"c", "cfg"},
-		Short:   "Retrieve Agentgateway configuration for a resource",
-		Long:    "Retrieve Agentgateway configuration for a resource.",
+		Short:   "Retrieve agentgateway configuration for a resource",
+		Long:    "Retrieve agentgateway configuration for a resource, such as the agentgateway controller or proxy.",
 		AddPersistentFlags: func(cmd *cobra.Command) {
 			common.attach(cmd)
 		},

--- a/controller/pkg/cli/controller/cmd.go
+++ b/controller/pkg/cli/controller/cmd.go
@@ -9,8 +9,8 @@ import (
 func Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "controller",
-		Short: "Inspect and manage the Agentgateway controller",
-		Long:  "Inspect and manage the Agentgateway controller admin API.",
+		Short: "Inspect and manage the agentgateway controller",
+		Long:  "Inspect and manage the agentgateway controller admin API.",
 	}
 
 	cmd.AddCommand(log.Command())

--- a/controller/pkg/cli/controller/log/cmd.go
+++ b/controller/pkg/cli/controller/log/cmd.go
@@ -26,18 +26,17 @@ func Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "log",
 		Short: "Get or set controller log levels",
-		Long: `Get or set log levels on the Agentgateway controller.
+		Long: `Get or set log levels on the agentgateway controller.
 
 With no flags, prints the current log level for each component.
 
-Examples:
-  agctl controller log                               # show current levels
-  agctl controller log --level debug                 # set all components to debug
-  agctl controller log --set reconciler=debug        # set a single component
-  agctl controller log --set reconciler=debug --set xds=info  # set multiple
-
 When multiple controller pods are running, all are targeted and output
 is prefixed per pod. All pods are attempted even if one fails.`,
+		Example: `
+agctl controller log                               # show current levels
+agctl controller log --level debug                 # set all components to debug
+agctl controller log --set reconciler=debug        # set a single component
+agctl controller log --set reconciler=debug --set xds=info  # set multiple`,
 		Args:         cobra.NoArgs,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/controller/pkg/cli/controller/log/cmd.go
+++ b/controller/pkg/cli/controller/log/cmd.go
@@ -32,8 +32,7 @@ With no flags, prints the current log level for each component.
 
 When multiple controller pods are running, all are targeted and output
 is prefixed per pod. All pods are attempted even if one fails.`,
-		Example: `
-agctl controller log                               # show current levels
+		Example: `agctl controller log                               # show current levels
 agctl controller log --level debug                 # set all components to debug
 agctl controller log --set reconciler=debug        # set a single component
 agctl controller log --set reconciler=debug --set xds=info  # set multiple`,

--- a/controller/pkg/cli/proxy/cmd.go
+++ b/controller/pkg/cli/proxy/cmd.go
@@ -12,8 +12,8 @@ import (
 func Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "proxy",
-		Short: "Inspect and manage the Agentgateway proxy",
-		Long:  "Inspect and manage the Agentgateway proxy admin API.",
+		Short: "Inspect and manage the agentgateway proxy",
+		Long:  "Inspect and manage the agentgateway proxy admin API.",
 	}
 
 	cmd.AddCommand(flag.BuildCobra(config.Command))

--- a/controller/pkg/cli/proxy/log/cmd.go
+++ b/controller/pkg/cli/proxy/log/cmd.go
@@ -25,24 +25,23 @@ func Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "log [resource]",
 		Short: "Get or set proxy log levels",
-		Long: `Get or set log levels on the Agentgateway proxy.
+		Long: `Get or set log levels on the agentgateway proxy.
 
 With no flags, prints the current active log filter directive.
 
 The proxy uses Rust tracing-subscriber filter directives. Module names are
-Rust crate paths (e.g. agentgateway::proxy). See the Agentgateway docs for
-the full list of valid module paths. Level changes via --set are additive:
-they append to the current directive rather than replacing it. Use --level
+Rust crate paths, such as 'agentgateway::proxy'. See the agentgateway docs for
+the full list of valid module paths. Level changes via '--set' are additive:
+they append to the current directive rather than replacing it. Use '--level'
 to reset to a clean global level.
-
-Examples:
-  agctl proxy log                                      # show current directive
-  agctl proxy log --level debug                        # set global level
-  agctl proxy log --set agentgateway::proxy=debug      # set a single module
-  agctl proxy log --set agentgateway::proxy=debug,agentgateway::http=info
 
 When multiple pods back a resource, all are targeted and output is
 prefixed per pod. All pods are attempted even if one fails.`,
+		Example: `
+agctl proxy log                                      # show current directive
+agctl proxy log --level debug                        # set global level
+agctl proxy log --set agentgateway::proxy=debug      # set a single module
+agctl proxy log --set agentgateway::proxy=debug,agentgateway::http=info`,
 		Args:         cobra.MaximumNArgs(1),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/controller/pkg/cli/proxy/log/cmd.go
+++ b/controller/pkg/cli/proxy/log/cmd.go
@@ -37,8 +37,7 @@ to reset to a clean global level.
 
 When multiple pods back a resource, all are targeted and output is
 prefixed per pod. All pods are attempted even if one fails.`,
-		Example: `
-agctl proxy log                                      # show current directive
+		Example: `agctl proxy log                                      # show current directive
 agctl proxy log --level debug                        # set global level
 agctl proxy log --set agentgateway::proxy=debug      # set a single module
 agctl proxy log --set agentgateway::proxy=debug,agentgateway::http=info`,

--- a/controller/pkg/cli/trace/cmd.go
+++ b/controller/pkg/cli/trace/cmd.go
@@ -26,25 +26,32 @@ func Command() flag.Command {
 
 	return flag.Command{
 		Use:   "trace [resource] [-- <curl args...>]",
-		Short: "Trace the next request handled by an Agentgateway pod or local instance",
-		Long:  "Start an Agentgateway debug trace, render it in a TUI or JSONL, and optionally trigger the traced request against a pod or a local instance.",
-		Example: `  agctl trace
+		Short: "Trace the next request handled by an agentgateway pod or local instance.",
+		Long:  "Start an agentgateway debug trace, render it in a TUI or JSONL, and optionally trigger the traced request against a pod or a local instance.",
+		Example: `  agctl proxy trace
+  
   # Watch for the next request on a pod and trace it, displaying the result in a TUI
-  agctl trace gateway/my-gateway
+  agctl proxy trace gateway/my-gateway
+  
   # Watch for the next request on a pod and trace it, displaying the result in a JSONL format
-  agctl trace --raw
-	# Enable tracing and send a request to the gateway. The <host> part of the request is only used for setting the Hostname of the request,
+  agctl proxy trace --raw
+  
+  # Enable tracing and send a request to the gateway. The <host> part of the request is only used for setting the Hostname of the request,
   # and is not used for DNS resolution.
-  agctl trace --port 80 -- http://host/some/path
+  agctl proxy trace --port 80 -- http://host/some/path
+  
   # Enable tracing and send a request to the gateway running locally.
-  agctl trace --local --port 8080 -- http://host/some/path
+  agctl proxy trace --local --port 8080 -- http://host/some/path
+  
   # Render trace JSONL from a file or stdin instead of opening a live trace.
-  agctl trace --file trace.jsonl
-  agctl trace --file - --raw
+  agctl proxy trace --file trace.jsonl
+  agctl proxy trace --file - --raw
+  
   # Watch for the next request matching a CEL expression.
-  agctl trace --expression 'request.path == "/healthz"'
+  agctl proxy trace --expression 'request.path == "/healthz"'
+  
   # Enable tracing and send a request to the gateway, with some curl arguments.
-  agctl trace gateway/my-gateway --raw --port 80 -- http://host/some/path -H "Authorization: Bearer sk-123"`,
+  agctl proxy trace gateway/my-gateway --raw --port 80 -- http://host/some/path -H "Authorization: Bearer sk-123"`,
 		Args: func(cmd *cobra.Command, args []string) error {
 			_, _, err := parseArgs(cmd, args, flags)
 			return err

--- a/controller/pkg/cli/version/cmd.go
+++ b/controller/pkg/cli/version/cmd.go
@@ -13,7 +13,7 @@ func Command() flag.Command {
 	return flag.Command{
 		Use:   "version",
 		Short: "Print agctl version information",
-		Long:  "Print agctl version information.",
+		Long:  "Print information for agctl, such as the version and build date.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fmt.Fprintln(cmd.OutOrStdout(), pkgversion.String())
 			return nil


### PR DESCRIPTION
- example formatting
- `agctl trace` to `agctl proxy trace`
- some style updates like sentence case for `agentgateway`