### PR TITLE
feat(llm): add llm.completionMessages for structured tool_use tracing

### DIFF
--- a/crates/agentgateway/src/cel/mod.rs
+++ b/crates/agentgateway/src/cel/mod.rs
@@ -103,6 +103,7 @@ flagset::flags! {
 		Llm,
 		LlmPrompt,
 		LlmCompletion,
+		LlmCompletionMessages,
 
 		Backend,
 
@@ -272,6 +273,9 @@ impl ContextBuilder {
 	pub fn needs_llm_completion(&self) -> bool {
 		self.any_has(Attributes::LlmCompletion)
 	}
+	pub fn needs_llm_completion_messages(&self) -> bool {
+		self.any_has(Attributes::LlmCompletionMessages)
+	}
 }
 
 impl Expression {
@@ -338,6 +342,9 @@ impl Expression {
 				},
 				["llm", "prompt", ..] => {
 					attributes |= Attributes::Llm | Attributes::LlmPrompt;
+				},
+				["llm", "completionMessages", ..] => {
+					attributes |= Attributes::Llm | Attributes::LlmCompletionMessages;
 				},
 				["llm", "completion", ..] => {
 					attributes |= Attributes::Llm | Attributes::LlmCompletion;

--- a/crates/agentgateway/src/cel/types.rs
+++ b/crates/agentgateway/src/cel/types.rs
@@ -1289,6 +1289,12 @@ pub struct LLMContext {
 	/// The completion from the LLM. Warning: accessing this has some performance impacts for large responses.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub completion: Option<Vec<String>>,
+	/// The structured completion from the LLM as a JSON string: an array of message-content
+	/// blocks (text, tool_use, thinking, ...). Unlike `completion` (text-only), this preserves
+	/// tool calls. Warning: accessing this has some performance impacts for large responses.
+	#[dynamic(rename = "completionMessages")]
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub completion_messages: Option<Strng>,
 	/// The parameters for the LLM request.
 	pub params: llm::LLMRequestParams,
 	/// The realized USD cost of the request from the model cost catalog.
@@ -1330,6 +1336,7 @@ impl LLMContext {
 			response_model: resp.provider_model.clone(),
 			// Not always set
 			completion: resp.completion.clone(),
+			completion_messages: resp.completion_messages.as_deref().map(Strng::from),
 			..LLMContext::from(value.request)
 		};
 
@@ -1401,6 +1408,7 @@ impl From<llm::LLMRequest> for LLMContext {
 			output_audio_tokens: None,
 			total_tokens: None,
 			completion: None,
+			completion_messages: None,
 			reasoning_tokens: None,
 			input_image_tokens: None,
 			input_text_tokens: None,
@@ -2074,6 +2082,7 @@ pub fn full_example_executor() -> ExecutorSerde {
 
 			prompt: None,
 			completion: Some(vec!["Hello".to_string()]),
+			completion_messages: None,
 			params: llm::LLMRequestParams {
 				temperature: Some(0.7),
 				top_p: Some(1.0),

--- a/crates/agentgateway/src/llm/conversion/bedrock.rs
+++ b/crates/agentgateway/src/llm/conversion/bedrock.rs
@@ -1490,6 +1490,17 @@ pub mod from_messages {
 		let mut pending_stop_reason: Option<bedrock::StopReason> = None;
 		let mut pending_usage: Option<bedrock::TokenUsage> = None;
 		let mut completion = include_completion_in_log.then(String::new);
+		// Structured completion: accumulate per content-block index so tool_use calls and
+		// thinking are preserved (not just text). Tool input arrives as partial-JSON string
+		// fragments, so it's buffered as a String and parsed at flush. Gated by the same
+		// flag as `completion`, and ordered by block index via BTreeMap.
+		enum StreamBlockAccum {
+			Text(String),
+			Thinking { thinking: String, signature: String },
+			ToolUse { id: String, name: String, input_json: String },
+		}
+		let mut completion_blocks: Option<std::collections::BTreeMap<i32, StreamBlockAccum>> =
+			include_completion_in_log.then(std::collections::BTreeMap::new);
 		let model = model.to_string();
 		parse::aws_sse::transform_multi(b, buffer_limit, move |aws_event| {
 			let event = match bedrock::ConverseStreamOutput::deserialize(aws_event) {
@@ -1556,6 +1567,25 @@ pub mod from_messages {
 						}),
 					};
 
+					// Mirror the started block into the structured accumulator.
+					if let (Some(blocks), Some(cb)) = (completion_blocks.as_mut(), {
+						match &content_block {
+							messages::ContentBlock::ToolUse { id, name, .. } => Some(StreamBlockAccum::ToolUse {
+								id: id.clone(),
+								name: name.clone(),
+								input_json: String::new(),
+							}),
+							messages::ContentBlock::Thinking { .. } => Some(StreamBlockAccum::Thinking {
+								thinking: String::new(),
+								signature: String::new(),
+							}),
+							messages::ContentBlock::Text(_) => Some(StreamBlockAccum::Text(String::new())),
+							_ => None,
+						}
+					}) {
+						blocks.insert(start.content_block_index, cb);
+					}
+
 					let event = messages::MessagesStreamEvent::ContentBlockStart {
 						index: start.content_block_index as usize,
 						content_block,
@@ -1608,18 +1638,39 @@ pub mod from_messages {
 							});
 						}
 
+						let idx = delta.content_block_index;
 						let anthropic_delta = match d {
 							bedrock::ContentBlockDelta::Text(text) => {
 								if let Some(c) = completion.as_mut() {
 									c.push_str(&text);
 								}
+								if let Some(blocks) = completion_blocks.as_mut() {
+									match blocks.entry(idx).or_insert_with(|| StreamBlockAccum::Text(String::new())) {
+										StreamBlockAccum::Text(s) => s.push_str(&text),
+										_ => {},
+									}
+								}
 								messages::ContentBlockDelta::TextDelta { text }
 							},
 							bedrock::ContentBlockDelta::ReasoningContent(rc) => match rc {
 								bedrock::ReasoningContentBlockDelta::Text(t) => {
+									if let Some(blocks) = completion_blocks.as_mut()
+										&& let StreamBlockAccum::Thinking { thinking, .. } = blocks
+											.entry(idx)
+											.or_insert_with(|| StreamBlockAccum::Thinking {
+												thinking: String::new(),
+												signature: String::new(),
+											}) {
+										thinking.push_str(&t);
+									}
 									messages::ContentBlockDelta::ThinkingDelta { thinking: t }
 								},
 								bedrock::ReasoningContentBlockDelta::Signature(sig) => {
+									if let Some(blocks) = completion_blocks.as_mut()
+										&& let Some(StreamBlockAccum::Thinking { signature, .. }) = blocks.get_mut(&idx)
+									{
+										signature.push_str(&sig);
+									}
 									messages::ContentBlockDelta::SignatureDelta { signature: sig }
 								},
 								bedrock::ReasoningContentBlockDelta::RedactedContent(_) => {
@@ -1634,6 +1685,11 @@ pub mod from_messages {
 								},
 							},
 							bedrock::ContentBlockDelta::ToolUse(tu) => {
+								if let Some(blocks) = completion_blocks.as_mut()
+									&& let Some(StreamBlockAccum::ToolUse { input_json, .. }) = blocks.get_mut(&idx)
+								{
+									input_json.push_str(&tu.input);
+								}
 								messages::ContentBlockDelta::InputJsonDelta {
 									partial_json: tu.input,
 								}
@@ -1665,6 +1721,36 @@ pub mod from_messages {
 				bedrock::ConverseStreamOutput::Metadata(meta) => {
 					if let Some(usage) = meta.usage {
 						pending_usage = Some(usage);
+						// Finalize structured blocks: parse each tool_use input buffer and
+						// serialize the ordered blocks to a JSON string for llm.completionMessages.
+						let completion_messages_json = completion_blocks.take().map(|blocks| {
+							let finalized: Vec<messages::ContentBlock> = blocks
+								.into_values()
+								.map(|b| match b {
+									StreamBlockAccum::Text(text) => {
+										messages::ContentBlock::Text(messages::ContentTextBlock {
+											text,
+											citations: None,
+											cache_control: None,
+										})
+									},
+									StreamBlockAccum::Thinking { thinking, signature } => {
+										messages::ContentBlock::Thinking { thinking, signature }
+									},
+									StreamBlockAccum::ToolUse { id, name, input_json } => {
+										let input = serde_json::from_str::<serde_json::Value>(&input_json)
+											.unwrap_or_else(|_| serde_json::json!({}));
+										messages::ContentBlock::ToolUse {
+											id,
+											name,
+											input,
+											cache_control: None,
+										}
+									},
+								})
+								.collect();
+							serde_json::to_string(&finalized).unwrap_or_default()
+						});
 						log.non_atomic_mutate(|r| {
 							r.response.output_tokens = Some(usage.output_tokens as u64);
 							r.response.input_tokens = Some(usage.input_tokens as u64);
@@ -1675,6 +1761,7 @@ pub mod from_messages {
 							if let Some(c) = completion.take() {
 								r.response.completion = Some(vec![c]);
 							}
+							r.response.completion_messages = completion_messages_json;
 						});
 					}
 

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -339,6 +339,13 @@ pub struct LLMResponse {
 	pub provider_model: Option<Strng>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub completion: Option<Vec<String>>,
+	/// Structured completion content as a serialized JSON array of message-content blocks
+	/// (e.g. Anthropic `{"type":"text",...}` / `{"type":"tool_use",...}`). Unlike
+	/// `completion` (text-only), this preserves tool calls and thinking so observability
+	/// backends can render them. Populated only when a CEL field references
+	/// `llm.completionMessages`. Currently produced by the Bedrock `from_messages` path.
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub completion_messages: Option<String>,
 
 	#[serde(skip)]
 	// Time to get the first token. Only used for streaming.

--- a/crates/agentgateway/src/llm/types/completions.rs
+++ b/crates/agentgateway/src/llm/types/completions.rs
@@ -196,6 +196,7 @@ impl ResponseType for Response {
 			} else {
 				None
 			},
+			completion_messages: None,
 			first_token: Default::default(),
 		}
 	}

--- a/crates/agentgateway/src/llm/types/detect.rs
+++ b/crates/agentgateway/src/llm/types/detect.rs
@@ -412,6 +412,7 @@ impl ResponseType for Response {
 				.map(Into::into),
 			provider_model: self.lookup(lookups::MODEL, |v| v.as_str()).map(Into::into),
 			completion: None,
+			completion_messages: None,
 			// TODO: we could probably derive this
 			first_token: None,
 		}

--- a/crates/agentgateway/src/llm/types/messages.rs
+++ b/crates/agentgateway/src/llm/types/messages.rs
@@ -388,6 +388,9 @@ impl ResponseType for Response {
 			} else {
 				None
 			},
+			// This response shape only exposes text cleanly; structured blocks are
+			// captured on the streaming path and the typed MessagesResponse path.
+			completion_messages: None,
 			first_token: Default::default(),
 		}
 	}
@@ -1029,6 +1032,13 @@ pub mod typed {
 							})
 							.collect(),
 					)
+				} else {
+					None
+				},
+				// Non-streaming: the typed response already holds structured content blocks
+				// (text, tool_use, thinking, ...). Serialize them for llm.completionMessages.
+				completion_messages: if include_completion_in_log {
+					serde_json::to_string(&self.content).ok()
 				} else {
 					None
 				},

--- a/crates/agentgateway/src/llm/types/responses.rs
+++ b/crates/agentgateway/src/llm/types/responses.rs
@@ -454,6 +454,7 @@ impl ResponseType for Response {
 			} else {
 				None
 			},
+			completion_messages: None,
 			first_token: Default::default(),
 		}
 	}

--- a/crates/agentgateway/src/parse/websocket.rs
+++ b/crates/agentgateway/src/parse/websocket.rs
@@ -69,6 +69,7 @@ impl<IO> Parser<IO> {
 						service_tier: None,
 						provider_model: None,
 						completion: None,
+						completion_messages: None,
 						first_token: None,
 						count_tokens: None,
 						reasoning_tokens: None,

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -2337,7 +2337,10 @@ async fn make_backend_call(
 	let llm_response_log = log.as_ref().map(|l| l.llm_response.clone());
 	let include_completion_in_log = log
 		.as_ref()
-		.map(|l| l.cel.cel_context.needs_llm_completion())
+		.map(|l| {
+			let cc = &l.cel.cel_context;
+			cc.needs_llm_completion() || cc.needs_llm_completion_messages()
+		})
 		.unwrap_or_default();
 	let a2a_type = response_policies.a2a_type.clone();
 


### PR DESCRIPTION
The text-only llm.completion field drops the assistant's tool_use blocks, so traces of agentic turns can't show what the model called. Add an opt-in llm.completionMessages CEL field that carries the structured assistant content (text + tool_use + thinking) as a JSON array, reassembled from the Bedrock streaming SSE on the gateway side.

- LLMResponse.completion_messages: serialized JSON of content blocks
- cel: LlmCompletionMessages attribute + needs_llm_completion_messages() gating so it costs nothing unless referenced
- bedrock from_messages: accumulate per content-block index (text / thinking / tool_use with partial-JSON buffering), finalize at the Metadata flush; non-streaming path serializes its content blocks
- llm.completion (text) is left unchanged

Refs: agentgateway/agentgateway#2227