### PR TITLE
dtrace: log body for streaming llm too

### DIFF
--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -1609,6 +1609,7 @@ impl AIProvider {
 
 		// Decompress before the SSE parser, which expects plaintext chunks.
 		let (mut parts, body) = resp.into_parts();
+		let body = dtrace::TracingBody::maybe_wrap("llm raw response", body, buffer);
 		let ce = parts.headers.typed_get::<ContentEncoding>();
 		let (body, decompressed_encoding) = http::compression::decompress_body(body, ce.as_ref())
 			.map_err(|e| map_compression_error(e, &parts.headers))?;


### PR DESCRIPTION
Before we only did it for non-stream

Signed-off-by: John Howard <john.howard@solo.io>
