### PR TITLE
Support A2A v1.0 agent card format in URL rewriting

### DIFF
--- a/crates/agentgateway/src/a2a/mod.rs
+++ b/crates/agentgateway/src/a2a/mod.rs
@@ -87,16 +87,15 @@ pub async fn apply_to_response(
 					.as_array_mut()
 					.ok_or_else(|| anyhow::anyhow!("agent card supportedInterfaces is not an array"))?;
 				for iface in arr.iter_mut() {
-					if let Some(url_val) = iface.get_mut("url") {
-						if let Some(s) = url_val.as_str() {
-							if let Ok(iface_uri) = s.parse::<Uri>() {
-								let path_and_query = iface_uri
-									.path_and_query()
-									.map(|pq| pq.as_str())
-									.unwrap_or_else(|| iface_uri.path());
-								*url_val = Value::String(format!("{gateway_base}{path_and_query}"));
-							}
-						}
+					if let Some(url_val) = iface.get_mut("url")
+						&& let Some(s) = url_val.as_str()
+						&& let Ok(iface_uri) = s.parse::<Uri>()
+					{
+						let path_and_query = iface_uri
+							.path_and_query()
+							.map(|pq| pq.as_str())
+							.unwrap_or_else(|| iface_uri.path());
+						*url_val = Value::String(format!("{gateway_base}{path_and_query}"));
 					}
 				}
 			} else if let Some(url_field) = json::traverse_mut(&mut agent_card, &["url"]) {

--- a/crates/agentgateway/src/a2a/mod.rs
+++ b/crates/agentgateway/src/a2a/mod.rs
@@ -79,12 +79,32 @@ pub async fn apply_to_response(
 			let Ok(mut agent_card) = json::from_body_with_limit::<Value>(body, buffer_limit).await else {
 				anyhow::bail!("agent card invalid JSON");
 			};
-			let Some(url_field) = json::traverse_mut(&mut agent_card, &["url"]) else {
-				anyhow::bail!("agent card missing URL");
-			};
-			let new_uri = build_agent_path(uri);
+			let gateway_base = build_agent_path(uri);
 
-			*url_field = Value::String(new_uri);
+			if let Some(interfaces) = agent_card.get_mut("supportedInterfaces") {
+				// A2A v1.0: rewrite url inside each AgentInterface entry.
+				let arr = interfaces
+					.as_array_mut()
+					.ok_or_else(|| anyhow::anyhow!("agent card supportedInterfaces is not an array"))?;
+				for iface in arr.iter_mut() {
+					if let Some(url_val) = iface.get_mut("url") {
+						if let Some(s) = url_val.as_str() {
+							if let Ok(iface_uri) = s.parse::<Uri>() {
+								let path_and_query = iface_uri
+									.path_and_query()
+									.map(|pq| pq.as_str())
+									.unwrap_or_else(|| iface_uri.path());
+								*url_val = Value::String(format!("{gateway_base}{path_and_query}"));
+							}
+						}
+					}
+				}
+			} else if let Some(url_field) = json::traverse_mut(&mut agent_card, &["url"]) {
+				// A2A v0.3: rewrite the single top-level url.
+				*url_field = Value::String(gateway_base);
+			} else {
+				anyhow::bail!("agent card missing URL (no 'url' or 'supportedInterfaces' field)");
+			}
 
 			resp.headers_mut().remove(header::CONTENT_LENGTH);
 			*resp.body_mut() = json::to_body(agent_card)?;

--- a/crates/agentgateway/src/a2a/tests.rs
+++ b/crates/agentgateway/src/a2a/tests.rs
@@ -355,14 +355,20 @@ async fn test_apply_to_response_errors_when_neither_url_field_present() {
 
 	let result = apply_to_response(
 		Some(&A2aPolicy {}),
-		RequestType::AgentCard("https://example.com/.well-known/agent-card.json".parse().unwrap()),
+		RequestType::AgentCard(
+			"https://example.com/.well-known/agent-card.json"
+				.parse()
+				.unwrap(),
+		),
 		&mut resp,
 	)
 	.await;
 
 	assert!(result.is_err());
-	assert!(result
-		.unwrap_err()
-		.to_string()
-		.contains("agent card missing URL"));
+	assert!(
+		result
+			.unwrap_err()
+			.to_string()
+			.contains("agent card missing URL")
+	);
 }

--- a/crates/agentgateway/src/a2a/tests.rs
+++ b/crates/agentgateway/src/a2a/tests.rs
@@ -196,3 +196,173 @@ async fn test_apply_to_response_rewrites_agent_card_url() {
 	let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
 	assert_eq!(json["url"], "https://example.com/api");
 }
+
+#[tokio::test]
+async fn test_apply_to_response_rewrites_v1_agent_card_single_interface() {
+	let mut resp = ::http::Response::builder()
+		.header(header::CONTENT_TYPE, "application/json")
+		.body(http::Body::from(
+			serde_json::to_vec(&json!({
+				"name": "example",
+				"supportedInterfaces": [
+					{ "protocolBinding": "JSONRPC", "url": "http://backend.internal/a2a/jsonrpc/" }
+				],
+			}))
+			.unwrap(),
+		))
+		.unwrap();
+
+	apply_to_response(
+		Some(&A2aPolicy {}),
+		RequestType::AgentCard(
+			"https://example.com/api/.well-known/agent-card.json"
+				.parse()
+				.unwrap(),
+		),
+		&mut resp,
+	)
+	.await
+	.unwrap();
+
+	let body = http::read_resp_body(resp).await.unwrap();
+	let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+	assert_eq!(
+		json["supportedInterfaces"][0]["url"],
+		"https://example.com/api/a2a/jsonrpc/"
+	);
+}
+
+#[tokio::test]
+async fn test_apply_to_response_rewrites_v1_agent_card_multiple_interfaces() {
+	let mut resp = ::http::Response::builder()
+		.header(header::CONTENT_TYPE, "application/json")
+		.body(http::Body::from(
+			serde_json::to_vec(&json!({
+				"name": "example",
+				"supportedInterfaces": [
+					{ "protocolBinding": "JSONRPC", "url": "http://backend.internal/a2a/jsonrpc/" },
+					{ "protocolBinding": "GRPC", "url": "http://backend.internal/grpc/" },
+				],
+			}))
+			.unwrap(),
+		))
+		.unwrap();
+
+	apply_to_response(
+		Some(&A2aPolicy {}),
+		RequestType::AgentCard(
+			"https://example.com/api/.well-known/agent-card.json"
+				.parse()
+				.unwrap(),
+		),
+		&mut resp,
+	)
+	.await
+	.unwrap();
+
+	let body = http::read_resp_body(resp).await.unwrap();
+	let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+	assert_eq!(
+		json["supportedInterfaces"][0]["url"],
+		"https://example.com/api/a2a/jsonrpc/"
+	);
+	assert_eq!(
+		json["supportedInterfaces"][1]["url"],
+		"https://example.com/api/grpc/"
+	);
+}
+
+#[tokio::test]
+async fn test_apply_to_response_rewrites_v1_agent_card_root_path() {
+	let mut resp = ::http::Response::builder()
+		.header(header::CONTENT_TYPE, "application/json")
+		.body(http::Body::from(
+			serde_json::to_vec(&json!({
+				"name": "example",
+				"supportedInterfaces": [
+					{ "protocolBinding": "JSONRPC", "url": "http://backend.internal/a2a/jsonrpc/" }
+				],
+			}))
+			.unwrap(),
+		))
+		.unwrap();
+
+	apply_to_response(
+		Some(&A2aPolicy {}),
+		RequestType::AgentCard(
+			"https://example.com/.well-known/agent-card.json"
+				.parse()
+				.unwrap(),
+		),
+		&mut resp,
+	)
+	.await
+	.unwrap();
+
+	let body = http::read_resp_body(resp).await.unwrap();
+	let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+	assert_eq!(
+		json["supportedInterfaces"][0]["url"],
+		"https://example.com/a2a/jsonrpc/"
+	);
+}
+
+#[tokio::test]
+async fn test_apply_to_response_skips_interface_without_url() {
+	let mut resp = ::http::Response::builder()
+		.header(header::CONTENT_TYPE, "application/json")
+		.body(http::Body::from(
+			serde_json::to_vec(&json!({
+				"name": "example",
+				"supportedInterfaces": [
+					{ "protocolBinding": "GRPC" },
+					{ "protocolBinding": "JSONRPC", "url": "http://backend.internal/a2a/jsonrpc/" },
+				],
+			}))
+			.unwrap(),
+		))
+		.unwrap();
+
+	apply_to_response(
+		Some(&A2aPolicy {}),
+		RequestType::AgentCard(
+			"https://example.com/api/.well-known/agent-card.json"
+				.parse()
+				.unwrap(),
+		),
+		&mut resp,
+	)
+	.await
+	.unwrap();
+
+	let body = http::read_resp_body(resp).await.unwrap();
+	let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+	assert!(json["supportedInterfaces"][0].get("url").is_none());
+	assert_eq!(
+		json["supportedInterfaces"][1]["url"],
+		"https://example.com/api/a2a/jsonrpc/"
+	);
+}
+
+#[tokio::test]
+async fn test_apply_to_response_errors_when_neither_url_field_present() {
+	let mut resp = ::http::Response::builder()
+		.header(header::CONTENT_TYPE, "application/json")
+		.body(http::Body::from(
+			serde_json::to_vec(&json!({ "name": "example" })).unwrap(),
+		))
+		.unwrap();
+
+	let result = apply_to_response(
+		Some(&A2aPolicy {}),
+		RequestType::AgentCard("https://example.com/.well-known/agent-card.json".parse().unwrap()),
+		&mut resp,
+	)
+	.await;
+
+	assert!(result.is_err());
+	assert!(result
+		.unwrap_err()
+		.to_string()
+		.contains("agent card missing URL"));
+}


### PR DESCRIPTION
A2A v1.0 removed the top-level `url` field from AgentCard and replaced it with a `supportedInterfaces` array where each AgentInterface carries its own `url`. The gateway's apply_to_response previously bailed with "agent card missing URL" on any v1.0 response.

I think this is a really important update, as url rewrites of a2a agent are a key feature of agentgateway.

See: https://github.com/a2aproject/a2a-python/blob/main/docs/migrations/v1_0/README.md for the migration guide
as well as https://github.com/a2aproject/a2a-python/blob/main/src/a2a/compat/v0_3/README.md for compatibility mode (chose the python sdk here as that's what I'm using).

Now detects the format and rewrites:
- v1.0 (supportedInterfaces): rewrites url in each interface entry
- v0.3 (url): existing behavior unchanged