### PR TITLE
Return request-phase MCP guardrail rejections as 200, matching the response phase

### DIFF
--- a/controller/test/e2e/extmcp_test.go
+++ b/controller/test/e2e/extmcp_test.go
@@ -45,16 +45,37 @@ func testExtMcpRequestDeniesForbiddenTool(t base.Test) {
 	// the retrying Send warms up the (otherwise cold) gRPC connection, mirroring the
 	// allowed/mutate cases. Without it, the first extmcp call in the suite can hang on
 	// connect until curl's timeout.
-	sendMCP(t, &testmatchers.HttpResponse{StatusCode: http.StatusBadRequest}, headers, body)
+	//
+	// A request-phase guardrail denial rides on HTTP 200: it is an application-level
+	// per-call refusal (JSON-RPC error in the body), not a transport failure. This
+	// matches the response-phase guardrail path and keeps MCP clients from tearing
+	// down the session on a non-2xx status.
+	sendMCP(t, &testmatchers.HttpResponse{StatusCode: http.StatusOK}, headers, body)
 	resp, raw, err := execCurlMCP(t, headers, body)
 	if err != nil {
 		t.Fatalf("tools/call: %v", err)
 	}
-	if resp.StatusCode != http.StatusBadRequest {
+	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("denied tools/call: status=%d body=%s", resp.StatusCode, raw)
 	}
 	if !strings.Contains(strings.ToLower(raw), "forbidden-tool") {
 		t.Fatalf("deny response should name the forbidden tool: %s", raw)
+	}
+	// Confirm the 200 carries a JSON-RPC error, not a success result.
+	// Guardrail rejections are plain application/json (not SSE), so fall back
+	// to parsing raw directly when SSE unwrapping finds no data frame.
+	var rpcResp struct {
+		Error *struct {
+			Message string `json:"message"`
+		} `json:"error,omitempty"`
+	}
+	payload, ok := FirstSSEDataPayload(raw)
+	if !ok {
+		payload = raw
+	}
+	_ = json.Unmarshal([]byte(payload), &rpcResp)
+	if rpcResp.Error == nil {
+		t.Fatalf("expected JSON-RPC error in deny response, got: %s", raw)
 	}
 }
 

--- a/crates/agentgateway/src/proxy/mod.rs
+++ b/crates/agentgateway/src/proxy/mod.rs
@@ -317,7 +317,7 @@ impl ProxyError {
 			ProxyError::MCP(mcp::Error::SendError(_, _)) => StatusCode::INTERNAL_SERVER_ERROR,
 			// Note: we do not return a 401/403 here, as the obscure that it was rejected due to auth
 			ProxyError::MCP(mcp::Error::Authorization(_, _, _)) => StatusCode::BAD_REQUEST,
-			ProxyError::MCP(mcp::Error::McpGuardrails(_, _)) => StatusCode::BAD_REQUEST,
+			ProxyError::MCP(mcp::Error::McpGuardrails(_, _)) => StatusCode::OK,
 		};
 		let grpc_status = is_grpc_request.then(|| proxy_error_to_grpc_status(&self, code));
 		let mut rb = ::http::Response::builder().status(code);


### PR DESCRIPTION
### Summary

A request-phase mcpGuardrails rejection is returned to the client as HTTP 400, while a response-phase rejection of the same kind is returned as HTTP 200 with the JSON-RPC error in the SSE body. This asymmetry causes spec-compliant MCP Streamable-HTTP clients to treat a per-call policy denial as a transport failure and tear down the whole session.

This changes the request-phase rejection to also return HTTP 200 with the JSON-RPC error in the body, so a guardrail denial surfaces to the client as a normal per-call error instead of a dead transport.

### Background / root cause

For MCP Streamable HTTP, the HTTP status code signals transport health; a per-call application error (including an authorization denial) is carried as a JSON-RPC error in the body, tagged to the request id. A compliant client therefore treats any non-2xx as "the transport/session is broken" and reinitializes, rather than reading the body.

agentgateway already does the right thing on the response phase:

- crates/agentgateway/src/mcp/handler.rs — apply_guardrails_response_intercept maps Outcome::Reject(rej) to ServerJsonRpcMessage::error(rej, id).
- crates/agentgateway/src/mcp/session.rs — sse_stream_response serves that stream with StatusCode::OK.

But on the request phase the identical Outcome::Reject is surfaced as mcp::Error::McpGuardrails(req_id, rej) and mapped to a non-2xx status:

- crates/agentgateway/src/proxy/mod.rs — in ProxyError::into_response_with_grpc, the McpGuardrails arm returns StatusCode::BAD_REQUEST.

The body for that arm is already a correct JSON-RPC error object tagged to the request id. Only the status line is wrong — so the fix is the status code, not the body.

### Symptom

With the reference Python mcp SDK (mcp/client/streamable_http.py), _handle_post_request special-cases only 202 and 404, then calls response.raise_for_status(). On the 400 this raises, the anyio task group unwinds, and the session is torn down before the body is read — so the JSON-RPC -32001 (PERMISSION_DENIED) carrying the rejection reason is never seen. To the agent driving that client, an intentional policy block is indistinguishable from "the MCP server disconnected."

This affects any request-phase mcpGuardrails processor, not a single deployment.

### Change

`crates/agentgateway/src/proxy/mod.rs`, in the status match of `into_response_with_grpc`:
```diff
-            ProxyError::MCP(mcp::Error::McpGuardrails(_, _)) => StatusCode::BAD_REQUEST,
+            ProxyError::MCP(mcp::Error::McpGuardrails(_, _)) => StatusCode::OK,
```

No change to the body-construction block for this arm; it already emits the JSON-RPC error tagged to the request id.

### Scope / what this does NOT change

- Error::Authorization (the tool-existence-hiding denial) is intentionally left at BAD_REQUEST — separate semantic, worth its own discussion. Happy to fold it in if maintainers prefer.
- Response-phase behavior unchanged (already 200).
- JSON-RPC error code (-32001) and message unchanged; only the HTTP status changes.
- A 200 here carries a JSON-RPC error object (not a result), so a compliant client still treats the call as failed — it just keeps the session.

### Compatibility notes

- rmcp-based clients already read the body regardless of HTTP status, so they're unaffected (same -32001).
- Gateway-side session continuity is preserved either way; this only stops clients from killing the session.
- Behavior change worth calling out: anything keying on the gateway's HTTP 4xx rate to detect guardrail blocks will no longer see a 4xx for request-phase denials.

### Alternative considered

ai.promptGuard already exposes a configurable rejection.status/body/headers. One option is to make mcpGuardrails rejections similarly configurable rather than fixing to 200. I went with 200 because MCP Streamable-HTTP semantics make 200-with-JSON-RPC-error the correct transport for a per-call denial, and it makes the request phase consistent with the response phase by default. Glad to rework as configurable if preferred.

### Testing

- `cargo test -p agentgateway mcp_guardrails` passes
  - Existing mcp_guardrails_reject_surfaces_jsonrpc_error still passes (status-agnostic, asserts code/message via rmcp).

Verified manually end-to-end: a denied tools/call now returns 200 with {"jsonrpc":"2.0","id":<id>,"error":{"code":-32001,...}}; the Python mcp SDK surfaces it as a per-call error and the session stays alive. A subsequent allowed call on the same session succeeds.