### PR TITLE
ui: fix wildcards and virtual models

### DIFF
--- a/ui/src/modelResolution.ts
+++ b/ui/src/modelResolution.ts
@@ -59,3 +59,53 @@ export function wildcardResolvedSuffix(
     ? targetModel.slice(prefix.length)
     : targetModel;
 }
+
+export function selectedConfiguredModelName(
+  concreteModel: string,
+  models: LlmModel[],
+) {
+  const exact = models.find((model) => model.name === concreteModel);
+  if (exact) return exact.name;
+  const wildcard = models
+    .map((model, index) => ({ model, index }))
+    .filter(
+      ({ model }) =>
+        isWildcardModelName(model.name) &&
+        (concreteModel === wildcardModelPrefix(model.name) ||
+          wildcardMatchesModel(model.name, concreteModel)),
+    )
+    .sort((left, right) => {
+      const specificity =
+        wildcardSpecificity(right.model.name) -
+        wildcardSpecificity(left.model.name);
+      return specificity || left.index - right.index;
+    })[0]?.model;
+  return wildcard?.name ?? models[0]?.name ?? "";
+}
+
+export function concreteModelName(
+  configuredModelName: string,
+  specificModel: string,
+) {
+  if (!isWildcardModelName(configuredModelName)) return configuredModelName;
+  return `${wildcardModelPrefix(configuredModelName)}${specificModel}`;
+}
+
+function wildcardMatchesModel(pattern: string, model: string) {
+  if (pattern === "*") return Boolean(model.trim());
+  const wildcardIndex = pattern.indexOf("*");
+  if (wildcardIndex < 0) return pattern === model;
+  const prefix = pattern.slice(0, wildcardIndex);
+  const suffix = pattern.slice(wildcardIndex + 1);
+  return (
+    model.startsWith(prefix) &&
+    model.endsWith(suffix) &&
+    model.length > prefix.length + suffix.length
+  );
+}
+
+function wildcardSpecificity(pattern: string) {
+  const wildcardIndex = pattern.indexOf("*");
+  if (wildcardIndex < 0) return Number.MAX_SAFE_INTEGER;
+  return pattern.length - 1;
+}

--- a/ui/src/pages/Models.tsx
+++ b/ui/src/pages/Models.tsx
@@ -50,8 +50,10 @@ import { cleanEmpty, parseYamlText, toYamlText } from "../policies/policyUtils";
 import type { AuthorizationDraft } from "../policies/types";
 import { useSchemaHelp, type SchemaHelp } from "../schemaHelp";
 import {
+  concreteModelName,
   isWildcardModelName,
   resolvedProviderLabel,
+  selectedConfiguredModelName,
   wildcardModelPrefix,
   wildcardResolvedSuffix,
 } from "../modelResolution";
@@ -82,7 +84,6 @@ import {
   failoverTargetGroups,
   isIncompleteWildcardTarget,
   modelTargetOptions,
-  selectedConfiguredTargetName,
   virtualModelStrategy,
   virtualModelSummary,
 } from "./models/virtualModelUtils";
@@ -1670,7 +1671,7 @@ function VirtualTargetSelector(props: {
   providers: LlmProvider[];
   onChange: (model: string) => void;
 }) {
-  const selectedModelName = selectedConfiguredTargetName(
+  const selectedModelName = selectedConfiguredModelName(
     props.targetModel,
     props.baseModels,
   );
@@ -1703,11 +1704,7 @@ function VirtualTargetSelector(props: {
         searchable
         options={props.options}
         placeholder="No configured models"
-        onChange={(value) =>
-          props.onChange(
-            isWildcardModelName(value) ? wildcardModelPrefix(value) : value,
-          )
-        }
+        onChange={(value) => props.onChange(concreteModelName(value, ""))}
       />
       {wildcard ? (
         <div className="target-resolved-composite">
@@ -1715,10 +1712,12 @@ function VirtualTargetSelector(props: {
             <span className="target-prefix">{wildcardPrefix}</span>
           ) : null}
           <CatalogModelSelector
-            ariaLabel="Resolved model"
+            ariaLabel="Specific model"
             value={resolvedSuffix}
             provider={provider}
-            onChange={(value) => props.onChange(`${wildcardPrefix}${value}`)}
+            onChange={(value) =>
+              props.onChange(concreteModelName(selectedModelName, value))
+            }
             placeholder="claude-haiku-4-5"
           />
         </div>

--- a/ui/src/pages/models/virtualModelUtils.tsx
+++ b/ui/src/pages/models/virtualModelUtils.tsx
@@ -1,6 +1,7 @@
 import { providerLabel } from "../../config";
 import {
   isWildcardModelName,
+  selectedConfiguredModelName,
   wildcardModelPrefix,
 } from "../../modelResolution";
 import type { LlmModel, LlmVirtualModel, ProviderName } from "../../types";
@@ -25,26 +26,11 @@ export function defaultVirtualTargetModel(models: LlmModel[]) {
     : model.name;
 }
 
-export function selectedConfiguredTargetName(
-  targetModel: string,
-  baseModels: LlmModel[],
-) {
-  const exact = baseModels.find((model) => model.name === targetModel);
-  if (exact) return exact.name;
-  const wildcard = baseModels.find(
-    (model) =>
-      isWildcardModelName(model.name) &&
-      (targetModel === wildcardModelPrefix(model.name) ||
-        wildcardMatchesModel(model.name, targetModel)),
-  );
-  return wildcard?.name ?? baseModels[0]?.name ?? "";
-}
-
 export function isIncompleteWildcardTarget(
   targetModel: string,
   baseModels: LlmModel[],
 ) {
-  const selected = selectedConfiguredTargetName(targetModel, baseModels);
+  const selected = selectedConfiguredModelName(targetModel, baseModels);
   if (!selected || !isWildcardModelName(selected)) return false;
   return (
     targetModel === selected || targetModel === wildcardModelPrefix(selected)
@@ -82,17 +68,4 @@ export function virtualModelSummary(model: LlmVirtualModel) {
   }
   const targets = model.routing.weighted?.targets ?? [];
   return `${targets.length} weighted ${targets.length === 1 ? "target" : "targets"}`;
-}
-
-function wildcardMatchesModel(pattern: string, model: string) {
-  if (pattern === "*") return Boolean(model.trim());
-  const wildcardIndex = pattern.indexOf("*");
-  if (wildcardIndex < 0) return pattern === model;
-  const prefix = pattern.slice(0, wildcardIndex);
-  const suffix = pattern.slice(wildcardIndex + 1);
-  return (
-    model.startsWith(prefix) &&
-    model.endsWith(suffix) &&
-    model.length > prefix.length + suffix.length
-  );
 }

--- a/ui/tests/e2e/ui.spec.ts
+++ b/ui/tests/e2e/ui.spec.ts
@@ -188,7 +188,7 @@ test("creates a weighted virtual model with a concrete wildcard target", async (
   ).toBeDisabled();
 
   await page
-    .getByRole("textbox", { name: "Resolved model" })
+    .getByRole("textbox", { name: "Specific model" })
     .fill("gpt-5.4-nano");
   await page.getByRole("button", { name: "Save virtual model" }).click();
 


### PR DESCRIPTION
The UI tries to map a concrete model like gemini/bar to a proider in the
list which may be like `gemini/*`. But it did so incorrectly resulting
in wonky behavior.

Signed-off-by: John Howard <john.howard@solo.io>
