### PR TITLE
llm: refactor standalone model router

### DIFF
--- a/crates/agentgateway/Cargo.toml
+++ b/crates/agentgateway/Cargo.toml
@@ -17,6 +17,7 @@ tls-openssl = ["dep:openssl", "dep:rustls-openssl"]
 ui = []
 schema = ["schemars"]
 internal_benches = ["divan"]
+assert_size_runtime = ["agent-core/assert_size_runtime"]
 
 [dependencies]
 agent-core.workspace = true

--- a/crates/agentgateway/src/http/authorization.rs
+++ b/crates/agentgateway/src/http/authorization.rs
@@ -16,6 +16,13 @@ impl HTTPAuthorizationSet {
 	pub fn new(rs: RuleSets) -> Self {
 		Self(rs)
 	}
+	pub fn merge(mut self, other: Self) -> Self {
+		self.0.0.extend(other.0.0);
+		self
+	}
+	pub fn expressions(&self) -> impl Iterator<Item = &cel::Expression> {
+		self.0.expressions()
+	}
 	pub fn apply(&self, req: &http::Request) -> anyhow::Result<()> {
 		tracing::debug!(info=?http::DebugExtensions(req), "Checking HTTP request");
 		let exec = cel::Executor::new_request(req);
@@ -32,6 +39,24 @@ impl crate::store::RequestPolicyTrait for HTTPAuthorizationSet {
 		&self,
 		_client: &crate::proxy::httpproxy::PolicyClient,
 		_log: &mut crate::telemetry::log::RequestLog,
+		req: &mut http::Request,
+	) -> Result<http::PolicyResponse, crate::proxy::ProxyResponse> {
+		self
+			.apply(req)
+			.map_err(|_| crate::proxy::ProxyResponse::from(ProxyError::AuthorizationFailed))?;
+		Ok(http::PolicyResponse::default())
+	}
+
+	fn expressions(&self) -> impl Iterator<Item = &cel::Expression> {
+		self.0.expressions()
+	}
+}
+
+impl crate::store::BackendPolicyTrait for HTTPAuthorizationSet {
+	async fn apply(
+		&self,
+		_client: &crate::proxy::httpproxy::PolicyClient,
+		_log: &mut Option<&mut crate::telemetry::log::RequestLog>,
 		req: &mut http::Request,
 	) -> Result<http::PolicyResponse, crate::proxy::ProxyResponse> {
 		self

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -995,21 +995,17 @@ impl AIProvider {
 			.read_body_and_default_model::<types::count_tokens::Request>(policies, req, log)
 			.await?;
 
-		let request_model = req.model.as_deref();
-		let effective_model = request_model
-			.and_then(|model| policies.and_then(|p| p.resolve_model_alias(model)))
-			.map(|model| model.as_str())
-			.or(request_model);
-
 		// Some Anthropic-compatible clients (e.g. Claude Code) always call
 		// `/v1/messages/count_tokens`. For providers/models without a native
 		// count-tokens endpoint, we must still answer this route, so we fall
 		// back to local token estimation using the normalized messages payload.
-		let use_local =
-			!self.supports_format(custom::ProviderFormat::AnthropicTokenCount, effective_model);
+		let use_local = !self.supports_format(
+			custom::ProviderFormat::AnthropicTokenCount,
+			req.model.as_deref(),
+		);
 		if use_local {
 			let messages = req.get_messages();
-			let model = effective_model.unwrap_or_default();
+			let model = req.model.as_deref().unwrap_or_default();
 			let count = num_tokens_from_messages(model, &messages)?;
 			let body = serde_json::to_vec(&types::count_tokens::Response {
 				input_tokens: count,
@@ -1094,16 +1090,6 @@ impl AIProvider {
 		tokenize: bool,
 		log: &mut Option<&mut RequestLog>,
 	) -> Result<RequestResult, AIError> {
-		if let Some(p) = policies {
-			// Apply model alias resolution
-			if req.supports_model()
-				&& let Some(model) = req.model()
-				&& let Some(aliased) = p.resolve_model_alias(model.as_str())
-			{
-				*model = aliased.to_string();
-			}
-		}
-
 		let request_model = if req.supports_model() {
 			req.model().as_deref().map(str::to_string)
 		} else {
@@ -1936,22 +1922,65 @@ impl AIProvider {
 		let Ok(bytes) = http::read_body_with_limit(body, buffer).await else {
 			return Err(AIError::RequestTooLarge);
 		};
-		let mut req: T = if let Some(p) = policies {
-			p.unmarshal_request(&bytes, log)?
+		let mut request: serde_json::Value =
+			serde_json::from_slice(bytes.as_ref()).map_err(AIError::RequestParsing)?;
+		self.set_provider_request_model(&parts, &mut request)?;
+		let mut request = if let Some(p) = policies {
+			p.apply_request_body_mutations(request, log)?
 		} else {
-			serde_json::from_slice(bytes.as_ref()).map_err(AIError::RequestParsing)?
+			request
 		};
+		self.finalize_request_model(policies, &mut request)?;
+		let req: T = serde_json::from_value(request).map_err(AIError::RequestParsing)?;
 
-		if let Some(provider_model) = &self.override_model() {
-			*req.model() = Some(provider_model.to_string());
-		} else if req.model().is_none() {
-			if let Some(path_model) = types::detect::extract_model_from_path(parts.uri.path()) {
-				*req.model() = Some(path_model.to_string());
-			} else {
-				return Err(AIError::MissingField("model not specified".into()));
-			}
-		}
 		Ok((parts, req))
+	}
+
+	fn set_provider_request_model(
+		&self,
+		parts: &Parts,
+		req: &mut serde_json::Value,
+	) -> Result<(), AIError> {
+		let Some(obj) = req.as_object_mut() else {
+			return Err(AIError::MissingField("request must be an object".into()));
+		};
+		if let Some(provider_model) = &self.override_model() {
+			obj.insert(
+				"model".to_string(),
+				serde_json::Value::String(provider_model.to_string()),
+			);
+		} else if !obj.contains_key("model")
+			&& let Some(path_model) = types::detect::extract_model_from_path(parts.uri.path())
+		{
+			obj.insert(
+				"model".to_string(),
+				serde_json::Value::String(path_model.to_string()),
+			);
+		}
+		Ok(())
+	}
+
+	fn finalize_request_model(
+		&self,
+		policies: Option<&Policy>,
+		req: &mut serde_json::Value,
+	) -> Result<(), AIError> {
+		let Some(obj) = req.as_object_mut() else {
+			return Err(AIError::MissingField("request must be an object".into()));
+		};
+		if !obj.contains_key("model") {
+			return Err(AIError::MissingField("model not specified".into()));
+		}
+		if let Some(p) = policies
+			&& let Some(model) = obj.get("model").and_then(serde_json::Value::as_str)
+			&& let Some(aliased) = p.resolve_model_alias(model)
+		{
+			obj.insert(
+				"model".to_string(),
+				serde_json::Value::String(aliased.to_string()),
+			);
+		}
+		Ok(())
 	}
 
 	fn process_error(

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -1922,6 +1922,24 @@ impl AIProvider {
 		let Ok(bytes) = http::read_body_with_limit(body, buffer).await else {
 			return Err(AIError::RequestTooLarge);
 		};
+
+		if self.override_model().is_none()
+			&& types::detect::extract_model_from_path(parts.uri.path()).is_none()
+			&& !policies.is_some_and(Policy::has_request_body_mutations)
+		{
+			let mut req: T = serde_json::from_slice(bytes.as_ref()).map_err(AIError::RequestParsing)?;
+			let model = req.model();
+			let Some(model_value) = model.as_deref() else {
+				return Err(AIError::MissingField("model not specified".into()));
+			};
+			if let Some(p) = policies
+				&& let Some(aliased) = p.resolve_model_alias(model_value)
+			{
+				*model = Some(aliased.to_string());
+			}
+			return Ok((parts, req));
+		}
+
 		let mut request: serde_json::Value =
 			serde_json::from_slice(bytes.as_ref()).map_err(AIError::RequestParsing)?;
 		self.set_provider_request_model(&parts, &mut request)?;
@@ -1949,7 +1967,7 @@ impl AIProvider {
 				"model".to_string(),
 				serde_json::Value::String(provider_model.to_string()),
 			);
-		} else if !obj.contains_key("model")
+		} else if !matches!(obj.get("model"), Some(serde_json::Value::String(_)))
 			&& let Some(path_model) = types::detect::extract_model_from_path(parts.uri.path())
 		{
 			obj.insert(
@@ -1968,11 +1986,10 @@ impl AIProvider {
 		let Some(obj) = req.as_object_mut() else {
 			return Err(AIError::MissingField("request must be an object".into()));
 		};
-		if !obj.contains_key("model") {
+		let Some(model) = obj.get("model").and_then(serde_json::Value::as_str) else {
 			return Err(AIError::MissingField("model not specified".into()));
-		}
+		};
 		if let Some(p) = policies
-			&& let Some(model) = obj.get("model").and_then(serde_json::Value::as_str)
 			&& let Some(aliased) = p.resolve_model_alias(model)
 		{
 			obj.insert(

--- a/crates/agentgateway/src/llm/model_router.rs
+++ b/crates/agentgateway/src/llm/model_router.rs
@@ -11,10 +11,10 @@ use serde_json::Value;
 use crate::http::transformation_cel::TransformationMetadata;
 use crate::http::{self, Request, Response};
 use crate::types::agent::{
-	BackendReference, BackendTrafficPolicy, HeaderMatch, HeaderValueMatch, RouteBackendReference,
-	TrafficPolicy,
+	Authorization, BackendReference, BackendTrafficPolicy, HeaderMatch, HeaderValueMatch,
+	RouteBackendReference,
 };
-use crate::{apply, cel, schema_enum};
+use crate::{apply, cel, llm, schema_enum};
 
 #[derive(Debug, Clone, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -23,8 +23,15 @@ pub struct ModelRoute {
 	pub visibility: ModelVisibility,
 	pub header_matches: Vec<Vec<HeaderMatch>>,
 	pub backend_key: Strng,
-	pub route_policies: Vec<TrafficPolicy>,
+	pub policies: ModelRoutePolicies,
 	pub backend_policies: Vec<BackendTrafficPolicy>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelRoutePolicies {
+	pub llm: Arc<llm::Policy>,
+	pub authorization: Option<Authorization>,
 }
 
 #[apply(schema_enum!)]
@@ -47,7 +54,7 @@ impl ModelVisibility {
 #[serde(rename_all = "camelCase")]
 pub struct VirtualModelRoute {
 	pub name: String,
-	pub route_policies: Vec<TrafficPolicy>,
+	pub llm_policy: Arc<llm::Policy>,
 	pub routing: VirtualModelRouting,
 }
 
@@ -84,7 +91,7 @@ pub struct ModelRouter {
 #[derive(Debug, Clone)]
 pub struct ResolvedBackend {
 	pub backend: RouteBackendReference,
-	pub route_policies: Vec<TrafficPolicy>,
+	pub llm_policy: Arc<llm::Policy>,
 }
 
 pub enum ResolveResult {
@@ -208,7 +215,7 @@ impl ModelRouter {
 						target: BackendReference::Backend(strng::format!("/{}", backend_key)).into(),
 						inline_policies: vec![],
 					},
-					route_policies: virtual_model.route_policies.clone(),
+					llm_policy: virtual_model.llm_policy.clone(),
 				});
 			},
 			VirtualModelRouting::Conditional(targets) => {
@@ -275,7 +282,7 @@ impl ModelRouter {
 				target: BackendReference::Backend(strng::format!("/{}", model.backend_key)).into(),
 				inline_policies: model.backend_policies.clone(),
 			},
-			route_policies: model.route_policies.clone(),
+			llm_policy: model.policies.llm.clone(),
 		})
 	}
 }
@@ -315,12 +322,10 @@ fn llm_error_response(status: ::http::StatusCode, message: &str, code: &str) -> 
 
 fn model_authorized(model: &ModelRoute, req: &Request) -> bool {
 	let rules = model
-		.route_policies
+		.policies
+		.authorization
 		.iter()
-		.filter_map(|policy| match policy {
-			TrafficPolicy::Authorization(authorization) => Some(authorization.0.clone()),
-			_ => None,
-		})
+		.map(|authorization| authorization.0.clone())
 		.collect::<Vec<_>>();
 	if rules.is_empty() {
 		return true;

--- a/crates/agentgateway/src/llm/policy/mod.rs
+++ b/crates/agentgateway/src/llm/policy/mod.rs
@@ -639,6 +639,26 @@ impl Policy {
 		// Slow path: bytes --> json (transform) --> typed
 		let v: serde_json::Value =
 			serde_json::from_slice(bytes.as_ref()).map_err(AIError::RequestParsing)?;
+		self.unmarshal_request_value(v, log)
+	}
+
+	pub fn unmarshal_request_value<T: DeserializeOwned>(
+		&self,
+		v: serde_json::Value,
+		log: &mut Option<&mut RequestLog>,
+	) -> Result<T, AIError> {
+		let v = self.apply_request_body_mutations(v, log)?;
+		serde_json::from_value(v).map_err(AIError::RequestParsing)
+	}
+
+	pub fn apply_request_body_mutations(
+		&self,
+		v: serde_json::Value,
+		log: &mut Option<&mut RequestLog>,
+	) -> Result<serde_json::Value, AIError> {
+		if !self.has_request_body_mutations() {
+			return Ok(v);
+		}
 		let exec = cel::Executor::new_llm(log.as_ref().and_then(|x| x.request_snapshot.as_deref()), &v);
 		let to_set: Vec<_> = self
 			.transformations
@@ -666,7 +686,7 @@ impl Policy {
 		for (k, v) in self.defaults.iter().flatten() {
 			map.entry(k.clone()).or_insert_with(|| v.clone());
 		}
-		serde_json::from_value(serde_json::Value::Object(map)).map_err(AIError::RequestParsing)
+		Ok(serde_json::Value::Object(map))
 	}
 
 	fn eval_transformation_expression(

--- a/crates/agentgateway/src/llm/tests.rs
+++ b/crates/agentgateway/src/llm/tests.rs
@@ -1065,6 +1065,115 @@ async fn count_tokens_resolves_model_alias_once_for_upstream_request() {
 	assert_eq!(llm_request.request_model, "middle-name");
 }
 
+#[tokio::test]
+async fn provider_model_is_set_before_llm_transformations() {
+	use crate::http::auth::BackendInfo;
+	use crate::llm::policy::Policy;
+	use crate::test_helpers::proxymock::setup_proxy_test;
+	use crate::types::agent::BackendTarget;
+
+	let provider = AIProvider::OpenAI(openai::Provider {
+		model: Some("gcp/failover-model".into()),
+	});
+	let inputs = setup_proxy_test("{}").unwrap().pi;
+	let backend_info = BackendInfo {
+		target: BackendTarget::Invalid,
+		call_target: Target::from(("api.openai.com", 443)),
+		inputs,
+	};
+	let policy = Policy {
+		transformations: Some(
+			[(
+				"model".to_string(),
+				std::sync::Arc::new(
+					crate::cel::Expression::new_strict(r#"llmRequest.model.stripPrefix("gcp/")"#).unwrap(),
+				),
+			)]
+			.into_iter()
+			.collect(),
+		),
+		..Default::default()
+	};
+	let req = ::http::Request::builder()
+		.uri("/v1/chat/completions")
+		.header(::http::header::CONTENT_TYPE, "application/json")
+		.body(Body::from(
+			br#"{
+				"model": "public-model",
+				"messages": [{"role": "user", "content": "hello"}]
+			}"#
+				.to_vec(),
+		))
+		.unwrap();
+
+	let RequestResult::Success(forwarded, llm_request) = provider
+		.process_completions_request(&backend_info, Some(&policy), req, false, &mut None)
+		.await
+		.expect("OpenAI completions request should process")
+	else {
+		panic!("expected forwarded request");
+	};
+
+	let forwarded_body = forwarded.collect().await.unwrap().to_bytes();
+	let forwarded_json: Value =
+		serde_json::from_slice(&forwarded_body).expect("forwarded request should be JSON");
+
+	assert_eq!(forwarded_json["model"], json!("failover-model"));
+	assert_eq!(llm_request.request_model, "failover-model");
+}
+
+#[tokio::test]
+async fn llm_transformations_can_set_missing_model() {
+	use crate::http::auth::BackendInfo;
+	use crate::llm::policy::Policy;
+	use crate::test_helpers::proxymock::setup_proxy_test;
+	use crate::types::agent::BackendTarget;
+
+	let provider = AIProvider::OpenAI(openai::Provider { model: None });
+	let inputs = setup_proxy_test("{}").unwrap().pi;
+	let backend_info = BackendInfo {
+		target: BackendTarget::Invalid,
+		call_target: Target::from(("api.openai.com", 443)),
+		inputs,
+	};
+	let policy = Policy {
+		transformations: Some(
+			[(
+				"model".to_string(),
+				std::sync::Arc::new(crate::cel::Expression::new_strict(r#""transformed-model""#).unwrap()),
+			)]
+			.into_iter()
+			.collect(),
+		),
+		..Default::default()
+	};
+	let req = ::http::Request::builder()
+		.uri("/v1/chat/completions")
+		.header(::http::header::CONTENT_TYPE, "application/json")
+		.body(Body::from(
+			br#"{
+				"messages": [{"role": "user", "content": "hello"}]
+			}"#
+				.to_vec(),
+		))
+		.unwrap();
+
+	let RequestResult::Success(forwarded, llm_request) = provider
+		.process_completions_request(&backend_info, Some(&policy), req, false, &mut None)
+		.await
+		.expect("OpenAI completions request should process")
+	else {
+		panic!("expected forwarded request");
+	};
+
+	let forwarded_body = forwarded.collect().await.unwrap().to_bytes();
+	let forwarded_json: Value =
+		serde_json::from_slice(&forwarded_body).expect("forwarded request should be JSON");
+
+	assert_eq!(forwarded_json["model"], json!("transformed-model"));
+	assert_eq!(llm_request.request_model, "transformed-model");
+}
+
 #[test]
 fn openai_token_limit_normalization_keeps_explicit_max_completion_tokens() {
 	let mut request: types::completions::Request = serde_json::from_value(json!({

--- a/crates/agentgateway/src/proxy/gateway.rs
+++ b/crates/agentgateway/src/proxy/gateway.rs
@@ -902,7 +902,7 @@ impl Gateway {
 					dtrace::DebugTracer::maybe_scope(req, |req| async move {
 						proxy.proxy(connection, req).map(Ok::<_, Infallible>).await
 					})
-					.assert_size::<{ 15 * 1024 }>(),
+					.assert_size::<{ 16 * 1024 }>(),
 				)
 			}),
 		);

--- a/crates/agentgateway/src/proxy/gateway_test.rs
+++ b/crates/agentgateway/src/proxy/gateway_test.rs
@@ -1477,54 +1477,6 @@ async fn setup_local_llm_config(yaml: &str) -> TestBind {
 	t
 }
 
-async fn setup_local_llm_config_with_user_model_header(yaml: &str) -> TestBind {
-	let t = setup_proxy_test("{}").unwrap();
-	let resources = crate::resource_manager::ResourceFetcher::direct(t.pi.upstream.clone());
-	let mut normalized = crate::types::local::NormalizedLocalConfig::from(
-		t.pi.cfg.as_ref(),
-		&resources,
-		t.pi.cfg.gateway(),
-		yaml,
-	)
-	.await
-	.expect("local config normalizes");
-	let transformation = crate::http::transformation_cel::Transformation::try_from_local_config(
-		crate::http::transformation_cel::LocalTransformationConfig {
-			request: Some(crate::http::transformation_cel::LocalTransform {
-				add: vec![(
-					strng::literal!("x-user-model"),
-					strng::literal!("metadata.agentgateway_user_model"),
-				)],
-				..Default::default()
-			}),
-			response: None,
-		},
-		true,
-	)
-	.expect("transformation config");
-	let route = normalized
-		.listener_routes
-		.iter_mut()
-		.flat_map(|(_, routes)| routes)
-		.find(|route| route.key == "llm:request")
-		.expect("LLM request route");
-	route
-		.inline_policies
-		.push(crate::types::agent::TrafficPolicy::Transformation(
-			crate::store::RequestPolicy::single(transformation),
-		));
-	t.pi.stores.binds.sync_local(
-		normalized.binds,
-		normalized.listener_routes,
-		normalized.listener_tcp_routes,
-		normalized.policies,
-		normalized.backends,
-		normalized.route_groups,
-		Default::default(),
-	);
-	t
-}
-
 #[tokio::test]
 async fn llm_local_router_handles_models_virtual_model_and_missing_model() {
 	let mock = body_mock(include_bytes!(
@@ -1539,19 +1491,30 @@ llm:
   - name: real-model
     visibility: internal
     provider: openAI
+    authorization:
+      rules:
+      - 'request.headers["x-model-auth"] == "yes"'
+    params:
+      baseUrl: http://{}
+  - name: direct-model
+    provider: openAI
+    authorization:
+      rules:
+      - 'request.headers["x-model-auth"] == "yes"'
     params:
       baseUrl: http://{}
   virtualModels:
   - name: public-model
     routing:
-      weighted:
+      failover:
         targets:
         - model: real-model
-          weight: 1
+          priority: 0
 "#,
+		mock.address(),
 		mock.address()
 	);
-	let t = setup_local_llm_config_with_user_model_header(&config).await;
+	let t = setup_local_llm_config(&config).await;
 	let io = t.serve_http(strng::literal!("bind/4000"));
 
 	let res = send_request(io.clone(), Method::GET, "http://lo/v1/models").await;
@@ -1567,20 +1530,56 @@ llm:
 		.collect::<Vec<_>>();
 	assert_eq!(model_ids, vec!["public-model"]);
 
-	let mut request_body: Value = serde_json::from_slice(include_bytes!(
-		"../llm/tests/requests/completions/basic.json"
-	))
-	.expect("request JSON");
-	request_body["model"] = json!("public-model");
-	let request_body = serde_json::to_vec(&request_body).expect("serialized request");
+	let res = send_request_headers(
+		io.clone(),
+		Method::GET,
+		"http://lo/v1/models",
+		&[("x-model-auth", "yes")],
+	)
+	.await;
+	assert_eq!(res.status(), StatusCode::OK);
+	let models: Value =
+		serde_json::from_slice(&read_body_raw(res.into_body()).await).expect("models JSON");
+	let model_ids = models["data"]
+		.as_array()
+		.expect("model list")
+		.iter()
+		.map(|model| model["id"].as_str().expect("model id"))
+		.collect::<Vec<_>>();
+	assert_eq!(model_ids, vec!["direct-model", "public-model"]);
+
+	let request_body = |model: &str| {
+		let mut body: Value = serde_json::from_slice(include_bytes!(
+			"../llm/tests/requests/completions/basic.json"
+		))
+		.expect("request JSON");
+		body["model"] = json!(model);
+		serde_json::to_vec(&body).expect("serialized request")
+	};
 
 	let res = send_request_body(
 		io.clone(),
 		Method::POST,
 		"http://lo/v1/chat/completions",
-		&request_body,
+		&request_body("public-model"),
 	)
 	.await;
+	assert_eq!(res.status(), StatusCode::FORBIDDEN);
+	assert_eq!(
+		mock
+			.received_requests()
+			.await
+			.expect("upstream requests")
+			.len(),
+		0
+	);
+
+	let res = RequestBuilder::new(Method::POST, "http://lo/v1/chat/completions")
+		.header("x-model-auth", "yes")
+		.body(Body::from(request_body("public-model")))
+		.send(io.clone())
+		.await
+		.expect("virtual model request");
 	assert_eq!(res.status(), StatusCode::OK);
 	read_body_raw(res.into_body()).await;
 
@@ -1589,15 +1588,38 @@ llm:
 	let upstream_body: Value =
 		serde_json::from_slice(&upstream_requests[0].body).expect("upstream request JSON");
 	assert_eq!(upstream_body["model"], "real-model");
+
+	let res = send_request_body(
+		io.clone(),
+		Method::POST,
+		"http://lo/v1/chat/completions",
+		&request_body("direct-model"),
+	)
+	.await;
+	assert_eq!(res.status(), StatusCode::FORBIDDEN);
 	assert_eq!(
-		upstream_requests[0]
-			.headers
-			.get("x-user-model")
-			.expect("user model header")
-			.to_str()
-			.expect("user model header value"),
-		"public-model"
+		mock
+			.received_requests()
+			.await
+			.expect("upstream requests")
+			.len(),
+		1
 	);
+
+	let res = RequestBuilder::new(Method::POST, "http://lo/v1/chat/completions")
+		.header("x-model-auth", "yes")
+		.body(Body::from(request_body("direct-model")))
+		.send(io.clone())
+		.await
+		.expect("direct model request");
+	assert_eq!(res.status(), StatusCode::OK);
+	read_body_raw(res.into_body()).await;
+
+	let upstream_requests = mock.received_requests().await.expect("upstream requests");
+	assert_eq!(upstream_requests.len(), 2);
+	let upstream_body: Value =
+		serde_json::from_slice(&upstream_requests[1].body).expect("upstream request JSON");
+	assert_eq!(upstream_body["model"], "direct-model");
 
 	let missing = json!({
 		"model": "missing-model",
@@ -1620,7 +1642,7 @@ llm:
 			.await
 			.expect("upstream requests")
 			.len(),
-		1
+		2
 	);
 }
 

--- a/crates/agentgateway/src/proxy/gateway_test.rs
+++ b/crates/agentgateway/src/proxy/gateway_test.rs
@@ -1496,6 +1496,16 @@ llm:
       - 'request.headers["x-model-auth"] == "yes"'
     params:
       baseUrl: http://{}
+    health:
+      eviction: {{}}
+      unhealthyExpression: 'response.code == 403'
+  - name: prefix/*
+    visibility: internal
+    provider: openai
+    params:
+      baseUrl: http://{}
+    transformation:
+      model: llmRequest.model.stripPrefix("prefix/")
   - name: direct-model
     provider: openAI
     authorization:
@@ -1504,146 +1514,124 @@ llm:
     params:
       baseUrl: http://{}
   virtualModels:
-  - name: public-model
+  - name: virtual-model
     routing:
       failover:
         targets:
         - model: real-model
           priority: 0
+  - name: failover
+    routing:
+      failover:
+        targets:
+        - model: real-model
+          priority: 0
+        - model: prefix/without-prefix
+          priority: 1
 "#,
+		mock.address(),
 		mock.address(),
 		mock.address()
 	);
 	let t = setup_local_llm_config(&config).await;
 	let io = t.serve_http(strng::literal!("bind/4000"));
 
-	let res = send_request(io.clone(), Method::GET, "http://lo/v1/models").await;
-	assert_eq!(res.status(), StatusCode::OK);
-	let models: Value =
-		serde_json::from_slice(&read_body_raw(res.into_body()).await).expect("models JSON");
-	assert_eq!(models["object"], "list");
-	let model_ids = models["data"]
-		.as_array()
-		.expect("model list")
-		.iter()
-		.map(|model| model["id"].as_str().expect("model id"))
-		.collect::<Vec<_>>();
-	assert_eq!(model_ids, vec!["public-model"]);
+	// check model list respects authorization
+	{
+		let model_ids = list_models(io.clone(), &[]).await;
+		assert_eq!(model_ids, vec!["virtual-model", "failover"]);
+		let model_ids = list_models(io.clone(), &[("x-model-auth", "yes")]).await;
+		assert_eq!(model_ids, vec!["direct-model", "virtual-model", "failover"]);
+	}
 
-	let res = send_request_headers(
-		io.clone(),
-		Method::GET,
-		"http://lo/v1/models",
-		&[("x-model-auth", "yes")],
-	)
-	.await;
-	assert_eq!(res.status(), StatusCode::OK);
-	let models: Value =
-		serde_json::from_slice(&read_body_raw(res.into_body()).await).expect("models JSON");
-	let model_ids = models["data"]
-		.as_array()
-		.expect("model list")
-		.iter()
-		.map(|model| model["id"].as_str().expect("model id"))
-		.collect::<Vec<_>>();
-	assert_eq!(model_ids, vec!["direct-model", "public-model"]);
+	// Virtual model
+	{
+		let res = send_completions_with_model(io.clone(), "virtual-model", &[]).await;
+		assert_eq!(res.status(), StatusCode::FORBIDDEN);
+		assert_eq!(
+			mock
+				.received_requests()
+				.await
+				.expect("upstream requests")
+				.len(),
+			0
+		);
 
-	let request_body = |model: &str| {
-		let mut body: Value = serde_json::from_slice(include_bytes!(
-			"../llm/tests/requests/completions/basic.json"
-		))
-		.expect("request JSON");
-		body["model"] = json!(model);
-		serde_json::to_vec(&body).expect("serialized request")
-	};
+		let res =
+			send_completions_with_model(io.clone(), "virtual-model", &[("x-model-auth", "yes")]).await;
+		assert_eq!(res.status(), StatusCode::OK);
 
-	let res = send_request_body(
-		io.clone(),
-		Method::POST,
-		"http://lo/v1/chat/completions",
-		&request_body("public-model"),
-	)
-	.await;
-	assert_eq!(res.status(), StatusCode::FORBIDDEN);
-	assert_eq!(
-		mock
-			.received_requests()
-			.await
-			.expect("upstream requests")
-			.len(),
-		0
-	);
+		let upstream_requests = mock.received_requests().await.expect("upstream requests");
+		assert_eq!(upstream_requests.len(), 1);
+		let upstream_body: Value =
+			serde_json::from_slice(&upstream_requests[0].body).expect("upstream request JSON");
+		assert_eq!(upstream_body["model"], "real-model");
+	}
 
-	let res = RequestBuilder::new(Method::POST, "http://lo/v1/chat/completions")
-		.header("x-model-auth", "yes")
-		.body(Body::from(request_body("public-model")))
-		.send(io.clone())
-		.await
-		.expect("virtual model request");
-	assert_eq!(res.status(), StatusCode::OK);
-	read_body_raw(res.into_body()).await;
+	// Direct model
+	{
+		let res = send_completions_with_model(io.clone(), "direct-model", &[]).await;
+		assert_eq!(res.status(), StatusCode::FORBIDDEN);
+		assert_eq!(
+			mock
+				.received_requests()
+				.await
+				.expect("upstream requests")
+				.len(),
+			1
+		);
 
-	let upstream_requests = mock.received_requests().await.expect("upstream requests");
-	assert_eq!(upstream_requests.len(), 1);
-	let upstream_body: Value =
-		serde_json::from_slice(&upstream_requests[0].body).expect("upstream request JSON");
-	assert_eq!(upstream_body["model"], "real-model");
+		let res =
+			send_completions_with_model(io.clone(), "direct-model", &[("x-model-auth", "yes")]).await;
+		assert_eq!(res.status(), StatusCode::OK);
+		let upstream_requests = mock.received_requests().await.expect("upstream requests");
+		assert_eq!(upstream_requests.len(), 2);
+		let upstream_body: Value =
+			serde_json::from_slice(&upstream_requests[1].body).expect("upstream request JSON");
+		assert_eq!(upstream_body["model"], "direct-model");
+	}
 
-	let res = send_request_body(
-		io.clone(),
-		Method::POST,
-		"http://lo/v1/chat/completions",
-		&request_body("direct-model"),
-	)
-	.await;
-	assert_eq!(res.status(), StatusCode::FORBIDDEN);
-	assert_eq!(
-		mock
-			.received_requests()
-			.await
-			.expect("upstream requests")
-			.len(),
-		1
-	);
+	// Failover model
+	{
+		// First attempt: fails
+		let res = send_completions_with_model(io.clone(), "failover", &[]).await;
+		assert_eq!(res.status(), StatusCode::FORBIDDEN);
+		assert_eq!(
+			mock
+				.received_requests()
+				.await
+				.expect("upstream requests")
+				.len(),
+			2
+		);
 
-	let res = RequestBuilder::new(Method::POST, "http://lo/v1/chat/completions")
-		.header("x-model-auth", "yes")
-		.body(Body::from(request_body("direct-model")))
-		.send(io.clone())
-		.await
-		.expect("direct model request");
-	assert_eq!(res.status(), StatusCode::OK);
-	read_body_raw(res.into_body()).await;
+		// Second attempt: failover to model without authz
+		let res = send_completions_with_model(io.clone(), "failover", &[]).await;
+		assert_eq!(res.status(), StatusCode::OK);
+		let upstream_requests = mock.received_requests().await.expect("upstream requests");
+		assert_eq!(upstream_requests.len(), 3);
+		let upstream_body: Value =
+			serde_json::from_slice(&upstream_requests[2].body).expect("upstream request JSON");
+		// Model should be explicitly rewritten and have the prefix removed
+		assert_eq!(upstream_body["model"], "without-prefix");
+	}
 
-	let upstream_requests = mock.received_requests().await.expect("upstream requests");
-	assert_eq!(upstream_requests.len(), 2);
-	let upstream_body: Value =
-		serde_json::from_slice(&upstream_requests[1].body).expect("upstream request JSON");
-	assert_eq!(upstream_body["model"], "direct-model");
-
-	let missing = json!({
-		"model": "missing-model",
-		"messages": [{"role": "user", "content": "hi"}]
-	});
-	let res = send_request_body(
-		io,
-		Method::POST,
-		"http://lo/v1/chat/completions",
-		&serde_json::to_vec(&missing).expect("serialized missing request"),
-	)
-	.await;
-	assert_eq!(res.status(), StatusCode::NOT_FOUND);
-	let missing_body: Value =
-		serde_json::from_slice(&read_body_raw(res.into_body()).await).expect("missing model JSON");
-	assert_eq!(missing_body["error"]["code"], "model_not_found");
-	assert_eq!(
-		mock
-			.received_requests()
-			.await
-			.expect("upstream requests")
-			.len(),
-		2
-	);
+	// Missing model
+	{
+		let res = send_completions_with_model(io, "missing-model", &[]).await;
+		assert_eq!(res.status(), StatusCode::NOT_FOUND);
+		let missing_body: Value =
+			serde_json::from_slice(&read_body_raw(res.into_body()).await).expect("missing model JSON");
+		assert_eq!(missing_body["error"]["code"], "model_not_found");
+		assert_eq!(
+			mock
+				.received_requests()
+				.await
+				.expect("upstream requests")
+				.len(),
+			3
+		);
+	}
 }
 
 #[tokio::test]
@@ -1674,18 +1662,7 @@ llm:
 	);
 	let t = setup_local_llm_config(&config).await;
 	let io = t.serve_http(strng::literal!("bind/4000"));
-	let request_body = json!({
-		"model": "public-model",
-		"messages": [{"role": "user", "content": "hi"}]
-	});
-
-	let res = send_request_body(
-		io,
-		Method::POST,
-		"http://lo/v1/chat/completions",
-		&serde_json::to_vec(&request_body).expect("serialized request"),
-	)
-	.await;
+	let res = send_completions_with_model(io, "public-model", &[]).await;
 
 	assert_eq!(res.status(), StatusCode::BAD_REQUEST);
 	let body: Value =
@@ -1866,13 +1843,7 @@ async fn llm_custom_provider_routes_to_provider_backend() {
 	let (mock, _bind, io) =
 		setup_custom_llm_provider_backend_mock(mock, vec![custom::ProviderFormat::Completions]);
 
-	let res = send_request_body(
-		io,
-		Method::POST,
-		"http://lo/v1/chat/completions",
-		include_bytes!("../llm/tests/requests/completions/basic.json"),
-	)
-	.await;
+	let res = send_completions_with_model(io, "replaceme", &[]).await;
 	assert_eq!(res.status(), 200);
 	let _ = res.into_body().collect().await.unwrap();
 
@@ -1896,13 +1867,7 @@ async fn llm_custom_provider_uses_native_format_fallback() {
 	let (mock, _bind, io) =
 		setup_custom_llm_provider_backend_mock(mock, vec![custom::ProviderFormat::Messages]);
 
-	let res = send_request_body(
-		io,
-		Method::POST,
-		"http://lo/v1/chat/completions",
-		include_bytes!("../llm/tests/requests/completions/basic.json"),
-	)
-	.await;
+	let res = send_completions_with_model(io, "replaceme", &[]).await;
 	assert_eq!(res.status(), 200);
 	let response_body: Value =
 		serde_json::from_slice(&read_body_raw(res.into_body()).await).expect("response is JSON");
@@ -1936,13 +1901,7 @@ async fn llm_custom_provider_uses_format_path_override() {
 		}],
 	);
 
-	let res = send_request_body(
-		io,
-		Method::POST,
-		"http://lo/v1/chat/completions",
-		include_bytes!("../llm/tests/requests/completions/basic.json"),
-	)
-	.await;
+	let res = send_completions_with_model(io, "replaceme", &[]).await;
 	assert_eq!(res.status(), 200);
 	let _ = res.into_body().collect().await.unwrap();
 
@@ -1966,13 +1925,7 @@ async fn llm_custom_provider_rejects_unsupported_format_before_upstream_call() {
 	let (mock, _bind, io) =
 		setup_custom_llm_provider_backend_mock(mock, vec![custom::ProviderFormat::Embeddings]);
 
-	let res = send_request_body(
-		io,
-		Method::POST,
-		"http://lo/v1/chat/completions",
-		include_bytes!("../llm/tests/requests/completions/basic.json"),
-	)
-	.await;
+	let res = send_completions_with_model(io, "replaceme", &[]).await;
 	assert_eq!(res.status(), 503);
 	let body = res.into_body().collect().await.unwrap().to_bytes();
 	assert!(
@@ -2026,6 +1979,50 @@ fn completions_request_body(streaming: bool) -> Vec<u8> {
 		body["stream"] = json!(true);
 	}
 	serde_json::to_vec(&body).expect("request fixture should serialize")
+}
+
+fn completions_request_body_with_model(model: &str) -> Vec<u8> {
+	let mut body: Value = serde_json::from_slice(include_bytes!(
+		"../llm/tests/requests/completions/basic.json"
+	))
+	.expect("request fixture should be valid JSON");
+	body["model"] = json!(model);
+	serde_json::to_vec(&body).expect("request fixture should serialize")
+}
+
+async fn send_completions_with_model(
+	io: Client<MemoryConnector, Body>,
+	model: &str,
+	headers: &[(&str, &str)],
+) -> Response {
+	let request_body = completions_request_body_with_model(model);
+	let mut request = RequestBuilder::new(Method::POST, "http://lo/v1/chat/completions");
+	for (key, value) in headers {
+		request = request.header(*key, *value);
+	}
+	request
+		.body(Body::from(request_body))
+		.send(io)
+		.await
+		.expect("completions request")
+}
+
+async fn list_models(io: Client<MemoryConnector, Body>, headers: &[(&str, &str)]) -> Vec<String> {
+	let res = if headers.is_empty() {
+		send_request(io, Method::GET, "http://lo/v1/models").await
+	} else {
+		send_request_headers(io, Method::GET, "http://lo/v1/models", headers).await
+	};
+	assert_eq!(res.status(), StatusCode::OK);
+	let models: Value =
+		serde_json::from_slice(&read_body_raw(res.into_body()).await).expect("models JSON");
+	assert_eq!(models["object"], "list");
+	models["data"]
+		.as_array()
+		.expect("model list")
+		.iter()
+		.map(|model| model["id"].as_str().expect("model id").to_string())
+		.collect()
 }
 
 async fn assert_llm_remote_rate_limit_cost(

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -291,6 +291,7 @@ async fn apply_backend_policies(
 		mcp_guardrails: _,
 		// Applied elsewhere
 		inference_routing: _,
+		authorization,
 		ext_authz,
 		request_header_modifier,
 		response_header_modifier,
@@ -312,6 +313,10 @@ async fn apply_backend_policies(
 		.as_ref()
 		.unwrap_or(&dh)
 		.apply(req, backend_call.http_version_override);
+
+	let _ = authorization
+		.apply("backend authorization", &client, log, req, rp.headers())
+		.await?;
 
 	// Ext auth has no response-side
 	let _ = ext_authz

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -4017,11 +4017,12 @@ impl PolicyClient {
 					&backend,
 					pols.into(),
 					None,
-				MustSnapshot::new(&mut req),
-				// Here we don't have a log to pass. MCP and LLM flows expect there to always be a log.
-				// As such, we ensure we ONLY call this with Simple backend type which cannot be MCP/LLM
-				None,
-				&mut Default::default(),)
+					MustSnapshot::new(&mut req),
+					// Here we don't have a log to pass. MCP and LLM flows expect there to always be a log.
+					// As such, we ensure we ONLY call this with Simple backend type which cannot be MCP/LLM
+					None,
+					&mut Default::default(),
+				)
 				.assert_size::<{ 7 * 1024 }>(),
 			)
 			.await

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -818,42 +818,11 @@ impl HTTPProxy {
 
 		debug!(bind=%bind_name, listener=%selected_listener.key, route=%selected_route.key, "selected route");
 
-		let selected_llm_backend = if let Some(router) = &selected_route.llm_router {
-			match router.resolve(&mut req).await {
-				model_router::ResolveResult::DirectResponse(resp) => {
-					return Err(ProxyResponse::DirectResponse(Box::new(resp))).snapshot_on_err(log, &mut req);
-				},
-				model_router::ResolveResult::Backend(backend) => Some(backend),
-			}
-		} else {
-			None
-		};
-
-		let mut route_inline_policy_storage;
-		let route_inlines = if let Some(selected_llm_backend) = &selected_llm_backend {
-			// LLM routing may add route policies to the final selected route. Clone the
-			// inline policy lists so we can append those policies without mutating config.
-			route_inline_policy_storage = selected_route_chain
-				.routes
-				.iter()
-				.map(|route| route.inline_policies.clone())
-				.collect::<Vec<_>>();
-			if let Some(inline_policies) = route_inline_policy_storage.last_mut() {
-				inline_policies.extend(selected_llm_backend.route_policies.clone());
-			}
-			route_inline_policy_storage
-				.iter()
-				.map(Vec::as_slice)
-				.collect::<Vec<_>>()
-		} else {
-			// Most requests do not use LLM routing, so borrow the existing inline policy
-			// lists directly and avoid cloning policy config.
-			selected_route_chain
-				.routes
-				.iter()
-				.map(|route| route.inline_policies.as_slice())
-				.collect()
-		};
+		let route_inlines = selected_route_chain
+			.routes
+			.iter()
+			.map(|route| route.inline_policies.as_slice())
+			.collect();
 		let route_path = RoutePath {
 			listener: &selected_listener.name,
 			service: selected_route_chain
@@ -903,9 +872,8 @@ impl HTTPProxy {
 		.snapshot_on_err(log, &mut req)?;
 		dtrace::snapshot!(Request, "route policies", &req);
 
-		let selected_backend_ref = selected_llm_backend
-			.map(|selected| selected.backend)
-			.or(selected_route_chain.backend)
+		let selected_backend_ref = selected_route_chain
+			.backend
 			.ok_or(ProxyError::NoValidBackends)
 			.snapshot_on_err(log, &mut req)?;
 		let selected_backend =
@@ -928,6 +896,10 @@ impl HTTPProxy {
 			let connect_upgrade = connect_upgrade
 				.ok_or_else(|| ProxyError::ProcessingString("CONNECT missing upgrade".to_string()))
 				.snapshot_on_err(log, &mut req)?;
+			if matches!(&selected_backend.backend.backend, Backend::LLMRouter(_, _)) {
+				return Err(ProxyResponse::Error(ProxyError::InvalidBackendType))
+					.snapshot_on_err(log, &mut req);
+			}
 			return self
 				.connect_tunnel(
 					log,
@@ -1009,6 +981,7 @@ impl HTTPProxy {
 						llm_request_policies,
 						&selected_backend,
 						backend_policies,
+						Some(route_path.clone()),
 						response_policies,
 						req,
 					)
@@ -1045,6 +1018,7 @@ impl HTTPProxy {
 					llm_request_policies.clone(),
 					&selected_backend,
 					backend_policies.clone(),
+					Some(route_path.clone()),
 					response_policies,
 					req,
 				)
@@ -1304,6 +1278,7 @@ impl HTTPProxy {
 		route_policies: Arc<store::LLMRequestPolicies>,
 		selected_backend: &RouteBackend,
 		backend_policies: Arc<BackendPolicies>,
+		route_path: Option<RoutePath<'_>>,
 		response_policies: &mut ResponsePolicies,
 		mut req: Request,
 	) -> Result<Response, SnapshottedProxyResponse> {
@@ -1328,6 +1303,7 @@ impl HTTPProxy {
 			route_policies.clone(),
 			&selected_backend.backend.backend,
 			backend_policies,
+			route_path,
 			MustSnapshot::new(&mut req_opt),
 			Some(log),
 			response_policies,
@@ -1936,10 +1912,39 @@ async fn make_backend_call(
 	route_policies: Arc<store::LLMRequestPolicies>,
 	backend: &Backend,
 	base_policies: Arc<BackendPolicies>,
+	route_path: Option<RoutePath<'_>>,
 	mut req: MustSnapshot<'_>,
 	mut log: Option<&mut RequestLog>,
 	response_policies: &mut ResponsePolicies,
 ) -> Result<Response, ProxyResponse> {
+	if let Backend::LLMRouter(_, router) = backend {
+		let resolved = match router.resolve(&mut req).await {
+			model_router::ResolveResult::DirectResponse(resp) => return Ok(resp),
+			model_router::ResolveResult::Backend(resolved) => resolved,
+		};
+		let selected_backend = resolve_backend(resolved.backend, inputs.as_ref())?;
+		let concrete_policies = get_backend_policies(
+			inputs.as_ref(),
+			&selected_backend.backend,
+			&selected_backend.inline_policies,
+			route_path.clone(),
+		);
+		let route_policies = route_policies.merge_backend_policies(Some(resolved.llm_policy));
+		let policies = Arc::new(base_policies.as_ref().clone().merge(concrete_policies));
+		let backend = selected_backend.backend.backend;
+		return Box::pin(make_backend_call(
+			inputs,
+			route_policies,
+			&backend,
+			policies,
+			route_path,
+			req,
+			log,
+			response_policies,
+		))
+		.await;
+	}
+
 	let policy_client = PolicyClient::new(inputs.clone());
 	let hbone_source = req
 		.extensions()
@@ -2159,6 +2164,7 @@ async fn make_backend_call(
 			.await;
 			return res.map_err(ProxyResponse::from);
 		},
+		Backend::LLMRouter(_, _) => unreachable!("LLMRouter is resolved before backend calls"),
 		Backend::Invalid => return Err(ProxyResponse::from(ProxyError::BackendDoesNotExist)),
 	};
 	log.add(|l| l.health_policy = backend_call.backend_policies.health.clone());
@@ -2598,9 +2604,11 @@ fn build_connect_backend_call(
 			policies,
 		)),
 		Backend::Invalid => Err(ProxyError::BackendDoesNotExist),
-		Backend::AI(_, _) | Backend::MCP(_, _) | Backend::Aws(_, _) | Backend::Internal(_, _) => {
-			Err(ProxyError::InvalidBackendType)
-		},
+		Backend::AI(_, _)
+		| Backend::LLMRouter(_, _)
+		| Backend::MCP(_, _)
+		| Backend::Aws(_, _)
+		| Backend::Internal(_, _) => Err(ProxyError::InvalidBackendType),
 	}
 }
 
@@ -4003,12 +4011,12 @@ impl PolicyClient {
 					Arc::new(LLMRequestPolicies::default()),
 					&backend,
 					pols.into(),
-					MustSnapshot::new(&mut req),
-					// Here we don't have a log to pass. MCP and LLM flows expect there to always be a log.
-					// As such, we ensure we ONLY call this with Simple backend type which cannot be MCP/LLM
 					None,
-					&mut Default::default(),
-				)
+				MustSnapshot::new(&mut req),
+				// Here we don't have a log to pass. MCP and LLM flows expect there to always be a log.
+				// As such, we ensure we ONLY call this with Simple backend type which cannot be MCP/LLM
+				None,
+				&mut Default::default(),)
 				.assert_size::<{ 7 * 1024 }>(),
 			)
 			.await

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -237,6 +237,7 @@ pub struct BackendPolicies {
 	pub llm_provider: Option<Arc<llm::NamedAIProvider>>,
 	pub llm: Option<Arc<llm::Policy>>,
 	pub inference_routing: Option<InferenceRouting>,
+	pub authorization: BackendPolicy<HTTPAuthorizationSet>,
 	pub ext_authz: BackendPolicy<ext_authz::ExtAuthz>,
 
 	pub mcp_authorization: Option<McpAuthorizationSet>,
@@ -272,6 +273,17 @@ impl BackendPolicies {
 			a2a: other.a2a.or(self.a2a),
 			llm_provider: other.llm_provider.or(self.llm_provider),
 			llm: other.llm.or(self.llm),
+			authorization: match (
+				self.authorization.into_arc(),
+				other.authorization.into_arc(),
+			) {
+				(Some(left), Some(right)) => BackendPolicy::from_arc(Arc::new(
+					Arc::unwrap_or_clone(left).merge(Arc::unwrap_or_clone(right)),
+				)),
+				(Some(left), None) => BackendPolicy::from_arc(left),
+				(None, Some(right)) => BackendPolicy::from_arc(right),
+				(None, None) => BackendPolicy::default(),
+			},
 			// TODO: is this right??
 			mcp_authorization: other.mcp_authorization.or(self.mcp_authorization),
 			mcp_authentication: other.mcp_authentication.or(self.mcp_authentication),
@@ -310,6 +322,7 @@ impl BackendPolicies {
 	}
 
 	pub fn register_cel_expressions(&self, ctx: &mut ContextBuilder) {
+		self.authorization.register_expressions(ctx);
 		self.ext_authz.register_expressions(ctx);
 		self.transformation.register_expressions(ctx);
 		if let Some(llm) = self.llm.as_ref() {
@@ -1118,10 +1131,14 @@ impl Store {
 			.flat_map(|p| p.iter())
 			.chain(rules);
 
+		let mut authz = Vec::new();
 		let mut mcp_authz = Vec::new();
 		let mut pol = BackendPolicies::default();
 		for rule in rules {
 			match &rule {
+				BackendTrafficPolicy::Authorization(p) => {
+					authz.push(p.clone().0);
+				},
 				BackendTrafficPolicy::A2a(p) => {
 					pol.a2a.get_or_insert_with(|| p.clone());
 				},
@@ -1188,6 +1205,11 @@ impl Store {
 					pol.mcp_guardrails.get_or_insert_with(|| p.clone());
 				},
 			}
+		}
+		if !authz.is_empty() {
+			pol.authorization = BackendPolicy::from_arc(Arc::new(HTTPAuthorizationSet::new(
+				crate::http::authorization::RuleSets::from_arcs(authz),
+			)));
 		}
 		if !mcp_authz.is_empty() {
 			pol.mcp_authorization = Some(McpAuthorizationSet::new(mcp_authz.into()));

--- a/crates/agentgateway/src/store/policy.rs
+++ b/crates/agentgateway/src/store/policy.rs
@@ -437,14 +437,25 @@ impl<T> Default for BackendPolicy<T> {
 	}
 }
 
-impl<T: BackendPolicyTrait> BackendPolicy<T> {
+impl<T> BackendPolicy<T> {
+	pub fn from_arc(pol: Arc<T>) -> Self {
+		Self(Some(pol))
+	}
+
+	pub fn into_arc(self) -> Option<Arc<T>> {
+		self.0
+	}
+
 	pub fn as_ref(&self) -> Option<&Arc<T>> {
 		self.0.as_ref()
 	}
+
 	pub fn or(self, other: Self) -> Self {
 		BackendPolicy(self.0.or(other.0))
 	}
+}
 
+impl<T: BackendPolicyTrait> BackendPolicy<T> {
 	pub fn set_if_unset(&mut self, pol: &Arc<T>) {
 		if self.0.is_none() {
 			self.0 = Some(pol.clone());

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -2487,6 +2487,7 @@ pub enum TrafficPolicy {
 #[derive(Debug, Clone, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub enum BackendTrafficPolicy {
+	Authorization(Authorization),
 	McpAuthorization(McpAuthorization),
 	McpAuthentication(McpAuthentication),
 	McpGuardrails(Arc<crate::mcp::guardrails::McpGuardrails>),

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -1224,6 +1224,8 @@ pub enum Backend {
 	MCP(ResourceName, McpBackend),
 	#[serde(rename = "ai", serialize_with = "serialize_backend_tuple")]
 	AI(ResourceName, crate::llm::AIBackend),
+	#[serde(rename = "llmRouter", serialize_with = "serialize_backend_tuple")]
+	LLMRouter(ResourceName, Arc<crate::llm::model_router::ModelRouter>),
 	#[serde(rename = "aws", serialize_with = "serialize_backend_tuple")]
 	Aws(ResourceName, crate::aws::AwsBackendConfig),
 	#[serde(serialize_with = "serialize_backend_tuple")]
@@ -1418,6 +1420,7 @@ impl Backend {
 			Backend::Opaque(name, _)
 			| Backend::MCP(name, _)
 			| Backend::AI(name, _)
+			| Backend::LLMRouter(name, _)
 			| Backend::Aws(name, _)
 			| Backend::Dynamic(name, _)
 			| Backend::Internal(name, _) => BackendTarget::Backend {
@@ -1439,6 +1442,7 @@ impl Backend {
 			Backend::Opaque(name, _)
 			| Backend::MCP(name, _)
 			| Backend::AI(name, _)
+			| Backend::LLMRouter(name, _)
 			| Backend::Aws(name, _)
 			| Backend::Dynamic(name, _)
 			| Backend::Internal(name, _) => BackendTargetRef::Backend {
@@ -1456,6 +1460,7 @@ impl Backend {
 			Backend::Opaque(name, _)
 			| Backend::MCP(name, _)
 			| Backend::AI(name, _)
+			| Backend::LLMRouter(name, _)
 			| Backend::Aws(name, _)
 			| Backend::Dynamic(name, _)
 			| Backend::Internal(name, _) => {
@@ -1474,7 +1479,7 @@ impl Backend {
 			Backend::Service(_, _) => cel::BackendType::Service,
 			Backend::Opaque(_, _) => cel::BackendType::Static,
 			Backend::MCP(_, _) => cel::BackendType::MCP,
-			Backend::AI(_, _) => cel::BackendType::AI,
+			Backend::AI(_, _) | Backend::LLMRouter(_, _) => cel::BackendType::AI,
 			Backend::Aws(_, _) => cel::BackendType::Unknown,
 			Backend::Dynamic(_, _) => cel::BackendType::Dynamic,
 			Backend::Internal(_, _) => cel::BackendType::Unknown,
@@ -1485,7 +1490,7 @@ impl Backend {
 	pub fn backend_protocol(&self) -> Option<cel::BackendProtocol> {
 		match self {
 			Backend::MCP(_, _) => Some(cel::BackendProtocol::mcp),
-			Backend::AI(_, _) => Some(cel::BackendProtocol::llm),
+			Backend::AI(_, _) | Backend::LLMRouter(_, _) => Some(cel::BackendProtocol::llm),
 			_ => None,
 		}
 	}

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -1373,19 +1373,19 @@ impl LocalBackend {
 		resources: &crate::resource_manager::ResourceFetcher,
 	) -> Result<BackendWithPolicies, anyhow::Error> {
 		let mut inline_policies = match policies {
-			Some(p) => {
-				LocalBackendPolicies {
-					simple: p.simple,
-					mcp_authorization: p.mcp_authorization,
-					mcp_guardrails: p.mcp_guardrails,
-					a2a: None,
-					inference_routing: None,
-					ai: None,
-					response_header_modifier: None,
-					request_redirect: None,
-					health: None,
-					ext_authz: None,
-				}
+			Some(p) => { LocalBackendPolicies {
+				simple: p.simple,
+				mcp_authorization: p.mcp_authorization,
+				mcp_guardrails: p.mcp_guardrails,
+				a2a: None,
+				inference_routing: None,
+				ai: None,
+				response_header_modifier: None,
+				request_redirect: None,
+				health: None,
+				ext_authz: None,
+				authorization: None,
+			}
 				.translate(resources)
 				.await?
 			},
@@ -2052,6 +2052,9 @@ pub struct LocalBackendPolicies {
 	/// Authorize incoming requests by calling an external authorization service after this backend is selected.
 	#[serde(default)]
 	pub ext_authz: Option<crate::http::ext_authz::ExtAuthz>,
+	/// Authorize incoming requests after this backend is selected.
+	#[serde(default)]
+	pub authorization: Option<Authorization>,
 
 	/// Authorization rules for MCP requests.
 	#[serde(default)]
@@ -2125,6 +2128,7 @@ impl LocalBackendPolicies {
 			request_redirect,
 			health,
 			ext_authz,
+			authorization,
 		} = self;
 		let mut pols = vec![];
 		if let Some(p) = tcp {
@@ -2175,6 +2179,9 @@ impl LocalBackendPolicies {
 			pols.push(BackendTrafficPolicy::ExtAuthz(Arc::new(
 				p.with_configured_cache_store(),
 			)))
+		}
+		if let Some(p) = authorization {
+			pols.push(BackendTrafficPolicy::Authorization(p))
 		}
 		if let Some(mut p) = ai {
 			p.compile_model_alias_patterns();
@@ -2647,7 +2654,6 @@ struct ResolvedLLMModelTarget {
 	name: String,
 	provider: NamedAIProvider,
 	inline_policies: Vec<BackendTrafficPolicy>,
-	authorization: Option<Authorization>,
 }
 
 struct LocalLLMModelRegistry {
@@ -2830,17 +2836,6 @@ impl ResolvedLLMModelRegistry {
 			}
 		}
 		bail!("virtual model target {target} does not match any llm.models entry")
-	}
-
-	fn resolve_failover_target(&self, target: &str) -> anyhow::Result<ResolvedLLMModelTarget> {
-		let resolved = self.resolve(target)?;
-		if resolved.authorization.is_some() {
-			// Technically this is possible but would require us to move authorization down into post-LB.
-			bail!(
-				"virtual model target {target} has authorization; failover virtual models cannot target authorized models"
-			);
-		}
-		Ok(resolved)
 	}
 }
 
@@ -3262,6 +3257,9 @@ async fn convert_llm_config(
 				|e: crate::cel::Error| anyhow::anyhow!("health.unhealthyExpression: {}", e),
 			)?));
 		}
+		if let Some(authorization) = model_config.authorization.clone() {
+			pols.push(BackendTrafficPolicy::Authorization(authorization));
+		}
 		let prompt_guard =
 			merge_prompt_guards(shared_prompt_guard.clone(), model_config.guardrails.clone());
 		pols.push(BackendTrafficPolicy::AI(Arc::new(llm::Policy {
@@ -3285,7 +3283,6 @@ async fn convert_llm_config(
 			name: model_config.name.clone(),
 			provider: resolved_provider,
 			inline_policies: resolved_inline_policies,
-			authorization: model_config.authorization.clone(),
 		});
 
 		router_models.push(llm::model_router::ModelRoute {
@@ -3356,7 +3353,7 @@ async fn convert_llm_config(
 					.map(|(_, targets)| {
 						targets
 							.map(|target| {
-								let resolved = resolved_models.resolve_failover_target(&target.model)?;
+								let resolved = resolved_models.resolve(&target.model)?;
 								let mut provider = resolved.provider.clone();
 								provider.name = strng::new(&target.model);
 								ensure_ai_provider_model(&mut provider.provider, &target.model);

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -1373,19 +1373,20 @@ impl LocalBackend {
 		resources: &crate::resource_manager::ResourceFetcher,
 	) -> Result<BackendWithPolicies, anyhow::Error> {
 		let mut inline_policies = match policies {
-			Some(p) => { LocalBackendPolicies {
-				simple: p.simple,
-				mcp_authorization: p.mcp_authorization,
-				mcp_guardrails: p.mcp_guardrails,
-				a2a: None,
-				inference_routing: None,
-				ai: None,
-				response_header_modifier: None,
-				request_redirect: None,
-				health: None,
-				ext_authz: None,
-				authorization: None,
-			}
+			Some(p) => {
+				LocalBackendPolicies {
+					simple: p.simple,
+					mcp_authorization: p.mcp_authorization,
+					mcp_guardrails: p.mcp_guardrails,
+					a2a: None,
+					inference_routing: None,
+					ai: None,
+					response_header_modifier: None,
+					request_redirect: None,
+					health: None,
+					ext_authz: None,
+					authorization: None,
+				}
 				.translate(resources)
 				.await?
 			},

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -2489,6 +2489,7 @@ async fn convert(
 			Backend::Opaque(n, _)
 			| Backend::MCP(n, _)
 			| Backend::AI(n, _)
+			| Backend::LLMRouter(n, _)
 			| Backend::Aws(n, _)
 			| Backend::Dynamic(n, _)
 			| Backend::Internal(n, _) => n == &name,
@@ -3287,13 +3288,6 @@ async fn convert_llm_config(
 			authorization: model_config.authorization.clone(),
 		});
 
-		let mut model_route_inline_policies = vec![TrafficPolicy::AI(Arc::new(crate::llm::Policy {
-			routes: llm_routes.into_iter().collect(),
-			..Default::default()
-		}))];
-		if let Some(p) = model_config.authorization.clone() {
-			model_route_inline_policies.push(TrafficPolicy::Authorization(p));
-		}
 		router_models.push(llm::model_router::ModelRoute {
 			name: model_config.name.clone(),
 			visibility: model_config.visibility,
@@ -3303,7 +3297,13 @@ async fn convert_llm_config(
 				.map(|m| m.headers.clone())
 				.collect(),
 			backend_key,
-			route_policies: model_route_inline_policies,
+			policies: llm::model_router::ModelRoutePolicies {
+				llm: Arc::new(crate::llm::Policy {
+					routes: llm_routes.into_iter().collect(),
+					..Default::default()
+				}),
+				authorization: model_config.authorization.clone(),
+			},
 			backend_policies: vec![],
 		});
 	}
@@ -3311,10 +3311,10 @@ async fn convert_llm_config(
 	let virtual_models = llm_registry.into_virtual_models();
 	let mut router_virtual_models = Vec::new();
 	for (idx, virtual_model) in virtual_models.into_iter().enumerate() {
-		let route_policies = vec![TrafficPolicy::AI(Arc::new(crate::llm::Policy {
+		let llm_policy = Arc::new(crate::llm::Policy {
 			routes: llm_route_types(None).into_iter().collect(),
 			..Default::default()
-		}))];
+		});
 		let routing = match virtual_model.routing_strategy()? {
 			LocalLLMVirtualRoutingStrategy::Conditional(conditional) => {
 				for target in &conditional.targets {
@@ -3383,10 +3383,23 @@ async fn convert_llm_config(
 		};
 		router_virtual_models.push(llm::model_router::VirtualModelRoute {
 			name: virtual_model.name,
-			route_policies,
+			llm_policy,
 			routing,
 		});
 	}
+
+	let router_backend_key = strng::new("llm:router");
+	all_backends.push(BackendWithPolicies {
+		backend: Backend::LLMRouter(
+			local_name(router_backend_key.clone()),
+			Arc::new(llm::model_router::ModelRouter::new(
+				router_models,
+				router_virtual_models,
+				startup_timestamp,
+			)),
+		),
+		inline_policies: vec![],
+	});
 
 	routes.push(Route {
 		key: strng::new("llm:request"),
@@ -3405,12 +3418,12 @@ async fn convert_llm_config(
 			headers: vec![],
 			query: vec![],
 		}],
-		backends: vec![],
-		llm_router: Some(Arc::new(llm::model_router::ModelRouter::new(
-			router_models,
-			router_virtual_models,
-			startup_timestamp,
-		))),
+		backends: vec![RouteBackendReference {
+			weight: 1,
+			target: BackendReference::Backend(strng::format!("/{router_backend_key}")).into(),
+			inline_policies: vec![],
+		}],
+		llm_router: None,
 		inline_policies: vec![],
 	});
 

--- a/crates/agentgateway/src/types/local_tests.rs
+++ b/crates/agentgateway/src/types/local_tests.rs
@@ -574,36 +574,6 @@ llm:
 }
 
 #[tokio::test]
-async fn test_llm_failover_virtual_model_rejects_authorized_target() {
-	let err = normalize_test_config(
-		r#"
-llm:
-  models:
-  - name: concrete
-    provider: openAI
-    authorization:
-      rules:
-      - 'request.headers["x-user"] == "admin"'
-  virtualModels:
-  - name: smart
-    routing:
-      failover:
-        targets:
-        - model: concrete
-          priority: 0
-"#,
-	)
-	.await
-	.expect_err("failover target authorization cannot be enforced after provider selection");
-	assert!(
-		err.to_string().contains(
-			"virtual model target concrete has authorization; failover virtual models cannot target authorized models"
-		),
-		"{err:?}"
-	);
-}
-
-#[tokio::test]
 async fn test_llm_conditional_virtual_model_allows_authorized_internal_target() {
 	let normalized = normalize_test_config(
 		r#"

--- a/crates/agentgateway/src/types/local_tests.rs
+++ b/crates/agentgateway/src/types/local_tests.rs
@@ -568,8 +568,22 @@ llm:
 		.find(|route| route.key == "llm:request")
 		.expect("expected single LLM request route");
 	assert!(
-		llm_route.llm_router.is_some(),
-		"LLM request route should carry the native model router"
+		llm_route.llm_router.is_none(),
+		"LLM request route should route through the LLMRouter backend"
+	);
+	assert!(
+		llm_route
+			.backends
+			.iter()
+			.any(|backend| matches!(&backend.target, RouteBackendTarget::Backend(name) if name.as_str() == "/llm:router")),
+		"LLM request route should target the LLMRouter backend"
+	);
+	assert!(
+		normalized
+			.backends
+			.iter()
+			.any(|backend| matches!(&backend.backend, Backend::LLMRouter(name, _) if name.name.as_str() == "llm:router")),
+		"normalized config should contain the LLMRouter backend"
 	);
 }
 
@@ -608,8 +622,22 @@ llm:
 		.find(|route| route.key == "llm:request")
 		.expect("expected single LLM request route");
 	assert!(
-		llm_route.llm_router.is_some(),
-		"LLM request route should carry the native model router"
+		llm_route.llm_router.is_none(),
+		"LLM request route should route through the LLMRouter backend"
+	);
+	assert!(
+		llm_route
+			.backends
+			.iter()
+			.any(|backend| matches!(&backend.target, RouteBackendTarget::Backend(name) if name.as_str() == "/llm:router")),
+		"LLM request route should target the LLMRouter backend"
+	);
+	assert!(
+		normalized
+			.backends
+			.iter()
+			.any(|backend| matches!(&backend.backend, Backend::LLMRouter(name, _) if name.name.as_str() == "llm:router")),
+		"normalized config should contain the LLMRouter backend"
 	);
 	assert!(
 		!routes

--- a/crates/agentgateway/src/types/local_tests/llm_provider_reference_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/llm_provider_reference_normalized.snap
@@ -18,32 +18,10 @@ binds:
         protocol: HTTP
 listener_routes:
   - - llm
-    - - key: "llm:request"
-        llmRouter:
-          models:
-            - name: anthropic/*
-              visibility: public
-              headerMatches: []
-              backendKey: "llm:model:anthropic/*:0"
-              routePolicies:
-                - ai:
-                    routes:
-                      "*": passthrough
-                      /v1/chat/completions: completions
-                      /v1/embeddings: embeddings
-                      /v1/images/edits: detect
-                      /v1/images/generations: detect
-                      /v1/images/variations: detect
-                      /v1/messages: messages
-                      /v1/rerank: rerank
-                      /v1/responses: responses
-                      /v1/responses/compact: detect
-                      /v2/rerank: rerank
-                      ":rawPredict": messages
-                      ":streamRawPredict": messages
-              backendPolicies: []
-          virtualModels: []
-          created: 0
+    - - backends:
+          - backend: "/llm:router"
+            weight: 1
+        key: "llm:request"
         matches:
           - path:
               pathPrefix: /
@@ -99,6 +77,36 @@ backends:
             cacheTools: false
             minTokens: 2048
             cacheMessageOffset: 0
+  - backend:
+      llmRouter:
+        name: "llm:router"
+        namespace: ""
+        target:
+          models:
+            - name: anthropic/*
+              visibility: public
+              headerMatches: []
+              backendKey: "llm:model:anthropic/*:0"
+              policies:
+                llm:
+                  routes:
+                    "*": passthrough
+                    /v1/chat/completions: completions
+                    /v1/embeddings: embeddings
+                    /v1/images/edits: detect
+                    /v1/images/generations: detect
+                    /v1/images/variations: detect
+                    /v1/messages: messages
+                    /v1/rerank: rerank
+                    /v1/responses: responses
+                    /v1/responses/compact: detect
+                    /v2/rerank: rerank
+                    ":rawPredict": messages
+                    ":streamRawPredict": messages
+                authorization: ~
+              backendPolicies: []
+          virtualModels: []
+          created: 0
 route_groups: []
 workloads: []
 services: []

--- a/crates/agentgateway/src/types/local_tests/llm_simple_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/llm_simple_normalized.snap
@@ -18,140 +18,10 @@ binds:
         protocol: HTTP
 listener_routes:
   - - llm
-    - - key: "llm:request"
-        llmRouter:
-          models:
-            - name: llama-3.1-8b-instant
-              visibility: public
-              headerMatches: []
-              backendKey: "llm:model:llama-3.1-8b-instant:0"
-              routePolicies:
-                - ai:
-                    routes:
-                      "*": passthrough
-                      /v1/chat/completions: completions
-                      /v1/embeddings: embeddings
-                      /v1/images/edits: detect
-                      /v1/images/generations: detect
-                      /v1/images/variations: detect
-                      /v1/messages: messages
-                      /v1/rerank: rerank
-                      /v1/responses: responses
-                      /v1/responses/compact: detect
-                      /v2/rerank: rerank
-                      ":rawPredict": messages
-                      ":streamRawPredict": messages
-              backendPolicies: []
-            - name: fireworks-llama
-              visibility: public
-              headerMatches: []
-              backendKey: "llm:model:fireworks-llama:1"
-              routePolicies:
-                - ai:
-                    routes:
-                      "*": passthrough
-                      /v1/chat/completions: completions
-                      /v1/embeddings: embeddings
-                      /v1/images/edits: detect
-                      /v1/images/generations: detect
-                      /v1/images/variations: detect
-                      /v1/messages: messages
-                      /v1/rerank: rerank
-                      /v1/responses: responses
-                      /v1/responses/compact: detect
-                      /v2/rerank: rerank
-                      ":rawPredict": messages
-                      ":streamRawPredict": messages
-              backendPolicies: []
-            - name: claude-3-haiku
-              visibility: public
-              headerMatches:
-                - - name: x-org
-                    value:
-                      exact: engineering
-              backendKey: "llm:model:claude-3-haiku:2"
-              routePolicies:
-                - ai:
-                    routes:
-                      "*": passthrough
-                      /v1/chat/completions: completions
-                      /v1/embeddings: embeddings
-                      /v1/images/edits: detect
-                      /v1/images/generations: detect
-                      /v1/images/variations: detect
-                      /v1/messages: messages
-                      /v1/rerank: rerank
-                      /v1/responses: responses
-                      /v1/responses/compact: detect
-                      /v2/rerank: rerank
-                      ":rawPredict": messages
-                      ":streamRawPredict": messages
-              backendPolicies: []
-            - name: gpt-3.5-turbo
-              visibility: public
-              headerMatches: []
-              backendKey: "llm:model:gpt-3.5-turbo:3"
-              routePolicies:
-                - ai:
-                    routes:
-                      "*": passthrough
-                      /v1/chat/completions: completions
-                      /v1/embeddings: embeddings
-                      /v1/images/edits: detect
-                      /v1/images/generations: detect
-                      /v1/images/variations: detect
-                      /v1/messages: messages
-                      /v1/rerank: rerank
-                      /v1/responses: responses
-                      /v1/responses/compact: detect
-                      /v2/rerank: rerank
-                      ":rawPredict": messages
-                      ":streamRawPredict": messages
-              backendPolicies: []
-            - name: gpt-7-max
-              visibility: public
-              headerMatches: []
-              backendKey: "llm:model:gpt-7-max:4"
-              routePolicies:
-                - ai:
-                    routes:
-                      "*": passthrough
-                      /v1/chat/completions: completions
-                      /v1/embeddings: embeddings
-                      /v1/images/edits: detect
-                      /v1/images/generations: detect
-                      /v1/images/variations: detect
-                      /v1/messages: messages
-                      /v1/rerank: rerank
-                      /v1/responses: responses
-                      /v1/responses/compact: detect
-                      /v2/rerank: rerank
-                      ":rawPredict": messages
-                      ":streamRawPredict": messages
-              backendPolicies: []
-            - name: "*"
-              visibility: public
-              headerMatches: []
-              backendKey: "llm:model:*:5"
-              routePolicies:
-                - ai:
-                    routes:
-                      "*": passthrough
-                      /v1/chat/completions: completions
-                      /v1/embeddings: embeddings
-                      /v1/images/edits: detect
-                      /v1/images/generations: detect
-                      /v1/images/variations: detect
-                      /v1/messages: messages
-                      /v1/rerank: rerank
-                      /v1/responses: responses
-                      /v1/responses/compact: detect
-                      /v2/rerank: rerank
-                      ":rawPredict": messages
-                      ":streamRawPredict": messages
-              backendPolicies: []
-          virtualModels: []
-          created: 0
+    - - backends:
+          - backend: "/llm:router"
+            weight: 1
+        key: "llm:request"
         matches:
           - path:
               pathPrefix: /
@@ -527,6 +397,149 @@ backends:
                 rejection:
                   body: The request was rejected due to inappropriate content
                   status: 400
+  - backend:
+      llmRouter:
+        name: "llm:router"
+        namespace: ""
+        target:
+          models:
+            - name: llama-3.1-8b-instant
+              visibility: public
+              headerMatches: []
+              backendKey: "llm:model:llama-3.1-8b-instant:0"
+              policies:
+                llm:
+                  routes:
+                    "*": passthrough
+                    /v1/chat/completions: completions
+                    /v1/embeddings: embeddings
+                    /v1/images/edits: detect
+                    /v1/images/generations: detect
+                    /v1/images/variations: detect
+                    /v1/messages: messages
+                    /v1/rerank: rerank
+                    /v1/responses: responses
+                    /v1/responses/compact: detect
+                    /v2/rerank: rerank
+                    ":rawPredict": messages
+                    ":streamRawPredict": messages
+                authorization: ~
+              backendPolicies: []
+            - name: fireworks-llama
+              visibility: public
+              headerMatches: []
+              backendKey: "llm:model:fireworks-llama:1"
+              policies:
+                llm:
+                  routes:
+                    "*": passthrough
+                    /v1/chat/completions: completions
+                    /v1/embeddings: embeddings
+                    /v1/images/edits: detect
+                    /v1/images/generations: detect
+                    /v1/images/variations: detect
+                    /v1/messages: messages
+                    /v1/rerank: rerank
+                    /v1/responses: responses
+                    /v1/responses/compact: detect
+                    /v2/rerank: rerank
+                    ":rawPredict": messages
+                    ":streamRawPredict": messages
+                authorization: ~
+              backendPolicies: []
+            - name: claude-3-haiku
+              visibility: public
+              headerMatches:
+                - - name: x-org
+                    value:
+                      exact: engineering
+              backendKey: "llm:model:claude-3-haiku:2"
+              policies:
+                llm:
+                  routes:
+                    "*": passthrough
+                    /v1/chat/completions: completions
+                    /v1/embeddings: embeddings
+                    /v1/images/edits: detect
+                    /v1/images/generations: detect
+                    /v1/images/variations: detect
+                    /v1/messages: messages
+                    /v1/rerank: rerank
+                    /v1/responses: responses
+                    /v1/responses/compact: detect
+                    /v2/rerank: rerank
+                    ":rawPredict": messages
+                    ":streamRawPredict": messages
+                authorization: ~
+              backendPolicies: []
+            - name: gpt-3.5-turbo
+              visibility: public
+              headerMatches: []
+              backendKey: "llm:model:gpt-3.5-turbo:3"
+              policies:
+                llm:
+                  routes:
+                    "*": passthrough
+                    /v1/chat/completions: completions
+                    /v1/embeddings: embeddings
+                    /v1/images/edits: detect
+                    /v1/images/generations: detect
+                    /v1/images/variations: detect
+                    /v1/messages: messages
+                    /v1/rerank: rerank
+                    /v1/responses: responses
+                    /v1/responses/compact: detect
+                    /v2/rerank: rerank
+                    ":rawPredict": messages
+                    ":streamRawPredict": messages
+                authorization: ~
+              backendPolicies: []
+            - name: gpt-7-max
+              visibility: public
+              headerMatches: []
+              backendKey: "llm:model:gpt-7-max:4"
+              policies:
+                llm:
+                  routes:
+                    "*": passthrough
+                    /v1/chat/completions: completions
+                    /v1/embeddings: embeddings
+                    /v1/images/edits: detect
+                    /v1/images/generations: detect
+                    /v1/images/variations: detect
+                    /v1/messages: messages
+                    /v1/rerank: rerank
+                    /v1/responses: responses
+                    /v1/responses/compact: detect
+                    /v2/rerank: rerank
+                    ":rawPredict": messages
+                    ":streamRawPredict": messages
+                authorization: ~
+              backendPolicies: []
+            - name: "*"
+              visibility: public
+              headerMatches: []
+              backendKey: "llm:model:*:5"
+              policies:
+                llm:
+                  routes:
+                    "*": passthrough
+                    /v1/chat/completions: completions
+                    /v1/embeddings: embeddings
+                    /v1/images/edits: detect
+                    /v1/images/generations: detect
+                    /v1/images/variations: detect
+                    /v1/messages: messages
+                    /v1/rerank: rerank
+                    /v1/responses: responses
+                    /v1/responses/compact: detect
+                    /v2/rerank: rerank
+                    ":rawPredict": messages
+                    ":streamRawPredict": messages
+                authorization: ~
+              backendPolicies: []
+          virtualModels: []
+          created: 0
 route_groups: []
 workloads: []
 services: []

--- a/crates/agentgateway/src/types/local_tests/llm_virtual_model_conditional_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/llm_virtual_model_conditional_normalized.snap
@@ -18,101 +18,10 @@ binds:
         protocol: HTTP
 listener_routes:
   - - llm
-    - - key: "llm:request"
-        llmRouter:
-          models:
-            - name: openai/gpt-5-mini
-              visibility: public
-              headerMatches: []
-              backendKey: "llm:model:openai/gpt-5-mini:0"
-              routePolicies:
-                - ai:
-                    routes:
-                      "*": passthrough
-                      /v1/chat/completions: completions
-                      /v1/embeddings: embeddings
-                      /v1/images/edits: detect
-                      /v1/images/generations: detect
-                      /v1/images/variations: detect
-                      /v1/messages: messages
-                      /v1/rerank: rerank
-                      /v1/responses: responses
-                      /v1/responses/compact: detect
-                      /v2/rerank: rerank
-                      ":rawPredict": messages
-                      ":streamRawPredict": messages
-              backendPolicies: []
-            - name: foo/*
-              visibility: public
-              headerMatches: []
-              backendKey: "llm:model:foo/*:1"
-              routePolicies:
-                - ai:
-                    routes:
-                      "*": passthrough
-                      /v1/chat/completions: completions
-                      /v1/embeddings: embeddings
-                      /v1/images/edits: detect
-                      /v1/images/generations: detect
-                      /v1/images/variations: detect
-                      /v1/messages: messages
-                      /v1/rerank: rerank
-                      /v1/responses: responses
-                      /v1/responses/compact: detect
-                      /v2/rerank: rerank
-                      ":rawPredict": messages
-                      ":streamRawPredict": messages
-              backendPolicies: []
-          virtualModels:
-            - name: smart
-              routePolicies:
-                - ai:
-                    routes:
-                      "*": passthrough
-                      /v1/chat/completions: completions
-                      /v1/embeddings: embeddings
-                      /v1/images/edits: detect
-                      /v1/images/generations: detect
-                      /v1/images/variations: detect
-                      /v1/messages: messages
-                      /v1/rerank: rerank
-                      /v1/responses: responses
-                      /v1/responses/compact: detect
-                      /v2/rerank: rerank
-                      ":rawPredict": messages
-                      ":streamRawPredict": messages
-              routing:
-                conditional:
-                  - model: foo/bar
-                    when: "json(request.body).route == \"code\""
-                  - model: openai/gpt-5-mini
-                    when: "json(request.body).route == \"fast\""
-                  - model: foo/baz
-                    when: ~
-            - name: simple
-              routePolicies:
-                - ai:
-                    routes:
-                      "*": passthrough
-                      /v1/chat/completions: completions
-                      /v1/embeddings: embeddings
-                      /v1/images/edits: detect
-                      /v1/images/generations: detect
-                      /v1/images/variations: detect
-                      /v1/messages: messages
-                      /v1/rerank: rerank
-                      /v1/responses: responses
-                      /v1/responses/compact: detect
-                      /v2/rerank: rerank
-                      ":rawPredict": messages
-                      ":streamRawPredict": messages
-              routing:
-                conditional:
-                  - model: openai/gpt-5-mini
-                    when: "json(request.body).route == \"legacy\""
-                  - model: foo/qux
-                    when: ~
-          created: 0
+    - - backends:
+          - backend: "/llm:router"
+            weight: 1
+        key: "llm:request"
         matches:
           - path:
               pathPrefix: /
@@ -189,6 +98,104 @@ backends:
       - ai:
           transformations:
             model: "llmRequest.model.stripPrefix(\"foo/\")"
+  - backend:
+      llmRouter:
+        name: "llm:router"
+        namespace: ""
+        target:
+          models:
+            - name: openai/gpt-5-mini
+              visibility: public
+              headerMatches: []
+              backendKey: "llm:model:openai/gpt-5-mini:0"
+              policies:
+                llm:
+                  routes:
+                    "*": passthrough
+                    /v1/chat/completions: completions
+                    /v1/embeddings: embeddings
+                    /v1/images/edits: detect
+                    /v1/images/generations: detect
+                    /v1/images/variations: detect
+                    /v1/messages: messages
+                    /v1/rerank: rerank
+                    /v1/responses: responses
+                    /v1/responses/compact: detect
+                    /v2/rerank: rerank
+                    ":rawPredict": messages
+                    ":streamRawPredict": messages
+                authorization: ~
+              backendPolicies: []
+            - name: foo/*
+              visibility: public
+              headerMatches: []
+              backendKey: "llm:model:foo/*:1"
+              policies:
+                llm:
+                  routes:
+                    "*": passthrough
+                    /v1/chat/completions: completions
+                    /v1/embeddings: embeddings
+                    /v1/images/edits: detect
+                    /v1/images/generations: detect
+                    /v1/images/variations: detect
+                    /v1/messages: messages
+                    /v1/rerank: rerank
+                    /v1/responses: responses
+                    /v1/responses/compact: detect
+                    /v2/rerank: rerank
+                    ":rawPredict": messages
+                    ":streamRawPredict": messages
+                authorization: ~
+              backendPolicies: []
+          virtualModels:
+            - name: smart
+              llmPolicy:
+                routes:
+                  "*": passthrough
+                  /v1/chat/completions: completions
+                  /v1/embeddings: embeddings
+                  /v1/images/edits: detect
+                  /v1/images/generations: detect
+                  /v1/images/variations: detect
+                  /v1/messages: messages
+                  /v1/rerank: rerank
+                  /v1/responses: responses
+                  /v1/responses/compact: detect
+                  /v2/rerank: rerank
+                  ":rawPredict": messages
+                  ":streamRawPredict": messages
+              routing:
+                conditional:
+                  - model: foo/bar
+                    when: "json(request.body).route == \"code\""
+                  - model: openai/gpt-5-mini
+                    when: "json(request.body).route == \"fast\""
+                  - model: foo/baz
+                    when: ~
+            - name: simple
+              llmPolicy:
+                routes:
+                  "*": passthrough
+                  /v1/chat/completions: completions
+                  /v1/embeddings: embeddings
+                  /v1/images/edits: detect
+                  /v1/images/generations: detect
+                  /v1/images/variations: detect
+                  /v1/messages: messages
+                  /v1/rerank: rerank
+                  /v1/responses: responses
+                  /v1/responses/compact: detect
+                  /v2/rerank: rerank
+                  ":rawPredict": messages
+                  ":streamRawPredict": messages
+              routing:
+                conditional:
+                  - model: openai/gpt-5-mini
+                    when: "json(request.body).route == \"legacy\""
+                  - model: foo/qux
+                    when: ~
+          created: 0
 route_groups: []
 workloads: []
 services: []

--- a/crates/agentgateway/src/types/local_tests/llm_virtual_model_failover_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/llm_virtual_model_failover_normalized.snap
@@ -18,73 +18,10 @@ binds:
         protocol: HTTP
 listener_routes:
   - - llm
-    - - key: "llm:request"
-        llmRouter:
-          models:
-            - name: openai/gpt-5-mini
-              visibility: public
-              headerMatches: []
-              backendKey: "llm:model:openai/gpt-5-mini:0"
-              routePolicies:
-                - ai:
-                    routes:
-                      "*": passthrough
-                      /v1/chat/completions: completions
-                      /v1/embeddings: embeddings
-                      /v1/images/edits: detect
-                      /v1/images/generations: detect
-                      /v1/images/variations: detect
-                      /v1/messages: messages
-                      /v1/rerank: rerank
-                      /v1/responses: responses
-                      /v1/responses/compact: detect
-                      /v2/rerank: rerank
-                      ":rawPredict": messages
-                      ":streamRawPredict": messages
-              backendPolicies: []
-            - name: anthropic/*
-              visibility: internal
-              headerMatches: []
-              backendKey: "llm:model:anthropic/*:1"
-              routePolicies:
-                - ai:
-                    routes:
-                      "*": passthrough
-                      /v1/chat/completions: completions
-                      /v1/embeddings: embeddings
-                      /v1/images/edits: detect
-                      /v1/images/generations: detect
-                      /v1/images/variations: detect
-                      /v1/messages: messages
-                      /v1/rerank: rerank
-                      /v1/responses: responses
-                      /v1/responses/compact: detect
-                      /v2/rerank: rerank
-                      ":rawPredict": messages
-                      ":streamRawPredict": messages
-              backendPolicies: []
-          virtualModels:
-            - name: resilient
-              routePolicies:
-                - ai:
-                    routes:
-                      "*": passthrough
-                      /v1/chat/completions: completions
-                      /v1/embeddings: embeddings
-                      /v1/images/edits: detect
-                      /v1/images/generations: detect
-                      /v1/images/variations: detect
-                      /v1/messages: messages
-                      /v1/rerank: rerank
-                      /v1/responses: responses
-                      /v1/responses/compact: detect
-                      /v2/rerank: rerank
-                      ":rawPredict": messages
-                      ":streamRawPredict": messages
-              routing:
-                failover:
-                  backend_key: "llm:virtual-model:resilient:0"
-          created: 0
+    - - backends:
+          - backend: "/llm:router"
+            weight: 1
+        key: "llm:request"
         matches:
           - path:
               pathPrefix: /
@@ -248,6 +185,77 @@ backends:
                     evictedUntil: ~
                   capacity: 1
               rejected: {}
+  - backend:
+      llmRouter:
+        name: "llm:router"
+        namespace: ""
+        target:
+          models:
+            - name: openai/gpt-5-mini
+              visibility: public
+              headerMatches: []
+              backendKey: "llm:model:openai/gpt-5-mini:0"
+              policies:
+                llm:
+                  routes:
+                    "*": passthrough
+                    /v1/chat/completions: completions
+                    /v1/embeddings: embeddings
+                    /v1/images/edits: detect
+                    /v1/images/generations: detect
+                    /v1/images/variations: detect
+                    /v1/messages: messages
+                    /v1/rerank: rerank
+                    /v1/responses: responses
+                    /v1/responses/compact: detect
+                    /v2/rerank: rerank
+                    ":rawPredict": messages
+                    ":streamRawPredict": messages
+                authorization: ~
+              backendPolicies: []
+            - name: anthropic/*
+              visibility: internal
+              headerMatches: []
+              backendKey: "llm:model:anthropic/*:1"
+              policies:
+                llm:
+                  routes:
+                    "*": passthrough
+                    /v1/chat/completions: completions
+                    /v1/embeddings: embeddings
+                    /v1/images/edits: detect
+                    /v1/images/generations: detect
+                    /v1/images/variations: detect
+                    /v1/messages: messages
+                    /v1/rerank: rerank
+                    /v1/responses: responses
+                    /v1/responses/compact: detect
+                    /v2/rerank: rerank
+                    ":rawPredict": messages
+                    ":streamRawPredict": messages
+                authorization: ~
+              backendPolicies: []
+          virtualModels:
+            - name: resilient
+              llmPolicy:
+                routes:
+                  "*": passthrough
+                  /v1/chat/completions: completions
+                  /v1/embeddings: embeddings
+                  /v1/images/edits: detect
+                  /v1/images/generations: detect
+                  /v1/images/variations: detect
+                  /v1/messages: messages
+                  /v1/rerank: rerank
+                  /v1/responses: responses
+                  /v1/responses/compact: detect
+                  /v2/rerank: rerank
+                  ":rawPredict": messages
+                  ":streamRawPredict": messages
+              routing:
+                failover:
+                  backend_key: "llm:virtual-model:resilient:0"
+          created: 0
 route_groups: []
 workloads: []
 services: []

--- a/crates/agentgateway/src/types/local_tests/llm_virtual_model_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/llm_virtual_model_normalized.snap
@@ -18,99 +18,10 @@ binds:
         protocol: HTTP
 listener_routes:
   - - llm
-    - - key: "llm:request"
-        llmRouter:
-          models:
-            - name: openai/gpt-5-mini
-              visibility: internal
-              headerMatches: []
-              backendKey: "llm:model:openai/gpt-5-mini:0"
-              routePolicies:
-                - ai:
-                    routes:
-                      "*": passthrough
-                      /v1/chat/completions: completions
-                      /v1/embeddings: embeddings
-                      /v1/images/edits: detect
-                      /v1/images/generations: detect
-                      /v1/images/variations: detect
-                      /v1/messages: messages
-                      /v1/rerank: rerank
-                      /v1/responses: responses
-                      /v1/responses/compact: detect
-                      /v2/rerank: rerank
-                      ":rawPredict": messages
-                      ":streamRawPredict": messages
-              backendPolicies: []
-            - name: anthropic/*
-              visibility: internal
-              headerMatches: []
-              backendKey: "llm:model:anthropic/*:1"
-              routePolicies:
-                - ai:
-                    routes:
-                      "*": passthrough
-                      /v1/chat/completions: completions
-                      /v1/embeddings: embeddings
-                      /v1/images/edits: detect
-                      /v1/images/generations: detect
-                      /v1/images/variations: detect
-                      /v1/messages: messages
-                      /v1/rerank: rerank
-                      /v1/responses: responses
-                      /v1/responses/compact: detect
-                      /v2/rerank: rerank
-                      ":rawPredict": messages
-                      ":streamRawPredict": messages
-              backendPolicies: []
-            - name: "*"
-              visibility: internal
-              headerMatches: []
-              backendKey: "llm:model:*:2"
-              routePolicies:
-                - ai:
-                    routes:
-                      "*": passthrough
-                      /v1/chat/completions: completions
-                      /v1/embeddings: embeddings
-                      /v1/images/edits: detect
-                      /v1/images/generations: detect
-                      /v1/images/variations: detect
-                      /v1/messages: messages
-                      /v1/rerank: rerank
-                      /v1/responses: responses
-                      /v1/responses/compact: detect
-                      /v2/rerank: rerank
-                      ":rawPredict": messages
-                      ":streamRawPredict": messages
-              backendPolicies: []
-          virtualModels:
-            - name: fast
-              routePolicies:
-                - ai:
-                    routes:
-                      "*": passthrough
-                      /v1/chat/completions: completions
-                      /v1/embeddings: embeddings
-                      /v1/images/edits: detect
-                      /v1/images/generations: detect
-                      /v1/images/variations: detect
-                      /v1/messages: messages
-                      /v1/rerank: rerank
-                      /v1/responses: responses
-                      /v1/responses/compact: detect
-                      /v2/rerank: rerank
-                      ":rawPredict": messages
-                      ":streamRawPredict": messages
-              routing:
-                weighted:
-                  - model: anthropic/haiku
-                    weight: 60
-                  - model: openai/gpt-5-mini
-                    weight: 30
-                  - model: fallback-small
-                    weight: 10
-          created: 0
+    - - backends:
+          - backend: "/llm:router"
+            weight: 1
+        key: "llm:request"
         matches:
           - path:
               pathPrefix: /
@@ -220,6 +131,104 @@ backends:
               rejected: {}
     inlinePolicies:
       - ai: {}
+  - backend:
+      llmRouter:
+        name: "llm:router"
+        namespace: ""
+        target:
+          models:
+            - name: openai/gpt-5-mini
+              visibility: internal
+              headerMatches: []
+              backendKey: "llm:model:openai/gpt-5-mini:0"
+              policies:
+                llm:
+                  routes:
+                    "*": passthrough
+                    /v1/chat/completions: completions
+                    /v1/embeddings: embeddings
+                    /v1/images/edits: detect
+                    /v1/images/generations: detect
+                    /v1/images/variations: detect
+                    /v1/messages: messages
+                    /v1/rerank: rerank
+                    /v1/responses: responses
+                    /v1/responses/compact: detect
+                    /v2/rerank: rerank
+                    ":rawPredict": messages
+                    ":streamRawPredict": messages
+                authorization: ~
+              backendPolicies: []
+            - name: anthropic/*
+              visibility: internal
+              headerMatches: []
+              backendKey: "llm:model:anthropic/*:1"
+              policies:
+                llm:
+                  routes:
+                    "*": passthrough
+                    /v1/chat/completions: completions
+                    /v1/embeddings: embeddings
+                    /v1/images/edits: detect
+                    /v1/images/generations: detect
+                    /v1/images/variations: detect
+                    /v1/messages: messages
+                    /v1/rerank: rerank
+                    /v1/responses: responses
+                    /v1/responses/compact: detect
+                    /v2/rerank: rerank
+                    ":rawPredict": messages
+                    ":streamRawPredict": messages
+                authorization: ~
+              backendPolicies: []
+            - name: "*"
+              visibility: internal
+              headerMatches: []
+              backendKey: "llm:model:*:2"
+              policies:
+                llm:
+                  routes:
+                    "*": passthrough
+                    /v1/chat/completions: completions
+                    /v1/embeddings: embeddings
+                    /v1/images/edits: detect
+                    /v1/images/generations: detect
+                    /v1/images/variations: detect
+                    /v1/messages: messages
+                    /v1/rerank: rerank
+                    /v1/responses: responses
+                    /v1/responses/compact: detect
+                    /v2/rerank: rerank
+                    ":rawPredict": messages
+                    ":streamRawPredict": messages
+                authorization: ~
+              backendPolicies: []
+          virtualModels:
+            - name: fast
+              llmPolicy:
+                routes:
+                  "*": passthrough
+                  /v1/chat/completions: completions
+                  /v1/embeddings: embeddings
+                  /v1/images/edits: detect
+                  /v1/images/generations: detect
+                  /v1/images/variations: detect
+                  /v1/messages: messages
+                  /v1/rerank: rerank
+                  /v1/responses: responses
+                  /v1/responses/compact: detect
+                  /v2/rerank: rerank
+                  ":rawPredict": messages
+                  ":streamRawPredict": messages
+              routing:
+                weighted:
+                  - model: anthropic/haiku
+                    weight: 60
+                  - model: openai/gpt-5-mini
+                    weight: 30
+                  - model: fallback-small
+                    weight: 10
+          created: 0
 route_groups: []
 workloads: []
 services: []

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -8,6 +8,9 @@ publish = { workspace = true }
 [lib]
 path = "src/lib.rs"
 
+[features]
+assert_size_runtime = []
+
 [dependencies]
 go-parse-duration.workspace = true
 durationfmt.workspace = true

--- a/crates/core/src/assertions.rs
+++ b/crates/core/src/assertions.rs
@@ -13,9 +13,20 @@ pub struct SizeAtMost<const MAX: usize>;
 impl<const MAX: usize> SizeAtMost<MAX> {
 	#[inline(always)]
 	pub fn check<T>(t: T) -> T {
+		#[cfg(not(feature = "assert_size_runtime"))]
 		const {
-			assert!(std::mem::size_of::<T>() <= MAX);
+			assert!(
+				std::mem::size_of::<T>() <= MAX,
+				"type size exceeds assert_size limit"
+			);
 		}
+		#[cfg(feature = "assert_size_runtime")]
+		assert!(
+			std::mem::size_of::<T>() <= MAX,
+			"type size {} exceeds maximum {}",
+			std::mem::size_of::<T>(),
+			MAX
+		);
 		t
 	}
 }

--- a/schema/config.json
+++ b/schema/config.json
@@ -7330,6 +7330,18 @@
           ],
           "default": null
         },
+        "authorization": {
+          "description": "Authorize incoming requests after this backend is selected.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Authorization"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "mcpAuthorization": {
           "description": "Authorization rules for MCP requests.",
           "anyOf": [

--- a/schema/config.md
+++ b/schema/config.md
@@ -2899,6 +2899,11 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.cache.key`|[]string|CEL expressions that make up the cache key. Empty keys are accepted, but do not produce cache hits.|
 |`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.cache.ttl`|string|CEL expression that returns how long cached authorization results are reused.<br>The expression is evaluated after the authorization response has been applied<br>to the request, and must return either a duration or timestamp.|
 |`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.cache.maxEntries`|integer|Maximum number of authorization results to keep in the cache.|
+|`binds[].listeners[].routes[].backends[].ai.policies.authorization`|object|Authorize incoming requests after this backend is selected.|
+|`binds[].listeners[].routes[].backends[].ai.policies.authorization.rules`|[]object|CEL authorization rules to evaluate for a request.|
+|`binds[].listeners[].routes[].backends[].ai.policies.authorization.rules[].allow`|string|Allow the request when this CEL expression is true.|
+|`binds[].listeners[].routes[].backends[].ai.policies.authorization.rules[].deny`|string|Deny the request when this CEL expression is true.|
+|`binds[].listeners[].routes[].backends[].ai.policies.authorization.rules[].require`|string|Require this CEL expression to be true.|
 |`binds[].listeners[].routes[].backends[].ai.policies.mcpAuthorization`|object|Authorization rules for MCP requests.|
 |`binds[].listeners[].routes[].backends[].ai.policies.mcpAuthorization.rules`|[]object|CEL authorization rules to evaluate for a request.|
 |`binds[].listeners[].routes[].backends[].ai.policies.mcpAuthorization.rules[].allow`|string|Allow the request when this CEL expression is true.|
@@ -4282,6 +4287,11 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.cache.key`|[]string|CEL expressions that make up the cache key. Empty keys are accepted, but do not produce cache hits.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.cache.ttl`|string|CEL expression that returns how long cached authorization results are reused.<br>The expression is evaluated after the authorization response has been applied<br>to the request, and must return either a duration or timestamp.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.cache.maxEntries`|integer|Maximum number of authorization results to keep in the cache.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.authorization`|object|Authorize incoming requests after this backend is selected.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.authorization.rules`|[]object|CEL authorization rules to evaluate for a request.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.authorization.rules[].allow`|string|Allow the request when this CEL expression is true.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.authorization.rules[].deny`|string|Deny the request when this CEL expression is true.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.authorization.rules[].require`|string|Require this CEL expression to be true.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpAuthorization`|object|Authorization rules for MCP requests.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpAuthorization.rules`|[]object|CEL authorization rules to evaluate for a request.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpAuthorization.rules[].allow`|string|Allow the request when this CEL expression is true.|
@@ -5635,6 +5645,11 @@
 |`binds[].listeners[].routes[].backends[].policies.extAuthz.cache.key`|[]string|CEL expressions that make up the cache key. Empty keys are accepted, but do not produce cache hits.|
 |`binds[].listeners[].routes[].backends[].policies.extAuthz.cache.ttl`|string|CEL expression that returns how long cached authorization results are reused.<br>The expression is evaluated after the authorization response has been applied<br>to the request, and must return either a duration or timestamp.|
 |`binds[].listeners[].routes[].backends[].policies.extAuthz.cache.maxEntries`|integer|Maximum number of authorization results to keep in the cache.|
+|`binds[].listeners[].routes[].backends[].policies.authorization`|object|Authorize incoming requests after this backend is selected.|
+|`binds[].listeners[].routes[].backends[].policies.authorization.rules`|[]object|CEL authorization rules to evaluate for a request.|
+|`binds[].listeners[].routes[].backends[].policies.authorization.rules[].allow`|string|Allow the request when this CEL expression is true.|
+|`binds[].listeners[].routes[].backends[].policies.authorization.rules[].deny`|string|Deny the request when this CEL expression is true.|
+|`binds[].listeners[].routes[].backends[].policies.authorization.rules[].require`|string|Require this CEL expression to be true.|
 |`binds[].listeners[].routes[].backends[].policies.mcpAuthorization`|object|Authorization rules for MCP requests.|
 |`binds[].listeners[].routes[].backends[].policies.mcpAuthorization.rules`|[]object|CEL authorization rules to evaluate for a request.|
 |`binds[].listeners[].routes[].backends[].policies.mcpAuthorization.rules[].allow`|string|Allow the request when this CEL expression is true.|
@@ -10658,6 +10673,11 @@
 |`backends[].ai.policies.extAuthz.cache.key`|[]string|CEL expressions that make up the cache key. Empty keys are accepted, but do not produce cache hits.|
 |`backends[].ai.policies.extAuthz.cache.ttl`|string|CEL expression that returns how long cached authorization results are reused.<br>The expression is evaluated after the authorization response has been applied<br>to the request, and must return either a duration or timestamp.|
 |`backends[].ai.policies.extAuthz.cache.maxEntries`|integer|Maximum number of authorization results to keep in the cache.|
+|`backends[].ai.policies.authorization`|object|Authorize incoming requests after this backend is selected.|
+|`backends[].ai.policies.authorization.rules`|[]object|CEL authorization rules to evaluate for a request.|
+|`backends[].ai.policies.authorization.rules[].allow`|string|Allow the request when this CEL expression is true.|
+|`backends[].ai.policies.authorization.rules[].deny`|string|Deny the request when this CEL expression is true.|
+|`backends[].ai.policies.authorization.rules[].require`|string|Require this CEL expression to be true.|
 |`backends[].ai.policies.mcpAuthorization`|object|Authorization rules for MCP requests.|
 |`backends[].ai.policies.mcpAuthorization.rules`|[]object|CEL authorization rules to evaluate for a request.|
 |`backends[].ai.policies.mcpAuthorization.rules[].allow`|string|Allow the request when this CEL expression is true.|
@@ -12041,6 +12061,11 @@
 |`backends[].ai.groups[].providers[].policies.extAuthz.cache.key`|[]string|CEL expressions that make up the cache key. Empty keys are accepted, but do not produce cache hits.|
 |`backends[].ai.groups[].providers[].policies.extAuthz.cache.ttl`|string|CEL expression that returns how long cached authorization results are reused.<br>The expression is evaluated after the authorization response has been applied<br>to the request, and must return either a duration or timestamp.|
 |`backends[].ai.groups[].providers[].policies.extAuthz.cache.maxEntries`|integer|Maximum number of authorization results to keep in the cache.|
+|`backends[].ai.groups[].providers[].policies.authorization`|object|Authorize incoming requests after this backend is selected.|
+|`backends[].ai.groups[].providers[].policies.authorization.rules`|[]object|CEL authorization rules to evaluate for a request.|
+|`backends[].ai.groups[].providers[].policies.authorization.rules[].allow`|string|Allow the request when this CEL expression is true.|
+|`backends[].ai.groups[].providers[].policies.authorization.rules[].deny`|string|Deny the request when this CEL expression is true.|
+|`backends[].ai.groups[].providers[].policies.authorization.rules[].require`|string|Require this CEL expression to be true.|
 |`backends[].ai.groups[].providers[].policies.mcpAuthorization`|object|Authorization rules for MCP requests.|
 |`backends[].ai.groups[].providers[].policies.mcpAuthorization.rules`|[]object|CEL authorization rules to evaluate for a request.|
 |`backends[].ai.groups[].providers[].policies.mcpAuthorization.rules[].allow`|string|Allow the request when this CEL expression is true.|
@@ -13392,6 +13417,11 @@
 |`backends[].policies.extAuthz.cache.key`|[]string|CEL expressions that make up the cache key. Empty keys are accepted, but do not produce cache hits.|
 |`backends[].policies.extAuthz.cache.ttl`|string|CEL expression that returns how long cached authorization results are reused.<br>The expression is evaluated after the authorization response has been applied<br>to the request, and must return either a duration or timestamp.|
 |`backends[].policies.extAuthz.cache.maxEntries`|integer|Maximum number of authorization results to keep in the cache.|
+|`backends[].policies.authorization`|object|Authorize incoming requests after this backend is selected.|
+|`backends[].policies.authorization.rules`|[]object|CEL authorization rules to evaluate for a request.|
+|`backends[].policies.authorization.rules[].allow`|string|Allow the request when this CEL expression is true.|
+|`backends[].policies.authorization.rules[].deny`|string|Deny the request when this CEL expression is true.|
+|`backends[].policies.authorization.rules[].require`|string|Require this CEL expression to be true.|
 |`backends[].policies.mcpAuthorization`|object|Authorization rules for MCP requests.|
 |`backends[].policies.mcpAuthorization.rules`|[]object|CEL authorization rules to evaluate for a request.|
 |`backends[].policies.mcpAuthorization.rules[].allow`|string|Allow the request when this CEL expression is true.|
@@ -17261,6 +17291,11 @@
 |`routeGroups[].routes[].backends[].ai.policies.extAuthz.cache.key`|[]string|CEL expressions that make up the cache key. Empty keys are accepted, but do not produce cache hits.|
 |`routeGroups[].routes[].backends[].ai.policies.extAuthz.cache.ttl`|string|CEL expression that returns how long cached authorization results are reused.<br>The expression is evaluated after the authorization response has been applied<br>to the request, and must return either a duration or timestamp.|
 |`routeGroups[].routes[].backends[].ai.policies.extAuthz.cache.maxEntries`|integer|Maximum number of authorization results to keep in the cache.|
+|`routeGroups[].routes[].backends[].ai.policies.authorization`|object|Authorize incoming requests after this backend is selected.|
+|`routeGroups[].routes[].backends[].ai.policies.authorization.rules`|[]object|CEL authorization rules to evaluate for a request.|
+|`routeGroups[].routes[].backends[].ai.policies.authorization.rules[].allow`|string|Allow the request when this CEL expression is true.|
+|`routeGroups[].routes[].backends[].ai.policies.authorization.rules[].deny`|string|Deny the request when this CEL expression is true.|
+|`routeGroups[].routes[].backends[].ai.policies.authorization.rules[].require`|string|Require this CEL expression to be true.|
 |`routeGroups[].routes[].backends[].ai.policies.mcpAuthorization`|object|Authorization rules for MCP requests.|
 |`routeGroups[].routes[].backends[].ai.policies.mcpAuthorization.rules`|[]object|CEL authorization rules to evaluate for a request.|
 |`routeGroups[].routes[].backends[].ai.policies.mcpAuthorization.rules[].allow`|string|Allow the request when this CEL expression is true.|
@@ -18644,6 +18679,11 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.cache.key`|[]string|CEL expressions that make up the cache key. Empty keys are accepted, but do not produce cache hits.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.cache.ttl`|string|CEL expression that returns how long cached authorization results are reused.<br>The expression is evaluated after the authorization response has been applied<br>to the request, and must return either a duration or timestamp.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.cache.maxEntries`|integer|Maximum number of authorization results to keep in the cache.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.authorization`|object|Authorize incoming requests after this backend is selected.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.authorization.rules`|[]object|CEL authorization rules to evaluate for a request.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.authorization.rules[].allow`|string|Allow the request when this CEL expression is true.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.authorization.rules[].deny`|string|Deny the request when this CEL expression is true.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.authorization.rules[].require`|string|Require this CEL expression to be true.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpAuthorization`|object|Authorization rules for MCP requests.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpAuthorization.rules`|[]object|CEL authorization rules to evaluate for a request.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpAuthorization.rules[].allow`|string|Allow the request when this CEL expression is true.|
@@ -19997,6 +20037,11 @@
 |`routeGroups[].routes[].backends[].policies.extAuthz.cache.key`|[]string|CEL expressions that make up the cache key. Empty keys are accepted, but do not produce cache hits.|
 |`routeGroups[].routes[].backends[].policies.extAuthz.cache.ttl`|string|CEL expression that returns how long cached authorization results are reused.<br>The expression is evaluated after the authorization response has been applied<br>to the request, and must return either a duration or timestamp.|
 |`routeGroups[].routes[].backends[].policies.extAuthz.cache.maxEntries`|integer|Maximum number of authorization results to keep in the cache.|
+|`routeGroups[].routes[].backends[].policies.authorization`|object|Authorize incoming requests after this backend is selected.|
+|`routeGroups[].routes[].backends[].policies.authorization.rules`|[]object|CEL authorization rules to evaluate for a request.|
+|`routeGroups[].routes[].backends[].policies.authorization.rules[].allow`|string|Allow the request when this CEL expression is true.|
+|`routeGroups[].routes[].backends[].policies.authorization.rules[].deny`|string|Deny the request when this CEL expression is true.|
+|`routeGroups[].routes[].backends[].policies.authorization.rules[].require`|string|Require this CEL expression to be true.|
 |`routeGroups[].routes[].backends[].policies.mcpAuthorization`|object|Authorization rules for MCP requests.|
 |`routeGroups[].routes[].backends[].policies.mcpAuthorization.rules`|[]object|CEL authorization rules to evaluate for a request.|
 |`routeGroups[].routes[].backends[].policies.mcpAuthorization.rules[].allow`|string|Allow the request when this CEL expression is true.|


### PR DESCRIPTION
Fixes https://github.com/agentgateway/agentgateway/issues/2258

This PR moves local LLM model routing into the backend flow and makes model authorization a backend policy, so model selection happens at the right point relative to route policies, retries, and failover.


- Added `Backend::LLMRouter` so local LLM traffic can enter the normal backend path instead of resolving pre-backend.
- Moved model router resolution later, after route policies and inside the retry/backend attempt flow.
- Added generic backend authorization support and wires model authorization through backend policies.
- Allows virtual model failover to resolve a concrete model per attempt, so failed/evicted targets can fall through correctly.
- Consolidated LLM model rewriting:
  - Provider/default model is written before LLM transformations.
  - Transformations can now operate on the concrete/provider model.
  - Missing-model validation happens after policies, so overrides/transformations can set it.
  - Alias resolution happens once after request mutations.
