### PR TITLE
Add h2c inference routing tests

### DIFF
--- a/controller/pkg/syncer/service_test.go
+++ b/controller/pkg/syncer/service_test.go
@@ -1,0 +1,75 @@
+package syncer
+
+import (
+	"testing"
+
+	"istio.io/istio/pkg/workloadapi"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	inf "sigs.k8s.io/gateway-api-inference-extension/api/v1"
+)
+
+func TestToInferencePoolAppProtocol(t *testing.T) {
+	testCases := []struct {
+		name        string
+		appProtocol inf.AppProtocol
+		want        workloadapi.AppProtocol
+	}{
+		{
+			name:        "h2c",
+			appProtocol: inf.AppProtocolH2C,
+			want:        workloadapi.AppProtocol_HTTP2,
+		},
+		{
+			name:        "http",
+			appProtocol: inf.AppProtocolHTTP,
+			want:        workloadapi.AppProtocol_HTTP11,
+		},
+		{
+			name: "unspecified",
+			want: workloadapi.AppProtocol_HTTP11,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := toInferencePoolAppProtocol(tc.appProtocol)
+			if got != tc.want {
+				t.Fatalf("toInferencePoolAppProtocol(%q) = %v, want %v", tc.appProtocol, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestInferencePoolBuilderPropagatesH2CAppProtocol(t *testing.T) {
+	pool := &inf.InferencePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "models",
+			Namespace: "default",
+		},
+		Spec: inf.InferencePoolSpec{
+			Selector: inf.LabelSelector{
+				MatchLabels: map[inf.LabelKey]inf.LabelValue{
+					"app": "models",
+				},
+			},
+			TargetPorts: []inf.Port{
+				{Number: 8000},
+				{Number: 8001},
+			},
+			AppProtocol: inf.AppProtocolH2C,
+		},
+	}
+
+	info := InferencePoolBuilder()(nil, pool)
+	if info == nil || info.Service == nil {
+		t.Fatalf("InferencePoolBuilder returned nil service info")
+	}
+	if len(info.Service.Ports) != len(pool.Spec.TargetPorts) {
+		t.Fatalf("got %d ports, want %d", len(info.Service.Ports), len(pool.Spec.TargetPorts))
+	}
+	for _, port := range info.Service.Ports {
+		if port.AppProtocol != workloadapi.AppProtocol_HTTP2 {
+			t.Fatalf("port %d AppProtocol = %v, want %v", port.ServicePort, port.AppProtocol, workloadapi.AppProtocol_HTTP2)
+		}
+	}
+}

--- a/crates/agentgateway/src/http/ext_proc_tests.rs
+++ b/crates/agentgateway/src/http/ext_proc_tests.rs
@@ -35,7 +35,7 @@ use crate::types::agent::{
 	BackendTarget, BackendTrafficPolicy, PolicyInheritance, PolicyTarget, SimpleBackendReference,
 	Target, TargetedPolicy,
 };
-use crate::types::discovery::NamespacedHostname;
+use crate::types::discovery::{AppProtocol, NamespacedHostname};
 use crate::*;
 
 // Processing-option decoding and default behavior.
@@ -2265,6 +2265,10 @@ async fn named_backend(body: &'static str) -> MockServer {
 }
 
 fn configure_standalone_service(t: &TestBind) {
+	configure_standalone_service_with_app_protocol(t, None);
+}
+
+fn configure_standalone_service_with_app_protocol(t: &TestBind, app_protocol: Option<AppProtocol>) {
 	use crate::types::discovery::{NetworkAddress, Service};
 
 	let service = Service {
@@ -2276,6 +2280,9 @@ fn configure_standalone_service(t: &TestBind) {
 			address: "127.0.0.1".parse().unwrap(),
 		}],
 		ports: HashMap::from([(STANDALONE_SERVICE_PORT, STANDALONE_SERVICE_PORT)]),
+		app_protocols: app_protocol
+			.map(|app_protocol| HashMap::from([(STANDALONE_SERVICE_PORT, app_protocol)]))
+			.unwrap_or_default(),
 		..Default::default()
 	};
 
@@ -2405,6 +2412,67 @@ mod standalone_inference_routing {
 				.len(),
 			1,
 			"EPP-selected endpoint should receive traffic",
+		);
+	}
+
+	#[tokio::test]
+	async fn standalone_inference_routing_h2c_service_uses_http2_upstream_for_grpc() {
+		let backend = simple_mock().await;
+		let backend_addr = *backend.address();
+		let request_headers_seen = Arc::new(AtomicUsize::new(0));
+		let ext_proc = ExtProcMock::new({
+			let request_headers_seen = request_headers_seen.clone();
+			move || StandaloneInferenceRouter::new(Some(backend_addr), request_headers_seen.clone())
+		})
+		.spawn()
+		.await;
+
+		let mut t = setup_proxy_test("{}").unwrap().with_bind(simple_bind());
+		configure_standalone_service_with_app_protocol(&t, Some(AppProtocol::Http2));
+		t.attach_route(json!({
+			"name": "standalone-epp-grpc",
+			"backends": [
+				{
+					"service": {
+						"name": STANDALONE_SERVICE_REF,
+						"port": STANDALONE_SERVICE_PORT,
+					},
+					"policies": {
+						"inferenceRouting": {
+							"endpointPicker": {
+								"host": ext_proc.address.to_string(),
+							},
+							"destinationMode": "passthrough",
+						},
+					},
+				}
+			],
+		}))
+		.await;
+		let io = t.serve_http2(BIND_KEY);
+
+		let res = crate::proxy::request_builder::RequestBuilder::new(
+			Method::POST,
+			"http://lo/inference.GRPC/Generate",
+		)
+		.version(::http::Version::HTTP_2)
+		.header(::http::header::CONTENT_TYPE, "application/grpc")
+		.body(Body::from(vec![0, 0, 0, 0, 0]))
+		.send(io)
+		.await
+		.unwrap();
+		assert_eq!(res.status(), 200);
+
+		let upstream = read_body(res.into_body()).await;
+		assert_eq!(upstream.version, ::http::Version::HTTP_2);
+		assert_eq!(
+			upstream.headers.get(::http::header::CONTENT_TYPE).unwrap(),
+			"application/grpc",
+		);
+		assert_eq!(
+			request_headers_seen.load(Ordering::SeqCst),
+			1,
+			"gRPC inference routing should consult EPP before the HTTP/2 upstream call",
 		);
 	}
 


### PR DESCRIPTION
- Adds controller coverage for InferencePool h2c appProtocol translation.
- Adds runtime coverage for gRPC inference routing over HTTP/2.

Fixes: #1385