### PR TITLE
standalone llm: allow guardrails as a shared top level resource

### DIFF
--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -298,9 +298,6 @@ pub struct LocalLLMConfig {
 	port: Option<u16>,
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	tls: Option<LocalTLSServerConfig>,
-	/// guardrails defines named prompt and response guardrails that can be reused by models.
-	#[serde(default, skip_serializing_if = "HashMap::is_empty")]
-	guardrails: HashMap<String, PromptGuard>,
 	/// models defines the set of models that can be served by this gateway. The model name refers to the
 	/// model in the users request that is matched; the model sent to the actual LLM can be overridden
 	/// on a per-model basis.
@@ -308,25 +305,6 @@ pub struct LocalLLMConfig {
 	/// policies defines policies for handling incoming requests, before a model is selected
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	policies: Option<LocalLLMPolicy>,
-}
-
-#[apply(schema_de!)]
-#[serde(untagged)]
-enum LocalLLMGuardrails {
-	Named(String),
-	Inline(PromptGuard),
-}
-
-impl LocalLLMGuardrails {
-	fn resolve(self, guardrails: &HashMap<String, PromptGuard>) -> anyhow::Result<PromptGuard> {
-		match self {
-			LocalLLMGuardrails::Inline(guardrail) => Ok(guardrail),
-			LocalLLMGuardrails::Named(name) => guardrails
-				.get(&name)
-				.cloned()
-				.with_context(|| format!("llm.models.guardrails references unknown guardrail '{name}'")),
-		}
-	}
 }
 
 #[apply(schema_de!)]
@@ -559,7 +537,7 @@ pub struct LocalLLMModels {
 	backend_tunnel: Option<backend::Tunnel>,
 	/// guardrails to apply to the request or response
 	#[serde(default, skip_serializing_if = "Option::is_none")]
-	guardrails: Option<LocalLLMGuardrails>,
+	guardrails: Option<PromptGuard>,
 	/// promptCaching configures cache point insertion for supported LLM providers.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	prompt_caching: Option<PromptCachingConfig>,
@@ -1452,6 +1430,9 @@ where
 struct LocalLLMPolicy {
 	#[serde(flatten)]
 	gateway: LocalGatewayPolicy,
+	/// Guardrails to apply to every configured model.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	guardrails: Option<PromptGuard>,
 	/// Local rate limits for incoming requests.
 	#[serde(default)]
 	local_rate_limit: Vec<crate::http::localratelimit::RateLimit>,
@@ -2107,6 +2088,21 @@ fn llm_model_match_specificity(model_name: &str) -> usize {
 	model_name.chars().filter(|c| *c != '*').count()
 }
 
+fn merge_prompt_guards(
+	shared: Option<PromptGuard>,
+	model: Option<PromptGuard>,
+) -> Option<PromptGuard> {
+	match (shared, model) {
+		(None, None) => None,
+		(Some(guardrails), None) | (None, Some(guardrails)) => Some(guardrails),
+		(Some(mut shared), Some(model)) => {
+			shared.request.extend(model.request);
+			shared.response.extend(model.response);
+			Some(shared)
+		},
+	}
+}
+
 #[allow(deprecated)]
 async fn convert_llm_config(
 	client: client::Client,
@@ -2123,7 +2119,6 @@ async fn convert_llm_config(
 	let LocalLLMConfig {
 		port,
 		tls,
-		guardrails,
 		models,
 		policies,
 	} = llm_config;
@@ -2133,12 +2128,15 @@ async fn convert_llm_config(
 	let mut all_policies = vec![];
 	let mut all_backends = vec![];
 	let mut routes = Vec::new();
+	let mut shared_prompt_guard = None;
 	let (listener_gateway_policies, listener_route_policies) = if let Some(pol) = policies {
 		let LocalLLMPolicy {
 			gateway,
+			guardrails,
 			local_rate_limit,
 			remote_rate_limit,
 		} = pol;
+		shared_prompt_guard = guardrails;
 		let route_policies = split_policies(
 			client.clone(),
 			FilterOrPolicy {
@@ -2436,11 +2434,8 @@ request.path.endsWith(":streamRawPredict") || request.path.endsWith(":rawPredict
 				|e: crate::cel::Error| anyhow::anyhow!("health.unhealthyExpression: {}", e),
 			)?));
 		}
-		let prompt_guard = model_config
-			.guardrails
-			.clone()
-			.map(|guardrail| guardrail.resolve(&guardrails))
-			.transpose()?;
+		let prompt_guard =
+			merge_prompt_guards(shared_prompt_guard.clone(), model_config.guardrails.clone());
 		pols.push(BackendTrafficPolicy::AI(Arc::new(llm::Policy {
 			defaults: model_config.defaults.clone(),
 			overrides: model_config.overrides.clone(),

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -298,6 +298,9 @@ pub struct LocalLLMConfig {
 	port: Option<u16>,
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	tls: Option<LocalTLSServerConfig>,
+	/// guardrails defines named prompt and response guardrails that can be reused by models.
+	#[serde(default, skip_serializing_if = "HashMap::is_empty")]
+	guardrails: HashMap<String, PromptGuard>,
 	/// models defines the set of models that can be served by this gateway. The model name refers to the
 	/// model in the users request that is matched; the model sent to the actual LLM can be overridden
 	/// on a per-model basis.
@@ -305,6 +308,25 @@ pub struct LocalLLMConfig {
 	/// policies defines policies for handling incoming requests, before a model is selected
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	policies: Option<LocalLLMPolicy>,
+}
+
+#[apply(schema_de!)]
+#[serde(untagged)]
+enum LocalLLMGuardrails {
+	Named(String),
+	Inline(PromptGuard),
+}
+
+impl LocalLLMGuardrails {
+	fn resolve(self, guardrails: &HashMap<String, PromptGuard>) -> anyhow::Result<PromptGuard> {
+		match self {
+			LocalLLMGuardrails::Inline(guardrail) => Ok(guardrail),
+			LocalLLMGuardrails::Named(name) => guardrails
+				.get(&name)
+				.cloned()
+				.with_context(|| format!("llm.models.guardrails references unknown guardrail '{name}'")),
+		}
+	}
 }
 
 #[apply(schema_de!)]
@@ -537,7 +559,7 @@ pub struct LocalLLMModels {
 	backend_tunnel: Option<backend::Tunnel>,
 	/// guardrails to apply to the request or response
 	#[serde(default, skip_serializing_if = "Option::is_none")]
-	guardrails: Option<PromptGuard>,
+	guardrails: Option<LocalLLMGuardrails>,
 	/// promptCaching configures cache point insertion for supported LLM providers.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	prompt_caching: Option<PromptCachingConfig>,
@@ -2101,6 +2123,7 @@ async fn convert_llm_config(
 	let LocalLLMConfig {
 		port,
 		tls,
+		guardrails,
 		models,
 		policies,
 	} = llm_config;
@@ -2413,11 +2436,16 @@ request.path.endsWith(":streamRawPredict") || request.path.endsWith(":rawPredict
 				|e: crate::cel::Error| anyhow::anyhow!("health.unhealthyExpression: {}", e),
 			)?));
 		}
+		let prompt_guard = model_config
+			.guardrails
+			.clone()
+			.map(|guardrail| guardrail.resolve(&guardrails))
+			.transpose()?;
 		pols.push(BackendTrafficPolicy::AI(Arc::new(llm::Policy {
 			defaults: model_config.defaults.clone(),
 			overrides: model_config.overrides.clone(),
 			transformations: model_config.transformation.clone(),
-			prompt_guard: model_config.guardrails.clone(),
+			prompt_guard,
 			prompts: None,
 			model_aliases: Default::default(),
 			wildcard_patterns: Arc::new(vec![]),

--- a/crates/agentgateway/src/types/local_tests/llm_simple_config.yaml
+++ b/crates/agentgateway/src/types/local_tests/llm_simple_config.yaml
@@ -4,8 +4,8 @@ frontendPolicies:
       user: request.headers["user-agent"]
 
 llm:
-  guardrails:
-    sharedPii:
+  policies:
+    guardrails:
       request:
       - regex:
           action: reject
@@ -13,7 +13,6 @@ llm:
           - builtin: email
         rejection:
           status: 400
-  policies:
     cors:
       allowOrigins:
         - http://localhost:15000
@@ -53,6 +52,17 @@ llm:
       cacheSystem: true
       cacheMessages: true
       minTokens: 1
+    guardrails:
+      request:
+      - regex:
+          action: reject
+          rules:
+          - builtin: creditCard
+      response:
+      - regex:
+          action: mask
+          rules:
+          - builtin: phoneNumber
   - name: '*'
     provider: vertex
     params:
@@ -69,4 +79,3 @@ llm:
       azureApiVersion: v1
   - name: gpt-3.5-turbo
     provider: openAI
-    guardrails: sharedPii

--- a/crates/agentgateway/src/types/local_tests/llm_simple_config.yaml
+++ b/crates/agentgateway/src/types/local_tests/llm_simple_config.yaml
@@ -4,6 +4,15 @@ frontendPolicies:
       user: request.headers["user-agent"]
 
 llm:
+  guardrails:
+    sharedPii:
+      request:
+      - regex:
+          action: reject
+          rules:
+          - builtin: email
+        rejection:
+          status: 400
   policies:
     cors:
       allowOrigins:
@@ -60,3 +69,4 @@ llm:
       azureApiVersion: v1
   - name: gpt-3.5-turbo
     provider: openAI
+    guardrails: sharedPii

--- a/crates/agentgateway/src/types/local_tests/llm_simple_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/llm_simple_normalized.snap
@@ -321,6 +321,30 @@ backends:
           eviction:
             duration: 30s
       - ai:
+          promptGuard:
+            request:
+              - regex:
+                  action: reject
+                  rules:
+                    - builtin: email
+                rejection:
+                  body: The request was rejected due to inappropriate content
+                  status: 400
+              - regex:
+                  action: reject
+                  rules:
+                    - builtin: creditCard
+                rejection:
+                  body: The request was rejected due to inappropriate content
+                  status: 403
+            response:
+              - regex:
+                  action: mask
+                  rules:
+                    - builtin: phoneNumber
+                rejection:
+                  body: The request was rejected due to inappropriate content
+                  status: 403
           promptCaching:
             cacheSystem: true
             cacheMessages: true
@@ -401,7 +425,16 @@ backends:
       - requestHeaderModifier:
           remove:
             - x-gateway-model-name
-      - ai: {}
+      - ai:
+          promptGuard:
+            request:
+              - regex:
+                  action: reject
+                  rules:
+                    - builtin: email
+                rejection:
+                  body: The request was rejected due to inappropriate content
+                  status: 400
   - backend:
       ai:
         name: "llm:model:*:3"
@@ -439,7 +472,16 @@ backends:
       - requestHeaderModifier:
           remove:
             - x-gateway-model-name
-      - ai: {}
+      - ai:
+          promptGuard:
+            request:
+              - regex:
+                  action: reject
+                  rules:
+                    - builtin: email
+                rejection:
+                  body: The request was rejected due to inappropriate content
+                  status: 400
 route_groups: []
 workloads: []
 services: []

--- a/crates/agentgateway/src/types/local_tests/llm_simple_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/llm_simple_normalized.snap
@@ -357,7 +357,16 @@ backends:
       - requestHeaderModifier:
           remove:
             - x-gateway-model-name
-      - ai: {}
+      - ai:
+          promptGuard:
+            request:
+              - regex:
+                  action: reject
+                  rules:
+                    - builtin: email
+                rejection:
+                  body: The request was rejected due to inappropriate content
+                  status: 400
   - backend:
       ai:
         name: "llm:model:gpt-7-max:2"

--- a/crates/xtask/src/schema.rs
+++ b/crates/xtask/src/schema.rs
@@ -90,6 +90,7 @@ fn dedupe_lines(input: &str) -> String {
 pub fn make<T: JsonSchema>(inline_subschemas: bool) -> anyhow::Result<String> {
 	let settings = schemars::generate::SchemaSettings::default().with(|s| {
 		s.inline_subschemas = inline_subschemas;
+		s.contract = schemars::generate::Contract::Deserialize;
 	});
 	let gens = schemars::SchemaGenerator::new(settings);
 	let schema = gens.into_root_schema_for::<T>();

--- a/schema/config.json
+++ b/schema/config.json
@@ -8300,13 +8300,6 @@
             }
           ]
         },
-        "guardrails": {
-          "description": "guardrails defines named prompt and response guardrails that can be reused by models.",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/PromptGuard"
-          }
-        },
         "models": {
           "description": "models defines the set of models that can be served by this gateway. The model name refers to the\nmodel in the users request that is matched; the model sent to the actual LLM can be overridden\non a per-model basis.",
           "type": "array",
@@ -8468,7 +8461,7 @@
           "description": "guardrails to apply to the request or response",
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalLLMGuardrails"
+              "$ref": "#/$defs/PromptGuard"
             },
             {
               "type": "null"
@@ -8660,16 +8653,6 @@
         }
       ]
     },
-    "LocalLLMGuardrails": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "$ref": "#/$defs/PromptGuard"
-        }
-      ]
-    },
     "LLMRouteMatch": {
       "type": "object",
       "properties": {
@@ -8780,6 +8763,17 @@
           "anyOf": [
             {
               "$ref": "#/$defs/LocalAPIKeys"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "guardrails": {
+          "description": "Guardrails to apply to every configured model.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PromptGuard"
             },
             {
               "type": "null"

--- a/schema/config.json
+++ b/schema/config.json
@@ -8300,6 +8300,13 @@
             }
           ]
         },
+        "guardrails": {
+          "description": "guardrails defines named prompt and response guardrails that can be reused by models.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/PromptGuard"
+          }
+        },
         "models": {
           "description": "models defines the set of models that can be served by this gateway. The model name refers to the\nmodel in the users request that is matched; the model sent to the actual LLM can be overridden\non a per-model basis.",
           "type": "array",
@@ -8461,7 +8468,7 @@
           "description": "guardrails to apply to the request or response",
           "anyOf": [
             {
-              "$ref": "#/$defs/PromptGuard"
+              "$ref": "#/$defs/LocalLLMGuardrails"
             },
             {
               "type": "null"
@@ -8650,6 +8657,16 @@
           "description": "Pass through the request without interpreting it as LLM traffic.",
           "type": "string",
           "const": "opaque"
+        }
+      ]
+    },
+    "LocalLLMGuardrails": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/PromptGuard"
         }
       ]
     },

--- a/schema/config.md
+++ b/schema/config.md
@@ -18981,6 +18981,7 @@
 |`llm.tls.minTLSVersion`|enum|Minimum supported TLS version (only TLS 1.2 and 1.3 are supported).<br>Possible values: `TLS_V1_0`, `TLS_V1_1`, `TLS_V1_2`, `TLS_V1_3`, `null`.|
 |`llm.tls.maxTLSVersion`|enum|Maximum supported TLS version (only TLS 1.2 and 1.3 are supported).<br>Possible values: `TLS_V1_0`, `TLS_V1_1`, `TLS_V1_2`, `TLS_V1_3`, `null`.|
 |`llm.tls.keyExchangeGroups`|[]string|Key exchange groups allowed for negotiating TLS.|
+|`llm.guardrails`|object|guardrails defines named prompt and response guardrails that can be reused by models.|
 |`llm.models`|[]object|models defines the set of models that can be served by this gateway. The model name refers to the<br>model in the users request that is matched; the model sent to the actual LLM can be overridden<br>on a per-model basis.|
 |`llm.models[].name`|string|name is the name of the model we are matching from a users request. If params.model is set, that<br>will be used in the request to the LLM provider. If not, the incoming model is used.|
 |`llm.models[].params`|object|params customizes parameters for the outgoing request|
@@ -19098,7 +19099,7 @@
 |`llm.models[].backendTunnel.proxy.service.port`|integer||
 |`llm.models[].backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.models[].backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.models[].guardrails`|object|guardrails to apply to the request or response|
+|`llm.models[].guardrails`|string|guardrails to apply to the request or response|
 |`llm.models[].guardrails.request`|[]object|Guards applied to client requests before they reach the LLM.|
 |`llm.models[].guardrails.request[].regex`|object|Apply regex-based masking or rejection rules.|
 |`llm.models[].guardrails.request[].regex.action`|enum|Action to take when a regex rule matches.<br>Possible values: `mask`, `reject`.|

--- a/schema/config.md
+++ b/schema/config.md
@@ -18981,7 +18981,6 @@
 |`llm.tls.minTLSVersion`|enum|Minimum supported TLS version (only TLS 1.2 and 1.3 are supported).<br>Possible values: `TLS_V1_0`, `TLS_V1_1`, `TLS_V1_2`, `TLS_V1_3`, `null`.|
 |`llm.tls.maxTLSVersion`|enum|Maximum supported TLS version (only TLS 1.2 and 1.3 are supported).<br>Possible values: `TLS_V1_0`, `TLS_V1_1`, `TLS_V1_2`, `TLS_V1_3`, `null`.|
 |`llm.tls.keyExchangeGroups`|[]string|Key exchange groups allowed for negotiating TLS.|
-|`llm.guardrails`|object|guardrails defines named prompt and response guardrails that can be reused by models.|
 |`llm.models`|[]object|models defines the set of models that can be served by this gateway. The model name refers to the<br>model in the users request that is matched; the model sent to the actual LLM can be overridden<br>on a per-model basis.|
 |`llm.models[].name`|string|name is the name of the model we are matching from a users request. If params.model is set, that<br>will be used in the request to the LLM provider. If not, the incoming model is used.|
 |`llm.models[].params`|object|params customizes parameters for the outgoing request|
@@ -19008,7 +19007,10 @@
 |`llm.models[].provider.custom.formats[].path`|string||
 |`llm.models[].passthrough`|enum|passthrough controls how requests are handled.<br>By default, requests will be parsed and translated as needed.<br>With passthrough, they will be unmodified and optionally inspected (with `detect`).<br>In this mode, requests must be sent in the native format of the provider.<br>Possible values: `detect`, `opaque`.|
 |`llm.models[].authorization`|object|authorization configures HTTP authorization rules for requests to this model.|
-|`llm.models[].authorization.rules`|[]string|CEL authorization rules to evaluate for a request.|
+|`llm.models[].authorization.rules`|[]object|CEL authorization rules to evaluate for a request.|
+|`llm.models[].authorization.rules[].allow`|string|Allow the request when this CEL expression is true.|
+|`llm.models[].authorization.rules[].deny`|string|Deny the request when this CEL expression is true.|
+|`llm.models[].authorization.rules[].require`|string|Require this CEL expression to be true.|
 |`llm.models[].defaults`|object|defaults allows setting default values for the request. If these are not present in the request body, they will be set.<br>To override even when set, use `overrides`.|
 |`llm.models[].overrides`|object|overrides allows setting values for the request, overriding any existing values|
 |`llm.models[].transformation`|object|transformation allows setting values from CEL expressions for the request, overriding any existing values.|
@@ -19099,7 +19101,7 @@
 |`llm.models[].backendTunnel.proxy.service.port`|integer||
 |`llm.models[].backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.models[].backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.models[].guardrails`|string|guardrails to apply to the request or response|
+|`llm.models[].guardrails`|object|guardrails to apply to the request or response|
 |`llm.models[].guardrails.request`|[]object|Guards applied to client requests before they reach the LLM.|
 |`llm.models[].guardrails.request[].regex`|object|Apply regex-based masking or rejection rules.|
 |`llm.models[].guardrails.request[].regex.action`|enum|Action to take when a regex rule matches.<br>Possible values: `mask`, `reject`.|
@@ -20538,6 +20540,813 @@
 |`llm.policies.apiKey.location.cookie.name`|string|Cookie name containing the credential.|
 |`llm.policies.apiKey.location.expression`|object|Read the credential from a CEL expression evaluated against the incoming request.|
 |`llm.policies.apiKey.location.expression.expression`|string|CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
+|`llm.policies.guardrails`|object|Guardrails to apply to every configured model.|
+|`llm.policies.guardrails.request`|[]object|Guards applied to client requests before they reach the LLM.|
+|`llm.policies.guardrails.request[].regex`|object|Apply regex-based masking or rejection rules.|
+|`llm.policies.guardrails.request[].regex.action`|enum|Action to take when a regex rule matches.<br>Possible values: `mask`, `reject`.|
+|`llm.policies.guardrails.request[].regex.rules`|[]object|Regex or built-in patterns to evaluate.|
+|`llm.policies.guardrails.request[].regex.rules[].builtin`|enum|Use a built-in sensitive data pattern.<br>Built-in pattern name.<br>Possible values: `ssn`, `creditCard`, `phoneNumber`, `email`, `caSin`.|
+|`llm.policies.guardrails.request[].regex.rules[].pattern`|string|Use a custom regular expression.<br>Regular expression pattern to evaluate.|
+|`llm.policies.guardrails.request[].webhook`|object|Call a webhook to evaluate the prompt.|
+|`llm.policies.guardrails.request[].webhook.target`|object|Backend that receives guardrail webhook requests.<br>Exactly one of service, host, or backend may be set.|
+|`llm.policies.guardrails.request[].webhook.target.service`|object|Service reference. Service must be defined in the top level services list.|
+|`llm.policies.guardrails.request[].webhook.target.service.name`|object||
+|`llm.policies.guardrails.request[].webhook.target.service.name.namespace`|string||
+|`llm.policies.guardrails.request[].webhook.target.service.name.hostname`|string||
+|`llm.policies.guardrails.request[].webhook.target.service.port`|integer||
+|`llm.policies.guardrails.request[].webhook.target.host`|string|Hostname or IP address|
+|`llm.policies.guardrails.request[].webhook.target.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.policies.guardrails.request[].webhook.forwardHeaderMatches`|[]object|Incoming request headers to forward to the webhook.|
+|`llm.policies.guardrails.request[].webhook.forwardHeaderMatches[].name`|string||
+|`llm.policies.guardrails.request[].webhook.forwardHeaderMatches[].value`|object|Exactly one of exact or regex may be set.|
+|`llm.policies.guardrails.request[].webhook.forwardHeaderMatches[].value.exact`|string||
+|`llm.policies.guardrails.request[].webhook.forwardHeaderMatches[].value.regex`|string||
+|`llm.policies.guardrails.request[].webhook.failureMode`|enum|Behavior when the webhook is unreachable or returns an error.<br>Defaults to `failClosed`.<br>Possible values: `failClosed`, `failOpen`.|
+|`llm.policies.guardrails.request[].openAIModeration`|object|Use OpenAI moderation to evaluate the prompt.|
+|`llm.policies.guardrails.request[].openAIModeration.model`|string|Moderation model to use. Defaults to `omni-moderation-latest`.|
+|`llm.policies.guardrails.request[].openAIModeration.policies`|object|Backend policies used when calling the moderation provider.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.requestHeaderModifier.set`|object|Headers to set, replacing any existing values.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.requestHeaderModifier.remove`|[]string|Header names to remove.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.transformations`|object|Modify request and response data for this backend.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.transformations.request`|object|Transform the request before it is forwarded.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.transformations.request.add`|object|Headers to append using CEL expressions for values.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.transformations.request.set`|object|Headers to set using CEL expressions for values.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.transformations.request.remove`|[]string|Header names to remove.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.transformations.request.body`|string|CEL expression that computes a replacement body.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.transformations.request.metadata`|object|Metadata values to add using CEL expressions.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.transformations.response`|object|Transform the response before it is returned.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.transformations.response.add`|object|Headers to append using CEL expressions for values.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.transformations.response.set`|object|Headers to set using CEL expressions for values.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.transformations.response.remove`|[]string|Header names to remove.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.transformations.response.body`|string|CEL expression that computes a replacement body.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.transformations.response.metadata`|object|Metadata values to add using CEL expressions.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendTLS`|object|TLS settings used when connecting to this backend.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendTLS.cert`|string|Client certificate file to present to the backend.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendTLS.key`|string|Private key file for the client certificate.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendTLS.root`|string|Root certificate bundle used to verify the backend certificate.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendTLS.hostname`|string|Server name to use for TLS verification and SNI.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendTLS.insecure`|boolean|Skip certificate trust verification for the backend connection.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendTLS.insecureHost`|boolean|Skip hostname verification for the backend certificate.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendTLS.alpn`|[]string|ALPN protocols to offer to the backend.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendTLS.subjectAltNames`|[]string|Additional subject alternative names accepted for the backend certificate.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendTLS.keyExchangeGroups`|[]enum|Key exchange groups allowed for negotiating TLS.<br>Possible values: `X25519`, `P-256`, `P-384`, `X25519_MLKEM768`.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth`|object|Authentication credentials sent to this backend.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.passthrough`|object|Forward the validated incoming JWT to the backend.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.passthrough.location`|object|Where to place the forwarded credential in the backend request.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.passthrough.location.header`|object|Read the credential from an HTTP header.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.passthrough.location.header.name`|string|Header name containing the credential.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.passthrough.location.header.prefix`|string|Prefix to remove from the header value before validation, such as `Bearer ` or `Basic `.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.passthrough.location.queryParameter`|object|Read the credential from a URL query parameter.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.passthrough.location.queryParameter.name`|string|Query parameter name containing the credential.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.passthrough.location.cookie`|object|Read the credential from a request cookie.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.passthrough.location.expression`|object|Read the credential from a CEL expression evaluated against the incoming request.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.passthrough.location.expression.expression`|string|CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.key.value.file`|string||
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.key.location.header.name`|string|Header name containing the credential.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.key.location.header.prefix`|string|Prefix to remove from the header value before validation, such as `Bearer ` or `Basic `.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.key.location.queryParameter`|object|Read the credential from a URL query parameter.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.key.location.queryParameter.name`|string|Query parameter name containing the credential.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.key.location.cookie`|object|Read the credential from a request cookie.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.key.location.cookie.name`|string|Cookie name containing the credential.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.key.location.expression`|object|Read the credential from a CEL expression evaluated against the incoming request.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.key.location.expression.expression`|string|CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.gcp`|object|Authenticate to Google Cloud services.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.gcp.type`|enum|Possible values: `idToken`.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.gcp.audience`|string|Audience for the token. If not set, the destination host will be used.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.gcp.credential`|object|ADC-compatible Google credential JSON. If not set, ambient credentials are used.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.gcp.credential.file`|string||
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.gcp.type`|enum|Possible values: `accessToken`, `null`.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.aws`|object|Sign backend requests with AWS credentials.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.aws.accessKeyId`|string||
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.aws.secretAccessKey`|string||
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.aws.region`|string||
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.aws.sessionToken`|string||
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.aws.serviceName`|string|AWS SigV4 signing service name (for example, "bedrock", "bedrock-agentcore", or "execute-api").|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.aws.assumeRole`|object|Optional AWS STS role to assume before signing requests.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.aws.assumeRole.roleArn`|string|AWS IAM role ARN to assume.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.azure`|object|Authenticate to Azure services.<br>Exactly one of explicitConfig, developerImplicit, or implicit may be set.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.azure.explicitConfig`|object|Use explicit Azure credentials<br>Exactly one of clientSecret, managedIdentity, or workloadIdentity may be set.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.azure.explicitConfig.clientSecret`|object||
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.azure.explicitConfig.clientSecret.tenant_id`|string||
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.azure.explicitConfig.clientSecret.client_id`|string||
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.azure.explicitConfig.clientSecret.client_secret`|string||
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.azure.explicitConfig.managedIdentity`|object||
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.azure.explicitConfig.managedIdentity.userAssignedIdentity`|object||
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.azure.explicitConfig.managedIdentity.userAssignedIdentity.clientId`|string||
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.azure.explicitConfig.managedIdentity.userAssignedIdentity.objectId`|string||
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.azure.explicitConfig.managedIdentity.userAssignedIdentity.resourceId`|string||
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.http`|object|HTTP protocol settings for this backend.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.http.version`|string|HTTP version to use when connecting to the backend.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.tcp`|object|TCP protocol settings for this backend.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.tcp.keepalives.enabled`|boolean||
+|`llm.policies.guardrails.request[].openAIModeration.policies.tcp.keepalives.time`|string||
+|`llm.policies.guardrails.request[].openAIModeration.policies.tcp.keepalives.interval`|string||
+|`llm.policies.guardrails.request[].openAIModeration.policies.tcp.keepalives.retries`|integer||
+|`llm.policies.guardrails.request[].openAIModeration.policies.tcp.connectTimeout`|object|Maximum time allowed to establish a backend TCP connection.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.tcp.connectTimeout.secs`|integer||
+|`llm.policies.guardrails.request[].openAIModeration.policies.tcp.connectTimeout.nanos`|integer||
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendTunnel`|object|Tunnel settings used when connecting to this backend.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendTunnel.proxy`|object|Proxy backend used to tunnel the connection.<br>Exactly one of service, host, or backend may be set.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendTunnel.proxy.service`|object|Service reference. Service must be defined in the top level services list.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendTunnel.proxy.service.name`|object||
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendTunnel.proxy.service.name.namespace`|string||
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendTunnel.proxy.service.name.hostname`|string||
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer||
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.policies.guardrails.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
+|`llm.policies.guardrails.request[].bedrockGuardrails.guardrailVersion`|string|The version of the guardrail|
+|`llm.policies.guardrails.request[].bedrockGuardrails.region`|string|AWS region where the guardrail is deployed|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies`|object|Backend policies for AWS authentication (optional, defaults to implicit AWS auth)|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.requestHeaderModifier.set`|object|Headers to set, replacing any existing values.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.requestHeaderModifier.remove`|[]string|Header names to remove.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.transformations`|object|Modify request and response data for this backend.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.transformations.request`|object|Transform the request before it is forwarded.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.transformations.request.add`|object|Headers to append using CEL expressions for values.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.transformations.request.set`|object|Headers to set using CEL expressions for values.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.transformations.request.remove`|[]string|Header names to remove.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.transformations.request.body`|string|CEL expression that computes a replacement body.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.transformations.request.metadata`|object|Metadata values to add using CEL expressions.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.transformations.response`|object|Transform the response before it is returned.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.transformations.response.add`|object|Headers to append using CEL expressions for values.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.transformations.response.set`|object|Headers to set using CEL expressions for values.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.transformations.response.remove`|[]string|Header names to remove.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.transformations.response.body`|string|CEL expression that computes a replacement body.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.transformations.response.metadata`|object|Metadata values to add using CEL expressions.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendTLS`|object|TLS settings used when connecting to this backend.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendTLS.cert`|string|Client certificate file to present to the backend.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendTLS.key`|string|Private key file for the client certificate.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendTLS.root`|string|Root certificate bundle used to verify the backend certificate.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendTLS.hostname`|string|Server name to use for TLS verification and SNI.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendTLS.insecure`|boolean|Skip certificate trust verification for the backend connection.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendTLS.insecureHost`|boolean|Skip hostname verification for the backend certificate.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendTLS.alpn`|[]string|ALPN protocols to offer to the backend.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendTLS.subjectAltNames`|[]string|Additional subject alternative names accepted for the backend certificate.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendTLS.keyExchangeGroups`|[]enum|Key exchange groups allowed for negotiating TLS.<br>Possible values: `X25519`, `P-256`, `P-384`, `X25519_MLKEM768`.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth`|object|Authentication credentials sent to this backend.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.passthrough`|object|Forward the validated incoming JWT to the backend.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.passthrough.location`|object|Where to place the forwarded credential in the backend request.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.passthrough.location.header`|object|Read the credential from an HTTP header.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.passthrough.location.header.name`|string|Header name containing the credential.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.passthrough.location.header.prefix`|string|Prefix to remove from the header value before validation, such as `Bearer ` or `Basic `.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.passthrough.location.queryParameter`|object|Read the credential from a URL query parameter.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.passthrough.location.queryParameter.name`|string|Query parameter name containing the credential.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.passthrough.location.cookie`|object|Read the credential from a request cookie.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.passthrough.location.expression`|object|Read the credential from a CEL expression evaluated against the incoming request.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.passthrough.location.expression.expression`|string|CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.key.value.file`|string||
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.key.location.header.name`|string|Header name containing the credential.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.key.location.header.prefix`|string|Prefix to remove from the header value before validation, such as `Bearer ` or `Basic `.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.key.location.queryParameter`|object|Read the credential from a URL query parameter.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.key.location.queryParameter.name`|string|Query parameter name containing the credential.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.key.location.cookie`|object|Read the credential from a request cookie.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.key.location.cookie.name`|string|Cookie name containing the credential.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.key.location.expression`|object|Read the credential from a CEL expression evaluated against the incoming request.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.key.location.expression.expression`|string|CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.gcp`|object|Authenticate to Google Cloud services.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.gcp.type`|enum|Possible values: `idToken`.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.gcp.audience`|string|Audience for the token. If not set, the destination host will be used.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.gcp.credential`|object|ADC-compatible Google credential JSON. If not set, ambient credentials are used.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.gcp.credential.file`|string||
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.gcp.type`|enum|Possible values: `accessToken`, `null`.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.aws`|object|Sign backend requests with AWS credentials.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.aws.accessKeyId`|string||
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.aws.secretAccessKey`|string||
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.aws.region`|string||
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.aws.sessionToken`|string||
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.aws.serviceName`|string|AWS SigV4 signing service name (for example, "bedrock", "bedrock-agentcore", or "execute-api").|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.aws.assumeRole`|object|Optional AWS STS role to assume before signing requests.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.aws.assumeRole.roleArn`|string|AWS IAM role ARN to assume.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.azure`|object|Authenticate to Azure services.<br>Exactly one of explicitConfig, developerImplicit, or implicit may be set.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.azure.explicitConfig`|object|Use explicit Azure credentials<br>Exactly one of clientSecret, managedIdentity, or workloadIdentity may be set.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.azure.explicitConfig.clientSecret`|object||
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.azure.explicitConfig.clientSecret.tenant_id`|string||
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.azure.explicitConfig.clientSecret.client_id`|string||
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.azure.explicitConfig.clientSecret.client_secret`|string||
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.azure.explicitConfig.managedIdentity`|object||
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.azure.explicitConfig.managedIdentity.userAssignedIdentity`|object||
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.azure.explicitConfig.managedIdentity.userAssignedIdentity.clientId`|string||
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.azure.explicitConfig.managedIdentity.userAssignedIdentity.objectId`|string||
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.azure.explicitConfig.managedIdentity.userAssignedIdentity.resourceId`|string||
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean||
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.tcp.keepalives.time`|string||
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.tcp.keepalives.interval`|string||
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.tcp.keepalives.retries`|integer||
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.tcp.connectTimeout`|object|Maximum time allowed to establish a backend TCP connection.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.tcp.connectTimeout.secs`|integer||
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.tcp.connectTimeout.nanos`|integer||
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendTunnel`|object|Tunnel settings used when connecting to this backend.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendTunnel.proxy`|object|Proxy backend used to tunnel the connection.<br>Exactly one of service, host, or backend may be set.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendTunnel.proxy.service`|object|Service reference. Service must be defined in the top level services list.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.name`|object||
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.name.namespace`|string||
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.name.hostname`|string||
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer||
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.policies.guardrails.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
+|`llm.policies.guardrails.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
+|`llm.policies.guardrails.request[].googleModelArmor.projectId`|string|The GCP project ID|
+|`llm.policies.guardrails.request[].googleModelArmor.location`|string|The GCP region (default: us-central1)|
+|`llm.policies.guardrails.request[].googleModelArmor.policies`|object|Backend policies for GCP authentication (optional, defaults to implicit GCP auth)|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.requestHeaderModifier.set`|object|Headers to set, replacing any existing values.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.requestHeaderModifier.remove`|[]string|Header names to remove.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.transformations`|object|Modify request and response data for this backend.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.transformations.request`|object|Transform the request before it is forwarded.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.transformations.request.add`|object|Headers to append using CEL expressions for values.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.transformations.request.set`|object|Headers to set using CEL expressions for values.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.transformations.request.remove`|[]string|Header names to remove.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.transformations.request.body`|string|CEL expression that computes a replacement body.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.transformations.request.metadata`|object|Metadata values to add using CEL expressions.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.transformations.response`|object|Transform the response before it is returned.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.transformations.response.add`|object|Headers to append using CEL expressions for values.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.transformations.response.set`|object|Headers to set using CEL expressions for values.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.transformations.response.remove`|[]string|Header names to remove.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.transformations.response.body`|string|CEL expression that computes a replacement body.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.transformations.response.metadata`|object|Metadata values to add using CEL expressions.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendTLS`|object|TLS settings used when connecting to this backend.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendTLS.cert`|string|Client certificate file to present to the backend.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendTLS.key`|string|Private key file for the client certificate.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendTLS.root`|string|Root certificate bundle used to verify the backend certificate.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendTLS.hostname`|string|Server name to use for TLS verification and SNI.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendTLS.insecure`|boolean|Skip certificate trust verification for the backend connection.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendTLS.insecureHost`|boolean|Skip hostname verification for the backend certificate.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendTLS.alpn`|[]string|ALPN protocols to offer to the backend.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendTLS.subjectAltNames`|[]string|Additional subject alternative names accepted for the backend certificate.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendTLS.keyExchangeGroups`|[]enum|Key exchange groups allowed for negotiating TLS.<br>Possible values: `X25519`, `P-256`, `P-384`, `X25519_MLKEM768`.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth`|object|Authentication credentials sent to this backend.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.passthrough`|object|Forward the validated incoming JWT to the backend.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.passthrough.location`|object|Where to place the forwarded credential in the backend request.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.passthrough.location.header`|object|Read the credential from an HTTP header.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.passthrough.location.header.name`|string|Header name containing the credential.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.passthrough.location.header.prefix`|string|Prefix to remove from the header value before validation, such as `Bearer ` or `Basic `.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.passthrough.location.queryParameter`|object|Read the credential from a URL query parameter.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.passthrough.location.queryParameter.name`|string|Query parameter name containing the credential.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.passthrough.location.cookie`|object|Read the credential from a request cookie.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.passthrough.location.expression`|object|Read the credential from a CEL expression evaluated against the incoming request.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.passthrough.location.expression.expression`|string|CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.key.value.file`|string||
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.key.location.header.name`|string|Header name containing the credential.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.key.location.header.prefix`|string|Prefix to remove from the header value before validation, such as `Bearer ` or `Basic `.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.key.location.queryParameter`|object|Read the credential from a URL query parameter.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.key.location.queryParameter.name`|string|Query parameter name containing the credential.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.key.location.cookie`|object|Read the credential from a request cookie.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.key.location.cookie.name`|string|Cookie name containing the credential.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.key.location.expression`|object|Read the credential from a CEL expression evaluated against the incoming request.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.key.location.expression.expression`|string|CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.gcp`|object|Authenticate to Google Cloud services.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.gcp.type`|enum|Possible values: `idToken`.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.gcp.audience`|string|Audience for the token. If not set, the destination host will be used.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.gcp.credential`|object|ADC-compatible Google credential JSON. If not set, ambient credentials are used.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.gcp.credential.file`|string||
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.gcp.type`|enum|Possible values: `accessToken`, `null`.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.aws`|object|Sign backend requests with AWS credentials.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.aws.accessKeyId`|string||
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.aws.secretAccessKey`|string||
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.aws.region`|string||
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.aws.sessionToken`|string||
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.aws.serviceName`|string|AWS SigV4 signing service name (for example, "bedrock", "bedrock-agentcore", or "execute-api").|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.aws.assumeRole`|object|Optional AWS STS role to assume before signing requests.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.aws.assumeRole.roleArn`|string|AWS IAM role ARN to assume.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.azure`|object|Authenticate to Azure services.<br>Exactly one of explicitConfig, developerImplicit, or implicit may be set.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.azure.explicitConfig`|object|Use explicit Azure credentials<br>Exactly one of clientSecret, managedIdentity, or workloadIdentity may be set.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.azure.explicitConfig.clientSecret`|object||
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.azure.explicitConfig.clientSecret.tenant_id`|string||
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.azure.explicitConfig.clientSecret.client_id`|string||
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.azure.explicitConfig.clientSecret.client_secret`|string||
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.azure.explicitConfig.managedIdentity`|object||
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.azure.explicitConfig.managedIdentity.userAssignedIdentity`|object||
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.azure.explicitConfig.managedIdentity.userAssignedIdentity.clientId`|string||
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.azure.explicitConfig.managedIdentity.userAssignedIdentity.objectId`|string||
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.azure.explicitConfig.managedIdentity.userAssignedIdentity.resourceId`|string||
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean||
+|`llm.policies.guardrails.request[].googleModelArmor.policies.tcp.keepalives.time`|string||
+|`llm.policies.guardrails.request[].googleModelArmor.policies.tcp.keepalives.interval`|string||
+|`llm.policies.guardrails.request[].googleModelArmor.policies.tcp.keepalives.retries`|integer||
+|`llm.policies.guardrails.request[].googleModelArmor.policies.tcp.connectTimeout`|object|Maximum time allowed to establish a backend TCP connection.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.tcp.connectTimeout.secs`|integer||
+|`llm.policies.guardrails.request[].googleModelArmor.policies.tcp.connectTimeout.nanos`|integer||
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendTunnel`|object|Tunnel settings used when connecting to this backend.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendTunnel.proxy`|object|Proxy backend used to tunnel the connection.<br>Exactly one of service, host, or backend may be set.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendTunnel.proxy.service`|object|Service reference. Service must be defined in the top level services list.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendTunnel.proxy.service.name`|object||
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendTunnel.proxy.service.name.namespace`|string||
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendTunnel.proxy.service.name.hostname`|string||
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer||
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.policies.guardrails.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
+|`llm.policies.guardrails.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
+|`llm.policies.guardrails.request[].azureContentSafety.policies`|object|Backend policies for Azure authentication (optional, defaults to implicit Azure auth)|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.requestHeaderModifier.set`|object|Headers to set, replacing any existing values.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.requestHeaderModifier.remove`|[]string|Header names to remove.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.transformations`|object|Modify request and response data for this backend.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.transformations.request`|object|Transform the request before it is forwarded.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.transformations.request.add`|object|Headers to append using CEL expressions for values.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.transformations.request.set`|object|Headers to set using CEL expressions for values.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.transformations.request.remove`|[]string|Header names to remove.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.transformations.request.body`|string|CEL expression that computes a replacement body.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.transformations.request.metadata`|object|Metadata values to add using CEL expressions.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.transformations.response`|object|Transform the response before it is returned.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.transformations.response.add`|object|Headers to append using CEL expressions for values.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.transformations.response.set`|object|Headers to set using CEL expressions for values.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.transformations.response.remove`|[]string|Header names to remove.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.transformations.response.body`|string|CEL expression that computes a replacement body.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.transformations.response.metadata`|object|Metadata values to add using CEL expressions.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendTLS`|object|TLS settings used when connecting to this backend.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendTLS.cert`|string|Client certificate file to present to the backend.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendTLS.key`|string|Private key file for the client certificate.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendTLS.root`|string|Root certificate bundle used to verify the backend certificate.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendTLS.hostname`|string|Server name to use for TLS verification and SNI.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendTLS.insecure`|boolean|Skip certificate trust verification for the backend connection.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendTLS.insecureHost`|boolean|Skip hostname verification for the backend certificate.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendTLS.alpn`|[]string|ALPN protocols to offer to the backend.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendTLS.subjectAltNames`|[]string|Additional subject alternative names accepted for the backend certificate.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendTLS.keyExchangeGroups`|[]enum|Key exchange groups allowed for negotiating TLS.<br>Possible values: `X25519`, `P-256`, `P-384`, `X25519_MLKEM768`.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth`|object|Authentication credentials sent to this backend.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.passthrough`|object|Forward the validated incoming JWT to the backend.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.passthrough.location`|object|Where to place the forwarded credential in the backend request.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.passthrough.location.header`|object|Read the credential from an HTTP header.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.passthrough.location.header.name`|string|Header name containing the credential.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.passthrough.location.header.prefix`|string|Prefix to remove from the header value before validation, such as `Bearer ` or `Basic `.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.passthrough.location.queryParameter`|object|Read the credential from a URL query parameter.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.passthrough.location.queryParameter.name`|string|Query parameter name containing the credential.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.passthrough.location.cookie`|object|Read the credential from a request cookie.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.passthrough.location.expression`|object|Read the credential from a CEL expression evaluated against the incoming request.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.passthrough.location.expression.expression`|string|CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.key.value.file`|string||
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.key.location.header.name`|string|Header name containing the credential.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.key.location.header.prefix`|string|Prefix to remove from the header value before validation, such as `Bearer ` or `Basic `.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.key.location.queryParameter`|object|Read the credential from a URL query parameter.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.key.location.queryParameter.name`|string|Query parameter name containing the credential.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.key.location.cookie`|object|Read the credential from a request cookie.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.key.location.cookie.name`|string|Cookie name containing the credential.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.key.location.expression`|object|Read the credential from a CEL expression evaluated against the incoming request.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.key.location.expression.expression`|string|CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.gcp`|object|Authenticate to Google Cloud services.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.gcp.type`|enum|Possible values: `idToken`.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.gcp.audience`|string|Audience for the token. If not set, the destination host will be used.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.gcp.credential`|object|ADC-compatible Google credential JSON. If not set, ambient credentials are used.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.gcp.credential.file`|string||
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.gcp.type`|enum|Possible values: `accessToken`, `null`.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.aws`|object|Sign backend requests with AWS credentials.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.aws.accessKeyId`|string||
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.aws.secretAccessKey`|string||
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.aws.region`|string||
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.aws.sessionToken`|string||
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.aws.serviceName`|string|AWS SigV4 signing service name (for example, "bedrock", "bedrock-agentcore", or "execute-api").|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.aws.assumeRole`|object|Optional AWS STS role to assume before signing requests.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.aws.assumeRole.roleArn`|string|AWS IAM role ARN to assume.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.azure`|object|Authenticate to Azure services.<br>Exactly one of explicitConfig, developerImplicit, or implicit may be set.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.azure.explicitConfig`|object|Use explicit Azure credentials<br>Exactly one of clientSecret, managedIdentity, or workloadIdentity may be set.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.azure.explicitConfig.clientSecret`|object||
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.azure.explicitConfig.clientSecret.tenant_id`|string||
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.azure.explicitConfig.clientSecret.client_id`|string||
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.azure.explicitConfig.clientSecret.client_secret`|string||
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.azure.explicitConfig.managedIdentity`|object||
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.azure.explicitConfig.managedIdentity.userAssignedIdentity`|object||
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.azure.explicitConfig.managedIdentity.userAssignedIdentity.clientId`|string||
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.azure.explicitConfig.managedIdentity.userAssignedIdentity.objectId`|string||
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.azure.explicitConfig.managedIdentity.userAssignedIdentity.resourceId`|string||
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean||
+|`llm.policies.guardrails.request[].azureContentSafety.policies.tcp.keepalives.time`|string||
+|`llm.policies.guardrails.request[].azureContentSafety.policies.tcp.keepalives.interval`|string||
+|`llm.policies.guardrails.request[].azureContentSafety.policies.tcp.keepalives.retries`|integer||
+|`llm.policies.guardrails.request[].azureContentSafety.policies.tcp.connectTimeout`|object|Maximum time allowed to establish a backend TCP connection.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.tcp.connectTimeout.secs`|integer||
+|`llm.policies.guardrails.request[].azureContentSafety.policies.tcp.connectTimeout.nanos`|integer||
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendTunnel`|object|Tunnel settings used when connecting to this backend.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendTunnel.proxy`|object|Proxy backend used to tunnel the connection.<br>Exactly one of service, host, or backend may be set.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendTunnel.proxy.service`|object|Service reference. Service must be defined in the top level services list.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendTunnel.proxy.service.name`|object||
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendTunnel.proxy.service.name.namespace`|string||
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendTunnel.proxy.service.name.hostname`|string||
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer||
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.policies.guardrails.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
+|`llm.policies.guardrails.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
+|`llm.policies.guardrails.request[].azureContentSafety.analyzeText.apiVersion`|string|API version to use (default: "2024-09-01")|
+|`llm.policies.guardrails.request[].azureContentSafety.analyzeText.blocklistNames`|[]string|Blocklist names to check against|
+|`llm.policies.guardrails.request[].azureContentSafety.analyzeText.haltOnBlocklistHit`|boolean|When true, further analysis stops if a blocklist is hit|
+|`llm.policies.guardrails.request[].azureContentSafety.detectJailbreak`|object|Detect Text Jailbreak configuration for detecting jailbreak attempts.<br>Only applicable to request guards.|
+|`llm.policies.guardrails.request[].azureContentSafety.detectJailbreak.apiVersion`|string|API version to use (default: "2024-02-15-preview")|
+|`llm.policies.guardrails.request[].rejection`|object|Response returned when the request is rejected.|
+|`llm.policies.guardrails.request[].rejection.body`|array|Response body returned when content is rejected.|
+|`llm.policies.guardrails.request[].rejection.status`|integer|HTTP status code returned when content is rejected.|
+|`llm.policies.guardrails.request[].rejection.headers`|object|Headers to add, set, or remove from the rejection response.|
+|`llm.policies.guardrails.request[].rejection.headers.add`|object|Headers to append without replacing existing values.|
+|`llm.policies.guardrails.request[].rejection.headers.set`|object|Headers to set, replacing any existing values.|
+|`llm.policies.guardrails.request[].rejection.headers.remove`|[]string|Header names to remove.|
+|`llm.policies.guardrails.response`|[]object|Guards applied to LLM responses before they reach the client.|
+|`llm.policies.guardrails.response[].regex`|object|Apply regex-based masking or rejection rules.|
+|`llm.policies.guardrails.response[].regex.action`|enum|Action to take when a regex rule matches.<br>Possible values: `mask`, `reject`.|
+|`llm.policies.guardrails.response[].regex.rules`|[]object|Regex or built-in patterns to evaluate.|
+|`llm.policies.guardrails.response[].regex.rules[].builtin`|enum|Use a built-in sensitive data pattern.<br>Built-in pattern name.<br>Possible values: `ssn`, `creditCard`, `phoneNumber`, `email`, `caSin`.|
+|`llm.policies.guardrails.response[].regex.rules[].pattern`|string|Use a custom regular expression.<br>Regular expression pattern to evaluate.|
+|`llm.policies.guardrails.response[].webhook`|object|Call a webhook to evaluate the response.|
+|`llm.policies.guardrails.response[].webhook.target`|object|Backend that receives guardrail webhook requests.<br>Exactly one of service, host, or backend may be set.|
+|`llm.policies.guardrails.response[].webhook.target.service`|object|Service reference. Service must be defined in the top level services list.|
+|`llm.policies.guardrails.response[].webhook.target.service.name`|object||
+|`llm.policies.guardrails.response[].webhook.target.service.name.namespace`|string||
+|`llm.policies.guardrails.response[].webhook.target.service.name.hostname`|string||
+|`llm.policies.guardrails.response[].webhook.target.service.port`|integer||
+|`llm.policies.guardrails.response[].webhook.target.host`|string|Hostname or IP address|
+|`llm.policies.guardrails.response[].webhook.target.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.policies.guardrails.response[].webhook.forwardHeaderMatches`|[]object|Incoming request headers to forward to the webhook.|
+|`llm.policies.guardrails.response[].webhook.forwardHeaderMatches[].name`|string||
+|`llm.policies.guardrails.response[].webhook.forwardHeaderMatches[].value`|object|Exactly one of exact or regex may be set.|
+|`llm.policies.guardrails.response[].webhook.forwardHeaderMatches[].value.exact`|string||
+|`llm.policies.guardrails.response[].webhook.forwardHeaderMatches[].value.regex`|string||
+|`llm.policies.guardrails.response[].webhook.failureMode`|enum|Behavior when the webhook is unreachable or returns an error.<br>Defaults to `failClosed`.<br>Possible values: `failClosed`, `failOpen`.|
+|`llm.policies.guardrails.response[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the response.<br>Configuration for AWS Bedrock Guardrails integration.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
+|`llm.policies.guardrails.response[].bedrockGuardrails.guardrailVersion`|string|The version of the guardrail|
+|`llm.policies.guardrails.response[].bedrockGuardrails.region`|string|AWS region where the guardrail is deployed|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies`|object|Backend policies for AWS authentication (optional, defaults to implicit AWS auth)|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.requestHeaderModifier.set`|object|Headers to set, replacing any existing values.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.requestHeaderModifier.remove`|[]string|Header names to remove.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.transformations`|object|Modify request and response data for this backend.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.transformations.request`|object|Transform the request before it is forwarded.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.transformations.request.add`|object|Headers to append using CEL expressions for values.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.transformations.request.set`|object|Headers to set using CEL expressions for values.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.transformations.request.remove`|[]string|Header names to remove.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.transformations.request.body`|string|CEL expression that computes a replacement body.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.transformations.request.metadata`|object|Metadata values to add using CEL expressions.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.transformations.response`|object|Transform the response before it is returned.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.transformations.response.add`|object|Headers to append using CEL expressions for values.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.transformations.response.set`|object|Headers to set using CEL expressions for values.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.transformations.response.remove`|[]string|Header names to remove.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.transformations.response.body`|string|CEL expression that computes a replacement body.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.transformations.response.metadata`|object|Metadata values to add using CEL expressions.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendTLS`|object|TLS settings used when connecting to this backend.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendTLS.cert`|string|Client certificate file to present to the backend.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendTLS.key`|string|Private key file for the client certificate.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendTLS.root`|string|Root certificate bundle used to verify the backend certificate.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendTLS.hostname`|string|Server name to use for TLS verification and SNI.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendTLS.insecure`|boolean|Skip certificate trust verification for the backend connection.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendTLS.insecureHost`|boolean|Skip hostname verification for the backend certificate.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendTLS.alpn`|[]string|ALPN protocols to offer to the backend.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendTLS.subjectAltNames`|[]string|Additional subject alternative names accepted for the backend certificate.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendTLS.keyExchangeGroups`|[]enum|Key exchange groups allowed for negotiating TLS.<br>Possible values: `X25519`, `P-256`, `P-384`, `X25519_MLKEM768`.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth`|object|Authentication credentials sent to this backend.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.passthrough`|object|Forward the validated incoming JWT to the backend.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.passthrough.location`|object|Where to place the forwarded credential in the backend request.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.passthrough.location.header`|object|Read the credential from an HTTP header.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.passthrough.location.header.name`|string|Header name containing the credential.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.passthrough.location.header.prefix`|string|Prefix to remove from the header value before validation, such as `Bearer ` or `Basic `.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.passthrough.location.queryParameter`|object|Read the credential from a URL query parameter.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.passthrough.location.queryParameter.name`|string|Query parameter name containing the credential.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.passthrough.location.cookie`|object|Read the credential from a request cookie.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.passthrough.location.expression`|object|Read the credential from a CEL expression evaluated against the incoming request.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.passthrough.location.expression.expression`|string|CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.key.value.file`|string||
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.key.location.header.name`|string|Header name containing the credential.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.key.location.header.prefix`|string|Prefix to remove from the header value before validation, such as `Bearer ` or `Basic `.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.key.location.queryParameter`|object|Read the credential from a URL query parameter.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.key.location.queryParameter.name`|string|Query parameter name containing the credential.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.key.location.cookie`|object|Read the credential from a request cookie.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.key.location.cookie.name`|string|Cookie name containing the credential.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.key.location.expression`|object|Read the credential from a CEL expression evaluated against the incoming request.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.key.location.expression.expression`|string|CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.gcp`|object|Authenticate to Google Cloud services.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.gcp.type`|enum|Possible values: `idToken`.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.gcp.audience`|string|Audience for the token. If not set, the destination host will be used.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.gcp.credential`|object|ADC-compatible Google credential JSON. If not set, ambient credentials are used.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.gcp.credential.file`|string||
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.gcp.type`|enum|Possible values: `accessToken`, `null`.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.aws`|object|Sign backend requests with AWS credentials.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.aws.accessKeyId`|string||
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.aws.secretAccessKey`|string||
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.aws.region`|string||
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.aws.sessionToken`|string||
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.aws.serviceName`|string|AWS SigV4 signing service name (for example, "bedrock", "bedrock-agentcore", or "execute-api").|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.aws.assumeRole`|object|Optional AWS STS role to assume before signing requests.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.aws.assumeRole.roleArn`|string|AWS IAM role ARN to assume.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.azure`|object|Authenticate to Azure services.<br>Exactly one of explicitConfig, developerImplicit, or implicit may be set.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.azure.explicitConfig`|object|Use explicit Azure credentials<br>Exactly one of clientSecret, managedIdentity, or workloadIdentity may be set.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.azure.explicitConfig.clientSecret`|object||
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.azure.explicitConfig.clientSecret.tenant_id`|string||
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.azure.explicitConfig.clientSecret.client_id`|string||
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.azure.explicitConfig.clientSecret.client_secret`|string||
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.azure.explicitConfig.managedIdentity`|object||
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.azure.explicitConfig.managedIdentity.userAssignedIdentity`|object||
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.azure.explicitConfig.managedIdentity.userAssignedIdentity.clientId`|string||
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.azure.explicitConfig.managedIdentity.userAssignedIdentity.objectId`|string||
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.azure.explicitConfig.managedIdentity.userAssignedIdentity.resourceId`|string||
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean||
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.tcp.keepalives.time`|string||
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.tcp.keepalives.interval`|string||
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.tcp.keepalives.retries`|integer||
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.tcp.connectTimeout`|object|Maximum time allowed to establish a backend TCP connection.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.tcp.connectTimeout.secs`|integer||
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.tcp.connectTimeout.nanos`|integer||
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendTunnel`|object|Tunnel settings used when connecting to this backend.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendTunnel.proxy`|object|Proxy backend used to tunnel the connection.<br>Exactly one of service, host, or backend may be set.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendTunnel.proxy.service`|object|Service reference. Service must be defined in the top level services list.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.name`|object||
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.name.namespace`|string||
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.name.hostname`|string||
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer||
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.policies.guardrails.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
+|`llm.policies.guardrails.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
+|`llm.policies.guardrails.response[].googleModelArmor.projectId`|string|The GCP project ID|
+|`llm.policies.guardrails.response[].googleModelArmor.location`|string|The GCP region (default: us-central1)|
+|`llm.policies.guardrails.response[].googleModelArmor.policies`|object|Backend policies for GCP authentication (optional, defaults to implicit GCP auth)|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.requestHeaderModifier.set`|object|Headers to set, replacing any existing values.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.requestHeaderModifier.remove`|[]string|Header names to remove.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.transformations`|object|Modify request and response data for this backend.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.transformations.request`|object|Transform the request before it is forwarded.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.transformations.request.add`|object|Headers to append using CEL expressions for values.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.transformations.request.set`|object|Headers to set using CEL expressions for values.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.transformations.request.remove`|[]string|Header names to remove.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.transformations.request.body`|string|CEL expression that computes a replacement body.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.transformations.request.metadata`|object|Metadata values to add using CEL expressions.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.transformations.response`|object|Transform the response before it is returned.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.transformations.response.add`|object|Headers to append using CEL expressions for values.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.transformations.response.set`|object|Headers to set using CEL expressions for values.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.transformations.response.remove`|[]string|Header names to remove.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.transformations.response.body`|string|CEL expression that computes a replacement body.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.transformations.response.metadata`|object|Metadata values to add using CEL expressions.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendTLS`|object|TLS settings used when connecting to this backend.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendTLS.cert`|string|Client certificate file to present to the backend.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendTLS.key`|string|Private key file for the client certificate.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendTLS.root`|string|Root certificate bundle used to verify the backend certificate.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendTLS.hostname`|string|Server name to use for TLS verification and SNI.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendTLS.insecure`|boolean|Skip certificate trust verification for the backend connection.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendTLS.insecureHost`|boolean|Skip hostname verification for the backend certificate.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendTLS.alpn`|[]string|ALPN protocols to offer to the backend.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendTLS.subjectAltNames`|[]string|Additional subject alternative names accepted for the backend certificate.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendTLS.keyExchangeGroups`|[]enum|Key exchange groups allowed for negotiating TLS.<br>Possible values: `X25519`, `P-256`, `P-384`, `X25519_MLKEM768`.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth`|object|Authentication credentials sent to this backend.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.passthrough`|object|Forward the validated incoming JWT to the backend.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.passthrough.location`|object|Where to place the forwarded credential in the backend request.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.passthrough.location.header`|object|Read the credential from an HTTP header.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.passthrough.location.header.name`|string|Header name containing the credential.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.passthrough.location.header.prefix`|string|Prefix to remove from the header value before validation, such as `Bearer ` or `Basic `.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.passthrough.location.queryParameter`|object|Read the credential from a URL query parameter.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.passthrough.location.queryParameter.name`|string|Query parameter name containing the credential.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.passthrough.location.cookie`|object|Read the credential from a request cookie.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.passthrough.location.expression`|object|Read the credential from a CEL expression evaluated against the incoming request.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.passthrough.location.expression.expression`|string|CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.key.value.file`|string||
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.key.location.header.name`|string|Header name containing the credential.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.key.location.header.prefix`|string|Prefix to remove from the header value before validation, such as `Bearer ` or `Basic `.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.key.location.queryParameter`|object|Read the credential from a URL query parameter.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.key.location.queryParameter.name`|string|Query parameter name containing the credential.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.key.location.cookie`|object|Read the credential from a request cookie.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.key.location.cookie.name`|string|Cookie name containing the credential.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.key.location.expression`|object|Read the credential from a CEL expression evaluated against the incoming request.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.key.location.expression.expression`|string|CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.gcp`|object|Authenticate to Google Cloud services.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.gcp.type`|enum|Possible values: `idToken`.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.gcp.audience`|string|Audience for the token. If not set, the destination host will be used.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.gcp.credential`|object|ADC-compatible Google credential JSON. If not set, ambient credentials are used.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.gcp.credential.file`|string||
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.gcp.type`|enum|Possible values: `accessToken`, `null`.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.aws`|object|Sign backend requests with AWS credentials.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.aws.accessKeyId`|string||
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.aws.secretAccessKey`|string||
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.aws.region`|string||
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.aws.sessionToken`|string||
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.aws.serviceName`|string|AWS SigV4 signing service name (for example, "bedrock", "bedrock-agentcore", or "execute-api").|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.aws.assumeRole`|object|Optional AWS STS role to assume before signing requests.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.aws.assumeRole.roleArn`|string|AWS IAM role ARN to assume.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.azure`|object|Authenticate to Azure services.<br>Exactly one of explicitConfig, developerImplicit, or implicit may be set.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.azure.explicitConfig`|object|Use explicit Azure credentials<br>Exactly one of clientSecret, managedIdentity, or workloadIdentity may be set.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.azure.explicitConfig.clientSecret`|object||
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.azure.explicitConfig.clientSecret.tenant_id`|string||
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.azure.explicitConfig.clientSecret.client_id`|string||
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.azure.explicitConfig.clientSecret.client_secret`|string||
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.azure.explicitConfig.managedIdentity`|object||
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.azure.explicitConfig.managedIdentity.userAssignedIdentity`|object||
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.azure.explicitConfig.managedIdentity.userAssignedIdentity.clientId`|string||
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.azure.explicitConfig.managedIdentity.userAssignedIdentity.objectId`|string||
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.azure.explicitConfig.managedIdentity.userAssignedIdentity.resourceId`|string||
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean||
+|`llm.policies.guardrails.response[].googleModelArmor.policies.tcp.keepalives.time`|string||
+|`llm.policies.guardrails.response[].googleModelArmor.policies.tcp.keepalives.interval`|string||
+|`llm.policies.guardrails.response[].googleModelArmor.policies.tcp.keepalives.retries`|integer||
+|`llm.policies.guardrails.response[].googleModelArmor.policies.tcp.connectTimeout`|object|Maximum time allowed to establish a backend TCP connection.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.tcp.connectTimeout.secs`|integer||
+|`llm.policies.guardrails.response[].googleModelArmor.policies.tcp.connectTimeout.nanos`|integer||
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendTunnel`|object|Tunnel settings used when connecting to this backend.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendTunnel.proxy`|object|Proxy backend used to tunnel the connection.<br>Exactly one of service, host, or backend may be set.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendTunnel.proxy.service`|object|Service reference. Service must be defined in the top level services list.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendTunnel.proxy.service.name`|object||
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendTunnel.proxy.service.name.namespace`|string||
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendTunnel.proxy.service.name.hostname`|string||
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer||
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.policies.guardrails.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
+|`llm.policies.guardrails.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
+|`llm.policies.guardrails.response[].azureContentSafety.policies`|object|Backend policies for Azure authentication (optional, defaults to implicit Azure auth)|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.requestHeaderModifier.set`|object|Headers to set, replacing any existing values.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.requestHeaderModifier.remove`|[]string|Header names to remove.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.transformations`|object|Modify request and response data for this backend.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.transformations.request`|object|Transform the request before it is forwarded.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.transformations.request.add`|object|Headers to append using CEL expressions for values.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.transformations.request.set`|object|Headers to set using CEL expressions for values.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.transformations.request.remove`|[]string|Header names to remove.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.transformations.request.body`|string|CEL expression that computes a replacement body.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.transformations.request.metadata`|object|Metadata values to add using CEL expressions.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.transformations.response`|object|Transform the response before it is returned.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.transformations.response.add`|object|Headers to append using CEL expressions for values.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.transformations.response.set`|object|Headers to set using CEL expressions for values.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.transformations.response.remove`|[]string|Header names to remove.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.transformations.response.body`|string|CEL expression that computes a replacement body.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.transformations.response.metadata`|object|Metadata values to add using CEL expressions.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendTLS`|object|TLS settings used when connecting to this backend.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendTLS.cert`|string|Client certificate file to present to the backend.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendTLS.key`|string|Private key file for the client certificate.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendTLS.root`|string|Root certificate bundle used to verify the backend certificate.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendTLS.hostname`|string|Server name to use for TLS verification and SNI.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendTLS.insecure`|boolean|Skip certificate trust verification for the backend connection.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendTLS.insecureHost`|boolean|Skip hostname verification for the backend certificate.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendTLS.alpn`|[]string|ALPN protocols to offer to the backend.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendTLS.subjectAltNames`|[]string|Additional subject alternative names accepted for the backend certificate.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendTLS.keyExchangeGroups`|[]enum|Key exchange groups allowed for negotiating TLS.<br>Possible values: `X25519`, `P-256`, `P-384`, `X25519_MLKEM768`.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth`|object|Authentication credentials sent to this backend.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.passthrough`|object|Forward the validated incoming JWT to the backend.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.passthrough.location`|object|Where to place the forwarded credential in the backend request.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.passthrough.location.header`|object|Read the credential from an HTTP header.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.passthrough.location.header.name`|string|Header name containing the credential.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.passthrough.location.header.prefix`|string|Prefix to remove from the header value before validation, such as `Bearer ` or `Basic `.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.passthrough.location.queryParameter`|object|Read the credential from a URL query parameter.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.passthrough.location.queryParameter.name`|string|Query parameter name containing the credential.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.passthrough.location.cookie`|object|Read the credential from a request cookie.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.passthrough.location.expression`|object|Read the credential from a CEL expression evaluated against the incoming request.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.passthrough.location.expression.expression`|string|CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.key.value.file`|string||
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.key.location.header.name`|string|Header name containing the credential.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.key.location.header.prefix`|string|Prefix to remove from the header value before validation, such as `Bearer ` or `Basic `.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.key.location.queryParameter`|object|Read the credential from a URL query parameter.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.key.location.queryParameter.name`|string|Query parameter name containing the credential.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.key.location.cookie`|object|Read the credential from a request cookie.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.key.location.cookie.name`|string|Cookie name containing the credential.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.key.location.expression`|object|Read the credential from a CEL expression evaluated against the incoming request.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.key.location.expression.expression`|string|CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.gcp`|object|Authenticate to Google Cloud services.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.gcp.type`|enum|Possible values: `idToken`.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.gcp.audience`|string|Audience for the token. If not set, the destination host will be used.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.gcp.credential`|object|ADC-compatible Google credential JSON. If not set, ambient credentials are used.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.gcp.credential.file`|string||
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.gcp.type`|enum|Possible values: `accessToken`, `null`.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.aws`|object|Sign backend requests with AWS credentials.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.aws.accessKeyId`|string||
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.aws.secretAccessKey`|string||
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.aws.region`|string||
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.aws.sessionToken`|string||
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.aws.serviceName`|string|AWS SigV4 signing service name (for example, "bedrock", "bedrock-agentcore", or "execute-api").|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.aws.assumeRole`|object|Optional AWS STS role to assume before signing requests.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.aws.assumeRole.roleArn`|string|AWS IAM role ARN to assume.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.azure`|object|Authenticate to Azure services.<br>Exactly one of explicitConfig, developerImplicit, or implicit may be set.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.azure.explicitConfig`|object|Use explicit Azure credentials<br>Exactly one of clientSecret, managedIdentity, or workloadIdentity may be set.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.azure.explicitConfig.clientSecret`|object||
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.azure.explicitConfig.clientSecret.tenant_id`|string||
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.azure.explicitConfig.clientSecret.client_id`|string||
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.azure.explicitConfig.clientSecret.client_secret`|string||
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.azure.explicitConfig.managedIdentity`|object||
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.azure.explicitConfig.managedIdentity.userAssignedIdentity`|object||
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.azure.explicitConfig.managedIdentity.userAssignedIdentity.clientId`|string||
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.azure.explicitConfig.managedIdentity.userAssignedIdentity.objectId`|string||
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.azure.explicitConfig.managedIdentity.userAssignedIdentity.resourceId`|string||
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean||
+|`llm.policies.guardrails.response[].azureContentSafety.policies.tcp.keepalives.time`|string||
+|`llm.policies.guardrails.response[].azureContentSafety.policies.tcp.keepalives.interval`|string||
+|`llm.policies.guardrails.response[].azureContentSafety.policies.tcp.keepalives.retries`|integer||
+|`llm.policies.guardrails.response[].azureContentSafety.policies.tcp.connectTimeout`|object|Maximum time allowed to establish a backend TCP connection.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.tcp.connectTimeout.secs`|integer||
+|`llm.policies.guardrails.response[].azureContentSafety.policies.tcp.connectTimeout.nanos`|integer||
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendTunnel`|object|Tunnel settings used when connecting to this backend.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendTunnel.proxy`|object|Proxy backend used to tunnel the connection.<br>Exactly one of service, host, or backend may be set.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendTunnel.proxy.service`|object|Service reference. Service must be defined in the top level services list.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendTunnel.proxy.service.name`|object||
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendTunnel.proxy.service.name.namespace`|string||
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendTunnel.proxy.service.name.hostname`|string||
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer||
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.policies.guardrails.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
+|`llm.policies.guardrails.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
+|`llm.policies.guardrails.response[].azureContentSafety.analyzeText.apiVersion`|string|API version to use (default: "2024-09-01")|
+|`llm.policies.guardrails.response[].azureContentSafety.analyzeText.blocklistNames`|[]string|Blocklist names to check against|
+|`llm.policies.guardrails.response[].azureContentSafety.analyzeText.haltOnBlocklistHit`|boolean|When true, further analysis stops if a blocklist is hit|
+|`llm.policies.guardrails.response[].azureContentSafety.detectJailbreak`|object|Detect Text Jailbreak configuration for detecting jailbreak attempts.<br>Only applicable to request guards.|
+|`llm.policies.guardrails.response[].azureContentSafety.detectJailbreak.apiVersion`|string|API version to use (default: "2024-02-15-preview")|
+|`llm.policies.guardrails.response[].rejection`|object|Response returned when the LLM response is rejected.|
+|`llm.policies.guardrails.response[].rejection.body`|array|Response body returned when content is rejected.|
+|`llm.policies.guardrails.response[].rejection.status`|integer|HTTP status code returned when content is rejected.|
+|`llm.policies.guardrails.response[].rejection.headers`|object|Headers to add, set, or remove from the rejection response.|
+|`llm.policies.guardrails.response[].rejection.headers.add`|object|Headers to append without replacing existing values.|
+|`llm.policies.guardrails.response[].rejection.headers.set`|object|Headers to set, replacing any existing values.|
+|`llm.policies.guardrails.response[].rejection.headers.remove`|[]string|Header names to remove.|
 |`llm.policies.localRateLimit`|[]object|Local rate limits for incoming requests.|
 |`llm.policies.localRateLimit[].maxTokens`|integer|Maximum number of tokens that can accumulate in the local bucket.|
 |`llm.policies.localRateLimit[].tokensPerFill`|integer|Number of tokens added to the local bucket each fill interval.|


### PR DESCRIPTION
These are too verbose to define on every single model. Allow a way to
reference and share.

Open question: should this be guardrail specific or allow any policy to
do this?

Signed-off-by: John Howard <john.howard@solo.io>
