### PR TITLE
Streaming Guardrails

### DIFF
--- a/api/resource.pb.go
+++ b/api/resource.pb.go
@@ -1623,6 +1623,52 @@ func (BackendPolicySpec_Ai_Webhook_FailureMode) EnumDescriptor() ([]byte, []int)
 	return file_resource_proto_rawDescGZIP(), []int{55, 0, 4, 0}
 }
 
+type BackendPolicySpec_Ai_PromptGuard_Streaming int32
+
+const (
+	BackendPolicySpec_Ai_PromptGuard_DISABLED BackendPolicySpec_Ai_PromptGuard_Streaming = 0
+	BackendPolicySpec_Ai_PromptGuard_ENABLED  BackendPolicySpec_Ai_PromptGuard_Streaming = 1
+)
+
+// Enum value maps for BackendPolicySpec_Ai_PromptGuard_Streaming.
+var (
+	BackendPolicySpec_Ai_PromptGuard_Streaming_name = map[int32]string{
+		0: "DISABLED",
+		1: "ENABLED",
+	}
+	BackendPolicySpec_Ai_PromptGuard_Streaming_value = map[string]int32{
+		"DISABLED": 0,
+		"ENABLED":  1,
+	}
+)
+
+func (x BackendPolicySpec_Ai_PromptGuard_Streaming) Enum() *BackendPolicySpec_Ai_PromptGuard_Streaming {
+	p := new(BackendPolicySpec_Ai_PromptGuard_Streaming)
+	*p = x
+	return p
+}
+
+func (x BackendPolicySpec_Ai_PromptGuard_Streaming) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (BackendPolicySpec_Ai_PromptGuard_Streaming) Descriptor() protoreflect.EnumDescriptor {
+	return file_resource_proto_enumTypes[31].Descriptor()
+}
+
+func (BackendPolicySpec_Ai_PromptGuard_Streaming) Type() protoreflect.EnumType {
+	return &file_resource_proto_enumTypes[31]
+}
+
+func (x BackendPolicySpec_Ai_PromptGuard_Streaming) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use BackendPolicySpec_Ai_PromptGuard_Streaming.Descriptor instead.
+func (BackendPolicySpec_Ai_PromptGuard_Streaming) EnumDescriptor() ([]byte, []int) {
+	return file_resource_proto_rawDescGZIP(), []int{55, 0, 12, 0}
+}
+
 type BackendPolicySpec_InferenceRouting_FailureMode int32
 
 const (
@@ -1656,11 +1702,11 @@ func (x BackendPolicySpec_InferenceRouting_FailureMode) String() string {
 }
 
 func (BackendPolicySpec_InferenceRouting_FailureMode) Descriptor() protoreflect.EnumDescriptor {
-	return file_resource_proto_enumTypes[31].Descriptor()
+	return file_resource_proto_enumTypes[32].Descriptor()
 }
 
 func (BackendPolicySpec_InferenceRouting_FailureMode) Type() protoreflect.EnumType {
-	return &file_resource_proto_enumTypes[31]
+	return &file_resource_proto_enumTypes[32]
 }
 
 func (x BackendPolicySpec_InferenceRouting_FailureMode) Number() protoreflect.EnumNumber {
@@ -1705,11 +1751,11 @@ func (x BackendPolicySpec_BackendTLS_VerificationMode) String() string {
 }
 
 func (BackendPolicySpec_BackendTLS_VerificationMode) Descriptor() protoreflect.EnumDescriptor {
-	return file_resource_proto_enumTypes[32].Descriptor()
+	return file_resource_proto_enumTypes[33].Descriptor()
 }
 
 func (BackendPolicySpec_BackendTLS_VerificationMode) Type() protoreflect.EnumType {
-	return &file_resource_proto_enumTypes[32]
+	return &file_resource_proto_enumTypes[33]
 }
 
 func (x BackendPolicySpec_BackendTLS_VerificationMode) Number() protoreflect.EnumNumber {
@@ -1754,11 +1800,11 @@ func (x BackendPolicySpec_BackendHTTP_HttpVersion) String() string {
 }
 
 func (BackendPolicySpec_BackendHTTP_HttpVersion) Descriptor() protoreflect.EnumDescriptor {
-	return file_resource_proto_enumTypes[33].Descriptor()
+	return file_resource_proto_enumTypes[34].Descriptor()
 }
 
 func (BackendPolicySpec_BackendHTTP_HttpVersion) Type() protoreflect.EnumType {
-	return &file_resource_proto_enumTypes[33]
+	return &file_resource_proto_enumTypes[34]
 }
 
 func (x BackendPolicySpec_BackendHTTP_HttpVersion) Number() protoreflect.EnumNumber {
@@ -1806,11 +1852,11 @@ func (x BackendPolicySpec_McpAuthentication_McpIDP) String() string {
 }
 
 func (BackendPolicySpec_McpAuthentication_McpIDP) Descriptor() protoreflect.EnumDescriptor {
-	return file_resource_proto_enumTypes[34].Descriptor()
+	return file_resource_proto_enumTypes[35].Descriptor()
 }
 
 func (BackendPolicySpec_McpAuthentication_McpIDP) Type() protoreflect.EnumType {
-	return &file_resource_proto_enumTypes[34]
+	return &file_resource_proto_enumTypes[35]
 }
 
 func (x BackendPolicySpec_McpAuthentication_McpIDP) Number() protoreflect.EnumNumber {
@@ -1859,11 +1905,11 @@ func (x BackendPolicySpec_McpAuthentication_Mode) String() string {
 }
 
 func (BackendPolicySpec_McpAuthentication_Mode) Descriptor() protoreflect.EnumDescriptor {
-	return file_resource_proto_enumTypes[35].Descriptor()
+	return file_resource_proto_enumTypes[36].Descriptor()
 }
 
 func (BackendPolicySpec_McpAuthentication_Mode) Type() protoreflect.EnumType {
-	return &file_resource_proto_enumTypes[35]
+	return &file_resource_proto_enumTypes[36]
 }
 
 func (x BackendPolicySpec_McpAuthentication_Mode) Number() protoreflect.EnumNumber {
@@ -1913,11 +1959,11 @@ func (x BackendPolicySpec_McpGuardrails_Phase) String() string {
 }
 
 func (BackendPolicySpec_McpGuardrails_Phase) Descriptor() protoreflect.EnumDescriptor {
-	return file_resource_proto_enumTypes[36].Descriptor()
+	return file_resource_proto_enumTypes[37].Descriptor()
 }
 
 func (BackendPolicySpec_McpGuardrails_Phase) Type() protoreflect.EnumType {
-	return &file_resource_proto_enumTypes[36]
+	return &file_resource_proto_enumTypes[37]
 }
 
 func (x BackendPolicySpec_McpGuardrails_Phase) Number() protoreflect.EnumNumber {
@@ -1959,11 +2005,11 @@ func (x BackendPolicySpec_McpGuardrails_FailureMode) String() string {
 }
 
 func (BackendPolicySpec_McpGuardrails_FailureMode) Descriptor() protoreflect.EnumDescriptor {
-	return file_resource_proto_enumTypes[37].Descriptor()
+	return file_resource_proto_enumTypes[38].Descriptor()
 }
 
 func (BackendPolicySpec_McpGuardrails_FailureMode) Type() protoreflect.EnumType {
-	return &file_resource_proto_enumTypes[37]
+	return &file_resource_proto_enumTypes[38]
 }
 
 func (x BackendPolicySpec_McpGuardrails_FailureMode) Number() protoreflect.EnumNumber {
@@ -2005,11 +2051,11 @@ func (x AIBackend_AzureResourceType) String() string {
 }
 
 func (AIBackend_AzureResourceType) Descriptor() protoreflect.EnumDescriptor {
-	return file_resource_proto_enumTypes[38].Descriptor()
+	return file_resource_proto_enumTypes[39].Descriptor()
 }
 
 func (AIBackend_AzureResourceType) Type() protoreflect.EnumType {
-	return &file_resource_proto_enumTypes[38]
+	return &file_resource_proto_enumTypes[39]
 }
 
 func (x AIBackend_AzureResourceType) Number() protoreflect.EnumNumber {
@@ -2069,11 +2115,11 @@ func (x AIBackend_ProviderFormat) String() string {
 }
 
 func (AIBackend_ProviderFormat) Descriptor() protoreflect.EnumDescriptor {
-	return file_resource_proto_enumTypes[39].Descriptor()
+	return file_resource_proto_enumTypes[40].Descriptor()
 }
 
 func (AIBackend_ProviderFormat) Type() protoreflect.EnumType {
-	return &file_resource_proto_enumTypes[39]
+	return &file_resource_proto_enumTypes[40]
 }
 
 func (x AIBackend_ProviderFormat) Number() protoreflect.EnumNumber {
@@ -2115,11 +2161,11 @@ func (x MCPBackend_StatefulMode) String() string {
 }
 
 func (MCPBackend_StatefulMode) Descriptor() protoreflect.EnumDescriptor {
-	return file_resource_proto_enumTypes[40].Descriptor()
+	return file_resource_proto_enumTypes[41].Descriptor()
 }
 
 func (MCPBackend_StatefulMode) Type() protoreflect.EnumType {
-	return &file_resource_proto_enumTypes[40]
+	return &file_resource_proto_enumTypes[41]
 }
 
 func (x MCPBackend_StatefulMode) Number() protoreflect.EnumNumber {
@@ -2161,11 +2207,11 @@ func (x MCPBackend_PrefixMode) String() string {
 }
 
 func (MCPBackend_PrefixMode) Descriptor() protoreflect.EnumDescriptor {
-	return file_resource_proto_enumTypes[41].Descriptor()
+	return file_resource_proto_enumTypes[42].Descriptor()
 }
 
 func (MCPBackend_PrefixMode) Type() protoreflect.EnumType {
-	return &file_resource_proto_enumTypes[41]
+	return &file_resource_proto_enumTypes[42]
 }
 
 func (x MCPBackend_PrefixMode) Number() protoreflect.EnumNumber {
@@ -2209,11 +2255,11 @@ func (x MCPBackend_FailureMode) String() string {
 }
 
 func (MCPBackend_FailureMode) Descriptor() protoreflect.EnumDescriptor {
-	return file_resource_proto_enumTypes[42].Descriptor()
+	return file_resource_proto_enumTypes[43].Descriptor()
 }
 
 func (MCPBackend_FailureMode) Type() protoreflect.EnumType {
-	return &file_resource_proto_enumTypes[42]
+	return &file_resource_proto_enumTypes[43]
 }
 
 func (x MCPBackend_FailureMode) Number() protoreflect.EnumNumber {
@@ -2258,11 +2304,11 @@ func (x MCPTarget_Protocol) String() string {
 }
 
 func (MCPTarget_Protocol) Descriptor() protoreflect.EnumDescriptor {
-	return file_resource_proto_enumTypes[43].Descriptor()
+	return file_resource_proto_enumTypes[44].Descriptor()
 }
 
 func (MCPTarget_Protocol) Type() protoreflect.EnumType {
-	return &file_resource_proto_enumTypes[43]
+	return &file_resource_proto_enumTypes[44]
 }
 
 func (x MCPTarget_Protocol) Number() protoreflect.EnumNumber {
@@ -13214,7 +13260,10 @@ type BackendPolicySpec_Ai_PromptGuard struct {
 	// Guards applied to client requests before they reach the LLM
 	Request []*BackendPolicySpec_Ai_RequestGuard `protobuf:"bytes,1,rep,name=request,proto3" json:"request,omitempty"`
 	// Guards applied to LLM responses before they reach the client
-	Response      []*BackendPolicySpec_Ai_ResponseGuard `protobuf:"bytes,2,rep,name=response,proto3" json:"response,omitempty"`
+	Response []*BackendPolicySpec_Ai_ResponseGuard `protobuf:"bytes,2,rep,name=response,proto3" json:"response,omitempty"`
+	// Apply guardrails to streaming responses and realtime websocket messages.
+	// Defaults to disabled to preserve streaming throughput unless explicitly enabled.
+	Streaming     BackendPolicySpec_Ai_PromptGuard_Streaming `protobuf:"varint,3,opt,name=streaming,proto3,enum=agentgateway.dev.resource.BackendPolicySpec_Ai_PromptGuard_Streaming" json:"streaming,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -13261,6 +13310,13 @@ func (x *BackendPolicySpec_Ai_PromptGuard) GetResponse() []*BackendPolicySpec_Ai
 		return x.Response
 	}
 	return nil
+}
+
+func (x *BackendPolicySpec_Ai_PromptGuard) GetStreaming() BackendPolicySpec_Ai_PromptGuard_Streaming {
+	if x != nil {
+		return x.Streaming
+	}
+	return BackendPolicySpec_Ai_PromptGuard_DISABLED
 }
 
 // Default JSON key-value pairs to add to the LLM request if the key is not set in the request.
@@ -15220,7 +15276,7 @@ const file_resource_proto_rawDesc = "" +
 	"\vPolicyPhase\x12\t\n" +
 	"\x05ROUTE\x10\x00\x12\v\n" +
 	"\aGATEWAY\x10\x01B\x06\n" +
-	"\x04kind\"\xc9W\n" +
+	"\x04kind\"\xd6X\n" +
 	"\x11BackendPolicySpec\x12D\n" +
 	"\x03a2a\x18\x01 \x01(\v20.agentgateway.dev.resource.BackendPolicySpec.A2aH\x00R\x03a2a\x12l\n" +
 	"\x11inference_routing\x18\x02 \x01(\v2=.agentgateway.dev.resource.BackendPolicySpec.InferenceRoutingH\x00R\x10inferenceRouting\x12Z\n" +
@@ -15242,7 +15298,7 @@ const file_resource_proto_rawDesc = "" +
 	"\x06health\x18\x0f \x01(\v23.agentgateway.dev.resource.BackendPolicySpec.HealthH\x00R\x06health\x12c\n" +
 	"\x0ebackend_tunnel\x18\x10 \x01(\v2:.agentgateway.dev.resource.BackendPolicySpec.BackendTunnelH\x00R\rbackendTunnel\x12X\n" +
 	"\text_authz\x18\x11 \x01(\v29.agentgateway.dev.resource.TrafficPolicySpec.ExternalAuthH\x00R\bextAuthz\x12c\n" +
-	"\x0emcp_guardrails\x18\x12 \x01(\v2:.agentgateway.dev.resource.BackendPolicySpec.McpGuardrailsH\x00R\rmcpGuardrails\x1a\xb4+\n" +
+	"\x0emcp_guardrails\x18\x12 \x01(\v2:.agentgateway.dev.resource.BackendPolicySpec.McpGuardrailsH\x00R\rmcpGuardrails\x1a\xc1,\n" +
 	"\x02Ai\x12^\n" +
 	"\fprompt_guard\x18\x01 \x01(\v2;.agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuardR\vpromptGuard\x12Y\n" +
 	"\bdefaults\x18\x02 \x03(\v2=.agentgateway.dev.resource.BackendPolicySpec.Ai.DefaultsEntryR\bdefaults\x12\\\n" +
@@ -15331,10 +15387,14 @@ const file_resource_proto_rawDesc = "" +
 	"\x12google_model_armor\x18\x05 \x01(\v2@.agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmorH\x00R\x10googleModelArmor\x12r\n" +
 	"\x12bedrock_guardrails\x18\x06 \x01(\v2A.agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrailsH\x00R\x11bedrockGuardrails\x12v\n" +
 	"\x14azure_content_safety\x18\a \x01(\v2B.agentgateway.dev.resource.BackendPolicySpec.Ai.AzureContentSafetyH\x00R\x12azureContentSafetyB\x06\n" +
-	"\x04kind\x1a\xc0\x01\n" +
+	"\x04kind\x1a\xcd\x02\n" +
 	"\vPromptGuard\x12V\n" +
 	"\arequest\x18\x01 \x03(\v2<.agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuardR\arequest\x12Y\n" +
-	"\bresponse\x18\x02 \x03(\v2=.agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuardR\bresponse\x1a\xfd\x01\n" +
+	"\bresponse\x18\x02 \x03(\v2=.agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuardR\bresponse\x12c\n" +
+	"\tstreaming\x18\x03 \x01(\x0e2E.agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.StreamingR\tstreaming\"&\n" +
+	"\tStreaming\x12\f\n" +
+	"\bDISABLED\x10\x00\x12\v\n" +
+	"\aENABLED\x10\x01\x1a\xfd\x01\n" +
 	"\rPromptCaching\x12!\n" +
 	"\fcache_system\x18\x01 \x01(\bR\vcacheSystem\x12%\n" +
 	"\x0ecache_messages\x18\x02 \x01(\bR\rcacheMessages\x12\x1f\n" +
@@ -15671,7 +15731,7 @@ func file_resource_proto_rawDescGZIP() []byte {
 	return file_resource_proto_rawDescData
 }
 
-var file_resource_proto_enumTypes = make([]protoimpl.EnumInfo, 44)
+var file_resource_proto_enumTypes = make([]protoimpl.EnumInfo, 45)
 var file_resource_proto_msgTypes = make([]protoimpl.MessageInfo, 180)
 var file_resource_proto_goTypes = []any{
 	(Protocol)(0),                                               // 0: agentgateway.dev.resource.Protocol
@@ -15705,525 +15765,527 @@ var file_resource_proto_goTypes = []any{
 	(BackendPolicySpec_Ai_ActionKind)(0),                        // 28: agentgateway.dev.resource.BackendPolicySpec.Ai.ActionKind
 	(BackendPolicySpec_Ai_RouteType)(0),                         // 29: agentgateway.dev.resource.BackendPolicySpec.Ai.RouteType
 	(BackendPolicySpec_Ai_Webhook_FailureMode)(0),               // 30: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.FailureMode
-	(BackendPolicySpec_InferenceRouting_FailureMode)(0),         // 31: agentgateway.dev.resource.BackendPolicySpec.InferenceRouting.FailureMode
-	(BackendPolicySpec_BackendTLS_VerificationMode)(0),          // 32: agentgateway.dev.resource.BackendPolicySpec.BackendTLS.VerificationMode
-	(BackendPolicySpec_BackendHTTP_HttpVersion)(0),              // 33: agentgateway.dev.resource.BackendPolicySpec.BackendHTTP.HttpVersion
-	(BackendPolicySpec_McpAuthentication_McpIDP)(0),             // 34: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.McpIDP
-	(BackendPolicySpec_McpAuthentication_Mode)(0),               // 35: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.Mode
-	(BackendPolicySpec_McpGuardrails_Phase)(0),                  // 36: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Phase
-	(BackendPolicySpec_McpGuardrails_FailureMode)(0),            // 37: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.FailureMode
-	(AIBackend_AzureResourceType)(0),                            // 38: agentgateway.dev.resource.AIBackend.AzureResourceType
-	(AIBackend_ProviderFormat)(0),                               // 39: agentgateway.dev.resource.AIBackend.ProviderFormat
-	(MCPBackend_StatefulMode)(0),                                // 40: agentgateway.dev.resource.MCPBackend.StatefulMode
-	(MCPBackend_PrefixMode)(0),                                  // 41: agentgateway.dev.resource.MCPBackend.PrefixMode
-	(MCPBackend_FailureMode)(0),                                 // 42: agentgateway.dev.resource.MCPBackend.FailureMode
-	(MCPTarget_Protocol)(0),                                     // 43: agentgateway.dev.resource.MCPTarget.Protocol
-	(*Resource)(nil),                                            // 44: agentgateway.dev.resource.Resource
-	(*Bind)(nil),                                                // 45: agentgateway.dev.resource.Bind
-	(*RouteName)(nil),                                           // 46: agentgateway.dev.resource.RouteName
-	(*ListenerName)(nil),                                        // 47: agentgateway.dev.resource.ListenerName
-	(*ResourceName)(nil),                                        // 48: agentgateway.dev.resource.ResourceName
-	(*TypedResourceName)(nil),                                   // 49: agentgateway.dev.resource.TypedResourceName
-	(*Listener)(nil),                                            // 50: agentgateway.dev.resource.Listener
-	(*Route)(nil),                                               // 51: agentgateway.dev.resource.Route
-	(*RouteGroup)(nil),                                          // 52: agentgateway.dev.resource.RouteGroup
-	(*TCPRoute)(nil),                                            // 53: agentgateway.dev.resource.TCPRoute
-	(*ConditionalPolicies)(nil),                                 // 54: agentgateway.dev.resource.ConditionalPolicies
-	(*ConditionalPolicy)(nil),                                   // 55: agentgateway.dev.resource.ConditionalPolicy
-	(*Policy)(nil),                                              // 56: agentgateway.dev.resource.Policy
-	(*Backend)(nil),                                             // 57: agentgateway.dev.resource.Backend
-	(*GuardrailBackend)(nil),                                    // 58: agentgateway.dev.resource.GuardrailBackend
-	(*TLSConfig)(nil),                                           // 59: agentgateway.dev.resource.TLSConfig
-	(*Timeout)(nil),                                             // 60: agentgateway.dev.resource.Timeout
-	(*Retry)(nil),                                               // 61: agentgateway.dev.resource.Retry
-	(*BackendAuthPolicy)(nil),                                   // 62: agentgateway.dev.resource.BackendAuthPolicy
-	(*AuthorizationLocation)(nil),                               // 63: agentgateway.dev.resource.AuthorizationLocation
-	(*Passthrough)(nil),                                         // 64: agentgateway.dev.resource.Passthrough
-	(*Key)(nil),                                                 // 65: agentgateway.dev.resource.Key
-	(*Gcp)(nil),                                                 // 66: agentgateway.dev.resource.Gcp
-	(*Aws)(nil),                                                 // 67: agentgateway.dev.resource.Aws
-	(*Azure)(nil),                                               // 68: agentgateway.dev.resource.Azure
-	(*AwsExplicitConfig)(nil),                                   // 69: agentgateway.dev.resource.AwsExplicitConfig
-	(*AwsImplicit)(nil),                                         // 70: agentgateway.dev.resource.AwsImplicit
-	(*AwsAssumeRole)(nil),                                       // 71: agentgateway.dev.resource.AwsAssumeRole
-	(*AzureExplicitConfig)(nil),                                 // 72: agentgateway.dev.resource.AzureExplicitConfig
-	(*AzureClientSecret)(nil),                                   // 73: agentgateway.dev.resource.AzureClientSecret
-	(*AzureManagedIdentityCredential)(nil),                      // 74: agentgateway.dev.resource.AzureManagedIdentityCredential
-	(*AzureWorkloadIdentityCredential)(nil),                     // 75: agentgateway.dev.resource.AzureWorkloadIdentityCredential
-	(*AzureDeveloperImplicit)(nil),                              // 76: agentgateway.dev.resource.AzureDeveloperImplicit
-	(*AzureImplicit)(nil),                                       // 77: agentgateway.dev.resource.AzureImplicit
-	(*RouteMatch)(nil),                                          // 78: agentgateway.dev.resource.RouteMatch
-	(*PathMatch)(nil),                                           // 79: agentgateway.dev.resource.PathMatch
-	(*QueryMatch)(nil),                                          // 80: agentgateway.dev.resource.QueryMatch
-	(*MethodMatch)(nil),                                         // 81: agentgateway.dev.resource.MethodMatch
-	(*HeaderMatch)(nil),                                         // 82: agentgateway.dev.resource.HeaderMatch
-	(*CORS)(nil),                                                // 83: agentgateway.dev.resource.CORS
-	(*DirectResponse)(nil),                                      // 84: agentgateway.dev.resource.DirectResponse
-	(*BufferBody)(nil),                                          // 85: agentgateway.dev.resource.BufferBody
-	(*Buffer)(nil),                                              // 86: agentgateway.dev.resource.Buffer
-	(*ExpressionHeader)(nil),                                    // 87: agentgateway.dev.resource.ExpressionHeader
-	(*HeaderModifier)(nil),                                      // 88: agentgateway.dev.resource.HeaderModifier
-	(*RequestMirrors)(nil),                                      // 89: agentgateway.dev.resource.RequestMirrors
-	(*RequestRedirect)(nil),                                     // 90: agentgateway.dev.resource.RequestRedirect
-	(*UrlRewrite)(nil),                                          // 91: agentgateway.dev.resource.UrlRewrite
-	(*Header)(nil),                                              // 92: agentgateway.dev.resource.Header
-	(*RouteBackend)(nil),                                        // 93: agentgateway.dev.resource.RouteBackend
-	(*PolicyTarget)(nil),                                        // 94: agentgateway.dev.resource.PolicyTarget
-	(*KeepaliveConfig)(nil),                                     // 95: agentgateway.dev.resource.KeepaliveConfig
-	(*FrontendPolicySpec)(nil),                                  // 96: agentgateway.dev.resource.FrontendPolicySpec
-	(*JWTValidationOptions)(nil),                                // 97: agentgateway.dev.resource.JWTValidationOptions
-	(*TrafficPolicySpec)(nil),                                   // 98: agentgateway.dev.resource.TrafficPolicySpec
-	(*BackendPolicySpec)(nil),                                   // 99: agentgateway.dev.resource.BackendPolicySpec
-	(*StaticBackend)(nil),                                       // 100: agentgateway.dev.resource.StaticBackend
-	(*DynamicForwardProxy)(nil),                                 // 101: agentgateway.dev.resource.DynamicForwardProxy
-	(*AwsBackend)(nil),                                          // 102: agentgateway.dev.resource.AwsBackend
-	(*AwsAgentCoreBackend)(nil),                                 // 103: agentgateway.dev.resource.AwsAgentCoreBackend
-	(*AIBackend)(nil),                                           // 104: agentgateway.dev.resource.AIBackend
-	(*MCPBackend)(nil),                                          // 105: agentgateway.dev.resource.MCPBackend
-	(*MCPTarget)(nil),                                           // 106: agentgateway.dev.resource.MCPTarget
-	(*BackendReference)(nil),                                    // 107: agentgateway.dev.resource.BackendReference
-	(*Alpn)(nil),                                                // 108: agentgateway.dev.resource.Alpn
-	(*GuardrailBackend_Bedrock)(nil),                            // 109: agentgateway.dev.resource.GuardrailBackend.Bedrock
-	(*GuardrailBackend_GoogleModelArmor)(nil),                   // 110: agentgateway.dev.resource.GuardrailBackend.GoogleModelArmor
-	(*GuardrailBackend_AzureContentSafety)(nil),                 // 111: agentgateway.dev.resource.GuardrailBackend.AzureContentSafety
-	(*GuardrailBackend_OpenAIModeration)(nil),                   // 112: agentgateway.dev.resource.GuardrailBackend.OpenAIModeration
-	(*AuthorizationLocation_Header)(nil),                        // 113: agentgateway.dev.resource.AuthorizationLocation.Header
-	(*AuthorizationLocation_QueryParameter)(nil),                // 114: agentgateway.dev.resource.AuthorizationLocation.QueryParameter
-	(*AuthorizationLocation_Cookie)(nil),                        // 115: agentgateway.dev.resource.AuthorizationLocation.Cookie
-	(*Gcp_AccessToken)(nil),                                     // 116: agentgateway.dev.resource.Gcp.AccessToken
-	(*Gcp_IdToken)(nil),                                         // 117: agentgateway.dev.resource.Gcp.IdToken
-	(*AzureManagedIdentityCredential_UserAssignedIdentity)(nil), // 118: agentgateway.dev.resource.AzureManagedIdentityCredential.UserAssignedIdentity
-	(*RequestMirrors_Mirror)(nil),                               // 119: agentgateway.dev.resource.RequestMirrors.Mirror
-	(*PolicyTarget_ServiceTarget)(nil),                          // 120: agentgateway.dev.resource.PolicyTarget.ServiceTarget
-	(*PolicyTarget_BackendTarget)(nil),                          // 121: agentgateway.dev.resource.PolicyTarget.BackendTarget
-	(*PolicyTarget_GatewayTarget)(nil),                          // 122: agentgateway.dev.resource.PolicyTarget.GatewayTarget
-	(*PolicyTarget_RouteTarget)(nil),                            // 123: agentgateway.dev.resource.PolicyTarget.RouteTarget
-	(*PolicyTarget_ListenerSetTarget)(nil),                      // 124: agentgateway.dev.resource.PolicyTarget.ListenerSetTarget
-	(*FrontendPolicySpec_HTTP)(nil),                             // 125: agentgateway.dev.resource.FrontendPolicySpec.HTTP
-	(*FrontendPolicySpec_TLS)(nil),                              // 126: agentgateway.dev.resource.FrontendPolicySpec.TLS
-	(*FrontendPolicySpec_TCP)(nil),                              // 127: agentgateway.dev.resource.FrontendPolicySpec.TCP
-	(*FrontendPolicySpec_NetworkAuthorization)(nil),             // 128: agentgateway.dev.resource.FrontendPolicySpec.NetworkAuthorization
-	(*FrontendPolicySpec_Logging)(nil),                          // 129: agentgateway.dev.resource.FrontendPolicySpec.Logging
-	(*FrontendPolicySpec_Tracing)(nil),                          // 130: agentgateway.dev.resource.FrontendPolicySpec.Tracing
-	(*FrontendPolicySpec_TracingAttribute)(nil),                 // 131: agentgateway.dev.resource.FrontendPolicySpec.TracingAttribute
-	(*FrontendPolicySpec_ProxyProtocol)(nil),                    // 132: agentgateway.dev.resource.FrontendPolicySpec.ProxyProtocol
-	(*FrontendPolicySpec_Connect)(nil),                          // 133: agentgateway.dev.resource.FrontendPolicySpec.Connect
-	(*FrontendPolicySpec_Metrics)(nil),                          // 134: agentgateway.dev.resource.FrontendPolicySpec.Metrics
-	(*FrontendPolicySpec_Logging_Field)(nil),                    // 135: agentgateway.dev.resource.FrontendPolicySpec.Logging.Field
-	(*FrontendPolicySpec_Logging_Fields)(nil),                   // 136: agentgateway.dev.resource.FrontendPolicySpec.Logging.Fields
-	(*FrontendPolicySpec_Logging_OtlpAccessLog)(nil),            // 137: agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog
-	(*FrontendPolicySpec_Metrics_Field)(nil),                    // 138: agentgateway.dev.resource.FrontendPolicySpec.Metrics.Field
-	(*FrontendPolicySpec_Metrics_Fields)(nil),                   // 139: agentgateway.dev.resource.FrontendPolicySpec.Metrics.Fields
-	(*TrafficPolicySpec_RemoteRateLimit)(nil),                   // 140: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit
-	(*TrafficPolicySpec_LocalRateLimit)(nil),                    // 141: agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit
-	(*TrafficPolicySpec_ExternalAuth)(nil),                      // 142: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth
-	(*TrafficPolicySpec_RBAC)(nil),                              // 143: agentgateway.dev.resource.TrafficPolicySpec.RBAC
-	(*TrafficPolicySpec_JWTProvider)(nil),                       // 144: agentgateway.dev.resource.TrafficPolicySpec.JWTProvider
-	(*TrafficPolicySpec_JWT)(nil),                               // 145: agentgateway.dev.resource.TrafficPolicySpec.JWT
-	(*TrafficPolicySpec_BasicAuthentication)(nil),               // 146: agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication
-	(*TrafficPolicySpec_APIKey)(nil),                            // 147: agentgateway.dev.resource.TrafficPolicySpec.APIKey
-	(*TrafficPolicySpec_TransformationPolicy)(nil),              // 148: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy
-	(*TrafficPolicySpec_HeaderTransformation)(nil),              // 149: agentgateway.dev.resource.TrafficPolicySpec.HeaderTransformation
-	(*TrafficPolicySpec_BodyTransformation)(nil),                // 150: agentgateway.dev.resource.TrafficPolicySpec.BodyTransformation
-	(*TrafficPolicySpec_CSRF)(nil),                              // 151: agentgateway.dev.resource.TrafficPolicySpec.CSRF
-	(*TrafficPolicySpec_ExtProc)(nil),                           // 152: agentgateway.dev.resource.TrafficPolicySpec.ExtProc
-	(*TrafficPolicySpec_HostRewrite)(nil),                       // 153: agentgateway.dev.resource.TrafficPolicySpec.HostRewrite
-	(*TrafficPolicySpec_RemoteRateLimit_Descriptor)(nil),        // 154: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor
-	(*TrafficPolicySpec_RemoteRateLimit_Entry)(nil),             // 155: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Entry
-	(*TrafficPolicySpec_ExternalAuth_BodyOptions)(nil),          // 156: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.BodyOptions
-	(*TrafficPolicySpec_ExternalAuth_Cache)(nil),                // 157: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.Cache
-	(*TrafficPolicySpec_ExternalAuth_GRPCProtocol)(nil),         // 158: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol
-	(*TrafficPolicySpec_ExternalAuth_HTTPProtocol)(nil),         // 159: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol
-	nil,                                   // 160: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.ContextEntry
-	nil,                                   // 161: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.MetadataEntry
-	nil,                                   // 162: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.AddRequestHeadersEntry
-	nil,                                   // 163: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.MetadataEntry
-	(*TrafficPolicySpec_JWT_MCP)(nil),     // 164: agentgateway.dev.resource.TrafficPolicySpec.JWT.MCP
-	(*TrafficPolicySpec_APIKey_User)(nil), // 165: agentgateway.dev.resource.TrafficPolicySpec.APIKey.User
-	(*TrafficPolicySpec_TransformationPolicy_Transform)(nil), // 166: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform
-	nil, // 167: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.MetadataEntry
-	nil, // 168: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.RequestAttributesEntry
-	nil, // 169: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ResponseAttributesEntry
-	(*TrafficPolicySpec_ExtProc_NamespacedMetadataContext)(nil), // 170: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext
-	(*TrafficPolicySpec_ExtProc_ProcessingOptions)(nil),         // 171: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ProcessingOptions
-	nil,                           // 172: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.MetadataContextEntry
-	nil,                           // 173: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext.ContextEntry
-	(*BackendPolicySpec_Ai)(nil),  // 174: agentgateway.dev.resource.BackendPolicySpec.Ai
-	(*BackendPolicySpec_A2A)(nil), // 175: agentgateway.dev.resource.BackendPolicySpec.A2a
-	(*BackendPolicySpec_InferenceRouting)(nil),      // 176: agentgateway.dev.resource.BackendPolicySpec.InferenceRouting
-	(*BackendPolicySpec_Eviction)(nil),              // 177: agentgateway.dev.resource.BackendPolicySpec.Eviction
-	(*BackendPolicySpec_Health)(nil),                // 178: agentgateway.dev.resource.BackendPolicySpec.Health
-	(*BackendPolicySpec_BackendTLS)(nil),            // 179: agentgateway.dev.resource.BackendPolicySpec.BackendTLS
-	(*BackendPolicySpec_BackendHTTP)(nil),           // 180: agentgateway.dev.resource.BackendPolicySpec.BackendHTTP
-	(*BackendPolicySpec_BackendTunnel)(nil),         // 181: agentgateway.dev.resource.BackendPolicySpec.BackendTunnel
-	(*BackendPolicySpec_BackendTCP)(nil),            // 182: agentgateway.dev.resource.BackendPolicySpec.BackendTCP
-	(*BackendPolicySpec_McpAuthorization)(nil),      // 183: agentgateway.dev.resource.BackendPolicySpec.McpAuthorization
-	(*BackendPolicySpec_McpAuthentication)(nil),     // 184: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication
-	(*BackendPolicySpec_McpGuardrails)(nil),         // 185: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails
-	(*BackendPolicySpec_Ai_Message)(nil),            // 186: agentgateway.dev.resource.BackendPolicySpec.Ai.Message
-	(*BackendPolicySpec_Ai_PromptEnrichment)(nil),   // 187: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment
-	(*BackendPolicySpec_Ai_RegexRule)(nil),          // 188: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRule
-	(*BackendPolicySpec_Ai_RegexRules)(nil),         // 189: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules
-	(*BackendPolicySpec_Ai_Webhook)(nil),            // 190: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook
-	(*BackendPolicySpec_Ai_Moderation)(nil),         // 191: agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation
-	(*BackendPolicySpec_Ai_BedrockGuardrails)(nil),  // 192: agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails
-	(*BackendPolicySpec_Ai_GoogleModelArmor)(nil),   // 193: agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor
-	(*BackendPolicySpec_Ai_AzureContentSafety)(nil), // 194: agentgateway.dev.resource.BackendPolicySpec.Ai.AzureContentSafety
-	(*BackendPolicySpec_Ai_RequestRejection)(nil),   // 195: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestRejection
-	(*BackendPolicySpec_Ai_ResponseGuard)(nil),      // 196: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard
-	(*BackendPolicySpec_Ai_RequestGuard)(nil),       // 197: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard
-	(*BackendPolicySpec_Ai_PromptGuard)(nil),        // 198: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard
-	(*BackendPolicySpec_Ai_PromptCaching)(nil),      // 199: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptCaching
-	nil, // 200: agentgateway.dev.resource.BackendPolicySpec.Ai.DefaultsEntry
-	nil, // 201: agentgateway.dev.resource.BackendPolicySpec.Ai.OverridesEntry
-	nil, // 202: agentgateway.dev.resource.BackendPolicySpec.Ai.TransformationsEntry
-	nil, // 203: agentgateway.dev.resource.BackendPolicySpec.Ai.ModelAliasesEntry
-	nil, // 204: agentgateway.dev.resource.BackendPolicySpec.Ai.RoutesEntry
-	(*BackendPolicySpec_McpAuthentication_ResourceMetadata)(nil), // 205: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata
-	nil, // 206: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntry
-	(*BackendPolicySpec_McpGuardrails_Remote)(nil),    // 207: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote
-	(*BackendPolicySpec_McpGuardrails_Processor)(nil), // 208: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor
-	nil,                                    // 209: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote.MetadataEntry
-	nil,                                    // 210: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor.MethodsEntry
-	(*AIBackend_HostOverride)(nil),         // 211: agentgateway.dev.resource.AIBackend.HostOverride
-	(*AIBackend_OpenAI)(nil),               // 212: agentgateway.dev.resource.AIBackend.OpenAI
-	(*AIBackend_Gemini)(nil),               // 213: agentgateway.dev.resource.AIBackend.Gemini
-	(*AIBackend_Vertex)(nil),               // 214: agentgateway.dev.resource.AIBackend.Vertex
-	(*AIBackend_Anthropic)(nil),            // 215: agentgateway.dev.resource.AIBackend.Anthropic
-	(*AIBackend_Bedrock)(nil),              // 216: agentgateway.dev.resource.AIBackend.Bedrock
-	(*AIBackend_AzureOpenAI)(nil),          // 217: agentgateway.dev.resource.AIBackend.AzureOpenAI
-	(*AIBackend_Azure)(nil),                // 218: agentgateway.dev.resource.AIBackend.Azure
-	(*AIBackend_ProviderFormatConfig)(nil), // 219: agentgateway.dev.resource.AIBackend.ProviderFormatConfig
-	(*AIBackend_Custom)(nil),               // 220: agentgateway.dev.resource.AIBackend.Custom
-	(*AIBackend_Provider)(nil),             // 221: agentgateway.dev.resource.AIBackend.Provider
-	(*AIBackend_ProviderGroup)(nil),        // 222: agentgateway.dev.resource.AIBackend.ProviderGroup
-	(*BackendReference_Service)(nil),       // 223: agentgateway.dev.resource.BackendReference.Service
-	(*workloadapi.Workload)(nil),           // 224: istio.workload.Workload
-	(*workloadapi.Service)(nil),            // 225: istio.workload.Service
-	(*workloadapi.NamespacedHostname)(nil), // 226: istio.workload.NamespacedHostname
-	(*durationpb.Duration)(nil),            // 227: google.protobuf.Duration
-	(*structpb.Struct)(nil),                // 228: google.protobuf.Struct
-	(*structpb.Value)(nil),                 // 229: google.protobuf.Value
+	(BackendPolicySpec_Ai_PromptGuard_Streaming)(0),             // 31: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.Streaming
+	(BackendPolicySpec_InferenceRouting_FailureMode)(0),         // 32: agentgateway.dev.resource.BackendPolicySpec.InferenceRouting.FailureMode
+	(BackendPolicySpec_BackendTLS_VerificationMode)(0),          // 33: agentgateway.dev.resource.BackendPolicySpec.BackendTLS.VerificationMode
+	(BackendPolicySpec_BackendHTTP_HttpVersion)(0),              // 34: agentgateway.dev.resource.BackendPolicySpec.BackendHTTP.HttpVersion
+	(BackendPolicySpec_McpAuthentication_McpIDP)(0),             // 35: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.McpIDP
+	(BackendPolicySpec_McpAuthentication_Mode)(0),               // 36: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.Mode
+	(BackendPolicySpec_McpGuardrails_Phase)(0),                  // 37: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Phase
+	(BackendPolicySpec_McpGuardrails_FailureMode)(0),            // 38: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.FailureMode
+	(AIBackend_AzureResourceType)(0),                            // 39: agentgateway.dev.resource.AIBackend.AzureResourceType
+	(AIBackend_ProviderFormat)(0),                               // 40: agentgateway.dev.resource.AIBackend.ProviderFormat
+	(MCPBackend_StatefulMode)(0),                                // 41: agentgateway.dev.resource.MCPBackend.StatefulMode
+	(MCPBackend_PrefixMode)(0),                                  // 42: agentgateway.dev.resource.MCPBackend.PrefixMode
+	(MCPBackend_FailureMode)(0),                                 // 43: agentgateway.dev.resource.MCPBackend.FailureMode
+	(MCPTarget_Protocol)(0),                                     // 44: agentgateway.dev.resource.MCPTarget.Protocol
+	(*Resource)(nil),                                            // 45: agentgateway.dev.resource.Resource
+	(*Bind)(nil),                                                // 46: agentgateway.dev.resource.Bind
+	(*RouteName)(nil),                                           // 47: agentgateway.dev.resource.RouteName
+	(*ListenerName)(nil),                                        // 48: agentgateway.dev.resource.ListenerName
+	(*ResourceName)(nil),                                        // 49: agentgateway.dev.resource.ResourceName
+	(*TypedResourceName)(nil),                                   // 50: agentgateway.dev.resource.TypedResourceName
+	(*Listener)(nil),                                            // 51: agentgateway.dev.resource.Listener
+	(*Route)(nil),                                               // 52: agentgateway.dev.resource.Route
+	(*RouteGroup)(nil),                                          // 53: agentgateway.dev.resource.RouteGroup
+	(*TCPRoute)(nil),                                            // 54: agentgateway.dev.resource.TCPRoute
+	(*ConditionalPolicies)(nil),                                 // 55: agentgateway.dev.resource.ConditionalPolicies
+	(*ConditionalPolicy)(nil),                                   // 56: agentgateway.dev.resource.ConditionalPolicy
+	(*Policy)(nil),                                              // 57: agentgateway.dev.resource.Policy
+	(*Backend)(nil),                                             // 58: agentgateway.dev.resource.Backend
+	(*GuardrailBackend)(nil),                                    // 59: agentgateway.dev.resource.GuardrailBackend
+	(*TLSConfig)(nil),                                           // 60: agentgateway.dev.resource.TLSConfig
+	(*Timeout)(nil),                                             // 61: agentgateway.dev.resource.Timeout
+	(*Retry)(nil),                                               // 62: agentgateway.dev.resource.Retry
+	(*BackendAuthPolicy)(nil),                                   // 63: agentgateway.dev.resource.BackendAuthPolicy
+	(*AuthorizationLocation)(nil),                               // 64: agentgateway.dev.resource.AuthorizationLocation
+	(*Passthrough)(nil),                                         // 65: agentgateway.dev.resource.Passthrough
+	(*Key)(nil),                                                 // 66: agentgateway.dev.resource.Key
+	(*Gcp)(nil),                                                 // 67: agentgateway.dev.resource.Gcp
+	(*Aws)(nil),                                                 // 68: agentgateway.dev.resource.Aws
+	(*Azure)(nil),                                               // 69: agentgateway.dev.resource.Azure
+	(*AwsExplicitConfig)(nil),                                   // 70: agentgateway.dev.resource.AwsExplicitConfig
+	(*AwsImplicit)(nil),                                         // 71: agentgateway.dev.resource.AwsImplicit
+	(*AwsAssumeRole)(nil),                                       // 72: agentgateway.dev.resource.AwsAssumeRole
+	(*AzureExplicitConfig)(nil),                                 // 73: agentgateway.dev.resource.AzureExplicitConfig
+	(*AzureClientSecret)(nil),                                   // 74: agentgateway.dev.resource.AzureClientSecret
+	(*AzureManagedIdentityCredential)(nil),                      // 75: agentgateway.dev.resource.AzureManagedIdentityCredential
+	(*AzureWorkloadIdentityCredential)(nil),                     // 76: agentgateway.dev.resource.AzureWorkloadIdentityCredential
+	(*AzureDeveloperImplicit)(nil),                              // 77: agentgateway.dev.resource.AzureDeveloperImplicit
+	(*AzureImplicit)(nil),                                       // 78: agentgateway.dev.resource.AzureImplicit
+	(*RouteMatch)(nil),                                          // 79: agentgateway.dev.resource.RouteMatch
+	(*PathMatch)(nil),                                           // 80: agentgateway.dev.resource.PathMatch
+	(*QueryMatch)(nil),                                          // 81: agentgateway.dev.resource.QueryMatch
+	(*MethodMatch)(nil),                                         // 82: agentgateway.dev.resource.MethodMatch
+	(*HeaderMatch)(nil),                                         // 83: agentgateway.dev.resource.HeaderMatch
+	(*CORS)(nil),                                                // 84: agentgateway.dev.resource.CORS
+	(*DirectResponse)(nil),                                      // 85: agentgateway.dev.resource.DirectResponse
+	(*BufferBody)(nil),                                          // 86: agentgateway.dev.resource.BufferBody
+	(*Buffer)(nil),                                              // 87: agentgateway.dev.resource.Buffer
+	(*ExpressionHeader)(nil),                                    // 88: agentgateway.dev.resource.ExpressionHeader
+	(*HeaderModifier)(nil),                                      // 89: agentgateway.dev.resource.HeaderModifier
+	(*RequestMirrors)(nil),                                      // 90: agentgateway.dev.resource.RequestMirrors
+	(*RequestRedirect)(nil),                                     // 91: agentgateway.dev.resource.RequestRedirect
+	(*UrlRewrite)(nil),                                          // 92: agentgateway.dev.resource.UrlRewrite
+	(*Header)(nil),                                              // 93: agentgateway.dev.resource.Header
+	(*RouteBackend)(nil),                                        // 94: agentgateway.dev.resource.RouteBackend
+	(*PolicyTarget)(nil),                                        // 95: agentgateway.dev.resource.PolicyTarget
+	(*KeepaliveConfig)(nil),                                     // 96: agentgateway.dev.resource.KeepaliveConfig
+	(*FrontendPolicySpec)(nil),                                  // 97: agentgateway.dev.resource.FrontendPolicySpec
+	(*JWTValidationOptions)(nil),                                // 98: agentgateway.dev.resource.JWTValidationOptions
+	(*TrafficPolicySpec)(nil),                                   // 99: agentgateway.dev.resource.TrafficPolicySpec
+	(*BackendPolicySpec)(nil),                                   // 100: agentgateway.dev.resource.BackendPolicySpec
+	(*StaticBackend)(nil),                                       // 101: agentgateway.dev.resource.StaticBackend
+	(*DynamicForwardProxy)(nil),                                 // 102: agentgateway.dev.resource.DynamicForwardProxy
+	(*AwsBackend)(nil),                                          // 103: agentgateway.dev.resource.AwsBackend
+	(*AwsAgentCoreBackend)(nil),                                 // 104: agentgateway.dev.resource.AwsAgentCoreBackend
+	(*AIBackend)(nil),                                           // 105: agentgateway.dev.resource.AIBackend
+	(*MCPBackend)(nil),                                          // 106: agentgateway.dev.resource.MCPBackend
+	(*MCPTarget)(nil),                                           // 107: agentgateway.dev.resource.MCPTarget
+	(*BackendReference)(nil),                                    // 108: agentgateway.dev.resource.BackendReference
+	(*Alpn)(nil),                                                // 109: agentgateway.dev.resource.Alpn
+	(*GuardrailBackend_Bedrock)(nil),                            // 110: agentgateway.dev.resource.GuardrailBackend.Bedrock
+	(*GuardrailBackend_GoogleModelArmor)(nil),                   // 111: agentgateway.dev.resource.GuardrailBackend.GoogleModelArmor
+	(*GuardrailBackend_AzureContentSafety)(nil),                 // 112: agentgateway.dev.resource.GuardrailBackend.AzureContentSafety
+	(*GuardrailBackend_OpenAIModeration)(nil),                   // 113: agentgateway.dev.resource.GuardrailBackend.OpenAIModeration
+	(*AuthorizationLocation_Header)(nil),                        // 114: agentgateway.dev.resource.AuthorizationLocation.Header
+	(*AuthorizationLocation_QueryParameter)(nil),                // 115: agentgateway.dev.resource.AuthorizationLocation.QueryParameter
+	(*AuthorizationLocation_Cookie)(nil),                        // 116: agentgateway.dev.resource.AuthorizationLocation.Cookie
+	(*Gcp_AccessToken)(nil),                                     // 117: agentgateway.dev.resource.Gcp.AccessToken
+	(*Gcp_IdToken)(nil),                                         // 118: agentgateway.dev.resource.Gcp.IdToken
+	(*AzureManagedIdentityCredential_UserAssignedIdentity)(nil), // 119: agentgateway.dev.resource.AzureManagedIdentityCredential.UserAssignedIdentity
+	(*RequestMirrors_Mirror)(nil),                               // 120: agentgateway.dev.resource.RequestMirrors.Mirror
+	(*PolicyTarget_ServiceTarget)(nil),                          // 121: agentgateway.dev.resource.PolicyTarget.ServiceTarget
+	(*PolicyTarget_BackendTarget)(nil),                          // 122: agentgateway.dev.resource.PolicyTarget.BackendTarget
+	(*PolicyTarget_GatewayTarget)(nil),                          // 123: agentgateway.dev.resource.PolicyTarget.GatewayTarget
+	(*PolicyTarget_RouteTarget)(nil),                            // 124: agentgateway.dev.resource.PolicyTarget.RouteTarget
+	(*PolicyTarget_ListenerSetTarget)(nil),                      // 125: agentgateway.dev.resource.PolicyTarget.ListenerSetTarget
+	(*FrontendPolicySpec_HTTP)(nil),                             // 126: agentgateway.dev.resource.FrontendPolicySpec.HTTP
+	(*FrontendPolicySpec_TLS)(nil),                              // 127: agentgateway.dev.resource.FrontendPolicySpec.TLS
+	(*FrontendPolicySpec_TCP)(nil),                              // 128: agentgateway.dev.resource.FrontendPolicySpec.TCP
+	(*FrontendPolicySpec_NetworkAuthorization)(nil),             // 129: agentgateway.dev.resource.FrontendPolicySpec.NetworkAuthorization
+	(*FrontendPolicySpec_Logging)(nil),                          // 130: agentgateway.dev.resource.FrontendPolicySpec.Logging
+	(*FrontendPolicySpec_Tracing)(nil),                          // 131: agentgateway.dev.resource.FrontendPolicySpec.Tracing
+	(*FrontendPolicySpec_TracingAttribute)(nil),                 // 132: agentgateway.dev.resource.FrontendPolicySpec.TracingAttribute
+	(*FrontendPolicySpec_ProxyProtocol)(nil),                    // 133: agentgateway.dev.resource.FrontendPolicySpec.ProxyProtocol
+	(*FrontendPolicySpec_Connect)(nil),                          // 134: agentgateway.dev.resource.FrontendPolicySpec.Connect
+	(*FrontendPolicySpec_Metrics)(nil),                          // 135: agentgateway.dev.resource.FrontendPolicySpec.Metrics
+	(*FrontendPolicySpec_Logging_Field)(nil),                    // 136: agentgateway.dev.resource.FrontendPolicySpec.Logging.Field
+	(*FrontendPolicySpec_Logging_Fields)(nil),                   // 137: agentgateway.dev.resource.FrontendPolicySpec.Logging.Fields
+	(*FrontendPolicySpec_Logging_OtlpAccessLog)(nil),            // 138: agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog
+	(*FrontendPolicySpec_Metrics_Field)(nil),                    // 139: agentgateway.dev.resource.FrontendPolicySpec.Metrics.Field
+	(*FrontendPolicySpec_Metrics_Fields)(nil),                   // 140: agentgateway.dev.resource.FrontendPolicySpec.Metrics.Fields
+	(*TrafficPolicySpec_RemoteRateLimit)(nil),                   // 141: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit
+	(*TrafficPolicySpec_LocalRateLimit)(nil),                    // 142: agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit
+	(*TrafficPolicySpec_ExternalAuth)(nil),                      // 143: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth
+	(*TrafficPolicySpec_RBAC)(nil),                              // 144: agentgateway.dev.resource.TrafficPolicySpec.RBAC
+	(*TrafficPolicySpec_JWTProvider)(nil),                       // 145: agentgateway.dev.resource.TrafficPolicySpec.JWTProvider
+	(*TrafficPolicySpec_JWT)(nil),                               // 146: agentgateway.dev.resource.TrafficPolicySpec.JWT
+	(*TrafficPolicySpec_BasicAuthentication)(nil),               // 147: agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication
+	(*TrafficPolicySpec_APIKey)(nil),                            // 148: agentgateway.dev.resource.TrafficPolicySpec.APIKey
+	(*TrafficPolicySpec_TransformationPolicy)(nil),              // 149: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy
+	(*TrafficPolicySpec_HeaderTransformation)(nil),              // 150: agentgateway.dev.resource.TrafficPolicySpec.HeaderTransformation
+	(*TrafficPolicySpec_BodyTransformation)(nil),                // 151: agentgateway.dev.resource.TrafficPolicySpec.BodyTransformation
+	(*TrafficPolicySpec_CSRF)(nil),                              // 152: agentgateway.dev.resource.TrafficPolicySpec.CSRF
+	(*TrafficPolicySpec_ExtProc)(nil),                           // 153: agentgateway.dev.resource.TrafficPolicySpec.ExtProc
+	(*TrafficPolicySpec_HostRewrite)(nil),                       // 154: agentgateway.dev.resource.TrafficPolicySpec.HostRewrite
+	(*TrafficPolicySpec_RemoteRateLimit_Descriptor)(nil),        // 155: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor
+	(*TrafficPolicySpec_RemoteRateLimit_Entry)(nil),             // 156: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Entry
+	(*TrafficPolicySpec_ExternalAuth_BodyOptions)(nil),          // 157: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.BodyOptions
+	(*TrafficPolicySpec_ExternalAuth_Cache)(nil),                // 158: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.Cache
+	(*TrafficPolicySpec_ExternalAuth_GRPCProtocol)(nil),         // 159: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol
+	(*TrafficPolicySpec_ExternalAuth_HTTPProtocol)(nil),         // 160: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol
+	nil,                                   // 161: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.ContextEntry
+	nil,                                   // 162: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.MetadataEntry
+	nil,                                   // 163: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.AddRequestHeadersEntry
+	nil,                                   // 164: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.MetadataEntry
+	(*TrafficPolicySpec_JWT_MCP)(nil),     // 165: agentgateway.dev.resource.TrafficPolicySpec.JWT.MCP
+	(*TrafficPolicySpec_APIKey_User)(nil), // 166: agentgateway.dev.resource.TrafficPolicySpec.APIKey.User
+	(*TrafficPolicySpec_TransformationPolicy_Transform)(nil), // 167: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform
+	nil, // 168: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.MetadataEntry
+	nil, // 169: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.RequestAttributesEntry
+	nil, // 170: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ResponseAttributesEntry
+	(*TrafficPolicySpec_ExtProc_NamespacedMetadataContext)(nil), // 171: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext
+	(*TrafficPolicySpec_ExtProc_ProcessingOptions)(nil),         // 172: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ProcessingOptions
+	nil,                           // 173: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.MetadataContextEntry
+	nil,                           // 174: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext.ContextEntry
+	(*BackendPolicySpec_Ai)(nil),  // 175: agentgateway.dev.resource.BackendPolicySpec.Ai
+	(*BackendPolicySpec_A2A)(nil), // 176: agentgateway.dev.resource.BackendPolicySpec.A2a
+	(*BackendPolicySpec_InferenceRouting)(nil),      // 177: agentgateway.dev.resource.BackendPolicySpec.InferenceRouting
+	(*BackendPolicySpec_Eviction)(nil),              // 178: agentgateway.dev.resource.BackendPolicySpec.Eviction
+	(*BackendPolicySpec_Health)(nil),                // 179: agentgateway.dev.resource.BackendPolicySpec.Health
+	(*BackendPolicySpec_BackendTLS)(nil),            // 180: agentgateway.dev.resource.BackendPolicySpec.BackendTLS
+	(*BackendPolicySpec_BackendHTTP)(nil),           // 181: agentgateway.dev.resource.BackendPolicySpec.BackendHTTP
+	(*BackendPolicySpec_BackendTunnel)(nil),         // 182: agentgateway.dev.resource.BackendPolicySpec.BackendTunnel
+	(*BackendPolicySpec_BackendTCP)(nil),            // 183: agentgateway.dev.resource.BackendPolicySpec.BackendTCP
+	(*BackendPolicySpec_McpAuthorization)(nil),      // 184: agentgateway.dev.resource.BackendPolicySpec.McpAuthorization
+	(*BackendPolicySpec_McpAuthentication)(nil),     // 185: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication
+	(*BackendPolicySpec_McpGuardrails)(nil),         // 186: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails
+	(*BackendPolicySpec_Ai_Message)(nil),            // 187: agentgateway.dev.resource.BackendPolicySpec.Ai.Message
+	(*BackendPolicySpec_Ai_PromptEnrichment)(nil),   // 188: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment
+	(*BackendPolicySpec_Ai_RegexRule)(nil),          // 189: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRule
+	(*BackendPolicySpec_Ai_RegexRules)(nil),         // 190: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules
+	(*BackendPolicySpec_Ai_Webhook)(nil),            // 191: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook
+	(*BackendPolicySpec_Ai_Moderation)(nil),         // 192: agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation
+	(*BackendPolicySpec_Ai_BedrockGuardrails)(nil),  // 193: agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails
+	(*BackendPolicySpec_Ai_GoogleModelArmor)(nil),   // 194: agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor
+	(*BackendPolicySpec_Ai_AzureContentSafety)(nil), // 195: agentgateway.dev.resource.BackendPolicySpec.Ai.AzureContentSafety
+	(*BackendPolicySpec_Ai_RequestRejection)(nil),   // 196: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestRejection
+	(*BackendPolicySpec_Ai_ResponseGuard)(nil),      // 197: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard
+	(*BackendPolicySpec_Ai_RequestGuard)(nil),       // 198: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard
+	(*BackendPolicySpec_Ai_PromptGuard)(nil),        // 199: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard
+	(*BackendPolicySpec_Ai_PromptCaching)(nil),      // 200: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptCaching
+	nil, // 201: agentgateway.dev.resource.BackendPolicySpec.Ai.DefaultsEntry
+	nil, // 202: agentgateway.dev.resource.BackendPolicySpec.Ai.OverridesEntry
+	nil, // 203: agentgateway.dev.resource.BackendPolicySpec.Ai.TransformationsEntry
+	nil, // 204: agentgateway.dev.resource.BackendPolicySpec.Ai.ModelAliasesEntry
+	nil, // 205: agentgateway.dev.resource.BackendPolicySpec.Ai.RoutesEntry
+	(*BackendPolicySpec_McpAuthentication_ResourceMetadata)(nil), // 206: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata
+	nil, // 207: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntry
+	(*BackendPolicySpec_McpGuardrails_Remote)(nil),    // 208: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote
+	(*BackendPolicySpec_McpGuardrails_Processor)(nil), // 209: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor
+	nil,                                    // 210: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote.MetadataEntry
+	nil,                                    // 211: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor.MethodsEntry
+	(*AIBackend_HostOverride)(nil),         // 212: agentgateway.dev.resource.AIBackend.HostOverride
+	(*AIBackend_OpenAI)(nil),               // 213: agentgateway.dev.resource.AIBackend.OpenAI
+	(*AIBackend_Gemini)(nil),               // 214: agentgateway.dev.resource.AIBackend.Gemini
+	(*AIBackend_Vertex)(nil),               // 215: agentgateway.dev.resource.AIBackend.Vertex
+	(*AIBackend_Anthropic)(nil),            // 216: agentgateway.dev.resource.AIBackend.Anthropic
+	(*AIBackend_Bedrock)(nil),              // 217: agentgateway.dev.resource.AIBackend.Bedrock
+	(*AIBackend_AzureOpenAI)(nil),          // 218: agentgateway.dev.resource.AIBackend.AzureOpenAI
+	(*AIBackend_Azure)(nil),                // 219: agentgateway.dev.resource.AIBackend.Azure
+	(*AIBackend_ProviderFormatConfig)(nil), // 220: agentgateway.dev.resource.AIBackend.ProviderFormatConfig
+	(*AIBackend_Custom)(nil),               // 221: agentgateway.dev.resource.AIBackend.Custom
+	(*AIBackend_Provider)(nil),             // 222: agentgateway.dev.resource.AIBackend.Provider
+	(*AIBackend_ProviderGroup)(nil),        // 223: agentgateway.dev.resource.AIBackend.ProviderGroup
+	(*BackendReference_Service)(nil),       // 224: agentgateway.dev.resource.BackendReference.Service
+	(*workloadapi.Workload)(nil),           // 225: istio.workload.Workload
+	(*workloadapi.Service)(nil),            // 226: istio.workload.Service
+	(*workloadapi.NamespacedHostname)(nil), // 227: istio.workload.NamespacedHostname
+	(*durationpb.Duration)(nil),            // 228: google.protobuf.Duration
+	(*structpb.Struct)(nil),                // 229: google.protobuf.Struct
+	(*structpb.Value)(nil),                 // 230: google.protobuf.Value
 }
 var file_resource_proto_depIdxs = []int32{
-	45,  // 0: agentgateway.dev.resource.Resource.bind:type_name -> agentgateway.dev.resource.Bind
-	50,  // 1: agentgateway.dev.resource.Resource.listener:type_name -> agentgateway.dev.resource.Listener
-	51,  // 2: agentgateway.dev.resource.Resource.route:type_name -> agentgateway.dev.resource.Route
-	57,  // 3: agentgateway.dev.resource.Resource.backend:type_name -> agentgateway.dev.resource.Backend
-	56,  // 4: agentgateway.dev.resource.Resource.policy:type_name -> agentgateway.dev.resource.Policy
-	53,  // 5: agentgateway.dev.resource.Resource.tcp_route:type_name -> agentgateway.dev.resource.TCPRoute
-	224, // 6: agentgateway.dev.resource.Resource.workload:type_name -> istio.workload.Workload
-	225, // 7: agentgateway.dev.resource.Resource.service:type_name -> istio.workload.Service
-	52,  // 8: agentgateway.dev.resource.Resource.route_group:type_name -> agentgateway.dev.resource.RouteGroup
+	46,  // 0: agentgateway.dev.resource.Resource.bind:type_name -> agentgateway.dev.resource.Bind
+	51,  // 1: agentgateway.dev.resource.Resource.listener:type_name -> agentgateway.dev.resource.Listener
+	52,  // 2: agentgateway.dev.resource.Resource.route:type_name -> agentgateway.dev.resource.Route
+	58,  // 3: agentgateway.dev.resource.Resource.backend:type_name -> agentgateway.dev.resource.Backend
+	57,  // 4: agentgateway.dev.resource.Resource.policy:type_name -> agentgateway.dev.resource.Policy
+	54,  // 5: agentgateway.dev.resource.Resource.tcp_route:type_name -> agentgateway.dev.resource.TCPRoute
+	225, // 6: agentgateway.dev.resource.Resource.workload:type_name -> istio.workload.Workload
+	226, // 7: agentgateway.dev.resource.Resource.service:type_name -> istio.workload.Service
+	53,  // 8: agentgateway.dev.resource.Resource.route_group:type_name -> agentgateway.dev.resource.RouteGroup
 	1,   // 9: agentgateway.dev.resource.Bind.protocol:type_name -> agentgateway.dev.resource.Bind.Protocol
 	2,   // 10: agentgateway.dev.resource.Bind.tunnel_protocol:type_name -> agentgateway.dev.resource.Bind.TunnelProtocol
-	48,  // 11: agentgateway.dev.resource.ListenerName.listener_set:type_name -> agentgateway.dev.resource.ResourceName
-	47,  // 12: agentgateway.dev.resource.Listener.name:type_name -> agentgateway.dev.resource.ListenerName
+	49,  // 11: agentgateway.dev.resource.ListenerName.listener_set:type_name -> agentgateway.dev.resource.ResourceName
+	48,  // 12: agentgateway.dev.resource.Listener.name:type_name -> agentgateway.dev.resource.ListenerName
 	0,   // 13: agentgateway.dev.resource.Listener.protocol:type_name -> agentgateway.dev.resource.Protocol
-	59,  // 14: agentgateway.dev.resource.Listener.tls:type_name -> agentgateway.dev.resource.TLSConfig
-	226, // 15: agentgateway.dev.resource.Route.service_key:type_name -> istio.workload.NamespacedHostname
-	46,  // 16: agentgateway.dev.resource.Route.name:type_name -> agentgateway.dev.resource.RouteName
-	78,  // 17: agentgateway.dev.resource.Route.matches:type_name -> agentgateway.dev.resource.RouteMatch
-	93,  // 18: agentgateway.dev.resource.Route.backends:type_name -> agentgateway.dev.resource.RouteBackend
-	98,  // 19: agentgateway.dev.resource.Route.traffic_policies:type_name -> agentgateway.dev.resource.TrafficPolicySpec
-	226, // 20: agentgateway.dev.resource.TCPRoute.service_key:type_name -> istio.workload.NamespacedHostname
-	46,  // 21: agentgateway.dev.resource.TCPRoute.name:type_name -> agentgateway.dev.resource.RouteName
-	93,  // 22: agentgateway.dev.resource.TCPRoute.backends:type_name -> agentgateway.dev.resource.RouteBackend
-	55,  // 23: agentgateway.dev.resource.ConditionalPolicies.policies:type_name -> agentgateway.dev.resource.ConditionalPolicy
-	98,  // 24: agentgateway.dev.resource.ConditionalPolicy.traffic:type_name -> agentgateway.dev.resource.TrafficPolicySpec
-	49,  // 25: agentgateway.dev.resource.Policy.name:type_name -> agentgateway.dev.resource.TypedResourceName
-	94,  // 26: agentgateway.dev.resource.Policy.target:type_name -> agentgateway.dev.resource.PolicyTarget
+	60,  // 14: agentgateway.dev.resource.Listener.tls:type_name -> agentgateway.dev.resource.TLSConfig
+	227, // 15: agentgateway.dev.resource.Route.service_key:type_name -> istio.workload.NamespacedHostname
+	47,  // 16: agentgateway.dev.resource.Route.name:type_name -> agentgateway.dev.resource.RouteName
+	79,  // 17: agentgateway.dev.resource.Route.matches:type_name -> agentgateway.dev.resource.RouteMatch
+	94,  // 18: agentgateway.dev.resource.Route.backends:type_name -> agentgateway.dev.resource.RouteBackend
+	99,  // 19: agentgateway.dev.resource.Route.traffic_policies:type_name -> agentgateway.dev.resource.TrafficPolicySpec
+	227, // 20: agentgateway.dev.resource.TCPRoute.service_key:type_name -> istio.workload.NamespacedHostname
+	47,  // 21: agentgateway.dev.resource.TCPRoute.name:type_name -> agentgateway.dev.resource.RouteName
+	94,  // 22: agentgateway.dev.resource.TCPRoute.backends:type_name -> agentgateway.dev.resource.RouteBackend
+	56,  // 23: agentgateway.dev.resource.ConditionalPolicies.policies:type_name -> agentgateway.dev.resource.ConditionalPolicy
+	99,  // 24: agentgateway.dev.resource.ConditionalPolicy.traffic:type_name -> agentgateway.dev.resource.TrafficPolicySpec
+	50,  // 25: agentgateway.dev.resource.Policy.name:type_name -> agentgateway.dev.resource.TypedResourceName
+	95,  // 26: agentgateway.dev.resource.Policy.target:type_name -> agentgateway.dev.resource.PolicyTarget
 	3,   // 27: agentgateway.dev.resource.Policy.inheritance:type_name -> agentgateway.dev.resource.Policy.Inheritance
-	98,  // 28: agentgateway.dev.resource.Policy.traffic:type_name -> agentgateway.dev.resource.TrafficPolicySpec
-	99,  // 29: agentgateway.dev.resource.Policy.backend:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	96,  // 30: agentgateway.dev.resource.Policy.frontend:type_name -> agentgateway.dev.resource.FrontendPolicySpec
-	54,  // 31: agentgateway.dev.resource.Policy.conditional:type_name -> agentgateway.dev.resource.ConditionalPolicies
-	48,  // 32: agentgateway.dev.resource.Backend.name:type_name -> agentgateway.dev.resource.ResourceName
-	100, // 33: agentgateway.dev.resource.Backend.static:type_name -> agentgateway.dev.resource.StaticBackend
-	104, // 34: agentgateway.dev.resource.Backend.ai:type_name -> agentgateway.dev.resource.AIBackend
-	105, // 35: agentgateway.dev.resource.Backend.mcp:type_name -> agentgateway.dev.resource.MCPBackend
-	101, // 36: agentgateway.dev.resource.Backend.dynamic:type_name -> agentgateway.dev.resource.DynamicForwardProxy
-	102, // 37: agentgateway.dev.resource.Backend.aws:type_name -> agentgateway.dev.resource.AwsBackend
-	58,  // 38: agentgateway.dev.resource.Backend.guardrail:type_name -> agentgateway.dev.resource.GuardrailBackend
-	99,  // 39: agentgateway.dev.resource.Backend.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	109, // 40: agentgateway.dev.resource.GuardrailBackend.bedrock:type_name -> agentgateway.dev.resource.GuardrailBackend.Bedrock
-	110, // 41: agentgateway.dev.resource.GuardrailBackend.google_model_armor:type_name -> agentgateway.dev.resource.GuardrailBackend.GoogleModelArmor
-	111, // 42: agentgateway.dev.resource.GuardrailBackend.azure_content_safety:type_name -> agentgateway.dev.resource.GuardrailBackend.AzureContentSafety
-	112, // 43: agentgateway.dev.resource.GuardrailBackend.openai_moderation:type_name -> agentgateway.dev.resource.GuardrailBackend.OpenAIModeration
+	99,  // 28: agentgateway.dev.resource.Policy.traffic:type_name -> agentgateway.dev.resource.TrafficPolicySpec
+	100, // 29: agentgateway.dev.resource.Policy.backend:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	97,  // 30: agentgateway.dev.resource.Policy.frontend:type_name -> agentgateway.dev.resource.FrontendPolicySpec
+	55,  // 31: agentgateway.dev.resource.Policy.conditional:type_name -> agentgateway.dev.resource.ConditionalPolicies
+	49,  // 32: agentgateway.dev.resource.Backend.name:type_name -> agentgateway.dev.resource.ResourceName
+	101, // 33: agentgateway.dev.resource.Backend.static:type_name -> agentgateway.dev.resource.StaticBackend
+	105, // 34: agentgateway.dev.resource.Backend.ai:type_name -> agentgateway.dev.resource.AIBackend
+	106, // 35: agentgateway.dev.resource.Backend.mcp:type_name -> agentgateway.dev.resource.MCPBackend
+	102, // 36: agentgateway.dev.resource.Backend.dynamic:type_name -> agentgateway.dev.resource.DynamicForwardProxy
+	103, // 37: agentgateway.dev.resource.Backend.aws:type_name -> agentgateway.dev.resource.AwsBackend
+	59,  // 38: agentgateway.dev.resource.Backend.guardrail:type_name -> agentgateway.dev.resource.GuardrailBackend
+	100, // 39: agentgateway.dev.resource.Backend.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	110, // 40: agentgateway.dev.resource.GuardrailBackend.bedrock:type_name -> agentgateway.dev.resource.GuardrailBackend.Bedrock
+	111, // 41: agentgateway.dev.resource.GuardrailBackend.google_model_armor:type_name -> agentgateway.dev.resource.GuardrailBackend.GoogleModelArmor
+	112, // 42: agentgateway.dev.resource.GuardrailBackend.azure_content_safety:type_name -> agentgateway.dev.resource.GuardrailBackend.AzureContentSafety
+	113, // 43: agentgateway.dev.resource.GuardrailBackend.openai_moderation:type_name -> agentgateway.dev.resource.GuardrailBackend.OpenAIModeration
 	7,   // 44: agentgateway.dev.resource.TLSConfig.cipher_suites:type_name -> agentgateway.dev.resource.TLSConfig.CipherSuite
 	5,   // 45: agentgateway.dev.resource.TLSConfig.min_version:type_name -> agentgateway.dev.resource.TLSConfig.TLSVersion
 	5,   // 46: agentgateway.dev.resource.TLSConfig.max_version:type_name -> agentgateway.dev.resource.TLSConfig.TLSVersion
 	6,   // 47: agentgateway.dev.resource.TLSConfig.mtls_mode:type_name -> agentgateway.dev.resource.TLSConfig.MTLSMode
 	8,   // 48: agentgateway.dev.resource.TLSConfig.key_exchange_groups:type_name -> agentgateway.dev.resource.TLSConfig.KeyExchangeGroup
 	4,   // 49: agentgateway.dev.resource.TLSConfig.certificate_source:type_name -> agentgateway.dev.resource.TLSConfig.CertificateSource
-	227, // 50: agentgateway.dev.resource.Timeout.request:type_name -> google.protobuf.Duration
-	227, // 51: agentgateway.dev.resource.Timeout.backend_request:type_name -> google.protobuf.Duration
-	227, // 52: agentgateway.dev.resource.Retry.backoff:type_name -> google.protobuf.Duration
-	64,  // 53: agentgateway.dev.resource.BackendAuthPolicy.passthrough:type_name -> agentgateway.dev.resource.Passthrough
-	65,  // 54: agentgateway.dev.resource.BackendAuthPolicy.key:type_name -> agentgateway.dev.resource.Key
-	66,  // 55: agentgateway.dev.resource.BackendAuthPolicy.gcp:type_name -> agentgateway.dev.resource.Gcp
-	67,  // 56: agentgateway.dev.resource.BackendAuthPolicy.aws:type_name -> agentgateway.dev.resource.Aws
-	68,  // 57: agentgateway.dev.resource.BackendAuthPolicy.azure:type_name -> agentgateway.dev.resource.Azure
-	113, // 58: agentgateway.dev.resource.AuthorizationLocation.header:type_name -> agentgateway.dev.resource.AuthorizationLocation.Header
-	114, // 59: agentgateway.dev.resource.AuthorizationLocation.query_parameter:type_name -> agentgateway.dev.resource.AuthorizationLocation.QueryParameter
-	115, // 60: agentgateway.dev.resource.AuthorizationLocation.cookie:type_name -> agentgateway.dev.resource.AuthorizationLocation.Cookie
-	63,  // 61: agentgateway.dev.resource.Passthrough.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
-	63,  // 62: agentgateway.dev.resource.Key.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
-	116, // 63: agentgateway.dev.resource.Gcp.access_token:type_name -> agentgateway.dev.resource.Gcp.AccessToken
-	117, // 64: agentgateway.dev.resource.Gcp.id_token:type_name -> agentgateway.dev.resource.Gcp.IdToken
-	69,  // 65: agentgateway.dev.resource.Aws.explicit_config:type_name -> agentgateway.dev.resource.AwsExplicitConfig
-	70,  // 66: agentgateway.dev.resource.Aws.implicit:type_name -> agentgateway.dev.resource.AwsImplicit
-	71,  // 67: agentgateway.dev.resource.Aws.assume_role:type_name -> agentgateway.dev.resource.AwsAssumeRole
-	72,  // 68: agentgateway.dev.resource.Azure.explicit_config:type_name -> agentgateway.dev.resource.AzureExplicitConfig
-	76,  // 69: agentgateway.dev.resource.Azure.developer_implicit:type_name -> agentgateway.dev.resource.AzureDeveloperImplicit
-	77,  // 70: agentgateway.dev.resource.Azure.implicit:type_name -> agentgateway.dev.resource.AzureImplicit
-	73,  // 71: agentgateway.dev.resource.AzureExplicitConfig.client_secret:type_name -> agentgateway.dev.resource.AzureClientSecret
-	74,  // 72: agentgateway.dev.resource.AzureExplicitConfig.managed_identity_credential:type_name -> agentgateway.dev.resource.AzureManagedIdentityCredential
-	75,  // 73: agentgateway.dev.resource.AzureExplicitConfig.workload_identity_credential:type_name -> agentgateway.dev.resource.AzureWorkloadIdentityCredential
-	118, // 74: agentgateway.dev.resource.AzureManagedIdentityCredential.user_assigned_identity:type_name -> agentgateway.dev.resource.AzureManagedIdentityCredential.UserAssignedIdentity
-	79,  // 75: agentgateway.dev.resource.RouteMatch.path:type_name -> agentgateway.dev.resource.PathMatch
-	82,  // 76: agentgateway.dev.resource.RouteMatch.headers:type_name -> agentgateway.dev.resource.HeaderMatch
-	81,  // 77: agentgateway.dev.resource.RouteMatch.method:type_name -> agentgateway.dev.resource.MethodMatch
-	80,  // 78: agentgateway.dev.resource.RouteMatch.query_params:type_name -> agentgateway.dev.resource.QueryMatch
-	227, // 79: agentgateway.dev.resource.CORS.max_age:type_name -> google.protobuf.Duration
-	87,  // 80: agentgateway.dev.resource.DirectResponse.headers:type_name -> agentgateway.dev.resource.ExpressionHeader
-	85,  // 81: agentgateway.dev.resource.Buffer.request:type_name -> agentgateway.dev.resource.BufferBody
-	85,  // 82: agentgateway.dev.resource.Buffer.response:type_name -> agentgateway.dev.resource.BufferBody
-	92,  // 83: agentgateway.dev.resource.HeaderModifier.add:type_name -> agentgateway.dev.resource.Header
-	92,  // 84: agentgateway.dev.resource.HeaderModifier.set:type_name -> agentgateway.dev.resource.Header
-	119, // 85: agentgateway.dev.resource.RequestMirrors.mirrors:type_name -> agentgateway.dev.resource.RequestMirrors.Mirror
-	107, // 86: agentgateway.dev.resource.RouteBackend.backend:type_name -> agentgateway.dev.resource.BackendReference
-	99,  // 87: agentgateway.dev.resource.RouteBackend.backend_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	122, // 88: agentgateway.dev.resource.PolicyTarget.gateway:type_name -> agentgateway.dev.resource.PolicyTarget.GatewayTarget
-	123, // 89: agentgateway.dev.resource.PolicyTarget.route:type_name -> agentgateway.dev.resource.PolicyTarget.RouteTarget
-	121, // 90: agentgateway.dev.resource.PolicyTarget.backend:type_name -> agentgateway.dev.resource.PolicyTarget.BackendTarget
-	120, // 91: agentgateway.dev.resource.PolicyTarget.service:type_name -> agentgateway.dev.resource.PolicyTarget.ServiceTarget
-	124, // 92: agentgateway.dev.resource.PolicyTarget.listener_set:type_name -> agentgateway.dev.resource.PolicyTarget.ListenerSetTarget
-	227, // 93: agentgateway.dev.resource.KeepaliveConfig.time:type_name -> google.protobuf.Duration
-	227, // 94: agentgateway.dev.resource.KeepaliveConfig.interval:type_name -> google.protobuf.Duration
-	127, // 95: agentgateway.dev.resource.FrontendPolicySpec.tcp:type_name -> agentgateway.dev.resource.FrontendPolicySpec.TCP
-	126, // 96: agentgateway.dev.resource.FrontendPolicySpec.tls:type_name -> agentgateway.dev.resource.FrontendPolicySpec.TLS
-	125, // 97: agentgateway.dev.resource.FrontendPolicySpec.http:type_name -> agentgateway.dev.resource.FrontendPolicySpec.HTTP
-	129, // 98: agentgateway.dev.resource.FrontendPolicySpec.logging:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging
-	130, // 99: agentgateway.dev.resource.FrontendPolicySpec.tracing:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Tracing
-	128, // 100: agentgateway.dev.resource.FrontendPolicySpec.network_authorization:type_name -> agentgateway.dev.resource.FrontendPolicySpec.NetworkAuthorization
-	132, // 101: agentgateway.dev.resource.FrontendPolicySpec.proxy_protocol:type_name -> agentgateway.dev.resource.FrontendPolicySpec.ProxyProtocol
-	134, // 102: agentgateway.dev.resource.FrontendPolicySpec.metrics:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Metrics
-	133, // 103: agentgateway.dev.resource.FrontendPolicySpec.connect:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Connect
+	228, // 50: agentgateway.dev.resource.Timeout.request:type_name -> google.protobuf.Duration
+	228, // 51: agentgateway.dev.resource.Timeout.backend_request:type_name -> google.protobuf.Duration
+	228, // 52: agentgateway.dev.resource.Retry.backoff:type_name -> google.protobuf.Duration
+	65,  // 53: agentgateway.dev.resource.BackendAuthPolicy.passthrough:type_name -> agentgateway.dev.resource.Passthrough
+	66,  // 54: agentgateway.dev.resource.BackendAuthPolicy.key:type_name -> agentgateway.dev.resource.Key
+	67,  // 55: agentgateway.dev.resource.BackendAuthPolicy.gcp:type_name -> agentgateway.dev.resource.Gcp
+	68,  // 56: agentgateway.dev.resource.BackendAuthPolicy.aws:type_name -> agentgateway.dev.resource.Aws
+	69,  // 57: agentgateway.dev.resource.BackendAuthPolicy.azure:type_name -> agentgateway.dev.resource.Azure
+	114, // 58: agentgateway.dev.resource.AuthorizationLocation.header:type_name -> agentgateway.dev.resource.AuthorizationLocation.Header
+	115, // 59: agentgateway.dev.resource.AuthorizationLocation.query_parameter:type_name -> agentgateway.dev.resource.AuthorizationLocation.QueryParameter
+	116, // 60: agentgateway.dev.resource.AuthorizationLocation.cookie:type_name -> agentgateway.dev.resource.AuthorizationLocation.Cookie
+	64,  // 61: agentgateway.dev.resource.Passthrough.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
+	64,  // 62: agentgateway.dev.resource.Key.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
+	117, // 63: agentgateway.dev.resource.Gcp.access_token:type_name -> agentgateway.dev.resource.Gcp.AccessToken
+	118, // 64: agentgateway.dev.resource.Gcp.id_token:type_name -> agentgateway.dev.resource.Gcp.IdToken
+	70,  // 65: agentgateway.dev.resource.Aws.explicit_config:type_name -> agentgateway.dev.resource.AwsExplicitConfig
+	71,  // 66: agentgateway.dev.resource.Aws.implicit:type_name -> agentgateway.dev.resource.AwsImplicit
+	72,  // 67: agentgateway.dev.resource.Aws.assume_role:type_name -> agentgateway.dev.resource.AwsAssumeRole
+	73,  // 68: agentgateway.dev.resource.Azure.explicit_config:type_name -> agentgateway.dev.resource.AzureExplicitConfig
+	77,  // 69: agentgateway.dev.resource.Azure.developer_implicit:type_name -> agentgateway.dev.resource.AzureDeveloperImplicit
+	78,  // 70: agentgateway.dev.resource.Azure.implicit:type_name -> agentgateway.dev.resource.AzureImplicit
+	74,  // 71: agentgateway.dev.resource.AzureExplicitConfig.client_secret:type_name -> agentgateway.dev.resource.AzureClientSecret
+	75,  // 72: agentgateway.dev.resource.AzureExplicitConfig.managed_identity_credential:type_name -> agentgateway.dev.resource.AzureManagedIdentityCredential
+	76,  // 73: agentgateway.dev.resource.AzureExplicitConfig.workload_identity_credential:type_name -> agentgateway.dev.resource.AzureWorkloadIdentityCredential
+	119, // 74: agentgateway.dev.resource.AzureManagedIdentityCredential.user_assigned_identity:type_name -> agentgateway.dev.resource.AzureManagedIdentityCredential.UserAssignedIdentity
+	80,  // 75: agentgateway.dev.resource.RouteMatch.path:type_name -> agentgateway.dev.resource.PathMatch
+	83,  // 76: agentgateway.dev.resource.RouteMatch.headers:type_name -> agentgateway.dev.resource.HeaderMatch
+	82,  // 77: agentgateway.dev.resource.RouteMatch.method:type_name -> agentgateway.dev.resource.MethodMatch
+	81,  // 78: agentgateway.dev.resource.RouteMatch.query_params:type_name -> agentgateway.dev.resource.QueryMatch
+	228, // 79: agentgateway.dev.resource.CORS.max_age:type_name -> google.protobuf.Duration
+	88,  // 80: agentgateway.dev.resource.DirectResponse.headers:type_name -> agentgateway.dev.resource.ExpressionHeader
+	86,  // 81: agentgateway.dev.resource.Buffer.request:type_name -> agentgateway.dev.resource.BufferBody
+	86,  // 82: agentgateway.dev.resource.Buffer.response:type_name -> agentgateway.dev.resource.BufferBody
+	93,  // 83: agentgateway.dev.resource.HeaderModifier.add:type_name -> agentgateway.dev.resource.Header
+	93,  // 84: agentgateway.dev.resource.HeaderModifier.set:type_name -> agentgateway.dev.resource.Header
+	120, // 85: agentgateway.dev.resource.RequestMirrors.mirrors:type_name -> agentgateway.dev.resource.RequestMirrors.Mirror
+	108, // 86: agentgateway.dev.resource.RouteBackend.backend:type_name -> agentgateway.dev.resource.BackendReference
+	100, // 87: agentgateway.dev.resource.RouteBackend.backend_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	123, // 88: agentgateway.dev.resource.PolicyTarget.gateway:type_name -> agentgateway.dev.resource.PolicyTarget.GatewayTarget
+	124, // 89: agentgateway.dev.resource.PolicyTarget.route:type_name -> agentgateway.dev.resource.PolicyTarget.RouteTarget
+	122, // 90: agentgateway.dev.resource.PolicyTarget.backend:type_name -> agentgateway.dev.resource.PolicyTarget.BackendTarget
+	121, // 91: agentgateway.dev.resource.PolicyTarget.service:type_name -> agentgateway.dev.resource.PolicyTarget.ServiceTarget
+	125, // 92: agentgateway.dev.resource.PolicyTarget.listener_set:type_name -> agentgateway.dev.resource.PolicyTarget.ListenerSetTarget
+	228, // 93: agentgateway.dev.resource.KeepaliveConfig.time:type_name -> google.protobuf.Duration
+	228, // 94: agentgateway.dev.resource.KeepaliveConfig.interval:type_name -> google.protobuf.Duration
+	128, // 95: agentgateway.dev.resource.FrontendPolicySpec.tcp:type_name -> agentgateway.dev.resource.FrontendPolicySpec.TCP
+	127, // 96: agentgateway.dev.resource.FrontendPolicySpec.tls:type_name -> agentgateway.dev.resource.FrontendPolicySpec.TLS
+	126, // 97: agentgateway.dev.resource.FrontendPolicySpec.http:type_name -> agentgateway.dev.resource.FrontendPolicySpec.HTTP
+	130, // 98: agentgateway.dev.resource.FrontendPolicySpec.logging:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging
+	131, // 99: agentgateway.dev.resource.FrontendPolicySpec.tracing:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Tracing
+	129, // 100: agentgateway.dev.resource.FrontendPolicySpec.network_authorization:type_name -> agentgateway.dev.resource.FrontendPolicySpec.NetworkAuthorization
+	133, // 101: agentgateway.dev.resource.FrontendPolicySpec.proxy_protocol:type_name -> agentgateway.dev.resource.FrontendPolicySpec.ProxyProtocol
+	135, // 102: agentgateway.dev.resource.FrontendPolicySpec.metrics:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Metrics
+	134, // 103: agentgateway.dev.resource.FrontendPolicySpec.connect:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Connect
 	15,  // 104: agentgateway.dev.resource.TrafficPolicySpec.phase:type_name -> agentgateway.dev.resource.TrafficPolicySpec.PolicyPhase
-	60,  // 105: agentgateway.dev.resource.TrafficPolicySpec.timeout:type_name -> agentgateway.dev.resource.Timeout
-	61,  // 106: agentgateway.dev.resource.TrafficPolicySpec.retry:type_name -> agentgateway.dev.resource.Retry
-	141, // 107: agentgateway.dev.resource.TrafficPolicySpec.local_rate_limit:type_name -> agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit
-	142, // 108: agentgateway.dev.resource.TrafficPolicySpec.ext_authz:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth
-	143, // 109: agentgateway.dev.resource.TrafficPolicySpec.authorization:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RBAC
-	145, // 110: agentgateway.dev.resource.TrafficPolicySpec.jwt:type_name -> agentgateway.dev.resource.TrafficPolicySpec.JWT
-	148, // 111: agentgateway.dev.resource.TrafficPolicySpec.transformation:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy
-	140, // 112: agentgateway.dev.resource.TrafficPolicySpec.remote_rate_limit:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit
-	151, // 113: agentgateway.dev.resource.TrafficPolicySpec.csrf:type_name -> agentgateway.dev.resource.TrafficPolicySpec.CSRF
-	152, // 114: agentgateway.dev.resource.TrafficPolicySpec.ext_proc:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc
-	88,  // 115: agentgateway.dev.resource.TrafficPolicySpec.request_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
-	88,  // 116: agentgateway.dev.resource.TrafficPolicySpec.response_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
-	90,  // 117: agentgateway.dev.resource.TrafficPolicySpec.request_redirect:type_name -> agentgateway.dev.resource.RequestRedirect
-	91,  // 118: agentgateway.dev.resource.TrafficPolicySpec.url_rewrite:type_name -> agentgateway.dev.resource.UrlRewrite
-	89,  // 119: agentgateway.dev.resource.TrafficPolicySpec.request_mirror:type_name -> agentgateway.dev.resource.RequestMirrors
-	84,  // 120: agentgateway.dev.resource.TrafficPolicySpec.direct_response:type_name -> agentgateway.dev.resource.DirectResponse
-	83,  // 121: agentgateway.dev.resource.TrafficPolicySpec.cors:type_name -> agentgateway.dev.resource.CORS
-	146, // 122: agentgateway.dev.resource.TrafficPolicySpec.basic_auth:type_name -> agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication
-	147, // 123: agentgateway.dev.resource.TrafficPolicySpec.api_key_auth:type_name -> agentgateway.dev.resource.TrafficPolicySpec.APIKey
-	153, // 124: agentgateway.dev.resource.TrafficPolicySpec.host_rewrite:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HostRewrite
-	86,  // 125: agentgateway.dev.resource.TrafficPolicySpec.buffer:type_name -> agentgateway.dev.resource.Buffer
-	175, // 126: agentgateway.dev.resource.BackendPolicySpec.a2a:type_name -> agentgateway.dev.resource.BackendPolicySpec.A2a
-	176, // 127: agentgateway.dev.resource.BackendPolicySpec.inference_routing:type_name -> agentgateway.dev.resource.BackendPolicySpec.InferenceRouting
-	179, // 128: agentgateway.dev.resource.BackendPolicySpec.backend_tls:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTLS
-	62,  // 129: agentgateway.dev.resource.BackendPolicySpec.auth:type_name -> agentgateway.dev.resource.BackendAuthPolicy
-	183, // 130: agentgateway.dev.resource.BackendPolicySpec.mcp_authorization:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthorization
-	184, // 131: agentgateway.dev.resource.BackendPolicySpec.mcp_authentication:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication
-	174, // 132: agentgateway.dev.resource.BackendPolicySpec.ai:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai
-	88,  // 133: agentgateway.dev.resource.BackendPolicySpec.request_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
-	88,  // 134: agentgateway.dev.resource.BackendPolicySpec.response_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
-	90,  // 135: agentgateway.dev.resource.BackendPolicySpec.request_redirect:type_name -> agentgateway.dev.resource.RequestRedirect
-	89,  // 136: agentgateway.dev.resource.BackendPolicySpec.request_mirror:type_name -> agentgateway.dev.resource.RequestMirrors
-	180, // 137: agentgateway.dev.resource.BackendPolicySpec.backend_http:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendHTTP
-	182, // 138: agentgateway.dev.resource.BackendPolicySpec.backend_tcp:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTCP
-	148, // 139: agentgateway.dev.resource.BackendPolicySpec.transformation:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy
-	178, // 140: agentgateway.dev.resource.BackendPolicySpec.health:type_name -> agentgateway.dev.resource.BackendPolicySpec.Health
-	181, // 141: agentgateway.dev.resource.BackendPolicySpec.backend_tunnel:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTunnel
-	142, // 142: agentgateway.dev.resource.BackendPolicySpec.ext_authz:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth
-	185, // 143: agentgateway.dev.resource.BackendPolicySpec.mcp_guardrails:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails
-	103, // 144: agentgateway.dev.resource.AwsBackend.agent_core:type_name -> agentgateway.dev.resource.AwsAgentCoreBackend
-	222, // 145: agentgateway.dev.resource.AIBackend.provider_groups:type_name -> agentgateway.dev.resource.AIBackend.ProviderGroup
-	106, // 146: agentgateway.dev.resource.MCPBackend.targets:type_name -> agentgateway.dev.resource.MCPTarget
-	40,  // 147: agentgateway.dev.resource.MCPBackend.stateful_mode:type_name -> agentgateway.dev.resource.MCPBackend.StatefulMode
-	41,  // 148: agentgateway.dev.resource.MCPBackend.prefix_mode:type_name -> agentgateway.dev.resource.MCPBackend.PrefixMode
-	42,  // 149: agentgateway.dev.resource.MCPBackend.failure_mode:type_name -> agentgateway.dev.resource.MCPBackend.FailureMode
-	107, // 150: agentgateway.dev.resource.MCPTarget.backend:type_name -> agentgateway.dev.resource.BackendReference
-	43,  // 151: agentgateway.dev.resource.MCPTarget.protocol:type_name -> agentgateway.dev.resource.MCPTarget.Protocol
-	223, // 152: agentgateway.dev.resource.BackendReference.service:type_name -> agentgateway.dev.resource.BackendReference.Service
-	107, // 153: agentgateway.dev.resource.RequestMirrors.Mirror.backend:type_name -> agentgateway.dev.resource.BackendReference
-	227, // 154: agentgateway.dev.resource.FrontendPolicySpec.HTTP.http1_idle_timeout:type_name -> google.protobuf.Duration
-	227, // 155: agentgateway.dev.resource.FrontendPolicySpec.HTTP.http2_keepalive_interval:type_name -> google.protobuf.Duration
-	227, // 156: agentgateway.dev.resource.FrontendPolicySpec.HTTP.http2_keepalive_timeout:type_name -> google.protobuf.Duration
-	227, // 157: agentgateway.dev.resource.FrontendPolicySpec.HTTP.max_connection_duration:type_name -> google.protobuf.Duration
+	61,  // 105: agentgateway.dev.resource.TrafficPolicySpec.timeout:type_name -> agentgateway.dev.resource.Timeout
+	62,  // 106: agentgateway.dev.resource.TrafficPolicySpec.retry:type_name -> agentgateway.dev.resource.Retry
+	142, // 107: agentgateway.dev.resource.TrafficPolicySpec.local_rate_limit:type_name -> agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit
+	143, // 108: agentgateway.dev.resource.TrafficPolicySpec.ext_authz:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth
+	144, // 109: agentgateway.dev.resource.TrafficPolicySpec.authorization:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RBAC
+	146, // 110: agentgateway.dev.resource.TrafficPolicySpec.jwt:type_name -> agentgateway.dev.resource.TrafficPolicySpec.JWT
+	149, // 111: agentgateway.dev.resource.TrafficPolicySpec.transformation:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy
+	141, // 112: agentgateway.dev.resource.TrafficPolicySpec.remote_rate_limit:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit
+	152, // 113: agentgateway.dev.resource.TrafficPolicySpec.csrf:type_name -> agentgateway.dev.resource.TrafficPolicySpec.CSRF
+	153, // 114: agentgateway.dev.resource.TrafficPolicySpec.ext_proc:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc
+	89,  // 115: agentgateway.dev.resource.TrafficPolicySpec.request_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
+	89,  // 116: agentgateway.dev.resource.TrafficPolicySpec.response_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
+	91,  // 117: agentgateway.dev.resource.TrafficPolicySpec.request_redirect:type_name -> agentgateway.dev.resource.RequestRedirect
+	92,  // 118: agentgateway.dev.resource.TrafficPolicySpec.url_rewrite:type_name -> agentgateway.dev.resource.UrlRewrite
+	90,  // 119: agentgateway.dev.resource.TrafficPolicySpec.request_mirror:type_name -> agentgateway.dev.resource.RequestMirrors
+	85,  // 120: agentgateway.dev.resource.TrafficPolicySpec.direct_response:type_name -> agentgateway.dev.resource.DirectResponse
+	84,  // 121: agentgateway.dev.resource.TrafficPolicySpec.cors:type_name -> agentgateway.dev.resource.CORS
+	147, // 122: agentgateway.dev.resource.TrafficPolicySpec.basic_auth:type_name -> agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication
+	148, // 123: agentgateway.dev.resource.TrafficPolicySpec.api_key_auth:type_name -> agentgateway.dev.resource.TrafficPolicySpec.APIKey
+	154, // 124: agentgateway.dev.resource.TrafficPolicySpec.host_rewrite:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HostRewrite
+	87,  // 125: agentgateway.dev.resource.TrafficPolicySpec.buffer:type_name -> agentgateway.dev.resource.Buffer
+	176, // 126: agentgateway.dev.resource.BackendPolicySpec.a2a:type_name -> agentgateway.dev.resource.BackendPolicySpec.A2a
+	177, // 127: agentgateway.dev.resource.BackendPolicySpec.inference_routing:type_name -> agentgateway.dev.resource.BackendPolicySpec.InferenceRouting
+	180, // 128: agentgateway.dev.resource.BackendPolicySpec.backend_tls:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTLS
+	63,  // 129: agentgateway.dev.resource.BackendPolicySpec.auth:type_name -> agentgateway.dev.resource.BackendAuthPolicy
+	184, // 130: agentgateway.dev.resource.BackendPolicySpec.mcp_authorization:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthorization
+	185, // 131: agentgateway.dev.resource.BackendPolicySpec.mcp_authentication:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication
+	175, // 132: agentgateway.dev.resource.BackendPolicySpec.ai:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai
+	89,  // 133: agentgateway.dev.resource.BackendPolicySpec.request_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
+	89,  // 134: agentgateway.dev.resource.BackendPolicySpec.response_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
+	91,  // 135: agentgateway.dev.resource.BackendPolicySpec.request_redirect:type_name -> agentgateway.dev.resource.RequestRedirect
+	90,  // 136: agentgateway.dev.resource.BackendPolicySpec.request_mirror:type_name -> agentgateway.dev.resource.RequestMirrors
+	181, // 137: agentgateway.dev.resource.BackendPolicySpec.backend_http:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendHTTP
+	183, // 138: agentgateway.dev.resource.BackendPolicySpec.backend_tcp:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTCP
+	149, // 139: agentgateway.dev.resource.BackendPolicySpec.transformation:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy
+	179, // 140: agentgateway.dev.resource.BackendPolicySpec.health:type_name -> agentgateway.dev.resource.BackendPolicySpec.Health
+	182, // 141: agentgateway.dev.resource.BackendPolicySpec.backend_tunnel:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTunnel
+	143, // 142: agentgateway.dev.resource.BackendPolicySpec.ext_authz:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth
+	186, // 143: agentgateway.dev.resource.BackendPolicySpec.mcp_guardrails:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails
+	104, // 144: agentgateway.dev.resource.AwsBackend.agent_core:type_name -> agentgateway.dev.resource.AwsAgentCoreBackend
+	223, // 145: agentgateway.dev.resource.AIBackend.provider_groups:type_name -> agentgateway.dev.resource.AIBackend.ProviderGroup
+	107, // 146: agentgateway.dev.resource.MCPBackend.targets:type_name -> agentgateway.dev.resource.MCPTarget
+	41,  // 147: agentgateway.dev.resource.MCPBackend.stateful_mode:type_name -> agentgateway.dev.resource.MCPBackend.StatefulMode
+	42,  // 148: agentgateway.dev.resource.MCPBackend.prefix_mode:type_name -> agentgateway.dev.resource.MCPBackend.PrefixMode
+	43,  // 149: agentgateway.dev.resource.MCPBackend.failure_mode:type_name -> agentgateway.dev.resource.MCPBackend.FailureMode
+	108, // 150: agentgateway.dev.resource.MCPTarget.backend:type_name -> agentgateway.dev.resource.BackendReference
+	44,  // 151: agentgateway.dev.resource.MCPTarget.protocol:type_name -> agentgateway.dev.resource.MCPTarget.Protocol
+	224, // 152: agentgateway.dev.resource.BackendReference.service:type_name -> agentgateway.dev.resource.BackendReference.Service
+	108, // 153: agentgateway.dev.resource.RequestMirrors.Mirror.backend:type_name -> agentgateway.dev.resource.BackendReference
+	228, // 154: agentgateway.dev.resource.FrontendPolicySpec.HTTP.http1_idle_timeout:type_name -> google.protobuf.Duration
+	228, // 155: agentgateway.dev.resource.FrontendPolicySpec.HTTP.http2_keepalive_interval:type_name -> google.protobuf.Duration
+	228, // 156: agentgateway.dev.resource.FrontendPolicySpec.HTTP.http2_keepalive_timeout:type_name -> google.protobuf.Duration
+	228, // 157: agentgateway.dev.resource.FrontendPolicySpec.HTTP.max_connection_duration:type_name -> google.protobuf.Duration
 	9,   // 158: agentgateway.dev.resource.FrontendPolicySpec.HTTP.http1_header_case:type_name -> agentgateway.dev.resource.FrontendPolicySpec.HTTP.HTTPHeaderCase
-	227, // 159: agentgateway.dev.resource.FrontendPolicySpec.TLS.handshake_timeout:type_name -> google.protobuf.Duration
-	108, // 160: agentgateway.dev.resource.FrontendPolicySpec.TLS.alpn:type_name -> agentgateway.dev.resource.Alpn
+	228, // 159: agentgateway.dev.resource.FrontendPolicySpec.TLS.handshake_timeout:type_name -> google.protobuf.Duration
+	109, // 160: agentgateway.dev.resource.FrontendPolicySpec.TLS.alpn:type_name -> agentgateway.dev.resource.Alpn
 	7,   // 161: agentgateway.dev.resource.FrontendPolicySpec.TLS.cipher_suites:type_name -> agentgateway.dev.resource.TLSConfig.CipherSuite
 	5,   // 162: agentgateway.dev.resource.FrontendPolicySpec.TLS.min_version:type_name -> agentgateway.dev.resource.TLSConfig.TLSVersion
 	5,   // 163: agentgateway.dev.resource.FrontendPolicySpec.TLS.max_version:type_name -> agentgateway.dev.resource.TLSConfig.TLSVersion
 	8,   // 164: agentgateway.dev.resource.FrontendPolicySpec.TLS.key_exchange_groups:type_name -> agentgateway.dev.resource.TLSConfig.KeyExchangeGroup
-	95,  // 165: agentgateway.dev.resource.FrontendPolicySpec.TCP.keepalives:type_name -> agentgateway.dev.resource.KeepaliveConfig
-	136, // 166: agentgateway.dev.resource.FrontendPolicySpec.Logging.fields:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging.Fields
-	137, // 167: agentgateway.dev.resource.FrontendPolicySpec.Logging.otlp_access_log:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog
-	107, // 168: agentgateway.dev.resource.FrontendPolicySpec.Tracing.provider_backend:type_name -> agentgateway.dev.resource.BackendReference
-	131, // 169: agentgateway.dev.resource.FrontendPolicySpec.Tracing.attributes:type_name -> agentgateway.dev.resource.FrontendPolicySpec.TracingAttribute
-	131, // 170: agentgateway.dev.resource.FrontendPolicySpec.Tracing.resources:type_name -> agentgateway.dev.resource.FrontendPolicySpec.TracingAttribute
+	96,  // 165: agentgateway.dev.resource.FrontendPolicySpec.TCP.keepalives:type_name -> agentgateway.dev.resource.KeepaliveConfig
+	137, // 166: agentgateway.dev.resource.FrontendPolicySpec.Logging.fields:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging.Fields
+	138, // 167: agentgateway.dev.resource.FrontendPolicySpec.Logging.otlp_access_log:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog
+	108, // 168: agentgateway.dev.resource.FrontendPolicySpec.Tracing.provider_backend:type_name -> agentgateway.dev.resource.BackendReference
+	132, // 169: agentgateway.dev.resource.FrontendPolicySpec.Tracing.attributes:type_name -> agentgateway.dev.resource.FrontendPolicySpec.TracingAttribute
+	132, // 170: agentgateway.dev.resource.FrontendPolicySpec.Tracing.resources:type_name -> agentgateway.dev.resource.FrontendPolicySpec.TracingAttribute
 	11,  // 171: agentgateway.dev.resource.FrontendPolicySpec.Tracing.protocol:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Tracing.Protocol
 	12,  // 172: agentgateway.dev.resource.FrontendPolicySpec.ProxyProtocol.version:type_name -> agentgateway.dev.resource.FrontendPolicySpec.ProxyProtocol.Version
 	13,  // 173: agentgateway.dev.resource.FrontendPolicySpec.ProxyProtocol.mode:type_name -> agentgateway.dev.resource.FrontendPolicySpec.ProxyProtocol.Mode
 	14,  // 174: agentgateway.dev.resource.FrontendPolicySpec.Connect.mode:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Connect.Mode
-	139, // 175: agentgateway.dev.resource.FrontendPolicySpec.Metrics.fields:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Metrics.Fields
-	135, // 176: agentgateway.dev.resource.FrontendPolicySpec.Logging.Fields.add:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging.Field
-	107, // 177: agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog.provider_backend:type_name -> agentgateway.dev.resource.BackendReference
-	99,  // 178: agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	140, // 175: agentgateway.dev.resource.FrontendPolicySpec.Metrics.fields:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Metrics.Fields
+	136, // 176: agentgateway.dev.resource.FrontendPolicySpec.Logging.Fields.add:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging.Field
+	108, // 177: agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog.provider_backend:type_name -> agentgateway.dev.resource.BackendReference
+	100, // 178: agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
 	10,  // 179: agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog.protocol:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog.Protocol
-	138, // 180: agentgateway.dev.resource.FrontendPolicySpec.Metrics.Fields.add:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Metrics.Field
-	154, // 181: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.descriptors:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor
-	107, // 182: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.target:type_name -> agentgateway.dev.resource.BackendReference
+	139, // 180: agentgateway.dev.resource.FrontendPolicySpec.Metrics.Fields.add:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Metrics.Field
+	155, // 181: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.descriptors:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor
+	108, // 182: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.target:type_name -> agentgateway.dev.resource.BackendReference
 	17,  // 183: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.failure_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.FailureMode
-	227, // 184: agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit.fill_interval:type_name -> google.protobuf.Duration
+	228, // 184: agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit.fill_interval:type_name -> google.protobuf.Duration
 	18,  // 185: agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit.type:type_name -> agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit.Type
-	107, // 186: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.target:type_name -> agentgateway.dev.resource.BackendReference
-	158, // 187: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.grpc:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol
-	159, // 188: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.http:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol
+	108, // 186: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.target:type_name -> agentgateway.dev.resource.BackendReference
+	159, // 187: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.grpc:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol
+	160, // 188: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.http:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol
 	19,  // 189: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.failure_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.FailureMode
-	156, // 190: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.include_request_body:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.BodyOptions
-	157, // 191: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.cache:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.Cache
-	97,  // 192: agentgateway.dev.resource.TrafficPolicySpec.JWTProvider.jwt_validation_options:type_name -> agentgateway.dev.resource.JWTValidationOptions
+	157, // 190: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.include_request_body:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.BodyOptions
+	158, // 191: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.cache:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.Cache
+	98,  // 192: agentgateway.dev.resource.TrafficPolicySpec.JWTProvider.jwt_validation_options:type_name -> agentgateway.dev.resource.JWTValidationOptions
 	20,  // 193: agentgateway.dev.resource.TrafficPolicySpec.JWT.mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.JWT.Mode
-	144, // 194: agentgateway.dev.resource.TrafficPolicySpec.JWT.providers:type_name -> agentgateway.dev.resource.TrafficPolicySpec.JWTProvider
-	164, // 195: agentgateway.dev.resource.TrafficPolicySpec.JWT.mcp:type_name -> agentgateway.dev.resource.TrafficPolicySpec.JWT.MCP
-	63,  // 196: agentgateway.dev.resource.TrafficPolicySpec.JWT.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
+	145, // 194: agentgateway.dev.resource.TrafficPolicySpec.JWT.providers:type_name -> agentgateway.dev.resource.TrafficPolicySpec.JWTProvider
+	165, // 195: agentgateway.dev.resource.TrafficPolicySpec.JWT.mcp:type_name -> agentgateway.dev.resource.TrafficPolicySpec.JWT.MCP
+	64,  // 196: agentgateway.dev.resource.TrafficPolicySpec.JWT.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
 	21,  // 197: agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication.mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication.Mode
-	63,  // 198: agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
-	165, // 199: agentgateway.dev.resource.TrafficPolicySpec.APIKey.api_keys:type_name -> agentgateway.dev.resource.TrafficPolicySpec.APIKey.User
+	64,  // 198: agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
+	166, // 199: agentgateway.dev.resource.TrafficPolicySpec.APIKey.api_keys:type_name -> agentgateway.dev.resource.TrafficPolicySpec.APIKey.User
 	22,  // 200: agentgateway.dev.resource.TrafficPolicySpec.APIKey.mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.APIKey.Mode
-	63,  // 201: agentgateway.dev.resource.TrafficPolicySpec.APIKey.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
-	166, // 202: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.request:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform
-	166, // 203: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.response:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform
-	107, // 204: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.target:type_name -> agentgateway.dev.resource.BackendReference
+	64,  // 201: agentgateway.dev.resource.TrafficPolicySpec.APIKey.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
+	167, // 202: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.request:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform
+	167, // 203: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.response:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform
+	108, // 204: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.target:type_name -> agentgateway.dev.resource.BackendReference
 	23,  // 205: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.failure_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.FailureMode
-	168, // 206: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.request_attributes:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.RequestAttributesEntry
-	169, // 207: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.response_attributes:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ResponseAttributesEntry
-	172, // 208: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.metadata_context:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.MetadataContextEntry
-	171, // 209: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.processing_options:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ProcessingOptions
+	169, // 206: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.request_attributes:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.RequestAttributesEntry
+	170, // 207: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.response_attributes:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ResponseAttributesEntry
+	173, // 208: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.metadata_context:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.MetadataContextEntry
+	172, // 209: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.processing_options:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ProcessingOptions
 	26,  // 210: agentgateway.dev.resource.TrafficPolicySpec.HostRewrite.mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HostRewrite.Mode
-	155, // 211: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor.entries:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Entry
+	156, // 211: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor.entries:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Entry
 	16,  // 212: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor.type:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Type
-	160, // 213: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.context:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.ContextEntry
-	161, // 214: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.metadata:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.MetadataEntry
-	162, // 215: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.add_request_headers:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.AddRequestHeadersEntry
-	163, // 216: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.metadata:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.MetadataEntry
-	34,  // 217: agentgateway.dev.resource.TrafficPolicySpec.JWT.MCP.provider:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.McpIDP
-	205, // 218: agentgateway.dev.resource.TrafficPolicySpec.JWT.MCP.resource_metadata:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata
-	228, // 219: agentgateway.dev.resource.TrafficPolicySpec.APIKey.User.metadata:type_name -> google.protobuf.Struct
-	149, // 220: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.set:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HeaderTransformation
-	149, // 221: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.add:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HeaderTransformation
-	150, // 222: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.body:type_name -> agentgateway.dev.resource.TrafficPolicySpec.BodyTransformation
-	167, // 223: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.metadata:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.MetadataEntry
-	173, // 224: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext.context:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext.ContextEntry
+	161, // 213: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.context:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.ContextEntry
+	162, // 214: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.metadata:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.MetadataEntry
+	163, // 215: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.add_request_headers:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.AddRequestHeadersEntry
+	164, // 216: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.metadata:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.MetadataEntry
+	35,  // 217: agentgateway.dev.resource.TrafficPolicySpec.JWT.MCP.provider:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.McpIDP
+	206, // 218: agentgateway.dev.resource.TrafficPolicySpec.JWT.MCP.resource_metadata:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata
+	229, // 219: agentgateway.dev.resource.TrafficPolicySpec.APIKey.User.metadata:type_name -> google.protobuf.Struct
+	150, // 220: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.set:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HeaderTransformation
+	150, // 221: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.add:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HeaderTransformation
+	151, // 222: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.body:type_name -> agentgateway.dev.resource.TrafficPolicySpec.BodyTransformation
+	168, // 223: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.metadata:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.MetadataEntry
+	174, // 224: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext.context:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext.ContextEntry
 	24,  // 225: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ProcessingOptions.request_body_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.BodySendMode
 	24,  // 226: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ProcessingOptions.response_body_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.BodySendMode
 	25,  // 227: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ProcessingOptions.request_header_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.HeaderTrailerSendMode
 	25,  // 228: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ProcessingOptions.response_header_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.HeaderTrailerSendMode
 	25,  // 229: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ProcessingOptions.request_trailer_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.HeaderTrailerSendMode
 	25,  // 230: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ProcessingOptions.response_trailer_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.HeaderTrailerSendMode
-	170, // 231: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.MetadataContextEntry.value:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext
-	198, // 232: agentgateway.dev.resource.BackendPolicySpec.Ai.prompt_guard:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard
-	200, // 233: agentgateway.dev.resource.BackendPolicySpec.Ai.defaults:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.DefaultsEntry
-	201, // 234: agentgateway.dev.resource.BackendPolicySpec.Ai.overrides:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.OverridesEntry
-	202, // 235: agentgateway.dev.resource.BackendPolicySpec.Ai.transformations:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.TransformationsEntry
-	187, // 236: agentgateway.dev.resource.BackendPolicySpec.Ai.prompts:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment
-	203, // 237: agentgateway.dev.resource.BackendPolicySpec.Ai.model_aliases:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ModelAliasesEntry
-	199, // 238: agentgateway.dev.resource.BackendPolicySpec.Ai.prompt_caching:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptCaching
-	204, // 239: agentgateway.dev.resource.BackendPolicySpec.Ai.routes:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RoutesEntry
-	107, // 240: agentgateway.dev.resource.BackendPolicySpec.InferenceRouting.endpoint_picker:type_name -> agentgateway.dev.resource.BackendReference
-	31,  // 241: agentgateway.dev.resource.BackendPolicySpec.InferenceRouting.failure_mode:type_name -> agentgateway.dev.resource.BackendPolicySpec.InferenceRouting.FailureMode
-	227, // 242: agentgateway.dev.resource.BackendPolicySpec.Eviction.duration:type_name -> google.protobuf.Duration
-	177, // 243: agentgateway.dev.resource.BackendPolicySpec.Health.eviction:type_name -> agentgateway.dev.resource.BackendPolicySpec.Eviction
-	32,  // 244: agentgateway.dev.resource.BackendPolicySpec.BackendTLS.verification:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTLS.VerificationMode
-	108, // 245: agentgateway.dev.resource.BackendPolicySpec.BackendTLS.alpn:type_name -> agentgateway.dev.resource.Alpn
+	171, // 231: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.MetadataContextEntry.value:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext
+	199, // 232: agentgateway.dev.resource.BackendPolicySpec.Ai.prompt_guard:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard
+	201, // 233: agentgateway.dev.resource.BackendPolicySpec.Ai.defaults:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.DefaultsEntry
+	202, // 234: agentgateway.dev.resource.BackendPolicySpec.Ai.overrides:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.OverridesEntry
+	203, // 235: agentgateway.dev.resource.BackendPolicySpec.Ai.transformations:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.TransformationsEntry
+	188, // 236: agentgateway.dev.resource.BackendPolicySpec.Ai.prompts:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment
+	204, // 237: agentgateway.dev.resource.BackendPolicySpec.Ai.model_aliases:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ModelAliasesEntry
+	200, // 238: agentgateway.dev.resource.BackendPolicySpec.Ai.prompt_caching:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptCaching
+	205, // 239: agentgateway.dev.resource.BackendPolicySpec.Ai.routes:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RoutesEntry
+	108, // 240: agentgateway.dev.resource.BackendPolicySpec.InferenceRouting.endpoint_picker:type_name -> agentgateway.dev.resource.BackendReference
+	32,  // 241: agentgateway.dev.resource.BackendPolicySpec.InferenceRouting.failure_mode:type_name -> agentgateway.dev.resource.BackendPolicySpec.InferenceRouting.FailureMode
+	228, // 242: agentgateway.dev.resource.BackendPolicySpec.Eviction.duration:type_name -> google.protobuf.Duration
+	178, // 243: agentgateway.dev.resource.BackendPolicySpec.Health.eviction:type_name -> agentgateway.dev.resource.BackendPolicySpec.Eviction
+	33,  // 244: agentgateway.dev.resource.BackendPolicySpec.BackendTLS.verification:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTLS.VerificationMode
+	109, // 245: agentgateway.dev.resource.BackendPolicySpec.BackendTLS.alpn:type_name -> agentgateway.dev.resource.Alpn
 	8,   // 246: agentgateway.dev.resource.BackendPolicySpec.BackendTLS.key_exchange_groups:type_name -> agentgateway.dev.resource.TLSConfig.KeyExchangeGroup
-	33,  // 247: agentgateway.dev.resource.BackendPolicySpec.BackendHTTP.version:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendHTTP.HttpVersion
-	227, // 248: agentgateway.dev.resource.BackendPolicySpec.BackendHTTP.request_timeout:type_name -> google.protobuf.Duration
-	107, // 249: agentgateway.dev.resource.BackendPolicySpec.BackendTunnel.proxy:type_name -> agentgateway.dev.resource.BackendReference
-	95,  // 250: agentgateway.dev.resource.BackendPolicySpec.BackendTCP.keepalive:type_name -> agentgateway.dev.resource.KeepaliveConfig
-	227, // 251: agentgateway.dev.resource.BackendPolicySpec.BackendTCP.connect_timeout:type_name -> google.protobuf.Duration
-	34,  // 252: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.provider:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.McpIDP
-	205, // 253: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.resource_metadata:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata
-	35,  // 254: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.mode:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.Mode
-	97,  // 255: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.jwt_validation_options:type_name -> agentgateway.dev.resource.JWTValidationOptions
-	63,  // 256: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
-	208, // 257: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.processors:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor
-	186, // 258: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment.append:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Message
-	186, // 259: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment.prepend:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Message
+	34,  // 247: agentgateway.dev.resource.BackendPolicySpec.BackendHTTP.version:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendHTTP.HttpVersion
+	228, // 248: agentgateway.dev.resource.BackendPolicySpec.BackendHTTP.request_timeout:type_name -> google.protobuf.Duration
+	108, // 249: agentgateway.dev.resource.BackendPolicySpec.BackendTunnel.proxy:type_name -> agentgateway.dev.resource.BackendReference
+	96,  // 250: agentgateway.dev.resource.BackendPolicySpec.BackendTCP.keepalive:type_name -> agentgateway.dev.resource.KeepaliveConfig
+	228, // 251: agentgateway.dev.resource.BackendPolicySpec.BackendTCP.connect_timeout:type_name -> google.protobuf.Duration
+	35,  // 252: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.provider:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.McpIDP
+	206, // 253: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.resource_metadata:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata
+	36,  // 254: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.mode:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.Mode
+	98,  // 255: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.jwt_validation_options:type_name -> agentgateway.dev.resource.JWTValidationOptions
+	64,  // 256: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
+	209, // 257: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.processors:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor
+	187, // 258: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment.append:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Message
+	187, // 259: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment.prepend:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Message
 	27,  // 260: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRule.builtin:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.BuiltinRegexRule
 	28,  // 261: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules.action:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ActionKind
-	188, // 262: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules.rules:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRule
-	107, // 263: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.backend:type_name -> agentgateway.dev.resource.BackendReference
-	82,  // 264: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.forward_header_matches:type_name -> agentgateway.dev.resource.HeaderMatch
+	189, // 262: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules.rules:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRule
+	108, // 263: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.backend:type_name -> agentgateway.dev.resource.BackendReference
+	83,  // 264: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.forward_header_matches:type_name -> agentgateway.dev.resource.HeaderMatch
 	30,  // 265: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.failure_mode:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.FailureMode
-	99,  // 266: agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	107, // 267: agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation.backend_ref:type_name -> agentgateway.dev.resource.BackendReference
-	99,  // 268: agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	107, // 269: agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails.backend_ref:type_name -> agentgateway.dev.resource.BackendReference
-	99,  // 270: agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	107, // 271: agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor.backend_ref:type_name -> agentgateway.dev.resource.BackendReference
-	99,  // 272: agentgateway.dev.resource.BackendPolicySpec.Ai.AzureContentSafety.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	107, // 273: agentgateway.dev.resource.BackendPolicySpec.Ai.AzureContentSafety.backend_ref:type_name -> agentgateway.dev.resource.BackendReference
-	195, // 274: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.rejection:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestRejection
-	189, // 275: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.regex:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules
-	190, // 276: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.webhook:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook
-	193, // 277: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.google_model_armor:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor
-	192, // 278: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.bedrock_guardrails:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails
-	194, // 279: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.azure_content_safety:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.AzureContentSafety
-	195, // 280: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.rejection:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestRejection
-	189, // 281: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.regex:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules
-	190, // 282: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.webhook:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook
-	191, // 283: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.openai_moderation:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation
-	193, // 284: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.google_model_armor:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor
-	192, // 285: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.bedrock_guardrails:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails
-	194, // 286: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.azure_content_safety:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.AzureContentSafety
-	197, // 287: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.request:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard
-	196, // 288: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.response:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard
-	29,  // 289: agentgateway.dev.resource.BackendPolicySpec.Ai.RoutesEntry.value:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RouteType
-	206, // 290: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.extra:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntry
-	229, // 291: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntry.value:type_name -> google.protobuf.Value
-	107, // 292: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote.target:type_name -> agentgateway.dev.resource.BackendReference
-	37,  // 293: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote.failure_mode:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.FailureMode
-	209, // 294: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote.metadata:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote.MetadataEntry
-	207, // 295: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor.remote:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote
-	210, // 296: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor.methods:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor.MethodsEntry
-	36,  // 297: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor.MethodsEntry.value:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Phase
-	38,  // 298: agentgateway.dev.resource.AIBackend.Azure.resource_type:type_name -> agentgateway.dev.resource.AIBackend.AzureResourceType
-	39,  // 299: agentgateway.dev.resource.AIBackend.ProviderFormatConfig.format:type_name -> agentgateway.dev.resource.AIBackend.ProviderFormat
-	219, // 300: agentgateway.dev.resource.AIBackend.Custom.formats:type_name -> agentgateway.dev.resource.AIBackend.ProviderFormatConfig
-	211, // 301: agentgateway.dev.resource.AIBackend.Provider.host_override:type_name -> agentgateway.dev.resource.AIBackend.HostOverride
-	107, // 302: agentgateway.dev.resource.AIBackend.Provider.provider_backend:type_name -> agentgateway.dev.resource.BackendReference
-	212, // 303: agentgateway.dev.resource.AIBackend.Provider.openai:type_name -> agentgateway.dev.resource.AIBackend.OpenAI
-	213, // 304: agentgateway.dev.resource.AIBackend.Provider.gemini:type_name -> agentgateway.dev.resource.AIBackend.Gemini
-	214, // 305: agentgateway.dev.resource.AIBackend.Provider.vertex:type_name -> agentgateway.dev.resource.AIBackend.Vertex
-	215, // 306: agentgateway.dev.resource.AIBackend.Provider.anthropic:type_name -> agentgateway.dev.resource.AIBackend.Anthropic
-	216, // 307: agentgateway.dev.resource.AIBackend.Provider.bedrock:type_name -> agentgateway.dev.resource.AIBackend.Bedrock
-	217, // 308: agentgateway.dev.resource.AIBackend.Provider.azureopenai:type_name -> agentgateway.dev.resource.AIBackend.AzureOpenAI
-	218, // 309: agentgateway.dev.resource.AIBackend.Provider.azure:type_name -> agentgateway.dev.resource.AIBackend.Azure
-	220, // 310: agentgateway.dev.resource.AIBackend.Provider.custom:type_name -> agentgateway.dev.resource.AIBackend.Custom
-	99,  // 311: agentgateway.dev.resource.AIBackend.Provider.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	221, // 312: agentgateway.dev.resource.AIBackend.ProviderGroup.providers:type_name -> agentgateway.dev.resource.AIBackend.Provider
-	313, // [313:313] is the sub-list for method output_type
-	313, // [313:313] is the sub-list for method input_type
-	313, // [313:313] is the sub-list for extension type_name
-	313, // [313:313] is the sub-list for extension extendee
-	0,   // [0:313] is the sub-list for field type_name
+	100, // 266: agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	108, // 267: agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation.backend_ref:type_name -> agentgateway.dev.resource.BackendReference
+	100, // 268: agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	108, // 269: agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails.backend_ref:type_name -> agentgateway.dev.resource.BackendReference
+	100, // 270: agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	108, // 271: agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor.backend_ref:type_name -> agentgateway.dev.resource.BackendReference
+	100, // 272: agentgateway.dev.resource.BackendPolicySpec.Ai.AzureContentSafety.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	108, // 273: agentgateway.dev.resource.BackendPolicySpec.Ai.AzureContentSafety.backend_ref:type_name -> agentgateway.dev.resource.BackendReference
+	196, // 274: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.rejection:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestRejection
+	190, // 275: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.regex:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules
+	191, // 276: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.webhook:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook
+	194, // 277: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.google_model_armor:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor
+	193, // 278: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.bedrock_guardrails:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails
+	195, // 279: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.azure_content_safety:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.AzureContentSafety
+	196, // 280: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.rejection:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestRejection
+	190, // 281: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.regex:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules
+	191, // 282: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.webhook:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook
+	192, // 283: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.openai_moderation:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation
+	194, // 284: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.google_model_armor:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor
+	193, // 285: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.bedrock_guardrails:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails
+	195, // 286: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.azure_content_safety:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.AzureContentSafety
+	198, // 287: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.request:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard
+	197, // 288: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.response:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard
+	31,  // 289: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.streaming:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.Streaming
+	29,  // 290: agentgateway.dev.resource.BackendPolicySpec.Ai.RoutesEntry.value:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RouteType
+	207, // 291: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.extra:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntry
+	230, // 292: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntry.value:type_name -> google.protobuf.Value
+	108, // 293: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote.target:type_name -> agentgateway.dev.resource.BackendReference
+	38,  // 294: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote.failure_mode:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.FailureMode
+	210, // 295: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote.metadata:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote.MetadataEntry
+	208, // 296: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor.remote:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote
+	211, // 297: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor.methods:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor.MethodsEntry
+	37,  // 298: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor.MethodsEntry.value:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Phase
+	39,  // 299: agentgateway.dev.resource.AIBackend.Azure.resource_type:type_name -> agentgateway.dev.resource.AIBackend.AzureResourceType
+	40,  // 300: agentgateway.dev.resource.AIBackend.ProviderFormatConfig.format:type_name -> agentgateway.dev.resource.AIBackend.ProviderFormat
+	220, // 301: agentgateway.dev.resource.AIBackend.Custom.formats:type_name -> agentgateway.dev.resource.AIBackend.ProviderFormatConfig
+	212, // 302: agentgateway.dev.resource.AIBackend.Provider.host_override:type_name -> agentgateway.dev.resource.AIBackend.HostOverride
+	108, // 303: agentgateway.dev.resource.AIBackend.Provider.provider_backend:type_name -> agentgateway.dev.resource.BackendReference
+	213, // 304: agentgateway.dev.resource.AIBackend.Provider.openai:type_name -> agentgateway.dev.resource.AIBackend.OpenAI
+	214, // 305: agentgateway.dev.resource.AIBackend.Provider.gemini:type_name -> agentgateway.dev.resource.AIBackend.Gemini
+	215, // 306: agentgateway.dev.resource.AIBackend.Provider.vertex:type_name -> agentgateway.dev.resource.AIBackend.Vertex
+	216, // 307: agentgateway.dev.resource.AIBackend.Provider.anthropic:type_name -> agentgateway.dev.resource.AIBackend.Anthropic
+	217, // 308: agentgateway.dev.resource.AIBackend.Provider.bedrock:type_name -> agentgateway.dev.resource.AIBackend.Bedrock
+	218, // 309: agentgateway.dev.resource.AIBackend.Provider.azureopenai:type_name -> agentgateway.dev.resource.AIBackend.AzureOpenAI
+	219, // 310: agentgateway.dev.resource.AIBackend.Provider.azure:type_name -> agentgateway.dev.resource.AIBackend.Azure
+	221, // 311: agentgateway.dev.resource.AIBackend.Provider.custom:type_name -> agentgateway.dev.resource.AIBackend.Custom
+	100, // 312: agentgateway.dev.resource.AIBackend.Provider.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	222, // 313: agentgateway.dev.resource.AIBackend.ProviderGroup.providers:type_name -> agentgateway.dev.resource.AIBackend.Provider
+	314, // [314:314] is the sub-list for method output_type
+	314, // [314:314] is the sub-list for method input_type
+	314, // [314:314] is the sub-list for extension type_name
+	314, // [314:314] is the sub-list for extension extendee
+	0,   // [0:314] is the sub-list for field type_name
 }
 
 func init() { file_resource_proto_init() }
@@ -16478,7 +16540,7 @@ func file_resource_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_resource_proto_rawDesc), len(file_resource_proto_rawDesc)),
-			NumEnums:      44,
+			NumEnums:      45,
 			NumMessages:   180,
 			NumExtensions: 0,
 			NumServices:   0,

--- a/controller/api/v1alpha1/agentgateway/ai_policy.go
+++ b/controller/api/v1alpha1/agentgateway/ai_policy.go
@@ -102,7 +102,7 @@ type PromptGuardStreamingMode string
 
 const (
 	// Enable prompt guards for streaming responses and realtime websocket messages.
-	PromptGuardStreamingModeEnabled PromptGuardStreamingMode = "ENABLED"
+	PromptGuardStreamingModeEnabled PromptGuardStreamingMode = "Enabled"
 )
 
 // Regular expression matching for prompt guards and data masking.
@@ -302,7 +302,6 @@ type PromptguardResponse struct {
 type AIPromptGuard struct {
 	// Apply prompt guards to streaming responses and realtime websocket messages.
 	// Defaults to disabled to preserve streaming throughput unless explicitly enabled.
-	// +kubebuilder:validation:Enum=ENABLED
 	// +optional
 	Streaming PromptGuardStreamingMode `json:"streaming,omitempty"`
 

--- a/controller/api/v1alpha1/agentgateway/ai_policy.go
+++ b/controller/api/v1alpha1/agentgateway/ai_policy.go
@@ -96,6 +96,15 @@ const (
 	REJECT Action = "Reject"
 )
 
+// Streaming prompt guard mode.
+// +k8s:enum
+type PromptGuardStreamingMode string
+
+const (
+	// Enable prompt guards for streaming responses and realtime websocket messages.
+	PromptGuardStreamingModeEnabled PromptGuardStreamingMode = "ENABLED"
+)
+
 // Regular expression matching for prompt guards and data masking.
 type Regex struct {
 	// Regex patterns to match against the request or response.
@@ -289,8 +298,14 @@ type PromptguardResponse struct {
 //		    - CREDIT_CARD
 //		    action: MASK
 //
-// +kubebuilder:validation:AtLeastOneFieldSet
+// +kubebuilder:validation:AtLeastOneFieldSet:fields=request;response
 type AIPromptGuard struct {
+	// Apply prompt guards to streaming responses and realtime websocket messages.
+	// Defaults to disabled to preserve streaming throughput unless explicitly enabled.
+	// +kubebuilder:validation:Enum=ENABLED
+	// +optional
+	Streaming PromptGuardStreamingMode `json:"streaming,omitempty"`
+
 	// Prompt guards to apply to requests sent by the client.
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=8

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
@@ -4813,7 +4813,7 @@ spec:
                                               Apply prompt guards to streaming responses and realtime websocket messages.
                                               Defaults to disabled to preserve streaming throughput unless explicitly enabled.
                                             enum:
-                                            - ENABLED
+                                            - Enabled
                                             type: string
                                         type: object
                                         x-kubernetes-validations:
@@ -11117,7 +11117,7 @@ spec:
                               Apply prompt guards to streaming responses and realtime websocket messages.
                               Defaults to disabled to preserve streaming throughput unless explicitly enabled.
                             enum:
-                            - ENABLED
+                            - Enabled
                             type: string
                         type: object
                         x-kubernetes-validations:

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
@@ -4808,6 +4808,13 @@ spec:
                                             maxItems: 8
                                             minItems: 1
                                             type: array
+                                          streaming:
+                                            description: |-
+                                              Apply prompt guards to streaming responses and realtime websocket messages.
+                                              Defaults to disabled to preserve streaming throughput unless explicitly enabled.
+                                            enum:
+                                            - ENABLED
+                                            type: string
                                         type: object
                                         x-kubernetes-validations:
                                         - message: at least one of the fields in [request
@@ -11105,6 +11112,13 @@ spec:
                             maxItems: 8
                             minItems: 1
                             type: array
+                          streaming:
+                            description: |-
+                              Apply prompt guards to streaming responses and realtime websocket messages.
+                              Defaults to disabled to preserve streaming throughput unless explicitly enabled.
+                            enum:
+                            - ENABLED
+                            type: string
                         type: object
                         x-kubernetes-validations:
                         - message: at least one of the fields in [request response]

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
@@ -4053,7 +4053,7 @@ spec:
                               Apply prompt guards to streaming responses and realtime websocket messages.
                               Defaults to disabled to preserve streaming throughput unless explicitly enabled.
                             enum:
-                            - ENABLED
+                            - Enabled
                             type: string
                         type: object
                         x-kubernetes-validations:

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
@@ -4048,6 +4048,13 @@ spec:
                             maxItems: 8
                             minItems: 1
                             type: array
+                          streaming:
+                            description: |-
+                              Apply prompt guards to streaming responses and realtime websocket messages.
+                              Defaults to disabled to preserve streaming throughput unless explicitly enabled.
+                            enum:
+                            - ENABLED
+                            type: string
                         type: object
                         x-kubernetes-validations:
                         - message: at least one of the fields in [request response]

--- a/controller/pkg/agentgateway/plugins/backend_policies.go
+++ b/controller/pkg/agentgateway/plugins/backend_policies.go
@@ -746,6 +746,9 @@ func translateBackendAI(ctx PolicyCtx, agwPolicy *agentgateway.AgentgatewayPolic
 		if translatedAIPolicy.PromptGuard == nil {
 			translatedAIPolicy.PromptGuard = &api.BackendPolicySpec_Ai_PromptGuard{}
 		}
+		if aiSpec.PromptGuard.Streaming == agentgateway.PromptGuardStreamingModeEnabled {
+			translatedAIPolicy.PromptGuard.Streaming = api.BackendPolicySpec_Ai_PromptGuard_ENABLED
+		}
 		if aiSpec.PromptGuard.Request != nil {
 			r, err := processRequestGuard(ctx, agwPolicy.Namespace, aiSpec.PromptGuard.Request)
 			if err != nil {

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -1615,7 +1615,8 @@ impl AIProvider {
 		// SSE output, not raw upstream bytes. Applying them before translation silently
 		// breaks Bedrock (AWS Event Stream is binary, not SSE) and any provider whose
 		// wire format differs from SSE. Detect paths are raw pass-throughs; skip them.
-		let evaluators = if !response_policies.prompt_guard.is_empty()
+		let evaluators = if response_policies.streaming_prompt_guard_enabled
+			&& !response_policies.prompt_guard.is_empty()
 			&& !matches!(input_format, InputFormat::Detect)
 		{
 			use policy::PromptGuard;

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -40,6 +40,7 @@ pub mod cost;
 pub mod policy;
 mod types;
 
+use policy::streaming_guardrails::GuardedSseBody;
 pub use types::SimpleChatCompletionMessage;
 
 use crate::cel::{Executor, LLMContext, RequestSnapshot};
@@ -1779,7 +1780,6 @@ impl AIProvider {
 		};
 
 		if !evaluators.is_empty() {
-			use policy::streaming_guardrails::GuardedSseBody;
 			// `logger` is owned by the translated body; pass None to avoid double-logging.
 			return Ok(translated.map(|b| GuardedSseBody::new(b, evaluators, buffer, None)));
 		}

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -1620,6 +1620,7 @@ impl AIProvider {
 		{
 			use policy::PromptGuard;
 			let temp_guard = PromptGuard {
+				streaming: policy::PromptGuardStreamingMode::Enabled,
 				request: vec![],
 				response: response_policies.prompt_guard.clone(),
 			};

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -1153,6 +1153,7 @@ impl AIProvider {
 		if req.streaming && resp.status().is_success() {
 			return self
 				.process_streaming(
+					client,
 					req,
 					rate_limit,
 					req_snapshot,
@@ -1559,8 +1560,9 @@ impl AIProvider {
 	#[allow(clippy::too_many_arguments)]
 	pub async fn process_streaming(
 		&self,
+		client: PolicyClient,
 		req: LLMRequest,
-		rate_limit: LLMResponsePolicies,
+		response_policies: LLMResponsePolicies,
 		req_snapshot: Option<Arc<RequestSnapshot>>,
 		log: AsyncLog<llm::LLMInfo>,
 		include_completion_in_log: bool,
@@ -1594,6 +1596,13 @@ impl AIProvider {
 			parts.headers.remove(header::CONTENT_LENGTH);
 			parts.headers.remove(header::TRANSFER_ENCODING);
 		}
+
+		// Build headers for guardrail evaluation (same as buffered path).
+		let prompt_guard_headers = response_prompt_guard_headers(
+			&parts.headers,
+			response_policies.request_traceparent.as_ref(),
+		);
+
 		let resp = Response::from_parts(parts, body);
 		let resp = if matches!(input_format, InputFormat::Detect) {
 			resp
@@ -1601,7 +1610,24 @@ impl AIProvider {
 			normalize_sse_response_headers(resp)
 		};
 
-		let logger = AmendOnDrop::new(log, rate_limit, req_snapshot, model_catalog);
+		// Build evaluators before format translation so guardrails run against translated
+		// SSE output, not raw upstream bytes. Applying them before translation silently
+		// breaks Bedrock (AWS Event Stream is binary, not SSE) and any provider whose
+		// wire format differs from SSE. Detect paths are raw pass-throughs; skip them.
+		let evaluators = if !response_policies.prompt_guard.is_empty()
+			&& !matches!(input_format, InputFormat::Detect)
+		{
+			use policy::PromptGuard;
+			let temp_guard = PromptGuard {
+				request: vec![],
+				response: response_policies.prompt_guard.clone(),
+			};
+			temp_guard.begin_streaming_response_guard(&client, &prompt_guard_headers)
+		} else {
+			vec![]
+		};
+
+		let logger = AmendOnDrop::new(log, response_policies, req_snapshot, model_catalog);
 		let stream_format = match self {
 			AIProvider::Bedrock(_) => "awsEventStream",
 			_ => "sseJson",
@@ -1614,7 +1640,7 @@ impl AIProvider {
 				stream_format.to_string(),
 			)
 		});
-		Ok(match (self, input_format, native_format) {
+		let translated = match (self, input_format, native_format) {
 			(
 				AIProvider::Custom(_),
 				InputFormat::Completions,
@@ -1750,7 +1776,14 @@ impl AIProvider {
 					"custom provider cannot translate {native:?} stream to {input:?}"
 				)));
 			},
-		})
+		};
+
+		if !evaluators.is_empty() {
+			use policy::streaming_guardrails::GuardedSseBody;
+			// `logger` is owned by the translated body; pass None to avoid double-logging.
+			return Ok(translated.map(|b| GuardedSseBody::new(b, evaluators, buffer, None)));
+		}
+		Ok(translated)
 	}
 
 	async fn read_body_and_default_model<T: RequestType + DeserializeOwned>(

--- a/crates/agentgateway/src/llm/policy/mod.rs
+++ b/crates/agentgateway/src/llm/policy/mod.rs
@@ -1,5 +1,6 @@
 use ::http::HeaderMap;
 use bytes::Bytes;
+use http_body_util::BodyExt as _;
 use itertools::Itertools;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -274,8 +275,41 @@ pub trait StreamingEvaluator: Send {
 
 /// Outcome returned by a `StreamingEvaluator`.
 pub enum StreamingGuardrailOutcome {
-	/// Content was blocked; include the human-readable reason if available.
-	Blocked(String),
+	/// Content was blocked; include the rejection body to encode for the stream.
+	Blocked(Bytes),
+}
+
+struct TextResponse {
+	content: String,
+}
+
+impl crate::llm::ResponseType for TextResponse {
+	fn to_llm_response(&self, include_completion_in_log: bool) -> crate::llm::LLMResponse {
+		crate::llm::LLMResponse {
+			completion: include_completion_in_log.then(|| vec![self.content.clone()]),
+			..Default::default()
+		}
+	}
+
+	fn to_webhook_choices(&self) -> Vec<webhook::ResponseChoice> {
+		vec![webhook::ResponseChoice {
+			message: crate::llm::SimpleChatCompletionMessage {
+				role: "assistant".into(),
+				content: self.content.clone().into(),
+			},
+		}]
+	}
+
+	fn set_webhook_choices(&mut self, resp: Vec<webhook::ResponseChoice>) -> anyhow::Result<()> {
+		if let Some(choice) = resp.into_iter().next() {
+			self.content = choice.message.content.to_string();
+		}
+		Ok(())
+	}
+
+	fn serialize(&self) -> serde_json::Result<Vec<u8>> {
+		serde_json::to_vec(&self.to_webhook_choices())
+	}
 }
 
 /// Adapter that wraps plain text extracted from a realtime WebSocket event as a `RequestType`.
@@ -326,26 +360,32 @@ impl crate::llm::RequestType for TextRequest {
 impl PromptGuard {
 	/// Apply request guards to a plain-text string extracted from a realtime WebSocket frame.
 	///
-	/// Returns `true` if the content should be blocked. Masking outcomes are treated as pass
-	/// because the realtime path cannot rewrite WebSocket frames in place.
+	/// Returns the rejection body if the content should be blocked. Masking outcomes are
+	/// treated as pass because the realtime path cannot rewrite WebSocket frames in place.
 	pub async fn apply_realtime_request_guards(
 		&self,
 		text: &str,
 		client: &crate::proxy::httpproxy::PolicyClient,
-	) -> bool {
+	) -> Option<Bytes> {
 		let headers = ::http::HeaderMap::new();
 		let mut req = TextRequest {
 			content: text.to_string(),
 		};
 		for g in &self.request {
 			match Policy::apply_single_request_guard(g, &mut req, &headers, client, None).await {
-				Ok(GuardrailOutcome::Rejected(_)) => {
+				Ok(GuardrailOutcome::Rejected(rejected)) => {
 					Policy::record_guardrail_trip(
 						client,
 						crate::telemetry::metrics::GuardrailPhase::Request,
 						crate::telemetry::metrics::GuardrailAction::Reject,
 					);
-					return true;
+					let body = rejected
+						.into_body()
+						.collect()
+						.await
+						.map(|b| b.to_bytes())
+						.unwrap_or_else(|_| g.rejection.body.clone());
+					return Some(body);
 				},
 				// Masking is not supported in the realtime path; treat as pass but still record.
 				Ok(GuardrailOutcome::Masked) => {
@@ -370,7 +410,7 @@ impl PromptGuard {
 							crate::telemetry::metrics::GuardrailPhase::Request,
 							crate::telemetry::metrics::GuardrailAction::Reject,
 						);
-						return true;
+						return Some(g.rejection.body.clone());
 					},
 					FailureMode::FailOpen => {
 						tracing::warn!("request guard error in realtime path, failing open: {e}");
@@ -383,7 +423,7 @@ impl PromptGuard {
 				},
 			}
 		}
-		false
+		None
 	}
 
 	/// Returns `true` if there is at least one response guard configured.
@@ -405,6 +445,34 @@ impl PromptGuard {
 			.iter()
 			.map(|g| streaming_guardrails::make_evaluator(g, client.clone(), http_headers.clone()))
 			.collect()
+	}
+
+	pub async fn evaluate_streaming_response_window(
+		guard: &ResponseGuard,
+		window: &str,
+		client: &crate::proxy::httpproxy::PolicyClient,
+		http_headers: &HeaderMap,
+	) -> anyhow::Result<Option<StreamingGuardrailOutcome>> {
+		if window.is_empty() {
+			return Ok(None);
+		}
+		let mut resp = TextResponse {
+			content: window.to_string(),
+		};
+		match Policy::apply_single_response_guard(guard, &mut resp, http_headers, client).await? {
+			GuardrailOutcome::Rejected(rejected) => {
+				let body = rejected.into_body().collect().await?.to_bytes();
+				Ok(Some(StreamingGuardrailOutcome::Blocked(body)))
+			},
+			GuardrailOutcome::Masked => {
+				debug_assert!(
+					false,
+					"streaming response guard unexpectedly returned Masked; streaming masking is not supported"
+				);
+				Ok(None)
+			},
+			GuardrailOutcome::None => Ok(None),
+		}
 	}
 }
 
@@ -1185,108 +1253,68 @@ impl Policy {
 		guards: &Vec<ResponseGuard>,
 	) -> anyhow::Result<Option<Response>> {
 		for g in guards {
-			match &g.kind {
-				ResponseGuardKind::Regex(rg) => match Self::apply_regex_response(resp, rg, &g.rejection)? {
-					GuardrailOutcome::Rejected(res) => {
-						Self::record_guardrail_trip(
-							client,
-							crate::telemetry::metrics::GuardrailPhase::Response,
-							crate::telemetry::metrics::GuardrailAction::Reject,
-						);
-						return Ok(Some(res));
-					},
-					GuardrailOutcome::Masked => {
-						Self::record_guardrail_trip(
-							client,
-							crate::telemetry::metrics::GuardrailPhase::Response,
-							crate::telemetry::metrics::GuardrailAction::Mask,
-						);
-					},
-					GuardrailOutcome::None => {
-						Self::record_guardrail_trip(
-							client,
-							crate::telemetry::metrics::GuardrailPhase::Response,
-							crate::telemetry::metrics::GuardrailAction::Allow,
-						);
-					},
+			match Self::apply_single_response_guard(g, resp, http_headers, client).await? {
+				GuardrailOutcome::Rejected(res) => {
+					Self::record_guardrail_trip(
+						client,
+						crate::telemetry::metrics::GuardrailPhase::Response,
+						crate::telemetry::metrics::GuardrailAction::Reject,
+					);
+					return Ok(Some(res));
 				},
-				ResponseGuardKind::Webhook(wh) => {
-					if let Some(res) = Self::apply_webhook_response(resp, http_headers, client, wh).await? {
-						Self::record_guardrail_trip(
-							client,
-							crate::telemetry::metrics::GuardrailPhase::Response,
-							crate::telemetry::metrics::GuardrailAction::Reject,
-						);
-						return Ok(Some(res));
-					}
+				GuardrailOutcome::Masked => {
+					Self::record_guardrail_trip(
+						client,
+						crate::telemetry::metrics::GuardrailPhase::Response,
+						crate::telemetry::metrics::GuardrailAction::Mask,
+					);
 				},
-				ResponseGuardKind::BedrockGuardrails(bg) => {
-					match Self::apply_bedrock_guardrails_response(resp, None, client, &g.rejection, bg)
-						.await?
-					{
-						GuardrailOutcome::Rejected(res) => {
-							Self::record_guardrail_trip(
-								client,
-								crate::telemetry::metrics::GuardrailPhase::Response,
-								crate::telemetry::metrics::GuardrailAction::Reject,
-							);
-							return Ok(Some(res));
-						},
-						GuardrailOutcome::Masked => {
-							Self::record_guardrail_trip(
-								client,
-								crate::telemetry::metrics::GuardrailPhase::Response,
-								crate::telemetry::metrics::GuardrailAction::Mask,
-							);
-						},
-						GuardrailOutcome::None => {
-							Self::record_guardrail_trip(
-								client,
-								crate::telemetry::metrics::GuardrailPhase::Response,
-								crate::telemetry::metrics::GuardrailAction::Allow,
-							);
-						},
-					}
-				},
-				ResponseGuardKind::GoogleModelArmor(gma) => {
-					if let Some(res) =
-						Self::apply_google_model_armor_response(resp, None, client, &g.rejection, gma).await?
-					{
-						Self::record_guardrail_trip(
-							client,
-							crate::telemetry::metrics::GuardrailPhase::Response,
-							crate::telemetry::metrics::GuardrailAction::Reject,
-						);
-						return Ok(Some(res));
-					} else {
-						Self::record_guardrail_trip(
-							client,
-							crate::telemetry::metrics::GuardrailPhase::Response,
-							crate::telemetry::metrics::GuardrailAction::Allow,
-						);
-					}
-				},
-				ResponseGuardKind::AzureContentSafety(acs) => {
-					if let Some(res) =
-						Self::apply_azure_content_safety_response(resp, None, client, &g.rejection, acs).await?
-					{
-						Self::record_guardrail_trip(
-							client,
-							crate::telemetry::metrics::GuardrailPhase::Response,
-							crate::telemetry::metrics::GuardrailAction::Reject,
-						);
-						return Ok(Some(res));
-					} else {
-						Self::record_guardrail_trip(
-							client,
-							crate::telemetry::metrics::GuardrailPhase::Response,
-							crate::telemetry::metrics::GuardrailAction::Allow,
-						);
-					}
+				GuardrailOutcome::None => {
+					Self::record_guardrail_trip(
+						client,
+						crate::telemetry::metrics::GuardrailPhase::Response,
+						crate::telemetry::metrics::GuardrailAction::Allow,
+					);
 				},
 			}
 		}
 		Ok(None)
+	}
+
+	async fn apply_single_response_guard(
+		guard: &ResponseGuard,
+		resp: &mut dyn ResponseType,
+		http_headers: &HeaderMap,
+		client: &PolicyClient,
+	) -> anyhow::Result<GuardrailOutcome> {
+		match &guard.kind {
+			ResponseGuardKind::Regex(rg) => Self::apply_regex_response(resp, rg, &guard.rejection),
+			ResponseGuardKind::Webhook(wh) => {
+				match Self::apply_webhook_response(resp, http_headers, client, wh).await? {
+					Some(res) => Ok(GuardrailOutcome::Rejected(res)),
+					None => Ok(GuardrailOutcome::None),
+				}
+			},
+			ResponseGuardKind::BedrockGuardrails(bg) => {
+				Self::apply_bedrock_guardrails_response(resp, None, client, &guard.rejection, bg).await
+			},
+			ResponseGuardKind::GoogleModelArmor(gma) => {
+				match Self::apply_google_model_armor_response(resp, None, client, &guard.rejection, gma)
+					.await?
+				{
+					Some(res) => Ok(GuardrailOutcome::Rejected(res)),
+					None => Ok(GuardrailOutcome::None),
+				}
+			},
+			ResponseGuardKind::AzureContentSafety(acs) => {
+				match Self::apply_azure_content_safety_response(resp, None, client, &guard.rejection, acs)
+					.await?
+				{
+					Some(res) => Ok(GuardrailOutcome::Rejected(res)),
+					None => Ok(GuardrailOutcome::None),
+				}
+			},
+		}
 	}
 }
 

--- a/crates/agentgateway/src/llm/policy/mod.rs
+++ b/crates/agentgateway/src/llm/policy/mod.rs
@@ -23,6 +23,7 @@ mod bedrock_guardrails;
 mod google_model_armor;
 mod moderation;
 mod pii;
+pub mod streaming_guardrails;
 #[cfg(test)]
 #[path = "tests.rs"]
 mod tests;
@@ -248,6 +249,176 @@ enum GuardrailOutcome {
 	Rejected(Response),
 }
 
+/// A streaming guardrail evaluator. Each guard kind gets one stateless implementation
+/// that evaluates a text window and reports whether it should be blocked.
+///
+/// Batching and overlap are owned by the driver (`GuardedSseBody` for SSE,
+/// `guarded_realtime_proxy` for WebSockets): the driver accumulates text until an
+/// evaluation threshold is reached, prepends an overlap tail from previously
+/// evaluated text (so patterns spanning a batch boundary are still seen
+/// contiguously), and calls `evaluate` with the combined window.
+///
+/// The trait is object-safe and `Send` so it can be boxed and driven from the
+/// `GuardedSseBody` future.
+#[async_trait::async_trait]
+pub trait StreamingEvaluator: Send {
+	/// Evaluate a text window. Returns `Some(Blocked)` if the content should be blocked.
+	async fn evaluate(&mut self, window: &str) -> anyhow::Result<Option<StreamingGuardrailOutcome>>;
+
+	/// Returns the failure mode to apply when `evaluate` returns an error.
+	/// Guard types without an explicit `failure_mode` field default to `FailOpen`.
+	fn failure_mode(&self) -> FailureMode {
+		FailureMode::FailOpen
+	}
+}
+
+/// Outcome returned by a `StreamingEvaluator`.
+pub enum StreamingGuardrailOutcome {
+	/// Content was blocked; include the human-readable reason if available.
+	Blocked(String),
+}
+
+/// Adapter that wraps plain text extracted from a realtime WebSocket event as a `RequestType`.
+///
+/// The OpenAI Realtime API uses structured events (`conversation.item.create`, etc.) with typed
+/// content. The proxy extracts text from those events before calling request guards, so by the
+/// time guards run there is a plain `&str` rather than a full request object. This adapter wraps
+/// that string to satisfy the `&mut dyn RequestType` interface that all guard implementations
+/// expect.
+struct TextRequest {
+	content: String,
+}
+
+impl crate::llm::RequestType for TextRequest {
+	fn supports_model(&self) -> bool {
+		false
+	}
+
+	fn model(&mut self) -> &mut Option<String> {
+		unimplemented!("TextRequest does not support model")
+	}
+
+	fn prepend_prompts(&mut self, _: Vec<crate::llm::SimpleChatCompletionMessage>) {}
+	fn append_prompts(&mut self, _: Vec<crate::llm::SimpleChatCompletionMessage>) {}
+
+	fn to_llm_request(
+		&self,
+		_: agent_core::prelude::Strng,
+		_: bool,
+	) -> Result<crate::llm::LLMRequest, crate::llm::AIError> {
+		unimplemented!("TextRequest does not support to_llm_request")
+	}
+
+	fn get_messages(&self) -> Vec<crate::llm::SimpleChatCompletionMessage> {
+		vec![crate::llm::SimpleChatCompletionMessage {
+			role: "user".into(),
+			content: self.content.clone().into(),
+		}]
+	}
+
+	fn set_messages(&mut self, msgs: Vec<crate::llm::SimpleChatCompletionMessage>) {
+		if let Some(m) = msgs.into_iter().next() {
+			self.content = m.content.to_string();
+		}
+	}
+}
+
+impl PromptGuard {
+	/// Apply request guards to a plain-text string extracted from a realtime WebSocket frame.
+	///
+	/// Returns `true` if the content should be blocked. Masking outcomes are treated as pass
+	/// because the realtime path cannot rewrite WebSocket frames in place.
+	pub async fn apply_realtime_request_guards(
+		&self,
+		text: &str,
+		client: &crate::proxy::httpproxy::PolicyClient,
+	) -> bool {
+		let headers = ::http::HeaderMap::new();
+		let mut req = TextRequest {
+			content: text.to_string(),
+		};
+		for g in &self.request {
+			match Policy::apply_single_request_guard(g, &mut req, &headers, client, None).await {
+				Ok(GuardrailOutcome::Rejected(_)) => {
+					Policy::record_guardrail_trip(
+						client,
+						crate::telemetry::metrics::GuardrailPhase::Request,
+						crate::telemetry::metrics::GuardrailAction::Reject,
+					);
+					return true;
+				},
+				// Masking is not supported in the realtime path; treat as pass but still record.
+				Ok(GuardrailOutcome::Masked) => {
+					Policy::record_guardrail_trip(
+						client,
+						crate::telemetry::metrics::GuardrailPhase::Request,
+						crate::telemetry::metrics::GuardrailAction::Mask,
+					);
+				},
+				Ok(GuardrailOutcome::None) => {
+					Policy::record_guardrail_trip(
+						client,
+						crate::telemetry::metrics::GuardrailPhase::Request,
+						crate::telemetry::metrics::GuardrailAction::Allow,
+					);
+				},
+				Err(e) => match g.failure_mode() {
+					FailureMode::FailClosed => {
+						tracing::warn!("request guard error in realtime path, failing closed: {e}");
+						Policy::record_guardrail_trip(
+							client,
+							crate::telemetry::metrics::GuardrailPhase::Request,
+							crate::telemetry::metrics::GuardrailAction::Reject,
+						);
+						return true;
+					},
+					FailureMode::FailOpen => {
+						tracing::warn!("request guard error in realtime path, failing open: {e}");
+						Policy::record_guardrail_trip(
+							client,
+							crate::telemetry::metrics::GuardrailPhase::Request,
+							crate::telemetry::metrics::GuardrailAction::FailOpen,
+						);
+					},
+				},
+			}
+		}
+		false
+	}
+
+	/// Returns `true` if there is at least one response guard configured.
+	pub fn has_response_guards(&self) -> bool {
+		!self.response.is_empty()
+	}
+
+	/// Build one `StreamingEvaluator` per configured response guard.
+	///
+	/// Each evaluator is a stateless wrapper around the existing non-streaming
+	/// response-guard logic; the caller drives windowed batching.
+	pub fn begin_streaming_response_guard(
+		&self,
+		client: &crate::proxy::httpproxy::PolicyClient,
+		http_headers: &HeaderMap,
+	) -> Vec<Box<dyn StreamingEvaluator>> {
+		self
+			.response
+			.iter()
+			.map(|g| streaming_guardrails::make_evaluator(g, client.clone(), http_headers.clone()))
+			.collect()
+	}
+}
+
+impl Policy {
+	/// Returns `true` if any prompt guard has response guards that require streaming evaluation.
+	pub fn has_streaming_response_guards(&self) -> bool {
+		self
+			.prompt_guard
+			.as_ref()
+			.map(|g| g.has_response_guards())
+			.unwrap_or(false)
+	}
+}
+
 impl Policy {
 	pub fn compile_model_alias_patterns(&mut self) {
 		let mut patterns = Vec::new();
@@ -395,139 +566,89 @@ impl Policy {
 			.iter()
 			.flat_map(|g| g.request.iter())
 		{
-			match &g.kind {
-				RequestGuardKind::Regex(rg) => match Self::apply_regex(req, rg, &g.rejection)? {
-					GuardrailOutcome::Rejected(res) => {
-						Self::record_guardrail_trip(
-							&client,
-							crate::telemetry::metrics::GuardrailPhase::Request,
-							crate::telemetry::metrics::GuardrailAction::Reject,
-						);
-						return Ok(Some(res));
-					},
-					GuardrailOutcome::Masked => {
-						Self::record_guardrail_trip(
-							&client,
-							crate::telemetry::metrics::GuardrailPhase::Request,
-							crate::telemetry::metrics::GuardrailAction::Mask,
-						);
-					},
-					GuardrailOutcome::None => {
-						Self::record_guardrail_trip(
-							&client,
-							crate::telemetry::metrics::GuardrailPhase::Request,
-							crate::telemetry::metrics::GuardrailAction::Allow,
-						);
-					},
-				},
-				RequestGuardKind::Webhook(wh) => {
-					if let Some(res) = Self::apply_webhook(req, http_headers, &client, wh).await? {
-						Self::record_guardrail_trip(
-							&client,
-							crate::telemetry::metrics::GuardrailPhase::Request,
-							crate::telemetry::metrics::GuardrailAction::Reject,
-						);
-						return Ok(Some(res));
-					}
-				},
-				RequestGuardKind::OpenAIModeration(m) => {
-					if let Some(res) =
-						Self::apply_moderation(req, claims.clone(), &client, &g.rejection, m).await?
-					{
-						Self::record_guardrail_trip(
-							&client,
-							crate::telemetry::metrics::GuardrailPhase::Request,
-							crate::telemetry::metrics::GuardrailAction::Reject,
-						);
-						return Ok(Some(res));
-					} else {
-						Self::record_guardrail_trip(
-							&client,
-							crate::telemetry::metrics::GuardrailPhase::Request,
-							crate::telemetry::metrics::GuardrailAction::Allow,
-						);
-					}
-				},
-				RequestGuardKind::BedrockGuardrails(bg) => {
-					match Self::apply_bedrock_guardrails_request(
-						req,
-						claims.clone(),
+			match Self::apply_single_request_guard(g, req, http_headers, &client, claims.clone()).await? {
+				GuardrailOutcome::Rejected(res) => {
+					Self::record_guardrail_trip(
 						&client,
-						&g.rejection,
-						bg,
-					)
-					.await?
-					{
-						GuardrailOutcome::Rejected(res) => {
-							Self::record_guardrail_trip(
-								&client,
-								crate::telemetry::metrics::GuardrailPhase::Request,
-								crate::telemetry::metrics::GuardrailAction::Reject,
-							);
-							return Ok(Some(res));
-						},
-						GuardrailOutcome::Masked => {
-							Self::record_guardrail_trip(
-								&client,
-								crate::telemetry::metrics::GuardrailPhase::Request,
-								crate::telemetry::metrics::GuardrailAction::Mask,
-							);
-						},
-						GuardrailOutcome::None => {
-							Self::record_guardrail_trip(
-								&client,
-								crate::telemetry::metrics::GuardrailPhase::Request,
-								crate::telemetry::metrics::GuardrailAction::Allow,
-							);
-						},
-					}
+						crate::telemetry::metrics::GuardrailPhase::Request,
+						crate::telemetry::metrics::GuardrailAction::Reject,
+					);
+					return Ok(Some(res));
 				},
-				RequestGuardKind::GoogleModelArmor(gma) => {
-					if let Some(res) =
-						Self::apply_google_model_armor_request(req, claims.clone(), &client, &g.rejection, gma)
-							.await?
-					{
-						Self::record_guardrail_trip(
-							&client,
-							crate::telemetry::metrics::GuardrailPhase::Request,
-							crate::telemetry::metrics::GuardrailAction::Reject,
-						);
-						return Ok(Some(res));
-					} else {
-						Self::record_guardrail_trip(
-							&client,
-							crate::telemetry::metrics::GuardrailPhase::Request,
-							crate::telemetry::metrics::GuardrailAction::Allow,
-						);
-					}
-				},
-				RequestGuardKind::AzureContentSafety(acs) => {
-					if let Some(res) = Self::apply_azure_content_safety_request(
-						req,
-						claims.clone(),
+				GuardrailOutcome::Masked => {
+					Self::record_guardrail_trip(
 						&client,
-						&g.rejection,
-						acs,
-					)
-					.await?
-					{
-						Self::record_guardrail_trip(
-							&client,
-							crate::telemetry::metrics::GuardrailPhase::Request,
-							crate::telemetry::metrics::GuardrailAction::Reject,
-						);
-						return Ok(Some(res));
-					} else {
-						Self::record_guardrail_trip(
-							&client,
-							crate::telemetry::metrics::GuardrailPhase::Request,
-							crate::telemetry::metrics::GuardrailAction::Allow,
-						);
-					}
+						crate::telemetry::metrics::GuardrailPhase::Request,
+						crate::telemetry::metrics::GuardrailAction::Mask,
+					);
+				},
+				GuardrailOutcome::None => {
+					Self::record_guardrail_trip(
+						&client,
+						crate::telemetry::metrics::GuardrailPhase::Request,
+						crate::telemetry::metrics::GuardrailAction::Allow,
+					);
 				},
 			}
 		}
 		Ok(None)
+	}
+
+	/// Evaluate a single request guard against `req` and return the outcome.
+	///
+	/// Callers are responsible for recording metrics and acting on the result.
+	/// This is the single place where every `RequestGuardKind` is dispatched,
+	/// so both the HTTP request path (`apply_prompt_guard`) and the realtime
+	/// WebSocket path (`apply_realtime_request_guards`) stay in sync.
+	async fn apply_single_request_guard(
+		guard: &RequestGuard,
+		req: &mut dyn RequestType,
+		http_headers: &HeaderMap,
+		client: &PolicyClient,
+		claims: Option<Claims>,
+	) -> anyhow::Result<GuardrailOutcome> {
+		match &guard.kind {
+			RequestGuardKind::Regex(rg) => Self::apply_regex(req, rg, &guard.rejection),
+			RequestGuardKind::Webhook(wh) => Self::apply_webhook(req, http_headers, client, wh).await,
+			RequestGuardKind::OpenAIModeration(m) => {
+				match Self::apply_moderation(req, claims.clone(), client, &guard.rejection, m).await? {
+					Some(res) => Ok(GuardrailOutcome::Rejected(res)),
+					None => Ok(GuardrailOutcome::None),
+				}
+			},
+			RequestGuardKind::BedrockGuardrails(bg) => {
+				Self::apply_bedrock_guardrails_request(req, claims.clone(), client, &guard.rejection, bg)
+					.await
+			},
+			RequestGuardKind::GoogleModelArmor(gma) => {
+				match Self::apply_google_model_armor_request(
+					req,
+					claims.clone(),
+					client,
+					&guard.rejection,
+					gma,
+				)
+				.await?
+				{
+					Some(res) => Ok(GuardrailOutcome::Rejected(res)),
+					None => Ok(GuardrailOutcome::None),
+				}
+			},
+			RequestGuardKind::AzureContentSafety(acs) => {
+				match Self::apply_azure_content_safety_request(
+					req,
+					claims.clone(),
+					client,
+					&guard.rejection,
+					acs,
+				)
+				.await?
+				{
+					Some(res) => Ok(GuardrailOutcome::Rejected(res)),
+					None => Ok(GuardrailOutcome::None),
+				}
+			},
+		}
 	}
 
 	async fn apply_moderation(
@@ -774,7 +895,7 @@ impl Policy {
 		http_headers: &HeaderMap,
 		client: &PolicyClient,
 		webhook: &Webhook,
-	) -> anyhow::Result<Option<Response>> {
+	) -> anyhow::Result<GuardrailOutcome> {
 		let messsages = req.get_messages();
 		let headers = Self::get_webhook_forward_headers(http_headers, &webhook.forward_header_matches);
 		let whr = match webhook::send_request(client, &webhook.target, &headers, messsages).await {
@@ -788,7 +909,7 @@ impl Policy {
 							crate::telemetry::metrics::GuardrailPhase::Request,
 							crate::telemetry::metrics::GuardrailAction::FailOpen,
 						);
-						Ok(None)
+						Ok(GuardrailOutcome::None)
 					},
 					FailureMode::FailClosed => Err(e),
 				};
@@ -805,13 +926,8 @@ impl Policy {
 				let MaskActionBody::PromptMessages(body) = mask.body else {
 					anyhow::bail!("invalid webhook response");
 				};
-				let msgs = body.messages;
-				req.set_messages(msgs);
-				Self::record_guardrail_trip(
-					client,
-					crate::telemetry::metrics::GuardrailPhase::Request,
-					crate::telemetry::metrics::GuardrailAction::Mask,
-				);
+				req.set_messages(body.messages);
+				Ok(GuardrailOutcome::Masked)
 			},
 			RequestAction::Reject(rej) => {
 				debug!(
@@ -820,11 +936,11 @@ impl Policy {
 						.reason
 						.unwrap_or_else(|| "no reason specified".to_string())
 				);
-				return Ok(Some(
+				Ok(GuardrailOutcome::Rejected(
 					::http::response::Builder::new()
 						.status(rej.status_code)
 						.body(http::Body::from(rej.body))?,
-				));
+				))
 			},
 			RequestAction::Pass(pass) => {
 				debug!(
@@ -833,14 +949,9 @@ impl Policy {
 						.reason
 						.unwrap_or_else(|| "no reason specified".to_string())
 				);
-				Self::record_guardrail_trip(
-					client,
-					crate::telemetry::metrics::GuardrailPhase::Request,
-					crate::telemetry::metrics::GuardrailAction::Allow,
-				);
+				Ok(GuardrailOutcome::None)
 			},
 		}
-		Ok(None)
 	}
 
 	async fn apply_webhook_response(
@@ -1192,6 +1303,17 @@ pub struct RequestGuard {
 	/// Guardrail provider or rule set to apply.
 	#[serde(flatten)]
 	pub kind: RequestGuardKind,
+}
+
+impl RequestGuard {
+	/// Returns the configured failure mode for this guard, defaulting to `FailOpen` for
+	/// guard types that do not have an explicit `failure_mode` field.
+	fn failure_mode(&self) -> FailureMode {
+		match &self.kind {
+			RequestGuardKind::Webhook(wh) => wh.failure_mode,
+			_ => FailureMode::FailOpen,
+		}
+	}
 }
 
 #[apply(schema!)]

--- a/crates/agentgateway/src/llm/policy/mod.rs
+++ b/crates/agentgateway/src/llm/policy/mod.rs
@@ -248,6 +248,9 @@ enum GuardrailOutcome {
 	None,
 	Masked,
 	Rejected(Response),
+	/// Guard service was unreachable and `failure_mode = FailOpen`; request is allowed
+	/// through but must be recorded as `FailOpen`, not `Allow`.
+	FailOpen,
 }
 
 /// A streaming guardrail evaluator. Each guard kind gets one stateless implementation
@@ -402,6 +405,13 @@ impl PromptGuard {
 						crate::telemetry::metrics::GuardrailAction::Allow,
 					);
 				},
+				Ok(GuardrailOutcome::FailOpen) => {
+					Policy::record_guardrail_trip(
+						client,
+						crate::telemetry::metrics::GuardrailPhase::Request,
+						crate::telemetry::metrics::GuardrailAction::FailOpen,
+					);
+				},
 				Err(e) => match g.failure_mode() {
 					FailureMode::FailClosed => {
 						tracing::warn!("request guard error in realtime path, failing closed: {e}");
@@ -472,6 +482,7 @@ impl PromptGuard {
 				Ok(None)
 			},
 			GuardrailOutcome::None => Ok(None),
+			GuardrailOutcome::FailOpen => Ok(None),
 		}
 	}
 }
@@ -655,6 +666,13 @@ impl Policy {
 						&client,
 						crate::telemetry::metrics::GuardrailPhase::Request,
 						crate::telemetry::metrics::GuardrailAction::Allow,
+					);
+				},
+				GuardrailOutcome::FailOpen => {
+					Self::record_guardrail_trip(
+						&client,
+						crate::telemetry::metrics::GuardrailPhase::Request,
+						crate::telemetry::metrics::GuardrailAction::FailOpen,
 					);
 				},
 			}
@@ -972,12 +990,7 @@ impl Policy {
 				return match webhook.failure_mode {
 					FailureMode::FailOpen => {
 						warn!("webhook guardrail unavailable, failing open: {}", e);
-						Self::record_guardrail_trip(
-							client,
-							crate::telemetry::metrics::GuardrailPhase::Request,
-							crate::telemetry::metrics::GuardrailAction::FailOpen,
-						);
-						Ok(GuardrailOutcome::None)
+						Ok(GuardrailOutcome::FailOpen)
 					},
 					FailureMode::FailClosed => Err(e),
 				};
@@ -1027,7 +1040,7 @@ impl Policy {
 		http_headers: &HeaderMap,
 		client: &PolicyClient,
 		webhook: &Webhook,
-	) -> anyhow::Result<Option<Response>> {
+	) -> anyhow::Result<GuardrailOutcome> {
 		let messsages = resp.to_webhook_choices();
 		let headers = Self::get_webhook_forward_headers(http_headers, &webhook.forward_header_matches);
 		let whr = match webhook::send_response(client, &webhook.target, &headers, messsages).await {
@@ -1036,12 +1049,7 @@ impl Policy {
 				return match webhook.failure_mode {
 					FailureMode::FailOpen => {
 						warn!("webhook guardrail unavailable, failing open: {}", e);
-						Self::record_guardrail_trip(
-							client,
-							crate::telemetry::metrics::GuardrailPhase::Response,
-							crate::telemetry::metrics::GuardrailAction::FailOpen,
-						);
-						Ok(None)
+						Ok(GuardrailOutcome::FailOpen)
 					},
 					FailureMode::FailClosed => Err(e),
 				};
@@ -1060,11 +1068,7 @@ impl Policy {
 				};
 				let msgs = body.choices;
 				resp.set_webhook_choices(msgs)?;
-				Self::record_guardrail_trip(
-					client,
-					crate::telemetry::metrics::GuardrailPhase::Response,
-					crate::telemetry::metrics::GuardrailAction::Mask,
-				);
+				Ok(GuardrailOutcome::Masked)
 			},
 			ResponseAction::Reject(rej) => {
 				debug!(
@@ -1073,16 +1077,11 @@ impl Policy {
 						.reason
 						.unwrap_or_else(|| "no reason specified".to_string())
 				);
-				Self::record_guardrail_trip(
-					client,
-					crate::telemetry::metrics::GuardrailPhase::Response,
-					crate::telemetry::metrics::GuardrailAction::Reject,
-				);
-				return Ok(Some(
+				Ok(GuardrailOutcome::Rejected(
 					::http::response::Builder::new()
 						.status(rej.status_code)
 						.body(http::Body::from(rej.body))?,
-				));
+				))
 			},
 			ResponseAction::Pass(pass) => {
 				debug!(
@@ -1091,14 +1090,9 @@ impl Policy {
 						.reason
 						.unwrap_or_else(|| "no reason specified".to_string())
 				);
-				Self::record_guardrail_trip(
-					client,
-					crate::telemetry::metrics::GuardrailPhase::Response,
-					crate::telemetry::metrics::GuardrailAction::Allow,
-				);
+				Ok(GuardrailOutcome::None)
 			},
 		}
-		Ok(None)
 	}
 
 	fn get_webhook_forward_headers(
@@ -1276,6 +1270,13 @@ impl Policy {
 						crate::telemetry::metrics::GuardrailAction::Allow,
 					);
 				},
+				GuardrailOutcome::FailOpen => {
+					Self::record_guardrail_trip(
+						client,
+						crate::telemetry::metrics::GuardrailPhase::Response,
+						crate::telemetry::metrics::GuardrailAction::FailOpen,
+					);
+				},
 			}
 		}
 		Ok(None)
@@ -1290,10 +1291,7 @@ impl Policy {
 		match &guard.kind {
 			ResponseGuardKind::Regex(rg) => Self::apply_regex_response(resp, rg, &guard.rejection),
 			ResponseGuardKind::Webhook(wh) => {
-				match Self::apply_webhook_response(resp, http_headers, client, wh).await? {
-					Some(res) => Ok(GuardrailOutcome::Rejected(res)),
-					None => Ok(GuardrailOutcome::None),
-				}
+				Self::apply_webhook_response(resp, http_headers, client, wh).await
 			},
 			ResponseGuardKind::BedrockGuardrails(bg) => {
 				Self::apply_bedrock_guardrails_response(resp, None, client, &guard.rejection, bg).await

--- a/crates/agentgateway/src/llm/policy/mod.rs
+++ b/crates/agentgateway/src/llm/policy/mod.rs
@@ -252,10 +252,10 @@ pub struct PromptGuard {
 pub enum PromptGuardStreamingMode {
 	/// Do not apply prompt guards to streaming responses or realtime websocket messages.
 	#[default]
-	#[serde(rename = "DISABLED")]
+	#[serde(rename = "Disabled")]
 	Disabled,
 	/// Apply prompt guards to streaming responses and realtime websocket messages.
-	#[serde(rename = "ENABLED")]
+	#[serde(rename = "Enabled")]
 	Enabled,
 }
 

--- a/crates/agentgateway/src/llm/policy/mod.rs
+++ b/crates/agentgateway/src/llm/policy/mod.rs
@@ -236,12 +236,37 @@ pub struct PromptEnrichment {
 
 #[apply(schema!)]
 pub struct PromptGuard {
+	/// Apply prompt guards to streaming responses and realtime websocket messages.
+	#[serde(default, skip_serializing_if = "PromptGuardStreamingMode::is_disabled")]
+	pub streaming: PromptGuardStreamingMode,
 	/// Guards applied to client requests before they reach the LLM.
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub request: Vec<RequestGuard>,
 	/// Guards applied to LLM responses before they reach the client.
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub response: Vec<ResponseGuard>,
+}
+
+#[apply(schema!)]
+#[derive(Default, Copy, PartialEq, Eq)]
+pub enum PromptGuardStreamingMode {
+	/// Do not apply prompt guards to streaming responses or realtime websocket messages.
+	#[default]
+	#[serde(rename = "DISABLED")]
+	Disabled,
+	/// Apply prompt guards to streaming responses and realtime websocket messages.
+	#[serde(rename = "ENABLED")]
+	Enabled,
+}
+
+impl PromptGuardStreamingMode {
+	pub(crate) fn is_disabled(&self) -> bool {
+		*self == Self::Disabled
+	}
+
+	pub(crate) fn is_enabled(&self) -> bool {
+		*self == Self::Enabled
+	}
 }
 
 enum GuardrailOutcome {
@@ -493,7 +518,7 @@ impl Policy {
 		self
 			.prompt_guard
 			.as_ref()
-			.map(|g| g.has_response_guards())
+			.map(|g| g.streaming.is_enabled() && g.has_response_guards())
 			.unwrap_or(false)
 	}
 }

--- a/crates/agentgateway/src/llm/policy/streaming_guardrails.rs
+++ b/crates/agentgateway/src/llm/policy/streaming_guardrails.rs
@@ -1,0 +1,823 @@
+//! Streaming guardrail infrastructure: `GuardedSseBody` and per-guardrail evaluators.
+//!
+//! `GuardedSseBody` implements **windowed guardrail evaluation**:
+//!
+//! 1. Incoming SSE byte frames are held (not forwarded) while text deltas are
+//!    accumulated into a pending batch.
+//! 2. When the batch reaches `eval_threshold` bytes of text (or the stream ends),
+//!    all `StreamingEvaluator`s are run against a window consisting of an
+//!    *overlap tail* from previously evaluated text plus the pending batch. The
+//!    overlap ensures patterns spanning a batch boundary are still seen
+//!    contiguously by at least one evaluation.
+//! 3. **Pass** → the held frames are flushed to the client and buffering resumes.
+//!    **Block** → the held (never-forwarded) frames are discarded and a synthetic
+//!    SSE error event is emitted. Content flushed by earlier passing windows
+//!    cannot be retracted — an accepted accuracy/latency tradeoff.
+//!
+//! This is not 100% accurate: a guard that needs full-response context, or a
+//! pattern spanning more than the overlap window, can be missed.
+
+use std::collections::VecDeque;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use ::http::HeaderMap;
+use bytes::Bytes;
+use http_body::Frame;
+use pin_project_lite::pin_project;
+use tokio_sse_codec::{Event, Frame as SseFrame, SseDecoder};
+use tokio_util::codec::Decoder;
+use tracing::warn;
+
+use super::{
+	AzureContentSafety, BedrockGuardrails, FailureMode, GoogleModelArmor, RegexRules, ResponseGuard,
+	ResponseGuardKind, StreamingEvaluator, StreamingGuardrailOutcome, Webhook,
+};
+use crate::llm::policy::Policy;
+use crate::proxy::httpproxy::PolicyClient;
+
+/// Text bytes accumulated before triggering a guardrail evaluation.
+/// Larger values reduce guardrail API calls but increase time-to-first-byte
+/// and the amount of content discarded on a mid-stream block.
+pub const DEFAULT_EVAL_THRESHOLD: usize = 1024;
+
+/// Tail bytes of previously evaluated text prepended to each new window so
+/// patterns spanning a batch boundary are still seen contiguously.
+pub const OVERLAP_BYTES: usize = 256;
+
+/// Return the last `max_bytes` of `s`, respecting UTF-8 char boundaries.
+pub fn tail_chars(s: &str, max_bytes: usize) -> &str {
+	if s.len() <= max_bytes {
+		return s;
+	}
+	let mut start = s.len() - max_bytes;
+	while !s.is_char_boundary(start) {
+		start += 1;
+	}
+	&s[start..]
+}
+
+/// Run all evaluators against a window. Returns `true` if any evaluator blocked.
+pub async fn evaluate_window(evaluators: &mut [Box<dyn StreamingEvaluator>], window: &str) -> bool {
+	for ev in evaluators.iter_mut() {
+		match ev.evaluate(window).await {
+			Ok(Some(StreamingGuardrailOutcome::Blocked(reason))) => {
+				tracing::debug!(reason = %reason, "streaming guardrail blocked response window");
+				return true;
+			},
+			Ok(None) => {},
+			Err(e) => match ev.failure_mode() {
+				FailureMode::FailClosed => {
+					warn!("streaming guardrail error, failing closed: {e}");
+					return true;
+				},
+				FailureMode::FailOpen => {
+					warn!("streaming guardrail error, failing open: {e}");
+				},
+			},
+		}
+	}
+	false
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/// Construct a boxed `StreamingEvaluator` for the given `ResponseGuard`.
+pub fn make_evaluator(
+	guard: &ResponseGuard,
+	client: PolicyClient,
+	http_headers: HeaderMap,
+) -> Box<dyn StreamingEvaluator> {
+	match &guard.kind {
+		ResponseGuardKind::Regex(rg) => Box::new(RegexEvaluator { rules: rg.clone() }),
+		ResponseGuardKind::Webhook(wh) => Box::new(WebhookEvaluator {
+			webhook: wh.clone(),
+			client,
+			http_headers,
+		}),
+		ResponseGuardKind::BedrockGuardrails(bg) => Box::new(BedrockEvaluator {
+			config: bg.clone(),
+			client,
+		}),
+		ResponseGuardKind::GoogleModelArmor(gma) => Box::new(GoogleModelArmorEvaluator {
+			config: gma.clone(),
+			client,
+		}),
+		ResponseGuardKind::AzureContentSafety(acs) => Box::new(AzureContentSafetyEvaluator {
+			config: acs.clone(),
+			client,
+		}),
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Regex evaluator
+// ---------------------------------------------------------------------------
+
+struct RegexEvaluator {
+	rules: RegexRules,
+}
+
+#[async_trait::async_trait]
+impl StreamingEvaluator for RegexEvaluator {
+	async fn evaluate(&mut self, window: &str) -> anyhow::Result<Option<StreamingGuardrailOutcome>> {
+		use super::{Action, RegexRule, pii};
+
+		// TODO: masking is not supported in streaming mode. Applying masks would require
+		// re-encoding the held SSE frames with the modified text, which is expensive
+		// and error-prone. Until that is implemented, mask rules pass through unchanged.
+		for rule in &self.rules.rules {
+			if !matches!(self.rules.action, Action::Reject) {
+				continue;
+			}
+			let matched = match rule {
+				RegexRule::Builtin { builtin } => {
+					use super::Builtin;
+					let rec = match builtin {
+						Builtin::Ssn => &*pii::SSN,
+						Builtin::CreditCard => &*pii::CC,
+						Builtin::PhoneNumber => &*pii::PHONE,
+						Builtin::Email => &*pii::EMAIL,
+						Builtin::CaSin => &*pii::CA_SIN,
+					};
+					!pii::recognizer(rec, window).is_empty()
+				},
+				RegexRule::Regex { pattern } => pattern.is_match(window),
+			};
+			if matched {
+				return Ok(Some(StreamingGuardrailOutcome::Blocked(
+					"regex guardrail blocked content".to_string(),
+				)));
+			}
+		}
+		Ok(None)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Webhook evaluator
+// ---------------------------------------------------------------------------
+
+struct WebhookEvaluator {
+	webhook: Webhook,
+	client: PolicyClient,
+	http_headers: HeaderMap,
+}
+
+#[async_trait::async_trait]
+impl StreamingEvaluator for WebhookEvaluator {
+	fn failure_mode(&self) -> FailureMode {
+		self.webhook.failure_mode
+	}
+
+	async fn evaluate(&mut self, window: &str) -> anyhow::Result<Option<StreamingGuardrailOutcome>> {
+		use crate::llm::SimpleChatCompletionMessage;
+		use crate::llm::policy::webhook::{ResponseAction, ResponseChoice};
+
+		// TODO: if the webhook advertises streaming support (e.g. via a capability header or
+		// config flag), forward raw chunks incrementally instead of sending each window as a
+		// standalone completion, so the webhook can do its own session-aware accumulation.
+		let choices = vec![ResponseChoice {
+			message: SimpleChatCompletionMessage {
+				role: "assistant".into(),
+				content: window.to_string().into(),
+			},
+		}];
+
+		let headers =
+			Policy::get_webhook_forward_headers(&self.http_headers, &self.webhook.forward_header_matches);
+		let whr =
+			super::webhook::send_response(&self.client, &self.webhook.target, &headers, choices).await?;
+
+		match whr.action {
+			ResponseAction::Reject(rej) => Ok(Some(StreamingGuardrailOutcome::Blocked(format!(
+				"webhook rejected response: {}",
+				rej.reason.unwrap_or_default()
+			)))),
+			_ => Ok(None),
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Bedrock guardrails evaluator
+// ---------------------------------------------------------------------------
+
+struct BedrockEvaluator {
+	config: BedrockGuardrails,
+	client: PolicyClient,
+}
+
+#[async_trait::async_trait]
+impl StreamingEvaluator for BedrockEvaluator {
+	async fn evaluate(&mut self, window: &str) -> anyhow::Result<Option<StreamingGuardrailOutcome>> {
+		if window.is_empty() {
+			return Ok(None);
+		}
+		let resp = super::bedrock_guardrails::send_response(
+			vec![window.to_string()],
+			None,
+			&self.client,
+			&self.config,
+		)
+		.await?;
+		if resp.is_blocked() {
+			Ok(Some(StreamingGuardrailOutcome::Blocked(
+				"Bedrock guardrail blocked streaming response content".to_string(),
+			)))
+		} else {
+			Ok(None)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Google Model Armor evaluator
+// ---------------------------------------------------------------------------
+
+struct GoogleModelArmorEvaluator {
+	config: GoogleModelArmor,
+	client: PolicyClient,
+}
+
+#[async_trait::async_trait]
+impl StreamingEvaluator for GoogleModelArmorEvaluator {
+	async fn evaluate(&mut self, window: &str) -> anyhow::Result<Option<StreamingGuardrailOutcome>> {
+		if window.is_empty() {
+			return Ok(None);
+		}
+		let resp = super::google_model_armor::send_response(
+			vec![window.to_string()],
+			None,
+			&self.client,
+			&self.config,
+		)
+		.await?;
+		if resp.is_blocked() {
+			Ok(Some(StreamingGuardrailOutcome::Blocked(
+				"Google Model Armor blocked streaming response content".to_string(),
+			)))
+		} else {
+			Ok(None)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Azure Content Safety evaluator
+// ---------------------------------------------------------------------------
+
+struct AzureContentSafetyEvaluator {
+	config: AzureContentSafety,
+	client: PolicyClient,
+}
+
+#[async_trait::async_trait]
+impl StreamingEvaluator for AzureContentSafetyEvaluator {
+	async fn evaluate(&mut self, window: &str) -> anyhow::Result<Option<StreamingGuardrailOutcome>> {
+		if window.is_empty() {
+			return Ok(None);
+		}
+		if let Some(ref analyze_text) = self.config.analyze_text {
+			let resp = super::azure_content_safety::send_analyze_text_for_response(
+				vec![window.to_string()],
+				None,
+				&self.client,
+				&self.config,
+				analyze_text,
+			)
+			.await?;
+			let threshold = analyze_text.severity_threshold.unwrap_or(2);
+			if resp.is_blocked(threshold) {
+				return Ok(Some(StreamingGuardrailOutcome::Blocked(
+					"Azure Content Safety blocked streaming response content".to_string(),
+				)));
+			}
+		}
+		Ok(None)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GuardedSseBody
+// ---------------------------------------------------------------------------
+
+/// Synthetic SSE error event sent to the client when a guardrail blocks content.
+///
+/// Encoded as a single `data: {...}\n\n` SSE frame.
+fn guardrail_blocked_sse_bytes() -> Bytes {
+	Bytes::from_static(
+		b"data: {\"error\":{\"type\":\"guardrail_blocked\",\"code\":\"guardrail_intervention\",\"message\":\"Content blocked by guardrail policy\"}}\n\n",
+	)
+}
+
+type EvalFuture =
+	Pin<Box<dyn Future<Output = (Vec<Box<dyn StreamingEvaluator>>, bool)> + Send + 'static>>;
+
+/// Internal state machine for `GuardedSseBody`.
+enum GuardedBodyState {
+	/// Reading from upstream, holding frames until the eval threshold is reached.
+	Buffering,
+	/// Evaluating the current window asynchronously. `eof` records whether the
+	/// upstream is already exhausted (this is the final evaluation).
+	Evaluating { fut: EvalFuture, eof: bool },
+	/// Yield held frames in order, then return to `Buffering` (or `Done` if `eof`).
+	Flushing { queue: VecDeque<Bytes>, eof: bool },
+	/// Send the synthetic error event then close.
+	Blocked,
+	/// Done – no more frames.
+	Done,
+}
+
+pin_project! {
+	// An `http_body::Body` wrapper that implements windowed guardrail evaluation.
+	pub struct GuardedSseBody {
+		#[pin]
+		inner: crate::http::Body,
+		evaluators: Vec<Box<dyn StreamingEvaluator>>,
+		eval_threshold: usize,
+		buffer_limit: usize,
+		held_frames: Vec<Bytes>,
+		held_bytes: usize,
+		pending_text: String,
+		overlap_tail: String,
+		sse_decoder: SseDecoder<Bytes>,
+		decode_buffer: bytes::BytesMut,
+		state: GuardedBodyState,
+		// Owns the rate-limit logger; dropped only when this body is fully consumed,
+		// so telemetry is recorded at the correct time.
+		logger: Option<crate::llm::AmendOnDrop>,
+	}
+}
+
+impl GuardedSseBody {
+	/// Create a new `GuardedSseBody` with the default evaluation threshold.
+	///
+	/// * `inner` – the upstream SSE body.
+	/// * `evaluators` – one evaluator per configured response guard.
+	/// * `buffer_limit` – max bytes of held frames; reaching it forces an evaluation.
+	/// * `logger` – rate-limit logger that must outlive the streaming response.
+	// We do actually return Self; just wrapped in an http_body::Body. The annotation silences a false positive from clippy about that.
+	#[allow(clippy::new_ret_no_self)]
+	pub fn new(
+		inner: crate::http::Body,
+		evaluators: Vec<Box<dyn StreamingEvaluator>>,
+		buffer_limit: usize,
+		logger: Option<crate::llm::AmendOnDrop>,
+	) -> crate::http::Body {
+		Self::with_threshold(
+			inner,
+			evaluators,
+			buffer_limit,
+			logger,
+			DEFAULT_EVAL_THRESHOLD,
+		)
+	}
+
+	/// Like [`GuardedSseBody::new`] but with an explicit evaluation threshold.
+	pub fn with_threshold(
+		inner: crate::http::Body,
+		evaluators: Vec<Box<dyn StreamingEvaluator>>,
+		buffer_limit: usize,
+		logger: Option<crate::llm::AmendOnDrop>,
+		eval_threshold: usize,
+	) -> crate::http::Body {
+		crate::http::Body::new(Self {
+			inner,
+			evaluators,
+			eval_threshold,
+			buffer_limit,
+			held_frames: Vec::new(),
+			held_bytes: 0,
+			pending_text: String::new(),
+			overlap_tail: String::new(),
+			sse_decoder: SseDecoder::with_max_size(buffer_limit),
+			decode_buffer: bytes::BytesMut::new(),
+			state: GuardedBodyState::Buffering,
+			logger,
+		})
+	}
+
+	/// Extract text delta from a parsed SSE frame if present.
+	fn extract_text_delta(frame: SseFrame<Bytes>) -> Option<String> {
+		let SseFrame::Event(Event { data, .. }) = frame else {
+			return None;
+		};
+		if data.as_ref() == b"[DONE]" {
+			return None;
+		}
+		if let Ok(v) = serde_json::from_slice::<serde_json::Value>(&data) {
+			// OpenAI completions: choices[0].delta.content
+			if let Some(text) = v
+				.get("choices")
+				.and_then(|c| c.get(0))
+				.and_then(|c| c.get("delta"))
+				.and_then(|d| d.get("content"))
+				.and_then(|s| s.as_str())
+			{
+				return Some(text.to_string());
+			}
+			// Anthropic messages: delta.text
+			if let Some(text) = v
+				.get("delta")
+				.and_then(|d| d.get("text"))
+				.and_then(|s| s.as_str())
+			{
+				return Some(text.to_string());
+			}
+		}
+		None
+	}
+}
+
+impl http_body::Body for GuardedSseBody {
+	type Data = Bytes;
+	type Error = crate::http::Error;
+
+	fn poll_frame(
+		self: Pin<&mut Self>,
+		cx: &mut Context<'_>,
+	) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+		let mut this = self.project();
+
+		loop {
+			match this.state {
+				// -----------------------------------------------------------------
+				// Flushing: yield held frames one at a time.
+				// -----------------------------------------------------------------
+				GuardedBodyState::Flushing { queue, eof } => {
+					if let Some(frame) = queue.pop_front() {
+						return Poll::Ready(Some(Ok(Frame::data(frame))));
+					} else if *eof {
+						*this.state = GuardedBodyState::Done;
+						return Poll::Ready(None);
+					} else {
+						*this.state = GuardedBodyState::Buffering;
+					}
+				},
+				// -----------------------------------------------------------------
+				// Blocked: yield synthetic error event, then done.
+				// -----------------------------------------------------------------
+				GuardedBodyState::Blocked => {
+					*this.state = GuardedBodyState::Done;
+					return Poll::Ready(Some(Ok(Frame::data(guardrail_blocked_sse_bytes()))));
+				},
+				// -----------------------------------------------------------------
+				// Done: stream exhausted.
+				// -----------------------------------------------------------------
+				GuardedBodyState::Done => {
+					return Poll::Ready(None);
+				},
+				// -----------------------------------------------------------------
+				// Evaluating: poll the guardrail future for the current window.
+				// -----------------------------------------------------------------
+				GuardedBodyState::Evaluating { fut, eof } => match fut.as_mut().poll(cx) {
+					Poll::Pending => return Poll::Pending,
+					Poll::Ready((evaluators, blocked)) => {
+						*this.evaluators = evaluators;
+						if blocked {
+							this.held_frames.clear();
+							*this.held_bytes = 0;
+							*this.state = GuardedBodyState::Blocked;
+						} else {
+							let queue: VecDeque<Bytes> = this.held_frames.drain(..).collect();
+							*this.held_bytes = 0;
+							*this.state = GuardedBodyState::Flushing { queue, eof: *eof };
+						}
+					},
+				},
+				// -----------------------------------------------------------------
+				// Buffering: read from upstream, holding frames until threshold.
+				// -----------------------------------------------------------------
+				GuardedBodyState::Buffering => {
+					match this.inner.as_mut().poll_frame(cx) {
+						Poll::Pending => return Poll::Pending,
+						Poll::Ready(Some(Err(e))) => return Poll::Ready(Some(Err(e))),
+						Poll::Ready(Some(Ok(frame))) => {
+							let Some(data) = frame.data_ref() else {
+								return Poll::Ready(Some(Ok(frame)));
+							};
+
+							let raw = data.clone();
+							*this.held_bytes += raw.len();
+							this.held_frames.push(raw.clone());
+
+							this.decode_buffer.extend_from_slice(&raw);
+							loop {
+								match this.sse_decoder.decode(this.decode_buffer) {
+									Ok(Some(sse_frame)) => {
+										if let Some(delta) = GuardedSseBody::extract_text_delta(sse_frame) {
+											this.pending_text.push_str(&delta);
+										}
+									},
+									Ok(None) => break,
+									Err(e) => {
+										// Clear the buffer and reset the decoder so invalid bytes
+										// don't accumulate across chunks and cause repeated errors.
+										warn!("SSE decode error in streaming guardrail body, resetting decoder: {e}");
+										this.decode_buffer.clear();
+										*this.sse_decoder = SseDecoder::with_max_size(*this.buffer_limit);
+										break;
+									},
+								}
+							}
+
+							let over_limit = *this.held_bytes >= *this.buffer_limit;
+							if this.pending_text.len() >= *this.eval_threshold || over_limit {
+								// Having a full buffer but empty text implies that the
+								// buffer is full of non-text frames (e.g. control frames or unsupported SSE formats that fail to decode).
+								// In that case, flush the buffer as-is without evaluation, to avoid stalling on unprocessable content.
+								if this.pending_text.is_empty() {
+									let queue: VecDeque<Bytes> = this.held_frames.drain(..).collect();
+									*this.held_bytes = 0;
+									*this.state = GuardedBodyState::Flushing { queue, eof: false };
+									continue;
+								}
+								let batch = std::mem::take(this.pending_text);
+								let window = format!("{}{}", this.overlap_tail, batch);
+								*this.overlap_tail = tail_chars(&window, OVERLAP_BYTES).to_string();
+								let mut evaluators = std::mem::take(this.evaluators);
+								let fut: EvalFuture = Box::pin(async move {
+									let blocked = evaluate_window(&mut evaluators, &window).await;
+									(evaluators, blocked)
+								});
+								*this.state = GuardedBodyState::Evaluating { fut, eof: false };
+							}
+						},
+						Poll::Ready(None) => {
+							loop {
+								match this.sse_decoder.decode_eof(this.decode_buffer) {
+									Ok(Some(sse_frame)) => {
+										if let Some(delta) = GuardedSseBody::extract_text_delta(sse_frame) {
+											this.pending_text.push_str(&delta);
+										}
+									},
+									Ok(None) => break,
+									Err(e) => {
+										warn!("SSE decode error at EOF in streaming guardrail body: {e}");
+										this.decode_buffer.clear();
+										break;
+									},
+								}
+							}
+
+							if this.pending_text.is_empty() {
+								let queue: VecDeque<Bytes> = this.held_frames.drain(..).collect();
+								*this.held_bytes = 0;
+								*this.state = GuardedBodyState::Flushing { queue, eof: true };
+								continue;
+							}
+
+							let batch = std::mem::take(this.pending_text);
+							let window = format!("{}{}", this.overlap_tail, batch);
+							this.overlap_tail.clear();
+							let mut evaluators = std::mem::take(this.evaluators);
+							let fut: EvalFuture = Box::pin(async move {
+								let blocked = evaluate_window(&mut evaluators, &window).await;
+								(evaluators, blocked)
+							});
+							*this.state = GuardedBodyState::Evaluating { fut, eof: true };
+						},
+					}
+				},
+			}
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use http_body_util::BodyExt as _;
+
+	use super::*;
+	use crate::llm::policy::{Action, RegexRule};
+
+	struct PassEvaluator;
+
+	#[async_trait::async_trait]
+	impl StreamingEvaluator for PassEvaluator {
+		async fn evaluate(
+			&mut self,
+			_window: &str,
+		) -> anyhow::Result<Option<StreamingGuardrailOutcome>> {
+			Ok(None)
+		}
+	}
+
+	struct BlockEvaluator;
+
+	#[async_trait::async_trait]
+	impl StreamingEvaluator for BlockEvaluator {
+		async fn evaluate(
+			&mut self,
+			_window: &str,
+		) -> anyhow::Result<Option<StreamingGuardrailOutcome>> {
+			Ok(Some(StreamingGuardrailOutcome::Blocked("blocked".into())))
+		}
+	}
+
+	struct ErrorEvaluator {
+		mode: crate::llm::policy::FailureMode,
+	}
+
+	#[async_trait::async_trait]
+	impl StreamingEvaluator for ErrorEvaluator {
+		fn failure_mode(&self) -> crate::llm::policy::FailureMode {
+			self.mode
+		}
+
+		async fn evaluate(
+			&mut self,
+			_window: &str,
+		) -> anyhow::Result<Option<StreamingGuardrailOutcome>> {
+			Err(anyhow::anyhow!("simulated evaluator error"))
+		}
+	}
+
+	fn sse_bytes(content: &str) -> Bytes {
+		Bytes::from(format!("data: {}\n\n", content))
+	}
+
+	fn delta_bytes(text: &str) -> Bytes {
+		sse_bytes(&format!(
+			"{{\"choices\":[{{\"delta\":{{\"content\":\"{}\"}}}}]}}",
+			text
+		))
+	}
+
+	fn make_body(chunks: Vec<Bytes>) -> crate::http::Body {
+		use std::convert::Infallible;
+
+		use futures_util::stream;
+		let stream = stream::iter(chunks.into_iter().map(Ok::<Bytes, Infallible>));
+		crate::http::Body::from_stream(stream)
+	}
+
+	fn contains(haystack: &[u8], needle: &[u8]) -> bool {
+		haystack.windows(needle.len()).any(|w| w == needle)
+	}
+
+	#[tokio::test]
+	async fn test_pass_through() {
+		let chunk = delta_bytes("hello");
+		let done = sse_bytes("[DONE]");
+		let body = make_body(vec![chunk.clone(), done.clone()]);
+
+		let guarded = GuardedSseBody::new(body, vec![Box::new(PassEvaluator)], 1024 * 1024, None);
+
+		let bytes = guarded.collect().await.unwrap().to_bytes();
+		assert!(bytes.starts_with(&chunk));
+	}
+
+	#[tokio::test]
+	async fn test_block() {
+		let chunk = delta_bytes("bad content");
+		let done = sse_bytes("[DONE]");
+		let body = make_body(vec![chunk, done]);
+
+		let guarded = GuardedSseBody::new(body, vec![Box::new(BlockEvaluator)], 1024 * 1024, None);
+
+		let bytes = guarded.collect().await.unwrap().to_bytes();
+		assert!(contains(&bytes, b"guardrail_blocked"));
+		assert!(!contains(&bytes, b"bad content"));
+	}
+
+	fn regex_evaluator(pattern: &str) -> RegexEvaluator {
+		RegexEvaluator {
+			rules: RegexRules {
+				action: Action::Reject,
+				rules: vec![RegexRule::Regex {
+					pattern: regex::Regex::new(pattern).unwrap(),
+				}],
+			},
+		}
+	}
+
+	#[tokio::test]
+	async fn test_regex_blocks_matching_response() {
+		let chunk = delta_bytes("my SSN is 123-45-6789");
+		let done = sse_bytes("[DONE]");
+		let body = make_body(vec![chunk, done]);
+
+		let guarded = GuardedSseBody::new(
+			body,
+			vec![Box::new(regex_evaluator("SSN"))],
+			1024 * 1024,
+			None,
+		);
+
+		let bytes = guarded.collect().await.unwrap().to_bytes();
+		assert!(contains(&bytes, b"guardrail_blocked"));
+		assert!(!contains(&bytes, b"SSN"));
+	}
+
+	#[tokio::test]
+	async fn test_regex_passes_non_matching_response() {
+		let chunk = delta_bytes("hello world");
+		let done = sse_bytes("[DONE]");
+		let body = make_body(vec![chunk.clone(), done]);
+
+		let guarded = GuardedSseBody::new(
+			body,
+			vec![Box::new(regex_evaluator("SSN"))],
+			1024 * 1024,
+			None,
+		);
+
+		let bytes = guarded.collect().await.unwrap().to_bytes();
+		assert!(bytes.starts_with(&chunk));
+		assert!(!contains(&bytes, b"guardrail_blocked"));
+	}
+
+	#[tokio::test]
+	async fn test_regex_accumulates_within_batch() {
+		let chunk1 = delta_bytes("my credit");
+		let chunk2 = delta_bytes(" card");
+		let done = sse_bytes("[DONE]");
+		let body = make_body(vec![chunk1, chunk2, done]);
+
+		let guarded = GuardedSseBody::new(
+			body,
+			vec![Box::new(regex_evaluator("credit card"))],
+			1024 * 1024,
+			None,
+		);
+
+		let bytes = guarded.collect().await.unwrap().to_bytes();
+		assert!(contains(&bytes, b"guardrail_blocked"));
+		assert!(!contains(&bytes, b"credit"));
+	}
+
+	#[tokio::test]
+	async fn test_windowed_incremental_flush_then_block() {
+		let chunk1 = delta_bytes("this part is fine");
+		let chunk2 = delta_bytes("forbidden words here");
+		let done = sse_bytes("[DONE]");
+		let body = make_body(vec![chunk1.clone(), chunk2, done]);
+
+		let guarded = GuardedSseBody::with_threshold(
+			body,
+			vec![Box::new(regex_evaluator("forbidden"))],
+			1024 * 1024,
+			None,
+			4,
+		);
+
+		let bytes = guarded.collect().await.unwrap().to_bytes();
+		assert!(contains(&bytes, b"this part is fine"));
+		assert!(!contains(&bytes, b"forbidden"));
+		assert!(contains(&bytes, b"guardrail_blocked"));
+	}
+
+	#[tokio::test]
+	async fn test_overlap_catches_boundary_spanning_pattern() {
+		let chunk1 = delta_bytes("my credit");
+		let chunk2 = delta_bytes(" card number");
+		let done = sse_bytes("[DONE]");
+		let body = make_body(vec![chunk1, chunk2, done]);
+
+		let guarded = GuardedSseBody::with_threshold(
+			body,
+			vec![Box::new(regex_evaluator("credit card"))],
+			1024 * 1024,
+			None,
+			4,
+		);
+
+		let bytes = guarded.collect().await.unwrap().to_bytes();
+		assert!(contains(&bytes, b"guardrail_blocked"));
+		assert!(!contains(&bytes, b"card number"));
+	}
+
+	#[test]
+	fn test_tail_chars_respects_utf8_boundaries() {
+		let s = "héllo wörld";
+		let t = tail_chars(s, 4);
+		assert!(t.len() <= 4);
+		assert!(s.ends_with(t));
+		let s2 = "aé";
+		assert_eq!(tail_chars(s2, 1), "");
+		assert_eq!(tail_chars(s2, 2), "é");
+	}
+
+	#[tokio::test]
+	async fn evaluate_window_fail_closed_blocks_on_error() {
+		use crate::llm::policy::FailureMode;
+		let mut evs: Vec<Box<dyn StreamingEvaluator>> = vec![Box::new(ErrorEvaluator {
+			mode: FailureMode::FailClosed,
+		})];
+		assert!(evaluate_window(&mut evs, "some text").await);
+	}
+
+	#[tokio::test]
+	async fn evaluate_window_fail_open_passes_on_error() {
+		use crate::llm::policy::FailureMode;
+		let mut evs: Vec<Box<dyn StreamingEvaluator>> = vec![Box::new(ErrorEvaluator {
+			mode: FailureMode::FailOpen,
+		})];
+		assert!(!evaluate_window(&mut evs, "some text").await);
+	}
+}

--- a/crates/agentgateway/src/llm/policy/streaming_guardrails.rs
+++ b/crates/agentgateway/src/llm/policy/streaming_guardrails.rs
@@ -31,10 +31,9 @@ use tokio_util::codec::Decoder;
 use tracing::warn;
 
 use super::{
-	AzureContentSafety, BedrockGuardrails, FailureMode, GoogleModelArmor, RegexRules, ResponseGuard,
-	ResponseGuardKind, StreamingEvaluator, StreamingGuardrailOutcome, Webhook,
+	FailureMode, ResponseGuard, ResponseGuardKind, StreamingEvaluator, StreamingGuardrailOutcome,
 };
-use crate::llm::policy::Policy;
+use crate::llm::policy::PromptGuard;
 use crate::proxy::httpproxy::PolicyClient;
 
 /// Text bytes accumulated before triggering a guardrail evaluation.
@@ -58,19 +57,22 @@ pub fn tail_chars(s: &str, max_bytes: usize) -> &str {
 	&s[start..]
 }
 
-/// Run all evaluators against a window. Returns `true` if any evaluator blocked.
-pub async fn evaluate_window(evaluators: &mut [Box<dyn StreamingEvaluator>], window: &str) -> bool {
+/// Run all evaluators against a window. Returns the rejection body if any evaluator blocked.
+pub async fn evaluate_window(
+	evaluators: &mut [Box<dyn StreamingEvaluator>],
+	window: &str,
+) -> Option<Bytes> {
 	for ev in evaluators.iter_mut() {
 		match ev.evaluate(window).await {
-			Ok(Some(StreamingGuardrailOutcome::Blocked(reason))) => {
-				tracing::debug!(reason = %reason, "streaming guardrail blocked response window");
-				return true;
+			Ok(Some(StreamingGuardrailOutcome::Blocked(body))) => {
+				tracing::debug!("streaming guardrail blocked response window");
+				return Some(body);
 			},
 			Ok(None) => {},
 			Err(e) => match ev.failure_mode() {
 				FailureMode::FailClosed => {
 					warn!("streaming guardrail error, failing closed: {e}");
-					return true;
+					return Some(Bytes::from_static(b"Content blocked by guardrail policy"));
 				},
 				FailureMode::FailOpen => {
 					warn!("streaming guardrail error, failing open: {e}");
@@ -78,7 +80,7 @@ pub async fn evaluate_window(evaluators: &mut [Box<dyn StreamingEvaluator>], win
 			},
 		}
 	}
-	false
+	None
 }
 
 // ---------------------------------------------------------------------------
@@ -91,213 +93,36 @@ pub fn make_evaluator(
 	client: PolicyClient,
 	http_headers: HeaderMap,
 ) -> Box<dyn StreamingEvaluator> {
-	match &guard.kind {
-		ResponseGuardKind::Regex(rg) => Box::new(RegexEvaluator { rules: rg.clone() }),
-		ResponseGuardKind::Webhook(wh) => Box::new(WebhookEvaluator {
-			webhook: wh.clone(),
-			client,
-			http_headers,
-		}),
-		ResponseGuardKind::BedrockGuardrails(bg) => Box::new(BedrockEvaluator {
-			config: bg.clone(),
-			client,
-		}),
-		ResponseGuardKind::GoogleModelArmor(gma) => Box::new(GoogleModelArmorEvaluator {
-			config: gma.clone(),
-			client,
-		}),
-		ResponseGuardKind::AzureContentSafety(acs) => Box::new(AzureContentSafetyEvaluator {
-			config: acs.clone(),
-			client,
-		}),
-	}
+	Box::new(ResponseGuardEvaluator {
+		guard: guard.clone(),
+		client,
+		http_headers,
+	})
 }
 
-// ---------------------------------------------------------------------------
-// Regex evaluator
-// ---------------------------------------------------------------------------
-
-struct RegexEvaluator {
-	rules: RegexRules,
-}
-
-#[async_trait::async_trait]
-impl StreamingEvaluator for RegexEvaluator {
-	async fn evaluate(&mut self, window: &str) -> anyhow::Result<Option<StreamingGuardrailOutcome>> {
-		use super::{Action, RegexRule, pii};
-
-		// TODO: masking is not supported in streaming mode. Applying masks would require
-		// re-encoding the held SSE frames with the modified text, which is expensive
-		// and error-prone. Until that is implemented, mask rules pass through unchanged.
-		for rule in &self.rules.rules {
-			if !matches!(self.rules.action, Action::Reject) {
-				continue;
-			}
-			let matched = match rule {
-				RegexRule::Builtin { builtin } => {
-					use super::Builtin;
-					let rec = match builtin {
-						Builtin::Ssn => &*pii::SSN,
-						Builtin::CreditCard => &*pii::CC,
-						Builtin::PhoneNumber => &*pii::PHONE,
-						Builtin::Email => &*pii::EMAIL,
-						Builtin::CaSin => &*pii::CA_SIN,
-					};
-					!pii::recognizer(rec, window).is_empty()
-				},
-				RegexRule::Regex { pattern } => pattern.is_match(window),
-			};
-			if matched {
-				return Ok(Some(StreamingGuardrailOutcome::Blocked(
-					"regex guardrail blocked content".to_string(),
-				)));
-			}
-		}
-		Ok(None)
-	}
-}
-
-// ---------------------------------------------------------------------------
-// Webhook evaluator
-// ---------------------------------------------------------------------------
-
-struct WebhookEvaluator {
-	webhook: Webhook,
+struct ResponseGuardEvaluator {
+	guard: ResponseGuard,
 	client: PolicyClient,
 	http_headers: HeaderMap,
 }
 
 #[async_trait::async_trait]
-impl StreamingEvaluator for WebhookEvaluator {
+impl StreamingEvaluator for ResponseGuardEvaluator {
 	fn failure_mode(&self) -> FailureMode {
-		self.webhook.failure_mode
+		match &self.guard.kind {
+			ResponseGuardKind::Webhook(wh) => wh.failure_mode,
+			_ => FailureMode::FailOpen,
+		}
 	}
 
 	async fn evaluate(&mut self, window: &str) -> anyhow::Result<Option<StreamingGuardrailOutcome>> {
-		use crate::llm::SimpleChatCompletionMessage;
-		use crate::llm::policy::webhook::{ResponseAction, ResponseChoice};
-
-		// TODO: if the webhook advertises streaming support (e.g. via a capability header or
-		// config flag), forward raw chunks incrementally instead of sending each window as a
-		// standalone completion, so the webhook can do its own session-aware accumulation.
-		let choices = vec![ResponseChoice {
-			message: SimpleChatCompletionMessage {
-				role: "assistant".into(),
-				content: window.to_string().into(),
-			},
-		}];
-
-		let headers =
-			Policy::get_webhook_forward_headers(&self.http_headers, &self.webhook.forward_header_matches);
-		let whr =
-			super::webhook::send_response(&self.client, &self.webhook.target, &headers, choices).await?;
-
-		match whr.action {
-			ResponseAction::Reject(rej) => Ok(Some(StreamingGuardrailOutcome::Blocked(format!(
-				"webhook rejected response: {}",
-				rej.reason.unwrap_or_default()
-			)))),
-			_ => Ok(None),
-		}
-	}
-}
-
-// ---------------------------------------------------------------------------
-// Bedrock guardrails evaluator
-// ---------------------------------------------------------------------------
-
-struct BedrockEvaluator {
-	config: BedrockGuardrails,
-	client: PolicyClient,
-}
-
-#[async_trait::async_trait]
-impl StreamingEvaluator for BedrockEvaluator {
-	async fn evaluate(&mut self, window: &str) -> anyhow::Result<Option<StreamingGuardrailOutcome>> {
-		if window.is_empty() {
-			return Ok(None);
-		}
-		let resp = super::bedrock_guardrails::send_response(
-			vec![window.to_string()],
-			None,
+		PromptGuard::evaluate_streaming_response_window(
+			&self.guard,
+			window,
 			&self.client,
-			&self.config,
+			&self.http_headers,
 		)
-		.await?;
-		if resp.is_blocked() {
-			Ok(Some(StreamingGuardrailOutcome::Blocked(
-				"Bedrock guardrail blocked streaming response content".to_string(),
-			)))
-		} else {
-			Ok(None)
-		}
-	}
-}
-
-// ---------------------------------------------------------------------------
-// Google Model Armor evaluator
-// ---------------------------------------------------------------------------
-
-struct GoogleModelArmorEvaluator {
-	config: GoogleModelArmor,
-	client: PolicyClient,
-}
-
-#[async_trait::async_trait]
-impl StreamingEvaluator for GoogleModelArmorEvaluator {
-	async fn evaluate(&mut self, window: &str) -> anyhow::Result<Option<StreamingGuardrailOutcome>> {
-		if window.is_empty() {
-			return Ok(None);
-		}
-		let resp = super::google_model_armor::send_response(
-			vec![window.to_string()],
-			None,
-			&self.client,
-			&self.config,
-		)
-		.await?;
-		if resp.is_blocked() {
-			Ok(Some(StreamingGuardrailOutcome::Blocked(
-				"Google Model Armor blocked streaming response content".to_string(),
-			)))
-		} else {
-			Ok(None)
-		}
-	}
-}
-
-// ---------------------------------------------------------------------------
-// Azure Content Safety evaluator
-// ---------------------------------------------------------------------------
-
-struct AzureContentSafetyEvaluator {
-	config: AzureContentSafety,
-	client: PolicyClient,
-}
-
-#[async_trait::async_trait]
-impl StreamingEvaluator for AzureContentSafetyEvaluator {
-	async fn evaluate(&mut self, window: &str) -> anyhow::Result<Option<StreamingGuardrailOutcome>> {
-		if window.is_empty() {
-			return Ok(None);
-		}
-		if let Some(ref analyze_text) = self.config.analyze_text {
-			let resp = super::azure_content_safety::send_analyze_text_for_response(
-				vec![window.to_string()],
-				None,
-				&self.client,
-				&self.config,
-				analyze_text,
-			)
-			.await?;
-			let threshold = analyze_text.severity_threshold.unwrap_or(2);
-			if resp.is_blocked(threshold) {
-				return Ok(Some(StreamingGuardrailOutcome::Blocked(
-					"Azure Content Safety blocked streaming response content".to_string(),
-				)));
-			}
-		}
-		Ok(None)
+		.await
 	}
 }
 
@@ -308,14 +133,20 @@ impl StreamingEvaluator for AzureContentSafetyEvaluator {
 /// Synthetic SSE error event sent to the client when a guardrail blocks content.
 ///
 /// Encoded as a single `data: {...}\n\n` SSE frame.
-fn guardrail_blocked_sse_bytes() -> Bytes {
-	Bytes::from_static(
-		b"data: {\"error\":{\"type\":\"guardrail_blocked\",\"code\":\"guardrail_intervention\",\"message\":\"Content blocked by guardrail policy\"}}\n\n",
-	)
+fn guardrail_blocked_sse_bytes(body: Bytes) -> Bytes {
+	let message = String::from_utf8_lossy(&body);
+	let event = serde_json::json!({
+		"error": {
+			"type": "guardrail_blocked",
+			"code": "guardrail_intervention",
+			"message": message,
+		}
+	});
+	Bytes::from(format!("data: {event}\n\n"))
 }
 
 type EvalFuture =
-	Pin<Box<dyn Future<Output = (Vec<Box<dyn StreamingEvaluator>>, bool)> + Send + 'static>>;
+	Pin<Box<dyn Future<Output = (Vec<Box<dyn StreamingEvaluator>>, Option<Bytes>)> + Send + 'static>>;
 
 /// Internal state machine for `GuardedSseBody`.
 enum GuardedBodyState {
@@ -327,7 +158,7 @@ enum GuardedBodyState {
 	/// Yield held frames in order, then return to `Buffering` (or `Done` if `eof`).
 	Flushing { queue: VecDeque<Bytes>, eof: bool },
 	/// Send the synthetic error event then close.
-	Blocked,
+	Blocked(Bytes),
 	/// Done – no more frames.
 	Done,
 }
@@ -410,6 +241,12 @@ impl GuardedSseBody {
 			return None;
 		}
 		if let Ok(v) = serde_json::from_slice::<serde_json::Value>(&data) {
+			// OpenAI responses: response.output_text.delta
+			if v.get("type").and_then(|t| t.as_str()) == Some("response.output_text.delta")
+				&& let Some(text) = v.get("delta").and_then(|s| s.as_str())
+			{
+				return Some(text.to_string());
+			}
 			// OpenAI completions: choices[0].delta.content
 			if let Some(text) = v
 				.get("choices")
@@ -461,9 +298,10 @@ impl http_body::Body for GuardedSseBody {
 				// -----------------------------------------------------------------
 				// Blocked: yield synthetic error event, then done.
 				// -----------------------------------------------------------------
-				GuardedBodyState::Blocked => {
+				GuardedBodyState::Blocked(body) => {
+					let body = std::mem::take(body);
 					*this.state = GuardedBodyState::Done;
-					return Poll::Ready(Some(Ok(Frame::data(guardrail_blocked_sse_bytes()))));
+					return Poll::Ready(Some(Ok(Frame::data(guardrail_blocked_sse_bytes(body)))));
 				},
 				// -----------------------------------------------------------------
 				// Done: stream exhausted.
@@ -476,12 +314,12 @@ impl http_body::Body for GuardedSseBody {
 				// -----------------------------------------------------------------
 				GuardedBodyState::Evaluating { fut, eof } => match fut.as_mut().poll(cx) {
 					Poll::Pending => return Poll::Pending,
-					Poll::Ready((evaluators, blocked)) => {
+					Poll::Ready((evaluators, blocked_body)) => {
 						*this.evaluators = evaluators;
-						if blocked {
+						if let Some(body) = blocked_body {
 							this.held_frames.clear();
 							*this.held_bytes = 0;
-							*this.state = GuardedBodyState::Blocked;
+							*this.state = GuardedBodyState::Blocked(body);
 						} else {
 							let queue: VecDeque<Bytes> = this.held_frames.drain(..).collect();
 							*this.held_bytes = 0;
@@ -541,8 +379,8 @@ impl http_body::Body for GuardedSseBody {
 								*this.overlap_tail = tail_chars(&window, OVERLAP_BYTES).to_string();
 								let mut evaluators = std::mem::take(this.evaluators);
 								let fut: EvalFuture = Box::pin(async move {
-									let blocked = evaluate_window(&mut evaluators, &window).await;
-									(evaluators, blocked)
+									let blocked_body = evaluate_window(&mut evaluators, &window).await;
+									(evaluators, blocked_body)
 								});
 								*this.state = GuardedBodyState::Evaluating { fut, eof: false };
 							}
@@ -576,8 +414,8 @@ impl http_body::Body for GuardedSseBody {
 							this.overlap_tail.clear();
 							let mut evaluators = std::mem::take(this.evaluators);
 							let fut: EvalFuture = Box::pin(async move {
-								let blocked = evaluate_window(&mut evaluators, &window).await;
-								(evaluators, blocked)
+								let blocked_body = evaluate_window(&mut evaluators, &window).await;
+								(evaluators, blocked_body)
 							});
 							*this.state = GuardedBodyState::Evaluating { fut, eof: true };
 						},
@@ -593,7 +431,6 @@ mod tests {
 	use http_body_util::BodyExt as _;
 
 	use super::*;
-	use crate::llm::policy::{Action, RegexRule};
 
 	struct PassEvaluator;
 
@@ -615,7 +452,28 @@ mod tests {
 			&mut self,
 			_window: &str,
 		) -> anyhow::Result<Option<StreamingGuardrailOutcome>> {
-			Ok(Some(StreamingGuardrailOutcome::Blocked("blocked".into())))
+			Ok(Some(StreamingGuardrailOutcome::Blocked(
+				Bytes::from_static(b"blocked"),
+			)))
+		}
+	}
+
+	struct PatternEvaluator {
+		pattern: regex::Regex,
+	}
+
+	#[async_trait::async_trait]
+	impl StreamingEvaluator for PatternEvaluator {
+		async fn evaluate(
+			&mut self,
+			window: &str,
+		) -> anyhow::Result<Option<StreamingGuardrailOutcome>> {
+			if self.pattern.is_match(window) {
+				return Ok(Some(StreamingGuardrailOutcome::Blocked(
+					Bytes::from_static(b"blocked"),
+				)));
+			}
+			Ok(None)
 		}
 	}
 
@@ -685,14 +543,9 @@ mod tests {
 		assert!(!contains(&bytes, b"bad content"));
 	}
 
-	fn regex_evaluator(pattern: &str) -> RegexEvaluator {
-		RegexEvaluator {
-			rules: RegexRules {
-				action: Action::Reject,
-				rules: vec![RegexRule::Regex {
-					pattern: regex::Regex::new(pattern).unwrap(),
-				}],
-			},
+	fn pattern_evaluator(pattern: &str) -> PatternEvaluator {
+		PatternEvaluator {
+			pattern: regex::Regex::new(pattern).unwrap(),
 		}
 	}
 
@@ -704,7 +557,7 @@ mod tests {
 
 		let guarded = GuardedSseBody::new(
 			body,
-			vec![Box::new(regex_evaluator("SSN"))],
+			vec![Box::new(pattern_evaluator("SSN"))],
 			1024 * 1024,
 			None,
 		);
@@ -722,7 +575,7 @@ mod tests {
 
 		let guarded = GuardedSseBody::new(
 			body,
-			vec![Box::new(regex_evaluator("SSN"))],
+			vec![Box::new(pattern_evaluator("SSN"))],
 			1024 * 1024,
 			None,
 		);
@@ -741,7 +594,7 @@ mod tests {
 
 		let guarded = GuardedSseBody::new(
 			body,
-			vec![Box::new(regex_evaluator("credit card"))],
+			vec![Box::new(pattern_evaluator("credit card"))],
 			1024 * 1024,
 			None,
 		);
@@ -760,7 +613,7 @@ mod tests {
 
 		let guarded = GuardedSseBody::with_threshold(
 			body,
-			vec![Box::new(regex_evaluator("forbidden"))],
+			vec![Box::new(pattern_evaluator("forbidden"))],
 			1024 * 1024,
 			None,
 			4,
@@ -781,7 +634,7 @@ mod tests {
 
 		let guarded = GuardedSseBody::with_threshold(
 			body,
-			vec![Box::new(regex_evaluator("credit card"))],
+			vec![Box::new(pattern_evaluator("credit card"))],
 			1024 * 1024,
 			None,
 			4,
@@ -809,7 +662,10 @@ mod tests {
 		let mut evs: Vec<Box<dyn StreamingEvaluator>> = vec![Box::new(ErrorEvaluator {
 			mode: FailureMode::FailClosed,
 		})];
-		assert!(evaluate_window(&mut evs, "some text").await);
+		assert_eq!(
+			evaluate_window(&mut evs, "some text").await.as_deref(),
+			Some(&b"Content blocked by guardrail policy"[..])
+		);
 	}
 
 	#[tokio::test]
@@ -818,6 +674,6 @@ mod tests {
 		let mut evs: Vec<Box<dyn StreamingEvaluator>> = vec![Box::new(ErrorEvaluator {
 			mode: FailureMode::FailOpen,
 		})];
-		assert!(!evaluate_window(&mut evs, "some text").await);
+		assert!(evaluate_window(&mut evs, "some text").await.is_none());
 	}
 }

--- a/crates/agentgateway/src/llm/policy/tests.rs
+++ b/crates/agentgateway/src/llm/policy/tests.rs
@@ -10,6 +10,7 @@ async fn webhook_fail_open_emits_single_metric() {
 	use crate::types::agent::SimpleBackendReference;
 
 	let guard = PromptGuard {
+		streaming: Default::default(),
 		request: vec![RequestGuard {
 			rejection: Default::default(),
 			kind: RequestGuardKind::Webhook(Webhook {
@@ -1075,6 +1076,7 @@ mod prompt_guard_config_tests {
 		let policy: Policy = serde_json::from_value(json).unwrap();
 		let prompt_guard = policy.prompt_guard.unwrap();
 		assert_eq!(prompt_guard.response.len(), 1);
+		assert!(prompt_guard.streaming.is_disabled());
 
 		match &prompt_guard.response[0].kind {
 			ResponseGuardKind::BedrockGuardrails(bg) => {
@@ -1084,6 +1086,56 @@ mod prompt_guard_config_tests {
 			},
 			_ => panic!("Expected BedrockGuardrails response guard kind"),
 		}
+	}
+
+	#[test]
+	fn test_streaming_response_guards_are_opt_in() {
+		let json = json!({
+			"promptGuard": {
+				"response": [{
+					"regex": {
+						"action": "reject",
+						"rules": [{
+							"pattern": "secret"
+						}]
+					}
+				}]
+			}
+		});
+
+		let policy: Policy = serde_json::from_value(json).unwrap();
+
+		assert!(
+			policy
+				.prompt_guard
+				.as_ref()
+				.unwrap()
+				.streaming
+				.is_disabled()
+		);
+		assert!(!policy.has_streaming_response_guards());
+	}
+
+	#[test]
+	fn test_streaming_response_guards_enable_with_streaming_true() {
+		let json = json!({
+			"promptGuard": {
+				"streaming": "ENABLED",
+				"response": [{
+					"regex": {
+						"action": "reject",
+						"rules": [{
+							"pattern": "secret"
+						}]
+					}
+				}]
+			}
+		});
+
+		let policy: Policy = serde_json::from_value(json).unwrap();
+
+		assert!(policy.prompt_guard.as_ref().unwrap().streaming.is_enabled());
+		assert!(policy.has_streaming_response_guards());
 	}
 
 	#[test]

--- a/crates/agentgateway/src/llm/policy/tests.rs
+++ b/crates/agentgateway/src/llm/policy/tests.rs
@@ -22,7 +22,9 @@ async fn webhook_fail_open_emits_single_metric() {
 	};
 
 	let client = crate::test_helpers::policy_client();
-	let blocked = guard.apply_realtime_request_guards("hello world", &client).await;
+	let blocked = guard
+		.apply_realtime_request_guards("hello world", &client)
+		.await;
 	assert!(blocked.is_none(), "FailOpen must not block the request");
 
 	let fail_open = client
@@ -45,7 +47,10 @@ async fn webhook_fail_open_emits_single_metric() {
 		.get();
 
 	assert_eq!(fail_open, 1, "FailOpen should be recorded exactly once");
-	assert_eq!(allow, 0, "Allow must not be recorded for a FailOpen outcome");
+	assert_eq!(
+		allow, 0,
+		"Allow must not be recorded for a FailOpen outcome"
+	);
 }
 
 #[test]

--- a/crates/agentgateway/src/llm/policy/tests.rs
+++ b/crates/agentgateway/src/llm/policy/tests.rs
@@ -1120,7 +1120,7 @@ mod prompt_guard_config_tests {
 	fn test_streaming_response_guards_enable_with_streaming_true() {
 		let json = json!({
 			"promptGuard": {
-				"streaming": "ENABLED",
+				"streaming": "Enabled",
 				"response": [{
 					"regex": {
 						"action": "reject",

--- a/crates/agentgateway/src/llm/policy/tests.rs
+++ b/crates/agentgateway/src/llm/policy/tests.rs
@@ -2,6 +2,52 @@ use ::http::{HeaderName, HeaderValue};
 
 use super::*;
 
+/// When a webhook guard fails open, exactly one metric must be emitted (`FailOpen`); the caller
+/// must not additionally record `Allow`.
+#[tokio::test]
+async fn webhook_fail_open_emits_single_metric() {
+	use crate::telemetry::metrics::{GuardrailAction, GuardrailLabels, GuardrailPhase};
+	use crate::types::agent::SimpleBackendReference;
+
+	let guard = PromptGuard {
+		request: vec![RequestGuard {
+			rejection: Default::default(),
+			kind: RequestGuardKind::Webhook(Webhook {
+				target: SimpleBackendReference::Invalid,
+				forward_header_matches: vec![],
+				failure_mode: FailureMode::FailOpen,
+			}),
+		}],
+		response: vec![],
+	};
+
+	let client = crate::test_helpers::policy_client();
+	let blocked = guard.apply_realtime_request_guards("hello world", &client).await;
+	assert!(blocked.is_none(), "FailOpen must not block the request");
+
+	let fail_open = client
+		.inputs
+		.metrics
+		.guardrail_checks
+		.get_or_create(&GuardrailLabels {
+			phase: GuardrailPhase::Request,
+			action: GuardrailAction::FailOpen,
+		})
+		.get();
+	let allow = client
+		.inputs
+		.metrics
+		.guardrail_checks
+		.get_or_create(&GuardrailLabels {
+			phase: GuardrailPhase::Request,
+			action: GuardrailAction::Allow,
+		})
+		.get();
+
+	assert_eq!(fail_open, 1, "FailOpen should be recorded exactly once");
+	assert_eq!(allow, 0, "Allow must not be recorded for a FailOpen outcome");
+}
+
 #[test]
 fn test_get_webhook_forward_headers() {
 	let mut headers = HeaderMap::new();

--- a/crates/agentgateway/src/llm/tests.rs
+++ b/crates/agentgateway/src/llm/tests.rs
@@ -723,10 +723,22 @@ mod response {
 	}
 
 	async fn test_streaming_response_for_provider(provider: &str, test: &str) {
+		use crate::proxy::httpproxy::PolicyClient;
+		use crate::test_helpers::proxymock::setup_proxy_test;
 		let (p, r) = build_provider_request(provider);
+		let client = PolicyClient::new(setup_proxy_test("{}").unwrap().pi);
 		let test_fn = async |i: Response, log: AsyncLog<llm::LLMInfo>| {
-			p.process_streaming(r, LLMResponsePolicies::default(), None, log, false, None, i)
-				.await
+			p.process_streaming(
+				client,
+				r,
+				LLMResponsePolicies::default(),
+				None,
+				log,
+				false,
+				None,
+				i,
+			)
+			.await
 		};
 		test_streaming(provider, test, test_fn).await
 	}
@@ -1348,6 +1360,8 @@ async fn process_response_routes_streaming_error_to_buffered_path() {
 
 #[tokio::test]
 async fn process_streaming_bedrock_completions_normalizes_sse_headers_and_done() {
+	use crate::proxy::httpproxy::PolicyClient;
+	use crate::test_helpers::proxymock::setup_proxy_test;
 	let bedrock = AIProvider::Bedrock(bedrock::Provider {
 		model: Some(strng::new("openai.gpt-oss-120b-1:0")),
 		region: strng::new("us-east-1"),
@@ -1371,8 +1385,10 @@ async fn process_streaming_bedrock_completions_normalizes_sse_headers_and_done()
 		"request_id".parse().unwrap(),
 	);
 
+	let client = PolicyClient::new(setup_proxy_test("{}").unwrap().pi);
 	let translated = bedrock
 		.process_streaming(
+			client,
 			LLMRequest {
 				input_tokens: None,
 				input_format: InputFormat::Completions,

--- a/crates/agentgateway/src/parse/websocket.rs
+++ b/crates/agentgateway/src/parse/websocket.rs
@@ -2,13 +2,17 @@ use std::io::{Error, IoSlice};
 use std::pin::Pin;
 use std::task::{Context, Poll, ready};
 
-use async_openai::types::realtime::RealtimeResponseUsage;
+use async_openai::types::realtime::{
+	RealtimeClientEvent, RealtimeResponseUsage, RealtimeServerEvent, UserMessageContent,
+};
 use bytes::{Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
-use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
-use websocket_sans_io::{FrameInfo, Opcode, WebsocketFrameEvent};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, ReadBuf};
+use websocket_sans_io::{FrameInfo, Opcode, WebsocketFrameEncoder, WebsocketFrameEvent};
 
+use crate::llm::policy::PromptGuard;
 use crate::llm::{LLMInfo, LLMResponse};
+use crate::proxy::httpproxy::PolicyClient;
 use crate::telemetry::log::AsyncLog;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -185,6 +189,399 @@ where
 		buffer_limit,
 		disabled: false,
 		log,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Guarded WebSocket realtime proxy
+// ---------------------------------------------------------------------------
+
+/// Encode a WebSocket text frame (server-side, unmasked) containing `payload`.
+fn encode_ws_text_frame(payload: &[u8]) -> Bytes {
+	let mut encoder = WebsocketFrameEncoder::new();
+	let frame_info = FrameInfo {
+		opcode: Opcode::Text,
+		payload_length: payload.len() as u64,
+		mask: None,
+		fin: true,
+		reserved: 0,
+	};
+	let header = encoder.start_frame(&frame_info);
+	let mut out = BytesMut::with_capacity(header.len() + payload.len());
+	out.extend_from_slice(&header);
+	out.extend_from_slice(payload);
+	out.freeze()
+}
+
+/// Encode a WebSocket text frame with `mask` (client-side, masked).
+fn encode_ws_text_frame_masked(payload: &[u8], mask: [u8; 4]) -> Bytes {
+	let mut encoder = WebsocketFrameEncoder::new();
+	let frame_info = FrameInfo {
+		opcode: Opcode::Text,
+		payload_length: payload.len() as u64,
+		mask: Some(mask),
+		fin: true,
+		reserved: 0,
+	};
+	let header = encoder.start_frame(&frame_info);
+	let mut out = BytesMut::with_capacity(header.len() + payload.len());
+	out.extend_from_slice(&header);
+	let mut payload_copy = payload.to_vec();
+	encoder.transform_frame_payload(&mut payload_copy);
+	out.extend_from_slice(&payload_copy);
+	out.freeze()
+}
+
+/// Synthetic WebSocket error event sent when a guardrail blocks content.
+fn guardrail_blocked_ws_event_bytes() -> Bytes {
+	let json = br#"{"type":"error","error":{"type":"guardrail_blocked","code":"guardrail_intervention","message":"Content blocked by guardrail policy"}}"#;
+	encode_ws_text_frame(json)
+}
+
+/// Synthetic `response.cancel` event sent to the server when a response guard blocks.
+///
+/// The WebSocket spec requires client→server frames to be masked. We use a zero mask
+/// so the XOR is identity (payload bytes are unchanged) while the frame is formally masked.
+fn response_cancel_event_bytes(mask: [u8; 4]) -> Bytes {
+	let json = br#"{"type":"response.cancel"}"#;
+	encode_ws_text_frame_masked(json, mask)
+}
+
+// ---------------------------------------------------------------------------
+// WebSocket frame accumulator
+// ---------------------------------------------------------------------------
+
+struct WsFrameAccumulator {
+	decoder: websocket_sans_io::WebsocketFrameDecoder,
+	pending: BytesMut,
+	frame_raw: BytesMut,
+	frame_payload: BytesMut,
+}
+
+enum WsCompletedFrame {
+	Text { raw: Bytes, payload: Bytes },
+	Other { raw: Bytes },
+}
+
+impl WsFrameAccumulator {
+	fn new() -> Self {
+		Self {
+			decoder: websocket_sans_io::WebsocketFrameDecoder::new(),
+			pending: BytesMut::new(),
+			frame_raw: BytesMut::new(),
+			frame_payload: BytesMut::new(),
+		}
+	}
+
+	fn push(&mut self, data: &[u8]) {
+		self.pending.extend_from_slice(data);
+	}
+
+	fn drain_frames(&mut self) -> Vec<WsCompletedFrame> {
+		let mut result = Vec::new();
+		loop {
+			let mut copy = self.pending.to_vec();
+			let ret = match self.decoder.add_data(&mut copy) {
+				Ok(r) => r,
+				Err(_) => {
+					// Protocol error: forward all pending raw bytes as an opaque frame and
+					// clear accumulator state so the proxy makes progress rather than
+					// retrying the same bytes and stalling indefinitely.
+					if !self.pending.is_empty() {
+						let raw = self.pending.split().freeze();
+						self.frame_raw.clear();
+						self.frame_payload.clear();
+						result.push(WsCompletedFrame::Other { raw });
+					}
+					break;
+				},
+			};
+			if ret.consumed_bytes == 0 && ret.event.is_none() {
+				break;
+			}
+
+			let raw_chunk = self.pending.split_to(ret.consumed_bytes).freeze();
+			self.frame_raw.extend_from_slice(&raw_chunk);
+
+			match ret.event {
+				Some(WebsocketFrameEvent::PayloadChunk {
+					original_opcode: Opcode::Text,
+				}) => {
+					self
+						.frame_payload
+						.extend_from_slice(&copy[..ret.consumed_bytes]);
+				},
+				Some(WebsocketFrameEvent::End {
+					original_opcode: Opcode::Text,
+					frame_info: FrameInfo { fin: true, .. },
+				}) => {
+					self
+						.frame_payload
+						.extend_from_slice(&copy[..ret.consumed_bytes]);
+					let raw = self.frame_raw.split().freeze();
+					let payload = self.frame_payload.split().freeze();
+					result.push(WsCompletedFrame::Text { raw, payload });
+				},
+				Some(WebsocketFrameEvent::End { .. }) => {
+					let raw = self.frame_raw.split().freeze();
+					self.frame_payload.clear();
+					result.push(WsCompletedFrame::Other { raw });
+				},
+				Some(WebsocketFrameEvent::PayloadChunk { .. })
+				| Some(WebsocketFrameEvent::Start { .. })
+				| None => {},
+			}
+		}
+		result
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Guarded realtime proxy
+// ---------------------------------------------------------------------------
+
+/// A bidirectional guarded WebSocket proxy for the OpenAI Realtime API.
+///
+/// - **Client→Server:** applies request guards to `conversation.item.create` events.
+/// - **Server→Client:** windowed evaluation of `response.output_text.delta` events —
+///   deltas are held until ~`DEFAULT_EVAL_THRESHOLD` bytes of text accumulate, then
+///   evaluated (with an overlap tail from previously evaluated text) and flushed on
+///   pass. On block, the held (never-forwarded) deltas are discarded, a synthetic
+///   error event is sent to the client, and `response.cancel` is sent to the server;
+///   subsequent deltas for that response are dropped.
+/// - Preserves existing telemetry on `response.done`.
+/// - All non-text frames (audio, control, etc.) are forwarded immediately.
+pub async fn guarded_realtime_proxy<C, S>(
+	client: C,
+	server: S,
+	guard: PromptGuard,
+	policy_client: PolicyClient,
+	log: AsyncLog<LLMInfo>,
+) where
+	C: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+	S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+{
+	use crate::llm::policy::streaming_guardrails::{
+		DEFAULT_EVAL_THRESHOLD, OVERLAP_BYTES, evaluate_window, tail_chars,
+	};
+
+	let (mut client_reader, mut client_writer_io) = tokio::io::split(client);
+	let (mut server_reader, mut server_writer_io) = tokio::io::split(server);
+
+	let (client_tx, mut client_rx) = tokio::sync::mpsc::channel::<Bytes>(256);
+	let (server_tx, mut server_rx) = tokio::sync::mpsc::channel::<Bytes>(256);
+
+	let guard_clone = guard.clone();
+	let policy_client_clone = policy_client.clone();
+	let log_clone = log.clone();
+
+	let client_to_server = {
+		let server_tx = server_tx.clone();
+		let client_tx_err = client_tx.clone();
+		async move {
+			let mut accum = WsFrameAccumulator::new();
+			let mut read_buf = [0u8; 4096];
+
+			loop {
+				let n = match client_reader.read(&mut read_buf).await {
+					Ok(0) | Err(_) => break,
+					Ok(n) => n,
+				};
+				accum.push(&read_buf[..n]);
+
+				for frame in accum.drain_frames() {
+					match frame {
+						WsCompletedFrame::Text { raw, payload } => {
+							if let Ok(text) = std::str::from_utf8(&payload)
+								&& let Ok(RealtimeClientEvent::ConversationItemCreate(create)) =
+									serde_json::from_str::<RealtimeClientEvent>(text)
+							{
+								let mut input_text = String::new();
+								if let async_openai::types::realtime::RealtimeConversationItem::Message(
+									async_openai::types::realtime::RealtimeConversationItemMessage::User(user_msg),
+								) = &create.item
+								{
+									for content in &user_msg.content {
+										if let UserMessageContent::InputText(t) = content {
+											input_text.push_str(&t.text);
+											input_text.push(' ');
+										}
+									}
+								}
+
+								if !input_text.is_empty()
+									&& guard
+										.apply_realtime_request_guards(input_text.trim(), &policy_client)
+										.await
+								{
+									let _ = client_tx_err.send(guardrail_blocked_ws_event_bytes()).await;
+									continue;
+								}
+							}
+							let _ = server_tx.send(raw).await;
+						},
+						WsCompletedFrame::Other { raw } => {
+							let _ = server_tx.send(raw).await;
+						},
+					}
+				}
+			}
+			drop(server_tx);
+		}
+	};
+
+	let server_to_client = {
+		async move {
+			let mut accum = WsFrameAccumulator::new();
+			let mut read_buf = [0u8; 4096];
+			let mut evaluators =
+				guard_clone.begin_streaming_response_guard(&policy_client_clone, &::http::HeaderMap::new());
+			let mut delta_hold: Vec<Bytes> = Vec::new();
+			let mut pending_text = String::new();
+			let mut overlap_tail = String::new();
+			let mut response_blocked = false;
+
+			loop {
+				let n = match server_reader.read(&mut read_buf).await {
+					Ok(0) | Err(_) => break,
+					Ok(n) => n,
+				};
+				accum.push(&read_buf[..n]);
+
+				for frame in accum.drain_frames() {
+					match frame {
+						WsCompletedFrame::Text { raw, payload } => {
+							let event = std::str::from_utf8(&payload)
+								.ok()
+								.and_then(|s| serde_json::from_str::<RealtimeServerEvent>(s).ok());
+
+							match event {
+								Some(RealtimeServerEvent::ResponseOutputTextDelta(ref delta_event)) => {
+									if response_blocked {
+										continue;
+									}
+									pending_text.push_str(&delta_event.delta);
+									delta_hold.push(raw);
+
+									if pending_text.len() >= DEFAULT_EVAL_THRESHOLD {
+										let batch = std::mem::take(&mut pending_text);
+										let window = format!("{overlap_tail}{batch}");
+										overlap_tail = tail_chars(&window, OVERLAP_BYTES).to_string();
+
+										if evaluate_window(&mut evaluators, &window).await {
+											delta_hold.clear();
+											response_blocked = true;
+											let _ = client_tx.send(guardrail_blocked_ws_event_bytes()).await;
+											let _ = server_tx
+												.send(response_cancel_event_bytes([0, 0, 0, 0]))
+												.await;
+										} else {
+											for f in delta_hold.drain(..) {
+												let _ = client_tx.send(f).await;
+											}
+										}
+									}
+								},
+								Some(RealtimeServerEvent::ResponseOutputTextDone(_)) => {
+									if response_blocked {
+										response_blocked = false;
+										overlap_tail.clear();
+										pending_text.clear();
+										delta_hold.clear();
+										continue;
+									}
+
+									let mut blocked = false;
+									if !pending_text.is_empty() {
+										let batch = std::mem::take(&mut pending_text);
+										let window = format!("{overlap_tail}{batch}");
+										blocked = evaluate_window(&mut evaluators, &window).await;
+									}
+									overlap_tail.clear();
+
+									if blocked {
+										delta_hold.clear();
+										// Prevent stale deltas from a race between the cancel
+										// reaching the server and buffered frames arriving here.
+										response_blocked = true;
+										let _ = client_tx.send(guardrail_blocked_ws_event_bytes()).await;
+										let _ = server_tx
+											.send(response_cancel_event_bytes([0, 0, 0, 0]))
+											.await;
+									} else {
+										for f in delta_hold.drain(..) {
+											let _ = client_tx.send(f).await;
+										}
+										let _ = client_tx.send(raw).await;
+									}
+								},
+								Some(RealtimeServerEvent::ResponseDone(ref done_event)) => {
+									if let Some(usage) = done_event.response.usage.as_ref() {
+										let usage_clone = usage.clone();
+										log_clone.non_atomic_mutate(|r| {
+											r.response = LLMResponse {
+												input_tokens: Some(usage_clone.input_tokens as u64),
+												input_image_tokens: None,
+												input_text_tokens: None,
+												input_audio_tokens: None,
+												output_tokens: Some(usage_clone.output_tokens as u64),
+												output_image_tokens: None,
+												output_text_tokens: None,
+												output_audio_tokens: None,
+												total_tokens: Some(usage_clone.total_tokens as u64),
+												service_tier: None,
+												provider_model: None,
+												completion: None,
+												first_token: None,
+												count_tokens: None,
+												reasoning_tokens: None,
+												cache_creation_input_tokens: None,
+												cached_input_tokens: usage_clone
+													.input_token_details
+													.as_ref()
+													.and_then(|d| d.cached_tokens)
+													.map(|x| x as u64),
+											}
+										});
+									}
+									let _ = client_tx.send(raw).await;
+								},
+								_ => {
+									let _ = client_tx.send(raw).await;
+								},
+							}
+						},
+						WsCompletedFrame::Other { raw } => {
+							let _ = client_tx.send(raw).await;
+						},
+					}
+				}
+			}
+			drop(client_tx);
+		}
+	};
+
+	let client_writer_task = async move {
+		while let Some(bytes) = client_rx.recv().await {
+			if client_writer_io.write_all(&bytes).await.is_err() {
+				break;
+			}
+		}
+	};
+
+	let server_writer_task = async move {
+		while let Some(bytes) = server_rx.recv().await {
+			if server_writer_io.write_all(&bytes).await.is_err() {
+				break;
+			}
+		}
+	};
+
+	tokio::select! {
+		_ = client_to_server => {},
+		_ = server_to_client => {},
+		_ = client_writer_task => {},
+		_ = server_writer_task => {},
 	}
 }
 

--- a/crates/agentgateway/src/parse/websocket.rs
+++ b/crates/agentgateway/src/parse/websocket.rs
@@ -235,8 +235,12 @@ fn guardrail_blocked_ws_event_bytes(body: Bytes) -> Bytes {
 /// The WebSocket spec requires client→server frames to be masked. We use a zero mask
 /// so the XOR is identity (payload bytes are unchanged) while the frame is formally masked.
 fn response_cancel_event_bytes(mask: [u8; 4]) -> Bytes {
-	let json = br#"{"type":"response.cancel"}"#;
-	encode_ws_text_frame_masked(json, mask)
+	// NOTE: response.cancel is sent without a response_id; the server cancels its most-recent
+	// active response. Correctly targeting a specific response in the Realtime API's out-of-band
+	// (concurrent) response pattern requires a response_id here and per-response blocked tracking
+	// — see https://github.com/agentgateway/agentgateway/issues/2213.
+	let json = r#"{"type":"response.cancel"}"#;
+	encode_ws_text_frame_masked(json.as_bytes(), mask)
 }
 
 // ---------------------------------------------------------------------------
@@ -349,6 +353,7 @@ pub async fn guarded_realtime_proxy<C, S>(
 	guard: PromptGuard,
 	policy_client: PolicyClient,
 	log: AsyncLog<LLMInfo>,
+	req_headers: ::http::HeaderMap,
 ) where
 	C: AsyncRead + AsyncWrite + Unpin + Send + 'static,
 	S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
@@ -429,7 +434,7 @@ pub async fn guarded_realtime_proxy<C, S>(
 			let mut accum = WsFrameAccumulator::new();
 			let mut read_buf = [0u8; 4096];
 			let mut evaluators =
-				guard_clone.begin_streaming_response_guard(&policy_client_clone, &::http::HeaderMap::new());
+				guard_clone.begin_streaming_response_guard(&policy_client_clone, &req_headers);
 			let mut delta_hold: Vec<Bytes> = Vec::new();
 			let mut pending_text = String::new();
 			let mut overlap_tail = String::new();
@@ -464,6 +469,10 @@ pub async fn guarded_realtime_proxy<C, S>(
 
 										if let Some(blocked_body) = evaluate_window(&mut evaluators, &window).await {
 											delta_hold.clear();
+											// Clear text-state so a blocked response's content does not
+											// bleed into the next response's evaluation window.
+											overlap_tail.clear();
+											pending_text.clear();
 											response_blocked = true;
 											let _ = client_tx
 												.send(guardrail_blocked_ws_event_bytes(blocked_body))
@@ -497,8 +506,6 @@ pub async fn guarded_realtime_proxy<C, S>(
 
 									if let Some(blocked_body) = blocked_body {
 										delta_hold.clear();
-										// Prevent stale deltas from a race between the cancel
-										// reaching the server and buffered frames arriving here.
 										response_blocked = true;
 										let _ = client_tx
 											.send(guardrail_blocked_ws_event_bytes(blocked_body))
@@ -559,28 +566,31 @@ pub async fn guarded_realtime_proxy<C, S>(
 		}
 	};
 
-	let client_writer_task = async move {
+	// Spawn writer tasks as independent tokio tasks so they drain their channels
+	// concurrently with the reader loops. Without independent tasks, the writers
+	// would only run after a reader exits, which would drop buffered frames.
+	let client_writer_join = tokio::spawn(async move {
 		while let Some(bytes) = client_rx.recv().await {
 			if client_writer_io.write_all(&bytes).await.is_err() {
 				break;
 			}
 		}
-	};
+	});
 
-	let server_writer_task = async move {
+	let server_writer_join = tokio::spawn(async move {
 		while let Some(bytes) = server_rx.recv().await {
 			if server_writer_io.write_all(&bytes).await.is_err() {
 				break;
 			}
 		}
-	};
+	});
 
+	// Exit when either reader closes; then wait for writers to drain remaining frames.
 	tokio::select! {
 		_ = client_to_server => {},
 		_ = server_to_client => {},
-		_ = client_writer_task => {},
-		_ = server_writer_task => {},
 	}
+	let _ = tokio::join!(client_writer_join, server_writer_join);
 }
 
 #[cfg(test)]

--- a/crates/agentgateway/src/parse/websocket.rs
+++ b/crates/agentgateway/src/parse/websocket.rs
@@ -29,8 +29,8 @@ pub struct ResponseResource {
 
 struct Parser<IO> {
 	inner: IO,
-	decoder: websocket_sans_io::WebsocketFrameDecoder,
-	buf: BytesMut,
+	frames: WsFrameAccumulator,
+	text_buffer: BytesMut,
 	buffer_limit: usize,
 	disabled: bool,
 	log: AsyncLog<LLMInfo>,
@@ -38,12 +38,12 @@ struct Parser<IO> {
 
 impl<IO> Parser<IO> {
 	fn record_text_payload(&mut self, data: &[u8]) -> bool {
-		if self.buf.len() + data.len() > self.buffer_limit {
-			self.buf = Default::default();
+		if self.text_buffer.len() + data.len() > self.buffer_limit {
+			self.text_buffer = Default::default();
 			self.disabled = true;
 			return false;
 		}
-		self.buf.extend_from_slice(data);
+		self.text_buffer.extend_from_slice(data);
 		true
 	}
 
@@ -133,34 +133,18 @@ impl<IO: AsyncRead + Unpin + 'static> AsyncRead for Parser<IO> {
 		if self.disabled {
 			return Poll::Ready(Ok(()));
 		}
-		let mut processed_offset = 0;
-		loop {
-			let unprocessed_part_of_buf = &buf.filled()[processed_offset..buf.filled().len()];
-			// Websocket logic needs owned copy to apply the mask. However, we need to keep the untouched stuff
-			// so we are not modifying the response.
-			let Ok(ret) = self.decoder.add_data(&mut unprocessed_part_of_buf.to_vec());
-			processed_offset += ret.consumed_bytes;
-
-			if ret.event.is_none() && ret.consumed_bytes == 0 {
-				return Poll::Ready(Ok(()));
-			}
-
-			match ret.event {
-				Some(WebsocketFrameEvent::PayloadChunk {
-					original_opcode: Opcode::Text,
-				}) if !self.record_text_payload(&unprocessed_part_of_buf[0..ret.consumed_bytes]) => {
+		let new_bytes = &buf.filled()[orig..];
+		self.frames.push(new_bytes);
+		for frame in self.frames.drain_frames() {
+			if let WsCompletedFrame::Text { payload, .. } = frame {
+				if !self.record_text_payload(&payload) {
 					return Poll::Ready(Ok(()));
-				},
-				Some(WebsocketFrameEvent::End {
-					frame_info: FrameInfo { fin: true, .. },
-					original_opcode: Opcode::Text,
-				}) => {
-					let got = self.buf.split();
-					self.emit(got.freeze());
-				},
-				_ => (),
+				}
+				let got = self.text_buffer.split();
+				self.emit(got.freeze());
 			}
 		}
+		Poll::Ready(Ok(()))
 	}
 }
 
@@ -184,8 +168,8 @@ where
 {
 	Parser {
 		inner: body,
-		decoder: websocket_sans_io::WebsocketFrameDecoder::new(),
-		buf: Default::default(),
+		frames: WsFrameAccumulator::new(),
+		text_buffer: Default::default(),
 		buffer_limit,
 		disabled: false,
 		log,
@@ -233,9 +217,17 @@ fn encode_ws_text_frame_masked(payload: &[u8], mask: [u8; 4]) -> Bytes {
 }
 
 /// Synthetic WebSocket error event sent when a guardrail blocks content.
-fn guardrail_blocked_ws_event_bytes() -> Bytes {
-	let json = br#"{"type":"error","error":{"type":"guardrail_blocked","code":"guardrail_intervention","message":"Content blocked by guardrail policy"}}"#;
-	encode_ws_text_frame(json)
+fn guardrail_blocked_ws_event_bytes(body: Bytes) -> Bytes {
+	let message = String::from_utf8_lossy(&body);
+	let event = serde_json::json!({
+		"type": "error",
+		"error": {
+			"type": "guardrail_blocked",
+			"code": "guardrail_intervention",
+			"message": message,
+		}
+	});
+	encode_ws_text_frame(event.to_string().as_bytes())
 }
 
 /// Synthetic `response.cancel` event sent to the server when a response guard blocks.
@@ -410,11 +402,13 @@ pub async fn guarded_realtime_proxy<C, S>(
 								}
 
 								if !input_text.is_empty()
-									&& guard
+									&& let Some(blocked_body) = guard
 										.apply_realtime_request_guards(input_text.trim(), &policy_client)
 										.await
 								{
-									let _ = client_tx_err.send(guardrail_blocked_ws_event_bytes()).await;
+									let _ = client_tx_err
+										.send(guardrail_blocked_ws_event_bytes(blocked_body))
+										.await;
 									continue;
 								}
 							}
@@ -468,10 +462,12 @@ pub async fn guarded_realtime_proxy<C, S>(
 										let window = format!("{overlap_tail}{batch}");
 										overlap_tail = tail_chars(&window, OVERLAP_BYTES).to_string();
 
-										if evaluate_window(&mut evaluators, &window).await {
+										if let Some(blocked_body) = evaluate_window(&mut evaluators, &window).await {
 											delta_hold.clear();
 											response_blocked = true;
-											let _ = client_tx.send(guardrail_blocked_ws_event_bytes()).await;
+											let _ = client_tx
+												.send(guardrail_blocked_ws_event_bytes(blocked_body))
+												.await;
 											let _ = server_tx
 												.send(response_cancel_event_bytes([0, 0, 0, 0]))
 												.await;
@@ -491,20 +487,22 @@ pub async fn guarded_realtime_proxy<C, S>(
 										continue;
 									}
 
-									let mut blocked = false;
+									let mut blocked_body = None;
 									if !pending_text.is_empty() {
 										let batch = std::mem::take(&mut pending_text);
 										let window = format!("{overlap_tail}{batch}");
-										blocked = evaluate_window(&mut evaluators, &window).await;
+										blocked_body = evaluate_window(&mut evaluators, &window).await;
 									}
 									overlap_tail.clear();
 
-									if blocked {
+									if let Some(blocked_body) = blocked_body {
 										delta_hold.clear();
 										// Prevent stale deltas from a race between the cancel
 										// reaching the server and buffered frames arriving here.
 										response_blocked = true;
-										let _ = client_tx.send(guardrail_blocked_ws_event_bytes()).await;
+										let _ = client_tx
+											.send(guardrail_blocked_ws_event_bytes(blocked_body))
+											.await;
 										let _ = server_tx
 											.send(response_cancel_event_bytes([0, 0, 0, 0]))
 											.await;
@@ -594,19 +592,19 @@ mod tests {
 		let (io, _) = tokio::io::duplex(1);
 		let mut parser = Parser {
 			inner: io,
-			decoder: websocket_sans_io::WebsocketFrameDecoder::new(),
-			buf: Default::default(),
+			frames: WsFrameAccumulator::new(),
+			text_buffer: Default::default(),
 			buffer_limit: 4,
 			disabled: false,
 			log: AsyncLog::default(),
 		};
 
 		assert!(parser.record_text_payload(b"abc"));
-		assert_eq!(&parser.buf[..], b"abc");
-		parser.buf.reserve(1024);
+		assert_eq!(&parser.text_buffer[..], b"abc");
+		parser.text_buffer.reserve(1024);
 		assert!(!parser.record_text_payload(b"de"));
 		assert!(parser.disabled);
-		assert!(parser.buf.is_empty());
-		assert_eq!(parser.buf.capacity(), 0);
+		assert!(parser.text_buffer.is_empty());
+		assert_eq!(parser.text_buffer.capacity(), 0);
 	}
 }

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -453,6 +453,7 @@ async fn apply_llm_request_policies(
 			.llm
 			.as_deref()
 			.and_then(|llm| llm.prompt_guard.as_ref())
+			.filter(|g| g.streaming.is_enabled())
 			.map(|g| g.response.clone())
 			.unwrap_or_default(),
 	})
@@ -1345,6 +1346,7 @@ impl HTTPProxy {
 				.llm
 				.as_deref()
 				.and_then(|p| p.prompt_guard.clone())
+				.filter(|g| g.streaming.is_enabled())
 			{
 				resp.extensions_mut().insert(RealtimeGuardContext {
 					prompt_guard,
@@ -2923,21 +2925,27 @@ fn should_retry(
 mod tests {
 	use std::collections::{HashMap, HashSet};
 	use std::net::SocketAddr;
+	use std::sync::Arc;
 
 	use ::http::Method;
 	use serde_json::json;
 	use wiremock::{Mock, ResponseTemplate};
 
 	use super::{
-		apply_auto_hostname, hop_by_hop_headers, resolved_workload_target_hostname,
-		select_service_target_port,
+		apply_auto_hostname, apply_llm_request_policies, hop_by_hop_headers,
+		resolved_workload_target_hostname, select_service_target_port,
 	};
-	use crate::http;
 	use crate::http::filters::AutoHostname;
+	use crate::llm::policy::{
+		PromptGuard, PromptGuardStreamingMode, RegexRule, RegexRules, RequestRejection, ResponseGuard,
+		ResponseGuardKind,
+	};
+	use crate::store::LLMRequestPolicies;
 	use crate::test_helpers::proxymock;
 	use crate::types::agent::{Backend, ResourceName, Target};
 	use crate::types::discovery::{AppProtocol, Endpoint, HealthStatus, Service};
 	use crate::types::local::LocalAIBackend;
+	use crate::{http, llm};
 
 	fn retry_policy(codes: &[u16], condition: Option<&str>) -> crate::http::retry::Policy {
 		crate::http::retry::Policy {
@@ -2951,6 +2959,79 @@ mod tests {
 			condition: condition
 				.map(|e| std::sync::Arc::new(crate::cel::Expression::new_strict(e).unwrap())),
 		}
+	}
+
+	fn response_regex_guard() -> ResponseGuard {
+		ResponseGuard {
+			rejection: RequestRejection::default(),
+			kind: ResponseGuardKind::Regex(RegexRules {
+				action: Default::default(),
+				rules: vec![RegexRule::Regex {
+					pattern: regex::Regex::new("secret").unwrap(),
+				}],
+			}),
+		}
+	}
+
+	fn llm_request() -> llm::LLMRequest {
+		llm::LLMRequest {
+			input_tokens: None,
+			input_format: llm::InputFormat::Completions,
+			native_format: Some(llm::custom::ProviderFormat::Completions),
+			cache_convention: llm::CacheTokenConvention::pending(),
+			request_model: "test-model".into(),
+			provider: "test-provider".into(),
+			streaming: true,
+			params: Default::default(),
+			prompt: None,
+		}
+	}
+
+	async fn response_prompt_guards_for_streaming_mode(
+		streaming: PromptGuardStreamingMode,
+	) -> Vec<ResponseGuard> {
+		let policy = llm::Policy {
+			prompt_guard: Some(PromptGuard {
+				streaming,
+				request: vec![],
+				response: vec![response_regex_guard()],
+			}),
+			..Default::default()
+		};
+		let policies = LLMRequestPolicies {
+			llm: Some(Arc::new(policy)),
+			..Default::default()
+		};
+		let mut req = ::http::Request::builder()
+			.body(http::Body::empty())
+			.unwrap();
+		let mut response_headers = ::http::HeaderMap::new();
+
+		apply_llm_request_policies(
+			&policies,
+			crate::test_helpers::policy_client(),
+			&mut req,
+			&llm_request(),
+			&mut response_headers,
+		)
+		.await
+		.expect("LLM request policies should apply")
+		.prompt_guard
+	}
+
+	#[tokio::test]
+	async fn apply_llm_request_policies_skips_streaming_guardrails_when_disabled() {
+		let guards =
+			response_prompt_guards_for_streaming_mode(PromptGuardStreamingMode::Disabled).await;
+
+		assert!(guards.is_empty());
+	}
+
+	#[tokio::test]
+	async fn apply_llm_request_policies_includes_streaming_guardrails_when_enabled() {
+		let guards = response_prompt_guards_for_streaming_mode(PromptGuardStreamingMode::Enabled).await;
+
+		assert_eq!(guards.len(), 1);
 	}
 
 	#[test]

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -1289,6 +1289,7 @@ impl HTTPProxy {
 				.extensions_mut()
 				.insert(BackendRequestTimeout(backend_timeout));
 		}
+		let upgrade_req_headers = req.headers().clone();
 		let mut req_opt = Some(req);
 		let timeout = response_policies
 			.timeout
@@ -1348,6 +1349,7 @@ impl HTTPProxy {
 				resp.extensions_mut().insert(RealtimeGuardContext {
 					prompt_guard,
 					policy_client: self.policy_client(),
+					req_headers: upgrade_req_headers,
 				});
 			}
 		}
@@ -1426,6 +1428,7 @@ async fn handle_upgrade(
 					guard_context.prompt_guard,
 					guard_context.policy_client,
 					llm,
+					guard_context.req_headers,
 				)
 				.await;
 				return;
@@ -3371,6 +3374,7 @@ struct ConnectTunnel {
 struct RealtimeGuardContext {
 	prompt_guard: crate::llm::policy::PromptGuard,
 	policy_client: PolicyClient,
+	req_headers: ::http::HeaderMap,
 }
 
 fn hop_by_hop_headers(req: &mut Request) -> Option<RequestUpgrade> {

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -445,17 +445,16 @@ async fn apply_llm_request_policies(
 		(http::PolicyResponse::default(), None)
 	};
 	rl_resp.apply(response_headers)?;
+	let prompt_guard = policies
+		.llm
+		.as_deref()
+		.and_then(|llm| llm.prompt_guard.as_ref());
 	Ok(store::LLMResponsePolicies {
 		local_rate_limit,
 		remote_rate_limit: response,
 		request_traceparent: req.headers().get(TRACEPARENT).cloned(),
-		prompt_guard: policies
-			.llm
-			.as_deref()
-			.and_then(|llm| llm.prompt_guard.as_ref())
-			.filter(|g| g.streaming.is_enabled())
-			.map(|g| g.response.clone())
-			.unwrap_or_default(),
+		prompt_guard: prompt_guard.map(|g| g.response.clone()).unwrap_or_default(),
+		streaming_prompt_guard_enabled: prompt_guard.is_some_and(|g| g.streaming.is_enabled()),
 	})
 }
 
@@ -2989,7 +2988,7 @@ mod tests {
 
 	async fn response_prompt_guards_for_streaming_mode(
 		streaming: PromptGuardStreamingMode,
-	) -> Vec<ResponseGuard> {
+	) -> crate::store::LLMResponsePolicies {
 		let policy = llm::Policy {
 			prompt_guard: Some(PromptGuard {
 				streaming,
@@ -3016,22 +3015,24 @@ mod tests {
 		)
 		.await
 		.expect("LLM request policies should apply")
-		.prompt_guard
 	}
 
 	#[tokio::test]
 	async fn apply_llm_request_policies_skips_streaming_guardrails_when_disabled() {
-		let guards =
+		let policies =
 			response_prompt_guards_for_streaming_mode(PromptGuardStreamingMode::Disabled).await;
 
-		assert!(guards.is_empty());
+		assert_eq!(policies.prompt_guard.len(), 1);
+		assert!(!policies.streaming_prompt_guard_enabled);
 	}
 
 	#[tokio::test]
 	async fn apply_llm_request_policies_includes_streaming_guardrails_when_enabled() {
-		let guards = response_prompt_guards_for_streaming_mode(PromptGuardStreamingMode::Enabled).await;
+		let policies =
+			response_prompt_guards_for_streaming_mode(PromptGuardStreamingMode::Enabled).await;
 
-		assert_eq!(guards.len(), 1);
+		assert_eq!(policies.prompt_guard.len(), 1);
+		assert!(policies.streaming_prompt_guard_enabled);
 	}
 
 	#[test]

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -619,21 +619,10 @@ impl HTTPProxy {
 			let Some(req_upgrade) = resp.extensions_mut().remove::<RequestUpgrade>() else {
 				return ProxyError::UpgradeFailed(None, None).into_response_with_grpc(is_grpc_request);
 			};
-			let mut realtime_prompt_guard: Option<crate::llm::policy::PromptGuard> = None;
-			let mut upgrade_policy_client = self.policy_client();
-			if let Some(ctx) = resp.extensions_mut().remove::<RealtimeUpgradeContext>() {
-				realtime_prompt_guard = ctx.prompt_guard;
-				upgrade_policy_client = ctx.policy_client;
-			}
-			handle_upgrade(
-				req_upgrade,
-				resp,
-				log,
-				realtime_prompt_guard,
-				upgrade_policy_client,
-			)
-			.await
-			.unwrap_or_else(|e| e.into_response_with_grpc(is_grpc_request))
+			let realtime_guard_context = resp.extensions_mut().remove::<RealtimeGuardContext>();
+			handle_upgrade(req_upgrade, resp, log, realtime_guard_context)
+				.await
+				.unwrap_or_else(|e| e.into_response_with_grpc(is_grpc_request))
 		} else {
 			resp.map(move |b| http::Body::new(LogBody::new(b, log)))
 		}
@@ -1351,14 +1340,16 @@ impl HTTPProxy {
 			};
 			resp.extensions_mut().insert(upgrade);
 			// Store prompt guard + policy client for the WebSocket upgrade path.
-			let prompt_guard = route_policies
+			if let Some(prompt_guard) = route_policies
 				.llm
 				.as_deref()
-				.and_then(|p| p.prompt_guard.clone());
-			resp.extensions_mut().insert(RealtimeUpgradeContext {
-				prompt_guard,
-				policy_client: self.policy_client(),
-			});
+				.and_then(|p| p.prompt_guard.clone())
+			{
+				resp.extensions_mut().insert(RealtimeGuardContext {
+					prompt_guard,
+					policy_client: self.policy_client(),
+				});
+			}
 		}
 
 		// gRPC status can be in the initial headers or a trailer, add if they are here
@@ -1389,8 +1380,7 @@ async fn handle_upgrade(
 	req_upgrade_type: RequestUpgrade,
 	mut resp: Response,
 	log: DropOnLog,
-	prompt_guard: Option<crate::llm::policy::PromptGuard>,
-	policy_client: PolicyClient,
+	realtime_guard_context: Option<RealtimeGuardContext>,
 ) -> Result<Response, ProxyError> {
 	let RequestUpgrade {
 		upgrade_type,
@@ -1429,12 +1419,12 @@ async fn handle_upgrade(
 			let llm = log.llm_response.clone();
 			let llm_info = LLMInfo::new(llm_req.clone(), LLMResponse::default());
 			llm.store(Some(llm_info));
-			if let Some(guard) = prompt_guard {
+			if let Some(guard_context) = realtime_guard_context {
 				parse::websocket::guarded_realtime_proxy(
 					TokioIo::new(req),
 					server,
-					guard,
-					policy_client,
+					guard_context.prompt_guard,
+					guard_context.policy_client,
 					llm,
 				)
 				.await;
@@ -3377,11 +3367,9 @@ struct ConnectTunnel {
 	upstream: Arc<Mutex<Option<Socket>>>,
 }
 
-/// Carries an optional `PromptGuard` and `PolicyClient` through response extensions
-/// so `handle_upgrade` can use them for the WebSocket realtime path.
 #[derive(Clone)]
-struct RealtimeUpgradeContext {
-	prompt_guard: Option<crate::llm::policy::PromptGuard>,
+struct RealtimeGuardContext {
+	prompt_guard: crate::llm::policy::PromptGuard,
 	policy_client: PolicyClient,
 }
 

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -619,9 +619,21 @@ impl HTTPProxy {
 			let Some(req_upgrade) = resp.extensions_mut().remove::<RequestUpgrade>() else {
 				return ProxyError::UpgradeFailed(None, None).into_response_with_grpc(is_grpc_request);
 			};
-			handle_upgrade(req_upgrade, resp, log)
-				.await
-				.unwrap_or_else(|e| e.into_response_with_grpc(is_grpc_request))
+			let mut realtime_prompt_guard: Option<crate::llm::policy::PromptGuard> = None;
+			let mut upgrade_policy_client = self.policy_client();
+			if let Some(ctx) = resp.extensions_mut().remove::<RealtimeUpgradeContext>() {
+				realtime_prompt_guard = ctx.prompt_guard;
+				upgrade_policy_client = ctx.policy_client;
+			}
+			handle_upgrade(
+				req_upgrade,
+				resp,
+				log,
+				realtime_prompt_guard,
+				upgrade_policy_client,
+			)
+			.await
+			.unwrap_or_else(|e| e.into_response_with_grpc(is_grpc_request))
 		} else {
 			resp.map(move |b| http::Body::new(LogBody::new(b, log)))
 		}
@@ -1338,6 +1350,15 @@ impl HTTPProxy {
 					.maybe_snapshot_on_err(log, &mut req_opt)?;
 			};
 			resp.extensions_mut().insert(upgrade);
+			// Store prompt guard + policy client for the WebSocket upgrade path.
+			let prompt_guard = route_policies
+				.llm
+				.as_deref()
+				.and_then(|p| p.prompt_guard.clone());
+			resp.extensions_mut().insert(RealtimeUpgradeContext {
+				prompt_guard,
+				policy_client: self.policy_client(),
+			});
 		}
 
 		// gRPC status can be in the initial headers or a trailer, add if they are here
@@ -1368,6 +1389,8 @@ async fn handle_upgrade(
 	req_upgrade_type: RequestUpgrade,
 	mut resp: Response,
 	log: DropOnLog,
+	prompt_guard: Option<crate::llm::policy::PromptGuard>,
+	policy_client: PolicyClient,
 ) -> Result<Response, ProxyError> {
 	let RequestUpgrade {
 		upgrade_type,
@@ -1406,6 +1429,17 @@ async fn handle_upgrade(
 			let llm = log.llm_response.clone();
 			let llm_info = LLMInfo::new(llm_req.clone(), LLMResponse::default());
 			llm.store(Some(llm_info));
+			if let Some(guard) = prompt_guard {
+				parse::websocket::guarded_realtime_proxy(
+					TokioIo::new(req),
+					server,
+					guard,
+					policy_client,
+					llm,
+				)
+				.await;
+				return;
+			}
 			let mut server = parse::websocket::parser(server, llm).await;
 			let _ = agent_core::copy::copy_bidirectional(
 				&mut TokioIo::new(req),
@@ -3341,6 +3375,14 @@ struct RequestUpgrade {
 struct ConnectTunnel {
 	upgrade: OnUpgrade,
 	upstream: Arc<Mutex<Option<Socket>>>,
+}
+
+/// Carries an optional `PromptGuard` and `PolicyClient` through response extensions
+/// so `handle_upgrade` can use them for the WebSocket realtime path.
+#[derive(Clone)]
+struct RealtimeUpgradeContext {
+	prompt_guard: Option<crate::llm::policy::PromptGuard>,
+	policy_client: PolicyClient,
 }
 
 fn hop_by_hop_headers(req: &mut Request) -> Option<RequestUpgrade> {

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -2857,6 +2857,7 @@ mod tests {
 		}));
 		let prompt_guard_policy = BackendTrafficPolicy::AI(Arc::new(llm::Policy {
 			prompt_guard: Some(PromptGuard {
+				streaming: Default::default(),
 				request: vec![RequestGuard {
 					rejection: Default::default(),
 					kind: RequestGuardKind::Regex(RegexRules {

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -482,6 +482,7 @@ pub struct LLMResponsePolicies {
 	pub remote_rate_limit: Option<http::remoteratelimit::LLMResponseAmend>,
 	pub request_traceparent: Option<HeaderValue>,
 	pub prompt_guard: Vec<ResponseGuard>,
+	pub streaming_prompt_guard_enabled: bool,
 }
 
 impl Default for Store {

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -887,7 +887,20 @@ fn convert_backend_ai_policy(
 			Some(llm::policy::ResponseGuard { rejection, kind })
 		});
 
+		let streaming =
+			match proto::agent::backend_policy_spec::ai::prompt_guard::Streaming::try_from(pg.streaming)
+				.map_err(|_| ProtoError::EnumParse("invalid prompt guard streaming mode".to_string()))?
+			{
+				proto::agent::backend_policy_spec::ai::prompt_guard::Streaming::Enabled => {
+					llm::policy::PromptGuardStreamingMode::Enabled
+				},
+				proto::agent::backend_policy_spec::ai::prompt_guard::Streaming::Disabled => {
+					llm::policy::PromptGuardStreamingMode::Disabled
+				},
+			};
+
 		Ok(llm::policy::PromptGuard {
+			streaming,
 			request,
 			response: response.collect_vec(),
 		})

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -2402,6 +2402,9 @@ fn merge_prompt_guards(
 		(None, None) => None,
 		(Some(guardrails), None) | (None, Some(guardrails)) => Some(guardrails),
 		(Some(mut shared), Some(model)) => {
+			if model.streaming.is_enabled() {
+				shared.streaming = model.streaming;
+			}
 			shared.request.extend(model.request);
 			shared.response.extend(model.response);
 			Some(shared)

--- a/crates/protos/proto/resource.proto
+++ b/crates/protos/proto/resource.proto
@@ -1253,10 +1253,18 @@ message BackendPolicySpec {
     }
 
     message PromptGuard {
+      enum Streaming {
+        DISABLED = 0;
+        ENABLED = 1;
+      }
+
       // Guards applied to client requests before they reach the LLM
       repeated RequestGuard request = 1;
       // Guards applied to LLM responses before they reach the client
       repeated ResponseGuard response = 2;
+      // Apply guardrails to streaming responses and realtime websocket messages.
+      // Defaults to disabled to preserve streaming throughput unless explicitly enabled.
+      Streaming streaming = 3;
     }
 
     PromptGuard prompt_guard = 1;

--- a/schema/config.json
+++ b/schema/config.json
@@ -3325,6 +3325,10 @@
     "PromptGuard": {
       "type": "object",
       "properties": {
+        "streaming": {
+          "description": "Apply prompt guards to streaming responses and realtime websocket messages.",
+          "$ref": "#/$defs/PromptGuardStreamingMode"
+        },
         "request": {
           "description": "Guards applied to client requests before they reach the LLM.",
           "type": "array",
@@ -3341,6 +3345,20 @@
         }
       },
       "additionalProperties": false
+    },
+    "PromptGuardStreamingMode": {
+      "oneOf": [
+        {
+          "description": "Do not apply prompt guards to streaming responses or realtime websocket messages.",
+          "type": "string",
+          "const": "Disabled"
+        },
+        {
+          "description": "Apply prompt guards to streaming responses and realtime websocket messages.",
+          "type": "string",
+          "const": "Enabled"
+        }
+      ]
     },
     "RequestGuard": {
       "type": "object",

--- a/schema/config.md
+++ b/schema/config.md
@@ -319,6 +319,7 @@
 |`binds[].listeners[].routes[].policies.a2a`|object|Mark this traffic as A2A to enable A2A processing and telemetry.|
 |`binds[].listeners[].routes[].policies.ai`|object|Mark this as LLM traffic to enable LLM processing.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard`|object|Prompt and response guardrails to apply to LLM traffic.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.streaming`|enum|Apply prompt guards to streaming responses and realtime websocket messages.<br>Possible values: `Disabled`, `Enabled`.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request`|[]object|Guards applied to client requests before they reach the LLM.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].regex`|object|Apply regex-based masking or rejection rules.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].regex.action`|enum|Action to take when a regex rule matches.<br>Possible values: `mask`, `reject`.|
@@ -2777,6 +2778,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.inferenceRouting.destinationMode`|enum|How to use the destination returned by the endpoint picker.<br>Possible values: `validated`, `passthrough`.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai`|object|Mark this as LLM traffic to enable LLM processing.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard`|object|Prompt and response guardrails to apply to LLM traffic.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.streaming`|enum|Apply prompt guards to streaming responses and realtime websocket messages.<br>Possible values: `Disabled`, `Enabled`.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request`|[]object|Guards applied to client requests before they reach the LLM.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].regex`|object|Apply regex-based masking or rejection rules.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].regex.action`|enum|Action to take when a regex rule matches.<br>Possible values: `mask`, `reject`.|
@@ -4028,6 +4030,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.inferenceRouting.destinationMode`|enum|How to use the destination returned by the endpoint picker.<br>Possible values: `validated`, `passthrough`.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai`|object|Mark this as LLM traffic to enable LLM processing.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard`|object|Prompt and response guardrails to apply to LLM traffic.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.streaming`|enum|Apply prompt guards to streaming responses and realtime websocket messages.<br>Possible values: `Disabled`, `Enabled`.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request`|[]object|Guards applied to client requests before they reach the LLM.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].regex`|object|Apply regex-based masking or rejection rules.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].regex.action`|enum|Action to take when a regex rule matches.<br>Possible values: `mask`, `reject`.|
@@ -5249,6 +5252,7 @@
 |`binds[].listeners[].routes[].backends[].policies.inferenceRouting.destinationMode`|enum|How to use the destination returned by the endpoint picker.<br>Possible values: `validated`, `passthrough`.|
 |`binds[].listeners[].routes[].backends[].policies.ai`|object|Mark this as LLM traffic to enable LLM processing.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard`|object|Prompt and response guardrails to apply to LLM traffic.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.streaming`|enum|Apply prompt guards to streaming responses and realtime websocket messages.<br>Possible values: `Disabled`, `Enabled`.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request`|[]object|Guards applied to client requests before they reach the LLM.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].regex`|object|Apply regex-based masking or rejection rules.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].regex.action`|enum|Action to take when a regex rule matches.<br>Possible values: `mask`, `reject`.|
@@ -7367,6 +7371,7 @@
 |`policies[].policy.a2a`|object|Mark this traffic as A2A to enable A2A processing and telemetry.|
 |`policies[].policy.ai`|object|Mark this as LLM traffic to enable LLM processing.|
 |`policies[].policy.ai.promptGuard`|object|Prompt and response guardrails to apply to LLM traffic.|
+|`policies[].policy.ai.promptGuard.streaming`|enum|Apply prompt guards to streaming responses and realtime websocket messages.<br>Possible values: `Disabled`, `Enabled`.|
 |`policies[].policy.ai.promptGuard.request`|[]object|Guards applied to client requests before they reach the LLM.|
 |`policies[].policy.ai.promptGuard.request[].regex`|object|Apply regex-based masking or rejection rules.|
 |`policies[].policy.ai.promptGuard.request[].regex.action`|enum|Action to take when a regex rule matches.<br>Possible values: `mask`, `reject`.|
@@ -9820,6 +9825,7 @@
 |`backends[].ai.policies.inferenceRouting.destinationMode`|enum|How to use the destination returned by the endpoint picker.<br>Possible values: `validated`, `passthrough`.|
 |`backends[].ai.policies.ai`|object|Mark this as LLM traffic to enable LLM processing.|
 |`backends[].ai.policies.ai.promptGuard`|object|Prompt and response guardrails to apply to LLM traffic.|
+|`backends[].ai.policies.ai.promptGuard.streaming`|enum|Apply prompt guards to streaming responses and realtime websocket messages.<br>Possible values: `Disabled`, `Enabled`.|
 |`backends[].ai.policies.ai.promptGuard.request`|[]object|Guards applied to client requests before they reach the LLM.|
 |`backends[].ai.policies.ai.promptGuard.request[].regex`|object|Apply regex-based masking or rejection rules.|
 |`backends[].ai.policies.ai.promptGuard.request[].regex.action`|enum|Action to take when a regex rule matches.<br>Possible values: `mask`, `reject`.|
@@ -11071,6 +11077,7 @@
 |`backends[].ai.groups[].providers[].policies.inferenceRouting.destinationMode`|enum|How to use the destination returned by the endpoint picker.<br>Possible values: `validated`, `passthrough`.|
 |`backends[].ai.groups[].providers[].policies.ai`|object|Mark this as LLM traffic to enable LLM processing.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard`|object|Prompt and response guardrails to apply to LLM traffic.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.streaming`|enum|Apply prompt guards to streaming responses and realtime websocket messages.<br>Possible values: `Disabled`, `Enabled`.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request`|[]object|Guards applied to client requests before they reach the LLM.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].regex`|object|Apply regex-based masking or rejection rules.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].regex.action`|enum|Action to take when a regex rule matches.<br>Possible values: `mask`, `reject`.|
@@ -12290,6 +12297,7 @@
 |`backends[].policies.inferenceRouting.destinationMode`|enum|How to use the destination returned by the endpoint picker.<br>Possible values: `validated`, `passthrough`.|
 |`backends[].policies.ai`|object|Mark this as LLM traffic to enable LLM processing.|
 |`backends[].policies.ai.promptGuard`|object|Prompt and response guardrails to apply to LLM traffic.|
+|`backends[].policies.ai.promptGuard.streaming`|enum|Apply prompt guards to streaming responses and realtime websocket messages.<br>Possible values: `Disabled`, `Enabled`.|
 |`backends[].policies.ai.promptGuard.request`|[]object|Guards applied to client requests before they reach the LLM.|
 |`backends[].policies.ai.promptGuard.request[].regex`|object|Apply regex-based masking or rejection rules.|
 |`backends[].policies.ai.promptGuard.request[].regex.action`|enum|Action to take when a regex rule matches.<br>Possible values: `mask`, `reject`.|
@@ -13348,6 +13356,7 @@
 |`routeGroups[].routes[].policies.a2a`|object|Mark this traffic as A2A to enable A2A processing and telemetry.|
 |`routeGroups[].routes[].policies.ai`|object|Mark this as LLM traffic to enable LLM processing.|
 |`routeGroups[].routes[].policies.ai.promptGuard`|object|Prompt and response guardrails to apply to LLM traffic.|
+|`routeGroups[].routes[].policies.ai.promptGuard.streaming`|enum|Apply prompt guards to streaming responses and realtime websocket messages.<br>Possible values: `Disabled`, `Enabled`.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request`|[]object|Guards applied to client requests before they reach the LLM.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].regex`|object|Apply regex-based masking or rejection rules.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].regex.action`|enum|Action to take when a regex rule matches.<br>Possible values: `mask`, `reject`.|
@@ -15806,6 +15815,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.inferenceRouting.destinationMode`|enum|How to use the destination returned by the endpoint picker.<br>Possible values: `validated`, `passthrough`.|
 |`routeGroups[].routes[].backends[].ai.policies.ai`|object|Mark this as LLM traffic to enable LLM processing.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard`|object|Prompt and response guardrails to apply to LLM traffic.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.streaming`|enum|Apply prompt guards to streaming responses and realtime websocket messages.<br>Possible values: `Disabled`, `Enabled`.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request`|[]object|Guards applied to client requests before they reach the LLM.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].regex`|object|Apply regex-based masking or rejection rules.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].regex.action`|enum|Action to take when a regex rule matches.<br>Possible values: `mask`, `reject`.|
@@ -17057,6 +17067,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.inferenceRouting.destinationMode`|enum|How to use the destination returned by the endpoint picker.<br>Possible values: `validated`, `passthrough`.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai`|object|Mark this as LLM traffic to enable LLM processing.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard`|object|Prompt and response guardrails to apply to LLM traffic.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.streaming`|enum|Apply prompt guards to streaming responses and realtime websocket messages.<br>Possible values: `Disabled`, `Enabled`.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request`|[]object|Guards applied to client requests before they reach the LLM.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].regex`|object|Apply regex-based masking or rejection rules.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].regex.action`|enum|Action to take when a regex rule matches.<br>Possible values: `mask`, `reject`.|
@@ -18278,6 +18289,7 @@
 |`routeGroups[].routes[].backends[].policies.inferenceRouting.destinationMode`|enum|How to use the destination returned by the endpoint picker.<br>Possible values: `validated`, `passthrough`.|
 |`routeGroups[].routes[].backends[].policies.ai`|object|Mark this as LLM traffic to enable LLM processing.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard`|object|Prompt and response guardrails to apply to LLM traffic.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.streaming`|enum|Apply prompt guards to streaming responses and realtime websocket messages.<br>Possible values: `Disabled`, `Enabled`.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request`|[]object|Guards applied to client requests before they reach the LLM.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].regex`|object|Apply regex-based masking or rejection rules.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].regex.action`|enum|Action to take when a regex rule matches.<br>Possible values: `mask`, `reject`.|
@@ -19382,6 +19394,7 @@
 |`llm.models[].backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.models[].backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
 |`llm.models[].guardrails`|object|guardrails to apply to the request or response|
+|`llm.models[].guardrails.streaming`|enum|Apply prompt guards to streaming responses and realtime websocket messages.<br>Possible values: `Disabled`, `Enabled`.|
 |`llm.models[].guardrails.request`|[]object|Guards applied to client requests before they reach the LLM.|
 |`llm.models[].guardrails.request[].regex`|object|Apply regex-based masking or rejection rules.|
 |`llm.models[].guardrails.request[].regex.action`|enum|Action to take when a regex rule matches.<br>Possible values: `mask`, `reject`.|
@@ -20836,6 +20849,7 @@
 |`llm.policies.apiKey.location.expression`|object|Read the credential from a CEL expression evaluated against the incoming request.|
 |`llm.policies.apiKey.location.expression.expression`|string|CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`llm.policies.guardrails`|object|Guardrails to apply to every configured model.|
+|`llm.policies.guardrails.streaming`|enum|Apply prompt guards to streaming responses and realtime websocket messages.<br>Possible values: `Disabled`, `Enabled`.|
 |`llm.policies.guardrails.request`|[]object|Guards applied to client requests before they reach the LLM.|
 |`llm.policies.guardrails.request[].regex`|object|Apply regex-based masking or rejection rules.|
 |`llm.policies.guardrails.request[].regex.action`|enum|Action to take when a regex rule matches.<br>Possible values: `mask`, `reject`.|
@@ -22232,6 +22246,7 @@
 |`mcp.policies.a2a`|object|Mark this traffic as A2A to enable A2A processing and telemetry.|
 |`mcp.policies.ai`|object|Mark this as LLM traffic to enable LLM processing.|
 |`mcp.policies.ai.promptGuard`|object|Prompt and response guardrails to apply to LLM traffic.|
+|`mcp.policies.ai.promptGuard.streaming`|enum|Apply prompt guards to streaming responses and realtime websocket messages.<br>Possible values: `Disabled`, `Enabled`.|
 |`mcp.policies.ai.promptGuard.request`|[]object|Guards applied to client requests before they reach the LLM.|
 |`mcp.policies.ai.promptGuard.request[].regex`|object|Apply regex-based masking or rejection rules.|
 |`mcp.policies.ai.promptGuard.request[].regex.action`|enum|Action to take when a regex rule matches.<br>Possible values: `mask`, `reject`.|


### PR DESCRIPTION
Allow streaming requests/responses (SSE and OpenAI realtime) to have guardrails execute (right now they're skipped/ignored)