### PR TITLE
auth: add RFC 8693 token exchange backend auth

### DIFF
--- a/api/resource.pb.go
+++ b/api/resource.pb.go
@@ -4013,6 +4013,7 @@ type BackendAuthPolicy struct {
 	//	*BackendAuthPolicy_Gcp
 	//	*BackendAuthPolicy_Aws
 	//	*BackendAuthPolicy_Azure
+	//	*BackendAuthPolicy_OauthTokenExchange
 	Kind          isBackendAuthPolicy_Kind `protobuf_oneof:"kind"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -4100,6 +4101,15 @@ func (x *BackendAuthPolicy) GetAzure() *Azure {
 	return nil
 }
 
+func (x *BackendAuthPolicy) GetOauthTokenExchange() *OAuthTokenExchange {
+	if x != nil {
+		if x, ok := x.Kind.(*BackendAuthPolicy_OauthTokenExchange); ok {
+			return x.OauthTokenExchange
+		}
+	}
+	return nil
+}
+
 type isBackendAuthPolicy_Kind interface {
 	isBackendAuthPolicy_Kind()
 }
@@ -4124,6 +4134,10 @@ type BackendAuthPolicy_Azure struct {
 	Azure *Azure `protobuf:"bytes,5,opt,name=azure,proto3,oneof"`
 }
 
+type BackendAuthPolicy_OauthTokenExchange struct {
+	OauthTokenExchange *OAuthTokenExchange `protobuf:"bytes,6,opt,name=oauth_token_exchange,json=oauthTokenExchange,proto3,oneof"`
+}
+
 func (*BackendAuthPolicy_Passthrough) isBackendAuthPolicy_Kind() {}
 
 func (*BackendAuthPolicy_Key) isBackendAuthPolicy_Kind() {}
@@ -4133,6 +4147,8 @@ func (*BackendAuthPolicy_Gcp) isBackendAuthPolicy_Kind() {}
 func (*BackendAuthPolicy_Aws) isBackendAuthPolicy_Kind() {}
 
 func (*BackendAuthPolicy_Azure) isBackendAuthPolicy_Kind() {}
+
+func (*BackendAuthPolicy_OauthTokenExchange) isBackendAuthPolicy_Kind() {}
 
 type AuthorizationLocation struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -7937,6 +7953,101 @@ func (x *Alpn) GetProtocols() []string {
 	return nil
 }
 
+// RFC 8693 OAuth 2.0 Token Exchange.
+type OAuthTokenExchange struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	TokenEndpoint *BackendReference      `protobuf:"bytes,1,opt,name=token_endpoint,json=tokenEndpoint,proto3" json:"token_endpoint,omitempty"`
+	// Token endpoint path on the backend; defaults to "/".
+	TokenEndpointPath string `protobuf:"bytes,7,opt,name=token_endpoint_path,json=tokenEndpointPath,proto3" json:"token_endpoint_path,omitempty"`
+	// Optional RFC 8693 request parameters; sent only when non-empty.
+	Audiences          []string                       `protobuf:"bytes,2,rep,name=audiences,proto3" json:"audiences,omitempty"`
+	Scopes             []string                       `protobuf:"bytes,3,rep,name=scopes,proto3" json:"scopes,omitempty"`
+	Resources          []string                       `protobuf:"bytes,4,rep,name=resources,proto3" json:"resources,omitempty"`
+	RequestedTokenType string                         `protobuf:"bytes,5,opt,name=requested_token_type,json=requestedTokenType,proto3" json:"requested_token_type,omitempty"`
+	ClientAuth         *OAuthTokenExchange_ClientAuth `protobuf:"bytes,6,opt,name=client_auth,json=clientAuth,proto3" json:"client_auth,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
+}
+
+func (x *OAuthTokenExchange) Reset() {
+	*x = OAuthTokenExchange{}
+	mi := &file_resource_proto_msgTypes[65]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *OAuthTokenExchange) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*OAuthTokenExchange) ProtoMessage() {}
+
+func (x *OAuthTokenExchange) ProtoReflect() protoreflect.Message {
+	mi := &file_resource_proto_msgTypes[65]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use OAuthTokenExchange.ProtoReflect.Descriptor instead.
+func (*OAuthTokenExchange) Descriptor() ([]byte, []int) {
+	return file_resource_proto_rawDescGZIP(), []int{65}
+}
+
+func (x *OAuthTokenExchange) GetTokenEndpoint() *BackendReference {
+	if x != nil {
+		return x.TokenEndpoint
+	}
+	return nil
+}
+
+func (x *OAuthTokenExchange) GetTokenEndpointPath() string {
+	if x != nil {
+		return x.TokenEndpointPath
+	}
+	return ""
+}
+
+func (x *OAuthTokenExchange) GetAudiences() []string {
+	if x != nil {
+		return x.Audiences
+	}
+	return nil
+}
+
+func (x *OAuthTokenExchange) GetScopes() []string {
+	if x != nil {
+		return x.Scopes
+	}
+	return nil
+}
+
+func (x *OAuthTokenExchange) GetResources() []string {
+	if x != nil {
+		return x.Resources
+	}
+	return nil
+}
+
+func (x *OAuthTokenExchange) GetRequestedTokenType() string {
+	if x != nil {
+		return x.RequestedTokenType
+	}
+	return ""
+}
+
+func (x *OAuthTokenExchange) GetClientAuth() *OAuthTokenExchange_ClientAuth {
+	if x != nil {
+		return x.ClientAuth
+	}
+	return nil
+}
+
 // AWS Bedrock Guardrails (ApplyGuardrail API)
 type GuardrailBackend_Bedrock struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -7953,7 +8064,7 @@ type GuardrailBackend_Bedrock struct {
 
 func (x *GuardrailBackend_Bedrock) Reset() {
 	*x = GuardrailBackend_Bedrock{}
-	mi := &file_resource_proto_msgTypes[65]
+	mi := &file_resource_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7965,7 +8076,7 @@ func (x *GuardrailBackend_Bedrock) String() string {
 func (*GuardrailBackend_Bedrock) ProtoMessage() {}
 
 func (x *GuardrailBackend_Bedrock) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[65]
+	mi := &file_resource_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8017,7 +8128,7 @@ type GuardrailBackend_GoogleModelArmor struct {
 
 func (x *GuardrailBackend_GoogleModelArmor) Reset() {
 	*x = GuardrailBackend_GoogleModelArmor{}
-	mi := &file_resource_proto_msgTypes[66]
+	mi := &file_resource_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8029,7 +8140,7 @@ func (x *GuardrailBackend_GoogleModelArmor) String() string {
 func (*GuardrailBackend_GoogleModelArmor) ProtoMessage() {}
 
 func (x *GuardrailBackend_GoogleModelArmor) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[66]
+	mi := &file_resource_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8082,7 +8193,7 @@ type GuardrailBackend_AzureContentSafety struct {
 
 func (x *GuardrailBackend_AzureContentSafety) Reset() {
 	*x = GuardrailBackend_AzureContentSafety{}
-	mi := &file_resource_proto_msgTypes[67]
+	mi := &file_resource_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8094,7 +8205,7 @@ func (x *GuardrailBackend_AzureContentSafety) String() string {
 func (*GuardrailBackend_AzureContentSafety) ProtoMessage() {}
 
 func (x *GuardrailBackend_AzureContentSafety) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[67]
+	mi := &file_resource_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8133,7 +8244,7 @@ type GuardrailBackend_OpenAIModeration struct {
 
 func (x *GuardrailBackend_OpenAIModeration) Reset() {
 	*x = GuardrailBackend_OpenAIModeration{}
-	mi := &file_resource_proto_msgTypes[68]
+	mi := &file_resource_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8145,7 +8256,7 @@ func (x *GuardrailBackend_OpenAIModeration) String() string {
 func (*GuardrailBackend_OpenAIModeration) ProtoMessage() {}
 
 func (x *GuardrailBackend_OpenAIModeration) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[68]
+	mi := &file_resource_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8171,7 +8282,7 @@ type AuthorizationLocation_Header struct {
 
 func (x *AuthorizationLocation_Header) Reset() {
 	*x = AuthorizationLocation_Header{}
-	mi := &file_resource_proto_msgTypes[69]
+	mi := &file_resource_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8183,7 +8294,7 @@ func (x *AuthorizationLocation_Header) String() string {
 func (*AuthorizationLocation_Header) ProtoMessage() {}
 
 func (x *AuthorizationLocation_Header) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[69]
+	mi := &file_resource_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8222,7 +8333,7 @@ type AuthorizationLocation_QueryParameter struct {
 
 func (x *AuthorizationLocation_QueryParameter) Reset() {
 	*x = AuthorizationLocation_QueryParameter{}
-	mi := &file_resource_proto_msgTypes[70]
+	mi := &file_resource_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8234,7 +8345,7 @@ func (x *AuthorizationLocation_QueryParameter) String() string {
 func (*AuthorizationLocation_QueryParameter) ProtoMessage() {}
 
 func (x *AuthorizationLocation_QueryParameter) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[70]
+	mi := &file_resource_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8266,7 +8377,7 @@ type AuthorizationLocation_Cookie struct {
 
 func (x *AuthorizationLocation_Cookie) Reset() {
 	*x = AuthorizationLocation_Cookie{}
-	mi := &file_resource_proto_msgTypes[71]
+	mi := &file_resource_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8278,7 +8389,7 @@ func (x *AuthorizationLocation_Cookie) String() string {
 func (*AuthorizationLocation_Cookie) ProtoMessage() {}
 
 func (x *AuthorizationLocation_Cookie) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[71]
+	mi := &file_resource_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8309,7 +8420,7 @@ type Gcp_AccessToken struct {
 
 func (x *Gcp_AccessToken) Reset() {
 	*x = Gcp_AccessToken{}
-	mi := &file_resource_proto_msgTypes[72]
+	mi := &file_resource_proto_msgTypes[73]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8321,7 +8432,7 @@ func (x *Gcp_AccessToken) String() string {
 func (*Gcp_AccessToken) ProtoMessage() {}
 
 func (x *Gcp_AccessToken) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[72]
+	mi := &file_resource_proto_msgTypes[73]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8347,7 +8458,7 @@ type Gcp_IdToken struct {
 
 func (x *Gcp_IdToken) Reset() {
 	*x = Gcp_IdToken{}
-	mi := &file_resource_proto_msgTypes[73]
+	mi := &file_resource_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8359,7 +8470,7 @@ func (x *Gcp_IdToken) String() string {
 func (*Gcp_IdToken) ProtoMessage() {}
 
 func (x *Gcp_IdToken) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[73]
+	mi := &file_resource_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8396,7 +8507,7 @@ type AzureManagedIdentityCredential_UserAssignedIdentity struct {
 
 func (x *AzureManagedIdentityCredential_UserAssignedIdentity) Reset() {
 	*x = AzureManagedIdentityCredential_UserAssignedIdentity{}
-	mi := &file_resource_proto_msgTypes[74]
+	mi := &file_resource_proto_msgTypes[75]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8408,7 +8519,7 @@ func (x *AzureManagedIdentityCredential_UserAssignedIdentity) String() string {
 func (*AzureManagedIdentityCredential_UserAssignedIdentity) ProtoMessage() {}
 
 func (x *AzureManagedIdentityCredential_UserAssignedIdentity) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[74]
+	mi := &file_resource_proto_msgTypes[75]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8494,7 +8605,7 @@ type RequestMirrors_Mirror struct {
 
 func (x *RequestMirrors_Mirror) Reset() {
 	*x = RequestMirrors_Mirror{}
-	mi := &file_resource_proto_msgTypes[75]
+	mi := &file_resource_proto_msgTypes[76]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8506,7 +8617,7 @@ func (x *RequestMirrors_Mirror) String() string {
 func (*RequestMirrors_Mirror) ProtoMessage() {}
 
 func (x *RequestMirrors_Mirror) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[75]
+	mi := &file_resource_proto_msgTypes[76]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8547,7 +8658,7 @@ type PolicyTarget_ServiceTarget struct {
 
 func (x *PolicyTarget_ServiceTarget) Reset() {
 	*x = PolicyTarget_ServiceTarget{}
-	mi := &file_resource_proto_msgTypes[76]
+	mi := &file_resource_proto_msgTypes[77]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8559,7 +8670,7 @@ func (x *PolicyTarget_ServiceTarget) String() string {
 func (*PolicyTarget_ServiceTarget) ProtoMessage() {}
 
 func (x *PolicyTarget_ServiceTarget) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[76]
+	mi := &file_resource_proto_msgTypes[77]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8607,7 +8718,7 @@ type PolicyTarget_BackendTarget struct {
 
 func (x *PolicyTarget_BackendTarget) Reset() {
 	*x = PolicyTarget_BackendTarget{}
-	mi := &file_resource_proto_msgTypes[77]
+	mi := &file_resource_proto_msgTypes[78]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8619,7 +8730,7 @@ func (x *PolicyTarget_BackendTarget) String() string {
 func (*PolicyTarget_BackendTarget) ProtoMessage() {}
 
 func (x *PolicyTarget_BackendTarget) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[77]
+	mi := &file_resource_proto_msgTypes[78]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8668,7 +8779,7 @@ type PolicyTarget_GatewayTarget struct {
 
 func (x *PolicyTarget_GatewayTarget) Reset() {
 	*x = PolicyTarget_GatewayTarget{}
-	mi := &file_resource_proto_msgTypes[78]
+	mi := &file_resource_proto_msgTypes[79]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8680,7 +8791,7 @@ func (x *PolicyTarget_GatewayTarget) String() string {
 func (*PolicyTarget_GatewayTarget) ProtoMessage() {}
 
 func (x *PolicyTarget_GatewayTarget) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[78]
+	mi := &file_resource_proto_msgTypes[79]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8736,7 +8847,7 @@ type PolicyTarget_RouteTarget struct {
 
 func (x *PolicyTarget_RouteTarget) Reset() {
 	*x = PolicyTarget_RouteTarget{}
-	mi := &file_resource_proto_msgTypes[79]
+	mi := &file_resource_proto_msgTypes[80]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8748,7 +8859,7 @@ func (x *PolicyTarget_RouteTarget) String() string {
 func (*PolicyTarget_RouteTarget) ProtoMessage() {}
 
 func (x *PolicyTarget_RouteTarget) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[79]
+	mi := &file_resource_proto_msgTypes[80]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8803,7 +8914,7 @@ type PolicyTarget_ListenerSetTarget struct {
 
 func (x *PolicyTarget_ListenerSetTarget) Reset() {
 	*x = PolicyTarget_ListenerSetTarget{}
-	mi := &file_resource_proto_msgTypes[80]
+	mi := &file_resource_proto_msgTypes[81]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8815,7 +8926,7 @@ func (x *PolicyTarget_ListenerSetTarget) String() string {
 func (*PolicyTarget_ListenerSetTarget) ProtoMessage() {}
 
 func (x *PolicyTarget_ListenerSetTarget) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[80]
+	mi := &file_resource_proto_msgTypes[81]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8872,7 +8983,7 @@ type FrontendPolicySpec_HTTP struct {
 
 func (x *FrontendPolicySpec_HTTP) Reset() {
 	*x = FrontendPolicySpec_HTTP{}
-	mi := &file_resource_proto_msgTypes[81]
+	mi := &file_resource_proto_msgTypes[82]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8884,7 +8995,7 @@ func (x *FrontendPolicySpec_HTTP) String() string {
 func (*FrontendPolicySpec_HTTP) ProtoMessage() {}
 
 func (x *FrontendPolicySpec_HTTP) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[81]
+	mi := &file_resource_proto_msgTypes[82]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9001,7 +9112,7 @@ type FrontendPolicySpec_TLS struct {
 
 func (x *FrontendPolicySpec_TLS) Reset() {
 	*x = FrontendPolicySpec_TLS{}
-	mi := &file_resource_proto_msgTypes[82]
+	mi := &file_resource_proto_msgTypes[83]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9013,7 +9124,7 @@ func (x *FrontendPolicySpec_TLS) String() string {
 func (*FrontendPolicySpec_TLS) ProtoMessage() {}
 
 func (x *FrontendPolicySpec_TLS) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[82]
+	mi := &file_resource_proto_msgTypes[83]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9081,7 +9192,7 @@ type FrontendPolicySpec_TCP struct {
 
 func (x *FrontendPolicySpec_TCP) Reset() {
 	*x = FrontendPolicySpec_TCP{}
-	mi := &file_resource_proto_msgTypes[83]
+	mi := &file_resource_proto_msgTypes[84]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9093,7 +9204,7 @@ func (x *FrontendPolicySpec_TCP) String() string {
 func (*FrontendPolicySpec_TCP) ProtoMessage() {}
 
 func (x *FrontendPolicySpec_TCP) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[83]
+	mi := &file_resource_proto_msgTypes[84]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9127,7 +9238,7 @@ type FrontendPolicySpec_NetworkAuthorization struct {
 
 func (x *FrontendPolicySpec_NetworkAuthorization) Reset() {
 	*x = FrontendPolicySpec_NetworkAuthorization{}
-	mi := &file_resource_proto_msgTypes[84]
+	mi := &file_resource_proto_msgTypes[85]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9139,7 +9250,7 @@ func (x *FrontendPolicySpec_NetworkAuthorization) String() string {
 func (*FrontendPolicySpec_NetworkAuthorization) ProtoMessage() {}
 
 func (x *FrontendPolicySpec_NetworkAuthorization) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[84]
+	mi := &file_resource_proto_msgTypes[85]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9191,7 +9302,7 @@ type FrontendPolicySpec_Logging struct {
 
 func (x *FrontendPolicySpec_Logging) Reset() {
 	*x = FrontendPolicySpec_Logging{}
-	mi := &file_resource_proto_msgTypes[85]
+	mi := &file_resource_proto_msgTypes[86]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9203,7 +9314,7 @@ func (x *FrontendPolicySpec_Logging) String() string {
 func (*FrontendPolicySpec_Logging) ProtoMessage() {}
 
 func (x *FrontendPolicySpec_Logging) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[85]
+	mi := &file_resource_proto_msgTypes[86]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9271,7 +9382,7 @@ type FrontendPolicySpec_Tracing struct {
 
 func (x *FrontendPolicySpec_Tracing) Reset() {
 	*x = FrontendPolicySpec_Tracing{}
-	mi := &file_resource_proto_msgTypes[86]
+	mi := &file_resource_proto_msgTypes[87]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9283,7 +9394,7 @@ func (x *FrontendPolicySpec_Tracing) String() string {
 func (*FrontendPolicySpec_Tracing) ProtoMessage() {}
 
 func (x *FrontendPolicySpec_Tracing) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[86]
+	mi := &file_resource_proto_msgTypes[87]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9372,7 +9483,7 @@ type FrontendPolicySpec_TracingAttribute struct {
 
 func (x *FrontendPolicySpec_TracingAttribute) Reset() {
 	*x = FrontendPolicySpec_TracingAttribute{}
-	mi := &file_resource_proto_msgTypes[87]
+	mi := &file_resource_proto_msgTypes[88]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9384,7 +9495,7 @@ func (x *FrontendPolicySpec_TracingAttribute) String() string {
 func (*FrontendPolicySpec_TracingAttribute) ProtoMessage() {}
 
 func (x *FrontendPolicySpec_TracingAttribute) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[87]
+	mi := &file_resource_proto_msgTypes[88]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9424,7 +9535,7 @@ type FrontendPolicySpec_ProxyProtocol struct {
 
 func (x *FrontendPolicySpec_ProxyProtocol) Reset() {
 	*x = FrontendPolicySpec_ProxyProtocol{}
-	mi := &file_resource_proto_msgTypes[88]
+	mi := &file_resource_proto_msgTypes[89]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9436,7 +9547,7 @@ func (x *FrontendPolicySpec_ProxyProtocol) String() string {
 func (*FrontendPolicySpec_ProxyProtocol) ProtoMessage() {}
 
 func (x *FrontendPolicySpec_ProxyProtocol) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[88]
+	mi := &file_resource_proto_msgTypes[89]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9475,7 +9586,7 @@ type FrontendPolicySpec_Connect struct {
 
 func (x *FrontendPolicySpec_Connect) Reset() {
 	*x = FrontendPolicySpec_Connect{}
-	mi := &file_resource_proto_msgTypes[89]
+	mi := &file_resource_proto_msgTypes[90]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9487,7 +9598,7 @@ func (x *FrontendPolicySpec_Connect) String() string {
 func (*FrontendPolicySpec_Connect) ProtoMessage() {}
 
 func (x *FrontendPolicySpec_Connect) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[89]
+	mi := &file_resource_proto_msgTypes[90]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9521,7 +9632,7 @@ type FrontendPolicySpec_Metrics struct {
 
 func (x *FrontendPolicySpec_Metrics) Reset() {
 	*x = FrontendPolicySpec_Metrics{}
-	mi := &file_resource_proto_msgTypes[90]
+	mi := &file_resource_proto_msgTypes[91]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9533,7 +9644,7 @@ func (x *FrontendPolicySpec_Metrics) String() string {
 func (*FrontendPolicySpec_Metrics) ProtoMessage() {}
 
 func (x *FrontendPolicySpec_Metrics) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[90]
+	mi := &file_resource_proto_msgTypes[91]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9566,7 +9677,7 @@ type FrontendPolicySpec_Logging_Field struct {
 
 func (x *FrontendPolicySpec_Logging_Field) Reset() {
 	*x = FrontendPolicySpec_Logging_Field{}
-	mi := &file_resource_proto_msgTypes[91]
+	mi := &file_resource_proto_msgTypes[92]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9578,7 +9689,7 @@ func (x *FrontendPolicySpec_Logging_Field) String() string {
 func (*FrontendPolicySpec_Logging_Field) ProtoMessage() {}
 
 func (x *FrontendPolicySpec_Logging_Field) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[91]
+	mi := &file_resource_proto_msgTypes[92]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9621,7 +9732,7 @@ type FrontendPolicySpec_Logging_Fields struct {
 
 func (x *FrontendPolicySpec_Logging_Fields) Reset() {
 	*x = FrontendPolicySpec_Logging_Fields{}
-	mi := &file_resource_proto_msgTypes[92]
+	mi := &file_resource_proto_msgTypes[93]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9633,7 +9744,7 @@ func (x *FrontendPolicySpec_Logging_Fields) String() string {
 func (*FrontendPolicySpec_Logging_Fields) ProtoMessage() {}
 
 func (x *FrontendPolicySpec_Logging_Fields) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[92]
+	mi := &file_resource_proto_msgTypes[93]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9681,7 +9792,7 @@ type FrontendPolicySpec_Logging_OtlpAccessLog struct {
 
 func (x *FrontendPolicySpec_Logging_OtlpAccessLog) Reset() {
 	*x = FrontendPolicySpec_Logging_OtlpAccessLog{}
-	mi := &file_resource_proto_msgTypes[93]
+	mi := &file_resource_proto_msgTypes[94]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9693,7 +9804,7 @@ func (x *FrontendPolicySpec_Logging_OtlpAccessLog) String() string {
 func (*FrontendPolicySpec_Logging_OtlpAccessLog) ProtoMessage() {}
 
 func (x *FrontendPolicySpec_Logging_OtlpAccessLog) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[93]
+	mi := &file_resource_proto_msgTypes[94]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9747,7 +9858,7 @@ type FrontendPolicySpec_Metrics_Field struct {
 
 func (x *FrontendPolicySpec_Metrics_Field) Reset() {
 	*x = FrontendPolicySpec_Metrics_Field{}
-	mi := &file_resource_proto_msgTypes[94]
+	mi := &file_resource_proto_msgTypes[95]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9759,7 +9870,7 @@ func (x *FrontendPolicySpec_Metrics_Field) String() string {
 func (*FrontendPolicySpec_Metrics_Field) ProtoMessage() {}
 
 func (x *FrontendPolicySpec_Metrics_Field) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[94]
+	mi := &file_resource_proto_msgTypes[95]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9798,7 +9909,7 @@ type FrontendPolicySpec_Metrics_Fields struct {
 
 func (x *FrontendPolicySpec_Metrics_Fields) Reset() {
 	*x = FrontendPolicySpec_Metrics_Fields{}
-	mi := &file_resource_proto_msgTypes[95]
+	mi := &file_resource_proto_msgTypes[96]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9810,7 +9921,7 @@ func (x *FrontendPolicySpec_Metrics_Fields) String() string {
 func (*FrontendPolicySpec_Metrics_Fields) ProtoMessage() {}
 
 func (x *FrontendPolicySpec_Metrics_Fields) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[95]
+	mi := &file_resource_proto_msgTypes[96]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9845,7 +9956,7 @@ type TrafficPolicySpec_RemoteRateLimit struct {
 
 func (x *TrafficPolicySpec_RemoteRateLimit) Reset() {
 	*x = TrafficPolicySpec_RemoteRateLimit{}
-	mi := &file_resource_proto_msgTypes[96]
+	mi := &file_resource_proto_msgTypes[97]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9857,7 +9968,7 @@ func (x *TrafficPolicySpec_RemoteRateLimit) String() string {
 func (*TrafficPolicySpec_RemoteRateLimit) ProtoMessage() {}
 
 func (x *TrafficPolicySpec_RemoteRateLimit) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[96]
+	mi := &file_resource_proto_msgTypes[97]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9913,7 +10024,7 @@ type TrafficPolicySpec_LocalRateLimit struct {
 
 func (x *TrafficPolicySpec_LocalRateLimit) Reset() {
 	*x = TrafficPolicySpec_LocalRateLimit{}
-	mi := &file_resource_proto_msgTypes[97]
+	mi := &file_resource_proto_msgTypes[98]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9925,7 +10036,7 @@ func (x *TrafficPolicySpec_LocalRateLimit) String() string {
 func (*TrafficPolicySpec_LocalRateLimit) ProtoMessage() {}
 
 func (x *TrafficPolicySpec_LocalRateLimit) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[97]
+	mi := &file_resource_proto_msgTypes[98]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9988,7 +10099,7 @@ type TrafficPolicySpec_ExternalAuth struct {
 
 func (x *TrafficPolicySpec_ExternalAuth) Reset() {
 	*x = TrafficPolicySpec_ExternalAuth{}
-	mi := &file_resource_proto_msgTypes[98]
+	mi := &file_resource_proto_msgTypes[99]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10000,7 +10111,7 @@ func (x *TrafficPolicySpec_ExternalAuth) String() string {
 func (*TrafficPolicySpec_ExternalAuth) ProtoMessage() {}
 
 func (x *TrafficPolicySpec_ExternalAuth) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[98]
+	mi := &file_resource_proto_msgTypes[99]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10110,7 +10221,7 @@ type TrafficPolicySpec_RBAC struct {
 
 func (x *TrafficPolicySpec_RBAC) Reset() {
 	*x = TrafficPolicySpec_RBAC{}
-	mi := &file_resource_proto_msgTypes[99]
+	mi := &file_resource_proto_msgTypes[100]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10122,7 +10233,7 @@ func (x *TrafficPolicySpec_RBAC) String() string {
 func (*TrafficPolicySpec_RBAC) ProtoMessage() {}
 
 func (x *TrafficPolicySpec_RBAC) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[99]
+	mi := &file_resource_proto_msgTypes[100]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10179,7 +10290,7 @@ type TrafficPolicySpec_JWTProvider struct {
 
 func (x *TrafficPolicySpec_JWTProvider) Reset() {
 	*x = TrafficPolicySpec_JWTProvider{}
-	mi := &file_resource_proto_msgTypes[100]
+	mi := &file_resource_proto_msgTypes[101]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10191,7 +10302,7 @@ func (x *TrafficPolicySpec_JWTProvider) String() string {
 func (*TrafficPolicySpec_JWTProvider) ProtoMessage() {}
 
 func (x *TrafficPolicySpec_JWTProvider) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[100]
+	mi := &file_resource_proto_msgTypes[101]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10269,7 +10380,7 @@ type TrafficPolicySpec_JWT struct {
 
 func (x *TrafficPolicySpec_JWT) Reset() {
 	*x = TrafficPolicySpec_JWT{}
-	mi := &file_resource_proto_msgTypes[101]
+	mi := &file_resource_proto_msgTypes[102]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10281,7 +10392,7 @@ func (x *TrafficPolicySpec_JWT) String() string {
 func (*TrafficPolicySpec_JWT) ProtoMessage() {}
 
 func (x *TrafficPolicySpec_JWT) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[101]
+	mi := &file_resource_proto_msgTypes[102]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10341,7 +10452,7 @@ type TrafficPolicySpec_BasicAuthentication struct {
 
 func (x *TrafficPolicySpec_BasicAuthentication) Reset() {
 	*x = TrafficPolicySpec_BasicAuthentication{}
-	mi := &file_resource_proto_msgTypes[102]
+	mi := &file_resource_proto_msgTypes[103]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10353,7 +10464,7 @@ func (x *TrafficPolicySpec_BasicAuthentication) String() string {
 func (*TrafficPolicySpec_BasicAuthentication) ProtoMessage() {}
 
 func (x *TrafficPolicySpec_BasicAuthentication) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[102]
+	mi := &file_resource_proto_msgTypes[103]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10410,7 +10521,7 @@ type TrafficPolicySpec_APIKey struct {
 
 func (x *TrafficPolicySpec_APIKey) Reset() {
 	*x = TrafficPolicySpec_APIKey{}
-	mi := &file_resource_proto_msgTypes[103]
+	mi := &file_resource_proto_msgTypes[104]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10422,7 +10533,7 @@ func (x *TrafficPolicySpec_APIKey) String() string {
 func (*TrafficPolicySpec_APIKey) ProtoMessage() {}
 
 func (x *TrafficPolicySpec_APIKey) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[103]
+	mi := &file_resource_proto_msgTypes[104]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10469,7 +10580,7 @@ type TrafficPolicySpec_TransformationPolicy struct {
 
 func (x *TrafficPolicySpec_TransformationPolicy) Reset() {
 	*x = TrafficPolicySpec_TransformationPolicy{}
-	mi := &file_resource_proto_msgTypes[104]
+	mi := &file_resource_proto_msgTypes[105]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10481,7 +10592,7 @@ func (x *TrafficPolicySpec_TransformationPolicy) String() string {
 func (*TrafficPolicySpec_TransformationPolicy) ProtoMessage() {}
 
 func (x *TrafficPolicySpec_TransformationPolicy) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[104]
+	mi := &file_resource_proto_msgTypes[105]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10521,7 +10632,7 @@ type TrafficPolicySpec_HeaderTransformation struct {
 
 func (x *TrafficPolicySpec_HeaderTransformation) Reset() {
 	*x = TrafficPolicySpec_HeaderTransformation{}
-	mi := &file_resource_proto_msgTypes[105]
+	mi := &file_resource_proto_msgTypes[106]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10533,7 +10644,7 @@ func (x *TrafficPolicySpec_HeaderTransformation) String() string {
 func (*TrafficPolicySpec_HeaderTransformation) ProtoMessage() {}
 
 func (x *TrafficPolicySpec_HeaderTransformation) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[105]
+	mi := &file_resource_proto_msgTypes[106]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10572,7 +10683,7 @@ type TrafficPolicySpec_BodyTransformation struct {
 
 func (x *TrafficPolicySpec_BodyTransformation) Reset() {
 	*x = TrafficPolicySpec_BodyTransformation{}
-	mi := &file_resource_proto_msgTypes[106]
+	mi := &file_resource_proto_msgTypes[107]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10584,7 +10695,7 @@ func (x *TrafficPolicySpec_BodyTransformation) String() string {
 func (*TrafficPolicySpec_BodyTransformation) ProtoMessage() {}
 
 func (x *TrafficPolicySpec_BodyTransformation) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[106]
+	mi := &file_resource_proto_msgTypes[107]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10620,7 +10731,7 @@ type TrafficPolicySpec_CSRF struct {
 
 func (x *TrafficPolicySpec_CSRF) Reset() {
 	*x = TrafficPolicySpec_CSRF{}
-	mi := &file_resource_proto_msgTypes[107]
+	mi := &file_resource_proto_msgTypes[108]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10632,7 +10743,7 @@ func (x *TrafficPolicySpec_CSRF) String() string {
 func (*TrafficPolicySpec_CSRF) ProtoMessage() {}
 
 func (x *TrafficPolicySpec_CSRF) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[107]
+	mi := &file_resource_proto_msgTypes[108]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10669,7 +10780,7 @@ type TrafficPolicySpec_ExtProc struct {
 
 func (x *TrafficPolicySpec_ExtProc) Reset() {
 	*x = TrafficPolicySpec_ExtProc{}
-	mi := &file_resource_proto_msgTypes[108]
+	mi := &file_resource_proto_msgTypes[109]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10681,7 +10792,7 @@ func (x *TrafficPolicySpec_ExtProc) String() string {
 func (*TrafficPolicySpec_ExtProc) ProtoMessage() {}
 
 func (x *TrafficPolicySpec_ExtProc) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[108]
+	mi := &file_resource_proto_msgTypes[109]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10748,7 +10859,7 @@ type TrafficPolicySpec_HostRewrite struct {
 
 func (x *TrafficPolicySpec_HostRewrite) Reset() {
 	*x = TrafficPolicySpec_HostRewrite{}
-	mi := &file_resource_proto_msgTypes[109]
+	mi := &file_resource_proto_msgTypes[110]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10760,7 +10871,7 @@ func (x *TrafficPolicySpec_HostRewrite) String() string {
 func (*TrafficPolicySpec_HostRewrite) ProtoMessage() {}
 
 func (x *TrafficPolicySpec_HostRewrite) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[109]
+	mi := &file_resource_proto_msgTypes[110]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10795,7 +10906,7 @@ type TrafficPolicySpec_RemoteRateLimit_Descriptor struct {
 
 func (x *TrafficPolicySpec_RemoteRateLimit_Descriptor) Reset() {
 	*x = TrafficPolicySpec_RemoteRateLimit_Descriptor{}
-	mi := &file_resource_proto_msgTypes[110]
+	mi := &file_resource_proto_msgTypes[111]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10807,7 +10918,7 @@ func (x *TrafficPolicySpec_RemoteRateLimit_Descriptor) String() string {
 func (*TrafficPolicySpec_RemoteRateLimit_Descriptor) ProtoMessage() {}
 
 func (x *TrafficPolicySpec_RemoteRateLimit_Descriptor) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[110]
+	mi := &file_resource_proto_msgTypes[111]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10861,7 +10972,7 @@ type TrafficPolicySpec_RemoteRateLimit_Entry struct {
 
 func (x *TrafficPolicySpec_RemoteRateLimit_Entry) Reset() {
 	*x = TrafficPolicySpec_RemoteRateLimit_Entry{}
-	mi := &file_resource_proto_msgTypes[111]
+	mi := &file_resource_proto_msgTypes[112]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10873,7 +10984,7 @@ func (x *TrafficPolicySpec_RemoteRateLimit_Entry) String() string {
 func (*TrafficPolicySpec_RemoteRateLimit_Entry) ProtoMessage() {}
 
 func (x *TrafficPolicySpec_RemoteRateLimit_Entry) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[111]
+	mi := &file_resource_proto_msgTypes[112]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10914,7 +11025,7 @@ type TrafficPolicySpec_ExternalAuth_BodyOptions struct {
 
 func (x *TrafficPolicySpec_ExternalAuth_BodyOptions) Reset() {
 	*x = TrafficPolicySpec_ExternalAuth_BodyOptions{}
-	mi := &file_resource_proto_msgTypes[112]
+	mi := &file_resource_proto_msgTypes[113]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10926,7 +11037,7 @@ func (x *TrafficPolicySpec_ExternalAuth_BodyOptions) String() string {
 func (*TrafficPolicySpec_ExternalAuth_BodyOptions) ProtoMessage() {}
 
 func (x *TrafficPolicySpec_ExternalAuth_BodyOptions) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[112]
+	mi := &file_resource_proto_msgTypes[113]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10974,7 +11085,7 @@ type TrafficPolicySpec_ExternalAuth_Cache struct {
 
 func (x *TrafficPolicySpec_ExternalAuth_Cache) Reset() {
 	*x = TrafficPolicySpec_ExternalAuth_Cache{}
-	mi := &file_resource_proto_msgTypes[113]
+	mi := &file_resource_proto_msgTypes[114]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10986,7 +11097,7 @@ func (x *TrafficPolicySpec_ExternalAuth_Cache) String() string {
 func (*TrafficPolicySpec_ExternalAuth_Cache) ProtoMessage() {}
 
 func (x *TrafficPolicySpec_ExternalAuth_Cache) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[113]
+	mi := &file_resource_proto_msgTypes[114]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11033,7 +11144,7 @@ type TrafficPolicySpec_ExternalAuth_GRPCProtocol struct {
 
 func (x *TrafficPolicySpec_ExternalAuth_GRPCProtocol) Reset() {
 	*x = TrafficPolicySpec_ExternalAuth_GRPCProtocol{}
-	mi := &file_resource_proto_msgTypes[114]
+	mi := &file_resource_proto_msgTypes[115]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11045,7 +11156,7 @@ func (x *TrafficPolicySpec_ExternalAuth_GRPCProtocol) String() string {
 func (*TrafficPolicySpec_ExternalAuth_GRPCProtocol) ProtoMessage() {}
 
 func (x *TrafficPolicySpec_ExternalAuth_GRPCProtocol) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[114]
+	mi := &file_resource_proto_msgTypes[115]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11089,7 +11200,7 @@ type TrafficPolicySpec_ExternalAuth_HTTPProtocol struct {
 
 func (x *TrafficPolicySpec_ExternalAuth_HTTPProtocol) Reset() {
 	*x = TrafficPolicySpec_ExternalAuth_HTTPProtocol{}
-	mi := &file_resource_proto_msgTypes[115]
+	mi := &file_resource_proto_msgTypes[116]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11101,7 +11212,7 @@ func (x *TrafficPolicySpec_ExternalAuth_HTTPProtocol) String() string {
 func (*TrafficPolicySpec_ExternalAuth_HTTPProtocol) ProtoMessage() {}
 
 func (x *TrafficPolicySpec_ExternalAuth_HTTPProtocol) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[115]
+	mi := &file_resource_proto_msgTypes[116]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11170,7 +11281,7 @@ type TrafficPolicySpec_JWT_MCP struct {
 
 func (x *TrafficPolicySpec_JWT_MCP) Reset() {
 	*x = TrafficPolicySpec_JWT_MCP{}
-	mi := &file_resource_proto_msgTypes[120]
+	mi := &file_resource_proto_msgTypes[121]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11182,7 +11293,7 @@ func (x *TrafficPolicySpec_JWT_MCP) String() string {
 func (*TrafficPolicySpec_JWT_MCP) ProtoMessage() {}
 
 func (x *TrafficPolicySpec_JWT_MCP) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[120]
+	mi := &file_resource_proto_msgTypes[121]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11230,7 +11341,7 @@ type TrafficPolicySpec_APIKey_User struct {
 
 func (x *TrafficPolicySpec_APIKey_User) Reset() {
 	*x = TrafficPolicySpec_APIKey_User{}
-	mi := &file_resource_proto_msgTypes[121]
+	mi := &file_resource_proto_msgTypes[122]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11242,7 +11353,7 @@ func (x *TrafficPolicySpec_APIKey_User) String() string {
 func (*TrafficPolicySpec_APIKey_User) ProtoMessage() {}
 
 func (x *TrafficPolicySpec_APIKey_User) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[121]
+	mi := &file_resource_proto_msgTypes[122]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11292,7 +11403,7 @@ type TrafficPolicySpec_TransformationPolicy_Transform struct {
 
 func (x *TrafficPolicySpec_TransformationPolicy_Transform) Reset() {
 	*x = TrafficPolicySpec_TransformationPolicy_Transform{}
-	mi := &file_resource_proto_msgTypes[122]
+	mi := &file_resource_proto_msgTypes[123]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11304,7 +11415,7 @@ func (x *TrafficPolicySpec_TransformationPolicy_Transform) String() string {
 func (*TrafficPolicySpec_TransformationPolicy_Transform) ProtoMessage() {}
 
 func (x *TrafficPolicySpec_TransformationPolicy_Transform) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[122]
+	mi := &file_resource_proto_msgTypes[123]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11364,7 +11475,7 @@ type TrafficPolicySpec_ExtProc_NamespacedMetadataContext struct {
 
 func (x *TrafficPolicySpec_ExtProc_NamespacedMetadataContext) Reset() {
 	*x = TrafficPolicySpec_ExtProc_NamespacedMetadataContext{}
-	mi := &file_resource_proto_msgTypes[126]
+	mi := &file_resource_proto_msgTypes[127]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11376,7 +11487,7 @@ func (x *TrafficPolicySpec_ExtProc_NamespacedMetadataContext) String() string {
 func (*TrafficPolicySpec_ExtProc_NamespacedMetadataContext) ProtoMessage() {}
 
 func (x *TrafficPolicySpec_ExtProc_NamespacedMetadataContext) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[126]
+	mi := &file_resource_proto_msgTypes[127]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11416,7 +11527,7 @@ type TrafficPolicySpec_ExtProc_ProcessingOptions struct {
 
 func (x *TrafficPolicySpec_ExtProc_ProcessingOptions) Reset() {
 	*x = TrafficPolicySpec_ExtProc_ProcessingOptions{}
-	mi := &file_resource_proto_msgTypes[127]
+	mi := &file_resource_proto_msgTypes[128]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11428,7 +11539,7 @@ func (x *TrafficPolicySpec_ExtProc_ProcessingOptions) String() string {
 func (*TrafficPolicySpec_ExtProc_ProcessingOptions) ProtoMessage() {}
 
 func (x *TrafficPolicySpec_ExtProc_ProcessingOptions) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[127]
+	mi := &file_resource_proto_msgTypes[128]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11517,7 +11628,7 @@ type BackendPolicySpec_Ai struct {
 
 func (x *BackendPolicySpec_Ai) Reset() {
 	*x = BackendPolicySpec_Ai{}
-	mi := &file_resource_proto_msgTypes[130]
+	mi := &file_resource_proto_msgTypes[131]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11529,7 +11640,7 @@ func (x *BackendPolicySpec_Ai) String() string {
 func (*BackendPolicySpec_Ai) ProtoMessage() {}
 
 func (x *BackendPolicySpec_Ai) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[130]
+	mi := &file_resource_proto_msgTypes[131]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11609,7 +11720,7 @@ type BackendPolicySpec_A2A struct {
 
 func (x *BackendPolicySpec_A2A) Reset() {
 	*x = BackendPolicySpec_A2A{}
-	mi := &file_resource_proto_msgTypes[131]
+	mi := &file_resource_proto_msgTypes[132]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11621,7 +11732,7 @@ func (x *BackendPolicySpec_A2A) String() string {
 func (*BackendPolicySpec_A2A) ProtoMessage() {}
 
 func (x *BackendPolicySpec_A2A) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[131]
+	mi := &file_resource_proto_msgTypes[132]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11647,7 +11758,7 @@ type BackendPolicySpec_InferenceRouting struct {
 
 func (x *BackendPolicySpec_InferenceRouting) Reset() {
 	*x = BackendPolicySpec_InferenceRouting{}
-	mi := &file_resource_proto_msgTypes[132]
+	mi := &file_resource_proto_msgTypes[133]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11659,7 +11770,7 @@ func (x *BackendPolicySpec_InferenceRouting) String() string {
 func (*BackendPolicySpec_InferenceRouting) ProtoMessage() {}
 
 func (x *BackendPolicySpec_InferenceRouting) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[132]
+	mi := &file_resource_proto_msgTypes[133]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11720,7 +11831,7 @@ type BackendPolicySpec_Eviction struct {
 
 func (x *BackendPolicySpec_Eviction) Reset() {
 	*x = BackendPolicySpec_Eviction{}
-	mi := &file_resource_proto_msgTypes[133]
+	mi := &file_resource_proto_msgTypes[134]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11732,7 +11843,7 @@ func (x *BackendPolicySpec_Eviction) String() string {
 func (*BackendPolicySpec_Eviction) ProtoMessage() {}
 
 func (x *BackendPolicySpec_Eviction) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[133]
+	mi := &file_resource_proto_msgTypes[134]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11791,7 +11902,7 @@ type BackendPolicySpec_Health struct {
 
 func (x *BackendPolicySpec_Health) Reset() {
 	*x = BackendPolicySpec_Health{}
-	mi := &file_resource_proto_msgTypes[134]
+	mi := &file_resource_proto_msgTypes[135]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11803,7 +11914,7 @@ func (x *BackendPolicySpec_Health) String() string {
 func (*BackendPolicySpec_Health) ProtoMessage() {}
 
 func (x *BackendPolicySpec_Health) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[134]
+	mi := &file_resource_proto_msgTypes[135]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11859,7 +11970,7 @@ type BackendPolicySpec_BackendTLS struct {
 
 func (x *BackendPolicySpec_BackendTLS) Reset() {
 	*x = BackendPolicySpec_BackendTLS{}
-	mi := &file_resource_proto_msgTypes[135]
+	mi := &file_resource_proto_msgTypes[136]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11871,7 +11982,7 @@ func (x *BackendPolicySpec_BackendTLS) String() string {
 func (*BackendPolicySpec_BackendTLS) ProtoMessage() {}
 
 func (x *BackendPolicySpec_BackendTLS) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[135]
+	mi := &file_resource_proto_msgTypes[136]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11953,7 +12064,7 @@ type BackendPolicySpec_BackendHTTP struct {
 
 func (x *BackendPolicySpec_BackendHTTP) Reset() {
 	*x = BackendPolicySpec_BackendHTTP{}
-	mi := &file_resource_proto_msgTypes[136]
+	mi := &file_resource_proto_msgTypes[137]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11965,7 +12076,7 @@ func (x *BackendPolicySpec_BackendHTTP) String() string {
 func (*BackendPolicySpec_BackendHTTP) ProtoMessage() {}
 
 func (x *BackendPolicySpec_BackendHTTP) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[136]
+	mi := &file_resource_proto_msgTypes[137]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12004,7 +12115,7 @@ type BackendPolicySpec_BackendTunnel struct {
 
 func (x *BackendPolicySpec_BackendTunnel) Reset() {
 	*x = BackendPolicySpec_BackendTunnel{}
-	mi := &file_resource_proto_msgTypes[137]
+	mi := &file_resource_proto_msgTypes[138]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12016,7 +12127,7 @@ func (x *BackendPolicySpec_BackendTunnel) String() string {
 func (*BackendPolicySpec_BackendTunnel) ProtoMessage() {}
 
 func (x *BackendPolicySpec_BackendTunnel) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[137]
+	mi := &file_resource_proto_msgTypes[138]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12049,7 +12160,7 @@ type BackendPolicySpec_BackendTCP struct {
 
 func (x *BackendPolicySpec_BackendTCP) Reset() {
 	*x = BackendPolicySpec_BackendTCP{}
-	mi := &file_resource_proto_msgTypes[138]
+	mi := &file_resource_proto_msgTypes[139]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12061,7 +12172,7 @@ func (x *BackendPolicySpec_BackendTCP) String() string {
 func (*BackendPolicySpec_BackendTCP) ProtoMessage() {}
 
 func (x *BackendPolicySpec_BackendTCP) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[138]
+	mi := &file_resource_proto_msgTypes[139]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12102,7 +12213,7 @@ type BackendPolicySpec_McpAuthorization struct {
 
 func (x *BackendPolicySpec_McpAuthorization) Reset() {
 	*x = BackendPolicySpec_McpAuthorization{}
-	mi := &file_resource_proto_msgTypes[139]
+	mi := &file_resource_proto_msgTypes[140]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12114,7 +12225,7 @@ func (x *BackendPolicySpec_McpAuthorization) String() string {
 func (*BackendPolicySpec_McpAuthorization) ProtoMessage() {}
 
 func (x *BackendPolicySpec_McpAuthorization) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[139]
+	mi := &file_resource_proto_msgTypes[140]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12170,7 +12281,7 @@ type BackendPolicySpec_McpAuthentication struct {
 
 func (x *BackendPolicySpec_McpAuthentication) Reset() {
 	*x = BackendPolicySpec_McpAuthentication{}
-	mi := &file_resource_proto_msgTypes[140]
+	mi := &file_resource_proto_msgTypes[141]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12182,7 +12293,7 @@ func (x *BackendPolicySpec_McpAuthentication) String() string {
 func (*BackendPolicySpec_McpAuthentication) ProtoMessage() {}
 
 func (x *BackendPolicySpec_McpAuthentication) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[140]
+	mi := &file_resource_proto_msgTypes[141]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12275,7 +12386,7 @@ type BackendPolicySpec_McpGuardrails struct {
 
 func (x *BackendPolicySpec_McpGuardrails) Reset() {
 	*x = BackendPolicySpec_McpGuardrails{}
-	mi := &file_resource_proto_msgTypes[141]
+	mi := &file_resource_proto_msgTypes[142]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12287,7 +12398,7 @@ func (x *BackendPolicySpec_McpGuardrails) String() string {
 func (*BackendPolicySpec_McpGuardrails) ProtoMessage() {}
 
 func (x *BackendPolicySpec_McpGuardrails) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[141]
+	mi := &file_resource_proto_msgTypes[142]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12320,7 +12431,7 @@ type BackendPolicySpec_Ai_Message struct {
 
 func (x *BackendPolicySpec_Ai_Message) Reset() {
 	*x = BackendPolicySpec_Ai_Message{}
-	mi := &file_resource_proto_msgTypes[142]
+	mi := &file_resource_proto_msgTypes[143]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12332,7 +12443,7 @@ func (x *BackendPolicySpec_Ai_Message) String() string {
 func (*BackendPolicySpec_Ai_Message) ProtoMessage() {}
 
 func (x *BackendPolicySpec_Ai_Message) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[142]
+	mi := &file_resource_proto_msgTypes[143]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12372,7 +12483,7 @@ type BackendPolicySpec_Ai_PromptEnrichment struct {
 
 func (x *BackendPolicySpec_Ai_PromptEnrichment) Reset() {
 	*x = BackendPolicySpec_Ai_PromptEnrichment{}
-	mi := &file_resource_proto_msgTypes[143]
+	mi := &file_resource_proto_msgTypes[144]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12384,7 +12495,7 @@ func (x *BackendPolicySpec_Ai_PromptEnrichment) String() string {
 func (*BackendPolicySpec_Ai_PromptEnrichment) ProtoMessage() {}
 
 func (x *BackendPolicySpec_Ai_PromptEnrichment) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[143]
+	mi := &file_resource_proto_msgTypes[144]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12427,7 +12538,7 @@ type BackendPolicySpec_Ai_RegexRule struct {
 
 func (x *BackendPolicySpec_Ai_RegexRule) Reset() {
 	*x = BackendPolicySpec_Ai_RegexRule{}
-	mi := &file_resource_proto_msgTypes[144]
+	mi := &file_resource_proto_msgTypes[145]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12439,7 +12550,7 @@ func (x *BackendPolicySpec_Ai_RegexRule) String() string {
 func (*BackendPolicySpec_Ai_RegexRule) ProtoMessage() {}
 
 func (x *BackendPolicySpec_Ai_RegexRule) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[144]
+	mi := &file_resource_proto_msgTypes[145]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12506,7 +12617,7 @@ type BackendPolicySpec_Ai_RegexRules struct {
 
 func (x *BackendPolicySpec_Ai_RegexRules) Reset() {
 	*x = BackendPolicySpec_Ai_RegexRules{}
-	mi := &file_resource_proto_msgTypes[145]
+	mi := &file_resource_proto_msgTypes[146]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12518,7 +12629,7 @@ func (x *BackendPolicySpec_Ai_RegexRules) String() string {
 func (*BackendPolicySpec_Ai_RegexRules) ProtoMessage() {}
 
 func (x *BackendPolicySpec_Ai_RegexRules) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[145]
+	mi := &file_resource_proto_msgTypes[146]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12559,7 +12670,7 @@ type BackendPolicySpec_Ai_Webhook struct {
 
 func (x *BackendPolicySpec_Ai_Webhook) Reset() {
 	*x = BackendPolicySpec_Ai_Webhook{}
-	mi := &file_resource_proto_msgTypes[146]
+	mi := &file_resource_proto_msgTypes[147]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12571,7 +12682,7 @@ func (x *BackendPolicySpec_Ai_Webhook) String() string {
 func (*BackendPolicySpec_Ai_Webhook) ProtoMessage() {}
 
 func (x *BackendPolicySpec_Ai_Webhook) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[146]
+	mi := &file_resource_proto_msgTypes[147]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12621,7 +12732,7 @@ type BackendPolicySpec_Ai_Moderation struct {
 
 func (x *BackendPolicySpec_Ai_Moderation) Reset() {
 	*x = BackendPolicySpec_Ai_Moderation{}
-	mi := &file_resource_proto_msgTypes[147]
+	mi := &file_resource_proto_msgTypes[148]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12633,7 +12744,7 @@ func (x *BackendPolicySpec_Ai_Moderation) String() string {
 func (*BackendPolicySpec_Ai_Moderation) ProtoMessage() {}
 
 func (x *BackendPolicySpec_Ai_Moderation) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[147]
+	mi := &file_resource_proto_msgTypes[148]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12685,7 +12796,7 @@ type BackendPolicySpec_Ai_BedrockGuardrails struct {
 
 func (x *BackendPolicySpec_Ai_BedrockGuardrails) Reset() {
 	*x = BackendPolicySpec_Ai_BedrockGuardrails{}
-	mi := &file_resource_proto_msgTypes[148]
+	mi := &file_resource_proto_msgTypes[149]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12697,7 +12808,7 @@ func (x *BackendPolicySpec_Ai_BedrockGuardrails) String() string {
 func (*BackendPolicySpec_Ai_BedrockGuardrails) ProtoMessage() {}
 
 func (x *BackendPolicySpec_Ai_BedrockGuardrails) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[148]
+	mi := &file_resource_proto_msgTypes[149]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12763,7 +12874,7 @@ type BackendPolicySpec_Ai_GoogleModelArmor struct {
 
 func (x *BackendPolicySpec_Ai_GoogleModelArmor) Reset() {
 	*x = BackendPolicySpec_Ai_GoogleModelArmor{}
-	mi := &file_resource_proto_msgTypes[149]
+	mi := &file_resource_proto_msgTypes[150]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12775,7 +12886,7 @@ func (x *BackendPolicySpec_Ai_GoogleModelArmor) String() string {
 func (*BackendPolicySpec_Ai_GoogleModelArmor) ProtoMessage() {}
 
 func (x *BackendPolicySpec_Ai_GoogleModelArmor) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[149]
+	mi := &file_resource_proto_msgTypes[150]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12847,7 +12958,7 @@ type BackendPolicySpec_Ai_AzureContentSafety struct {
 
 func (x *BackendPolicySpec_Ai_AzureContentSafety) Reset() {
 	*x = BackendPolicySpec_Ai_AzureContentSafety{}
-	mi := &file_resource_proto_msgTypes[150]
+	mi := &file_resource_proto_msgTypes[151]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12859,7 +12970,7 @@ func (x *BackendPolicySpec_Ai_AzureContentSafety) String() string {
 func (*BackendPolicySpec_Ai_AzureContentSafety) ProtoMessage() {}
 
 func (x *BackendPolicySpec_Ai_AzureContentSafety) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[150]
+	mi := &file_resource_proto_msgTypes[151]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12935,7 +13046,7 @@ type BackendPolicySpec_Ai_RequestRejection struct {
 
 func (x *BackendPolicySpec_Ai_RequestRejection) Reset() {
 	*x = BackendPolicySpec_Ai_RequestRejection{}
-	mi := &file_resource_proto_msgTypes[151]
+	mi := &file_resource_proto_msgTypes[152]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12947,7 +13058,7 @@ func (x *BackendPolicySpec_Ai_RequestRejection) String() string {
 func (*BackendPolicySpec_Ai_RequestRejection) ProtoMessage() {}
 
 func (x *BackendPolicySpec_Ai_RequestRejection) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[151]
+	mi := &file_resource_proto_msgTypes[152]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12996,7 +13107,7 @@ type BackendPolicySpec_Ai_ResponseGuard struct {
 
 func (x *BackendPolicySpec_Ai_ResponseGuard) Reset() {
 	*x = BackendPolicySpec_Ai_ResponseGuard{}
-	mi := &file_resource_proto_msgTypes[152]
+	mi := &file_resource_proto_msgTypes[153]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13008,7 +13119,7 @@ func (x *BackendPolicySpec_Ai_ResponseGuard) String() string {
 func (*BackendPolicySpec_Ai_ResponseGuard) ProtoMessage() {}
 
 func (x *BackendPolicySpec_Ai_ResponseGuard) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[152]
+	mi := &file_resource_proto_msgTypes[153]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13140,7 +13251,7 @@ type BackendPolicySpec_Ai_RequestGuard struct {
 
 func (x *BackendPolicySpec_Ai_RequestGuard) Reset() {
 	*x = BackendPolicySpec_Ai_RequestGuard{}
-	mi := &file_resource_proto_msgTypes[153]
+	mi := &file_resource_proto_msgTypes[154]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13152,7 +13263,7 @@ func (x *BackendPolicySpec_Ai_RequestGuard) String() string {
 func (*BackendPolicySpec_Ai_RequestGuard) ProtoMessage() {}
 
 func (x *BackendPolicySpec_Ai_RequestGuard) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[153]
+	mi := &file_resource_proto_msgTypes[154]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13295,7 +13406,7 @@ type BackendPolicySpec_Ai_PromptGuard struct {
 
 func (x *BackendPolicySpec_Ai_PromptGuard) Reset() {
 	*x = BackendPolicySpec_Ai_PromptGuard{}
-	mi := &file_resource_proto_msgTypes[154]
+	mi := &file_resource_proto_msgTypes[155]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13307,7 +13418,7 @@ func (x *BackendPolicySpec_Ai_PromptGuard) String() string {
 func (*BackendPolicySpec_Ai_PromptGuard) ProtoMessage() {}
 
 func (x *BackendPolicySpec_Ai_PromptGuard) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[154]
+	mi := &file_resource_proto_msgTypes[155]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13358,7 +13469,7 @@ type BackendPolicySpec_Ai_PromptCaching struct {
 
 func (x *BackendPolicySpec_Ai_PromptCaching) Reset() {
 	*x = BackendPolicySpec_Ai_PromptCaching{}
-	mi := &file_resource_proto_msgTypes[155]
+	mi := &file_resource_proto_msgTypes[156]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13370,7 +13481,7 @@ func (x *BackendPolicySpec_Ai_PromptCaching) String() string {
 func (*BackendPolicySpec_Ai_PromptCaching) ProtoMessage() {}
 
 func (x *BackendPolicySpec_Ai_PromptCaching) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[155]
+	mi := &file_resource_proto_msgTypes[156]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13430,7 +13541,7 @@ type BackendPolicySpec_McpAuthentication_ResourceMetadata struct {
 
 func (x *BackendPolicySpec_McpAuthentication_ResourceMetadata) Reset() {
 	*x = BackendPolicySpec_McpAuthentication_ResourceMetadata{}
-	mi := &file_resource_proto_msgTypes[161]
+	mi := &file_resource_proto_msgTypes[162]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13442,7 +13553,7 @@ func (x *BackendPolicySpec_McpAuthentication_ResourceMetadata) String() string {
 func (*BackendPolicySpec_McpAuthentication_ResourceMetadata) ProtoMessage() {}
 
 func (x *BackendPolicySpec_McpAuthentication_ResourceMetadata) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[161]
+	mi := &file_resource_proto_msgTypes[162]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13490,7 +13601,7 @@ type BackendPolicySpec_McpGuardrails_Remote struct {
 
 func (x *BackendPolicySpec_McpGuardrails_Remote) Reset() {
 	*x = BackendPolicySpec_McpGuardrails_Remote{}
-	mi := &file_resource_proto_msgTypes[163]
+	mi := &file_resource_proto_msgTypes[164]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13502,7 +13613,7 @@ func (x *BackendPolicySpec_McpGuardrails_Remote) String() string {
 func (*BackendPolicySpec_McpGuardrails_Remote) ProtoMessage() {}
 
 func (x *BackendPolicySpec_McpGuardrails_Remote) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[163]
+	mi := &file_resource_proto_msgTypes[164]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13572,7 +13683,7 @@ type BackendPolicySpec_McpGuardrails_Processor struct {
 
 func (x *BackendPolicySpec_McpGuardrails_Processor) Reset() {
 	*x = BackendPolicySpec_McpGuardrails_Processor{}
-	mi := &file_resource_proto_msgTypes[164]
+	mi := &file_resource_proto_msgTypes[165]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13584,7 +13695,7 @@ func (x *BackendPolicySpec_McpGuardrails_Processor) String() string {
 func (*BackendPolicySpec_McpGuardrails_Processor) ProtoMessage() {}
 
 func (x *BackendPolicySpec_McpGuardrails_Processor) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[164]
+	mi := &file_resource_proto_msgTypes[165]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13644,7 +13755,7 @@ type AIBackend_HostOverride struct {
 
 func (x *AIBackend_HostOverride) Reset() {
 	*x = AIBackend_HostOverride{}
-	mi := &file_resource_proto_msgTypes[167]
+	mi := &file_resource_proto_msgTypes[168]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13656,7 +13767,7 @@ func (x *AIBackend_HostOverride) String() string {
 func (*AIBackend_HostOverride) ProtoMessage() {}
 
 func (x *AIBackend_HostOverride) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[167]
+	mi := &file_resource_proto_msgTypes[168]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13695,7 +13806,7 @@ type AIBackend_OpenAI struct {
 
 func (x *AIBackend_OpenAI) Reset() {
 	*x = AIBackend_OpenAI{}
-	mi := &file_resource_proto_msgTypes[168]
+	mi := &file_resource_proto_msgTypes[169]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13707,7 +13818,7 @@ func (x *AIBackend_OpenAI) String() string {
 func (*AIBackend_OpenAI) ProtoMessage() {}
 
 func (x *AIBackend_OpenAI) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[168]
+	mi := &file_resource_proto_msgTypes[169]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13739,7 +13850,7 @@ type AIBackend_Gemini struct {
 
 func (x *AIBackend_Gemini) Reset() {
 	*x = AIBackend_Gemini{}
-	mi := &file_resource_proto_msgTypes[169]
+	mi := &file_resource_proto_msgTypes[170]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13751,7 +13862,7 @@ func (x *AIBackend_Gemini) String() string {
 func (*AIBackend_Gemini) ProtoMessage() {}
 
 func (x *AIBackend_Gemini) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[169]
+	mi := &file_resource_proto_msgTypes[170]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13785,7 +13896,7 @@ type AIBackend_Vertex struct {
 
 func (x *AIBackend_Vertex) Reset() {
 	*x = AIBackend_Vertex{}
-	mi := &file_resource_proto_msgTypes[170]
+	mi := &file_resource_proto_msgTypes[171]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13797,7 +13908,7 @@ func (x *AIBackend_Vertex) String() string {
 func (*AIBackend_Vertex) ProtoMessage() {}
 
 func (x *AIBackend_Vertex) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[170]
+	mi := &file_resource_proto_msgTypes[171]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13843,7 +13954,7 @@ type AIBackend_Anthropic struct {
 
 func (x *AIBackend_Anthropic) Reset() {
 	*x = AIBackend_Anthropic{}
-	mi := &file_resource_proto_msgTypes[171]
+	mi := &file_resource_proto_msgTypes[172]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13855,7 +13966,7 @@ func (x *AIBackend_Anthropic) String() string {
 func (*AIBackend_Anthropic) ProtoMessage() {}
 
 func (x *AIBackend_Anthropic) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[171]
+	mi := &file_resource_proto_msgTypes[172]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13890,7 +14001,7 @@ type AIBackend_Bedrock struct {
 
 func (x *AIBackend_Bedrock) Reset() {
 	*x = AIBackend_Bedrock{}
-	mi := &file_resource_proto_msgTypes[172]
+	mi := &file_resource_proto_msgTypes[173]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13902,7 +14013,7 @@ func (x *AIBackend_Bedrock) String() string {
 func (*AIBackend_Bedrock) ProtoMessage() {}
 
 func (x *AIBackend_Bedrock) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[172]
+	mi := &file_resource_proto_msgTypes[173]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13958,7 +14069,7 @@ type AIBackend_AzureOpenAI struct {
 
 func (x *AIBackend_AzureOpenAI) Reset() {
 	*x = AIBackend_AzureOpenAI{}
-	mi := &file_resource_proto_msgTypes[173]
+	mi := &file_resource_proto_msgTypes[174]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13970,7 +14081,7 @@ func (x *AIBackend_AzureOpenAI) String() string {
 func (*AIBackend_AzureOpenAI) ProtoMessage() {}
 
 func (x *AIBackend_AzureOpenAI) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[173]
+	mi := &file_resource_proto_msgTypes[174]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14034,7 +14145,7 @@ type AIBackend_Azure struct {
 
 func (x *AIBackend_Azure) Reset() {
 	*x = AIBackend_Azure{}
-	mi := &file_resource_proto_msgTypes[174]
+	mi := &file_resource_proto_msgTypes[175]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14046,7 +14157,7 @@ func (x *AIBackend_Azure) String() string {
 func (*AIBackend_Azure) ProtoMessage() {}
 
 func (x *AIBackend_Azure) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[174]
+	mi := &file_resource_proto_msgTypes[175]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14107,7 +14218,7 @@ type AIBackend_ProviderFormatConfig struct {
 
 func (x *AIBackend_ProviderFormatConfig) Reset() {
 	*x = AIBackend_ProviderFormatConfig{}
-	mi := &file_resource_proto_msgTypes[175]
+	mi := &file_resource_proto_msgTypes[176]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14119,7 +14230,7 @@ func (x *AIBackend_ProviderFormatConfig) String() string {
 func (*AIBackend_ProviderFormatConfig) ProtoMessage() {}
 
 func (x *AIBackend_ProviderFormatConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[175]
+	mi := &file_resource_proto_msgTypes[176]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14160,7 +14271,7 @@ type AIBackend_Custom struct {
 
 func (x *AIBackend_Custom) Reset() {
 	*x = AIBackend_Custom{}
-	mi := &file_resource_proto_msgTypes[176]
+	mi := &file_resource_proto_msgTypes[177]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14172,7 +14283,7 @@ func (x *AIBackend_Custom) String() string {
 func (*AIBackend_Custom) ProtoMessage() {}
 
 func (x *AIBackend_Custom) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[176]
+	mi := &file_resource_proto_msgTypes[177]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14234,7 +14345,7 @@ type AIBackend_Provider struct {
 
 func (x *AIBackend_Provider) Reset() {
 	*x = AIBackend_Provider{}
-	mi := &file_resource_proto_msgTypes[177]
+	mi := &file_resource_proto_msgTypes[178]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14246,7 +14357,7 @@ func (x *AIBackend_Provider) String() string {
 func (*AIBackend_Provider) ProtoMessage() {}
 
 func (x *AIBackend_Provider) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[177]
+	mi := &file_resource_proto_msgTypes[178]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14444,7 +14555,7 @@ type AIBackend_ProviderGroup struct {
 
 func (x *AIBackend_ProviderGroup) Reset() {
 	*x = AIBackend_ProviderGroup{}
-	mi := &file_resource_proto_msgTypes[178]
+	mi := &file_resource_proto_msgTypes[179]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14456,7 +14567,7 @@ func (x *AIBackend_ProviderGroup) String() string {
 func (*AIBackend_ProviderGroup) ProtoMessage() {}
 
 func (x *AIBackend_ProviderGroup) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[178]
+	mi := &file_resource_proto_msgTypes[179]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14489,7 +14600,7 @@ type BackendReference_Service struct {
 
 func (x *BackendReference_Service) Reset() {
 	*x = BackendReference_Service{}
-	mi := &file_resource_proto_msgTypes[179]
+	mi := &file_resource_proto_msgTypes[180]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14501,7 +14612,7 @@ func (x *BackendReference_Service) String() string {
 func (*BackendReference_Service) ProtoMessage() {}
 
 func (x *BackendReference_Service) ProtoReflect() protoreflect.Message {
-	mi := &file_resource_proto_msgTypes[179]
+	mi := &file_resource_proto_msgTypes[180]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14527,6 +14638,50 @@ func (x *BackendReference_Service) GetNamespace() string {
 func (x *BackendReference_Service) GetHostname() string {
 	if x != nil {
 		return x.Hostname
+	}
+	return ""
+}
+
+type OAuthTokenExchange_ClientAuth struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ClientId      string                 `protobuf:"bytes,1,opt,name=client_id,json=clientId,proto3" json:"client_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *OAuthTokenExchange_ClientAuth) Reset() {
+	*x = OAuthTokenExchange_ClientAuth{}
+	mi := &file_resource_proto_msgTypes[181]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *OAuthTokenExchange_ClientAuth) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*OAuthTokenExchange_ClientAuth) ProtoMessage() {}
+
+func (x *OAuthTokenExchange_ClientAuth) ProtoReflect() protoreflect.Message {
+	mi := &file_resource_proto_msgTypes[181]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use OAuthTokenExchange_ClientAuth.ProtoReflect.Descriptor instead.
+func (*OAuthTokenExchange_ClientAuth) Descriptor() ([]byte, []int) {
+	return file_resource_proto_rawDescGZIP(), []int{65, 0}
+}
+
+func (x *OAuthTokenExchange_ClientAuth) GetClientId() string {
+	if x != nil {
+		return x.ClientId
 	}
 	return ""
 }
@@ -14734,13 +14889,14 @@ const file_resource_proto_rawDesc = "" +
 	"\battempts\x18\x02 \x01(\x05R\battempts\x123\n" +
 	"\abackoff\x18\x03 \x01(\v2\x19.google.protobuf.DurationR\abackoff\x12\"\n" +
 	"\fprecondition\x18\x04 \x01(\tR\fprecondition\x12\x1c\n" +
-	"\tcondition\x18\x05 \x01(\tR\tcondition\"\xbd\x02\n" +
+	"\tcondition\x18\x05 \x01(\tR\tcondition\"\xa0\x03\n" +
 	"\x11BackendAuthPolicy\x12J\n" +
 	"\vpassthrough\x18\x01 \x01(\v2&.agentgateway.dev.resource.PassthroughH\x00R\vpassthrough\x122\n" +
 	"\x03key\x18\x02 \x01(\v2\x1e.agentgateway.dev.resource.KeyH\x00R\x03key\x122\n" +
 	"\x03gcp\x18\x03 \x01(\v2\x1e.agentgateway.dev.resource.GcpH\x00R\x03gcp\x122\n" +
 	"\x03aws\x18\x04 \x01(\v2\x1e.agentgateway.dev.resource.AwsH\x00R\x03aws\x128\n" +
-	"\x05azure\x18\x05 \x01(\v2 .agentgateway.dev.resource.AzureH\x00R\x05azureB\x06\n" +
+	"\x05azure\x18\x05 \x01(\v2 .agentgateway.dev.resource.AzureH\x00R\x05azure\x12a\n" +
+	"\x14oauth_token_exchange\x18\x06 \x01(\v2-.agentgateway.dev.resource.OAuthTokenExchangeH\x00R\x12oauthTokenExchangeB\x06\n" +
 	"\x04kind\"\xdd\x03\n" +
 	"\x15AuthorizationLocation\x12Q\n" +
 	"\x06header\x18\x01 \x01(\v27.agentgateway.dev.resource.AuthorizationLocation.HeaderH\x00R\x06header\x12j\n" +
@@ -15740,7 +15896,19 @@ const file_resource_proto_rawDesc = "" +
 	"\bhostname\x18\x02 \x01(\tR\bhostnameB\x06\n" +
 	"\x04kind\"$\n" +
 	"\x04Alpn\x12\x1c\n" +
-	"\tprotocols\x18\x01 \x03(\tR\tprotocols*I\n" +
+	"\tprotocols\x18\x01 \x03(\tR\tprotocols\"\xa4\x03\n" +
+	"\x12OAuthTokenExchange\x12R\n" +
+	"\x0etoken_endpoint\x18\x01 \x01(\v2+.agentgateway.dev.resource.BackendReferenceR\rtokenEndpoint\x12.\n" +
+	"\x13token_endpoint_path\x18\a \x01(\tR\x11tokenEndpointPath\x12\x1c\n" +
+	"\taudiences\x18\x02 \x03(\tR\taudiences\x12\x16\n" +
+	"\x06scopes\x18\x03 \x03(\tR\x06scopes\x12\x1c\n" +
+	"\tresources\x18\x04 \x03(\tR\tresources\x120\n" +
+	"\x14requested_token_type\x18\x05 \x01(\tR\x12requestedTokenType\x12Y\n" +
+	"\vclient_auth\x18\x06 \x01(\v28.agentgateway.dev.resource.OAuthTokenExchange.ClientAuthR\n" +
+	"clientAuth\x1a)\n" +
+	"\n" +
+	"ClientAuth\x12\x1b\n" +
+	"\tclient_id\x18\x01 \x01(\tR\bclientId*I\n" +
 	"\bProtocol\x12\v\n" +
 	"\aUNKNOWN\x10\x00\x12\b\n" +
 	"\x04HTTP\x10\x01\x12\t\n" +
@@ -15762,7 +15930,7 @@ func file_resource_proto_rawDescGZIP() []byte {
 }
 
 var file_resource_proto_enumTypes = make([]protoimpl.EnumInfo, 45)
-var file_resource_proto_msgTypes = make([]protoimpl.MessageInfo, 180)
+var file_resource_proto_msgTypes = make([]protoimpl.MessageInfo, 182)
 var file_resource_proto_goTypes = []any{
 	(Protocol)(0),                                               // 0: agentgateway.dev.resource.Protocol
 	(Bind_Protocol)(0),                                          // 1: agentgateway.dev.resource.Bind.Protocol
@@ -15874,127 +16042,129 @@ var file_resource_proto_goTypes = []any{
 	(*MCPTarget)(nil),                                           // 107: agentgateway.dev.resource.MCPTarget
 	(*BackendReference)(nil),                                    // 108: agentgateway.dev.resource.BackendReference
 	(*Alpn)(nil),                                                // 109: agentgateway.dev.resource.Alpn
-	(*GuardrailBackend_Bedrock)(nil),                            // 110: agentgateway.dev.resource.GuardrailBackend.Bedrock
-	(*GuardrailBackend_GoogleModelArmor)(nil),                   // 111: agentgateway.dev.resource.GuardrailBackend.GoogleModelArmor
-	(*GuardrailBackend_AzureContentSafety)(nil),                 // 112: agentgateway.dev.resource.GuardrailBackend.AzureContentSafety
-	(*GuardrailBackend_OpenAIModeration)(nil),                   // 113: agentgateway.dev.resource.GuardrailBackend.OpenAIModeration
-	(*AuthorizationLocation_Header)(nil),                        // 114: agentgateway.dev.resource.AuthorizationLocation.Header
-	(*AuthorizationLocation_QueryParameter)(nil),                // 115: agentgateway.dev.resource.AuthorizationLocation.QueryParameter
-	(*AuthorizationLocation_Cookie)(nil),                        // 116: agentgateway.dev.resource.AuthorizationLocation.Cookie
-	(*Gcp_AccessToken)(nil),                                     // 117: agentgateway.dev.resource.Gcp.AccessToken
-	(*Gcp_IdToken)(nil),                                         // 118: agentgateway.dev.resource.Gcp.IdToken
-	(*AzureManagedIdentityCredential_UserAssignedIdentity)(nil), // 119: agentgateway.dev.resource.AzureManagedIdentityCredential.UserAssignedIdentity
-	(*RequestMirrors_Mirror)(nil),                               // 120: agentgateway.dev.resource.RequestMirrors.Mirror
-	(*PolicyTarget_ServiceTarget)(nil),                          // 121: agentgateway.dev.resource.PolicyTarget.ServiceTarget
-	(*PolicyTarget_BackendTarget)(nil),                          // 122: agentgateway.dev.resource.PolicyTarget.BackendTarget
-	(*PolicyTarget_GatewayTarget)(nil),                          // 123: agentgateway.dev.resource.PolicyTarget.GatewayTarget
-	(*PolicyTarget_RouteTarget)(nil),                            // 124: agentgateway.dev.resource.PolicyTarget.RouteTarget
-	(*PolicyTarget_ListenerSetTarget)(nil),                      // 125: agentgateway.dev.resource.PolicyTarget.ListenerSetTarget
-	(*FrontendPolicySpec_HTTP)(nil),                             // 126: agentgateway.dev.resource.FrontendPolicySpec.HTTP
-	(*FrontendPolicySpec_TLS)(nil),                              // 127: agentgateway.dev.resource.FrontendPolicySpec.TLS
-	(*FrontendPolicySpec_TCP)(nil),                              // 128: agentgateway.dev.resource.FrontendPolicySpec.TCP
-	(*FrontendPolicySpec_NetworkAuthorization)(nil),             // 129: agentgateway.dev.resource.FrontendPolicySpec.NetworkAuthorization
-	(*FrontendPolicySpec_Logging)(nil),                          // 130: agentgateway.dev.resource.FrontendPolicySpec.Logging
-	(*FrontendPolicySpec_Tracing)(nil),                          // 131: agentgateway.dev.resource.FrontendPolicySpec.Tracing
-	(*FrontendPolicySpec_TracingAttribute)(nil),                 // 132: agentgateway.dev.resource.FrontendPolicySpec.TracingAttribute
-	(*FrontendPolicySpec_ProxyProtocol)(nil),                    // 133: agentgateway.dev.resource.FrontendPolicySpec.ProxyProtocol
-	(*FrontendPolicySpec_Connect)(nil),                          // 134: agentgateway.dev.resource.FrontendPolicySpec.Connect
-	(*FrontendPolicySpec_Metrics)(nil),                          // 135: agentgateway.dev.resource.FrontendPolicySpec.Metrics
-	(*FrontendPolicySpec_Logging_Field)(nil),                    // 136: agentgateway.dev.resource.FrontendPolicySpec.Logging.Field
-	(*FrontendPolicySpec_Logging_Fields)(nil),                   // 137: agentgateway.dev.resource.FrontendPolicySpec.Logging.Fields
-	(*FrontendPolicySpec_Logging_OtlpAccessLog)(nil),            // 138: agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog
-	(*FrontendPolicySpec_Metrics_Field)(nil),                    // 139: agentgateway.dev.resource.FrontendPolicySpec.Metrics.Field
-	(*FrontendPolicySpec_Metrics_Fields)(nil),                   // 140: agentgateway.dev.resource.FrontendPolicySpec.Metrics.Fields
-	(*TrafficPolicySpec_RemoteRateLimit)(nil),                   // 141: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit
-	(*TrafficPolicySpec_LocalRateLimit)(nil),                    // 142: agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit
-	(*TrafficPolicySpec_ExternalAuth)(nil),                      // 143: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth
-	(*TrafficPolicySpec_RBAC)(nil),                              // 144: agentgateway.dev.resource.TrafficPolicySpec.RBAC
-	(*TrafficPolicySpec_JWTProvider)(nil),                       // 145: agentgateway.dev.resource.TrafficPolicySpec.JWTProvider
-	(*TrafficPolicySpec_JWT)(nil),                               // 146: agentgateway.dev.resource.TrafficPolicySpec.JWT
-	(*TrafficPolicySpec_BasicAuthentication)(nil),               // 147: agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication
-	(*TrafficPolicySpec_APIKey)(nil),                            // 148: agentgateway.dev.resource.TrafficPolicySpec.APIKey
-	(*TrafficPolicySpec_TransformationPolicy)(nil),              // 149: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy
-	(*TrafficPolicySpec_HeaderTransformation)(nil),              // 150: agentgateway.dev.resource.TrafficPolicySpec.HeaderTransformation
-	(*TrafficPolicySpec_BodyTransformation)(nil),                // 151: agentgateway.dev.resource.TrafficPolicySpec.BodyTransformation
-	(*TrafficPolicySpec_CSRF)(nil),                              // 152: agentgateway.dev.resource.TrafficPolicySpec.CSRF
-	(*TrafficPolicySpec_ExtProc)(nil),                           // 153: agentgateway.dev.resource.TrafficPolicySpec.ExtProc
-	(*TrafficPolicySpec_HostRewrite)(nil),                       // 154: agentgateway.dev.resource.TrafficPolicySpec.HostRewrite
-	(*TrafficPolicySpec_RemoteRateLimit_Descriptor)(nil),        // 155: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor
-	(*TrafficPolicySpec_RemoteRateLimit_Entry)(nil),             // 156: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Entry
-	(*TrafficPolicySpec_ExternalAuth_BodyOptions)(nil),          // 157: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.BodyOptions
-	(*TrafficPolicySpec_ExternalAuth_Cache)(nil),                // 158: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.Cache
-	(*TrafficPolicySpec_ExternalAuth_GRPCProtocol)(nil),         // 159: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol
-	(*TrafficPolicySpec_ExternalAuth_HTTPProtocol)(nil),         // 160: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol
-	nil,                                   // 161: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.ContextEntry
-	nil,                                   // 162: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.MetadataEntry
-	nil,                                   // 163: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.AddRequestHeadersEntry
-	nil,                                   // 164: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.MetadataEntry
-	(*TrafficPolicySpec_JWT_MCP)(nil),     // 165: agentgateway.dev.resource.TrafficPolicySpec.JWT.MCP
-	(*TrafficPolicySpec_APIKey_User)(nil), // 166: agentgateway.dev.resource.TrafficPolicySpec.APIKey.User
-	(*TrafficPolicySpec_TransformationPolicy_Transform)(nil), // 167: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform
-	nil, // 168: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.MetadataEntry
-	nil, // 169: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.RequestAttributesEntry
-	nil, // 170: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ResponseAttributesEntry
-	(*TrafficPolicySpec_ExtProc_NamespacedMetadataContext)(nil), // 171: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext
-	(*TrafficPolicySpec_ExtProc_ProcessingOptions)(nil),         // 172: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ProcessingOptions
-	nil,                           // 173: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.MetadataContextEntry
-	nil,                           // 174: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext.ContextEntry
-	(*BackendPolicySpec_Ai)(nil),  // 175: agentgateway.dev.resource.BackendPolicySpec.Ai
-	(*BackendPolicySpec_A2A)(nil), // 176: agentgateway.dev.resource.BackendPolicySpec.A2a
-	(*BackendPolicySpec_InferenceRouting)(nil),      // 177: agentgateway.dev.resource.BackendPolicySpec.InferenceRouting
-	(*BackendPolicySpec_Eviction)(nil),              // 178: agentgateway.dev.resource.BackendPolicySpec.Eviction
-	(*BackendPolicySpec_Health)(nil),                // 179: agentgateway.dev.resource.BackendPolicySpec.Health
-	(*BackendPolicySpec_BackendTLS)(nil),            // 180: agentgateway.dev.resource.BackendPolicySpec.BackendTLS
-	(*BackendPolicySpec_BackendHTTP)(nil),           // 181: agentgateway.dev.resource.BackendPolicySpec.BackendHTTP
-	(*BackendPolicySpec_BackendTunnel)(nil),         // 182: agentgateway.dev.resource.BackendPolicySpec.BackendTunnel
-	(*BackendPolicySpec_BackendTCP)(nil),            // 183: agentgateway.dev.resource.BackendPolicySpec.BackendTCP
-	(*BackendPolicySpec_McpAuthorization)(nil),      // 184: agentgateway.dev.resource.BackendPolicySpec.McpAuthorization
-	(*BackendPolicySpec_McpAuthentication)(nil),     // 185: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication
-	(*BackendPolicySpec_McpGuardrails)(nil),         // 186: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails
-	(*BackendPolicySpec_Ai_Message)(nil),            // 187: agentgateway.dev.resource.BackendPolicySpec.Ai.Message
-	(*BackendPolicySpec_Ai_PromptEnrichment)(nil),   // 188: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment
-	(*BackendPolicySpec_Ai_RegexRule)(nil),          // 189: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRule
-	(*BackendPolicySpec_Ai_RegexRules)(nil),         // 190: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules
-	(*BackendPolicySpec_Ai_Webhook)(nil),            // 191: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook
-	(*BackendPolicySpec_Ai_Moderation)(nil),         // 192: agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation
-	(*BackendPolicySpec_Ai_BedrockGuardrails)(nil),  // 193: agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails
-	(*BackendPolicySpec_Ai_GoogleModelArmor)(nil),   // 194: agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor
-	(*BackendPolicySpec_Ai_AzureContentSafety)(nil), // 195: agentgateway.dev.resource.BackendPolicySpec.Ai.AzureContentSafety
-	(*BackendPolicySpec_Ai_RequestRejection)(nil),   // 196: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestRejection
-	(*BackendPolicySpec_Ai_ResponseGuard)(nil),      // 197: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard
-	(*BackendPolicySpec_Ai_RequestGuard)(nil),       // 198: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard
-	(*BackendPolicySpec_Ai_PromptGuard)(nil),        // 199: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard
-	(*BackendPolicySpec_Ai_PromptCaching)(nil),      // 200: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptCaching
-	nil, // 201: agentgateway.dev.resource.BackendPolicySpec.Ai.DefaultsEntry
-	nil, // 202: agentgateway.dev.resource.BackendPolicySpec.Ai.OverridesEntry
-	nil, // 203: agentgateway.dev.resource.BackendPolicySpec.Ai.TransformationsEntry
-	nil, // 204: agentgateway.dev.resource.BackendPolicySpec.Ai.ModelAliasesEntry
-	nil, // 205: agentgateway.dev.resource.BackendPolicySpec.Ai.RoutesEntry
-	(*BackendPolicySpec_McpAuthentication_ResourceMetadata)(nil), // 206: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata
-	nil, // 207: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntry
-	(*BackendPolicySpec_McpGuardrails_Remote)(nil),    // 208: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote
-	(*BackendPolicySpec_McpGuardrails_Processor)(nil), // 209: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor
-	nil,                                    // 210: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote.MetadataEntry
-	nil,                                    // 211: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor.MethodsEntry
-	(*AIBackend_HostOverride)(nil),         // 212: agentgateway.dev.resource.AIBackend.HostOverride
-	(*AIBackend_OpenAI)(nil),               // 213: agentgateway.dev.resource.AIBackend.OpenAI
-	(*AIBackend_Gemini)(nil),               // 214: agentgateway.dev.resource.AIBackend.Gemini
-	(*AIBackend_Vertex)(nil),               // 215: agentgateway.dev.resource.AIBackend.Vertex
-	(*AIBackend_Anthropic)(nil),            // 216: agentgateway.dev.resource.AIBackend.Anthropic
-	(*AIBackend_Bedrock)(nil),              // 217: agentgateway.dev.resource.AIBackend.Bedrock
-	(*AIBackend_AzureOpenAI)(nil),          // 218: agentgateway.dev.resource.AIBackend.AzureOpenAI
-	(*AIBackend_Azure)(nil),                // 219: agentgateway.dev.resource.AIBackend.Azure
-	(*AIBackend_ProviderFormatConfig)(nil), // 220: agentgateway.dev.resource.AIBackend.ProviderFormatConfig
-	(*AIBackend_Custom)(nil),               // 221: agentgateway.dev.resource.AIBackend.Custom
-	(*AIBackend_Provider)(nil),             // 222: agentgateway.dev.resource.AIBackend.Provider
-	(*AIBackend_ProviderGroup)(nil),        // 223: agentgateway.dev.resource.AIBackend.ProviderGroup
-	(*BackendReference_Service)(nil),       // 224: agentgateway.dev.resource.BackendReference.Service
-	(*workloadapi.Workload)(nil),           // 225: istio.workload.Workload
-	(*workloadapi.Service)(nil),            // 226: istio.workload.Service
-	(*workloadapi.NamespacedHostname)(nil), // 227: istio.workload.NamespacedHostname
-	(*durationpb.Duration)(nil),            // 228: google.protobuf.Duration
-	(*structpb.Struct)(nil),                // 229: google.protobuf.Struct
-	(*structpb.Value)(nil),                 // 230: google.protobuf.Value
+	(*OAuthTokenExchange)(nil),                                  // 110: agentgateway.dev.resource.OAuthTokenExchange
+	(*GuardrailBackend_Bedrock)(nil),                            // 111: agentgateway.dev.resource.GuardrailBackend.Bedrock
+	(*GuardrailBackend_GoogleModelArmor)(nil),                   // 112: agentgateway.dev.resource.GuardrailBackend.GoogleModelArmor
+	(*GuardrailBackend_AzureContentSafety)(nil),                 // 113: agentgateway.dev.resource.GuardrailBackend.AzureContentSafety
+	(*GuardrailBackend_OpenAIModeration)(nil),                   // 114: agentgateway.dev.resource.GuardrailBackend.OpenAIModeration
+	(*AuthorizationLocation_Header)(nil),                        // 115: agentgateway.dev.resource.AuthorizationLocation.Header
+	(*AuthorizationLocation_QueryParameter)(nil),                // 116: agentgateway.dev.resource.AuthorizationLocation.QueryParameter
+	(*AuthorizationLocation_Cookie)(nil),                        // 117: agentgateway.dev.resource.AuthorizationLocation.Cookie
+	(*Gcp_AccessToken)(nil),                                     // 118: agentgateway.dev.resource.Gcp.AccessToken
+	(*Gcp_IdToken)(nil),                                         // 119: agentgateway.dev.resource.Gcp.IdToken
+	(*AzureManagedIdentityCredential_UserAssignedIdentity)(nil), // 120: agentgateway.dev.resource.AzureManagedIdentityCredential.UserAssignedIdentity
+	(*RequestMirrors_Mirror)(nil),                               // 121: agentgateway.dev.resource.RequestMirrors.Mirror
+	(*PolicyTarget_ServiceTarget)(nil),                          // 122: agentgateway.dev.resource.PolicyTarget.ServiceTarget
+	(*PolicyTarget_BackendTarget)(nil),                          // 123: agentgateway.dev.resource.PolicyTarget.BackendTarget
+	(*PolicyTarget_GatewayTarget)(nil),                          // 124: agentgateway.dev.resource.PolicyTarget.GatewayTarget
+	(*PolicyTarget_RouteTarget)(nil),                            // 125: agentgateway.dev.resource.PolicyTarget.RouteTarget
+	(*PolicyTarget_ListenerSetTarget)(nil),                      // 126: agentgateway.dev.resource.PolicyTarget.ListenerSetTarget
+	(*FrontendPolicySpec_HTTP)(nil),                             // 127: agentgateway.dev.resource.FrontendPolicySpec.HTTP
+	(*FrontendPolicySpec_TLS)(nil),                              // 128: agentgateway.dev.resource.FrontendPolicySpec.TLS
+	(*FrontendPolicySpec_TCP)(nil),                              // 129: agentgateway.dev.resource.FrontendPolicySpec.TCP
+	(*FrontendPolicySpec_NetworkAuthorization)(nil),             // 130: agentgateway.dev.resource.FrontendPolicySpec.NetworkAuthorization
+	(*FrontendPolicySpec_Logging)(nil),                          // 131: agentgateway.dev.resource.FrontendPolicySpec.Logging
+	(*FrontendPolicySpec_Tracing)(nil),                          // 132: agentgateway.dev.resource.FrontendPolicySpec.Tracing
+	(*FrontendPolicySpec_TracingAttribute)(nil),                 // 133: agentgateway.dev.resource.FrontendPolicySpec.TracingAttribute
+	(*FrontendPolicySpec_ProxyProtocol)(nil),                    // 134: agentgateway.dev.resource.FrontendPolicySpec.ProxyProtocol
+	(*FrontendPolicySpec_Connect)(nil),                          // 135: agentgateway.dev.resource.FrontendPolicySpec.Connect
+	(*FrontendPolicySpec_Metrics)(nil),                          // 136: agentgateway.dev.resource.FrontendPolicySpec.Metrics
+	(*FrontendPolicySpec_Logging_Field)(nil),                    // 137: agentgateway.dev.resource.FrontendPolicySpec.Logging.Field
+	(*FrontendPolicySpec_Logging_Fields)(nil),                   // 138: agentgateway.dev.resource.FrontendPolicySpec.Logging.Fields
+	(*FrontendPolicySpec_Logging_OtlpAccessLog)(nil),            // 139: agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog
+	(*FrontendPolicySpec_Metrics_Field)(nil),                    // 140: agentgateway.dev.resource.FrontendPolicySpec.Metrics.Field
+	(*FrontendPolicySpec_Metrics_Fields)(nil),                   // 141: agentgateway.dev.resource.FrontendPolicySpec.Metrics.Fields
+	(*TrafficPolicySpec_RemoteRateLimit)(nil),                   // 142: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit
+	(*TrafficPolicySpec_LocalRateLimit)(nil),                    // 143: agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit
+	(*TrafficPolicySpec_ExternalAuth)(nil),                      // 144: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth
+	(*TrafficPolicySpec_RBAC)(nil),                              // 145: agentgateway.dev.resource.TrafficPolicySpec.RBAC
+	(*TrafficPolicySpec_JWTProvider)(nil),                       // 146: agentgateway.dev.resource.TrafficPolicySpec.JWTProvider
+	(*TrafficPolicySpec_JWT)(nil),                               // 147: agentgateway.dev.resource.TrafficPolicySpec.JWT
+	(*TrafficPolicySpec_BasicAuthentication)(nil),               // 148: agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication
+	(*TrafficPolicySpec_APIKey)(nil),                            // 149: agentgateway.dev.resource.TrafficPolicySpec.APIKey
+	(*TrafficPolicySpec_TransformationPolicy)(nil),              // 150: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy
+	(*TrafficPolicySpec_HeaderTransformation)(nil),              // 151: agentgateway.dev.resource.TrafficPolicySpec.HeaderTransformation
+	(*TrafficPolicySpec_BodyTransformation)(nil),                // 152: agentgateway.dev.resource.TrafficPolicySpec.BodyTransformation
+	(*TrafficPolicySpec_CSRF)(nil),                              // 153: agentgateway.dev.resource.TrafficPolicySpec.CSRF
+	(*TrafficPolicySpec_ExtProc)(nil),                           // 154: agentgateway.dev.resource.TrafficPolicySpec.ExtProc
+	(*TrafficPolicySpec_HostRewrite)(nil),                       // 155: agentgateway.dev.resource.TrafficPolicySpec.HostRewrite
+	(*TrafficPolicySpec_RemoteRateLimit_Descriptor)(nil),        // 156: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor
+	(*TrafficPolicySpec_RemoteRateLimit_Entry)(nil),             // 157: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Entry
+	(*TrafficPolicySpec_ExternalAuth_BodyOptions)(nil),          // 158: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.BodyOptions
+	(*TrafficPolicySpec_ExternalAuth_Cache)(nil),                // 159: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.Cache
+	(*TrafficPolicySpec_ExternalAuth_GRPCProtocol)(nil),         // 160: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol
+	(*TrafficPolicySpec_ExternalAuth_HTTPProtocol)(nil),         // 161: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol
+	nil,                                   // 162: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.ContextEntry
+	nil,                                   // 163: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.MetadataEntry
+	nil,                                   // 164: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.AddRequestHeadersEntry
+	nil,                                   // 165: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.MetadataEntry
+	(*TrafficPolicySpec_JWT_MCP)(nil),     // 166: agentgateway.dev.resource.TrafficPolicySpec.JWT.MCP
+	(*TrafficPolicySpec_APIKey_User)(nil), // 167: agentgateway.dev.resource.TrafficPolicySpec.APIKey.User
+	(*TrafficPolicySpec_TransformationPolicy_Transform)(nil), // 168: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform
+	nil, // 169: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.MetadataEntry
+	nil, // 170: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.RequestAttributesEntry
+	nil, // 171: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ResponseAttributesEntry
+	(*TrafficPolicySpec_ExtProc_NamespacedMetadataContext)(nil), // 172: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext
+	(*TrafficPolicySpec_ExtProc_ProcessingOptions)(nil),         // 173: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ProcessingOptions
+	nil,                           // 174: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.MetadataContextEntry
+	nil,                           // 175: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext.ContextEntry
+	(*BackendPolicySpec_Ai)(nil),  // 176: agentgateway.dev.resource.BackendPolicySpec.Ai
+	(*BackendPolicySpec_A2A)(nil), // 177: agentgateway.dev.resource.BackendPolicySpec.A2a
+	(*BackendPolicySpec_InferenceRouting)(nil),      // 178: agentgateway.dev.resource.BackendPolicySpec.InferenceRouting
+	(*BackendPolicySpec_Eviction)(nil),              // 179: agentgateway.dev.resource.BackendPolicySpec.Eviction
+	(*BackendPolicySpec_Health)(nil),                // 180: agentgateway.dev.resource.BackendPolicySpec.Health
+	(*BackendPolicySpec_BackendTLS)(nil),            // 181: agentgateway.dev.resource.BackendPolicySpec.BackendTLS
+	(*BackendPolicySpec_BackendHTTP)(nil),           // 182: agentgateway.dev.resource.BackendPolicySpec.BackendHTTP
+	(*BackendPolicySpec_BackendTunnel)(nil),         // 183: agentgateway.dev.resource.BackendPolicySpec.BackendTunnel
+	(*BackendPolicySpec_BackendTCP)(nil),            // 184: agentgateway.dev.resource.BackendPolicySpec.BackendTCP
+	(*BackendPolicySpec_McpAuthorization)(nil),      // 185: agentgateway.dev.resource.BackendPolicySpec.McpAuthorization
+	(*BackendPolicySpec_McpAuthentication)(nil),     // 186: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication
+	(*BackendPolicySpec_McpGuardrails)(nil),         // 187: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails
+	(*BackendPolicySpec_Ai_Message)(nil),            // 188: agentgateway.dev.resource.BackendPolicySpec.Ai.Message
+	(*BackendPolicySpec_Ai_PromptEnrichment)(nil),   // 189: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment
+	(*BackendPolicySpec_Ai_RegexRule)(nil),          // 190: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRule
+	(*BackendPolicySpec_Ai_RegexRules)(nil),         // 191: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules
+	(*BackendPolicySpec_Ai_Webhook)(nil),            // 192: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook
+	(*BackendPolicySpec_Ai_Moderation)(nil),         // 193: agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation
+	(*BackendPolicySpec_Ai_BedrockGuardrails)(nil),  // 194: agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails
+	(*BackendPolicySpec_Ai_GoogleModelArmor)(nil),   // 195: agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor
+	(*BackendPolicySpec_Ai_AzureContentSafety)(nil), // 196: agentgateway.dev.resource.BackendPolicySpec.Ai.AzureContentSafety
+	(*BackendPolicySpec_Ai_RequestRejection)(nil),   // 197: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestRejection
+	(*BackendPolicySpec_Ai_ResponseGuard)(nil),      // 198: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard
+	(*BackendPolicySpec_Ai_RequestGuard)(nil),       // 199: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard
+	(*BackendPolicySpec_Ai_PromptGuard)(nil),        // 200: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard
+	(*BackendPolicySpec_Ai_PromptCaching)(nil),      // 201: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptCaching
+	nil, // 202: agentgateway.dev.resource.BackendPolicySpec.Ai.DefaultsEntry
+	nil, // 203: agentgateway.dev.resource.BackendPolicySpec.Ai.OverridesEntry
+	nil, // 204: agentgateway.dev.resource.BackendPolicySpec.Ai.TransformationsEntry
+	nil, // 205: agentgateway.dev.resource.BackendPolicySpec.Ai.ModelAliasesEntry
+	nil, // 206: agentgateway.dev.resource.BackendPolicySpec.Ai.RoutesEntry
+	(*BackendPolicySpec_McpAuthentication_ResourceMetadata)(nil), // 207: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata
+	nil, // 208: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntry
+	(*BackendPolicySpec_McpGuardrails_Remote)(nil),    // 209: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote
+	(*BackendPolicySpec_McpGuardrails_Processor)(nil), // 210: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor
+	nil,                                    // 211: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote.MetadataEntry
+	nil,                                    // 212: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor.MethodsEntry
+	(*AIBackend_HostOverride)(nil),         // 213: agentgateway.dev.resource.AIBackend.HostOverride
+	(*AIBackend_OpenAI)(nil),               // 214: agentgateway.dev.resource.AIBackend.OpenAI
+	(*AIBackend_Gemini)(nil),               // 215: agentgateway.dev.resource.AIBackend.Gemini
+	(*AIBackend_Vertex)(nil),               // 216: agentgateway.dev.resource.AIBackend.Vertex
+	(*AIBackend_Anthropic)(nil),            // 217: agentgateway.dev.resource.AIBackend.Anthropic
+	(*AIBackend_Bedrock)(nil),              // 218: agentgateway.dev.resource.AIBackend.Bedrock
+	(*AIBackend_AzureOpenAI)(nil),          // 219: agentgateway.dev.resource.AIBackend.AzureOpenAI
+	(*AIBackend_Azure)(nil),                // 220: agentgateway.dev.resource.AIBackend.Azure
+	(*AIBackend_ProviderFormatConfig)(nil), // 221: agentgateway.dev.resource.AIBackend.ProviderFormatConfig
+	(*AIBackend_Custom)(nil),               // 222: agentgateway.dev.resource.AIBackend.Custom
+	(*AIBackend_Provider)(nil),             // 223: agentgateway.dev.resource.AIBackend.Provider
+	(*AIBackend_ProviderGroup)(nil),        // 224: agentgateway.dev.resource.AIBackend.ProviderGroup
+	(*BackendReference_Service)(nil),       // 225: agentgateway.dev.resource.BackendReference.Service
+	(*OAuthTokenExchange_ClientAuth)(nil),  // 226: agentgateway.dev.resource.OAuthTokenExchange.ClientAuth
+	(*workloadapi.Workload)(nil),           // 227: istio.workload.Workload
+	(*workloadapi.Service)(nil),            // 228: istio.workload.Service
+	(*workloadapi.NamespacedHostname)(nil), // 229: istio.workload.NamespacedHostname
+	(*durationpb.Duration)(nil),            // 230: google.protobuf.Duration
+	(*structpb.Struct)(nil),                // 231: google.protobuf.Struct
+	(*structpb.Value)(nil),                 // 232: google.protobuf.Value
 }
 var file_resource_proto_depIdxs = []int32{
 	46,  // 0: agentgateway.dev.resource.Resource.bind:type_name -> agentgateway.dev.resource.Bind
@@ -16003,8 +16173,8 @@ var file_resource_proto_depIdxs = []int32{
 	58,  // 3: agentgateway.dev.resource.Resource.backend:type_name -> agentgateway.dev.resource.Backend
 	57,  // 4: agentgateway.dev.resource.Resource.policy:type_name -> agentgateway.dev.resource.Policy
 	54,  // 5: agentgateway.dev.resource.Resource.tcp_route:type_name -> agentgateway.dev.resource.TCPRoute
-	225, // 6: agentgateway.dev.resource.Resource.workload:type_name -> istio.workload.Workload
-	226, // 7: agentgateway.dev.resource.Resource.service:type_name -> istio.workload.Service
+	227, // 6: agentgateway.dev.resource.Resource.workload:type_name -> istio.workload.Workload
+	228, // 7: agentgateway.dev.resource.Resource.service:type_name -> istio.workload.Service
 	53,  // 8: agentgateway.dev.resource.Resource.route_group:type_name -> agentgateway.dev.resource.RouteGroup
 	1,   // 9: agentgateway.dev.resource.Bind.protocol:type_name -> agentgateway.dev.resource.Bind.Protocol
 	2,   // 10: agentgateway.dev.resource.Bind.tunnel_protocol:type_name -> agentgateway.dev.resource.Bind.TunnelProtocol
@@ -16012,12 +16182,12 @@ var file_resource_proto_depIdxs = []int32{
 	48,  // 12: agentgateway.dev.resource.Listener.name:type_name -> agentgateway.dev.resource.ListenerName
 	0,   // 13: agentgateway.dev.resource.Listener.protocol:type_name -> agentgateway.dev.resource.Protocol
 	60,  // 14: agentgateway.dev.resource.Listener.tls:type_name -> agentgateway.dev.resource.TLSConfig
-	227, // 15: agentgateway.dev.resource.Route.service_key:type_name -> istio.workload.NamespacedHostname
+	229, // 15: agentgateway.dev.resource.Route.service_key:type_name -> istio.workload.NamespacedHostname
 	47,  // 16: agentgateway.dev.resource.Route.name:type_name -> agentgateway.dev.resource.RouteName
 	79,  // 17: agentgateway.dev.resource.Route.matches:type_name -> agentgateway.dev.resource.RouteMatch
 	94,  // 18: agentgateway.dev.resource.Route.backends:type_name -> agentgateway.dev.resource.RouteBackend
 	99,  // 19: agentgateway.dev.resource.Route.traffic_policies:type_name -> agentgateway.dev.resource.TrafficPolicySpec
-	227, // 20: agentgateway.dev.resource.TCPRoute.service_key:type_name -> istio.workload.NamespacedHostname
+	229, // 20: agentgateway.dev.resource.TCPRoute.service_key:type_name -> istio.workload.NamespacedHostname
 	47,  // 21: agentgateway.dev.resource.TCPRoute.name:type_name -> agentgateway.dev.resource.RouteName
 	94,  // 22: agentgateway.dev.resource.TCPRoute.backends:type_name -> agentgateway.dev.resource.RouteBackend
 	56,  // 23: agentgateway.dev.resource.ConditionalPolicies.policies:type_name -> agentgateway.dev.resource.ConditionalPolicy
@@ -16037,285 +16207,288 @@ var file_resource_proto_depIdxs = []int32{
 	103, // 37: agentgateway.dev.resource.Backend.aws:type_name -> agentgateway.dev.resource.AwsBackend
 	59,  // 38: agentgateway.dev.resource.Backend.guardrail:type_name -> agentgateway.dev.resource.GuardrailBackend
 	100, // 39: agentgateway.dev.resource.Backend.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	110, // 40: agentgateway.dev.resource.GuardrailBackend.bedrock:type_name -> agentgateway.dev.resource.GuardrailBackend.Bedrock
-	111, // 41: agentgateway.dev.resource.GuardrailBackend.google_model_armor:type_name -> agentgateway.dev.resource.GuardrailBackend.GoogleModelArmor
-	112, // 42: agentgateway.dev.resource.GuardrailBackend.azure_content_safety:type_name -> agentgateway.dev.resource.GuardrailBackend.AzureContentSafety
-	113, // 43: agentgateway.dev.resource.GuardrailBackend.openai_moderation:type_name -> agentgateway.dev.resource.GuardrailBackend.OpenAIModeration
+	111, // 40: agentgateway.dev.resource.GuardrailBackend.bedrock:type_name -> agentgateway.dev.resource.GuardrailBackend.Bedrock
+	112, // 41: agentgateway.dev.resource.GuardrailBackend.google_model_armor:type_name -> agentgateway.dev.resource.GuardrailBackend.GoogleModelArmor
+	113, // 42: agentgateway.dev.resource.GuardrailBackend.azure_content_safety:type_name -> agentgateway.dev.resource.GuardrailBackend.AzureContentSafety
+	114, // 43: agentgateway.dev.resource.GuardrailBackend.openai_moderation:type_name -> agentgateway.dev.resource.GuardrailBackend.OpenAIModeration
 	7,   // 44: agentgateway.dev.resource.TLSConfig.cipher_suites:type_name -> agentgateway.dev.resource.TLSConfig.CipherSuite
 	5,   // 45: agentgateway.dev.resource.TLSConfig.min_version:type_name -> agentgateway.dev.resource.TLSConfig.TLSVersion
 	5,   // 46: agentgateway.dev.resource.TLSConfig.max_version:type_name -> agentgateway.dev.resource.TLSConfig.TLSVersion
 	6,   // 47: agentgateway.dev.resource.TLSConfig.mtls_mode:type_name -> agentgateway.dev.resource.TLSConfig.MTLSMode
 	8,   // 48: agentgateway.dev.resource.TLSConfig.key_exchange_groups:type_name -> agentgateway.dev.resource.TLSConfig.KeyExchangeGroup
 	4,   // 49: agentgateway.dev.resource.TLSConfig.certificate_source:type_name -> agentgateway.dev.resource.TLSConfig.CertificateSource
-	228, // 50: agentgateway.dev.resource.Timeout.request:type_name -> google.protobuf.Duration
-	228, // 51: agentgateway.dev.resource.Timeout.backend_request:type_name -> google.protobuf.Duration
-	228, // 52: agentgateway.dev.resource.Retry.backoff:type_name -> google.protobuf.Duration
+	230, // 50: agentgateway.dev.resource.Timeout.request:type_name -> google.protobuf.Duration
+	230, // 51: agentgateway.dev.resource.Timeout.backend_request:type_name -> google.protobuf.Duration
+	230, // 52: agentgateway.dev.resource.Retry.backoff:type_name -> google.protobuf.Duration
 	65,  // 53: agentgateway.dev.resource.BackendAuthPolicy.passthrough:type_name -> agentgateway.dev.resource.Passthrough
 	66,  // 54: agentgateway.dev.resource.BackendAuthPolicy.key:type_name -> agentgateway.dev.resource.Key
 	67,  // 55: agentgateway.dev.resource.BackendAuthPolicy.gcp:type_name -> agentgateway.dev.resource.Gcp
 	68,  // 56: agentgateway.dev.resource.BackendAuthPolicy.aws:type_name -> agentgateway.dev.resource.Aws
 	69,  // 57: agentgateway.dev.resource.BackendAuthPolicy.azure:type_name -> agentgateway.dev.resource.Azure
-	114, // 58: agentgateway.dev.resource.AuthorizationLocation.header:type_name -> agentgateway.dev.resource.AuthorizationLocation.Header
-	115, // 59: agentgateway.dev.resource.AuthorizationLocation.query_parameter:type_name -> agentgateway.dev.resource.AuthorizationLocation.QueryParameter
-	116, // 60: agentgateway.dev.resource.AuthorizationLocation.cookie:type_name -> agentgateway.dev.resource.AuthorizationLocation.Cookie
-	64,  // 61: agentgateway.dev.resource.Passthrough.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
-	64,  // 62: agentgateway.dev.resource.Key.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
-	117, // 63: agentgateway.dev.resource.Gcp.access_token:type_name -> agentgateway.dev.resource.Gcp.AccessToken
-	118, // 64: agentgateway.dev.resource.Gcp.id_token:type_name -> agentgateway.dev.resource.Gcp.IdToken
-	70,  // 65: agentgateway.dev.resource.Aws.explicit_config:type_name -> agentgateway.dev.resource.AwsExplicitConfig
-	71,  // 66: agentgateway.dev.resource.Aws.implicit:type_name -> agentgateway.dev.resource.AwsImplicit
-	72,  // 67: agentgateway.dev.resource.Aws.assume_role:type_name -> agentgateway.dev.resource.AwsAssumeRole
-	73,  // 68: agentgateway.dev.resource.Azure.explicit_config:type_name -> agentgateway.dev.resource.AzureExplicitConfig
-	77,  // 69: agentgateway.dev.resource.Azure.developer_implicit:type_name -> agentgateway.dev.resource.AzureDeveloperImplicit
-	78,  // 70: agentgateway.dev.resource.Azure.implicit:type_name -> agentgateway.dev.resource.AzureImplicit
-	74,  // 71: agentgateway.dev.resource.AzureExplicitConfig.client_secret:type_name -> agentgateway.dev.resource.AzureClientSecret
-	75,  // 72: agentgateway.dev.resource.AzureExplicitConfig.managed_identity_credential:type_name -> agentgateway.dev.resource.AzureManagedIdentityCredential
-	76,  // 73: agentgateway.dev.resource.AzureExplicitConfig.workload_identity_credential:type_name -> agentgateway.dev.resource.AzureWorkloadIdentityCredential
-	119, // 74: agentgateway.dev.resource.AzureManagedIdentityCredential.user_assigned_identity:type_name -> agentgateway.dev.resource.AzureManagedIdentityCredential.UserAssignedIdentity
-	80,  // 75: agentgateway.dev.resource.RouteMatch.path:type_name -> agentgateway.dev.resource.PathMatch
-	83,  // 76: agentgateway.dev.resource.RouteMatch.headers:type_name -> agentgateway.dev.resource.HeaderMatch
-	82,  // 77: agentgateway.dev.resource.RouteMatch.method:type_name -> agentgateway.dev.resource.MethodMatch
-	81,  // 78: agentgateway.dev.resource.RouteMatch.query_params:type_name -> agentgateway.dev.resource.QueryMatch
-	228, // 79: agentgateway.dev.resource.CORS.max_age:type_name -> google.protobuf.Duration
-	88,  // 80: agentgateway.dev.resource.DirectResponse.headers:type_name -> agentgateway.dev.resource.ExpressionHeader
-	86,  // 81: agentgateway.dev.resource.Buffer.request:type_name -> agentgateway.dev.resource.BufferBody
-	86,  // 82: agentgateway.dev.resource.Buffer.response:type_name -> agentgateway.dev.resource.BufferBody
-	93,  // 83: agentgateway.dev.resource.HeaderModifier.add:type_name -> agentgateway.dev.resource.Header
-	93,  // 84: agentgateway.dev.resource.HeaderModifier.set:type_name -> agentgateway.dev.resource.Header
-	120, // 85: agentgateway.dev.resource.RequestMirrors.mirrors:type_name -> agentgateway.dev.resource.RequestMirrors.Mirror
-	108, // 86: agentgateway.dev.resource.RouteBackend.backend:type_name -> agentgateway.dev.resource.BackendReference
-	100, // 87: agentgateway.dev.resource.RouteBackend.backend_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	123, // 88: agentgateway.dev.resource.PolicyTarget.gateway:type_name -> agentgateway.dev.resource.PolicyTarget.GatewayTarget
-	124, // 89: agentgateway.dev.resource.PolicyTarget.route:type_name -> agentgateway.dev.resource.PolicyTarget.RouteTarget
-	122, // 90: agentgateway.dev.resource.PolicyTarget.backend:type_name -> agentgateway.dev.resource.PolicyTarget.BackendTarget
-	121, // 91: agentgateway.dev.resource.PolicyTarget.service:type_name -> agentgateway.dev.resource.PolicyTarget.ServiceTarget
-	125, // 92: agentgateway.dev.resource.PolicyTarget.listener_set:type_name -> agentgateway.dev.resource.PolicyTarget.ListenerSetTarget
-	228, // 93: agentgateway.dev.resource.KeepaliveConfig.time:type_name -> google.protobuf.Duration
-	228, // 94: agentgateway.dev.resource.KeepaliveConfig.interval:type_name -> google.protobuf.Duration
-	128, // 95: agentgateway.dev.resource.FrontendPolicySpec.tcp:type_name -> agentgateway.dev.resource.FrontendPolicySpec.TCP
-	127, // 96: agentgateway.dev.resource.FrontendPolicySpec.tls:type_name -> agentgateway.dev.resource.FrontendPolicySpec.TLS
-	126, // 97: agentgateway.dev.resource.FrontendPolicySpec.http:type_name -> agentgateway.dev.resource.FrontendPolicySpec.HTTP
-	130, // 98: agentgateway.dev.resource.FrontendPolicySpec.logging:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging
-	131, // 99: agentgateway.dev.resource.FrontendPolicySpec.tracing:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Tracing
-	129, // 100: agentgateway.dev.resource.FrontendPolicySpec.network_authorization:type_name -> agentgateway.dev.resource.FrontendPolicySpec.NetworkAuthorization
-	133, // 101: agentgateway.dev.resource.FrontendPolicySpec.proxy_protocol:type_name -> agentgateway.dev.resource.FrontendPolicySpec.ProxyProtocol
-	135, // 102: agentgateway.dev.resource.FrontendPolicySpec.metrics:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Metrics
-	134, // 103: agentgateway.dev.resource.FrontendPolicySpec.connect:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Connect
-	15,  // 104: agentgateway.dev.resource.TrafficPolicySpec.phase:type_name -> agentgateway.dev.resource.TrafficPolicySpec.PolicyPhase
-	61,  // 105: agentgateway.dev.resource.TrafficPolicySpec.timeout:type_name -> agentgateway.dev.resource.Timeout
-	62,  // 106: agentgateway.dev.resource.TrafficPolicySpec.retry:type_name -> agentgateway.dev.resource.Retry
-	142, // 107: agentgateway.dev.resource.TrafficPolicySpec.local_rate_limit:type_name -> agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit
-	143, // 108: agentgateway.dev.resource.TrafficPolicySpec.ext_authz:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth
-	144, // 109: agentgateway.dev.resource.TrafficPolicySpec.authorization:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RBAC
-	146, // 110: agentgateway.dev.resource.TrafficPolicySpec.jwt:type_name -> agentgateway.dev.resource.TrafficPolicySpec.JWT
-	149, // 111: agentgateway.dev.resource.TrafficPolicySpec.transformation:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy
-	141, // 112: agentgateway.dev.resource.TrafficPolicySpec.remote_rate_limit:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit
-	152, // 113: agentgateway.dev.resource.TrafficPolicySpec.csrf:type_name -> agentgateway.dev.resource.TrafficPolicySpec.CSRF
-	153, // 114: agentgateway.dev.resource.TrafficPolicySpec.ext_proc:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc
-	89,  // 115: agentgateway.dev.resource.TrafficPolicySpec.request_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
-	89,  // 116: agentgateway.dev.resource.TrafficPolicySpec.response_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
-	91,  // 117: agentgateway.dev.resource.TrafficPolicySpec.request_redirect:type_name -> agentgateway.dev.resource.RequestRedirect
-	92,  // 118: agentgateway.dev.resource.TrafficPolicySpec.url_rewrite:type_name -> agentgateway.dev.resource.UrlRewrite
-	90,  // 119: agentgateway.dev.resource.TrafficPolicySpec.request_mirror:type_name -> agentgateway.dev.resource.RequestMirrors
-	85,  // 120: agentgateway.dev.resource.TrafficPolicySpec.direct_response:type_name -> agentgateway.dev.resource.DirectResponse
-	84,  // 121: agentgateway.dev.resource.TrafficPolicySpec.cors:type_name -> agentgateway.dev.resource.CORS
-	147, // 122: agentgateway.dev.resource.TrafficPolicySpec.basic_auth:type_name -> agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication
-	148, // 123: agentgateway.dev.resource.TrafficPolicySpec.api_key_auth:type_name -> agentgateway.dev.resource.TrafficPolicySpec.APIKey
-	154, // 124: agentgateway.dev.resource.TrafficPolicySpec.host_rewrite:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HostRewrite
-	87,  // 125: agentgateway.dev.resource.TrafficPolicySpec.buffer:type_name -> agentgateway.dev.resource.Buffer
-	176, // 126: agentgateway.dev.resource.BackendPolicySpec.a2a:type_name -> agentgateway.dev.resource.BackendPolicySpec.A2a
-	177, // 127: agentgateway.dev.resource.BackendPolicySpec.inference_routing:type_name -> agentgateway.dev.resource.BackendPolicySpec.InferenceRouting
-	180, // 128: agentgateway.dev.resource.BackendPolicySpec.backend_tls:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTLS
-	63,  // 129: agentgateway.dev.resource.BackendPolicySpec.auth:type_name -> agentgateway.dev.resource.BackendAuthPolicy
-	184, // 130: agentgateway.dev.resource.BackendPolicySpec.mcp_authorization:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthorization
-	185, // 131: agentgateway.dev.resource.BackendPolicySpec.mcp_authentication:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication
-	175, // 132: agentgateway.dev.resource.BackendPolicySpec.ai:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai
-	89,  // 133: agentgateway.dev.resource.BackendPolicySpec.request_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
-	89,  // 134: agentgateway.dev.resource.BackendPolicySpec.response_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
-	91,  // 135: agentgateway.dev.resource.BackendPolicySpec.request_redirect:type_name -> agentgateway.dev.resource.RequestRedirect
-	90,  // 136: agentgateway.dev.resource.BackendPolicySpec.request_mirror:type_name -> agentgateway.dev.resource.RequestMirrors
-	181, // 137: agentgateway.dev.resource.BackendPolicySpec.backend_http:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendHTTP
-	183, // 138: agentgateway.dev.resource.BackendPolicySpec.backend_tcp:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTCP
-	149, // 139: agentgateway.dev.resource.BackendPolicySpec.transformation:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy
-	179, // 140: agentgateway.dev.resource.BackendPolicySpec.health:type_name -> agentgateway.dev.resource.BackendPolicySpec.Health
-	182, // 141: agentgateway.dev.resource.BackendPolicySpec.backend_tunnel:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTunnel
-	143, // 142: agentgateway.dev.resource.BackendPolicySpec.ext_authz:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth
-	186, // 143: agentgateway.dev.resource.BackendPolicySpec.mcp_guardrails:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails
-	104, // 144: agentgateway.dev.resource.AwsBackend.agent_core:type_name -> agentgateway.dev.resource.AwsAgentCoreBackend
-	223, // 145: agentgateway.dev.resource.AIBackend.provider_groups:type_name -> agentgateway.dev.resource.AIBackend.ProviderGroup
-	107, // 146: agentgateway.dev.resource.MCPBackend.targets:type_name -> agentgateway.dev.resource.MCPTarget
-	41,  // 147: agentgateway.dev.resource.MCPBackend.stateful_mode:type_name -> agentgateway.dev.resource.MCPBackend.StatefulMode
-	42,  // 148: agentgateway.dev.resource.MCPBackend.prefix_mode:type_name -> agentgateway.dev.resource.MCPBackend.PrefixMode
-	43,  // 149: agentgateway.dev.resource.MCPBackend.failure_mode:type_name -> agentgateway.dev.resource.MCPBackend.FailureMode
-	108, // 150: agentgateway.dev.resource.MCPTarget.backend:type_name -> agentgateway.dev.resource.BackendReference
-	44,  // 151: agentgateway.dev.resource.MCPTarget.protocol:type_name -> agentgateway.dev.resource.MCPTarget.Protocol
-	224, // 152: agentgateway.dev.resource.BackendReference.service:type_name -> agentgateway.dev.resource.BackendReference.Service
-	108, // 153: agentgateway.dev.resource.RequestMirrors.Mirror.backend:type_name -> agentgateway.dev.resource.BackendReference
-	228, // 154: agentgateway.dev.resource.FrontendPolicySpec.HTTP.http1_idle_timeout:type_name -> google.protobuf.Duration
-	228, // 155: agentgateway.dev.resource.FrontendPolicySpec.HTTP.http2_keepalive_interval:type_name -> google.protobuf.Duration
-	228, // 156: agentgateway.dev.resource.FrontendPolicySpec.HTTP.http2_keepalive_timeout:type_name -> google.protobuf.Duration
-	228, // 157: agentgateway.dev.resource.FrontendPolicySpec.HTTP.max_connection_duration:type_name -> google.protobuf.Duration
-	9,   // 158: agentgateway.dev.resource.FrontendPolicySpec.HTTP.http1_header_case:type_name -> agentgateway.dev.resource.FrontendPolicySpec.HTTP.HTTPHeaderCase
-	228, // 159: agentgateway.dev.resource.FrontendPolicySpec.TLS.handshake_timeout:type_name -> google.protobuf.Duration
-	109, // 160: agentgateway.dev.resource.FrontendPolicySpec.TLS.alpn:type_name -> agentgateway.dev.resource.Alpn
-	7,   // 161: agentgateway.dev.resource.FrontendPolicySpec.TLS.cipher_suites:type_name -> agentgateway.dev.resource.TLSConfig.CipherSuite
-	5,   // 162: agentgateway.dev.resource.FrontendPolicySpec.TLS.min_version:type_name -> agentgateway.dev.resource.TLSConfig.TLSVersion
-	5,   // 163: agentgateway.dev.resource.FrontendPolicySpec.TLS.max_version:type_name -> agentgateway.dev.resource.TLSConfig.TLSVersion
-	8,   // 164: agentgateway.dev.resource.FrontendPolicySpec.TLS.key_exchange_groups:type_name -> agentgateway.dev.resource.TLSConfig.KeyExchangeGroup
-	96,  // 165: agentgateway.dev.resource.FrontendPolicySpec.TCP.keepalives:type_name -> agentgateway.dev.resource.KeepaliveConfig
-	137, // 166: agentgateway.dev.resource.FrontendPolicySpec.Logging.fields:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging.Fields
-	138, // 167: agentgateway.dev.resource.FrontendPolicySpec.Logging.otlp_access_log:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog
-	108, // 168: agentgateway.dev.resource.FrontendPolicySpec.Tracing.provider_backend:type_name -> agentgateway.dev.resource.BackendReference
-	132, // 169: agentgateway.dev.resource.FrontendPolicySpec.Tracing.attributes:type_name -> agentgateway.dev.resource.FrontendPolicySpec.TracingAttribute
-	132, // 170: agentgateway.dev.resource.FrontendPolicySpec.Tracing.resources:type_name -> agentgateway.dev.resource.FrontendPolicySpec.TracingAttribute
-	11,  // 171: agentgateway.dev.resource.FrontendPolicySpec.Tracing.protocol:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Tracing.Protocol
-	12,  // 172: agentgateway.dev.resource.FrontendPolicySpec.ProxyProtocol.version:type_name -> agentgateway.dev.resource.FrontendPolicySpec.ProxyProtocol.Version
-	13,  // 173: agentgateway.dev.resource.FrontendPolicySpec.ProxyProtocol.mode:type_name -> agentgateway.dev.resource.FrontendPolicySpec.ProxyProtocol.Mode
-	14,  // 174: agentgateway.dev.resource.FrontendPolicySpec.Connect.mode:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Connect.Mode
-	140, // 175: agentgateway.dev.resource.FrontendPolicySpec.Metrics.fields:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Metrics.Fields
-	136, // 176: agentgateway.dev.resource.FrontendPolicySpec.Logging.Fields.add:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging.Field
-	108, // 177: agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog.provider_backend:type_name -> agentgateway.dev.resource.BackendReference
-	100, // 178: agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	10,  // 179: agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog.protocol:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog.Protocol
-	139, // 180: agentgateway.dev.resource.FrontendPolicySpec.Metrics.Fields.add:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Metrics.Field
-	155, // 181: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.descriptors:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor
-	108, // 182: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.target:type_name -> agentgateway.dev.resource.BackendReference
-	17,  // 183: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.failure_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.FailureMode
-	228, // 184: agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit.fill_interval:type_name -> google.protobuf.Duration
-	18,  // 185: agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit.type:type_name -> agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit.Type
-	108, // 186: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.target:type_name -> agentgateway.dev.resource.BackendReference
-	159, // 187: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.grpc:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol
-	160, // 188: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.http:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol
-	19,  // 189: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.failure_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.FailureMode
-	157, // 190: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.include_request_body:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.BodyOptions
-	158, // 191: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.cache:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.Cache
-	98,  // 192: agentgateway.dev.resource.TrafficPolicySpec.JWTProvider.jwt_validation_options:type_name -> agentgateway.dev.resource.JWTValidationOptions
-	20,  // 193: agentgateway.dev.resource.TrafficPolicySpec.JWT.mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.JWT.Mode
-	145, // 194: agentgateway.dev.resource.TrafficPolicySpec.JWT.providers:type_name -> agentgateway.dev.resource.TrafficPolicySpec.JWTProvider
-	165, // 195: agentgateway.dev.resource.TrafficPolicySpec.JWT.mcp:type_name -> agentgateway.dev.resource.TrafficPolicySpec.JWT.MCP
-	64,  // 196: agentgateway.dev.resource.TrafficPolicySpec.JWT.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
-	21,  // 197: agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication.mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication.Mode
-	64,  // 198: agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
-	166, // 199: agentgateway.dev.resource.TrafficPolicySpec.APIKey.api_keys:type_name -> agentgateway.dev.resource.TrafficPolicySpec.APIKey.User
-	22,  // 200: agentgateway.dev.resource.TrafficPolicySpec.APIKey.mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.APIKey.Mode
-	64,  // 201: agentgateway.dev.resource.TrafficPolicySpec.APIKey.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
-	167, // 202: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.request:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform
-	167, // 203: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.response:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform
-	108, // 204: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.target:type_name -> agentgateway.dev.resource.BackendReference
-	23,  // 205: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.failure_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.FailureMode
-	169, // 206: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.request_attributes:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.RequestAttributesEntry
-	170, // 207: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.response_attributes:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ResponseAttributesEntry
-	173, // 208: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.metadata_context:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.MetadataContextEntry
-	172, // 209: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.processing_options:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ProcessingOptions
-	26,  // 210: agentgateway.dev.resource.TrafficPolicySpec.HostRewrite.mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HostRewrite.Mode
-	156, // 211: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor.entries:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Entry
-	16,  // 212: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor.type:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Type
-	161, // 213: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.context:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.ContextEntry
-	162, // 214: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.metadata:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.MetadataEntry
-	163, // 215: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.add_request_headers:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.AddRequestHeadersEntry
-	164, // 216: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.metadata:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.MetadataEntry
-	35,  // 217: agentgateway.dev.resource.TrafficPolicySpec.JWT.MCP.provider:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.McpIDP
-	206, // 218: agentgateway.dev.resource.TrafficPolicySpec.JWT.MCP.resource_metadata:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata
-	229, // 219: agentgateway.dev.resource.TrafficPolicySpec.APIKey.User.metadata:type_name -> google.protobuf.Struct
-	150, // 220: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.set:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HeaderTransformation
-	150, // 221: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.add:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HeaderTransformation
-	151, // 222: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.body:type_name -> agentgateway.dev.resource.TrafficPolicySpec.BodyTransformation
-	168, // 223: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.metadata:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.MetadataEntry
-	174, // 224: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext.context:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext.ContextEntry
-	24,  // 225: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ProcessingOptions.request_body_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.BodySendMode
-	24,  // 226: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ProcessingOptions.response_body_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.BodySendMode
-	25,  // 227: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ProcessingOptions.request_header_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.HeaderTrailerSendMode
-	25,  // 228: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ProcessingOptions.response_header_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.HeaderTrailerSendMode
-	25,  // 229: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ProcessingOptions.request_trailer_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.HeaderTrailerSendMode
-	25,  // 230: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ProcessingOptions.response_trailer_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.HeaderTrailerSendMode
-	171, // 231: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.MetadataContextEntry.value:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext
-	199, // 232: agentgateway.dev.resource.BackendPolicySpec.Ai.prompt_guard:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard
-	201, // 233: agentgateway.dev.resource.BackendPolicySpec.Ai.defaults:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.DefaultsEntry
-	202, // 234: agentgateway.dev.resource.BackendPolicySpec.Ai.overrides:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.OverridesEntry
-	203, // 235: agentgateway.dev.resource.BackendPolicySpec.Ai.transformations:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.TransformationsEntry
-	188, // 236: agentgateway.dev.resource.BackendPolicySpec.Ai.prompts:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment
-	204, // 237: agentgateway.dev.resource.BackendPolicySpec.Ai.model_aliases:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ModelAliasesEntry
-	200, // 238: agentgateway.dev.resource.BackendPolicySpec.Ai.prompt_caching:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptCaching
-	205, // 239: agentgateway.dev.resource.BackendPolicySpec.Ai.routes:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RoutesEntry
-	108, // 240: agentgateway.dev.resource.BackendPolicySpec.InferenceRouting.endpoint_picker:type_name -> agentgateway.dev.resource.BackendReference
-	32,  // 241: agentgateway.dev.resource.BackendPolicySpec.InferenceRouting.failure_mode:type_name -> agentgateway.dev.resource.BackendPolicySpec.InferenceRouting.FailureMode
-	228, // 242: agentgateway.dev.resource.BackendPolicySpec.Eviction.duration:type_name -> google.protobuf.Duration
-	178, // 243: agentgateway.dev.resource.BackendPolicySpec.Health.eviction:type_name -> agentgateway.dev.resource.BackendPolicySpec.Eviction
-	33,  // 244: agentgateway.dev.resource.BackendPolicySpec.BackendTLS.verification:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTLS.VerificationMode
-	109, // 245: agentgateway.dev.resource.BackendPolicySpec.BackendTLS.alpn:type_name -> agentgateway.dev.resource.Alpn
-	8,   // 246: agentgateway.dev.resource.BackendPolicySpec.BackendTLS.key_exchange_groups:type_name -> agentgateway.dev.resource.TLSConfig.KeyExchangeGroup
-	34,  // 247: agentgateway.dev.resource.BackendPolicySpec.BackendHTTP.version:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendHTTP.HttpVersion
-	228, // 248: agentgateway.dev.resource.BackendPolicySpec.BackendHTTP.request_timeout:type_name -> google.protobuf.Duration
-	108, // 249: agentgateway.dev.resource.BackendPolicySpec.BackendTunnel.proxy:type_name -> agentgateway.dev.resource.BackendReference
-	96,  // 250: agentgateway.dev.resource.BackendPolicySpec.BackendTCP.keepalive:type_name -> agentgateway.dev.resource.KeepaliveConfig
-	228, // 251: agentgateway.dev.resource.BackendPolicySpec.BackendTCP.connect_timeout:type_name -> google.protobuf.Duration
-	35,  // 252: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.provider:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.McpIDP
-	206, // 253: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.resource_metadata:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata
-	36,  // 254: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.mode:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.Mode
-	98,  // 255: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.jwt_validation_options:type_name -> agentgateway.dev.resource.JWTValidationOptions
-	64,  // 256: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
-	209, // 257: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.processors:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor
-	187, // 258: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment.append:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Message
-	187, // 259: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment.prepend:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Message
-	27,  // 260: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRule.builtin:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.BuiltinRegexRule
-	28,  // 261: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules.action:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ActionKind
-	189, // 262: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules.rules:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRule
-	108, // 263: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.backend:type_name -> agentgateway.dev.resource.BackendReference
-	83,  // 264: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.forward_header_matches:type_name -> agentgateway.dev.resource.HeaderMatch
-	30,  // 265: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.failure_mode:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.FailureMode
-	100, // 266: agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	108, // 267: agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation.backend_ref:type_name -> agentgateway.dev.resource.BackendReference
-	100, // 268: agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	108, // 269: agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails.backend_ref:type_name -> agentgateway.dev.resource.BackendReference
-	100, // 270: agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	108, // 271: agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor.backend_ref:type_name -> agentgateway.dev.resource.BackendReference
-	100, // 272: agentgateway.dev.resource.BackendPolicySpec.Ai.AzureContentSafety.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	108, // 273: agentgateway.dev.resource.BackendPolicySpec.Ai.AzureContentSafety.backend_ref:type_name -> agentgateway.dev.resource.BackendReference
-	196, // 274: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.rejection:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestRejection
-	190, // 275: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.regex:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules
-	191, // 276: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.webhook:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook
-	194, // 277: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.google_model_armor:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor
-	193, // 278: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.bedrock_guardrails:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails
-	195, // 279: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.azure_content_safety:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.AzureContentSafety
-	196, // 280: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.rejection:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestRejection
-	190, // 281: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.regex:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules
-	191, // 282: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.webhook:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook
-	192, // 283: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.openai_moderation:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation
-	194, // 284: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.google_model_armor:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor
-	193, // 285: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.bedrock_guardrails:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails
-	195, // 286: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.azure_content_safety:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.AzureContentSafety
-	198, // 287: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.request:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard
-	197, // 288: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.response:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard
-	31,  // 289: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.streaming:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.Streaming
-	29,  // 290: agentgateway.dev.resource.BackendPolicySpec.Ai.RoutesEntry.value:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RouteType
-	207, // 291: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.extra:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntry
-	230, // 292: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntry.value:type_name -> google.protobuf.Value
-	108, // 293: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote.target:type_name -> agentgateway.dev.resource.BackendReference
-	38,  // 294: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote.failure_mode:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.FailureMode
-	210, // 295: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote.metadata:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote.MetadataEntry
-	208, // 296: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor.remote:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote
-	211, // 297: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor.methods:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor.MethodsEntry
-	37,  // 298: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor.MethodsEntry.value:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Phase
-	39,  // 299: agentgateway.dev.resource.AIBackend.Azure.resource_type:type_name -> agentgateway.dev.resource.AIBackend.AzureResourceType
-	40,  // 300: agentgateway.dev.resource.AIBackend.ProviderFormatConfig.format:type_name -> agentgateway.dev.resource.AIBackend.ProviderFormat
-	220, // 301: agentgateway.dev.resource.AIBackend.Custom.formats:type_name -> agentgateway.dev.resource.AIBackend.ProviderFormatConfig
-	212, // 302: agentgateway.dev.resource.AIBackend.Provider.host_override:type_name -> agentgateway.dev.resource.AIBackend.HostOverride
-	108, // 303: agentgateway.dev.resource.AIBackend.Provider.provider_backend:type_name -> agentgateway.dev.resource.BackendReference
-	213, // 304: agentgateway.dev.resource.AIBackend.Provider.openai:type_name -> agentgateway.dev.resource.AIBackend.OpenAI
-	214, // 305: agentgateway.dev.resource.AIBackend.Provider.gemini:type_name -> agentgateway.dev.resource.AIBackend.Gemini
-	215, // 306: agentgateway.dev.resource.AIBackend.Provider.vertex:type_name -> agentgateway.dev.resource.AIBackend.Vertex
-	216, // 307: agentgateway.dev.resource.AIBackend.Provider.anthropic:type_name -> agentgateway.dev.resource.AIBackend.Anthropic
-	217, // 308: agentgateway.dev.resource.AIBackend.Provider.bedrock:type_name -> agentgateway.dev.resource.AIBackend.Bedrock
-	218, // 309: agentgateway.dev.resource.AIBackend.Provider.azureopenai:type_name -> agentgateway.dev.resource.AIBackend.AzureOpenAI
-	219, // 310: agentgateway.dev.resource.AIBackend.Provider.azure:type_name -> agentgateway.dev.resource.AIBackend.Azure
-	221, // 311: agentgateway.dev.resource.AIBackend.Provider.custom:type_name -> agentgateway.dev.resource.AIBackend.Custom
-	100, // 312: agentgateway.dev.resource.AIBackend.Provider.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	222, // 313: agentgateway.dev.resource.AIBackend.ProviderGroup.providers:type_name -> agentgateway.dev.resource.AIBackend.Provider
-	314, // [314:314] is the sub-list for method output_type
-	314, // [314:314] is the sub-list for method input_type
-	314, // [314:314] is the sub-list for extension type_name
-	314, // [314:314] is the sub-list for extension extendee
-	0,   // [0:314] is the sub-list for field type_name
+	110, // 58: agentgateway.dev.resource.BackendAuthPolicy.oauth_token_exchange:type_name -> agentgateway.dev.resource.OAuthTokenExchange
+	115, // 59: agentgateway.dev.resource.AuthorizationLocation.header:type_name -> agentgateway.dev.resource.AuthorizationLocation.Header
+	116, // 60: agentgateway.dev.resource.AuthorizationLocation.query_parameter:type_name -> agentgateway.dev.resource.AuthorizationLocation.QueryParameter
+	117, // 61: agentgateway.dev.resource.AuthorizationLocation.cookie:type_name -> agentgateway.dev.resource.AuthorizationLocation.Cookie
+	64,  // 62: agentgateway.dev.resource.Passthrough.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
+	64,  // 63: agentgateway.dev.resource.Key.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
+	118, // 64: agentgateway.dev.resource.Gcp.access_token:type_name -> agentgateway.dev.resource.Gcp.AccessToken
+	119, // 65: agentgateway.dev.resource.Gcp.id_token:type_name -> agentgateway.dev.resource.Gcp.IdToken
+	70,  // 66: agentgateway.dev.resource.Aws.explicit_config:type_name -> agentgateway.dev.resource.AwsExplicitConfig
+	71,  // 67: agentgateway.dev.resource.Aws.implicit:type_name -> agentgateway.dev.resource.AwsImplicit
+	72,  // 68: agentgateway.dev.resource.Aws.assume_role:type_name -> agentgateway.dev.resource.AwsAssumeRole
+	73,  // 69: agentgateway.dev.resource.Azure.explicit_config:type_name -> agentgateway.dev.resource.AzureExplicitConfig
+	77,  // 70: agentgateway.dev.resource.Azure.developer_implicit:type_name -> agentgateway.dev.resource.AzureDeveloperImplicit
+	78,  // 71: agentgateway.dev.resource.Azure.implicit:type_name -> agentgateway.dev.resource.AzureImplicit
+	74,  // 72: agentgateway.dev.resource.AzureExplicitConfig.client_secret:type_name -> agentgateway.dev.resource.AzureClientSecret
+	75,  // 73: agentgateway.dev.resource.AzureExplicitConfig.managed_identity_credential:type_name -> agentgateway.dev.resource.AzureManagedIdentityCredential
+	76,  // 74: agentgateway.dev.resource.AzureExplicitConfig.workload_identity_credential:type_name -> agentgateway.dev.resource.AzureWorkloadIdentityCredential
+	120, // 75: agentgateway.dev.resource.AzureManagedIdentityCredential.user_assigned_identity:type_name -> agentgateway.dev.resource.AzureManagedIdentityCredential.UserAssignedIdentity
+	80,  // 76: agentgateway.dev.resource.RouteMatch.path:type_name -> agentgateway.dev.resource.PathMatch
+	83,  // 77: agentgateway.dev.resource.RouteMatch.headers:type_name -> agentgateway.dev.resource.HeaderMatch
+	82,  // 78: agentgateway.dev.resource.RouteMatch.method:type_name -> agentgateway.dev.resource.MethodMatch
+	81,  // 79: agentgateway.dev.resource.RouteMatch.query_params:type_name -> agentgateway.dev.resource.QueryMatch
+	230, // 80: agentgateway.dev.resource.CORS.max_age:type_name -> google.protobuf.Duration
+	88,  // 81: agentgateway.dev.resource.DirectResponse.headers:type_name -> agentgateway.dev.resource.ExpressionHeader
+	86,  // 82: agentgateway.dev.resource.Buffer.request:type_name -> agentgateway.dev.resource.BufferBody
+	86,  // 83: agentgateway.dev.resource.Buffer.response:type_name -> agentgateway.dev.resource.BufferBody
+	93,  // 84: agentgateway.dev.resource.HeaderModifier.add:type_name -> agentgateway.dev.resource.Header
+	93,  // 85: agentgateway.dev.resource.HeaderModifier.set:type_name -> agentgateway.dev.resource.Header
+	121, // 86: agentgateway.dev.resource.RequestMirrors.mirrors:type_name -> agentgateway.dev.resource.RequestMirrors.Mirror
+	108, // 87: agentgateway.dev.resource.RouteBackend.backend:type_name -> agentgateway.dev.resource.BackendReference
+	100, // 88: agentgateway.dev.resource.RouteBackend.backend_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	124, // 89: agentgateway.dev.resource.PolicyTarget.gateway:type_name -> agentgateway.dev.resource.PolicyTarget.GatewayTarget
+	125, // 90: agentgateway.dev.resource.PolicyTarget.route:type_name -> agentgateway.dev.resource.PolicyTarget.RouteTarget
+	123, // 91: agentgateway.dev.resource.PolicyTarget.backend:type_name -> agentgateway.dev.resource.PolicyTarget.BackendTarget
+	122, // 92: agentgateway.dev.resource.PolicyTarget.service:type_name -> agentgateway.dev.resource.PolicyTarget.ServiceTarget
+	126, // 93: agentgateway.dev.resource.PolicyTarget.listener_set:type_name -> agentgateway.dev.resource.PolicyTarget.ListenerSetTarget
+	230, // 94: agentgateway.dev.resource.KeepaliveConfig.time:type_name -> google.protobuf.Duration
+	230, // 95: agentgateway.dev.resource.KeepaliveConfig.interval:type_name -> google.protobuf.Duration
+	129, // 96: agentgateway.dev.resource.FrontendPolicySpec.tcp:type_name -> agentgateway.dev.resource.FrontendPolicySpec.TCP
+	128, // 97: agentgateway.dev.resource.FrontendPolicySpec.tls:type_name -> agentgateway.dev.resource.FrontendPolicySpec.TLS
+	127, // 98: agentgateway.dev.resource.FrontendPolicySpec.http:type_name -> agentgateway.dev.resource.FrontendPolicySpec.HTTP
+	131, // 99: agentgateway.dev.resource.FrontendPolicySpec.logging:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging
+	132, // 100: agentgateway.dev.resource.FrontendPolicySpec.tracing:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Tracing
+	130, // 101: agentgateway.dev.resource.FrontendPolicySpec.network_authorization:type_name -> agentgateway.dev.resource.FrontendPolicySpec.NetworkAuthorization
+	134, // 102: agentgateway.dev.resource.FrontendPolicySpec.proxy_protocol:type_name -> agentgateway.dev.resource.FrontendPolicySpec.ProxyProtocol
+	136, // 103: agentgateway.dev.resource.FrontendPolicySpec.metrics:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Metrics
+	135, // 104: agentgateway.dev.resource.FrontendPolicySpec.connect:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Connect
+	15,  // 105: agentgateway.dev.resource.TrafficPolicySpec.phase:type_name -> agentgateway.dev.resource.TrafficPolicySpec.PolicyPhase
+	61,  // 106: agentgateway.dev.resource.TrafficPolicySpec.timeout:type_name -> agentgateway.dev.resource.Timeout
+	62,  // 107: agentgateway.dev.resource.TrafficPolicySpec.retry:type_name -> agentgateway.dev.resource.Retry
+	143, // 108: agentgateway.dev.resource.TrafficPolicySpec.local_rate_limit:type_name -> agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit
+	144, // 109: agentgateway.dev.resource.TrafficPolicySpec.ext_authz:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth
+	145, // 110: agentgateway.dev.resource.TrafficPolicySpec.authorization:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RBAC
+	147, // 111: agentgateway.dev.resource.TrafficPolicySpec.jwt:type_name -> agentgateway.dev.resource.TrafficPolicySpec.JWT
+	150, // 112: agentgateway.dev.resource.TrafficPolicySpec.transformation:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy
+	142, // 113: agentgateway.dev.resource.TrafficPolicySpec.remote_rate_limit:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit
+	153, // 114: agentgateway.dev.resource.TrafficPolicySpec.csrf:type_name -> agentgateway.dev.resource.TrafficPolicySpec.CSRF
+	154, // 115: agentgateway.dev.resource.TrafficPolicySpec.ext_proc:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc
+	89,  // 116: agentgateway.dev.resource.TrafficPolicySpec.request_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
+	89,  // 117: agentgateway.dev.resource.TrafficPolicySpec.response_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
+	91,  // 118: agentgateway.dev.resource.TrafficPolicySpec.request_redirect:type_name -> agentgateway.dev.resource.RequestRedirect
+	92,  // 119: agentgateway.dev.resource.TrafficPolicySpec.url_rewrite:type_name -> agentgateway.dev.resource.UrlRewrite
+	90,  // 120: agentgateway.dev.resource.TrafficPolicySpec.request_mirror:type_name -> agentgateway.dev.resource.RequestMirrors
+	85,  // 121: agentgateway.dev.resource.TrafficPolicySpec.direct_response:type_name -> agentgateway.dev.resource.DirectResponse
+	84,  // 122: agentgateway.dev.resource.TrafficPolicySpec.cors:type_name -> agentgateway.dev.resource.CORS
+	148, // 123: agentgateway.dev.resource.TrafficPolicySpec.basic_auth:type_name -> agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication
+	149, // 124: agentgateway.dev.resource.TrafficPolicySpec.api_key_auth:type_name -> agentgateway.dev.resource.TrafficPolicySpec.APIKey
+	155, // 125: agentgateway.dev.resource.TrafficPolicySpec.host_rewrite:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HostRewrite
+	87,  // 126: agentgateway.dev.resource.TrafficPolicySpec.buffer:type_name -> agentgateway.dev.resource.Buffer
+	177, // 127: agentgateway.dev.resource.BackendPolicySpec.a2a:type_name -> agentgateway.dev.resource.BackendPolicySpec.A2a
+	178, // 128: agentgateway.dev.resource.BackendPolicySpec.inference_routing:type_name -> agentgateway.dev.resource.BackendPolicySpec.InferenceRouting
+	181, // 129: agentgateway.dev.resource.BackendPolicySpec.backend_tls:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTLS
+	63,  // 130: agentgateway.dev.resource.BackendPolicySpec.auth:type_name -> agentgateway.dev.resource.BackendAuthPolicy
+	185, // 131: agentgateway.dev.resource.BackendPolicySpec.mcp_authorization:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthorization
+	186, // 132: agentgateway.dev.resource.BackendPolicySpec.mcp_authentication:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication
+	176, // 133: agentgateway.dev.resource.BackendPolicySpec.ai:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai
+	89,  // 134: agentgateway.dev.resource.BackendPolicySpec.request_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
+	89,  // 135: agentgateway.dev.resource.BackendPolicySpec.response_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
+	91,  // 136: agentgateway.dev.resource.BackendPolicySpec.request_redirect:type_name -> agentgateway.dev.resource.RequestRedirect
+	90,  // 137: agentgateway.dev.resource.BackendPolicySpec.request_mirror:type_name -> agentgateway.dev.resource.RequestMirrors
+	182, // 138: agentgateway.dev.resource.BackendPolicySpec.backend_http:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendHTTP
+	184, // 139: agentgateway.dev.resource.BackendPolicySpec.backend_tcp:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTCP
+	150, // 140: agentgateway.dev.resource.BackendPolicySpec.transformation:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy
+	180, // 141: agentgateway.dev.resource.BackendPolicySpec.health:type_name -> agentgateway.dev.resource.BackendPolicySpec.Health
+	183, // 142: agentgateway.dev.resource.BackendPolicySpec.backend_tunnel:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTunnel
+	144, // 143: agentgateway.dev.resource.BackendPolicySpec.ext_authz:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth
+	187, // 144: agentgateway.dev.resource.BackendPolicySpec.mcp_guardrails:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails
+	104, // 145: agentgateway.dev.resource.AwsBackend.agent_core:type_name -> agentgateway.dev.resource.AwsAgentCoreBackend
+	224, // 146: agentgateway.dev.resource.AIBackend.provider_groups:type_name -> agentgateway.dev.resource.AIBackend.ProviderGroup
+	107, // 147: agentgateway.dev.resource.MCPBackend.targets:type_name -> agentgateway.dev.resource.MCPTarget
+	41,  // 148: agentgateway.dev.resource.MCPBackend.stateful_mode:type_name -> agentgateway.dev.resource.MCPBackend.StatefulMode
+	42,  // 149: agentgateway.dev.resource.MCPBackend.prefix_mode:type_name -> agentgateway.dev.resource.MCPBackend.PrefixMode
+	43,  // 150: agentgateway.dev.resource.MCPBackend.failure_mode:type_name -> agentgateway.dev.resource.MCPBackend.FailureMode
+	108, // 151: agentgateway.dev.resource.MCPTarget.backend:type_name -> agentgateway.dev.resource.BackendReference
+	44,  // 152: agentgateway.dev.resource.MCPTarget.protocol:type_name -> agentgateway.dev.resource.MCPTarget.Protocol
+	225, // 153: agentgateway.dev.resource.BackendReference.service:type_name -> agentgateway.dev.resource.BackendReference.Service
+	108, // 154: agentgateway.dev.resource.OAuthTokenExchange.token_endpoint:type_name -> agentgateway.dev.resource.BackendReference
+	226, // 155: agentgateway.dev.resource.OAuthTokenExchange.client_auth:type_name -> agentgateway.dev.resource.OAuthTokenExchange.ClientAuth
+	108, // 156: agentgateway.dev.resource.RequestMirrors.Mirror.backend:type_name -> agentgateway.dev.resource.BackendReference
+	230, // 157: agentgateway.dev.resource.FrontendPolicySpec.HTTP.http1_idle_timeout:type_name -> google.protobuf.Duration
+	230, // 158: agentgateway.dev.resource.FrontendPolicySpec.HTTP.http2_keepalive_interval:type_name -> google.protobuf.Duration
+	230, // 159: agentgateway.dev.resource.FrontendPolicySpec.HTTP.http2_keepalive_timeout:type_name -> google.protobuf.Duration
+	230, // 160: agentgateway.dev.resource.FrontendPolicySpec.HTTP.max_connection_duration:type_name -> google.protobuf.Duration
+	9,   // 161: agentgateway.dev.resource.FrontendPolicySpec.HTTP.http1_header_case:type_name -> agentgateway.dev.resource.FrontendPolicySpec.HTTP.HTTPHeaderCase
+	230, // 162: agentgateway.dev.resource.FrontendPolicySpec.TLS.handshake_timeout:type_name -> google.protobuf.Duration
+	109, // 163: agentgateway.dev.resource.FrontendPolicySpec.TLS.alpn:type_name -> agentgateway.dev.resource.Alpn
+	7,   // 164: agentgateway.dev.resource.FrontendPolicySpec.TLS.cipher_suites:type_name -> agentgateway.dev.resource.TLSConfig.CipherSuite
+	5,   // 165: agentgateway.dev.resource.FrontendPolicySpec.TLS.min_version:type_name -> agentgateway.dev.resource.TLSConfig.TLSVersion
+	5,   // 166: agentgateway.dev.resource.FrontendPolicySpec.TLS.max_version:type_name -> agentgateway.dev.resource.TLSConfig.TLSVersion
+	8,   // 167: agentgateway.dev.resource.FrontendPolicySpec.TLS.key_exchange_groups:type_name -> agentgateway.dev.resource.TLSConfig.KeyExchangeGroup
+	96,  // 168: agentgateway.dev.resource.FrontendPolicySpec.TCP.keepalives:type_name -> agentgateway.dev.resource.KeepaliveConfig
+	138, // 169: agentgateway.dev.resource.FrontendPolicySpec.Logging.fields:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging.Fields
+	139, // 170: agentgateway.dev.resource.FrontendPolicySpec.Logging.otlp_access_log:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog
+	108, // 171: agentgateway.dev.resource.FrontendPolicySpec.Tracing.provider_backend:type_name -> agentgateway.dev.resource.BackendReference
+	133, // 172: agentgateway.dev.resource.FrontendPolicySpec.Tracing.attributes:type_name -> agentgateway.dev.resource.FrontendPolicySpec.TracingAttribute
+	133, // 173: agentgateway.dev.resource.FrontendPolicySpec.Tracing.resources:type_name -> agentgateway.dev.resource.FrontendPolicySpec.TracingAttribute
+	11,  // 174: agentgateway.dev.resource.FrontendPolicySpec.Tracing.protocol:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Tracing.Protocol
+	12,  // 175: agentgateway.dev.resource.FrontendPolicySpec.ProxyProtocol.version:type_name -> agentgateway.dev.resource.FrontendPolicySpec.ProxyProtocol.Version
+	13,  // 176: agentgateway.dev.resource.FrontendPolicySpec.ProxyProtocol.mode:type_name -> agentgateway.dev.resource.FrontendPolicySpec.ProxyProtocol.Mode
+	14,  // 177: agentgateway.dev.resource.FrontendPolicySpec.Connect.mode:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Connect.Mode
+	141, // 178: agentgateway.dev.resource.FrontendPolicySpec.Metrics.fields:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Metrics.Fields
+	137, // 179: agentgateway.dev.resource.FrontendPolicySpec.Logging.Fields.add:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging.Field
+	108, // 180: agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog.provider_backend:type_name -> agentgateway.dev.resource.BackendReference
+	100, // 181: agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	10,  // 182: agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog.protocol:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog.Protocol
+	140, // 183: agentgateway.dev.resource.FrontendPolicySpec.Metrics.Fields.add:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Metrics.Field
+	156, // 184: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.descriptors:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor
+	108, // 185: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.target:type_name -> agentgateway.dev.resource.BackendReference
+	17,  // 186: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.failure_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.FailureMode
+	230, // 187: agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit.fill_interval:type_name -> google.protobuf.Duration
+	18,  // 188: agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit.type:type_name -> agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit.Type
+	108, // 189: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.target:type_name -> agentgateway.dev.resource.BackendReference
+	160, // 190: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.grpc:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol
+	161, // 191: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.http:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol
+	19,  // 192: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.failure_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.FailureMode
+	158, // 193: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.include_request_body:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.BodyOptions
+	159, // 194: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.cache:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.Cache
+	98,  // 195: agentgateway.dev.resource.TrafficPolicySpec.JWTProvider.jwt_validation_options:type_name -> agentgateway.dev.resource.JWTValidationOptions
+	20,  // 196: agentgateway.dev.resource.TrafficPolicySpec.JWT.mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.JWT.Mode
+	146, // 197: agentgateway.dev.resource.TrafficPolicySpec.JWT.providers:type_name -> agentgateway.dev.resource.TrafficPolicySpec.JWTProvider
+	166, // 198: agentgateway.dev.resource.TrafficPolicySpec.JWT.mcp:type_name -> agentgateway.dev.resource.TrafficPolicySpec.JWT.MCP
+	64,  // 199: agentgateway.dev.resource.TrafficPolicySpec.JWT.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
+	21,  // 200: agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication.mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication.Mode
+	64,  // 201: agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
+	167, // 202: agentgateway.dev.resource.TrafficPolicySpec.APIKey.api_keys:type_name -> agentgateway.dev.resource.TrafficPolicySpec.APIKey.User
+	22,  // 203: agentgateway.dev.resource.TrafficPolicySpec.APIKey.mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.APIKey.Mode
+	64,  // 204: agentgateway.dev.resource.TrafficPolicySpec.APIKey.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
+	168, // 205: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.request:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform
+	168, // 206: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.response:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform
+	108, // 207: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.target:type_name -> agentgateway.dev.resource.BackendReference
+	23,  // 208: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.failure_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.FailureMode
+	170, // 209: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.request_attributes:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.RequestAttributesEntry
+	171, // 210: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.response_attributes:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ResponseAttributesEntry
+	174, // 211: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.metadata_context:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.MetadataContextEntry
+	173, // 212: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.processing_options:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ProcessingOptions
+	26,  // 213: agentgateway.dev.resource.TrafficPolicySpec.HostRewrite.mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HostRewrite.Mode
+	157, // 214: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor.entries:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Entry
+	16,  // 215: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor.type:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Type
+	162, // 216: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.context:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.ContextEntry
+	163, // 217: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.metadata:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.MetadataEntry
+	164, // 218: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.add_request_headers:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.AddRequestHeadersEntry
+	165, // 219: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.metadata:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.MetadataEntry
+	35,  // 220: agentgateway.dev.resource.TrafficPolicySpec.JWT.MCP.provider:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.McpIDP
+	207, // 221: agentgateway.dev.resource.TrafficPolicySpec.JWT.MCP.resource_metadata:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata
+	231, // 222: agentgateway.dev.resource.TrafficPolicySpec.APIKey.User.metadata:type_name -> google.protobuf.Struct
+	151, // 223: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.set:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HeaderTransformation
+	151, // 224: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.add:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HeaderTransformation
+	152, // 225: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.body:type_name -> agentgateway.dev.resource.TrafficPolicySpec.BodyTransformation
+	169, // 226: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.metadata:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.MetadataEntry
+	175, // 227: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext.context:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext.ContextEntry
+	24,  // 228: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ProcessingOptions.request_body_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.BodySendMode
+	24,  // 229: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ProcessingOptions.response_body_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.BodySendMode
+	25,  // 230: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ProcessingOptions.request_header_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.HeaderTrailerSendMode
+	25,  // 231: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ProcessingOptions.response_header_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.HeaderTrailerSendMode
+	25,  // 232: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ProcessingOptions.request_trailer_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.HeaderTrailerSendMode
+	25,  // 233: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ProcessingOptions.response_trailer_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.HeaderTrailerSendMode
+	172, // 234: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.MetadataContextEntry.value:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext
+	200, // 235: agentgateway.dev.resource.BackendPolicySpec.Ai.prompt_guard:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard
+	202, // 236: agentgateway.dev.resource.BackendPolicySpec.Ai.defaults:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.DefaultsEntry
+	203, // 237: agentgateway.dev.resource.BackendPolicySpec.Ai.overrides:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.OverridesEntry
+	204, // 238: agentgateway.dev.resource.BackendPolicySpec.Ai.transformations:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.TransformationsEntry
+	189, // 239: agentgateway.dev.resource.BackendPolicySpec.Ai.prompts:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment
+	205, // 240: agentgateway.dev.resource.BackendPolicySpec.Ai.model_aliases:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ModelAliasesEntry
+	201, // 241: agentgateway.dev.resource.BackendPolicySpec.Ai.prompt_caching:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptCaching
+	206, // 242: agentgateway.dev.resource.BackendPolicySpec.Ai.routes:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RoutesEntry
+	108, // 243: agentgateway.dev.resource.BackendPolicySpec.InferenceRouting.endpoint_picker:type_name -> agentgateway.dev.resource.BackendReference
+	32,  // 244: agentgateway.dev.resource.BackendPolicySpec.InferenceRouting.failure_mode:type_name -> agentgateway.dev.resource.BackendPolicySpec.InferenceRouting.FailureMode
+	230, // 245: agentgateway.dev.resource.BackendPolicySpec.Eviction.duration:type_name -> google.protobuf.Duration
+	179, // 246: agentgateway.dev.resource.BackendPolicySpec.Health.eviction:type_name -> agentgateway.dev.resource.BackendPolicySpec.Eviction
+	33,  // 247: agentgateway.dev.resource.BackendPolicySpec.BackendTLS.verification:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTLS.VerificationMode
+	109, // 248: agentgateway.dev.resource.BackendPolicySpec.BackendTLS.alpn:type_name -> agentgateway.dev.resource.Alpn
+	8,   // 249: agentgateway.dev.resource.BackendPolicySpec.BackendTLS.key_exchange_groups:type_name -> agentgateway.dev.resource.TLSConfig.KeyExchangeGroup
+	34,  // 250: agentgateway.dev.resource.BackendPolicySpec.BackendHTTP.version:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendHTTP.HttpVersion
+	230, // 251: agentgateway.dev.resource.BackendPolicySpec.BackendHTTP.request_timeout:type_name -> google.protobuf.Duration
+	108, // 252: agentgateway.dev.resource.BackendPolicySpec.BackendTunnel.proxy:type_name -> agentgateway.dev.resource.BackendReference
+	96,  // 253: agentgateway.dev.resource.BackendPolicySpec.BackendTCP.keepalive:type_name -> agentgateway.dev.resource.KeepaliveConfig
+	230, // 254: agentgateway.dev.resource.BackendPolicySpec.BackendTCP.connect_timeout:type_name -> google.protobuf.Duration
+	35,  // 255: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.provider:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.McpIDP
+	207, // 256: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.resource_metadata:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata
+	36,  // 257: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.mode:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.Mode
+	98,  // 258: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.jwt_validation_options:type_name -> agentgateway.dev.resource.JWTValidationOptions
+	64,  // 259: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
+	210, // 260: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.processors:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor
+	188, // 261: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment.append:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Message
+	188, // 262: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment.prepend:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Message
+	27,  // 263: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRule.builtin:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.BuiltinRegexRule
+	28,  // 264: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules.action:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ActionKind
+	190, // 265: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules.rules:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRule
+	108, // 266: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.backend:type_name -> agentgateway.dev.resource.BackendReference
+	83,  // 267: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.forward_header_matches:type_name -> agentgateway.dev.resource.HeaderMatch
+	30,  // 268: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.failure_mode:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.FailureMode
+	100, // 269: agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	108, // 270: agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation.backend_ref:type_name -> agentgateway.dev.resource.BackendReference
+	100, // 271: agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	108, // 272: agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails.backend_ref:type_name -> agentgateway.dev.resource.BackendReference
+	100, // 273: agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	108, // 274: agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor.backend_ref:type_name -> agentgateway.dev.resource.BackendReference
+	100, // 275: agentgateway.dev.resource.BackendPolicySpec.Ai.AzureContentSafety.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	108, // 276: agentgateway.dev.resource.BackendPolicySpec.Ai.AzureContentSafety.backend_ref:type_name -> agentgateway.dev.resource.BackendReference
+	197, // 277: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.rejection:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestRejection
+	191, // 278: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.regex:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules
+	192, // 279: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.webhook:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook
+	195, // 280: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.google_model_armor:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor
+	194, // 281: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.bedrock_guardrails:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails
+	196, // 282: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.azure_content_safety:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.AzureContentSafety
+	197, // 283: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.rejection:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestRejection
+	191, // 284: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.regex:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules
+	192, // 285: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.webhook:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook
+	193, // 286: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.openai_moderation:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation
+	195, // 287: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.google_model_armor:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor
+	194, // 288: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.bedrock_guardrails:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails
+	196, // 289: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.azure_content_safety:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.AzureContentSafety
+	199, // 290: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.request:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard
+	198, // 291: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.response:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard
+	31,  // 292: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.streaming:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.Streaming
+	29,  // 293: agentgateway.dev.resource.BackendPolicySpec.Ai.RoutesEntry.value:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RouteType
+	208, // 294: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.extra:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntry
+	232, // 295: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntry.value:type_name -> google.protobuf.Value
+	108, // 296: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote.target:type_name -> agentgateway.dev.resource.BackendReference
+	38,  // 297: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote.failure_mode:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.FailureMode
+	211, // 298: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote.metadata:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote.MetadataEntry
+	209, // 299: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor.remote:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote
+	212, // 300: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor.methods:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor.MethodsEntry
+	37,  // 301: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor.MethodsEntry.value:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Phase
+	39,  // 302: agentgateway.dev.resource.AIBackend.Azure.resource_type:type_name -> agentgateway.dev.resource.AIBackend.AzureResourceType
+	40,  // 303: agentgateway.dev.resource.AIBackend.ProviderFormatConfig.format:type_name -> agentgateway.dev.resource.AIBackend.ProviderFormat
+	221, // 304: agentgateway.dev.resource.AIBackend.Custom.formats:type_name -> agentgateway.dev.resource.AIBackend.ProviderFormatConfig
+	213, // 305: agentgateway.dev.resource.AIBackend.Provider.host_override:type_name -> agentgateway.dev.resource.AIBackend.HostOverride
+	108, // 306: agentgateway.dev.resource.AIBackend.Provider.provider_backend:type_name -> agentgateway.dev.resource.BackendReference
+	214, // 307: agentgateway.dev.resource.AIBackend.Provider.openai:type_name -> agentgateway.dev.resource.AIBackend.OpenAI
+	215, // 308: agentgateway.dev.resource.AIBackend.Provider.gemini:type_name -> agentgateway.dev.resource.AIBackend.Gemini
+	216, // 309: agentgateway.dev.resource.AIBackend.Provider.vertex:type_name -> agentgateway.dev.resource.AIBackend.Vertex
+	217, // 310: agentgateway.dev.resource.AIBackend.Provider.anthropic:type_name -> agentgateway.dev.resource.AIBackend.Anthropic
+	218, // 311: agentgateway.dev.resource.AIBackend.Provider.bedrock:type_name -> agentgateway.dev.resource.AIBackend.Bedrock
+	219, // 312: agentgateway.dev.resource.AIBackend.Provider.azureopenai:type_name -> agentgateway.dev.resource.AIBackend.AzureOpenAI
+	220, // 313: agentgateway.dev.resource.AIBackend.Provider.azure:type_name -> agentgateway.dev.resource.AIBackend.Azure
+	222, // 314: agentgateway.dev.resource.AIBackend.Provider.custom:type_name -> agentgateway.dev.resource.AIBackend.Custom
+	100, // 315: agentgateway.dev.resource.AIBackend.Provider.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	223, // 316: agentgateway.dev.resource.AIBackend.ProviderGroup.providers:type_name -> agentgateway.dev.resource.AIBackend.Provider
+	317, // [317:317] is the sub-list for method output_type
+	317, // [317:317] is the sub-list for method input_type
+	317, // [317:317] is the sub-list for extension type_name
+	317, // [317:317] is the sub-list for extension extendee
+	0,   // [0:317] is the sub-list for field type_name
 }
 
 func init() { file_resource_proto_init() }
@@ -16366,6 +16539,7 @@ func file_resource_proto_init() {
 		(*BackendAuthPolicy_Gcp)(nil),
 		(*BackendAuthPolicy_Aws)(nil),
 		(*BackendAuthPolicy_Azure)(nil),
+		(*BackendAuthPolicy_OauthTokenExchange)(nil),
 	}
 	file_resource_proto_msgTypes[19].OneofWrappers = []any{
 		(*AuthorizationLocation_Header_)(nil),
@@ -16487,54 +16661,54 @@ func file_resource_proto_init() {
 		(*BackendReference_Service_)(nil),
 		(*BackendReference_Backend)(nil),
 	}
-	file_resource_proto_msgTypes[66].OneofWrappers = []any{}
 	file_resource_proto_msgTypes[67].OneofWrappers = []any{}
-	file_resource_proto_msgTypes[69].OneofWrappers = []any{}
-	file_resource_proto_msgTypes[73].OneofWrappers = []any{}
-	file_resource_proto_msgTypes[74].OneofWrappers = []any{
+	file_resource_proto_msgTypes[68].OneofWrappers = []any{}
+	file_resource_proto_msgTypes[70].OneofWrappers = []any{}
+	file_resource_proto_msgTypes[74].OneofWrappers = []any{}
+	file_resource_proto_msgTypes[75].OneofWrappers = []any{
 		(*AzureManagedIdentityCredential_UserAssignedIdentity_ClientId)(nil),
 		(*AzureManagedIdentityCredential_UserAssignedIdentity_ObjectId)(nil),
 		(*AzureManagedIdentityCredential_UserAssignedIdentity_ResourceId)(nil),
 	}
-	file_resource_proto_msgTypes[76].OneofWrappers = []any{}
 	file_resource_proto_msgTypes[77].OneofWrappers = []any{}
 	file_resource_proto_msgTypes[78].OneofWrappers = []any{}
 	file_resource_proto_msgTypes[79].OneofWrappers = []any{}
 	file_resource_proto_msgTypes[80].OneofWrappers = []any{}
 	file_resource_proto_msgTypes[81].OneofWrappers = []any{}
 	file_resource_proto_msgTypes[82].OneofWrappers = []any{}
-	file_resource_proto_msgTypes[85].OneofWrappers = []any{}
+	file_resource_proto_msgTypes[83].OneofWrappers = []any{}
 	file_resource_proto_msgTypes[86].OneofWrappers = []any{}
-	file_resource_proto_msgTypes[93].OneofWrappers = []any{}
-	file_resource_proto_msgTypes[98].OneofWrappers = []any{
+	file_resource_proto_msgTypes[87].OneofWrappers = []any{}
+	file_resource_proto_msgTypes[94].OneofWrappers = []any{}
+	file_resource_proto_msgTypes[99].OneofWrappers = []any{
 		(*TrafficPolicySpec_ExternalAuth_Grpc)(nil),
 		(*TrafficPolicySpec_ExternalAuth_Http)(nil),
 	}
-	file_resource_proto_msgTypes[100].OneofWrappers = []any{
+	file_resource_proto_msgTypes[101].OneofWrappers = []any{
 		(*TrafficPolicySpec_JWTProvider_Inline)(nil),
 	}
-	file_resource_proto_msgTypes[102].OneofWrappers = []any{}
-	file_resource_proto_msgTypes[110].OneofWrappers = []any{}
-	file_resource_proto_msgTypes[115].OneofWrappers = []any{}
-	file_resource_proto_msgTypes[120].OneofWrappers = []any{}
-	file_resource_proto_msgTypes[133].OneofWrappers = []any{}
-	file_resource_proto_msgTypes[135].OneofWrappers = []any{}
-	file_resource_proto_msgTypes[140].OneofWrappers = []any{}
-	file_resource_proto_msgTypes[144].OneofWrappers = []any{
+	file_resource_proto_msgTypes[103].OneofWrappers = []any{}
+	file_resource_proto_msgTypes[111].OneofWrappers = []any{}
+	file_resource_proto_msgTypes[116].OneofWrappers = []any{}
+	file_resource_proto_msgTypes[121].OneofWrappers = []any{}
+	file_resource_proto_msgTypes[134].OneofWrappers = []any{}
+	file_resource_proto_msgTypes[136].OneofWrappers = []any{}
+	file_resource_proto_msgTypes[141].OneofWrappers = []any{}
+	file_resource_proto_msgTypes[145].OneofWrappers = []any{
 		(*BackendPolicySpec_Ai_RegexRule_Builtin)(nil),
 		(*BackendPolicySpec_Ai_RegexRule_Regex)(nil),
 	}
-	file_resource_proto_msgTypes[147].OneofWrappers = []any{}
-	file_resource_proto_msgTypes[149].OneofWrappers = []any{}
+	file_resource_proto_msgTypes[148].OneofWrappers = []any{}
 	file_resource_proto_msgTypes[150].OneofWrappers = []any{}
-	file_resource_proto_msgTypes[152].OneofWrappers = []any{
+	file_resource_proto_msgTypes[151].OneofWrappers = []any{}
+	file_resource_proto_msgTypes[153].OneofWrappers = []any{
 		(*BackendPolicySpec_Ai_ResponseGuard_Regex)(nil),
 		(*BackendPolicySpec_Ai_ResponseGuard_Webhook)(nil),
 		(*BackendPolicySpec_Ai_ResponseGuard_GoogleModelArmor)(nil),
 		(*BackendPolicySpec_Ai_ResponseGuard_BedrockGuardrails)(nil),
 		(*BackendPolicySpec_Ai_ResponseGuard_AzureContentSafety)(nil),
 	}
-	file_resource_proto_msgTypes[153].OneofWrappers = []any{
+	file_resource_proto_msgTypes[154].OneofWrappers = []any{
 		(*BackendPolicySpec_Ai_RequestGuard_Regex)(nil),
 		(*BackendPolicySpec_Ai_RequestGuard_Webhook)(nil),
 		(*BackendPolicySpec_Ai_RequestGuard_OpenaiModeration)(nil),
@@ -16542,11 +16716,10 @@ func file_resource_proto_init() {
 		(*BackendPolicySpec_Ai_RequestGuard_BedrockGuardrails)(nil),
 		(*BackendPolicySpec_Ai_RequestGuard_AzureContentSafety)(nil),
 	}
-	file_resource_proto_msgTypes[155].OneofWrappers = []any{}
-	file_resource_proto_msgTypes[164].OneofWrappers = []any{
+	file_resource_proto_msgTypes[156].OneofWrappers = []any{}
+	file_resource_proto_msgTypes[165].OneofWrappers = []any{
 		(*BackendPolicySpec_McpGuardrails_Processor_Remote)(nil),
 	}
-	file_resource_proto_msgTypes[168].OneofWrappers = []any{}
 	file_resource_proto_msgTypes[169].OneofWrappers = []any{}
 	file_resource_proto_msgTypes[170].OneofWrappers = []any{}
 	file_resource_proto_msgTypes[171].OneofWrappers = []any{}
@@ -16555,7 +16728,8 @@ func file_resource_proto_init() {
 	file_resource_proto_msgTypes[174].OneofWrappers = []any{}
 	file_resource_proto_msgTypes[175].OneofWrappers = []any{}
 	file_resource_proto_msgTypes[176].OneofWrappers = []any{}
-	file_resource_proto_msgTypes[177].OneofWrappers = []any{
+	file_resource_proto_msgTypes[177].OneofWrappers = []any{}
+	file_resource_proto_msgTypes[178].OneofWrappers = []any{
 		(*AIBackend_Provider_Openai)(nil),
 		(*AIBackend_Provider_Gemini)(nil),
 		(*AIBackend_Provider_Vertex)(nil),
@@ -16571,7 +16745,7 @@ func file_resource_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_resource_proto_rawDesc), len(file_resource_proto_rawDesc)),
 			NumEnums:      45,
-			NumMessages:   180,
+			NumMessages:   182,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/resource_json.gen.go
+++ b/api/resource_json.gen.go
@@ -1799,6 +1799,28 @@ func (this *Alpn) UnmarshalJSON(b []byte) error {
 	return ResourceUnmarshaler.Unmarshal(bytes.NewReader(b), this)
 }
 
+// MarshalJSON is a custom marshaler for OAuthTokenExchange
+func (this *OAuthTokenExchange) MarshalJSON() ([]byte, error) {
+	str, err := ResourceMarshaler.MarshalToString(this)
+	return []byte(str), err
+}
+
+// UnmarshalJSON is a custom unmarshaler for OAuthTokenExchange
+func (this *OAuthTokenExchange) UnmarshalJSON(b []byte) error {
+	return ResourceUnmarshaler.Unmarshal(bytes.NewReader(b), this)
+}
+
+// MarshalJSON is a custom marshaler for OAuthTokenExchange_ClientAuth
+func (this *OAuthTokenExchange_ClientAuth) MarshalJSON() ([]byte, error) {
+	str, err := ResourceMarshaler.MarshalToString(this)
+	return []byte(str), err
+}
+
+// UnmarshalJSON is a custom unmarshaler for OAuthTokenExchange_ClientAuth
+func (this *OAuthTokenExchange_ClientAuth) UnmarshalJSON(b []byte) error {
+	return ResourceUnmarshaler.Unmarshal(bytes.NewReader(b), this)
+}
+
 var (
 	ResourceMarshaler   = &jsonpb.Marshaler{}
 	ResourceUnmarshaler = &jsonpb.Unmarshaler{AllowUnknownFields: true}

--- a/crates/agentgateway/src/http/auth/mod.rs
+++ b/crates/agentgateway/src/http/auth/mod.rs
@@ -2,6 +2,7 @@ pub mod aws;
 pub mod azure;
 mod copilot;
 pub mod gcp;
+pub mod token_exchange;
 
 use std::borrow::Cow;
 
@@ -11,6 +12,7 @@ pub use azure::AzureAuth;
 use cookie::Cookie;
 pub use gcp::GcpAuth;
 use secrecy::{ExposeSecret, SecretString};
+pub use token_exchange::{OAuthClientAuth, OAuthTokenExchangeAuth};
 use url::form_urlencoded;
 
 use crate::http::Request;
@@ -54,6 +56,7 @@ pub enum BackendAuth {
 	/// Authenticate to GitHub Copilot.
 	#[serde(rename = "copilot")]
 	Copilot,
+	OAuthTokenExchange(token_exchange::OAuthTokenExchangeAuth),
 }
 
 /// Records whether the backend auth location was explicitly configured by the user
@@ -158,6 +161,33 @@ pub async fn apply_backend_auth(
 				.await
 				.map_err(ProxyError::BackendAuthenticationFailed)?;
 		},
+		BackendAuth::OAuthTokenExchange(te_auth) => {
+			let subject_token = if let Some(claims) = req.extensions().get::<Claims>() {
+				claims.jwt.expose_secret().to_string()
+			} else if let Some(token) = DEFAULT_AUTHORIZATION_LOCATION.extract(req) {
+				token.into_owned()
+			} else {
+				return Err(ProxyError::ProcessingString(
+					"token exchange backend auth requires a bearer token in the request".to_string(),
+				));
+			};
+			let policy_client = crate::proxy::httpproxy::PolicyClient::new(backend_info.inputs.clone());
+			let access_token = token_exchange::fetch_token(
+				&policy_client,
+				te_auth,
+				&subject_token,
+				token_exchange::TOKEN_TYPE_ACCESS,
+			)
+			.await
+			.map_err(ProxyError::BackendAuthenticationFailed)?;
+			let mut hv = HeaderValue::from_str(&format!("Bearer {}", access_token.expose_secret()))
+				.map_err(|e| ProxyError::Processing(e.into()))?;
+			hv.set_sensitive(true);
+			req.headers_mut().insert(http::header::AUTHORIZATION, hv);
+			req
+				.extensions_mut()
+				.insert(AppliedBackendAuthLocation { explicit: true });
+		},
 	}
 	Ok(())
 }
@@ -180,6 +210,7 @@ pub async fn apply_late_backend_auth(
 		},
 		BackendAuth::Azure(_) => {},
 		BackendAuth::Copilot => {},
+		BackendAuth::OAuthTokenExchange(_) => {},
 	};
 	Ok(())
 }

--- a/crates/agentgateway/src/http/auth/token_exchange.rs
+++ b/crates/agentgateway/src/http/auth/token_exchange.rs
@@ -1,0 +1,390 @@
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use ::http::header::{ACCEPT, CONTENT_TYPE};
+use quick_cache::sync::Cache;
+use secrecy::SecretString;
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use tracing::trace;
+use url::form_urlencoded;
+
+use crate::http::Body;
+use crate::proxy::httpproxy::PolicyClient;
+use crate::serdes::schema;
+use crate::types::agent::SimpleBackendReference;
+use crate::{apply, http, json};
+
+#[apply(schema!)]
+pub struct OAuthTokenExchangeAuth {
+	/// Backend serving the RFC 8693 token endpoint.
+	pub(super) token_endpoint: Arc<SimpleBackendReference>,
+	/// Token endpoint path on the backend; defaults to "/".
+	#[serde(default, skip_serializing_if = "String::is_empty")]
+	pub(super) token_endpoint_path: String,
+	/// `audience` parameters naming the target services at the authorization server.
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub(super) audiences: Vec<String>,
+	/// `scope` values for the requested token, sent space-delimited.
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub(super) scopes: Vec<String>,
+	/// `resource` parameters with the target service URIs.
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub(super) resources: Vec<String>,
+	/// `requested_token_type` parameter; the server picks when unset.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub(super) requested_token_type: Option<String>,
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub(super) client_auth: Option<OAuthClientAuth>,
+	#[serde(skip)]
+	#[cfg_attr(feature = "schema", schemars(skip))]
+	cache: TokenExchangeCache,
+}
+
+#[apply(schema!)]
+pub struct OAuthClientAuth {
+	/// `client_id` parameter identifying the gateway at the authorization server.
+	pub(super) client_id: String,
+}
+
+impl OAuthClientAuth {
+	pub fn new(client_id: String) -> Self {
+		Self { client_id }
+	}
+}
+
+impl OAuthTokenExchangeAuth {
+	pub fn new(
+		token_endpoint: Arc<SimpleBackendReference>,
+		token_endpoint_path: String,
+		audiences: Vec<String>,
+		scopes: Vec<String>,
+		resources: Vec<String>,
+		requested_token_type: Option<String>,
+		client_auth: Option<OAuthClientAuth>,
+	) -> Self {
+		Self {
+			token_endpoint,
+			token_endpoint_path,
+			audiences,
+			scopes,
+			resources,
+			requested_token_type,
+			client_auth,
+			cache: TokenExchangeCache::default(),
+		}
+	}
+}
+
+const GRANT_TYPE: &str = "urn:ietf:params:oauth:grant-type:token-exchange";
+pub(super) const TOKEN_TYPE_ACCESS: &str = "urn:ietf:params:oauth:token-type:access_token";
+const TOKEN_TYPE_JWT: &str = "urn:ietf:params:oauth:token-type:jwt";
+
+const CACHE_SAFETY_MARGIN: Duration = Duration::from_secs(30);
+const CACHE_CAPACITY: usize = 1024;
+
+#[derive(Debug, Deserialize)]
+struct TokenResponse {
+	access_token: SecretString,
+	issued_token_type: String,
+	token_type: String,
+	#[serde(default)]
+	expires_in: Option<u64>,
+}
+
+#[derive(Clone)]
+struct CachedToken {
+	access_token: SecretString,
+	expires_at: Instant,
+}
+
+#[derive(Clone)]
+struct TokenExchangeCache(Arc<Cache<String, CachedToken>>);
+
+impl Default for TokenExchangeCache {
+	fn default() -> Self {
+		Self(Arc::new(Cache::new(CACHE_CAPACITY)))
+	}
+}
+
+impl std::fmt::Debug for TokenExchangeCache {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.write_str("TokenExchangeCache")
+	}
+}
+
+pub(super) async fn fetch_token(
+	client: &PolicyClient,
+	auth: &OAuthTokenExchangeAuth,
+	subject_token: &str,
+	subject_token_type: &str,
+) -> anyhow::Result<SecretString> {
+	let cache_key = {
+		let mut h = Sha256::new();
+		h.update(subject_token.as_bytes());
+		hex::encode(h.finalize())
+	};
+	let cache = &auth.cache.0;
+	if let Some(cached) = cache.get(&cache_key) {
+		if cached.expires_at > Instant::now() {
+			trace!("token exchange cache hit");
+			return Ok(cached.access_token);
+		}
+		cache.remove(&cache_key);
+	}
+
+	let guard = match cache.get_value_or_guard_async(&cache_key).await {
+		Ok(cached) => return Ok(cached.access_token),
+		Err(guard) => guard,
+	};
+
+	let body = {
+		let mut ser = form_urlencoded::Serializer::new(String::new());
+		ser
+			.append_pair("grant_type", GRANT_TYPE)
+			.append_pair("subject_token", subject_token)
+			.append_pair("subject_token_type", subject_token_type);
+		for audience in &auth.audiences {
+			ser.append_pair("audience", audience);
+		}
+		if !auth.scopes.is_empty() {
+			ser.append_pair("scope", &auth.scopes.join(" "));
+		}
+		for resource in &auth.resources {
+			ser.append_pair("resource", resource);
+		}
+		if let Some(rtt) = &auth.requested_token_type {
+			ser.append_pair("requested_token_type", rtt);
+		}
+		if let Some(client_auth) = &auth.client_auth {
+			ser.append_pair("client_id", &client_auth.client_id);
+		}
+		ser.finish()
+	};
+
+	let path = if auth.token_endpoint_path.is_empty() {
+		"/"
+	} else {
+		auth.token_endpoint_path.as_str()
+	};
+	let req = ::http::Request::builder()
+		.method(::http::Method::POST)
+		.uri(path)
+		.header(CONTENT_TYPE, "application/x-www-form-urlencoded")
+		.header(ACCEPT, "application/json")
+		.body(Body::from(body.into_bytes()))?;
+
+	let resp = client
+		.call_reference(req, &auth.token_endpoint)
+		.await
+		.map_err(|e| anyhow::anyhow!("token exchange request failed: {e}"))?;
+
+	let status = resp.status();
+	let limit = http::response_buffer_limit(&resp);
+	if !status.is_success() {
+		let body = http::read_body_with_limit(resp.into_body(), limit)
+			.await
+			.unwrap_or_default();
+		let body: String = String::from_utf8_lossy(&body).chars().take(256).collect();
+		anyhow::bail!("token exchange returned status {status}: {body}");
+	}
+
+	let parsed: TokenResponse = json::from_body_with_limit(resp.into_body(), limit)
+		.await
+		.map_err(|e| anyhow::anyhow!("token exchange response decode failed: {e}"))?;
+
+	if !parsed.token_type.eq_ignore_ascii_case("Bearer") {
+		anyhow::bail!(
+			"token exchange returned unsupported token_type: {}",
+			parsed.token_type
+		);
+	}
+
+	if parsed.issued_token_type != TOKEN_TYPE_ACCESS && parsed.issued_token_type != TOKEN_TYPE_JWT {
+		anyhow::bail!(
+			"token exchange returned unusable issued_token_type: {}",
+			parsed.issued_token_type
+		);
+	}
+
+	let access_token = parsed.access_token;
+
+	if let Some(secs) = parsed.expires_in
+		&& secs > CACHE_SAFETY_MARGIN.as_secs()
+	{
+		let ttl = Duration::from_secs(secs) - CACHE_SAFETY_MARGIN;
+		let _ = guard.insert(CachedToken {
+			access_token: access_token.clone(),
+			expires_at: Instant::now() + ttl,
+		});
+	}
+
+	trace!("token exchange succeeded");
+	Ok(access_token)
+}
+
+#[cfg(test)]
+mod tests {
+	use std::collections::HashMap;
+
+	use secrecy::ExposeSecret;
+	use serde_json::json;
+	use wiremock::matchers::{method, path};
+	use wiremock::{Mock, MockServer, ResponseTemplate};
+
+	use super::*;
+	use crate::types::agent::Target;
+
+	fn policy_client() -> PolicyClient {
+		PolicyClient::new(
+			crate::test_helpers::proxymock::setup_proxy_test("{}")
+				.unwrap()
+				.inputs(),
+		)
+	}
+
+	fn token_body() -> serde_json::Value {
+		json!({
+			"access_token": "upstream-token",
+			"token_type": "Bearer",
+			"issued_token_type": TOKEN_TYPE_ACCESS,
+			"expires_in": 3600,
+		})
+	}
+
+	async fn mock_token_endpoint(body: ResponseTemplate) -> MockServer {
+		let mock = MockServer::start().await;
+		Mock::given(method("POST"))
+			.and(path("/token"))
+			.respond_with(body)
+			.mount(&mock)
+			.await;
+		mock
+	}
+
+	fn endpoint(mock: &MockServer) -> Arc<SimpleBackendReference> {
+		Arc::new(SimpleBackendReference::InlineBackend(Target::Address(
+			*mock.address(),
+		)))
+	}
+
+	fn auth(endpoint: Arc<SimpleBackendReference>) -> OAuthTokenExchangeAuth {
+		OAuthTokenExchangeAuth::new(
+			endpoint,
+			"/token".into(),
+			vec!["https://upstream.example".into()],
+			vec![],
+			vec![],
+			None,
+			None,
+		)
+	}
+
+	async fn sent_form_params(mock: &MockServer) -> HashMap<String, String> {
+		let req = &mock.received_requests().await.unwrap()[0];
+		form_urlencoded::parse(&req.body).into_owned().collect()
+	}
+
+	#[test]
+	fn deserializes_minimal_config() {
+		let a: OAuthTokenExchangeAuth =
+			serde_json::from_str(r#"{"tokenEndpoint": {"host": "localhost:8089"}}"#).unwrap();
+		assert!(matches!(
+			a.token_endpoint.as_ref(),
+			SimpleBackendReference::InlineBackend(_)
+		));
+		assert!(a.token_endpoint_path.is_empty());
+	}
+
+	#[tokio::test]
+	async fn sends_form_params() {
+		let mock = mock_token_endpoint(ResponseTemplate::new(200).set_body_json(token_body())).await;
+		let a = auth(endpoint(&mock));
+
+		let tok = fetch_token(&policy_client(), &a, "subj-jwt", TOKEN_TYPE_ACCESS)
+			.await
+			.expect("exchange succeeds");
+		assert_eq!(tok.expose_secret(), "upstream-token");
+
+		let pairs = sent_form_params(&mock).await;
+		assert_eq!(pairs["grant_type"], GRANT_TYPE);
+		assert_eq!(pairs["subject_token"], "subj-jwt");
+		assert_eq!(pairs["subject_token_type"], TOKEN_TYPE_ACCESS);
+		assert_eq!(pairs["audience"], "https://upstream.example");
+		for k in ["scope", "resource", "requested_token_type", "client_id"] {
+			assert!(!pairs.contains_key(k), "unset param {k} must not be sent");
+		}
+	}
+
+	#[tokio::test]
+	async fn sends_optional_params() {
+		let mock = mock_token_endpoint(ResponseTemplate::new(200).set_body_json(token_body())).await;
+		let a = OAuthTokenExchangeAuth::new(
+			endpoint(&mock),
+			"/token".into(),
+			vec![],
+			vec!["read".into(), "write".into()],
+			vec!["https://upstream.example/api".into()],
+			Some(TOKEN_TYPE_ACCESS.into()),
+			Some(OAuthClientAuth {
+				client_id: "gateway-client".into(),
+			}),
+		);
+
+		fetch_token(&policy_client(), &a, "subj", TOKEN_TYPE_JWT)
+			.await
+			.unwrap();
+		let pairs = sent_form_params(&mock).await;
+		assert!(!pairs.contains_key("audience"));
+		assert_eq!(pairs["subject_token_type"], TOKEN_TYPE_JWT);
+		assert_eq!(pairs["scope"], "read write");
+		assert_eq!(pairs["resource"], "https://upstream.example/api");
+		assert_eq!(pairs["requested_token_type"], TOKEN_TYPE_ACCESS);
+		assert_eq!(pairs["client_id"], "gateway-client");
+	}
+
+	#[tokio::test]
+	async fn fails_closed_on_client_error() {
+		let mock = mock_token_endpoint(ResponseTemplate::new(401)).await;
+		let a = auth(endpoint(&mock));
+
+		assert!(
+			fetch_token(&policy_client(), &a, "subj", TOKEN_TYPE_ACCESS)
+				.await
+				.is_err()
+		);
+	}
+
+	#[tokio::test]
+	async fn rejects_unusable_issued_token_type() {
+		let mock = mock_token_endpoint(ResponseTemplate::new(200).set_body_json(json!({
+			"access_token": "t",
+			"token_type": "Bearer",
+			"issued_token_type": "urn:ietf:params:oauth:token-type:saml2",
+		})))
+		.await;
+		let a = auth(endpoint(&mock));
+
+		assert!(
+			fetch_token(&policy_client(), &a, "subj", TOKEN_TYPE_ACCESS)
+				.await
+				.is_err()
+		);
+	}
+
+	#[tokio::test]
+	async fn caches_per_subject() {
+		let mock = mock_token_endpoint(ResponseTemplate::new(200).set_body_json(token_body())).await;
+		let a = auth(endpoint(&mock));
+		let client = policy_client();
+
+		let t1 = fetch_token(&client, &a, "subj", TOKEN_TYPE_ACCESS)
+			.await
+			.unwrap();
+		let t2 = fetch_token(&client, &a, "subj", TOKEN_TYPE_ACCESS)
+			.await
+			.unwrap();
+		assert_eq!(t1.expose_secret(), t2.expose_secret());
+		assert_eq!(mock.received_requests().await.unwrap().len(), 1);
+	}
+}

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -25,7 +25,7 @@ use itertools::Itertools;
 use llm::{AIBackend, AIProvider, NamedAIProvider};
 
 use super::agent::*;
-use crate::http::auth::{AwsAuth, BackendAuth, GcpAuth};
+use crate::http::auth::{AwsAuth, BackendAuth, GcpAuth, OAuthTokenExchangeAuth};
 use crate::http::buffer::BufferBody;
 use crate::http::transformation_cel::{LocalTransform, LocalTransformationConfig, Transformation};
 use crate::http::{HeaderOrPseudo, Scheme, auth, authorization, health};
@@ -1079,6 +1079,23 @@ fn backend_auth_from_proto(
 				None => return Err(ProtoError::MissingRequiredField),
 			};
 			BackendAuth::Azure(azure_auth)
+		},
+		Some(proto::agent::backend_auth_policy::Kind::OauthTokenExchange(t)) => {
+			let opt = |s: String| (!s.is_empty()).then_some(s);
+			let endpoint = Arc::new(resolve_simple_reference(t.token_endpoint.as_ref()));
+			let client_auth = t
+				.client_auth
+				.and_then(|c| opt(c.client_id))
+				.map(auth::OAuthClientAuth::new);
+			BackendAuth::OAuthTokenExchange(OAuthTokenExchangeAuth::new(
+				endpoint,
+				t.token_endpoint_path,
+				t.audiences,
+				t.scopes,
+				t.resources,
+				opt(t.requested_token_type),
+				client_auth,
+			))
 		},
 		None => return Err(ProtoError::MissingRequiredField),
 	})

--- a/crates/protos/proto/resource.proto
+++ b/crates/protos/proto/resource.proto
@@ -333,6 +333,7 @@ message BackendAuthPolicy {
     Gcp gcp = 3;
     Aws aws = 4;
     Azure azure = 5;
+    OAuthTokenExchange oauth_token_exchange = 6;
   }
 }
 
@@ -1711,4 +1712,20 @@ message BackendReference {
 
 message Alpn {
   repeated string protocols = 1;
+}
+
+// RFC 8693 OAuth 2.0 Token Exchange.
+message OAuthTokenExchange {
+  message ClientAuth {
+    string client_id = 1;
+  }
+  BackendReference token_endpoint = 1;
+  // Token endpoint path on the backend; defaults to "/".
+  string token_endpoint_path = 7;
+  // Optional RFC 8693 request parameters; sent only when non-empty.
+  repeated string audiences = 2;
+  repeated string scopes = 3;
+  repeated string resources = 4;
+  string requested_token_type = 5;
+  ClientAuth client_auth = 6;
 }

--- a/schema/config.json
+++ b/schema/config.json
@@ -2791,6 +2791,18 @@
           "description": "Authenticate to GitHub Copilot.",
           "type": "string",
           "const": "copilot"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "oAuthTokenExchange": {
+              "$ref": "#/$defs/OAuthTokenExchangeAuth"
+            }
+          },
+          "required": [
+            "oAuthTokenExchange"
+          ],
+          "additionalProperties": false
         }
       ]
     },
@@ -3199,6 +3211,74 @@
           ],
           "additionalProperties": false
         }
+      ]
+    },
+    "OAuthTokenExchangeAuth": {
+      "type": "object",
+      "properties": {
+        "tokenEndpoint": {
+          "description": "Backend serving the RFC 8693 token endpoint.",
+          "$ref": "#/$defs/SimpleLocalBackendSerde"
+        },
+        "tokenEndpointPath": {
+          "description": "Token endpoint path on the backend; defaults to \"/\".",
+          "type": "string"
+        },
+        "audiences": {
+          "description": "`audience` parameters naming the target services at the authorization server.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "scopes": {
+          "description": "`scope` values for the requested token, sent space-delimited.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "resources": {
+          "description": "`resource` parameters with the target service URIs.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "requestedTokenType": {
+          "description": "`requested_token_type` parameter; the server picks when unset.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "clientAuth": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OAuthClientAuth"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "tokenEndpoint"
+      ]
+    },
+    "OAuthClientAuth": {
+      "type": "object",
+      "properties": {
+        "clientId": {
+          "description": "`client_id` parameter identifying the gateway at the authorization server.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "clientId"
       ]
     },
     "HTTP": {

--- a/schema/config.md
+++ b/schema/config.md
@@ -266,6 +266,20 @@
 |`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange`|object||
+|`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -430,6 +444,20 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange`|object||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -536,6 +564,20 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange`|object||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -642,6 +684,20 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange`|object||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -746,6 +802,20 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange`|object||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -885,6 +955,20 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange`|object||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -991,6 +1075,20 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange`|object||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -1095,6 +1193,20 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange`|object||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -1218,6 +1330,20 @@
 |`binds[].listeners[].routes[].policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`binds[].listeners[].routes[].policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`binds[].listeners[].routes[].policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`binds[].listeners[].routes[].policies.backendAuth.oAuthTokenExchange`|object||
+|`binds[].listeners[].routes[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`binds[].listeners[].routes[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`binds[].listeners[].routes[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`binds[].listeners[].routes[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`binds[].listeners[].routes[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`binds[].listeners[].routes[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`binds[].listeners[].routes[].policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`binds[].listeners[].routes[].policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`binds[].listeners[].routes[].policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`binds[].listeners[].routes[].policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`binds[].listeners[].routes[].policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`binds[].listeners[].routes[].policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`binds[].listeners[].routes[].policies.localRateLimit`|object|Local rate limits for incoming requests.|
 |`binds[].listeners[].routes[].policies.localRateLimit.conditional`|[]object|conditional policy entries. An entry without a condition must be the final fallback.|
 |`binds[].listeners[].routes[].policies.localRateLimit.conditional[].condition`|string|condition must evaluate to true for this policy to execute. If unset, the policy is the fallback.|
@@ -1321,6 +1447,20 @@
 |`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange`|object||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -1437,6 +1577,20 @@
 |`binds[].listeners[].routes[].policies.remoteRateLimit.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`binds[].listeners[].routes[].policies.remoteRateLimit.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`binds[].listeners[].routes[].policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange`|object||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`binds[].listeners[].routes[].policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`binds[].listeners[].routes[].policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`binds[].listeners[].routes[].policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`binds[].listeners[].routes[].policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`binds[].listeners[].routes[].policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`binds[].listeners[].routes[].policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`binds[].listeners[].routes[].policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`binds[].listeners[].routes[].policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`binds[].listeners[].routes[].policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -1628,6 +1782,20 @@
 |`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange`|object||
+|`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -1757,6 +1925,20 @@
 |`binds[].listeners[].routes[].policies.extAuthz.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`binds[].listeners[].routes[].policies.extAuthz.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`binds[].listeners[].routes[].policies.extAuthz.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`binds[].listeners[].routes[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange`|object||
+|`binds[].listeners[].routes[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`binds[].listeners[].routes[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`binds[].listeners[].routes[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`binds[].listeners[].routes[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`binds[].listeners[].routes[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`binds[].listeners[].routes[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`binds[].listeners[].routes[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`binds[].listeners[].routes[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`binds[].listeners[].routes[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`binds[].listeners[].routes[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`binds[].listeners[].routes[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`binds[].listeners[].routes[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`binds[].listeners[].routes[].policies.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].policies.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -1889,6 +2071,20 @@
 |`binds[].listeners[].routes[].policies.extProc.conditional[].policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`binds[].listeners[].routes[].policies.extProc.conditional[].policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`binds[].listeners[].routes[].policies.extProc.conditional[].policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`binds[].listeners[].routes[].policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange`|object||
+|`binds[].listeners[].routes[].policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`binds[].listeners[].routes[].policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`binds[].listeners[].routes[].policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`binds[].listeners[].routes[].policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`binds[].listeners[].routes[].policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`binds[].listeners[].routes[].policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`binds[].listeners[].routes[].policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`binds[].listeners[].routes[].policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`binds[].listeners[].routes[].policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`binds[].listeners[].routes[].policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`binds[].listeners[].routes[].policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`binds[].listeners[].routes[].policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`binds[].listeners[].routes[].policies.extProc.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.extProc.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].policies.extProc.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -2008,6 +2204,20 @@
 |`binds[].listeners[].routes[].policies.extProc.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`binds[].listeners[].routes[].policies.extProc.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`binds[].listeners[].routes[].policies.extProc.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`binds[].listeners[].routes[].policies.extProc.policies.backendAuth.oAuthTokenExchange`|object||
+|`binds[].listeners[].routes[].policies.extProc.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`binds[].listeners[].routes[].policies.extProc.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`binds[].listeners[].routes[].policies.extProc.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`binds[].listeners[].routes[].policies.extProc.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`binds[].listeners[].routes[].policies.extProc.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`binds[].listeners[].routes[].policies.extProc.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].policies.extProc.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`binds[].listeners[].routes[].policies.extProc.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`binds[].listeners[].routes[].policies.extProc.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`binds[].listeners[].routes[].policies.extProc.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`binds[].listeners[].routes[].policies.extProc.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`binds[].listeners[].routes[].policies.extProc.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`binds[].listeners[].routes[].policies.extProc.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`binds[].listeners[].routes[].policies.extProc.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.extProc.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].policies.extProc.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -2199,6 +2409,20 @@
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.backendAuth.oAuthTokenExchange`|object||
+|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -2313,6 +2537,20 @@
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange`|object||
+|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -2461,6 +2699,20 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.oAuthTokenExchange`|object||
+|`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`binds[].listeners[].routes[].backends[].ai.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -2590,6 +2842,20 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.oAuthTokenExchange`|object||
+|`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -2726,6 +2992,20 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange`|object||
+|`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -2868,6 +3148,20 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange`|object||
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -2974,6 +3268,20 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange`|object||
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -3080,6 +3388,20 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange`|object||
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -3184,6 +3506,20 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange`|object||
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -3323,6 +3659,20 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange`|object||
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -3429,6 +3779,20 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange`|object||
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -3533,6 +3897,20 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange`|object||
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -3704,6 +4082,20 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oAuthTokenExchange`|object||
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -3833,6 +4225,20 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange`|object||
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -3969,6 +4375,20 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange`|object||
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -4111,6 +4531,20 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange`|object||
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -4217,6 +4651,20 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange`|object||
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -4323,6 +4771,20 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange`|object||
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -4427,6 +4889,20 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange`|object||
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -4566,6 +5042,20 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange`|object||
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -4672,6 +5162,20 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange`|object||
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -4776,6 +5280,20 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange`|object||
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -4917,6 +5435,20 @@
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`binds[].listeners[].routes[].backends[].policies.backendAuth.oAuthTokenExchange`|object||
+|`binds[].listeners[].routes[].backends[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`binds[].listeners[].routes[].backends[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`binds[].listeners[].routes[].backends[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`binds[].listeners[].routes[].backends[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`binds[].listeners[].routes[].backends[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`binds[].listeners[].routes[].backends[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`binds[].listeners[].routes[].backends[].policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`binds[].listeners[].routes[].backends[].policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`binds[].listeners[].routes[].backends[].policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`binds[].listeners[].routes[].backends[].policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`binds[].listeners[].routes[].backends[].policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`binds[].listeners[].routes[].backends[].policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`binds[].listeners[].routes[].backends[].policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -5046,6 +5578,20 @@
 |`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange`|object||
+|`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -5182,6 +5728,20 @@
 |`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange`|object||
+|`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -5324,6 +5884,20 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange`|object||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -5430,6 +6004,20 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange`|object||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -5536,6 +6124,20 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange`|object||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -5640,6 +6242,20 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange`|object||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -5779,6 +6395,20 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange`|object||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -5885,6 +6515,20 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange`|object||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -5989,6 +6633,20 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange`|object||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -6220,6 +6878,20 @@
 |`binds[].listeners[].policies.extAuthz.conditional[].policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`binds[].listeners[].policies.extAuthz.conditional[].policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`binds[].listeners[].policies.extAuthz.conditional[].policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`binds[].listeners[].policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange`|object||
+|`binds[].listeners[].policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`binds[].listeners[].policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`binds[].listeners[].policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`binds[].listeners[].policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`binds[].listeners[].policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`binds[].listeners[].policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`binds[].listeners[].policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`binds[].listeners[].policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`binds[].listeners[].policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`binds[].listeners[].policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`binds[].listeners[].policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`binds[].listeners[].policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`binds[].listeners[].policies.extAuthz.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].policies.extAuthz.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].policies.extAuthz.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -6349,6 +7021,20 @@
 |`binds[].listeners[].policies.extAuthz.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`binds[].listeners[].policies.extAuthz.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`binds[].listeners[].policies.extAuthz.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`binds[].listeners[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange`|object||
+|`binds[].listeners[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`binds[].listeners[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`binds[].listeners[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`binds[].listeners[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`binds[].listeners[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`binds[].listeners[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`binds[].listeners[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`binds[].listeners[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`binds[].listeners[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`binds[].listeners[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`binds[].listeners[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`binds[].listeners[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`binds[].listeners[].policies.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].policies.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].policies.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -6481,6 +7167,20 @@
 |`binds[].listeners[].policies.extProc.conditional[].policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`binds[].listeners[].policies.extProc.conditional[].policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`binds[].listeners[].policies.extProc.conditional[].policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`binds[].listeners[].policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange`|object||
+|`binds[].listeners[].policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`binds[].listeners[].policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`binds[].listeners[].policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`binds[].listeners[].policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`binds[].listeners[].policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`binds[].listeners[].policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`binds[].listeners[].policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`binds[].listeners[].policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`binds[].listeners[].policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`binds[].listeners[].policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`binds[].listeners[].policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`binds[].listeners[].policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`binds[].listeners[].policies.extProc.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].policies.extProc.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].policies.extProc.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -6600,6 +7300,20 @@
 |`binds[].listeners[].policies.extProc.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`binds[].listeners[].policies.extProc.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`binds[].listeners[].policies.extProc.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`binds[].listeners[].policies.extProc.policies.backendAuth.oAuthTokenExchange`|object||
+|`binds[].listeners[].policies.extProc.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`binds[].listeners[].policies.extProc.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`binds[].listeners[].policies.extProc.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`binds[].listeners[].policies.extProc.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`binds[].listeners[].policies.extProc.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`binds[].listeners[].policies.extProc.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].policies.extProc.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`binds[].listeners[].policies.extProc.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`binds[].listeners[].policies.extProc.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`binds[].listeners[].policies.extProc.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`binds[].listeners[].policies.extProc.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`binds[].listeners[].policies.extProc.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`binds[].listeners[].policies.extProc.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`binds[].listeners[].policies.extProc.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].policies.extProc.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].policies.extProc.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -6829,6 +7543,20 @@
 |`frontendPolicies.accessLog.otlp.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`frontendPolicies.accessLog.otlp.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`frontendPolicies.accessLog.otlp.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`frontendPolicies.accessLog.otlp.policies.backendAuth.oAuthTokenExchange`|object||
+|`frontendPolicies.accessLog.otlp.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`frontendPolicies.accessLog.otlp.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`frontendPolicies.accessLog.otlp.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`frontendPolicies.accessLog.otlp.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`frontendPolicies.accessLog.otlp.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`frontendPolicies.accessLog.otlp.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`frontendPolicies.accessLog.otlp.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`frontendPolicies.accessLog.otlp.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`frontendPolicies.accessLog.otlp.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`frontendPolicies.accessLog.otlp.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`frontendPolicies.accessLog.otlp.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`frontendPolicies.accessLog.otlp.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`frontendPolicies.accessLog.otlp.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`frontendPolicies.accessLog.otlp.policies.http`|object|HTTP protocol settings for this backend.|
 |`frontendPolicies.accessLog.otlp.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`frontendPolicies.accessLog.otlp.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -6945,6 +7673,20 @@
 |`frontendPolicies.logging.otlp.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`frontendPolicies.logging.otlp.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`frontendPolicies.logging.otlp.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`frontendPolicies.logging.otlp.policies.backendAuth.oAuthTokenExchange`|object||
+|`frontendPolicies.logging.otlp.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`frontendPolicies.logging.otlp.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`frontendPolicies.logging.otlp.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`frontendPolicies.logging.otlp.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`frontendPolicies.logging.otlp.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`frontendPolicies.logging.otlp.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`frontendPolicies.logging.otlp.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`frontendPolicies.logging.otlp.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`frontendPolicies.logging.otlp.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`frontendPolicies.logging.otlp.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`frontendPolicies.logging.otlp.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`frontendPolicies.logging.otlp.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`frontendPolicies.logging.otlp.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`frontendPolicies.logging.otlp.policies.http`|object|HTTP protocol settings for this backend.|
 |`frontendPolicies.logging.otlp.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`frontendPolicies.logging.otlp.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -7057,6 +7799,20 @@
 |`frontendPolicies.tracing.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`frontendPolicies.tracing.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`frontendPolicies.tracing.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`frontendPolicies.tracing.policies.backendAuth.oAuthTokenExchange`|object||
+|`frontendPolicies.tracing.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`frontendPolicies.tracing.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`frontendPolicies.tracing.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`frontendPolicies.tracing.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`frontendPolicies.tracing.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`frontendPolicies.tracing.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`frontendPolicies.tracing.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`frontendPolicies.tracing.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`frontendPolicies.tracing.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`frontendPolicies.tracing.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`frontendPolicies.tracing.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`frontendPolicies.tracing.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`frontendPolicies.tracing.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`frontendPolicies.tracing.policies.http`|object|HTTP protocol settings for this backend.|
 |`frontendPolicies.tracing.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`frontendPolicies.tracing.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -7261,6 +8017,20 @@
 |`policies[].policy.mcpGuardrails.processors[].policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`policies[].policy.mcpGuardrails.processors[].policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`policies[].policy.mcpGuardrails.processors[].policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`policies[].policy.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange`|object||
+|`policies[].policy.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`policies[].policy.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`policies[].policy.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`policies[].policy.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`policies[].policy.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`policies[].policy.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`policies[].policy.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`policies[].policy.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`policies[].policy.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`policies[].policy.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`policies[].policy.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`policies[].policy.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`policies[].policy.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`policies[].policy.mcpGuardrails.processors[].policies.http`|object|HTTP protocol settings for this backend.|
 |`policies[].policy.mcpGuardrails.processors[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`policies[].policy.mcpGuardrails.processors[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -7425,6 +8195,20 @@
 |`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange`|object||
+|`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.http`|object|HTTP protocol settings for this backend.|
 |`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -7531,6 +8315,20 @@
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange`|object||
+|`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -7637,6 +8435,20 @@
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange`|object||
+|`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -7741,6 +8553,20 @@
 |`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange`|object||
+|`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -7880,6 +8706,20 @@
 |`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange`|object||
+|`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -7986,6 +8826,20 @@
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange`|object||
+|`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -8090,6 +8944,20 @@
 |`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange`|object||
+|`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -8213,6 +9081,20 @@
 |`policies[].policy.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`policies[].policy.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`policies[].policy.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`policies[].policy.backendAuth.oAuthTokenExchange`|object||
+|`policies[].policy.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`policies[].policy.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`policies[].policy.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`policies[].policy.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`policies[].policy.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`policies[].policy.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`policies[].policy.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`policies[].policy.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`policies[].policy.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`policies[].policy.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`policies[].policy.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`policies[].policy.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`policies[].policy.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`policies[].policy.localRateLimit`|object|Local rate limits for incoming requests.|
 |`policies[].policy.localRateLimit.conditional`|[]object|conditional policy entries. An entry without a condition must be the final fallback.|
 |`policies[].policy.localRateLimit.conditional[].condition`|string|condition must evaluate to true for this policy to execute. If unset, the policy is the fallback.|
@@ -8316,6 +9198,20 @@
 |`policies[].policy.remoteRateLimit.conditional[].policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`policies[].policy.remoteRateLimit.conditional[].policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`policies[].policy.remoteRateLimit.conditional[].policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`policies[].policy.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange`|object||
+|`policies[].policy.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`policies[].policy.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`policies[].policy.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`policies[].policy.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`policies[].policy.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`policies[].policy.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`policies[].policy.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`policies[].policy.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`policies[].policy.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`policies[].policy.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`policies[].policy.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`policies[].policy.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`policies[].policy.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`policies[].policy.remoteRateLimit.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`policies[].policy.remoteRateLimit.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`policies[].policy.remoteRateLimit.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -8432,6 +9328,20 @@
 |`policies[].policy.remoteRateLimit.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`policies[].policy.remoteRateLimit.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`policies[].policy.remoteRateLimit.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`policies[].policy.remoteRateLimit.policies.backendAuth.oAuthTokenExchange`|object||
+|`policies[].policy.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`policies[].policy.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`policies[].policy.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`policies[].policy.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`policies[].policy.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`policies[].policy.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`policies[].policy.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`policies[].policy.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`policies[].policy.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`policies[].policy.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`policies[].policy.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`policies[].policy.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`policies[].policy.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`policies[].policy.remoteRateLimit.policies.http`|object|HTTP protocol settings for this backend.|
 |`policies[].policy.remoteRateLimit.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`policies[].policy.remoteRateLimit.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -8623,6 +9533,20 @@
 |`policies[].policy.extAuthz.conditional[].policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`policies[].policy.extAuthz.conditional[].policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`policies[].policy.extAuthz.conditional[].policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`policies[].policy.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange`|object||
+|`policies[].policy.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`policies[].policy.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`policies[].policy.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`policies[].policy.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`policies[].policy.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`policies[].policy.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`policies[].policy.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`policies[].policy.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`policies[].policy.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`policies[].policy.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`policies[].policy.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`policies[].policy.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`policies[].policy.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`policies[].policy.extAuthz.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`policies[].policy.extAuthz.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`policies[].policy.extAuthz.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -8752,6 +9676,20 @@
 |`policies[].policy.extAuthz.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`policies[].policy.extAuthz.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`policies[].policy.extAuthz.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`policies[].policy.extAuthz.policies.backendAuth.oAuthTokenExchange`|object||
+|`policies[].policy.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`policies[].policy.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`policies[].policy.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`policies[].policy.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`policies[].policy.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`policies[].policy.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`policies[].policy.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`policies[].policy.extAuthz.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`policies[].policy.extAuthz.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`policies[].policy.extAuthz.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`policies[].policy.extAuthz.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`policies[].policy.extAuthz.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`policies[].policy.extAuthz.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`policies[].policy.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`policies[].policy.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`policies[].policy.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -8884,6 +9822,20 @@
 |`policies[].policy.extProc.conditional[].policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`policies[].policy.extProc.conditional[].policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`policies[].policy.extProc.conditional[].policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`policies[].policy.extProc.conditional[].policies.backendAuth.oAuthTokenExchange`|object||
+|`policies[].policy.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`policies[].policy.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`policies[].policy.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`policies[].policy.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`policies[].policy.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`policies[].policy.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`policies[].policy.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`policies[].policy.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`policies[].policy.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`policies[].policy.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`policies[].policy.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`policies[].policy.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`policies[].policy.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`policies[].policy.extProc.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`policies[].policy.extProc.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`policies[].policy.extProc.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -9003,6 +9955,20 @@
 |`policies[].policy.extProc.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`policies[].policy.extProc.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`policies[].policy.extProc.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`policies[].policy.extProc.policies.backendAuth.oAuthTokenExchange`|object||
+|`policies[].policy.extProc.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`policies[].policy.extProc.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`policies[].policy.extProc.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`policies[].policy.extProc.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`policies[].policy.extProc.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`policies[].policy.extProc.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`policies[].policy.extProc.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`policies[].policy.extProc.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`policies[].policy.extProc.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`policies[].policy.extProc.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`policies[].policy.extProc.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`policies[].policy.extProc.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`policies[].policy.extProc.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`policies[].policy.extProc.policies.http`|object|HTTP protocol settings for this backend.|
 |`policies[].policy.extProc.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`policies[].policy.extProc.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -9191,6 +10157,20 @@
 |`backends[].mcp.targets[].policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`backends[].mcp.targets[].policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`backends[].mcp.targets[].policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`backends[].mcp.targets[].policies.backendAuth.oAuthTokenExchange`|object||
+|`backends[].mcp.targets[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`backends[].mcp.targets[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`backends[].mcp.targets[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`backends[].mcp.targets[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`backends[].mcp.targets[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`backends[].mcp.targets[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].mcp.targets[].policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`backends[].mcp.targets[].policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`backends[].mcp.targets[].policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`backends[].mcp.targets[].policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`backends[].mcp.targets[].policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`backends[].mcp.targets[].policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`backends[].mcp.targets[].policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`backends[].mcp.targets[].policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].mcp.targets[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].mcp.targets[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -9305,6 +10285,20 @@
 |`backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange`|object||
+|`backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -9453,6 +10447,20 @@
 |`backends[].ai.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`backends[].ai.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`backends[].ai.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`backends[].ai.policies.backendAuth.oAuthTokenExchange`|object||
+|`backends[].ai.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`backends[].ai.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`backends[].ai.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`backends[].ai.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`backends[].ai.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`backends[].ai.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].ai.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`backends[].ai.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`backends[].ai.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`backends[].ai.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`backends[].ai.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`backends[].ai.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`backends[].ai.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`backends[].ai.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -9582,6 +10590,20 @@
 |`backends[].ai.policies.extAuthz.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`backends[].ai.policies.extAuthz.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`backends[].ai.policies.extAuthz.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`backends[].ai.policies.extAuthz.policies.backendAuth.oAuthTokenExchange`|object||
+|`backends[].ai.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`backends[].ai.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`backends[].ai.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`backends[].ai.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`backends[].ai.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`backends[].ai.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].ai.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`backends[].ai.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`backends[].ai.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`backends[].ai.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`backends[].ai.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`backends[].ai.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`backends[].ai.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`backends[].ai.policies.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.policies.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.policies.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -9718,6 +10740,20 @@
 |`backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange`|object||
+|`backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`backends[].ai.policies.mcpGuardrails.processors[].policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.policies.mcpGuardrails.processors[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.policies.mcpGuardrails.processors[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -9860,6 +10896,20 @@
 |`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange`|object||
+|`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -9966,6 +11016,20 @@
 |`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange`|object||
+|`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -10072,6 +11136,20 @@
 |`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange`|object||
+|`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -10176,6 +11254,20 @@
 |`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange`|object||
+|`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -10315,6 +11407,20 @@
 |`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange`|object||
+|`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -10421,6 +11527,20 @@
 |`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange`|object||
+|`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -10525,6 +11645,20 @@
 |`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange`|object||
+|`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -10696,6 +11830,20 @@
 |`backends[].ai.groups[].providers[].policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`backends[].ai.groups[].providers[].policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`backends[].ai.groups[].providers[].policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`backends[].ai.groups[].providers[].policies.backendAuth.oAuthTokenExchange`|object||
+|`backends[].ai.groups[].providers[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`backends[].ai.groups[].providers[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`backends[].ai.groups[].providers[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`backends[].ai.groups[].providers[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`backends[].ai.groups[].providers[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`backends[].ai.groups[].providers[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].ai.groups[].providers[].policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`backends[].ai.groups[].providers[].policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`backends[].ai.groups[].providers[].policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`backends[].ai.groups[].providers[].policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`backends[].ai.groups[].providers[].policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`backends[].ai.groups[].providers[].policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`backends[].ai.groups[].providers[].policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`backends[].ai.groups[].providers[].policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.groups[].providers[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -10825,6 +11973,20 @@
 |`backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange`|object||
+|`backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`backends[].ai.groups[].providers[].policies.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.groups[].providers[].policies.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -10961,6 +12123,20 @@
 |`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange`|object||
+|`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -11103,6 +12279,20 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange`|object||
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -11209,6 +12399,20 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange`|object||
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -11315,6 +12519,20 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange`|object||
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -11419,6 +12637,20 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange`|object||
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -11558,6 +12790,20 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange`|object||
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -11664,6 +12910,20 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange`|object||
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -11768,6 +13028,20 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange`|object||
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -11907,6 +13181,20 @@
 |`backends[].policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`backends[].policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`backends[].policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`backends[].policies.backendAuth.oAuthTokenExchange`|object||
+|`backends[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`backends[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`backends[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`backends[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`backends[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`backends[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`backends[].policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`backends[].policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`backends[].policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`backends[].policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`backends[].policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`backends[].policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`backends[].policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -12036,6 +13324,20 @@
 |`backends[].policies.extAuthz.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`backends[].policies.extAuthz.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`backends[].policies.extAuthz.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`backends[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange`|object||
+|`backends[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`backends[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`backends[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`backends[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`backends[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`backends[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`backends[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`backends[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`backends[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`backends[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`backends[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`backends[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`backends[].policies.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].policies.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].policies.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -12172,6 +13474,20 @@
 |`backends[].policies.mcpGuardrails.processors[].policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`backends[].policies.mcpGuardrails.processors[].policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`backends[].policies.mcpGuardrails.processors[].policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`backends[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange`|object||
+|`backends[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`backends[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`backends[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`backends[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`backends[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`backends[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`backends[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`backends[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`backends[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`backends[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`backends[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`backends[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`backends[].policies.mcpGuardrails.processors[].policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].policies.mcpGuardrails.processors[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].policies.mcpGuardrails.processors[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -12314,6 +13630,20 @@
 |`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange`|object||
+|`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -12420,6 +13750,20 @@
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange`|object||
+|`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -12526,6 +13870,20 @@
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange`|object||
+|`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -12630,6 +13988,20 @@
 |`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange`|object||
+|`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -12769,6 +14141,20 @@
 |`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange`|object||
+|`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -12875,6 +14261,20 @@
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange`|object||
+|`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -12979,6 +14379,20 @@
 |`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange`|object||
+|`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -13201,6 +14615,20 @@
 |`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange`|object||
+|`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -13365,6 +14793,20 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange`|object||
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -13471,6 +14913,20 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange`|object||
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -13577,6 +15033,20 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange`|object||
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -13681,6 +15151,20 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange`|object||
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -13820,6 +15304,20 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange`|object||
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -13926,6 +15424,20 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange`|object||
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -14030,6 +15542,20 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange`|object||
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -14153,6 +15679,20 @@
 |`routeGroups[].routes[].policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`routeGroups[].routes[].policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`routeGroups[].routes[].policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`routeGroups[].routes[].policies.backendAuth.oAuthTokenExchange`|object||
+|`routeGroups[].routes[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`routeGroups[].routes[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`routeGroups[].routes[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`routeGroups[].routes[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`routeGroups[].routes[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`routeGroups[].routes[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`routeGroups[].routes[].policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`routeGroups[].routes[].policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`routeGroups[].routes[].policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`routeGroups[].routes[].policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`routeGroups[].routes[].policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`routeGroups[].routes[].policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`routeGroups[].routes[].policies.localRateLimit`|object|Local rate limits for incoming requests.|
 |`routeGroups[].routes[].policies.localRateLimit.conditional`|[]object|conditional policy entries. An entry without a condition must be the final fallback.|
 |`routeGroups[].routes[].policies.localRateLimit.conditional[].condition`|string|condition must evaluate to true for this policy to execute. If unset, the policy is the fallback.|
@@ -14256,6 +15796,20 @@
 |`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange`|object||
+|`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -14372,6 +15926,20 @@
 |`routeGroups[].routes[].policies.remoteRateLimit.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`routeGroups[].routes[].policies.remoteRateLimit.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`routeGroups[].routes[].policies.remoteRateLimit.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`routeGroups[].routes[].policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange`|object||
+|`routeGroups[].routes[].policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`routeGroups[].routes[].policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`routeGroups[].routes[].policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`routeGroups[].routes[].policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`routeGroups[].routes[].policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`routeGroups[].routes[].policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`routeGroups[].routes[].policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`routeGroups[].routes[].policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`routeGroups[].routes[].policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`routeGroups[].routes[].policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`routeGroups[].routes[].policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`routeGroups[].routes[].policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`routeGroups[].routes[].policies.remoteRateLimit.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.remoteRateLimit.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].policies.remoteRateLimit.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -14563,6 +16131,20 @@
 |`routeGroups[].routes[].policies.extAuthz.conditional[].policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`routeGroups[].routes[].policies.extAuthz.conditional[].policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`routeGroups[].routes[].policies.extAuthz.conditional[].policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`routeGroups[].routes[].policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange`|object||
+|`routeGroups[].routes[].policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`routeGroups[].routes[].policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`routeGroups[].routes[].policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`routeGroups[].routes[].policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`routeGroups[].routes[].policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`routeGroups[].routes[].policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`routeGroups[].routes[].policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`routeGroups[].routes[].policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`routeGroups[].routes[].policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`routeGroups[].routes[].policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`routeGroups[].routes[].policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`routeGroups[].routes[].policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`routeGroups[].routes[].policies.extAuthz.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.extAuthz.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].policies.extAuthz.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -14692,6 +16274,20 @@
 |`routeGroups[].routes[].policies.extAuthz.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`routeGroups[].routes[].policies.extAuthz.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`routeGroups[].routes[].policies.extAuthz.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`routeGroups[].routes[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange`|object||
+|`routeGroups[].routes[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`routeGroups[].routes[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`routeGroups[].routes[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`routeGroups[].routes[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`routeGroups[].routes[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`routeGroups[].routes[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`routeGroups[].routes[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`routeGroups[].routes[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`routeGroups[].routes[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`routeGroups[].routes[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`routeGroups[].routes[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`routeGroups[].routes[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`routeGroups[].routes[].policies.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].policies.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -14824,6 +16420,20 @@
 |`routeGroups[].routes[].policies.extProc.conditional[].policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`routeGroups[].routes[].policies.extProc.conditional[].policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`routeGroups[].routes[].policies.extProc.conditional[].policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`routeGroups[].routes[].policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange`|object||
+|`routeGroups[].routes[].policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`routeGroups[].routes[].policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`routeGroups[].routes[].policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`routeGroups[].routes[].policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`routeGroups[].routes[].policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`routeGroups[].routes[].policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`routeGroups[].routes[].policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`routeGroups[].routes[].policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`routeGroups[].routes[].policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`routeGroups[].routes[].policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`routeGroups[].routes[].policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`routeGroups[].routes[].policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`routeGroups[].routes[].policies.extProc.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.extProc.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].policies.extProc.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -14943,6 +16553,20 @@
 |`routeGroups[].routes[].policies.extProc.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`routeGroups[].routes[].policies.extProc.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`routeGroups[].routes[].policies.extProc.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`routeGroups[].routes[].policies.extProc.policies.backendAuth.oAuthTokenExchange`|object||
+|`routeGroups[].routes[].policies.extProc.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`routeGroups[].routes[].policies.extProc.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`routeGroups[].routes[].policies.extProc.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`routeGroups[].routes[].policies.extProc.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`routeGroups[].routes[].policies.extProc.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`routeGroups[].routes[].policies.extProc.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].policies.extProc.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`routeGroups[].routes[].policies.extProc.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`routeGroups[].routes[].policies.extProc.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`routeGroups[].routes[].policies.extProc.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`routeGroups[].routes[].policies.extProc.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`routeGroups[].routes[].policies.extProc.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`routeGroups[].routes[].policies.extProc.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`routeGroups[].routes[].policies.extProc.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.extProc.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].policies.extProc.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -15134,6 +16758,20 @@
 |`routeGroups[].routes[].backends[].mcp.targets[].policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`routeGroups[].routes[].backends[].mcp.targets[].policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`routeGroups[].routes[].backends[].mcp.targets[].policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`routeGroups[].routes[].backends[].mcp.targets[].policies.backendAuth.oAuthTokenExchange`|object||
+|`routeGroups[].routes[].backends[].mcp.targets[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`routeGroups[].routes[].backends[].mcp.targets[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`routeGroups[].routes[].backends[].mcp.targets[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`routeGroups[].routes[].backends[].mcp.targets[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`routeGroups[].routes[].backends[].mcp.targets[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`routeGroups[].routes[].backends[].mcp.targets[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].mcp.targets[].policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`routeGroups[].routes[].backends[].mcp.targets[].policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`routeGroups[].routes[].backends[].mcp.targets[].policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`routeGroups[].routes[].backends[].mcp.targets[].policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`routeGroups[].routes[].backends[].mcp.targets[].policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`routeGroups[].routes[].backends[].mcp.targets[].policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`routeGroups[].routes[].backends[].mcp.targets[].policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`routeGroups[].routes[].backends[].mcp.targets[].policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].mcp.targets[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].mcp.targets[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -15248,6 +16886,20 @@
 |`routeGroups[].routes[].backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`routeGroups[].routes[].backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`routeGroups[].routes[].backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`routeGroups[].routes[].backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange`|object||
+|`routeGroups[].routes[].backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`routeGroups[].routes[].backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`routeGroups[].routes[].backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`routeGroups[].routes[].backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`routeGroups[].routes[].backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`routeGroups[].routes[].backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`routeGroups[].routes[].backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`routeGroups[].routes[].backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`routeGroups[].routes[].backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`routeGroups[].routes[].backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`routeGroups[].routes[].backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`routeGroups[].routes[].backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`routeGroups[].routes[].backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].mcp.targets[].policies.mcpGuardrails.processors[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -15396,6 +17048,20 @@
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`routeGroups[].routes[].backends[].ai.policies.backendAuth.oAuthTokenExchange`|object||
+|`routeGroups[].routes[].backends[].ai.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`routeGroups[].routes[].backends[].ai.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`routeGroups[].routes[].backends[].ai.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`routeGroups[].routes[].backends[].ai.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`routeGroups[].routes[].backends[].ai.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`routeGroups[].routes[].backends[].ai.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].ai.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`routeGroups[].routes[].backends[].ai.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`routeGroups[].routes[].backends[].ai.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`routeGroups[].routes[].backends[].ai.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`routeGroups[].routes[].backends[].ai.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`routeGroups[].routes[].backends[].ai.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`routeGroups[].routes[].backends[].ai.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`routeGroups[].routes[].backends[].ai.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -15525,6 +17191,20 @@
 |`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.oAuthTokenExchange`|object||
+|`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -15661,6 +17341,20 @@
 |`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange`|object||
+|`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -15803,6 +17497,20 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange`|object||
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -15909,6 +17617,20 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange`|object||
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -16015,6 +17737,20 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange`|object||
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -16119,6 +17855,20 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange`|object||
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -16258,6 +18008,20 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange`|object||
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -16364,6 +18128,20 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange`|object||
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -16468,6 +18246,20 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange`|object||
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -16639,6 +18431,20 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oAuthTokenExchange`|object||
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -16768,6 +18574,20 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange`|object||
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -16904,6 +18724,20 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange`|object||
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -17046,6 +18880,20 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange`|object||
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -17152,6 +19000,20 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange`|object||
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -17258,6 +19120,20 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange`|object||
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -17362,6 +19238,20 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange`|object||
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -17501,6 +19391,20 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange`|object||
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -17607,6 +19511,20 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange`|object||
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -17711,6 +19629,20 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange`|object||
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -17852,6 +19784,20 @@
 |`routeGroups[].routes[].backends[].policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`routeGroups[].routes[].backends[].policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`routeGroups[].routes[].backends[].policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`routeGroups[].routes[].backends[].policies.backendAuth.oAuthTokenExchange`|object||
+|`routeGroups[].routes[].backends[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`routeGroups[].routes[].backends[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`routeGroups[].routes[].backends[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`routeGroups[].routes[].backends[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`routeGroups[].routes[].backends[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`routeGroups[].routes[].backends[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`routeGroups[].routes[].backends[].policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`routeGroups[].routes[].backends[].policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`routeGroups[].routes[].backends[].policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`routeGroups[].routes[].backends[].policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`routeGroups[].routes[].backends[].policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`routeGroups[].routes[].backends[].policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`routeGroups[].routes[].backends[].policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -17981,6 +19927,20 @@
 |`routeGroups[].routes[].backends[].policies.extAuthz.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`routeGroups[].routes[].backends[].policies.extAuthz.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`routeGroups[].routes[].backends[].policies.extAuthz.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`routeGroups[].routes[].backends[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange`|object||
+|`routeGroups[].routes[].backends[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`routeGroups[].routes[].backends[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`routeGroups[].routes[].backends[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`routeGroups[].routes[].backends[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`routeGroups[].routes[].backends[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`routeGroups[].routes[].backends[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`routeGroups[].routes[].backends[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`routeGroups[].routes[].backends[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`routeGroups[].routes[].backends[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`routeGroups[].routes[].backends[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`routeGroups[].routes[].backends[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`routeGroups[].routes[].backends[].policies.extAuthz.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`routeGroups[].routes[].backends[].policies.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].policies.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -18117,6 +20077,20 @@
 |`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange`|object||
+|`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -18259,6 +20233,20 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange`|object||
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -18365,6 +20353,20 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange`|object||
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -18471,6 +20473,20 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange`|object||
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -18575,6 +20591,20 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange`|object||
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -18714,6 +20744,20 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange`|object||
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -18820,6 +20864,20 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange`|object||
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -18924,6 +20982,20 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange`|object||
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -19101,6 +21173,20 @@
 |`llm.providers[].defaults.auth.azure.explicitConfig.workloadIdentity`|object||
 |`llm.providers[].defaults.auth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`llm.providers[].defaults.auth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`llm.providers[].defaults.auth.oAuthTokenExchange`|object||
+|`llm.providers[].defaults.auth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`llm.providers[].defaults.auth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`llm.providers[].defaults.auth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`llm.providers[].defaults.auth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`llm.providers[].defaults.auth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`llm.providers[].defaults.auth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.providers[].defaults.auth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`llm.providers[].defaults.auth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`llm.providers[].defaults.auth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`llm.providers[].defaults.auth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`llm.providers[].defaults.auth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`llm.providers[].defaults.auth.oAuthTokenExchange.clientAuth`|object||
+|`llm.providers[].defaults.auth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`llm.providers[].defaults.health`|object|Local/config health policy with CEL as string; converted to Policy by compiling the expression.<br>Mirrors the proto `Health` message structure.|
 |`llm.providers[].defaults.health.unhealthyExpression`|string|CEL expression where `true` marks the backend response as unhealthy.<br>When unset, any 5xx response or connection failure is treated as unhealthy.|
 |`llm.providers[].defaults.health.eviction`|object|Settings for temporarily removing unhealthy backends.|
@@ -19240,6 +21326,20 @@
 |`llm.models[].auth.azure.explicitConfig.workloadIdentity`|object||
 |`llm.models[].auth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`llm.models[].auth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`llm.models[].auth.oAuthTokenExchange`|object||
+|`llm.models[].auth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`llm.models[].auth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`llm.models[].auth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`llm.models[].auth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`llm.models[].auth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`llm.models[].auth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.models[].auth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`llm.models[].auth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`llm.models[].auth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`llm.models[].auth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`llm.models[].auth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`llm.models[].auth.oAuthTokenExchange.clientAuth`|object||
+|`llm.models[].auth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`llm.models[].health`|object|health configures outlier detection for this model backend.|
 |`llm.models[].health.unhealthyExpression`|string|CEL expression where `true` marks the backend response as unhealthy.<br>When unset, any 5xx response or connection failure is treated as unhealthy.|
 |`llm.models[].health.eviction`|object|Settings for temporarily removing unhealthy backends.|
@@ -19360,6 +21460,20 @@
 |`llm.models[].guardrails.request[].openAIModeration.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`llm.models[].guardrails.request[].openAIModeration.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`llm.models[].guardrails.request[].openAIModeration.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`llm.models[].guardrails.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange`|object||
+|`llm.models[].guardrails.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`llm.models[].guardrails.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`llm.models[].guardrails.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`llm.models[].guardrails.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`llm.models[].guardrails.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`llm.models[].guardrails.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.models[].guardrails.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`llm.models[].guardrails.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`llm.models[].guardrails.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`llm.models[].guardrails.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`llm.models[].guardrails.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`llm.models[].guardrails.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`llm.models[].guardrails.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`llm.models[].guardrails.request[].openAIModeration.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.models[].guardrails.request[].openAIModeration.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.models[].guardrails.request[].openAIModeration.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -19466,6 +21580,20 @@
 |`llm.models[].guardrails.request[].bedrockGuardrails.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`llm.models[].guardrails.request[].bedrockGuardrails.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`llm.models[].guardrails.request[].bedrockGuardrails.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`llm.models[].guardrails.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange`|object||
+|`llm.models[].guardrails.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`llm.models[].guardrails.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`llm.models[].guardrails.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`llm.models[].guardrails.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`llm.models[].guardrails.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`llm.models[].guardrails.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.models[].guardrails.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`llm.models[].guardrails.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`llm.models[].guardrails.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`llm.models[].guardrails.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`llm.models[].guardrails.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`llm.models[].guardrails.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`llm.models[].guardrails.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`llm.models[].guardrails.request[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.models[].guardrails.request[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.models[].guardrails.request[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -19572,6 +21700,20 @@
 |`llm.models[].guardrails.request[].googleModelArmor.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`llm.models[].guardrails.request[].googleModelArmor.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`llm.models[].guardrails.request[].googleModelArmor.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`llm.models[].guardrails.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange`|object||
+|`llm.models[].guardrails.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`llm.models[].guardrails.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`llm.models[].guardrails.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`llm.models[].guardrails.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`llm.models[].guardrails.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`llm.models[].guardrails.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.models[].guardrails.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`llm.models[].guardrails.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`llm.models[].guardrails.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`llm.models[].guardrails.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`llm.models[].guardrails.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`llm.models[].guardrails.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`llm.models[].guardrails.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`llm.models[].guardrails.request[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.models[].guardrails.request[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.models[].guardrails.request[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -19676,6 +21818,20 @@
 |`llm.models[].guardrails.request[].azureContentSafety.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`llm.models[].guardrails.request[].azureContentSafety.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`llm.models[].guardrails.request[].azureContentSafety.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`llm.models[].guardrails.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange`|object||
+|`llm.models[].guardrails.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`llm.models[].guardrails.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`llm.models[].guardrails.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`llm.models[].guardrails.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`llm.models[].guardrails.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`llm.models[].guardrails.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.models[].guardrails.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`llm.models[].guardrails.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`llm.models[].guardrails.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`llm.models[].guardrails.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`llm.models[].guardrails.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`llm.models[].guardrails.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`llm.models[].guardrails.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`llm.models[].guardrails.request[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.models[].guardrails.request[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.models[].guardrails.request[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -19815,6 +21971,20 @@
 |`llm.models[].guardrails.response[].bedrockGuardrails.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`llm.models[].guardrails.response[].bedrockGuardrails.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`llm.models[].guardrails.response[].bedrockGuardrails.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`llm.models[].guardrails.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange`|object||
+|`llm.models[].guardrails.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`llm.models[].guardrails.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`llm.models[].guardrails.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`llm.models[].guardrails.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`llm.models[].guardrails.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`llm.models[].guardrails.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.models[].guardrails.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`llm.models[].guardrails.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`llm.models[].guardrails.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`llm.models[].guardrails.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`llm.models[].guardrails.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`llm.models[].guardrails.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`llm.models[].guardrails.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`llm.models[].guardrails.response[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.models[].guardrails.response[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.models[].guardrails.response[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -19921,6 +22091,20 @@
 |`llm.models[].guardrails.response[].googleModelArmor.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`llm.models[].guardrails.response[].googleModelArmor.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`llm.models[].guardrails.response[].googleModelArmor.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`llm.models[].guardrails.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange`|object||
+|`llm.models[].guardrails.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`llm.models[].guardrails.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`llm.models[].guardrails.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`llm.models[].guardrails.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`llm.models[].guardrails.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`llm.models[].guardrails.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.models[].guardrails.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`llm.models[].guardrails.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`llm.models[].guardrails.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`llm.models[].guardrails.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`llm.models[].guardrails.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`llm.models[].guardrails.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`llm.models[].guardrails.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`llm.models[].guardrails.response[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.models[].guardrails.response[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.models[].guardrails.response[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -20025,6 +22209,20 @@
 |`llm.models[].guardrails.response[].azureContentSafety.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`llm.models[].guardrails.response[].azureContentSafety.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`llm.models[].guardrails.response[].azureContentSafety.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`llm.models[].guardrails.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange`|object||
+|`llm.models[].guardrails.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`llm.models[].guardrails.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`llm.models[].guardrails.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`llm.models[].guardrails.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`llm.models[].guardrails.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`llm.models[].guardrails.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.models[].guardrails.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`llm.models[].guardrails.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`llm.models[].guardrails.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`llm.models[].guardrails.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`llm.models[].guardrails.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`llm.models[].guardrails.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`llm.models[].guardrails.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`llm.models[].guardrails.response[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.models[].guardrails.response[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.models[].guardrails.response[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -20224,6 +22422,20 @@
 |`llm.policies.extAuthz.conditional[].policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`llm.policies.extAuthz.conditional[].policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`llm.policies.extAuthz.conditional[].policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`llm.policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange`|object||
+|`llm.policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`llm.policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`llm.policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`llm.policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`llm.policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`llm.policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`llm.policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`llm.policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`llm.policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`llm.policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`llm.policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`llm.policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`llm.policies.extAuthz.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.policies.extAuthz.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.policies.extAuthz.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -20353,6 +22565,20 @@
 |`llm.policies.extAuthz.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`llm.policies.extAuthz.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`llm.policies.extAuthz.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`llm.policies.extAuthz.policies.backendAuth.oAuthTokenExchange`|object||
+|`llm.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`llm.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`llm.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`llm.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`llm.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`llm.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`llm.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`llm.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`llm.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`llm.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`llm.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`llm.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`llm.policies.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.policies.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.policies.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -20485,6 +22711,20 @@
 |`llm.policies.extProc.conditional[].policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`llm.policies.extProc.conditional[].policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`llm.policies.extProc.conditional[].policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`llm.policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange`|object||
+|`llm.policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`llm.policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`llm.policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`llm.policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`llm.policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`llm.policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`llm.policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`llm.policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`llm.policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`llm.policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`llm.policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`llm.policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`llm.policies.extProc.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.policies.extProc.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.policies.extProc.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -20604,6 +22844,20 @@
 |`llm.policies.extProc.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`llm.policies.extProc.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`llm.policies.extProc.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`llm.policies.extProc.policies.backendAuth.oAuthTokenExchange`|object||
+|`llm.policies.extProc.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`llm.policies.extProc.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`llm.policies.extProc.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`llm.policies.extProc.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`llm.policies.extProc.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`llm.policies.extProc.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.policies.extProc.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`llm.policies.extProc.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`llm.policies.extProc.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`llm.policies.extProc.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`llm.policies.extProc.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`llm.policies.extProc.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`llm.policies.extProc.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`llm.policies.extProc.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.policies.extProc.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.policies.extProc.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -20806,6 +23060,20 @@
 |`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange`|object||
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`llm.policies.guardrails.request[].openAIModeration.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.policies.guardrails.request[].openAIModeration.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.policies.guardrails.request[].openAIModeration.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -20912,6 +23180,20 @@
 |`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange`|object||
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`llm.policies.guardrails.request[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.policies.guardrails.request[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.policies.guardrails.request[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -21018,6 +23300,20 @@
 |`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange`|object||
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`llm.policies.guardrails.request[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.policies.guardrails.request[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.policies.guardrails.request[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -21122,6 +23418,20 @@
 |`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange`|object||
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`llm.policies.guardrails.request[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.policies.guardrails.request[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.policies.guardrails.request[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -21261,6 +23571,20 @@
 |`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange`|object||
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`llm.policies.guardrails.response[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.policies.guardrails.response[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.policies.guardrails.response[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -21367,6 +23691,20 @@
 |`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange`|object||
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`llm.policies.guardrails.response[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.policies.guardrails.response[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.policies.guardrails.response[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -21471,6 +23809,20 @@
 |`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange`|object||
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`llm.policies.guardrails.response[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.policies.guardrails.response[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.policies.guardrails.response[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -21599,6 +23951,20 @@
 |`llm.policies.remoteRateLimit.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`llm.policies.remoteRateLimit.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`llm.policies.remoteRateLimit.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`llm.policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange`|object||
+|`llm.policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`llm.policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`llm.policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`llm.policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`llm.policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`llm.policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`llm.policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`llm.policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`llm.policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`llm.policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`llm.policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`llm.policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`llm.policies.remoteRateLimit.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.policies.remoteRateLimit.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.policies.remoteRateLimit.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -21736,6 +24102,20 @@
 |`mcp.targets[].policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`mcp.targets[].policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`mcp.targets[].policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`mcp.targets[].policies.backendAuth.oAuthTokenExchange`|object||
+|`mcp.targets[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`mcp.targets[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`mcp.targets[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`mcp.targets[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`mcp.targets[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`mcp.targets[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`mcp.targets[].policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`mcp.targets[].policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`mcp.targets[].policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`mcp.targets[].policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`mcp.targets[].policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`mcp.targets[].policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`mcp.targets[].policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`mcp.targets[].policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.targets[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.targets[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -21850,6 +24230,20 @@
 |`mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange`|object||
+|`mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`mcp.targets[].policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`mcp.targets[].policies.mcpGuardrails.processors[].policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.targets[].policies.mcpGuardrails.processors[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.targets[].policies.mcpGuardrails.processors[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -22027,6 +24421,20 @@
 |`mcp.policies.mcpGuardrails.processors[].policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`mcp.policies.mcpGuardrails.processors[].policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`mcp.policies.mcpGuardrails.processors[].policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`mcp.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange`|object||
+|`mcp.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`mcp.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`mcp.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`mcp.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`mcp.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`mcp.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`mcp.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`mcp.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`mcp.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`mcp.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`mcp.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`mcp.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`mcp.policies.mcpGuardrails.processors[].policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`mcp.policies.mcpGuardrails.processors[].policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.policies.mcpGuardrails.processors[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.policies.mcpGuardrails.processors[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -22191,6 +24599,20 @@
 |`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange`|object||
+|`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -22297,6 +24719,20 @@
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange`|object||
+|`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -22403,6 +24839,20 @@
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange`|object||
+|`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -22507,6 +24957,20 @@
 |`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange`|object||
+|`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -22646,6 +25110,20 @@
 |`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange`|object||
+|`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -22752,6 +25230,20 @@
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange`|object||
+|`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -22856,6 +25348,20 @@
 |`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange`|object||
+|`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -22979,6 +25485,20 @@
 |`mcp.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`mcp.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`mcp.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`mcp.policies.backendAuth.oAuthTokenExchange`|object||
+|`mcp.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`mcp.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`mcp.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`mcp.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`mcp.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`mcp.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`mcp.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`mcp.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`mcp.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`mcp.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`mcp.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`mcp.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`mcp.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`mcp.policies.localRateLimit`|object|Local rate limits for incoming requests.|
 |`mcp.policies.localRateLimit.conditional`|[]object|conditional policy entries. An entry without a condition must be the final fallback.|
 |`mcp.policies.localRateLimit.conditional[].condition`|string|condition must evaluate to true for this policy to execute. If unset, the policy is the fallback.|
@@ -23082,6 +25602,20 @@
 |`mcp.policies.remoteRateLimit.conditional[].policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`mcp.policies.remoteRateLimit.conditional[].policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`mcp.policies.remoteRateLimit.conditional[].policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`mcp.policies.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange`|object||
+|`mcp.policies.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`mcp.policies.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`mcp.policies.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`mcp.policies.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`mcp.policies.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`mcp.policies.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`mcp.policies.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`mcp.policies.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`mcp.policies.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`mcp.policies.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`mcp.policies.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`mcp.policies.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`mcp.policies.remoteRateLimit.conditional[].policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`mcp.policies.remoteRateLimit.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.policies.remoteRateLimit.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.policies.remoteRateLimit.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -23198,6 +25732,20 @@
 |`mcp.policies.remoteRateLimit.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`mcp.policies.remoteRateLimit.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`mcp.policies.remoteRateLimit.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`mcp.policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange`|object||
+|`mcp.policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`mcp.policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`mcp.policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`mcp.policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`mcp.policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`mcp.policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`mcp.policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`mcp.policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`mcp.policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`mcp.policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`mcp.policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`mcp.policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`mcp.policies.remoteRateLimit.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`mcp.policies.remoteRateLimit.policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.policies.remoteRateLimit.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.policies.remoteRateLimit.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -23389,6 +25937,20 @@
 |`mcp.policies.extAuthz.conditional[].policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`mcp.policies.extAuthz.conditional[].policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`mcp.policies.extAuthz.conditional[].policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`mcp.policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange`|object||
+|`mcp.policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`mcp.policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`mcp.policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`mcp.policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`mcp.policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`mcp.policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`mcp.policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`mcp.policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`mcp.policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`mcp.policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`mcp.policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`mcp.policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`mcp.policies.extAuthz.conditional[].policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`mcp.policies.extAuthz.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.policies.extAuthz.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.policies.extAuthz.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -23518,6 +26080,20 @@
 |`mcp.policies.extAuthz.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`mcp.policies.extAuthz.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`mcp.policies.extAuthz.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`mcp.policies.extAuthz.policies.backendAuth.oAuthTokenExchange`|object||
+|`mcp.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`mcp.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`mcp.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`mcp.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`mcp.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`mcp.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`mcp.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`mcp.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`mcp.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`mcp.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`mcp.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`mcp.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`mcp.policies.extAuthz.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`mcp.policies.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.policies.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.policies.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -23650,6 +26226,20 @@
 |`mcp.policies.extProc.conditional[].policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`mcp.policies.extProc.conditional[].policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`mcp.policies.extProc.conditional[].policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`mcp.policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange`|object||
+|`mcp.policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`mcp.policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`mcp.policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`mcp.policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`mcp.policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`mcp.policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`mcp.policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`mcp.policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`mcp.policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`mcp.policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`mcp.policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`mcp.policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`mcp.policies.extProc.conditional[].policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`mcp.policies.extProc.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.policies.extProc.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.policies.extProc.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
@@ -23769,6 +26359,20 @@
 |`mcp.policies.extProc.policies.backendAuth.azure.explicitConfig.workloadIdentity`|object||
 |`mcp.policies.extProc.policies.backendAuth.azure.developerImplicit`|object|Use implicit Azure auth. Note that this is for developer use-cases only!|
 |`mcp.policies.extProc.policies.backendAuth.azure.implicit`|object|Automatically detect authentication method based on environment.<br>Uses Workload Identity on K8s, Managed Identity on Azure VMs, or Developer Tools locally.|
+|`mcp.policies.extProc.policies.backendAuth.oAuthTokenExchange`|object||
+|`mcp.policies.extProc.policies.backendAuth.oAuthTokenExchange.tokenEndpoint`|object|Backend serving the RFC 8693 token endpoint.<br>Exactly one of service, host, or backend may be set.|
+|`mcp.policies.extProc.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service`|object|Service reference. Service must be defined in the top level services list.|
+|`mcp.policies.extProc.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.name`|string||
+|`mcp.policies.extProc.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.service.port`|integer||
+|`mcp.policies.extProc.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.host`|string|Hostname or IP address|
+|`mcp.policies.extProc.policies.backendAuth.oAuthTokenExchange.tokenEndpoint.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`mcp.policies.extProc.policies.backendAuth.oAuthTokenExchange.tokenEndpointPath`|string|Token endpoint path on the backend; defaults to "/".|
+|`mcp.policies.extProc.policies.backendAuth.oAuthTokenExchange.audiences`|[]string|`audience` parameters naming the target services at the authorization server.|
+|`mcp.policies.extProc.policies.backendAuth.oAuthTokenExchange.scopes`|[]string|`scope` values for the requested token, sent space-delimited.|
+|`mcp.policies.extProc.policies.backendAuth.oAuthTokenExchange.resources`|[]string|`resource` parameters with the target service URIs.|
+|`mcp.policies.extProc.policies.backendAuth.oAuthTokenExchange.requestedTokenType`|string|`requested_token_type` parameter; the server picks when unset.|
+|`mcp.policies.extProc.policies.backendAuth.oAuthTokenExchange.clientAuth`|object||
+|`mcp.policies.extProc.policies.backendAuth.oAuthTokenExchange.clientAuth.clientId`|string|`client_id` parameter identifying the gateway at the authorization server.|
 |`mcp.policies.extProc.policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.policies.extProc.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.policies.extProc.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|


### PR DESCRIPTION
## What

Adds a `tokenExchange` backend auth mode: the gateway exchanges the inbound
user's bearer token at a configured RFC 8693 token endpoint and sends the
resulting token as the upstream `Authorization: Bearer`. This lets one gateway
front multiple upstreams that each require their own per-user credential,
natively rather than hand-rolling the exchange in ext_proc.

```yaml
backendAuth:
  tokenExchange:
    tokenEndpoint: https://idp.example.com/oauth/v2/token
    audience: upstream-api          # optional
    scope: read write               # optional
    resource: https://upstream/api  # optional
    requestedTokenType: ...         # optional
    clientId: gateway               # optional (public-client identification)
```

## Design notes

- **Subject token type is `access_token`.** Backend auth runs at the egress
  step of a client→resource call, so the inbound bearer is, by OAuth role, an
  access token regardless of JWT/opaque format. `fetch_token` takes the type as
  a parameter so a future cross-domain federation caller can pass `jwt`/`id_token`,
  but the only sourcing path today is the resource-facing bearer.
- **Client identification** via optional `clientId` (RFC 6749 §3.2.1 public client).
  Confidential-client authentication (`client_secret_basic`/`post`) is a planned
  follow-up.

## Verified

Manually verified end-to-end against a local ZITADEL (public client, token-exchange
grant enabled): inbound user JWT → exchanged at ZITADEL → upstream received the
exchanged token (not the original), which resolves at ZITADEL's `userinfo` to the
original subject; repeated calls served from cache.

## Relation to existing issues

- #239, #2064 — the per-user-auth-to-external-MCP problem this addresses.
- #2021 / #2027 — `jwt.rawToken` enabled doing this in ext_proc; this is the native path.
- #2029 — implements the "general RFC 8693 tokenExchange policy" shape discussed there;
  `requestedTokenType` is in place for the ID-JAG flow.

## Out of scope / follow-ups

- Confidential client auth (`client_secret_basic`/`post`).
- An `examples/` entry — naturally lands on the existing `examples/mcp-authentication`
  Keycloak scaffold once confidential-client auth exists (Keycloak token exchange
  requires it).
