### PR TITLE
llm: support more custom providers as simple UX affordance

### DIFF
--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -22,9 +22,7 @@ use crate::http::{
 	HeaderName, HeaderOrPseudo, filters, health, retry, timeout, transformation_cel,
 };
 use crate::llm::policy::{PromptCachingConfig, PromptGuard};
-use crate::llm::{
-	AIBackend, AIProvider, LocalModelAIProvider, NamedAIProvider, anthropic, copilot, openai,
-};
+use crate::llm::{AIBackend, AIProvider, NamedAIProvider, anthropic, copilot, custom, openai};
 use crate::mcp::{FailureMode, McpAuthorization};
 use crate::store::{LocalWorkload, RequestPolicy};
 use crate::types::agent::{
@@ -570,6 +568,35 @@ pub struct LLMRouteMatch {
 	pub headers: Vec<HeaderMatch>,
 }
 
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "lowercase", deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum LocalModelAIProvider {
+	#[serde(alias = "openAI")]
+	OpenAI,
+	Gemini,
+	Vertex,
+	Anthropic,
+	Bedrock,
+	Azure,
+	Copilot,
+	Custom(custom::Provider),
+	// Providers below are synthetic conversions to custom with preconfigured defaults.
+	Cohere,
+	Ollama,
+	Baseten,
+	Cerebras,
+	Deepinfra,
+	Deepseek,
+	Groq,
+	Huggingface,
+	Mistral,
+	Openrouter,
+	Togetherai,
+	XAI,
+	Fireworks,
+}
+
 #[apply(schema_de!)]
 pub struct SecretFromFile(
 	#[cfg_attr(feature = "schema", schemars(with = "FileOrInline"))]
@@ -627,6 +654,97 @@ pub struct LocalLLMParams {
 
 impl LocalLLMModels {
 	#[allow(deprecated)]
+	fn apply_provider_defaults(&mut self) {
+		if self.params.base_url.is_some()
+			|| self.params.host_override.is_some()
+			|| self.params.path_override.is_some()
+		{
+			return;
+		}
+		match &self.provider {
+			LocalModelAIProvider::Cohere => {
+				self
+					.params
+					.base_url
+					.get_or_insert_with(|| strng::new("https://api.cohere.ai"));
+			},
+			LocalModelAIProvider::Ollama => {
+				self
+					.params
+					.base_url
+					.get_or_insert_with(|| strng::new("http://localhost:11434/v1"));
+			},
+			LocalModelAIProvider::Baseten => {
+				self
+					.params
+					.base_url
+					.get_or_insert_with(|| strng::new("https://inference.baseten.co/v1"));
+			},
+			LocalModelAIProvider::Cerebras => {
+				self
+					.params
+					.base_url
+					.get_or_insert_with(|| strng::new("https://api.cerebras.ai/v1"));
+			},
+			LocalModelAIProvider::Deepinfra => {
+				self
+					.params
+					.base_url
+					.get_or_insert_with(|| strng::new("https://api.deepinfra.com/v1/openai"));
+			},
+			LocalModelAIProvider::Deepseek => {
+				self
+					.params
+					.base_url
+					.get_or_insert_with(|| strng::new("https://api.deepseek.com/v1"));
+			},
+			LocalModelAIProvider::Groq => {
+				self
+					.params
+					.base_url
+					.get_or_insert_with(|| strng::new("https://api.groq.com/openai/v1"));
+			},
+			LocalModelAIProvider::Huggingface => {
+				self
+					.params
+					.base_url
+					.get_or_insert_with(|| strng::new("https://router.huggingface.co/v1"));
+			},
+			LocalModelAIProvider::Mistral => {
+				self
+					.params
+					.base_url
+					.get_or_insert_with(|| strng::new("https://api.mistral.ai/v1"));
+			},
+			LocalModelAIProvider::Openrouter => {
+				self
+					.params
+					.base_url
+					.get_or_insert_with(|| strng::new("https://openrouter.ai/api/v1"));
+			},
+			LocalModelAIProvider::Togetherai => {
+				self
+					.params
+					.base_url
+					.get_or_insert_with(|| strng::new("https://api.together.xyz/v1"));
+			},
+			LocalModelAIProvider::XAI => {
+				self
+					.params
+					.base_url
+					.get_or_insert_with(|| strng::new("https://api.x.ai/v1"));
+			},
+			LocalModelAIProvider::Fireworks => {
+				self
+					.params
+					.base_url
+					.get_or_insert_with(|| strng::new("https://api.fireworks.ai/inference/v1"));
+			},
+			_ => {},
+		}
+	}
+
+	#[allow(deprecated)]
 	fn apply_base_url(&mut self) -> anyhow::Result<()> {
 		let Some(base_url) = self.params.base_url.as_deref() else {
 			return Ok(());
@@ -642,15 +760,31 @@ impl LocalLLMModels {
 		let host = url
 			.host_str()
 			.with_context(|| format!("params.baseUrl for model {} must include a host", self.name))?;
-		self.params.host_override = Some((host, port).into());
+		self
+			.params
+			.host_override
+			.get_or_insert_with(|| (host, port).into());
 		let path = url.path().trim_end_matches('/');
-		if !path.is_empty() {
-			self.params.path_prefix = Some(strng::new(path));
+		if !path.is_empty() && self.params.path_override.is_none() {
+			self
+				.params
+				.path_prefix
+				.get_or_insert_with(|| strng::new(path));
 		}
 		if url.scheme() == "https" && self.backend_tls.is_none() {
 			self.backend_tls = Some(http::backendtls::LocalBackendTLS::default());
 		}
 		Ok(())
+	}
+}
+
+fn custom_provider_format(
+	format: custom::ProviderFormat,
+	path: Option<&'static str>,
+) -> custom::ProviderFormatConfig {
+	custom::ProviderFormatConfig {
+		format,
+		path: path.map(strng::new),
 	}
 }
 
@@ -2271,6 +2405,7 @@ request.path.endsWith(":streamRawPredict") || request.path.endsWith(":rawPredict
 	// Create routes and backends for each model
 	for (idx, (_, model_config)) in ordered_models.into_iter().enumerate() {
 		let mut model_config = model_config;
+		model_config.apply_provider_defaults();
 		model_config.apply_base_url()?;
 		let model_name = strng::new(&model_config.name);
 		// Index is needed because the same name can be used with different match criteria
@@ -2346,6 +2481,120 @@ request.path.endsWith(":streamRawPredict") || request.path.endsWith(":rawPredict
 					..custom_provider.clone()
 				})
 			},
+			LocalModelAIProvider::Cohere => AIProvider::Custom(custom::Provider {
+				model,
+				formats: vec![
+					custom_provider_format(
+						custom::ProviderFormat::Completions,
+						Some("/compatibility/v1/chat/completions"),
+					),
+					custom_provider_format(
+						custom::ProviderFormat::Embeddings,
+						Some("/compatibility/v1/embeddings"),
+					),
+					custom_provider_format(custom::ProviderFormat::Rerank, Some("/v2/rerank")),
+				],
+			}),
+			LocalModelAIProvider::Ollama => AIProvider::Custom(custom::Provider {
+				model,
+				formats: vec![
+					custom_provider_format(custom::ProviderFormat::Completions, None),
+					custom_provider_format(custom::ProviderFormat::Responses, None),
+					custom_provider_format(custom::ProviderFormat::Embeddings, None),
+				],
+			}),
+			LocalModelAIProvider::Baseten => AIProvider::Custom(custom::Provider {
+				model,
+				formats: vec![
+					custom_provider_format(custom::ProviderFormat::Completions, None),
+					custom_provider_format(custom::ProviderFormat::Messages, None),
+				],
+			}),
+			LocalModelAIProvider::Cerebras => AIProvider::Custom(custom::Provider {
+				model,
+				formats: vec![custom_provider_format(
+					custom::ProviderFormat::Completions,
+					None,
+				)],
+			}),
+			LocalModelAIProvider::Deepinfra => AIProvider::Custom(custom::Provider {
+				model,
+				formats: vec![
+					custom_provider_format(custom::ProviderFormat::Completions, None),
+					custom_provider_format(
+						custom::ProviderFormat::Messages,
+						Some("/anthropic/v1/messages"),
+					),
+					custom_provider_format(custom::ProviderFormat::Embeddings, None),
+				],
+			}),
+			LocalModelAIProvider::Deepseek => AIProvider::Custom(custom::Provider {
+				model,
+				formats: vec![
+					custom_provider_format(custom::ProviderFormat::Completions, None),
+					custom_provider_format(
+						custom::ProviderFormat::Messages,
+						Some("/anthropic/v1/messages"),
+					),
+				],
+			}),
+			LocalModelAIProvider::Groq => AIProvider::Custom(custom::Provider {
+				model,
+				formats: vec![
+					custom_provider_format(custom::ProviderFormat::Completions, None),
+					custom_provider_format(custom::ProviderFormat::Responses, None),
+				],
+			}),
+			LocalModelAIProvider::Huggingface => AIProvider::Custom(custom::Provider {
+				model,
+				formats: vec![
+					custom_provider_format(custom::ProviderFormat::Completions, None),
+					custom_provider_format(custom::ProviderFormat::Responses, None),
+				],
+			}),
+			LocalModelAIProvider::Mistral => AIProvider::Custom(custom::Provider {
+				model,
+				formats: vec![
+					custom_provider_format(custom::ProviderFormat::Completions, None),
+					custom_provider_format(custom::ProviderFormat::Embeddings, None),
+				],
+			}),
+			LocalModelAIProvider::Openrouter => AIProvider::Custom(custom::Provider {
+				model,
+				formats: vec![
+					custom_provider_format(custom::ProviderFormat::Completions, None),
+					custom_provider_format(custom::ProviderFormat::Messages, None),
+					custom_provider_format(custom::ProviderFormat::Responses, None),
+					custom_provider_format(custom::ProviderFormat::Embeddings, None),
+					custom_provider_format(custom::ProviderFormat::Rerank, None),
+				],
+			}),
+			LocalModelAIProvider::Togetherai => AIProvider::Custom(custom::Provider {
+				model,
+				formats: vec![
+					custom_provider_format(custom::ProviderFormat::Completions, None),
+					custom_provider_format(custom::ProviderFormat::Embeddings, None),
+					custom_provider_format(custom::ProviderFormat::Rerank, None),
+				],
+			}),
+			LocalModelAIProvider::XAI => AIProvider::Custom(custom::Provider {
+				model,
+				formats: vec![
+					custom_provider_format(custom::ProviderFormat::Completions, None),
+					custom_provider_format(custom::ProviderFormat::Responses, None),
+					custom_provider_format(custom::ProviderFormat::Realtime, None),
+				],
+			}),
+			LocalModelAIProvider::Fireworks => AIProvider::Custom(custom::Provider {
+				model,
+				formats: vec![
+					custom_provider_format(custom::ProviderFormat::Completions, None),
+					custom_provider_format(custom::ProviderFormat::Messages, None),
+					custom_provider_format(custom::ProviderFormat::Responses, None),
+					custom_provider_format(custom::ProviderFormat::Embeddings, None),
+					custom_provider_format(custom::ProviderFormat::Rerank, None),
+				],
+			}),
 			LocalModelAIProvider::Vertex => AIProvider::Vertex(crate::llm::vertex::Provider {
 				model,
 

--- a/crates/agentgateway/src/types/local_tests.rs
+++ b/crates/agentgateway/src/types/local_tests.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use secrecy::SecretString;
 
-use crate::llm::AIProvider;
+use crate::llm::{AIProvider, NamedAIProvider};
 use crate::serdes::FileInlineOrRemote;
 use crate::types::agent::{
 	Backend, BackendTrafficPolicy, HeaderValueMatch, ListenerTarget, PolicyPhase, PolicyTarget,
@@ -125,6 +125,29 @@ async fn normalize_test_config(yaml_str: &str) -> anyhow::Result<NormalizedLocal
 	.await
 }
 
+fn selected_ai_provider(normalized: &NormalizedLocalConfig) -> Arc<NamedAIProvider> {
+	let backend = normalized
+		.backends
+		.iter()
+		.find(|backend| matches!(backend.backend, Backend::AI(_, _)))
+		.expect("expected generated AI backend");
+	let Backend::AI(_, ai) = &backend.backend else {
+		panic!("expected generated AI backend");
+	};
+	let (provider, _handle) = ai.select_provider().expect("expected selected provider");
+	provider
+}
+
+fn assert_hostname_target(target: &Target, expected_host: &str, expected_port: u16) {
+	match target {
+		Target::Hostname(host, port) => {
+			assert_eq!(host.as_str(), expected_host);
+			assert_eq!(*port, expected_port);
+		},
+		other => panic!("expected hostname target, got {other:?}"),
+	}
+}
+
 #[tokio::test]
 async fn test_local_dynamic_backend_reference_uses_generated_backend() {
 	let normalized = normalize_test_yaml(
@@ -236,15 +259,7 @@ llm:
 	.await
 	.expect("custom LLM provider should normalize");
 
-	let ai = normalized
-		.backends
-		.iter()
-		.find_map(|backend| match &backend.backend {
-			Backend::AI(_, ai) => Some(ai),
-			_ => None,
-		})
-		.expect("expected generated AI backend");
-	let (provider, _handle) = ai.select_provider().expect("expected selected provider");
+	let provider = selected_ai_provider(&normalized);
 	let AIProvider::Custom(custom_provider) = &provider.provider else {
 		panic!("expected custom provider");
 	};
@@ -252,17 +267,101 @@ llm:
 	assert!(custom_provider.formats.iter().any(|format| format.format
 		== crate::llm::custom::ProviderFormat::Messages
 		&& format.path.as_deref() == Some("/api/messages")));
-	match provider
-		.host_override
-		.as_ref()
-		.expect("expected host override")
-	{
-		Target::Hostname(host, port) => {
-			assert_eq!(host.as_str(), "custom.example.com");
-			assert_eq!(*port, 8080);
-		},
-		other => panic!("expected hostname target, got {other:?}"),
-	}
+	assert_hostname_target(
+		provider
+			.host_override
+			.as_ref()
+			.expect("expected host override"),
+		"custom.example.com",
+		8080,
+	);
+}
+
+#[tokio::test]
+async fn test_llm_synthetic_provider_defaults_do_not_override_host_override() {
+	let normalized = normalize_test_config(
+		r#"
+llm:
+  models:
+  - name: hosted-groq
+    provider: groq
+    params:
+      hostOverride: proxy.example.com:8443
+      pathPrefix: /proxy/openai
+"#,
+	)
+	.await
+	.expect("synthetic LLM provider should normalize with explicit host override");
+
+	let provider = selected_ai_provider(&normalized);
+	assert!(matches!(provider.provider, AIProvider::Custom(_)));
+	assert_hostname_target(
+		provider
+			.host_override
+			.as_ref()
+			.expect("expected host override"),
+		"proxy.example.com",
+		8443,
+	);
+	assert_eq!(provider.path_prefix.as_deref(), Some("/proxy/openai"));
+}
+
+#[tokio::test]
+async fn test_llm_base_url_does_not_override_explicit_path_prefix() {
+	let normalized = normalize_test_config(
+		r#"
+llm:
+  models:
+  - name: proxied-groq
+    provider: groq
+    params:
+      baseUrl: https://api.groq.com/openai/v1
+      pathPrefix: /gateway/openai
+"#,
+	)
+	.await
+	.expect("synthetic LLM provider should normalize with explicit path prefix");
+
+	let provider = selected_ai_provider(&normalized);
+	assert!(matches!(provider.provider, AIProvider::Custom(_)));
+	assert_hostname_target(
+		provider
+			.host_override
+			.as_ref()
+			.expect("expected host override"),
+		"api.groq.com",
+		443,
+	);
+	assert_eq!(provider.path_prefix.as_deref(), Some("/gateway/openai"));
+}
+
+#[tokio::test]
+async fn test_llm_base_url_does_not_override_explicit_host_override() {
+	let normalized = normalize_test_config(
+		r#"
+llm:
+  models:
+  - name: proxied-fireworks
+    provider: fireworks
+    params:
+      baseUrl: https://api.fireworks.ai/inference/v1
+      hostOverride: proxy.example.com:8443
+"#,
+	)
+	.await
+	.expect("synthetic LLM provider should normalize with explicit host override");
+
+	let provider = selected_ai_provider(&normalized);
+	assert!(matches!(provider.provider, AIProvider::Custom(_)));
+	assert_hostname_target(
+		provider
+			.host_override
+			.as_ref()
+			.expect("expected host override"),
+		"proxy.example.com",
+		8443,
+	);
+	assert_eq!(provider.path_prefix.as_deref(), Some("/inference/v1"));
 }
 
 #[tokio::test]

--- a/crates/agentgateway/src/types/local_tests/llm_simple_config.yaml
+++ b/crates/agentgateway/src/types/local_tests/llm_simple_config.yaml
@@ -78,4 +78,8 @@ llm:
       azureResourceType: openAI
       azureApiVersion: v1
   - name: gpt-3.5-turbo
-    provider: openAI
+    provider: openai
+  - name: llama-3.1-8b-instant
+    provider: groq
+  - name: fireworks-llama
+    provider: fireworks

--- a/crates/agentgateway/src/types/local_tests/llm_simple_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/llm_simple_normalized.snap
@@ -37,6 +37,12 @@ listener_routes:
                   - id: gpt-3.5-turbo
                     created: 0
                     authorization: ~
+                  - id: llama-3.1-8b-instant
+                    created: 0
+                    authorization: ~
+                  - id: fireworks-llama
+                    created: 0
+                    authorization: ~
         key: "llm:admin:model-list"
         matches:
           - path:
@@ -46,7 +52,7 @@ listener_routes:
         name: "admin:model-list"
         namespace: internal
       - backends:
-          - backend: "/llm:model:claude-3-haiku:0"
+          - backend: "/llm:model:llama-3.1-8b-instant:0"
             weight: 1
         inlinePolicies:
           - ai:
@@ -64,7 +70,65 @@ listener_routes:
                 /v2/rerank: rerank
                 ":rawPredict": messages
                 ":streamRawPredict": messages
-        key: "llm:model:000000:claude-3-haiku"
+        key: "llm:model:000000:llama-3.1-8b-instant"
+        matches:
+          - headers:
+              - name: x-gateway-model-name
+                value:
+                  exact: llama-3.1-8b-instant
+            path:
+              pathPrefix: /
+        name: "model:llama-3.1-8b-instant"
+        namespace: internal
+      - backends:
+          - backend: "/llm:model:fireworks-llama:1"
+            weight: 1
+        inlinePolicies:
+          - ai:
+              routes:
+                "*": passthrough
+                /v1/chat/completions: completions
+                /v1/embeddings: embeddings
+                /v1/images/edits: detect
+                /v1/images/generations: detect
+                /v1/images/variations: detect
+                /v1/messages: messages
+                /v1/rerank: rerank
+                /v1/responses: responses
+                /v1/responses/compact: detect
+                /v2/rerank: rerank
+                ":rawPredict": messages
+                ":streamRawPredict": messages
+        key: "llm:model:000001:fireworks-llama"
+        matches:
+          - headers:
+              - name: x-gateway-model-name
+                value:
+                  exact: fireworks-llama
+            path:
+              pathPrefix: /
+        name: "model:fireworks-llama"
+        namespace: internal
+      - backends:
+          - backend: "/llm:model:claude-3-haiku:2"
+            weight: 1
+        inlinePolicies:
+          - ai:
+              routes:
+                "*": passthrough
+                /v1/chat/completions: completions
+                /v1/embeddings: embeddings
+                /v1/images/edits: detect
+                /v1/images/generations: detect
+                /v1/images/variations: detect
+                /v1/messages: messages
+                /v1/rerank: rerank
+                /v1/responses: responses
+                /v1/responses/compact: detect
+                /v2/rerank: rerank
+                ":rawPredict": messages
+                ":streamRawPredict": messages
+        key: "llm:model:000002:claude-3-haiku"
         matches:
           - headers:
               - name: x-org
@@ -78,7 +142,7 @@ listener_routes:
         name: "model:claude-3-haiku"
         namespace: internal
       - backends:
-          - backend: "/llm:model:gpt-3.5-turbo:1"
+          - backend: "/llm:model:gpt-3.5-turbo:3"
             weight: 1
         inlinePolicies:
           - ai:
@@ -96,7 +160,7 @@ listener_routes:
                 /v2/rerank: rerank
                 ":rawPredict": messages
                 ":streamRawPredict": messages
-        key: "llm:model:000001:gpt-3.5-turbo"
+        key: "llm:model:000003:gpt-3.5-turbo"
         matches:
           - headers:
               - name: x-gateway-model-name
@@ -107,7 +171,7 @@ listener_routes:
         name: "model:gpt-3.5-turbo"
         namespace: internal
       - backends:
-          - backend: "/llm:model:gpt-7-max:2"
+          - backend: "/llm:model:gpt-7-max:4"
             weight: 1
         inlinePolicies:
           - ai:
@@ -125,7 +189,7 @@ listener_routes:
                 /v2/rerank: rerank
                 ":rawPredict": messages
                 ":streamRawPredict": messages
-        key: "llm:model:000002:gpt-7-max"
+        key: "llm:model:000004:gpt-7-max"
         matches:
           - headers:
               - name: x-gateway-model-name
@@ -136,7 +200,7 @@ listener_routes:
         name: "model:gpt-7-max"
         namespace: internal
       - backends:
-          - backend: "/llm:model:*:3"
+          - backend: "/llm:model:*:5"
             weight: 1
         inlinePolicies:
           - ai:
@@ -154,7 +218,7 @@ listener_routes:
                 /v2/rerank: rerank
                 ":rawPredict": messages
                 ":streamRawPredict": messages
-        key: "llm:model:000003:*"
+        key: "llm:model:000005:*"
         matches:
           - headers:
               - name: x-gateway-model-name
@@ -278,7 +342,107 @@ policies:
 backends:
   - backend:
       ai:
-        name: "llm:model:claude-3-haiku:0"
+        name: "llm:model:llama-3.1-8b-instant:0"
+        namespace: ""
+        target:
+          providers:
+            - active:
+                llama-3.1-8b-instant:
+                  endpoint:
+                    name: llama-3.1-8b-instant
+                    provider:
+                      custom:
+                        formats:
+                          - type: completions
+                            path: ~
+                          - type: responses
+                            path: ~
+                    hostOverride: "api.groq.com:443"
+                    pathOverride: ~
+                    pathPrefix: /openai/v1
+                    tokenize: false
+                  info:
+                    health: 1
+                    requestLatency: 0
+                    pendingRequests: 0
+                    totalRequests: 0
+                    consecutiveFailures: 0
+                    timesEjected: 0
+                    evictedUntil: ~
+                  capacity: 1
+              rejected: {}
+    inlinePolicies:
+      - backendTLS:
+          systemRoots: true
+      - requestHeaderModifier:
+          remove:
+            - x-gateway-model-name
+      - ai:
+          promptGuard:
+            request:
+              - regex:
+                  action: reject
+                  rules:
+                    - builtin: email
+                rejection:
+                  body: The request was rejected due to inappropriate content
+                  status: 400
+  - backend:
+      ai:
+        name: "llm:model:fireworks-llama:1"
+        namespace: ""
+        target:
+          providers:
+            - active:
+                fireworks-llama:
+                  endpoint:
+                    name: fireworks-llama
+                    provider:
+                      custom:
+                        formats:
+                          - type: completions
+                            path: ~
+                          - type: messages
+                            path: ~
+                          - type: responses
+                            path: ~
+                          - type: embeddings
+                            path: ~
+                          - type: rerank
+                            path: ~
+                    hostOverride: "api.fireworks.ai:443"
+                    pathOverride: ~
+                    pathPrefix: /inference/v1
+                    tokenize: false
+                  info:
+                    health: 1
+                    requestLatency: 0
+                    pendingRequests: 0
+                    totalRequests: 0
+                    consecutiveFailures: 0
+                    timesEjected: 0
+                    evictedUntil: ~
+                  capacity: 1
+              rejected: {}
+    inlinePolicies:
+      - backendTLS:
+          systemRoots: true
+      - requestHeaderModifier:
+          remove:
+            - x-gateway-model-name
+      - ai:
+          promptGuard:
+            request:
+              - regex:
+                  action: reject
+                  rules:
+                    - builtin: email
+                rejection:
+                  body: The request was rejected due to inappropriate content
+                  status: 400
+  - backend:
+      ai:
+        name: "llm:model:claude-3-haiku:2"
         namespace: ""
         target:
           providers:
@@ -353,7 +517,7 @@ backends:
             cacheMessageOffset: 0
   - backend:
       ai:
-        name: "llm:model:gpt-3.5-turbo:1"
+        name: "llm:model:gpt-3.5-turbo:3"
         namespace: ""
         target:
           providers:
@@ -393,7 +557,7 @@ backends:
                   status: 400
   - backend:
       ai:
-        name: "llm:model:gpt-7-max:2"
+        name: "llm:model:gpt-7-max:4"
         namespace: ""
         target:
           providers:
@@ -437,7 +601,7 @@ backends:
                   status: 400
   - backend:
       ai:
-        name: "llm:model:*:3"
+        name: "llm:model:*:5"
         namespace: ""
         target:
           providers:

--- a/schema/config.json
+++ b/schema/config.json
@@ -8677,13 +8677,27 @@
         {
           "type": "string",
           "enum": [
+            "openai",
             "openAI",
             "gemini",
             "vertex",
             "anthropic",
             "bedrock",
             "azure",
-            "copilot"
+            "copilot",
+            "cohere",
+            "ollama",
+            "baseten",
+            "cerebras",
+            "deepinfra",
+            "deepseek",
+            "groq",
+            "huggingface",
+            "mistral",
+            "openrouter",
+            "togetherai",
+            "xai",
+            "fireworks"
           ]
         },
         {


### PR DESCRIPTION
This adds a bunch of providers to the standalone mode. These are simple a mapping of `provider name -> {url,capabilities}` so cheap to maintain. With https://github.com/agentgateway/agentgateway/pull/2180 this will also allow joining them up with costs which is huge. As is this will also be consumed by the UI as well