### PR TITLE
buffer: copy buffer limit around more

### DIFF
--- a/crates/agentgateway/src/http/buffer.rs
+++ b/crates/agentgateway/src/http/buffer.rs
@@ -56,6 +56,9 @@ impl Buffer {
 		};
 		debug!(bytes = bytes.len(), "buffered request body");
 		*req.body_mut() = crate::http::Body::from(bytes);
+		req
+			.extensions_mut()
+			.insert(crate::transport::BufferLimit::new(limit));
 
 		Ok(())
 	}
@@ -93,6 +96,9 @@ impl Buffer {
 		};
 		debug!(bytes = bytes.len(), "buffered response body");
 		*resp.body_mut() = crate::http::Body::from(bytes);
+		resp
+			.extensions_mut()
+			.insert(crate::transport::BufferLimit::new(limit));
 
 		Ok(())
 	}

--- a/crates/agentgateway/src/http/buffer_tests.rs
+++ b/crates/agentgateway/src/http/buffer_tests.rs
@@ -254,6 +254,7 @@ async fn apply_to_request_uses_explicit_max_bytes_over_extension_limit() {
 		read_request_body_bytes(&mut req).await,
 		Bytes::from_static(b"payload")
 	);
+	assert_eq!(crate::http::buffer_limit(&req), 64);
 }
 
 #[tokio::test]
@@ -399,6 +400,7 @@ async fn apply_to_response_uses_explicit_max_bytes_over_extension_limit() {
 		read_response_body_bytes(&mut resp).await,
 		Bytes::from_static(b"payload")
 	);
+	assert_eq!(crate::http::response_buffer_limit(&resp), 64);
 }
 
 #[tokio::test]

--- a/crates/agentgateway/src/proxy/gateway.rs
+++ b/crates/agentgateway/src/proxy/gateway.rs
@@ -775,6 +775,7 @@ impl Gateway {
 						};
 						let mut downstream = Socket::from_upgraded(connection, target_address, downstream);
 						downstream.ext_mut().insert(ConnectHeaders(connect_headers));
+						downstream.ext_mut().insert(BufferLimit::new(buffer));
 						Self::proxy_bind(bind.key.clone(), bind.protocol, downstream, inputs, drain).await;
 					});
 
@@ -872,10 +873,12 @@ impl Gateway {
 		stream.set_transport_metrics(transport_metrics, transport_labels);
 
 		let def = frontend::HTTP::default();
+		let tunneled_buffer = stream.ext::<BufferLimit>().map(|b| b.0);
 		let buffer = policies
 			.http
 			.as_ref()
 			.map(|h| h.max_buffer_size)
+			.or(tunneled_buffer)
 			.unwrap_or(def.max_buffer_size);
 
 		let max_connection_duration = policies


### PR DESCRIPTION
Inspired by https://github.com/agentgateway/agentgateway/issues/2350 but
not fixing it

1. If http buffer policy is set, overide the buffer limit for future
   steps
2. IfCONNECT is used properly thread the buffer through

Signed-off-by: John Howard <john.howard@solo.io>
