### PR TITLE
feat(ui): detect Claude subscription misuse and show warning

### DIFF
--- a/ui/src/claudeSubscription.ts
+++ b/ui/src/claudeSubscription.ts
@@ -60,7 +60,7 @@ export function claudeSubscriptionWarning(
 
   return (
     "This model uses a Claude subscription key (sk-ant-oat…). " +
-    "Anthropic requires the client to identify as Claude Code " +
-    "for sonnet and opus models on subscription plans."
+    "Anthropic maybe reject clients other than Claude Code " +
+    "for Sonnet and Opus models with subscription key."
   );
 }

--- a/ui/src/claudeSubscription.ts
+++ b/ui/src/claudeSubscription.ts
@@ -1,0 +1,66 @@
+import { providerLabel, providerReferenceName } from "./config";
+import type { LlmModel, LlmProvider } from "./types";
+
+/**
+ * Claude subscription tokens use the `sk-ant-oat` prefix.
+ * Returns true if the value looks like a Claude subscription key.
+ */
+export function isClaudeSubscriptionKey(apiKey: unknown): boolean {
+  return typeof apiKey === "string" && apiKey.startsWith("sk-ant-oat");
+}
+
+/**
+ * Resolves the literal backend API key string for a model, following
+ * provider references if needed.  Returns null when the key is not a
+ * plain string (env-var reference, file reference, or absent).
+ */
+export function resolveBackendApiKey(
+  model: LlmModel | undefined,
+  providers: LlmProvider[],
+): string | null {
+  if (!model) return null;
+
+  // Direct key on the model params takes priority.
+  const directKey = model.params?.apiKey;
+  if (typeof directKey === "string" && directKey.trim()) return directKey;
+
+  // If the model uses a provider reference, look up that provider's key.
+  const refName = providerReferenceName(model.provider);
+  if (refName) {
+    const provider = providers.find((item) => item.name === refName);
+    const refKey = provider?.params?.apiKey;
+    if (typeof refKey === "string" && refKey.trim()) return refKey;
+  }
+
+  return null;
+}
+
+/**
+ * Returns a user-facing warning string if the selected model is backed
+ * by a Claude subscription key, or null when no warning applies.
+ */
+export function claudeSubscriptionWarning(
+  model: LlmModel | undefined,
+  providers: LlmProvider[],
+): string | null {
+  if (!model) return null;
+
+  const provider = providerLabel(model.provider);
+  const refName = providerReferenceName(model.provider);
+  const resolvedProvider = refName
+    ? providerLabel(
+        providers.find((item) => item.name === refName)?.provider ?? null,
+      )
+    : provider;
+
+  if (resolvedProvider !== "anthropic") return null;
+
+  const apiKey = resolveBackendApiKey(model, providers);
+  if (!isClaudeSubscriptionKey(apiKey)) return null;
+
+  return (
+    "This model uses a Claude subscription key (sk-ant-oat…). " +
+    "Anthropic requires the client to identify as Claude Code " +
+    "for sonnet and opus models on subscription plans."
+  );
+}

--- a/ui/src/pages/ClientSetup.tsx
+++ b/ui/src/pages/ClientSetup.tsx
@@ -10,6 +10,7 @@ import {
   StatusBanner,
 } from "../components/Primitives";
 import { CatalogModelSelector } from "../components/CatalogModelSelector";
+import { claudeSubscriptionWarning } from "../claudeSubscription";
 import { hasKeyValue, keyLabel, maskKey } from "../credentialDisplay";
 import { gatewayOrigin } from "../gatewayUrls";
 import { useGatewayConfig } from "../hooks";
@@ -131,6 +132,17 @@ export function ClientSetupPage() {
       {modelOptions.length === 0 && !config.isLoading ? (
         <StatusBanner state="warn" title="No models configured">
           Create an LLM model before wiring clients to the gateway.
+        </StatusBanner>
+      ) : null}
+      {claudeSubscriptionWarning(
+        selectedModelConfig,
+        config.data?.llm?.providers ?? [],
+      ) ? (
+        <StatusBanner state="warn" title="Claude subscription key detected">
+          {claudeSubscriptionWarning(
+            selectedModelConfig,
+            config.data?.llm?.providers ?? [],
+          )}
         </StatusBanner>
       ) : null}
 

--- a/ui/src/pages/Playground.tsx
+++ b/ui/src/pages/Playground.tsx
@@ -13,6 +13,7 @@ import {
   User,
 } from "lucide-react";
 import { sendChatCompletion, sendMcpJsonRpc } from "../api/playgroundApi";
+import { claudeSubscriptionWarning } from "../claudeSubscription";
 import { providerLabel } from "../config";
 import { applyPlaygroundCors, corsNeedsUpdate, currentOrigin } from "../cors";
 import { hasKeyValue, keyLabel } from "../credentialDisplay";
@@ -562,6 +563,11 @@ export function PlaygroundPage() {
       {modelOptions.length === 0 ? (
         <StatusBanner state="warn" title="No configured models">
           Create a model before testing chat traffic.
+        </StatusBanner>
+      ) : null}
+      {claudeSubscriptionWarning(selectedModelConfig, providers) ? (
+        <StatusBanner state="warn" title="Claude subscription key detected">
+          {claudeSubscriptionWarning(selectedModelConfig, providers)}
         </StatusBanner>
       ) : null}
       {error ? (

--- a/ui/tests/e2e/fixtures.ts
+++ b/ui/tests/e2e/fixtures.ts
@@ -423,3 +423,19 @@ async function json(
     body: JSON.stringify(body),
   });
 }
+
+export function configWithClaudeSubscriptionKey(): TestConfig {
+  const config = populatedConfig();
+  const llm = config.llm as {
+    models: Array<Record<string, unknown>>;
+    providers?: unknown[];
+  };
+  llm.models.push({
+    name: "claude-sub",
+    provider: "anthropic",
+    params: {
+      apiKey: "sk-ant-oat01-testkey1234567890abcdef",
+    },
+  });
+  return config;
+}

--- a/ui/tests/e2e/ui.spec.ts
+++ b/ui/tests/e2e/ui.spec.ts
@@ -1,5 +1,10 @@
 import { expect, test } from "@playwright/test";
-import { emptyConfig, mockGateway, populatedConfig } from "./fixtures";
+import {
+  configWithClaudeSubscriptionKey,
+  emptyConfig,
+  mockGateway,
+  populatedConfig,
+} from "./fixtures";
 
 const pages = [
   ["/", "Gateway Overview"],
@@ -448,6 +453,48 @@ test("edits listener and route policies from traffic drawers", async ({
     routePolicy.binds?.[0].listeners[0].routes?.[0].policies?.cors
       ?.allowOrigins,
   ).toContain("http://127.0.0.1:19100");
+});
+
+test("Playground shows Claude subscription key warning", async ({ page }) => {
+  await mockGateway(page, configWithClaudeSubscriptionKey());
+  await page.goto("/llm/playground");
+
+  await page.getByRole("combobox", { name: "Model" }).click();
+  await page.getByRole("option", { name: /claude-sub/ }).click();
+
+  await expect(
+    page.getByText("Claude subscription key detected"),
+  ).toBeVisible();
+  await expect(page.getByText("sk-ant-oat")).toBeVisible();
+});
+
+test("Client Setup shows Claude subscription key warning", async ({
+  page,
+}) => {
+  await mockGateway(page, configWithClaudeSubscriptionKey());
+  await page.goto("/llm/client-setup");
+
+  await page.getByRole("combobox", { name: "Model" }).click();
+  await page.getByRole("option", { name: /claude-sub/ }).click();
+
+  await expect(
+    page.getByText("Claude subscription key detected"),
+  ).toBeVisible();
+  await expect(page.getByText("sk-ant-oat")).toBeVisible();
+});
+
+test("no Claude subscription warning for env-var API keys", async ({
+  page,
+}) => {
+  await mockGateway(page);
+  await page.goto("/llm/playground");
+
+  await page.getByRole("combobox", { name: "Model" }).click();
+  await page.getByRole("option", { name: /anthropic/ }).click();
+
+  await expect(
+    page.getByText("Claude subscription key detected"),
+  ).toHaveCount(0);
 });
 
 function emptyConfigWithModels() {


### PR DESCRIPTION
This PR introduces a warning in the UI when a user selects an Anthropic model that is backed by a Claude subscription key (sk-ant-oat...).

**Anthropic** requires clients to identify as "Claude Code" for Sonnet and Opus models on subscription plans. By detecting these keys and displaying a warning banner, we ensure users are aware of this limitation before they encounter unexpected errors when wiring clients to the gateway or testing in the playground.
