### PR TITLE
feat(helm): add podLabels for controller pod template

### DIFF
--- a/controller/install/helm/agentgateway/templates/deployment.yaml
+++ b/controller/install/helm/agentgateway/templates/deployment.yaml
@@ -26,6 +26,9 @@ spec:
         {{- toYaml .Values.podAnnotations | nindent 8 }}
       labels:
         {{- include "agentgateway.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/controller/install/helm/agentgateway/values.yaml
+++ b/controller/install/helm/agentgateway/values.yaml
@@ -26,6 +26,9 @@ deploymentAnnotations: {}
 podAnnotations:
   prometheus.io/scrape: "true"
 
+# -- Add labels to the agentgateway pods. Useful for `NetworkPolicy` selectors (e.g. opt-in egress labels on Cilium-based clusters).
+podLabels: {}
+
 # -- Set the pod-level security context. For example, 'fsGroup: 2000' sets the filesystem group to 2000.
 podSecurityContext: {}
 


### PR DESCRIPTION
Fixes #2237.

The chart exposes `podAnnotations`, `podSecurityContext`, `nodeSelector`, etc. at the top level for the controller pod template, but no equivalent `podLabels` — `selectorLabels` are hardcoded with no extension hook.

This blocks Cilium-based platforms that gate pod egress on opt-in pod labels (e.g. `allow-to/internet: "true"`): without a way to set the label, the controller can't reach external JWKS sources referenced by `AgentgatewayBackend`s, the JWKS cache stays empty, and the data plane rejects every JWT with `authentication failure: token uses the unknown key "<kid>"`.

## Change

Two lines:

```diff
       labels:
         {{- include "agentgateway.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
```

Plus the matching `podLabels: {}` default in `values.yaml` next to `podAnnotations`.

## Notes

- `with`-guard rather than the bare `toYaml` form so the default `{}` doesn't render an inline empty map inside the labels block (helm lint catches that — verified locally).
- Default is empty; no behaviour change for existing installs.
- Data-plane Gateway pods already expose this via `AgentgatewayParameters.spec.deployment.spec.template.metadata.labels`; this PR brings the controller's own pod template in line.

## Verification

```
$ helm lint .                                              # default values
1 chart(s) linted, 0 chart(s) failed

$ helm lint . --set 'podLabels.allow-to/internet=true'     # override
1 chart(s) linted, 0 chart(s) failed

$ helm template t . --set 'podLabels.allow-to/internet=true' \
    | grep -A 1 selectorLabels-rendered-block
      labels:
        agentgateway: agentgateway
        app.kubernetes.io/name: agentgateway
        app.kubernetes.io/instance: t
        allow-to/internet: true
```