### PR TITLE
ui: fix virtual API key copy button

### DIFF
--- a/ui/src/pages/Keys.tsx
+++ b/ui/src/pages/Keys.tsx
@@ -754,13 +754,28 @@ function linkedVirtualKey(value: string | null, keys: VirtualApiKey[]) {
   return null;
 }
 
-async function copyVirtualKey(
-  key: string,
-  setCopiedKey: (key: string | null) => void,
-) {
-  await navigator.clipboard.writeText(key);
-  setCopiedKey(key);
-  window.setTimeout(() => setCopiedKey(null), 1400);
+async function copyVirtualKey(key: string): Promise<boolean> {
+  if (navigator.clipboard) {
+    try {
+      await navigator.clipboard.writeText(key);
+      return true;
+    } catch {
+      // fall through to execCommand fallback
+    }
+  }
+  // Fallback for non-secure contexts (HTTP, non-localhost)
+  try {
+    const el = document.createElement("textarea");
+    el.value = key;
+    el.style.cssText = "position:fixed;left:-9999px;top:0;opacity:0";
+    document.body.appendChild(el);
+    el.select();
+    const success = document.execCommand("copy");
+    document.body.removeChild(el);
+    return success;
+  } catch {
+    return false;
+  }
 }
 
 function VirtualKeyValue(props: { value: string }) {
@@ -786,11 +801,14 @@ function VirtualKeyValue(props: { value: string }) {
             className={copied ? "table-action copied" : "table-action"}
             type="button"
             aria-label="Copy key"
-            onClick={() =>
-              void copyVirtualKey(props.value, (next) => {
-                setCopied(Boolean(next));
-              })
-            }
+            onClick={() => {
+              void copyVirtualKey(props.value).then((success) => {
+                if (success) {
+                  setCopied(true);
+                  window.setTimeout(() => setCopied(false), 1400);
+                }
+              });
+            }}
           >
             {copied ? <Check size={14} /> : <Copy size={14} />}
             Copy

--- a/ui/tests/e2e/ui.spec.ts
+++ b/ui/tests/e2e/ui.spec.ts
@@ -222,6 +222,21 @@ test("reveals a virtual API key explicitly", async ({ page }) => {
   await expect(page.getByText("agw_sk_testkey123456789")).toBeVisible();
 });
 
+test("copies a virtual API key to clipboard", async ({ page, context }) => {
+  await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+  await mockGateway(page);
+  await page.goto("/llm/keys");
+
+  await page.getByRole("button", { name: "Copy key" }).click();
+  await expect(page.getByRole("button", { name: "Copy key" })).toHaveClass(
+    /copied/,
+  );
+  const clipboardText = await page.evaluate(() =>
+    navigator.clipboard.readText(),
+  );
+  expect(clipboardText).toBe("agw_sk_testkey123456789");
+});
+
 test("LLM playground sends selected virtual model name", async ({ page }) => {
   const gateway = await mockGateway(page);
   await page.goto("/llm/playground");


### PR DESCRIPTION
## Summary

- The **Copy** button on the Virtual API Keys page was non-functional in non-secure contexts (HTTP served from a non-localhost address). `navigator.clipboard.writeText()` throws when the Clipboard API is unavailable, and the error was silently swallowed by `void`, causing the button to do nothing with no feedback.
- Rewrote `copyVirtualKey` to: first attempt the modern `navigator.clipboard` API, then fall back to the legacy `document.execCommand('copy')` method for HTTP/non-localhost environments.
- Visual "Copied" feedback is now only shown when the copy actually succeeds.
- Added an e2e Playwright test that grants clipboard permissions and verifies both the visual state change and the actual clipboard content.

## Test plan

- [ ] Navigate to the Virtual API Keys page with at least one key configured
- [ ] Click the **Copy** button — it should briefly change to a checkmark ("Copied") state
- [ ] Paste into a text editor and verify the full key value is present
- [ ] Verify behaviour in both HTTPS and HTTP (non-localhost) environments
- [ ] Run `npm run test:e2e` — the new `copies a virtual API key to clipboard` test should pass