### PR TITLE
Release standalone Helm chart

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -693,6 +693,7 @@ jobs:
           **Helm charts** are available:
           * `cr.agentgateway.dev/charts/agentgateway:v${{ env.VERSION }}`
           * `cr.agentgateway.dev/charts/agentgateway-crds:v${{ env.VERSION }}`
+          * `cr.agentgateway.dev/charts/agentgateway-standalone:v${{ env.VERSION }}`
 
           **Binaries** for `agentgateway` and the `agctl` CLI are available below.
 

--- a/controller/Makefile
+++ b/controller/Makefile
@@ -509,10 +509,11 @@ HELM_PACKAGE_ARGS ?= --version $(HELM_CHART_VERSION_NO_V) --app-version $(HELM_C
 EXTRA_HELM_TAG ?=
 HELM_CHART_DIR_AGW=install/helm/agentgateway
 HELM_CHART_DIR_AGW_CRD=install/helm/agentgateway-crds
+HELM_CHART_DIR_AGW_STANDALONE=install/helm/agentgateway-standalone
 HELM_ADDITIONAL_VALUES ?= hack/helm/dev.yaml
 
 .PHONY: package-agentgateway-charts
-package-agentgateway-charts: package-agentgateway-chart package-agentgateway-crd-chart ## Package the agentgateway charts
+package-agentgateway-charts: package-agentgateway-chart package-agentgateway-crd-chart package-agentgateway-standalone-chart ## Package the agentgateway charts
 
 .PHONY: package-agentgateway-chart
 package-agentgateway-chart: ## Package the agentgateway chart
@@ -526,7 +527,13 @@ package-agentgateway-crd-chart: ## Package the agentgateway crd chart
 	$(HELM) package $(HELM_PACKAGE_ARGS) --destination $(TEST_ASSET_DIR) $(HELM_CHART_DIR_AGW_CRD); \
 	$(HELM) repo index $(TEST_ASSET_DIR);
 
-CHART_NAMES := agentgateway agentgateway-crds
+.PHONY: package-agentgateway-standalone-chart
+package-agentgateway-standalone-chart: ## Package the standalone agentgateway chart
+	mkdir -p $(TEST_ASSET_DIR); \
+	$(HELM) package $(HELM_PACKAGE_ARGS) --destination $(TEST_ASSET_DIR) $(HELM_CHART_DIR_AGW_STANDALONE); \
+	$(HELM) repo index $(TEST_ASSET_DIR);
+
+CHART_NAMES := agentgateway agentgateway-crds agentgateway-standalone
 
 .PHONY: release-charts
 release-charts: package-agentgateway-charts
@@ -536,12 +543,18 @@ release-charts: package-agentgateway-charts
 	mkdir -p $(TEST_ASSET_DIR); \
 	$(HELM) package --version $(HELM_CHART_VERSION_V) --app-version $(HELM_CHART_VERSION_V) --destination $(TEST_ASSET_DIR) $(HELM_CHART_DIR_AGW_CRD); \
 	$(HELM) repo index $(TEST_ASSET_DIR);
+	mkdir -p $(TEST_ASSET_DIR); \
+	$(HELM) package --version $(HELM_CHART_VERSION_V) --app-version $(HELM_CHART_VERSION_V) --destination $(TEST_ASSET_DIR) $(HELM_CHART_DIR_AGW_STANDALONE); \
+	$(HELM) repo index $(TEST_ASSET_DIR);
 	@if [ -n "$(EXTRA_HELM_TAG)" ]; then \
 		mkdir -p $(TEST_ASSET_DIR); \
 		$(HELM) package --version $(EXTRA_HELM_TAG) --app-version $(VERSION) --destination $(TEST_ASSET_DIR) $(HELM_CHART_DIR_AGW); \
 		$(HELM) repo index $(TEST_ASSET_DIR); \
 		mkdir -p $(TEST_ASSET_DIR); \
 		$(HELM) package --version $(EXTRA_HELM_TAG) --app-version $(VERSION) --destination $(TEST_ASSET_DIR) $(HELM_CHART_DIR_AGW_CRD); \
+		$(HELM) repo index $(TEST_ASSET_DIR); \
+		mkdir -p $(TEST_ASSET_DIR); \
+		$(HELM) package --version $(EXTRA_HELM_TAG) --app-version $(VERSION) --destination $(TEST_ASSET_DIR) $(HELM_CHART_DIR_AGW_STANDALONE); \
 		$(HELM) repo index $(TEST_ASSET_DIR); \
 	fi
 	@for chart in $(CHART_NAMES); do \
@@ -569,6 +582,7 @@ deploy-agentgateway-chart: ## Deploy the agentgateway chart
 lint-charts: ## Lint the agentgateway charts
 	$(HELM) lint $(HELM_CHART_DIR_AGW)
 	$(HELM) lint $(HELM_CHART_DIR_AGW_CRD)
+	$(HELM) lint $(HELM_CHART_DIR_AGW_STANDALONE)
 
 #----------------------------------------------------------------------------------
 # Release


### PR DESCRIPTION
## Summary
- Package the standalone Helm chart in the shared chart packaging target.
- Include agentgateway-standalone in release chart packaging and OCI push loops, including v-prefixed and extra nightly Helm tags.
- Lint the standalone chart with the other Helm charts and list it in release notes.

## Testing
- make -n -C controller release-charts VERSION=1.2.3 EXTRA_HELM_TAG=0.0.0-latest-dev | rg 'agentgateway-standalone|for chart'
- make -C controller lint-charts
- make -C controller package-agentgateway-charts VERSION=1.2.3 TEST_ASSET_DIR=/tmp/agw-chart-packages
- helm package --version v1.2.3 --app-version v1.2.3 --destination /tmp/agw-chart-packages-v controller/install/helm/agentgateway-standalone
- helm package --version 0.0.0-latest-dev --app-version 1.2.3 --destination /tmp/agw-chart-packages-extra controller/install/helm/agentgateway-standalone
- git diff --check