### PR TITLE
llm: add virtual model concept

### DIFF
--- a/crates/agentgateway/src/http/ext_proc_tests.rs
+++ b/crates/agentgateway/src/http/ext_proc_tests.rs
@@ -165,7 +165,7 @@ mod body_modes {
 		assert_eq!(
 			body
 				.headers
-				.get("x-ext-proc-model-name")
+				.get("x-gateway-model-name")
 				.unwrap()
 				.to_str()
 				.unwrap(),
@@ -198,7 +198,7 @@ mod body_modes {
 		assert_eq!(
 			body
 				.headers
-				.get("x-ext-proc-model-name")
+				.get("x-gateway-model-name")
 				.unwrap()
 				.to_str()
 				.unwrap(),
@@ -2982,7 +2982,7 @@ impl Handler for BBRExtProc {
 					header_mutation: Some(HeaderMutation {
 						set_headers: vec![HeaderValueOption {
 							header: Some(HeaderValue {
-								key: "X-Ext-Proc-Model-Name".to_string(),
+								key: "X-Gateway-Model-Name".to_string(),
 								value: String::new(),
 								raw_value: b"my-model-name".to_vec(),
 							}),

--- a/crates/agentgateway/src/http/ext_proc_tests.rs
+++ b/crates/agentgateway/src/http/ext_proc_tests.rs
@@ -165,7 +165,7 @@ mod body_modes {
 		assert_eq!(
 			body
 				.headers
-				.get("x-gateway-model-name")
+				.get("x-ext-proc-model-name")
 				.unwrap()
 				.to_str()
 				.unwrap(),
@@ -198,7 +198,7 @@ mod body_modes {
 		assert_eq!(
 			body
 				.headers
-				.get("x-gateway-model-name")
+				.get("x-ext-proc-model-name")
 				.unwrap()
 				.to_str()
 				.unwrap(),
@@ -2982,7 +2982,7 @@ impl Handler for BBRExtProc {
 					header_mutation: Some(HeaderMutation {
 						set_headers: vec![HeaderValueOption {
 							header: Some(HeaderValue {
-								key: "X-Gateway-Model-Name".to_string(),
+								key: "X-Ext-Proc-Model-Name".to_string(),
 								value: String::new(),
 								raw_value: b"my-model-name".to_vec(),
 							}),

--- a/crates/agentgateway/src/http/filters.rs
+++ b/crates/agentgateway/src/http/filters.rs
@@ -288,7 +288,7 @@ pub struct AuthorizationFilteredModelListEntry {
 }
 
 impl AuthorizationFilteredModelList {
-	fn body(&self, req: &Request) -> Result<Bytes, Error> {
+	pub(crate) fn body(&self, req: &Request) -> Result<Bytes, Error> {
 		let data = self
 			.entries
 			.iter()

--- a/crates/agentgateway/src/http/filters.rs
+++ b/crates/agentgateway/src/http/filters.rs
@@ -275,53 +275,6 @@ impl crate::store::RequestPolicyTrait for UrlRewrite {
 	}
 }
 
-#[derive(Clone, Debug, serde::Serialize)]
-pub struct AuthorizationFilteredModelList {
-	pub entries: Arc<Vec<AuthorizationFilteredModelListEntry>>,
-}
-
-#[derive(Clone, Debug, serde::Serialize)]
-pub struct AuthorizationFilteredModelListEntry {
-	pub id: String,
-	pub created: u64,
-	pub authorization: Option<crate::types::agent::Authorization>,
-}
-
-impl AuthorizationFilteredModelList {
-	pub(crate) fn body(&self, req: &Request) -> Result<Bytes, Error> {
-		let data = self
-			.entries
-			.iter()
-			.filter(|entry| {
-				entry.authorization.as_ref().is_none_or(|authorization| {
-					crate::http::authorization::HTTPAuthorizationSet::new(
-						crate::http::authorization::RuleSets::from_arcs(vec![authorization.0.clone()]),
-					)
-					.apply(req)
-					.is_ok()
-				})
-			})
-			.map(|entry| {
-				serde_json::json!({
-					"id": entry.id,
-					"object": "model",
-					"created": entry.created,
-					"owned_by": "openai",
-				})
-			})
-			.collect::<Vec<_>>();
-		serde_json::to_vec(&serde_json::json!({
-			"data": data,
-			"object": "list",
-		}))
-		.map(Bytes::from)
-		.map_err(|e| Error::InvalidFilterConfiguration(e.to_string()))
-	}
-}
-
-// DirectResponse is user-configurable, but not every field on it is. Internal
-// helpers may serialize for dumps/debugging, but must stay skipped from
-// deserialization and schema so users cannot set them in config.
 #[apply(schema!)]
 pub struct DirectResponse {
 	/// Static response body, encoded as bytes.
@@ -339,12 +292,6 @@ pub struct DirectResponse {
 	#[serde(with = "http_serde::status_code")]
 	#[cfg_attr(feature = "schema", schemars(with = "std::num::NonZeroU16"))]
 	pub status: StatusCode,
-	// Internal-only hook for the generated local LLM `/v1/models` response.
-	// This serializes for dumps/debugging, but is deliberately not deserialized
-	// or included in the public schema.
-	#[serde(default, skip_serializing_if = "Option::is_none", skip_deserializing)]
-	#[cfg_attr(feature = "schema", schemars(skip))]
-	pub authorization_filtered_model_list: Option<AuthorizationFilteredModelList>,
 }
 
 impl DirectResponse {
@@ -355,17 +302,7 @@ impl DirectResponse {
 			Apply,
 			"applied direct response"
 		);
-		let body = if let Some(model_list) = &self.authorization_filtered_model_list {
-			// This branch is only reachable for DirectResponse values constructed
-			// internally by local LLM config normalization.
-			if !self.body.is_empty() || self.body_expression.is_some() {
-				return Err(Error::InvalidFilterConfiguration(
-					"body, bodyExpression, and authorizationFilteredModelList are mutually exclusive"
-						.to_string(),
-				));
-			}
-			model_list.body(req)?
-		} else if let Some(expr) = &self.body_expression {
+		let body = if let Some(expr) = &self.body_expression {
 			if !self.body.is_empty() {
 				return Err(Error::InvalidFilterConfiguration(
 					"body and bodyExpression may not both be set".to_string(),

--- a/crates/agentgateway/src/http/route.rs
+++ b/crates/agentgateway/src/http/route.rs
@@ -186,6 +186,7 @@ pub fn select_best_route(
 				hostnames: vec![],
 				matches: vec![],
 				inline_policies: vec![],
+				llm_router: None,
 				backends: vec![RouteBackendReference {
 					weight: 1,
 					target: BackendReference::Service {
@@ -291,7 +292,13 @@ fn compare_route_match(a: &agent::RouteMatch, b: &agent::RouteMatch) -> cmp::Ord
 		return header_count1.cmp(&header_count2);
 	}
 
-	a.query.len().cmp(&b.query.len())
+	let query_count1 = a.query.len();
+	let query_count2 = b.query.len();
+	if query_count1 != query_count2 {
+		return query_count1.cmp(&query_count2);
+	}
+
+	cmp::Ordering::Equal
 }
 
 fn get_path_rank(path: &PathMatch) -> u8 {

--- a/crates/agentgateway/src/http/route.rs
+++ b/crates/agentgateway/src/http/route.rs
@@ -292,13 +292,7 @@ fn compare_route_match(a: &agent::RouteMatch, b: &agent::RouteMatch) -> cmp::Ord
 		return header_count1.cmp(&header_count2);
 	}
 
-	let query_count1 = a.query.len();
-	let query_count2 = b.query.len();
-	if query_count1 != query_count2 {
-		return query_count1.cmp(&query_count2);
-	}
-
-	cmp::Ordering::Equal
+	a.query.len().cmp(&b.query.len())
 }
 
 fn get_path_rank(path: &PathMatch) -> u8 {

--- a/crates/agentgateway/src/http/route_test.rs
+++ b/crates/agentgateway/src/http/route_test.rs
@@ -42,6 +42,7 @@ fn setup_listener(routes: &[(&str, Vec<&str>, Vec<RouteMatch>)]) -> (Arc<Listene
 		matches,
 		name: Default::default(),
 		backends: vec![],
+		llm_router: None,
 		inline_policies: vec![],
 	};
 
@@ -1175,6 +1176,7 @@ fn service_route(key: &str, service_key: NamespacedHostname, matches: Vec<RouteM
 		hostnames: vec![], // GAMMA: hostname matching skipped for service routes
 		matches,
 		backends: vec![],
+		llm_router: None,
 		inline_policies: vec![],
 	}
 }
@@ -1477,6 +1479,7 @@ fn bench(b: Bencher, (host, route): (u64, u64)) {
 		hostnames: host.into_iter().map(|s| s.into()).collect(),
 		matches,
 		backends: vec![],
+		llm_router: None,
 		inline_policies: vec![],
 	}) {
 		stores

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -31,6 +31,7 @@ pub mod bedrock;
 pub mod copilot;
 pub mod custom;
 pub mod gemini;
+pub mod model_router;
 pub mod openai;
 pub mod vertex;
 

--- a/crates/agentgateway/src/llm/model_router.rs
+++ b/crates/agentgateway/src/llm/model_router.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use agent_core::prelude::Strng;
 use agent_core::strng;
-use anyhow::Context;
 use bytes::Bytes;
 use rand::seq::IndexedRandom;
 use serde_json::Value;
@@ -91,6 +90,11 @@ pub enum ResolveResult {
 	Backend(ResolvedBackend),
 }
 
+struct RequestedModel {
+	model: String,
+	body: Option<Value>,
+}
+
 impl ModelRouter {
 	pub fn new(
 		models: Vec<ModelRoute>,
@@ -104,18 +108,13 @@ impl ModelRouter {
 		}
 	}
 
-	pub async fn resolve(&self, req: &mut Request) -> anyhow::Result<ResolveResult> {
+	pub async fn resolve(&self, req: &mut Request) -> ResolveResult {
 		if is_model_list_request(req) {
-			return Ok(ResolveResult::DirectResponse(
-				self.model_list_response(req)?,
-			));
+			return ResolveResult::DirectResponse(self.model_list_response(req));
 		}
 		let requested_model = match requested_model(req).await {
-			Ok(model) => model,
-			Err(err) => {
-				tracing::debug!(%err, "failed to read LLM request model");
-				return Ok(ResolveResult::DirectResponse(model_not_found_response()));
-			},
+			Ok(requested_model) => requested_model,
+			Err(resp) => return ResolveResult::DirectResponse(resp),
 		};
 		req
 			.extensions_mut()
@@ -123,34 +122,25 @@ impl ModelRouter {
 			.0
 			.insert(
 				"agentgateway_user_model".to_string(),
-				Value::String(requested_model.clone()),
+				Value::String(requested_model.model.clone()),
 			);
 		if let Some(virtual_model) = self
 			.virtual_models
 			.iter()
-			.find(|model| model.name == requested_model)
+			.find(|model| model.name == requested_model.model)
 		{
-			return Ok(match self.resolve_virtual_model(virtual_model, req).await {
-				Ok(backend) => ResolveResult::Backend(backend),
-				Err(err) => {
-					tracing::debug!(%err, "failed to resolve LLM virtual model");
-					ResolveResult::DirectResponse(model_not_found_response())
-				},
-			});
+			return self
+				.resolve_virtual_model(virtual_model, req, requested_model.body)
+				.await;
 		}
 
-		Ok(
-			match self.resolve_concrete_model(&requested_model, false, req) {
-				Ok(route) => ResolveResult::Backend(route),
-				Err(err) => {
-					tracing::debug!(%err, "failed to resolve LLM model");
-					ResolveResult::DirectResponse(model_not_found_response())
-				},
-			},
-		)
+		match self.resolve_concrete_model(&requested_model.model, false, req) {
+			Some(route) => ResolveResult::Backend(route),
+			None => ResolveResult::DirectResponse(model_not_found_response()),
+		}
 	}
 
-	fn model_list_response(&self, req: &Request) -> anyhow::Result<Response> {
+	fn model_list_response(&self, req: &Request) -> Response {
 		let data = self
 			.models
 			.iter()
@@ -164,30 +154,40 @@ impl ModelRouter {
 					.map(|model| model_list_entry(&model.name, self.created)),
 			)
 			.collect::<Vec<_>>();
-		let body = serde_json::to_vec(&serde_json::json!({
+		let body = serde_json::json!({
 			"data": data,
 			"object": "list",
-		}))?;
-		Ok(
-			::http::Response::builder()
-				.status(::http::StatusCode::OK)
-				.header(::http::header::CONTENT_TYPE, "application/json")
-				.body(http::Body::from(body))?,
-		)
+		})
+		.to_string();
+		::http::Response::builder()
+			.status(::http::StatusCode::OK)
+			.header(::http::header::CONTENT_TYPE, "application/json")
+			.body(http::Body::from(body))
+			.expect("LLM model list response is valid")
 	}
 
 	async fn resolve_virtual_model(
 		&self,
 		virtual_model: &VirtualModelRoute,
 		req: &mut Request,
-	) -> anyhow::Result<ResolvedBackend> {
+		body: Option<Value>,
+	) -> ResolveResult {
 		let target = match &virtual_model.routing {
-			VirtualModelRouting::Weighted(targets) => targets
-				.choose_weighted(&mut rand::rng(), |target| target.weight)
-				.map(|target| target.model.clone())
-				.context("virtual model has no valid weighted targets")?,
+			VirtualModelRouting::Weighted(targets) => {
+				match targets.choose_weighted(&mut rand::rng(), |target| target.weight) {
+					Ok(target) => target.model.clone(),
+					Err(err) => {
+						tracing::debug!(%err, "failed to select weighted virtual model target");
+						return ResolveResult::DirectResponse(llm_error_response(
+							::http::StatusCode::NOT_FOUND,
+							&format!("Virtual model {} could not be resolved", virtual_model.name),
+							"virtual_model_not_resolved",
+						));
+					},
+				}
+			},
 			VirtualModelRouting::Failover { backend_key } => {
-				return Ok(ResolvedBackend {
+				return ResolveResult::Backend(ResolvedBackend {
 					backend: RouteBackendReference {
 						weight: 1,
 						target: BackendReference::Backend(strng::format!("/{}", backend_key)).into(),
@@ -198,23 +198,43 @@ impl ModelRouter {
 			},
 			VirtualModelRouting::Conditional(targets) => {
 				let exec = cel::Executor::new_request(req);
-				targets
-					.iter()
-					.find(|target| {
-						target
-							.when
-							.as_ref()
-							.map(|expr| exec.eval_bool(expr))
-							.unwrap_or(true)
-					})
-					.map(|target| target.model.clone())
-					.context("virtual model did not match any conditional target")?
+				match targets.iter().find(|target| {
+					target
+						.when
+						.as_ref()
+						.map(|expr| exec.eval_bool(expr))
+						.unwrap_or(true)
+				}) {
+					Some(target) => target.model.clone(),
+					None => {
+						return ResolveResult::DirectResponse(llm_error_response(
+							::http::StatusCode::BAD_REQUEST,
+							&format!(
+								"Virtual model {} did not match any conditional target",
+								virtual_model.name
+							),
+							"virtual_model_no_matching_target",
+						));
+					},
+				}
 			},
 		};
-		rewrite_body_model(req, &target).await?;
-		self
-			.resolve_concrete_model(&target, true, req)
-			.with_context(|| format!("failed to resolve LLM virtual model target {target}"))
+		if let Some(body) = body {
+			if let Err(resp) = rewrite_body_model(req, body, &target) {
+				return ResolveResult::DirectResponse(resp);
+			}
+		}
+		match self.resolve_concrete_model(&target, true, req) {
+			Some(route) => ResolveResult::Backend(route),
+			None => ResolveResult::DirectResponse(llm_error_response(
+				::http::StatusCode::NOT_FOUND,
+				&format!(
+					"Virtual model {} selected target {target}, but no matching model was found",
+					virtual_model.name
+				),
+				"virtual_model_target_not_found",
+			)),
+		}
 	}
 
 	fn resolve_concrete_model(
@@ -222,17 +242,14 @@ impl ModelRouter {
 		requested_model: &str,
 		allow_internal: bool,
 		req: &Request,
-	) -> anyhow::Result<ResolvedBackend> {
-		let model = self
-			.models
-			.iter()
-			.find(|model| {
-				(allow_internal || model.visibility == ModelVisibility::Public)
-					&& model_name_matches(&model.name, requested_model)
-					&& header_matches(&model.header_matches, req)
-			})
-			.with_context(|| format!("model not found: {requested_model}"))?;
-		Ok(ResolvedBackend {
+	) -> Option<ResolvedBackend> {
+		// `models` can store things like `provider/*`. The concrete `requested_model` will be like `provider/real-model`.
+		let model = self.models.iter().find(|model| {
+			(allow_internal || model.visibility == ModelVisibility::Public)
+				&& model_name_matches(&model.name, requested_model)
+				&& header_matches(&model.header_matches, req)
+		})?;
+		Some(ResolvedBackend {
 			backend: RouteBackendReference {
 				weight: 1,
 				target: BackendReference::Backend(strng::format!("/{}", model.backend_key)).into(),
@@ -244,13 +261,28 @@ impl ModelRouter {
 }
 
 fn model_not_found_response() -> Response {
+	llm_error_response(
+		::http::StatusCode::NOT_FOUND,
+		"Model not found",
+		"model_not_found",
+	)
+}
+
+fn llm_error_response(status: ::http::StatusCode, message: &str, code: &str) -> Response {
 	::http::Response::builder()
-		.status(::http::StatusCode::NOT_FOUND)
+		.status(status)
 		.header(::http::header::CONTENT_TYPE, "application/json")
 		.body(http::Body::from(
-			r#"{"error":{"message":"Model not found","type":"invalid_request_error","code":"model_not_found"}}"#,
+			serde_json::json!({
+				"error": {
+					"message": message,
+					"type": "invalid_request_error",
+					"code": code,
+				}
+			})
+			.to_string(),
 		))
-		.expect("static LLM model not found response is valid")
+		.expect("LLM error response is valid")
 }
 
 fn model_authorized(model: &ModelRoute, req: &Request) -> bool {
@@ -277,6 +309,7 @@ fn model_list_entry(id: &str, created: u64) -> serde_json::Value {
 		"id": id,
 		"object": "model",
 		"created": created,
+		// TODO: this matches some other gateways but seems odd. Should we use the real provide here?
 		"owned_by": "openai",
 	})
 }
@@ -341,56 +374,98 @@ fn model_name_matches(pattern: &str, model: &str) -> bool {
 	pattern == model
 }
 
-async fn requested_model(req: &mut Request) -> anyhow::Result<String> {
+async fn requested_model(req: &mut Request) -> Result<RequestedModel, Response> {
 	let path = req.uri().path();
 	if path.ends_with(":streamRawPredict") || path.ends_with(":rawPredict") {
 		return path
 			.rsplit_once("/publishers/anthropic/models/")
 			.and_then(|(_, rest)| rest.split_once(':'))
-			.map(|(model, _)| model.to_string())
-			.context("missing vertex anthropic model in request path");
+			.map(|(model, _)| RequestedModel {
+				model: model.to_string(),
+				body: None,
+			})
+			.ok_or_else(|| {
+				llm_error_response(
+					::http::StatusCode::BAD_REQUEST,
+					"LLM request path is missing model",
+					"missing_model",
+				)
+			});
 	}
 	if path.ends_with("/invoke-with-response-stream") || path.ends_with("/invoke") {
 		return path
 			.rsplit_once("/model/")
 			.and_then(|(_, rest)| rest.split_once("/invoke"))
-			.map(|(model, _)| model.to_string())
-			.context("missing bedrock model in request path");
+			.map(|(model, _)| RequestedModel {
+				model: model.to_string(),
+				body: None,
+			})
+			.ok_or_else(|| {
+				llm_error_response(
+					::http::StatusCode::BAD_REQUEST,
+					"LLM request path is missing model",
+					"missing_model",
+				)
+			});
 	}
 
 	let body = body_bytes(req).await?;
-	let body: Value = serde_json::from_slice(&body).context("failed to parse LLM request body")?;
-	body
+	let body: Value = serde_json::from_slice(&body).map_err(|err| {
+		tracing::debug!(%err, "failed to parse LLM request body");
+		llm_error_response(
+			::http::StatusCode::BAD_REQUEST,
+			"LLM request body must be valid JSON",
+			"invalid_request_body",
+		)
+	})?;
+	let model = body
 		.get("model")
 		.and_then(Value::as_str)
 		.map(ToString::to_string)
-		.context("LLM request body is missing string field 'model'")
+		.ok_or_else(|| {
+			llm_error_response(
+				::http::StatusCode::BAD_REQUEST,
+				"LLM request body is missing string field 'model'",
+				"missing_model",
+			)
+		})?;
+	Ok(RequestedModel {
+		model,
+		body: Some(body),
+	})
 }
 
-async fn rewrite_body_model(req: &mut Request, target: &str) -> anyhow::Result<()> {
-	let body = body_bytes(req).await?;
-	if body.is_empty() {
-		return Ok(());
-	}
-	let Ok(mut json) = serde_json::from_slice::<Value>(&body) else {
-		return Ok(());
-	};
-	let Some(obj) = json.as_object_mut() else {
+fn rewrite_body_model(req: &mut Request, mut body: Value, target: &str) -> Result<(), Response> {
+	let Some(obj) = body.as_object_mut() else {
 		return Ok(());
 	};
 	obj.insert("model".to_string(), Value::String(target.to_string()));
-	let body = serde_json::to_vec(&json)?;
+	let body = serde_json::to_vec(&body).map_err(|err| {
+		tracing::debug!(%err, "failed to serialize rewritten LLM request body");
+		llm_error_response(
+			::http::StatusCode::BAD_REQUEST,
+			"Failed to rewrite LLM request body model",
+			"request_body_rewrite_failed",
+		)
+	})?;
 	*req.body_mut() = http::Body::from(body);
 	req.headers_mut().remove(::http::header::CONTENT_LENGTH);
 	req.extensions_mut().remove::<cel::BufferedBody>();
 	Ok(())
 }
 
-async fn body_bytes(req: &mut Request) -> anyhow::Result<Bytes> {
+async fn body_bytes(req: &mut Request) -> Result<Bytes, Response> {
 	if let Some(body) = req.extensions().get::<cel::BufferedBody>() {
 		return Ok(body.0.clone());
 	}
-	let body = http::inspect_body(req).await?;
+	let body = http::inspect_body(req).await.map_err(|err| {
+		tracing::debug!(%err, "failed to read LLM request body");
+		llm_error_response(
+			::http::StatusCode::BAD_REQUEST,
+			"Failed to read LLM request body",
+			"request_body_read_failed",
+		)
+	})?;
 	req.extensions_mut().insert(cel::BufferedBody(body.clone()));
 	Ok(body)
 }

--- a/crates/agentgateway/src/llm/model_router.rs
+++ b/crates/agentgateway/src/llm/model_router.rs
@@ -1,0 +1,392 @@
+use std::sync::Arc;
+
+use agent_core::prelude::Strng;
+use agent_core::strng;
+use anyhow::{Context, bail};
+use bytes::Bytes;
+use rand::seq::IndexedRandom;
+use serde_json::Value;
+
+use crate::cel;
+use crate::http::transformation_cel::TransformationMetadata;
+use crate::http::{self, Request, Response};
+use crate::types::agent::{
+	BackendReference, BackendTrafficPolicy, HeaderMatch, HeaderValueMatch, RouteBackendReference,
+	TrafficPolicy,
+};
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelRoute {
+	pub name: String,
+	pub visibility: ModelVisibility,
+	pub header_matches: Vec<Vec<HeaderMatch>>,
+	pub backend_key: Strng,
+	pub route_policies: Vec<TrafficPolicy>,
+	pub backend_policies: Vec<BackendTrafficPolicy>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ModelVisibility {
+	Public,
+	Internal,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VirtualModelRoute {
+	pub name: String,
+	pub route_policies: Vec<TrafficPolicy>,
+	pub routing: VirtualModelRouting,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum VirtualModelRouting {
+	Weighted(Vec<WeightedTarget>),
+	Failover { backend_key: Strng },
+	Conditional(Vec<ConditionalTarget>),
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WeightedTarget {
+	pub model: String,
+	pub weight: usize,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConditionalTarget {
+	pub model: String,
+	pub when: Option<Arc<cel::Expression>>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelRouter {
+	models: Vec<ModelRoute>,
+	virtual_models: Vec<VirtualModelRoute>,
+	created: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct ResolvedBackend {
+	pub backend: RouteBackendReference,
+	pub route_policies: Vec<TrafficPolicy>,
+}
+
+pub enum ResolveResult {
+	DirectResponse(Response),
+	Backend(ResolvedBackend),
+}
+
+impl ModelRouter {
+	pub fn new(
+		models: Vec<ModelRoute>,
+		virtual_models: Vec<VirtualModelRoute>,
+		created: u64,
+	) -> Self {
+		Self {
+			models,
+			virtual_models,
+			created,
+		}
+	}
+
+	pub async fn resolve(&self, req: &mut Request) -> anyhow::Result<ResolveResult> {
+		if is_model_list_request(req) {
+			return Ok(ResolveResult::DirectResponse(
+				self.model_list_response(req)?,
+			));
+		}
+		let requested_model = match requested_model(req).await {
+			Ok(model) => model,
+			Err(err) => {
+				tracing::debug!(%err, "failed to read LLM request model");
+				return Ok(ResolveResult::DirectResponse(model_not_found_response()));
+			},
+		};
+		req
+			.extensions_mut()
+			.get_or_insert_with(TransformationMetadata::default)
+			.0
+			.insert(
+				"agentgateway_user_model".to_string(),
+				Value::String(requested_model.clone()),
+			);
+		if let Some(virtual_model) = self
+			.virtual_models
+			.iter()
+			.find(|model| model.name == requested_model)
+		{
+			if let VirtualModelRouting::Failover { backend_key } = &virtual_model.routing {
+				return Ok(ResolveResult::Backend(ResolvedBackend {
+					backend: RouteBackendReference {
+						weight: 1,
+						target: BackendReference::Backend(strng::format!("/{}", backend_key)).into(),
+						inline_policies: vec![],
+					},
+					route_policies: virtual_model.route_policies.clone(),
+				}));
+			}
+			let target = match self.resolve_virtual_model(virtual_model, req) {
+				Ok(target) => target,
+				Err(err) => {
+					tracing::debug!(%err, "failed to resolve LLM virtual model");
+					return Ok(ResolveResult::DirectResponse(model_not_found_response()));
+				},
+			};
+			rewrite_body_model(req, &target).await?;
+			return Ok(match self.resolve_concrete_model(&target, true, req) {
+				Ok(route) => ResolveResult::Backend(route),
+				Err(err) => {
+					tracing::debug!(%err, "failed to resolve LLM virtual model target");
+					ResolveResult::DirectResponse(model_not_found_response())
+				},
+			});
+		}
+
+		Ok(
+			match self.resolve_concrete_model(&requested_model, false, req) {
+				Ok(route) => ResolveResult::Backend(route),
+				Err(err) => {
+					tracing::debug!(%err, "failed to resolve LLM model");
+					ResolveResult::DirectResponse(model_not_found_response())
+				},
+			},
+		)
+	}
+
+	fn model_list_response(&self, req: &Request) -> anyhow::Result<Response> {
+		let data = self
+			.models
+			.iter()
+			.filter(|model| model.visibility == ModelVisibility::Public)
+			.filter(|model| model_authorized(model, req))
+			.map(|model| model_list_entry(&model.name, self.created))
+			.chain(
+				self
+					.virtual_models
+					.iter()
+					.map(|model| model_list_entry(&model.name, self.created)),
+			)
+			.collect::<Vec<_>>();
+		let body = serde_json::to_vec(&serde_json::json!({
+			"data": data,
+			"object": "list",
+		}))?;
+		Ok(
+			::http::Response::builder()
+				.status(::http::StatusCode::OK)
+				.header(::http::header::CONTENT_TYPE, "application/json")
+				.body(http::Body::from(body))?,
+		)
+	}
+
+	fn resolve_virtual_model(
+		&self,
+		virtual_model: &VirtualModelRoute,
+		req: &Request,
+	) -> anyhow::Result<String> {
+		match &virtual_model.routing {
+			VirtualModelRouting::Weighted(targets) => targets
+				.choose_weighted(&mut rand::rng(), |target| target.weight)
+				.map(|target| target.model.clone())
+				.context("virtual model has no valid weighted targets"),
+			VirtualModelRouting::Failover { .. } => unreachable!("handled before target resolution"),
+			VirtualModelRouting::Conditional(targets) => {
+				let exec = cel::Executor::new_request(req);
+				for target in targets {
+					let matched = target
+						.when
+						.as_ref()
+						.map(|expr| exec.eval_bool(expr))
+						.unwrap_or(true);
+					if matched {
+						return Ok(target.model.clone());
+					}
+				}
+				bail!("virtual model did not match any conditional target")
+			},
+		}
+	}
+
+	fn resolve_concrete_model(
+		&self,
+		requested_model: &str,
+		allow_internal: bool,
+		req: &Request,
+	) -> anyhow::Result<ResolvedBackend> {
+		let model = self
+			.models
+			.iter()
+			.find(|model| {
+				(allow_internal || model.visibility == ModelVisibility::Public)
+					&& model_name_matches(&model.name, requested_model)
+					&& header_matches(&model.header_matches, req)
+			})
+			.with_context(|| format!("model not found: {requested_model}"))?;
+		Ok(ResolvedBackend {
+			backend: RouteBackendReference {
+				weight: 1,
+				target: BackendReference::Backend(strng::format!("/{}", model.backend_key)).into(),
+				inline_policies: model.backend_policies.clone(),
+			},
+			route_policies: model.route_policies.clone(),
+		})
+	}
+}
+
+fn model_not_found_response() -> Response {
+	::http::Response::builder()
+		.status(::http::StatusCode::NOT_FOUND)
+		.header(::http::header::CONTENT_TYPE, "application/json")
+		.body(http::Body::from(
+			r#"{"error":{"message":"Model not found","type":"invalid_request_error","code":"model_not_found"}}"#,
+		))
+		.expect("static LLM model not found response is valid")
+}
+
+fn model_authorized(model: &ModelRoute, req: &Request) -> bool {
+	let rules = model
+		.route_policies
+		.iter()
+		.filter_map(|policy| match policy {
+			TrafficPolicy::Authorization(authorization) => Some(authorization.0.clone()),
+			_ => None,
+		})
+		.collect::<Vec<_>>();
+	if rules.is_empty() {
+		return true;
+	}
+	crate::http::authorization::HTTPAuthorizationSet::new(
+		crate::http::authorization::RuleSets::from_arcs(rules),
+	)
+	.apply(req)
+	.is_ok()
+}
+
+fn model_list_entry(id: &str, created: u64) -> serde_json::Value {
+	serde_json::json!({
+		"id": id,
+		"object": "model",
+		"created": created,
+		"owned_by": "openai",
+	})
+}
+
+fn is_model_list_request(req: &Request) -> bool {
+	let path = req.uri().path().trim_end_matches('/');
+	path == "/v1/models"
+		|| path
+			.strip_prefix("/v1/models")
+			.is_some_and(|suffix| suffix.starts_with('/'))
+		|| path == "/models"
+		|| path
+			.strip_prefix("/models")
+			.is_some_and(|suffix| suffix.starts_with('/'))
+}
+
+fn header_matches(matches: &[Vec<HeaderMatch>], req: &Request) -> bool {
+	if matches.is_empty() {
+		return true;
+	}
+	matches.iter().any(|headers| headers_match(headers, req))
+}
+
+fn headers_match(headers: &[HeaderMatch], req: &Request) -> bool {
+	for HeaderMatch { name, value } in headers {
+		let Some(have) = http::get_pseudo_or_header_value(name, req) else {
+			return false;
+		};
+		match value {
+			HeaderValueMatch::Exact(want) => {
+				if have.as_ref() != *want {
+					return false;
+				}
+			},
+			HeaderValueMatch::Regex(want) => {
+				let Some(have_str) = have.to_str().ok() else {
+					return false;
+				};
+				let Some(m) = want.find(have_str) else {
+					return false;
+				};
+				if !(m.start() == 0 && m.end() == have_str.len()) {
+					return false;
+				}
+			},
+			HeaderValueMatch::Invalid => return false,
+		}
+	}
+	true
+}
+
+fn model_name_matches(pattern: &str, model: &str) -> bool {
+	if pattern == "*" {
+		return true;
+	}
+	if let Some(prefix) = pattern.strip_suffix('*') {
+		return model.starts_with(prefix);
+	}
+	if let Some(suffix) = pattern.strip_prefix('*') {
+		return model.ends_with(suffix);
+	}
+	pattern == model
+}
+
+async fn requested_model(req: &mut Request) -> anyhow::Result<String> {
+	let path = req.uri().path();
+	if path.ends_with(":streamRawPredict") || path.ends_with(":rawPredict") {
+		return path
+			.rsplit_once("/publishers/anthropic/models/")
+			.and_then(|(_, rest)| rest.split_once(':'))
+			.map(|(model, _)| model.to_string())
+			.context("missing vertex anthropic model in request path");
+	}
+	if path.ends_with("/invoke-with-response-stream") || path.ends_with("/invoke") {
+		return path
+			.rsplit_once("/model/")
+			.and_then(|(_, rest)| rest.split_once("/invoke"))
+			.map(|(model, _)| model.to_string())
+			.context("missing bedrock model in request path");
+	}
+
+	let body = body_bytes(req).await?;
+	let body: Value = serde_json::from_slice(&body).context("failed to parse LLM request body")?;
+	body
+		.get("model")
+		.and_then(Value::as_str)
+		.map(ToString::to_string)
+		.context("LLM request body is missing string field 'model'")
+}
+
+async fn rewrite_body_model(req: &mut Request, target: &str) -> anyhow::Result<()> {
+	let body = body_bytes(req).await?;
+	if body.is_empty() {
+		return Ok(());
+	}
+	let Ok(mut json) = serde_json::from_slice::<Value>(&body) else {
+		return Ok(());
+	};
+	let Some(obj) = json.as_object_mut() else {
+		return Ok(());
+	};
+	obj.insert("model".to_string(), Value::String(target.to_string()));
+	let body = serde_json::to_vec(&json)?;
+	*req.body_mut() = http::Body::from(body);
+	req.headers_mut().remove(::http::header::CONTENT_LENGTH);
+	req.extensions_mut().remove::<cel::BufferedBody>();
+	Ok(())
+}
+
+async fn body_bytes(req: &mut Request) -> anyhow::Result<Bytes> {
+	if let Some(body) = req.extensions().get::<cel::BufferedBody>() {
+		return Ok(body.0.clone());
+	}
+	let body = http::inspect_body(req).await?;
+	req.extensions_mut().insert(cel::BufferedBody(body.clone()));
+	Ok(body)
+}

--- a/crates/agentgateway/src/llm/model_router.rs
+++ b/crates/agentgateway/src/llm/model_router.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use agent_core::prelude::Strng;
 use agent_core::strng;
 use bytes::Bytes;
+use percent_encoding::{AsciiSet, CONTROLS, utf8_percent_encode};
 use rand::seq::IndexedRandom;
 use serde_json::Value;
 
@@ -92,7 +93,12 @@ pub enum ResolveResult {
 
 struct RequestedModel {
 	model: String,
-	body: Option<Value>,
+	location: RequestedModelLocation,
+}
+
+enum RequestedModelLocation {
+	Body(Value),
+	Path,
 }
 
 impl ModelRouter {
@@ -130,7 +136,7 @@ impl ModelRouter {
 			.find(|model| model.name == requested_model.model)
 		{
 			return self
-				.resolve_virtual_model(virtual_model, req, requested_model.body)
+				.resolve_virtual_model(virtual_model, req, requested_model.location)
 				.await;
 		}
 
@@ -170,7 +176,7 @@ impl ModelRouter {
 		&self,
 		virtual_model: &VirtualModelRoute,
 		req: &mut Request,
-		body: Option<Value>,
+		location: RequestedModelLocation,
 	) -> ResolveResult {
 		let target = match &virtual_model.routing {
 			VirtualModelRouting::Weighted(targets) => {
@@ -219,10 +225,8 @@ impl ModelRouter {
 				}
 			},
 		};
-		if let Some(body) = body {
-			if let Err(resp) = rewrite_body_model(req, body, &target) {
-				return ResolveResult::DirectResponse(resp);
-			}
+		if let Err(resp) = rewrite_request_model(req, location, &target) {
+			return ResolveResult::DirectResponse(resp);
 		}
 		match self.resolve_concrete_model(&target, true, req) {
 			Some(route) => ResolveResult::Backend(route),
@@ -376,37 +380,11 @@ fn model_name_matches(pattern: &str, model: &str) -> bool {
 
 async fn requested_model(req: &mut Request) -> Result<RequestedModel, Response> {
 	let path = req.uri().path();
-	if path.ends_with(":streamRawPredict") || path.ends_with(":rawPredict") {
-		return path
-			.rsplit_once("/publishers/anthropic/models/")
-			.and_then(|(_, rest)| rest.split_once(':'))
-			.map(|(model, _)| RequestedModel {
-				model: model.to_string(),
-				body: None,
-			})
-			.ok_or_else(|| {
-				llm_error_response(
-					::http::StatusCode::BAD_REQUEST,
-					"LLM request path is missing model",
-					"missing_model",
-				)
-			});
-	}
-	if path.ends_with("/invoke-with-response-stream") || path.ends_with("/invoke") {
-		return path
-			.rsplit_once("/model/")
-			.and_then(|(_, rest)| rest.split_once("/invoke"))
-			.map(|(model, _)| RequestedModel {
-				model: model.to_string(),
-				body: None,
-			})
-			.ok_or_else(|| {
-				llm_error_response(
-					::http::StatusCode::BAD_REQUEST,
-					"LLM request path is missing model",
-					"missing_model",
-				)
-			});
+	if let Some(model) = crate::llm::types::detect::extract_model_from_path(path) {
+		return Ok(RequestedModel {
+			model: model.to_string(),
+			location: RequestedModelLocation::Path,
+		});
 	}
 
 	let body = body_bytes(req).await?;
@@ -431,8 +409,19 @@ async fn requested_model(req: &mut Request) -> Result<RequestedModel, Response> 
 		})?;
 	Ok(RequestedModel {
 		model,
-		body: Some(body),
+		location: RequestedModelLocation::Body(body),
 	})
+}
+
+fn rewrite_request_model(
+	req: &mut Request,
+	location: RequestedModelLocation,
+	target: &str,
+) -> Result<(), Response> {
+	match location {
+		RequestedModelLocation::Body(body) => rewrite_body_model(req, body, target),
+		RequestedModelLocation::Path => rewrite_uri_model(req, target),
+	}
 }
 
 fn rewrite_body_model(req: &mut Request, mut body: Value, target: &str) -> Result<(), Response> {
@@ -454,6 +443,71 @@ fn rewrite_body_model(req: &mut Request, mut body: Value, target: &str) -> Resul
 	Ok(())
 }
 
+fn rewrite_uri_model(req: &mut Request, target: &str) -> Result<(), Response> {
+	let Some(path_and_query) = req.uri().path_and_query() else {
+		return Ok(());
+	};
+	let Some(path) = rewrite_path_model(path_and_query.path(), target) else {
+		return Ok(());
+	};
+	let path_and_query = if let Some(query) = path_and_query.query() {
+		format!("{path}?{query}")
+	} else {
+		path
+	};
+	let path_and_query = path_and_query.parse().map_err(|err| {
+		tracing::debug!(%err, "failed to rewrite LLM request URI model");
+		llm_error_response(
+			::http::StatusCode::BAD_REQUEST,
+			"Failed to rewrite LLM request URI model",
+			"request_uri_rewrite_failed",
+		)
+	})?;
+	let mut parts = req.uri().clone().into_parts();
+	parts.path_and_query = Some(path_and_query);
+	*req.uri_mut() = ::http::Uri::from_parts(parts).map_err(|err| {
+		tracing::debug!(%err, "failed to rebuild LLM request URI");
+		llm_error_response(
+			::http::StatusCode::BAD_REQUEST,
+			"Failed to rewrite LLM request URI model",
+			"request_uri_rewrite_failed",
+		)
+	})?;
+	Ok(())
+}
+
+fn rewrite_path_model(path: &str, target: &str) -> Option<String> {
+	if path.ends_with(":streamRawPredict") || path.ends_with(":rawPredict") {
+		let (prefix, rest) = path.split_once("/publishers/anthropic/models/")?;
+		let (_, suffix) = rest.split_once(':')?;
+		return Some(format!(
+			"{prefix}/publishers/anthropic/models/{}:{suffix}",
+			encode_model_path_segment(target)
+		));
+	}
+	for suffix in [
+		"/invoke-with-response-stream",
+		"/invoke",
+		"/converse-stream",
+		"/converse",
+	] {
+		if let Some(before_suffix) = path.strip_suffix(suffix)
+			&& let Some((prefix, _)) = before_suffix.split_once("/model/")
+		{
+			return Some(format!(
+				"{prefix}/model/{}{suffix}",
+				encode_model_path_segment(target)
+			));
+		}
+	}
+	None
+}
+
+fn encode_model_path_segment(model: &str) -> String {
+	const MODEL_SEGMENT: &AsciiSet = &CONTROLS.add(b'/').add(b'%');
+	utf8_percent_encode(model, MODEL_SEGMENT).to_string()
+}
+
 async fn body_bytes(req: &mut Request) -> Result<Bytes, Response> {
 	if let Some(body) = req.extensions().get::<cel::BufferedBody>() {
 		return Ok(body.0.clone());
@@ -468,4 +522,60 @@ async fn body_bytes(req: &mut Request) -> Result<Bytes, Response> {
 	})?;
 	req.extensions_mut().insert(cel::BufferedBody(body.clone()));
 	Ok(body)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn rewrite_path_model_rewrites_bedrock_converse_and_preserves_suffix() {
+		assert_eq!(
+			rewrite_path_model(
+				"/model/anthropic.claude-3-5-sonnet-20241022-v2:0/converse",
+				"anthropic.claude-3-haiku-20240307-v1:0",
+			)
+			.as_deref(),
+			Some("/model/anthropic.claude-3-haiku-20240307-v1:0/converse")
+		);
+	}
+
+	#[test]
+	fn rewrite_path_model_rewrites_bedrock_invoke_and_encodes_slashes() {
+		assert_eq!(
+			rewrite_path_model(
+				"/model/virtual/invoke-with-response-stream",
+				"arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/my-profile",
+			)
+			.as_deref(),
+			Some(
+				"/model/arn:aws:bedrock:us-east-1:123456789012:application-inference-profile%2Fmy-profile/invoke-with-response-stream"
+			)
+		);
+	}
+
+	#[test]
+	fn rewrite_path_model_rewrites_vertex_raw_predict() {
+		assert_eq!(
+			rewrite_path_model(
+				"/v1/projects/p/locations/us/publishers/anthropic/models/virtual:rawPredict",
+				"claude-sonnet",
+			)
+			.as_deref(),
+			Some("/v1/projects/p/locations/us/publishers/anthropic/models/claude-sonnet:rawPredict")
+		);
+	}
+
+	#[test]
+	fn rewrite_uri_model_preserves_query() {
+		let mut req = ::http::Request::builder()
+			.uri("http://example.com/model/virtual/converse?trace=true")
+			.body(http::Body::empty())
+			.unwrap();
+		rewrite_uri_model(&mut req, "real/model").expect("URI rewrites");
+		assert_eq!(
+			req.uri().to_string(),
+			"http://example.com/model/real%2Fmodel/converse?trace=true"
+		);
+	}
 }

--- a/crates/agentgateway/src/llm/model_router.rs
+++ b/crates/agentgateway/src/llm/model_router.rs
@@ -2,18 +2,18 @@ use std::sync::Arc;
 
 use agent_core::prelude::Strng;
 use agent_core::strng;
-use anyhow::{Context, bail};
+use anyhow::Context;
 use bytes::Bytes;
 use rand::seq::IndexedRandom;
 use serde_json::Value;
 
-use crate::cel;
 use crate::http::transformation_cel::TransformationMetadata;
 use crate::http::{self, Request, Response};
 use crate::types::agent::{
 	BackendReference, BackendTrafficPolicy, HeaderMatch, HeaderValueMatch, RouteBackendReference,
 	TrafficPolicy,
 };
+use crate::{apply, cel, schema_enum};
 
 #[derive(Debug, Clone, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -26,11 +26,20 @@ pub struct ModelRoute {
 	pub backend_policies: Vec<BackendTrafficPolicy>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
+#[apply(schema_enum!)]
+#[derive(Default)]
 pub enum ModelVisibility {
+	/// Public models can be requested directly by clients and are included in the model list.
+	#[default]
 	Public,
+	/// Internal models can be targeted by virtual models but cannot be requested directly.
 	Internal,
+}
+
+impl ModelVisibility {
+	pub fn is_public(&self) -> bool {
+		matches!(self, Self::Public)
+	}
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -121,28 +130,10 @@ impl ModelRouter {
 			.iter()
 			.find(|model| model.name == requested_model)
 		{
-			if let VirtualModelRouting::Failover { backend_key } = &virtual_model.routing {
-				return Ok(ResolveResult::Backend(ResolvedBackend {
-					backend: RouteBackendReference {
-						weight: 1,
-						target: BackendReference::Backend(strng::format!("/{}", backend_key)).into(),
-						inline_policies: vec![],
-					},
-					route_policies: virtual_model.route_policies.clone(),
-				}));
-			}
-			let target = match self.resolve_virtual_model(virtual_model, req) {
-				Ok(target) => target,
+			return Ok(match self.resolve_virtual_model(virtual_model, req).await {
+				Ok(backend) => ResolveResult::Backend(backend),
 				Err(err) => {
 					tracing::debug!(%err, "failed to resolve LLM virtual model");
-					return Ok(ResolveResult::DirectResponse(model_not_found_response()));
-				},
-			};
-			rewrite_body_model(req, &target).await?;
-			return Ok(match self.resolve_concrete_model(&target, true, req) {
-				Ok(route) => ResolveResult::Backend(route),
-				Err(err) => {
-					tracing::debug!(%err, "failed to resolve LLM virtual model target");
 					ResolveResult::DirectResponse(model_not_found_response())
 				},
 			});
@@ -185,32 +176,45 @@ impl ModelRouter {
 		)
 	}
 
-	fn resolve_virtual_model(
+	async fn resolve_virtual_model(
 		&self,
 		virtual_model: &VirtualModelRoute,
-		req: &Request,
-	) -> anyhow::Result<String> {
-		match &virtual_model.routing {
+		req: &mut Request,
+	) -> anyhow::Result<ResolvedBackend> {
+		let target = match &virtual_model.routing {
 			VirtualModelRouting::Weighted(targets) => targets
 				.choose_weighted(&mut rand::rng(), |target| target.weight)
 				.map(|target| target.model.clone())
-				.context("virtual model has no valid weighted targets"),
-			VirtualModelRouting::Failover { .. } => unreachable!("handled before target resolution"),
+				.context("virtual model has no valid weighted targets")?,
+			VirtualModelRouting::Failover { backend_key } => {
+				return Ok(ResolvedBackend {
+					backend: RouteBackendReference {
+						weight: 1,
+						target: BackendReference::Backend(strng::format!("/{}", backend_key)).into(),
+						inline_policies: vec![],
+					},
+					route_policies: virtual_model.route_policies.clone(),
+				});
+			},
 			VirtualModelRouting::Conditional(targets) => {
 				let exec = cel::Executor::new_request(req);
-				for target in targets {
-					let matched = target
-						.when
-						.as_ref()
-						.map(|expr| exec.eval_bool(expr))
-						.unwrap_or(true);
-					if matched {
-						return Ok(target.model.clone());
-					}
-				}
-				bail!("virtual model did not match any conditional target")
+				targets
+					.iter()
+					.find(|target| {
+						target
+							.when
+							.as_ref()
+							.map(|expr| exec.eval_bool(expr))
+							.unwrap_or(true)
+					})
+					.map(|target| target.model.clone())
+					.context("virtual model did not match any conditional target")?
 			},
-		}
+		};
+		rewrite_body_model(req, &target).await?;
+		self
+			.resolve_concrete_model(&target, true, req)
+			.with_context(|| format!("failed to resolve LLM virtual model target {target}"))
 	}
 
 	fn resolve_concrete_model(

--- a/crates/agentgateway/src/llm/model_router.rs
+++ b/crates/agentgateway/src/llm/model_router.rs
@@ -91,6 +91,8 @@ pub enum ResolveResult {
 	Backend(ResolvedBackend),
 }
 
+type RouterResult<T> = Result<T, Box<Response>>;
+
 struct RequestedModel {
 	model: String,
 	location: RequestedModelLocation,
@@ -120,7 +122,7 @@ impl ModelRouter {
 		}
 		let requested_model = match requested_model(req).await {
 			Ok(requested_model) => requested_model,
-			Err(resp) => return ResolveResult::DirectResponse(resp),
+			Err(resp) => return ResolveResult::DirectResponse(*resp),
 		};
 		req
 			.extensions_mut()
@@ -139,6 +141,11 @@ impl ModelRouter {
 				.resolve_virtual_model(virtual_model, req, requested_model.location)
 				.await;
 		}
+		tracing::trace!(
+			requested_model = %requested_model.model,
+			virtual_model_count = self.virtual_models.len(),
+			"unable to find declared virtual model; trying concrete model routes",
+		);
 
 		match self.resolve_concrete_model(&requested_model.model, false, req) {
 			Some(route) => ResolveResult::Backend(route),
@@ -226,18 +233,25 @@ impl ModelRouter {
 			},
 		};
 		if let Err(resp) = rewrite_request_model(req, location, &target) {
-			return ResolveResult::DirectResponse(resp);
+			return ResolveResult::DirectResponse(*resp);
 		}
 		match self.resolve_concrete_model(&target, true, req) {
 			Some(route) => ResolveResult::Backend(route),
-			None => ResolveResult::DirectResponse(llm_error_response(
-				::http::StatusCode::NOT_FOUND,
-				&format!(
-					"Virtual model {} selected target {target}, but no matching model was found",
-					virtual_model.name
-				),
-				"virtual_model_target_not_found",
-			)),
+			None => {
+				tracing::debug!(
+					virtual_model = %virtual_model.name,
+					target_model = %target,
+					"virtual model selected target with no declared concrete model",
+				);
+				ResolveResult::DirectResponse(llm_error_response(
+					::http::StatusCode::NOT_FOUND,
+					&format!(
+						"Virtual model {} selected target {target}, but no matching model was found",
+						virtual_model.name
+					),
+					"virtual_model_target_not_found",
+				))
+			},
 		}
 	}
 
@@ -378,7 +392,7 @@ fn model_name_matches(pattern: &str, model: &str) -> bool {
 	pattern == model
 }
 
-async fn requested_model(req: &mut Request) -> Result<RequestedModel, Response> {
+async fn requested_model(req: &mut Request) -> RouterResult<RequestedModel> {
 	let path = req.uri().path();
 	if let Some(model) = crate::llm::types::detect::extract_model_from_path(path) {
 		return Ok(RequestedModel {
@@ -390,22 +404,22 @@ async fn requested_model(req: &mut Request) -> Result<RequestedModel, Response> 
 	let body = body_bytes(req).await?;
 	let body: Value = serde_json::from_slice(&body).map_err(|err| {
 		tracing::debug!(%err, "failed to parse LLM request body");
-		llm_error_response(
+		Box::new(llm_error_response(
 			::http::StatusCode::BAD_REQUEST,
 			"LLM request body must be valid JSON",
 			"invalid_request_body",
-		)
+		))
 	})?;
 	let model = body
 		.get("model")
 		.and_then(Value::as_str)
 		.map(ToString::to_string)
 		.ok_or_else(|| {
-			llm_error_response(
+			Box::new(llm_error_response(
 				::http::StatusCode::BAD_REQUEST,
 				"LLM request body is missing string field 'model'",
 				"missing_model",
-			)
+			))
 		})?;
 	Ok(RequestedModel {
 		model,
@@ -417,25 +431,25 @@ fn rewrite_request_model(
 	req: &mut Request,
 	location: RequestedModelLocation,
 	target: &str,
-) -> Result<(), Response> {
+) -> RouterResult<()> {
 	match location {
 		RequestedModelLocation::Body(body) => rewrite_body_model(req, body, target),
 		RequestedModelLocation::Path => rewrite_uri_model(req, target),
 	}
 }
 
-fn rewrite_body_model(req: &mut Request, mut body: Value, target: &str) -> Result<(), Response> {
+fn rewrite_body_model(req: &mut Request, mut body: Value, target: &str) -> RouterResult<()> {
 	let Some(obj) = body.as_object_mut() else {
 		return Ok(());
 	};
 	obj.insert("model".to_string(), Value::String(target.to_string()));
 	let body = serde_json::to_vec(&body).map_err(|err| {
 		tracing::debug!(%err, "failed to serialize rewritten LLM request body");
-		llm_error_response(
+		Box::new(llm_error_response(
 			::http::StatusCode::BAD_REQUEST,
 			"Failed to rewrite LLM request body model",
 			"request_body_rewrite_failed",
-		)
+		))
 	})?;
 	*req.body_mut() = http::Body::from(body);
 	req.headers_mut().remove(::http::header::CONTENT_LENGTH);
@@ -443,7 +457,7 @@ fn rewrite_body_model(req: &mut Request, mut body: Value, target: &str) -> Resul
 	Ok(())
 }
 
-fn rewrite_uri_model(req: &mut Request, target: &str) -> Result<(), Response> {
+fn rewrite_uri_model(req: &mut Request, target: &str) -> RouterResult<()> {
 	let Some(path_and_query) = req.uri().path_and_query() else {
 		return Ok(());
 	};
@@ -457,21 +471,21 @@ fn rewrite_uri_model(req: &mut Request, target: &str) -> Result<(), Response> {
 	};
 	let path_and_query = path_and_query.parse().map_err(|err| {
 		tracing::debug!(%err, "failed to rewrite LLM request URI model");
-		llm_error_response(
+		Box::new(llm_error_response(
 			::http::StatusCode::BAD_REQUEST,
 			"Failed to rewrite LLM request URI model",
 			"request_uri_rewrite_failed",
-		)
+		))
 	})?;
 	let mut parts = req.uri().clone().into_parts();
 	parts.path_and_query = Some(path_and_query);
 	*req.uri_mut() = ::http::Uri::from_parts(parts).map_err(|err| {
 		tracing::debug!(%err, "failed to rebuild LLM request URI");
-		llm_error_response(
+		Box::new(llm_error_response(
 			::http::StatusCode::BAD_REQUEST,
 			"Failed to rewrite LLM request URI model",
 			"request_uri_rewrite_failed",
-		)
+		))
 	})?;
 	Ok(())
 }
@@ -508,17 +522,17 @@ fn encode_model_path_segment(model: &str) -> String {
 	utf8_percent_encode(model, MODEL_SEGMENT).to_string()
 }
 
-async fn body_bytes(req: &mut Request) -> Result<Bytes, Response> {
+async fn body_bytes(req: &mut Request) -> RouterResult<Bytes> {
 	if let Some(body) = req.extensions().get::<cel::BufferedBody>() {
 		return Ok(body.0.clone());
 	}
 	let body = http::inspect_body(req).await.map_err(|err| {
 		tracing::debug!(%err, "failed to read LLM request body");
-		llm_error_response(
+		Box::new(llm_error_response(
 			::http::StatusCode::BAD_REQUEST,
 			"Failed to read LLM request body",
 			"request_body_read_failed",
-		)
+		))
 	})?;
 	req.extensions_mut().insert(cel::BufferedBody(body.clone()));
 	Ok(body)

--- a/crates/agentgateway/src/proxy/gateway_test.rs
+++ b/crates/agentgateway/src/proxy/gateway_test.rs
@@ -1319,6 +1319,174 @@ async fn llm_openai_tokenize() {
 	.await;
 }
 
+async fn setup_local_llm_config(yaml: &str) -> TestBind {
+	let t = setup_proxy_test("{}").unwrap();
+	let normalized = crate::types::local::NormalizedLocalConfig::from(
+		t.pi.cfg.as_ref(),
+		t.pi.upstream.clone(),
+		t.pi.cfg.gateway(),
+		yaml,
+	)
+	.await
+	.expect("local config normalizes");
+	t.pi.stores.binds.sync_local(
+		normalized.binds,
+		normalized.listener_routes,
+		normalized.listener_tcp_routes,
+		normalized.policies,
+		normalized.backends,
+		normalized.route_groups,
+		Default::default(),
+	);
+	t
+}
+
+async fn setup_local_llm_config_with_user_model_header(yaml: &str) -> TestBind {
+	let t = setup_proxy_test("{}").unwrap();
+	let mut normalized = crate::types::local::NormalizedLocalConfig::from(
+		t.pi.cfg.as_ref(),
+		t.pi.upstream.clone(),
+		t.pi.cfg.gateway(),
+		yaml,
+	)
+	.await
+	.expect("local config normalizes");
+	let transformation = crate::http::transformation_cel::Transformation::try_from_local_config(
+		crate::http::transformation_cel::LocalTransformationConfig {
+			request: Some(crate::http::transformation_cel::LocalTransform {
+				add: vec![(
+					strng::literal!("x-user-model"),
+					strng::literal!("metadata.agentgateway_user_model"),
+				)],
+				..Default::default()
+			}),
+			response: None,
+		},
+		true,
+	)
+	.expect("transformation config");
+	let route = normalized
+		.listener_routes
+		.iter_mut()
+		.flat_map(|(_, routes)| routes)
+		.find(|route| route.key == "llm:request")
+		.expect("LLM request route");
+	route
+		.inline_policies
+		.push(crate::types::agent::TrafficPolicy::Transformation(
+			Arc::new(transformation),
+		));
+	t.pi.stores.binds.sync_local(
+		normalized.binds,
+		normalized.listener_routes,
+		normalized.listener_tcp_routes,
+		normalized.policies,
+		normalized.backends,
+		normalized.route_groups,
+		Default::default(),
+	);
+	t
+}
+
+#[tokio::test]
+async fn llm_local_router_handles_models_virtual_model_and_missing_model() {
+	let mock = body_mock(include_bytes!(
+		"../llm/tests/response/completions/basic.json"
+	))
+	.await;
+	let config = format!(
+		r#"
+llm:
+  port: 4000
+  models:
+  - name: real-model
+    visibility: internal
+    provider: openAI
+    params:
+      baseUrl: http://{}
+  virtualModels:
+  - name: public-model
+    routing:
+      weighted:
+        targets:
+        - model: real-model
+          weight: 1
+"#,
+		mock.address()
+	);
+	let t = setup_local_llm_config_with_user_model_header(&config).await;
+	let io = t.serve_http(strng::literal!("bind/4000"));
+
+	let res = send_request(io.clone(), Method::GET, "http://lo/v1/models").await;
+	assert_eq!(res.status(), StatusCode::OK);
+	let models: Value =
+		serde_json::from_slice(&read_body_raw(res.into_body()).await).expect("models JSON");
+	assert_eq!(models["object"], "list");
+	let model_ids = models["data"]
+		.as_array()
+		.expect("model list")
+		.iter()
+		.map(|model| model["id"].as_str().expect("model id"))
+		.collect::<Vec<_>>();
+	assert_eq!(model_ids, vec!["public-model"]);
+
+	let mut request_body: Value = serde_json::from_slice(include_bytes!(
+		"../llm/tests/requests/completions/basic.json"
+	))
+	.expect("request JSON");
+	request_body["model"] = json!("public-model");
+	let request_body = serde_json::to_vec(&request_body).expect("serialized request");
+
+	let res = send_request_body(
+		io.clone(),
+		Method::POST,
+		"http://lo/v1/chat/completions",
+		&request_body,
+	)
+	.await;
+	assert_eq!(res.status(), StatusCode::OK);
+	read_body_raw(res.into_body()).await;
+
+	let upstream_requests = mock.received_requests().await.expect("upstream requests");
+	assert_eq!(upstream_requests.len(), 1);
+	let upstream_body: Value =
+		serde_json::from_slice(&upstream_requests[0].body).expect("upstream request JSON");
+	assert_eq!(upstream_body["model"], "real-model");
+	assert_eq!(
+		upstream_requests[0]
+			.headers
+			.get("x-user-model")
+			.expect("user model header")
+			.to_str()
+			.expect("user model header value"),
+		"public-model"
+	);
+
+	let missing = json!({
+		"model": "missing-model",
+		"messages": [{"role": "user", "content": "hi"}]
+	});
+	let res = send_request_body(
+		io,
+		Method::POST,
+		"http://lo/v1/chat/completions",
+		&serde_json::to_vec(&missing).expect("serialized missing request"),
+	)
+	.await;
+	assert_eq!(res.status(), StatusCode::NOT_FOUND);
+	let missing_body: Value =
+		serde_json::from_slice(&read_body_raw(res.into_body()).await).expect("missing model JSON");
+	assert_eq!(missing_body["error"]["code"], "model_not_found");
+	assert_eq!(
+		mock
+			.received_requests()
+			.await
+			.expect("upstream requests")
+			.len(),
+		1
+	);
+}
+
 #[tokio::test]
 async fn llm_custom_rerank() {
 	let mock = body_mock(include_bytes!("../llm/tests/response/cohere/rerank.json")).await;
@@ -3778,6 +3946,7 @@ async fn waypoint_http_port_selects_distinct_backend() {
 			method: None,
 			query: vec![],
 		}],
+		llm_router: None,
 		inline_policies: vec![],
 		backends: vec![crate::types::agent::RouteBackendReference {
 			weight: 1,

--- a/crates/agentgateway/src/proxy/gateway_test.rs
+++ b/crates/agentgateway/src/proxy/gateway_test.rs
@@ -1319,28 +1319,6 @@ async fn llm_openai_tokenize() {
 	.await;
 }
 
-async fn setup_local_llm_config(yaml: &str) -> TestBind {
-	let t = setup_proxy_test("{}").unwrap();
-	let normalized = crate::types::local::NormalizedLocalConfig::from(
-		t.pi.cfg.as_ref(),
-		t.pi.upstream.clone(),
-		t.pi.cfg.gateway(),
-		yaml,
-	)
-	.await
-	.expect("local config normalizes");
-	t.pi.stores.binds.sync_local(
-		normalized.binds,
-		normalized.listener_routes,
-		normalized.listener_tcp_routes,
-		normalized.policies,
-		normalized.backends,
-		normalized.route_groups,
-		Default::default(),
-	);
-	t
-}
-
 async fn setup_local_llm_config_with_user_model_header(yaml: &str) -> TestBind {
 	let t = setup_proxy_test("{}").unwrap();
 	let mut normalized = crate::types::local::NormalizedLocalConfig::from(
@@ -1374,7 +1352,7 @@ async fn setup_local_llm_config_with_user_model_header(yaml: &str) -> TestBind {
 	route
 		.inline_policies
 		.push(crate::types::agent::TrafficPolicy::Transformation(
-			Arc::new(transformation),
+			crate::store::RequestPolicy::single(transformation),
 		));
 	t.pi.stores.binds.sync_local(
 		normalized.binds,

--- a/crates/agentgateway/src/proxy/gateway_test.rs
+++ b/crates/agentgateway/src/proxy/gateway_test.rs
@@ -1319,6 +1319,28 @@ async fn llm_openai_tokenize() {
 	.await;
 }
 
+async fn setup_local_llm_config(yaml: &str) -> TestBind {
+	let t = setup_proxy_test("{}").unwrap();
+	let normalized = crate::types::local::NormalizedLocalConfig::from(
+		t.pi.cfg.as_ref(),
+		t.pi.upstream.clone(),
+		t.pi.cfg.gateway(),
+		yaml,
+	)
+	.await
+	.expect("local config normalizes");
+	t.pi.stores.binds.sync_local(
+		normalized.binds,
+		normalized.listener_routes,
+		normalized.listener_tcp_routes,
+		normalized.policies,
+		normalized.backends,
+		normalized.route_groups,
+		Default::default(),
+	);
+	t
+}
+
 async fn setup_local_llm_config_with_user_model_header(yaml: &str) -> TestBind {
 	let t = setup_proxy_test("{}").unwrap();
 	let mut normalized = crate::types::local::NormalizedLocalConfig::from(
@@ -1462,6 +1484,62 @@ llm:
 			.expect("upstream requests")
 			.len(),
 		1
+	);
+}
+
+#[tokio::test]
+async fn llm_conditional_virtual_model_no_match_returns_json_error() {
+	let mock = body_mock(include_bytes!(
+		"../llm/tests/response/completions/basic.json"
+	))
+	.await;
+	let config = format!(
+		r#"
+llm:
+  port: 4000
+  models:
+  - name: real-model
+    visibility: internal
+    provider: openAI
+    params:
+      baseUrl: http://{}
+  virtualModels:
+  - name: public-model
+    routing:
+      conditional:
+        targets:
+        - model: real-model
+          when: request.headers["x-use-model"] == "true"
+"#,
+		mock.address()
+	);
+	let t = setup_local_llm_config(&config).await;
+	let io = t.serve_http(strng::literal!("bind/4000"));
+	let request_body = json!({
+		"model": "public-model",
+		"messages": [{"role": "user", "content": "hi"}]
+	});
+
+	let res = send_request_body(
+		io,
+		Method::POST,
+		"http://lo/v1/chat/completions",
+		&serde_json::to_vec(&request_body).expect("serialized request"),
+	)
+	.await;
+
+	assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+	let body: Value =
+		serde_json::from_slice(&read_body_raw(res.into_body()).await).expect("error JSON");
+	assert_eq!(body["error"]["code"], "virtual_model_no_matching_target");
+	assert_eq!(body["error"]["type"], "invalid_request_error");
+	assert_eq!(
+		mock
+			.received_requests()
+			.await
+			.expect("upstream requests")
+			.len(),
+		0
 	);
 }
 

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -805,6 +805,31 @@ impl HTTPProxy {
 			None
 		};
 
+		let mut route_inline_policy_storage;
+		let route_inlines = if let Some(selected_llm_backend) = &selected_llm_backend {
+			// LLM routing may add route policies to the final selected route. Clone the
+			// inline policy lists so we can append those policies without mutating config.
+			route_inline_policy_storage = selected_route_chain
+				.routes
+				.iter()
+				.map(|route| route.inline_policies.clone())
+				.collect::<Vec<_>>();
+			if let Some(inline_policies) = route_inline_policy_storage.last_mut() {
+				inline_policies.extend(selected_llm_backend.route_policies.clone());
+			}
+			route_inline_policy_storage
+				.iter()
+				.map(Vec::as_slice)
+				.collect::<Vec<_>>()
+		} else {
+			// Most requests do not use LLM routing, so borrow the existing inline policy
+			// lists directly and avoid cloning policy config.
+			selected_route_chain
+				.routes
+				.iter()
+				.map(|route| route.inline_policies.as_slice())
+				.collect()
+		};
 		let route_path = RoutePath {
 			listener: &selected_listener.name,
 			service: selected_route_chain
@@ -816,19 +841,9 @@ impl HTTPProxy {
 				.iter()
 				.map(|route| &route.name)
 				.collect(),
+			route_inlines,
 		};
-		let route_policies = inputs.stores.read_binds().route_policies(
-			&route_path,
-			selected_route_chain
-				.routes
-				.iter()
-				.flat_map(|route| route.inline_policies.iter())
-				.chain(
-					selected_llm_backend
-						.iter()
-						.flat_map(|backend| backend.route_policies.iter()),
-				),
-		);
+		let route_policies = inputs.stores.read_binds().route_policies(&route_path);
 		// Register all expressions
 		route_policies.register_cel_expressions(log.cel.ctx());
 		let mut route_retry = route_policies.retry.select("retry", &req);

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -29,7 +29,9 @@ use crate::http::{
 	Authority, HeaderName, HeaderValue, Request, Response, Scheme, StatusCode, Uri, auth, filters,
 	merge_in_headers, retry,
 };
-use crate::llm::{InputFormat, LLMInfo, LLMRequest, LLMResponse, RequestResult, RouteType};
+use crate::llm::{
+	InputFormat, LLMInfo, LLMRequest, LLMResponse, RequestResult, RouteType, model_router,
+};
 use crate::proxy::tcpproxy::TCPProxy;
 use crate::proxy::{
 	ProxyError, ProxyResponse, ProxyResponseReason, WaypointService, dtrace, resolve_simple_backend,
@@ -792,6 +794,22 @@ impl HTTPProxy {
 
 		debug!(bind=%bind_name, listener=%selected_listener.key, route=%selected_route.key, "selected route");
 
+		let selected_llm_backend = if let Some(router) = &selected_route.llm_router {
+			match router
+				.resolve(&mut req)
+				.await
+				.map_err(|err| ProxyError::Processing(err.into()))
+				.snapshot_on_err(log, &mut req)?
+			{
+				model_router::ResolveResult::DirectResponse(resp) => {
+					return Err(ProxyResponse::DirectResponse(Box::new(resp))).snapshot_on_err(log, &mut req);
+				},
+				model_router::ResolveResult::Backend(backend) => Some(backend),
+			}
+		} else {
+			None
+		};
+
 		let route_path = RoutePath {
 			listener: &selected_listener.name,
 			service: selected_route_chain
@@ -804,16 +822,18 @@ impl HTTPProxy {
 				.map(|route| &route.name)
 				.collect(),
 		};
-		let route_inline_policies = selected_route_chain
-			.routes
-			.iter()
-			.map(|route| route.inline_policies.as_slice())
-			.collect::<Vec<_>>();
-
-		let route_policies = inputs
-			.stores
-			.read_binds()
-			.route_policies(&route_path, &route_inline_policies);
+		let route_policies = inputs.stores.read_binds().route_policies(
+			&route_path,
+			selected_route_chain
+				.routes
+				.iter()
+				.flat_map(|route| route.inline_policies.iter())
+				.chain(
+					selected_llm_backend
+						.iter()
+						.flat_map(|backend| backend.route_policies.iter()),
+				),
+		);
 		// Register all expressions
 		route_policies.register_cel_expressions(log.cel.ctx());
 		let mut route_retry = route_policies.retry.select("retry", &req);
@@ -849,8 +869,9 @@ impl HTTPProxy {
 		.snapshot_on_err(log, &mut req)?;
 		dtrace::snapshot!(Request, "route policies", &req);
 
-		let selected_backend_ref = selected_route_chain
-			.backend
+		let selected_backend_ref = selected_llm_backend
+			.map(|selected| selected.backend)
+			.or(selected_route_chain.backend)
 			.ok_or(ProxyError::NoValidBackends)
 			.snapshot_on_err(log, &mut req)?;
 		let selected_backend =
@@ -3765,6 +3786,7 @@ mod route_chain_tests {
 				target,
 				inline_policies: Vec::new(),
 			}],
+			llm_router: None,
 			inline_policies: Vec::new(),
 		}
 	}
@@ -3788,6 +3810,7 @@ mod route_chain_tests {
 				query: Vec::new(),
 			}],
 			backends: Vec::new(),
+			llm_router: None,
 			inline_policies: Vec::new(),
 		}
 	}

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -795,12 +795,7 @@ impl HTTPProxy {
 		debug!(bind=%bind_name, listener=%selected_listener.key, route=%selected_route.key, "selected route");
 
 		let selected_llm_backend = if let Some(router) = &selected_route.llm_router {
-			match router
-				.resolve(&mut req)
-				.await
-				.map_err(ProxyError::Processing)
-				.snapshot_on_err(log, &mut req)?
-			{
+			match router.resolve(&mut req).await {
 				model_router::ResolveResult::DirectResponse(resp) => {
 					return Err(ProxyResponse::DirectResponse(Box::new(resp))).snapshot_on_err(log, &mut req);
 				},

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -798,7 +798,7 @@ impl HTTPProxy {
 			match router
 				.resolve(&mut req)
 				.await
-				.map_err(|err| ProxyError::Processing(err.into()))
+				.map_err(ProxyError::Processing)
 				.snapshot_on_err(log, &mut req)?
 			{
 				model_router::ResolveResult::DirectResponse(resp) => {

--- a/crates/agentgateway/src/proxy/locality_test.rs
+++ b/crates/agentgateway/src/proxy/locality_test.rs
@@ -795,6 +795,7 @@ fn service_route() -> Route {
 			method: None,
 			query: vec![],
 		}],
+		llm_router: None,
 		inline_policies: Default::default(),
 		backends: vec![RouteBackendReference {
 			weight: 1,

--- a/crates/agentgateway/src/proxy/tcpproxy.rs
+++ b/crates/agentgateway/src/proxy/tcpproxy.rs
@@ -159,6 +159,7 @@ impl TCPProxy {
 			routes: vec![&selected_route.name],
 			service: selected_route.service_key.as_ref(),
 			listener: &selected_listener.name,
+			route_inlines: vec![&[]],
 		};
 
 		debug!(bind=%bind_name, listener=%selected_listener.key, route=%selected_route.key, "selected route");

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -726,7 +726,11 @@ impl Store {
 		tokio_stream::wrappers::UnboundedReceiverStream::new(sub)
 	}
 
-	pub fn route_policies(&self, path: &RoutePath<'_>, inline: &[&[TrafficPolicy]]) -> RoutePolicies {
+	pub fn route_policies<'a>(
+		&self,
+		path: &RoutePath<'_>,
+		inline: impl IntoIterator<Item = &'a TrafficPolicy>,
+	) -> RoutePolicies {
 		let listener = &path.listener;
 		let gateway = self
 			.policies_by_target
@@ -739,7 +743,7 @@ impl Store {
 			.and_then(|s| self.policies_by_target.get(&s.as_policy_target_ref()));
 
 		let mut route_rules = Vec::new();
-		for (idx, route) in path.routes.iter().enumerate() {
+		for route in &path.routes {
 			route_rules.extend(
 				self
 					.policies_by_target
@@ -766,15 +770,8 @@ impl Store {
 							.map(|inner| (p.inheritance, inner))
 					}),
 			);
-			route_rules.extend(
-				inline
-					.get(idx)
-					.copied()
-					.unwrap_or_default()
-					.iter()
-					.map(|p| (PolicyInheritance::Default, p)),
-			);
 		}
+		route_rules.extend(inline.into_iter().map(|p| (PolicyInheritance::Default, p)));
 
 		let shared_rules = gateway
 			.iter()
@@ -2064,6 +2061,7 @@ mod tests {
 			},
 			hostnames: vec![],
 			matches: vec![],
+			llm_router: None,
 			inline_policies: vec![],
 			backends: vec![],
 		};

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -497,6 +497,7 @@ pub struct RoutePath<'a> {
 	// the originally intended service, pre-routing
 	pub service: Option<&'a NamespacedHostname>,
 	pub routes: Vec<&'a RouteName>,
+	pub route_inlines: Vec<&'a [TrafficPolicy]>,
 }
 
 impl<'a> RoutePath<'a> {
@@ -726,11 +727,7 @@ impl Store {
 		tokio_stream::wrappers::UnboundedReceiverStream::new(sub)
 	}
 
-	pub fn route_policies<'a>(
-		&self,
-		path: &RoutePath<'_>,
-		inline: impl IntoIterator<Item = &'a TrafficPolicy>,
-	) -> RoutePolicies {
+	pub fn route_policies(&self, path: &RoutePath<'_>) -> RoutePolicies {
 		let listener = &path.listener;
 		let gateway = self
 			.policies_by_target
@@ -743,7 +740,7 @@ impl Store {
 			.and_then(|s| self.policies_by_target.get(&s.as_policy_target_ref()));
 
 		let mut route_rules = Vec::new();
-		for route in &path.routes {
+		for (idx, route) in path.routes.iter().enumerate() {
 			route_rules.extend(
 				self
 					.policies_by_target
@@ -770,8 +767,10 @@ impl Store {
 							.map(|inner| (p.inheritance, inner))
 					}),
 			);
+			if let Some(inline) = path.route_inlines.get(idx) {
+				route_rules.extend(inline.iter().map(|p| (PolicyInheritance::Default, p)));
+			}
 		}
-		route_rules.extend(inline.into_iter().map(|p| (PolicyInheritance::Default, p)));
 
 		let shared_rules = gateway
 			.iter()
@@ -2170,14 +2169,12 @@ mod tests {
 			"route with route_group_key must not also live in service-keyed routes",
 		);
 
-		let pols = store.route_policies(
-			&RoutePath {
-				listener: &listener,
-				service: in_group.service_key.as_ref(),
-				routes: vec![&in_group.name],
-			},
-			&[],
-		);
+		let pols = store.route_policies(&RoutePath {
+			listener: &listener,
+			service: in_group.service_key.as_ref(),
+			routes: vec![&in_group.name],
+			route_inlines: vec![&[]],
+		});
 		assert_eq!(
 			pols
 				.timeout
@@ -2320,14 +2317,12 @@ mod tests {
 		let http_timeout = insert_route_timeout_policy(&mut store, "p-http", http_route.clone(), 1);
 		let grpc_timeout = insert_route_timeout_policy(&mut store, "p-grpc", grpc_route.clone(), 2);
 
-		let http_pols = store.route_policies(
-			&RoutePath {
-				listener: &listener,
-				service: None,
-				routes: vec![&http_route],
-			},
-			&[],
-		);
+		let http_pols = store.route_policies(&RoutePath {
+			listener: &listener,
+			service: None,
+			routes: vec![&http_route],
+			route_inlines: vec![&[]],
+		});
 		assert_eq!(
 			http_pols
 				.timeout
@@ -2337,14 +2332,12 @@ mod tests {
 			Some(http_timeout)
 		);
 
-		let grpc_pols = store.route_policies(
-			&RoutePath {
-				listener: &listener,
-				service: None,
-				routes: vec![&grpc_route],
-			},
-			&[],
-		);
+		let grpc_pols = store.route_policies(&RoutePath {
+			listener: &listener,
+			service: None,
+			routes: vec![&grpc_route],
+			route_inlines: vec![&[]],
+		});
 		assert_eq!(
 			grpc_pols
 				.timeout
@@ -2366,14 +2359,44 @@ mod tests {
 			insert_route_timeout_policy(&mut store, "p-parent", parent_route.clone(), 1);
 		let child_timeout = insert_route_timeout_policy(&mut store, "p-child", child_route.clone(), 2);
 
-		let pols = store.route_policies(
-			&RoutePath {
-				listener: &listener,
-				service: None,
-				routes: vec![&parent_route, &child_route],
-			},
-			&[],
+		let pols = store.route_policies(&RoutePath {
+			listener: &listener,
+			service: None,
+			routes: vec![&parent_route, &child_route],
+			route_inlines: vec![&[], &[]],
+		});
+
+		assert_ne!(parent_timeout, child_timeout);
+		assert_eq!(
+			pols
+				.timeout
+				.select("timeout", &request_for_policy_selection())
+				.as_deref()
+				.cloned(),
+			Some(child_timeout)
 		);
+	}
+
+	#[test]
+	fn route_policies_preserve_inline_policy_route_specificity() {
+		let mut store = Store::default();
+		let listener = listener();
+		let parent_route = route("parent", "ns", Some("HTTPRoute"));
+		let child_route = route("child", "ns", Some("HTTPRoute"));
+
+		let parent_timeout = timeout::Policy {
+			request_timeout: Some(Duration::from_secs(1)),
+			backend_request_timeout: None,
+		};
+		let child_timeout = insert_route_timeout_policy(&mut store, "p-child", child_route.clone(), 2);
+		let parent_inline = [TrafficPolicy::Timeout(parent_timeout.clone())];
+
+		let pols = store.route_policies(&RoutePath {
+			listener: &listener,
+			service: None,
+			routes: vec![&parent_route, &child_route],
+			route_inlines: vec![&parent_inline, &[]],
+		});
 
 		assert_ne!(parent_timeout, child_timeout);
 		assert_eq!(
@@ -2428,14 +2451,12 @@ mod tests {
 			TrafficPolicy::HostRewrite(agent::HostRedirectOverride::Auto),
 		);
 
-		let pols = store.route_policies(
-			&RoutePath {
-				listener: &listener,
-				service: None,
-				routes: vec![&route],
-			},
-			&[],
-		);
+		let pols = store.route_policies(&RoutePath {
+			listener: &listener,
+			service: None,
+			routes: vec![&route],
+			route_inlines: vec![&[]],
+		});
 
 		assert_ne!(gateway_timeout, route_timeout);
 		assert_eq!(

--- a/crates/agentgateway/src/test_helpers/proxymock.rs
+++ b/crates/agentgateway/src/test_helpers/proxymock.rs
@@ -241,6 +241,7 @@ pub fn basic_named_route(target: Strng) -> Route {
 			method: None,
 			query: vec![],
 		}],
+		llm_router: None,
 		inline_policies: Default::default(),
 		backends: vec![RouteBackendReference {
 			weight: 1,

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -685,6 +685,9 @@ pub struct Route {
 	pub matches: Vec<RouteMatch>,
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub backends: Vec<RouteBackendReference>,
+	#[serde(default, skip_serializing_if = "Option::is_none", skip_deserializing)]
+	#[cfg_attr(feature = "schema", schemars(skip))]
+	pub llm_router: Option<Arc<llm::model_router::ModelRouter>>,
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub inline_policies: Vec<TrafficPolicy>,
 }
@@ -2810,6 +2813,7 @@ mod tests {
 			hostnames: hostnames.into_iter().map(strng::new).collect(),
 			matches,
 			backends: vec![],
+			llm_router: None,
 			inline_policies: vec![],
 		}
 	}

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -686,7 +686,6 @@ pub struct Route {
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub backends: Vec<RouteBackendReference>,
 	#[serde(default, skip_serializing_if = "Option::is_none", skip_deserializing)]
-	#[cfg_attr(feature = "schema", schemars(skip))]
 	pub llm_router: Option<Arc<llm::model_router::ModelRouter>>,
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub inline_policies: Vec<TrafficPolicy>,

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -2279,7 +2279,6 @@ fn traffic_policy_from_proto(
 					})
 					.collect::<Result<_, ProtoError>>()?,
 				status: StatusCode::from_u16(dr.status as u16)?,
-				authorization_filtered_model_list: None,
 			}))
 		},
 		Some(tps::Kind::Cors(c)) => TrafficPolicy::CORS(RequestPolicy::single(

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -1231,6 +1231,7 @@ impl Route {
 				.iter()
 				.map(|backend| route_backend_reference_from_proto(backend, diagnostics))
 				.collect::<Result<Vec<_>, _>>()?,
+			llm_router: None,
 			inline_policies: s
 				.traffic_policies
 				.iter()

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -2,7 +2,9 @@ use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::path::PathBuf;
 use std::sync::{Arc, OnceLock};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::Duration;
+#[cfg(not(test))]
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use ::http::Uri;
 use agent_core::prelude::Strng;
@@ -2628,6 +2630,9 @@ async fn convert_llm_config(
 	};
 
 	// Get static startup unix timestamp
+	#[cfg(test)]
+	let startup_timestamp = 0;
+	#[cfg(not(test))]
 	let startup_timestamp = *STARTUP_TIMESTAMP.get_or_init(|| {
 		SystemTime::now()
 			.duration_since(UNIX_EPOCH)

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -320,10 +320,17 @@ pub struct LocalLLMVirtualModel {
 
 #[apply(schema_de!)]
 pub struct LocalLLMVirtualModelRouting {
+	/// weighted enables weight-based selection of the target model.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	weighted: Option<LocalLLMWeightedRouting>,
+	/// failover enables priority-based selection of the target model.
+	/// Within a priority level, the best provider is selected by a composite score factoring in health
+	/// and latency.
+	/// If all models within a priority level are degraded, requests will move onto the next priority group.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	failover: Option<LocalLLMFailoverRouting>,
+	/// Conditional enables condition-based selection of the target model. Each condition is evaluated
+	/// in order until the best match is found.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	conditional: Option<LocalLLMConditionalRouting>,
 }
@@ -556,8 +563,11 @@ pub struct LocalLLMModels {
 	/// will be used in the request to the LLM provider. If not, the incoming model is used.
 	name: String,
 	/// visibility controls whether clients can request this model directly (rather than only via a `virtualModel`).
-	#[serde(default, skip_serializing_if = "LocalLLMModelVisibility::is_public")]
-	visibility: LocalLLMModelVisibility,
+	#[serde(
+		default,
+		skip_serializing_if = "llm::model_router::ModelVisibility::is_public"
+	)]
+	visibility: llm::model_router::ModelVisibility,
 	/// params customizes parameters for the outgoing request
 	#[serde(default)]
 	params: LocalLLMParams,
@@ -612,22 +622,6 @@ pub struct LocalLLMModels {
 	/// matches specifies the conditions under which this model should be used in addition to matching the model name.
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	matches: Vec<LLMRouteMatch>,
-}
-
-#[apply(schema_enum!)]
-#[derive(Default)]
-pub enum LocalLLMModelVisibility {
-	/// Public models can be requested directly by clients and are included in the model list.
-	#[default]
-	Public,
-	/// Internal models can be targeted by virtual models but cannot be requested directly.
-	Internal,
-}
-
-impl LocalLLMModelVisibility {
-	fn is_public(&self) -> bool {
-		matches!(self, Self::Public)
-	}
 }
 
 #[apply(schema_de!)]
@@ -2476,11 +2470,12 @@ impl ResolvedLLMModelRegistry {
 		bail!("virtual model target {target} does not match any llm.models entry")
 	}
 
-	fn resolve_without_authorization(&self, target: &str) -> anyhow::Result<ResolvedLLMModelTarget> {
+	fn resolve_failover_target(&self, target: &str) -> anyhow::Result<ResolvedLLMModelTarget> {
 		let resolved = self.resolve(target)?;
 		if resolved.authorization.is_some() {
+			// Technically this is possible but would require us to move authorization down into post-LB.
 			bail!(
-				"virtual model target {target} has authorization; only conditional virtual models can target authorized models"
+				"virtual model target {target} has authorization; failover virtual models cannot target authorized models"
 			);
 		}
 		Ok(resolved)
@@ -2584,7 +2579,9 @@ async fn convert_llm_config(
 			local_rate_limit,
 			remote_rate_limit,
 		} = pol;
+		// Guardrail is per-model config, but we let users configure it top level. Pull it out here.
 		shared_prompt_guard = guardrails;
+		// Rate limit is applied per-route as well. Resolve them here.
 		let route_policies = split_policies(
 			client.clone(),
 			FilterOrPolicy {
@@ -2596,6 +2593,8 @@ async fn convert_llm_config(
 			None,
 		)
 		.await?;
+
+		// Rest of policies are PreRoute gateway policies; resolve these to our listener.
 		let gateway_policies: FilterOrPolicy = gateway.into();
 		let gateway_policies = split_policies(
 			client.clone(),
@@ -2775,7 +2774,6 @@ async fn convert_llm_config(
 			}),
 			LocalModelAIProvider::Vertex => AIProvider::Vertex(crate::llm::vertex::Provider {
 				model,
-
 				region: p.vertex_region,
 				project_id: p.vertex_project.context("vertex requires vertex_project")?,
 			}),
@@ -2887,11 +2885,7 @@ async fn convert_llm_config(
 		}
 		router_models.push(llm::model_router::ModelRoute {
 			name: model_config.name.clone(),
-			visibility: if model_config.visibility.is_public() {
-				llm::model_router::ModelVisibility::Public
-			} else {
-				llm::model_router::ModelVisibility::Internal
-			},
+			visibility: model_config.visibility,
 			header_matches: model_config
 				.matches
 				.iter()
@@ -2928,7 +2922,7 @@ async fn convert_llm_config(
 			},
 			LocalLLMVirtualRoutingStrategy::Weighted(weighted) => {
 				for target in &weighted.targets {
-					resolved_models.resolve_without_authorization(&target.model)?;
+					resolved_models.resolve(&target.model)?;
 				}
 				llm::model_router::VirtualModelRouting::Weighted(
 					weighted
@@ -2951,7 +2945,7 @@ async fn convert_llm_config(
 					.map(|(_, targets)| {
 						targets
 							.map(|target| {
-								let resolved = resolved_models.resolve_without_authorization(&target.model)?;
+								let resolved = resolved_models.resolve_failover_target(&target.model)?;
 								let mut provider = resolved.provider.clone();
 								provider.name = strng::new(&target.model);
 								ensure_ai_provider_model(&mut provider.provider, &target.model);

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -2271,6 +2271,17 @@ fn llm_model_match_specificity(model_name: &str) -> usize {
 	model_name.chars().filter(|c| *c != '*').count()
 }
 
+fn validate_llm_model_pattern(pattern: &str) -> anyhow::Result<()> {
+	let wildcard_count = pattern.chars().filter(|c| *c == '*').count();
+	if wildcard_count > 1 {
+		bail!("model name wildcard may only appear once: '{pattern}'");
+	}
+	if wildcard_count == 1 && pattern != "*" && !pattern.starts_with('*') && !pattern.ends_with('*') {
+		bail!("model name wildcard must be either at the beginning or the end: '{pattern}'");
+	}
+	Ok(())
+}
+
 fn merge_prompt_guards(
 	shared: Option<PromptGuard>,
 	model: Option<PromptGuard>,
@@ -2310,6 +2321,7 @@ enum LocalLLMVirtualRoutingStrategy<'a> {
 }
 
 fn llm_model_matches(pattern: &str, model: &str) -> anyhow::Result<bool> {
+	validate_llm_model_pattern(pattern)?;
 	if pattern == "*" {
 		return Ok(true);
 	}
@@ -2318,9 +2330,6 @@ fn llm_model_matches(pattern: &str, model: &str) -> anyhow::Result<bool> {
 	}
 	if let Some(suffix) = pattern.strip_prefix('*') {
 		return Ok(model.ends_with(suffix));
-	}
-	if pattern.contains('*') {
-		bail!("model name wildcard must be either at the beginning or the end: '{pattern}'");
 	}
 	Ok(pattern == model)
 }
@@ -2408,8 +2417,16 @@ impl LocalLLMModelRegistry {
 			models,
 			virtual_models,
 		};
+		registry.validate_model_patterns()?;
 		registry.validate_virtual_models()?;
 		Ok(registry)
+	}
+
+	fn validate_model_patterns(&self) -> anyhow::Result<()> {
+		for model in &self.models {
+			validate_llm_model_pattern(&model.name)?;
+		}
+		Ok(())
 	}
 
 	fn model_matches(&self, target: &str) -> anyhow::Result<bool> {

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -300,9 +300,79 @@ pub struct LocalLLMConfig {
 	/// model in the users request that is matched; the model sent to the actual LLM can be overridden
 	/// on a per-model basis.
 	models: Vec<LocalLLMModels>,
+	/// virtualModels defines a set of models that can be served from the gateway. The model name refers to the
+	/// model in the users request that is matched. However, unlike the `models` field, virtual models will
+	/// dynamically route to a specific model (configured in `models`) based on the configured logic.
+	#[serde(
+		default,
+		rename = "virtualModels",
+		skip_serializing_if = "Vec::is_empty"
+	)]
+	virtual_models: Vec<LocalLLMVirtualModel>,
 	/// policies defines policies for handling incoming requests, before a model is selected
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	policies: Option<LocalLLMPolicy>,
+}
+
+#[apply(schema_de!)]
+pub struct LocalLLMVirtualModel {
+	/// name is the public model name clients request.
+	name: String,
+	/// routing selects an existing LLM model backend for each request.
+	routing: LocalLLMVirtualModelRouting,
+}
+
+#[apply(schema_de!)]
+pub struct LocalLLMVirtualModelRouting {
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	weighted: Option<LocalLLMWeightedRouting>,
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	failover: Option<LocalLLMFailoverRouting>,
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	conditional: Option<LocalLLMConditionalRouting>,
+}
+
+#[apply(schema_de!)]
+pub struct LocalLLMWeightedRouting {
+	/// targets are existing model names or names matched by wildcard model entries.
+	targets: Vec<LocalLLMWeightedTarget>,
+}
+
+#[apply(schema_de!)]
+pub struct LocalLLMWeightedTarget {
+	/// model is resolved against llm.models using the same wildcard matching as client requests.
+	model: String,
+	#[serde(default = "default_weight")]
+	weight: usize,
+}
+
+#[apply(schema_de!)]
+pub struct LocalLLMFailoverRouting {
+	/// targets are grouped by priority. Lower priority values are tried first.
+	targets: Vec<LocalLLMFailoverTarget>,
+}
+
+#[apply(schema_de!)]
+pub struct LocalLLMFailoverTarget {
+	/// model is resolved against llm.models using the same wildcard matching as client requests.
+	model: String,
+	/// priority groups targets for failover. Lower values are preferred.
+	priority: usize,
+}
+
+#[apply(schema_de!)]
+pub struct LocalLLMConditionalRouting {
+	/// targets are evaluated in order. The first matching condition selects the model.
+	targets: Vec<LocalLLMConditionalTarget>,
+}
+
+#[apply(schema_de!)]
+pub struct LocalLLMConditionalTarget {
+	/// when must evaluate to true for this target to be selected. Omit only on the final fallback target.
+	#[serde(default)]
+	when: Option<Arc<cel::Expression>>,
+	/// model is resolved against llm.models using the same wildcard matching as client requests.
+	model: String,
 }
 
 #[apply(schema_de!)]
@@ -489,6 +559,9 @@ pub struct LocalLLMModels {
 	/// name is the name of the model we are matching from a users request. If params.model is set, that
 	/// will be used in the request to the LLM provider. If not, the incoming model is used.
 	name: String,
+	/// visibility controls whether clients can request this model directly (rather than only via a `virtualModel`).
+	#[serde(default, skip_serializing_if = "LocalLLMModelVisibility::is_public")]
+	visibility: LocalLLMModelVisibility,
 	/// params customizes parameters for the outgoing request
 	#[serde(default)]
 	params: LocalLLMParams,
@@ -543,6 +616,22 @@ pub struct LocalLLMModels {
 	/// matches specifies the conditions under which this model should be used in addition to matching the model name.
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	matches: Vec<LLMRouteMatch>,
+}
+
+#[apply(schema_enum!)]
+#[derive(Default)]
+pub enum LocalLLMModelVisibility {
+	/// Public models can be requested directly by clients and are included in the model list.
+	#[default]
+	Public,
+	/// Internal models can be targeted by virtual models but cannot be requested directly.
+	Internal,
+}
+
+impl LocalLLMModelVisibility {
+	fn is_public(&self) -> bool {
+		matches!(self, Self::Public)
+	}
 }
 
 #[apply(schema_de!)]
@@ -2236,6 +2325,269 @@ fn merge_prompt_guards(
 	}
 }
 
+#[derive(Clone)]
+struct ResolvedLLMModelTarget {
+	name: String,
+	backend_key: Strng,
+	provider: NamedAIProvider,
+	inline_policies: Vec<BackendTrafficPolicy>,
+}
+
+fn llm_model_matches(pattern: &str, model: &str) -> anyhow::Result<bool> {
+	if pattern == "*" {
+		return Ok(true);
+	}
+	if let Some(prefix) = pattern.strip_suffix('*') {
+		return Ok(model.starts_with(prefix));
+	}
+	if let Some(suffix) = pattern.strip_prefix('*') {
+		return Ok(model.ends_with(suffix));
+	}
+	if pattern.contains('*') {
+		bail!("model name wildcard must be either at the beginning or the end: '{pattern}'");
+	}
+	Ok(pattern == model)
+}
+
+fn resolve_llm_model_target(
+	models: &[ResolvedLLMModelTarget],
+	target: &str,
+) -> anyhow::Result<ResolvedLLMModelTarget> {
+	for model in models {
+		if llm_model_matches(&model.name, target)? {
+			return Ok(model.clone());
+		}
+	}
+	bail!("virtual model target {target} does not match any llm.models entry")
+}
+
+fn validate_llm_virtual_model_target(
+	models: &[LocalLLMModels],
+	target: &str,
+) -> anyhow::Result<()> {
+	for model in models {
+		if llm_model_matches(&model.name, target)? {
+			return Ok(());
+		}
+	}
+	bail!("virtual model target {target} does not match any llm.models entry")
+}
+
+fn validate_llm_virtual_models(
+	virtual_models: &[LocalLLMVirtualModel],
+	models: &[LocalLLMModels],
+) -> anyhow::Result<()> {
+	for virtual_model in virtual_models {
+		let strategy_count = usize::from(virtual_model.routing.weighted.is_some())
+			+ usize::from(virtual_model.routing.failover.is_some())
+			+ usize::from(virtual_model.routing.conditional.is_some());
+		if strategy_count != 1 {
+			bail!(
+				"virtual model {} must specify exactly one routing strategy",
+				virtual_model.name
+			);
+		}
+		if let Some(conditional) = virtual_model.routing.conditional.as_ref() {
+			if conditional.targets.is_empty() {
+				bail!(
+					"virtual model {} must specify at least one conditional target",
+					virtual_model.name
+				);
+			}
+			if let Some(unconditional_idx) = conditional
+				.targets
+				.iter()
+				.position(|target| target.when.is_none())
+				&& unconditional_idx + 1 != conditional.targets.len()
+			{
+				bail!(
+					"virtual model {} conditional fallback target must be last",
+					virtual_model.name
+				);
+			}
+			for target in &conditional.targets {
+				validate_llm_virtual_model_target(models, &target.model)?;
+			}
+			continue;
+		}
+		if let Some(weighted) = virtual_model.routing.weighted.as_ref() {
+			if weighted.targets.is_empty() {
+				bail!(
+					"virtual model {} must specify at least one weighted target",
+					virtual_model.name
+				);
+			}
+			for target in &weighted.targets {
+				validate_llm_virtual_model_target(models, &target.model)?;
+			}
+			continue;
+		}
+		let failover = virtual_model
+			.routing
+			.failover
+			.as_ref()
+			.expect("strategy count checked");
+		if failover.targets.is_empty() {
+			bail!(
+				"virtual model {} must specify at least one failover target",
+				virtual_model.name
+			);
+		}
+		for target in &failover.targets {
+			validate_llm_virtual_model_target(models, &target.model)?;
+		}
+	}
+	Ok(())
+}
+
+fn llm_route_types(
+	passthrough: Option<&LocalLLMPassthrough>,
+) -> Vec<(Strng, crate::llm::RouteType)> {
+	if let Some(passthrough) = passthrough {
+		return vec![(strng::new("*"), passthrough.route_type())];
+	}
+	vec![
+		(
+			strng::new("/v1/chat/completions"),
+			crate::llm::RouteType::Completions,
+		),
+		(strng::new("/v1/messages"), crate::llm::RouteType::Messages),
+		// TODO: we could do this to support vertex calls. But we would need to extract the model name from the URL
+		(strng::new(":rawPredict"), crate::llm::RouteType::Messages),
+		(
+			strng::new(":streamRawPredict"),
+			crate::llm::RouteType::Messages,
+		),
+		(
+			strng::new("/v1/responses"),
+			crate::llm::RouteType::Responses,
+		),
+		(
+			strng::new("/v1/images/generations"),
+			crate::llm::RouteType::Detect,
+		),
+		(
+			strng::new("/v1/images/edits"),
+			crate::llm::RouteType::Detect,
+		),
+		(
+			strng::new("/v1/images/variations"),
+			crate::llm::RouteType::Detect,
+		),
+		(
+			strng::new("/v1/responses/compact"),
+			crate::llm::RouteType::Detect,
+		),
+		(
+			strng::new("/v1/embeddings"),
+			crate::llm::RouteType::Embeddings,
+		),
+		(strng::new("/v1/rerank"), crate::llm::RouteType::Rerank),
+		(strng::new("/v2/rerank"), crate::llm::RouteType::Rerank),
+		(strng::new("*"), crate::llm::RouteType::Passthrough),
+	]
+}
+
+fn virtual_target_model_body_transform_backend_policy(
+	target: &str,
+) -> anyhow::Result<BackendTrafficPolicy> {
+	let target = serde_json::to_string(target)?;
+	let body = format!(r#"coalesce(json(request.body).merge({{"model": {target}}}), request.body)"#);
+	let transformation = http::transformation_cel::Transformation::try_from_local_config(
+		LocalTransformationConfig {
+			request: Some(http::transformation_cel::LocalTransform {
+				metadata: Vec::new(),
+				set: vec![],
+				add: vec![],
+				remove: vec![],
+				body: Some(strng::new(body)),
+			}),
+			response: None,
+		},
+		true,
+	)?;
+	Ok(BackendTrafficPolicy::Transformation(Arc::new(
+		transformation,
+	)))
+}
+
+fn virtual_model_match_cel(pattern: &str, model_expr: &str) -> anyhow::Result<String> {
+	if pattern == "*" {
+		return Ok("true".to_string());
+	}
+	if let Some(prefix) = pattern.strip_suffix('*') {
+		return Ok(format!(
+			"{model_expr}.startsWith({})",
+			serde_json::to_string(prefix)?
+		));
+	}
+	if let Some(suffix) = pattern.strip_prefix('*') {
+		return Ok(format!(
+			"{model_expr}.endsWith({})",
+			serde_json::to_string(suffix)?
+		));
+	}
+	if pattern.contains('*') {
+		bail!("model name wildcard must be either at the beginning or the end: '{pattern}'");
+	}
+	Ok(format!(
+		"{model_expr} == {}",
+		serde_json::to_string(pattern)?
+	))
+}
+
+fn conditional_virtual_model_target_expr(
+	virtual_models: &[LocalLLMVirtualModel],
+) -> anyhow::Result<Option<String>> {
+	let mut branches = Vec::new();
+	let requested_model = "requestedModel";
+	for virtual_model in virtual_models {
+		let Some(conditional) = virtual_model.routing.conditional.as_ref() else {
+			continue;
+		};
+		let model_match = virtual_model_match_cel(&virtual_model.name, requested_model)?;
+		let mut target_expr = requested_model.to_string();
+		for target in conditional.targets.iter().rev() {
+			let target_model = serde_json::to_string(&target.model)?;
+			target_expr = match &target.when {
+				Some(condition) => format!(
+					"({}) ? {target_model} : ({target_expr})",
+					condition.original_expression
+				),
+				None => target_model,
+			};
+		}
+		branches.push(format!("({model_match}) ? ({target_expr})"));
+	}
+	if branches.is_empty() {
+		return Ok(None);
+	}
+	let body = {
+		let mut expr = requested_model.to_string();
+		for branch in branches.into_iter().rev() {
+			expr = format!("{branch} : ({expr})");
+		}
+		expr
+	};
+	// Conditional virtual models are selected before route matching. Bind the
+	// original requested model once, then compare every virtual model against
+	// that stable value.
+	Ok(Some(format!(
+		"({}).with({requested_model}, {body})",
+		llm_request_model_expression()
+	)))
+}
+
+fn llm_request_model_expression() -> &'static str {
+	r#"
+request.path.endsWith(":streamRawPredict") || request.path.endsWith(":rawPredict") ?
+	request.path.regexReplace("^.*/publishers/anthropic/models/(.+?):.*", "${1}") :
+	(request.path.endsWith("/invoke-with-response-stream") || request.path.endsWith("/invoke") ?
+	request.path.regexReplace("^.*/model/(.+?)/invoke.*", "${1}") :
+	json(request.body).model)
+"#
+}
+
 #[allow(deprecated)]
 async fn convert_llm_config(
 	client: client::Client,
@@ -2253,6 +2605,7 @@ async fn convert_llm_config(
 		port,
 		tls,
 		models,
+		virtual_models,
 		policies,
 	} = llm_config;
 	let port = port.unwrap_or(DEFAULT_LLM_PORT);
@@ -2296,26 +2649,28 @@ async fn convert_llm_config(
 		(vec![], vec![])
 	};
 
-	// Create transformation policy to set x-gateway-model-name header from request body
+	validate_llm_virtual_models(&virtual_models, &models)?;
+
+	let llm_model_expression = conditional_virtual_model_target_expr(&virtual_models)?
+		.unwrap_or_else(|| llm_request_model_expression().to_string());
+	let llm_model_body_expression = r#"coalesce(json(request.body).merge({"model": request.headers["x-gateway-model-name"]}), request.body)"#;
+
+	// Create transformation policy to set x-gateway-model-name header from request body.
+	// Conditional virtual models use this same pre-routing transform to select the
+	// concrete target. The header makes route matching choose that concrete model
+	// route; the body rewrite makes downstream LLM policy/transformation logic see
+	// the selected target instead of the public virtual model name.
 	let transformation = http::transformation_cel::Transformation::try_from_local_config(
 		LocalTransformationConfig {
 			request: Some(http::transformation_cel::LocalTransform {
 				metadata: Vec::new(),
 				set: vec![(
 					strng::new("x-gateway-model-name"),
-					strng::new(
-						r#"
-request.path.endsWith(":streamRawPredict") || request.path.endsWith(":rawPredict") ?
-	request.path.regexReplace("^.*/publishers/anthropic/models/(.+?):.*", "${1}") :
-	(request.path.endsWith("/invoke-with-response-stream") || request.path.endsWith("/invoke") ?
-	request.path.regexReplace("^.*/model/(.+?)/invoke.*", "${1}") :
-	json(request.body).model)
-"#,
-					),
+					strng::new(llm_model_expression),
 				)],
 				add: vec![],
 				remove: vec![],
-				body: None,
+				body: Some(strng::new(llm_model_body_expression)),
 			}),
 			response: None,
 		},
@@ -2339,6 +2694,15 @@ request.path.endsWith(":streamRawPredict") || request.path.endsWith(":rawPredict
 				created: startup_timestamp,
 				authorization: model.authorization.clone(),
 			})
+			.chain(
+				virtual_models
+					.iter()
+					.map(|model| filters::AuthorizationFilteredModelListEntry {
+						id: model.name.clone(),
+						created: startup_timestamp,
+						authorization: None,
+					}),
+			)
 			.collect::<Vec<_>>(),
 	);
 
@@ -2402,6 +2766,8 @@ request.path.endsWith(":streamRawPredict") || request.path.endsWith(":rawPredict
 		})
 		.collect_vec();
 
+	let mut resolved_models = Vec::new();
+
 	// Create routes and backends for each model
 	for (idx, (_, model_config)) in ordered_models.into_iter().enumerate() {
 		let mut model_config = model_config;
@@ -2412,50 +2778,7 @@ request.path.endsWith(":streamRawPredict") || request.path.endsWith(":rawPredict
 		let backend_key = strng::format!("llm:model:{}:{idx}", model_config.name);
 		let p = model_config.params.clone();
 		let model = p.model;
-		let llm_routes = if let Some(passthrough) = model_config.passthrough.as_ref() {
-			vec![(strng::new("*"), passthrough.route_type())]
-		} else {
-			vec![
-				(
-					strng::new("/v1/chat/completions"),
-					crate::llm::RouteType::Completions,
-				),
-				(strng::new("/v1/messages"), crate::llm::RouteType::Messages),
-				// TODO: we could do this to support vertex calls. But we would need to extract the model name from the URL
-				(strng::new(":rawPredict"), crate::llm::RouteType::Messages),
-				(
-					strng::new(":streamRawPredict"),
-					crate::llm::RouteType::Messages,
-				),
-				(
-					strng::new("/v1/responses"),
-					crate::llm::RouteType::Responses,
-				),
-				(
-					strng::new("/v1/images/generations"),
-					crate::llm::RouteType::Detect,
-				),
-				(
-					strng::new("/v1/images/edits"),
-					crate::llm::RouteType::Detect,
-				),
-				(
-					strng::new("/v1/images/variations"),
-					crate::llm::RouteType::Detect,
-				),
-				(
-					strng::new("/v1/responses/compact"),
-					crate::llm::RouteType::Detect,
-				),
-				(
-					strng::new("/v1/embeddings"),
-					crate::llm::RouteType::Embeddings,
-				),
-				(strng::new("/v1/rerank"), crate::llm::RouteType::Rerank),
-				(strng::new("/v2/rerank"), crate::llm::RouteType::Rerank),
-				(strng::new("*"), crate::llm::RouteType::Passthrough),
-			]
-		};
+		let llm_routes = llm_route_types(model_config.passthrough.as_ref());
 
 		// Use provider from config and set the model name
 		let provider = match &model_config.provider {
@@ -2644,6 +2967,7 @@ request.path.endsWith(":streamRawPredict") || request.path.endsWith(":rawPredict
 			tokenize: p.tokenize,
 			inline_policies: pols,
 		};
+		let resolved_provider = named_provider.clone();
 
 		let ai_backend = AIBackend {
 			providers: crate::types::loadbalancer::EndpointSet::new(vec![vec![(
@@ -2695,11 +3019,22 @@ request.path.endsWith(":streamRawPredict") || request.path.endsWith(":rawPredict
 			prompt_caching: model_config.prompt_caching.clone(),
 			routes: Default::default(),
 		})));
+		let resolved_inline_policies = pols.clone();
 		let backend_with_policies = BackendWithPolicies {
 			backend: Backend::AI(local_name(backend_key.clone()), ai_backend),
 			inline_policies: pols,
 		};
 		all_backends.push(backend_with_policies);
+		resolved_models.push(ResolvedLLMModelTarget {
+			name: model_config.name.clone(),
+			backend_key: backend_key.clone(),
+			provider: resolved_provider,
+			inline_policies: resolved_inline_policies,
+		});
+
+		if !model_config.visibility.is_public() {
+			continue;
+		}
 
 		// Create route for this model
 		// Index is needed because the same name can be used with different match criteria
@@ -2766,6 +3101,150 @@ request.path.endsWith(":streamRawPredict") || request.path.endsWith(":rawPredict
 			inline_policies: model_route_inline_policies,
 		};
 		routes.push(model_route);
+	}
+
+	for (idx, virtual_model) in virtual_models.into_iter().enumerate() {
+		let strategy_count = usize::from(virtual_model.routing.weighted.is_some())
+			+ usize::from(virtual_model.routing.failover.is_some())
+			+ usize::from(virtual_model.routing.conditional.is_some());
+		if strategy_count != 1 {
+			bail!(
+				"virtual model {} must specify exactly one routing strategy",
+				virtual_model.name
+			);
+		}
+		if let Some(conditional) = virtual_model.routing.conditional.as_ref() {
+			if conditional.targets.is_empty() {
+				bail!(
+					"virtual model {} must specify at least one conditional target",
+					virtual_model.name
+				);
+			}
+			if let Some(unconditional_idx) = conditional
+				.targets
+				.iter()
+				.position(|target| target.when.is_none())
+				&& unconditional_idx + 1 != conditional.targets.len()
+			{
+				bail!(
+					"virtual model {} conditional fallback target must be last",
+					virtual_model.name
+				);
+			}
+			for target in &conditional.targets {
+				resolve_llm_model_target(&resolved_models, &target.model)?;
+			}
+			continue;
+		}
+		let backends = if let Some(weighted) = virtual_model.routing.weighted.as_ref() {
+			if weighted.targets.is_empty() {
+				bail!(
+					"virtual model {} must specify at least one weighted target",
+					virtual_model.name
+				);
+			}
+			weighted
+				.targets
+				.iter()
+				.map(|target| {
+					let resolved = resolve_llm_model_target(&resolved_models, &target.model)?;
+					Ok(RouteBackendReference {
+						weight: target.weight,
+						target: BackendReference::Backend(strng::format!("/{}", resolved.backend_key)).into(),
+						// Weighted selection happens after the pre-routing transform, so rewrite
+						// the body model here to the concrete target picked by this backend ref.
+						inline_policies: vec![virtual_target_model_body_transform_backend_policy(
+							&target.model,
+						)?],
+					})
+				})
+				.collect::<anyhow::Result<Vec<_>>>()?
+		} else {
+			let failover = virtual_model
+				.routing
+				.failover
+				.as_ref()
+				.expect("strategy count checked");
+			if failover.targets.is_empty() {
+				bail!(
+					"virtual model {} must specify at least one failover target",
+					virtual_model.name
+				);
+			}
+			let provider_groups = failover
+				.targets
+				.iter()
+				.sorted_by_key(|target| target.priority)
+				.chunk_by(|target| target.priority)
+				.into_iter()
+				.map(|(_, targets)| {
+					targets
+						.map(|target| {
+							let resolved = resolve_llm_model_target(&resolved_models, &target.model)?;
+							let mut provider = resolved.provider.clone();
+							provider.name = strng::new(&target.model);
+							provider
+								.inline_policies
+								.extend(resolved.inline_policies.clone());
+							// Failover chooses a provider from these groups after route matching.
+							// Attach the target rewrite to each provider so the upstream request
+							// uses the concrete model that actually won failover selection.
+							provider
+								.inline_policies
+								.push(virtual_target_model_body_transform_backend_policy(
+									&target.model,
+								)?);
+							Ok((strng::new(&target.model), provider))
+						})
+						.collect::<anyhow::Result<Vec<_>>>()
+				})
+				.collect::<anyhow::Result<Vec<_>>>()?;
+			let backend_key = strng::format!("llm:virtual-model:{}:{idx}", virtual_model.name);
+			all_backends.push(BackendWithPolicies {
+				backend: Backend::AI(
+					local_name(backend_key.clone()),
+					AIBackend {
+						providers: crate::types::loadbalancer::EndpointSet::new(provider_groups),
+					},
+				),
+				inline_policies: vec![],
+			});
+			vec![RouteBackendReference {
+				weight: 1,
+				target: BackendReference::Backend(strng::format!("/{}", backend_key)).into(),
+				inline_policies: vec![],
+			}]
+		};
+
+		let matches = vec![RouteMatch {
+			path: PathMatch::PathPrefix(strng::new("/")),
+			method: None,
+			headers: vec![HeaderMatch {
+				name: HeaderOrPseudo::Header(HeaderName::from_static("x-gateway-model-name")),
+				value: llm_model_name_header_match(&virtual_model.name)?,
+			}],
+			query: vec![],
+		}];
+		let route_key = strng::format!("llm:virtual-model:{idx:06}:{}", virtual_model.name);
+		let virtual_model_route = Route {
+			key: route_key,
+			service_key: None,
+			service_port: 0,
+			name: RouteName {
+				name: strng::format!("virtual-model:{}", virtual_model.name),
+				namespace: strng::new("internal"),
+				rule_name: None,
+				kind: None,
+			},
+			hostnames: vec![],
+			matches,
+			backends,
+			inline_policies: vec![TrafficPolicy::AI(Arc::new(crate::llm::Policy {
+				routes: llm_route_types(None).into_iter().collect(),
+				..Default::default()
+			}))],
+		};
+		routes.push(virtual_model_route);
 	}
 
 	let fallback_inline_policies = vec![

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -7,7 +7,6 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use ::http::Uri;
 use agent_core::prelude::Strng;
 use anyhow::{Context, Error, anyhow, bail};
-use bytes::Bytes;
 use frozen_collections::Len;
 use itertools::Itertools;
 use macro_rules_attribute::apply;
@@ -16,23 +15,20 @@ use secrecy::SecretString;
 use crate::client::Client;
 use crate::http::auth::BackendAuth;
 use crate::http::backendtls::LocalBackendTLS;
-use crate::http::filters::HeaderModifier;
 use crate::http::transformation_cel::{LocalTransformationConfig, Transformation};
-use crate::http::{
-	HeaderName, HeaderOrPseudo, filters, health, retry, timeout, transformation_cel,
-};
+use crate::http::{filters, health, retry, timeout, transformation_cel};
 use crate::llm::policy::{PromptCachingConfig, PromptGuard};
 use crate::llm::{AIBackend, AIProvider, NamedAIProvider, anthropic, copilot, custom, openai};
 use crate::mcp::{FailureMode, McpAuthorization};
 use crate::store::{LocalWorkload, RequestPolicy};
 use crate::types::agent::{
 	A2aPolicy, Authorization, Backend, BackendKey, BackendReference, BackendTrafficPolicy,
-	BackendWithPolicies, Bind, BindProtocol, FrontendPolicy, HeaderMatch, HeaderValueMatch,
-	JwtAuthentication, Listener, ListenerKey, ListenerName, ListenerProtocol, ListenerSet,
-	ListenerTarget, LocalMcpAuthentication, McpAuthentication, McpBackend, McpTarget, McpTargetName,
-	McpTargetSpec, OpenAPITarget, PathMatch, PolicyPhase, PolicyTarget, PolicyType, ResourceName,
-	Route, RouteBackendReference, RouteBackendTarget, RouteGroupKey, RouteMatch, RouteName,
-	ServerTLSConfig, SimpleBackend, SimpleBackendReference, SimpleBackendWithPolicies, SseTargetSpec,
+	BackendWithPolicies, Bind, BindProtocol, FrontendPolicy, HeaderMatch, JwtAuthentication,
+	Listener, ListenerKey, ListenerName, ListenerProtocol, ListenerSet, ListenerTarget,
+	LocalMcpAuthentication, McpAuthentication, McpBackend, McpTarget, McpTargetName, McpTargetSpec,
+	OpenAPITarget, PathMatch, PolicyPhase, PolicyTarget, PolicyType, ResourceName, Route,
+	RouteBackendReference, RouteBackendTarget, RouteGroupKey, RouteMatch, RouteName, ServerTLSConfig,
+	SimpleBackend, SimpleBackendReference, SimpleBackendWithPolicies, SseTargetSpec,
 	StreamableHTTPTargetSpec, TCPRoute, TCPRouteBackendReference, Target, TargetedPolicy,
 	TracingConfig, TrafficPolicy, TunnelProtocol, TypedResourceName, validate_mcp_target_name,
 };
@@ -2277,35 +2273,6 @@ async fn convert(
 
 static STARTUP_TIMESTAMP: OnceLock<u64> = OnceLock::new();
 
-fn llm_model_name_header_match(model_name: &str) -> anyhow::Result<HeaderValueMatch> {
-	let wildcard_count = model_name.matches('*').count();
-	if wildcard_count > 1 {
-		bail!("model name '{model_name}' may only include a single '*' wildcard");
-	}
-
-	if wildcard_count == 0 {
-		return Ok(HeaderValueMatch::Exact(::http::HeaderValue::from_str(
-			model_name,
-		)?));
-	}
-
-	if model_name == "*" {
-		return Ok(HeaderValueMatch::Regex(regex::Regex::new(r".*")?));
-	}
-
-	if let Some(suffix) = model_name.strip_prefix('*') {
-		let pattern = format!(".*{}", regex::escape(suffix));
-		return Ok(HeaderValueMatch::Regex(regex::Regex::new(&pattern)?));
-	}
-
-	if let Some(prefix) = model_name.strip_suffix('*') {
-		let pattern = format!("{}.*", regex::escape(prefix));
-		return Ok(HeaderValueMatch::Regex(regex::Regex::new(&pattern)?));
-	}
-
-	bail!("model name wildcard must be either at the beginning or the end: '{model_name}'")
-}
-
 fn llm_model_match_specificity(model_name: &str) -> usize {
 	model_name.chars().filter(|c| *c != '*').count()
 }
@@ -2328,9 +2295,24 @@ fn merge_prompt_guards(
 #[derive(Clone)]
 struct ResolvedLLMModelTarget {
 	name: String,
-	backend_key: Strng,
 	provider: NamedAIProvider,
 	inline_policies: Vec<BackendTrafficPolicy>,
+	authorization: Option<Authorization>,
+}
+
+struct LocalLLMModelRegistry {
+	models: Vec<LocalLLMModels>,
+	virtual_models: Vec<LocalLLMVirtualModel>,
+}
+
+struct ResolvedLLMModelRegistry {
+	models: Vec<ResolvedLLMModelTarget>,
+}
+
+enum LocalLLMVirtualRoutingStrategy<'a> {
+	Weighted(&'a LocalLLMWeightedRouting),
+	Failover(&'a LocalLLMFailoverRouting),
+	Conditional(&'a LocalLLMConditionalRouting),
 }
 
 fn llm_model_matches(pattern: &str, model: &str) -> anyhow::Result<bool> {
@@ -2349,49 +2331,41 @@ fn llm_model_matches(pattern: &str, model: &str) -> anyhow::Result<bool> {
 	Ok(pattern == model)
 }
 
-fn resolve_llm_model_target(
-	models: &[ResolvedLLMModelTarget],
-	target: &str,
-) -> anyhow::Result<ResolvedLLMModelTarget> {
-	for model in models {
-		if llm_model_matches(&model.name, target)? {
-			return Ok(model.clone());
+impl<'a> LocalLLMVirtualRoutingStrategy<'a> {
+	fn targets(&self) -> Box<dyn Iterator<Item = &'a str> + 'a> {
+		match self {
+			Self::Weighted(weighted) => {
+				Box::new(weighted.targets.iter().map(|target| target.model.as_str()))
+			},
+			Self::Failover(failover) => {
+				Box::new(failover.targets.iter().map(|target| target.model.as_str()))
+			},
+			Self::Conditional(conditional) => Box::new(
+				conditional
+					.targets
+					.iter()
+					.map(|target| target.model.as_str()),
+			),
 		}
 	}
-	bail!("virtual model target {target} does not match any llm.models entry")
 }
 
-fn validate_llm_virtual_model_target(
-	models: &[LocalLLMModels],
-	target: &str,
-) -> anyhow::Result<()> {
-	for model in models {
-		if llm_model_matches(&model.name, target)? {
-			return Ok(());
-		}
-	}
-	bail!("virtual model target {target} does not match any llm.models entry")
-}
-
-fn validate_llm_virtual_models(
-	virtual_models: &[LocalLLMVirtualModel],
-	models: &[LocalLLMModels],
-) -> anyhow::Result<()> {
-	for virtual_model in virtual_models {
-		let strategy_count = usize::from(virtual_model.routing.weighted.is_some())
-			+ usize::from(virtual_model.routing.failover.is_some())
-			+ usize::from(virtual_model.routing.conditional.is_some());
+impl LocalLLMVirtualModel {
+	fn routing_strategy(&self) -> anyhow::Result<LocalLLMVirtualRoutingStrategy<'_>> {
+		let strategy_count = usize::from(self.routing.weighted.is_some())
+			+ usize::from(self.routing.failover.is_some())
+			+ usize::from(self.routing.conditional.is_some());
 		if strategy_count != 1 {
 			bail!(
 				"virtual model {} must specify exactly one routing strategy",
-				virtual_model.name
+				self.name
 			);
 		}
-		if let Some(conditional) = virtual_model.routing.conditional.as_ref() {
+		if let Some(conditional) = self.routing.conditional.as_ref() {
 			if conditional.targets.is_empty() {
 				bail!(
 					"virtual model {} must specify at least one conditional target",
-					virtual_model.name
+					self.name
 				);
 			}
 			if let Some(unconditional_idx) = conditional
@@ -2402,27 +2376,21 @@ fn validate_llm_virtual_models(
 			{
 				bail!(
 					"virtual model {} conditional fallback target must be last",
-					virtual_model.name
+					self.name
 				);
 			}
-			for target in &conditional.targets {
-				validate_llm_virtual_model_target(models, &target.model)?;
-			}
-			continue;
+			return Ok(LocalLLMVirtualRoutingStrategy::Conditional(conditional));
 		}
-		if let Some(weighted) = virtual_model.routing.weighted.as_ref() {
+		if let Some(weighted) = self.routing.weighted.as_ref() {
 			if weighted.targets.is_empty() {
 				bail!(
 					"virtual model {} must specify at least one weighted target",
-					virtual_model.name
+					self.name
 				);
 			}
-			for target in &weighted.targets {
-				validate_llm_virtual_model_target(models, &target.model)?;
-			}
-			continue;
+			return Ok(LocalLLMVirtualRoutingStrategy::Weighted(weighted));
 		}
-		let failover = virtual_model
+		let failover = self
 			.routing
 			.failover
 			.as_ref()
@@ -2430,14 +2398,93 @@ fn validate_llm_virtual_models(
 		if failover.targets.is_empty() {
 			bail!(
 				"virtual model {} must specify at least one failover target",
-				virtual_model.name
+				self.name
 			);
 		}
-		for target in &failover.targets {
-			validate_llm_virtual_model_target(models, &target.model)?;
-		}
+		Ok(LocalLLMVirtualRoutingStrategy::Failover(failover))
 	}
-	Ok(())
+}
+
+impl LocalLLMModelRegistry {
+	fn new(
+		models: Vec<LocalLLMModels>,
+		virtual_models: Vec<LocalLLMVirtualModel>,
+	) -> anyhow::Result<Self> {
+		let registry = Self {
+			models,
+			virtual_models,
+		};
+		registry.validate_virtual_models()?;
+		Ok(registry)
+	}
+
+	fn model_matches(&self, target: &str) -> anyhow::Result<bool> {
+		for model in &self.models {
+			if llm_model_matches(&model.name, target)? {
+				return Ok(true);
+			}
+		}
+		Ok(false)
+	}
+
+	fn validate_virtual_models(&self) -> anyhow::Result<()> {
+		for virtual_model in &self.virtual_models {
+			for target in virtual_model.routing_strategy()?.targets() {
+				if !self.model_matches(target)? {
+					bail!("virtual model target {target} does not match any llm.models entry");
+				}
+			}
+		}
+		Ok(())
+	}
+
+	fn ordered_models(&self) -> Vec<(usize, LocalLLMModels)> {
+		self
+			.models
+			.iter()
+			.cloned()
+			.enumerate()
+			.sorted_by_key(|(original_idx, model)| {
+				(
+					std::cmp::Reverse(llm_model_match_specificity(&model.name)),
+					*original_idx,
+				)
+			})
+			.collect_vec()
+	}
+
+	fn into_virtual_models(self) -> Vec<LocalLLMVirtualModel> {
+		self.virtual_models
+	}
+}
+
+impl ResolvedLLMModelRegistry {
+	fn new() -> Self {
+		Self { models: Vec::new() }
+	}
+
+	fn push(&mut self, model: ResolvedLLMModelTarget) {
+		self.models.push(model);
+	}
+
+	fn resolve(&self, target: &str) -> anyhow::Result<ResolvedLLMModelTarget> {
+		for model in &self.models {
+			if llm_model_matches(&model.name, target)? {
+				return Ok(model.clone());
+			}
+		}
+		bail!("virtual model target {target} does not match any llm.models entry")
+	}
+
+	fn resolve_without_authorization(&self, target: &str) -> anyhow::Result<ResolvedLLMModelTarget> {
+		let resolved = self.resolve(target)?;
+		if resolved.authorization.is_some() {
+			bail!(
+				"virtual model target {target} has authorization; only conditional virtual models can target authorized models"
+			);
+		}
+		Ok(resolved)
+	}
 }
 
 fn llm_route_types(
@@ -2488,104 +2535,18 @@ fn llm_route_types(
 	]
 }
 
-fn virtual_target_model_body_transform_backend_policy(
-	target: &str,
-) -> anyhow::Result<BackendTrafficPolicy> {
-	let target = serde_json::to_string(target)?;
-	let body = format!(r#"coalesce(json(request.body).merge({{"model": {target}}}), request.body)"#);
-	let transformation = http::transformation_cel::Transformation::try_from_local_config(
-		LocalTransformationConfig {
-			request: Some(http::transformation_cel::LocalTransform {
-				metadata: Vec::new(),
-				set: vec![],
-				add: vec![],
-				remove: vec![],
-				body: Some(strng::new(body)),
-			}),
-			response: None,
-		},
-		true,
-	)?;
-	Ok(BackendTrafficPolicy::Transformation(Arc::new(
-		transformation,
-	)))
-}
-
-fn virtual_model_match_cel(pattern: &str, model_expr: &str) -> anyhow::Result<String> {
-	if pattern == "*" {
-		return Ok("true".to_string());
+fn ensure_ai_provider_model(provider: &mut AIProvider, model: &str) {
+	let model = || Some(strng::new(model));
+	match provider {
+		AIProvider::Anthropic(p) => p.model = p.model.clone().or_else(model),
+		AIProvider::OpenAI(p) => p.model = p.model.clone().or_else(model),
+		AIProvider::Copilot(p) => p.model = p.model.clone().or_else(model),
+		AIProvider::Gemini(p) => p.model = p.model.clone().or_else(model),
+		AIProvider::Custom(p) => p.model = p.model.clone().or_else(model),
+		AIProvider::Vertex(p) => p.model = p.model.clone().or_else(model),
+		AIProvider::Bedrock(p) => p.model = p.model.clone().or_else(model),
+		AIProvider::Azure(p) => p.model = p.model.clone().or_else(model),
 	}
-	if let Some(prefix) = pattern.strip_suffix('*') {
-		return Ok(format!(
-			"{model_expr}.startsWith({})",
-			serde_json::to_string(prefix)?
-		));
-	}
-	if let Some(suffix) = pattern.strip_prefix('*') {
-		return Ok(format!(
-			"{model_expr}.endsWith({})",
-			serde_json::to_string(suffix)?
-		));
-	}
-	if pattern.contains('*') {
-		bail!("model name wildcard must be either at the beginning or the end: '{pattern}'");
-	}
-	Ok(format!(
-		"{model_expr} == {}",
-		serde_json::to_string(pattern)?
-	))
-}
-
-fn conditional_virtual_model_target_expr(
-	virtual_models: &[LocalLLMVirtualModel],
-) -> anyhow::Result<Option<String>> {
-	let mut branches = Vec::new();
-	let requested_model = "requestedModel";
-	for virtual_model in virtual_models {
-		let Some(conditional) = virtual_model.routing.conditional.as_ref() else {
-			continue;
-		};
-		let model_match = virtual_model_match_cel(&virtual_model.name, requested_model)?;
-		let mut target_expr = requested_model.to_string();
-		for target in conditional.targets.iter().rev() {
-			let target_model = serde_json::to_string(&target.model)?;
-			target_expr = match &target.when {
-				Some(condition) => format!(
-					"({}) ? {target_model} : ({target_expr})",
-					condition.original_expression
-				),
-				None => target_model,
-			};
-		}
-		branches.push(format!("({model_match}) ? ({target_expr})"));
-	}
-	if branches.is_empty() {
-		return Ok(None);
-	}
-	let body = {
-		let mut expr = requested_model.to_string();
-		for branch in branches.into_iter().rev() {
-			expr = format!("{branch} : ({expr})");
-		}
-		expr
-	};
-	// Conditional virtual models are selected before route matching. Bind the
-	// original requested model once, then compare every virtual model against
-	// that stable value.
-	Ok(Some(format!(
-		"({}).with({requested_model}, {body})",
-		llm_request_model_expression()
-	)))
-}
-
-fn llm_request_model_expression() -> &'static str {
-	r#"
-request.path.endsWith(":streamRawPredict") || request.path.endsWith(":rawPredict") ?
-	request.path.regexReplace("^.*/publishers/anthropic/models/(.+?):.*", "${1}") :
-	(request.path.endsWith("/invoke-with-response-stream") || request.path.endsWith("/invoke") ?
-	request.path.regexReplace("^.*/model/(.+?)/invoke.*", "${1}") :
-	json(request.body).model)
-"#
 }
 
 #[allow(deprecated)]
@@ -2610,6 +2571,7 @@ async fn convert_llm_config(
 	} = llm_config;
 	let port = port.unwrap_or(DEFAULT_LLM_PORT);
 	let tls = tls.map(TryInto::try_into).transpose()?;
+	let llm_registry = LocalLLMModelRegistry::new(models, virtual_models)?;
 
 	let mut all_policies = vec![];
 	let mut all_backends = vec![];
@@ -2649,34 +2611,6 @@ async fn convert_llm_config(
 		(vec![], vec![])
 	};
 
-	validate_llm_virtual_models(&virtual_models, &models)?;
-
-	let llm_model_expression = conditional_virtual_model_target_expr(&virtual_models)?
-		.unwrap_or_else(|| llm_request_model_expression().to_string());
-	let llm_model_body_expression = r#"coalesce(json(request.body).merge({"model": request.headers["x-gateway-model-name"]}), request.body)"#;
-
-	// Create transformation policy to set x-gateway-model-name header from request body.
-	// Conditional virtual models use this same pre-routing transform to select the
-	// concrete target. The header makes route matching choose that concrete model
-	// route; the body rewrite makes downstream LLM policy/transformation logic see
-	// the selected target instead of the public virtual model name.
-	let transformation = http::transformation_cel::Transformation::try_from_local_config(
-		LocalTransformationConfig {
-			request: Some(http::transformation_cel::LocalTransform {
-				metadata: Vec::new(),
-				set: vec![(
-					strng::new("x-gateway-model-name"),
-					strng::new(llm_model_expression),
-				)],
-				add: vec![],
-				remove: vec![],
-				body: Some(strng::new(llm_model_body_expression)),
-			}),
-			response: None,
-		},
-		false,
-	)?;
-
 	// Get static startup unix timestamp
 	let startup_timestamp = *STARTUP_TIMESTAMP.get_or_init(|| {
 		SystemTime::now()
@@ -2685,88 +2619,9 @@ async fn convert_llm_config(
 			.as_secs()
 	});
 
-	// Create model list route
-	let model_list_entries = Arc::new(
-		models
-			.iter()
-			.map(|model| filters::AuthorizationFilteredModelListEntry {
-				id: model.name.clone(),
-				created: startup_timestamp,
-				authorization: model.authorization.clone(),
-			})
-			.chain(
-				virtual_models
-					.iter()
-					.map(|model| filters::AuthorizationFilteredModelListEntry {
-						id: model.name.clone(),
-						created: startup_timestamp,
-						authorization: None,
-					}),
-			)
-			.collect::<Vec<_>>(),
-	);
-
-	let model_list_inline_policies = vec![
-		TrafficPolicy::ResponseHeaderModifier(RequestPolicy::single(
-			crate::http::filters::HeaderModifier {
-				set: vec![(strng::new("Content-Type"), strng::new("application/json"))],
-				add: vec![],
-				remove: vec![],
-			},
-		)),
-		TrafficPolicy::DirectResponse(RequestPolicy::single(filters::DirectResponse {
-			body: Bytes::new(),
-			body_expression: None,
-			headers: Vec::new(),
-			status: ::http::StatusCode::OK,
-			authorization_filtered_model_list: Some(filters::AuthorizationFilteredModelList {
-				entries: model_list_entries,
-			}),
-		})),
-	];
-	let model_list_route = Route {
-		key: strng::new("llm:admin:model-list"),
-		service_key: None,
-		service_port: 0,
-		name: RouteName {
-			name: strng::new("admin:model-list"),
-			namespace: strng::new("internal"),
-			kind: None,
-			rule_name: None,
-		},
-		hostnames: vec![],
-		matches: vec![
-			RouteMatch {
-				path: PathMatch::PathPrefix(strng::new("/v1/models")),
-				headers: vec![],
-				method: None,
-				query: vec![],
-			},
-			RouteMatch {
-				path: PathMatch::PathPrefix(strng::new("/models")),
-				headers: vec![],
-				method: None,
-				query: vec![],
-			},
-		],
-		backends: vec![],
-		inline_policies: model_list_inline_policies,
-	};
-	routes.push(model_list_route);
-
-	let ordered_models = models
-		.iter()
-		.cloned()
-		.enumerate()
-		.sorted_by_key(|(original_idx, model)| {
-			(
-				std::cmp::Reverse(llm_model_match_specificity(&model.name)),
-				*original_idx,
-			)
-		})
-		.collect_vec();
-
-	let mut resolved_models = Vec::new();
+	let ordered_models = llm_registry.ordered_models();
+	let mut resolved_models = ResolvedLLMModelRegistry::new();
+	let mut router_models = Vec::new();
 
 	// Create routes and backends for each model
 	for (idx, (_, model_config)) in ordered_models.into_iter().enumerate() {
@@ -2986,17 +2841,8 @@ async fn convert_llm_config(
 		if let Some(p) = model_config.backend_tunnel.clone() {
 			pols.push(BackendTrafficPolicy::Tunnel(p));
 		}
-		if let Some(mut rh) = model_config.request_headers.clone() {
-			rh.remove.push(strng::literal!("x-gateway-model-name"));
+		if let Some(rh) = model_config.request_headers.clone() {
 			pols.push(BackendTrafficPolicy::RequestHeaderModifier(rh));
-		} else {
-			pols.push(BackendTrafficPolicy::RequestHeaderModifier(
-				HeaderModifier {
-					remove: vec![strng::literal!("x-gateway-model-name")],
-					add: vec![],
-					set: vec![],
-				},
-			));
 		}
 		if let Some(rh) = model_config.response_headers.clone() {
 			pols.push(BackendTrafficPolicy::ResponseHeaderModifier(Arc::new(rh)));
@@ -3027,51 +2873,10 @@ async fn convert_llm_config(
 		all_backends.push(backend_with_policies);
 		resolved_models.push(ResolvedLLMModelTarget {
 			name: model_config.name.clone(),
-			backend_key: backend_key.clone(),
 			provider: resolved_provider,
 			inline_policies: resolved_inline_policies,
+			authorization: model_config.authorization.clone(),
 		});
-
-		if !model_config.visibility.is_public() {
-			continue;
-		}
-
-		// Create route for this model
-		// Index is needed because the same name can be used with different match criteria
-		// Models are sorted by specificity first, so more precise model matches win
-		// over less precise matches like "*", regardless of the original model list order.
-		// 999999 routes ought to be enough for anyone.
-		let route_key = strng::format!("llm:model:{idx:06}:{}", model_config.name);
-		let user_matches = if model_config.matches.is_empty() {
-			vec![RouteMatch {
-				path: PathMatch::PathPrefix(strng::new("/")),
-				method: None,
-				headers: vec![],
-				query: vec![],
-			}]
-		} else {
-			model_config
-				.matches
-				.iter()
-				.map(|m| RouteMatch {
-					headers: m.headers.clone(),
-					path: PathMatch::PathPrefix(strng::new("/")),
-					method: None,
-					query: vec![],
-				})
-				.collect_vec()
-		};
-		let matches = user_matches
-			.into_iter()
-			.map(|mut m| {
-				let header_match = HeaderMatch {
-					name: HeaderOrPseudo::Header(HeaderName::from_static("x-gateway-model-name")),
-					value: llm_model_name_header_match(&model_config.name)?,
-				};
-				m.headers.push(header_match);
-				Ok(m)
-			})
-			.collect::<anyhow::Result<Vec<_>>>()?;
 
 		let mut model_route_inline_policies = vec![TrafficPolicy::AI(Arc::new(crate::llm::Policy {
 			routes: llm_routes.into_iter().collect(),
@@ -3080,213 +2885,110 @@ async fn convert_llm_config(
 		if let Some(p) = model_config.authorization.clone() {
 			model_route_inline_policies.push(TrafficPolicy::Authorization(p));
 		}
-
-		let model_route = Route {
-			key: route_key.clone(),
-			service_key: None,
-			service_port: 0,
-			name: RouteName {
-				name: strng::format!("model:{}", model_config.name),
-				namespace: strng::new("internal"),
-				rule_name: None,
-				kind: None,
+		router_models.push(llm::model_router::ModelRoute {
+			name: model_config.name.clone(),
+			visibility: if model_config.visibility.is_public() {
+				llm::model_router::ModelVisibility::Public
+			} else {
+				llm::model_router::ModelVisibility::Internal
 			},
-			hostnames: vec![],
-			matches,
-			backends: vec![RouteBackendReference {
-				weight: 1,
-				target: BackendReference::Backend(strng::format!("/{}", backend_key)).into(),
-				inline_policies: vec![],
-			}],
-			inline_policies: model_route_inline_policies,
-		};
-		routes.push(model_route);
+			header_matches: model_config
+				.matches
+				.iter()
+				.map(|m| m.headers.clone())
+				.collect(),
+			backend_key,
+			route_policies: model_route_inline_policies,
+			backend_policies: vec![],
+		});
 	}
 
+	let virtual_models = llm_registry.into_virtual_models();
+	let mut router_virtual_models = Vec::new();
 	for (idx, virtual_model) in virtual_models.into_iter().enumerate() {
-		let strategy_count = usize::from(virtual_model.routing.weighted.is_some())
-			+ usize::from(virtual_model.routing.failover.is_some())
-			+ usize::from(virtual_model.routing.conditional.is_some());
-		if strategy_count != 1 {
-			bail!(
-				"virtual model {} must specify exactly one routing strategy",
-				virtual_model.name
-			);
-		}
-		if let Some(conditional) = virtual_model.routing.conditional.as_ref() {
-			if conditional.targets.is_empty() {
-				bail!(
-					"virtual model {} must specify at least one conditional target",
-					virtual_model.name
-				);
-			}
-			if let Some(unconditional_idx) = conditional
-				.targets
-				.iter()
-				.position(|target| target.when.is_none())
-				&& unconditional_idx + 1 != conditional.targets.len()
-			{
-				bail!(
-					"virtual model {} conditional fallback target must be last",
-					virtual_model.name
-				);
-			}
-			for target in &conditional.targets {
-				resolve_llm_model_target(&resolved_models, &target.model)?;
-			}
-			continue;
-		}
-		let backends = if let Some(weighted) = virtual_model.routing.weighted.as_ref() {
-			if weighted.targets.is_empty() {
-				bail!(
-					"virtual model {} must specify at least one weighted target",
-					virtual_model.name
-				);
-			}
-			weighted
-				.targets
-				.iter()
-				.map(|target| {
-					let resolved = resolve_llm_model_target(&resolved_models, &target.model)?;
-					Ok(RouteBackendReference {
-						weight: target.weight,
-						target: BackendReference::Backend(strng::format!("/{}", resolved.backend_key)).into(),
-						// Weighted selection happens after the pre-routing transform, so rewrite
-						// the body model here to the concrete target picked by this backend ref.
-						inline_policies: vec![virtual_target_model_body_transform_backend_policy(
-							&target.model,
-						)?],
-					})
-				})
-				.collect::<anyhow::Result<Vec<_>>>()?
-		} else {
-			let failover = virtual_model
-				.routing
-				.failover
-				.as_ref()
-				.expect("strategy count checked");
-			if failover.targets.is_empty() {
-				bail!(
-					"virtual model {} must specify at least one failover target",
-					virtual_model.name
-				);
-			}
-			let provider_groups = failover
-				.targets
-				.iter()
-				.sorted_by_key(|target| target.priority)
-				.chunk_by(|target| target.priority)
-				.into_iter()
-				.map(|(_, targets)| {
-					targets
-						.map(|target| {
-							let resolved = resolve_llm_model_target(&resolved_models, &target.model)?;
-							let mut provider = resolved.provider.clone();
-							provider.name = strng::new(&target.model);
-							provider
-								.inline_policies
-								.extend(resolved.inline_policies.clone());
-							// Failover chooses a provider from these groups after route matching.
-							// Attach the target rewrite to each provider so the upstream request
-							// uses the concrete model that actually won failover selection.
-							provider
-								.inline_policies
-								.push(virtual_target_model_body_transform_backend_policy(
-									&target.model,
-								)?);
-							Ok((strng::new(&target.model), provider))
+		let route_policies = vec![TrafficPolicy::AI(Arc::new(crate::llm::Policy {
+			routes: llm_route_types(None).into_iter().collect(),
+			..Default::default()
+		}))];
+		let routing = match virtual_model.routing_strategy()? {
+			LocalLLMVirtualRoutingStrategy::Conditional(conditional) => {
+				for target in &conditional.targets {
+					resolved_models.resolve(&target.model)?;
+				}
+				llm::model_router::VirtualModelRouting::Conditional(
+					conditional
+						.targets
+						.iter()
+						.map(|target| llm::model_router::ConditionalTarget {
+							model: target.model.clone(),
+							when: target.when.clone(),
 						})
-						.collect::<anyhow::Result<Vec<_>>>()
-				})
-				.collect::<anyhow::Result<Vec<_>>>()?;
-			let backend_key = strng::format!("llm:virtual-model:{}:{idx}", virtual_model.name);
-			all_backends.push(BackendWithPolicies {
-				backend: Backend::AI(
-					local_name(backend_key.clone()),
-					AIBackend {
-						providers: crate::types::loadbalancer::EndpointSet::new(provider_groups),
-					},
-				),
-				inline_policies: vec![],
-			});
-			vec![RouteBackendReference {
-				weight: 1,
-				target: BackendReference::Backend(strng::format!("/{}", backend_key)).into(),
-				inline_policies: vec![],
-			}]
-		};
-
-		let matches = vec![RouteMatch {
-			path: PathMatch::PathPrefix(strng::new("/")),
-			method: None,
-			headers: vec![HeaderMatch {
-				name: HeaderOrPseudo::Header(HeaderName::from_static("x-gateway-model-name")),
-				value: llm_model_name_header_match(&virtual_model.name)?,
-			}],
-			query: vec![],
-		}];
-		let route_key = strng::format!("llm:virtual-model:{idx:06}:{}", virtual_model.name);
-		let virtual_model_route = Route {
-			key: route_key,
-			service_key: None,
-			service_port: 0,
-			name: RouteName {
-				name: strng::format!("virtual-model:{}", virtual_model.name),
-				namespace: strng::new("internal"),
-				rule_name: None,
-				kind: None,
+						.collect(),
+				)
 			},
-			hostnames: vec![],
-			matches,
-			backends,
-			inline_policies: vec![TrafficPolicy::AI(Arc::new(crate::llm::Policy {
-				routes: llm_route_types(None).into_iter().collect(),
-				..Default::default()
-			}))],
+			LocalLLMVirtualRoutingStrategy::Weighted(weighted) => {
+				for target in &weighted.targets {
+					resolved_models.resolve_without_authorization(&target.model)?;
+				}
+				llm::model_router::VirtualModelRouting::Weighted(
+					weighted
+						.targets
+						.iter()
+						.map(|target| llm::model_router::WeightedTarget {
+							model: target.model.clone(),
+							weight: target.weight,
+						})
+						.collect(),
+				)
+			},
+			LocalLLMVirtualRoutingStrategy::Failover(failover) => {
+				let provider_groups = failover
+					.targets
+					.iter()
+					.sorted_by_key(|target| target.priority)
+					.chunk_by(|target| target.priority)
+					.into_iter()
+					.map(|(_, targets)| {
+						targets
+							.map(|target| {
+								let resolved = resolved_models.resolve_without_authorization(&target.model)?;
+								let mut provider = resolved.provider.clone();
+								provider.name = strng::new(&target.model);
+								ensure_ai_provider_model(&mut provider.provider, &target.model);
+								provider
+									.inline_policies
+									.extend(resolved.inline_policies.clone());
+								Ok((strng::new(&target.model), provider))
+							})
+							.collect::<anyhow::Result<Vec<_>>>()
+					})
+					.collect::<anyhow::Result<Vec<_>>>()?;
+				let backend_key = strng::format!("llm:virtual-model:{}:{idx}", virtual_model.name);
+				all_backends.push(BackendWithPolicies {
+					backend: Backend::AI(
+						local_name(backend_key.clone()),
+						AIBackend {
+							providers: crate::types::loadbalancer::EndpointSet::new(provider_groups),
+						},
+					),
+					inline_policies: vec![],
+				});
+				llm::model_router::VirtualModelRouting::Failover { backend_key }
+			},
 		};
-		routes.push(virtual_model_route);
+		router_virtual_models.push(llm::model_router::VirtualModelRoute {
+			name: virtual_model.name,
+			route_policies,
+			routing,
+		});
 	}
 
-	let fallback_inline_policies = vec![
-		TrafficPolicy::ResponseHeaderModifier(RequestPolicy::single(
-			crate::http::filters::HeaderModifier {
-				set: vec![(strng::new("Content-Type"), strng::new("application/json"))],
-				add: vec![],
-				remove: vec![],
-			},
-		)),
-		TrafficPolicy::DirectResponse(RequestPolicy::single(filters::DirectResponse {
-			body: Bytes::new(),
-			body_expression: Some(Arc::new(cel::Expression::new_strict(
-				r#"
-"x-gateway-model-name" in request.headers ?
-	{
-		"error": {
-			"message": "Model " + request.headers["x-gateway-model-name"] + " not found",
-			"type": "invalid_request_error",
-			"code": "model_not_found"
-		}
-	} :
-	{
-		"error": {
-			"message": "No model set",
-			"type": "invalid_request_error",
-			"code": "model_not_found"
-		}
-	}
-"#,
-			)?)),
-			headers: Vec::new(),
-			status: ::http::StatusCode::NOT_FOUND,
-			authorization_filtered_model_list: None,
-		})),
-	];
 	routes.push(Route {
-		key: strng::new("llm:model:fallback"),
+		key: strng::new("llm:request"),
 		service_key: None,
 		service_port: 0,
 		name: RouteName {
-			name: strng::new("model:fallback"),
+			name: strng::new("llm:request"),
 			namespace: strng::new("internal"),
 			rule_name: None,
 			kind: None,
@@ -3299,7 +3001,12 @@ async fn convert_llm_config(
 			query: vec![],
 		}],
 		backends: vec![],
-		inline_policies: fallback_inline_policies,
+		llm_router: Some(Arc::new(llm::model_router::ModelRouter::new(
+			router_models,
+			router_virtual_models,
+			startup_timestamp,
+		))),
+		inline_policies: vec![],
 	});
 
 	// Create listener
@@ -3345,24 +3052,6 @@ async fn convert_llm_config(
 			});
 		}
 	}
-
-	// Create transformation policy for the listener
-	let listener_target: ListenerTarget = listener_name.clone().into();
-	let transformation_policy = TargetedPolicy {
-		name: Some(TypedResourceName {
-			kind: strng::literal!("Local"),
-			name: strng::new("llm:transformation"),
-			namespace: strng::new("internal"),
-		}),
-		key: strng::new("llm:transformation"),
-		target: PolicyTarget::Gateway(listener_target),
-		inheritance: Default::default(),
-		policy: PolicyType::from((
-			TrafficPolicy::Transformation(RequestPolicy::single(transformation)),
-			PolicyPhase::Gateway,
-		)),
-	};
-	all_policies.push(transformation_policy);
 
 	let mut listener_set = ListenerSet::default();
 	listener_set.insert(listener);
@@ -3433,6 +3122,7 @@ async fn convert_mcp_config(
 			target: BackendReference::Backend(strng::new("/mcp")).into(),
 			inline_policies: resolved_policies.backend_policies,
 		}],
+		llm_router: None,
 		inline_policies: resolved_policies.route_policies,
 	};
 	routes.push(route);
@@ -3728,6 +3418,7 @@ pub async fn convert_route(
 		hostnames,
 		matches,
 		backends: backend_refs,
+		llm_router: None,
 		inline_policies,
 	};
 	Ok((route, external_backends))

--- a/crates/agentgateway/src/types/local_tests.rs
+++ b/crates/agentgateway/src/types/local_tests.rs
@@ -341,6 +341,46 @@ llm:
 }
 
 #[tokio::test]
+async fn test_llm_model_rejects_multiple_wildcards() {
+	let err = normalize_test_config(
+		r#"
+llm:
+  models:
+  - name: '*foo*'
+    provider: openAI
+"#,
+	)
+	.await
+	.expect_err("model name with multiple wildcards should fail");
+	assert!(
+		err
+			.to_string()
+			.contains("model name wildcard may only appear once: '*foo*'"),
+		"{err:?}"
+	);
+}
+
+#[tokio::test]
+async fn test_llm_model_rejects_middle_wildcard() {
+	let err = normalize_test_config(
+		r#"
+llm:
+  models:
+  - name: foo*bar
+    provider: openAI
+"#,
+	)
+	.await
+	.expect_err("model name with middle wildcard should fail");
+	assert!(
+		err
+			.to_string()
+			.contains("model name wildcard must be either at the beginning or the end: 'foo*bar'"),
+		"{err:?}"
+	);
+}
+
+#[tokio::test]
 async fn test_llm_weighted_virtual_model_allows_authorized_target() {
 	let normalized = normalize_test_config(
 		r#"

--- a/crates/agentgateway/src/types/local_tests.rs
+++ b/crates/agentgateway/src/types/local_tests.rs
@@ -239,6 +239,108 @@ async fn test_llm_simple_config() {
 }
 
 #[tokio::test]
+async fn test_llm_virtual_model_config() {
+	test_config_parsing("llm_virtual_model").await;
+}
+
+#[tokio::test]
+async fn test_llm_virtual_model_failover_config() {
+	test_config_parsing("llm_virtual_model_failover").await;
+}
+
+#[tokio::test]
+async fn test_llm_virtual_model_conditional_config() {
+	test_config_parsing("llm_virtual_model_conditional").await;
+}
+
+#[tokio::test]
+async fn test_llm_conditional_virtual_model_requires_fallback_last() {
+	let err = normalize_test_config(
+		r#"
+llm:
+  models:
+  - name: concrete
+    provider: openAI
+  virtualModels:
+  - name: smart
+    routing:
+      conditional:
+        targets:
+        - model: concrete
+        - when: json(request.body).route == "fast"
+          model: concrete
+"#,
+	)
+	.await
+	.expect_err("fallback target must be last");
+	assert!(
+		err
+			.to_string()
+			.contains("virtual model smart conditional fallback target must be last"),
+		"{err:?}"
+	);
+}
+
+#[tokio::test]
+async fn test_llm_conditional_virtual_model_rejects_unknown_target() {
+	let err = normalize_test_config(
+		r#"
+llm:
+  models:
+  - name: concrete
+    provider: openAI
+  virtualModels:
+  - name: smart
+    routing:
+      conditional:
+        targets:
+        - model: missing
+"#,
+	)
+	.await
+	.expect_err("unknown target should fail");
+	assert!(
+		err
+			.to_string()
+			.contains("virtual model target missing does not match any llm.models entry"),
+		"{err:?}"
+	);
+}
+
+#[tokio::test]
+async fn test_llm_conditional_virtual_model_rejects_unknown_target_before_expression_compile() {
+	let err = normalize_test_config(
+		r#"
+llm:
+  models:
+  - name: concrete
+    provider: openAI
+  virtualModels:
+  - name: smart
+    routing:
+      conditional:
+        targets:
+        - model: concrete
+  - name: simple
+    routing:
+      conditional:
+        targets:
+        - when: json(request.body).route == "legacy"
+          model: concrete
+        - model: missing
+"#,
+	)
+	.await
+	.expect_err("unknown target should fail before expression compilation");
+	assert!(
+		err
+			.to_string()
+			.contains("virtual model target missing does not match any llm.models entry"),
+		"{err:?}"
+	);
+}
+
+#[tokio::test]
 async fn test_llm_custom_provider_config() {
 	let normalized = normalize_test_config(
 		r#"

--- a/crates/agentgateway/src/types/local_tests.rs
+++ b/crates/agentgateway/src/types/local_tests.rs
@@ -7,8 +7,8 @@ use secrecy::SecretString;
 use crate::llm::{AIProvider, NamedAIProvider};
 use crate::serdes::FileInlineOrRemote;
 use crate::types::agent::{
-	Backend, BackendTrafficPolicy, HeaderValueMatch, ListenerTarget, PolicyPhase, PolicyTarget,
-	PolicyType, ResourceName, RouteBackendTarget, Target, TrafficPolicy,
+	Backend, BackendTrafficPolicy, ListenerTarget, PolicyPhase, PolicyTarget, PolicyType,
+	ResourceName, RouteBackendTarget, Target, TrafficPolicy,
 };
 use crate::types::local::NormalizedLocalConfig;
 use crate::*;
@@ -337,6 +337,111 @@ llm:
 			.to_string()
 			.contains("virtual model target missing does not match any llm.models entry"),
 		"{err:?}"
+	);
+}
+
+#[tokio::test]
+async fn test_llm_weighted_virtual_model_rejects_authorized_target() {
+	let err = normalize_test_config(
+		r#"
+llm:
+  models:
+  - name: concrete
+    provider: openAI
+    authorization:
+      rules:
+      - 'request.headers["x-user"] == "admin"'
+  virtualModels:
+  - name: smart
+    routing:
+      weighted:
+        targets:
+        - model: concrete
+"#,
+	)
+	.await
+	.expect_err("weighted target authorization cannot be enforced after backend selection");
+	assert!(
+		err.to_string().contains(
+			"virtual model target concrete has authorization; only conditional virtual models can target authorized models"
+		),
+		"{err:?}"
+	);
+}
+
+#[tokio::test]
+async fn test_llm_failover_virtual_model_rejects_authorized_target() {
+	let err = normalize_test_config(
+		r#"
+llm:
+  models:
+  - name: concrete
+    provider: openAI
+    authorization:
+      rules:
+      - 'request.headers["x-user"] == "admin"'
+  virtualModels:
+  - name: smart
+    routing:
+      failover:
+        targets:
+        - model: concrete
+          priority: 0
+"#,
+	)
+	.await
+	.expect_err("failover target authorization cannot be enforced after provider selection");
+	assert!(
+		err.to_string().contains(
+			"virtual model target concrete has authorization; only conditional virtual models can target authorized models"
+		),
+		"{err:?}"
+	);
+}
+
+#[tokio::test]
+async fn test_llm_conditional_virtual_model_allows_authorized_internal_target() {
+	let normalized = normalize_test_config(
+		r#"
+llm:
+  models:
+  - name: concrete
+    visibility: internal
+    provider: openAI
+    authorization:
+      rules:
+      - 'request.headers["x-user"] == "admin"'
+  virtualModels:
+  - name: smart
+    routing:
+      conditional:
+        targets:
+        - model: concrete
+"#,
+	)
+	.await
+	.expect("conditional virtual model should preserve target authorization");
+
+	let routes = &normalized.listener_routes[0].1;
+	assert!(
+		!routes
+			.iter()
+			.any(|route| route.key.contains("model:concrete")),
+		"internal concrete model should not have a direct route"
+	);
+	let llm_route = routes
+		.iter()
+		.find(|route| route.key == "llm:request")
+		.expect("expected single LLM request route");
+	assert!(
+		llm_route.llm_router.is_some(),
+		"LLM request route should carry the native model router"
+	);
+	assert!(
+		!routes
+			.iter()
+			.any(|route| route.key.contains("virtual-model")),
+		"virtual model routing should not generate HTTP routes"
 	);
 }
 
@@ -881,35 +986,6 @@ binds:
 		),
 		"unexpected error: {err}"
 	);
-}
-
-#[test]
-fn test_llm_model_name_header_match_valid_patterns() {
-	match super::llm_model_name_header_match("*").unwrap() {
-		HeaderValueMatch::Regex(re) => assert_eq!(re.as_str(), ".*"),
-		other => panic!("expected regex for '*', got {other:?}"),
-	}
-
-	match super::llm_model_name_header_match("*gpt-4.1").unwrap() {
-		HeaderValueMatch::Regex(re) => assert_eq!(re.as_str(), ".*gpt\\-4\\.1"),
-		other => panic!("expected regex for '*gpt-4.1', got {other:?}"),
-	}
-
-	match super::llm_model_name_header_match("gpt-4.1*").unwrap() {
-		HeaderValueMatch::Regex(re) => assert_eq!(re.as_str(), "gpt\\-4\\.1.*"),
-		other => panic!("expected regex for 'gpt-4.1*', got {other:?}"),
-	}
-
-	match super::llm_model_name_header_match("gpt-4.1").unwrap() {
-		HeaderValueMatch::Exact(v) => assert_eq!(v, ::http::HeaderValue::from_static("gpt-4.1")),
-		other => panic!("expected exact header value for 'gpt-4.1', got {other:?}"),
-	}
-}
-
-#[test]
-fn test_llm_model_name_header_match_invalid_patterns() {
-	assert!(super::llm_model_name_header_match("*gpt*").is_err());
-	assert!(super::llm_model_name_header_match("g*pt").is_err());
 }
 
 #[test]

--- a/crates/agentgateway/src/types/local_tests.rs
+++ b/crates/agentgateway/src/types/local_tests.rs
@@ -341,8 +341,8 @@ llm:
 }
 
 #[tokio::test]
-async fn test_llm_weighted_virtual_model_rejects_authorized_target() {
-	let err = normalize_test_config(
+async fn test_llm_weighted_virtual_model_allows_authorized_target() {
+	let normalized = normalize_test_config(
 		r#"
 llm:
   models:
@@ -360,12 +360,16 @@ llm:
 "#,
 	)
 	.await
-	.expect_err("weighted target authorization cannot be enforced after backend selection");
+	.expect("weighted target authorization should be preserved on selected target");
+
+	let routes = &normalized.listener_routes[0].1;
+	let llm_route = routes
+		.iter()
+		.find(|route| route.key == "llm:request")
+		.expect("expected single LLM request route");
 	assert!(
-		err.to_string().contains(
-			"virtual model target concrete has authorization; only conditional virtual models can target authorized models"
-		),
-		"{err:?}"
+		llm_route.llm_router.is_some(),
+		"LLM request route should carry the native model router"
 	);
 }
 
@@ -393,7 +397,7 @@ llm:
 	.expect_err("failover target authorization cannot be enforced after provider selection");
 	assert!(
 		err.to_string().contains(
-			"virtual model target concrete has authorization; only conditional virtual models can target authorized models"
+			"virtual model target concrete has authorization; failover virtual models cannot target authorized models"
 		),
 		"{err:?}"
 	);

--- a/crates/agentgateway/src/types/local_tests/llm_simple_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/llm_simple_normalized.snap
@@ -18,229 +18,144 @@ binds:
         protocol: HTTP
 listener_routes:
   - - llm
-    - - inlinePolicies:
-          - responseHeaderModifier:
-              set:
-                Content-Type: application/json
-          - directResponse:
-              status: 200
-              authorizationFilteredModelList:
-                entries:
-                  - id: claude-3-haiku
-                    created: 0
-                    authorization: ~
-                  - id: "*"
-                    created: 0
-                    authorization: ~
-                  - id: gpt-7-max
-                    created: 0
-                    authorization: ~
-                  - id: gpt-3.5-turbo
-                    created: 0
-                    authorization: ~
-                  - id: llama-3.1-8b-instant
-                    created: 0
-                    authorization: ~
-                  - id: fireworks-llama
-                    created: 0
-                    authorization: ~
-        key: "llm:admin:model-list"
-        matches:
-          - path:
-              pathPrefix: /v1/models
-          - path:
-              pathPrefix: /models
-        name: "admin:model-list"
-        namespace: internal
-      - backends:
-          - backend: "/llm:model:llama-3.1-8b-instant:0"
-            weight: 1
-        inlinePolicies:
-          - ai:
-              routes:
-                "*": passthrough
-                /v1/chat/completions: completions
-                /v1/embeddings: embeddings
-                /v1/images/edits: detect
-                /v1/images/generations: detect
-                /v1/images/variations: detect
-                /v1/messages: messages
-                /v1/rerank: rerank
-                /v1/responses: responses
-                /v1/responses/compact: detect
-                /v2/rerank: rerank
-                ":rawPredict": messages
-                ":streamRawPredict": messages
-        key: "llm:model:000000:llama-3.1-8b-instant"
-        matches:
-          - headers:
-              - name: x-gateway-model-name
-                value:
-                  exact: llama-3.1-8b-instant
-            path:
-              pathPrefix: /
-        name: "model:llama-3.1-8b-instant"
-        namespace: internal
-      - backends:
-          - backend: "/llm:model:fireworks-llama:1"
-            weight: 1
-        inlinePolicies:
-          - ai:
-              routes:
-                "*": passthrough
-                /v1/chat/completions: completions
-                /v1/embeddings: embeddings
-                /v1/images/edits: detect
-                /v1/images/generations: detect
-                /v1/images/variations: detect
-                /v1/messages: messages
-                /v1/rerank: rerank
-                /v1/responses: responses
-                /v1/responses/compact: detect
-                /v2/rerank: rerank
-                ":rawPredict": messages
-                ":streamRawPredict": messages
-        key: "llm:model:000001:fireworks-llama"
-        matches:
-          - headers:
-              - name: x-gateway-model-name
-                value:
-                  exact: fireworks-llama
-            path:
-              pathPrefix: /
-        name: "model:fireworks-llama"
-        namespace: internal
-      - backends:
-          - backend: "/llm:model:claude-3-haiku:2"
-            weight: 1
-        inlinePolicies:
-          - ai:
-              routes:
-                "*": passthrough
-                /v1/chat/completions: completions
-                /v1/embeddings: embeddings
-                /v1/images/edits: detect
-                /v1/images/generations: detect
-                /v1/images/variations: detect
-                /v1/messages: messages
-                /v1/rerank: rerank
-                /v1/responses: responses
-                /v1/responses/compact: detect
-                /v2/rerank: rerank
-                ":rawPredict": messages
-                ":streamRawPredict": messages
-        key: "llm:model:000002:claude-3-haiku"
-        matches:
-          - headers:
-              - name: x-org
-                value:
-                  exact: engineering
-              - name: x-gateway-model-name
-                value:
-                  exact: claude-3-haiku
-            path:
-              pathPrefix: /
-        name: "model:claude-3-haiku"
-        namespace: internal
-      - backends:
-          - backend: "/llm:model:gpt-3.5-turbo:3"
-            weight: 1
-        inlinePolicies:
-          - ai:
-              routes:
-                "*": passthrough
-                /v1/chat/completions: completions
-                /v1/embeddings: embeddings
-                /v1/images/edits: detect
-                /v1/images/generations: detect
-                /v1/images/variations: detect
-                /v1/messages: messages
-                /v1/rerank: rerank
-                /v1/responses: responses
-                /v1/responses/compact: detect
-                /v2/rerank: rerank
-                ":rawPredict": messages
-                ":streamRawPredict": messages
-        key: "llm:model:000003:gpt-3.5-turbo"
-        matches:
-          - headers:
-              - name: x-gateway-model-name
-                value:
-                  exact: gpt-3.5-turbo
-            path:
-              pathPrefix: /
-        name: "model:gpt-3.5-turbo"
-        namespace: internal
-      - backends:
-          - backend: "/llm:model:gpt-7-max:4"
-            weight: 1
-        inlinePolicies:
-          - ai:
-              routes:
-                "*": passthrough
-                /v1/chat/completions: completions
-                /v1/embeddings: embeddings
-                /v1/images/edits: detect
-                /v1/images/generations: detect
-                /v1/images/variations: detect
-                /v1/messages: messages
-                /v1/rerank: rerank
-                /v1/responses: responses
-                /v1/responses/compact: detect
-                /v2/rerank: rerank
-                ":rawPredict": messages
-                ":streamRawPredict": messages
-        key: "llm:model:000004:gpt-7-max"
-        matches:
-          - headers:
-              - name: x-gateway-model-name
-                value:
-                  exact: gpt-7-max
-            path:
-              pathPrefix: /
-        name: "model:gpt-7-max"
-        namespace: internal
-      - backends:
-          - backend: "/llm:model:*:5"
-            weight: 1
-        inlinePolicies:
-          - ai:
-              routes:
-                "*": passthrough
-                /v1/chat/completions: completions
-                /v1/embeddings: embeddings
-                /v1/images/edits: detect
-                /v1/images/generations: detect
-                /v1/images/variations: detect
-                /v1/messages: messages
-                /v1/rerank: rerank
-                /v1/responses: responses
-                /v1/responses/compact: detect
-                /v2/rerank: rerank
-                ":rawPredict": messages
-                ":streamRawPredict": messages
-        key: "llm:model:000005:*"
-        matches:
-          - headers:
-              - name: x-gateway-model-name
-                value:
-                  regex: ".*"
-            path:
-              pathPrefix: /
-        name: "model:*"
-        namespace: internal
-      - inlinePolicies:
-          - responseHeaderModifier:
-              set:
-                Content-Type: application/json
-          - directResponse:
-              bodyExpression: "\n\"x-gateway-model-name\" in request.headers ?\n\t{\n\t\t\"error\": {\n\t\t\t\"message\": \"Model \" + request.headers[\"x-gateway-model-name\"] + \" not found\",\n\t\t\t\"type\": \"invalid_request_error\",\n\t\t\t\"code\": \"model_not_found\"\n\t\t}\n\t} :\n\t{\n\t\t\"error\": {\n\t\t\t\"message\": \"No model set\",\n\t\t\t\"type\": \"invalid_request_error\",\n\t\t\t\"code\": \"model_not_found\"\n\t\t}\n\t}\n"
-              status: 404
-        key: "llm:model:fallback"
+    - - key: "llm:request"
+        llmRouter:
+          models:
+            - name: llama-3.1-8b-instant
+              visibility: public
+              headerMatches: []
+              backendKey: "llm:model:llama-3.1-8b-instant:0"
+              routePolicies:
+                - ai:
+                    routes:
+                      "*": passthrough
+                      /v1/chat/completions: completions
+                      /v1/embeddings: embeddings
+                      /v1/images/edits: detect
+                      /v1/images/generations: detect
+                      /v1/images/variations: detect
+                      /v1/messages: messages
+                      /v1/rerank: rerank
+                      /v1/responses: responses
+                      /v1/responses/compact: detect
+                      /v2/rerank: rerank
+                      ":rawPredict": messages
+                      ":streamRawPredict": messages
+              backendPolicies: []
+            - name: fireworks-llama
+              visibility: public
+              headerMatches: []
+              backendKey: "llm:model:fireworks-llama:1"
+              routePolicies:
+                - ai:
+                    routes:
+                      "*": passthrough
+                      /v1/chat/completions: completions
+                      /v1/embeddings: embeddings
+                      /v1/images/edits: detect
+                      /v1/images/generations: detect
+                      /v1/images/variations: detect
+                      /v1/messages: messages
+                      /v1/rerank: rerank
+                      /v1/responses: responses
+                      /v1/responses/compact: detect
+                      /v2/rerank: rerank
+                      ":rawPredict": messages
+                      ":streamRawPredict": messages
+              backendPolicies: []
+            - name: claude-3-haiku
+              visibility: public
+              headerMatches:
+                - - name: x-org
+                    value:
+                      exact: engineering
+              backendKey: "llm:model:claude-3-haiku:2"
+              routePolicies:
+                - ai:
+                    routes:
+                      "*": passthrough
+                      /v1/chat/completions: completions
+                      /v1/embeddings: embeddings
+                      /v1/images/edits: detect
+                      /v1/images/generations: detect
+                      /v1/images/variations: detect
+                      /v1/messages: messages
+                      /v1/rerank: rerank
+                      /v1/responses: responses
+                      /v1/responses/compact: detect
+                      /v2/rerank: rerank
+                      ":rawPredict": messages
+                      ":streamRawPredict": messages
+              backendPolicies: []
+            - name: gpt-3.5-turbo
+              visibility: public
+              headerMatches: []
+              backendKey: "llm:model:gpt-3.5-turbo:3"
+              routePolicies:
+                - ai:
+                    routes:
+                      "*": passthrough
+                      /v1/chat/completions: completions
+                      /v1/embeddings: embeddings
+                      /v1/images/edits: detect
+                      /v1/images/generations: detect
+                      /v1/images/variations: detect
+                      /v1/messages: messages
+                      /v1/rerank: rerank
+                      /v1/responses: responses
+                      /v1/responses/compact: detect
+                      /v2/rerank: rerank
+                      ":rawPredict": messages
+                      ":streamRawPredict": messages
+              backendPolicies: []
+            - name: gpt-7-max
+              visibility: public
+              headerMatches: []
+              backendKey: "llm:model:gpt-7-max:4"
+              routePolicies:
+                - ai:
+                    routes:
+                      "*": passthrough
+                      /v1/chat/completions: completions
+                      /v1/embeddings: embeddings
+                      /v1/images/edits: detect
+                      /v1/images/generations: detect
+                      /v1/images/variations: detect
+                      /v1/messages: messages
+                      /v1/rerank: rerank
+                      /v1/responses: responses
+                      /v1/responses/compact: detect
+                      /v2/rerank: rerank
+                      ":rawPredict": messages
+                      ":streamRawPredict": messages
+              backendPolicies: []
+            - name: "*"
+              visibility: public
+              headerMatches: []
+              backendKey: "llm:model:*:5"
+              routePolicies:
+                - ai:
+                    routes:
+                      "*": passthrough
+                      /v1/chat/completions: completions
+                      /v1/embeddings: embeddings
+                      /v1/images/edits: detect
+                      /v1/images/generations: detect
+                      /v1/images/variations: detect
+                      /v1/messages: messages
+                      /v1/rerank: rerank
+                      /v1/responses: responses
+                      /v1/responses/compact: detect
+                      /v2/rerank: rerank
+                      ":rawPredict": messages
+                      ":streamRawPredict": messages
+              backendPolicies: []
+          virtualModels: []
+          created: 0
         matches:
           - path:
               pathPrefix: /
-        name: "model:fallback"
+        name: "llm:request"
         namespace: internal
 listener_tcp_routes:
   - - llm
@@ -309,26 +224,6 @@ policies:
             tokensPerFill: 10
             type: tokens
         phase: route
-  - key: "llm:transformation"
-    name:
-      kind: Local
-      name: "llm:transformation"
-      namespace: internal
-    target:
-      gateway:
-        gatewayName: name
-        gatewayNamespace: ns
-        listenerName: llm
-    policy:
-      traffic:
-        phase: gateway
-        transformation:
-          request:
-            set:
-              - - x-gateway-model-name
-                - "\nrequest.path.endsWith(\":streamRawPredict\") || request.path.endsWith(\":rawPredict\") ?\n\trequest.path.regexReplace(\"^.*/publishers/anthropic/models/(.+?):.*\", \"${1}\") :\n\t(request.path.endsWith(\"/invoke-with-response-stream\") || request.path.endsWith(\"/invoke\") ?\n\trequest.path.regexReplace(\"^.*/model/(.+?)/invoke.*\", \"${1}\") :\n\tjson(request.body).model)\n"
-            body: "coalesce(json(request.body).merge({\"model\": request.headers[\"x-gateway-model-name\"]}), request.body)"
-          response: {}
   - key: frontend/accessLog
     name: ~
     target:
@@ -376,9 +271,6 @@ backends:
     inlinePolicies:
       - backendTLS:
           systemRoots: true
-      - requestHeaderModifier:
-          remove:
-            - x-gateway-model-name
       - ai:
           promptGuard:
             request:
@@ -429,9 +321,6 @@ backends:
     inlinePolicies:
       - backendTLS:
           systemRoots: true
-      - requestHeaderModifier:
-          remove:
-            - x-gateway-model-name
       - ai:
           promptGuard:
             request:
@@ -476,9 +365,6 @@ backends:
     inlinePolicies:
       - backendTLS:
           systemRoots: true
-      - requestHeaderModifier:
-          remove:
-            - x-gateway-model-name
       - responseHeaderModifier:
           remove:
             - server
@@ -544,9 +430,6 @@ backends:
                   capacity: 1
               rejected: {}
     inlinePolicies:
-      - requestHeaderModifier:
-          remove:
-            - x-gateway-model-name
       - ai:
           promptGuard:
             request:
@@ -588,9 +471,6 @@ backends:
                   capacity: 1
               rejected: {}
     inlinePolicies:
-      - requestHeaderModifier:
-          remove:
-            - x-gateway-model-name
       - ai:
           promptGuard:
             request:
@@ -635,9 +515,6 @@ backends:
                   capacity: 1
               rejected: {}
     inlinePolicies:
-      - requestHeaderModifier:
-          remove:
-            - x-gateway-model-name
       - ai:
           promptGuard:
             request:

--- a/crates/agentgateway/src/types/local_tests/llm_simple_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/llm_simple_normalized.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/agentgateway/src/types/local_tests.rs
+assertion_line: 207
 description: "Config normalization test for llm_simple: YAML -> LocalConfig -> NormalizedLocalConfig -> YAML"
 ---
 binds:
@@ -326,6 +327,7 @@ policies:
             set:
               - - x-gateway-model-name
                 - "\nrequest.path.endsWith(\":streamRawPredict\") || request.path.endsWith(\":rawPredict\") ?\n\trequest.path.regexReplace(\"^.*/publishers/anthropic/models/(.+?):.*\", \"${1}\") :\n\t(request.path.endsWith(\"/invoke-with-response-stream\") || request.path.endsWith(\"/invoke\") ?\n\trequest.path.regexReplace(\"^.*/model/(.+?)/invoke.*\", \"${1}\") :\n\tjson(request.body).model)\n"
+            body: "coalesce(json(request.body).merge({\"model\": request.headers[\"x-gateway-model-name\"]}), request.body)"
           response: {}
   - key: frontend/accessLog
     name: ~

--- a/crates/agentgateway/src/types/local_tests/llm_virtual_model_conditional_config.yaml
+++ b/crates/agentgateway/src/types/local_tests/llm_virtual_model_conditional_config.yaml
@@ -1,0 +1,31 @@
+llm:
+  models:
+  - name: foo/*
+    provider: openAI
+    params:
+      apiKey:
+        file: $HOME/.secrets/openai
+    transformation:
+      model: llmRequest.model.stripPrefix("foo/")
+  - name: openai/gpt-5-mini
+    provider: openAI
+    params:
+      apiKey:
+        file: $HOME/.secrets/openai
+  virtualModels:
+  - name: smart
+    routing:
+      conditional:
+        targets:
+        - when: json(request.body).route == "code"
+          model: foo/bar
+        - when: json(request.body).route == "fast"
+          model: openai/gpt-5-mini
+        - model: foo/baz
+  - name: simple
+    routing:
+      conditional:
+        targets:
+        - when: json(request.body).route == "legacy"
+          model: openai/gpt-5-mini
+        - model: foo/qux

--- a/crates/agentgateway/src/types/local_tests/llm_virtual_model_conditional_config.yaml
+++ b/crates/agentgateway/src/types/local_tests/llm_virtual_model_conditional_config.yaml
@@ -3,15 +3,13 @@ llm:
   - name: foo/*
     provider: openAI
     params:
-      apiKey:
-        file: $HOME/.secrets/openai
+      apiKey: sk-openai
     transformation:
       model: llmRequest.model.stripPrefix("foo/")
   - name: openai/gpt-5-mini
     provider: openAI
     params:
-      apiKey:
-        file: $HOME/.secrets/openai
+      apiKey: sk-openai
   virtualModels:
   - name: smart
     routing:

--- a/crates/agentgateway/src/types/local_tests/llm_virtual_model_conditional_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/llm_virtual_model_conditional_normalized.snap
@@ -18,129 +18,110 @@ binds:
         protocol: HTTP
 listener_routes:
   - - llm
-    - - inlinePolicies:
-          - responseHeaderModifier:
-              set:
-                Content-Type: application/json
-          - directResponse:
-              status: 200
-              authorizationFilteredModelList:
-                entries:
-                  - id: foo/*
-                    created: 0
-                    authorization: ~
-                  - id: openai/gpt-5-mini
-                    created: 0
-                    authorization: ~
-                  - id: smart
-                    created: 0
-                    authorization: ~
-                  - id: simple
-                    created: 0
-                    authorization: ~
-        key: "llm:admin:model-list"
+    - - key: "llm:request"
+        llmRouter:
+          models:
+            - name: openai/gpt-5-mini
+              visibility: public
+              headerMatches: []
+              backendKey: "llm:model:openai/gpt-5-mini:0"
+              routePolicies:
+                - ai:
+                    routes:
+                      "*": passthrough
+                      /v1/chat/completions: completions
+                      /v1/embeddings: embeddings
+                      /v1/images/edits: detect
+                      /v1/images/generations: detect
+                      /v1/images/variations: detect
+                      /v1/messages: messages
+                      /v1/rerank: rerank
+                      /v1/responses: responses
+                      /v1/responses/compact: detect
+                      /v2/rerank: rerank
+                      ":rawPredict": messages
+                      ":streamRawPredict": messages
+              backendPolicies: []
+            - name: foo/*
+              visibility: public
+              headerMatches: []
+              backendKey: "llm:model:foo/*:1"
+              routePolicies:
+                - ai:
+                    routes:
+                      "*": passthrough
+                      /v1/chat/completions: completions
+                      /v1/embeddings: embeddings
+                      /v1/images/edits: detect
+                      /v1/images/generations: detect
+                      /v1/images/variations: detect
+                      /v1/messages: messages
+                      /v1/rerank: rerank
+                      /v1/responses: responses
+                      /v1/responses/compact: detect
+                      /v2/rerank: rerank
+                      ":rawPredict": messages
+                      ":streamRawPredict": messages
+              backendPolicies: []
+          virtualModels:
+            - name: smart
+              routePolicies:
+                - ai:
+                    routes:
+                      "*": passthrough
+                      /v1/chat/completions: completions
+                      /v1/embeddings: embeddings
+                      /v1/images/edits: detect
+                      /v1/images/generations: detect
+                      /v1/images/variations: detect
+                      /v1/messages: messages
+                      /v1/rerank: rerank
+                      /v1/responses: responses
+                      /v1/responses/compact: detect
+                      /v2/rerank: rerank
+                      ":rawPredict": messages
+                      ":streamRawPredict": messages
+              routing:
+                conditional:
+                  - model: foo/bar
+                    when: "json(request.body).route == \"code\""
+                  - model: openai/gpt-5-mini
+                    when: "json(request.body).route == \"fast\""
+                  - model: foo/baz
+                    when: ~
+            - name: simple
+              routePolicies:
+                - ai:
+                    routes:
+                      "*": passthrough
+                      /v1/chat/completions: completions
+                      /v1/embeddings: embeddings
+                      /v1/images/edits: detect
+                      /v1/images/generations: detect
+                      /v1/images/variations: detect
+                      /v1/messages: messages
+                      /v1/rerank: rerank
+                      /v1/responses: responses
+                      /v1/responses/compact: detect
+                      /v2/rerank: rerank
+                      ":rawPredict": messages
+                      ":streamRawPredict": messages
+              routing:
+                conditional:
+                  - model: openai/gpt-5-mini
+                    when: "json(request.body).route == \"legacy\""
+                  - model: foo/qux
+                    when: ~
+          created: 0
         matches:
           - path:
-              pathPrefix: /v1/models
-          - path:
-              pathPrefix: /models
-        name: "admin:model-list"
-        namespace: internal
-      - backends:
-          - backend: "/llm:model:openai/gpt-5-mini:0"
-            weight: 1
-        inlinePolicies:
-          - ai:
-              routes:
-                "*": passthrough
-                /v1/chat/completions: completions
-                /v1/embeddings: embeddings
-                /v1/images/edits: detect
-                /v1/images/generations: detect
-                /v1/images/variations: detect
-                /v1/messages: messages
-                /v1/rerank: rerank
-                /v1/responses: responses
-                /v1/responses/compact: detect
-                /v2/rerank: rerank
-                ":rawPredict": messages
-                ":streamRawPredict": messages
-        key: "llm:model:000000:openai/gpt-5-mini"
-        matches:
-          - headers:
-              - name: x-gateway-model-name
-                value:
-                  exact: openai/gpt-5-mini
-            path:
               pathPrefix: /
-        name: "model:openai/gpt-5-mini"
-        namespace: internal
-      - backends:
-          - backend: "/llm:model:foo/*:1"
-            weight: 1
-        inlinePolicies:
-          - ai:
-              routes:
-                "*": passthrough
-                /v1/chat/completions: completions
-                /v1/embeddings: embeddings
-                /v1/images/edits: detect
-                /v1/images/generations: detect
-                /v1/images/variations: detect
-                /v1/messages: messages
-                /v1/rerank: rerank
-                /v1/responses: responses
-                /v1/responses/compact: detect
-                /v2/rerank: rerank
-                ":rawPredict": messages
-                ":streamRawPredict": messages
-        key: "llm:model:000001:foo/*"
-        matches:
-          - headers:
-              - name: x-gateway-model-name
-                value:
-                  regex: foo/.*
-            path:
-              pathPrefix: /
-        name: "model:foo/*"
-        namespace: internal
-      - inlinePolicies:
-          - responseHeaderModifier:
-              set:
-                Content-Type: application/json
-          - directResponse:
-              bodyExpression: "\n\"x-gateway-model-name\" in request.headers ?\n\t{\n\t\t\"error\": {\n\t\t\t\"message\": \"Model \" + request.headers[\"x-gateway-model-name\"] + \" not found\",\n\t\t\t\"type\": \"invalid_request_error\",\n\t\t\t\"code\": \"model_not_found\"\n\t\t}\n\t} :\n\t{\n\t\t\"error\": {\n\t\t\t\"message\": \"No model set\",\n\t\t\t\"type\": \"invalid_request_error\",\n\t\t\t\"code\": \"model_not_found\"\n\t\t}\n\t}\n"
-              status: 404
-        key: "llm:model:fallback"
-        matches:
-          - path:
-              pathPrefix: /
-        name: "model:fallback"
+        name: "llm:request"
         namespace: internal
 listener_tcp_routes:
   - - llm
     - []
-policies:
-  - key: "llm:transformation"
-    name:
-      kind: Local
-      name: "llm:transformation"
-      namespace: internal
-    target:
-      gateway:
-        gatewayName: name
-        gatewayNamespace: ns
-        listenerName: llm
-    policy:
-      traffic:
-        phase: gateway
-        transformation:
-          request:
-            set:
-              - - x-gateway-model-name
-                - "(\nrequest.path.endsWith(\":streamRawPredict\") || request.path.endsWith(\":rawPredict\") ?\n\trequest.path.regexReplace(\"^.*/publishers/anthropic/models/(.+?):.*\", \"${1}\") :\n\t(request.path.endsWith(\"/invoke-with-response-stream\") || request.path.endsWith(\"/invoke\") ?\n\trequest.path.regexReplace(\"^.*/model/(.+?)/invoke.*\", \"${1}\") :\n\tjson(request.body).model)\n).with(requestedModel, (requestedModel == \"smart\") ? ((json(request.body).route == \"code\") ? \"foo/bar\" : ((json(request.body).route == \"fast\") ? \"openai/gpt-5-mini\" : (\"foo/baz\"))) : ((requestedModel == \"simple\") ? ((json(request.body).route == \"legacy\") ? \"openai/gpt-5-mini\" : (\"foo/qux\")) : (requestedModel)))"
-            body: "coalesce(json(request.body).merge({\"model\": request.headers[\"x-gateway-model-name\"]}), request.body)"
-          response: {}
+policies: []
 backends:
   - backend:
       ai:
@@ -173,9 +154,6 @@ backends:
                   capacity: 1
               rejected: {}
     inlinePolicies:
-      - requestHeaderModifier:
-          remove:
-            - x-gateway-model-name
       - ai: {}
   - backend:
       ai:
@@ -208,9 +186,6 @@ backends:
                   capacity: 1
               rejected: {}
     inlinePolicies:
-      - requestHeaderModifier:
-          remove:
-            - x-gateway-model-name
       - ai:
           transformations:
             model: "llmRequest.model.stripPrefix(\"foo/\")"

--- a/crates/agentgateway/src/types/local_tests/llm_virtual_model_conditional_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/llm_virtual_model_conditional_normalized.snap
@@ -1,0 +1,219 @@
+---
+source: crates/agentgateway/src/types/local_tests.rs
+assertion_line: 207
+description: "Config normalization test for llm_virtual_model_conditional: YAML -> LocalConfig -> NormalizedLocalConfig -> YAML"
+---
+binds:
+  - key: bind/4000
+    address: "[::]:4000"
+    protocol: http
+    tunnelProtocol: direct
+    listeners:
+      llm:
+        gatewayName: name
+        gatewayNamespace: ns
+        hostname: "*"
+        key: llm
+        listenerName: llm
+        protocol: HTTP
+listener_routes:
+  - - llm
+    - - inlinePolicies:
+          - responseHeaderModifier:
+              set:
+                Content-Type: application/json
+          - directResponse:
+              status: 200
+              authorizationFilteredModelList:
+                entries:
+                  - id: foo/*
+                    created: 0
+                    authorization: ~
+                  - id: openai/gpt-5-mini
+                    created: 0
+                    authorization: ~
+                  - id: smart
+                    created: 0
+                    authorization: ~
+                  - id: simple
+                    created: 0
+                    authorization: ~
+        key: "llm:admin:model-list"
+        matches:
+          - path:
+              pathPrefix: /v1/models
+          - path:
+              pathPrefix: /models
+        name: "admin:model-list"
+        namespace: internal
+      - backends:
+          - backend: "/llm:model:openai/gpt-5-mini:0"
+            weight: 1
+        inlinePolicies:
+          - ai:
+              routes:
+                "*": passthrough
+                /v1/chat/completions: completions
+                /v1/embeddings: embeddings
+                /v1/images/edits: detect
+                /v1/images/generations: detect
+                /v1/images/variations: detect
+                /v1/messages: messages
+                /v1/rerank: rerank
+                /v1/responses: responses
+                /v1/responses/compact: detect
+                /v2/rerank: rerank
+                ":rawPredict": messages
+                ":streamRawPredict": messages
+        key: "llm:model:000000:openai/gpt-5-mini"
+        matches:
+          - headers:
+              - name: x-gateway-model-name
+                value:
+                  exact: openai/gpt-5-mini
+            path:
+              pathPrefix: /
+        name: "model:openai/gpt-5-mini"
+        namespace: internal
+      - backends:
+          - backend: "/llm:model:foo/*:1"
+            weight: 1
+        inlinePolicies:
+          - ai:
+              routes:
+                "*": passthrough
+                /v1/chat/completions: completions
+                /v1/embeddings: embeddings
+                /v1/images/edits: detect
+                /v1/images/generations: detect
+                /v1/images/variations: detect
+                /v1/messages: messages
+                /v1/rerank: rerank
+                /v1/responses: responses
+                /v1/responses/compact: detect
+                /v2/rerank: rerank
+                ":rawPredict": messages
+                ":streamRawPredict": messages
+        key: "llm:model:000001:foo/*"
+        matches:
+          - headers:
+              - name: x-gateway-model-name
+                value:
+                  regex: foo/.*
+            path:
+              pathPrefix: /
+        name: "model:foo/*"
+        namespace: internal
+      - inlinePolicies:
+          - responseHeaderModifier:
+              set:
+                Content-Type: application/json
+          - directResponse:
+              bodyExpression: "\n\"x-gateway-model-name\" in request.headers ?\n\t{\n\t\t\"error\": {\n\t\t\t\"message\": \"Model \" + request.headers[\"x-gateway-model-name\"] + \" not found\",\n\t\t\t\"type\": \"invalid_request_error\",\n\t\t\t\"code\": \"model_not_found\"\n\t\t}\n\t} :\n\t{\n\t\t\"error\": {\n\t\t\t\"message\": \"No model set\",\n\t\t\t\"type\": \"invalid_request_error\",\n\t\t\t\"code\": \"model_not_found\"\n\t\t}\n\t}\n"
+              status: 404
+        key: "llm:model:fallback"
+        matches:
+          - path:
+              pathPrefix: /
+        name: "model:fallback"
+        namespace: internal
+listener_tcp_routes:
+  - - llm
+    - []
+policies:
+  - key: "llm:transformation"
+    name:
+      kind: Local
+      name: "llm:transformation"
+      namespace: internal
+    target:
+      gateway:
+        gatewayName: name
+        gatewayNamespace: ns
+        listenerName: llm
+    policy:
+      traffic:
+        phase: gateway
+        transformation:
+          request:
+            set:
+              - - x-gateway-model-name
+                - "(\nrequest.path.endsWith(\":streamRawPredict\") || request.path.endsWith(\":rawPredict\") ?\n\trequest.path.regexReplace(\"^.*/publishers/anthropic/models/(.+?):.*\", \"${1}\") :\n\t(request.path.endsWith(\"/invoke-with-response-stream\") || request.path.endsWith(\"/invoke\") ?\n\trequest.path.regexReplace(\"^.*/model/(.+?)/invoke.*\", \"${1}\") :\n\tjson(request.body).model)\n).with(requestedModel, (requestedModel == \"smart\") ? ((json(request.body).route == \"code\") ? \"foo/bar\" : ((json(request.body).route == \"fast\") ? \"openai/gpt-5-mini\" : (\"foo/baz\"))) : ((requestedModel == \"simple\") ? ((json(request.body).route == \"legacy\") ? \"openai/gpt-5-mini\" : (\"foo/qux\")) : (requestedModel)))"
+            body: "coalesce(json(request.body).merge({\"model\": request.headers[\"x-gateway-model-name\"]}), request.body)"
+          response: {}
+backends:
+  - backend:
+      ai:
+        name: "llm:model:openai/gpt-5-mini:0"
+        namespace: ""
+        target:
+          providers:
+            - active:
+                openai/gpt-5-mini:
+                  endpoint:
+                    name: openai/gpt-5-mini
+                    provider:
+                      openAI: {}
+                    hostOverride: ~
+                    pathOverride: ~
+                    pathPrefix: ~
+                    tokenize: false
+                    inlinePolicies:
+                      - backendAuth:
+                          key:
+                            value: "<redacted>"
+                  info:
+                    health: 1
+                    requestLatency: 0
+                    pendingRequests: 0
+                    totalRequests: 0
+                    consecutiveFailures: 0
+                    timesEjected: 0
+                    evictedUntil: ~
+                  capacity: 1
+              rejected: {}
+    inlinePolicies:
+      - requestHeaderModifier:
+          remove:
+            - x-gateway-model-name
+      - ai: {}
+  - backend:
+      ai:
+        name: "llm:model:foo/*:1"
+        namespace: ""
+        target:
+          providers:
+            - active:
+                foo/*:
+                  endpoint:
+                    name: foo/*
+                    provider:
+                      openAI: {}
+                    hostOverride: ~
+                    pathOverride: ~
+                    pathPrefix: ~
+                    tokenize: false
+                    inlinePolicies:
+                      - backendAuth:
+                          key:
+                            value: "<redacted>"
+                  info:
+                    health: 1
+                    requestLatency: 0
+                    pendingRequests: 0
+                    totalRequests: 0
+                    consecutiveFailures: 0
+                    timesEjected: 0
+                    evictedUntil: ~
+                  capacity: 1
+              rejected: {}
+    inlinePolicies:
+      - requestHeaderModifier:
+          remove:
+            - x-gateway-model-name
+      - ai:
+          transformations:
+            model: "llmRequest.model.stripPrefix(\"foo/\")"
+route_groups: []
+workloads: []
+services: []

--- a/crates/agentgateway/src/types/local_tests/llm_virtual_model_config.yaml
+++ b/crates/agentgateway/src/types/local_tests/llm_virtual_model_config.yaml
@@ -1,0 +1,34 @@
+llm:
+  models:
+  - name: anthropic/*
+    visibility: internal
+    provider: anthropic
+    params:
+      apiKey:
+        file: $HOME/.secrets/anthropic
+    transformation:
+      model: llmRequest.model.stripPrefix("anthropic/")
+  - name: openai/gpt-5-mini
+    visibility: internal
+    provider: openAI
+    params:
+      model: gpt-5-mini
+      apiKey:
+        file: $HOME/.secrets/openai
+  - name: "*"
+    visibility: internal
+    provider: openAI
+    params:
+      apiKey:
+        file: $HOME/.secrets/openai
+  virtualModels:
+  - name: fast
+    routing:
+      weighted:
+        targets:
+        - model: anthropic/haiku
+          weight: 60
+        - model: openai/gpt-5-mini
+          weight: 30
+        - model: fallback-small
+          weight: 10

--- a/crates/agentgateway/src/types/local_tests/llm_virtual_model_config.yaml
+++ b/crates/agentgateway/src/types/local_tests/llm_virtual_model_config.yaml
@@ -4,8 +4,7 @@ llm:
     visibility: internal
     provider: anthropic
     params:
-      apiKey:
-        file: $HOME/.secrets/anthropic
+      apiKey: sk-anthropic
     transformation:
       model: llmRequest.model.stripPrefix("anthropic/")
   - name: openai/gpt-5-mini
@@ -13,14 +12,12 @@ llm:
     provider: openAI
     params:
       model: gpt-5-mini
-      apiKey:
-        file: $HOME/.secrets/openai
+      apiKey: sk-openai
   - name: "*"
     visibility: internal
     provider: openAI
     params:
-      apiKey:
-        file: $HOME/.secrets/openai
+      apiKey: sk-openai
   virtualModels:
   - name: fast
     routing:

--- a/crates/agentgateway/src/types/local_tests/llm_virtual_model_failover_config.yaml
+++ b/crates/agentgateway/src/types/local_tests/llm_virtual_model_failover_config.yaml
@@ -4,14 +4,12 @@ llm:
     provider: openAI
     params:
       model: gpt-5-mini
-      apiKey:
-        file: $HOME/.secrets/openai
+      apiKey: sk-openai
   - name: anthropic/*
     visibility: internal
     provider: anthropic
     params:
-      apiKey:
-        file: $HOME/.secrets/anthropic
+      apiKey: sk-anthropic
     transformation:
       model: llmRequest.model.stripPrefix("anthropic/")
   virtualModels:

--- a/crates/agentgateway/src/types/local_tests/llm_virtual_model_failover_config.yaml
+++ b/crates/agentgateway/src/types/local_tests/llm_virtual_model_failover_config.yaml
@@ -1,0 +1,27 @@
+llm:
+  models:
+  - name: openai/gpt-5-mini
+    provider: openAI
+    params:
+      model: gpt-5-mini
+      apiKey:
+        file: $HOME/.secrets/openai
+  - name: anthropic/*
+    visibility: internal
+    provider: anthropic
+    params:
+      apiKey:
+        file: $HOME/.secrets/anthropic
+    transformation:
+      model: llmRequest.model.stripPrefix("anthropic/")
+  virtualModels:
+  - name: resilient
+    routing:
+      failover:
+        targets:
+        - model: openai/gpt-5-mini
+          priority: 0
+        - model: anthropic/haiku
+          priority: 1
+        - model: anthropic/sonnet
+          priority: 1

--- a/crates/agentgateway/src/types/local_tests/llm_virtual_model_failover_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/llm_virtual_model_failover_normalized.snap
@@ -1,0 +1,322 @@
+---
+source: crates/agentgateway/src/types/local_tests.rs
+assertion_line: 207
+description: "Config normalization test for llm_virtual_model_failover: YAML -> LocalConfig -> NormalizedLocalConfig -> YAML"
+---
+binds:
+  - key: bind/4000
+    address: "[::]:4000"
+    protocol: http
+    tunnelProtocol: direct
+    listeners:
+      llm:
+        gatewayName: name
+        gatewayNamespace: ns
+        hostname: "*"
+        key: llm
+        listenerName: llm
+        protocol: HTTP
+listener_routes:
+  - - llm
+    - - inlinePolicies:
+          - responseHeaderModifier:
+              set:
+                Content-Type: application/json
+          - directResponse:
+              status: 200
+              authorizationFilteredModelList:
+                entries:
+                  - id: openai/gpt-5-mini
+                    created: 0
+                    authorization: ~
+                  - id: anthropic/*
+                    created: 0
+                    authorization: ~
+                  - id: resilient
+                    created: 0
+                    authorization: ~
+        key: "llm:admin:model-list"
+        matches:
+          - path:
+              pathPrefix: /v1/models
+          - path:
+              pathPrefix: /models
+        name: "admin:model-list"
+        namespace: internal
+      - backends:
+          - backend: "/llm:model:openai/gpt-5-mini:0"
+            weight: 1
+        inlinePolicies:
+          - ai:
+              routes:
+                "*": passthrough
+                /v1/chat/completions: completions
+                /v1/embeddings: embeddings
+                /v1/images/edits: detect
+                /v1/images/generations: detect
+                /v1/images/variations: detect
+                /v1/messages: messages
+                /v1/rerank: rerank
+                /v1/responses: responses
+                /v1/responses/compact: detect
+                /v2/rerank: rerank
+                ":rawPredict": messages
+                ":streamRawPredict": messages
+        key: "llm:model:000000:openai/gpt-5-mini"
+        matches:
+          - headers:
+              - name: x-gateway-model-name
+                value:
+                  exact: openai/gpt-5-mini
+            path:
+              pathPrefix: /
+        name: "model:openai/gpt-5-mini"
+        namespace: internal
+      - backends:
+          - backend: "/llm:virtual-model:resilient:0"
+            weight: 1
+        inlinePolicies:
+          - ai:
+              routes:
+                "*": passthrough
+                /v1/chat/completions: completions
+                /v1/embeddings: embeddings
+                /v1/images/edits: detect
+                /v1/images/generations: detect
+                /v1/images/variations: detect
+                /v1/messages: messages
+                /v1/rerank: rerank
+                /v1/responses: responses
+                /v1/responses/compact: detect
+                /v2/rerank: rerank
+                ":rawPredict": messages
+                ":streamRawPredict": messages
+        key: "llm:virtual-model:000000:resilient"
+        matches:
+          - headers:
+              - name: x-gateway-model-name
+                value:
+                  exact: resilient
+            path:
+              pathPrefix: /
+        name: "virtual-model:resilient"
+        namespace: internal
+      - inlinePolicies:
+          - responseHeaderModifier:
+              set:
+                Content-Type: application/json
+          - directResponse:
+              bodyExpression: "\n\"x-gateway-model-name\" in request.headers ?\n\t{\n\t\t\"error\": {\n\t\t\t\"message\": \"Model \" + request.headers[\"x-gateway-model-name\"] + \" not found\",\n\t\t\t\"type\": \"invalid_request_error\",\n\t\t\t\"code\": \"model_not_found\"\n\t\t}\n\t} :\n\t{\n\t\t\"error\": {\n\t\t\t\"message\": \"No model set\",\n\t\t\t\"type\": \"invalid_request_error\",\n\t\t\t\"code\": \"model_not_found\"\n\t\t}\n\t}\n"
+              status: 404
+        key: "llm:model:fallback"
+        matches:
+          - path:
+              pathPrefix: /
+        name: "model:fallback"
+        namespace: internal
+listener_tcp_routes:
+  - - llm
+    - []
+policies:
+  - key: "llm:transformation"
+    name:
+      kind: Local
+      name: "llm:transformation"
+      namespace: internal
+    target:
+      gateway:
+        gatewayName: name
+        gatewayNamespace: ns
+        listenerName: llm
+    policy:
+      traffic:
+        phase: gateway
+        transformation:
+          request:
+            set:
+              - - x-gateway-model-name
+                - "\nrequest.path.endsWith(\":streamRawPredict\") || request.path.endsWith(\":rawPredict\") ?\n\trequest.path.regexReplace(\"^.*/publishers/anthropic/models/(.+?):.*\", \"${1}\") :\n\t(request.path.endsWith(\"/invoke-with-response-stream\") || request.path.endsWith(\"/invoke\") ?\n\trequest.path.regexReplace(\"^.*/model/(.+?)/invoke.*\", \"${1}\") :\n\tjson(request.body).model)\n"
+            body: "coalesce(json(request.body).merge({\"model\": request.headers[\"x-gateway-model-name\"]}), request.body)"
+          response: {}
+backends:
+  - backend:
+      ai:
+        name: "llm:model:openai/gpt-5-mini:0"
+        namespace: ""
+        target:
+          providers:
+            - active:
+                openai/gpt-5-mini:
+                  endpoint:
+                    name: openai/gpt-5-mini
+                    provider:
+                      openAI:
+                        model: gpt-5-mini
+                    hostOverride: ~
+                    pathOverride: ~
+                    pathPrefix: ~
+                    tokenize: false
+                    inlinePolicies:
+                      - backendAuth:
+                          key:
+                            value: "<redacted>"
+                  info:
+                    health: 1
+                    requestLatency: 0
+                    pendingRequests: 0
+                    totalRequests: 0
+                    consecutiveFailures: 0
+                    timesEjected: 0
+                    evictedUntil: ~
+                  capacity: 1
+              rejected: {}
+    inlinePolicies:
+      - requestHeaderModifier:
+          remove:
+            - x-gateway-model-name
+      - ai: {}
+  - backend:
+      ai:
+        name: "llm:model:anthropic/*:1"
+        namespace: ""
+        target:
+          providers:
+            - active:
+                anthropic/*:
+                  endpoint:
+                    name: anthropic/*
+                    provider:
+                      anthropic: {}
+                    hostOverride: ~
+                    pathOverride: ~
+                    pathPrefix: ~
+                    tokenize: false
+                    inlinePolicies:
+                      - backendAuth:
+                          key:
+                            value: "<redacted>"
+                  info:
+                    health: 1
+                    requestLatency: 0
+                    pendingRequests: 0
+                    totalRequests: 0
+                    consecutiveFailures: 0
+                    timesEjected: 0
+                    evictedUntil: ~
+                  capacity: 1
+              rejected: {}
+    inlinePolicies:
+      - requestHeaderModifier:
+          remove:
+            - x-gateway-model-name
+      - ai:
+          transformations:
+            model: "llmRequest.model.stripPrefix(\"anthropic/\")"
+  - backend:
+      ai:
+        name: "llm:virtual-model:resilient:0"
+        namespace: ""
+        target:
+          providers:
+            - active:
+                openai/gpt-5-mini:
+                  endpoint:
+                    name: openai/gpt-5-mini
+                    provider:
+                      openAI:
+                        model: gpt-5-mini
+                    hostOverride: ~
+                    pathOverride: ~
+                    pathPrefix: ~
+                    tokenize: false
+                    inlinePolicies:
+                      - backendAuth:
+                          key:
+                            value: "<redacted>"
+                      - requestHeaderModifier:
+                          remove:
+                            - x-gateway-model-name
+                      - ai: {}
+                      - transformation:
+                          request:
+                            body: "coalesce(json(request.body).merge({\"model\": \"openai/gpt-5-mini\"}), request.body)"
+                          response: {}
+                  info:
+                    health: 1
+                    requestLatency: 0
+                    pendingRequests: 0
+                    totalRequests: 0
+                    consecutiveFailures: 0
+                    timesEjected: 0
+                    evictedUntil: ~
+                  capacity: 1
+              rejected: {}
+            - active:
+                anthropic/haiku:
+                  endpoint:
+                    name: anthropic/haiku
+                    provider:
+                      anthropic: {}
+                    hostOverride: ~
+                    pathOverride: ~
+                    pathPrefix: ~
+                    tokenize: false
+                    inlinePolicies:
+                      - backendAuth:
+                          key:
+                            value: "<redacted>"
+                      - requestHeaderModifier:
+                          remove:
+                            - x-gateway-model-name
+                      - ai:
+                          transformations:
+                            model: "llmRequest.model.stripPrefix(\"anthropic/\")"
+                      - transformation:
+                          request:
+                            body: "coalesce(json(request.body).merge({\"model\": \"anthropic/haiku\"}), request.body)"
+                          response: {}
+                  info:
+                    health: 1
+                    requestLatency: 0
+                    pendingRequests: 0
+                    totalRequests: 0
+                    consecutiveFailures: 0
+                    timesEjected: 0
+                    evictedUntil: ~
+                  capacity: 1
+                anthropic/sonnet:
+                  endpoint:
+                    name: anthropic/sonnet
+                    provider:
+                      anthropic: {}
+                    hostOverride: ~
+                    pathOverride: ~
+                    pathPrefix: ~
+                    tokenize: false
+                    inlinePolicies:
+                      - backendAuth:
+                          key:
+                            value: "<redacted>"
+                      - requestHeaderModifier:
+                          remove:
+                            - x-gateway-model-name
+                      - ai:
+                          transformations:
+                            model: "llmRequest.model.stripPrefix(\"anthropic/\")"
+                      - transformation:
+                          request:
+                            body: "coalesce(json(request.body).merge({\"model\": \"anthropic/sonnet\"}), request.body)"
+                          response: {}
+                  info:
+                    health: 1
+                    requestLatency: 0
+                    pendingRequests: 0
+                    totalRequests: 0
+                    consecutiveFailures: 0
+                    timesEjected: 0
+                    evictedUntil: ~
+                  capacity: 1
+              rejected: {}
+route_groups: []
+workloads: []
+services: []

--- a/crates/agentgateway/src/types/local_tests/llm_virtual_model_failover_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/llm_virtual_model_failover_normalized.snap
@@ -18,126 +18,82 @@ binds:
         protocol: HTTP
 listener_routes:
   - - llm
-    - - inlinePolicies:
-          - responseHeaderModifier:
-              set:
-                Content-Type: application/json
-          - directResponse:
-              status: 200
-              authorizationFilteredModelList:
-                entries:
-                  - id: openai/gpt-5-mini
-                    created: 0
-                    authorization: ~
-                  - id: anthropic/*
-                    created: 0
-                    authorization: ~
-                  - id: resilient
-                    created: 0
-                    authorization: ~
-        key: "llm:admin:model-list"
-        matches:
-          - path:
-              pathPrefix: /v1/models
-          - path:
-              pathPrefix: /models
-        name: "admin:model-list"
-        namespace: internal
-      - backends:
-          - backend: "/llm:model:openai/gpt-5-mini:0"
-            weight: 1
-        inlinePolicies:
-          - ai:
-              routes:
-                "*": passthrough
-                /v1/chat/completions: completions
-                /v1/embeddings: embeddings
-                /v1/images/edits: detect
-                /v1/images/generations: detect
-                /v1/images/variations: detect
-                /v1/messages: messages
-                /v1/rerank: rerank
-                /v1/responses: responses
-                /v1/responses/compact: detect
-                /v2/rerank: rerank
-                ":rawPredict": messages
-                ":streamRawPredict": messages
-        key: "llm:model:000000:openai/gpt-5-mini"
-        matches:
-          - headers:
-              - name: x-gateway-model-name
-                value:
-                  exact: openai/gpt-5-mini
-            path:
-              pathPrefix: /
-        name: "model:openai/gpt-5-mini"
-        namespace: internal
-      - backends:
-          - backend: "/llm:virtual-model:resilient:0"
-            weight: 1
-        inlinePolicies:
-          - ai:
-              routes:
-                "*": passthrough
-                /v1/chat/completions: completions
-                /v1/embeddings: embeddings
-                /v1/images/edits: detect
-                /v1/images/generations: detect
-                /v1/images/variations: detect
-                /v1/messages: messages
-                /v1/rerank: rerank
-                /v1/responses: responses
-                /v1/responses/compact: detect
-                /v2/rerank: rerank
-                ":rawPredict": messages
-                ":streamRawPredict": messages
-        key: "llm:virtual-model:000000:resilient"
-        matches:
-          - headers:
-              - name: x-gateway-model-name
-                value:
-                  exact: resilient
-            path:
-              pathPrefix: /
-        name: "virtual-model:resilient"
-        namespace: internal
-      - inlinePolicies:
-          - responseHeaderModifier:
-              set:
-                Content-Type: application/json
-          - directResponse:
-              bodyExpression: "\n\"x-gateway-model-name\" in request.headers ?\n\t{\n\t\t\"error\": {\n\t\t\t\"message\": \"Model \" + request.headers[\"x-gateway-model-name\"] + \" not found\",\n\t\t\t\"type\": \"invalid_request_error\",\n\t\t\t\"code\": \"model_not_found\"\n\t\t}\n\t} :\n\t{\n\t\t\"error\": {\n\t\t\t\"message\": \"No model set\",\n\t\t\t\"type\": \"invalid_request_error\",\n\t\t\t\"code\": \"model_not_found\"\n\t\t}\n\t}\n"
-              status: 404
-        key: "llm:model:fallback"
+    - - key: "llm:request"
+        llmRouter:
+          models:
+            - name: openai/gpt-5-mini
+              visibility: public
+              headerMatches: []
+              backendKey: "llm:model:openai/gpt-5-mini:0"
+              routePolicies:
+                - ai:
+                    routes:
+                      "*": passthrough
+                      /v1/chat/completions: completions
+                      /v1/embeddings: embeddings
+                      /v1/images/edits: detect
+                      /v1/images/generations: detect
+                      /v1/images/variations: detect
+                      /v1/messages: messages
+                      /v1/rerank: rerank
+                      /v1/responses: responses
+                      /v1/responses/compact: detect
+                      /v2/rerank: rerank
+                      ":rawPredict": messages
+                      ":streamRawPredict": messages
+              backendPolicies: []
+            - name: anthropic/*
+              visibility: internal
+              headerMatches: []
+              backendKey: "llm:model:anthropic/*:1"
+              routePolicies:
+                - ai:
+                    routes:
+                      "*": passthrough
+                      /v1/chat/completions: completions
+                      /v1/embeddings: embeddings
+                      /v1/images/edits: detect
+                      /v1/images/generations: detect
+                      /v1/images/variations: detect
+                      /v1/messages: messages
+                      /v1/rerank: rerank
+                      /v1/responses: responses
+                      /v1/responses/compact: detect
+                      /v2/rerank: rerank
+                      ":rawPredict": messages
+                      ":streamRawPredict": messages
+              backendPolicies: []
+          virtualModels:
+            - name: resilient
+              routePolicies:
+                - ai:
+                    routes:
+                      "*": passthrough
+                      /v1/chat/completions: completions
+                      /v1/embeddings: embeddings
+                      /v1/images/edits: detect
+                      /v1/images/generations: detect
+                      /v1/images/variations: detect
+                      /v1/messages: messages
+                      /v1/rerank: rerank
+                      /v1/responses: responses
+                      /v1/responses/compact: detect
+                      /v2/rerank: rerank
+                      ":rawPredict": messages
+                      ":streamRawPredict": messages
+              routing:
+                failover:
+                  backend_key: "llm:virtual-model:resilient:0"
+          created: 0
         matches:
           - path:
               pathPrefix: /
-        name: "model:fallback"
+        name: "llm:request"
         namespace: internal
 listener_tcp_routes:
   - - llm
     - []
-policies:
-  - key: "llm:transformation"
-    name:
-      kind: Local
-      name: "llm:transformation"
-      namespace: internal
-    target:
-      gateway:
-        gatewayName: name
-        gatewayNamespace: ns
-        listenerName: llm
-    policy:
-      traffic:
-        phase: gateway
-        transformation:
-          request:
-            set:
-              - - x-gateway-model-name
-                - "\nrequest.path.endsWith(\":streamRawPredict\") || request.path.endsWith(\":rawPredict\") ?\n\trequest.path.regexReplace(\"^.*/publishers/anthropic/models/(.+?):.*\", \"${1}\") :\n\t(request.path.endsWith(\"/invoke-with-response-stream\") || request.path.endsWith(\"/invoke\") ?\n\trequest.path.regexReplace(\"^.*/model/(.+?)/invoke.*\", \"${1}\") :\n\tjson(request.body).model)\n"
-            body: "coalesce(json(request.body).merge({\"model\": request.headers[\"x-gateway-model-name\"]}), request.body)"
-          response: {}
+policies: []
 backends:
   - backend:
       ai:
@@ -171,9 +127,6 @@ backends:
                   capacity: 1
               rejected: {}
     inlinePolicies:
-      - requestHeaderModifier:
-          remove:
-            - x-gateway-model-name
       - ai: {}
   - backend:
       ai:
@@ -206,9 +159,6 @@ backends:
                   capacity: 1
               rejected: {}
     inlinePolicies:
-      - requestHeaderModifier:
-          remove:
-            - x-gateway-model-name
       - ai:
           transformations:
             model: "llmRequest.model.stripPrefix(\"anthropic/\")"
@@ -233,14 +183,7 @@ backends:
                       - backendAuth:
                           key:
                             value: "<redacted>"
-                      - requestHeaderModifier:
-                          remove:
-                            - x-gateway-model-name
                       - ai: {}
-                      - transformation:
-                          request:
-                            body: "coalesce(json(request.body).merge({\"model\": \"openai/gpt-5-mini\"}), request.body)"
-                          response: {}
                   info:
                     health: 1
                     requestLatency: 0
@@ -256,7 +199,8 @@ backends:
                   endpoint:
                     name: anthropic/haiku
                     provider:
-                      anthropic: {}
+                      anthropic:
+                        model: anthropic/haiku
                     hostOverride: ~
                     pathOverride: ~
                     pathPrefix: ~
@@ -265,16 +209,9 @@ backends:
                       - backendAuth:
                           key:
                             value: "<redacted>"
-                      - requestHeaderModifier:
-                          remove:
-                            - x-gateway-model-name
                       - ai:
                           transformations:
                             model: "llmRequest.model.stripPrefix(\"anthropic/\")"
-                      - transformation:
-                          request:
-                            body: "coalesce(json(request.body).merge({\"model\": \"anthropic/haiku\"}), request.body)"
-                          response: {}
                   info:
                     health: 1
                     requestLatency: 0
@@ -288,7 +225,8 @@ backends:
                   endpoint:
                     name: anthropic/sonnet
                     provider:
-                      anthropic: {}
+                      anthropic:
+                        model: anthropic/sonnet
                     hostOverride: ~
                     pathOverride: ~
                     pathPrefix: ~
@@ -297,16 +235,9 @@ backends:
                       - backendAuth:
                           key:
                             value: "<redacted>"
-                      - requestHeaderModifier:
-                          remove:
-                            - x-gateway-model-name
                       - ai:
                           transformations:
                             model: "llmRequest.model.stripPrefix(\"anthropic/\")"
-                      - transformation:
-                          request:
-                            body: "coalesce(json(request.body).merge({\"model\": \"anthropic/sonnet\"}), request.body)"
-                          response: {}
                   info:
                     health: 1
                     requestLatency: 0

--- a/crates/agentgateway/src/types/local_tests/llm_virtual_model_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/llm_virtual_model_normalized.snap
@@ -1,0 +1,245 @@
+---
+source: crates/agentgateway/src/types/local_tests.rs
+assertion_line: 207
+description: "Config normalization test for llm_virtual_model: YAML -> LocalConfig -> NormalizedLocalConfig -> YAML"
+---
+binds:
+  - key: bind/4000
+    address: "[::]:4000"
+    protocol: http
+    tunnelProtocol: direct
+    listeners:
+      llm:
+        gatewayName: name
+        gatewayNamespace: ns
+        hostname: "*"
+        key: llm
+        listenerName: llm
+        protocol: HTTP
+listener_routes:
+  - - llm
+    - - inlinePolicies:
+          - responseHeaderModifier:
+              set:
+                Content-Type: application/json
+          - directResponse:
+              status: 200
+              authorizationFilteredModelList:
+                entries:
+                  - id: anthropic/*
+                    created: 0
+                    authorization: ~
+                  - id: openai/gpt-5-mini
+                    created: 0
+                    authorization: ~
+                  - id: "*"
+                    created: 0
+                    authorization: ~
+                  - id: fast
+                    created: 0
+                    authorization: ~
+        key: "llm:admin:model-list"
+        matches:
+          - path:
+              pathPrefix: /v1/models
+          - path:
+              pathPrefix: /models
+        name: "admin:model-list"
+        namespace: internal
+      - backends:
+          - backend: "/llm:model:anthropic/*:1"
+            inlinePolicies:
+              - transformation:
+                  request:
+                    body: "coalesce(json(request.body).merge({\"model\": \"anthropic/haiku\"}), request.body)"
+                  response: {}
+            weight: 60
+          - backend: "/llm:model:openai/gpt-5-mini:0"
+            inlinePolicies:
+              - transformation:
+                  request:
+                    body: "coalesce(json(request.body).merge({\"model\": \"openai/gpt-5-mini\"}), request.body)"
+                  response: {}
+            weight: 30
+          - backend: "/llm:model:*:2"
+            inlinePolicies:
+              - transformation:
+                  request:
+                    body: "coalesce(json(request.body).merge({\"model\": \"fallback-small\"}), request.body)"
+                  response: {}
+            weight: 10
+        inlinePolicies:
+          - ai:
+              routes:
+                "*": passthrough
+                /v1/chat/completions: completions
+                /v1/embeddings: embeddings
+                /v1/images/edits: detect
+                /v1/images/generations: detect
+                /v1/images/variations: detect
+                /v1/messages: messages
+                /v1/rerank: rerank
+                /v1/responses: responses
+                /v1/responses/compact: detect
+                /v2/rerank: rerank
+                ":rawPredict": messages
+                ":streamRawPredict": messages
+        key: "llm:virtual-model:000000:fast"
+        matches:
+          - headers:
+              - name: x-gateway-model-name
+                value:
+                  exact: fast
+            path:
+              pathPrefix: /
+        name: "virtual-model:fast"
+        namespace: internal
+      - inlinePolicies:
+          - responseHeaderModifier:
+              set:
+                Content-Type: application/json
+          - directResponse:
+              bodyExpression: "\n\"x-gateway-model-name\" in request.headers ?\n\t{\n\t\t\"error\": {\n\t\t\t\"message\": \"Model \" + request.headers[\"x-gateway-model-name\"] + \" not found\",\n\t\t\t\"type\": \"invalid_request_error\",\n\t\t\t\"code\": \"model_not_found\"\n\t\t}\n\t} :\n\t{\n\t\t\"error\": {\n\t\t\t\"message\": \"No model set\",\n\t\t\t\"type\": \"invalid_request_error\",\n\t\t\t\"code\": \"model_not_found\"\n\t\t}\n\t}\n"
+              status: 404
+        key: "llm:model:fallback"
+        matches:
+          - path:
+              pathPrefix: /
+        name: "model:fallback"
+        namespace: internal
+listener_tcp_routes:
+  - - llm
+    - []
+policies:
+  - key: "llm:transformation"
+    name:
+      kind: Local
+      name: "llm:transformation"
+      namespace: internal
+    target:
+      gateway:
+        gatewayName: name
+        gatewayNamespace: ns
+        listenerName: llm
+    policy:
+      traffic:
+        phase: gateway
+        transformation:
+          request:
+            set:
+              - - x-gateway-model-name
+                - "\nrequest.path.endsWith(\":streamRawPredict\") || request.path.endsWith(\":rawPredict\") ?\n\trequest.path.regexReplace(\"^.*/publishers/anthropic/models/(.+?):.*\", \"${1}\") :\n\t(request.path.endsWith(\"/invoke-with-response-stream\") || request.path.endsWith(\"/invoke\") ?\n\trequest.path.regexReplace(\"^.*/model/(.+?)/invoke.*\", \"${1}\") :\n\tjson(request.body).model)\n"
+            body: "coalesce(json(request.body).merge({\"model\": request.headers[\"x-gateway-model-name\"]}), request.body)"
+          response: {}
+backends:
+  - backend:
+      ai:
+        name: "llm:model:openai/gpt-5-mini:0"
+        namespace: ""
+        target:
+          providers:
+            - active:
+                openai/gpt-5-mini:
+                  endpoint:
+                    name: openai/gpt-5-mini
+                    provider:
+                      openAI:
+                        model: gpt-5-mini
+                    hostOverride: ~
+                    pathOverride: ~
+                    pathPrefix: ~
+                    tokenize: false
+                    inlinePolicies:
+                      - backendAuth:
+                          key:
+                            value: "<redacted>"
+                  info:
+                    health: 1
+                    requestLatency: 0
+                    pendingRequests: 0
+                    totalRequests: 0
+                    consecutiveFailures: 0
+                    timesEjected: 0
+                    evictedUntil: ~
+                  capacity: 1
+              rejected: {}
+    inlinePolicies:
+      - requestHeaderModifier:
+          remove:
+            - x-gateway-model-name
+      - ai: {}
+  - backend:
+      ai:
+        name: "llm:model:anthropic/*:1"
+        namespace: ""
+        target:
+          providers:
+            - active:
+                anthropic/*:
+                  endpoint:
+                    name: anthropic/*
+                    provider:
+                      anthropic: {}
+                    hostOverride: ~
+                    pathOverride: ~
+                    pathPrefix: ~
+                    tokenize: false
+                    inlinePolicies:
+                      - backendAuth:
+                          key:
+                            value: "<redacted>"
+                  info:
+                    health: 1
+                    requestLatency: 0
+                    pendingRequests: 0
+                    totalRequests: 0
+                    consecutiveFailures: 0
+                    timesEjected: 0
+                    evictedUntil: ~
+                  capacity: 1
+              rejected: {}
+    inlinePolicies:
+      - requestHeaderModifier:
+          remove:
+            - x-gateway-model-name
+      - ai:
+          transformations:
+            model: "llmRequest.model.stripPrefix(\"anthropic/\")"
+  - backend:
+      ai:
+        name: "llm:model:*:2"
+        namespace: ""
+        target:
+          providers:
+            - active:
+                "*":
+                  endpoint:
+                    name: "*"
+                    provider:
+                      openAI: {}
+                    hostOverride: ~
+                    pathOverride: ~
+                    pathPrefix: ~
+                    tokenize: false
+                    inlinePolicies:
+                      - backendAuth:
+                          key:
+                            value: "<redacted>"
+                  info:
+                    health: 1
+                    requestLatency: 0
+                    pendingRequests: 0
+                    totalRequests: 0
+                    consecutiveFailures: 0
+                    timesEjected: 0
+                    evictedUntil: ~
+                  capacity: 1
+              rejected: {}
+    inlinePolicies:
+      - requestHeaderModifier:
+          remove:
+            - x-gateway-model-name
+      - ai: {}
+route_groups: []
+workloads: []
+services: []

--- a/crates/agentgateway/src/types/local_tests/llm_virtual_model_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/llm_virtual_model_normalized.snap
@@ -18,119 +18,108 @@ binds:
         protocol: HTTP
 listener_routes:
   - - llm
-    - - inlinePolicies:
-          - responseHeaderModifier:
-              set:
-                Content-Type: application/json
-          - directResponse:
-              status: 200
-              authorizationFilteredModelList:
-                entries:
-                  - id: anthropic/*
-                    created: 0
-                    authorization: ~
-                  - id: openai/gpt-5-mini
-                    created: 0
-                    authorization: ~
-                  - id: "*"
-                    created: 0
-                    authorization: ~
-                  - id: fast
-                    created: 0
-                    authorization: ~
-        key: "llm:admin:model-list"
+    - - key: "llm:request"
+        llmRouter:
+          models:
+            - name: openai/gpt-5-mini
+              visibility: internal
+              headerMatches: []
+              backendKey: "llm:model:openai/gpt-5-mini:0"
+              routePolicies:
+                - ai:
+                    routes:
+                      "*": passthrough
+                      /v1/chat/completions: completions
+                      /v1/embeddings: embeddings
+                      /v1/images/edits: detect
+                      /v1/images/generations: detect
+                      /v1/images/variations: detect
+                      /v1/messages: messages
+                      /v1/rerank: rerank
+                      /v1/responses: responses
+                      /v1/responses/compact: detect
+                      /v2/rerank: rerank
+                      ":rawPredict": messages
+                      ":streamRawPredict": messages
+              backendPolicies: []
+            - name: anthropic/*
+              visibility: internal
+              headerMatches: []
+              backendKey: "llm:model:anthropic/*:1"
+              routePolicies:
+                - ai:
+                    routes:
+                      "*": passthrough
+                      /v1/chat/completions: completions
+                      /v1/embeddings: embeddings
+                      /v1/images/edits: detect
+                      /v1/images/generations: detect
+                      /v1/images/variations: detect
+                      /v1/messages: messages
+                      /v1/rerank: rerank
+                      /v1/responses: responses
+                      /v1/responses/compact: detect
+                      /v2/rerank: rerank
+                      ":rawPredict": messages
+                      ":streamRawPredict": messages
+              backendPolicies: []
+            - name: "*"
+              visibility: internal
+              headerMatches: []
+              backendKey: "llm:model:*:2"
+              routePolicies:
+                - ai:
+                    routes:
+                      "*": passthrough
+                      /v1/chat/completions: completions
+                      /v1/embeddings: embeddings
+                      /v1/images/edits: detect
+                      /v1/images/generations: detect
+                      /v1/images/variations: detect
+                      /v1/messages: messages
+                      /v1/rerank: rerank
+                      /v1/responses: responses
+                      /v1/responses/compact: detect
+                      /v2/rerank: rerank
+                      ":rawPredict": messages
+                      ":streamRawPredict": messages
+              backendPolicies: []
+          virtualModels:
+            - name: fast
+              routePolicies:
+                - ai:
+                    routes:
+                      "*": passthrough
+                      /v1/chat/completions: completions
+                      /v1/embeddings: embeddings
+                      /v1/images/edits: detect
+                      /v1/images/generations: detect
+                      /v1/images/variations: detect
+                      /v1/messages: messages
+                      /v1/rerank: rerank
+                      /v1/responses: responses
+                      /v1/responses/compact: detect
+                      /v2/rerank: rerank
+                      ":rawPredict": messages
+                      ":streamRawPredict": messages
+              routing:
+                weighted:
+                  - model: anthropic/haiku
+                    weight: 60
+                  - model: openai/gpt-5-mini
+                    weight: 30
+                  - model: fallback-small
+                    weight: 10
+          created: 0
         matches:
           - path:
-              pathPrefix: /v1/models
-          - path:
-              pathPrefix: /models
-        name: "admin:model-list"
-        namespace: internal
-      - backends:
-          - backend: "/llm:model:anthropic/*:1"
-            inlinePolicies:
-              - transformation:
-                  request:
-                    body: "coalesce(json(request.body).merge({\"model\": \"anthropic/haiku\"}), request.body)"
-                  response: {}
-            weight: 60
-          - backend: "/llm:model:openai/gpt-5-mini:0"
-            inlinePolicies:
-              - transformation:
-                  request:
-                    body: "coalesce(json(request.body).merge({\"model\": \"openai/gpt-5-mini\"}), request.body)"
-                  response: {}
-            weight: 30
-          - backend: "/llm:model:*:2"
-            inlinePolicies:
-              - transformation:
-                  request:
-                    body: "coalesce(json(request.body).merge({\"model\": \"fallback-small\"}), request.body)"
-                  response: {}
-            weight: 10
-        inlinePolicies:
-          - ai:
-              routes:
-                "*": passthrough
-                /v1/chat/completions: completions
-                /v1/embeddings: embeddings
-                /v1/images/edits: detect
-                /v1/images/generations: detect
-                /v1/images/variations: detect
-                /v1/messages: messages
-                /v1/rerank: rerank
-                /v1/responses: responses
-                /v1/responses/compact: detect
-                /v2/rerank: rerank
-                ":rawPredict": messages
-                ":streamRawPredict": messages
-        key: "llm:virtual-model:000000:fast"
-        matches:
-          - headers:
-              - name: x-gateway-model-name
-                value:
-                  exact: fast
-            path:
               pathPrefix: /
-        name: "virtual-model:fast"
-        namespace: internal
-      - inlinePolicies:
-          - responseHeaderModifier:
-              set:
-                Content-Type: application/json
-          - directResponse:
-              bodyExpression: "\n\"x-gateway-model-name\" in request.headers ?\n\t{\n\t\t\"error\": {\n\t\t\t\"message\": \"Model \" + request.headers[\"x-gateway-model-name\"] + \" not found\",\n\t\t\t\"type\": \"invalid_request_error\",\n\t\t\t\"code\": \"model_not_found\"\n\t\t}\n\t} :\n\t{\n\t\t\"error\": {\n\t\t\t\"message\": \"No model set\",\n\t\t\t\"type\": \"invalid_request_error\",\n\t\t\t\"code\": \"model_not_found\"\n\t\t}\n\t}\n"
-              status: 404
-        key: "llm:model:fallback"
-        matches:
-          - path:
-              pathPrefix: /
-        name: "model:fallback"
+        name: "llm:request"
         namespace: internal
 listener_tcp_routes:
   - - llm
     - []
-policies:
-  - key: "llm:transformation"
-    name:
-      kind: Local
-      name: "llm:transformation"
-      namespace: internal
-    target:
-      gateway:
-        gatewayName: name
-        gatewayNamespace: ns
-        listenerName: llm
-    policy:
-      traffic:
-        phase: gateway
-        transformation:
-          request:
-            set:
-              - - x-gateway-model-name
-                - "\nrequest.path.endsWith(\":streamRawPredict\") || request.path.endsWith(\":rawPredict\") ?\n\trequest.path.regexReplace(\"^.*/publishers/anthropic/models/(.+?):.*\", \"${1}\") :\n\t(request.path.endsWith(\"/invoke-with-response-stream\") || request.path.endsWith(\"/invoke\") ?\n\trequest.path.regexReplace(\"^.*/model/(.+?)/invoke.*\", \"${1}\") :\n\tjson(request.body).model)\n"
-            body: "coalesce(json(request.body).merge({\"model\": request.headers[\"x-gateway-model-name\"]}), request.body)"
-          response: {}
+policies: []
 backends:
   - backend:
       ai:
@@ -164,9 +153,6 @@ backends:
                   capacity: 1
               rejected: {}
     inlinePolicies:
-      - requestHeaderModifier:
-          remove:
-            - x-gateway-model-name
       - ai: {}
   - backend:
       ai:
@@ -199,9 +185,6 @@ backends:
                   capacity: 1
               rejected: {}
     inlinePolicies:
-      - requestHeaderModifier:
-          remove:
-            - x-gateway-model-name
       - ai:
           transformations:
             model: "llmRequest.model.stripPrefix(\"anthropic/\")"
@@ -236,9 +219,6 @@ backends:
                   capacity: 1
               rejected: {}
     inlinePolicies:
-      - requestHeaderModifier:
-          remove:
-            - x-gateway-model-name
       - ai: {}
 route_groups: []
 workloads: []

--- a/schema/config.json
+++ b/schema/config.json
@@ -8406,7 +8406,7 @@
         },
         "visibility": {
           "description": "visibility controls whether clients can request this model directly (rather than only via a `virtualModel`).",
-          "$ref": "#/$defs/LocalLLMModelVisibility"
+          "$ref": "#/$defs/ModelVisibility"
         },
         "params": {
           "description": "params customizes parameters for the outgoing request",
@@ -8591,7 +8591,7 @@
         }
       ]
     },
-    "LocalLLMModelVisibility": {
+    "ModelVisibility": {
       "oneOf": [
         {
           "description": "Public models can be requested directly by clients and are included in the model list.",
@@ -8813,6 +8813,7 @@
       "type": "object",
       "properties": {
         "weighted": {
+          "description": "weighted enables weight-based selection of the target model.",
           "anyOf": [
             {
               "$ref": "#/$defs/LocalLLMWeightedRouting"
@@ -8823,6 +8824,7 @@
           ]
         },
         "failover": {
+          "description": "failover enables priority-based selection of the target model.\nWithin a priority level, the best provider is selected by a composite score factoring in health\nand latency.\nIf all models within a priority level are degraded, requests will move onto the next priority group.",
           "anyOf": [
             {
               "$ref": "#/$defs/LocalLLMFailoverRouting"
@@ -8833,6 +8835,7 @@
           ]
         },
         "conditional": {
+          "description": "Conditional enables condition-based selection of the target model. Each condition is evaluated\nin order until the best match is found.",
           "anyOf": [
             {
               "$ref": "#/$defs/LocalLLMConditionalRouting"

--- a/schema/config.json
+++ b/schema/config.json
@@ -8373,6 +8373,13 @@
             "$ref": "#/$defs/LocalLLMModels"
           }
         },
+        "virtualModels": {
+          "description": "virtualModels defines a set of models that can be served from the gateway. The model name refers to the\nmodel in the users request that is matched. However, unlike the `models` field, virtual models will\ndynamically route to a specific model (configured in `models`) based on the configured logic.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/LocalLLMVirtualModel"
+          }
+        },
         "policies": {
           "description": "policies defines policies for handling incoming requests, before a model is selected",
           "anyOf": [
@@ -8396,6 +8403,10 @@
         "name": {
           "description": "name is the name of the model we are matching from a users request. If params.model is set, that\nwill be used in the request to the LLM provider. If not, the incoming model is used.",
           "type": "string"
+        },
+        "visibility": {
+          "description": "visibility controls whether clients can request this model directly (rather than only via a `virtualModel`).",
+          "$ref": "#/$defs/LocalLLMModelVisibility"
         },
         "params": {
           "description": "params customizes parameters for the outgoing request",
@@ -8577,6 +8588,20 @@
               "tls"
             ]
           }
+        }
+      ]
+    },
+    "LocalLLMModelVisibility": {
+      "oneOf": [
+        {
+          "description": "Public models can be requested directly by clients and are included in the model list.",
+          "type": "string",
+          "const": "public"
+        },
+        {
+          "description": "Internal models can be targeted by virtual models but cannot be requested directly.",
+          "type": "string",
+          "const": "internal"
         }
       ]
     },
@@ -8765,6 +8790,172 @@
         }
       },
       "additionalProperties": false
+    },
+    "LocalLLMVirtualModel": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "name is the public model name clients request.",
+          "type": "string"
+        },
+        "routing": {
+          "description": "routing selects an existing LLM model backend for each request.",
+          "$ref": "#/$defs/LocalLLMVirtualModelRouting"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "routing"
+      ]
+    },
+    "LocalLLMVirtualModelRouting": {
+      "type": "object",
+      "properties": {
+        "weighted": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LocalLLMWeightedRouting"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "failover": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LocalLLMFailoverRouting"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "conditional": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LocalLLMConditionalRouting"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "LocalLLMWeightedRouting": {
+      "type": "object",
+      "properties": {
+        "targets": {
+          "description": "targets are existing model names or names matched by wildcard model entries.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/LocalLLMWeightedTarget"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "targets"
+      ]
+    },
+    "LocalLLMWeightedTarget": {
+      "type": "object",
+      "properties": {
+        "model": {
+          "description": "model is resolved against llm.models using the same wildcard matching as client requests.",
+          "type": "string"
+        },
+        "weight": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0,
+          "default": 1
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "model"
+      ]
+    },
+    "LocalLLMFailoverRouting": {
+      "type": "object",
+      "properties": {
+        "targets": {
+          "description": "targets are grouped by priority. Lower priority values are tried first.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/LocalLLMFailoverTarget"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "targets"
+      ]
+    },
+    "LocalLLMFailoverTarget": {
+      "type": "object",
+      "properties": {
+        "model": {
+          "description": "model is resolved against llm.models using the same wildcard matching as client requests.",
+          "type": "string"
+        },
+        "priority": {
+          "description": "priority groups targets for failover. Lower values are preferred.",
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "model",
+        "priority"
+      ]
+    },
+    "LocalLLMConditionalRouting": {
+      "type": "object",
+      "properties": {
+        "targets": {
+          "description": "targets are evaluated in order. The first matching condition selects the model.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/LocalLLMConditionalTarget"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "targets"
+      ]
+    },
+    "LocalLLMConditionalTarget": {
+      "type": "object",
+      "properties": {
+        "when": {
+          "description": "when must evaluate to true for this target to be selected. Omit only on the final fallback target.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Expression"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "model": {
+          "description": "model is resolved against llm.models using the same wildcard matching as client requests.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "model"
+      ]
     },
     "LocalLLMPolicy": {
       "type": "object",

--- a/schema/config.md
+++ b/schema/config.md
@@ -20061,15 +20061,15 @@
 |`llm.virtualModels`|[]object|virtualModels defines a set of models that can be served from the gateway. The model name refers to the<br>model in the users request that is matched. However, unlike the `models` field, virtual models will<br>dynamically route to a specific model (configured in `models`) based on the configured logic.|
 |`llm.virtualModels[].name`|string|name is the public model name clients request.|
 |`llm.virtualModels[].routing`|object|routing selects an existing LLM model backend for each request.|
-|`llm.virtualModels[].routing.weighted`|object||
+|`llm.virtualModels[].routing.weighted`|object|weighted enables weight-based selection of the target model.|
 |`llm.virtualModels[].routing.weighted.targets`|[]object|targets are existing model names or names matched by wildcard model entries.|
 |`llm.virtualModels[].routing.weighted.targets[].model`|string|model is resolved against llm.models using the same wildcard matching as client requests.|
 |`llm.virtualModels[].routing.weighted.targets[].weight`|integer||
-|`llm.virtualModels[].routing.failover`|object||
+|`llm.virtualModels[].routing.failover`|object|failover enables priority-based selection of the target model.<br>Within a priority level, the best provider is selected by a composite score factoring in health<br>and latency.<br>If all models within a priority level are degraded, requests will move onto the next priority group.|
 |`llm.virtualModels[].routing.failover.targets`|[]object|targets are grouped by priority. Lower priority values are tried first.|
 |`llm.virtualModels[].routing.failover.targets[].model`|string|model is resolved against llm.models using the same wildcard matching as client requests.|
 |`llm.virtualModels[].routing.failover.targets[].priority`|integer|priority groups targets for failover. Lower values are preferred.|
-|`llm.virtualModels[].routing.conditional`|object||
+|`llm.virtualModels[].routing.conditional`|object|Conditional enables condition-based selection of the target model. Each condition is evaluated<br>in order until the best match is found.|
 |`llm.virtualModels[].routing.conditional.targets`|[]object|targets are evaluated in order. The first matching condition selects the model.|
 |`llm.virtualModels[].routing.conditional.targets[].when`|string|when must evaluate to true for this target to be selected. Omit only on the final fallback target.|
 |`llm.virtualModels[].routing.conditional.targets[].model`|string|model is resolved against llm.models using the same wildcard matching as client requests.|

--- a/schema/config.md
+++ b/schema/config.md
@@ -19110,6 +19110,7 @@
 |`llm.tls.keyExchangeGroups`|[]string|Key exchange groups allowed for negotiating TLS.|
 |`llm.models`|[]object|models defines the set of models that can be served by this gateway. The model name refers to the<br>model in the users request that is matched; the model sent to the actual LLM can be overridden<br>on a per-model basis.|
 |`llm.models[].name`|string|name is the name of the model we are matching from a users request. If params.model is set, that<br>will be used in the request to the LLM provider. If not, the incoming model is used.|
+|`llm.models[].visibility`|enum|visibility controls whether clients can request this model directly (rather than only via a `virtualModel`).<br>Possible values: `public`, `internal`.|
 |`llm.models[].params`|object|params customizes parameters for the outgoing request|
 |`llm.models[].params.model`|string|The model to send to the provider.<br>If unset, the same model will be used from the request.|
 |`llm.models[].params.apiKey`|object|An API key to attach to the request.<br>If unset this will be automatically detected from the environment.|
@@ -20057,6 +20058,21 @@
 |`llm.models[].matches[].headers[].value`|object|Exactly one of exact or regex may be set.|
 |`llm.models[].matches[].headers[].value.exact`|string||
 |`llm.models[].matches[].headers[].value.regex`|string||
+|`llm.virtualModels`|[]object|virtualModels defines a set of models that can be served from the gateway. The model name refers to the<br>model in the users request that is matched. However, unlike the `models` field, virtual models will<br>dynamically route to a specific model (configured in `models`) based on the configured logic.|
+|`llm.virtualModels[].name`|string|name is the public model name clients request.|
+|`llm.virtualModels[].routing`|object|routing selects an existing LLM model backend for each request.|
+|`llm.virtualModels[].routing.weighted`|object||
+|`llm.virtualModels[].routing.weighted.targets`|[]object|targets are existing model names or names matched by wildcard model entries.|
+|`llm.virtualModels[].routing.weighted.targets[].model`|string|model is resolved against llm.models using the same wildcard matching as client requests.|
+|`llm.virtualModels[].routing.weighted.targets[].weight`|integer||
+|`llm.virtualModels[].routing.failover`|object||
+|`llm.virtualModels[].routing.failover.targets`|[]object|targets are grouped by priority. Lower priority values are tried first.|
+|`llm.virtualModels[].routing.failover.targets[].model`|string|model is resolved against llm.models using the same wildcard matching as client requests.|
+|`llm.virtualModels[].routing.failover.targets[].priority`|integer|priority groups targets for failover. Lower values are preferred.|
+|`llm.virtualModels[].routing.conditional`|object||
+|`llm.virtualModels[].routing.conditional.targets`|[]object|targets are evaluated in order. The first matching condition selects the model.|
+|`llm.virtualModels[].routing.conditional.targets[].when`|string|when must evaluate to true for this target to be selected. Omit only on the final fallback target.|
+|`llm.virtualModels[].routing.conditional.targets[].model`|string|model is resolved against llm.models using the same wildcard matching as client requests.|
 |`llm.policies`|object|policies defines policies for handling incoming requests, before a model is selected|
 |`llm.policies.oidc`|object|Authenticate browser requests with OIDC authorization code flow.|
 |`llm.policies.oidc.issuer`|string|Issuer used for discovery and ID token validation.|


### PR DESCRIPTION
This changes LLM routing from generated CEL/header-based routes into a native Rust model router, so model list handling, direct model matching, virtual model selection, request body rewrites, and selected backend policies all live in one explicit request path.

That removes the synthetic `x-gateway-model-name` header stuff, the crazy complex "get model from body/req" CEL expression, etc.

Additionally, we add the new 'virtual model' concept. A virtual model is one that routes to a selected other defined `model`  using a configurable selection criteria. Today, we have `weighted`, `conditional`, and `failover`. In the future you could imagine `lowCost`, `semantic` etc.

The refactoring ensures  virtual model implementation doesn't turn our already "on the edge of too complex" behavior into "way too complex" and opens the door for some future k8s support.
