### PR TITLE
llm: remove unnecessary async/.await from process_streaming

### DIFF
--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -1264,18 +1264,16 @@ impl AIProvider {
 		// Only enter the streaming path for successful responses; errors
 		// fall through to the buffered path where process_error translates them.
 		if req.streaming && resp.status().is_success() {
-			return self
-				.process_streaming(
-					client,
-					req,
-					rate_limit,
-					req_snapshot,
-					log,
-					include_completion_in_log,
-					model_catalog.cloned(),
-					resp,
-				)
-				.await;
+			return self.process_streaming(
+				client,
+				req,
+				rate_limit,
+				req_snapshot,
+				log,
+				include_completion_in_log,
+				model_catalog.cloned(),
+				resp,
+			);
 		}
 		let model_catalog = model_catalog.map(Arc::as_ref);
 
@@ -1686,7 +1684,7 @@ impl AIProvider {
 	}
 
 	#[allow(clippy::too_many_arguments)]
-	pub async fn process_streaming(
+	pub fn process_streaming(
 		&self,
 		client: PolicyClient,
 		req: LLMRequest,

--- a/crates/agentgateway/src/llm/tests.rs
+++ b/crates/agentgateway/src/llm/tests.rs
@@ -738,7 +738,6 @@ mod response {
 				None,
 				i,
 			)
-			.await
 		};
 		test_streaming(provider, test, test_fn).await
 	}
@@ -1456,7 +1455,6 @@ async fn process_streaming_bedrock_completions_normalizes_sse_headers_and_done()
 			None,
 			resp,
 		)
-		.await
 		.expect("Bedrock streaming translation should succeed");
 
 	crate::http::tests_common::assert_header(


### PR DESCRIPTION
Removes the unnecessary async/.await from `process_streaming`. This change is partly due to the recent #2336 improvements.