### PR TITLE
Add agctl virtualkey import command

### DIFF
--- a/controller/pkg/cli/root.go
+++ b/controller/pkg/cli/root.go
@@ -12,6 +12,7 @@ import (
 	proxycmd "github.com/agentgateway/agentgateway/controller/pkg/cli/proxy"
 	"github.com/agentgateway/agentgateway/controller/pkg/cli/trace"
 	cliversion "github.com/agentgateway/agentgateway/controller/pkg/cli/version"
+	"github.com/agentgateway/agentgateway/controller/pkg/cli/virtualkey"
 )
 
 func NewRootCmd() *cobra.Command {
@@ -25,6 +26,7 @@ func NewRootCmd() *cobra.Command {
 	rootCmd.AddCommand(proxycmd.Command())
 	rootCmd.AddCommand(controllercmd.Command())
 	rootCmd.AddCommand(costs.Command())
+	rootCmd.AddCommand(flag.BuildCobra(virtualkey.Command))
 
 	rootCmd.AddCommand(flag.BuildCobra(config.Command))
 	rootCmd.AddCommand(flag.BuildCobra(trace.Command))

--- a/controller/pkg/cli/virtualkey/cmd.go
+++ b/controller/pkg/cli/virtualkey/cmd.go
@@ -1,0 +1,324 @@
+package virtualkey
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/agentgateway/agentgateway/controller/pkg/cli/flag"
+	"github.com/agentgateway/agentgateway/controller/pkg/cli/kubeutil"
+	"github.com/agentgateway/agentgateway/controller/pkg/cli/printer"
+)
+
+const (
+	outputJSON = "json"
+	outputText = "text"
+	outputYAML = "yaml"
+)
+
+func Command() flag.Command {
+	return flag.Command{
+		Use:   "virtualkey",
+		Short: "Manage virtual API keys",
+		Long: strings.TrimSpace(`Manage virtual API keys.
+
+Generated keys and import output contain secret key material. Store command
+output securely.`),
+		Children: []flag.CommandBuilder{
+			importCommand,
+			generateCommand,
+		},
+	}
+}
+
+type importFlags struct {
+	file                   string
+	secretName             string
+	namespace              string
+	output                 string
+	mode                   string
+	strict                 bool
+	escapeSpecialChars     bool
+	labels                 []string
+	kubecontext            string
+	collisionCheckSecret   string
+	collisionCheckSelector string
+}
+
+func importCommand() flag.Command {
+	flags := &importFlags{
+		output: outputYAML,
+		mode:   "replace",
+	}
+	return flag.Command{
+		Use:   "import",
+		Short: "Import virtual API keys from CSV",
+		Long: strings.TrimSpace(`Import virtual API keys from CSV and print Kubernetes Secret manifests.
+
+The CSV must include a header row. The key column is optional; empty key values
+cause agctl to generate new keys. The optional entry column controls the Secret
+data key; when omitted, agctl derives one from id or the row number. The id or
+metadata.id column is stored as stable key identity metadata. Columns named
+metadata.<name> are stored as metadata, and other non-reserved columns are also
+preserved as metadata.
+
+By default, id values containing reserved special characters are rejected. Use
+--escape-special-characters to store escaped id values instead.
+
+Stdout contains Secret manifests with key material. Store it securely.`),
+		Example: strings.TrimSpace(`
+agctl virtualkey import -f virtual-keys.csv --secret-name agw-virtual-keys -n default
+agctl virtualkey import -f virtual-keys.csv --secret-name agw-virtual-keys -n default | kubectl apply -f -
+agctl virtualkey import -f virtual-keys.csv --secret-name agw-virtual-keys --escape-special-characters
+`),
+		Args: cobra.NoArgs,
+		AddFlags: func(cmd *cobra.Command) {
+			cmd.Flags().StringVarP(&flags.file, "file", "f", "", "CSV input path, or - for stdin")
+			cmd.Flags().StringVar(&flags.secretName, "secret-name", "", "Name of the Secret to emit")
+			cmd.Flags().StringVarP(&flags.namespace, "namespace", "n", "", "Namespace for the emitted Secret")
+			cmd.Flags().StringVarP(&flags.output, "output", "o", flags.output, "Output format: one of yaml|json")
+			cmd.Flags().StringVar(&flags.mode, "mode", flags.mode, "Import mode; only replace is currently supported")
+			cmd.Flags().BoolVar(&flags.strict, "strict", false, "Treat warnings, such as missing or duplicate id metadata, as errors")
+			cmd.Flags().BoolVar(&flags.escapeSpecialChars, "escape-special-characters", false, "Escape reserved id values (<missing>, |, ^, or backtick) instead of rejecting them")
+			cmd.Flags().StringArrayVar(&flags.labels, "label", nil, "Additional Secret label in key=value form (may be repeated)")
+			cmd.Flags().StringVar(&flags.kubecontext, "kubecontext", "", "Kubeconfig context for collision checks")
+			cmd.Flags().StringVar(&flags.collisionCheckSecret, "collision-check-secret", "", "Existing Secret name to check for imported API key collisions")
+			cmd.Flags().StringVar(&flags.collisionCheckSelector, "collision-check-selector", "", "Label selector for existing Secrets to check for imported API key collisions")
+			_ = cmd.MarkFlagRequired("file")
+			_ = cmd.MarkFlagRequired("secret-name")
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runImport(cmd, flags)
+		},
+	}
+}
+
+func runImport(cmd *cobra.Command, flags *importFlags) error {
+	if flags.mode != "replace" {
+		return fmt.Errorf("--mode %q is not supported; v1 import emits a replacement Secret manifest", flags.mode)
+	}
+	if flags.output != outputYAML && flags.output != outputJSON {
+		return fmt.Errorf("output format %q not supported", flags.output)
+	}
+	if flags.collisionCheckSecret != "" && flags.collisionCheckSelector != "" {
+		return fmt.Errorf("--collision-check-secret and --collision-check-selector are mutually exclusive")
+	}
+	labels, err := parseLabels(flags.labels)
+	if err != nil {
+		return err
+	}
+	namespace, err := kubeutil.LoadNamespace(flags.namespace)
+	if err != nil {
+		return err
+	}
+	input, closeInput, err := openInput(flags.file)
+	if err != nil {
+		return err
+	}
+	defer closeInput()
+
+	result, err := importCSV(input, importOptions{
+		SecretName: flags.secretName,
+		Namespace:  namespace,
+		Labels:     labels,
+		Strict:     flags.strict,
+		EscapeIDs:  flags.escapeSpecialChars,
+	})
+	if err != nil {
+		return err
+	}
+	if flags.collisionCheckSecret != "" || flags.collisionCheckSelector != "" {
+		keys, err := loadCollisionKeys(cmd.Context(), namespace, flags.kubecontext, flags.collisionCheckSecret, flags.collisionCheckSelector)
+		if err != nil {
+			return err
+		}
+		if err := checkCollisions(result.ImportedKeys, keys); err != nil {
+			return err
+		}
+	}
+
+	if warning := warnIfPermissive(flags.file); warning != "" {
+		fmt.Fprintln(cmd.ErrOrStderr(), "warning:", warning)
+	}
+	for _, warning := range result.Warnings {
+		fmt.Fprintln(cmd.ErrOrStderr(), "warning:", warning)
+	}
+	if len(result.GeneratedRows) > 0 {
+		fmt.Fprintf(cmd.ErrOrStderr(), "notice: generated API keys for rows %s; the emitted Secret manifest contains those key values\n", formatRows(result.GeneratedRows))
+	}
+	if len(result.Secrets) > 1 {
+		fmt.Fprintf(cmd.ErrOrStderr(), "notice: split import into %d Secrets to keep each manifest below %d bytes\n", len(result.Secrets), defaultMaxSerializedSecretSize)
+	}
+
+	p, err := printer.New(flags.output)
+	if err != nil {
+		return err
+	}
+	return p.Print(cmd.OutOrStdout(), result.Manifest())
+}
+
+type generateFlags struct {
+	count                  int
+	label                  string
+	namespace              string
+	output                 string
+	kubecontext            string
+	collisionCheckSecret   string
+	collisionCheckSelector string
+}
+
+func generateCommand() flag.Command {
+	flags := &generateFlags{
+		count:  1,
+		label:  "key",
+		output: outputText,
+	}
+	return flag.Command{
+		Use:   "generate",
+		Short: "Generate virtual API keys",
+		Long: strings.TrimSpace(`Generate virtual API keys and print them to stdout.
+
+Generated keys use the form sk-<label>-<random>. The label is lowercased,
+sanitized, and truncated before it is embedded in the key. Stdout is the only
+record of the generated key material; store it securely.`),
+		Example: strings.TrimSpace(`
+agctl virtualkey generate --label alice
+agctl virtualkey generate --count 5 --label batch-import
+agctl virtualkey generate --label alice --collision-check-secret default/agw-virtual-keys
+`),
+		Args: cobra.NoArgs,
+		AddFlags: func(cmd *cobra.Command) {
+			cmd.Flags().IntVarP(&flags.count, "count", "n", flags.count, "Number of keys to generate")
+			cmd.Flags().StringVar(&flags.label, "label", flags.label, "Human-readable label to sanitize and embed in generated keys")
+			cmd.Flags().StringVar(&flags.namespace, "namespace", "", "Namespace for collision checks")
+			cmd.Flags().StringVarP(&flags.output, "output", "o", flags.output, "Output format: one of text|json|yaml")
+			cmd.Flags().StringVar(&flags.kubecontext, "kubecontext", "", "Kubeconfig context for collision checks")
+			cmd.Flags().StringVar(&flags.collisionCheckSecret, "collision-check-secret", "", "Existing Secret name to avoid generated API key collisions; may be namespace/name")
+			cmd.Flags().StringVar(&flags.collisionCheckSelector, "collision-check-selector", "", "Label selector for existing Secrets to avoid generated API key collisions")
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runGenerate(cmd, flags)
+		},
+	}
+}
+
+func runGenerate(cmd *cobra.Command, flags *generateFlags) error {
+	if flags.count < 1 {
+		return fmt.Errorf("--count must be greater than 0")
+	}
+	switch flags.output {
+	case outputText, outputJSON, outputYAML:
+	default:
+		return fmt.Errorf("output format %q not supported", flags.output)
+	}
+	if flags.collisionCheckSecret != "" && flags.collisionCheckSelector != "" {
+		return fmt.Errorf("--collision-check-secret and --collision-check-selector are mutually exclusive")
+	}
+
+	namespace, secretName := splitNamespacedSecret(flags.namespace, flags.collisionCheckSecret)
+	if namespace == "" {
+		var err error
+		namespace, err = kubeutil.LoadNamespace("")
+		if err != nil {
+			return err
+		}
+	}
+
+	var existing []existingKey
+	var err error
+	if secretName != "" || flags.collisionCheckSelector != "" {
+		existing, err = loadCollisionKeys(cmd.Context(), namespace, flags.kubecontext, secretName, flags.collisionCheckSelector)
+		if err != nil {
+			return err
+		}
+	}
+
+	keys := make([]string, 0, flags.count)
+	for i := 0; i < flags.count; i++ {
+		label := flags.label
+		if flags.count > 1 {
+			label = fmt.Sprintf("%s-%04d", flags.label, i+1)
+		}
+		key, err := generateNonCollidingKey(label, existing)
+		if err != nil {
+			return err
+		}
+		keys = append(keys, key)
+		existing = append(existing, existingKey{Entry: fmt.Sprintf("generated-%d", i), Key: key})
+	}
+
+	if flags.output == outputText {
+		for _, key := range keys {
+			fmt.Fprintln(cmd.OutOrStdout(), key)
+		}
+		return nil
+	}
+	p, err := printer.New(flags.output)
+	if err != nil {
+		return err
+	}
+	return p.Print(cmd.OutOrStdout(), keys)
+}
+
+func generateNonCollidingKey(label string, existing []existingKey) (string, error) {
+	for attempt := 0; attempt < 3; attempt++ {
+		key, err := generateAPIKey(label)
+		if err != nil {
+			return "", err
+		}
+		if err := checkCollisions(map[int]string{1: key}, existing); err == nil {
+			return key, nil
+		}
+	}
+	return "", fmt.Errorf("generated key collided with existing data after 3 attempts")
+}
+
+func openInput(path string) (io.Reader, func(), error) {
+	if path == "-" {
+		return os.Stdin, func() {}, nil
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, func() {}, fmt.Errorf("open CSV file %q: %w", path, err)
+	}
+	return file, func() { _ = file.Close() }, nil
+}
+
+func loadCollisionKeys(ctx context.Context, namespace, kubecontext, secretName, selector string) ([]existingKey, error) {
+	client, err := newCoreClient(kubecontext)
+	if err != nil {
+		return nil, err
+	}
+	return loadExistingKeys(ctx, client.CoreV1().Secrets(namespace), secretName, selector)
+}
+
+func newCoreClient(kubecontext string) (kubernetes.Interface, error) {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	if kubeconfig := flag.Kubeconfig(); kubeconfig != "" {
+		loadingRules.ExplicitPath = kubeconfig
+	}
+	overrides := &clientcmd.ConfigOverrides{CurrentContext: kubecontext}
+	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, overrides).ClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build Kubernetes client config: %w", err)
+	}
+	client, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build Kubernetes client: %w", err)
+	}
+	return client, nil
+}
+
+func splitNamespacedSecret(namespace, secret string) (string, string) {
+	ns, name, ok := strings.Cut(secret, "/")
+	if !ok {
+		return namespace, secret
+	}
+	return ns, name
+}

--- a/controller/pkg/cli/virtualkey/cmd.go
+++ b/controller/pkg/cli/virtualkey/cmd.go
@@ -88,7 +88,7 @@ agctl virtualkey import -f virtual-keys.csv --secret-name agw-virtual-keys --esc
 			cmd.Flags().BoolVar(&flags.escapeSpecialChars, "escape-special-characters", false, "Escape reserved id values (<missing>, |, ^, or backtick) instead of rejecting them")
 			cmd.Flags().StringArrayVar(&flags.labels, "label", nil, "Additional Secret label in key=value form (may be repeated)")
 			cmd.Flags().StringVar(&flags.kubecontext, "kubecontext", "", "Kubeconfig context for collision checks")
-			cmd.Flags().StringVar(&flags.collisionCheckSecret, "collision-check-secret", "", "Existing Secret name to check for imported API key collisions")
+			cmd.Flags().StringVar(&flags.collisionCheckSecret, "collision-check-secret", "", "Existing Secret name to check for imported API key collisions; may be namespace/name")
 			cmd.Flags().StringVar(&flags.collisionCheckSelector, "collision-check-selector", "", "Label selector for existing Secrets to check for imported API key collisions")
 			_ = cmd.MarkFlagRequired("file")
 			_ = cmd.MarkFlagRequired("secret-name")
@@ -134,7 +134,8 @@ func runImport(cmd *cobra.Command, flags *importFlags) error {
 		return err
 	}
 	if flags.collisionCheckSecret != "" || flags.collisionCheckSelector != "" {
-		keys, err := loadCollisionKeys(cmd.Context(), namespace, flags.kubecontext, flags.collisionCheckSecret, flags.collisionCheckSelector)
+		collisionNamespace, collisionSecret := splitNamespacedSecret(namespace, flags.collisionCheckSecret)
+		keys, err := loadCollisionKeys(cmd.Context(), collisionNamespace, flags.kubecontext, collisionSecret, flags.collisionCheckSelector)
 		if err != nil {
 			return err
 		}
@@ -267,7 +268,7 @@ func runGenerate(cmd *cobra.Command, flags *generateFlags) error {
 }
 
 func generateNonCollidingKey(label string, existing []existingKey) (string, error) {
-	for attempt := 0; attempt < 3; attempt++ {
+	for range 3 {
 		key, err := generateAPIKey(label)
 		if err != nil {
 			return "", err

--- a/controller/pkg/cli/virtualkey/generator.go
+++ b/controller/pkg/cli/virtualkey/generator.go
@@ -1,0 +1,168 @@
+package virtualkey
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"unicode"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+const (
+	keyPrefix       = "sk"
+	keyRandomLength = 18
+	maxLabelLength  = 24
+)
+
+var keyAlphabet = []byte("0123456789abcdefghijklmnopqrstuvwxyz")
+
+type apiKeyEntry struct {
+	Key      string            `json:"key"`
+	Metadata map[string]string `json:"metadata,omitempty"`
+}
+
+type existingKey struct {
+	Secret string
+	Entry  string
+	Key    string
+}
+
+func generateAPIKey(label string) (string, error) {
+	random, err := randomBase36(keyRandomLength)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s-%s-%s", keyPrefix, sanitizeLabel(label), random), nil
+}
+
+func sanitizeLabel(s string) string {
+	var b strings.Builder
+	lastHyphen := false
+	for _, r := range strings.ToLower(s) {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			b.WriteRune(r)
+			lastHyphen = false
+			continue
+		}
+		if !lastHyphen {
+			b.WriteByte('-')
+			lastHyphen = true
+		}
+	}
+	out := strings.Trim(b.String(), "-")
+	if out == "" {
+		return "key"
+	}
+	if len(out) > maxLabelLength {
+		out = strings.Trim(out[:maxLabelLength], "-")
+	}
+	if out == "" {
+		return "key"
+	}
+	return out
+}
+
+func randomBase36(n int) (string, error) {
+	if n < 0 {
+		return "", fmt.Errorf("random length must be non-negative")
+	}
+	out := make([]byte, 0, n)
+	buf := make([]byte, n)
+	for len(out) < n {
+		if _, err := rand.Read(buf); err != nil {
+			return "", fmt.Errorf("generate random key material: %w", err)
+		}
+		for _, b := range buf {
+			// 252 is the largest multiple of 36 below 256; rejecting larger
+			// values keeps every alphabet character equally likely.
+			if b >= 252 {
+				continue
+			}
+			out = append(out, keyAlphabet[int(b)%len(keyAlphabet)])
+			if len(out) == n {
+				break
+			}
+		}
+	}
+	return string(out), nil
+}
+
+func loadExistingKeys(ctx context.Context, secrets corev1client.SecretInterface, secretName, selector string) ([]existingKey, error) {
+	switch {
+	case secretName != "":
+		secret, err := secrets.Get(ctx, secretName, metav1.GetOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("fetch collision-check secret %q: %w", secretName, err)
+		}
+		return existingKeysFromSecret(secret)
+	case selector != "":
+		list, err := secrets.List(ctx, metav1.ListOptions{LabelSelector: selector})
+		if err != nil {
+			return nil, fmt.Errorf("fetch collision-check secrets matching %q: %w", selector, err)
+		}
+		var keys []existingKey
+		for i := range list.Items {
+			parsed, err := existingKeysFromSecret(&list.Items[i])
+			if err != nil {
+				return nil, err
+			}
+			keys = append(keys, parsed...)
+		}
+		return keys, nil
+	default:
+		return nil, nil
+	}
+}
+
+func existingKeysFromSecret(secret *corev1.Secret) ([]existingKey, error) {
+	keys := make([]existingKey, 0, len(secret.Data))
+	for entry, value := range secret.Data {
+		raw, err := keyFromSecretValue(value)
+		if err != nil {
+			return nil, fmt.Errorf("secret %q entry %q has invalid API key data: %w", secret.Name, entry, err)
+		}
+		if raw == "" {
+			continue
+		}
+		keys = append(keys, existingKey{
+			Secret: secret.Name,
+			Entry:  entry,
+			Key:    raw,
+		})
+	}
+	return keys, nil
+}
+
+func keyFromSecretValue(value []byte) (string, error) {
+	trimmed := strings.TrimSpace(string(value))
+	if trimmed == "" {
+		return "", nil
+	}
+	if !strings.HasPrefix(trimmed, "{") {
+		return string(value), nil
+	}
+	var entry struct {
+		Key string `json:"key"`
+	}
+	if err := json.Unmarshal([]byte(trimmed), &entry); err != nil {
+		return "", err
+	}
+	return entry.Key, nil
+}
+
+func checkCollisions(imported map[int]string, existing []existingKey) error {
+	for row, key := range imported {
+		for _, candidate := range existing {
+			if subtle.ConstantTimeCompare([]byte(key), []byte(candidate.Key)) == 1 {
+				return fmt.Errorf("row %d collides with existing secret %q entry %q", row, candidate.Secret, candidate.Entry)
+			}
+		}
+	}
+	return nil
+}

--- a/controller/pkg/cli/virtualkey/generator_test.go
+++ b/controller/pkg/cli/virtualkey/generator_test.go
@@ -1,0 +1,100 @@
+package virtualkey
+
+import (
+	"context"
+	"regexp"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestGenerateAPIKeyFormat(t *testing.T) {
+	key, err := generateAPIKey("Alice Smith")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !regexp.MustCompile(`^sk-alice-smith-[a-z0-9]{18}$`).MatchString(key) {
+		t.Fatalf("generated key has unexpected format: %s", key)
+	}
+}
+
+func TestGenerateAPIKeyFallbackLabel(t *testing.T) {
+	key, err := generateAPIKey("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !regexp.MustCompile(`^sk-key-[a-z0-9]{18}$`).MatchString(key) {
+		t.Fatalf("generated key has unexpected fallback format: %s", key)
+	}
+}
+
+func TestGenerateAPIKeyUnique(t *testing.T) {
+	seen := map[string]struct{}{}
+	for i := 0; i < 100; i++ {
+		key, err := generateAPIKey("alice")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, ok := seen[key]; ok {
+			t.Fatalf("generated duplicate key at iteration %d", i)
+		}
+		seen[key] = struct{}{}
+	}
+}
+
+func TestSanitizeLabel(t *testing.T) {
+	tests := map[string]string{
+		"":                                      "key",
+		"Sales/Alice!!":                         "sales-alice",
+		"---":                                   "key",
+		"this-label-is-definitely-way-too-long": "this-label-is-definitely",
+	}
+	for input, want := range tests {
+		if got := sanitizeLabel(input); got != want {
+			t.Fatalf("sanitizeLabel(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestLoadExistingKeysParsesRawAndJSONSecretValues(t *testing.T) {
+	client := fake.NewSimpleClientset(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "keys", Namespace: "default"},
+		Data: map[string][]byte{
+			"raw":  []byte("k-raw"),
+			"json": []byte(`{"key":"k-json","metadata":{"id":"vk-json"}}`),
+		},
+	})
+
+	keys, err := loadExistingKeys(context.Background(), client.CoreV1().Secrets("default"), "keys", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]string{}
+	for _, key := range keys {
+		got[key.Entry] = key.Key
+	}
+	if got["raw"] != "k-raw" || got["json"] != "k-json" {
+		t.Fatalf("unexpected parsed keys: %#v", got)
+	}
+}
+
+func TestCheckCollisionsDoesNotLeakRawKey(t *testing.T) {
+	err := checkCollisions(map[int]string{7: "k-secret-value"}, []existingKey{{
+		Secret: "existing",
+		Entry:  "alice",
+		Key:    "k-secret-value",
+	}})
+	if err == nil {
+		t.Fatal("expected collision error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "row 7") || !strings.Contains(msg, "existing") || !strings.Contains(msg, "alice") {
+		t.Fatalf("collision error missing expected context: %s", msg)
+	}
+	if strings.Contains(msg, "k-secret-value") {
+		t.Fatalf("collision error leaked raw key: %s", msg)
+	}
+}

--- a/controller/pkg/cli/virtualkey/generator_test.go
+++ b/controller/pkg/cli/virtualkey/generator_test.go
@@ -33,7 +33,7 @@ func TestGenerateAPIKeyFallbackLabel(t *testing.T) {
 
 func TestGenerateAPIKeyUnique(t *testing.T) {
 	seen := map[string]struct{}{}
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		key, err := generateAPIKey("alice")
 		if err != nil {
 			t.Fatal(err)

--- a/controller/pkg/cli/virtualkey/importer.go
+++ b/controller/pkg/cli/virtualkey/importer.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"sort"
 	"strings"
@@ -223,13 +224,9 @@ func newSecretManifest(name, namespace string, labels map[string]string) secretM
 func cloneSecretManifest(secret secretManifest) secretManifest {
 	clone := secret
 	clone.Metadata.Labels = map[string]string{}
-	for k, v := range secret.Metadata.Labels {
-		clone.Metadata.Labels[k] = v
-	}
+	maps.Copy(clone.Metadata.Labels, secret.Metadata.Labels)
 	clone.StringData = map[string]string{}
-	for k, v := range secret.StringData {
-		clone.StringData[k] = v
-	}
+	maps.Copy(clone.StringData, secret.StringData)
 	return clone
 }
 
@@ -401,10 +398,9 @@ func escapeID(value string) string {
 }
 
 func secretLabels(extra map[string]string) map[string]string {
-	labels := map[string]string{virtualKeysLabel: "true"}
-	for k, v := range extra {
-		labels[k] = v
-	}
+	labels := map[string]string{}
+	maps.Copy(labels, extra)
+	labels[virtualKeysLabel] = "true"
 	return labels
 }
 

--- a/controller/pkg/cli/virtualkey/importer.go
+++ b/controller/pkg/cli/virtualkey/importer.go
@@ -1,0 +1,475 @@
+package virtualkey
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+)
+
+const virtualKeysLabel = "agentgateway.dev/virtual-keys"
+const defaultMaxSerializedSecretSize = 1024 * 1024
+const maxSecretNameLength = 253
+
+type importOptions struct {
+	SecretName              string
+	Namespace               string
+	Labels                  map[string]string
+	Strict                  bool
+	EscapeIDs               bool
+	MaxSerializedSecretSize int
+}
+
+type importResult struct {
+	Secrets       []secretManifest
+	Secret        secretManifest
+	Warnings      []string
+	GeneratedRows []int
+	ImportedKeys  map[int]string
+}
+
+type secretManifest struct {
+	APIVersion string            `json:"apiVersion" yaml:"apiVersion"`
+	Kind       string            `json:"kind" yaml:"kind"`
+	Metadata   manifestMetadata  `json:"metadata" yaml:"metadata"`
+	Type       string            `json:"type" yaml:"type"`
+	StringData map[string]string `json:"stringData" yaml:"stringData"`
+}
+
+type manifestMetadata struct {
+	Name      string            `json:"name" yaml:"name"`
+	Namespace string            `json:"namespace,omitempty" yaml:"namespace,omitempty"`
+	Labels    map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+}
+
+type manifestList struct {
+	APIVersion string           `json:"apiVersion" yaml:"apiVersion"`
+	Kind       string           `json:"kind" yaml:"kind"`
+	Items      []secretManifest `json:"items" yaml:"items"`
+}
+
+type csvRow struct {
+	Line     int
+	Columns  map[string]string
+	Metadata map[string]string
+}
+
+type secretEntry struct {
+	Name  string
+	Value string
+	Line  int
+}
+
+func importCSV(r io.Reader, opts importOptions) (*importResult, error) {
+	if opts.SecretName == "" {
+		return nil, fmt.Errorf("--secret-name is required")
+	}
+	if opts.MaxSerializedSecretSize == 0 {
+		opts.MaxSerializedSecretSize = defaultMaxSerializedSecretSize
+	}
+	if opts.MaxSerializedSecretSize < 0 {
+		return nil, fmt.Errorf("max serialized Secret size must be greater than 0")
+	}
+	reader := csv.NewReader(r)
+	reader.FieldsPerRecord = -1
+	reader.TrimLeadingSpace = true
+
+	header, err := reader.Read()
+	if err != nil {
+		if err == io.EOF {
+			return nil, fmt.Errorf("CSV input is empty")
+		}
+		return nil, fmt.Errorf("read CSV header: %w", err)
+	}
+	headers, err := normalizeHeaders(header)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &importResult{
+		ImportedKeys: map[int]string{},
+	}
+
+	seenEntries := map[string]int{}
+	seenIDs := map[string][]int{}
+	seenKeys := map[string][]int{}
+	var entries []secretEntry
+	line := 1
+	for {
+		record, err := reader.Read()
+		if err == io.EOF {
+			break
+		}
+		line++
+		if err != nil {
+			return nil, fmt.Errorf("read CSV row %d: %w", line, err)
+		}
+		if isEmptyRecord(record) {
+			continue
+		}
+		row, err := parseCSVRow(line, headers, record)
+		if err != nil {
+			return nil, err
+		}
+		entryName, encoded, key, generated, err := buildEntry(row, opts.EscapeIDs)
+		if err != nil {
+			return nil, err
+		}
+		if previous, ok := seenEntries[entryName]; ok {
+			return nil, fmt.Errorf("duplicate Secret entry %q at rows %d and %d", entryName, previous, row.Line)
+		}
+		seenEntries[entryName] = row.Line
+		entries = append(entries, secretEntry{Name: entryName, Value: encoded, Line: row.Line})
+		result.ImportedKeys[row.Line] = key
+		seenKeys[key] = append(seenKeys[key], row.Line)
+		if generated {
+			result.GeneratedRows = append(result.GeneratedRows, row.Line)
+		}
+		if id := row.Metadata["id"]; id != "" {
+			seenIDs[id] = append(seenIDs[id], row.Line)
+		} else {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("row %d has no id metadata; it will authenticate but has no stable virtual-key identity", row.Line))
+		}
+	}
+	if len(entries) == 0 {
+		return nil, fmt.Errorf("CSV input contains no data rows")
+	}
+
+	secrets, err := splitSecrets(entries, opts)
+	if err != nil {
+		return nil, err
+	}
+	result.Secrets = secrets
+	result.Secret = secrets[0]
+
+	for _, rows := range sortedDuplicateRows(seenKeys) {
+		result.Warnings = append(result.Warnings, fmt.Sprintf("duplicate API key value at rows %s; runtime deduplicates matching raw keys", formatRows(rows)))
+	}
+	for _, rows := range sortedDuplicateRows(seenIDs) {
+		result.Warnings = append(result.Warnings, fmt.Sprintf("duplicate id metadata at rows %s; runtime keeps the first sorted key", formatRows(rows)))
+	}
+	if opts.Strict && len(result.Warnings) > 0 {
+		return nil, fmt.Errorf("strict validation failed: %s", strings.Join(result.Warnings, "; "))
+	}
+	return result, nil
+}
+
+func (r *importResult) Manifest() any {
+	if len(r.Secrets) == 1 {
+		return r.Secrets[0]
+	}
+	return manifestList{
+		APIVersion: "v1",
+		Kind:       "List",
+		Items:      r.Secrets,
+	}
+}
+
+func splitSecrets(entries []secretEntry, opts importOptions) ([]secretManifest, error) {
+	var secrets []secretManifest
+	current := newSecretManifest(opts.SecretName, opts.Namespace, opts.Labels)
+	for _, entry := range entries {
+		candidate := cloneSecretManifest(current)
+		candidate.StringData[entry.Name] = entry.Value
+		size, err := serializedSecretSize(candidate)
+		if err != nil {
+			return nil, fmt.Errorf("measure Secret %q: %w", candidate.Metadata.Name, err)
+		}
+		if size <= opts.MaxSerializedSecretSize {
+			current = candidate
+			continue
+		}
+		if len(current.StringData) == 0 {
+			return nil, fmt.Errorf("row %d Secret entry %q exceeds max serialized Secret size %d bytes", entry.Line, entry.Name, opts.MaxSerializedSecretSize)
+		}
+		secrets = append(secrets, current)
+		name, err := suffixedSecretName(opts.SecretName, len(secrets)+1)
+		if err != nil {
+			return nil, err
+		}
+		current = newSecretManifest(name, opts.Namespace, opts.Labels)
+		current.StringData[entry.Name] = entry.Value
+		size, err = serializedSecretSize(current)
+		if err != nil {
+			return nil, fmt.Errorf("measure Secret %q: %w", current.Metadata.Name, err)
+		}
+		if size > opts.MaxSerializedSecretSize {
+			return nil, fmt.Errorf("row %d Secret entry %q exceeds max serialized Secret size %d bytes", entry.Line, entry.Name, opts.MaxSerializedSecretSize)
+		}
+	}
+	if len(current.StringData) > 0 {
+		secrets = append(secrets, current)
+	}
+	return secrets, nil
+}
+
+func newSecretManifest(name, namespace string, labels map[string]string) secretManifest {
+	return secretManifest{
+		APIVersion: "v1",
+		Kind:       "Secret",
+		Metadata: manifestMetadata{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    secretLabels(labels),
+		},
+		Type:       "Opaque",
+		StringData: map[string]string{},
+	}
+}
+
+func cloneSecretManifest(secret secretManifest) secretManifest {
+	clone := secret
+	clone.Metadata.Labels = map[string]string{}
+	for k, v := range secret.Metadata.Labels {
+		clone.Metadata.Labels[k] = v
+	}
+	clone.StringData = map[string]string{}
+	for k, v := range secret.StringData {
+		clone.StringData[k] = v
+	}
+	return clone
+}
+
+func serializedSecretSize(secret secretManifest) (int, error) {
+	b, err := json.Marshal(secret)
+	if err != nil {
+		return 0, err
+	}
+	return len(b), nil
+}
+
+func suffixedSecretName(base string, ordinal int) (string, error) {
+	if ordinal == 1 {
+		return base, nil
+	}
+	name := fmt.Sprintf("%s-%04d", base, ordinal)
+	if len(name) > maxSecretNameLength {
+		return "", fmt.Errorf("secret name %q is too long to split into Secret %d; suffixed name %q exceeds %d characters", base, ordinal, name, maxSecretNameLength)
+	}
+	return name, nil
+}
+
+func normalizeHeaders(header []string) ([]string, error) {
+	seen := map[string]struct{}{}
+	headers := make([]string, len(header))
+	for i, h := range header {
+		name := strings.TrimSpace(h)
+		if name == "" {
+			return nil, fmt.Errorf("CSV header column %d is empty", i+1)
+		}
+		if _, ok := seen[name]; ok {
+			return nil, fmt.Errorf("duplicate CSV header %q", name)
+		}
+		seen[name] = struct{}{}
+		headers[i] = name
+	}
+	return headers, nil
+}
+
+func parseCSVRow(line int, headers, record []string) (csvRow, error) {
+	row := csvRow{
+		Line:     line,
+		Columns:  map[string]string{},
+		Metadata: map[string]string{},
+	}
+	for i, header := range headers {
+		value := ""
+		if i < len(record) {
+			value = record[i]
+		}
+		switch {
+		case header == "key":
+			row.Columns[header] = strings.TrimSpace(value)
+		case isReservedColumn(header):
+			row.Columns[header] = strings.TrimSpace(value)
+		case strings.HasPrefix(header, "metadata."):
+			name := strings.TrimPrefix(header, "metadata.")
+			if name == "" {
+				return row, fmt.Errorf("row %d column %q has an empty metadata key", line, header)
+			}
+			row.Metadata[name] = strings.TrimSpace(value)
+		default:
+			row.Metadata[header] = strings.TrimSpace(value)
+		}
+	}
+	if id := row.Columns["id"]; id != "" {
+		if metadataID := row.Metadata["id"]; metadataID != "" && metadataID != id {
+			return row, fmt.Errorf("row %d has conflicting id and metadata.id values", line)
+		}
+		row.Metadata["id"] = id
+	}
+	return row, nil
+}
+
+func buildEntry(row csvRow, escapeIDs bool) (string, string, string, bool, error) {
+	id := row.Metadata["id"]
+	if id != "" {
+		normalized, err := normalizeID(id, escapeIDs)
+		if err != nil {
+			return "", "", "", false, fmt.Errorf("row %d column id: %w", row.Line, err)
+		}
+		row.Metadata["id"] = normalized
+		id = normalized
+	}
+
+	entryName := row.Columns["entry"]
+	if entryName == "" {
+		if id != "" {
+			entryName = "vk-" + sanitizeLabel(id)
+		} else {
+			entryName = fmt.Sprintf("row-%06d", row.Line)
+		}
+	} else {
+		entryName = sanitizeLabel(entryName)
+	}
+	if entryName == "" {
+		return "", "", "", false, fmt.Errorf("row %d has an empty Secret entry name", row.Line)
+	}
+
+	key := row.Columns["key"]
+	generated := false
+	if key == "" {
+		label := row.Columns["entry"]
+		if label == "" {
+			label = id
+		}
+		if label == "" {
+			label = fmt.Sprintf("row-%06d", row.Line)
+		}
+		var err error
+		key, err = generateAPIKey(label)
+		if err != nil {
+			return "", "", "", false, fmt.Errorf("row %d generated key: %w", row.Line, err)
+		}
+		generated = true
+	}
+
+	metadata := map[string]string{}
+	for k, v := range row.Metadata {
+		if strings.TrimSpace(k) == "" {
+			return "", "", "", false, fmt.Errorf("row %d has an empty metadata key", row.Line)
+		}
+		if v == "" {
+			continue
+		}
+		metadata[k] = v
+	}
+	entry := apiKeyEntry{Key: key, Metadata: metadata}
+	encoded, err := json.Marshal(entry)
+	if err != nil {
+		return "", "", "", false, fmt.Errorf("row %d encode Secret entry: %w", row.Line, err)
+	}
+	return entryName, string(encoded), key, generated, nil
+}
+
+func normalizeID(value string, escape bool) (string, error) {
+	if escape {
+		return escapeID(value), nil
+	}
+	if value == "<missing>" {
+		return "", fmt.Errorf("value %q is reserved; use --escape-special-characters to store an escaped value", value)
+	}
+	if strings.ContainsAny(value, "|^`") {
+		return "", fmt.Errorf("value contains reserved special characters; use --escape-special-characters to store an escaped value")
+	}
+	return value, nil
+}
+
+func escapeID(value string) string {
+	if value == "<missing>" {
+		return `\<missing>`
+	}
+	var b strings.Builder
+	for _, r := range value {
+		switch r {
+		case '\\':
+			b.WriteString(`\\`)
+		case '|':
+			b.WriteString(`\|`)
+		case '^':
+			b.WriteString(`\^`)
+		case '`':
+			b.WriteString("\\`")
+		default:
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+func secretLabels(extra map[string]string) map[string]string {
+	labels := map[string]string{virtualKeysLabel: "true"}
+	for k, v := range extra {
+		labels[k] = v
+	}
+	return labels
+}
+
+func parseLabels(values []string) (map[string]string, error) {
+	labels := map[string]string{}
+	for _, value := range values {
+		key, val, ok := strings.Cut(value, "=")
+		if !ok || strings.TrimSpace(key) == "" {
+			return nil, fmt.Errorf("label %q must be in key=value form", value)
+		}
+		labels[strings.TrimSpace(key)] = strings.TrimSpace(val)
+	}
+	return labels, nil
+}
+
+func sortedDuplicateRows(values map[string][]int) [][]int {
+	var duplicates [][]int
+	for _, rows := range values {
+		if len(rows) > 1 {
+			sort.Ints(rows)
+			duplicates = append(duplicates, rows)
+		}
+	}
+	sort.Slice(duplicates, func(i, j int) bool {
+		return duplicates[i][0] < duplicates[j][0]
+	})
+	return duplicates
+}
+
+func formatRows(rows []int) string {
+	parts := make([]string, len(rows))
+	for i, row := range rows {
+		parts[i] = fmt.Sprint(row)
+	}
+	return strings.Join(parts, ", ")
+}
+
+func isReservedColumn(header string) bool {
+	switch header {
+	case "entry", "id", "secretName", "namespace":
+		return true
+	default:
+		return false
+	}
+}
+
+func isEmptyRecord(record []string) bool {
+	for _, field := range record {
+		if strings.TrimSpace(field) != "" {
+			return false
+		}
+	}
+	return true
+}
+
+func warnIfPermissive(path string) string {
+	if path == "-" {
+		return ""
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return ""
+	}
+	if info.Mode().Perm()&0o077 != 0 {
+		return "input file is readable by other users; consider chmod 0600"
+	}
+	return ""
+}

--- a/controller/pkg/cli/virtualkey/importer_test.go
+++ b/controller/pkg/cli/virtualkey/importer_test.go
@@ -1,0 +1,258 @@
+package virtualkey
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestImportCSVBuildsSecretManifest(t *testing.T) {
+	input := `entry,key,id,metadata.group,metadata.tier,metadata.owner
+alice,k-live-alice-001,vk-sales-alice,sales,premium,alice
+bob,k-live-bob-001,vk-sales-bob,sales,standard,bob
+`
+	result, err := importCSV(strings.NewReader(input), importOptions{
+		SecretName: "agw-virtual-keys",
+		Namespace:  "default",
+		Labels:     map[string]string{"team": "platform"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Secret.APIVersion != "v1" || result.Secret.Kind != "Secret" || result.Secret.Type != "Opaque" {
+		t.Fatalf("unexpected Secret metadata: %#v", result.Secret)
+	}
+	if result.Secret.Metadata.Name != "agw-virtual-keys" || result.Secret.Metadata.Namespace != "default" {
+		t.Fatalf("unexpected manifest metadata: %#v", result.Secret.Metadata)
+	}
+	if result.Secret.Metadata.Labels[virtualKeysLabel] != "true" || result.Secret.Metadata.Labels["team"] != "platform" {
+		t.Fatalf("unexpected labels: %#v", result.Secret.Metadata.Labels)
+	}
+	if len(result.Secrets) != 1 {
+		t.Fatalf("expected normal import to stay in one Secret, got %d", len(result.Secrets))
+	}
+
+	entry := decodeEntry(t, result.Secret.StringData["alice"])
+	if entry.Key != "k-live-alice-001" {
+		t.Fatal("expected imported key to be preserved")
+	}
+	if entry.Metadata["id"] != "vk-sales-alice" || entry.Metadata["group"] != "sales" || entry.Metadata["tier"] != "premium" {
+		t.Fatalf("unexpected metadata: %#v", entry.Metadata)
+	}
+	if _, ok := entry.Metadata["owner"]; !ok {
+		t.Fatalf("expected arbitrary metadata column to be preserved: %#v", entry.Metadata)
+	}
+}
+
+func TestImportCSVGeneratesMissingKeyAndOmitsEmptyMetadata(t *testing.T) {
+	input := `entry,key,id,metadata.group,metadata.empty
+charlie,,vk-sales-charlie,sales,
+`
+	result, err := importCSV(strings.NewReader(input), importOptions{SecretName: "keys"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.GeneratedRows) != 1 || result.GeneratedRows[0] != 2 {
+		t.Fatalf("unexpected generated rows: %#v", result.GeneratedRows)
+	}
+	entry := decodeEntry(t, result.Secret.StringData["charlie"])
+	if !regexp.MustCompile(`^sk-charlie-[a-z0-9]{18}$`).MatchString(entry.Key) {
+		t.Fatalf("generated key has unexpected format: %s", entry.Key)
+	}
+	if _, ok := entry.Metadata["empty"]; ok {
+		t.Fatalf("expected empty metadata value to be omitted: %#v", entry.Metadata)
+	}
+}
+
+func TestImportCSVSplitsLargeImports(t *testing.T) {
+	input := largeImportCSV(4, 520)
+	result, err := importCSV(strings.NewReader(input), importOptions{
+		SecretName:              "agw-virtual-keys",
+		Namespace:               "default",
+		Labels:                  map[string]string{"team": "platform"},
+		MaxSerializedSecretSize: 1350,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Secrets) != 4 {
+		t.Fatalf("expected one entry per split Secret, got %d", len(result.Secrets))
+	}
+	wantNames := []string{"agw-virtual-keys", "agw-virtual-keys-0002", "agw-virtual-keys-0003", "agw-virtual-keys-0004"}
+	for i, secret := range result.Secrets {
+		if secret.Metadata.Name != wantNames[i] {
+			t.Fatalf("secret %d name = %q, want %q", i, secret.Metadata.Name, wantNames[i])
+		}
+		if secret.Metadata.Namespace != "default" {
+			t.Fatalf("secret %d namespace = %q", i, secret.Metadata.Namespace)
+		}
+		if secret.Metadata.Labels[virtualKeysLabel] != "true" || secret.Metadata.Labels["team"] != "platform" {
+			t.Fatalf("secret %d labels = %#v", i, secret.Metadata.Labels)
+		}
+		entryName := wantEntryName(i + 1)
+		if _, ok := secret.StringData[entryName]; !ok {
+			t.Fatalf("secret %d missing deterministic entry %q: %#v", i, entryName, secret.StringData)
+		}
+		size, err := serializedSecretSize(secret)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if size > 1350 {
+			t.Fatalf("secret %q serialized size %d exceeds threshold", secret.Metadata.Name, size)
+		}
+	}
+
+	manifest, ok := result.Manifest().(manifestList)
+	if !ok {
+		t.Fatalf("expected split import to print a List, got %T", result.Manifest())
+	}
+	if len(manifest.Items) != len(result.Secrets) {
+		t.Fatalf("manifest items = %d, want %d", len(manifest.Items), len(result.Secrets))
+	}
+}
+
+func TestImportCSVRejectsOverlargeSingleRow(t *testing.T) {
+	input := largeImportCSV(1, 800)
+	_, err := importCSV(strings.NewReader(input), importOptions{
+		SecretName:              "keys",
+		MaxSerializedSecretSize: 300,
+	})
+	if err == nil {
+		t.Fatal("expected overlarge single row error")
+	}
+	if !strings.Contains(err.Error(), `row 2 Secret entry "entry-0001" exceeds max serialized Secret size 300 bytes`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(err.Error(), strings.Repeat("x", 20)) {
+		t.Fatalf("error leaked metadata payload: %v", err)
+	}
+}
+
+func TestImportCSVRejectsSplitSecretNameTooLong(t *testing.T) {
+	input := largeImportCSV(2, 520)
+	_, err := importCSV(strings.NewReader(input), importOptions{
+		SecretName:              strings.Repeat("a", maxSecretNameLength-4),
+		MaxSerializedSecretSize: 1350,
+	})
+	if err == nil {
+		t.Fatal("expected long split name error")
+	}
+	if !strings.Contains(err.Error(), "is too long to split") || !strings.Contains(err.Error(), "exceeds 253 characters") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestImportCSVWarnsForMissingIDAndDuplicates(t *testing.T) {
+	input := `entry,key,id,metadata.group
+a,k-shared,,support
+b,k-shared,,support
+`
+	result, err := importCSV(strings.NewReader(input), importOptions{SecretName: "keys"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := strings.Join(result.Warnings, "\n")
+	for _, want := range []string{"row 2 has no id", "row 3 has no id", "duplicate API key value at rows 2, 3"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("warnings missing %q: %s", want, got)
+		}
+	}
+	if strings.Contains(got, "k-shared") {
+		t.Fatalf("warning leaked raw key: %s", got)
+	}
+}
+
+func TestImportCSVStrictTreatsWarningsAsErrors(t *testing.T) {
+	input := `entry,key,id
+a,k-a,
+`
+	_, err := importCSV(strings.NewReader(input), importOptions{SecretName: "keys", Strict: true})
+	if err == nil {
+		t.Fatal("expected strict mode error")
+	}
+	if !strings.Contains(err.Error(), "strict validation failed") || strings.Contains(err.Error(), "k-a") {
+		t.Fatalf("unexpected strict error: %v", err)
+	}
+}
+
+func TestImportCSVRejectsDuplicateEntryNames(t *testing.T) {
+	input := `entry,key,id
+alice,k-a,vk-a
+alice,k-b,vk-b
+`
+	_, err := importCSV(strings.NewReader(input), importOptions{SecretName: "keys"})
+	if err == nil {
+		t.Fatal("expected duplicate entry error")
+	}
+	if strings.Contains(err.Error(), "k-a") || strings.Contains(err.Error(), "k-b") {
+		t.Fatalf("duplicate entry error leaked raw key: %v", err)
+	}
+}
+
+func TestImportCSVRejectsReservedIDCharactersByDefault(t *testing.T) {
+	input := "entry,key,id\nalice,k-a,vk|alice\n"
+	_, err := importCSV(strings.NewReader(input), importOptions{SecretName: "keys"})
+	if err == nil || !strings.Contains(err.Error(), "reserved special characters") {
+		t.Fatalf("expected reserved character error, got %v", err)
+	}
+}
+
+func TestImportCSVEscapesReservedIDCharacters(t *testing.T) {
+	input := "entry,key,id\nalice,k-a,vk|alice\n"
+	result, err := importCSV(strings.NewReader(input), importOptions{SecretName: "keys", EscapeIDs: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry := decodeEntry(t, result.Secret.StringData["alice"])
+	if entry.Metadata["id"] != `vk\|alice` {
+		t.Fatalf("expected escaped id, got %#v", entry.Metadata["id"])
+	}
+}
+
+func TestImportCSVEscapesReservedIDValue(t *testing.T) {
+	input := "entry,key,id\nalice,k-a,<missing>\n"
+	result, err := importCSV(strings.NewReader(input), importOptions{SecretName: "keys", EscapeIDs: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry := decodeEntry(t, result.Secret.StringData["alice"])
+	if entry.Metadata["id"] != `\<missing>` {
+		t.Fatalf("expected escaped id, got %#v", entry.Metadata["id"])
+	}
+}
+
+func TestImportCSVRejectsConflictingMetadataID(t *testing.T) {
+	input := "entry,key,id,metadata.id\nalice,k-a,vk-a,vk-b\n"
+	_, err := importCSV(strings.NewReader(input), importOptions{SecretName: "keys"})
+	if err == nil || !strings.Contains(err.Error(), "conflicting id") {
+		t.Fatalf("expected conflicting id error, got %v", err)
+	}
+}
+
+func decodeEntry(t *testing.T, value string) apiKeyEntry {
+	t.Helper()
+	var entry apiKeyEntry
+	if err := json.Unmarshal([]byte(value), &entry); err != nil {
+		t.Fatal(err)
+	}
+	return entry
+}
+
+func largeImportCSV(rows, metadataSize int) string {
+	var b strings.Builder
+	b.WriteString("entry,key,id,metadata.notes\n")
+	for i := 1; i <= rows; i++ {
+		fmt.Fprintf(&b, "entry-%04d,k-%04d,%s,%s\n", i, i, wantEntryID(i), strings.Repeat("x", metadataSize))
+	}
+	return b.String()
+}
+
+func wantEntryID(i int) string {
+	return fmt.Sprintf("vk-%04d", i)
+}
+
+func wantEntryName(i int) string {
+	return fmt.Sprintf("entry-%04d", i)
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -51,3 +51,7 @@ The `prompt-enrichment` example shows how to append or preprend prompts to agent
 
 The `standalone-epp` example shows the v1 local config shape for running agentgateway as the sidecar proxy
 next to a standalone EPP deployment on Kubernetes.
+
+### [Virtual Key Import](virtualkey-import/README.md)
+
+The `virtualkey-import` example shows how to generate or import virtual API keys with `agctl`.

--- a/examples/virtualkey-import/README.md
+++ b/examples/virtualkey-import/README.md
@@ -1,0 +1,108 @@
+# agctl virtualkey import
+
+This example imports virtual API keys from CSV and emits the Kubernetes Secret
+shape consumed by `AgentgatewayPolicy.spec.traffic.apiKeyAuthentication`.
+Large imports are split into multiple labeled Secrets automatically.
+
+The CSV contains secret material. The generated manifest also contains secret
+material, especially for rows where `key` is empty and `agctl` generates a key.
+Store the output securely.
+
+## Generate a Secret manifest
+
+```bash
+agctl virtualkey import \
+  --file examples/virtualkey-import/virtual-keys.csv \
+  --secret-name agw-virtual-keys \
+  --namespace default \
+  --output yaml > /tmp/agw-virtual-keys.yaml
+```
+
+The `charlie` row has an empty `key`, so `agctl` generates a key in the
+`sk-charlie-<random>` format and writes it into the Secret manifest.
+
+## Generate keys directly
+
+Use `agctl virtualkey generate` when you need raw virtual API keys before
+building or updating an import CSV.
+
+```bash
+agctl virtualkey generate --label alice
+```
+
+The generated key uses the `sk-alice-<random>` format. The label is sanitized
+before it is embedded in the key.
+
+Generate a batch when you want to fill multiple CSV rows:
+
+```bash
+agctl virtualkey generate \
+  --count 5 \
+  --label batch-import \
+  --output text > /tmp/generated-virtual-keys.txt
+```
+
+The output file contains secret key material. Restrict access to it before
+sharing or storing it.
+
+```bash
+chmod 0600 /tmp/generated-virtual-keys.txt
+```
+
+When generating keys for an existing virtual-key Secret, `agctl` can query the
+Secret first and retry if a generated key collides with an existing value.
+
+```bash
+agctl virtualkey generate \
+  --label alice \
+  --collision-check-secret default/agw-virtual-keys
+```
+
+Use `--collision-check-selector` instead when keys are split across multiple
+Secrets selected by label.
+
+Large imports are automatically split into multiple labeled Secrets before any
+one Secret approaches Kubernetes object size limits. The first Secret uses the
+requested name, and additional Secrets use deterministic suffixes such as
+`agw-virtual-keys-0002`.
+If the import is large, the output is a Kubernetes `List` containing multiple
+Secrets named from the requested `--secret-name`, such as `agw-virtual-keys`,
+`agw-virtual-keys-0002`, and `agw-virtual-keys-0003`.
+
+## Apply the Secret
+
+```bash
+kubectl apply -f /tmp/agw-virtual-keys.yaml
+```
+
+Or stream the generated manifest directly:
+
+```bash
+agctl virtualkey import \
+  --file examples/virtualkey-import/virtual-keys.csv \
+  --secret-name agw-virtual-keys \
+  --namespace default | kubectl apply -f -
+```
+
+## Select the imported keys from policy
+
+```yaml
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: api-key-auth
+  namespace: default
+spec:
+  traffic:
+    apiKeyAuthentication:
+      secretSelector:
+        matchLabels:
+          agentgateway.dev/virtual-keys: "true"
+```
+
+Each Secret entry is emitted as JSON with `key` and `metadata`. The `id` column
+is stored as `metadata.id`, which is the stable virtual-key identity.
+ID values containing reserved special characters are rejected by default; pass
+`--escape-special-characters` to store escaped values instead.
+For large imports, use `secretSelector.matchLabels` as shown above so every
+split Secret is selected.

--- a/examples/virtualkey-import/virtual-keys.csv
+++ b/examples/virtualkey-import/virtual-keys.csv
@@ -1,0 +1,5 @@
+entry,key,id,metadata.group,metadata.tier,metadata.owner,metadata.created_at
+alice,k-live-alice-001,vk-sales-alice,sales,premium,alice,2026-06-12T00:00:00Z
+bob,k-live-bob-001,vk-sales-bob,sales,standard,bob,2026-06-12T00:00:00Z
+raw-compatible,k-legacy-import,,support,legacy,,2026-06-12T00:00:00Z
+charlie,,vk-sales-charlie,sales,premium,charlie,2026-06-12T00:00:00Z


### PR DESCRIPTION
Allow users to batch create [Virtual Keys](https://agentgateway.dev/docs/standalone/main/llm/virtual-keys/) from a CSV file. We'll automatically break large imports into multiple `Secrets` to work around Kubernetes's etcd limit.