### PR TITLE
proxy: terminate outer TLS before serving CONNECT tunnels

### DIFF
--- a/crates/agentgateway/src/proxy/gateway.rs
+++ b/crates/agentgateway/src/proxy/gateway.rs
@@ -652,7 +652,23 @@ impl Gateway {
 					)
 					.await
 					{
-						Ok((_listener, tls_stream)) => tls_stream,
+						Ok((listener, tls_stream)) => {
+							// A TLS-passthrough listener (`ListenerProtocol::TLS(None)`) does not
+							// terminate TLS, so `tls_stream` is still encrypted. Serving CONNECT
+							// would parse HTTP from ciphertext and fail opaquely. CONNECT requires
+							// plaintext to read the request, so passthrough is incompatible; reject
+							// with an actionable error instead.
+							if matches!(listener.protocol, ListenerProtocol::TLS(None)) {
+								warn!(
+									src.addr = %peer_addr,
+									"cannot serve CONNECT tunnel: listener {} is TLS passthrough (no termination); \
+									 configure TLS termination on this listener to use tunnelProtocol: Connect",
+									listener.name.listener_name,
+								);
+								return;
+							}
+							tls_stream
+						},
 						Err(e) => {
 							warn!(src.addr = %peer_addr, "connect tunnel TLS termination error: {e}");
 							return;

--- a/crates/agentgateway/src/proxy/gateway.rs
+++ b/crates/agentgateway/src/proxy/gateway.rs
@@ -636,7 +636,32 @@ impl Gateway {
 				let _ = Self::terminate_gateway_hbone(inputs, raw_stream, policies, drain).await;
 			},
 			TunnelProtocol::Connect => {
-				let err = Self::terminate_connect_tunnel(inputs, raw_stream, policies, drain).await;
+				// Terminate the OUTER TLS (when the bind is TLS) BEFORE serving CONNECT,
+				// so the CONNECT request and its headers are encrypted on the wire.
+				// Without this, a `tunnelProtocol: Connect` bind would ignore its listener
+				// TLS config and serve CONNECT in plaintext on the raw socket. Any inner
+				// TLS is terminated separately when the tunnel re-enters the destination
+				// bind (maybe_terminate_tls in proxy_bind).
+				let stream = if matches!(bind_protocol, BindProtocol::tls) {
+					match Self::maybe_terminate_tls(
+						inputs.clone(),
+						raw_stream,
+						&policies,
+						bind_name.clone(),
+						true,
+					)
+					.await
+					{
+						Ok((_listener, tls_stream)) => tls_stream,
+						Err(e) => {
+							warn!(src.addr = %peer_addr, "connect tunnel TLS termination error: {e}");
+							return;
+						},
+					}
+				} else {
+					raw_stream
+				};
+				let err = Self::terminate_connect_tunnel(inputs, stream, policies, drain).await;
 				if let Err(e) = err {
 					warn!(src.addr = %peer_addr, "connect tunnel error: {e}");
 				}

--- a/crates/agentgateway/src/proxy/gateway_test.rs
+++ b/crates/agentgateway/src/proxy/gateway_test.rs
@@ -40,7 +40,7 @@ use crate::types::agent::{
 	Backend, BackendTarget, BackendTrafficPolicy, BackendWithPolicies, Bind, BindProtocol,
 	FrontendPolicy, Listener, ListenerProtocol, ListenerSet, ListenerTarget, PathMatch,
 	PolicyInheritance, PolicyTarget, ResourceName, Route, RouteMatch, SimpleBackendReference, Target,
-	TargetedPolicy,
+	TargetedPolicy, TunnelProtocol,
 };
 use crate::types::{backend, frontend};
 use crate::{read_body, *};
@@ -3372,6 +3372,749 @@ async fn incoming_connect_tunnel_exposes_connect_headers_to_cel() {
 	assert!(
 		denied.starts_with("HTTP/1.1 403 Forbidden\r\n"),
 		"expected inner request to be denied, got: {denied}",
+	);
+}
+
+/// A `tunnelProtocol: Connect` bind with an HTTPS listener terminates the OUTER
+/// TLS BEFORE serving CONNECT, so the CONNECT request and its headers are
+/// encrypted on the wire.
+///
+/// The client completes a TLS handshake to the outer bind (which only
+/// succeeds if the gateway terminated the outer TLS rather than serving plaintext
+/// CONNECT on the raw socket), sends CONNECT inside that TLS carrying a custom
+/// header, and the re-entered inner request is authorized iff the header survived
+/// (`source.connectHeaders`).
+#[tokio::test]
+async fn connect_tunnel_terminates_outer_tls() {
+	// SNI must match the `*.example.com` static cert at examples/tls/certs.
+	const SNI: &str = "gw.example.com";
+
+	async fn tls_connect_inner(custom_header: Option<&str>) -> String {
+		let mock = simple_mock().await;
+
+		// OUTER bind: HTTPS Static cert + tunnelProtocol Connect. The fix terminates
+		// this outer TLS before serving CONNECT.
+		let outer = Bind {
+			key: strng::literal!("outer"),
+			address: "127.0.0.1:15011".parse().unwrap(),
+			listeners: ListenerSet::from_list([Listener {
+				key: LISTENER_KEY,
+				name: Default::default(),
+				hostname: strng::new("*.example.com"),
+				protocol: ListenerProtocol::HTTPS(
+					types::local::LocalTLSServerConfig {
+						mode: Default::default(), // Static
+						cert: "../../examples/tls/certs/cert.pem".into(),
+						key: "../../examples/tls/certs/key.pem".into(),
+						root: None,
+						cipher_suites: None,
+						min_tls_version: None,
+						max_tls_version: None,
+						key_exchange_groups: None,
+					}
+					.try_into()
+					.unwrap(),
+				),
+			}]),
+			protocol: BindProtocol::tls,
+			tunnel_protocol: TunnelProtocol::Connect,
+		};
+
+		// INNER plain bind, re-entered by the CONNECT authority port.
+		let mut inner = simple_bind();
+		inner.address = "127.0.0.1:18083".parse().unwrap();
+
+		let mut t = setup_proxy_test("{}")
+			.unwrap()
+			.with_backend(*mock.address())
+			.with_bind(outer)
+			.with_bind(inner)
+			.with_route(basic_route(*mock.address()));
+		// Authorize the inner request only when the custom header carried on the
+		// (TLS-encrypted) CONNECT survived termination + re-entry.
+		t.attach_route_policy(json!({
+			"authorization": {
+				"rules": ["source.connectHeaders[\"x-custom-header\"] == \"custom-value\""],
+			},
+		}))
+		.await;
+
+		// Complete the OUTER TLS handshake to the Connect bind. This is the core
+		// assertion: a plaintext CONNECT bind would fail this handshake.
+		let raw = t.serve_tunnel(strng::literal!("outer"));
+		let client_tls: crate::http::backendtls::BackendTLS =
+			crate::http::backendtls::ResolvedBackendTLS {
+				root: Some(include_bytes!("../../../../examples/tls/certs/ca-cert.pem").to_vec()),
+				hostname: Some(SNI.to_string()),
+				insecure_host: true,
+				..Default::default()
+			}
+			.try_into()
+			.unwrap();
+		let mut io = TlsConnector::from(client_tls.base_config().config)
+			.connect(ServerName::try_from(SNI.to_string()).unwrap(), raw)
+			.await
+			.expect("outer TLS handshake should succeed (gateway terminates outer TLS before CONNECT)");
+
+		// CONNECT inside the outer TLS, optionally carrying the custom header.
+		let connect = match custom_header {
+			Some(v) => format!(
+				"CONNECT inner.local:18083 HTTP/1.1\r\nHost: inner.local:18083\r\nx-custom-header: {v}\r\n\r\n"
+			),
+			None => "CONNECT inner.local:18083 HTTP/1.1\r\nHost: inner.local:18083\r\n\r\n".to_string(),
+		};
+		io.write_all(connect.as_bytes()).await.unwrap();
+
+		let mut response = Vec::new();
+		loop {
+			let mut chunk = [0; 1024];
+			let n = io.read(&mut chunk).await.unwrap();
+			assert!(n > 0, "CONNECT response unexpectedly closed");
+			response.extend_from_slice(&chunk[..n]);
+			if response.windows(4).any(|w| w == b"\r\n\r\n") {
+				break;
+			}
+		}
+		assert!(
+			String::from_utf8_lossy(&response).starts_with("HTTP/1.1 200 OK\r\n"),
+			"unexpected CONNECT response: {}",
+			String::from_utf8_lossy(&response),
+		);
+
+		// Inner request over the tunnel (plaintext within the outer TLS).
+		io.write_all(b"GET /foo HTTP/1.1\r\nHost: lo\r\nConnection: close\r\n\r\n")
+			.await
+			.unwrap();
+		let mut tunneled = Vec::new();
+		tokio::time::timeout(Duration::from_secs(5), io.read_to_end(&mut tunneled))
+			.await
+			.expect("timed out waiting for tunneled HTTP response")
+			.unwrap();
+		String::from_utf8_lossy(&tunneled).to_string()
+	}
+
+	// Header present + matching: authorized (200) — proves the outer TLS was
+	// terminated, the CONNECT was read inside it, and the header reached CEL.
+	let allowed = tls_connect_inner(Some("custom-value")).await;
+	assert!(
+		allowed.starts_with("HTTP/1.1 200 OK\r\n"),
+		"expected authorized inner request, got: {allowed}",
+	);
+	// Wrong / absent header: denied (403).
+	let wrong = tls_connect_inner(Some("other-value")).await;
+	assert!(
+		wrong.starts_with("HTTP/1.1 403 Forbidden\r\n"),
+		"expected denied inner request for wrong header, got: {wrong}",
+	);
+	let absent = tls_connect_inner(None).await;
+	assert!(
+		absent.starts_with("HTTP/1.1 403 Forbidden\r\n"),
+		"expected denied inner request without the header, got: {absent}",
+	);
+}
+
+/// End-to-end on-behalf-of (OBO) token exchange over a CONNECT tunnel.
+///
+/// CONNECT (carrying `x-actor-token`, the actor token) -> Tunnel re-entry ->
+/// ext-authz builds an RFC 8693 token-exchange body from
+/// `source.connectHeaders["x-actor-token"]` (actor) and
+/// `request.headers["authorization"]` (subject) -> a mock STS returns an OBO JWT
+/// -> `transformations` injects `Authorization: Bearer <obo>` -> the route
+/// backend forwards it upstream.
+///
+/// Proves that `source.connectHeaders`, the ext-authz `http.body` CEL, the
+/// ext-authz cache, transformations, and the re-entered request pipeline compose
+/// into a working OBO injection. The STS is mocked, so this proves the gateway
+/// wiring rather than STS semantics.
+///
+/// Note: this uses a fixed route backend rather than `dynamic: {}`; the OBO
+/// injection (decrypted inner request) is orthogonal to how the destination is
+/// resolved, so the simpler proven CONNECT-re-entry fixture is used here.
+#[tokio::test]
+async fn connect_tunnel_obo_exchange_injects_token() {
+	use std::collections::HashMap;
+
+	// An unsigned JWT (`header.payload.signature`) carrying a near-future `exp`,
+	// so `unvalidatedJwtPayload(...).exp` resolves for the cache TTL. The gateway
+	// never validates the signature.
+	fn unsigned_jwt(payload: serde_json::Value) -> String {
+		use base64::Engine;
+		let b64 = base64::prelude::BASE64_URL_SAFE_NO_PAD;
+		let header = b64.encode(br#"{"alg":"none","typ":"JWT"}"#);
+		let body = b64.encode(serde_json::to_vec(&payload).unwrap());
+		format!("{header}.{body}.")
+	}
+
+	fn parse_form(body: &[u8]) -> HashMap<String, String> {
+		url::form_urlencoded::parse(body).into_owned().collect()
+	}
+
+	let exp = std::time::SystemTime::now()
+		.duration_since(std::time::UNIX_EPOCH)
+		.unwrap()
+		.as_secs()
+		+ 3600;
+	let obo_jwt = unsigned_jwt(json!({"sub": "obo-subject", "exp": exp}));
+	let obo_bearer = format!("Bearer {obo_jwt}");
+
+	// Mock STS: records each token-exchange request and returns the OBO JWT as an
+	// RFC 8693 token-exchange response.
+	let sts = MockServer::start().await;
+	let sts_bodies = Arc::new(StdMutex::new(Vec::<Vec<u8>>::new()));
+	let sts_paths = Arc::new(StdMutex::new(Vec::<String>::new()));
+	let sts_methods = Arc::new(StdMutex::new(Vec::<String>::new()));
+	{
+		let sts_bodies = sts_bodies.clone();
+		let sts_paths = sts_paths.clone();
+		let sts_methods = sts_methods.clone();
+		let token = obo_jwt.clone();
+		Mock::given(wiremock::matchers::any())
+			.respond_with(move |req: &wiremock::Request| {
+				sts_bodies.lock().unwrap().push(req.body.clone());
+				sts_paths.lock().unwrap().push(req.url.path().to_string());
+				sts_methods.lock().unwrap().push(req.method.to_string());
+				ResponseTemplate::new(200).set_body_json(json!({
+					"access_token": token,
+					"issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+					"token_type": "Bearer",
+				}))
+			})
+			.mount(&sts)
+			.await;
+	}
+
+	// Mock upstream: records the `authorization` header it receives so we can
+	// assert the OBO token was injected.
+	let upstream = MockServer::start().await;
+	let upstream_auth = Arc::new(StdMutex::new(Vec::<Option<String>>::new()));
+	{
+		let upstream_auth = upstream_auth.clone();
+		Mock::given(wiremock::matchers::any())
+			.respond_with(move |req: &wiremock::Request| {
+				let auth = req
+					.headers
+					.get("authorization")
+					.and_then(|v| v.to_str().ok())
+					.map(str::to_string);
+				upstream_auth.lock().unwrap().push(auth);
+				ResponseTemplate::new(200)
+			})
+			.mount(&upstream)
+			.await;
+	}
+
+	// Outer bind terminates the CONNECT tunnel; the inner (plain HTTP) bind is
+	// re-entered by authority port and carries the OBO policies.
+	let mut outer = simple_bind();
+	outer.key = strng::literal!("outer");
+	outer.address = "127.0.0.1:15008".parse().unwrap();
+	let mut inner = simple_bind();
+	inner.address = "127.0.0.1:18080".parse().unwrap();
+	let mut t = setup_proxy_test("{}")
+		.unwrap()
+		.with_backend(*upstream.address())
+		.with_bind(outer)
+		.with_bind(inner)
+		.with_route(basic_route(*upstream.address()))
+		.with_connect_mode_on_port(frontend::ConnectMode::Tunnel, 15008);
+
+	// ext-authz performs the RFC 8693 token exchange (actor from the CONNECT
+	// header, subject from the inner request's authorization header), caches the
+	// result keyed by subject+actor, and exposes the OBO token under `extauthz`.
+	// The transformation then injects it as the outbound `Authorization` header.
+	// Both token types are JWT: the enterprise STS `validateTokenType` accepts only
+	// `urn:ietf:params:oauth:token-type:jwt` and rejects `access_token`/`id_token`.
+	let body_expr = r#"form.encode({
+		"grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+		"subject_token": request.headers["authorization"].regexReplace("^Bearer ", ""),
+		"subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+		"actor_token": source.connectHeaders["x-actor-token"],
+		"actor_token_type": "urn:ietf:params:oauth:token-type:jwt",
+		"audience": "https://api.example.test"
+	})"#;
+	t.attach_route_policy(json!({
+		"extAuthz": {
+			"host": sts.address().to_string(),
+			"cache": {
+				"key": [
+					"request.headers[\"authorization\"]",
+					"source.connectHeaders[\"x-actor-token\"]"
+				],
+				"ttl": "extauthz.expires - 5",
+				"maxEntries": 1024
+			},
+			"protocol": {
+				"http": {
+					"path": "\"/token\"",
+					"addRequestHeaders": {
+						"content-type": "\"application/x-www-form-urlencoded\"",
+						":method": "\"POST\""
+					},
+					"body": body_expr,
+					"metadata": {
+						"token": "json(response.body).access_token",
+						"expires": "unvalidatedJwtPayload(json(response.body).access_token).exp"
+					}
+				}
+			}
+		},
+		"transformations": {
+			"request": {
+				"set": {
+					"authorization": "\"Bearer \" + extauthz.token"
+				}
+			}
+		}
+	}))
+	.await;
+
+	// Open a fresh CONNECT tunnel, optionally carrying the actor token, and send
+	// the inner request with the subject token. Returns the raw inner response.
+	async fn tunnel_request(t: &TestBind, actor: Option<&str>, subject: &str) -> String {
+		let mut io = t.serve_tunnel(strng::literal!("outer"));
+		let connect = match actor {
+			Some(a) => format!(
+				"CONNECT api.example.test:18080 HTTP/1.1\r\nHost: api.example.test:18080\r\nx-actor-token: {a}\r\n\r\n"
+			),
+			None => "CONNECT api.example.test:18080 HTTP/1.1\r\nHost: api.example.test:18080\r\n\r\n"
+				.to_string(),
+		};
+		io.write_all(connect.as_bytes()).await.unwrap();
+
+		let mut response = Vec::new();
+		loop {
+			let mut chunk = [0; 1024];
+			let n = io.read(&mut chunk).await.unwrap();
+			assert!(n > 0, "CONNECT response unexpectedly closed");
+			response.extend_from_slice(&chunk[..n]);
+			if response.windows(4).any(|w| w == b"\r\n\r\n") {
+				break;
+			}
+		}
+		assert!(
+			String::from_utf8_lossy(&response).starts_with("HTTP/1.1 200 OK\r\n"),
+			"unexpected CONNECT response: {}",
+			String::from_utf8_lossy(&response),
+		);
+
+		let inner = format!(
+			"GET /foo HTTP/1.1\r\nHost: lo\r\nauthorization: Bearer {subject}\r\nConnection: close\r\n\r\n"
+		);
+		io.write_all(inner.as_bytes()).await.unwrap();
+		let mut tunneled = Vec::new();
+		tokio::time::timeout(Duration::from_secs(5), io.read_to_end(&mut tunneled))
+			.await
+			.expect("timed out waiting for tunneled HTTP response")
+			.unwrap();
+		String::from_utf8_lossy(&tunneled).to_string()
+	}
+
+	// 1. First request: the OBO token is exchanged and injected upstream.
+	let resp1 = tunnel_request(&t, Some("actor-token-A"), "subject-token-S").await;
+	assert!(
+		resp1.starts_with("HTTP/1.1 200 OK\r\n"),
+		"unexpected inner response: {resp1}",
+	);
+	assert_eq!(
+		sts_bodies.lock().unwrap().len(),
+		1,
+		"STS should be called once"
+	);
+	// Upstream sees the OBO bearer, not the original subject token.
+	assert_eq!(
+		upstream_auth.lock().unwrap().last().unwrap().as_deref(),
+		Some(obo_bearer.as_str()),
+	);
+	// The STS request body is a well-formed RFC 8693 exchange built from both the
+	// actor (CONNECT header) and subject (inner authorization header) tokens.
+	let form = parse_form(&sts_bodies.lock().unwrap()[0]);
+	assert_eq!(
+		form.get("grant_type").map(String::as_str),
+		Some("urn:ietf:params:oauth:grant-type:token-exchange"),
+	);
+	assert_eq!(
+		form.get("subject_token").map(String::as_str),
+		Some("subject-token-S"),
+	);
+	assert_eq!(
+		form.get("actor_token").map(String::as_str),
+		Some("actor-token-A"),
+	);
+	assert_eq!(
+		form.get("audience").map(String::as_str),
+		Some("https://api.example.test"),
+	);
+	assert_eq!(
+		form.get("subject_token_type").map(String::as_str),
+		Some("urn:ietf:params:oauth:token-type:jwt"),
+	);
+	assert_eq!(
+		form.get("actor_token_type").map(String::as_str),
+		Some("urn:ietf:params:oauth:token-type:jwt"),
+	);
+	assert_eq!(sts_paths.lock().unwrap()[0], "/token");
+	assert_eq!(sts_methods.lock().unwrap()[0], "POST");
+
+	// 2. Cache hit: same subject+actor on a fresh tunnel reuses the cached OBO
+	// token without calling the STS again.
+	let resp2 = tunnel_request(&t, Some("actor-token-A"), "subject-token-S").await;
+	assert!(
+		resp2.starts_with("HTTP/1.1 200 OK\r\n"),
+		"unexpected inner response: {resp2}",
+	);
+	assert_eq!(
+		sts_bodies.lock().unwrap().len(),
+		1,
+		"cache hit: STS should not be called again",
+	);
+	assert_eq!(
+		upstream_auth.lock().unwrap().last().unwrap().as_deref(),
+		Some(obo_bearer.as_str()),
+	);
+
+	// 3. Cache miss: a different actor token (the cache key includes the actor)
+	// triggers a new exchange.
+	let resp3 = tunnel_request(&t, Some("actor-token-B"), "subject-token-S").await;
+	assert!(
+		resp3.starts_with("HTTP/1.1 200 OK\r\n"),
+		"unexpected inner response: {resp3}",
+	);
+	assert_eq!(
+		sts_bodies.lock().unwrap().len(),
+		2,
+		"different actor should miss the cache",
+	);
+	let form_b = parse_form(&sts_bodies.lock().unwrap()[1]);
+	assert_eq!(
+		form_b.get("actor_token").map(String::as_str),
+		Some("actor-token-B"),
+	);
+
+	// 4. Negative: without the actor token, the body expression fails to evaluate
+	// (indexing the missing CONNECT header errors), so the request is rejected and
+	// the STS is never called. This documents the dependency on the actor token.
+	let resp4 = tunnel_request(&t, None, "subject-token-S").await;
+	assert!(
+		resp4.starts_with("HTTP/1.1 403 Forbidden\r\n"),
+		"expected 403 without the actor token, got: {resp4}",
+	);
+	assert_eq!(
+		sts_bodies.lock().unwrap().len(),
+		2,
+		"rejected request must not call the STS",
+	);
+}
+
+/// Full assembled MITM + OBO chain in one test:
+///
+/// CONNECT (carrying `x-actor-token`) -> Tunnel re-entry by authority port into a
+/// dynamic-CA HTTPS bind -> inner TLS terminated with a minted per-SNI cert ->
+/// ext-authz RFC 8693 exchange (actor from `source.connectHeaders`, subject from
+/// the decrypted `authorization`, both JWT token types) -> mock STS returns the
+/// OBO -> `transformations` injects `Authorization: Bearer <obo>` -> a
+/// `dynamic: {}` (DFP) backend forwards to the upstream named by the inner Host.
+///
+/// This exercises the joints the OBO test and a plain authz test only prove
+/// separately: (1) re-entry by port into a TLS-terminating bind, (2) dynamic-CA
+/// minting a trusted per-SNI cert, (3) `ConnectHeaders` surviving
+/// `maybe_terminate_tls` into the OBO body, and (4) the decrypted request flowing
+/// into the `dynamic: {}` backend path.
+#[cfg(feature = "tls-aws-lc")]
+#[tokio::test]
+async fn connect_tunnel_dynamic_ca_obo_dynamic_backend() {
+	use std::collections::HashMap;
+
+	// SNI drives dynamic-CA cert minting; it must be a hostname (rustls sends no SNI
+	// for an IP). The DFP destination is taken from the inner request's `Host` and
+	// uses the upstream mock's address, so the two legitimately differ in the test.
+	const SNI: &str = "api.example.test";
+
+	fn unsigned_jwt(payload: serde_json::Value) -> String {
+		use base64::Engine;
+		let b64 = base64::prelude::BASE64_URL_SAFE_NO_PAD;
+		let header = b64.encode(br#"{"alg":"none","typ":"JWT"}"#);
+		let body = b64.encode(serde_json::to_vec(&payload).unwrap());
+		format!("{header}.{body}.")
+	}
+	fn parse_form(body: &[u8]) -> HashMap<String, String> {
+		url::form_urlencoded::parse(body).into_owned().collect()
+	}
+
+	let _ = rustls::crypto::CryptoProvider::install_default(Arc::unwrap_or_clone(
+		crate::transport::tls::provider(),
+	));
+
+	let exp = std::time::SystemTime::now()
+		.duration_since(std::time::UNIX_EPOCH)
+		.unwrap()
+		.as_secs()
+		+ 3600;
+	let obo_jwt = unsigned_jwt(json!({"sub": "obo-subject", "exp": exp}));
+	let obo_bearer = format!("Bearer {obo_jwt}");
+
+	// Mock STS: records the token-exchange request body and returns the OBO JWT.
+	let sts = MockServer::start().await;
+	let sts_bodies = Arc::new(StdMutex::new(Vec::<Vec<u8>>::new()));
+	{
+		let sts_bodies = sts_bodies.clone();
+		let token = obo_jwt.clone();
+		Mock::given(wiremock::matchers::any())
+			.respond_with(move |req: &wiremock::Request| {
+				sts_bodies.lock().unwrap().push(req.body.clone());
+				ResponseTemplate::new(200).set_body_json(json!({
+					"access_token": token,
+					"issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+					"token_type": "Bearer",
+				}))
+			})
+			.mount(&sts)
+			.await;
+	}
+
+	// Mock upstream: the `dynamic: {}` destination. Records the `authorization`
+	// header it receives so we can confirm the OBO was injected.
+	let upstream = MockServer::start().await;
+	let upstream_addr = upstream.address().to_string();
+	let upstream_auth = Arc::new(StdMutex::new(Vec::<Option<String>>::new()));
+	{
+		let upstream_auth = upstream_auth.clone();
+		Mock::given(wiremock::matchers::any())
+			.respond_with(move |req: &wiremock::Request| {
+				let auth = req
+					.headers
+					.get("authorization")
+					.and_then(|v| v.to_str().ok())
+					.map(str::to_string);
+				upstream_auth.lock().unwrap().push(auth);
+				ResponseTemplate::new(200)
+			})
+			.mount(&upstream)
+			.await;
+	}
+
+	// Generate a self-signed CA; the dynamic-CA inner bind mints a leaf per SNI, and
+	// the inner TLS client trusts it as its root.
+	let ca_key = rcgen::KeyPair::generate().expect("generate CA key");
+	let mut ca_params = rcgen::CertificateParams::default();
+	ca_params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+	let ca_cert = ca_params.self_signed(&ca_key).expect("generate CA cert");
+	let ca_cert_pem = ca_cert.pem().into_bytes();
+
+	let tls_config = crate::types::agent::ServerTLSConfig::dynamic_ca_with_profile(
+		ca_cert_pem.clone(),
+		ca_key.serialize_pem().into_bytes(),
+		vec![b"http/1.1".to_vec()],
+		None,
+		None,
+		None,
+		None,
+		Default::default(),
+	)
+	.expect("build dynamic CA TLS config");
+
+	// Outer bind terminates the CONNECT tunnel via the bind-level `tunnelProtocol: Connect`
+	let mut outer = simple_bind();
+	outer.key = strng::literal!("outer");
+	outer.address = "127.0.0.1:15010".parse().unwrap();
+	outer.tunnel_protocol = TunnelProtocol::Connect;
+	// Inner bind terminates TLS with the dynamic CA (empty hostname = match any SNI).
+	let inner = Bind {
+		key: BIND_KEY,
+		address: "127.0.0.1:18082".parse().unwrap(),
+		listeners: ListenerSet::from_list([Listener {
+			key: LISTENER_KEY,
+			name: Default::default(),
+			hostname: Default::default(),
+			protocol: ListenerProtocol::HTTPS(tls_config),
+		}]),
+		protocol: BindProtocol::tls,
+		tunnel_protocol: Default::default(),
+	};
+
+	// `dynamic: {}` backend: the upstream is resolved from the decrypted request's
+	// Host/authority (DFP), proven on direct requests by `dfp_uses_host_port`.
+	let dynamic_backend = Backend::Dynamic(ResourceName::new("dynamic".into(), "".into()), ());
+	let t = setup_proxy_test("{}").unwrap();
+	t.inputs()
+		.stores
+		.binds
+		.write()
+		.insert_backend(dynamic_backend.name(), dynamic_backend.into());
+	let mut t = t
+		.with_bind(outer)
+		.with_bind(inner)
+		.with_route(basic_named_route("/dynamic".into()));
+
+	// Both token types are JWT (the enterprise STS rejects `access_token`); the
+	// actor is the surviving CONNECT header, the subject the decrypted authorization.
+	let body_expr = r#"form.encode({
+		"grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+		"subject_token": request.headers["authorization"].regexReplace("^Bearer ", ""),
+		"subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+		"actor_token": source.connectHeaders["x-actor-token"],
+		"actor_token_type": "urn:ietf:params:oauth:token-type:jwt",
+		"audience": request.host
+	})"#;
+	t.attach_route_policy(json!({
+		"extAuthz": {
+			"host": sts.address().to_string(),
+			"protocol": {
+				"http": {
+					"path": "\"/token\"",
+					"addRequestHeaders": {
+						"content-type": "\"application/x-www-form-urlencoded\"",
+						":method": "\"POST\""
+					},
+					"body": body_expr,
+					"metadata": {
+						"token": "json(response.body).access_token"
+					}
+				}
+			}
+		},
+		"transformations": {
+			"request": {
+				"set": {
+					"authorization": "\"Bearer \" + extauthz.token"
+				}
+			}
+		}
+	}))
+	.await;
+
+	// Open a CONNECT tunnel (optionally carrying the actor token), run an inner TLS
+	// handshake over the tunnel trusting the generated CA, then send an HTTPS request
+	// whose Host names the DFP upstream. The handshake is expected to succeed in all
+	// cases; the status reflects whether the OBO exchange (and thus the actor header)
+	// completed.
+	async fn tls_tunnel_request(
+		t: &TestBind,
+		ca_pem: &[u8],
+		upstream_host: &str,
+		actor: Option<&str>,
+	) -> StatusCode {
+		let mut io = t.serve_tunnel(strng::literal!("outer"));
+		let connect = match actor {
+			Some(a) => {
+				format!("CONNECT {SNI}:18082 HTTP/1.1\r\nHost: {SNI}:18082\r\nx-actor-token: {a}\r\n\r\n")
+			},
+			None => format!("CONNECT {SNI}:18082 HTTP/1.1\r\nHost: {SNI}:18082\r\n\r\n"),
+		};
+		io.write_all(connect.as_bytes()).await.unwrap();
+
+		let mut response = Vec::new();
+		loop {
+			let mut chunk = [0; 1024];
+			let n = io.read(&mut chunk).await.unwrap();
+			assert!(n > 0, "CONNECT response unexpectedly closed");
+			response.extend_from_slice(&chunk[..n]);
+			if response.windows(4).any(|w| w == b"\r\n\r\n") {
+				break;
+			}
+		}
+		assert!(
+			String::from_utf8_lossy(&response).starts_with("HTTP/1.1 200 OK\r\n"),
+			"unexpected CONNECT response: {}",
+			String::from_utf8_lossy(&response),
+		);
+
+		// Inner TLS handshake as a client trusting the generated CA. Success proves
+		// re-entry-by-port reached the dynamic-CA bind and it minted a trusted cert
+		// for the SNI.
+		let client_tls: crate::http::backendtls::BackendTLS =
+			crate::http::backendtls::ResolvedBackendTLS {
+				root: Some(ca_pem.to_vec()),
+				hostname: Some(SNI.to_string()),
+				alpn: Some(vec!["http/1.1".to_string()]),
+				..Default::default()
+			}
+			.try_into()
+			.unwrap();
+		let tls = TlsConnector::from(client_tls.base_config().config)
+			.connect(ServerName::try_from(SNI.to_string()).unwrap(), io)
+			.await
+			.expect("inner TLS handshake should succeed (dynamic CA mints a trusted cert)");
+
+		let (mut sender, conn) = http1::handshake(TokioIo::new(tls)).await.unwrap();
+		let conn = tokio::spawn(conn);
+		let res = sender
+			.send_request(
+				::http::Request::builder()
+					.method(Method::GET)
+					.uri("/foo")
+					.header(header::HOST, upstream_host)
+					.header(header::AUTHORIZATION, "Bearer subject-token-S")
+					.header(header::CONNECTION, "close")
+					.body(Body::empty())
+					.unwrap(),
+			)
+			.await
+			.unwrap();
+		let status = res.status();
+		conn.abort();
+		status
+	}
+
+	// Actor token present: the handshake succeeds, the OBO is exchanged (JWT types)
+	// and injected, and the DFP upstream receives `Bearer <obo>` (200).
+	assert_eq!(
+		tls_tunnel_request(&t, &ca_cert_pem, &upstream_addr, Some("actor-token-A")).await,
+		StatusCode::OK,
+	);
+	assert_eq!(
+		sts_bodies.lock().unwrap().len(),
+		1,
+		"STS should be called once"
+	);
+	assert_eq!(
+		upstream_auth.lock().unwrap().last().unwrap().as_deref(),
+		Some(obo_bearer.as_str()),
+		"DFP upstream must receive the injected OBO token",
+	);
+	// The exchange body is well-formed: actor from the surviving CONNECT header,
+	// subject from the decrypted request, JWT token types, audience = inner Host.
+	let form = parse_form(&sts_bodies.lock().unwrap()[0]);
+	assert_eq!(
+		form.get("grant_type").map(String::as_str),
+		Some("urn:ietf:params:oauth:grant-type:token-exchange"),
+	);
+	assert_eq!(
+		form.get("subject_token").map(String::as_str),
+		Some("subject-token-S"),
+	);
+	assert_eq!(
+		form.get("actor_token").map(String::as_str),
+		Some("actor-token-A"),
+	);
+	assert_eq!(
+		form.get("subject_token_type").map(String::as_str),
+		Some("urn:ietf:params:oauth:token-type:jwt"),
+	);
+	assert_eq!(
+		form.get("actor_token_type").map(String::as_str),
+		Some("urn:ietf:params:oauth:token-type:jwt"),
+	);
+	assert_eq!(
+		form.get("audience").map(String::as_str),
+		Some(upstream_addr.as_str())
+	);
+
+	// Actor token absent: the handshake still succeeds (TLS termination is
+	// independent of the actor), but the OBO body fails to evaluate, so the request
+	// is rejected (403) and neither the STS nor the upstream sees a second call.
+	assert_eq!(
+		tls_tunnel_request(&t, &ca_cert_pem, &upstream_addr, None).await,
+		StatusCode::FORBIDDEN,
+	);
+	assert_eq!(
+		sts_bodies.lock().unwrap().len(),
+		1,
+		"rejected request must not call the STS",
+	);
+	assert_eq!(
+		upstream_auth.lock().unwrap().len(),
+		1,
+		"rejected request must not reach the upstream",
 	);
 }
 


### PR DESCRIPTION
Currently, a bind with `tunnelProtocol: Connect` serves the CONNECT request directly on the raw socket in `handle_tunnel`, ignoring the listener's TLS config, so the CONNECT request and its headers are always in plaintext even on an HTTPS bind.

This change terminate the outer TLS via `maybe_terminate_tls` before serving CONNECT when the bind is TLS `BindProtocol::tls`, then tunnel over the terminated stream. Plaintext `http` binds are unchanged, and any inner TLS is still terminated separately when the tunnel re-enters the destination bind.

Adds the following tests:
- connect_tunnel_obo_exchange_injects_token: CONNECT -> re-entry -> ext-authz RFC 8693 token exchange -> mock STS -> transformation injects the returned token -> upstream; asserts injection, body correctness, cache hit/miss, and rejection without the connect header.
- connect_tunnel_dynamic_ca_obo_dynamic_backend: the full MITM chain - re-entry into a dynamic-CA TLS-terminating bind, per-SNI cert minting, ConnectHeaders surviving maybe_terminate_tls, the exchange, and a dynamic: {} (DFP) backend resolved from the decrypted inner Host.
- connect_tunnel_terminates_outer_tls: an HTTPS `tunnelProtocol: Connect` bind; asserts the client TLS-handshakes to the outer bind and a header carried on the encrypted CONNECT reaches `source.connectHeaders` on the re-entered request.