### PR TITLE
llm: pre-filter empty services

### DIFF
--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -88,6 +88,13 @@ impl AIBackend {
 		let handle = self.providers.start_request(ep.name.clone(), ep_info);
 		Some((ep, handle))
 	}
+
+	pub fn select_provider_if(
+		&self,
+		eligible: impl FnMut(&NamedAIProvider) -> bool,
+	) -> Option<(Arc<NamedAIProvider>, ActiveHandle)> {
+		self.providers.select_matching(eligible)
+	}
 }
 
 #[derive(Debug, Clone, serde::Serialize)]

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -59,6 +59,22 @@ fn select_backend(route: &Route, _req: &Request) -> Option<RouteBackendReference
 		.cloned()
 }
 
+fn provider_backend_has_endpoints(
+	inputs: &ProxyInputs,
+	provider: &crate::llm::NamedAIProvider,
+) -> bool {
+	let Some(SimpleBackendReference::Service { name, port }) = &provider.provider_backend else {
+		return true;
+	};
+	let discovery = inputs.stores.read_discovery();
+	let Some(svc) = discovery.services.get_by_namespaced_host(name) else {
+		return false;
+	};
+	svc
+		.endpoints
+		.has_available_endpoint(&discovery.workloads, svc.as_ref(), *port)
+}
+
 #[derive(Debug)]
 struct SelectedRouteChain {
 	routes: Vec<Arc<Route>>,
@@ -1972,7 +1988,9 @@ async fn make_backend_call(
 
 	let (mut backend_call, mut maybe_inference) = match backend {
 		Backend::AI(n, ai) => {
-			let (provider, handle) = ai.select_provider().ok_or(ProxyError::NoHealthyEndpoints)?;
+			let (provider, handle) = ai
+				.select_provider_if(|provider| provider_backend_has_endpoints(&inputs, provider))
+				.ok_or(ProxyError::NoHealthyEndpoints)?;
 			log.add(move |l| l.request_handle = Some(handle));
 			let sub_backend_name = BackendTargetRef::Backend {
 				name: n.name.as_ref(),

--- a/crates/agentgateway/src/types/loadbalancer.rs
+++ b/crates/agentgateway/src/types/loadbalancer.rs
@@ -231,6 +231,21 @@ impl EndpointSet<Endpoint> {
 		Some((c.endpoint, handle, c.workload))
 	}
 
+	pub fn has_available_endpoint(
+		&self,
+		workloads: &store::WorkloadStore,
+		svc: &Service,
+		svc_port: u16,
+	) -> bool {
+		let Some(target_port) = svc.ports.get(&svc_port).copied() else {
+			return false;
+		};
+		self
+			.select_p2c(workloads, svc, svc_port, target_port)
+			.or_else(|| self.select_fallback(workloads, svc_port, target_port))
+			.is_some()
+	}
+
 	/// Explicit destination bypasses bucketing and health — search every endpoint
 	/// (active + rejected) so an evicted-but-explicitly-targeted backend is still reachable.
 	fn select_override(&self, workloads: &store::WorkloadStore, o: SocketAddr) -> Option<Candidate> {
@@ -564,6 +579,43 @@ impl<T: Clone + Sync + Send + 'static> EndpointSet<T> {
 
 	pub fn start_request(&self, key: Strng, info: &Arc<EndpointInfo>) -> ActiveHandle {
 		info.start_request(key, self.tx_eviction.clone(), self.eviction_worker.clone())
+	}
+
+	pub fn select_matching(
+		&self,
+		mut eligible: impl FnMut(&T) -> bool,
+	) -> Option<(Arc<T>, ActiveHandle)> {
+		let mut rng = rand::rng();
+		for active_phase in [true, false] {
+			for bucket in self.buckets.iter() {
+				let group = bucket.load_full();
+				let map = if active_phase {
+					&group.active
+				} else {
+					&group.rejected
+				};
+				let candidates = map
+					.iter()
+					.filter(|(_, ewi)| eligible(ewi.endpoint.as_ref()))
+					.collect_vec();
+				if candidates.is_empty() {
+					continue;
+				}
+				let len = candidates.len();
+				let a = rng.random_range(0..len);
+				let b = rng.random_range(0..len);
+				let (key, ewi) = [a, b]
+					.into_iter()
+					.map(|idx| candidates[idx])
+					.max_by(|(_, a), (_, b)| a.info.score().total_cmp(&b.info.score()))
+					.expect("candidates is non-empty");
+				return Some((
+					ewi.endpoint.clone(),
+					self.start_request(key.clone(), &ewi.info),
+				));
+			}
+		}
+		None
 	}
 
 	fn find_bucket(&self, key: &EndpointKey) -> Option<Arc<EndpointGroup<T>>> {


### PR DESCRIPTION
If we have a case where we have an AI provider like:

```
groups:
- [svc1,svc2]
- [svc3]
```

We can see svc1 as unhealthy only after we attempt to send to it and
fail. But if it has 0 healthy endpoints we could pre-filter it up-front.

Signed-off-by: John Howard <john.howard@solo.io>
