### PR TITLE
llm: fix detect and audio endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,6 +213,7 @@ dependencies = [
  "libc",
  "macro_rules_attribute",
  "mimalloc",
+ "multer",
  "notify",
  "notify-debouncer-full",
  "num_cpus",
@@ -4212,6 +4213,23 @@ dependencies = [
  "smallvec",
  "tagptr",
  "uuid",
+]
+
+[[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http 1.4.2",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin 0.9.8",
+ "version_check",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ rustls-openssl = { version = "0.3", features = ["tls12"] }
 axum = { version = "0.8", features = ["macros"] }
 axum-core = "0.5"
 axum-extra = { version = "0.12", features = ["json-lines", "typed-header"] }
+multer = "3.0.0"
 # Disable default features to avoid pulling in native-tls and requiring openssl
 # TODO: allow default features if we ever add an openssl feature
 azure_identity = { version = "1.0", default-features = false }

--- a/crates/agentgateway/Cargo.toml
+++ b/crates/agentgateway/Cargo.toml
@@ -83,6 +83,7 @@ notify-debouncer-full.workspace = true
 notify.workspace = true
 num_cpus.workspace = true
 once_cell.workspace = true
+multer.workspace = true
 openapiv3.workspace = true
 opentelemetry-otlp.workspace = true
 opentelemetry-proto.workspace = true

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -1021,7 +1021,9 @@ impl AIProvider {
 		};
 
 		let req = if is_json {
-			if let Some(p) = policies {
+			if let Some(p) = policies
+				&& p.has_request_body_mutations()
+			{
 				p.unmarshal_request(&bytes, log)
 			} else {
 				serde_json::from_slice(bytes.as_ref()).map_err(AIError::RequestParsing)
@@ -1065,7 +1067,11 @@ impl AIProvider {
 			}
 		}
 
-		let request_model = req.model().as_deref().map(str::to_string);
+		let request_model = if req.supports_model() {
+			req.model().as_deref().map(str::to_string)
+		} else {
+			None
+		};
 		let native_format = if original_format == InputFormat::Detect {
 			None
 		} else {

--- a/crates/agentgateway/src/llm/model_router.rs
+++ b/crates/agentgateway/src/llm/model_router.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use agent_core::prelude::Strng;
 use agent_core::strng;
 use bytes::Bytes;
+use futures_util::stream;
 use percent_encoding::{AsciiSet, CONTROLS, utf8_percent_encode};
 use rand::seq::IndexedRandom;
 use serde_json::Value;
@@ -100,6 +101,7 @@ struct RequestedModel {
 
 enum RequestedModelLocation {
 	Body(Value),
+	Multipart,
 	Path,
 }
 
@@ -286,6 +288,14 @@ fn model_not_found_response() -> Response {
 	)
 }
 
+fn request_body_too_large_response() -> Response {
+	llm_error_response(
+		::http::StatusCode::PAYLOAD_TOO_LARGE,
+		"LLM request body exceeded the buffer limit",
+		"request_body_too_large",
+	)
+}
+
 fn llm_error_response(status: ::http::StatusCode, message: &str, code: &str) -> Response {
 	::http::Response::builder()
 		.status(status)
@@ -402,6 +412,13 @@ async fn requested_model(req: &mut Request) -> RouterResult<RequestedModel> {
 	}
 
 	let body = body_bytes(req).await?;
+	if let Some(boundary) = multipart_boundary(req) {
+		let model = multipart_model(&body, &boundary).await?;
+		return Ok(RequestedModel {
+			model,
+			location: RequestedModelLocation::Multipart,
+		});
+	}
 	let body: Value = serde_json::from_slice(&body).map_err(|err| {
 		tracing::debug!(%err, "failed to parse LLM request body");
 		Box::new(llm_error_response(
@@ -435,6 +452,8 @@ fn rewrite_request_model(
 	match location {
 		RequestedModelLocation::Body(body) => rewrite_body_model(req, body, target),
 		RequestedModelLocation::Path => rewrite_uri_model(req, target),
+		// TODO: Rewrite multipart model fields for virtual model routing.
+		RequestedModelLocation::Multipart => Ok(()),
 	}
 }
 
@@ -522,18 +541,70 @@ fn encode_model_path_segment(model: &str) -> String {
 	utf8_percent_encode(model, MODEL_SEGMENT).to_string()
 }
 
-async fn body_bytes(req: &mut Request) -> RouterResult<Bytes> {
-	if let Some(body) = req.extensions().get::<cel::BufferedBody>() {
-		return Ok(body.0.clone());
-	}
-	let body = http::inspect_body(req).await.map_err(|err| {
-		tracing::debug!(%err, "failed to read LLM request body");
+fn multipart_boundary(req: &Request) -> Option<String> {
+	req
+		.headers()
+		.get(::http::header::CONTENT_TYPE)
+		.and_then(|content_type| content_type.to_str().ok())
+		.and_then(|content_type| multer::parse_boundary(content_type).ok())
+}
+
+async fn multipart_model(body: &Bytes, boundary: &str) -> RouterResult<String> {
+	let stream = stream::once(std::future::ready(Ok::<Bytes, multer::Error>(body.clone())));
+	let mut multipart = multer::Multipart::new(stream, boundary);
+	while let Some(field) = multipart.next_field().await.map_err(|err| {
+		tracing::debug!(%err, "failed to parse LLM multipart request body");
 		Box::new(llm_error_response(
 			::http::StatusCode::BAD_REQUEST,
-			"Failed to read LLM request body",
-			"request_body_read_failed",
+			"LLM multipart request body must be valid multipart/form-data",
+			"invalid_request_body",
 		))
-	})?;
+	})? {
+		if field.name() == Some("model") {
+			return field.text().await.map_err(|err| {
+				tracing::debug!(%err, "failed to parse LLM multipart model field");
+				Box::new(llm_error_response(
+					::http::StatusCode::BAD_REQUEST,
+					"LLM multipart request body has invalid string field 'model'",
+					"invalid_model",
+				))
+			});
+		}
+	}
+	Err(Box::new(llm_error_response(
+		::http::StatusCode::BAD_REQUEST,
+		"LLM multipart request body is missing string field 'model'",
+		"missing_model",
+	)))
+}
+
+async fn body_bytes(req: &mut Request) -> RouterResult<Bytes> {
+	let limit = http::buffer_limit(req);
+	if let Some(body) = req.extensions().get::<cel::BufferedBody>() {
+		if body.0.len() < limit {
+			return Ok(body.0.clone());
+		}
+		if body.0.len() > limit {
+			return Err(Box::new(request_body_too_large_response()));
+		}
+	}
+	let inspect_limit = limit.saturating_add(1);
+	let mut body = http::inspect_body_with_limit(req.body_mut(), inspect_limit)
+		.await
+		.map_err(|err| {
+			tracing::debug!(%err, "failed to read LLM request body");
+			Box::new(llm_error_response(
+				::http::StatusCode::BAD_REQUEST,
+				"Failed to read LLM request body",
+				"request_body_read_failed",
+			))
+		})?;
+	if body.len() > limit {
+		return Err(Box::new(request_body_too_large_response()));
+	}
+	if body.len() == inspect_limit {
+		body.truncate(limit);
+	}
 	req.extensions_mut().insert(cel::BufferedBody(body.clone()));
 	Ok(body)
 }
@@ -541,6 +612,7 @@ async fn body_bytes(req: &mut Request) -> RouterResult<Bytes> {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use crate::transport::BufferLimit;
 
 	#[test]
 	fn rewrite_path_model_rewrites_bedrock_converse_and_preserves_suffix() {
@@ -591,5 +663,30 @@ mod tests {
 			req.uri().to_string(),
 			"http://example.com/model/real%2Fmodel/converse?trace=true"
 		);
+	}
+
+	#[tokio::test]
+	async fn body_bytes_rejects_json_body_over_buffer_limit() {
+		let request_body = br#"{"model":"real-model","messages":[{"role":"user","content":"this part is over the limit"}]}"#;
+		let mut req = ::http::Request::builder()
+			.uri("http://example.com/v1/chat/completions")
+			.body(http::Body::from(request_body.as_slice()))
+			.unwrap();
+		req.extensions_mut().insert(BufferLimit(24));
+
+		let resp = *body_bytes(&mut req)
+			.await
+			.expect_err("over-limit body should fail");
+		assert_eq!(resp.status(), ::http::StatusCode::PAYLOAD_TOO_LARGE);
+		let error_body = http::read_body_with_limit(resp.into_body(), 1024)
+			.await
+			.expect("error body");
+		let error: Value = serde_json::from_slice(&error_body).expect("error JSON");
+		assert_eq!(error["error"]["code"], "request_body_too_large");
+
+		let restored = http::read_body_with_limit(req.into_body(), 1024)
+			.await
+			.expect("restored request body");
+		assert_eq!(restored, Bytes::from_static(request_body));
 	}
 }

--- a/crates/agentgateway/src/llm/policy/mod.rs
+++ b/crates/agentgateway/src/llm/policy/mod.rs
@@ -606,12 +606,16 @@ impl Policy {
 		wildcard.unwrap_or(crate::llm::RouteType::Completions)
 	}
 
+	pub fn has_request_body_mutations(&self) -> bool {
+		self.defaults.is_some() || self.overrides.is_some() || self.transformations.is_some()
+	}
+
 	pub fn unmarshal_request<T: DeserializeOwned>(
 		&self,
 		bytes: &Bytes,
 		log: &mut Option<&mut RequestLog>,
 	) -> Result<T, AIError> {
-		if self.defaults.is_none() && self.overrides.is_none() && self.transformations.is_none() {
+		if !self.has_request_body_mutations() {
 			// Fast path: directly bytes to typed
 			return serde_json::from_slice(bytes.as_ref()).map_err(AIError::RequestParsing);
 		}

--- a/crates/agentgateway/src/llm/types/detect.rs
+++ b/crates/agentgateway/src/llm/types/detect.rs
@@ -47,6 +47,7 @@ impl Request {
 	pub fn new_raw(body: Bytes) -> Self {
 		Self::Raw(body)
 	}
+
 	pub fn lookup<'a, T, const C: usize>(
 		&'a self,
 		path: [&[&str]; C],

--- a/crates/agentgateway/src/proxy/gateway_test.rs
+++ b/crates/agentgateway/src/proxy/gateway_test.rs
@@ -1319,6 +1319,138 @@ async fn llm_openai_tokenize() {
 	.await;
 }
 
+#[tokio::test]
+async fn llm_detect_mode_passthrough_without_rewrite() {
+	let mock = body_mock(include_bytes!(
+		"../llm/tests/response/completions/basic.json"
+	))
+	.await;
+	let provider = crate::types::local::LocalNamedAIProvider {
+		name: "default".into(),
+		provider: AIProvider::OpenAI(openai::Provider { model: None }),
+		host_override: Some(Target::Address(*mock.address())),
+		path_override: None,
+		path_prefix: None,
+		tokenize: false,
+		policies: serde_json::from_value(json!({
+			"ai": {
+				"routes": {
+					"/v1/chat/completions": "detect"
+				}
+			}
+		}))
+		.unwrap(),
+	};
+	let (mock, _bind, io) = setup_llm_named_provider_mock(mock, provider, "{}");
+	let body = include_bytes!("../llm/tests/requests/completions/basic.json");
+
+	let res = RequestBuilder::new(Method::POST, "http://lo/v1/chat/completions?trace=repro")
+		.header(header::CONTENT_TYPE, "application/json")
+		.body(Body::from(body.to_vec()))
+		.send(io.clone())
+		.await
+		.unwrap();
+	assert_eq!(res.status(), StatusCode::OK);
+	let _ = read_body_raw(res.into_body()).await;
+
+	let requests = mock
+		.received_requests()
+		.await
+		.expect("request recording should be enabled");
+	assert_eq!(requests.len(), 1);
+	assert_eq!(
+		&requests[0].url[Position::BeforePath..Position::AfterQuery],
+		"/v1/chat/completions?trace=repro"
+	);
+	let upstream_body: Value =
+		serde_json::from_slice(&requests[0].body).expect("upstream request should be JSON");
+	let original_body: Value = serde_json::from_slice(body).expect("original request should be JSON");
+	assert_eq!(upstream_body, original_body);
+
+	let log = agent_core::telemetry::testing::eventually_find(&[
+		("scope", "request"),
+		("http.path", "/v1/chat/completions?trace=repro"),
+	])
+	.await
+	.unwrap();
+	let want = json!({
+		"gen_ai.operation.name": "chat",
+		"gen_ai.provider.name": "openai",
+		"gen_ai.request.model": "replaceme",
+		"gen_ai.response.model": "gpt-3.5-turbo-0125",
+		"gen_ai.usage.input_tokens": 17,
+		"gen_ai.usage.output_tokens": 23
+	});
+	assert!(is_json_subset(&want, &log), "want={want:#?} got={log:#?}");
+}
+
+#[tokio::test]
+async fn llm_detect_mode_respects_model_rewrite() {
+	let mock = body_mock(include_bytes!(
+		"../llm/tests/response/completions/basic.json"
+	))
+	.await;
+	let provider = crate::types::local::LocalNamedAIProvider {
+		name: "default".into(),
+		provider: AIProvider::OpenAI(openai::Provider { model: None }),
+		host_override: Some(Target::Address(*mock.address())),
+		path_override: None,
+		path_prefix: None,
+		tokenize: false,
+		policies: serde_json::from_value(json!({
+			"ai": {
+				"routes": {
+					"/v1/chat/completions": "detect"
+				},
+				"overrides": {
+					"model": "replaceme-overwrite"
+				}
+			}
+		}))
+		.unwrap(),
+	};
+	let (mock, _bind, io) = setup_llm_named_provider_mock(mock, provider, "{}");
+	let body = include_bytes!("../llm/tests/requests/completions/basic.json");
+
+	let res = RequestBuilder::new(Method::POST, "http://lo/v1/chat/completions?trace=rewrite")
+		.header(header::CONTENT_TYPE, "application/json")
+		.body(Body::from(body.to_vec()))
+		.send(io.clone())
+		.await
+		.unwrap();
+	assert_eq!(res.status(), StatusCode::OK);
+	let _ = read_body_raw(res.into_body()).await;
+
+	let requests = mock
+		.received_requests()
+		.await
+		.expect("request recording should be enabled");
+	assert_eq!(requests.len(), 1);
+	assert_eq!(
+		&requests[0].url[Position::BeforePath..Position::AfterQuery],
+		"/v1/chat/completions?trace=rewrite"
+	);
+	let upstream_body: Value =
+		serde_json::from_slice(&requests[0].body).expect("upstream request should be JSON");
+	assert_eq!(upstream_body["model"], "replaceme-overwrite");
+
+	let log = agent_core::telemetry::testing::eventually_find(&[
+		("scope", "request"),
+		("http.path", "/v1/chat/completions?trace=rewrite"),
+	])
+	.await
+	.unwrap();
+	let want = json!({
+		"gen_ai.operation.name": "chat",
+		"gen_ai.provider.name": "openai",
+		"gen_ai.request.model": "replaceme-overwrite",
+		"gen_ai.response.model": "gpt-3.5-turbo-0125",
+		"gen_ai.usage.input_tokens": 17,
+		"gen_ai.usage.output_tokens": 23
+	});
+	assert!(is_json_subset(&want, &log), "want={want:#?} got={log:#?}");
+}
+
 async fn setup_local_llm_config(yaml: &str) -> TestBind {
 	let t = setup_proxy_test("{}").unwrap();
 	let normalized = crate::types::local::NormalizedLocalConfig::from(
@@ -1541,6 +1673,79 @@ llm:
 			.len(),
 		0
 	);
+}
+
+#[tokio::test]
+async fn llm_model_router_handles_multipart_audio_detect_request() {
+	let mock = body_mock(include_bytes!(
+		"../llm/tests/response/completions/basic.json"
+	))
+	.await;
+	let config = format!(
+		r#"
+llm:
+  port: 4000
+  models:
+  - name: real-model
+    provider: openAI
+    params:
+      baseUrl: http://{}
+    passthrough: detect
+"#,
+		mock.address()
+	);
+	let t = setup_local_llm_config(&config).await;
+	let io = t.serve_http(strng::literal!("bind/4000"));
+	let body = concat!(
+		"--audio-boundary\r\n",
+		"Content-Disposition: form-data; name=\"file\"; filename=\"audio.wav\"\r\n",
+		"Content-Type: audio/wav\r\n",
+		"\r\n",
+		"fake-audio-bytes\r\n",
+		"--audio-boundary\r\n",
+		"Content-Disposition: form-data; name=\"model\"\r\n",
+		"\r\n",
+		"real-model\r\n",
+		"--audio-boundary--\r\n",
+	)
+	.as_bytes();
+
+	let res = RequestBuilder::new(Method::POST, "http://lo/v1/audio/transcriptions")
+		.header(
+			header::CONTENT_TYPE,
+			"multipart/form-data; boundary=audio-boundary",
+		)
+		.body(Body::from(body.to_vec()))
+		.send(io.clone())
+		.await
+		.unwrap();
+	assert_eq!(res.status(), StatusCode::OK);
+	let _ = read_body_raw(res.into_body()).await;
+
+	let requests = mock
+		.received_requests()
+		.await
+		.expect("request recording should be enabled");
+	assert_eq!(requests.len(), 1);
+	assert_eq!(
+		&requests[0].url[Position::BeforePath..Position::AfterPath],
+		"/v1/audio/transcriptions"
+	);
+	assert_eq!(requests[0].body, body);
+
+	let log = agent_core::telemetry::testing::eventually_find(&[
+		("scope", "request"),
+		("http.path", "/v1/audio/transcriptions"),
+	])
+	.await
+	.unwrap();
+	let want = json!({
+		"gen_ai.provider.name": "openai",
+		"gen_ai.response.model": "gpt-3.5-turbo-0125",
+		"gen_ai.usage.input_tokens": 17,
+		"gen_ai.usage.output_tokens": 23
+	});
+	assert!(is_json_subset(&want, &log), "want={want:#?} got={log:#?}");
 }
 
 #[tokio::test]

--- a/crates/agentgateway/src/types/local_tests/llm_simple_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/llm_simple_normalized.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/agentgateway/src/types/local_tests.rs
-assertion_line: 207
 description: "Config normalization test for llm_simple: YAML -> LocalConfig -> NormalizedLocalConfig -> YAML"
 ---
 binds:


### PR DESCRIPTION
test coverage

Audio is broken (not new) in standalone mode as the model based routing
doesn't understand the non-json inputs. Related
https://github.com/agentgateway/agentgateway/issues/2292.
This is addressed by multipart handling. Note we only support
detect/passthrough with these still.

Signed-off-by: John Howard <john.howard@solo.io>
