### PR TITLE
Centralize LLM provider format capabilities

### DIFF
--- a/crates/agentgateway/src/llm/custom.rs
+++ b/crates/agentgateway/src/llm/custom.rs
@@ -26,17 +26,8 @@ impl Provider {
 	}
 
 	pub fn native_format_for(&self, input_format: InputFormat) -> Option<ProviderFormat> {
-		let preferences: &[ProviderFormat] = match input_format {
-			InputFormat::Completions => &[ProviderFormat::Completions, ProviderFormat::Messages],
-			InputFormat::Messages => &[ProviderFormat::Messages, ProviderFormat::Completions],
-			InputFormat::Responses => &[ProviderFormat::Responses, ProviderFormat::Completions],
-			InputFormat::Embeddings => &[ProviderFormat::Embeddings],
-			InputFormat::CountTokens => &[ProviderFormat::AnthropicTokenCount],
-			InputFormat::Realtime => &[ProviderFormat::Realtime],
-			InputFormat::Rerank => &[ProviderFormat::Rerank],
-			InputFormat::Detect => return None,
-		};
-		preferences
+		input_format
+			.provider_format_preferences()
 			.iter()
 			.copied()
 			.find(|format| self.supports(*format))

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -243,16 +243,17 @@ impl InputFormat {
 		}
 	}
 
-	fn provider_format(&self) -> Option<custom::ProviderFormat> {
+	fn provider_format_preferences(&self) -> &'static [custom::ProviderFormat] {
+		use custom::ProviderFormat::*;
 		match self {
-			InputFormat::Completions => Some(custom::ProviderFormat::Completions),
-			InputFormat::Messages => Some(custom::ProviderFormat::Messages),
-			InputFormat::Responses => Some(custom::ProviderFormat::Responses),
-			InputFormat::Embeddings => Some(custom::ProviderFormat::Embeddings),
-			InputFormat::Realtime => Some(custom::ProviderFormat::Realtime),
-			InputFormat::CountTokens => Some(custom::ProviderFormat::AnthropicTokenCount),
-			InputFormat::Detect => None,
-			InputFormat::Rerank => Some(custom::ProviderFormat::Rerank),
+			InputFormat::Completions => &[Completions, Messages],
+			InputFormat::Messages => &[Messages, Completions],
+			InputFormat::Responses => &[Responses, Completions],
+			InputFormat::Embeddings => &[Embeddings],
+			InputFormat::Realtime => &[Realtime],
+			InputFormat::CountTokens => &[AnthropicTokenCount],
+			InputFormat::Detect => &[],
+			InputFormat::Rerank => &[Rerank],
 		}
 	}
 }
@@ -381,6 +382,70 @@ impl AIProvider {
 			AIProvider::Custom(p) => p.model.clone(),
 		}
 	}
+
+	pub fn supported_formats(&self, request_model: Option<&str>) -> Vec<custom::ProviderFormat> {
+		use custom::ProviderFormat::*;
+		match self {
+			AIProvider::OpenAI(_) => vec![Completions, Responses, Embeddings, Realtime, Rerank],
+			AIProvider::Copilot(_) => vec![Completions, Responses, Rerank],
+			AIProvider::Azure(p) => {
+				let mut formats = vec![Completions, Responses, Embeddings, Rerank];
+				if matches!(p.resource_type, azure::AzureResourceType::Foundry)
+					&& p.is_anthropic_model(request_model)
+				{
+					formats.extend([Messages, AnthropicTokenCount]);
+				}
+				formats
+			},
+			AIProvider::Gemini(_) => vec![Completions, Embeddings],
+			AIProvider::Anthropic(_) => vec![Messages, AnthropicTokenCount],
+			AIProvider::Bedrock(p) => {
+				let mut formats = vec![Completions, Messages, Responses, Embeddings, Rerank];
+				if p.is_anthropic_model(request_model) {
+					formats.push(AnthropicTokenCount);
+				}
+				formats
+			},
+			AIProvider::Vertex(p) => {
+				let mut formats = if p.is_anthropic_model(request_model) {
+					vec![Messages, AnthropicTokenCount]
+				} else {
+					vec![Completions]
+				};
+				formats.extend([Embeddings, Rerank]);
+				formats
+			},
+			AIProvider::Custom(p) => p.formats.iter().map(|f| f.format).collect(),
+		}
+	}
+
+	pub fn supports_format(
+		&self,
+		format: custom::ProviderFormat,
+		request_model: Option<&str>,
+	) -> bool {
+		self.supported_formats(request_model).contains(&format)
+	}
+
+	pub fn native_format_for(
+		&self,
+		input_format: InputFormat,
+		request_model: Option<&str>,
+	) -> Option<custom::ProviderFormat> {
+		// Vertex currently supports Responses only in the streaming response mapper; the
+		// request path does not translate Responses bodies to its OpenAI-compatible chat endpoint.
+		if matches!(self, AIProvider::Vertex(_)) && input_format == InputFormat::Responses {
+			return None;
+		}
+
+		let supported = self.supported_formats(request_model);
+		input_format
+			.provider_format_preferences()
+			.iter()
+			.copied()
+			.find(|format| supported.contains(format))
+	}
+
 	/// Default backend policies (TLS + auth) for connecting to the provider. Split from
 	/// [`Self::default_connector_target`] so callers can compute effective policies, resolve the LLM
 	/// route from them, and only then pick the connection target. Returns `None` for custom providers,
@@ -893,24 +958,21 @@ impl AIProvider {
 			.read_body_and_default_model::<types::count_tokens::Request>(policies, req, log)
 			.await?;
 
+		let request_model = req.model.as_deref();
+		let effective_model = request_model
+			.and_then(|model| policies.and_then(|p| p.resolve_model_alias(model)))
+			.map(|model| model.as_str())
+			.or(request_model);
+
 		// Some Anthropic-compatible clients (e.g. Claude Code) always call
 		// `/v1/messages/count_tokens`. For providers/models without a native
 		// count-tokens endpoint, we must still answer this route, so we fall
 		// back to local token estimation using the normalized messages payload.
-		let use_local = match self {
-			AIProvider::Anthropic(_) => false,
-			AIProvider::Bedrock(p) => !p.is_anthropic_model(req.model.as_deref()),
-			AIProvider::Vertex(p) => !p.is_anthropic_model(req.model.as_deref()),
-			AIProvider::Azure(p) => {
-				!matches!(p.resource_type, azure::AzureResourceType::Foundry)
-					|| !p.is_anthropic_model(req.model.as_deref())
-			},
-			AIProvider::Custom(p) => !p.supports(custom::ProviderFormat::AnthropicTokenCount),
-			_ => true,
-		};
+		let use_local =
+			!self.supports_format(custom::ProviderFormat::AnthropicTokenCount, effective_model);
 		if use_local {
 			let messages = req.get_messages();
-			let model = req.model.as_deref().unwrap_or_default();
+			let model = effective_model.unwrap_or_default();
 			let count = num_tokens_from_messages(model, &messages)?;
 			let body = serde_json::to_vec(&types::count_tokens::Response {
 				input_tokens: count,
@@ -993,94 +1055,6 @@ impl AIProvider {
 		tokenize: bool,
 		log: &mut Option<&mut RequestLog>,
 	) -> Result<RequestResult, AIError> {
-		let native_format = match self {
-			AIProvider::Custom(_) if original_format == InputFormat::Detect => None,
-			AIProvider::Custom(p) => p
-				.native_format_for(original_format)
-				.ok_or_else(|| {
-					AIError::UnsupportedConversion(strng::format!(
-						"from {original_format:?} to provider {}",
-						self.provider()
-					))
-				})?
-				.into(),
-			_ => original_format.provider_format(),
-		};
-		match (self, original_format) {
-			(_, InputFormat::Detect) => {
-				// All providers support detect; this is a passthrough!
-			},
-			(AIProvider::Custom(_), _) => {},
-			(_, InputFormat::Completions) => {
-				// All providers support completions input
-			},
-			(
-				AIProvider::OpenAI(_)
-				| AIProvider::Copilot(_)
-				| AIProvider::Azure(_)
-				| AIProvider::Bedrock(_)
-				| AIProvider::Gemini(_),
-				InputFormat::Responses,
-			) => {
-				// OpenAI supports responses input (Bedrock & Gemini support responses input via translation)
-			},
-			(
-				AIProvider::Anthropic(_)
-				| AIProvider::Bedrock(_)
-				| AIProvider::Vertex(_)
-				| AIProvider::OpenAI(_)
-				| AIProvider::Copilot(_)
-				| AIProvider::Gemini(_)
-				| AIProvider::Azure(_),
-				InputFormat::Messages,
-			) => {
-				// Anthropic supports messages input (Bedrock & Vertex support assuming serving Anthropic models)
-				// OpenAI/Gemini/Azure support messages via translation to chat completions
-			},
-			(
-				AIProvider::Anthropic(_)
-				| AIProvider::Bedrock(_)
-				| AIProvider::Vertex(_)
-				| AIProvider::Azure(_),
-				InputFormat::CountTokens,
-			) => {
-				// Anthropic supports count_tokens natively (Bedrock & Vertex assumes its serving Anthropic
-				// models; Azure only when Foundry is serving a Claude model, enforced during translation).
-			},
-			(
-				AIProvider::OpenAI(_)
-				| AIProvider::Gemini(_)
-				| AIProvider::Azure(_)
-				| AIProvider::Bedrock(_)
-				| AIProvider::Vertex(_),
-				InputFormat::Embeddings,
-			) => {
-				// OpenAI compatible, Gemini, Bedrock, or Vertex
-			},
-			(
-				AIProvider::OpenAI(_)
-				| AIProvider::Copilot(_)
-				| AIProvider::Azure(_)
-				| AIProvider::Bedrock(_)
-				| AIProvider::Vertex(_),
-				InputFormat::Rerank,
-			) => {
-				// OpenAI-compatible providers (OpenAI/Copilot/Azure-Foundry) pass the
-				// Cohere-shaped request through unchanged; Bedrock & Vertex translate.
-				// Custom is already covered above. These OpenAI-compatible surfaces only
-				// actually serve rerank when pointed (e.g. via hostOverride or Azure Foundry)
-				// at a Cohere-compatible backend; otherwise the upstream returns its own 404.
-				// Anthropic and Gemini have no rerank endpoint and fall through to the
-				// unsupported arm below.
-			},
-			(p, m) => {
-				// Unsupported provider/format combination.
-				return Err(AIError::UnsupportedConversion(strng::format!(
-					"from {m:?} to provider {}",
-					p.provider()
-				)));
-			},
-		}
 		if let Some(p) = policies {
 			// Apply model alias resolution
 			if req.supports_model()
@@ -1089,6 +1063,24 @@ impl AIProvider {
 			{
 				*model = aliased.to_string();
 			}
+		}
+
+		let request_model = req.model().as_deref().map(str::to_string);
+		let native_format = if original_format == InputFormat::Detect {
+			None
+		} else {
+			self
+				.native_format_for(original_format, request_model.as_deref())
+				.ok_or_else(|| {
+					AIError::UnsupportedConversion(strng::format!(
+						"from {original_format:?} to provider {}",
+						self.provider()
+					))
+				})?
+				.into()
+		};
+
+		if let Some(p) = policies {
 			p.apply_prompt_enrichment(&mut req);
 
 			if original_format.supports_prompt_guard() {

--- a/crates/agentgateway/src/llm/tests.rs
+++ b/crates/agentgateway/src/llm/tests.rs
@@ -800,7 +800,7 @@ mod response {
 		LLMRequest {
 			input_tokens: None,
 			input_format,
-			native_format: input_format.provider_format(),
+			native_format: input_format.provider_format_preferences().first().copied(),
 			cache_convention: CacheTokenConvention::pending(),
 			request_model: "input-model".into(),
 			provider: Default::default(),
@@ -1015,6 +1015,55 @@ async fn openai_provider_preserves_max_tokens_for_non_gpt_models() {
 	assert_eq!(forwarded_json["max_tokens"], json!(1024));
 	assert!(forwarded_json.get("max_completion_tokens").is_none());
 	assert_eq!(llm_request.params.max_tokens, Some(1024));
+}
+
+#[tokio::test]
+async fn count_tokens_resolves_model_alias_once_for_upstream_request() {
+	use crate::http::auth::BackendInfo;
+	use crate::llm::policy::Policy;
+	use crate::test_helpers::proxymock::setup_proxy_test;
+	use crate::types::agent::BackendTarget;
+
+	let provider = AIProvider::Anthropic(anthropic::Provider { model: None });
+	let inputs = setup_proxy_test("{}").unwrap().pi;
+	let backend_info = BackendInfo {
+		target: BackendTarget::Invalid,
+		call_target: Target::from(("api.anthropic.com", 443)),
+		inputs,
+	};
+	let policy = Policy {
+		model_aliases: std::collections::HashMap::from([
+			(strng::new("short-name"), strng::new("middle-name")),
+			(strng::new("middle-name"), strng::new("final-name")),
+		]),
+		..Default::default()
+	};
+	let req = ::http::Request::builder()
+		.uri("/v1/messages/count_tokens")
+		.header(::http::header::CONTENT_TYPE, "application/json")
+		.body(Body::from(
+			br#"{
+				"model": "short-name",
+				"messages": [{"role": "user", "content": "hello"}]
+			}"#
+				.to_vec(),
+		))
+		.unwrap();
+
+	let RequestResult::Success(forwarded, llm_request) = provider
+		.process_count_tokens_request(&backend_info, req, Some(&policy), &mut None)
+		.await
+		.expect("count_tokens request should process")
+	else {
+		panic!("expected forwarded request");
+	};
+
+	let forwarded_body = forwarded.collect().await.unwrap().to_bytes();
+	let forwarded_json: Value =
+		serde_json::from_slice(&forwarded_body).expect("forwarded request should be JSON");
+
+	assert_eq!(forwarded_json["model"], json!("middle-name"));
+	assert_eq!(llm_request.request_model, "middle-name");
 }
 
 #[test]
@@ -1886,12 +1935,153 @@ fn vertex_provider(model: &str) -> AIProvider {
 	})
 }
 
+fn bedrock_provider(model: &str) -> AIProvider {
+	AIProvider::Bedrock(bedrock::Provider {
+		model: Some(strng::new(model)),
+		region: strng::new("us-west-2"),
+		guardrail_identifier: None,
+		guardrail_version: None,
+		source_credentials_cache: Default::default(),
+		assume_role_cache: Default::default(),
+	})
+}
+
 fn custom_provider(format: custom::ProviderFormat) -> AIProvider {
 	AIProvider::Custom(custom::Provider {
 		model: None,
 		provider_override: None,
 		formats: vec![custom::ProviderFormatConfig { format, path: None }],
 	})
+}
+
+#[test]
+fn provider_capabilities_select_native_formats() {
+	use custom::ProviderFormat::{
+		AnthropicTokenCount, Completions, Embeddings, Messages, Realtime, Rerank, Responses,
+	};
+
+	let openai = AIProvider::OpenAI(openai::Provider { model: None });
+	assert_eq!(
+		openai.native_format_for(InputFormat::Messages, Some("gpt-4.1")),
+		Some(Completions)
+	);
+	assert_eq!(
+		openai.native_format_for(InputFormat::Responses, Some("gpt-4.1")),
+		Some(Responses)
+	);
+	assert_eq!(
+		openai.native_format_for(InputFormat::CountTokens, Some("gpt-4.1")),
+		None
+	);
+	assert_eq!(
+		openai.native_format_for(InputFormat::Realtime, Some("gpt-4o-realtime-preview")),
+		Some(Realtime)
+	);
+
+	let anthropic = AIProvider::Anthropic(anthropic::Provider { model: None });
+	assert_eq!(
+		anthropic.native_format_for(InputFormat::Completions, Some("claude-sonnet-4-5")),
+		Some(Messages)
+	);
+	assert_eq!(
+		anthropic.native_format_for(InputFormat::CountTokens, Some("claude-sonnet-4-5")),
+		Some(AnthropicTokenCount)
+	);
+	assert_eq!(
+		anthropic.native_format_for(InputFormat::Embeddings, Some("claude-sonnet-4-5")),
+		None
+	);
+
+	let azure_foundry = AIProvider::Azure(azure::Provider {
+		model: None,
+		resource_name: strng::new("example"),
+		resource_type: azure::AzureResourceType::Foundry,
+		api_version: None,
+		project_name: Some(strng::new("project")),
+		cached_cred: Default::default(),
+	});
+	assert_eq!(
+		azure_foundry.native_format_for(InputFormat::Messages, Some("claude-sonnet-4-5")),
+		Some(Messages)
+	);
+	assert_eq!(
+		azure_foundry.native_format_for(InputFormat::CountTokens, Some("claude-sonnet-4-5")),
+		Some(AnthropicTokenCount)
+	);
+	assert_eq!(
+		azure_foundry.native_format_for(InputFormat::CountTokens, Some("gpt-4.1")),
+		None
+	);
+
+	let gemini = AIProvider::Gemini(gemini::Provider { model: None });
+	assert_eq!(
+		gemini.native_format_for(InputFormat::Responses, Some("gemini-2.5-pro")),
+		Some(Completions)
+	);
+	assert_eq!(
+		gemini.native_format_for(InputFormat::Embeddings, Some("text-embedding-004")),
+		Some(Embeddings)
+	);
+	assert_eq!(
+		gemini.native_format_for(InputFormat::Rerank, Some("semantic-ranker")),
+		None
+	);
+
+	let vertex_anthropic = vertex_provider("anthropic/claude-sonnet-4-5");
+	assert_eq!(
+		vertex_anthropic.native_format_for(InputFormat::Completions, None),
+		Some(Messages)
+	);
+	assert_eq!(
+		vertex_anthropic.native_format_for(InputFormat::CountTokens, None),
+		Some(AnthropicTokenCount)
+	);
+
+	let vertex_openai_compat = vertex_provider("gemini-2.0-flash");
+	assert_eq!(
+		vertex_openai_compat.native_format_for(InputFormat::Messages, None),
+		Some(Completions)
+	);
+	assert_eq!(
+		vertex_openai_compat.native_format_for(InputFormat::Responses, None),
+		None
+	);
+	assert_eq!(
+		vertex_openai_compat.native_format_for(InputFormat::Rerank, None),
+		Some(Rerank)
+	);
+
+	let bedrock_anthropic = bedrock_provider("anthropic.claude-3-5-sonnet-20241022-v2:0");
+	assert_eq!(
+		bedrock_anthropic.native_format_for(InputFormat::CountTokens, None),
+		Some(AnthropicTokenCount)
+	);
+	let bedrock_titan = bedrock_provider("amazon.titan-embed-text-v2:0");
+	assert_eq!(
+		bedrock_titan.native_format_for(InputFormat::CountTokens, None),
+		None
+	);
+}
+
+#[test]
+fn custom_provider_capabilities_use_shared_preferences() {
+	let messages_only = custom_provider(custom::ProviderFormat::Messages);
+	assert_eq!(
+		messages_only.native_format_for(InputFormat::Completions, Some("model")),
+		Some(custom::ProviderFormat::Messages)
+	);
+
+	let completions_only = custom_provider(custom::ProviderFormat::Completions);
+	assert_eq!(
+		completions_only.native_format_for(InputFormat::Responses, Some("model")),
+		Some(custom::ProviderFormat::Completions)
+	);
+
+	let rerank_only = custom_provider(custom::ProviderFormat::Rerank);
+	assert_eq!(
+		rerank_only.native_format_for(InputFormat::Messages, Some("model")),
+		None
+	);
 }
 
 #[test]


### PR DESCRIPTION
- Add provider-level supported format selection.
- Reuse the shared input-to-provider preference table for custom provider native format selection.
- Make count-token fallback decisions use provider format support after model alias resolution.
- Add coverage for provider capability and native format selection.

Fixes: #2025