### PR TITLE
Fix Responses --> Completions streaming

### DIFF
--- a/crates/agentgateway/src/llm/conversion/openai_compat.rs
+++ b/crates/agentgateway/src/llm/conversion/openai_compat.rs
@@ -510,6 +510,7 @@ pub mod to_responses {
 		let response_id = format!("resp_{:016x}", rand::rng().random::<u64>());
 		let message_item_id = format!("msg_{:016x}", rand::rng().random::<u64>());
 		let model_holder: std::cell::RefCell<String> = std::cell::RefCell::new(String::new());
+		let mut text_buffer = String::new();
 
 		let mut next_output_index: u32 = 1;
 		let mut tool_calls: HashMap<u32, (String, String, String, u32)> = HashMap::new();
@@ -534,6 +535,7 @@ pub mod to_responses {
 								&mut pending_usage,
 								&message_item_id,
 								&sent_content_part,
+								&text_buffer,
 								&log,
 								&response_id,
 								&model_holder.borrow(),
@@ -614,6 +616,8 @@ pub mod to_responses {
 										r.response.first_token = Some(Instant::now());
 									});
 								}
+
+								text_buffer.push_str(content);
 
 								sequence_number += 1;
 								events.push((
@@ -712,6 +716,7 @@ pub mod to_responses {
 								&mut pending_usage,
 								&message_item_id,
 								&sent_content_part,
+								&text_buffer,
 								&log,
 								&response_id,
 								&model_holder.borrow(),
@@ -741,15 +746,17 @@ pub mod to_responses {
 		pending_usage: &mut Option<completions::Usage>,
 		message_item_id: &str,
 		sent_content_part: &bool,
+		text_buffer: &str,
 		log: &AmendOnDrop,
 		response_id: &str,
 		model: &str,
 	) {
 		use responses::{
 			AssistantRole, ErrorObject, FunctionToolCall, IncompleteDetails, InputTokenDetails,
-			OutputContent, OutputItem, OutputMessage, OutputStatus, OutputTextContent,
-			OutputTokenDetails, ResponseContentPartDoneEvent, ResponseFunctionCallArgumentsDoneEvent,
-			ResponseOutputItemDoneEvent, ResponseStreamEvent, ResponseUsage,
+			OutputContent, OutputItem, OutputMessage, OutputMessageContent, OutputStatus,
+			OutputTextContent, OutputTokenDetails, ResponseContentPartDoneEvent,
+			ResponseFunctionCallArgumentsDoneEvent, ResponseOutputItemDoneEvent, ResponseStreamEvent,
+			ResponseTextDoneEvent, ResponseUsage,
 		};
 
 		let stop_reason = pending_stop_reason.take();
@@ -795,6 +802,19 @@ pub mod to_responses {
 			*sequence_number += 1;
 			events.push((
 				"event",
+				ResponseStreamEvent::ResponseOutputTextDone(ResponseTextDoneEvent {
+					sequence_number: *sequence_number,
+					item_id: message_item_id.to_string(),
+					output_index: 0,
+					content_index: 0,
+					text: text_buffer.to_string(),
+					logprobs: None,
+				}),
+			));
+
+			*sequence_number += 1;
+			events.push((
+				"event",
 				ResponseStreamEvent::ResponseContentPartDone(ResponseContentPartDoneEvent {
 					sequence_number: *sequence_number,
 					item_id: message_item_id.to_string(),
@@ -803,11 +823,28 @@ pub mod to_responses {
 					part: OutputContent::OutputText(OutputTextContent {
 						annotations: Vec::new(),
 						logprobs: None,
-						text: String::new(),
+						text: text_buffer.to_string(),
 					}),
 				}),
 			));
 		}
+
+		let message_content = if *sent_content_part {
+			vec![OutputMessageContent::OutputText(OutputTextContent {
+				annotations: Vec::new(),
+				logprobs: None,
+				text: text_buffer.to_string(),
+			})]
+		} else {
+			Vec::new()
+		};
+		let message_item = OutputItem::Message(OutputMessage {
+			content: message_content,
+			id: message_item_id.to_string(),
+			role: AssistantRole::Assistant,
+			phase: None,
+			status: OutputStatus::Completed,
+		});
 
 		*sequence_number += 1;
 		events.push((
@@ -815,13 +852,7 @@ pub mod to_responses {
 			ResponseStreamEvent::ResponseOutputItemDone(ResponseOutputItemDoneEvent {
 				sequence_number: *sequence_number,
 				output_index: 0,
-				item: OutputItem::Message(OutputMessage {
-					content: Vec::new(),
-					id: message_item_id.to_string(),
-					role: AssistantRole::Assistant,
-					phase: None,
-					status: OutputStatus::Completed,
-				}),
+				item: message_item.clone(),
 			}),
 		));
 
@@ -865,7 +896,7 @@ pub mod to_responses {
 			types::responses::ResponseBuilder::new(response_id.to_string(), model.to_string());
 
 		*sequence_number += 1;
-		let done_event = match stop_reason {
+		let mut done_event = match stop_reason {
 			Some(completions::FinishReason::Stop)
 			| Some(completions::FinishReason::ToolCalls)
 			| Some(completions::FinishReason::FunctionCall)
@@ -886,6 +917,15 @@ pub mod to_responses {
 				},
 			),
 		};
+
+		if *sent_content_part {
+			match &mut done_event {
+				ResponseStreamEvent::ResponseCompleted(e) => e.response.output = vec![message_item],
+				ResponseStreamEvent::ResponseIncomplete(e) => e.response.output = vec![message_item],
+				ResponseStreamEvent::ResponseFailed(e) => e.response.output = vec![message_item],
+				_ => {},
+			}
+		}
 
 		events.push(("event", done_event));
 	}

--- a/crates/agentgateway/src/llm/conversion/openai_compat.rs
+++ b/crates/agentgateway/src/llm/conversion/openai_compat.rs
@@ -646,6 +646,9 @@ pub mod to_responses {
 										(item_id, String::new(), String::new(), output_index)
 									});
 
+									if let Some(id) = &tc.id {
+										entry.0 = id.clone();
+									}
 									if let Some(function) = &tc.function {
 										if let Some(name) = &function.name {
 											entry.1 = name.clone();
@@ -764,6 +767,7 @@ pub mod to_responses {
 
 		let mut sorted_tools: Vec<_> = tool_calls.drain().collect();
 		sorted_tools.sort_by_key(|(_, (_, _, _, output_index))| *output_index);
+		let mut response_output = Vec::new();
 
 		for (_, (item_id, name, buffer, output_index)) in sorted_tools {
 			*sequence_number += 1;
@@ -780,20 +784,23 @@ pub mod to_responses {
 				),
 			));
 
+			let item = OutputItem::FunctionCall(FunctionToolCall {
+				arguments: buffer,
+				call_id: item_id.clone(),
+				namespace: None,
+				name,
+				id: Some(item_id),
+				status: Some(OutputStatus::Completed),
+			});
+			response_output.push(item.clone());
+
 			*sequence_number += 1;
 			events.push((
 				"event",
 				ResponseStreamEvent::ResponseOutputItemDone(ResponseOutputItemDoneEvent {
 					sequence_number: *sequence_number,
 					output_index,
-					item: OutputItem::FunctionCall(FunctionToolCall {
-						arguments: buffer,
-						call_id: item_id.clone(),
-						namespace: None,
-						name,
-						id: Some(item_id),
-						status: Some(OutputStatus::Completed),
-					}),
+					item,
 				}),
 			));
 		}
@@ -919,10 +926,13 @@ pub mod to_responses {
 		};
 
 		if *sent_content_part {
+			response_output.insert(0, message_item);
+		}
+		if !response_output.is_empty() {
 			match &mut done_event {
-				ResponseStreamEvent::ResponseCompleted(e) => e.response.output = vec![message_item],
-				ResponseStreamEvent::ResponseIncomplete(e) => e.response.output = vec![message_item],
-				ResponseStreamEvent::ResponseFailed(e) => e.response.output = vec![message_item],
+				ResponseStreamEvent::ResponseCompleted(e) => e.response.output = response_output,
+				ResponseStreamEvent::ResponseIncomplete(e) => e.response.output = response_output,
+				ResponseStreamEvent::ResponseFailed(e) => e.response.output = response_output,
 				_ => {},
 			}
 		}

--- a/crates/agentgateway/src/llm/tests.rs
+++ b/crates/agentgateway/src/llm/tests.rs
@@ -550,6 +550,7 @@ mod response {
 	const MESSAGES_TO_DETECT: &str = "messages-detect";
 	const COMPLETIONS_TO_MESSAGES: &str = "completions-messages";
 	const COMPLETIONS_TO_DETECT: &str = "completions-detect";
+	const COMPLETIONS_TO_RESPONSES: &str = "completions-responses";
 	const BEDROCK_TO_MESSAGES: &str = "bedrock-messages";
 	const BEDROCK_TO_COMPLETIONS: &str = "bedrock-completions";
 	const BEDROCK_TO_RESPONSES: &str = "bedrock-responses";
@@ -607,6 +608,7 @@ mod response {
 	const COMPLETIONS_STREAM_RESPONSES: &[(&str, &[&str])] = &[
 		("stream", ALL_COMPLETIONS),
 		("stream_tool_empty_content", &[COMPLETIONS_TO_MESSAGES]),
+		("stream_terminal_text", &[COMPLETIONS_TO_RESPONSES]),
 	];
 
 	const EMBEDDING_RESPONSES: &[(&str, &[&str])] = &[
@@ -780,6 +782,20 @@ mod response {
 			COMPLETIONS_TO_DETECT => (
 				AIProvider::OpenAI(openai::Provider { model: None }),
 				dummy_llm_req(InputFormat::Detect),
+			),
+			COMPLETIONS_TO_RESPONSES => (
+				AIProvider::Custom(custom::Provider {
+					model: None,
+					provider_override: None,
+					formats: vec![custom::ProviderFormatConfig {
+						format: custom::ProviderFormat::Completions,
+						path: None,
+					}],
+				}),
+				LLMRequest {
+					native_format: Some(custom::ProviderFormat::Completions),
+					..dummy_llm_req(InputFormat::Responses)
+				},
 			),
 			MESSAGES_TO_DETECT => (
 				AIProvider::Anthropic(anthropic::Provider { model: None }),

--- a/crates/agentgateway/src/llm/tests.rs
+++ b/crates/agentgateway/src/llm/tests.rs
@@ -298,6 +298,9 @@ mod requests {
 		("basic", &[BEDROCK, GEMINI]),
 		("instructions", &[BEDROCK, GEMINI]),
 		("input-list", &[BEDROCK, GEMINI]),
+		// Minimal Responses assistant output_text history currently fails before translation:
+		// https://github.com/64bit/async-openai/issues/565
+		("minimal-output", &[GEMINI]),
 		("parallel-tool-call", &[BEDROCK, GEMINI]),
 	];
 	pub const COUNT_TOKENS_REQUESTS: &[(&str, &[&str])] = &[
@@ -608,6 +611,7 @@ mod response {
 	const COMPLETIONS_STREAM_RESPONSES: &[(&str, &[&str])] = &[
 		("stream", ALL_COMPLETIONS),
 		("stream_tool_empty_content", &[COMPLETIONS_TO_MESSAGES]),
+		("stream_tool_single_chunk", &[COMPLETIONS_TO_RESPONSES]),
 		("stream_terminal_text", &[COMPLETIONS_TO_RESPONSES]),
 	];
 

--- a/crates/agentgateway/src/llm/tests/requests/responses/minimal-output.gemini.snap
+++ b/crates/agentgateway/src/llm/tests/requests/responses/minimal-output.gemini.snap
@@ -1,0 +1,31 @@
+---
+source: crates/agentgateway/src/llm/tests.rs
+description: src/llm/tests/requests/responses/minimal-output.json
+info:
+  model: gpt-5.5
+  input:
+    - content:
+        - text: hello
+          type: output_text
+      role: assistant
+      type: message
+    - content:
+        - text: what did you say to me last?
+          type: input_text
+      role: user
+      type: message
+---
+{
+  "messages": [
+    {
+      "role": "assistant",
+      "content": "hello"
+    },
+    {
+      "role": "user",
+      "content": "what did you say to me last?"
+    }
+  ],
+  "model": "gpt-5.5",
+  "stream": false
+}

--- a/crates/agentgateway/src/llm/tests/requests/responses/minimal-output.json
+++ b/crates/agentgateway/src/llm/tests/requests/responses/minimal-output.json
@@ -1,0 +1,25 @@
+{
+  "model": "gpt-5.5",
+  "input": [
+    {
+      "content": [
+        {
+          "text": "hello",
+          "type": "output_text"
+        }
+      ],
+      "role": "assistant",
+      "type": "message"
+    },
+    {
+      "content": [
+        {
+          "text": "what did you say to me last?",
+          "type": "input_text"
+        }
+      ],
+      "role": "user",
+      "type": "message"
+    }
+  ]
+}

--- a/crates/agentgateway/src/llm/tests/response/completions/stream_terminal_text.completions-responses-streaming.snap
+++ b/crates/agentgateway/src/llm/tests/response/completions/stream_terminal_text.completions-responses-streaming.snap
@@ -1,0 +1,39 @@
+---
+source: crates/agentgateway/src/llm/tests.rs
+description: src/llm/tests/response/completions/stream_terminal_text.json
+---
+event: event
+data: {"type":"response.created","sequence_number":1,"response":{"created_at":123,"id":"","model":"test-model","object":"response","output":[],"status":"in_progress"}}
+
+event: event
+data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"type":"message","content":[],"id":"","role":"assistant","status":"in_progress"}}
+
+event: event
+data: {"type":"response.content_part.added","sequence_number":3,"item_id":"","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":null,"text":""}}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"","output_index":0,"content_index":0,"delta":""}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"","output_index":0,"content_index":0,"delta":"4"}
+
+event: event
+data: {"type":"response.output_text.done","sequence_number":6,"item_id":"","output_index":0,"content_index":0,"text":"4"}
+
+event: event
+data: {"type":"response.content_part.done","sequence_number":7,"item_id":"","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":null,"text":"4"}}
+
+event: event
+data: {"type":"response.output_item.done","sequence_number":8,"output_index":0,"item":{"type":"message","content":[{"type":"output_text","annotations":[],"logprobs":null,"text":"4"}],"id":"","role":"assistant","status":"completed"}}
+
+event: event
+data: {"type":"response.completed","sequence_number":9,"response":{"created_at":123,"id":"","model":"test-model","object":"response","output":[{"type":"message","content":[{"type":"output_text","annotations":[],"logprobs":null,"text":"4"}],"id":"","role":"assistant","status":"completed"}],"status":"completed","usage":{"input_tokens":8,"input_tokens_details":{"cached_tokens":0},"output_tokens":1,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":9}}}
+
+
+
+{
+  "input_tokens": 8,
+  "output_tokens": 1,
+  "total_tokens": 9,
+  "provider_model": "test-model"
+}

--- a/crates/agentgateway/src/llm/tests/response/completions/stream_terminal_text.json
+++ b/crates/agentgateway/src/llm/tests/response/completions/stream_terminal_text.json
@@ -1,0 +1,6 @@
+data: {"id":"chatcmpl-terminal-text","object":"chat.completion.chunk","created":1772656915,"model":"test-model","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}],"usage":null}
+
+data: {"id":"chatcmpl-terminal-text","object":"chat.completion.chunk","created":1772656915,"model":"test-model","choices":[{"index":0,"delta":{"content":"4"},"finish_reason":null}],"usage":null}
+
+data: {"id":"chatcmpl-terminal-text","object":"chat.completion.chunk","created":1772656915,"model":"test-model","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":8,"completion_tokens":1,"total_tokens":9}}
+

--- a/crates/agentgateway/src/llm/tests/response/completions/stream_tool_single_chunk.completions-responses-streaming.snap
+++ b/crates/agentgateway/src/llm/tests/response/completions/stream_tool_single_chunk.completions-responses-streaming.snap
@@ -1,0 +1,36 @@
+---
+source: crates/agentgateway/src/llm/tests.rs
+description: src/llm/tests/response/completions/stream_tool_single_chunk.json
+---
+event: event
+data: {"type":"response.created","sequence_number":1,"response":{"created_at":123,"id":"","model":"gemini-2.5-flash-lite","object":"response","output":[],"status":"in_progress"}}
+
+event: event
+data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"type":"message","content":[],"id":"","role":"assistant","status":"in_progress"}}
+
+event: event
+data: {"type":"response.output_item.added","sequence_number":3,"output_index":1,"item":{"type":"function_call","arguments":"","call_id":"function-call-14340045308038776752","name":"exec_command","id":"function-call-14340045308038776752","status":"in_progress"}}
+
+event: event
+data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"function-call-14340045308038776752","output_index":1,"delta":"{\"cmd\":\"echo \\\"Hello, World!\\\" \\u003e greeting.sh && chmod +x greeting.sh && ./greeting.sh\",\"workdir\":\"/tmp/tmp.0PpRrcOVsJ\"}"}
+
+event: event
+data: {"type":"response.function_call_arguments.done","name":"exec_command","sequence_number":5,"item_id":"function-call-14340045308038776752","output_index":1,"arguments":"{\"cmd\":\"echo \\\"Hello, World!\\\" \\u003e greeting.sh && chmod +x greeting.sh && ./greeting.sh\",\"workdir\":\"/tmp/tmp.0PpRrcOVsJ\"}"}
+
+event: event
+data: {"type":"response.output_item.done","sequence_number":6,"output_index":1,"item":{"type":"function_call","arguments":"{\"cmd\":\"echo \\\"Hello, World!\\\" \\u003e greeting.sh && chmod +x greeting.sh && ./greeting.sh\",\"workdir\":\"/tmp/tmp.0PpRrcOVsJ\"}","call_id":"function-call-14340045308038776752","name":"exec_command","id":"function-call-14340045308038776752","status":"completed"}}
+
+event: event
+data: {"type":"response.output_item.done","sequence_number":7,"output_index":0,"item":{"type":"message","content":[],"id":"","role":"assistant","status":"completed"}}
+
+event: event
+data: {"type":"response.completed","sequence_number":8,"response":{"created_at":123,"id":"","model":"gemini-2.5-flash-lite","object":"response","output":[{"type":"function_call","arguments":"{\"cmd\":\"echo \\\"Hello, World!\\\" \\u003e greeting.sh && chmod +x greeting.sh && ./greeting.sh\",\"workdir\":\"/tmp/tmp.0PpRrcOVsJ\"}","call_id":"function-call-14340045308038776752","name":"exec_command","id":"function-call-14340045308038776752","status":"completed"}],"status":"completed","usage":{"input_tokens":4821,"input_tokens_details":{"cached_tokens":0},"output_tokens":53,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":4874}}}
+
+
+
+{
+  "input_tokens": 4821,
+  "output_tokens": 53,
+  "total_tokens": 4874,
+  "provider_model": "gemini-2.5-flash-lite"
+}

--- a/crates/agentgateway/src/llm/tests/response/completions/stream_tool_single_chunk.json
+++ b/crates/agentgateway/src/llm/tests/response/completions/stream_tool_single_chunk.json
@@ -1,0 +1,4 @@
+data: {"choices":[{"delta":{"role":"assistant","tool_calls":[{"function":{"arguments":"{\"cmd\":\"echo \\\"Hello, World!\\\" \\u003e greeting.sh && chmod +x greeting.sh && ./greeting.sh\",\"workdir\":\"/tmp/tmp.0PpRrcOVsJ\"}","name":"exec_command"},"id":"function-call-14340045308038776752","type":"function"}]},"finish_reason":"tool_calls","index":0}],"created":1782173193,"id":"Cc45au33H7HW1MkP-Z2tiA4","model":"gemini-2.5-flash-lite","object":"chat.completion.chunk","usage":{"completion_tokens":53,"prompt_tokens":4821,"total_tokens":4874}}
+
+data: [DONE]
+

--- a/crates/agentgateway/src/llm/types/completions.rs
+++ b/crates/agentgateway/src/llm/types/completions.rs
@@ -417,7 +417,7 @@ pub mod typed {
 	#[allow(deprecated_in_future)]
 	pub use async_openai::types::chat::{
 		ChatCompletionAudio, ChatCompletionFunctionCall, ChatCompletionFunctions,
-		ChatCompletionMessageToolCall as MessageToolCall, ChatCompletionMessageToolCallChunk,
+		ChatCompletionMessageToolCall as MessageToolCall,
 		ChatCompletionMessageToolCalls as MessageToolCalls,
 		ChatCompletionNamedToolChoice as NamedToolChoice,
 		ChatCompletionRequestAssistantMessageAudio as RequestAssistantMessageAudio,
@@ -446,6 +446,18 @@ pub mod typed {
 		StopConfiguration as Stop, ToolChoiceOptions, WebSearchOptions,
 	};
 	use serde::{Deserialize, Serialize};
+
+	#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+	pub struct ChatCompletionMessageToolCallChunk {
+		#[serde(default)]
+		pub index: u32,
+		#[serde(skip_serializing_if = "Option::is_none")]
+		pub id: Option<String>,
+		#[serde(skip_serializing_if = "Option::is_none")]
+		pub r#type: Option<FunctionType>,
+		#[serde(skip_serializing_if = "Option::is_none")]
+		pub function: Option<FunctionCallStream>,
+	}
 
 	/// Agentgateway fork of async-openai's `ChatCompletionRequestMessage`.
 	///

--- a/crates/agentgateway/src/llm/types/responses.rs
+++ b/crates/agentgateway/src/llm/types/responses.rs
@@ -533,11 +533,23 @@ pub mod typed {
 		ReasoningEffort, Response, ResponseCompletedEvent, ResponseContentPartAddedEvent,
 		ResponseContentPartDoneEvent, ResponseCreatedEvent, ResponseErrorEvent, ResponseFailedEvent,
 		ResponseFunctionCallArgumentsDeltaEvent, ResponseFunctionCallArgumentsDoneEvent,
-		ResponseIncompleteEvent, ResponseOutputItemAddedEvent, ResponseOutputItemDoneEvent,
-		ResponseTextDeltaEvent, ResponseTextParam, ResponseUsage, Role, Status,
-		TextResponseFormatConfiguration, Tool, ToolChoiceFunction, ToolChoiceOptions, ToolChoiceParam,
+		ResponseIncompleteEvent, ResponseLogProb, ResponseOutputItemAddedEvent,
+		ResponseOutputItemDoneEvent, ResponseTextDeltaEvent, ResponseTextParam, ResponseUsage, Role,
+		Status, TextResponseFormatConfiguration, Tool, ToolChoiceFunction, ToolChoiceOptions,
+		ToolChoiceParam,
 	};
 	use serde::{Deserialize, Serialize};
+
+	#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+	pub struct ResponseTextDoneEvent {
+		pub sequence_number: u64,
+		pub item_id: String,
+		pub output_index: u32,
+		pub content_index: u32,
+		pub text: String,
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		pub logprobs: Option<Vec<ResponseLogProb>>,
+	}
 
 	/// Event types for streaming responses from the Responses API (minimal strict subset).
 	#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
@@ -556,6 +568,9 @@ pub mod typed {
 		/// Emitted when there is an additional text delta.
 		#[serde(rename = "response.output_text.delta")]
 		ResponseOutputTextDelta(openai_responses::ResponseTextDeltaEvent),
+		/// Emitted when output text is finalized.
+		#[serde(rename = "response.output_text.done")]
+		ResponseOutputTextDone(ResponseTextDoneEvent),
 		/// Emitted when there is a partial function-call arguments delta.
 		#[serde(rename = "response.function_call_arguments.delta")]
 		ResponseFunctionCallArgumentsDelta(openai_responses::ResponseFunctionCallArgumentsDeltaEvent),


### PR DESCRIPTION
Responses-API clients (e.g. the OpenAI Codex CLI, which is Responses-only) build the final message from the terminal events (response.output_item.done / response.completed), not from the deltas — so the answer is lost and the client renders nothing, even though the request succeeds (HTTP 200) and the model produced the answer.

Actual (Gemini, translated) — terminal events empty
response.output_text.delta   delta="4"          # correct
response.content_part.done   part.text=""       # WRONG (should be "4")
                             # response.output_text.done is MISSING
response.output_item.done    item.content=[]    # WRONG (should contain the text)
response.completed           response.output=[] # WRONG (should contain the message)

Expected (matches OpenAI native passthrough)
response.output_text.delta   delta="4"
response.output_text.done    text="4"
response.content_part.done   part.text="4"
response.output_item.done    item.content=[{output_text, text:"4"}]
response.completed           response.output=[..., {message, content:[{output_text, text:"4"}]}]

Signed-off-by: John Howard <john.howard@solo.io>
