### PR TITLE
fix(mcp): route client JSON-RPC responses for server-initiated requests

### DIFF
--- a/crates/agentgateway/src/mcp/handler.rs
+++ b/crates/agentgateway/src/mcp/handler.rs
@@ -1210,11 +1210,8 @@ impl Relay {
 			match result {
 				Ok(s) => {
 					let s = self.rewrite_outbound_server_messages(name.as_str(), s, cel.clone());
-					let s = track_outbound_server_requests(
-						name.clone(),
-						s,
-						self.pending_server_requests.clone(),
-					);
+					let s =
+						track_outbound_server_requests(name.clone(), s, self.pending_server_requests.clone());
 					streams.push((name, s));
 				},
 				Err(e) => {
@@ -1289,11 +1286,8 @@ impl Relay {
 			.into_iter()
 			.map(|(name, s)| {
 				let s = self.rewrite_outbound_server_messages(name.as_str(), s, cel.clone());
-				let s = track_outbound_server_requests(
-					name.clone(),
-					s,
-					self.pending_server_requests.clone(),
-				);
+				let s =
+					track_outbound_server_requests(name.clone(), s, self.pending_server_requests.clone());
 				(name, s)
 			})
 			.collect::<Vec<_>>();
@@ -2187,8 +2181,14 @@ mod tests {
 		assert_eq!(id_b, downstream_server_request_id(b.as_str(), &shared_id));
 
 		let map = pending.lock().expect("lock");
-		assert_eq!(map.get(&id_a).map(|e| e.upstream.as_str()), Some("upstream-a"));
-		assert_eq!(map.get(&id_b).map(|e| e.upstream.as_str()), Some("upstream-b"));
+		assert_eq!(
+			map.get(&id_a).map(|e| e.upstream.as_str()),
+			Some("upstream-a")
+		);
+		assert_eq!(
+			map.get(&id_b).map(|e| e.upstream.as_str()),
+			Some("upstream-b")
+		);
 		assert_eq!(
 			map.get(&id_a).map(|e| e.original_id.clone()),
 			Some(shared_id.clone())

--- a/crates/agentgateway/src/mcp/handler.rs
+++ b/crates/agentgateway/src/mcp/handler.rs
@@ -1323,16 +1323,36 @@ impl Relay {
 		message: ClientJsonRpcMessage,
 		ctx: IncomingRequestContext,
 	) -> Result<Response, UpstreamError> {
-		let request_id = match &message {
-			ClientJsonRpcMessage::Response(r) => r.id.clone(),
-			ClientJsonRpcMessage::Error(e) => e.id.clone().ok_or_else(|| {
-				UpstreamError::InvalidRequest("JSON-RPC error response missing id".into())
-			})?,
+		match &message {
+			ClientJsonRpcMessage::Error(e) if e.id.is_none() => {
+				if self.upstreams.size() == 1 {
+					let name = self
+						.upstreams
+						.iter_named()
+						.next()
+						.map(|(name, _)| name)
+						.ok_or_else(|| UpstreamError::InvalidRequest("no upstreams available".into()))?;
+					let us = self.upstreams.get(name.as_str())?;
+					us.generic_client_message(message, &ctx).await?;
+					return Ok(accepted_response());
+				}
+				warn!(
+					"dropping client JSON-RPC error without id in multiplexed session; cannot route upstream"
+				);
+				return Ok(accepted_response());
+			},
+			ClientJsonRpcMessage::Response(_) | ClientJsonRpcMessage::Error(_) => {},
 			_ => {
 				return Err(UpstreamError::InvalidRequest(
 					"expected client JSON-RPC response".into(),
 				));
 			},
+		}
+
+		let request_id = match &message {
+			ClientJsonRpcMessage::Response(r) => r.id.clone(),
+			ClientJsonRpcMessage::Error(e) => e.id.clone().expect("id checked above"),
+			_ => unreachable!(),
 		};
 
 		let pending = resolve_pending_server_request(self, &request_id)?;

--- a/crates/agentgateway/src/mcp/handler.rs
+++ b/crates/agentgateway/src/mcp/handler.rs
@@ -222,6 +222,10 @@ pub(crate) struct PendingServerRequest {
 
 pub(crate) type PendingServerRequestMap = Arc<Mutex<HashMap<RequestId, PendingServerRequest>>>;
 
+/// Cap unanswered server-initiated requests (e.g. heartbeat pings) so a session cannot grow
+/// the pending map without bound when clients never reply.
+const MAX_PENDING_SERVER_REQUESTS: usize = 256;
+
 #[derive(Debug, Clone)]
 pub struct Relay {
 	pub(crate) upstreams: Arc<upstream::UpstreamGroup>,
@@ -1147,10 +1151,11 @@ impl Relay {
 			Box::pin(us.generic_stream(r, &ctx).assert_size::<{ 3 * 1024 }>()).await?,
 			cel,
 		);
-		let stream = track_outbound_server_requests(
+		let stream = track_outbound_server_requests_for_downstream(
 			service_name.into(),
 			stream,
 			self.pending_server_requests.clone(),
+			ctx_downstream_modern(&ctx),
 		);
 
 		respond_with_guardrails(id, stream, guardrails, mcp_log, &ctx)
@@ -1210,8 +1215,12 @@ impl Relay {
 			match result {
 				Ok(s) => {
 					let s = self.rewrite_outbound_server_messages(name.as_str(), s, cel.clone());
-					let s =
-						track_outbound_server_requests(name.clone(), s, self.pending_server_requests.clone());
+					let s = track_outbound_server_requests_for_downstream(
+						name.clone(),
+						s,
+						self.pending_server_requests.clone(),
+						ctx_downstream_modern(&ctx),
+					);
 					streams.push((name, s));
 				},
 				Err(e) => {
@@ -1286,8 +1295,12 @@ impl Relay {
 			.into_iter()
 			.map(|(name, s)| {
 				let s = self.rewrite_outbound_server_messages(name.as_str(), s, cel.clone());
-				let s =
-					track_outbound_server_requests(name.clone(), s, self.pending_server_requests.clone());
+				let s = track_outbound_server_requests_for_downstream(
+					name.clone(),
+					s,
+					self.pending_server_requests.clone(),
+					ctx_downstream_modern(&ctx),
+				);
 				(name, s)
 			})
 			.collect::<Vec<_>>();
@@ -1851,6 +1864,37 @@ fn downstream_server_request_id(upstream: &str, original: &RequestId) -> Request
 	}
 }
 
+fn insert_pending_server_request(
+	pending_server_requests: &PendingServerRequestMap,
+	downstream_id: RequestId,
+	entry: PendingServerRequest,
+) {
+	let mut map = pending_server_requests
+		.lock()
+		.expect("pending_server_requests lock poisoned");
+	while map.len() >= MAX_PENDING_SERVER_REQUESTS {
+		let Some(evict) = map.keys().next().cloned() else {
+			break;
+		};
+		map.remove(&evict);
+	}
+	map.insert(downstream_id, entry);
+}
+
+/// Remap and track server-initiated requests only when the downstream client can reply
+/// (legacy protocol). Modern downstreams reject direct server→client requests in SSE.
+fn track_outbound_server_requests_for_downstream(
+	upstream: Strng,
+	stream: Messages,
+	pending_server_requests: PendingServerRequestMap,
+	downstream_modern: bool,
+) -> Messages {
+	if downstream_modern {
+		return stream;
+	}
+	track_outbound_server_requests(upstream, stream, pending_server_requests)
+}
+
 fn track_outbound_server_requests(
 	upstream: Strng,
 	stream: Messages,
@@ -1860,16 +1904,14 @@ fn track_outbound_server_requests(
 		ServerJsonRpcMessage::Request(mut req) => {
 			let original_id = req.id.clone();
 			let downstream_id = downstream_server_request_id(upstream.as_str(), &original_id);
-			pending_server_requests
-				.lock()
-				.expect("pending_server_requests lock poisoned")
-				.insert(
-					downstream_id.clone(),
-					PendingServerRequest {
-						upstream: upstream.clone(),
-						original_id,
-					},
-				);
+			insert_pending_server_request(
+				&pending_server_requests,
+				downstream_id.clone(),
+				PendingServerRequest {
+					upstream: upstream.clone(),
+					original_id,
+				},
+			);
 			req.id = downstream_id;
 			ServerJsonRpcMessage::Request(req)
 		},
@@ -2234,5 +2276,62 @@ mod tests {
 			other => panic!("expected response, got {other:?}"),
 		}
 		assert!(pending.lock().expect("lock").contains_key(&remapped));
+	}
+
+	#[tokio::test]
+	async fn track_outbound_server_requests_skipped_for_modern_downstream() {
+		use futures_util::StreamExt;
+		use rmcp::model::{PingRequest, ServerRequest};
+
+		let pending = Arc::new(Mutex::new(HashMap::new()));
+		let upstream: Strng = "backend".into();
+		let original_id = RequestId::Number(7);
+		let ping = ServerJsonRpcMessage::request(
+			ServerRequest::PingRequest(PingRequest::default()),
+			original_id.clone(),
+		);
+		let mut tracked = track_outbound_server_requests_for_downstream(
+			upstream,
+			Messages::from(ping),
+			pending.clone(),
+			true,
+		);
+		let forwarded = tracked.next().await.expect("message").expect("ok");
+		match forwarded {
+			ServerJsonRpcMessage::Request(req) => assert_eq!(req.id, original_id),
+			other => panic!("expected request, got {other:?}"),
+		}
+		assert!(pending.lock().expect("lock").is_empty());
+	}
+
+	#[tokio::test]
+	async fn insert_pending_server_request_evicts_when_at_capacity() {
+		let pending: PendingServerRequestMap = Arc::new(Mutex::new(HashMap::new()));
+		let upstream: Strng = "backend".into();
+		for n in 0..MAX_PENDING_SERVER_REQUESTS {
+			insert_pending_server_request(
+				&pending,
+				RequestId::Number(n as i64),
+				PendingServerRequest {
+					upstream: upstream.clone(),
+					original_id: RequestId::Number(n as i64),
+				},
+			);
+		}
+		assert_eq!(
+			pending.lock().expect("lock").len(),
+			MAX_PENDING_SERVER_REQUESTS
+		);
+		insert_pending_server_request(
+			&pending,
+			RequestId::Number(9999),
+			PendingServerRequest {
+				upstream: upstream.clone(),
+				original_id: RequestId::Number(9999),
+			},
+		);
+		let map = pending.lock().expect("lock");
+		assert_eq!(map.len(), MAX_PENDING_SERVER_REQUESTS);
+		assert!(map.contains_key(&RequestId::Number(9999)));
 	}
 }

--- a/crates/agentgateway/src/mcp/handler.rs
+++ b/crates/agentgateway/src/mcp/handler.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use agent_core::prelude::{AssertSize, Strng};
 use agent_core::version::BuildInfo;
@@ -11,7 +11,7 @@ use http::request::Parts;
 use itertools::Itertools;
 use rmcp::ErrorData;
 use rmcp::model::{
-	CacheScope, ClientNotification, ClientRequest, ConstString, DiscoverResult,
+	CacheScope, ClientJsonRpcMessage, ClientNotification, ClientRequest, ConstString, DiscoverResult,
 	ExtensionCapabilities, Implementation, JsonRpcNotification, JsonRpcRequest, ListPromptsResult,
 	ListResourceTemplatesResult, ListResourcesResult, ListToolsResult, PaginatedRequestParams,
 	ProtocolVersion, RequestId, ResultType, ServerCapabilities, ServerInfo, ServerJsonRpcMessage,
@@ -212,12 +212,24 @@ impl ResolveKind {
 	}
 }
 
+/// Tracks a server-initiated JSON-RPC request so a later downstream Response/Error
+/// can be routed to the issuing upstream with the original request id restored.
+#[derive(Debug, Clone)]
+pub(crate) struct PendingServerRequest {
+	upstream: Strng,
+	original_id: RequestId,
+}
+
+pub(crate) type PendingServerRequestMap = Arc<Mutex<HashMap<RequestId, PendingServerRequest>>>;
+
 #[derive(Debug, Clone)]
 pub struct Relay {
 	pub(crate) upstreams: Arc<upstream::UpstreamGroup>,
 	pub policies: McpAuthorizationSet,
 	pub(crate) mcp_guardrails: Option<Arc<crate::mcp::guardrails::McpGuardrails>>,
 	pub(crate) policy_client: PolicyClient,
+	/// Downstream-facing server-initiated request ids → upstream + original id.
+	pending_server_requests: PendingServerRequestMap,
 }
 
 pub struct RelayInputs {
@@ -248,6 +260,7 @@ impl Relay {
 			policies,
 			mcp_guardrails: None,
 			policy_client: client,
+			pending_server_requests: Arc::new(Mutex::new(HashMap::new())),
 		})
 	}
 	pub fn with_policies(&self, policies: McpAuthorizationSet) -> Self {
@@ -256,6 +269,7 @@ impl Relay {
 			policies,
 			mcp_guardrails: self.mcp_guardrails.clone(),
 			policy_client: self.policy_client.clone(),
+			pending_server_requests: self.pending_server_requests.clone(),
 		}
 	}
 
@@ -1133,6 +1147,11 @@ impl Relay {
 			Box::pin(us.generic_stream(r, &ctx).assert_size::<{ 3 * 1024 }>()).await?,
 			cel,
 		);
+		let stream = track_outbound_server_requests(
+			service_name.into(),
+			stream,
+			self.pending_server_requests.clone(),
+		);
 
 		respond_with_guardrails(id, stream, guardrails, mcp_log, &ctx)
 	}
@@ -1191,6 +1210,11 @@ impl Relay {
 			match result {
 				Ok(s) => {
 					let s = self.rewrite_outbound_server_messages(name.as_str(), s, cel.clone());
+					let s = track_outbound_server_requests(
+						name.clone(),
+						s,
+						self.pending_server_requests.clone(),
+					);
 					streams.push((name, s));
 				},
 				Err(e) => {
@@ -1265,6 +1289,11 @@ impl Relay {
 			.into_iter()
 			.map(|(name, s)| {
 				let s = self.rewrite_outbound_server_messages(name.as_str(), s, cel.clone());
+				let s = track_outbound_server_requests(
+					name.clone(),
+					s,
+					self.pending_server_requests.clone(),
+				);
 				(name, s)
 			})
 			.collect::<Vec<_>>();
@@ -1281,6 +1310,31 @@ impl Relay {
 			&ctx,
 		)
 	}
+
+	pub async fn send_client_response(
+		&self,
+		message: ClientJsonRpcMessage,
+		ctx: IncomingRequestContext,
+	) -> Result<Response, UpstreamError> {
+		let request_id = match &message {
+			ClientJsonRpcMessage::Response(r) => r.id.clone(),
+			ClientJsonRpcMessage::Error(e) => e.id.clone().ok_or_else(|| {
+				UpstreamError::InvalidRequest("JSON-RPC error response missing id".into())
+			})?,
+			_ => {
+				return Err(UpstreamError::InvalidRequest(
+					"expected client JSON-RPC response".into(),
+				));
+			},
+		};
+
+		let pending = resolve_pending_server_request(self, &request_id)?;
+		let message = restore_client_response_id(message, pending.original_id)?;
+		let us = self.upstreams.get(pending.upstream.as_str())?;
+		us.generic_client_message(message, &ctx).await?;
+		Ok(accepted_response())
+	}
+
 	pub async fn send_notification(
 		&self,
 		r: JsonRpcNotification<ClientNotification>,
@@ -1791,6 +1845,92 @@ fn accepted_response() -> Response {
 		.expect("valid response")
 }
 
+/// Namespace a server-initiated request id for the downstream connection.
+///
+/// Upstream JSON-RPC ids are scoped per connection. Multiplexed backends can
+/// both emit id `0`; remapping keeps the downstream map collision-free and
+/// retains the original id for the reverse path.
+fn downstream_server_request_id(upstream: &str, original: &RequestId) -> RequestId {
+	match original {
+		RequestId::Number(n) => RequestId::String(format!("agw:{upstream}:n:{n}").into()),
+		RequestId::String(s) => RequestId::String(format!("agw:{upstream}:s:{s}").into()),
+	}
+}
+
+fn track_outbound_server_requests(
+	upstream: Strng,
+	stream: Messages,
+	pending_server_requests: PendingServerRequestMap,
+) -> Messages {
+	stream.map_server_messages(move |msg| match msg {
+		ServerJsonRpcMessage::Request(mut req) => {
+			let original_id = req.id.clone();
+			let downstream_id = downstream_server_request_id(upstream.as_str(), &original_id);
+			pending_server_requests
+				.lock()
+				.expect("pending_server_requests lock poisoned")
+				.insert(
+					downstream_id.clone(),
+					PendingServerRequest {
+						upstream: upstream.clone(),
+						original_id,
+					},
+				);
+			req.id = downstream_id;
+			ServerJsonRpcMessage::Request(req)
+		},
+		other => other,
+	})
+}
+
+fn resolve_pending_server_request(
+	relay: &Relay,
+	request_id: &RequestId,
+) -> Result<PendingServerRequest, UpstreamError> {
+	if let Some(pending) = relay
+		.pending_server_requests
+		.lock()
+		.expect("pending_server_requests lock poisoned")
+		.remove(request_id)
+	{
+		return Ok(pending);
+	}
+	if relay.upstreams.size() == 1 {
+		let name = relay
+			.upstreams
+			.iter_named()
+			.next()
+			.map(|(name, _)| name)
+			.ok_or_else(|| UpstreamError::InvalidRequest("no upstreams available".into()))?;
+		return Ok(PendingServerRequest {
+			upstream: name,
+			original_id: request_id.clone(),
+		});
+	}
+	Err(UpstreamError::InvalidRequest(format!(
+		"no upstream registered for server-initiated request id {request_id:?}"
+	)))
+}
+
+fn restore_client_response_id(
+	message: ClientJsonRpcMessage,
+	original_id: RequestId,
+) -> Result<ClientJsonRpcMessage, UpstreamError> {
+	match message {
+		ClientJsonRpcMessage::Response(mut r) => {
+			r.id = original_id;
+			Ok(ClientJsonRpcMessage::Response(r))
+		},
+		ClientJsonRpcMessage::Error(mut e) => {
+			e.id = Some(original_id);
+			Ok(ClientJsonRpcMessage::Error(e))
+		},
+		_ => Err(UpstreamError::InvalidRequest(
+			"expected client JSON-RPC response".into(),
+		)),
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use futures_util::{StreamExt, stream};
@@ -1979,5 +2119,120 @@ mod tests {
 				.unwrap()
 				.contains("boom")
 		);
+	}
+
+	#[tokio::test]
+	async fn track_outbound_server_requests_registers_remapped_server_initiated_request_id() {
+		use futures_util::StreamExt;
+		use rmcp::model::{PingRequest, ServerRequest};
+
+		let pending = Arc::new(Mutex::new(HashMap::new()));
+		let upstream: Strng = "backend".into();
+		let original_id = RequestId::Number(7);
+		let remapped = downstream_server_request_id(upstream.as_str(), &original_id);
+		let ping = ServerJsonRpcMessage::request(
+			ServerRequest::PingRequest(PingRequest::default()),
+			original_id.clone(),
+		);
+		let mut tracked =
+			track_outbound_server_requests(upstream.clone(), Messages::from(ping), pending.clone());
+		let forwarded = tracked.next().await.expect("message").expect("ok");
+		match forwarded {
+			ServerJsonRpcMessage::Request(req) => assert_eq!(req.id, remapped),
+			other => panic!("expected request, got {other:?}"),
+		}
+		let entry = pending.lock().expect("lock").get(&remapped).cloned();
+		assert_eq!(entry.as_ref().map(|e| e.upstream.as_str()), Some("backend"));
+		assert_eq!(
+			entry.as_ref().map(|e| e.original_id.clone()),
+			Some(original_id)
+		);
+	}
+
+	#[tokio::test]
+	async fn track_outbound_server_requests_namespaces_colliding_ids_across_upstreams() {
+		use futures_util::StreamExt;
+		use rmcp::model::{PingRequest, ServerRequest};
+
+		let pending = Arc::new(Mutex::new(HashMap::new()));
+		let shared_id = RequestId::Number(0);
+		let a: Strng = "upstream-a".into();
+		let b: Strng = "upstream-b".into();
+		let ping_a = ServerJsonRpcMessage::request(
+			ServerRequest::PingRequest(PingRequest::default()),
+			shared_id.clone(),
+		);
+		let ping_b = ServerJsonRpcMessage::request(
+			ServerRequest::PingRequest(PingRequest::default()),
+			shared_id.clone(),
+		);
+
+		let mut tracked_a =
+			track_outbound_server_requests(a.clone(), Messages::from(ping_a), pending.clone());
+		let mut tracked_b =
+			track_outbound_server_requests(b.clone(), Messages::from(ping_b), pending.clone());
+		let fwd_a = tracked_a.next().await.expect("a").expect("ok");
+		let fwd_b = tracked_b.next().await.expect("b").expect("ok");
+
+		let id_a = match fwd_a {
+			ServerJsonRpcMessage::Request(req) => req.id,
+			other => panic!("expected request, got {other:?}"),
+		};
+		let id_b = match fwd_b {
+			ServerJsonRpcMessage::Request(req) => req.id,
+			other => panic!("expected request, got {other:?}"),
+		};
+		assert_ne!(id_a, id_b);
+		assert_eq!(id_a, downstream_server_request_id(a.as_str(), &shared_id));
+		assert_eq!(id_b, downstream_server_request_id(b.as_str(), &shared_id));
+
+		let map = pending.lock().expect("lock");
+		assert_eq!(map.get(&id_a).map(|e| e.upstream.as_str()), Some("upstream-a"));
+		assert_eq!(map.get(&id_b).map(|e| e.upstream.as_str()), Some("upstream-b"));
+		assert_eq!(
+			map.get(&id_a).map(|e| e.original_id.clone()),
+			Some(shared_id.clone())
+		);
+		assert_eq!(
+			map.get(&id_b).map(|e| e.original_id.clone()),
+			Some(shared_id)
+		);
+	}
+
+	#[tokio::test]
+	async fn track_outbound_server_requests_covers_post_originated_sse_streams() {
+		// send_single / send_fanout_to wrap POST-originated SSE the same way as
+		// send_fanout_get: rewrite then track_outbound_server_requests.
+		use futures_util::StreamExt;
+		use rmcp::model::{PingRequest, ServerRequest};
+
+		let pending = Arc::new(Mutex::new(HashMap::new()));
+		let upstream: Strng = "post-backend".into();
+		let original_id = RequestId::String("ping-1".into());
+		let remapped = downstream_server_request_id(upstream.as_str(), &original_id);
+		let ping = ServerJsonRpcMessage::request(
+			ServerRequest::PingRequest(PingRequest::default()),
+			original_id.clone(),
+		);
+
+		// Same wrapper sequence used by send_single after rewrite_outbound_server_messages.
+		let mut tracked =
+			track_outbound_server_requests(upstream.clone(), Messages::from(ping), pending.clone());
+		let forwarded = tracked.next().await.expect("message").expect("ok");
+		match forwarded {
+			ServerJsonRpcMessage::Request(req) => assert_eq!(req.id, remapped),
+			other => panic!("expected request, got {other:?}"),
+		}
+
+		let restored = restore_client_response_id(
+			ClientJsonRpcMessage::response(rmcp::model::ClientResult::empty(()), remapped.clone()),
+			original_id.clone(),
+		)
+		.expect("restore");
+		match restored {
+			ClientJsonRpcMessage::Response(r) => assert_eq!(r.id, original_id),
+			other => panic!("expected response, got {other:?}"),
+		}
+		assert!(pending.lock().expect("lock").contains_key(&remapped));
 	}
 }

--- a/crates/agentgateway/src/mcp/handler.rs
+++ b/crates/agentgateway/src/mcp/handler.rs
@@ -1291,11 +1291,8 @@ impl Relay {
 			match result {
 				Ok(s) => {
 					let s = self.rewrite_outbound_server_messages(name.as_str(), s, cel.clone());
-					let s = track_outbound_server_requests(
-						name.clone(),
-						s,
-						self.pending_server_requests.clone(),
-					);
+					let s =
+						track_outbound_server_requests(name.clone(), s, self.pending_server_requests.clone());
 					streams.push((name, s));
 				},
 				Err(e) => {
@@ -1370,11 +1367,8 @@ impl Relay {
 			.into_iter()
 			.map(|(name, s)| {
 				let s = self.rewrite_outbound_server_messages(name.as_str(), s, cel.clone());
-				let s = track_outbound_server_requests(
-					name.clone(),
-					s,
-					self.pending_server_requests.clone(),
-				);
+				let s =
+					track_outbound_server_requests(name.clone(), s, self.pending_server_requests.clone());
 				(name, s)
 			})
 			.collect::<Vec<_>>();
@@ -2230,8 +2224,14 @@ mod tests {
 		assert_eq!(id_b, downstream_server_request_id(b.as_str(), &shared_id));
 
 		let map = pending.lock().expect("lock");
-		assert_eq!(map.get(&id_a).map(|e| e.upstream.as_str()), Some("upstream-a"));
-		assert_eq!(map.get(&id_b).map(|e| e.upstream.as_str()), Some("upstream-b"));
+		assert_eq!(
+			map.get(&id_a).map(|e| e.upstream.as_str()),
+			Some("upstream-a")
+		);
+		assert_eq!(
+			map.get(&id_b).map(|e| e.upstream.as_str()),
+			Some("upstream-b")
+		);
 		assert_eq!(
 			map.get(&id_a).map(|e| e.original_id.clone()),
 			Some(shared_id.clone())

--- a/crates/agentgateway/src/mcp/handler.rs
+++ b/crates/agentgateway/src/mcp/handler.rs
@@ -1404,16 +1404,36 @@ impl Relay {
 		message: ClientJsonRpcMessage,
 		ctx: IncomingRequestContext,
 	) -> Result<Response, UpstreamError> {
-		let request_id = match &message {
-			ClientJsonRpcMessage::Response(r) => r.id.clone(),
-			ClientJsonRpcMessage::Error(e) => e.id.clone().ok_or_else(|| {
-				UpstreamError::InvalidRequest("JSON-RPC error response missing id".into())
-			})?,
+		match &message {
+			ClientJsonRpcMessage::Error(e) if e.id.is_none() => {
+				if self.upstreams.size() == 1 {
+					let name = self
+						.upstreams
+						.iter_named()
+						.next()
+						.map(|(name, _)| name)
+						.ok_or_else(|| UpstreamError::InvalidRequest("no upstreams available".into()))?;
+					let us = self.upstreams.get(name.as_str())?;
+					us.generic_client_message(message, &ctx).await?;
+					return Ok(accepted_response());
+				}
+				warn!(
+					"dropping client JSON-RPC error without id in multiplexed session; cannot route upstream"
+				);
+				return Ok(accepted_response());
+			},
+			ClientJsonRpcMessage::Response(_) | ClientJsonRpcMessage::Error(_) => {},
 			_ => {
 				return Err(UpstreamError::InvalidRequest(
 					"expected client JSON-RPC response".into(),
 				));
 			},
+		}
+
+		let request_id = match &message {
+			ClientJsonRpcMessage::Response(r) => r.id.clone(),
+			ClientJsonRpcMessage::Error(e) => e.id.clone().expect("id checked above"),
+			_ => unreachable!(),
 		};
 
 		let pending = resolve_pending_server_request(self, &request_id)?;

--- a/crates/agentgateway/src/mcp/handler.rs
+++ b/crates/agentgateway/src/mcp/handler.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use agent_core::prelude::{AssertSize, Strng};
 use agent_core::version::BuildInfo;
@@ -11,7 +11,7 @@ use http::request::Parts;
 use itertools::Itertools;
 use rmcp::ErrorData;
 use rmcp::model::{
-	CacheScope, ClientNotification, ClientRequest, ConstString, DiscoverResult,
+	CacheScope, ClientJsonRpcMessage, ClientNotification, ClientRequest, ConstString, DiscoverResult,
 	ExtensionCapabilities, Implementation, JsonRpcNotification, JsonRpcRequest, ListPromptsResult,
 	ListResourceTemplatesResult, ListResourcesResult, ListToolsResult, PaginatedRequestParams,
 	ProtocolVersion, RequestId, ResultType, ServerCapabilities, ServerInfo, ServerJsonRpcMessage,
@@ -275,12 +275,24 @@ impl ResolveKind {
 	}
 }
 
+/// Tracks a server-initiated JSON-RPC request so a later downstream Response/Error
+/// can be routed to the issuing upstream with the original request id restored.
+#[derive(Debug, Clone)]
+pub(crate) struct PendingServerRequest {
+	upstream: Strng,
+	original_id: RequestId,
+}
+
+pub(crate) type PendingServerRequestMap = Arc<Mutex<HashMap<RequestId, PendingServerRequest>>>;
+
 #[derive(Debug, Clone)]
 pub struct Relay {
 	pub(crate) upstreams: Arc<upstream::UpstreamGroup>,
 	pub policies: McpAuthorizationSet,
 	pub(crate) mcp_guardrails: Option<Arc<crate::mcp::guardrails::McpGuardrails>>,
 	pub(crate) policy_client: PolicyClient,
+	/// Downstream-facing server-initiated request ids → upstream + original id.
+	pending_server_requests: PendingServerRequestMap,
 }
 
 pub struct RelayInputs {
@@ -312,6 +324,7 @@ impl Relay {
 			policies,
 			mcp_guardrails: None,
 			policy_client: client,
+			pending_server_requests: Arc::new(Mutex::new(HashMap::new())),
 		})
 	}
 	pub fn with_policies(&self, policies: McpAuthorizationSet) -> Self {
@@ -320,6 +333,7 @@ impl Relay {
 			policies,
 			mcp_guardrails: self.mcp_guardrails.clone(),
 			policy_client: self.policy_client.clone(),
+			pending_server_requests: self.pending_server_requests.clone(),
 		}
 	}
 
@@ -1214,6 +1228,11 @@ impl Relay {
 			Box::pin(us.generic_stream(r, &ctx).assert_size::<{ 3 * 1024 }>()).await?,
 			cel,
 		);
+		let stream = track_outbound_server_requests(
+			service_name.into(),
+			stream,
+			self.pending_server_requests.clone(),
+		);
 
 		respond_with_guardrails(id, stream, guardrails, mcp_log, &ctx)
 	}
@@ -1272,6 +1291,11 @@ impl Relay {
 			match result {
 				Ok(s) => {
 					let s = self.rewrite_outbound_server_messages(name.as_str(), s, cel.clone());
+					let s = track_outbound_server_requests(
+						name.clone(),
+						s,
+						self.pending_server_requests.clone(),
+					);
 					streams.push((name, s));
 				},
 				Err(e) => {
@@ -1346,6 +1370,11 @@ impl Relay {
 			.into_iter()
 			.map(|(name, s)| {
 				let s = self.rewrite_outbound_server_messages(name.as_str(), s, cel.clone());
+				let s = track_outbound_server_requests(
+					name.clone(),
+					s,
+					self.pending_server_requests.clone(),
+				);
 				(name, s)
 			})
 			.collect::<Vec<_>>();
@@ -1362,6 +1391,31 @@ impl Relay {
 			&ctx,
 		)
 	}
+
+	pub async fn send_client_response(
+		&self,
+		message: ClientJsonRpcMessage,
+		ctx: IncomingRequestContext,
+	) -> Result<Response, UpstreamError> {
+		let request_id = match &message {
+			ClientJsonRpcMessage::Response(r) => r.id.clone(),
+			ClientJsonRpcMessage::Error(e) => e.id.clone().ok_or_else(|| {
+				UpstreamError::InvalidRequest("JSON-RPC error response missing id".into())
+			})?,
+			_ => {
+				return Err(UpstreamError::InvalidRequest(
+					"expected client JSON-RPC response".into(),
+				));
+			},
+		};
+
+		let pending = resolve_pending_server_request(self, &request_id)?;
+		let message = restore_client_response_id(message, pending.original_id)?;
+		let us = self.upstreams.get(pending.upstream.as_str())?;
+		us.generic_client_message(message, &ctx).await?;
+		Ok(accepted_response())
+	}
+
 	pub async fn send_notification(
 		&self,
 		r: JsonRpcNotification<ClientNotification>,
@@ -1845,6 +1899,92 @@ fn accepted_response() -> Response {
 		.expect("valid response")
 }
 
+/// Namespace a server-initiated request id for the downstream connection.
+///
+/// Upstream JSON-RPC ids are scoped per connection. Multiplexed backends can
+/// both emit id `0`; remapping keeps the downstream map collision-free and
+/// retains the original id for the reverse path.
+fn downstream_server_request_id(upstream: &str, original: &RequestId) -> RequestId {
+	match original {
+		RequestId::Number(n) => RequestId::String(format!("agw:{upstream}:n:{n}").into()),
+		RequestId::String(s) => RequestId::String(format!("agw:{upstream}:s:{s}").into()),
+	}
+}
+
+fn track_outbound_server_requests(
+	upstream: Strng,
+	stream: Messages,
+	pending_server_requests: PendingServerRequestMap,
+) -> Messages {
+	stream.map_server_messages(move |msg| match msg {
+		ServerJsonRpcMessage::Request(mut req) => {
+			let original_id = req.id.clone();
+			let downstream_id = downstream_server_request_id(upstream.as_str(), &original_id);
+			pending_server_requests
+				.lock()
+				.expect("pending_server_requests lock poisoned")
+				.insert(
+					downstream_id.clone(),
+					PendingServerRequest {
+						upstream: upstream.clone(),
+						original_id,
+					},
+				);
+			req.id = downstream_id;
+			ServerJsonRpcMessage::Request(req)
+		},
+		other => other,
+	})
+}
+
+fn resolve_pending_server_request(
+	relay: &Relay,
+	request_id: &RequestId,
+) -> Result<PendingServerRequest, UpstreamError> {
+	if let Some(pending) = relay
+		.pending_server_requests
+		.lock()
+		.expect("pending_server_requests lock poisoned")
+		.remove(request_id)
+	{
+		return Ok(pending);
+	}
+	if relay.upstreams.size() == 1 {
+		let name = relay
+			.upstreams
+			.iter_named()
+			.next()
+			.map(|(name, _)| name)
+			.ok_or_else(|| UpstreamError::InvalidRequest("no upstreams available".into()))?;
+		return Ok(PendingServerRequest {
+			upstream: name,
+			original_id: request_id.clone(),
+		});
+	}
+	Err(UpstreamError::InvalidRequest(format!(
+		"no upstream registered for server-initiated request id {request_id:?}"
+	)))
+}
+
+fn restore_client_response_id(
+	message: ClientJsonRpcMessage,
+	original_id: RequestId,
+) -> Result<ClientJsonRpcMessage, UpstreamError> {
+	match message {
+		ClientJsonRpcMessage::Response(mut r) => {
+			r.id = original_id;
+			Ok(ClientJsonRpcMessage::Response(r))
+		},
+		ClientJsonRpcMessage::Error(mut e) => {
+			e.id = Some(original_id);
+			Ok(ClientJsonRpcMessage::Error(e))
+		},
+		_ => Err(UpstreamError::InvalidRequest(
+			"expected client JSON-RPC response".into(),
+		)),
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use futures_util::{StreamExt, stream};
@@ -2022,5 +2162,120 @@ mod tests {
 		let info = log.take().unwrap();
 		assert_eq!(info.error.as_ref().unwrap().code, -32603);
 		assert_eq!(info.error.as_ref().unwrap().message, "boom");
+	}
+
+	#[tokio::test]
+	async fn track_outbound_server_requests_registers_remapped_server_initiated_request_id() {
+		use futures_util::StreamExt;
+		use rmcp::model::{PingRequest, ServerRequest};
+
+		let pending = Arc::new(Mutex::new(HashMap::new()));
+		let upstream: Strng = "backend".into();
+		let original_id = RequestId::Number(7);
+		let remapped = downstream_server_request_id(upstream.as_str(), &original_id);
+		let ping = ServerJsonRpcMessage::request(
+			ServerRequest::PingRequest(PingRequest::default()),
+			original_id.clone(),
+		);
+		let mut tracked =
+			track_outbound_server_requests(upstream.clone(), Messages::from(ping), pending.clone());
+		let forwarded = tracked.next().await.expect("message").expect("ok");
+		match forwarded {
+			ServerJsonRpcMessage::Request(req) => assert_eq!(req.id, remapped),
+			other => panic!("expected request, got {other:?}"),
+		}
+		let entry = pending.lock().expect("lock").get(&remapped).cloned();
+		assert_eq!(entry.as_ref().map(|e| e.upstream.as_str()), Some("backend"));
+		assert_eq!(
+			entry.as_ref().map(|e| e.original_id.clone()),
+			Some(original_id)
+		);
+	}
+
+	#[tokio::test]
+	async fn track_outbound_server_requests_namespaces_colliding_ids_across_upstreams() {
+		use futures_util::StreamExt;
+		use rmcp::model::{PingRequest, ServerRequest};
+
+		let pending = Arc::new(Mutex::new(HashMap::new()));
+		let shared_id = RequestId::Number(0);
+		let a: Strng = "upstream-a".into();
+		let b: Strng = "upstream-b".into();
+		let ping_a = ServerJsonRpcMessage::request(
+			ServerRequest::PingRequest(PingRequest::default()),
+			shared_id.clone(),
+		);
+		let ping_b = ServerJsonRpcMessage::request(
+			ServerRequest::PingRequest(PingRequest::default()),
+			shared_id.clone(),
+		);
+
+		let mut tracked_a =
+			track_outbound_server_requests(a.clone(), Messages::from(ping_a), pending.clone());
+		let mut tracked_b =
+			track_outbound_server_requests(b.clone(), Messages::from(ping_b), pending.clone());
+		let fwd_a = tracked_a.next().await.expect("a").expect("ok");
+		let fwd_b = tracked_b.next().await.expect("b").expect("ok");
+
+		let id_a = match fwd_a {
+			ServerJsonRpcMessage::Request(req) => req.id,
+			other => panic!("expected request, got {other:?}"),
+		};
+		let id_b = match fwd_b {
+			ServerJsonRpcMessage::Request(req) => req.id,
+			other => panic!("expected request, got {other:?}"),
+		};
+		assert_ne!(id_a, id_b);
+		assert_eq!(id_a, downstream_server_request_id(a.as_str(), &shared_id));
+		assert_eq!(id_b, downstream_server_request_id(b.as_str(), &shared_id));
+
+		let map = pending.lock().expect("lock");
+		assert_eq!(map.get(&id_a).map(|e| e.upstream.as_str()), Some("upstream-a"));
+		assert_eq!(map.get(&id_b).map(|e| e.upstream.as_str()), Some("upstream-b"));
+		assert_eq!(
+			map.get(&id_a).map(|e| e.original_id.clone()),
+			Some(shared_id.clone())
+		);
+		assert_eq!(
+			map.get(&id_b).map(|e| e.original_id.clone()),
+			Some(shared_id)
+		);
+	}
+
+	#[tokio::test]
+	async fn track_outbound_server_requests_covers_post_originated_sse_streams() {
+		// send_single / send_fanout_to wrap POST-originated SSE the same way as
+		// send_fanout_get: rewrite then track_outbound_server_requests.
+		use futures_util::StreamExt;
+		use rmcp::model::{PingRequest, ServerRequest};
+
+		let pending = Arc::new(Mutex::new(HashMap::new()));
+		let upstream: Strng = "post-backend".into();
+		let original_id = RequestId::String("ping-1".into());
+		let remapped = downstream_server_request_id(upstream.as_str(), &original_id);
+		let ping = ServerJsonRpcMessage::request(
+			ServerRequest::PingRequest(PingRequest::default()),
+			original_id.clone(),
+		);
+
+		// Same wrapper sequence used by send_single after rewrite_outbound_server_messages.
+		let mut tracked =
+			track_outbound_server_requests(upstream.clone(), Messages::from(ping), pending.clone());
+		let forwarded = tracked.next().await.expect("message").expect("ok");
+		match forwarded {
+			ServerJsonRpcMessage::Request(req) => assert_eq!(req.id, remapped),
+			other => panic!("expected request, got {other:?}"),
+		}
+
+		let restored = restore_client_response_id(
+			ClientJsonRpcMessage::response(rmcp::model::ClientResult::empty(()), remapped.clone()),
+			original_id.clone(),
+		)
+		.expect("restore");
+		match restored {
+			ClientJsonRpcMessage::Response(r) => assert_eq!(r.id, original_id),
+			other => panic!("expected response, got {other:?}"),
+		}
+		assert!(pending.lock().expect("lock").contains_key(&remapped));
 	}
 }

--- a/crates/agentgateway/src/mcp/handler.rs
+++ b/crates/agentgateway/src/mcp/handler.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use agent_core::prelude::{AssertSize, Strng};
 use agent_core::version::BuildInfo;
@@ -275,19 +275,12 @@ impl ResolveKind {
 	}
 }
 
-/// Tracks a server-initiated JSON-RPC request so a later downstream Response/Error
-/// can be routed to the issuing upstream with the original request id restored.
+/// Parsed routing state for a downstream-facing server-initiated request id.
 #[derive(Debug, Clone)]
 pub(crate) struct PendingServerRequest {
 	upstream: Strng,
 	original_id: RequestId,
 }
-
-pub(crate) type PendingServerRequestMap = Arc<Mutex<HashMap<RequestId, PendingServerRequest>>>;
-
-/// Cap unanswered server-initiated requests (e.g. heartbeat pings) so a session cannot grow
-/// the pending map without bound when clients never reply.
-const MAX_PENDING_SERVER_REQUESTS: usize = 256;
 
 #[derive(Debug, Clone)]
 pub struct Relay {
@@ -295,8 +288,6 @@ pub struct Relay {
 	pub policies: McpAuthorizationSet,
 	pub(crate) mcp_guardrails: Option<Arc<crate::mcp::guardrails::McpGuardrails>>,
 	pub(crate) policy_client: PolicyClient,
-	/// Downstream-facing server-initiated request ids → upstream + original id.
-	pending_server_requests: PendingServerRequestMap,
 }
 
 pub struct RelayInputs {
@@ -328,7 +319,6 @@ impl Relay {
 			policies,
 			mcp_guardrails: None,
 			policy_client: client,
-			pending_server_requests: Arc::new(Mutex::new(HashMap::new())),
 		})
 	}
 	pub fn with_policies(&self, policies: McpAuthorizationSet) -> Self {
@@ -337,7 +327,6 @@ impl Relay {
 			policies,
 			mcp_guardrails: self.mcp_guardrails.clone(),
 			policy_client: self.policy_client.clone(),
-			pending_server_requests: self.pending_server_requests.clone(),
 		}
 	}
 
@@ -1235,7 +1224,6 @@ impl Relay {
 		let stream = track_outbound_server_requests_for_downstream(
 			service_name.into(),
 			stream,
-			self.pending_server_requests.clone(),
 			ctx_downstream_modern(&ctx),
 		);
 
@@ -1299,7 +1287,6 @@ impl Relay {
 					let s = track_outbound_server_requests_for_downstream(
 						name.clone(),
 						s,
-						self.pending_server_requests.clone(),
 						ctx_downstream_modern(&ctx),
 					);
 					streams.push((name, s));
@@ -1379,7 +1366,6 @@ impl Relay {
 				let s = track_outbound_server_requests_for_downstream(
 					name.clone(),
 					s,
-					self.pending_server_requests.clone(),
 					ctx_downstream_modern(&ctx),
 				);
 				(name, s)
@@ -1929,8 +1915,8 @@ fn accepted_response() -> Response {
 /// Namespace a server-initiated request id for the downstream connection.
 ///
 /// Upstream JSON-RPC ids are scoped per connection. Multiplexed backends can
-/// both emit id `0`; remapping keeps the downstream map collision-free and
-/// retains the original id for the reverse path.
+/// both emit id `0`; remapping keeps downstream ids collision-free and encodes
+/// the upstream name plus original id for the reverse path.
 fn downstream_server_request_id(upstream: &str, original: &RequestId) -> RequestId {
 	match original {
 		RequestId::Number(n) => RequestId::String(format!("agw:{upstream}:n:{n}").into()),
@@ -1938,55 +1924,48 @@ fn downstream_server_request_id(upstream: &str, original: &RequestId) -> Request
 	}
 }
 
-fn insert_pending_server_request(
-	pending_server_requests: &PendingServerRequestMap,
-	downstream_id: RequestId,
-	entry: PendingServerRequest,
-) {
-	let mut map = pending_server_requests
-		.lock()
-		.expect("pending_server_requests lock poisoned");
-	while map.len() >= MAX_PENDING_SERVER_REQUESTS {
-		let Some(evict) = map.keys().next().cloned() else {
-			break;
-		};
-		map.remove(&evict);
+fn parse_downstream_server_request_id(id: &RequestId) -> Option<PendingServerRequest> {
+	let RequestId::String(encoded) = id else {
+		return None;
+	};
+	let rest = encoded.as_ref().strip_prefix("agw:")?;
+	if let Some(idx) = rest.rfind(":n:") {
+		let upstream = &rest[..idx];
+		let n: i64 = rest[idx + 3..].parse().ok()?;
+		return Some(PendingServerRequest {
+			upstream: upstream.into(),
+			original_id: RequestId::Number(n),
+		});
 	}
-	map.insert(downstream_id, entry);
+	if let Some(idx) = rest.rfind(":s:") {
+		let upstream = &rest[..idx];
+		let original = &rest[idx + 3..];
+		return Some(PendingServerRequest {
+			upstream: upstream.into(),
+			original_id: RequestId::String(original.into()),
+		});
+	}
+	None
 }
 
-/// Remap and track server-initiated requests only when the downstream client can reply
+/// Remap server-initiated requests only when the downstream client can reply
 /// (legacy protocol). Modern downstreams reject direct server→client requests in SSE.
 fn track_outbound_server_requests_for_downstream(
 	upstream: Strng,
 	stream: Messages,
-	pending_server_requests: PendingServerRequestMap,
 	downstream_modern: bool,
 ) -> Messages {
 	if downstream_modern {
 		return stream;
 	}
-	track_outbound_server_requests(upstream, stream, pending_server_requests)
+	track_outbound_server_requests(upstream, stream)
 }
 
-fn track_outbound_server_requests(
-	upstream: Strng,
-	stream: Messages,
-	pending_server_requests: PendingServerRequestMap,
-) -> Messages {
+fn track_outbound_server_requests(upstream: Strng, stream: Messages) -> Messages {
 	stream.map_server_messages(move |msg| match msg {
 		ServerJsonRpcMessage::Request(mut req) => {
 			let original_id = req.id.clone();
-			let downstream_id = downstream_server_request_id(upstream.as_str(), &original_id);
-			insert_pending_server_request(
-				&pending_server_requests,
-				downstream_id.clone(),
-				PendingServerRequest {
-					upstream: upstream.clone(),
-					original_id,
-				},
-			);
-			req.id = downstream_id;
+			req.id = downstream_server_request_id(upstream.as_str(), &original_id);
 			ServerJsonRpcMessage::Request(req)
 		},
 		other => other,
@@ -1997,12 +1976,7 @@ fn resolve_pending_server_request(
 	relay: &Relay,
 	request_id: &RequestId,
 ) -> Result<PendingServerRequest, UpstreamError> {
-	if let Some(pending) = relay
-		.pending_server_requests
-		.lock()
-		.expect("pending_server_requests lock poisoned")
-		.remove(request_id)
-	{
+	if let Some(pending) = parse_downstream_server_request_id(request_id) {
 		return Ok(pending);
 	}
 	if relay.upstreams.size() == 1 {
@@ -2225,7 +2199,6 @@ mod tests {
 		use futures_util::StreamExt;
 		use rmcp::model::{PingRequest, ServerRequest};
 
-		let pending = Arc::new(Mutex::new(HashMap::new()));
 		let upstream: Strng = "backend".into();
 		let original_id = RequestId::Number(7);
 		let remapped = downstream_server_request_id(upstream.as_str(), &original_id);
@@ -2234,18 +2207,15 @@ mod tests {
 			original_id.clone(),
 		);
 		let mut tracked =
-			track_outbound_server_requests(upstream.clone(), Messages::from(ping), pending.clone());
+			track_outbound_server_requests(upstream.clone(), Messages::from(ping));
 		let forwarded = tracked.next().await.expect("message").expect("ok");
 		match forwarded {
 			ServerJsonRpcMessage::Request(req) => assert_eq!(req.id, remapped),
 			other => panic!("expected request, got {other:?}"),
 		}
-		let entry = pending.lock().expect("lock").get(&remapped).cloned();
-		assert_eq!(entry.as_ref().map(|e| e.upstream.as_str()), Some("backend"));
-		assert_eq!(
-			entry.as_ref().map(|e| e.original_id.clone()),
-			Some(original_id)
-		);
+		let parsed = parse_downstream_server_request_id(&remapped).expect("parsed");
+		assert_eq!(parsed.upstream.as_str(), "backend");
+		assert_eq!(parsed.original_id, original_id);
 	}
 
 	#[tokio::test]
@@ -2253,7 +2223,6 @@ mod tests {
 		use futures_util::StreamExt;
 		use rmcp::model::{PingRequest, ServerRequest};
 
-		let pending = Arc::new(Mutex::new(HashMap::new()));
 		let shared_id = RequestId::Number(0);
 		let a: Strng = "upstream-a".into();
 		let b: Strng = "upstream-b".into();
@@ -2267,9 +2236,9 @@ mod tests {
 		);
 
 		let mut tracked_a =
-			track_outbound_server_requests(a.clone(), Messages::from(ping_a), pending.clone());
+			track_outbound_server_requests(a.clone(), Messages::from(ping_a));
 		let mut tracked_b =
-			track_outbound_server_requests(b.clone(), Messages::from(ping_b), pending.clone());
+			track_outbound_server_requests(b.clone(), Messages::from(ping_b));
 		let fwd_a = tracked_a.next().await.expect("a").expect("ok");
 		let fwd_b = tracked_b.next().await.expect("b").expect("ok");
 
@@ -2285,21 +2254,24 @@ mod tests {
 		assert_eq!(id_a, downstream_server_request_id(a.as_str(), &shared_id));
 		assert_eq!(id_b, downstream_server_request_id(b.as_str(), &shared_id));
 
-		let map = pending.lock().expect("lock");
 		assert_eq!(
-			map.get(&id_a).map(|e| e.upstream.as_str()),
+			parse_downstream_server_request_id(&id_a)
+				.as_ref()
+				.map(|e| e.upstream.as_str()),
 			Some("upstream-a")
 		);
 		assert_eq!(
-			map.get(&id_b).map(|e| e.upstream.as_str()),
+			parse_downstream_server_request_id(&id_b)
+				.as_ref()
+				.map(|e| e.upstream.as_str()),
 			Some("upstream-b")
 		);
 		assert_eq!(
-			map.get(&id_a).map(|e| e.original_id.clone()),
+			parse_downstream_server_request_id(&id_a).map(|e| e.original_id),
 			Some(shared_id.clone())
 		);
 		assert_eq!(
-			map.get(&id_b).map(|e| e.original_id.clone()),
+			parse_downstream_server_request_id(&id_b).map(|e| e.original_id),
 			Some(shared_id)
 		);
 	}
@@ -2311,7 +2283,6 @@ mod tests {
 		use futures_util::StreamExt;
 		use rmcp::model::{PingRequest, ServerRequest};
 
-		let pending = Arc::new(Mutex::new(HashMap::new()));
 		let upstream: Strng = "post-backend".into();
 		let original_id = RequestId::String("ping-1".into());
 		let remapped = downstream_server_request_id(upstream.as_str(), &original_id);
@@ -2322,7 +2293,7 @@ mod tests {
 
 		// Same wrapper sequence used by send_single after rewrite_outbound_server_messages.
 		let mut tracked =
-			track_outbound_server_requests(upstream.clone(), Messages::from(ping), pending.clone());
+			track_outbound_server_requests(upstream.clone(), Messages::from(ping));
 		let forwarded = tracked.next().await.expect("message").expect("ok");
 		match forwarded {
 			ServerJsonRpcMessage::Request(req) => assert_eq!(req.id, remapped),
@@ -2338,7 +2309,9 @@ mod tests {
 			ClientJsonRpcMessage::Response(r) => assert_eq!(r.id, original_id),
 			other => panic!("expected response, got {other:?}"),
 		}
-		assert!(pending.lock().expect("lock").contains_key(&remapped));
+		let parsed = parse_downstream_server_request_id(&remapped).expect("parsed");
+		assert_eq!(parsed.upstream.as_str(), "post-backend");
+		assert_eq!(parsed.original_id, original_id);
 	}
 
 	#[tokio::test]
@@ -2346,7 +2319,6 @@ mod tests {
 		use futures_util::StreamExt;
 		use rmcp::model::{PingRequest, ServerRequest};
 
-		let pending = Arc::new(Mutex::new(HashMap::new()));
 		let upstream: Strng = "backend".into();
 		let original_id = RequestId::Number(7);
 		let ping = ServerJsonRpcMessage::request(
@@ -2356,7 +2328,6 @@ mod tests {
 		let mut tracked = track_outbound_server_requests_for_downstream(
 			upstream,
 			Messages::from(ping),
-			pending.clone(),
 			true,
 		);
 		let forwarded = tracked.next().await.expect("message").expect("ok");
@@ -2364,37 +2335,15 @@ mod tests {
 			ServerJsonRpcMessage::Request(req) => assert_eq!(req.id, original_id),
 			other => panic!("expected request, got {other:?}"),
 		}
-		assert!(pending.lock().expect("lock").is_empty());
 	}
 
-	#[tokio::test]
-	async fn insert_pending_server_request_evicts_when_at_capacity() {
-		let pending: PendingServerRequestMap = Arc::new(Mutex::new(HashMap::new()));
-		let upstream: Strng = "backend".into();
-		for n in 0..MAX_PENDING_SERVER_REQUESTS {
-			insert_pending_server_request(
-				&pending,
-				RequestId::Number(n as i64),
-				PendingServerRequest {
-					upstream: upstream.clone(),
-					original_id: RequestId::Number(n as i64),
-				},
-			);
-		}
-		assert_eq!(
-			pending.lock().expect("lock").len(),
-			MAX_PENDING_SERVER_REQUESTS
-		);
-		insert_pending_server_request(
-			&pending,
-			RequestId::Number(9999),
-			PendingServerRequest {
-				upstream: upstream.clone(),
-				original_id: RequestId::Number(9999),
-			},
-		);
-		let map = pending.lock().expect("lock");
-		assert_eq!(map.len(), MAX_PENDING_SERVER_REQUESTS);
-		assert!(map.contains_key(&RequestId::Number(9999)));
+	#[test]
+	fn parse_downstream_server_request_id_roundtrips_string_ids_with_colons() {
+		let upstream = "post-backend";
+		let original_id = RequestId::String("part:a:part".into());
+		let remapped = downstream_server_request_id(upstream, &original_id);
+		let parsed = parse_downstream_server_request_id(&remapped).expect("parsed");
+		assert_eq!(parsed.upstream.as_str(), upstream);
+		assert_eq!(parsed.original_id, original_id);
 	}
 }

--- a/crates/agentgateway/src/mcp/handler.rs
+++ b/crates/agentgateway/src/mcp/handler.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use agent_core::prelude::{AssertSize, Strng};
 use agent_core::version::BuildInfo;
+use base64::Engine;
 use futures_core::Stream;
 use futures_util::StreamExt;
 use http::StatusCode;
@@ -1920,7 +1921,10 @@ fn accepted_response() -> Response {
 fn downstream_server_request_id(upstream: &str, original: &RequestId) -> RequestId {
 	match original {
 		RequestId::Number(n) => RequestId::String(format!("agw:{upstream}:n:{n}").into()),
-		RequestId::String(s) => RequestId::String(format!("agw:{upstream}:s:{s}").into()),
+		RequestId::String(s) => {
+			let encoded = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(s.as_bytes());
+			RequestId::String(format!("agw:{upstream}:s:{encoded}").into())
+		},
 	}
 }
 
@@ -1929,23 +1933,29 @@ fn parse_downstream_server_request_id(id: &RequestId) -> Option<PendingServerReq
 		return None;
 	};
 	let rest = encoded.as_ref().strip_prefix("agw:")?;
-	if let Some(idx) = rest.rfind(":n:") {
-		let upstream = &rest[..idx];
-		let n: i64 = rest[idx + 3..].parse().ok()?;
+	if let Some((upstream, n_str)) = rest.rsplit_once(":n:") {
+		let n: i64 = n_str.parse().ok()?;
 		return Some(PendingServerRequest {
 			upstream: upstream.into(),
 			original_id: RequestId::Number(n),
 		});
 	}
-	if let Some(idx) = rest.rfind(":s:") {
-		let upstream = &rest[..idx];
-		let original = &rest[idx + 3..];
+	if let Some((upstream, payload)) = rest.split_once(":s:") {
+		let original = decode_downstream_string_request_id(payload)?;
 		return Some(PendingServerRequest {
 			upstream: upstream.into(),
 			original_id: RequestId::String(original.into()),
 		});
 	}
 	None
+}
+
+fn decode_downstream_string_request_id(payload: &str) -> Option<String> {
+	if let Ok(decoded) = base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(payload) {
+		return String::from_utf8(decoded).ok();
+	}
+	// Legacy remapped ids stored the raw string after the first `:s:` delimiter.
+	Some(payload.to_string())
 }
 
 /// Remap server-initiated requests only when the downstream client can reply
@@ -2334,6 +2344,16 @@ mod tests {
 	fn parse_downstream_server_request_id_roundtrips_string_ids_with_colons() {
 		let upstream = "post-backend";
 		let original_id = RequestId::String("part:a:part".into());
+		let remapped = downstream_server_request_id(upstream, &original_id);
+		let parsed = parse_downstream_server_request_id(&remapped).expect("parsed");
+		assert_eq!(parsed.upstream.as_str(), upstream);
+		assert_eq!(parsed.original_id, original_id);
+	}
+
+	#[test]
+	fn parse_downstream_server_request_id_roundtrips_string_ids_with_numeric_delimiter() {
+		let upstream = "backend";
+		let original_id = RequestId::String("part:n:7".into());
 		let remapped = downstream_server_request_id(upstream, &original_id);
 		let parsed = parse_downstream_server_request_id(&remapped).expect("parsed");
 		assert_eq!(parsed.upstream.as_str(), upstream);

--- a/crates/agentgateway/src/mcp/handler.rs
+++ b/crates/agentgateway/src/mcp/handler.rs
@@ -285,6 +285,10 @@ pub(crate) struct PendingServerRequest {
 
 pub(crate) type PendingServerRequestMap = Arc<Mutex<HashMap<RequestId, PendingServerRequest>>>;
 
+/// Cap unanswered server-initiated requests (e.g. heartbeat pings) so a session cannot grow
+/// the pending map without bound when clients never reply.
+const MAX_PENDING_SERVER_REQUESTS: usize = 256;
+
 #[derive(Debug, Clone)]
 pub struct Relay {
 	pub(crate) upstreams: Arc<upstream::UpstreamGroup>,
@@ -1228,10 +1232,11 @@ impl Relay {
 			Box::pin(us.generic_stream(r, &ctx).assert_size::<{ 3 * 1024 }>()).await?,
 			cel,
 		);
-		let stream = track_outbound_server_requests(
+		let stream = track_outbound_server_requests_for_downstream(
 			service_name.into(),
 			stream,
 			self.pending_server_requests.clone(),
+			ctx_downstream_modern(&ctx),
 		);
 
 		respond_with_guardrails(id, stream, guardrails, mcp_log, &ctx)
@@ -1291,8 +1296,12 @@ impl Relay {
 			match result {
 				Ok(s) => {
 					let s = self.rewrite_outbound_server_messages(name.as_str(), s, cel.clone());
-					let s =
-						track_outbound_server_requests(name.clone(), s, self.pending_server_requests.clone());
+					let s = track_outbound_server_requests_for_downstream(
+						name.clone(),
+						s,
+						self.pending_server_requests.clone(),
+						ctx_downstream_modern(&ctx),
+					);
 					streams.push((name, s));
 				},
 				Err(e) => {
@@ -1367,8 +1376,12 @@ impl Relay {
 			.into_iter()
 			.map(|(name, s)| {
 				let s = self.rewrite_outbound_server_messages(name.as_str(), s, cel.clone());
-				let s =
-					track_outbound_server_requests(name.clone(), s, self.pending_server_requests.clone());
+				let s = track_outbound_server_requests_for_downstream(
+					name.clone(),
+					s,
+					self.pending_server_requests.clone(),
+					ctx_downstream_modern(&ctx),
+				);
 				(name, s)
 			})
 			.collect::<Vec<_>>();
@@ -1905,6 +1918,37 @@ fn downstream_server_request_id(upstream: &str, original: &RequestId) -> Request
 	}
 }
 
+fn insert_pending_server_request(
+	pending_server_requests: &PendingServerRequestMap,
+	downstream_id: RequestId,
+	entry: PendingServerRequest,
+) {
+	let mut map = pending_server_requests
+		.lock()
+		.expect("pending_server_requests lock poisoned");
+	while map.len() >= MAX_PENDING_SERVER_REQUESTS {
+		let Some(evict) = map.keys().next().cloned() else {
+			break;
+		};
+		map.remove(&evict);
+	}
+	map.insert(downstream_id, entry);
+}
+
+/// Remap and track server-initiated requests only when the downstream client can reply
+/// (legacy protocol). Modern downstreams reject direct server→client requests in SSE.
+fn track_outbound_server_requests_for_downstream(
+	upstream: Strng,
+	stream: Messages,
+	pending_server_requests: PendingServerRequestMap,
+	downstream_modern: bool,
+) -> Messages {
+	if downstream_modern {
+		return stream;
+	}
+	track_outbound_server_requests(upstream, stream, pending_server_requests)
+}
+
 fn track_outbound_server_requests(
 	upstream: Strng,
 	stream: Messages,
@@ -1914,16 +1958,14 @@ fn track_outbound_server_requests(
 		ServerJsonRpcMessage::Request(mut req) => {
 			let original_id = req.id.clone();
 			let downstream_id = downstream_server_request_id(upstream.as_str(), &original_id);
-			pending_server_requests
-				.lock()
-				.expect("pending_server_requests lock poisoned")
-				.insert(
-					downstream_id.clone(),
-					PendingServerRequest {
-						upstream: upstream.clone(),
-						original_id,
-					},
-				);
+			insert_pending_server_request(
+				&pending_server_requests,
+				downstream_id.clone(),
+				PendingServerRequest {
+					upstream: upstream.clone(),
+					original_id,
+				},
+			);
 			req.id = downstream_id;
 			ServerJsonRpcMessage::Request(req)
 		},
@@ -2277,5 +2319,62 @@ mod tests {
 			other => panic!("expected response, got {other:?}"),
 		}
 		assert!(pending.lock().expect("lock").contains_key(&remapped));
+	}
+
+	#[tokio::test]
+	async fn track_outbound_server_requests_skipped_for_modern_downstream() {
+		use futures_util::StreamExt;
+		use rmcp::model::{PingRequest, ServerRequest};
+
+		let pending = Arc::new(Mutex::new(HashMap::new()));
+		let upstream: Strng = "backend".into();
+		let original_id = RequestId::Number(7);
+		let ping = ServerJsonRpcMessage::request(
+			ServerRequest::PingRequest(PingRequest::default()),
+			original_id.clone(),
+		);
+		let mut tracked = track_outbound_server_requests_for_downstream(
+			upstream,
+			Messages::from(ping),
+			pending.clone(),
+			true,
+		);
+		let forwarded = tracked.next().await.expect("message").expect("ok");
+		match forwarded {
+			ServerJsonRpcMessage::Request(req) => assert_eq!(req.id, original_id),
+			other => panic!("expected request, got {other:?}"),
+		}
+		assert!(pending.lock().expect("lock").is_empty());
+	}
+
+	#[tokio::test]
+	async fn insert_pending_server_request_evicts_when_at_capacity() {
+		let pending: PendingServerRequestMap = Arc::new(Mutex::new(HashMap::new()));
+		let upstream: Strng = "backend".into();
+		for n in 0..MAX_PENDING_SERVER_REQUESTS {
+			insert_pending_server_request(
+				&pending,
+				RequestId::Number(n as i64),
+				PendingServerRequest {
+					upstream: upstream.clone(),
+					original_id: RequestId::Number(n as i64),
+				},
+			);
+		}
+		assert_eq!(
+			pending.lock().expect("lock").len(),
+			MAX_PENDING_SERVER_REQUESTS
+		);
+		insert_pending_server_request(
+			&pending,
+			RequestId::Number(9999),
+			PendingServerRequest {
+				upstream: upstream.clone(),
+				original_id: RequestId::Number(9999),
+			},
+		);
+		let map = pending.lock().expect("lock");
+		assert_eq!(map.len(), MAX_PENDING_SERVER_REQUESTS);
+		assert!(map.contains_key(&RequestId::Number(9999)));
 	}
 }

--- a/crates/agentgateway/src/mcp/handler.rs
+++ b/crates/agentgateway/src/mcp/handler.rs
@@ -2206,8 +2206,7 @@ mod tests {
 			ServerRequest::PingRequest(PingRequest::default()),
 			original_id.clone(),
 		);
-		let mut tracked =
-			track_outbound_server_requests(upstream.clone(), Messages::from(ping));
+		let mut tracked = track_outbound_server_requests(upstream.clone(), Messages::from(ping));
 		let forwarded = tracked.next().await.expect("message").expect("ok");
 		match forwarded {
 			ServerJsonRpcMessage::Request(req) => assert_eq!(req.id, remapped),
@@ -2235,10 +2234,8 @@ mod tests {
 			shared_id.clone(),
 		);
 
-		let mut tracked_a =
-			track_outbound_server_requests(a.clone(), Messages::from(ping_a));
-		let mut tracked_b =
-			track_outbound_server_requests(b.clone(), Messages::from(ping_b));
+		let mut tracked_a = track_outbound_server_requests(a.clone(), Messages::from(ping_a));
+		let mut tracked_b = track_outbound_server_requests(b.clone(), Messages::from(ping_b));
 		let fwd_a = tracked_a.next().await.expect("a").expect("ok");
 		let fwd_b = tracked_b.next().await.expect("b").expect("ok");
 
@@ -2292,8 +2289,7 @@ mod tests {
 		);
 
 		// Same wrapper sequence used by send_single after rewrite_outbound_server_messages.
-		let mut tracked =
-			track_outbound_server_requests(upstream.clone(), Messages::from(ping));
+		let mut tracked = track_outbound_server_requests(upstream.clone(), Messages::from(ping));
 		let forwarded = tracked.next().await.expect("message").expect("ok");
 		match forwarded {
 			ServerJsonRpcMessage::Request(req) => assert_eq!(req.id, remapped),
@@ -2325,11 +2321,8 @@ mod tests {
 			ServerRequest::PingRequest(PingRequest::default()),
 			original_id.clone(),
 		);
-		let mut tracked = track_outbound_server_requests_for_downstream(
-			upstream,
-			Messages::from(ping),
-			true,
-		);
+		let mut tracked =
+			track_outbound_server_requests_for_downstream(upstream, Messages::from(ping), true);
 		let forwarded = tracked.next().await.expect("message").expect("ok");
 		match forwarded {
 			ServerJsonRpcMessage::Request(req) => assert_eq!(req.id, original_id),

--- a/crates/agentgateway/src/mcp/handler.rs
+++ b/crates/agentgateway/src/mcp/handler.rs
@@ -2163,8 +2163,7 @@ mod tests {
 			ServerRequest::PingRequest(PingRequest::default()),
 			original_id.clone(),
 		);
-		let mut tracked =
-			track_outbound_server_requests(upstream.clone(), Messages::from(ping));
+		let mut tracked = track_outbound_server_requests(upstream.clone(), Messages::from(ping));
 		let forwarded = tracked.next().await.expect("message").expect("ok");
 		match forwarded {
 			ServerJsonRpcMessage::Request(req) => assert_eq!(req.id, remapped),
@@ -2192,10 +2191,8 @@ mod tests {
 			shared_id.clone(),
 		);
 
-		let mut tracked_a =
-			track_outbound_server_requests(a.clone(), Messages::from(ping_a));
-		let mut tracked_b =
-			track_outbound_server_requests(b.clone(), Messages::from(ping_b));
+		let mut tracked_a = track_outbound_server_requests(a.clone(), Messages::from(ping_a));
+		let mut tracked_b = track_outbound_server_requests(b.clone(), Messages::from(ping_b));
 		let fwd_a = tracked_a.next().await.expect("a").expect("ok");
 		let fwd_b = tracked_b.next().await.expect("b").expect("ok");
 
@@ -2249,8 +2246,7 @@ mod tests {
 		);
 
 		// Same wrapper sequence used by send_single after rewrite_outbound_server_messages.
-		let mut tracked =
-			track_outbound_server_requests(upstream.clone(), Messages::from(ping));
+		let mut tracked = track_outbound_server_requests(upstream.clone(), Messages::from(ping));
 		let forwarded = tracked.next().await.expect("message").expect("ok");
 		match forwarded {
 			ServerJsonRpcMessage::Request(req) => assert_eq!(req.id, remapped),
@@ -2282,11 +2278,8 @@ mod tests {
 			ServerRequest::PingRequest(PingRequest::default()),
 			original_id.clone(),
 		);
-		let mut tracked = track_outbound_server_requests_for_downstream(
-			upstream,
-			Messages::from(ping),
-			true,
-		);
+		let mut tracked =
+			track_outbound_server_requests_for_downstream(upstream, Messages::from(ping), true);
 		let forwarded = tracked.next().await.expect("message").expect("ok");
 		match forwarded {
 			ServerJsonRpcMessage::Request(req) => assert_eq!(req.id, original_id),

--- a/crates/agentgateway/src/mcp/handler.rs
+++ b/crates/agentgateway/src/mcp/handler.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use agent_core::prelude::{AssertSize, Strng};
 use agent_core::version::BuildInfo;
@@ -212,19 +212,12 @@ impl ResolveKind {
 	}
 }
 
-/// Tracks a server-initiated JSON-RPC request so a later downstream Response/Error
-/// can be routed to the issuing upstream with the original request id restored.
+/// Parsed routing state for a downstream-facing server-initiated request id.
 #[derive(Debug, Clone)]
 pub(crate) struct PendingServerRequest {
 	upstream: Strng,
 	original_id: RequestId,
 }
-
-pub(crate) type PendingServerRequestMap = Arc<Mutex<HashMap<RequestId, PendingServerRequest>>>;
-
-/// Cap unanswered server-initiated requests (e.g. heartbeat pings) so a session cannot grow
-/// the pending map without bound when clients never reply.
-const MAX_PENDING_SERVER_REQUESTS: usize = 256;
 
 #[derive(Debug, Clone)]
 pub struct Relay {
@@ -232,8 +225,6 @@ pub struct Relay {
 	pub policies: McpAuthorizationSet,
 	pub(crate) mcp_guardrails: Option<Arc<crate::mcp::guardrails::McpGuardrails>>,
 	pub(crate) policy_client: PolicyClient,
-	/// Downstream-facing server-initiated request ids → upstream + original id.
-	pending_server_requests: PendingServerRequestMap,
 }
 
 pub struct RelayInputs {
@@ -264,7 +255,6 @@ impl Relay {
 			policies,
 			mcp_guardrails: None,
 			policy_client: client,
-			pending_server_requests: Arc::new(Mutex::new(HashMap::new())),
 		})
 	}
 	pub fn with_policies(&self, policies: McpAuthorizationSet) -> Self {
@@ -273,7 +263,6 @@ impl Relay {
 			policies,
 			mcp_guardrails: self.mcp_guardrails.clone(),
 			policy_client: self.policy_client.clone(),
-			pending_server_requests: self.pending_server_requests.clone(),
 		}
 	}
 
@@ -1154,7 +1143,6 @@ impl Relay {
 		let stream = track_outbound_server_requests_for_downstream(
 			service_name.into(),
 			stream,
-			self.pending_server_requests.clone(),
 			ctx_downstream_modern(&ctx),
 		);
 
@@ -1218,7 +1206,6 @@ impl Relay {
 					let s = track_outbound_server_requests_for_downstream(
 						name.clone(),
 						s,
-						self.pending_server_requests.clone(),
 						ctx_downstream_modern(&ctx),
 					);
 					streams.push((name, s));
@@ -1298,7 +1285,6 @@ impl Relay {
 				let s = track_outbound_server_requests_for_downstream(
 					name.clone(),
 					s,
-					self.pending_server_requests.clone(),
 					ctx_downstream_modern(&ctx),
 				);
 				(name, s)
@@ -1875,8 +1861,8 @@ fn accepted_response() -> Response {
 /// Namespace a server-initiated request id for the downstream connection.
 ///
 /// Upstream JSON-RPC ids are scoped per connection. Multiplexed backends can
-/// both emit id `0`; remapping keeps the downstream map collision-free and
-/// retains the original id for the reverse path.
+/// both emit id `0`; remapping keeps downstream ids collision-free and encodes
+/// the upstream name plus original id for the reverse path.
 fn downstream_server_request_id(upstream: &str, original: &RequestId) -> RequestId {
 	match original {
 		RequestId::Number(n) => RequestId::String(format!("agw:{upstream}:n:{n}").into()),
@@ -1884,55 +1870,48 @@ fn downstream_server_request_id(upstream: &str, original: &RequestId) -> Request
 	}
 }
 
-fn insert_pending_server_request(
-	pending_server_requests: &PendingServerRequestMap,
-	downstream_id: RequestId,
-	entry: PendingServerRequest,
-) {
-	let mut map = pending_server_requests
-		.lock()
-		.expect("pending_server_requests lock poisoned");
-	while map.len() >= MAX_PENDING_SERVER_REQUESTS {
-		let Some(evict) = map.keys().next().cloned() else {
-			break;
-		};
-		map.remove(&evict);
+fn parse_downstream_server_request_id(id: &RequestId) -> Option<PendingServerRequest> {
+	let RequestId::String(encoded) = id else {
+		return None;
+	};
+	let rest = encoded.as_ref().strip_prefix("agw:")?;
+	if let Some(idx) = rest.rfind(":n:") {
+		let upstream = &rest[..idx];
+		let n: i64 = rest[idx + 3..].parse().ok()?;
+		return Some(PendingServerRequest {
+			upstream: upstream.into(),
+			original_id: RequestId::Number(n),
+		});
 	}
-	map.insert(downstream_id, entry);
+	if let Some(idx) = rest.rfind(":s:") {
+		let upstream = &rest[..idx];
+		let original = &rest[idx + 3..];
+		return Some(PendingServerRequest {
+			upstream: upstream.into(),
+			original_id: RequestId::String(original.into()),
+		});
+	}
+	None
 }
 
-/// Remap and track server-initiated requests only when the downstream client can reply
+/// Remap server-initiated requests only when the downstream client can reply
 /// (legacy protocol). Modern downstreams reject direct server→client requests in SSE.
 fn track_outbound_server_requests_for_downstream(
 	upstream: Strng,
 	stream: Messages,
-	pending_server_requests: PendingServerRequestMap,
 	downstream_modern: bool,
 ) -> Messages {
 	if downstream_modern {
 		return stream;
 	}
-	track_outbound_server_requests(upstream, stream, pending_server_requests)
+	track_outbound_server_requests(upstream, stream)
 }
 
-fn track_outbound_server_requests(
-	upstream: Strng,
-	stream: Messages,
-	pending_server_requests: PendingServerRequestMap,
-) -> Messages {
+fn track_outbound_server_requests(upstream: Strng, stream: Messages) -> Messages {
 	stream.map_server_messages(move |msg| match msg {
 		ServerJsonRpcMessage::Request(mut req) => {
 			let original_id = req.id.clone();
-			let downstream_id = downstream_server_request_id(upstream.as_str(), &original_id);
-			insert_pending_server_request(
-				&pending_server_requests,
-				downstream_id.clone(),
-				PendingServerRequest {
-					upstream: upstream.clone(),
-					original_id,
-				},
-			);
-			req.id = downstream_id;
+			req.id = downstream_server_request_id(upstream.as_str(), &original_id);
 			ServerJsonRpcMessage::Request(req)
 		},
 		other => other,
@@ -1943,12 +1922,7 @@ fn resolve_pending_server_request(
 	relay: &Relay,
 	request_id: &RequestId,
 ) -> Result<PendingServerRequest, UpstreamError> {
-	if let Some(pending) = relay
-		.pending_server_requests
-		.lock()
-		.expect("pending_server_requests lock poisoned")
-		.remove(request_id)
-	{
+	if let Some(pending) = parse_downstream_server_request_id(request_id) {
 		return Ok(pending);
 	}
 	if relay.upstreams.size() == 1 {
@@ -2182,7 +2156,6 @@ mod tests {
 		use futures_util::StreamExt;
 		use rmcp::model::{PingRequest, ServerRequest};
 
-		let pending = Arc::new(Mutex::new(HashMap::new()));
 		let upstream: Strng = "backend".into();
 		let original_id = RequestId::Number(7);
 		let remapped = downstream_server_request_id(upstream.as_str(), &original_id);
@@ -2191,18 +2164,15 @@ mod tests {
 			original_id.clone(),
 		);
 		let mut tracked =
-			track_outbound_server_requests(upstream.clone(), Messages::from(ping), pending.clone());
+			track_outbound_server_requests(upstream.clone(), Messages::from(ping));
 		let forwarded = tracked.next().await.expect("message").expect("ok");
 		match forwarded {
 			ServerJsonRpcMessage::Request(req) => assert_eq!(req.id, remapped),
 			other => panic!("expected request, got {other:?}"),
 		}
-		let entry = pending.lock().expect("lock").get(&remapped).cloned();
-		assert_eq!(entry.as_ref().map(|e| e.upstream.as_str()), Some("backend"));
-		assert_eq!(
-			entry.as_ref().map(|e| e.original_id.clone()),
-			Some(original_id)
-		);
+		let parsed = parse_downstream_server_request_id(&remapped).expect("parsed");
+		assert_eq!(parsed.upstream.as_str(), "backend");
+		assert_eq!(parsed.original_id, original_id);
 	}
 
 	#[tokio::test]
@@ -2210,7 +2180,6 @@ mod tests {
 		use futures_util::StreamExt;
 		use rmcp::model::{PingRequest, ServerRequest};
 
-		let pending = Arc::new(Mutex::new(HashMap::new()));
 		let shared_id = RequestId::Number(0);
 		let a: Strng = "upstream-a".into();
 		let b: Strng = "upstream-b".into();
@@ -2224,9 +2193,9 @@ mod tests {
 		);
 
 		let mut tracked_a =
-			track_outbound_server_requests(a.clone(), Messages::from(ping_a), pending.clone());
+			track_outbound_server_requests(a.clone(), Messages::from(ping_a));
 		let mut tracked_b =
-			track_outbound_server_requests(b.clone(), Messages::from(ping_b), pending.clone());
+			track_outbound_server_requests(b.clone(), Messages::from(ping_b));
 		let fwd_a = tracked_a.next().await.expect("a").expect("ok");
 		let fwd_b = tracked_b.next().await.expect("b").expect("ok");
 
@@ -2242,21 +2211,24 @@ mod tests {
 		assert_eq!(id_a, downstream_server_request_id(a.as_str(), &shared_id));
 		assert_eq!(id_b, downstream_server_request_id(b.as_str(), &shared_id));
 
-		let map = pending.lock().expect("lock");
 		assert_eq!(
-			map.get(&id_a).map(|e| e.upstream.as_str()),
+			parse_downstream_server_request_id(&id_a)
+				.as_ref()
+				.map(|e| e.upstream.as_str()),
 			Some("upstream-a")
 		);
 		assert_eq!(
-			map.get(&id_b).map(|e| e.upstream.as_str()),
+			parse_downstream_server_request_id(&id_b)
+				.as_ref()
+				.map(|e| e.upstream.as_str()),
 			Some("upstream-b")
 		);
 		assert_eq!(
-			map.get(&id_a).map(|e| e.original_id.clone()),
+			parse_downstream_server_request_id(&id_a).map(|e| e.original_id),
 			Some(shared_id.clone())
 		);
 		assert_eq!(
-			map.get(&id_b).map(|e| e.original_id.clone()),
+			parse_downstream_server_request_id(&id_b).map(|e| e.original_id),
 			Some(shared_id)
 		);
 	}
@@ -2268,7 +2240,6 @@ mod tests {
 		use futures_util::StreamExt;
 		use rmcp::model::{PingRequest, ServerRequest};
 
-		let pending = Arc::new(Mutex::new(HashMap::new()));
 		let upstream: Strng = "post-backend".into();
 		let original_id = RequestId::String("ping-1".into());
 		let remapped = downstream_server_request_id(upstream.as_str(), &original_id);
@@ -2279,7 +2250,7 @@ mod tests {
 
 		// Same wrapper sequence used by send_single after rewrite_outbound_server_messages.
 		let mut tracked =
-			track_outbound_server_requests(upstream.clone(), Messages::from(ping), pending.clone());
+			track_outbound_server_requests(upstream.clone(), Messages::from(ping));
 		let forwarded = tracked.next().await.expect("message").expect("ok");
 		match forwarded {
 			ServerJsonRpcMessage::Request(req) => assert_eq!(req.id, remapped),
@@ -2295,7 +2266,9 @@ mod tests {
 			ClientJsonRpcMessage::Response(r) => assert_eq!(r.id, original_id),
 			other => panic!("expected response, got {other:?}"),
 		}
-		assert!(pending.lock().expect("lock").contains_key(&remapped));
+		let parsed = parse_downstream_server_request_id(&remapped).expect("parsed");
+		assert_eq!(parsed.upstream.as_str(), "post-backend");
+		assert_eq!(parsed.original_id, original_id);
 	}
 
 	#[tokio::test]
@@ -2303,7 +2276,6 @@ mod tests {
 		use futures_util::StreamExt;
 		use rmcp::model::{PingRequest, ServerRequest};
 
-		let pending = Arc::new(Mutex::new(HashMap::new()));
 		let upstream: Strng = "backend".into();
 		let original_id = RequestId::Number(7);
 		let ping = ServerJsonRpcMessage::request(
@@ -2313,7 +2285,6 @@ mod tests {
 		let mut tracked = track_outbound_server_requests_for_downstream(
 			upstream,
 			Messages::from(ping),
-			pending.clone(),
 			true,
 		);
 		let forwarded = tracked.next().await.expect("message").expect("ok");
@@ -2321,37 +2292,15 @@ mod tests {
 			ServerJsonRpcMessage::Request(req) => assert_eq!(req.id, original_id),
 			other => panic!("expected request, got {other:?}"),
 		}
-		assert!(pending.lock().expect("lock").is_empty());
 	}
 
-	#[tokio::test]
-	async fn insert_pending_server_request_evicts_when_at_capacity() {
-		let pending: PendingServerRequestMap = Arc::new(Mutex::new(HashMap::new()));
-		let upstream: Strng = "backend".into();
-		for n in 0..MAX_PENDING_SERVER_REQUESTS {
-			insert_pending_server_request(
-				&pending,
-				RequestId::Number(n as i64),
-				PendingServerRequest {
-					upstream: upstream.clone(),
-					original_id: RequestId::Number(n as i64),
-				},
-			);
-		}
-		assert_eq!(
-			pending.lock().expect("lock").len(),
-			MAX_PENDING_SERVER_REQUESTS
-		);
-		insert_pending_server_request(
-			&pending,
-			RequestId::Number(9999),
-			PendingServerRequest {
-				upstream: upstream.clone(),
-				original_id: RequestId::Number(9999),
-			},
-		);
-		let map = pending.lock().expect("lock");
-		assert_eq!(map.len(), MAX_PENDING_SERVER_REQUESTS);
-		assert!(map.contains_key(&RequestId::Number(9999)));
+	#[test]
+	fn parse_downstream_server_request_id_roundtrips_string_ids_with_colons() {
+		let upstream = "post-backend";
+		let original_id = RequestId::String("part:a:part".into());
+		let remapped = downstream_server_request_id(upstream, &original_id);
+		let parsed = parse_downstream_server_request_id(&remapped).expect("parsed");
+		assert_eq!(parsed.upstream.as_str(), upstream);
+		assert_eq!(parsed.original_id, original_id);
 	}
 }

--- a/crates/agentgateway/src/mcp/handler.rs
+++ b/crates/agentgateway/src/mcp/handler.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 
 use agent_core::prelude::{AssertSize, Strng};
 use agent_core::version::BuildInfo;
-use base64::Engine;
 use futures_core::Stream;
 use futures_util::StreamExt;
 use http::StatusCode;
@@ -278,7 +277,7 @@ impl ResolveKind {
 
 /// Parsed routing state for a downstream-facing server-initiated request id.
 #[derive(Debug, Clone)]
-pub(crate) struct PendingServerRequest {
+pub(crate) struct ServerRequestRoute {
 	upstream: Strng,
 	original_id: RequestId,
 }
@@ -1391,41 +1390,35 @@ impl Relay {
 		message: ClientJsonRpcMessage,
 		ctx: IncomingRequestContext,
 	) -> Result<Response, UpstreamError> {
-		match &message {
-			ClientJsonRpcMessage::Error(e) if e.id.is_none() => {
-				if self.upstreams.size() == 1 {
-					let name = self
-						.upstreams
-						.iter_named()
-						.next()
-						.map(|(name, _)| name)
-						.ok_or_else(|| UpstreamError::InvalidRequest("no upstreams available".into()))?;
-					let us = self.upstreams.get(name.as_str())?;
-					us.generic_client_message(message, &ctx).await?;
-					return Ok(accepted_response());
-				}
-				warn!(
-					"dropping client JSON-RPC error without id in multiplexed session; cannot route upstream"
-				);
-				return Ok(accepted_response());
-			},
-			ClientJsonRpcMessage::Response(_) | ClientJsonRpcMessage::Error(_) => {},
+		let request_id = match &message {
+			ClientJsonRpcMessage::Response(r) => Some(r.id.clone()),
+			ClientJsonRpcMessage::Error(e) => e.id.clone(),
 			_ => {
 				return Err(UpstreamError::InvalidRequest(
 					"expected client JSON-RPC response".into(),
 				));
 			},
-		}
-
-		let request_id = match &message {
-			ClientJsonRpcMessage::Response(r) => r.id.clone(),
-			ClientJsonRpcMessage::Error(e) => e.id.clone().expect("id checked above"),
-			_ => unreachable!(),
 		};
 
-		let pending = resolve_pending_server_request(self, &request_id)?;
-		let message = restore_client_response_id(message, pending.original_id)?;
-		let us = self.upstreams.get(pending.upstream.as_str())?;
+		let (upstream, message) = match request_id {
+			Some(id) => {
+				let route = resolve_server_request_route(self, &id)?;
+				(
+					route.upstream,
+					restore_client_response_id(message, route.original_id),
+				)
+			},
+			// Errors may omit an id; without one we can only route to a default target.
+			None => match &self.upstreams.default_target_name {
+				Some(name) => (name.as_str().into(), message),
+				None => {
+					warn!("dropping id-less client JSON-RPC error; cannot route in multiplexed session");
+					return Ok(accepted_response());
+				},
+			},
+		};
+
+		let us = self.upstreams.get(upstream.as_str())?;
 		us.generic_client_message(message, &ctx).await?;
 		Ok(accepted_response())
 	}
@@ -1918,44 +1911,42 @@ fn accepted_response() -> Response {
 /// Upstream JSON-RPC ids are scoped per connection. Multiplexed backends can
 /// both emit id `0`; remapping keeps downstream ids collision-free and encodes
 /// the upstream name plus original id for the reverse path.
+///
+/// Layout is `agw_{upstream}_{n|s}_{original}`:
+/// * `agw_` helps us ensure we don't rewrite IDs that we didn't generate.
+/// * `{upstream}` is the name of the upstream connection that generated the request.
+/// * `{n|s}` is a tag for the original id type: `n`
+/// * `{original}` is the original id, either a number or string.
 fn downstream_server_request_id(upstream: &str, original: &RequestId) -> RequestId {
 	match original {
-		RequestId::Number(n) => RequestId::String(format!("agw:{upstream}:n:{n}").into()),
+		RequestId::Number(n) => {
+			RequestId::String(format!("agw{DELIMITER}{upstream}{DELIMITER}n{DELIMITER}{n}").into())
+		},
 		RequestId::String(s) => {
-			let encoded = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(s.as_bytes());
-			RequestId::String(format!("agw:{upstream}:s:{encoded}").into())
+			RequestId::String(format!("agw{DELIMITER}{upstream}{DELIMITER}s{DELIMITER}{s}").into())
 		},
 	}
 }
 
-fn parse_downstream_server_request_id(id: &RequestId) -> Option<PendingServerRequest> {
+fn parse_downstream_server_request_id(id: &RequestId) -> Option<ServerRequestRoute> {
 	let RequestId::String(encoded) = id else {
 		return None;
 	};
-	let rest = encoded.as_ref().strip_prefix("agw:")?;
-	if let Some((upstream, n_str)) = rest.rsplit_once(":n:") {
-		let n: i64 = n_str.parse().ok()?;
-		return Some(PendingServerRequest {
-			upstream: upstream.into(),
-			original_id: RequestId::Number(n),
-		});
-	}
-	if let Some((upstream, payload)) = rest.split_once(":s:") {
-		let original = decode_downstream_string_request_id(payload)?;
-		return Some(PendingServerRequest {
-			upstream: upstream.into(),
-			original_id: RequestId::String(original.into()),
-		});
-	}
-	None
-}
-
-fn decode_downstream_string_request_id(payload: &str) -> Option<String> {
-	if let Ok(decoded) = base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(payload) {
-		return String::from_utf8(decoded).ok();
-	}
-	// Legacy remapped ids stored the raw string after the first `:s:` delimiter.
-	Some(payload.to_string())
+	let rest = encoded
+		.as_ref()
+		.strip_prefix("agw")?
+		.strip_prefix(DELIMITER)?;
+	let (upstream, rest) = rest.split_once(DELIMITER)?;
+	let (tag, payload) = rest.split_once(DELIMITER)?;
+	let original_id = match tag {
+		"n" => RequestId::Number(payload.parse().ok()?),
+		"s" => RequestId::String(payload.into()),
+		_ => return None,
+	};
+	Some(ServerRequestRoute {
+		upstream: upstream.into(),
+		original_id,
+	})
 }
 
 /// Remap server-initiated requests only when the downstream client can reply
@@ -1982,22 +1973,16 @@ fn track_outbound_server_requests(upstream: Strng, stream: Messages) -> Messages
 	})
 }
 
-fn resolve_pending_server_request(
+fn resolve_server_request_route(
 	relay: &Relay,
 	request_id: &RequestId,
-) -> Result<PendingServerRequest, UpstreamError> {
-	if let Some(pending) = parse_downstream_server_request_id(request_id) {
-		return Ok(pending);
+) -> Result<ServerRequestRoute, UpstreamError> {
+	if let Some(route) = parse_downstream_server_request_id(request_id) {
+		return Ok(route);
 	}
-	if relay.upstreams.size() == 1 {
-		let name = relay
-			.upstreams
-			.iter_named()
-			.next()
-			.map(|(name, _)| name)
-			.ok_or_else(|| UpstreamError::InvalidRequest("no upstreams available".into()))?;
-		return Ok(PendingServerRequest {
-			upstream: name,
+	if let Some(name) = &relay.upstreams.default_target_name {
+		return Ok(ServerRequestRoute {
+			upstream: name.as_str().into(),
 			original_id: request_id.clone(),
 		});
 	}
@@ -2009,19 +1994,17 @@ fn resolve_pending_server_request(
 fn restore_client_response_id(
 	message: ClientJsonRpcMessage,
 	original_id: RequestId,
-) -> Result<ClientJsonRpcMessage, UpstreamError> {
+) -> ClientJsonRpcMessage {
 	match message {
 		ClientJsonRpcMessage::Response(mut r) => {
 			r.id = original_id;
-			Ok(ClientJsonRpcMessage::Response(r))
+			ClientJsonRpcMessage::Response(r)
 		},
 		ClientJsonRpcMessage::Error(mut e) => {
 			e.id = Some(original_id);
-			Ok(ClientJsonRpcMessage::Error(e))
+			ClientJsonRpcMessage::Error(e)
 		},
-		_ => Err(UpstreamError::InvalidRequest(
-			"expected client JSON-RPC response".into(),
-		)),
+		_ => unreachable!("send_client_response validates message type before calling"),
 	}
 }
 
@@ -2205,29 +2188,6 @@ mod tests {
 	}
 
 	#[tokio::test]
-	async fn track_outbound_server_requests_registers_remapped_server_initiated_request_id() {
-		use futures_util::StreamExt;
-		use rmcp::model::{PingRequest, ServerRequest};
-
-		let upstream: Strng = "backend".into();
-		let original_id = RequestId::Number(7);
-		let remapped = downstream_server_request_id(upstream.as_str(), &original_id);
-		let ping = ServerJsonRpcMessage::request(
-			ServerRequest::PingRequest(PingRequest::default()),
-			original_id.clone(),
-		);
-		let mut tracked = track_outbound_server_requests(upstream.clone(), Messages::from(ping));
-		let forwarded = tracked.next().await.expect("message").expect("ok");
-		match forwarded {
-			ServerJsonRpcMessage::Request(req) => assert_eq!(req.id, remapped),
-			other => panic!("expected request, got {other:?}"),
-		}
-		let parsed = parse_downstream_server_request_id(&remapped).expect("parsed");
-		assert_eq!(parsed.upstream.as_str(), "backend");
-		assert_eq!(parsed.original_id, original_id);
-	}
-
-	#[tokio::test]
 	async fn track_outbound_server_requests_namespaces_colliding_ids_across_upstreams() {
 		use futures_util::StreamExt;
 		use rmcp::model::{PingRequest, ServerRequest};
@@ -2284,43 +2244,6 @@ mod tests {
 	}
 
 	#[tokio::test]
-	async fn track_outbound_server_requests_covers_post_originated_sse_streams() {
-		// send_single / send_fanout_to wrap POST-originated SSE the same way as
-		// send_fanout_get: rewrite then track_outbound_server_requests.
-		use futures_util::StreamExt;
-		use rmcp::model::{PingRequest, ServerRequest};
-
-		let upstream: Strng = "post-backend".into();
-		let original_id = RequestId::String("ping-1".into());
-		let remapped = downstream_server_request_id(upstream.as_str(), &original_id);
-		let ping = ServerJsonRpcMessage::request(
-			ServerRequest::PingRequest(PingRequest::default()),
-			original_id.clone(),
-		);
-
-		// Same wrapper sequence used by send_single after rewrite_outbound_server_messages.
-		let mut tracked = track_outbound_server_requests(upstream.clone(), Messages::from(ping));
-		let forwarded = tracked.next().await.expect("message").expect("ok");
-		match forwarded {
-			ServerJsonRpcMessage::Request(req) => assert_eq!(req.id, remapped),
-			other => panic!("expected request, got {other:?}"),
-		}
-
-		let restored = restore_client_response_id(
-			ClientJsonRpcMessage::response(rmcp::model::ClientResult::empty(()), remapped.clone()),
-			original_id.clone(),
-		)
-		.expect("restore");
-		match restored {
-			ClientJsonRpcMessage::Response(r) => assert_eq!(r.id, original_id),
-			other => panic!("expected response, got {other:?}"),
-		}
-		let parsed = parse_downstream_server_request_id(&remapped).expect("parsed");
-		assert_eq!(parsed.upstream.as_str(), "post-backend");
-		assert_eq!(parsed.original_id, original_id);
-	}
-
-	#[tokio::test]
 	async fn track_outbound_server_requests_skipped_for_modern_downstream() {
 		use futures_util::StreamExt;
 		use rmcp::model::{PingRequest, ServerRequest};
@@ -2354,6 +2277,16 @@ mod tests {
 	fn parse_downstream_server_request_id_roundtrips_string_ids_with_numeric_delimiter() {
 		let upstream = "backend";
 		let original_id = RequestId::String("part:n:7".into());
+		let remapped = downstream_server_request_id(upstream, &original_id);
+		let parsed = parse_downstream_server_request_id(&remapped).expect("parsed");
+		assert_eq!(parsed.upstream.as_str(), upstream);
+		assert_eq!(parsed.original_id, original_id);
+	}
+
+	#[test]
+	fn parse_downstream_server_request_id_roundtrips_string_ids_with_underscores() {
+		let upstream = "backend";
+		let original_id = RequestId::String("part_a_part".into());
 		let remapped = downstream_server_request_id(upstream, &original_id);
 		let parsed = parse_downstream_server_request_id(&remapped).expect("parsed");
 		assert_eq!(parsed.upstream.as_str(), upstream);

--- a/crates/agentgateway/src/mcp/handler.rs
+++ b/crates/agentgateway/src/mcp/handler.rs
@@ -2004,7 +2004,7 @@ fn restore_client_response_id(
 			e.id = Some(original_id);
 			ClientJsonRpcMessage::Error(e)
 		},
-		_ => unreachable!("send_client_response validates message type before calling"),
+		other => other,
 	}
 }
 

--- a/crates/agentgateway/src/mcp/handler.rs
+++ b/crates/agentgateway/src/mcp/handler.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use agent_core::prelude::{AssertSize, Strng};
 use agent_core::version::BuildInfo;
+use base64::Engine;
 use futures_core::Stream;
 use futures_util::StreamExt;
 use http::StatusCode;
@@ -1866,7 +1867,10 @@ fn accepted_response() -> Response {
 fn downstream_server_request_id(upstream: &str, original: &RequestId) -> RequestId {
 	match original {
 		RequestId::Number(n) => RequestId::String(format!("agw:{upstream}:n:{n}").into()),
-		RequestId::String(s) => RequestId::String(format!("agw:{upstream}:s:{s}").into()),
+		RequestId::String(s) => {
+			let encoded = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(s.as_bytes());
+			RequestId::String(format!("agw:{upstream}:s:{encoded}").into())
+		},
 	}
 }
 
@@ -1875,23 +1879,29 @@ fn parse_downstream_server_request_id(id: &RequestId) -> Option<PendingServerReq
 		return None;
 	};
 	let rest = encoded.as_ref().strip_prefix("agw:")?;
-	if let Some(idx) = rest.rfind(":n:") {
-		let upstream = &rest[..idx];
-		let n: i64 = rest[idx + 3..].parse().ok()?;
+	if let Some((upstream, n_str)) = rest.rsplit_once(":n:") {
+		let n: i64 = n_str.parse().ok()?;
 		return Some(PendingServerRequest {
 			upstream: upstream.into(),
 			original_id: RequestId::Number(n),
 		});
 	}
-	if let Some(idx) = rest.rfind(":s:") {
-		let upstream = &rest[..idx];
-		let original = &rest[idx + 3..];
+	if let Some((upstream, payload)) = rest.split_once(":s:") {
+		let original = decode_downstream_string_request_id(payload)?;
 		return Some(PendingServerRequest {
 			upstream: upstream.into(),
 			original_id: RequestId::String(original.into()),
 		});
 	}
 	None
+}
+
+fn decode_downstream_string_request_id(payload: &str) -> Option<String> {
+	if let Ok(decoded) = base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(payload) {
+		return String::from_utf8(decoded).ok();
+	}
+	// Legacy remapped ids stored the raw string after the first `:s:` delimiter.
+	Some(payload.to_string())
 }
 
 /// Remap server-initiated requests only when the downstream client can reply
@@ -2291,6 +2301,16 @@ mod tests {
 	fn parse_downstream_server_request_id_roundtrips_string_ids_with_colons() {
 		let upstream = "post-backend";
 		let original_id = RequestId::String("part:a:part".into());
+		let remapped = downstream_server_request_id(upstream, &original_id);
+		let parsed = parse_downstream_server_request_id(&remapped).expect("parsed");
+		assert_eq!(parsed.upstream.as_str(), upstream);
+		assert_eq!(parsed.original_id, original_id);
+	}
+
+	#[test]
+	fn parse_downstream_server_request_id_roundtrips_string_ids_with_numeric_delimiter() {
+		let upstream = "backend";
+		let original_id = RequestId::String("part:n:7".into());
 		let remapped = downstream_server_request_id(upstream, &original_id);
 		let parsed = parse_downstream_server_request_id(&remapped).expect("parsed");
 		assert_eq!(parsed.upstream.as_str(), upstream);

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -1715,6 +1715,217 @@ async fn streamable_http_downstream_sse_frames_include_message_event() {
 	);
 }
 
+#[tokio::test]
+async fn multiplexed_pong_routes_to_pinging_upstream() {
+	// A stateful streamable upstream heartbeats with `ping` on the GET stream and
+	// the legacy downstream replies on POST (#2187). With two upstreams, the pong
+	// must reach the one that pinged, carrying its original request id.
+	use std::sync::{Arc, Mutex};
+
+	use futures_util::StreamExt;
+	use wiremock::matchers::method;
+	use wiremock::{Mock, Request, Respond, ResponseTemplate};
+
+	const INIT_FRAME: &str = concat!(
+		"data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{",
+		"\"protocolVersion\":\"2025-06-18\",",
+		"\"capabilities\":{\"tools\":{}},",
+		"\"serverInfo\":{\"name\":\"mock\",\"version\":\"0.0.1\"}",
+		"}}\n\n",
+	);
+
+	type Pongs = Arc<Mutex<Vec<serde_json::Value>>>;
+	struct UpstreamPost {
+		pongs: Pongs,
+	}
+	impl Respond for UpstreamPost {
+		fn respond(&self, req: &Request) -> ResponseTemplate {
+			let body: serde_json::Value = serde_json::from_slice(&req.body).unwrap();
+			if body["method"] == "initialize" {
+				return ResponseTemplate::new(200)
+					.insert_header("mcp-session-id", "upstream-session")
+					.set_body_raw(INIT_FRAME, "text/event-stream");
+			}
+			// Anything without a method is the client reply we are waiting for.
+			if body.get("method").is_none() {
+				self.pongs.lock().unwrap().push(body);
+			}
+			ResponseTemplate::new(202)
+		}
+	}
+
+	async fn upstream(ping: bool) -> (wiremock::MockServer, Pongs) {
+		let pongs = Pongs::default();
+		let server = wiremock::MockServer::start().await;
+		Mock::given(method("POST"))
+			.respond_with(UpstreamPost {
+				pongs: pongs.clone(),
+			})
+			.mount(&server)
+			.await;
+		let get_body = if ping {
+			"data: {\"jsonrpc\":\"2.0\",\"id\":7,\"method\":\"ping\"}\n\n"
+		} else {
+			": keepalive\n\n"
+		};
+		Mock::given(method("GET"))
+			.respond_with(ResponseTemplate::new(200).set_body_raw(get_body, "text/event-stream"))
+			.mount(&server)
+			.await;
+		(server, pongs)
+	}
+
+	let (alpha, alpha_pongs) = upstream(true).await;
+	let (beta, beta_pongs) = upstream(false).await;
+
+	let t = setup_proxy_test("{}")
+		.unwrap()
+		.with_multiplex_mcp_backend(
+			"mcp",
+			vec![
+				("alpha", *alpha.address(), false),
+				("beta", *beta.address(), false),
+			],
+			true,
+		)
+		.with_bind(simple_bind())
+		.with_route(basic_named_route(strng::new("/mcp")));
+	let io = t.serve_real_listener(strng::new("bind")).await;
+	let client = reqwest::Client::new();
+	let url = format!("http://{io}/mcp");
+
+	let init_body = serde_json::json!({
+		"jsonrpc": "2.0",
+		"id": 1,
+		"method": "initialize",
+		"params": {
+			"protocolVersion": "2025-06-18",
+			"capabilities": {},
+			"clientInfo": {"name": "test-client", "version": "0.0.1"}
+		}
+	});
+	let init = mcp_json_post(&client, &url, &init_body)
+		.send()
+		.await
+		.unwrap();
+	assert_eq!(init.status(), reqwest::StatusCode::OK);
+	let session_id = init.headers()["mcp-session-id"]
+		.to_str()
+		.unwrap()
+		.to_string();
+	init.bytes().await.unwrap();
+
+	let initialized = serde_json::json!({"jsonrpc": "2.0", "method": "notifications/initialized"});
+	let ack = mcp_json_post(&client, &url, &initialized)
+		.header("mcp-session-id", session_id.clone())
+		.header("mcp-protocol-version", "2025-06-18")
+		.send()
+		.await
+		.unwrap();
+	assert!(ack.status().is_success());
+
+	let get = client
+		.get(&url)
+		.header(http::header::ACCEPT.as_str(), "text/event-stream")
+		.header("mcp-session-id", session_id.clone())
+		.header("mcp-protocol-version", "2025-06-18")
+		.send()
+		.await
+		.unwrap();
+	assert_eq!(get.status(), reqwest::StatusCode::OK);
+
+	// The forwarded ping's id is remapped by the proxy; echo back whatever we got.
+	let ping_id = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+		let mut stream = get.bytes_stream();
+		let mut buf = String::new();
+		loop {
+			let chunk = stream
+				.next()
+				.await
+				.expect("GET stream ended without a ping")
+				.unwrap();
+			buf.push_str(std::str::from_utf8(&chunk).unwrap());
+			if let Some(id) = buf
+				.lines()
+				.filter_map(|l| l.strip_prefix("data: "))
+				.filter_map(|d| serde_json::from_str::<serde_json::Value>(d).ok())
+				.find(|v| v["method"] == "ping")
+				.map(|v| v["id"].clone())
+			{
+				return id;
+			}
+		}
+	})
+	.await
+	.unwrap();
+
+	let pong_body = serde_json::json!({"jsonrpc": "2.0", "id": ping_id, "result": {}});
+	let pong = mcp_json_post(&client, &url, &pong_body)
+		.header("mcp-session-id", session_id)
+		.header("mcp-protocol-version", "2025-06-18")
+		.send()
+		.await
+		.unwrap();
+	assert_eq!(pong.status(), reqwest::StatusCode::ACCEPTED);
+
+	// The proxy forwards the pong before answering 202, so no waiting is needed.
+	let pongs = alpha_pongs.lock().unwrap();
+	assert_eq!(pongs.len(), 1, "pinging upstream should get the pong");
+	assert_eq!(pongs[0]["id"], 7, "pong must carry the original id");
+	assert!(beta_pongs.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn elicitation_roundtrip_completes_tool_call() {
+	// Mid-tools/call the upstream elicits input from the client; the reply must
+	// route back so the tool call completes instead of hanging.
+	use rmcp::ServiceExt;
+	use rmcp::model::{
+		ClientCapabilities, ClientInfo, ElicitRequestParams, ElicitResult, ElicitationAction,
+		Implementation, ProtocolVersion,
+	};
+	use rmcp::service::RequestContext;
+	use rmcp::transport::StreamableHttpClientTransport;
+
+	struct ElicitingClient;
+	impl rmcp::ClientHandler for ElicitingClient {
+		async fn create_elicitation(
+			&self,
+			_request: ElicitRequestParams,
+			_context: RequestContext<RoleClient>,
+		) -> Result<ElicitResult, rmcp::ErrorData> {
+			Ok(
+				ElicitResult::new(ElicitationAction::Accept)
+					.with_content(serde_json::json!({"confirm": "yes"})),
+			)
+		}
+		fn get_info(&self) -> ClientInfo {
+			let mut info = ClientInfo::new(
+				ClientCapabilities::default(),
+				Implementation::new("test client".to_string(), "0.0.1".to_string()),
+			);
+			// Pre-SEP-2575 client: server-initiated requests are forwarded to it.
+			info.protocol_version = ProtocolVersion::V_2025_06_18;
+			info.capabilities.elicitation = Some(Default::default());
+			info
+		}
+	}
+
+	let mock = mock_streamable_http_server(true).await;
+	let (_bind, io) = setup_proxy(&mock, true, false).await;
+	let transport =
+		StreamableHttpClientTransport::<reqwest::Client>::from_uri(format!("http://{io}/mcp"));
+	let client = ElicitingClient.serve(transport).await.unwrap();
+	let res = client
+		.call_tool(rmcp::model::CallToolRequestParams::new("elicit"))
+		.await
+		.unwrap();
+	assert_eq!(
+		&res.content[0].as_text().unwrap().text,
+		r#"{"confirm":"yes"}"#
+	);
+}
+
 // Forwarded modern responses may come back as a single JSON object or as an SSE stream.
 // Validation-layer errors are always plain JSON.
 async fn read_response_message(response: reqwest::Response) -> serde_json::Value {
@@ -4431,6 +4642,32 @@ mod mockserver {
 			let init_counter = self.init_counter.lock().await;
 			Ok(CallToolResult::success(vec![ContentBlock::text(
 				init_counter.to_string(),
+			)]))
+		}
+
+		#[tool(description = "Ask the client for confirmation before proceeding")]
+		async fn elicit(&self, rq: RequestContext<RoleServer>) -> Result<CallToolResult, McpError> {
+			// The typed create_elicitation helper is behind a disabled cargo feature;
+			// the generic peer request is equivalent on the wire.
+			let res = rq
+				.peer
+				.send_request(ServerRequest::ElicitRequest(ElicitRequest::new(
+					ElicitRequestParams::FormElicitationParams {
+						meta: None,
+						message: "confirm?".to_string(),
+						requested_schema: ElicitationSchema::new(Default::default()),
+					},
+				)))
+				.await
+				.map_err(|e| McpError::internal_error(e.to_string(), None))?;
+			let ClientResult::ElicitResult(res) = res else {
+				return Err(McpError::internal_error(
+					"unexpected elicitation reply",
+					None,
+				));
+			};
+			Ok(CallToolResult::success(vec![ContentBlock::text(
+				serde_json::to_string(&res.content).unwrap(),
 			)]))
 		}
 	}

--- a/crates/agentgateway/src/mcp/session.rs
+++ b/crates/agentgateway/src/mcp/session.rs
@@ -721,9 +721,35 @@ impl Session {
 				Box::pin(self.relay.send_notification(r, ctx)).await
 			},
 
-			_ => Err(UpstreamError::InvalidRequest(
-				"unsupported message type".to_string(),
-			)),
+			ClientJsonRpcMessage::Response(r) => {
+				let ctx = IncomingRequestContext::new(&parts);
+				let (_span, log, _cel) = mcp::handler::setup_request_log(parts, "response");
+				let session_id = self.id.to_string();
+				log.non_atomic_mutate(|l| {
+					l.session_id = Some(session_id);
+				});
+				Box::pin(
+					self
+						.relay
+						.send_client_response(ClientJsonRpcMessage::Response(r), ctx),
+				)
+				.await
+			},
+
+			ClientJsonRpcMessage::Error(e) => {
+				let ctx = IncomingRequestContext::new(&parts);
+				let (_span, log, _cel) = mcp::handler::setup_request_log(parts, "response");
+				let session_id = self.id.to_string();
+				log.non_atomic_mutate(|l| {
+					l.session_id = Some(session_id);
+				});
+				Box::pin(
+					self
+						.relay
+						.send_client_response(ClientJsonRpcMessage::Error(e), ctx),
+				)
+				.await
+			},
 		}
 	}
 

--- a/crates/agentgateway/src/mcp/session.rs
+++ b/crates/agentgateway/src/mcp/session.rs
@@ -721,34 +721,14 @@ impl Session {
 				Box::pin(self.relay.send_notification(r, ctx)).await
 			},
 
-			ClientJsonRpcMessage::Response(r) => {
+			ClientJsonRpcMessage::Response(_) | ClientJsonRpcMessage::Error(_) => {
 				let ctx = IncomingRequestContext::new(&parts);
 				let (_span, log, _cel) = mcp::handler::setup_request_log(parts, "response");
 				let session_id = self.id.to_string();
 				log.non_atomic_mutate(|l| {
 					l.session_id = Some(session_id);
 				});
-				Box::pin(
-					self
-						.relay
-						.send_client_response(ClientJsonRpcMessage::Response(r), ctx),
-				)
-				.await
-			},
-
-			ClientJsonRpcMessage::Error(e) => {
-				let ctx = IncomingRequestContext::new(&parts);
-				let (_span, log, _cel) = mcp::handler::setup_request_log(parts, "response");
-				let session_id = self.id.to_string();
-				log.non_atomic_mutate(|l| {
-					l.session_id = Some(session_id);
-				});
-				Box::pin(
-					self
-						.relay
-						.send_client_response(ClientJsonRpcMessage::Error(e), ctx),
-				)
-				.await
+				Box::pin(self.relay.send_client_response(message, ctx)).await
 			},
 		}
 	}

--- a/crates/agentgateway/src/mcp/session.rs
+++ b/crates/agentgateway/src/mcp/session.rs
@@ -790,9 +790,35 @@ impl Session {
 				Box::pin(self.relay.send_notification(r, ctx)).await
 			},
 
-			_ => Err(UpstreamError::InvalidRequest(
-				"unsupported message type".to_string(),
-			)),
+			ClientJsonRpcMessage::Response(r) => {
+				let ctx = IncomingRequestContext::new(&parts);
+				let (_span, log, _cel) = mcp::handler::setup_request_log(parts, "response");
+				let session_id = self.id.to_string();
+				log.non_atomic_mutate(|l| {
+					l.session_id = Some(session_id);
+				});
+				Box::pin(
+					self
+						.relay
+						.send_client_response(ClientJsonRpcMessage::Response(r), ctx),
+				)
+				.await
+			},
+
+			ClientJsonRpcMessage::Error(e) => {
+				let ctx = IncomingRequestContext::new(&parts);
+				let (_span, log, _cel) = mcp::handler::setup_request_log(parts, "response");
+				let session_id = self.id.to_string();
+				log.non_atomic_mutate(|l| {
+					l.session_id = Some(session_id);
+				});
+				Box::pin(
+					self
+						.relay
+						.send_client_response(ClientJsonRpcMessage::Error(e), ctx),
+				)
+				.await
+			},
 		}
 	}
 

--- a/crates/agentgateway/src/mcp/session.rs
+++ b/crates/agentgateway/src/mcp/session.rs
@@ -793,9 +793,9 @@ impl Session {
 			ClientJsonRpcMessage::Response(_) | ClientJsonRpcMessage::Error(_) => {
 				let ctx = IncomingRequestContext::new(&parts);
 				let (_span, log, _cel) = mcp::handler::setup_request_log(parts, "response");
-				let session_id = self.id.to_string();
+				let session_id = (!self.synthetic).then(|| self.id.to_string());
 				log.non_atomic_mutate(|l| {
-					l.session_id = Some(session_id);
+					l.session_id = session_id;
 				});
 				Box::pin(self.relay.send_client_response(message, ctx)).await
 			},

--- a/crates/agentgateway/src/mcp/session.rs
+++ b/crates/agentgateway/src/mcp/session.rs
@@ -790,34 +790,14 @@ impl Session {
 				Box::pin(self.relay.send_notification(r, ctx)).await
 			},
 
-			ClientJsonRpcMessage::Response(r) => {
+			ClientJsonRpcMessage::Response(_) | ClientJsonRpcMessage::Error(_) => {
 				let ctx = IncomingRequestContext::new(&parts);
 				let (_span, log, _cel) = mcp::handler::setup_request_log(parts, "response");
 				let session_id = self.id.to_string();
 				log.non_atomic_mutate(|l| {
 					l.session_id = Some(session_id);
 				});
-				Box::pin(
-					self
-						.relay
-						.send_client_response(ClientJsonRpcMessage::Response(r), ctx),
-				)
-				.await
-			},
-
-			ClientJsonRpcMessage::Error(e) => {
-				let ctx = IncomingRequestContext::new(&parts);
-				let (_span, log, _cel) = mcp::handler::setup_request_log(parts, "response");
-				let session_id = self.id.to_string();
-				log.non_atomic_mutate(|l| {
-					l.session_id = Some(session_id);
-				});
-				Box::pin(
-					self
-						.relay
-						.send_client_response(ClientJsonRpcMessage::Error(e), ctx),
-				)
-				.await
+				Box::pin(self.relay.send_client_response(message, ctx)).await
 			},
 		}
 	}

--- a/crates/agentgateway/src/mcp/upstream/mod.rs
+++ b/crates/agentgateway/src/mcp/upstream/mod.rs
@@ -12,7 +12,8 @@ pub(crate) use client::McpHttpClient;
 use itertools::Itertools;
 pub use openapi::ParseError as OpenAPIParseError;
 use rmcp::model::{
-	ClientNotification, ClientRequest, ExtensionCapabilities, GetMeta, JsonObject, JsonRpcRequest,
+	ClientJsonRpcMessage, ClientNotification, ClientRequest, ExtensionCapabilities, GetMeta,
+	JsonObject, JsonRpcRequest,
 };
 use rmcp::transport::TokioChildProcess;
 use rmcp::transport::common::http_header::HEADER_SESSION_ID;
@@ -287,6 +288,29 @@ impl Upstream {
 			Upstream::OpenAPI(_) => {},
 		}
 		Ok(())
+	}
+
+	pub(crate) async fn generic_client_message(
+		&self,
+		message: ClientJsonRpcMessage,
+		ctx: &IncomingRequestContext,
+	) -> Result<(), UpstreamError> {
+		match &self {
+			Upstream::McpStdio(c) => c.send_client_message(message, ctx).await,
+			Upstream::McpSSE(c) => c.send_client_message(message, ctx).await,
+			Upstream::McpStreamable(c) => {
+				let res = c.send_client_message(message, ctx).await?;
+				match res {
+					StreamableHttpPostResponse::Accepted => Ok(()),
+					_ => Err(UpstreamError::InvalidRequest(
+						"expected accepted response for client JSON-RPC reply".into(),
+					)),
+				}
+			},
+			Upstream::OpenAPI(_) => Err(UpstreamError::InvalidRequest(
+				"openapi upstream does not support server-to-client routing".into(),
+			)),
+		}
 	}
 }
 

--- a/crates/agentgateway/src/mcp/upstream/mod.rs
+++ b/crates/agentgateway/src/mcp/upstream/mod.rs
@@ -304,9 +304,6 @@ impl Upstream {
 					StreamableHttpPostResponse::Accepted
 					| StreamableHttpPostResponse::Json(_, _)
 					| StreamableHttpPostResponse::Sse(_, _) => Ok(()),
-					_ => Err(UpstreamError::InvalidRequest(
-						"unexpected response for client JSON-RPC reply".into(),
-					)),
 				}
 			},
 			Upstream::OpenAPI(_) => Err(UpstreamError::InvalidRequest(

--- a/crates/agentgateway/src/mcp/upstream/mod.rs
+++ b/crates/agentgateway/src/mcp/upstream/mod.rs
@@ -301,9 +301,11 @@ impl Upstream {
 			Upstream::McpStreamable(c) => {
 				let res = c.send_client_message(message, ctx).await?;
 				match res {
-					StreamableHttpPostResponse::Accepted => Ok(()),
+					StreamableHttpPostResponse::Accepted
+					| StreamableHttpPostResponse::Json(_, _)
+					| StreamableHttpPostResponse::Sse(_, _) => Ok(()),
 					_ => Err(UpstreamError::InvalidRequest(
-						"expected accepted response for client JSON-RPC reply".into(),
+						"unexpected response for client JSON-RPC reply".into(),
 					)),
 				}
 			},

--- a/crates/agentgateway/src/mcp/upstream/mod.rs
+++ b/crates/agentgateway/src/mcp/upstream/mod.rs
@@ -299,12 +299,8 @@ impl Upstream {
 			Upstream::McpStdio(c) => c.send_client_message(message, ctx).await,
 			Upstream::McpSSE(c) => c.send_client_message(message, ctx).await,
 			Upstream::McpStreamable(c) => {
-				let res = c.send_client_message(message, ctx).await?;
-				match res {
-					StreamableHttpPostResponse::Accepted
-					| StreamableHttpPostResponse::Json(_, _)
-					| StreamableHttpPostResponse::Sse(_, _) => Ok(()),
-				}
+				c.send_client_message(message, ctx).await?;
+				Ok(())
 			},
 			Upstream::OpenAPI(_) => Err(UpstreamError::InvalidRequest(
 				"openapi upstream does not support server-to-client routing".into(),

--- a/crates/agentgateway/src/mcp/upstream/sse.rs
+++ b/crates/agentgateway/src/mcp/upstream/sse.rs
@@ -245,6 +245,15 @@ impl Client {
 		let stream = self.get_stream(ctx).await?;
 		stream.send_notification(req, ctx).await
 	}
+
+	pub async fn send_client_message(
+		&self,
+		message: ClientJsonRpcMessage,
+		ctx: &IncomingRequestContext,
+	) -> Result<(), UpstreamError> {
+		let stream = self.get_stream(ctx).await?;
+		stream.send_client_message(message, ctx).await
+	}
 }
 
 fn message_endpoint(base: Uri, endpoint: String) -> Result<Uri, http::uri::InvalidUri> {

--- a/crates/agentgateway/src/mcp/upstream/stdio.rs
+++ b/crates/agentgateway/src/mcp/upstream/stdio.rs
@@ -103,6 +103,22 @@ impl Process {
 			.map_err(|_| UpstreamError::Send)?;
 		Ok(())
 	}
+
+	pub async fn send_client_message(
+		&self,
+		msg: ClientJsonRpcMessage,
+		ctx: &IncomingRequestContext,
+	) -> Result<(), UpstreamError> {
+		if !self.is_alive() {
+			return Err(UpstreamError::Send);
+		}
+		self
+			.sender
+			.send((msg, ctx.clone()))
+			.await
+			.map_err(|_| UpstreamError::Send)?;
+		Ok(())
+	}
 }
 
 impl Process {

--- a/crates/agentgateway/src/mcp/upstream/streamablehttp.rs
+++ b/crates/agentgateway/src/mcp/upstream/streamablehttp.rs
@@ -74,6 +74,14 @@ impl Client {
 		let message = ClientJsonRpcMessage::notification(req);
 		self.send_message(message, ctx).await
 	}
+
+	pub async fn send_client_message(
+		&self,
+		message: ClientJsonRpcMessage,
+		ctx: &IncomingRequestContext,
+	) -> Result<StreamableHttpPostResponse, ClientError> {
+		self.send_message(message, ctx).await
+	}
 	async fn send_message(
 		&self,
 		message: ClientJsonRpcMessage,


### PR DESCRIPTION
## Summary

Fixes Streamable HTTP MCP sessions where downstream heartbeat pongs were rejected with HTTP 500 (`unsupported message type`).

- Track server-initiated JSON-RPC request ids from the GET event stream and map them to the issuing upstream
- Forward `ClientJsonRpcMessage::Response` / `Error` posts from the downstream client back to the correct upstream (streamable HTTP, SSE, and stdio transports)
- For a single-upstream session, fall back to that upstream when no explicit mapping exists

Fixes #2187

## Problem

In stateful Streamable HTTP mode, upstream servers can send JSON-RPC requests (for example `ping`) on the GET SSE stream. The downstream MCP client auto-replies with a JSON-RPC response on POST. `Session::send_internal` only handled client requests and notifications, so pongs hit the catch-all arm and failed.

## Approach

1. Add per-session `pending_server_requests` (`RequestId` → upstream name), populated when forwarding `ServerJsonRpcMessage::Request` on the GET stream.
2. Handle `ClientJsonRpcMessage::Response` and `Error` in `send_internal`, routing via `Relay::send_client_response`.
3. Add `Upstream::generic_client_message` so all MCP transports can accept arbitrary downstream replies (streamable HTTP expects `202 Accepted`).

## Test plan

- [x] `cargo test -p agentgateway track_outbound_server_requests_registers_server_initiated_request_id`
- [x] `cargo test -p agentgateway mcp::handler::tests`
- [x] `cargo build -p agentgateway`

## Local CI verification (macOS)

First contribution to this repo. Ran the Branch workflow checks locally while CI is waiting on maintainer workflow approval for fork PRs.

**Host:** macOS arm64 (darwin 25.4.0)  
**Toolchain:** Rust 1.96.0, Go 1.26.4, Node v26.3.0, Docker 29.5.2, kind 0.32.0, Helm 3.21.2, bash 5.3.15  
**Branch checked:** `fix/mcp-streamable-http-client-response-routing` @ `de043d9`  
**Worktree:** `/Users/piyush/ag-pr2207-local-1782641235` (no spaces in path; required for controller Makefile/scripts)

| Workflow job | Local command | Result |
|---|---|---|
| DCO | signed-off commits | green on GitHub |
| Proxy Test (Mac) | `env -u DYNAMIC_CA_CERT_CACHE_CAPACITY RUST_TEST_THREADS=1 make test` | pass |
| proxy-lint | `make generate-schema check-clean-repo && make lint` | pass |
| ui-lint | `(cd ui && npm ci && npm run lint)` | pass |
| controller-test | `PATH=/opt/homebrew/opt/helm@3/bin:$PATH go test -race ./...` | pass |
| controller-lint | `make -C controller analyze`; `go mod tidy && git diff --exit-code go.mod go.sum`; `make generate-apis check-clean-repo && make -C controller verify` | pass |
| Proxy Test (Linux) | not run locally | deferred to CI (Linux runner + validation deps) |
| Proxy Test (Windows) | not run locally | deferred to CI (Windows runner) |
| controller-e2e | `TEST_MODE=e2e /opt/homebrew/bin/bash ./controller/test/setup/setup-kind-ci.sh` then `CGO_ENABLED=0 PERSIST_INSTALL=true go test -tags=e2e -v ./controller/test/e2e` | blocked locally: push to kind local registry `localhost:5000` timed out on macOS Docker |
| controller-conformance | `TEST_MODE=conformance /opt/homebrew/bin/bash ./controller/test/setup/setup-kind-ci.sh` then `make -C controller all-conformance` | blocked locally: incomplete kind install (`GatewayClass agentgateway` not found) |

**Notes**

- `make test` failed once with a pre-existing local env var `DYNAMIC_CA_CERT_CACHE_CAPACITY=0`; reran with it unset and `RUST_TEST_THREADS=1`.
- Controller Makefile/scripts fail from the iCloud checkout path because of spaces in `Mobile Documents`; reran from a no-space worktree.
- Helm chart golden tests require Helm 3 (`helm@3`); Helm 4 produced template whitespace diffs only.
