### PR TITLE
return rate limit headers on successful requests

### DIFF
--- a/crates/agentgateway/src/http/localratelimit.rs
+++ b/crates/agentgateway/src/http/localratelimit.rs
@@ -780,3 +780,77 @@ mod ratelimit {
 		}
 	}
 }
+
+#[cfg(test)]
+mod check_request_tests {
+	use std::time::Duration;
+
+	use super::*;
+
+	fn make_rate_limit(max_tokens: u64) -> RateLimit {
+		RateLimit::try_from(RateLimitSpec {
+			max_tokens,
+			tokens_per_fill: 1,
+			fill_interval: Duration::from_secs(60),
+			limit_type: RateLimitType::Requests,
+		})
+		.unwrap()
+	}
+
+	#[test]
+	fn success_returns_rate_limit_headers() {
+		let rl = make_rate_limit(10);
+		let resp = rl.check_request().unwrap();
+		let headers = resp.response_headers.unwrap();
+		assert!(headers.contains_key(http::x_headers::X_RATELIMIT_LIMIT));
+		assert!(headers.contains_key(http::x_headers::X_RATELIMIT_REMAINING));
+		assert!(headers.contains_key(http::x_headers::X_RATELIMIT_RESET));
+	}
+
+	#[test]
+	fn remaining_decreases_each_request() {
+		let rl = make_rate_limit(5);
+		let remaining1 = rl.check_request().unwrap().response_headers.unwrap()
+			.get(http::x_headers::X_RATELIMIT_REMAINING).unwrap()
+			.to_str().unwrap().parse::<u64>().unwrap();
+		let remaining2 = rl.check_request().unwrap().response_headers.unwrap()
+			.get(http::x_headers::X_RATELIMIT_REMAINING).unwrap()
+			.to_str().unwrap().parse::<u64>().unwrap();
+		assert!(remaining1 > remaining2);
+	}
+
+	#[test]
+	fn exhausted_bucket_returns_error() {
+		let rl = make_rate_limit(2);
+		let _ = rl.check_request();
+		let _ = rl.check_request();
+		let err = rl.check_request().unwrap_err();
+		assert!(matches!(err, ProxyError::RateLimitExceeded { .. }));
+	}
+
+	#[test]
+	fn token_type_skips_check() {
+		let rl = RateLimit::try_from(RateLimitSpec {
+			max_tokens: 10,
+			tokens_per_fill: 1,
+			fill_interval: Duration::from_secs(60),
+			limit_type: RateLimitType::Tokens,
+		})
+		.unwrap();
+		let resp = rl.check_request().unwrap();
+		assert!(resp.response_headers.is_none());
+	}
+
+	#[test]
+	fn remaining_counts_down_to_zero() {
+		let rl = make_rate_limit(5);
+		for expected_remaining in (0..5).rev() {
+			let resp = rl.check_request().unwrap();
+			let remaining = resp.response_headers.unwrap()
+				.get(http::x_headers::X_RATELIMIT_REMAINING).unwrap()
+				.to_str().unwrap().parse::<u64>().unwrap();
+			assert_eq!(remaining, expected_remaining);
+		}
+		assert!(matches!(rl.check_request().unwrap_err(), ProxyError::RateLimitExceeded { .. }));
+	}
+}

--- a/crates/agentgateway/src/http/localratelimit.rs
+++ b/crates/agentgateway/src/http/localratelimit.rs
@@ -70,11 +70,10 @@ impl TryFrom<RateLimitSpec> for RateLimit {
 }
 
 impl RateLimit {
-	pub fn check_request(&self) -> Result<(), ProxyError> {
+	pub fn check_request(&self) -> Result<http::PolicyResponse, ProxyError> {
 		if self.spec.limit_type != RateLimitType::Requests {
-			return Ok(());
+			return Ok(http::PolicyResponse::default());
 		}
-		// TODO: return headers on success, not just failure
 		self
 			.ratelimit
 			.try_wait()
@@ -82,6 +81,26 @@ impl RateLimit {
 				limit,
 				remaining,
 				reset_seconds: reset.as_secs(),
+			})
+			.map(|()| {
+				let limit = self.ratelimit.max_tokens();
+				let remaining = self.ratelimit.available();
+				let reset = (self.ratelimit.next_refill() - clocksource::precise::Instant::now())
+					.as_secs();
+				let mut headers = http::HeaderMap::new();
+				if let Ok(v) = http::HeaderValue::try_from(limit.to_string()) {
+					headers.insert(http::x_headers::X_RATELIMIT_LIMIT, v);
+				}
+				if let Ok(v) = http::HeaderValue::try_from(remaining.to_string()) {
+					headers.insert(http::x_headers::X_RATELIMIT_REMAINING, v);
+				}
+				if let Ok(v) = http::HeaderValue::try_from(reset.to_string()) {
+					headers.insert(http::x_headers::X_RATELIMIT_RESET, v);
+				}
+				http::PolicyResponse {
+					direct_response: None,
+					response_headers: Some(headers),
+				}
 			})
 	}
 
@@ -134,10 +153,12 @@ impl crate::store::RequestPolicyTrait for Vec<RateLimit> {
 		_log: &mut crate::telemetry::log::RequestLog,
 		_req: &mut http::Request,
 	) -> Result<http::PolicyResponse, crate::proxy::ProxyResponse> {
+		let mut combined = http::PolicyResponse::default();
 		for rate_limit in self {
-			rate_limit.check_request()?;
+			let resp = rate_limit.check_request()?;
+			combined = combined.merge(resp);
 		}
-		Ok(http::PolicyResponse::default())
+		Ok(combined)
 	}
 }
 


### PR DESCRIPTION
Fixed Todo: Gives users visibility to their rate limits based on the limit of their requests, remaning requests, and seconds until the next refill.

Why do we need this: Users can get a grasp of when to slow down requests.