### PR TITLE
api: allow pre-routing authorization

### DIFF
--- a/controller/api/tests/testdata/agentgateway_policy_invalid.yaml
+++ b/controller/api/tests/testdata/agentgateway_policy_invalid.yaml
@@ -923,7 +923,7 @@ spec:
           - name: X-Gateway
             value: '"true"'
 ---
-_err: "phase PreRouting only supports extAuth, transformation, "
+_err: "phase PreRouting only supports extAuth, authorization, transformation, "
 apiVersion: agentgateway.dev/v1alpha1
 kind: AgentgatewayPolicy
 metadata:

--- a/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
+++ b/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
@@ -755,7 +755,7 @@ const (
 	PolicyPhasePostRouting PolicyPhase = "PostRouting"
 )
 
-// +kubebuilder:validation:IfThenOnlyFields:if="has(self.phase) && self.phase == 'PreRouting'",fields=phase;transformation;extProc;extAuth;jwtAuthentication;basicAuthentication;apiKeyAuthentication;cors,message="phase PreRouting only supports extAuth, transformation, extProc, jwtAuthentication, basicAuthentication, apiKeyAuthentication and cors"
+// +kubebuilder:validation:IfThenOnlyFields:if="has(self.phase) && self.phase == 'PreRouting'",fields=phase;authorization;transformation;extProc;extAuth;jwtAuthentication;basicAuthentication;apiKeyAuthentication;cors,message="phase PreRouting only supports extAuth, authorization, transformation, extProc, jwtAuthentication, basicAuthentication, apiKeyAuthentication and cors"
 type Traffic struct {
 	// The phase to apply the traffic policy to. If the phase is `PreRouting`,
 	// the `targetRef` must be a `Gateway` or a `Listener`. `PreRouting` is

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
@@ -10092,10 +10092,10 @@ spec:
                         == 0 : true'
                 type: object
                 x-kubernetes-validations:
-                - message: phase PreRouting only supports extAuth, transformation,
-                    extProc, jwtAuthentication, basicAuthentication, apiKeyAuthentication
-                    and cors
-                  rule: 'has(self.phase) && self.phase == ''PreRouting'' ? [has(self.authorization),has(self.buffer),has(self.csrf),has(self.directResponse),has(self.headerModifiers),has(self.hostRewrite),has(self.rateLimit),has(self.retry),has(self.timeouts)].filter(x,x==true).size()
+                - message: phase PreRouting only supports extAuth, authorization,
+                    transformation, extProc, jwtAuthentication, basicAuthentication,
+                    apiKeyAuthentication and cors
+                  rule: 'has(self.phase) && self.phase == ''PreRouting'' ? [has(self.buffer),has(self.csrf),has(self.directResponse),has(self.headerModifiers),has(self.hostRewrite),has(self.rateLimit),has(self.retry),has(self.timeouts)].filter(x,x==true).size()
                     == 0 : true'
             type: object
             x-kubernetes-validations:

--- a/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/authorization-pre-routing.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/authorization-pre-routing.yaml
@@ -1,0 +1,65 @@
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: authorization-pre-routing
+  namespace: default
+spec:
+  targetRefs:
+  - kind: Gateway
+    name: test
+    group: gateway.networking.k8s.io
+  traffic:
+    phase: PreRouting
+    authorization:
+      policy:
+        matchExpressions:
+        - request.headers["x-pre-routing"] == "yes"
+
+---
+# Output
+output:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
+    policy:
+      key: traffic/default/authorization-pre-routing:rbac:default/test
+      name:
+        kind: AgentgatewayPolicy
+        name: authorization-pre-routing
+        namespace: default
+      target:
+        gateway:
+          name: test
+          namespace: default
+      traffic:
+        authorization:
+          allow:
+          - request.headers["x-pre-routing"] == "yes"
+        phase: GATEWAY
+status:
+- apiVersion: agentgateway.dev/v1alpha1
+  kind: AgentgatewayPolicy
+  metadata:
+    name: authorization-pre-routing
+    namespace: default
+  spec: null
+  status:
+    ancestors:
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: test
+        namespace: default
+      conditions:
+      - lastTransitionTime: fake
+        message: Policy accepted
+        reason: Valid
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: Attached to all targets
+        reason: Attached
+        status: "True"
+        type: Attached
+      controllerName: agentgateway.dev/agentgateway

--- a/controller/pkg/agentgateway/plugins/traffic_plugin.go
+++ b/controller/pkg/agentgateway/plugins/traffic_plugin.go
@@ -489,7 +489,7 @@ func translateTrafficPolicyToAgw(
 
 	// Convert Authorization policy if present
 	if traffic.Authorization != nil {
-		appendPolicy("authorization")(processAuthorizationPolicy(traffic.Authorization, basePolicyName, policyName))
+		appendPolicy("authorization")(processAuthorizationPolicy(traffic.Authorization, traffic.Phase, basePolicyName, policyName))
 	}
 
 	// Process RateLimit policies if present
@@ -1412,6 +1412,7 @@ func castExtAuthCacheTTL(item agentgateway.CELExpression, invalid func(agentgate
 // processAuthorizationPolicy processes Authorization configuration and creates corresponding Agw policies
 func processAuthorizationPolicy(
 	auth *agentgateway.Authorization,
+	policyPhase *agentgateway.PolicyPhase,
 	basePolicyName string,
 	policy types.NamespacedName,
 ) (*api.Policy, error) {
@@ -1433,6 +1434,7 @@ func processAuthorizationPolicy(
 		Name: TypedResourceFromName(wellknown.AgentgatewayPolicyGVK.Kind, policy),
 		Kind: &api.Policy_Traffic{
 			Traffic: &api.TrafficPolicySpec{
+				Phase: phase(policyPhase),
 				Kind: &api.TrafficPolicySpec_Authorization{
 					Authorization: &api.TrafficPolicySpec_RBAC{
 						Allow:   allowPolicies,

--- a/crates/agentgateway/src/proxy/gateway_test.rs
+++ b/crates/agentgateway/src/proxy/gateway_test.rs
@@ -862,6 +862,33 @@ async fn gateway_phase_cors_handles_preflight_before_route_selection() {
 }
 
 #[tokio::test]
+async fn gateway_phase_authorization_runs_before_route_selection() {
+	let (_mock, mut bind, io) = basic_setup().await;
+	bind
+		.attach_gateway_policy(json!({
+			"authorization": {
+				"rules": [
+					{"allow": "request.headers[\"x-pre-routing\"] == \"yes\""}
+				]
+			}
+		}))
+		.await;
+
+	let denied = send_request(io.clone(), Method::GET, "http://lo/no-route-needed").await;
+	assert_eq!(denied.status(), 403);
+	assert_eq!(read_body!(denied).as_bytes(), b"authorization failed");
+
+	let allowed = send_request_headers(
+		io,
+		Method::GET,
+		"http://lo/upstream",
+		&[("x-pre-routing", "yes")],
+	)
+	.await;
+	assert_eq!(allowed.status(), 200);
+}
+
+#[tokio::test]
 async fn network_authorization_allow() {
 	let (_mock, mut bind, io) = basic_setup().await;
 	bind

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -374,6 +374,17 @@ async fn apply_gateway_policies(
 		.apply_without_response("gateway ext authz", c, l, req, response_policies.headers())
 		.await?;
 
+	policies
+		.authorization
+		.apply_without_response(
+			"gateway authorization",
+			c,
+			l,
+			req,
+			response_policies.headers(),
+		)
+		.await?;
+
 	// ExtProc uses RequestPolicy for conditional selection and CEL registration only.
 	// The selected config is built into per-request state, which must be retained for
 	// the response mutation phase instead of applying ExtProc directly.

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -338,6 +338,7 @@ pub struct GatewayPolicies {
 	pub ext_proc: RequestPolicy<ext_proc::ExtProc>,
 	pub oidc: RequestPolicy<oidc::OidcPolicy>,
 	pub jwt: RequestPolicy<JwtAuthentication>,
+	pub authorization: RequestPolicy<HTTPAuthorizationSet>,
 	pub ext_authz: RequestPolicy<ext_authz::ExtAuthz>,
 	pub transformation: RequestPolicy<http::transformation_cel::Transformation>,
 	pub basic_auth: RequestPolicy<http::basicauth::BasicAuthentication>,
@@ -352,6 +353,7 @@ impl GatewayPolicies {
 			&self.ext_proc as &dyn PolicyExpressions,
 			&self.oidc as &dyn PolicyExpressions,
 			&self.jwt as &dyn PolicyExpressions,
+			&self.authorization as &dyn PolicyExpressions,
 			&self.ext_authz as &dyn PolicyExpressions,
 			&self.transformation as &dyn PolicyExpressions,
 			&self.basic_auth as &dyn PolicyExpressions,
@@ -926,6 +928,7 @@ impl Store {
 			.filter_map(|n| self.policies_by_key.get(n))
 			.filter_map(|p| p.policy.as_traffic_gateway_phase());
 
+		let mut authz = Vec::new();
 		let mut pol = GatewayPolicies::default();
 		for rule in rules {
 			match rule {
@@ -944,6 +947,9 @@ impl Store {
 				TrafficPolicy::APIKey(p) => {
 					pol.api_key.set_if_unset(p);
 				},
+				TrafficPolicy::Authorization(p) => {
+					authz.push(p.clone().0);
+				},
 				TrafficPolicy::ExtAuthz(p) => {
 					pol.ext_authz.set_if_unset(p);
 				},
@@ -957,6 +963,11 @@ impl Store {
 					warn!("unexpected gateway policy: {:?}", other);
 				},
 			}
+		}
+		if !authz.is_empty() {
+			pol.authorization = RequestPolicy::single(HTTPAuthorizationSet::new(
+				crate::http::authorization::RuleSets::from_arcs(authz),
+			));
 		}
 		dtrace::trace(|t| {
 			let s = serde_json::to_value(&pol).unwrap_or_default();

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -1427,9 +1427,6 @@ where
 struct LocalLLMPolicy {
 	#[serde(flatten)]
 	gateway: LocalGatewayPolicy,
-	/// Authorization rules for incoming HTTP requests.
-	#[serde(default)]
-	authorization: Option<Authorization>,
 	/// Local rate limits for incoming requests.
 	#[serde(default)]
 	local_rate_limit: Vec<crate::http::localratelimit::RateLimit>,
@@ -1447,6 +1444,9 @@ struct LocalGatewayPolicy {
 	/// Authenticate incoming requests with JWT bearer tokens.
 	#[serde(default)]
 	jwt_auth: Option<crate::http::jwt::LocalJwtConfig>,
+	/// Authorization rules for incoming HTTP requests.
+	#[serde(default)]
+	authorization: Option<Authorization>,
 	/// Authorize incoming requests by calling an external authorization service.
 	#[serde(default)]
 	ext_authz: Option<LocalExtAuthzPolicy>,
@@ -1476,6 +1476,7 @@ impl From<LocalGatewayPolicy> for FilterOrPolicy {
 		let LocalGatewayPolicy {
 			oidc,
 			jwt_auth,
+			authorization,
 			ext_authz,
 			ext_proc,
 			cors,
@@ -1486,6 +1487,7 @@ impl From<LocalGatewayPolicy> for FilterOrPolicy {
 		FilterOrPolicy {
 			oidc,
 			jwt_auth,
+			authorization,
 			ext_authz,
 			ext_proc,
 			cors,
@@ -2108,14 +2110,12 @@ async fn convert_llm_config(
 	let (listener_gateway_policies, listener_route_policies) = if let Some(pol) = policies {
 		let LocalLLMPolicy {
 			gateway,
-			authorization,
 			local_rate_limit,
 			remote_rate_limit,
 		} = pol;
 		let route_policies = split_policies(
 			client.clone(),
 			FilterOrPolicy {
-				authorization,
 				local_rate_limit: (!local_rate_limit.is_empty())
 					.then_some(LocalRateLimitPolicy::Explicit(local_rate_limit)),
 				remote_rate_limit: remote_rate_limit.map(LocalExplicitOrConditional::Explicit),

--- a/crates/agentgateway/src/types/local_tests/llm_simple_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/llm_simple_normalized.snap
@@ -216,7 +216,7 @@ policies:
           rules:
             allow:
               - "jwt.email.endsWith(\"@example.com\")"
-        phase: route
+        phase: gateway
   - key: listener/3
     name: ~
     target:

--- a/schema/config.json
+++ b/schema/config.json
@@ -7185,6 +7185,18 @@
             }
           ]
         },
+        "authorization": {
+          "description": "Authorization rules for incoming HTTP requests.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Authorization"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "extAuthz": {
           "description": "Authorize incoming requests by calling an external authorization service.",
           "anyOf": [
@@ -8667,6 +8679,18 @@
             }
           ]
         },
+        "authorization": {
+          "description": "Authorization rules for incoming HTTP requests.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Authorization"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "extAuthz": {
           "description": "Authorize incoming requests by calling an external authorization service.",
           "anyOf": [
@@ -8733,18 +8757,6 @@
               "type": "null"
             }
           ]
-        },
-        "authorization": {
-          "description": "Authorization rules for incoming HTTP requests.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Authorization"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
         },
         "localRateLimit": {
           "description": "Local rate limits for incoming requests.",

--- a/schema/config.md
+++ b/schema/config.md
@@ -6153,6 +6153,11 @@
 |`binds[].listeners[].policies.jwtAuth.jwks.url`|string||
 |`binds[].listeners[].policies.jwtAuth.jwtValidationOptions`|object|Claim requirements to enforce after the token signature is verified.|
 |`binds[].listeners[].policies.jwtAuth.jwtValidationOptions.requiredClaims`|[]string|Claims that must be present in the token before validation.<br>Only "exp", "nbf", "aud", "iss", "sub" are enforced; others<br>(including "iat" and "jti") are ignored.<br>Defaults to ["exp"]. Use an empty list to require no claims.|
+|`binds[].listeners[].policies.authorization`|object|Authorization rules for incoming HTTP requests.|
+|`binds[].listeners[].policies.authorization.rules`|[]object|CEL authorization rules to evaluate for a request.|
+|`binds[].listeners[].policies.authorization.rules[].allow`|string|Allow the request when this CEL expression is true.|
+|`binds[].listeners[].policies.authorization.rules[].deny`|string|Deny the request when this CEL expression is true.|
+|`binds[].listeners[].policies.authorization.rules[].require`|string|Require this CEL expression to be true.|
 |`binds[].listeners[].policies.extAuthz`|object|Authorize incoming requests by calling an external authorization service.|
 |`binds[].listeners[].policies.extAuthz.conditional`|[]object|conditional policy entries. An entry without a condition must be the final fallback.|
 |`binds[].listeners[].policies.extAuthz.conditional[].service`|object|Service reference. Service must be defined in the top level services list.|
@@ -19953,6 +19958,11 @@
 |`llm.policies.jwtAuth.jwks.url`|string||
 |`llm.policies.jwtAuth.jwtValidationOptions`|object|Claim requirements to enforce after the token signature is verified.|
 |`llm.policies.jwtAuth.jwtValidationOptions.requiredClaims`|[]string|Claims that must be present in the token before validation.<br>Only "exp", "nbf", "aud", "iss", "sub" are enforced; others<br>(including "iat" and "jti") are ignored.<br>Defaults to ["exp"]. Use an empty list to require no claims.|
+|`llm.policies.authorization`|object|Authorization rules for incoming HTTP requests.|
+|`llm.policies.authorization.rules`|[]object|CEL authorization rules to evaluate for a request.|
+|`llm.policies.authorization.rules[].allow`|string|Allow the request when this CEL expression is true.|
+|`llm.policies.authorization.rules[].deny`|string|Deny the request when this CEL expression is true.|
+|`llm.policies.authorization.rules[].require`|string|Require this CEL expression to be true.|
 |`llm.policies.extAuthz`|object|Authorize incoming requests by calling an external authorization service.|
 |`llm.policies.extAuthz.conditional`|[]object|conditional policy entries. An entry without a condition must be the final fallback.|
 |`llm.policies.extAuthz.conditional[].service`|object|Service reference. Service must be defined in the top level services list.|
@@ -20525,11 +20535,6 @@
 |`llm.policies.apiKey.location.cookie.name`|string|Cookie name containing the credential.|
 |`llm.policies.apiKey.location.expression`|object|Read the credential from a CEL expression evaluated against the incoming request.|
 |`llm.policies.apiKey.location.expression.expression`|string|CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
-|`llm.policies.authorization`|object|Authorization rules for incoming HTTP requests.|
-|`llm.policies.authorization.rules`|[]object|CEL authorization rules to evaluate for a request.|
-|`llm.policies.authorization.rules[].allow`|string|Allow the request when this CEL expression is true.|
-|`llm.policies.authorization.rules[].deny`|string|Deny the request when this CEL expression is true.|
-|`llm.policies.authorization.rules[].require`|string|Require this CEL expression to be true.|
 |`llm.policies.localRateLimit`|[]object|Local rate limits for incoming requests.|
 |`llm.policies.localRateLimit[].maxTokens`|integer|Maximum number of tokens that can accumulate in the local bucket.|
 |`llm.policies.localRateLimit[].tokensPerFill`|integer|Number of tokens added to the local bucket each fill interval.|


### PR DESCRIPTION
The primary goal is to have 2 tiers of authorization that are AND
together. Like in LLM

Signed-off-by: John Howard <john.howard@solo.io>
