### PR TITLE
Drop and test large stack sizes

### DIFF
--- a/crates/agentgateway/src/client/mod.rs
+++ b/crates/agentgateway/src/client/mod.rs
@@ -605,109 +605,116 @@ impl Client {
 			.map_err(ProxyError::UpstreamTCPCallFailed)
 	}
 
-	pub async fn call(&self, call: Call) -> Result<http::Response, ProxyError> {
+	pub fn call(
+		&self,
+		call: Call,
+	) -> impl std::future::Future<Output = Result<http::Response, ProxyError>> + '_ {
+		let client = &self.client;
+		let connector = &self.connector;
 		let start = std::time::Instant::now();
 		let Call {
 			mut req,
 			target,
 			transport,
 		} = call;
-		let dest = self
-			.connector
-			.resolve_target(transport.skip_dns_resolution(), &target)
-			.await?;
-		http::modify_req_uri(&mut req, |uri| {
-			let scheme = transport.scheme();
-			// Strip the port from the hostname if its the default already
-			// The hyper client does this for HTTP/1.1 but not for HTTP2
-			if let Some(a) = uri.authority.as_mut()
-				&& ((scheme == Scheme::HTTPS && a.port_u16() == Some(443))
-					|| (scheme == Scheme::HTTP && a.port_u16() == Some(80)))
+		async move {
+			let dest = connector
+				.resolve_target(transport.skip_dns_resolution(), &target)
+				.await?;
+			http::modify_req_uri(&mut req, |uri| {
+				let scheme = transport.scheme();
+				// Strip the port from the hostname if its the default already
+				// The hyper client does this for HTTP/1.1 but not for HTTP2
+				if let Some(a) = uri.authority.as_mut()
+					&& ((scheme == Scheme::HTTPS && a.port_u16() == Some(443))
+						|| (scheme == Scheme::HTTP && a.port_u16() == Some(80)))
+				{
+					*a =
+						Authority::from_str(a.host()).expect("host must be valid since it was already a host");
+				}
+				uri.scheme = Some(scheme);
+
+				Ok(())
+			})
+			.map_err(ProxyError::Processing)?;
+			if req.extensions().get::<filters::AutoHostname>().is_some() {
+				req.headers_mut().remove(::http::header::HOST);
+			}
+			let version = req.version();
+			let transport_name = transport.name();
+			// We are going to do a HTTP absolute form tunnel request. For CONNECT this is handled
+			// in the connect layer, but here we need to merge it into the request
+			if let Transport::Tunnel(app, tc) = &transport
+				&& let Some(h) = tc.token.as_ref()
+				&& matches!(app, ApplicationTransport::Plaintext)
 			{
-				*a = Authority::from_str(a.host()).expect("host must be valid since it was already a host");
+				req
+					.headers_mut()
+					.insert(http::header::PROXY_AUTHORIZATION, h.clone());
 			}
-			uri.scheme = Some(scheme);
+			let key = PoolKey(target.clone(), dest, transport, version);
+			trace!(?req, ?key, "sending request");
+			req.extensions_mut().insert(key);
+			let method = req.method().clone();
+			let uri = req.uri().clone();
+			let path = uri.path();
+			let host = uri.authority().to_owned();
+			event!(
+				target: "upstream request",
+				parent: None,
+				tracing::Level::TRACE,
 
-			Ok(())
-		})
-		.map_err(ProxyError::Processing)?;
-		if req.extensions().get::<filters::AutoHostname>().is_some() {
-			req.headers_mut().remove(::http::header::HOST);
+				request =? req,
+				extensions =? crate::http::DebugExtensions(&req)
+			);
+			let buffer_limit = http::buffer_limit(&req);
+			let to = req.extensions().get::<BackendRequestTimeout>().cloned();
+			let call = client.request(req);
+			let resp = if let Some(to) = to {
+				match tokio::time::timeout(to.0, call).await {
+					Err(_) => Err(ProxyError::UpstreamCallTimeout),
+					Ok(Err(e)) => Err(ProxyError::UpstreamCallFailed(e)),
+					Ok(Ok(resp)) => Ok(resp),
+				}
+			} else {
+				call.await.map_err(ProxyError::UpstreamCallFailed)
+			};
+			let dur = format!("{}ms", start.elapsed().as_millis());
+			// If version changed due to ALPN negotiation, make sure we get the real version
+			let version = resp.as_ref().map(|resp| resp.version()).unwrap_or(version);
+			event!(
+				target: "upstream request",
+				parent: None,
+				tracing::Level::DEBUG,
+
+				target = %target,
+				endpoint = %dest,
+				transport = %transport_name,
+
+				http.method = %method,
+				http.host = host.as_ref().map(display),
+				http.path = %path,
+				http.version = ?version,
+				http.status = resp.as_ref().ok().map(|s| s.status().as_u16()).unwrap_or_default(),
+
+				duration = dur,
+			);
+			let mut resp = resp?;
+
+			event!(
+				target: "upstream response",
+				parent: None,
+				tracing::Level::TRACE,
+
+				response =?resp
+			);
+
+			resp
+				.extensions_mut()
+				.insert(transport::BufferLimit::new(buffer_limit));
+			resp.extensions_mut().insert(ResolvedDestination(dest));
+			Ok(resp)
 		}
-		let version = req.version();
-		let transport_name = transport.name();
-		// We are going to do a HTTP absolute form tunnel request. For CONNECT this is handled
-		// in the connect layer, but here we need to merge it into the request
-		if let Transport::Tunnel(app, tc) = &transport
-			&& let Some(h) = tc.token.as_ref()
-			&& matches!(app, ApplicationTransport::Plaintext)
-		{
-			req
-				.headers_mut()
-				.insert(http::header::PROXY_AUTHORIZATION, h.clone());
-		}
-		let key = PoolKey(target.clone(), dest, transport, version);
-		trace!(?req, ?key, "sending request");
-		req.extensions_mut().insert(key);
-		let method = req.method().clone();
-		let uri = req.uri().clone();
-		let path = uri.path();
-		let host = uri.authority().to_owned();
-		event!(
-			target: "upstream request",
-			parent: None,
-			tracing::Level::TRACE,
-
-			request =? req,
-			extensions =? crate::http::DebugExtensions(&req)
-		);
-		let buffer_limit = http::buffer_limit(&req);
-		let to = req.extensions().get::<BackendRequestTimeout>().cloned();
-		let call = self.client.request(req);
-		let resp = if let Some(to) = to {
-			match tokio::time::timeout(to.0, call).await {
-				Err(_) => Err(ProxyError::UpstreamCallTimeout),
-				Ok(Err(e)) => Err(ProxyError::UpstreamCallFailed(e)),
-				Ok(Ok(resp)) => Ok(resp),
-			}
-		} else {
-			call.await.map_err(ProxyError::UpstreamCallFailed)
-		};
-		let dur = format!("{}ms", start.elapsed().as_millis());
-		// If version changed due to ALPN negotiation, make sure we get the real version
-		let version = resp.as_ref().map(|resp| resp.version()).unwrap_or(version);
-		event!(
-			target: "upstream request",
-			parent: None,
-			tracing::Level::DEBUG,
-
-			target = %target,
-			endpoint = %dest,
-			transport = %transport_name,
-
-			http.method = %method,
-			http.host = host.as_ref().map(display),
-			http.path = %path,
-			http.version = ?version,
-			http.status = resp.as_ref().ok().map(|s| s.status().as_u16()).unwrap_or_default(),
-
-			duration = dur,
-		);
-		let mut resp = resp?;
-
-		event!(
-			target: "upstream response",
-			parent: None,
-			tracing::Level::TRACE,
-
-			response =?resp
-		);
-
-		resp
-			.extensions_mut()
-			.insert(transport::BufferLimit::new(buffer_limit));
-		resp.extensions_mut().insert(ResolvedDestination(dest));
-		Ok(resp)
 	}
 }
 

--- a/crates/agentgateway/src/http/auth/aws.rs
+++ b/crates/agentgateway/src/http/auth/aws.rs
@@ -156,7 +156,7 @@ pub(super) async fn sign_request(
 			}
 		},
 	};
-	let creds = load_credentials(aws_auth, region).await?.into();
+	let creds = Box::pin(load_credentials(aws_auth, region)).await?.into();
 
 	let service = signing_service_name(req, aws_auth);
 	trace!("AWS signing with region: {}, service: {}", region, service);

--- a/crates/agentgateway/src/http/ext_proc.rs
+++ b/crates/agentgateway/src/http/ext_proc.rs
@@ -195,6 +195,10 @@ impl InferenceRouting {
 }
 
 impl InferencePoolRouter {
+	pub fn is_enabled(&self) -> bool {
+		self.ext_proc.is_some()
+	}
+
 	pub async fn mutate_request(
 		&mut self,
 		req: &mut http::Request,

--- a/crates/agentgateway/src/mcp/handler.rs
+++ b/crates/agentgateway/src/mcp/handler.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use agent_core::prelude::AssertSize;
 use agent_core::version::BuildInfo;
 use futures_core::Stream;
 use http::StatusCode;
@@ -536,8 +537,10 @@ impl Relay {
 			)));
 		};
 		let guardrails = self.build_guardrails_ctx(&r, &ctx, vec![service_name.to_string()]);
-		let stream =
-			self.rewrite_outbound_server_messages(service_name, us.generic_stream(r, &ctx).await?);
+		let stream = self.rewrite_outbound_server_messages(
+			service_name,
+			Box::pin(us.generic_stream(r, &ctx).assert_size::<{ 3 * 1024 }>()).await?,
+		);
 
 		match guardrails {
 			Some(guardrails) => {
@@ -661,15 +664,18 @@ impl Relay {
 		if let Some(ext) = self.mcp_guardrails.as_ref() {
 			// params is None, so mutations are discarded unparsed and the params
 			// type is never used.
-			let outcome = crate::mcp::guardrails::run_call_request::<serde_json::Value>(
-				ext,
-				&mut crate::mcp::guardrails::CallRequestCtx {
-					backends: service_names.as_deref().unwrap_or_default(),
-					method,
-					params: None,
-				},
-				&mut ctx,
-				&self.policy_client,
+			let outcome = Box::pin(
+				crate::mcp::guardrails::run_call_request::<serde_json::Value>(
+					ext,
+					&mut crate::mcp::guardrails::CallRequestCtx {
+						backends: service_names.as_deref().unwrap_or_default(),
+						method,
+						params: None,
+					},
+					&mut ctx,
+					&self.policy_client,
+				)
+				.assert_size::<{ 4 * 1024 }>(),
 			)
 			.await;
 			if let crate::mcp::guardrails::Outcome::Reject(rej) = outcome {

--- a/crates/agentgateway/src/mcp/router.rs
+++ b/crates/agentgateway/src/mcp/router.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use agent_core::prelude::Strng;
+use agent_core::prelude::{AssertSize, Strng};
 use axum::response::Response;
 
 use crate::http::authorization::RuleSets;
@@ -148,15 +148,19 @@ impl App {
 			// Legacy handling
 			// Assume this is streamable HTTP otherwise
 			let sse = LegacySSEService::new(sessions);
-			Box::pin(sse.handle(
-				req,
-				RelayInputs {
-					backend: backends.clone(),
-					policies: authorization_policies.clone(),
-					mcp_guardrails: mcp_guardrails.clone(),
-					client: client.clone(),
-				},
-			))
+			Box::pin(
+				sse
+					.handle(
+						req,
+						RelayInputs {
+							backend: backends.clone(),
+							policies: authorization_policies.clone(),
+							mcp_guardrails: mcp_guardrails.clone(),
+							client: client.clone(),
+						},
+					)
+					.assert_size::<{ 20 * 1024 }>(),
+			)
 			.await
 		} else {
 			let streamable = StreamableHttpService::new(
@@ -165,15 +169,19 @@ impl App {
 					stateful_mode: backend.stateful,
 				},
 			);
-			Box::pin(streamable.handle(
-				req,
-				RelayInputs {
-					backend: backends.clone(),
-					policies: authorization_policies.clone(),
-					mcp_guardrails: mcp_guardrails.clone(),
-					client: client.clone(),
-				},
-			))
+			Box::pin(
+				streamable
+					.handle(
+						req,
+						RelayInputs {
+							backend: backends.clone(),
+							policies: authorization_policies.clone(),
+							mcp_guardrails: mcp_guardrails.clone(),
+							client: client.clone(),
+						},
+					)
+					.assert_size::<{ 4 * 1024 }>(),
+			)
 			.await
 		};
 		let upstream_end = Instant::now();

--- a/crates/agentgateway/src/mcp/session.rs
+++ b/crates/agentgateway/src/mcp/session.rs
@@ -6,6 +6,7 @@ use std::time::{Duration, Instant};
 use ::http::StatusCode;
 use ::http::header::CONTENT_TYPE;
 use ::http::request::Parts;
+use agent_core::prelude::AssertSize;
 use agent_core::version::BuildInfo;
 use anyhow::anyhow;
 use futures_util::StreamExt;
@@ -56,7 +57,11 @@ impl Session {
 			ClientJsonRpcMessage::Request(r) => Some(r.id.clone()),
 			_ => None,
 		};
-		Self::handle_error(req_id, self.send_internal(parts, message).await).await
+		let res = self
+			.send_internal(parts, message)
+			.assert_size::<{ 6 * 1024 }>()
+			.await;
+		Self::handle_error(req_id, res).await
 	}
 
 	/// send a message to upstream server(s), when using stateless mode. In stateless mode, every message
@@ -398,16 +403,16 @@ impl Session {
 						self.strip_unsupported_client_capabilities(&mut ir.params.capabilities);
 
 						let pv = ir.params.protocol_version.clone();
-						let res = self
-							.relay
-							.send_fanout(
+						let res = Box::pin(
+							self.relay.send_fanout(
 								r,
 								ctx,
 								self
 									.relay
 									.merge_initialize(pv, self.relay.is_multiplexing()),
-							)
-							.await;
+							),
+						)
+						.await;
 						if let Some(sessions) = self.relay.get_sessions() {
 							let s = http::sessionpersistence::SessionState::MCP(
 								http::sessionpersistence::MCPSessionState::new(sessions),
@@ -419,36 +424,26 @@ impl Session {
 						res
 					},
 					ClientRequest::ListToolsRequest(_) => {
-						self
-							.relay
-							.send_fanout(r, ctx, self.relay.merge_tools())
-							.await
+						Box::pin(self.relay.send_fanout(r, ctx, self.relay.merge_tools())).await
 					},
 					// TODO(keithmattix): should we forward pings or should we do our own independent pings
 					// as heuristic for the connection pool (and handle client pings as a local reply from agentgateway)?
 					ClientRequest::PingRequest(_) | ClientRequest::SetLevelRequest(_) => {
-						self
-							.relay
-							.send_fanout(r, ctx, self.relay.merge_empty())
-							.await
+						Box::pin(self.relay.send_fanout(r, ctx, self.relay.merge_empty())).await
 					},
 					ClientRequest::ListPromptsRequest(_) => {
-						self
-							.relay
-							.send_fanout(r, ctx, self.relay.merge_prompts())
-							.await
+						Box::pin(self.relay.send_fanout(r, ctx, self.relay.merge_prompts())).await
 					},
 					ClientRequest::ListResourcesRequest(_) => {
-						self
-							.relay
-							.send_fanout(r, ctx, self.relay.merge_resources())
-							.await
+						Box::pin(self.relay.send_fanout(r, ctx, self.relay.merge_resources())).await
 					},
 					ClientRequest::ListResourceTemplatesRequest(_) => {
-						self
-							.relay
-							.send_fanout(r, ctx, self.relay.merge_resource_templates())
-							.await
+						Box::pin(
+							self
+								.relay
+								.send_fanout(r, ctx, self.relay.merge_resource_templates()),
+						)
+						.await
 					},
 					ClientRequest::CallToolRequest(ctr) => {
 						let name = ctr.params.name.clone();
@@ -461,24 +456,25 @@ impl Session {
 						});
 						let tn = tool.to_string();
 						ctr.params.name = tn.into();
-						self
-							.authorize_with_ctx(
-								service_name,
-								mcp::guardrails::methods::TOOLS_CALL,
-								&mut ctr.params,
-								&mut ctx,
-								rbac::ResourceType::Tool(rbac::ResourceId::new(
-									service_name.to_string(),
-									tool.to_string(),
-								)),
-								"tool",
-								&name,
-							)
-							.await?;
-						self
-							.relay
-							.send_single(r, ctx, service_name, Some(log.clone()))
-							.await
+						Box::pin(self.authorize_with_ctx(
+							service_name,
+							mcp::guardrails::methods::TOOLS_CALL,
+							&mut ctr.params,
+							&mut ctx,
+							rbac::ResourceType::Tool(rbac::ResourceId::new(
+								service_name.to_string(),
+								tool.to_string(),
+							)),
+							"tool",
+							&name,
+						))
+						.await?;
+						Box::pin(
+							self
+								.relay
+								.send_single(r, ctx, service_name, Some(log.clone())),
+						)
+						.await
 					},
 					ClientRequest::GetPromptRequest(gpr) => {
 						let name = gpr.params.name.clone();
@@ -488,21 +484,20 @@ impl Session {
 							l.set_prompt(service_name.to_string(), prompt.to_string());
 						});
 						gpr.params.name = prompt.to_string();
-						self
-							.authorize_with_ctx(
-								service_name,
-								mcp::guardrails::methods::PROMPTS_GET,
-								&mut gpr.params,
-								&mut ctx,
-								rbac::ResourceType::Prompt(rbac::ResourceId::new(
-									service_name.to_string(),
-									prompt.to_string(),
-								)),
-								"prompt",
-								&name,
-							)
-							.await?;
-						self.relay.send_single(r, ctx, service_name, None).await
+						Box::pin(self.authorize_with_ctx(
+							service_name,
+							mcp::guardrails::methods::PROMPTS_GET,
+							&mut gpr.params,
+							&mut ctx,
+							rbac::ResourceType::Prompt(rbac::ResourceId::new(
+								service_name.to_string(),
+								prompt.to_string(),
+							)),
+							"prompt",
+							&name,
+						))
+						.await?;
+						Box::pin(self.relay.send_single(r, ctx, service_name, None)).await
 					},
 					ClientRequest::ReadResourceRequest(rrr) => {
 						let uri = rrr.params.uri.clone();
@@ -512,21 +507,20 @@ impl Session {
 							l.set_resource(service_name.to_string(), original_uri.to_string());
 						});
 						rrr.params.uri = original_uri.clone();
-						self
-							.authorize_with_ctx(
-								service_name,
-								mcp::guardrails::methods::RESOURCES_READ,
-								&mut rrr.params,
-								&mut ctx,
-								rbac::ResourceType::Resource(rbac::ResourceId::new(
-									service_name.to_string(),
-									original_uri,
-								)),
-								"resource",
-								&uri,
-							)
-							.await?;
-						self.relay.send_single(r, ctx, service_name, None).await
+						Box::pin(self.authorize_with_ctx(
+							service_name,
+							mcp::guardrails::methods::RESOURCES_READ,
+							&mut rrr.params,
+							&mut ctx,
+							rbac::ResourceType::Resource(rbac::ResourceId::new(
+								service_name.to_string(),
+								original_uri,
+							)),
+							"resource",
+							&uri,
+						))
+						.await?;
+						Box::pin(self.relay.send_single(r, ctx, service_name, None)).await
 					},
 					ClientRequest::SubscribeRequest(sr) => {
 						let uri = sr.params.uri.clone();
@@ -540,7 +534,7 @@ impl Session {
 							&cel,
 						)?;
 						sr.params.uri = original_uri;
-						self.relay.send_single(r, ctx, service_name, None).await
+						Box::pin(self.relay.send_single(r, ctx, service_name, None)).await
 					},
 					ClientRequest::UnsubscribeRequest(ur) => {
 						let uri = ur.params.uri.clone();
@@ -554,7 +548,7 @@ impl Session {
 							&cel,
 						)?;
 						ur.params.uri = original_uri;
-						self.relay.send_single(r, ctx, service_name, None).await
+						Box::pin(self.relay.send_single(r, ctx, service_name, None)).await
 					},
 
 					ClientRequest::ListTasksRequest(_)
@@ -571,7 +565,7 @@ impl Session {
 							let (service_name, prompt_name) =
 								self.authorize_prompt_request(&name, &method, &mut span, &log, &cel)?;
 							cr.params.r#ref = Reference::for_prompt(prompt_name.to_string());
-							self.relay.send_single(r, ctx, service_name, None).await
+							Box::pin(self.relay.send_single(r, ctx, service_name, None)).await
 						},
 						Reference::Resource(resource) => {
 							let uri = resource.uri.clone();
@@ -585,7 +579,7 @@ impl Session {
 								&cel,
 							)?;
 							cr.params.r#ref = Reference::for_resource(original_uri);
-							self.relay.send_single(r, ctx, service_name, None).await
+							Box::pin(self.relay.send_single(r, ctx, service_name, None)).await
 						},
 					},
 				}
@@ -607,7 +601,7 @@ impl Session {
 				});
 				// TODO: the notification needs to be fanned out in some cases and sent to a single one in others
 				// however, we don't have a way to map to the correct service yet
-				self.relay.send_notification(r, ctx).await
+				Box::pin(self.relay.send_notification(r, ctx)).await
 			},
 
 			_ => Err(UpstreamError::InvalidRequest(

--- a/crates/agentgateway/src/mcp/streamablehttp.rs
+++ b/crates/agentgateway/src/mcp/streamablehttp.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use ::http::StatusCode;
+use agent_core::prelude::AssertSize;
 use rmcp::model::{ClientJsonRpcMessage, ClientRequest, ProtocolVersion, ServerJsonRpcMessage};
 use rmcp::transport::common::http_header::{
 	EVENT_STREAM_MIME_TYPE, HEADER_MCP_PROTOCOL_VERSION, HEADER_SESSION_ID, JSON_MIME_TYPE,
@@ -63,7 +64,14 @@ impl StreamableHttpService {
 		let method = request.method().clone();
 
 		match (method, self.config.stateful_mode) {
-			(http::Method::POST, _) => Box::pin(self.handle_post(request, inputs)).await,
+			(http::Method::POST, _) => {
+				Box::pin(
+					self
+						.handle_post(request, inputs)
+						.assert_size::<{ 4 * 1024 }>(),
+				)
+				.await
+			},
 			// if we're not in stateful mode, we don't support GET or DELETE because there is no session
 			(http::Method::GET, true) => self.handle_get(request, inputs).await,
 			(http::Method::DELETE, true) => self.handle_delete(request).await,

--- a/crates/agentgateway/src/mcp/upstream/mod.rs
+++ b/crates/agentgateway/src/mcp/upstream/mod.rs
@@ -6,6 +6,7 @@ mod streamablehttp;
 
 use std::io;
 
+use agent_core::prelude::AssertSize;
 pub(crate) use client::McpHttpClient;
 pub use openapi::ParseError as OpenAPIParseError;
 use rmcp::model::{ClientNotification, ClientRequest, JsonRpcRequest};
@@ -206,14 +207,14 @@ impl Upstream {
 	) -> Result<mergestream::Messages, UpstreamError> {
 		match &self {
 			Upstream::McpStdio(c) => Ok(mergestream::Messages::from(
-				c.send_message(request, ctx).await?,
+				Box::pin(c.send_message(request, ctx).assert_size::<{ 6 * 1024 }>()).await?,
 			)),
 			Upstream::McpSSE(c) => Ok(mergestream::Messages::from(
-				c.send_message(request, ctx).await?,
+				Box::pin(c.send_message(request, ctx).assert_size::<{ 6 * 1024 }>()).await?,
 			)),
 			Upstream::McpStreamable(c) => {
 				let is_init = matches!(&request.request, &ClientRequest::InitializeRequest(_));
-				let res = c.send_request(request, ctx).await?;
+				let res = Box::pin(c.send_request(request, ctx).assert_size::<{ 6 * 1024 }>()).await?;
 				if is_init {
 					let sid = match &res {
 						StreamableHttpPostResponse::Accepted => None,
@@ -224,7 +225,9 @@ impl Upstream {
 				}
 				res.try_into().map_err(Into::into)
 			},
-			Upstream::OpenAPI(c) => Ok(c.send_message(request, ctx).await?),
+			Upstream::OpenAPI(c) => {
+				Ok(Box::pin(c.send_message(request, ctx).assert_size::<{ 6 * 1024 }>()).await?)
+			},
 		}
 	}
 

--- a/crates/agentgateway/src/proxy/gateway.rs
+++ b/crates/agentgateway/src/proxy/gateway.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use agent_core::drain::{DrainUpgrader, DrainWatcher};
+use agent_core::prelude::AssertSize;
 use agent_core::{drain, strng, telemetry};
 use agent_hbone::server::H2Request;
 use anyhow::anyhow;
@@ -880,9 +881,14 @@ impl Gateway {
 				let connection = connection.clone();
 				req.extensions_mut().insert(BufferLimit::new(buffer));
 				let req = req.map(crate::http::Body::new);
-				telemetry::request_scope(dtrace::DebugTracer::maybe_scope(req, |req| async move {
-					proxy.proxy(connection, req).map(Ok::<_, Infallible>).await
-				}))
+				telemetry::request_scope(
+					// This is the per-request HTTP flow future. It is the baseline task state
+					// multiplied by concurrent in-flight requests on this connection.
+					dtrace::DebugTracer::maybe_scope(req, |req| async move {
+						proxy.proxy(connection, req).map(Ok::<_, Infallible>).await
+					})
+					.assert_size::<{ 15 * 1024 }>(),
+				)
 			}),
 		);
 		let (connection_drain_tx, connection_drain_rx) = drain::new();

--- a/crates/agentgateway/src/proxy/gateway_test.rs
+++ b/crates/agentgateway/src/proxy/gateway_test.rs
@@ -5476,7 +5476,7 @@ async fn ingress_use_waypoint_sets_waypoint_target() {
 
 	// Waypoint target should be populated
 	let wp = backend_call
-		.waypoint
+		.waypoint()
 		.expect("waypoint target must be set when ingress_use_waypoint is true");
 	assert_eq!(
 		wp.address.ip(),
@@ -5537,7 +5537,7 @@ async fn ingress_use_waypoint_false_no_waypoint() {
 
 	// Waypoint should NOT be set
 	assert!(
-		backend_call.waypoint.is_none(),
+		backend_call.waypoint().is_none(),
 		"waypoint should not be set when ingress_use_waypoint is false"
 	);
 
@@ -5679,13 +5679,13 @@ async fn ingress_use_waypoint_remote_waypoint_uses_network_gateway() {
 	.expect("build_service_call should succeed");
 
 	assert!(
-		backend_call.waypoint.is_none(),
+		backend_call.waypoint().is_none(),
 		"remote waypoint should be reached through double HBONE, not direct waypoint transport"
 	);
 	let (resolved_gw, gw_identities) = backend_call
-		.network_gateway
+		.network_gateway()
 		.expect("remote waypoint should resolve a network gateway");
-	assert_matches!(resolved_gw.destination, Destination::Address(addr) => {
+	assert_matches!(&resolved_gw.destination, Destination::Address(addr) => {
 		assert_eq!(addr.address, gateway_ip);
 		assert_eq!(addr.network, remote_network);
 	});
@@ -5693,7 +5693,7 @@ async fn ingress_use_waypoint_remote_waypoint_uses_network_gateway() {
 	// Outer tunnel: gateway workload id (the gateway is referenced by address, so no SANs).
 	assert_eq!(
 		gw_identities,
-		vec![Identity::Spiffe {
+		&vec![Identity::Spiffe {
 			trust_domain: strng::EMPTY,
 			namespace: strng::literal!("istio-gateways"),
 			service_account: strng::literal!("istio-eastwest"),
@@ -5810,7 +5810,7 @@ async fn ingress_use_waypoint_ip_based_waypoint() {
 	.expect("build_service_call should succeed");
 
 	let wp = backend_call
-		.waypoint
+		.waypoint()
 		.expect("waypoint target must be set for IP-based waypoint");
 	assert_eq!(wp.address.ip(), waypoint_ip);
 	assert_eq!(wp.address.port(), 15008);
@@ -5883,7 +5883,7 @@ async fn ingress_use_waypoint_no_waypoint_field_no_routing() {
 
 	// No waypoint configured, so it should fall back to direct routing
 	assert!(
-		backend_call.waypoint.is_none(),
+		backend_call.waypoint().is_none(),
 		"waypoint should not be set when no waypoint is configured on the service"
 	);
 	assert_matches!(backend_call.target, Target::Address(_));
@@ -5923,7 +5923,7 @@ async fn ingress_use_waypoint_build_transport_falls_back_without_ca() {
 	)
 	.expect("build_service_call should succeed");
 
-	assert!(backend_call.waypoint.is_some());
+	assert!(backend_call.waypoint().is_some());
 
 	// build_transport with no CA should fall back to plain transport
 	let transport = httpproxy::build_transport(&t.pi, &backend_call, None, None, None, None)
@@ -6050,10 +6050,10 @@ async fn network_gateway_hostname_resolves_via_service_endpoint() {
 	.expect("build_service_call should succeed");
 
 	let (resolved_gw, gw_identities) = backend_call
-		.network_gateway
+		.network_gateway()
 		.expect("network_gateway must be resolved for hostname-form destination");
 
-	assert_matches!(resolved_gw.destination, Destination::Address(addr) => {
+	assert_matches!(&resolved_gw.destination, Destination::Address(addr) => {
 		assert_eq!(addr.address, gw_ip, "should resolve to the gateway endpoint IP");
 		assert_eq!(addr.network, remote_network, "network should be the gateway workload's network");
 	});
@@ -6064,7 +6064,7 @@ async fn network_gateway_hostname_resolves_via_service_endpoint() {
 	// Outer-tunnel identities match ztunnel: gateway workload id + gateway service SANs.
 	assert_eq!(
 		gw_identities,
-		vec![
+		&vec![
 			Identity::Spiffe {
 				trust_domain: strng::EMPTY,
 				namespace: gateway_namespace.clone(),

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -6,8 +6,10 @@ use std::sync::{Arc, Mutex};
 
 use ::http::uri::PathAndQuery;
 use ::http::{HeaderMap, header};
+use agent_core::prelude::AssertSize;
 use anyhow::anyhow;
 use frozen_collections::Len;
+use futures_util::FutureExt;
 use headers::HeaderMapExt;
 use hyper::upgrade::OnUpgrade;
 use hyper_util::rt::TokioIo;
@@ -190,7 +192,11 @@ async fn apply_request_policies(
 		.select("ext proc", req)
 		.map(|p| p.build(c.clone()));
 	if let Some(x) = rp.ext_proc.as_mut() {
-		x.mutate_request(req).await?.apply(rp.headers())?;
+		x.mutate_request(req)
+			.assert_size::<{ 4 * 1024 }>()
+			.boxed()
+			.await?
+			.apply(rp.headers())?;
 		dtrace::snapshot!(Request, "ext proc", &req);
 	}
 
@@ -399,6 +405,8 @@ async fn apply_gateway_policies(
 		.map(|p| p.build(client.clone()));
 	if let Some(x) = ext_proc.as_mut() {
 		x.mutate_request(req)
+			.assert_size::<{ 4 * 1024 }>()
+			.boxed()
 			.await?
 			.apply(response_policies.headers())?;
 		dtrace::snapshot!(Request, "gateway ext proc", &req);
@@ -890,12 +898,12 @@ impl HTTPProxy {
 			.snapshot_on_err(log, &mut req)?;
 		let selected_backend =
 			resolve_backend(selected_backend_ref, self.inputs.as_ref()).snapshot_on_err(log, &mut req)?;
-		let backend_policies = get_backend_policies(
+		let backend_policies = Arc::new(get_backend_policies(
 			self.inputs.as_ref(),
 			&selected_backend.backend,
 			&selected_backend.inline_policies,
 			Some(route_path.clone()),
-		);
+		));
 		backend_policies.register_cel_expressions(log.cel.ctx());
 		log.cel.ctx().maybe_buffer_request_body(&mut req).await;
 		log.health_policy = backend_policies.health.clone();
@@ -917,6 +925,8 @@ impl HTTPProxy {
 					response_policies,
 					&mut req,
 				)
+				.assert_size::<{ 11 * 1024 }>()
+				.boxed()
 				.await
 				.snapshot_on_err(log, &mut req);
 		}
@@ -947,7 +957,6 @@ impl HTTPProxy {
 				}
 			});
 		}
-
 		const MAX_BUFFERED_BYTES: usize = 64 * 1024;
 		let retries = route_retry;
 
@@ -1069,14 +1078,14 @@ impl HTTPProxy {
 		log: &mut RequestLog,
 		upgrade: OnUpgrade,
 		selected_backend: &RouteBackend,
-		backend_policies: BackendPolicies,
+		backend_policies: Arc<BackendPolicies>,
 		response_policies: &mut ResponsePolicies,
 		req: &mut Request,
 	) -> Result<Response, ProxyResponse> {
 		let backend_call = build_connect_backend_call(
 			self.inputs.as_ref(),
 			&selected_backend.backend.backend,
-			backend_policies.into(),
+			backend_policies,
 			log,
 			req,
 		)?;
@@ -1282,7 +1291,7 @@ impl HTTPProxy {
 		req_upgrade: &mut Option<RequestUpgrade>,
 		route_policies: Arc<store::LLMRequestPolicies>,
 		selected_backend: &RouteBackend,
-		backend_policies: BackendPolicies,
+		backend_policies: Arc<BackendPolicies>,
 		response_policies: &mut ResponsePolicies,
 		mut req: Request,
 	) -> Result<Response, SnapshottedProxyResponse> {
@@ -1306,11 +1315,12 @@ impl HTTPProxy {
 			self.inputs.clone(),
 			route_policies.clone(),
 			&selected_backend.backend.backend,
-			backend_policies.into(),
+			backend_policies,
 			MustSnapshot::new(&mut req_opt),
 			Some(log),
 			response_policies,
-		);
+		)
+		.assert_size::<{ 7 * 1024 }>();
 
 		// Setup timeout
 		let call_result = if let Some(timeout) = timeout {
@@ -1590,7 +1600,7 @@ pub async fn build_transport(
 	}
 
 	// Check if we should route through a waypoint proxy (ingress_use_waypoint)
-	if let (Some(wp), Some(ca)) = (&backend_call.waypoint, &inputs.ca) {
+	if let (Some(wp), Some(ca)) = (backend_call.waypoint(), &inputs.ca) {
 		if ca.get_identity().await.is_ok() {
 			tracing::debug!("using HBONE waypoint at {} for service", wp.address);
 			return Ok(Transport::HboneWaypoint {
@@ -1611,7 +1621,7 @@ pub async fn build_transport(
 		Some((InboundProtocol::HBONE, waypoint_identities)),
 		Some(ca),
 	) = (
-		&backend_call.network_gateway,
+		backend_call.network_gateway(),
 		&backend_call.transport_override,
 		&inputs.ca,
 	) {
@@ -1791,9 +1801,19 @@ async fn apply_inference_routing(
 	req: &mut Request,
 	log: &mut Option<&mut RequestLog>,
 	response_policies: &mut ResponsePolicies,
-) -> Result<(http::ext_proc::InferencePoolRouter, ServiceCallOverride), ProxyResponse> {
+) -> Result<
+	(
+		Option<Box<http::ext_proc::InferencePoolRouter>>,
+		ServiceCallOverride,
+	),
+	ProxyResponse,
+> {
 	let mut maybe_inference = policies.build_inference(policy_client);
-	let inference_result = Box::pin(maybe_inference.mutate_request(req)).await?;
+	let inference_result = if let Some(maybe_inference) = maybe_inference.as_mut() {
+		Box::pin(maybe_inference.mutate_request(req)).await?
+	} else {
+		Default::default()
+	};
 	inference_result
 		.policy_response
 		.apply(response_policies.headers())?;
@@ -1826,7 +1846,13 @@ async fn build_simple_backend_call(
 	log: &mut Option<&mut RequestLog>,
 	response_policies: &mut ResponsePolicies,
 	hbone_source: Option<HboneSourceRole>,
-) -> Result<(BackendCall, http::ext_proc::InferencePoolRouter), ProxyResponse> {
+) -> Result<
+	(
+		BackendCall,
+		Option<Box<http::ext_proc::InferencePoolRouter>>,
+	),
+	ProxyResponse,
+> {
 	let (maybe_inference, service_override) =
 		apply_inference_routing(&policies, policy_client, req, log, response_policies).await?;
 	let backend_call = match backend {
@@ -2095,11 +2121,11 @@ async fn make_backend_call(
 		},
 		Backend::Dynamic(_, _) => {
 			let backend_call = BackendCall::from_shared(target_from_request(&req)?, policies);
-			(backend_call, http::ext_proc::InferencePoolRouter::default())
+			(backend_call, None)
 		},
 		Backend::Internal(_, _) => (
 			BackendCall::from_shared(Target::Hostname("internal".into(), 80), policies),
-			http::ext_proc::InferencePoolRouter::default(),
+			None,
 		),
 		Backend::MCP(name, backend) => {
 			let inputs = inputs.clone();
@@ -2111,11 +2137,14 @@ async fn make_backend_call(
 					ProxyError::ProcessingString("invalid: log required for MCP".to_string()).into(),
 				);
 			};
-			let res = inputs
-				.clone()
-				.mcp_state
-				.serve(inputs, name, backend, policies.as_ref().clone(), req, log)
-				.await;
+			let res = Box::pin(
+				inputs
+					.clone()
+					.mcp_state
+					.serve(inputs, name, backend, policies.as_ref().clone(), req, log)
+					.assert_size::<{ 4 * 1024 }>(),
+			)
+			.await;
 			return res.map_err(ProxyResponse::from);
 		},
 		Backend::Invalid => return Err(ProxyResponse::from(ProxyError::BackendDoesNotExist)),
@@ -2284,12 +2313,15 @@ async fn make_backend_call(
 					let response_policies = if route_type == RouteType::AnthropicTokenCount {
 						LLMResponsePolicies::default()
 					} else {
-						apply_llm_request_policies(
-							&llm_request_policies,
-							policy_client.clone(),
-							&mut req,
-							&llm_request,
-							&mut response_policies.response_headers,
+						Box::pin(
+							apply_llm_request_policies(
+								&llm_request_policies,
+								policy_client.clone(),
+								&mut req,
+								&llm_request,
+								&mut response_policies.response_headers,
+							)
+							.assert_size::<{ 3 * 1024 }>(),
 						)
 						.await?
 					};
@@ -2363,6 +2395,7 @@ async fn make_backend_call(
 		backend_call.backend_policies.backend_auth.as_ref(),
 		&mut req,
 	)
+	.assert_size::<{ 2 * 1024 }>()
 	.await?;
 	if let Backend::Internal(_, internal) = backend {
 		apply_internal_path(&mut req, internal).map_err(ProxyError::Processing)?;
@@ -2470,25 +2503,35 @@ async fn make_backend_call(
 		backend_call.backend_policies.llm_provider.clone(),
 		llm_request,
 	) {
-		llm
-			.provider
-			.process_response(
-				policy_client.clone(),
-				llm_request,
-				llm_response_policies,
-				log.as_ref().expect("must be set").request_snapshot.clone(),
-				llm_response_log.expect("must be set"),
-				include_completion_in_log,
-				Some(&inputs.model_catalog),
-				resp,
-			)
-			.await
-			.map_err(|e| ProxyError::Processing(e.into()))?
+		Box::pin(
+			llm
+				.provider
+				.process_response(
+					policy_client.clone(),
+					llm_request,
+					llm_response_policies,
+					log.as_ref().expect("must be set").request_snapshot.clone(),
+					llm_response_log.expect("must be set"),
+					include_completion_in_log,
+					Some(&inputs.model_catalog),
+					resp,
+				)
+				.assert_size::<{ 4 * 1024 }>(),
+		)
+		.await
+		.map_err(|e| ProxyError::Processing(e.into()))?
 	} else {
 		resp
 	};
 	// TODO: we currently do not support ImmediateResponse from inference router
-	let _ = maybe_inference.mutate_response(&mut resp).await?;
+	if let Some(maybe_inference) = maybe_inference.as_mut() {
+		let _ = Box::pin(
+			maybe_inference
+				.mutate_response(&mut resp)
+				.assert_size::<{ 4 * 1024 }>(),
+		)
+		.await?;
+	}
 	if let Some(log) = log.as_ref() {
 		dtrace::snapshot!(Response, "backend response ready", log, &resp);
 	}
@@ -2576,8 +2619,7 @@ pub fn build_service_call(
 			http_version_override,
 			transport_override: None,
 			hbone_port: agent_hbone::DEFAULT_HBONE_PORT,
-			network_gateway: None,
-			waypoint: None,
+			advanced_routing: None,
 			backend_policies,
 		});
 	}
@@ -2741,8 +2783,7 @@ pub fn build_service_call(
 		http_version_override,
 		transport_override,
 		hbone_port,
-		network_gateway,
-		waypoint,
+		advanced_routing: BackendCallAdvancedRouting::new(network_gateway, waypoint),
 		backend_policies,
 	})
 }
@@ -3633,8 +3674,7 @@ pub struct BackendCall {
 	pub http_version_override: Option<::http::Version>,
 	pub transport_override: Option<(InboundProtocol, Vec<Identity>)>,
 	pub hbone_port: u16,
-	pub network_gateway: Option<(GatewayAddress, Vec<Identity>)>, /* For double hbone: (gateway_address, gateway_identities) */
-	pub waypoint: Option<WaypointTarget>,                         // For ingress waypoint routing
+	advanced_routing: Option<Box<BackendCallAdvancedRouting>>,
 	pub backend_policies: Arc<BackendPolicies>,
 }
 
@@ -3649,9 +3689,45 @@ impl BackendCall {
 			http_version_override: None,
 			transport_override: None,
 			hbone_port: agent_hbone::DEFAULT_HBONE_PORT,
-			network_gateway: None,
-			waypoint: None,
+			advanced_routing: None,
 			backend_policies,
+		}
+	}
+
+	pub(crate) fn network_gateway(&self) -> Option<&(GatewayAddress, Vec<Identity>)> {
+		self
+			.advanced_routing
+			.as_ref()
+			.and_then(|routing| routing.network_gateway.as_ref())
+	}
+
+	pub(crate) fn waypoint(&self) -> Option<&WaypointTarget> {
+		self
+			.advanced_routing
+			.as_ref()
+			.and_then(|routing| routing.waypoint.as_ref())
+	}
+}
+
+struct BackendCallAdvancedRouting {
+	/// For double hbone: (gateway_address, gateway_identities)
+	network_gateway: Option<(GatewayAddress, Vec<Identity>)>,
+	/// For ingress waypoint routing.
+	waypoint: Option<WaypointTarget>,
+}
+
+impl BackendCallAdvancedRouting {
+	fn new(
+		network_gateway: Option<(GatewayAddress, Vec<Identity>)>,
+		waypoint: Option<WaypointTarget>,
+	) -> Option<Box<Self>> {
+		if network_gateway.is_none() && waypoint.is_none() {
+			None
+		} else {
+			Some(Box::new(Self {
+				network_gateway,
+				waypoint,
+			}))
 		}
 	}
 }
@@ -3742,12 +3818,16 @@ impl ResponsePolicies {
 		if is_upstream_response {
 			if let Some(x) = self.ext_proc.as_mut() {
 				x.mutate_response(resp, l.request_snapshot.as_deref())
+					.assert_size::<{ 4 * 1024 }>()
+					.boxed()
 					.await?
 					.apply(&mut self.response_headers)?;
 				dtrace::snapshot!(Response, "ext proc", l, &resp);
 			};
 			if let Some(x) = self.gateway_ext_proc.as_mut() {
 				x.mutate_response(resp, l.request_snapshot.as_deref())
+					.assert_size::<{ 4 * 1024 }>()
+					.boxed()
 					.await?
 					.apply(&mut self.response_headers)?;
 				dtrace::snapshot!(Response, "gateway ext proc", l, &resp);
@@ -3900,16 +3980,19 @@ impl PolicyClient {
 	) -> Pin<Box<dyn Future<Output = Result<Response, ProxyError>> + Send + '_>> {
 		let mut req = Some(req);
 		Box::pin(async move {
-			make_backend_call(
-				self.inputs.clone(),
-				Arc::new(LLMRequestPolicies::default()),
-				&backend,
-				pols.into(),
-				MustSnapshot::new(&mut req),
-				// Here we don't have a log to pass. MCP and LLM flows expect there to always be a log.
-				// As such, we ensure we ONLY call this with Simple backend type which cannot be MCP/LLM
-				None,
-				&mut Default::default(),
+			Box::pin(
+				make_backend_call(
+					self.inputs.clone(),
+					Arc::new(LLMRequestPolicies::default()),
+					&backend,
+					pols.into(),
+					MustSnapshot::new(&mut req),
+					// Here we don't have a log to pass. MCP and LLM flows expect there to always be a log.
+					// As such, we ensure we ONLY call this with Simple backend type which cannot be MCP/LLM
+					None,
+					&mut Default::default(),
+				)
+				.assert_size::<{ 7 * 1024 }>(),
 			)
 			.await
 			.map_err(ProxyResponse::downcast)

--- a/crates/agentgateway/src/proxy/tcpproxy.rs
+++ b/crates/agentgateway/src/proxy/tcpproxy.rs
@@ -992,7 +992,7 @@ mod tests {
 		);
 		assert!(result.http_version_override.is_none());
 		assert!(result.transport_override.is_none());
-		assert!(result.network_gateway.is_none());
+		assert!(result.network_gateway().is_none());
 	}
 
 	#[test]

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -288,13 +288,14 @@ impl BackendPolicies {
 			override_dest: other.override_dest.or(self.override_dest),
 		}
 	}
-	/// build the inference routing configuration. This may be a NO-OP config.
-	pub fn build_inference(&self, client: PolicyClient) -> ext_proc::InferencePoolRouter {
-		if let Some(inference) = &self.inference_routing {
-			inference.build(client)
-		} else {
-			ext_proc::InferencePoolRouter::default()
-		}
+	pub fn build_inference(
+		&self,
+		client: PolicyClient,
+	) -> Option<Box<ext_proc::InferencePoolRouter>> {
+		self
+			.inference_routing
+			.as_ref()
+			.map(|inference| Box::new(inference.build(client)))
 	}
 
 	pub fn register_cel_expressions(&self, ctx: &mut ContextBuilder) {

--- a/crates/core/src/assertions.rs
+++ b/crates/core/src/assertions.rs
@@ -1,0 +1,30 @@
+// Helper functions for checking type sizes. They are primarily useful for
+// futures whose concrete types cannot be named directly. Future size is
+// determined by the largest suspend state, so deeply branched async code can
+// quietly grow connection/task memory and stack pressure.
+
+#[inline(always)]
+pub fn size_at_most<const MAX: usize, T>(t: T) -> T {
+	SizeAtMost::<MAX>::check(t)
+}
+
+pub struct SizeAtMost<const MAX: usize>;
+
+impl<const MAX: usize> SizeAtMost<MAX> {
+	#[inline(always)]
+	pub fn check<T>(t: T) -> T {
+		const {
+			assert!(std::mem::size_of::<T>() <= MAX);
+		}
+		t
+	}
+}
+
+pub trait AssertSize: Sized {
+	#[inline(always)]
+	fn assert_size<const MAX: usize>(self) -> Self {
+		SizeAtMost::<MAX>::check(self)
+	}
+}
+
+impl<T> AssertSize for T {}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,4 +1,5 @@
 mod arc;
+pub mod assertions;
 pub mod bow;
 pub mod copy;
 pub mod drain;

--- a/crates/core/src/prelude.rs
+++ b/crates/core/src/prelude.rs
@@ -11,5 +11,6 @@ pub use tokio::sync::Mutex as AsyncMutex;
 pub use tracing::{Instrument, debug, error, info, trace, warn};
 
 pub use crate::arc::{Atomic, AtomicOption};
+pub use crate::assertions::AssertSize;
 pub use crate::strng;
 pub use crate::strng::Strng;


### PR DESCRIPTION
Added compile-time future/type-size assertions via `AssertSize::assert_size::<MAX>()` / `size_at_most::<MAX, T>()`.

Boxed `connect_tunnel` at the CONNECT-only branch.
Boxed ext-proc mutation futures at the high-level policy call sites.
Boxed several slow/niche AI and inference-router paths rather than keeping their branch futures inline.
Reduced the previously large `apply_late_backend_auth` future by boxing the AWS credential load path.

Moved `BackendPolicies` into `Arc` earlier, before passing into CONNECT/attempt upstream.
- Avoids carrying/copying the full backend policy struct deeper in the async state.
- This matches the existing `BackendCall` model, which already wanted an `Arc<BackendPolicies>`.

Final sizes:
```text
per-request DebugTracer::maybe_scope: 14,704 bytes
Tokio H2 task cell:                 15,104 bytes
HTTPProxy::proxy:                   13,744 bytes
proxy_internal:                     10,264 bytes
attempt_upstream:                    6,552 bytes
make_backend_call:                   5,488 bytes
ResponsePolicies::apply:               448 bytes
```

Overall:
- Per-request future went from about `20,064` bytes to `14,704` bytes.
- That is about a `5.3KiB` reduction per in-flight HTTP request.

Signed-off-by: John Howard <john.howard@solo.io>
