### PR TITLE
feat(vertex): support multi-region endpoints

### DIFF
--- a/controller/api/v1alpha1/agentgateway/agentgateway_backend_types.go
+++ b/controller/api/v1alpha1/agentgateway/agentgateway_backend_types.go
@@ -475,6 +475,8 @@ type VertexAIConfig struct {
 	ProjectId TinyString `json:"projectId"`
 
 	// The location of the Google Cloud Project that you use for the Vertex AI.
+	// Special values: `global` uses the global endpoint, while `us` and `eu` use restricted
+	// multi-region endpoints. Other values are treated as regional locations.
 	// Defaults to `global` if not specified.
 	// +optional
 	// +kubebuilder:default=global

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
@@ -5865,6 +5865,8 @@ spec:
                                     default: global
                                     description: |-
                                       The location of the Google Cloud Project that you use for the Vertex AI.
+                                      Special values: `global` uses the global endpoint, while `us` and `eu` use restricted
+                                      multi-region endpoints. Other values are treated as regional locations.
                                       Defaults to `global` if not specified.
                                     maxLength: 64
                                     minLength: 1
@@ -6230,6 +6232,8 @@ spec:
                             default: global
                             description: |-
                               The location of the Google Cloud Project that you use for the Vertex AI.
+                              Special values: `global` uses the global endpoint, while `us` and `eu` use restricted
+                              multi-region endpoints. Other values are treated as regional locations.
                               Defaults to `global` if not specified.
                             maxLength: 64
                             minLength: 1

--- a/crates/agentgateway/src/llm/vertex.rs
+++ b/crates/agentgateway/src/llm/vertex.rs
@@ -17,6 +17,8 @@ pub const DISCOVERY_ENGINE_HOST: Strng = strng::literal!("discoveryengine.google
 pub struct Provider {
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub model: Option<Strng>,
+	/// Vertex AI region. Special values: `global` uses the global endpoint, while `us` and `eu`
+	/// use restricted multi-region endpoints. Other values are treated as regional locations.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub region: Option<Strng>,
 	pub project_id: Strng,

--- a/crates/agentgateway/src/llm/vertex.rs
+++ b/crates/agentgateway/src/llm/vertex.rs
@@ -138,6 +138,9 @@ impl Provider {
 		match &self.region {
 			None => strng::literal!("aiplatform.googleapis.com"),
 			Some(region) if region == "global" => strng::literal!("aiplatform.googleapis.com"),
+			Some(region) if region == "us" || region == "eu" => {
+				strng::format!("aiplatform.{region}.rep.googleapis.com")
+			},
 			Some(region) => strng::format!("{region}-aiplatform.googleapis.com"),
 		}
 	}
@@ -252,6 +255,7 @@ mod tests {
 	#[rstest::rstest]
 	#[case::no_region(None, "aiplatform.googleapis.com")]
 	#[case::global_region(Some("global"), "aiplatform.googleapis.com")]
+	#[case::multi_region(Some("us"), "aiplatform.us.rep.googleapis.com")]
 	#[case::regional(Some("us-central1"), "us-central1-aiplatform.googleapis.com")]
 	fn test_get_host(#[case] region: Option<&str>, #[case] expected: &str) {
 		let p = Provider {

--- a/schema/config.json
+++ b/schema/config.json
@@ -6601,6 +6601,7 @@
           ]
         },
         "region": {
+          "description": "Vertex AI region. Special values: `global` uses the global endpoint, while `us` and `eu`\nuse restricted multi-region endpoints. Other values are treated as regional locations.",
           "type": [
             "string",
             "null"

--- a/schema/config.md
+++ b/schema/config.md
@@ -2368,7 +2368,7 @@
 |`binds[].listeners[].routes[].backends[].ai.provider.gemini.model`|string||
 |`binds[].listeners[].routes[].backends[].ai.provider.vertex`|object||
 |`binds[].listeners[].routes[].backends[].ai.provider.vertex.model`|string||
-|`binds[].listeners[].routes[].backends[].ai.provider.vertex.region`|string||
+|`binds[].listeners[].routes[].backends[].ai.provider.vertex.region`|string|Vertex AI region. Special values: `global` uses the global endpoint, while `us` and `eu`<br>use restricted multi-region endpoints. Other values are treated as regional locations.|
 |`binds[].listeners[].routes[].backends[].ai.provider.vertex.projectId`|string||
 |`binds[].listeners[].routes[].backends[].ai.provider.anthropic`|object||
 |`binds[].listeners[].routes[].backends[].ai.provider.anthropic.model`|string||
@@ -3620,7 +3620,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].provider.gemini.model`|string||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].provider.vertex`|object||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].provider.vertex.model`|string||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].provider.vertex.region`|string||
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].provider.vertex.region`|string|Vertex AI region. Special values: `global` uses the global endpoint, while `us` and `eu`<br>use restricted multi-region endpoints. Other values are treated as regional locations.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].provider.vertex.projectId`|string||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].provider.anthropic`|object||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].provider.anthropic.model`|string||
@@ -9419,7 +9419,7 @@
 |`backends[].ai.provider.gemini.model`|string||
 |`backends[].ai.provider.vertex`|object||
 |`backends[].ai.provider.vertex.model`|string||
-|`backends[].ai.provider.vertex.region`|string||
+|`backends[].ai.provider.vertex.region`|string|Vertex AI region. Special values: `global` uses the global endpoint, while `us` and `eu`<br>use restricted multi-region endpoints. Other values are treated as regional locations.|
 |`backends[].ai.provider.vertex.projectId`|string||
 |`backends[].ai.provider.anthropic`|object||
 |`backends[].ai.provider.anthropic.model`|string||
@@ -10671,7 +10671,7 @@
 |`backends[].ai.groups[].providers[].provider.gemini.model`|string||
 |`backends[].ai.groups[].providers[].provider.vertex`|object||
 |`backends[].ai.groups[].providers[].provider.vertex.model`|string||
-|`backends[].ai.groups[].providers[].provider.vertex.region`|string||
+|`backends[].ai.groups[].providers[].provider.vertex.region`|string|Vertex AI region. Special values: `global` uses the global endpoint, while `us` and `eu`<br>use restricted multi-region endpoints. Other values are treated as regional locations.|
 |`backends[].ai.groups[].providers[].provider.vertex.projectId`|string||
 |`backends[].ai.groups[].providers[].provider.anthropic`|object||
 |`backends[].ai.groups[].providers[].provider.anthropic.model`|string||
@@ -15409,7 +15409,7 @@
 |`routeGroups[].routes[].backends[].ai.provider.gemini.model`|string||
 |`routeGroups[].routes[].backends[].ai.provider.vertex`|object||
 |`routeGroups[].routes[].backends[].ai.provider.vertex.model`|string||
-|`routeGroups[].routes[].backends[].ai.provider.vertex.region`|string||
+|`routeGroups[].routes[].backends[].ai.provider.vertex.region`|string|Vertex AI region. Special values: `global` uses the global endpoint, while `us` and `eu`<br>use restricted multi-region endpoints. Other values are treated as regional locations.|
 |`routeGroups[].routes[].backends[].ai.provider.vertex.projectId`|string||
 |`routeGroups[].routes[].backends[].ai.provider.anthropic`|object||
 |`routeGroups[].routes[].backends[].ai.provider.anthropic.model`|string||
@@ -16661,7 +16661,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].provider.gemini.model`|string||
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].provider.vertex`|object||
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].provider.vertex.model`|string||
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].provider.vertex.region`|string||
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].provider.vertex.region`|string|Vertex AI region. Special values: `global` uses the global endpoint, while `us` and `eu`<br>use restricted multi-region endpoints. Other values are treated as regional locations.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].provider.vertex.projectId`|string||
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].provider.anthropic`|object||
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].provider.anthropic.model`|string||


### PR DESCRIPTION
Starting with its new models (Gemini 3.x) and third-party models (Opus 4.8, for example), Google offers new multi-region endpoints (mostly for companies with compliance needs), which don't follow the historical endpoint format: https://docs.cloud.google.com/gemini-enterprise-agent-platform/resources/locations#multi-region_endpoints

This MR adds support for these new endpoints.