### PR TITLE
mcp: reconcile session target roster on reuse

### DIFF
--- a/crates/agentgateway/src/mcp/handler.rs
+++ b/crates/agentgateway/src/mcp/handler.rs
@@ -526,6 +526,23 @@ impl Relay {
 		}
 		Ok(())
 	}
+
+	pub fn fork_with_inputs(&self, inputs: &RelayInputs) -> Result<Relay, mcp::Error> {
+		let new = Relay::new(
+			inputs.backend.clone(),
+			inputs.policies.clone(),
+			inputs.client.clone(),
+		)?;
+		for (name, old) in self.upstreams.iter_named() {
+			if let Ok(new_up) = new.upstreams.get(name.as_str())
+				&& let Some(s) = old.get_session_state()
+			{
+				new_up.set_session_id(s.session.as_deref(), s.backend);
+			}
+		}
+		Ok(new)
+	}
+
 	pub fn is_multiplexing(&self) -> bool {
 		self.upstreams.is_multiplexing
 	}

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -13,7 +13,7 @@ use secrecy::SecretString;
 use crate::http::auth::BackendAuthKind;
 use crate::http::authorization::{PolicySet, RuleSet};
 use crate::http::sessionpersistence::MCPSession;
-use crate::mcp::handler::Relay;
+use crate::mcp::handler::{Relay, RelayInputs};
 use crate::mcp::router::{McpBackendGroup, McpTarget};
 use crate::mcp::{FailureMode, McpAuthorization, guardrails};
 use crate::proxy::httpproxy::PolicyClient;
@@ -4495,6 +4495,119 @@ async fn test_all_targets_fail_open_still_errors() {
 	let client = PolicyClient::new(setup_proxy_test("{}").unwrap().pi);
 	let err = crate::mcp::upstream::UpstreamGroup::new(client, backend).unwrap_err();
 	assert!(matches!(err, crate::mcp::Error::NoBackends));
+}
+
+#[tokio::test]
+async fn reconcile_forks_roster_and_preserves_surviving_sessions() {
+	let mock_a = mock_streamable_http_server(true).await;
+	let mock_b = mock_streamable_http_server(true).await;
+	let mock_c = mock_streamable_http_server(true).await;
+	let client = PolicyClient::new(setup_proxy_test("{}").unwrap().pi);
+	let relay = Relay::new(
+		McpBackendGroup {
+			targets: vec![
+				fake_streamable_target("a", mock_a.addr),
+				fake_streamable_target("b", mock_b.addr),
+			],
+			stateful: true,
+			..Default::default()
+		},
+		empty_mcp_policies(),
+		client.clone(),
+	)
+	.unwrap();
+	// Simulate target "a" having an established upstream session.
+	relay
+		.upstreams
+		.get("a")
+		.unwrap()
+		.set_session_id(Some("sid-a"), None);
+
+	// Unchanged roster: no reconcile. Changed roster {a,b} -> {a,c}: reconcile.
+	let new_targets = vec![
+		fake_streamable_target("a", mock_a.addr),
+		fake_streamable_target("c", mock_c.addr),
+	];
+	assert!(!relay.upstreams.should_reconcile(&[
+		fake_streamable_target("a", mock_a.addr),
+		fake_streamable_target("b", mock_b.addr),
+	]));
+	assert!(relay.upstreams.should_reconcile(&new_targets));
+
+	let inputs = RelayInputs {
+		backend: McpBackendGroup {
+			targets: new_targets,
+			stateful: true,
+			..Default::default()
+		},
+		policies: empty_mcp_policies(),
+		mcp_guardrails: None,
+		client,
+	};
+	let forked = relay.fork_with_inputs(&inputs).unwrap();
+
+	// Surviving target keeps its upstream session; the removed one is gone and
+	// the new one starts fresh.
+	assert_eq!(
+		forked
+			.upstreams
+			.get("a")
+			.unwrap()
+			.get_session_state()
+			.and_then(|s| s.session)
+			.as_deref(),
+		Some("sid-a")
+	);
+	assert!(
+		forked
+			.upstreams
+			.get("c")
+			.unwrap()
+			.get_session_state()
+			.and_then(|s| s.session)
+			.is_none()
+	);
+	assert!(forked.upstreams.get("b").is_err());
+}
+
+#[tokio::test]
+async fn reconcile_skips_non_streamable_rosters() {
+	let mock_a = mock_streamable_http_server(true).await;
+	let client = PolicyClient::new(setup_proxy_test("{}").unwrap().pi);
+	let relay = Relay::new(
+		McpBackendGroup {
+			targets: vec![
+				fake_streamable_target("a", mock_a.addr),
+				// Nonexistent binary + failOpen: setup skips it, but it stays in
+				// the configured roster, so the relay is not all-streamable.
+				Arc::new(McpTarget {
+					name: "s".into(),
+					spec: crate::types::agent::McpTargetSpec::Stdio {
+						cmd: "this-binary-does-not-exist-agentgateway-test".into(),
+						args: vec![],
+						env: Default::default(),
+						clear_env: false,
+					},
+					backend_policies: Default::default(),
+					backend: None,
+					always_use_prefix: false,
+				}),
+			],
+			stateful: true,
+			failure_mode: FailureMode::FailOpen,
+			..Default::default()
+		},
+		empty_mcp_policies(),
+		client,
+	)
+	.unwrap();
+	// Roster change to {a}, but the current relay has a non-streamable (stdio)
+	// target, so it must not reconcile.
+	assert!(
+		!relay
+			.upstreams
+			.should_reconcile(&[fake_streamable_target("a", mock_a.addr)])
+	);
 }
 
 fn fake_streamable_target(name: &str, addr: SocketAddr) -> Arc<McpTarget> {

--- a/crates/agentgateway/src/mcp/session.rs
+++ b/crates/agentgateway/src/mcp/session.rs
@@ -788,10 +788,25 @@ impl SessionManager {
 			.get_or_init(|| tokio::spawn(run_idle_reaper(self.sessions.clone())).abort_handle());
 	}
 
+	fn reconcile_targets(session: &mut Session, builder: &RelayInputs) {
+		if !session
+			.relay
+			.upstreams
+			.should_reconcile(&builder.backend.targets)
+		{
+			return;
+		}
+		match session.relay.fork_with_inputs(builder) {
+			Ok(r) => session.relay = Arc::new(r),
+			Err(e) => warn!("failed to fork relay after target roster change: {e}"),
+		}
+	}
+
 	pub fn get_session(&self, id: &str, builder: RelayInputs) -> Option<Session> {
 		let mut sessions = self.sessions.write().ok()?;
 		let entry = sessions.get_mut(id)?;
 		entry.last_access = Instant::now();
+		Self::reconcile_targets(&mut entry.session, &builder);
 		Some(entry.session.clone().with_inputs(builder))
 	}
 
@@ -802,6 +817,7 @@ impl SessionManager {
 	) -> Result<Option<Session>, mcp::Error> {
 		if let Some(s) = self.sessions.write().expect("poisoned").get_mut(id) {
 			s.last_access = Instant::now();
+			Self::reconcile_targets(&mut s.session, &builder);
 			return Ok(Some(s.session.clone().with_inputs(builder)));
 		}
 		let idle_ttl = builder.backend.session_idle_ttl;

--- a/crates/agentgateway/src/mcp/upstream/mod.rs
+++ b/crates/agentgateway/src/mcp/upstream/mod.rs
@@ -313,6 +313,26 @@ impl UpstreamGroup {
 		self.by_name.len()
 	}
 
+	/// Whether a live session should rebuild its relay for the `new` roster:
+	/// only when the target name set actually changed and both the current and
+	/// new rosters are entirely streamable HTTP (the only transport that
+	/// rebuilds cheaply, without spawning a process or doing I/O).
+	pub(crate) fn should_reconcile(&self, new: &[Arc<McpTarget>]) -> bool {
+		let cur: std::collections::HashSet<&str> = self
+			.backend
+			.targets
+			.iter()
+			.map(|t| t.name.as_str())
+			.collect();
+		let next: std::collections::HashSet<&str> = new.iter().map(|t| t.name.as_str()).collect();
+		if cur == next {
+			return false;
+		}
+		let all_streamable =
+			|ts: &[Arc<McpTarget>]| ts.iter().all(|t| matches!(t.spec, McpTargetSpec::Mcp(_)));
+		all_streamable(&self.backend.targets) && all_streamable(new)
+	}
+
 	pub(crate) fn new(client: PolicyClient, backend: McpBackendGroup) -> Result<Self, mcp::Error> {
 		let is_multiplexing = backend.targets.len() != 1;
 		let default_target_name = (!is_multiplexing && backend.prefix_mode != McpPrefixMode::Always)


### PR DESCRIPTION
A live MCP session freezes its upstream target set at creation. Reusing a session
only refreshes policies, so a target added or removed in a later xDS push stays
invisible (or lingers) until the session expires — the roster a client sees can
drift from the configured backend for the lifetime of the session.

This change reconciles the roster on session reuse: when the target *name* set has
changed, it rebuilds the relay from the current inputs and carries over the upstream
sessions of surviving targets so they are not re-initialized. Unchanged rosters are a
no-op, so the common reuse path is unaffected.

The reuse path already rebuilds the full backend group per request (resolving each
target's backend and policies under the binds lock); on top of that we add only an
O(target-names) set comparison, taken under the session lock that reuse already holds
to bump `last_access`, and we fork only when that set actually changed. In return a
client sees roster changes on its next request instead of waiting for the session to
expire.

Reconciliation is intentionally limited to sessions whose rosters are entirely
streamable HTTP, both before and after the change. The rebuild re-runs every upstream,
which for stdio would re-spawn the child process and for SSE would re-establish the
event stream; a streamable client is cheap to rebuild and holds no such resource. A
single non-streamable target therefore makes the whole session ineligible, and it is
left untouched until it expires.

Tests:
- `reconcile_forks_roster_and_preserves_surviving_sessions`: a streamable roster `{a, b}`
  with a live session on `a`; asserts an unchanged set does not reconcile, a changed set
  `{a, c}` does, and that forking preserves `a`'s session, initializes `c` fresh, and drops `b`.
- `reconcile_skips_non_streamable_rosters`: a mixed `{streamable, stdio}` roster is not
  reconciled even when its name set changes.
