### PR TITLE
admin.rs: add conditional deadcode check for dataplane flush

### DIFF
--- a/crates/agentgateway/src/management/admin.rs
+++ b/crates/agentgateway/src/management/admin.rs
@@ -69,6 +69,7 @@ struct AdminState {
 	config: Arc<Config>,
 	shutdown_trigger: signal::ShutdownTrigger,
 	config_dump_handlers: Vec<Arc<dyn ConfigDumpHandler>>,
+	#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 	dataplane_handle: Handle,
 }
 


### PR DESCRIPTION
make lint fails for non-linux due to admin refactor removing the default task dump path and moving it to linux only