### PR TITLE
Fix an off-by-one issue on long password in htpasswd-verify-fork

### DIFF
--- a/crates/htpasswd-verify-fork/src/lib.rs
+++ b/crates/htpasswd-verify-fork/src/lib.rs
@@ -128,6 +128,7 @@ mod tests {
 
 	static DATA: &str = "user2:$apr1$7/CTEZag$omWmIgXPJYoxB3joyuq4S/
 user:$apr1$lZL6V/ci$eIMz/iKDkbtys/uU7LEK00
+longpassword:$apr1$5jJtzRYw$xQlupJ3AHTXrqQiCyLBwY1
 bcrypt_test:$2y$05$nC6nErr9XZJuMJ57WyCob.EuZEjylDt2KaHfbfOtyb.EgL1I2jCVa
 sha1_test:{SHA}W6ph5Mm5Pz8GgiULbPgzG37mj9g=
 crypt_test:bGVh02xkuGli2";
@@ -157,6 +158,8 @@ crypt_test:bGVh02xkuGli2";
 		assert!(!htpasswd.check("user", "passwort"));
 		assert!(htpasswd.check("user2", "zaq1@WSX"));
 		assert!(!htpasswd.check("user2", "ZAQ1@WSX"));
+		assert!(htpasswd.check("longpassword", "password-longer-than-16-chars"));
+		assert!(!htpasswd.check("longpassword", "passwort-longer-than-16-chars"));
 	}
 
 	#[test]

--- a/crates/htpasswd-verify-fork/src/md5.rs
+++ b/crates/htpasswd-verify-fork/src/md5.rs
@@ -80,7 +80,7 @@ pub fn md5_apr1_encode(pw: &str, salt: &str) -> String {
 	let mut digest = ctx1.finalize_reset();
 
 	for pl in (0..pw.len()).rev().step_by(Md5::output_size()) {
-		let digest_pl = pl.min(Md5::output_size()) + 1;
+		let digest_pl = (pl + 1).min(Md5::output_size());
 		ctx.update(&digest[..digest_pl]);
 	}
 


### PR DESCRIPTION
# Problem

The md5 implementation of htpasswd-verify-fork has an off-by-one issue which triggers when passwords are longer than 16 chars.

For such password, the agentgateway fails with the following error:
```
thread 'agentgateway-4' (17) panicked at crates/htpasswd-verify-fork/src/md5.rs:84:27:
range end index 17 out of range for slice of length 16
stack backtrace:
   0: __rustc::rust_begin_unwind
   1: core::panicking::panic_fmt
   2: core::slice::index::slice_index_fail
   3: htpasswd_verify_fork::md5::md5_apr1_encode
   4: agentgateway::store::policy::RequestPolicy<T>::apply_internal::{{closure}}
   5: agentgateway::store::policy::RequestPolicy<T>::apply_without_response::{{closure}}
   6: agentgateway::proxy::httpproxy::apply_request_policies::{{closure}}
   7: agentgateway::proxy::httpproxy::HTTPProxy::proxy_internal::{{closure}}
   8: agentgateway::proxy::httpproxy::HTTPProxy::proxy::{{closure}}
   9: agentgateway::proxy::gateway::Gateway::proxy::{{closure}}::{{closure}}::{{closure}}
  10: agentgateway::proxy::dtrace::DebugTracer::maybe_scope::{{closure}}
  11: <tokio::runtime::task::trace::Root<T> as core::future::future::Future>::poll
  12: tokio::runtime::task::raw::poll
  13: tokio::runtime::scheduler::multi_thread::worker::Context::run_task
  14: tokio::runtime::context::runtime::enter_runtime
  15: tokio::runtime::task::raw::poll
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

# Fix & Test

This simply fix the Off-By-One issue and adds a specific test to check that passwords longer than 16 characters works.