### PR TITLE
fix(bedrock): set toolConfig when messages carry tool history but request omits tools

### DIFF
--- a/crates/agentgateway/src/llm/conversion/bedrock.rs
+++ b/crates/agentgateway/src/llm/conversion/bedrock.rs
@@ -669,6 +669,7 @@ pub mod from_completions {
 			}
 		}
 
+		super::helpers::ensure_tool_config_for_history(&mut bedrock_request);
 		bedrock_request
 	}
 
@@ -1403,7 +1404,7 @@ pub mod from_messages {
 			Some(metadata)
 		};
 
-		Ok(bedrock::ConverseRequest {
+		let mut bedrock_request = bedrock::ConverseRequest {
 			model_id: req.model,
 			messages,
 			system: system_content,
@@ -1416,7 +1417,9 @@ pub mod from_messages {
 			additional_model_response_field_paths: None,
 			request_metadata: metadata,
 			performance_config: None,
-		})
+		};
+		super::helpers::ensure_tool_config_for_history(&mut bedrock_request);
+		Ok(bedrock_request)
 	}
 
 	fn messages_output_format_to_bedrock_output_config(
@@ -2207,6 +2210,7 @@ pub mod from_responses {
 				.and_then(|tc| tc.tool_choice.as_ref())
 		);
 
+		super::helpers::ensure_tool_config_for_history(&mut bedrock_request);
 		bedrock_request
 	}
 
@@ -2735,6 +2739,49 @@ mod helpers {
 			.collect()
 	});
 	use crate::llm::types::bedrock;
+
+	/// Bedrock's Converse API rejects any request whose messages contain `toolUse` or
+	/// `toolResult` content blocks unless a `toolConfig` is also present — even on a
+	/// follow-up or summary turn that legitimately omits `tools` (which the OpenAI and
+	/// Anthropic Messages APIs both allow). When a translated request carries tool history
+	/// but no `toolConfig`, reconstruct a minimal one from the tool names referenced in the
+	/// history so Bedrock accepts the request instead of returning a 400.
+	pub fn ensure_tool_config_for_history(req: &mut bedrock::ConverseRequest) {
+		if req.tool_config.is_some() {
+			return;
+		}
+		let mut seen = std::collections::BTreeSet::new();
+		let mut tools = Vec::new();
+		let mut has_tool_blocks = false;
+		for msg in &req.messages {
+			for block in &msg.content {
+				match block {
+					bedrock::ContentBlock::ToolUse(tool_use) => {
+						has_tool_blocks = true;
+						if seen.insert(tool_use.name.clone()) {
+							tools.push(bedrock::Tool::ToolSpec(bedrock::ToolSpecification {
+								name: tool_use.name.clone(),
+								description: None,
+								// The original schema is unavailable on a tools-less turn; a permissive
+								// object schema is enough for Bedrock to validate the tool history.
+								input_schema: Some(bedrock::ToolInputSchema::Json(
+									serde_json::json!({ "type": "object" }),
+								)),
+							}));
+						}
+					},
+					bedrock::ContentBlock::ToolResult(_) => has_tool_blocks = true,
+					_ => {},
+				}
+			}
+		}
+		if has_tool_blocks && !tools.is_empty() {
+			req.tool_config = Some(bedrock::ToolConfiguration {
+				tools,
+				tool_choice: None,
+			});
+		}
+	}
 
 	pub fn create_cache_point() -> bedrock::CachePointBlock {
 		bedrock::CachePointBlock {

--- a/crates/agentgateway/src/llm/conversion/bedrock_tests.rs
+++ b/crates/agentgateway/src/llm/conversion/bedrock_tests.rs
@@ -1497,3 +1497,125 @@ fn test_insert_cache_point_empty_messages_noop() {
 	helpers::insert_message_cache_point(&mut msgs, 0);
 	assert!(msgs.is_empty());
 }
+
+fn make_tool_use_message(call_id: &str, tool_name: &str) -> types::bedrock::Message {
+	types::bedrock::Message {
+		role: types::bedrock::Role::Assistant,
+		content: vec![types::bedrock::ContentBlock::ToolUse(
+			types::bedrock::ToolUseBlock {
+				tool_use_id: call_id.to_string(),
+				name: tool_name.to_string(),
+				input: json!({}),
+			},
+		)],
+	}
+}
+
+fn make_tool_result_message(call_id: &str) -> types::bedrock::Message {
+	types::bedrock::Message {
+		role: types::bedrock::Role::User,
+		content: vec![types::bedrock::ContentBlock::ToolResult(
+			types::bedrock::ToolResultBlock {
+				tool_use_id: call_id.to_string(),
+				content: vec![types::bedrock::ToolResultContentBlock::Text(
+					"done".to_string(),
+				)],
+				status: None,
+			},
+		)],
+	}
+}
+
+fn request_with(messages: Vec<types::bedrock::Message>) -> types::bedrock::ConverseRequest {
+	types::bedrock::ConverseRequest {
+		model_id: "amazon.nova-pro-v1:0".to_string(),
+		messages,
+		system: None,
+		inference_config: None,
+		output_config: None,
+		tool_config: None,
+		guardrail_config: None,
+		additional_model_request_fields: None,
+		prompt_variables: None,
+		additional_model_response_field_paths: None,
+		request_metadata: None,
+		performance_config: None,
+	}
+}
+
+#[test]
+fn test_ensure_tool_config_reconstructs_from_history() {
+	// A tools-less follow-up turn that still carries tool history (an assistant `toolUse`
+	// plus its `toolResult`). Bedrock requires `toolConfig` here, so it must be reconstructed.
+	let mut req = request_with(vec![
+		make_message(types::bedrock::Role::User, "list the pods"),
+		make_tool_use_message("call_1", "get_pods"),
+		make_tool_result_message("call_1"),
+	]);
+
+	helpers::ensure_tool_config_for_history(&mut req);
+
+	let tool_config = req
+		.tool_config
+		.expect("toolConfig must be reconstructed when messages carry tool history");
+	assert_eq!(tool_config.tools.len(), 1);
+	match &tool_config.tools[0] {
+		types::bedrock::Tool::ToolSpec(spec) => assert_eq!(spec.name, "get_pods"),
+		_ => panic!("expected a reconstructed ToolSpec"),
+	}
+}
+
+#[test]
+fn test_ensure_tool_config_dedups_repeated_tools() {
+	let mut req = request_with(vec![
+		make_tool_use_message("call_1", "get_pods"),
+		make_tool_result_message("call_1"),
+		make_tool_use_message("call_2", "get_pods"),
+		make_tool_result_message("call_2"),
+	]);
+
+	helpers::ensure_tool_config_for_history(&mut req);
+
+	let tool_config = req.tool_config.expect("toolConfig must be reconstructed");
+	assert_eq!(
+		tool_config.tools.len(),
+		1,
+		"repeated tool names must be de-duplicated"
+	);
+}
+
+#[test]
+fn test_ensure_tool_config_noop_without_tool_history() {
+	let mut req = request_with(vec![make_message(types::bedrock::Role::User, "hello")]);
+
+	helpers::ensure_tool_config_for_history(&mut req);
+
+	assert!(
+		req.tool_config.is_none(),
+		"toolConfig must not be added when there is no tool history"
+	);
+}
+
+#[test]
+fn test_ensure_tool_config_preserves_existing() {
+	let mut req = request_with(vec![make_tool_use_message("call_1", "get_pods")]);
+	req.tool_config = Some(types::bedrock::ToolConfiguration {
+		tools: vec![types::bedrock::Tool::ToolSpec(
+			types::bedrock::ToolSpecification {
+				name: "existing".to_string(),
+				description: None,
+				input_schema: None,
+			},
+		)],
+		tool_choice: None,
+	});
+
+	helpers::ensure_tool_config_for_history(&mut req);
+
+	let tool_config = req.tool_config.expect("existing toolConfig must be kept");
+	assert_eq!(tool_config.tools.len(), 1);
+	match &tool_config.tools[0] {
+		types::bedrock::Tool::ToolSpec(spec) => assert_eq!(spec.name, "existing"),
+		_ => panic!("expected the original ToolSpec"),
+	}
+}


### PR DESCRIPTION
## Problem

Bedrock's Converse API rejects any request whose `messages` contain `toolUse` or `toolResult` content blocks unless a `toolConfig` is also present — **even on a follow-up/summary turn that legitimately omits `tools`** (which the OpenAI Chat Completions and Anthropic Messages APIs both allow).

The OpenAI/Anthropic → Bedrock translation only set `toolConfig` when the incoming request itself carried `tools`. So when an agent runs a multi-step tool loop and then issues a turn **without** `tools` (e.g. a final summarization), the converted request still carries the prior `toolUse`/`toolResult` blocks but no `toolConfig`, and Bedrock returns:

```
ValidationException: The toolConfig field must be defined when using toolUse and toolResult content blocks.
```

This is the same well-known Converse constraint seen across the ecosystem's OpenAI→Bedrock translation layers:
- pydantic-ai#1966 — "Running agent without tools fails when using messages from an agent with tools"
- opencode#10259 — "toolConfig not included when conversation has tool history"
- langchain-ai/langchain-aws#591

### Reproduction
An OpenAI-compatible client (e.g. an agent driven by LiteLLM) makes tool calls, then sends a turn that includes the tool history but omits `tools` → 400 from Bedrock. Light tool use that always re-sends `tools` does not hit it, which is why it mostly surfaces on heavier agentic loops.

## Fix

Add `helpers::ensure_tool_config_for_history(&mut ConverseRequest)`: when a translated request has no `toolConfig` but its messages contain tool blocks, reconstruct a minimal `toolConfig` from the tool names referenced in the history (a permissive `{"type":"object"}` input schema is enough for Bedrock to validate the history). Repeated tool names are de-duplicated, requests without tool history are left untouched, and an existing `toolConfig` is preserved.

Applied in all three Converse translation paths: `from_completions`, `from_messages`, `from_responses`.

## Tests

Added unit tests in `bedrock_tests.rs`:
- reconstructs `toolConfig` from tool history when the request omits `tools`
- de-duplicates repeated tool names
- no-op when there is no tool history
- preserves an existing `toolConfig`

`cargo fmt --check` and `cargo clippy --lib --tests -- -D warnings` pass locally.
