### PR TITLE
cel: expose CONNECT request headers as source.connectHeaders

### DIFF
--- a/crates/agentgateway/src/cel/types.rs
+++ b/crates/agentgateway/src/cel/types.rs
@@ -294,16 +294,25 @@ pub struct SourceContext {
 	/// authors should prefer `source.identity.*` for trust-sensitive checks.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub unverified_workload: Option<WorkloadContext>,
-	/// HTTP CONNECT request headers (lowercased name -> value), when this stream
-	/// originated from a CONNECT tunnel. Empty otherwise. Exposed in CEL as
-	/// `source.connectHeaders`.
+	/// HTTP CONNECT request headers, when this stream originated from a CONNECT
+	/// tunnel. Empty otherwise. Exposed in CEL as `source.connectHeaders`, which
+	/// supports the same accessors as `request.headers` (indexing, `join()`,
+	/// `split()`, etc.).
 	///
 	/// CONNECT headers are client-supplied and unauthenticated at the transport
 	/// layer, so trust decisions should validate the values (e.g. signature or
 	/// issuer checks) rather than trusting header presence alone.
-	#[serde(default, skip_serializing_if = "std::collections::HashMap::is_empty")]
-	#[dynamic(rename = "connectHeaders")]
-	pub connect_headers: std::collections::HashMap<String, String>,
+	#[serde(
+		default,
+		with = "http_serde::header_map",
+		skip_serializing_if = "http::HeaderMap::is_empty"
+	)]
+	#[cfg_attr(
+		feature = "schema",
+		schemars(with = "std::collections::HashMap<String, String>")
+	)]
+	#[dynamic(rename = "connectHeaders", with_value = "connect_headers_to_value")]
+	pub connect_headers: http::HeaderMap,
 }
 
 #[apply(schema!)]
@@ -336,7 +345,7 @@ impl SourceContext {
 			raw_port: raw_peer_addr.port(),
 			tls,
 			unverified_workload,
-			connect_headers: std::collections::HashMap::new(),
+			connect_headers: http::HeaderMap::new(),
 		}
 	}
 }
@@ -1473,6 +1482,12 @@ fn version_to_value<'a>(c: &'a http::Version) -> Value<'a> {
 	Value::String(crate::http::version_str(c).into())
 }
 
+/// Expose a captured CONNECT `HeaderMap` to CEL with the same accessors as
+/// `request.headers` (map indexing, `join()`, `split()`, `redacted()`, etc.).
+fn connect_headers_to_value(headers: &http::HeaderMap) -> Value<'_> {
+	Value::Dynamic(DynamicValue::new_owned(Headers::new(headers)))
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum HeadersMode {
 	First,
@@ -2041,9 +2056,9 @@ pub fn full_example_executor() -> ExecutorSerde {
 				namespace: "ns-1".into(),
 				service_account: "sa-1".into(),
 			}),
-			connect_headers: std::collections::HashMap::from([(
-				"x-custom-header".to_string(),
-				"custom-value".to_string(),
+			connect_headers: http::HeaderMap::from_iter([(
+				http::HeaderName::from_static("x-custom-header"),
+				http::HeaderValue::from_static("custom-value"),
 			)]),
 		}),
 		jwt: Some(jwt::Claims {

--- a/crates/agentgateway/src/cel/types.rs
+++ b/crates/agentgateway/src/cel/types.rs
@@ -294,6 +294,16 @@ pub struct SourceContext {
 	/// authors should prefer `source.identity.*` for trust-sensitive checks.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub unverified_workload: Option<WorkloadContext>,
+	/// HTTP CONNECT request headers (lowercased name -> value), when this stream
+	/// originated from a CONNECT tunnel. Empty otherwise. Exposed in CEL as
+	/// `source.connectHeaders`.
+	///
+	/// CONNECT headers are client-supplied and unauthenticated at the transport
+	/// layer, so trust decisions should validate the values (e.g. signature or
+	/// issuer checks) rather than trusting header presence alone.
+	#[serde(default, skip_serializing_if = "std::collections::HashMap::is_empty")]
+	#[dynamic(rename = "connectHeaders")]
+	pub connect_headers: std::collections::HashMap<String, String>,
 }
 
 #[apply(schema!)]
@@ -326,6 +336,7 @@ impl SourceContext {
 			raw_port: raw_peer_addr.port(),
 			tls,
 			unverified_workload,
+			connect_headers: std::collections::HashMap::new(),
 		}
 	}
 }
@@ -2030,6 +2041,10 @@ pub fn full_example_executor() -> ExecutorSerde {
 				namespace: "ns-1".into(),
 				service_account: "sa-1".into(),
 			}),
+			connect_headers: std::collections::HashMap::from([(
+				"x-custom-header".to_string(),
+				"custom-value".to_string(),
+			)]),
 		}),
 		jwt: Some(jwt::Claims {
 			inner: serde_json::Map::from_iter(vec![

--- a/crates/agentgateway/src/cel/types_test.rs
+++ b/crates/agentgateway/src/cel/types_test.rs
@@ -34,7 +34,7 @@ fn build_test_request() -> crate::http::Request {
 		raw_port: 54321,
 		tls: None,
 		unverified_workload: None,
-		connect_headers: std::collections::HashMap::new(),
+		connect_headers: http::HeaderMap::new(),
 	};
 	req.extensions_mut().insert(source);
 
@@ -423,7 +423,7 @@ fn test_extension_or_direct_serialization() {
 		raw_port: 8080,
 		tls: None,
 		unverified_workload: None,
-		connect_headers: std::collections::HashMap::new(),
+		connect_headers: http::HeaderMap::new(),
 	};
 	let ext_or_direct: ExtensionOrDirect<SourceContext> = ExtensionOrDirect::Direct(Some(&value));
 	let json = serde_json::to_value(&ext_or_direct).expect("failed to serialize");
@@ -440,7 +440,21 @@ fn test_extension_or_direct_serialization() {
 
 #[test]
 fn test_source_connect_headers() {
-	// Populated map: `source.connectHeaders["x-custom-header"]` resolves to the value.
+	// Populated map: `source.connectHeaders["x-custom-header"]` resolves to the value,
+	// and multi-value headers are preserved (HeaderMap fidelity).
+	let mut headers = http::HeaderMap::new();
+	headers.insert(
+		http::HeaderName::from_static("x-custom-header"),
+		http::HeaderValue::from_static("custom-value"),
+	);
+	headers.append(
+		http::HeaderName::from_static("x-multi"),
+		http::HeaderValue::from_static("a"),
+	);
+	headers.append(
+		http::HeaderName::from_static("x-multi"),
+		http::HeaderValue::from_static("b"),
+	);
 	let src = SourceContext {
 		address: "10.0.0.1".parse().unwrap(),
 		port: 12345,
@@ -448,19 +462,17 @@ fn test_source_connect_headers() {
 		raw_port: 12345,
 		tls: None,
 		unverified_workload: None,
-		connect_headers: std::collections::HashMap::from([(
-			"x-custom-header".to_string(),
-			"custom-value".to_string(),
-		)]),
+		connect_headers: headers,
 	};
 	let exec = ExecutorSerde {
 		source: Some(src),
 		..Default::default()
 	};
 	let executor = exec.as_executor();
-	let expr =
-		Expression::new_strict(r#"source.connectHeaders["x-custom-header"] == "custom-value""#)
-			.expect("failed to compile");
+	let expr = Expression::new_strict(
+		r#"source.connectHeaders["x-custom-header"] == "custom-value" && source.connectHeaders.raw()["x-multi"] == ["a", "b"]"#,
+	)
+	.expect("failed to compile");
 	assert!(executor.eval_bool(&expr));
 
 	// Empty map when unset: indexing a missing key yields a no-such-key error.
@@ -471,7 +483,7 @@ fn test_source_connect_headers() {
 		raw_port: 12345,
 		tls: None,
 		unverified_workload: None,
-		connect_headers: std::collections::HashMap::new(),
+		connect_headers: http::HeaderMap::new(),
 	};
 	let exec_empty = ExecutorSerde {
 		source: Some(src_empty),
@@ -483,5 +495,38 @@ fn test_source_connect_headers() {
 	assert!(
 		executor_empty.eval(&missing).is_err(),
 		"indexing an empty connectHeaders map should error"
+	);
+}
+
+#[test]
+fn test_source_connect_headers_sensitive_redacted_in_debug() {
+	// Sensitive-marked connect headers (as done at capture for authorization/cookie
+	// etc.) must not leak their value via SourceContext's Debug, which is what
+	// `DebugExtensions` prints into debug logs.
+	let mut headers = http::HeaderMap::new();
+	let mut secret = http::HeaderValue::from_static("Bearer super-secret-token");
+	secret.set_sensitive(true);
+	headers.insert(http::header::AUTHORIZATION, secret);
+	headers.insert(
+		http::HeaderName::from_static("x-custom-header"),
+		http::HeaderValue::from_static("custom-value"),
+	);
+	let src = SourceContext {
+		address: "10.0.0.1".parse().unwrap(),
+		port: 12345,
+		raw_address: "10.0.0.1".parse().unwrap(),
+		raw_port: 12345,
+		tls: None,
+		unverified_workload: None,
+		connect_headers: headers,
+	};
+	let debug = format!("{src:?}");
+	assert!(
+		!debug.contains("super-secret-token"),
+		"sensitive header value leaked in Debug: {debug}"
+	);
+	assert!(
+		debug.contains("custom-value"),
+		"non-sensitive header should still be visible in Debug: {debug}"
 	);
 }

--- a/crates/agentgateway/src/cel/types_test.rs
+++ b/crates/agentgateway/src/cel/types_test.rs
@@ -34,6 +34,7 @@ fn build_test_request() -> crate::http::Request {
 		raw_port: 54321,
 		tls: None,
 		unverified_workload: None,
+		connect_headers: std::collections::HashMap::new(),
 	};
 	req.extensions_mut().insert(source);
 
@@ -422,6 +423,7 @@ fn test_extension_or_direct_serialization() {
 		raw_port: 8080,
 		tls: None,
 		unverified_workload: None,
+		connect_headers: std::collections::HashMap::new(),
 	};
 	let ext_or_direct: ExtensionOrDirect<SourceContext> = ExtensionOrDirect::Direct(Some(&value));
 	let json = serde_json::to_value(&ext_or_direct).expect("failed to serialize");
@@ -434,4 +436,52 @@ fn test_extension_or_direct_serialization() {
 	let ext_or_direct_none: ExtensionOrDirect<SourceContext> = ExtensionOrDirect::Direct(None);
 	let json_none = serde_json::to_value(&ext_or_direct_none).expect("failed to serialize");
 	assert!(json_none.is_null());
+}
+
+#[test]
+fn test_source_connect_headers() {
+	// Populated map: `source.connectHeaders["x-custom-header"]` resolves to the value.
+	let src = SourceContext {
+		address: "10.0.0.1".parse().unwrap(),
+		port: 12345,
+		raw_address: "10.0.0.1".parse().unwrap(),
+		raw_port: 12345,
+		tls: None,
+		unverified_workload: None,
+		connect_headers: std::collections::HashMap::from([(
+			"x-custom-header".to_string(),
+			"custom-value".to_string(),
+		)]),
+	};
+	let exec = ExecutorSerde {
+		source: Some(src),
+		..Default::default()
+	};
+	let executor = exec.as_executor();
+	let expr =
+		Expression::new_strict(r#"source.connectHeaders["x-custom-header"] == "custom-value""#)
+			.expect("failed to compile");
+	assert!(executor.eval_bool(&expr));
+
+	// Empty map when unset: indexing a missing key yields a no-such-key error.
+	let src_empty = SourceContext {
+		address: "10.0.0.1".parse().unwrap(),
+		port: 12345,
+		raw_address: "10.0.0.1".parse().unwrap(),
+		raw_port: 12345,
+		tls: None,
+		unverified_workload: None,
+		connect_headers: std::collections::HashMap::new(),
+	};
+	let exec_empty = ExecutorSerde {
+		source: Some(src_empty),
+		..Default::default()
+	};
+	let executor_empty = exec_empty.as_executor();
+	let missing = Expression::new_strict(r#"source.connectHeaders["x-custom-header"]"#)
+		.expect("failed to compile");
+	assert!(
+		executor_empty.eval(&missing).is_err(),
+		"indexing an empty connectHeaders map should error"
+	);
 }

--- a/crates/agentgateway/src/http/authorization_tests.rs
+++ b/crates/agentgateway/src/http/authorization_tests.rs
@@ -190,7 +190,7 @@ fn test_network_authorization_allows_source_cidr() {
 		raw_port: 15000,
 		tls: None,
 		unverified_workload: None,
-		connect_headers: std::collections::HashMap::new(),
+		connect_headers: http::HeaderMap::new(),
 	};
 
 	assert_matches!(network_authz.apply(&source), Ok(()));
@@ -212,7 +212,7 @@ fn test_network_authorization_deny_takes_precedence() {
 		raw_port: 15000,
 		tls: None,
 		unverified_workload: None,
-		connect_headers: std::collections::HashMap::new(),
+		connect_headers: http::HeaderMap::new(),
 	};
 
 	assert_matches!(network_authz.apply(&source), Err(_));

--- a/crates/agentgateway/src/http/authorization_tests.rs
+++ b/crates/agentgateway/src/http/authorization_tests.rs
@@ -190,6 +190,7 @@ fn test_network_authorization_allows_source_cidr() {
 		raw_port: 15000,
 		tls: None,
 		unverified_workload: None,
+		connect_headers: std::collections::HashMap::new(),
 	};
 
 	assert_matches!(network_authz.apply(&source), Ok(()));
@@ -211,6 +212,7 @@ fn test_network_authorization_deny_takes_precedence() {
 		raw_port: 15000,
 		tls: None,
 		unverified_workload: None,
+		connect_headers: std::collections::HashMap::new(),
 	};
 
 	assert_matches!(network_authz.apply(&source), Err(_));

--- a/crates/agentgateway/src/proxy/gateway.rs
+++ b/crates/agentgateway/src/proxy/gateway.rs
@@ -690,18 +690,20 @@ impl Gateway {
 					let Some(upgrade) = req.extensions_mut().remove::<hyper::upgrade::OnUpgrade>() else {
 						return Ok(ProxyError::InvalidRequest.into_response_with_grpc(false));
 					};
-					// Snapshot the CONNECT request headers (lowercased name -> value) so they
-					// can be surfaced to CEL policies on the tunneled request via
-					// `source.connectHeaders`. HeaderMap keys are already lowercase.
-					let connect_headers: std::collections::HashMap<String, String> = req
-						.headers()
-						.iter()
-						.filter_map(|(k, v)| {
-							v.to_str()
-								.ok()
-								.map(|s| (k.as_str().to_owned(), s.to_owned()))
-						})
-						.collect();
+					// Snapshot the CONNECT request headers so they can be surfaced to CEL
+					// policies on the tunneled request via `source.connectHeaders`. Mark
+					// well-known sensitive headers so their values are redacted in debug logs
+					// (SourceContext derives Debug and is printed via DebugExtensions) and by
+					// the CEL `source.connectHeaders.redacted()` accessor.
+					let mut connect_headers = req.headers().clone();
+					for (name, value) in connect_headers.iter_mut() {
+						if matches!(
+							name.as_str(),
+							"authorization" | "proxy-authorization" | "cookie" | "set-cookie"
+						) {
+							value.set_sensitive(true);
+						}
+					}
 					let authority = match req.uri().authority() {
 						Some(authority) => authority.as_str(),
 						None => return Ok(ProxyError::InvalidRequest.into_response_with_grpc(false)),
@@ -809,8 +811,10 @@ impl Gateway {
 		);
 		// Surface CONNECT tunnel headers (captured in `terminate_connect_tunnel`) on
 		// the source context so request policies can reference `source.connectHeaders`.
-		if let Some(ch) = stream.ext::<ConnectHeaders>() {
-			src.connect_headers = ch.0.clone();
+		// Move the map out of the stream extension (it has no other consumer) to avoid
+		// cloning the header map.
+		if let Some(ch) = stream.ext_mut().remove::<ConnectHeaders>() {
+			src.connect_headers = ch.0;
 		}
 		if let Some(network_authorization) = policies.network_authorization.as_ref()
 			&& let Err(e) = network_authorization.apply(&src)

--- a/crates/agentgateway/src/proxy/gateway.rs
+++ b/crates/agentgateway/src/proxy/gateway.rs
@@ -27,7 +27,7 @@ use crate::store::{BindEvent, BindListeners, FrontendPolices};
 use crate::telemetry::metrics::TCPLabels;
 use crate::transport::BufferLimit;
 use crate::transport::stream::{
-	Extension, LoggingMode, Socket, TCPConnectionInfo, TLSConnectionInfo,
+	ConnectHeaders, Extension, LoggingMode, Socket, TCPConnectionInfo, TLSConnectionInfo,
 };
 use crate::transport::tls::TlsInfo;
 use crate::types::agent::{
@@ -690,6 +690,18 @@ impl Gateway {
 					let Some(upgrade) = req.extensions_mut().remove::<hyper::upgrade::OnUpgrade>() else {
 						return Ok(ProxyError::InvalidRequest.into_response_with_grpc(false));
 					};
+					// Snapshot the CONNECT request headers (lowercased name -> value) so they
+					// can be surfaced to CEL policies on the tunneled request via
+					// `source.connectHeaders`. HeaderMap keys are already lowercase.
+					let connect_headers: std::collections::HashMap<String, String> = req
+						.headers()
+						.iter()
+						.filter_map(|(k, v)| {
+							v.to_str()
+								.ok()
+								.map(|s| (k.as_str().to_owned(), s.to_owned()))
+						})
+						.collect();
 					let authority = match req.uri().authority() {
 						Some(authority) => authority.as_str(),
 						None => return Ok(ProxyError::InvalidRequest.into_response_with_grpc(false)),
@@ -725,7 +737,8 @@ impl Gateway {
 								return;
 							},
 						};
-						let downstream = Socket::from_upgraded(connection, target_address, downstream);
+						let mut downstream = Socket::from_upgraded(connection, target_address, downstream);
+						downstream.ext_mut().insert(ConnectHeaders(connect_headers));
 						Self::proxy_bind(bind.key.clone(), bind.protocol, downstream, inputs, drain).await;
 					});
 
@@ -789,11 +802,16 @@ impl Gateway {
 			&inputs.cfg.network,
 			tcp.peer_addr.ip(),
 		);
-		let src = crate::cel::SourceContext::from_tcp_connection(
+		let mut src = crate::cel::SourceContext::from_tcp_connection(
 			tcp,
 			tls.and_then(|t| t.src_identity.clone()),
 			unverified_workload,
 		);
+		// Surface CONNECT tunnel headers (captured in `terminate_connect_tunnel`) on
+		// the source context so request policies can reference `source.connectHeaders`.
+		if let Some(ch) = stream.ext::<ConnectHeaders>() {
+			src.connect_headers = ch.0.clone();
+		}
 		if let Some(network_authorization) = policies.network_authorization.as_ref()
 			&& let Err(e) = network_authorization.apply(&src)
 		{

--- a/crates/agentgateway/src/proxy/gateway_test.rs
+++ b/crates/agentgateway/src/proxy/gateway_test.rs
@@ -3045,6 +3045,88 @@ async fn incoming_connect_tunnel_reenters_bind_flow() {
 	);
 }
 
+/// Headers carried on a CONNECT request are captured and surfaced to CEL as
+/// `source.connectHeaders` on the re-entered (tunneled) request, so an
+/// authorization policy on the inner bind can match against them.
+#[tokio::test]
+async fn incoming_connect_tunnel_exposes_connect_headers_to_cel() {
+	async fn tunnel_inner_request(custom_header: Option<&str>) -> String {
+		let mock = simple_mock().await;
+		let mut outer = simple_bind();
+		outer.key = strng::literal!("outer");
+		outer.address = "127.0.0.1:15008".parse().unwrap();
+		let mut inner = simple_bind();
+		inner.address = "127.0.0.1:18080".parse().unwrap();
+		let mut t = setup_proxy_test("{}")
+			.unwrap()
+			.with_backend(*mock.address())
+			.with_bind(outer)
+			.with_bind(inner)
+			.with_route(basic_route(*mock.address()))
+			.with_connect_mode_on_port(frontend::ConnectMode::Tunnel, 15008);
+		// Authorization on the re-entered request only allows when the custom header
+		// carried on the CONNECT request is present and matches.
+		t.attach_route_policy(json!({
+			"authorization": {
+				"rules": ["source.connectHeaders[\"x-custom-header\"] == \"custom-value\""],
+			},
+		}))
+		.await;
+
+		let mut io = t.serve_tunnel(strng::literal!("outer"));
+		let connect = match custom_header {
+			Some(v) => format!(
+				"CONNECT httpbingo.org:18080 HTTP/1.1\r\nHost: httpbingo.org:18080\r\nx-custom-header: {v}\r\n\r\n"
+			),
+			None => {
+				"CONNECT httpbingo.org:18080 HTTP/1.1\r\nHost: httpbingo.org:18080\r\n\r\n".to_string()
+			},
+		};
+		io.write_all(connect.as_bytes()).await.unwrap();
+
+		let mut response = Vec::new();
+		loop {
+			let mut chunk = [0; 1024];
+			let n = io.read(&mut chunk).await.unwrap();
+			assert!(n > 0, "CONNECT response unexpectedly closed");
+			response.extend_from_slice(&chunk[..n]);
+			if response.windows(4).any(|w| w == b"\r\n\r\n") {
+				break;
+			}
+		}
+		assert!(
+			String::from_utf8_lossy(&response).starts_with("HTTP/1.1 200 OK\r\n"),
+			"unexpected CONNECT response: {}",
+			String::from_utf8_lossy(&response),
+		);
+
+		io.write_all(b"GET /foo HTTP/1.1\r\nHost: lo\r\nConnection: close\r\n\r\n")
+			.await
+			.unwrap();
+		let mut tunneled = Vec::new();
+		tokio::time::timeout(Duration::from_secs(5), io.read_to_end(&mut tunneled))
+			.await
+			.expect("timed out waiting for tunneled HTTP response")
+			.unwrap();
+		String::from_utf8_lossy(&tunneled).to_string()
+	}
+
+	// Header present and matching: the inner request is authorized (200).
+	let allowed = tunnel_inner_request(Some("custom-value")).await;
+	assert!(
+		allowed.starts_with("HTTP/1.1 200 OK\r\n"),
+		"expected inner request to be authorized, got: {allowed}",
+	);
+
+	// Header absent: `source.connectHeaders` is empty, the rule does not match,
+	// and the inner request is denied (403).
+	let denied = tunnel_inner_request(None).await;
+	assert!(
+		denied.starts_with("HTTP/1.1 403 Forbidden\r\n"),
+		"expected inner request to be denied, got: {denied}",
+	);
+}
+
 #[tokio::test]
 async fn incoming_connect_applies_backend_tls() {
 	let (mock, certs) = tls_mock().await;

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -2571,6 +2571,7 @@ mod tests {
 					raw_port: 12345,
 					tls: None,
 					unverified_workload: None,
+					connect_headers: std::collections::HashMap::new(),
 				})
 				.is_ok()
 		);
@@ -2583,6 +2584,7 @@ mod tests {
 					raw_port: 12345,
 					tls: None,
 					unverified_workload: None,
+					connect_headers: std::collections::HashMap::new(),
 				})
 				.is_ok()
 		);
@@ -2595,6 +2597,7 @@ mod tests {
 					raw_port: 12345,
 					tls: None,
 					unverified_workload: None,
+					connect_headers: std::collections::HashMap::new(),
 				})
 				.is_err()
 		);

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -2571,7 +2571,7 @@ mod tests {
 					raw_port: 12345,
 					tls: None,
 					unverified_workload: None,
-					connect_headers: std::collections::HashMap::new(),
+					connect_headers: http::HeaderMap::new(),
 				})
 				.is_ok()
 		);
@@ -2584,7 +2584,7 @@ mod tests {
 					raw_port: 12345,
 					tls: None,
 					unverified_workload: None,
-					connect_headers: std::collections::HashMap::new(),
+					connect_headers: http::HeaderMap::new(),
 				})
 				.is_ok()
 		);
@@ -2597,7 +2597,7 @@ mod tests {
 					raw_port: 12345,
 					tls: None,
 					unverified_workload: None,
-					connect_headers: std::collections::HashMap::new(),
+					connect_headers: http::HeaderMap::new(),
 				})
 				.is_err()
 		);

--- a/crates/agentgateway/src/transport/stream.rs
+++ b/crates/agentgateway/src/transport/stream.rs
@@ -555,6 +555,13 @@ pub enum Extension {
 	Wrapped(http::Extensions, Arc<Extension>),
 }
 
+/// HTTP CONNECT request headers captured when terminating a CONNECT tunnel,
+/// carried on the per-stream socket extension so they can be surfaced to CEL
+/// policies via `source.connectHeaders`. New type wrapper to avoid colliding
+/// with other `HashMap`-typed extensions in the type-keyed `Extension` map.
+#[derive(Clone, Debug, Default)]
+pub struct ConnectHeaders(pub std::collections::HashMap<String, String>);
+
 impl Default for Extension {
 	fn default() -> Self {
 		Self::new()

--- a/crates/agentgateway/src/transport/stream.rs
+++ b/crates/agentgateway/src/transport/stream.rs
@@ -558,9 +558,9 @@ pub enum Extension {
 /// HTTP CONNECT request headers captured when terminating a CONNECT tunnel,
 /// carried on the per-stream socket extension so they can be surfaced to CEL
 /// policies via `source.connectHeaders`. New type wrapper to avoid colliding
-/// with other `HashMap`-typed extensions in the type-keyed `Extension` map.
+/// with other `HeaderMap`-typed extensions in the type-keyed `Extension` map.
 #[derive(Clone, Debug, Default)]
-pub struct ConnectHeaders(pub std::collections::HashMap<String, String>);
+pub struct ConnectHeaders(pub http::HeaderMap);
 
 impl Default for Extension {
 	fn default() -> Self {

--- a/schema/cel.json
+++ b/schema/cel.json
@@ -815,6 +815,13 @@
             }
           },
           "additionalProperties": false
+        },
+        "connectHeaders": {
+          "description": "HTTP CONNECT request headers, when this stream originated from a CONNECT\ntunnel. Empty otherwise. Exposed in CEL as `source.connectHeaders`, which\nsupports the same accessors as `request.headers` (indexing, `join()`,\n`split()`, etc.).\n\nCONNECT headers are client-supplied and unauthenticated at the transport\nlayer, so trust decisions should validate the values (e.g. signature or\nissuer checks) rather than trusting header presence alone.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
         }
       },
       "additionalProperties": false

--- a/schema/cel.md
+++ b/schema/cel.md
@@ -114,6 +114,7 @@
 |`source.unverifiedWorkload.name`|string|The pod name of the source workload.|
 |`source.unverifiedWorkload.namespace`|string|The namespace of the source workload.|
 |`source.unverifiedWorkload.serviceAccount`|string|The service account of the source workload.|
+|`source.connectHeaders`|object|HTTP CONNECT request headers, when this stream originated from a CONNECT<br>tunnel. Empty otherwise. Exposed in CEL as `source.connectHeaders`, which<br>supports the same accessors as `request.headers` (indexing, `join()`,<br>`split()`, etc.).<br><br>CONNECT headers are client-supplied and unauthenticated at the transport<br>layer, so trust decisions should validate the values (e.g. signature or<br>issuer checks) rather than trusting header presence alone.|
 |`mcp`|object|`mcp` contains attributes about the MCP request.<br>Request-time CEL only includes identity fields such as `tool`, `prompt`, or `resource`.<br>Post-request CEL may also include fields like `methodName`, `sessionId`, and tool payloads.|
 |`mcp.methodName`|string||
 |`mcp.sessionId`|string||


### PR DESCRIPTION
Capture the headers on a terminated CONNECT request and surface them on the tunneled (re-entered) stream as a read-only CEL map, so request policies can reference source.connectHeaders["x-custom-header"]. Headers are captured per-stream and set on the existing SourceContext, empty for non-CONNECT streams.