### PR TITLE
ui: fix pricing catalog

### DIFF
--- a/crates/agentgateway/src/lib.rs
+++ b/crates/agentgateway/src/lib.rs
@@ -560,6 +560,7 @@ pub struct ModelCatalogConfig {
 pub enum ModelCatalogSource {
 	File { file: PathBuf },
 	Inline { inline: String },
+	InlineCatalog { inline: llm::cost::Catalog },
 }
 
 #[apply(schema!)]

--- a/crates/agentgateway/src/llm/cost/catalog.rs
+++ b/crates/agentgateway/src/llm/cost/catalog.rs
@@ -6,6 +6,7 @@ use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(deny_unknown_fields)]
 pub struct Catalog {
 	#[serde(default)]
@@ -55,6 +56,7 @@ pub fn from_json(s: &str) -> anyhow::Result<Catalog> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(deny_unknown_fields)]
 pub struct Provider {
 	#[serde(default)]
@@ -62,6 +64,7 @@ pub struct Provider {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct Model {
 	#[serde(default, skip_serializing_if = "Rates::is_empty")]
@@ -71,6 +74,7 @@ pub struct Model {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct Rates {
 	#[serde(default, skip_serializing_if = "Option::is_none")]
@@ -109,6 +113,7 @@ impl Rates {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct Tier {
 	pub context_over: u64,
@@ -118,6 +123,17 @@ pub struct Tier {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(try_from = "String", into = "String")]
 pub struct Money(pub Decimal);
+
+#[cfg(feature = "schema")]
+impl schemars::JsonSchema for Money {
+	fn schema_name() -> std::borrow::Cow<'static, str> {
+		"Money".into()
+	}
+
+	fn json_schema(schema_gen: &mut schemars::SchemaGenerator) -> schemars::Schema {
+		String::json_schema(schema_gen)
+	}
+}
 
 impl Money {
 	pub fn parse(s: &str) -> Result<Money, String> {

--- a/crates/agentgateway/src/llm/cost/mod.rs
+++ b/crates/agentgateway/src/llm/cost/mod.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use anyhow::{Context, bail};
 use arc_swap::ArcSwap;
-pub use catalog::Breakdown;
+pub use catalog::{Breakdown, Catalog};
 use catalog::{Catalog as CatalogData, Rates, Usage};
 use prometheus_client::encoding::EncodeLabelValue;
 use rust_decimal::Decimal;
@@ -52,6 +52,7 @@ impl ModelCatalog {
 			.filter_map(|s| match s {
 				ModelCatalogSource::File { file } => Some(file.clone()),
 				ModelCatalogSource::Inline { .. } => None,
+				ModelCatalogSource::InlineCatalog { .. } => None,
 			})
 			.collect();
 		tokio::spawn({
@@ -484,6 +485,10 @@ async fn load_sources(sources: &[ModelCatalogSource]) -> anyhow::Result<LoadedCa
 			ModelCatalogSource::Inline { inline } => {
 				let catalog = catalog::from_json(inline).context("invalid inline model catalog")?;
 				catalogs.push(catalog);
+			},
+			ModelCatalogSource::InlineCatalog { inline } => {
+				inline.validate().context("invalid inline model catalog")?;
+				catalogs.push(inline.clone());
 			},
 		}
 	}

--- a/crates/agentgateway/src/ui.rs
+++ b/crates/agentgateway/src/ui.rs
@@ -246,7 +246,7 @@ async fn refresh_base_costs(State(app): State<App>) -> Result<Json<Value>, Error
 	if let Value::Object(fields) = &mut response {
 		fields.insert(
 			"file".to_string(),
-			Value::String(BASE_COSTS_FILE.to_string()),
+			Value::String(base_costs_file.to_string_lossy().to_string()),
 		);
 	}
 	Ok(Json(response))

--- a/schema/config.json
+++ b/schema/config.json
@@ -395,7 +395,156 @@
           "required": [
             "inline"
           ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "inline": {
+              "$ref": "#/$defs/Catalog"
+            }
+          },
+          "required": [
+            "inline"
+          ]
         }
+      ]
+    },
+    "Catalog": {
+      "type": "object",
+      "properties": {
+        "providers": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/Provider"
+          },
+          "default": {}
+        }
+      },
+      "additionalProperties": false
+    },
+    "Provider": {
+      "type": "object",
+      "properties": {
+        "models": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/Model"
+          },
+          "default": {}
+        }
+      },
+      "additionalProperties": false
+    },
+    "Model": {
+      "type": "object",
+      "properties": {
+        "rates": {
+          "$ref": "#/$defs/Rates"
+        },
+        "tiers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Tier"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "Rates": {
+      "type": "object",
+      "properties": {
+        "input": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Money"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "output": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Money"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "cacheRead": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Money"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "cacheWrite": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Money"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "reasoning": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Money"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "inputAudio": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Money"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "outputAudio": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Money"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "Money": {
+      "type": "string"
+    },
+    "Tier": {
+      "type": "object",
+      "properties": {
+        "contextOver": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0
+        },
+        "rates": {
+          "$ref": "#/$defs/Rates"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "contextOver",
+        "rates"
       ]
     },
     "Config": {

--- a/schema/config.md
+++ b/schema/config.md
@@ -11,6 +11,8 @@
 |`config.modelCatalog`|[]object|Model cost catalog sources; entries are merged in order, with later entries taking precedence.|
 |`config.modelCatalog[].file`|string||
 |`config.modelCatalog[].inline`|string||
+|`config.modelCatalog[].inline`|object||
+|`config.modelCatalog[].inline.providers`|object||
 |`config.database`|object|Primary database used by local runtime features.|
 |`config.database.url`|string||
 |`config.caAddress`|string||


### PR DESCRIPTION
Two bugs caused by last minute rebase:
* `inline` only supported stringified json. Added mode to support proper
  json
* Properly base the cost path on the config instead of using relative
  dir which breaks when user changes dir.

Signed-off-by: John Howard <john.howard@solo.io>
