### PR TITLE
docs: Update tool names in Authorization example

### DIFF
--- a/examples/authorization/config.yaml
+++ b/examples/authorization/config.yaml
@@ -23,10 +23,10 @@ binds:
           rules:
           # Allow anyone to call 'echo'
           - 'mcp.tool.name == "echo"'
-          # Only the test-user can call 'add'
-          - 'jwt.sub == "test-user" && mcp.tool.name == "add"'
-          # Any authenticated user with the claim `nested.key == value` can access 'printEnv'
-          - 'mcp.tool.name == "printEnv" && jwt.nested.key == "value"'
+          # Only the test-user can call 'get-sum'
+          - 'jwt.sub == "test-user" && mcp.tool.name == "get-sum"'
+          # Any authenticated user with the claim `nested.key == value` can access 'get-env'
+          - 'mcp.tool.name == "get-env" && jwt.nested.key == "value"'
       backends:
       - mcp:
           targets:


### PR DESCRIPTION
While reviewing the examples in this repo, I was unable to get the authorization example to work correctly. I looked into it and it seems that the tool names from the model context protocol everything server have changed from `add -> get-sum` and `printEnv -> get-env`. Raising this PR to fix this.

I was able to verify this works
<img width="1435" height="718" alt="image" src="https://github.com/user-attachments/assets/ee2187b1-74c2-4b7e-bff0-e9167269b235" />
