### PR TITLE
pprof: use frame-pointers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,6 +143,7 @@ pprof = { version = "0.15", features = [
     "protobuf",
     "protobuf-codec",
     "criterion",
+    "frame-pointer"
 ] }
 pretty_env_logger = "0.5"
 prometheus-client = "0.25"


### PR DESCRIPTION
Without this, we do stack unwinding in the symbol handler. this has been
observed to crash when we we call the handler during a AWS TLS
handshake. Frame pointers to not experience the same and we already
enable them for heap profiling.

Signed-off-by: John Howard <john.howard@solo.io>
