### PR TITLE
fix extproc attributes and grpc initial metadata

### DIFF
--- a/crates/agentgateway/src/cel/mod.rs
+++ b/crates/agentgateway/src/cel/mod.rs
@@ -109,6 +109,7 @@ pub fn register_custom_functions(definitions: &str) -> Result<(), Error> {
 flagset::flags! {
 	enum Attributes: u32 {
 		Source,
+		Destination,
 
 		Request,
 		RequestBody,
@@ -209,6 +210,7 @@ impl ContextBuilder {
 		clear: bool,
 	) -> Option<RequestSnapshot> {
 		if self.any_has(Attributes::Source)
+			|| self.any_has(Attributes::Destination)
 			|| self.any_has(Attributes::Request)
 			|| self.any_has(Attributes::Llm)
 			|| self.any_has(Attributes::Proxy)
@@ -377,6 +379,9 @@ fn attributes_for(expression: &cel::IdedExpr) -> FlagSet<Attributes> {
 			},
 			["source", ..] => {
 				attributes |= Attributes::Source;
+			},
+			["destination", ..] => {
+				attributes |= Attributes::Destination;
 			},
 			["backend", ..] => {
 				attributes |= Attributes::Backend;

--- a/crates/agentgateway/src/cel/types.rs
+++ b/crates/agentgateway/src/cel/types.rs
@@ -1886,6 +1886,10 @@ pub struct ExecutorSerde {
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub source: Option<SourceContext>,
 
+	/// `destination` contains attributes about the downstream request destination at agentgateway.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub destination: Option<DestinationContext>,
+
 	/// `mcp` contains attributes about the MCP request.
 	/// Request-time CEL only includes identity fields such as `tool`, `prompt`, or `resource`.
 	/// Post-request CEL may also include fields like `methodName`, `sessionId`, and tool payloads.
@@ -1990,6 +1994,7 @@ impl ExecutorSerde {
 
 		// Set all the ExtensionOrDirect fields
 		exec.source = ExtensionOrDirect::Direct(self.source.as_ref());
+		exec.destination = ExtensionOrDirect::Direct(self.destination.as_ref());
 		exec.jwt = ExtensionOrDirect::Direct(self.jwt.as_ref());
 		exec.api_key = ExtensionOrDirect::Direct(self.api_key.as_ref());
 		exec.basic_auth = ExtensionOrDirect::Direct(self.basic_auth.as_ref());
@@ -2083,6 +2088,10 @@ pub fn full_example_executor() -> ExecutorSerde {
 				http::HeaderName::from_static("x-custom-header"),
 				http::HeaderValue::from_static("custom-value"),
 			)]),
+		}),
+		destination: Some(DestinationContext {
+			address: "10.0.0.1".parse().unwrap(),
+			port: 8080,
 		}),
 		jwt: Some(jwt::Claims {
 			inner: serde_json::Map::from_iter(vec![

--- a/crates/agentgateway/src/cel/types.rs
+++ b/crates/agentgateway/src/cel/types.rs
@@ -49,6 +49,8 @@ pub struct Executor<'a> {
 
 	pub source: ExtensionOrDirect<'a, SourceContext>,
 
+	pub destination: ExtensionOrDirect<'a, DestinationContext>,
+
 	pub jwt: ExtensionOrDirect<'a, jwt::Claims>,
 
 	#[dynamic(rename = "apiKey")]
@@ -317,6 +319,17 @@ pub struct SourceContext {
 
 #[apply(schema!)]
 #[derive(cel::DynamicType)]
+pub struct DestinationContext {
+	#[serde(default = "dummy_address")]
+	/// The IP address of the downstream request destination at agentgateway.
+	pub address: IpAddr,
+	#[serde(default)]
+	/// The port of the downstream request destination at agentgateway.
+	pub port: u16,
+}
+
+#[apply(schema!)]
+#[derive(cel::DynamicType)]
 /// Workload context wrapper. All fields live under `unverified` to make it
 /// clear that the data is resolved by IP, not cryptographically verified.
 pub struct WorkloadContext {
@@ -346,6 +359,15 @@ impl SourceContext {
 			tls,
 			unverified_workload,
 			connect_headers: http::HeaderMap::new(),
+		}
+	}
+}
+
+impl DestinationContext {
+	pub fn from_tcp_connection(tcp: &crate::transport::stream::TCPConnectionInfo) -> Self {
+		Self {
+			address: tcp.local_addr.ip(),
+			port: tcp.local_addr.port(),
 		}
 	}
 }
@@ -539,6 +561,7 @@ impl<'a> Executor<'a> {
 		self.backend = ExtensionOrDirect::Extension(ext);
 		self.proxy = ExtensionOrDirect::Extension(ext);
 		self.source = ExtensionOrDirect::Extension(ext);
+		self.destination = ExtensionOrDirect::Extension(ext);
 	}
 	fn set_request_snapshot(&mut self, req: &'a RequestSnapshot) {
 		self.request = Some(req.into());
@@ -553,6 +576,7 @@ impl<'a> Executor<'a> {
 		self.backend = ExtensionOrDirect::Direct(req.backend.as_ref());
 		self.proxy = ExtensionOrDirect::Direct(req.proxy.as_ref());
 		self.source = ExtensionOrDirect::Direct(req.source.as_ref());
+		self.destination = ExtensionOrDirect::Direct(req.destination.as_ref());
 	}
 	fn set_response(&mut self, resp: &'a crate::http::Response) {
 		self.response = Some(resp.into());
@@ -775,6 +799,7 @@ pub fn snapshot_request(req: &mut crate::http::Request, clear: bool) -> RequestS
 		backend: ext::<BackendContext>(req, clear),
 		proxy: ext::<ProxyContext>(req, clear),
 		source: ext::<SourceContext>(req, clear),
+		destination: ext::<DestinationContext>(req, clear),
 		extauthz: ext::<ExtAuthzDynamicMetadata>(req, clear),
 		extproc: ext::<ExtProcDynamicMetadata>(req, clear),
 		mcp_guardrails: ext::<McpGuardrailsDynamicMetadata>(req, clear),
@@ -826,6 +851,8 @@ pub struct RequestSnapshot {
 	pub proxy: Option<ProxyContext>,
 
 	pub source: Option<SourceContext>,
+
+	pub destination: Option<DestinationContext>,
 
 	pub start_time: Option<RequestTime>,
 

--- a/crates/agentgateway/src/http/ext_proc.rs
+++ b/crates/agentgateway/src/http/ext_proc.rs
@@ -29,6 +29,10 @@ use crate::{http, *};
 
 /// The namespace key used for ext_proc attributes in ProcessingRequest.attributes
 const EXTPROC_ATTRIBUTES_NAMESPACE: &str = "envoy.filters.http.ext_proc";
+/// Reserved internal metadata_context namespace whose key/value pairs are copied
+/// into outbound gRPC initial metadata when the ext_proc stream is opened.
+pub(crate) const EXTPROC_GRPC_INITIAL_METADATA_NAMESPACE: &str =
+	"agentgateway.dev.grpc_initial_metadata";
 
 #[cfg(test)]
 #[path = "ext_proc_tests.rs"]
@@ -381,7 +385,8 @@ struct ExtProcInstance {
 	request_body_immediate_response: Arc<Mutex<Option<http::Response>>>,
 	protocol_config_sent: bool,
 	mode_state: ModeStateMachine,
-	tx_req: Sender<ProcessingRequest>,
+	client: Option<proto::external_processor_client::ExternalProcessorClient<GrpcReferenceChannel>>,
+	tx_req: Option<Sender<ProcessingRequest>>,
 	rx_resp_for_request: Option<Receiver<ProcessingResponse>>,
 	rx_resp_for_response: Option<Receiver<ProcessingResponse>>,
 	metadata_context: Option<HashMap<String, HashMap<String, Arc<cel::Expression>>>>,
@@ -407,14 +412,41 @@ impl ExtProcInstance {
 			client: client.with_outbound(OutboundCallKind::Policy, OutboundCallSubtype::ExtProc),
 			policies: Arc::new(policies),
 		};
-		let mut c = proto::external_processor_client::ExternalProcessorClient::new(chan);
+		Self {
+			skipped: Default::default(),
+			request_body_immediate_response: Arc::new(Mutex::new(None)),
+			failure_mode,
+			protocol_config_sent: false,
+			mode_state: processing_options.into(),
+			client: Some(proto::external_processor_client::ExternalProcessorClient::new(chan)),
+			tx_req: None,
+			rx_resp_for_request: None,
+			rx_resp_for_response: None,
+			metadata_context,
+			req_attributes,
+			resp_attributes,
+		}
+	}
+
+	fn ensure_stream_started(&mut self, exec: &Executor<'_>) -> Result<(), Error> {
+		if self.tx_req.is_some() {
+			return Ok(());
+		}
+
+		// Delay stream creation until we have a request/response executor so
+		// metadata_context CEL can be resolved into gRPC initial metadata.
+		let grpc_initial_metadata = build_grpc_initial_metadata(exec, self.metadata_context.as_ref());
+		let Some(mut client) = self.client.take() else {
+			return Err(Error::RequestSend);
+		};
+		let failure_mode = self.failure_mode;
 		let (tx_req, rx_req) = tokio::sync::mpsc::channel(10);
 		let (tx_resp, mut rx_resp) = tokio::sync::mpsc::channel(10);
 		let req_stream = tokio_stream::wrappers::ReceiverStream::new(rx_req);
 		tokio::task::spawn(async move {
-			// Spawn a task to handle processing requests.
-			// Incoming requests get send to tx_req and will be piped through here.
-			let responses = match c.process(req_stream).await {
+			let mut request = tonic::Request::new(req_stream);
+			*request.metadata_mut() = grpc_initial_metadata;
+			let responses = match client.process(request).await {
 				Ok(r) => r,
 				Err(e) => {
 					warn!(?failure_mode, "failed to initialize extproc client: {e:?}");
@@ -428,6 +460,7 @@ impl ExtProcInstance {
 				let _ = tx_resp.send(item).await;
 			}
 		});
+
 		let (tx_resp_for_request, rx_resp_for_request) = tokio::sync::mpsc::channel(1);
 		let (tx_resp_for_response, rx_resp_for_response) = tokio::sync::mpsc::channel(1);
 		tokio::task::spawn(async move {
@@ -444,8 +477,8 @@ impl ExtProcInstance {
 						let _ = tx_resp_for_request.send(item).await;
 					},
 					Some(processing_response::Response::ImmediateResponse(_)) => {
-						// In this case we aren't sure which is going to handle things...
-						// Send to both
+						// Immediate responses can terminate either the request-side or
+						// response-side flow, so fan them out to both waiters.
 						let _ = tx_resp_for_request.send(item.clone()).await;
 						let _ = tx_resp_for_response.send(item).await;
 					},
@@ -453,23 +486,25 @@ impl ExtProcInstance {
 				}
 			}
 		});
-		Self {
-			skipped: Default::default(),
-			request_body_immediate_response: Arc::new(Mutex::new(None)),
-			failure_mode,
-			protocol_config_sent: false,
-			mode_state: processing_options.into(),
-			tx_req,
-			rx_resp_for_request: Some(rx_resp_for_request),
-			rx_resp_for_response: Some(rx_resp_for_response),
-			metadata_context,
-			req_attributes,
-			resp_attributes,
-		}
+
+		self.tx_req = Some(tx_req);
+		self.rx_resp_for_request = Some(rx_resp_for_request);
+		self.rx_resp_for_response = Some(rx_resp_for_response);
+		Ok(())
 	}
 
 	async fn send_request(&mut self, req: ProcessingRequest) -> Result<(), Error> {
-		self.tx_req.send(req).await.map_err(|_| Error::RequestSend)
+		self
+			.tx_req
+			.as_ref()
+			.ok_or(Error::RequestSend)?
+			.send(req)
+			.await
+			.map_err(|_| Error::RequestSend)
+	}
+
+	fn request_sender(&self) -> Result<Sender<ProcessingRequest>, Error> {
+		self.tx_req.clone().ok_or(Error::RequestSend)
 	}
 
 	fn protocol_config_for_headers(
@@ -511,7 +546,7 @@ impl ExtProcInstance {
 				Self::send_body_stream(
 					metadata_context.clone(),
 					body,
-					self.tx_req.clone(),
+					self.request_sender()?,
 					body_direction,
 					send_trailers,
 					first_message,
@@ -530,7 +565,7 @@ impl ExtProcInstance {
 					FirstExtProcMessage::take_for_send(first_message);
 				Self::send_partial_body(
 					metadata_context.clone(),
-					self.tx_req.clone(),
+					self.request_sender()?,
 					body_direction,
 					body,
 					end_stream,
@@ -790,28 +825,13 @@ impl ExtProcInstance {
 		let headers = req_to_header_map(&req);
 
 		let exec = cel::Executor::new_request(&req);
+		self.ensure_stream_started(&exec)?;
 		// request_attributes should only be sent on first ProcessingRequest
 		// this will need to be modified if we configure which Requests to send
 		// Wrap metadata_context in Arc for cheap cloning across body chunks
-		let metadata_context = self.metadata_context.as_ref().map(|meta| {
-			Arc::new(Metadata {
-				filter_metadata: meta
-					.iter()
-					.filter_map(|(n, e)| {
-						eval_to_struct(&exec, e).map(|v| (n.clone(), v)).ok() // TODO(mk): where best to log convertion issues
-					})
-					.collect(),
-			})
-		});
-		let attributes = self
-			.req_attributes
-			.as_ref()
-			.and_then(|attrs| {
-				eval_to_struct(&exec, attrs)
-					.map(|v| HashMap::from([(EXTPROC_ATTRIBUTES_NAMESPACE.to_string(), v)]))
-					.ok()
-			})
-			.unwrap_or_default();
+		let metadata_context = build_processing_metadata_context(&exec, self.metadata_context.as_ref())
+			.map(|filter_metadata| Arc::new(Metadata { filter_metadata }));
+		let attributes = build_request_attributes(&exec, self.req_attributes.as_ref());
 
 		let failure_mode = self.failure_mode;
 		let end_of_stream = req.body().is_end_stream();
@@ -897,7 +917,7 @@ impl ExtProcInstance {
 			self.spawn_body_stream(
 				&metadata_context,
 				&mut pending_full_duplex_body,
-				tx.clone(),
+				tx.clone().ok_or(Error::RequestSend)?,
 				BodyStreamDirection::Request,
 				send_request_trailers,
 				first_message,
@@ -1103,7 +1123,7 @@ impl ExtProcInstance {
 					self.spawn_body_stream(
 						&metadata_context,
 						&mut pending_full_duplex_body,
-						tx.clone(),
+						tx.clone().ok_or(Error::RequestSend)?,
 						BodyStreamDirection::Request,
 						send_request_trailers,
 						first_message,
@@ -1314,6 +1334,7 @@ impl ExtProcInstance {
 		let send_response_headers = self.mode_state.response_header_mode == HeaderSendMode::Send;
 
 		let exec = cel::Executor::new_response(request, &response);
+		self.ensure_stream_started(&exec)?;
 		// Wrap metadata_context in Arc for cheap cloning across body chunks
 		let metadata_context = if self.metadata_context.is_none()
 			&& let Some(rd) = resolved_destination_metadata
@@ -1327,14 +1348,8 @@ impl ExtProcInstance {
 				)]),
 			}))
 		} else {
-			self.metadata_context.as_ref().map(|meta| {
-				Arc::new(Metadata {
-					filter_metadata: meta
-						.iter()
-						.filter_map(|(n, e)| eval_to_struct(&exec, e).map(|v| (n.clone(), v)).ok())
-						.collect(),
-				})
-			})
+			build_processing_metadata_context(&exec, self.metadata_context.as_ref())
+				.map(|filter_metadata| Arc::new(Metadata { filter_metadata }))
 		};
 		// response_attributes should only be sent on first ProcessingRequest
 		// this will need to be modified if we configure which Requests to send
@@ -1409,7 +1424,7 @@ impl ExtProcInstance {
 			self.spawn_body_stream(
 				&metadata_context,
 				&mut pending_response_body,
-				tx.clone(),
+				tx.clone().ok_or(Error::RequestSend)?,
 				BodyStreamDirection::Response,
 				send_response_trailers,
 				first_message,
@@ -1440,7 +1455,7 @@ impl ExtProcInstance {
 				self.spawn_body_stream(
 					&metadata_context,
 					&mut pending_response_body,
-					tx.clone(),
+					tx.clone().ok_or(Error::RequestSend)?,
 					BodyStreamDirection::Response,
 					send_response_trailers,
 					first_message,
@@ -1551,7 +1566,7 @@ impl ExtProcInstance {
 						self.spawn_body_stream(
 							&metadata_context,
 							&mut pending_response_body,
-							tx.clone(),
+							tx.clone().ok_or(Error::RequestSend)?,
 							BodyStreamDirection::Response,
 							send_response_trailers,
 							first_message,
@@ -1605,4 +1620,109 @@ fn eval_to_struct(
 			})
 			.collect(),
 	})
+}
+
+fn build_processing_metadata_context(
+	exec: &Executor<'_>,
+	metadata_context: Option<&HashMap<String, HashMap<String, Arc<cel::Expression>>>>,
+) -> Option<HashMap<String, prost_wkt_types::Struct>> {
+	metadata_context.map(|meta| {
+		meta
+			// The reserved namespace is transported as gRPC initial metadata
+			// instead of regular ext_proc metadata_context.
+			.iter()
+			.filter(|(namespace, _)| namespace.as_str() != EXTPROC_GRPC_INITIAL_METADATA_NAMESPACE)
+			.filter_map(|(namespace, expressions)| {
+				eval_to_struct(exec, expressions)
+					.map(|value| (namespace.clone(), value))
+					.ok()
+			})
+			.collect()
+	})
+}
+
+fn build_request_attributes(
+	exec: &Executor<'_>,
+	request_attributes: Option<&HashMap<String, Arc<cel::Expression>>>,
+) -> HashMap<String, prost_wkt_types::Struct> {
+	let Some(attributes) = request_attributes else {
+		return HashMap::new();
+	};
+
+	let fields = eval_to_struct(exec, attributes)
+		.map(|s| s.fields)
+		.unwrap_or_default();
+	if fields.is_empty() {
+		HashMap::new()
+	} else {
+		HashMap::from([(
+			EXTPROC_ATTRIBUTES_NAMESPACE.to_string(),
+			prost_wkt_types::Struct { fields },
+		)])
+	}
+}
+
+fn build_grpc_initial_metadata(
+	exec: &Executor<'_>,
+	metadata_context: Option<&HashMap<String, HashMap<String, Arc<cel::Expression>>>>,
+) -> tonic::metadata::MetadataMap {
+	let mut metadata = tonic::metadata::MetadataMap::new();
+	let Some(expressions) =
+		metadata_context.and_then(|ctx| ctx.get(EXTPROC_GRPC_INITIAL_METADATA_NAMESPACE))
+	else {
+		return metadata;
+	};
+
+	// CEL values in the reserved namespace are copied into the outbound gRPC
+	// stream-open metadata, skipping entries that cannot be represented there.
+	for (key, expr) in expressions {
+		let value = match eval_expression(exec, expr) {
+			Ok(value) => value,
+			Err(error) => {
+				warn!(
+					%key,
+					%error,
+					"failed to evaluate gRPC initial metadata CEL expression"
+				);
+				continue;
+			},
+		};
+		let Some(string_value) = prost_value_to_metadata_string(&value) else {
+			continue;
+		};
+		let metadata_key = match tonic::metadata::MetadataKey::from_bytes(key.as_bytes()) {
+			Ok(metadata_key) => metadata_key,
+			Err(error) => {
+				warn!(%key, %error, "failed to convert gRPC initial metadata key");
+				continue;
+			},
+		};
+		let metadata_value = match tonic::metadata::MetadataValue::try_from(string_value.as_str()) {
+			Ok(metadata_value) => metadata_value,
+			Err(error) => {
+				warn!(
+					%key,
+					value = %string_value,
+					%error,
+					"failed to convert gRPC initial metadata value"
+				);
+				continue;
+			},
+		};
+		metadata.insert(metadata_key, metadata_value);
+	}
+
+	metadata
+}
+
+fn prost_value_to_metadata_string(value: &prost_wkt_types::Value) -> Option<String> {
+	use prost_wkt_types::value::Kind;
+
+	match value.kind.as_ref()? {
+		Kind::StringValue(s) => Some(s.clone()),
+		Kind::NumberValue(n) => Some(n.to_string()),
+		Kind::BoolValue(b) => Some(b.to_string()),
+		Kind::NullValue(_) => None,
+		Kind::StructValue(_) | Kind::ListValue(_) => None,
+	}
 }

--- a/crates/agentgateway/src/http/ext_proc.rs
+++ b/crates/agentgateway/src/http/ext_proc.rs
@@ -434,6 +434,8 @@ impl ExtProcInstance {
 			return Ok(());
 		}
 
+		// Delay stream creation until we have a request/response executor so
+		// metadata_context CEL can be resolved into gRPC initial metadata.
 		let grpc_initial_metadata = build_grpc_initial_metadata(exec, self.metadata_context.as_ref());
 		let Some(mut client) = self.client.take() else {
 			return Err(Error::RequestSend);
@@ -476,6 +478,8 @@ impl ExtProcInstance {
 						let _ = tx_resp_for_request.send(item).await;
 					},
 					Some(processing_response::Response::ImmediateResponse(_)) => {
+						// Immediate responses can terminate either the request-side or
+						// response-side flow, so fan them out to both waiters.
 						let _ = tx_resp_for_request.send(item.clone()).await;
 						let _ = tx_resp_for_response.send(item).await;
 					},
@@ -1634,6 +1638,8 @@ fn build_processing_metadata_context(
 ) -> Option<HashMap<String, prost_wkt_types::Struct>> {
 	metadata_context.map(|meta| {
 		meta
+			// The reserved namespace is transported as gRPC initial metadata
+			// instead of regular ext_proc metadata_context.
 			.iter()
 			.filter(|(namespace, _)| namespace.as_str() != EXTPROC_GRPC_INITIAL_METADATA_NAMESPACE)
 			.filter_map(|(namespace, expressions)| {
@@ -1659,6 +1665,8 @@ fn build_request_attributes(
 		.unwrap_or_default();
 
 	if let Some(tcp) = req.extensions().get::<TCPConnectionInfo>() {
+		// When these well-known keys are requested, source them from the live
+		// connection/request state rather than whatever CEL happened to evaluate.
 		for (key, value) in standard_ext_proc_request_attributes(req, tcp) {
 			if attributes.contains_key(&key) {
 				fields.insert(key, value);
@@ -1687,6 +1695,8 @@ fn build_grpc_initial_metadata(
 		return metadata;
 	};
 
+	// CEL values in the reserved namespace are copied into the outbound gRPC
+	// stream-open metadata, skipping entries that cannot be represented there.
 	for (key, expr) in expressions {
 		let value = match eval_expression(exec, expr) {
 			Ok(value) => value,

--- a/crates/agentgateway/src/http/ext_proc.rs
+++ b/crates/agentgateway/src/http/ext_proc.rs
@@ -24,11 +24,16 @@ use crate::proxy::ProxyError;
 use crate::proxy::dtrace::{self, pol_result};
 use crate::proxy::httpproxy::PolicyClient;
 use crate::telemetry::metrics::{OutboundCallKind, OutboundCallSubtype};
+use crate::transport::stream::TCPConnectionInfo;
 use crate::types::agent::{BackendTrafficPolicy, SimpleBackendReference};
 use crate::{http, *};
 
 /// The namespace key used for ext_proc attributes in ProcessingRequest.attributes
 const EXTPROC_ATTRIBUTES_NAMESPACE: &str = "envoy.filters.http.ext_proc";
+/// Reserved internal metadata_context namespace whose key/value pairs are copied
+/// into outbound gRPC initial metadata when the ext_proc stream is opened.
+pub(crate) const EXTPROC_GRPC_INITIAL_METADATA_NAMESPACE: &str =
+	"agentgateway.dev.grpc_initial_metadata";
 
 #[cfg(test)]
 #[path = "ext_proc_tests.rs"]
@@ -48,6 +53,8 @@ pub enum Error {
 	BodyBuffer(String),
 	#[error("invalid body mutation: {0}")]
 	BodyMutation(String),
+	#[error("failed to evaluate gRPC initial metadata: {0}")]
+	MetadataEvaluation(String),
 	#[error("failed to convert metadata value: {0}")]
 	MetadataConversion(String),
 	#[error(transparent)]
@@ -381,7 +388,8 @@ struct ExtProcInstance {
 	request_body_immediate_response: Arc<Mutex<Option<http::Response>>>,
 	protocol_config_sent: bool,
 	mode_state: ModeStateMachine,
-	tx_req: Sender<ProcessingRequest>,
+	client: Option<proto::external_processor_client::ExternalProcessorClient<GrpcReferenceChannel>>,
+	tx_req: Option<Sender<ProcessingRequest>>,
 	rx_resp_for_request: Option<Receiver<ProcessingResponse>>,
 	rx_resp_for_response: Option<Receiver<ProcessingResponse>>,
 	metadata_context: Option<HashMap<String, HashMap<String, Arc<cel::Expression>>>>,
@@ -407,14 +415,41 @@ impl ExtProcInstance {
 			client: client.with_outbound(OutboundCallKind::Policy, OutboundCallSubtype::ExtProc),
 			policies: Arc::new(policies),
 		};
-		let mut c = proto::external_processor_client::ExternalProcessorClient::new(chan);
+		Self {
+			skipped: Default::default(),
+			request_body_immediate_response: Arc::new(Mutex::new(None)),
+			failure_mode,
+			protocol_config_sent: false,
+			mode_state: processing_options.into(),
+			client: Some(proto::external_processor_client::ExternalProcessorClient::new(chan)),
+			tx_req: None,
+			rx_resp_for_request: None,
+			rx_resp_for_response: None,
+			metadata_context,
+			req_attributes,
+			resp_attributes,
+		}
+	}
+
+	fn ensure_stream_started(
+		&mut self,
+		grpc_initial_metadata: tonic::metadata::MetadataMap,
+	) -> Result<(), Error> {
+		if self.tx_req.is_some() {
+			return Ok(());
+		}
+
+		let Some(mut client) = self.client.take() else {
+			return Err(Error::RequestSend);
+		};
+		let failure_mode = self.failure_mode;
 		let (tx_req, rx_req) = tokio::sync::mpsc::channel(10);
 		let (tx_resp, mut rx_resp) = tokio::sync::mpsc::channel(10);
 		let req_stream = tokio_stream::wrappers::ReceiverStream::new(rx_req);
 		tokio::task::spawn(async move {
-			// Spawn a task to handle processing requests.
-			// Incoming requests get send to tx_req and will be piped through here.
-			let responses = match c.process(req_stream).await {
+			let mut request = tonic::Request::new(req_stream);
+			*request.metadata_mut() = grpc_initial_metadata;
+			let responses = match client.process(request).await {
 				Ok(r) => r,
 				Err(e) => {
 					warn!(?failure_mode, "failed to initialize extproc client: {e:?}");
@@ -428,6 +463,7 @@ impl ExtProcInstance {
 				let _ = tx_resp.send(item).await;
 			}
 		});
+
 		let (tx_resp_for_request, rx_resp_for_request) = tokio::sync::mpsc::channel(1);
 		let (tx_resp_for_response, rx_resp_for_response) = tokio::sync::mpsc::channel(1);
 		tokio::task::spawn(async move {
@@ -444,8 +480,6 @@ impl ExtProcInstance {
 						let _ = tx_resp_for_request.send(item).await;
 					},
 					Some(processing_response::Response::ImmediateResponse(_)) => {
-						// In this case we aren't sure which is going to handle things...
-						// Send to both
 						let _ = tx_resp_for_request.send(item.clone()).await;
 						let _ = tx_resp_for_response.send(item).await;
 					},
@@ -453,23 +487,21 @@ impl ExtProcInstance {
 				}
 			}
 		});
-		Self {
-			skipped: Default::default(),
-			request_body_immediate_response: Arc::new(Mutex::new(None)),
-			failure_mode,
-			protocol_config_sent: false,
-			mode_state: processing_options.into(),
-			tx_req,
-			rx_resp_for_request: Some(rx_resp_for_request),
-			rx_resp_for_response: Some(rx_resp_for_response),
-			metadata_context,
-			req_attributes,
-			resp_attributes,
-		}
+
+		self.tx_req = Some(tx_req);
+		self.rx_resp_for_request = Some(rx_resp_for_request);
+		self.rx_resp_for_response = Some(rx_resp_for_response);
+		Ok(())
 	}
 
 	async fn send_request(&mut self, req: ProcessingRequest) -> Result<(), Error> {
-		self.tx_req.send(req).await.map_err(|_| Error::RequestSend)
+		self
+			.tx_req
+			.as_ref()
+			.ok_or(Error::RequestSend)?
+			.send(req)
+			.await
+			.map_err(|_| Error::RequestSend)
 	}
 
 	fn protocol_config_for_headers(
@@ -511,7 +543,10 @@ impl ExtProcInstance {
 				Self::send_body_stream(
 					metadata_context.clone(),
 					body,
-					self.tx_req.clone(),
+					self
+						.tx_req
+						.clone()
+						.expect("ext_proc request sender must exist before sending buffered body"),
 					body_direction,
 					send_trailers,
 					first_message,
@@ -530,7 +565,10 @@ impl ExtProcInstance {
 					FirstExtProcMessage::take_for_send(first_message);
 				Self::send_partial_body(
 					metadata_context.clone(),
-					self.tx_req.clone(),
+					self
+						.tx_req
+						.clone()
+						.expect("ext_proc request sender must exist before sending partial body"),
 					body_direction,
 					body,
 					end_stream,
@@ -790,28 +828,14 @@ impl ExtProcInstance {
 		let headers = req_to_header_map(&req);
 
 		let exec = cel::Executor::new_request(&req);
+		let grpc_initial_metadata = build_grpc_initial_metadata(&exec, self.metadata_context.as_ref())?;
+		self.ensure_stream_started(grpc_initial_metadata)?;
 		// request_attributes should only be sent on first ProcessingRequest
 		// this will need to be modified if we configure which Requests to send
 		// Wrap metadata_context in Arc for cheap cloning across body chunks
-		let metadata_context = self.metadata_context.as_ref().map(|meta| {
-			Arc::new(Metadata {
-				filter_metadata: meta
-					.iter()
-					.filter_map(|(n, e)| {
-						eval_to_struct(&exec, e).map(|v| (n.clone(), v)).ok() // TODO(mk): where best to log convertion issues
-					})
-					.collect(),
-			})
-		});
-		let attributes = self
-			.req_attributes
-			.as_ref()
-			.and_then(|attrs| {
-				eval_to_struct(&exec, attrs)
-					.map(|v| HashMap::from([(EXTPROC_ATTRIBUTES_NAMESPACE.to_string(), v)]))
-					.ok()
-			})
-			.unwrap_or_default();
+		let metadata_context = build_processing_metadata_context(&exec, self.metadata_context.as_ref())
+			.map(|filter_metadata| Arc::new(Metadata { filter_metadata }));
+		let attributes = build_request_attributes(&req, &exec, self.req_attributes.as_ref());
 
 		let failure_mode = self.failure_mode;
 		let end_of_stream = req.body().is_end_stream();
@@ -897,7 +921,8 @@ impl ExtProcInstance {
 			self.spawn_body_stream(
 				&metadata_context,
 				&mut pending_full_duplex_body,
-				tx.clone(),
+				tx.clone()
+					.expect("ext_proc request sender must exist before streaming request body"),
 				BodyStreamDirection::Request,
 				send_request_trailers,
 				first_message,
@@ -1103,7 +1128,8 @@ impl ExtProcInstance {
 					self.spawn_body_stream(
 						&metadata_context,
 						&mut pending_full_duplex_body,
-						tx.clone(),
+						tx.clone()
+							.expect("ext_proc request sender must exist before continuing request body stream"),
 						BodyStreamDirection::Request,
 						send_request_trailers,
 						first_message,
@@ -1314,6 +1340,8 @@ impl ExtProcInstance {
 		let send_response_headers = self.mode_state.response_header_mode == HeaderSendMode::Send;
 
 		let exec = cel::Executor::new_response(request, &response);
+		let grpc_initial_metadata = build_grpc_initial_metadata(&exec, self.metadata_context.as_ref())?;
+		self.ensure_stream_started(grpc_initial_metadata)?;
 		// Wrap metadata_context in Arc for cheap cloning across body chunks
 		let metadata_context = if self.metadata_context.is_none()
 			&& let Some(rd) = resolved_destination_metadata
@@ -1327,14 +1355,8 @@ impl ExtProcInstance {
 				)]),
 			}))
 		} else {
-			self.metadata_context.as_ref().map(|meta| {
-				Arc::new(Metadata {
-					filter_metadata: meta
-						.iter()
-						.filter_map(|(n, e)| eval_to_struct(&exec, e).map(|v| (n.clone(), v)).ok())
-						.collect(),
-				})
-			})
+			build_processing_metadata_context(&exec, self.metadata_context.as_ref())
+				.map(|filter_metadata| Arc::new(Metadata { filter_metadata }))
 		};
 		// response_attributes should only be sent on first ProcessingRequest
 		// this will need to be modified if we configure which Requests to send
@@ -1409,7 +1431,8 @@ impl ExtProcInstance {
 			self.spawn_body_stream(
 				&metadata_context,
 				&mut pending_response_body,
-				tx.clone(),
+				tx.clone()
+					.expect("ext_proc request sender must exist before streaming response body"),
 				BodyStreamDirection::Response,
 				send_response_trailers,
 				first_message,
@@ -1440,7 +1463,9 @@ impl ExtProcInstance {
 				self.spawn_body_stream(
 					&metadata_context,
 					&mut pending_response_body,
-					tx.clone(),
+					tx.clone().expect(
+						"ext_proc request sender must exist before starting fallback response body stream",
+					),
 					BodyStreamDirection::Response,
 					send_response_trailers,
 					first_message,
@@ -1551,7 +1576,9 @@ impl ExtProcInstance {
 						self.spawn_body_stream(
 							&metadata_context,
 							&mut pending_response_body,
-							tx.clone(),
+							tx.clone().expect(
+								"ext_proc request sender must exist before continuing response body stream",
+							),
 							BodyStreamDirection::Response,
 							send_response_trailers,
 							first_message,
@@ -1605,4 +1632,150 @@ fn eval_to_struct(
 			})
 			.collect(),
 	})
+}
+
+fn build_processing_metadata_context(
+	exec: &Executor<'_>,
+	metadata_context: Option<&HashMap<String, HashMap<String, Arc<cel::Expression>>>>,
+) -> Option<HashMap<String, prost_wkt_types::Struct>> {
+	metadata_context.map(|meta| {
+		meta
+			.iter()
+			.filter(|(namespace, _)| namespace.as_str() != EXTPROC_GRPC_INITIAL_METADATA_NAMESPACE)
+			.filter_map(|(namespace, expressions)| {
+				eval_to_struct(exec, expressions)
+					.map(|value| (namespace.clone(), value))
+					.ok()
+			})
+			.collect()
+	})
+}
+
+fn build_request_attributes(
+	req: &http::Request,
+	exec: &Executor<'_>,
+	request_attributes: Option<&HashMap<String, Arc<cel::Expression>>>,
+) -> HashMap<String, prost_wkt_types::Struct> {
+	let Some(attributes) = request_attributes else {
+		return HashMap::new();
+	};
+
+	let mut fields = eval_to_struct(exec, attributes)
+		.map(|s| s.fields)
+		.unwrap_or_default();
+
+	if let Some(tcp) = req.extensions().get::<TCPConnectionInfo>() {
+		for (key, value) in standard_ext_proc_request_attributes(req, tcp) {
+			if attributes.contains_key(&key) {
+				fields.insert(key, value);
+			}
+		}
+	}
+
+	if fields.is_empty() {
+		HashMap::new()
+	} else {
+		HashMap::from([(
+			EXTPROC_ATTRIBUTES_NAMESPACE.to_string(),
+			prost_wkt_types::Struct { fields },
+		)])
+	}
+}
+
+fn build_grpc_initial_metadata(
+	exec: &Executor<'_>,
+	metadata_context: Option<&HashMap<String, HashMap<String, Arc<cel::Expression>>>>,
+) -> Result<tonic::metadata::MetadataMap, Error> {
+	let mut metadata = tonic::metadata::MetadataMap::new();
+	let Some(expressions) =
+		metadata_context.and_then(|ctx| ctx.get(EXTPROC_GRPC_INITIAL_METADATA_NAMESPACE))
+	else {
+		return Ok(metadata);
+	};
+
+	for (key, expr) in expressions {
+		let value =
+			eval_expression(exec, expr).map_err(|e| Error::MetadataEvaluation(e.to_string()))?;
+		let Some(string_value) = prost_value_to_metadata_string(&value) else {
+			continue;
+		};
+		let metadata_key = tonic::metadata::MetadataKey::from_bytes(key.as_bytes())
+			.map_err(|e| Error::MetadataConversion(e.to_string()))?;
+		let metadata_value = tonic::metadata::MetadataValue::try_from(string_value.as_str())
+			.map_err(|e| Error::MetadataConversion(e.to_string()))?;
+		metadata.insert(metadata_key, metadata_value);
+	}
+
+	Ok(metadata)
+}
+
+fn prost_value_to_metadata_string(value: &prost_wkt_types::Value) -> Option<String> {
+	use prost_wkt_types::value::Kind;
+
+	match value.kind.as_ref()? {
+		Kind::StringValue(s) => Some(s.clone()),
+		Kind::NumberValue(n) => Some(n.to_string()),
+		Kind::BoolValue(b) => Some(b.to_string()),
+		Kind::NullValue(_) => None,
+		Kind::StructValue(_) | Kind::ListValue(_) => None,
+	}
+}
+
+fn standard_ext_proc_request_attributes(
+	req: &http::Request,
+	tcp: &TCPConnectionInfo,
+) -> HashMap<String, prost_wkt_types::Value> {
+	HashMap::from([
+		(
+			"source.address".to_string(),
+			prost_wkt_types::Value {
+				kind: Some(prost_wkt_types::value::Kind::StringValue(
+					tcp.peer_addr.to_string(),
+				)),
+			},
+		),
+		(
+			"source.port".to_string(),
+			prost_wkt_types::Value {
+				kind: Some(prost_wkt_types::value::Kind::NumberValue(
+					tcp.peer_addr.port() as f64,
+				)),
+			},
+		),
+		(
+			"destination.address".to_string(),
+			prost_wkt_types::Value {
+				kind: Some(prost_wkt_types::value::Kind::StringValue(
+					tcp.local_addr.to_string(),
+				)),
+			},
+		),
+		(
+			"destination.port".to_string(),
+			prost_wkt_types::Value {
+				kind: Some(prost_wkt_types::value::Kind::NumberValue(
+					tcp.local_addr.port() as f64,
+				)),
+			},
+		),
+		(
+			"request.protocol".to_string(),
+			prost_wkt_types::Value {
+				kind: Some(prost_wkt_types::value::Kind::StringValue(
+					http_version_string(req.version()).to_string(),
+				)),
+			},
+		),
+	])
+}
+
+fn http_version_string(version: ::http::Version) -> &'static str {
+	match version {
+		::http::Version::HTTP_09 => "HTTP/0.9",
+		::http::Version::HTTP_10 => "HTTP/1.0",
+		::http::Version::HTTP_11 => "HTTP/1.1",
+		::http::Version::HTTP_2 => "HTTP/2",
+		::http::Version::HTTP_3 => "HTTP/3",
+		_ => "HTTP",
+	}
 }

--- a/crates/agentgateway/src/http/ext_proc.rs
+++ b/crates/agentgateway/src/http/ext_proc.rs
@@ -53,8 +53,8 @@ pub enum Error {
 	BodyBuffer(String),
 	#[error("invalid body mutation: {0}")]
 	BodyMutation(String),
-	#[error("invalid ext_proc metadata: {0}")]
-	Metadata(String),
+	#[error("failed to convert metadata value: {0}")]
+	MetadataConversion(String),
 	#[error(transparent)]
 	InvalidHeaderName(#[from] http::header::InvalidHeaderName),
 	#[error(transparent)]
@@ -1780,20 +1780,9 @@ fn standard_ext_proc_request_attributes(
 			"request.protocol".to_string(),
 			prost_wkt_types::Value {
 				kind: Some(prost_wkt_types::value::Kind::StringValue(
-					http_version_string(req.version()).to_string(),
+					crate::http::version_str(&req.version()).to_string(),
 				)),
 			},
 		),
 	])
-}
-
-fn http_version_string(version: ::http::Version) -> &'static str {
-	match version {
-		::http::Version::HTTP_09 => "HTTP/0.9",
-		::http::Version::HTTP_10 => "HTTP/1.0",
-		::http::Version::HTTP_11 => "HTTP/1.1",
-		::http::Version::HTTP_2 => "HTTP/2",
-		::http::Version::HTTP_3 => "HTTP/3",
-		_ => "HTTP",
-	}
 }

--- a/crates/agentgateway/src/http/ext_proc.rs
+++ b/crates/agentgateway/src/http/ext_proc.rs
@@ -24,16 +24,11 @@ use crate::proxy::ProxyError;
 use crate::proxy::dtrace::{self, pol_result};
 use crate::proxy::httpproxy::PolicyClient;
 use crate::telemetry::metrics::{OutboundCallKind, OutboundCallSubtype};
-use crate::transport::stream::TCPConnectionInfo;
 use crate::types::agent::{BackendTrafficPolicy, SimpleBackendReference};
 use crate::{http, *};
 
 /// The namespace key used for ext_proc attributes in ProcessingRequest.attributes
 const EXTPROC_ATTRIBUTES_NAMESPACE: &str = "envoy.filters.http.ext_proc";
-/// Reserved internal metadata_context namespace whose key/value pairs are copied
-/// into outbound gRPC initial metadata when the ext_proc stream is opened.
-pub(crate) const EXTPROC_GRPC_INITIAL_METADATA_NAMESPACE: &str =
-	"agentgateway.dev.grpc_initial_metadata";
 
 #[cfg(test)]
 #[path = "ext_proc_tests.rs"]
@@ -386,8 +381,7 @@ struct ExtProcInstance {
 	request_body_immediate_response: Arc<Mutex<Option<http::Response>>>,
 	protocol_config_sent: bool,
 	mode_state: ModeStateMachine,
-	client: Option<proto::external_processor_client::ExternalProcessorClient<GrpcReferenceChannel>>,
-	tx_req: Option<Sender<ProcessingRequest>>,
+	tx_req: Sender<ProcessingRequest>,
 	rx_resp_for_request: Option<Receiver<ProcessingResponse>>,
 	rx_resp_for_response: Option<Receiver<ProcessingResponse>>,
 	metadata_context: Option<HashMap<String, HashMap<String, Arc<cel::Expression>>>>,
@@ -413,41 +407,14 @@ impl ExtProcInstance {
 			client: client.with_outbound(OutboundCallKind::Policy, OutboundCallSubtype::ExtProc),
 			policies: Arc::new(policies),
 		};
-		Self {
-			skipped: Default::default(),
-			request_body_immediate_response: Arc::new(Mutex::new(None)),
-			failure_mode,
-			protocol_config_sent: false,
-			mode_state: processing_options.into(),
-			client: Some(proto::external_processor_client::ExternalProcessorClient::new(chan)),
-			tx_req: None,
-			rx_resp_for_request: None,
-			rx_resp_for_response: None,
-			metadata_context,
-			req_attributes,
-			resp_attributes,
-		}
-	}
-
-	fn ensure_stream_started(&mut self, exec: &Executor<'_>) -> Result<(), Error> {
-		if self.tx_req.is_some() {
-			return Ok(());
-		}
-
-		// Delay stream creation until we have a request/response executor so
-		// metadata_context CEL can be resolved into gRPC initial metadata.
-		let grpc_initial_metadata = build_grpc_initial_metadata(exec, self.metadata_context.as_ref());
-		let Some(mut client) = self.client.take() else {
-			return Err(Error::RequestSend);
-		};
-		let failure_mode = self.failure_mode;
+		let mut c = proto::external_processor_client::ExternalProcessorClient::new(chan);
 		let (tx_req, rx_req) = tokio::sync::mpsc::channel(10);
 		let (tx_resp, mut rx_resp) = tokio::sync::mpsc::channel(10);
 		let req_stream = tokio_stream::wrappers::ReceiverStream::new(rx_req);
 		tokio::task::spawn(async move {
-			let mut request = tonic::Request::new(req_stream);
-			*request.metadata_mut() = grpc_initial_metadata;
-			let responses = match client.process(request).await {
+			// Spawn a task to handle processing requests.
+			// Incoming requests get send to tx_req and will be piped through here.
+			let responses = match c.process(req_stream).await {
 				Ok(r) => r,
 				Err(e) => {
 					warn!(?failure_mode, "failed to initialize extproc client: {e:?}");
@@ -461,7 +428,6 @@ impl ExtProcInstance {
 				let _ = tx_resp.send(item).await;
 			}
 		});
-
 		let (tx_resp_for_request, rx_resp_for_request) = tokio::sync::mpsc::channel(1);
 		let (tx_resp_for_response, rx_resp_for_response) = tokio::sync::mpsc::channel(1);
 		tokio::task::spawn(async move {
@@ -478,8 +444,8 @@ impl ExtProcInstance {
 						let _ = tx_resp_for_request.send(item).await;
 					},
 					Some(processing_response::Response::ImmediateResponse(_)) => {
-						// Immediate responses can terminate either the request-side or
-						// response-side flow, so fan them out to both waiters.
+						// In this case we aren't sure which is going to handle things...
+						// Send to both
 						let _ = tx_resp_for_request.send(item.clone()).await;
 						let _ = tx_resp_for_response.send(item).await;
 					},
@@ -487,25 +453,23 @@ impl ExtProcInstance {
 				}
 			}
 		});
-
-		self.tx_req = Some(tx_req);
-		self.rx_resp_for_request = Some(rx_resp_for_request);
-		self.rx_resp_for_response = Some(rx_resp_for_response);
-		Ok(())
+		Self {
+			skipped: Default::default(),
+			request_body_immediate_response: Arc::new(Mutex::new(None)),
+			failure_mode,
+			protocol_config_sent: false,
+			mode_state: processing_options.into(),
+			tx_req,
+			rx_resp_for_request: Some(rx_resp_for_request),
+			rx_resp_for_response: Some(rx_resp_for_response),
+			metadata_context,
+			req_attributes,
+			resp_attributes,
+		}
 	}
 
 	async fn send_request(&mut self, req: ProcessingRequest) -> Result<(), Error> {
-		self
-			.tx_req
-			.as_ref()
-			.ok_or(Error::RequestSend)?
-			.send(req)
-			.await
-			.map_err(|_| Error::RequestSend)
-	}
-
-	fn request_sender(&self) -> Result<Sender<ProcessingRequest>, Error> {
-		self.tx_req.clone().ok_or(Error::RequestSend)
+		self.tx_req.send(req).await.map_err(|_| Error::RequestSend)
 	}
 
 	fn protocol_config_for_headers(
@@ -547,7 +511,7 @@ impl ExtProcInstance {
 				Self::send_body_stream(
 					metadata_context.clone(),
 					body,
-					self.request_sender()?,
+					self.tx_req.clone(),
 					body_direction,
 					send_trailers,
 					first_message,
@@ -566,7 +530,7 @@ impl ExtProcInstance {
 					FirstExtProcMessage::take_for_send(first_message);
 				Self::send_partial_body(
 					metadata_context.clone(),
-					self.request_sender()?,
+					self.tx_req.clone(),
 					body_direction,
 					body,
 					end_stream,
@@ -826,13 +790,28 @@ impl ExtProcInstance {
 		let headers = req_to_header_map(&req);
 
 		let exec = cel::Executor::new_request(&req);
-		self.ensure_stream_started(&exec)?;
 		// request_attributes should only be sent on first ProcessingRequest
 		// this will need to be modified if we configure which Requests to send
 		// Wrap metadata_context in Arc for cheap cloning across body chunks
-		let metadata_context = build_processing_metadata_context(&exec, self.metadata_context.as_ref())
-			.map(|filter_metadata| Arc::new(Metadata { filter_metadata }));
-		let attributes = build_request_attributes(&req, &exec, self.req_attributes.as_ref());
+		let metadata_context = self.metadata_context.as_ref().map(|meta| {
+			Arc::new(Metadata {
+				filter_metadata: meta
+					.iter()
+					.filter_map(|(n, e)| {
+						eval_to_struct(&exec, e).map(|v| (n.clone(), v)).ok() // TODO(mk): where best to log convertion issues
+					})
+					.collect(),
+			})
+		});
+		let attributes = self
+			.req_attributes
+			.as_ref()
+			.and_then(|attrs| {
+				eval_to_struct(&exec, attrs)
+					.map(|v| HashMap::from([(EXTPROC_ATTRIBUTES_NAMESPACE.to_string(), v)]))
+					.ok()
+			})
+			.unwrap_or_default();
 
 		let failure_mode = self.failure_mode;
 		let end_of_stream = req.body().is_end_stream();
@@ -918,7 +897,7 @@ impl ExtProcInstance {
 			self.spawn_body_stream(
 				&metadata_context,
 				&mut pending_full_duplex_body,
-				tx.clone().ok_or(Error::RequestSend)?,
+				tx.clone(),
 				BodyStreamDirection::Request,
 				send_request_trailers,
 				first_message,
@@ -1124,7 +1103,7 @@ impl ExtProcInstance {
 					self.spawn_body_stream(
 						&metadata_context,
 						&mut pending_full_duplex_body,
-						tx.clone().ok_or(Error::RequestSend)?,
+						tx.clone(),
 						BodyStreamDirection::Request,
 						send_request_trailers,
 						first_message,
@@ -1335,7 +1314,6 @@ impl ExtProcInstance {
 		let send_response_headers = self.mode_state.response_header_mode == HeaderSendMode::Send;
 
 		let exec = cel::Executor::new_response(request, &response);
-		self.ensure_stream_started(&exec)?;
 		// Wrap metadata_context in Arc for cheap cloning across body chunks
 		let metadata_context = if self.metadata_context.is_none()
 			&& let Some(rd) = resolved_destination_metadata
@@ -1349,8 +1327,14 @@ impl ExtProcInstance {
 				)]),
 			}))
 		} else {
-			build_processing_metadata_context(&exec, self.metadata_context.as_ref())
-				.map(|filter_metadata| Arc::new(Metadata { filter_metadata }))
+			self.metadata_context.as_ref().map(|meta| {
+				Arc::new(Metadata {
+					filter_metadata: meta
+						.iter()
+						.filter_map(|(n, e)| eval_to_struct(&exec, e).map(|v| (n.clone(), v)).ok())
+						.collect(),
+				})
+			})
 		};
 		// response_attributes should only be sent on first ProcessingRequest
 		// this will need to be modified if we configure which Requests to send
@@ -1425,7 +1409,7 @@ impl ExtProcInstance {
 			self.spawn_body_stream(
 				&metadata_context,
 				&mut pending_response_body,
-				tx.clone().ok_or(Error::RequestSend)?,
+				tx.clone(),
 				BodyStreamDirection::Response,
 				send_response_trailers,
 				first_message,
@@ -1456,7 +1440,7 @@ impl ExtProcInstance {
 				self.spawn_body_stream(
 					&metadata_context,
 					&mut pending_response_body,
-					tx.clone().ok_or(Error::RequestSend)?,
+					tx.clone(),
 					BodyStreamDirection::Response,
 					send_response_trailers,
 					first_message,
@@ -1567,7 +1551,7 @@ impl ExtProcInstance {
 						self.spawn_body_stream(
 							&metadata_context,
 							&mut pending_response_body,
-							tx.clone().ok_or(Error::RequestSend)?,
+							tx.clone(),
 							BodyStreamDirection::Response,
 							send_response_trailers,
 							first_message,
@@ -1621,169 +1605,4 @@ fn eval_to_struct(
 			})
 			.collect(),
 	})
-}
-
-fn build_processing_metadata_context(
-	exec: &Executor<'_>,
-	metadata_context: Option<&HashMap<String, HashMap<String, Arc<cel::Expression>>>>,
-) -> Option<HashMap<String, prost_wkt_types::Struct>> {
-	metadata_context.map(|meta| {
-		meta
-			// The reserved namespace is transported as gRPC initial metadata
-			// instead of regular ext_proc metadata_context.
-			.iter()
-			.filter(|(namespace, _)| namespace.as_str() != EXTPROC_GRPC_INITIAL_METADATA_NAMESPACE)
-			.filter_map(|(namespace, expressions)| {
-				eval_to_struct(exec, expressions)
-					.map(|value| (namespace.clone(), value))
-					.ok()
-			})
-			.collect()
-	})
-}
-
-fn build_request_attributes(
-	req: &http::Request,
-	exec: &Executor<'_>,
-	request_attributes: Option<&HashMap<String, Arc<cel::Expression>>>,
-) -> HashMap<String, prost_wkt_types::Struct> {
-	let Some(attributes) = request_attributes else {
-		return HashMap::new();
-	};
-
-	let mut fields = eval_to_struct(exec, attributes)
-		.map(|s| s.fields)
-		.unwrap_or_default();
-
-	if let Some(tcp) = req.extensions().get::<TCPConnectionInfo>() {
-		// When these well-known keys are requested, source them from the live
-		// connection/request state rather than whatever CEL happened to evaluate.
-		for (key, value) in standard_ext_proc_request_attributes(req, tcp) {
-			if attributes.contains_key(&key) {
-				fields.insert(key, value);
-			}
-		}
-	}
-
-	if fields.is_empty() {
-		HashMap::new()
-	} else {
-		HashMap::from([(
-			EXTPROC_ATTRIBUTES_NAMESPACE.to_string(),
-			prost_wkt_types::Struct { fields },
-		)])
-	}
-}
-
-fn build_grpc_initial_metadata(
-	exec: &Executor<'_>,
-	metadata_context: Option<&HashMap<String, HashMap<String, Arc<cel::Expression>>>>,
-) -> tonic::metadata::MetadataMap {
-	let mut metadata = tonic::metadata::MetadataMap::new();
-	let Some(expressions) =
-		metadata_context.and_then(|ctx| ctx.get(EXTPROC_GRPC_INITIAL_METADATA_NAMESPACE))
-	else {
-		return metadata;
-	};
-
-	// CEL values in the reserved namespace are copied into the outbound gRPC
-	// stream-open metadata, skipping entries that cannot be represented there.
-	for (key, expr) in expressions {
-		let value = match eval_expression(exec, expr) {
-			Ok(value) => value,
-			Err(error) => {
-				warn!(
-					%key,
-					%error,
-					"failed to evaluate gRPC initial metadata CEL expression"
-				);
-				continue;
-			},
-		};
-		let Some(string_value) = prost_value_to_metadata_string(&value) else {
-			continue;
-		};
-		let metadata_key = match tonic::metadata::MetadataKey::from_bytes(key.as_bytes()) {
-			Ok(metadata_key) => metadata_key,
-			Err(error) => {
-				warn!(%key, %error, "failed to convert gRPC initial metadata key");
-				continue;
-			},
-		};
-		let metadata_value = match tonic::metadata::MetadataValue::try_from(string_value.as_str()) {
-			Ok(metadata_value) => metadata_value,
-			Err(error) => {
-				warn!(
-					%key,
-					value = %string_value,
-					%error,
-					"failed to convert gRPC initial metadata value"
-				);
-				continue;
-			},
-		};
-		metadata.insert(metadata_key, metadata_value);
-	}
-
-	metadata
-}
-
-fn prost_value_to_metadata_string(value: &prost_wkt_types::Value) -> Option<String> {
-	use prost_wkt_types::value::Kind;
-
-	match value.kind.as_ref()? {
-		Kind::StringValue(s) => Some(s.clone()),
-		Kind::NumberValue(n) => Some(n.to_string()),
-		Kind::BoolValue(b) => Some(b.to_string()),
-		Kind::NullValue(_) => None,
-		Kind::StructValue(_) | Kind::ListValue(_) => None,
-	}
-}
-
-fn standard_ext_proc_request_attributes(
-	req: &http::Request,
-	tcp: &TCPConnectionInfo,
-) -> HashMap<String, prost_wkt_types::Value> {
-	HashMap::from([
-		(
-			"source.address".to_string(),
-			prost_wkt_types::Value {
-				kind: Some(prost_wkt_types::value::Kind::StringValue(
-					tcp.peer_addr.ip().to_string(),
-				)),
-			},
-		),
-		(
-			"source.port".to_string(),
-			prost_wkt_types::Value {
-				kind: Some(prost_wkt_types::value::Kind::NumberValue(
-					tcp.peer_addr.port() as f64,
-				)),
-			},
-		),
-		(
-			"destination.address".to_string(),
-			prost_wkt_types::Value {
-				kind: Some(prost_wkt_types::value::Kind::StringValue(
-					tcp.local_addr.ip().to_string(),
-				)),
-			},
-		),
-		(
-			"destination.port".to_string(),
-			prost_wkt_types::Value {
-				kind: Some(prost_wkt_types::value::Kind::NumberValue(
-					tcp.local_addr.port() as f64,
-				)),
-			},
-		),
-		(
-			"request.protocol".to_string(),
-			prost_wkt_types::Value {
-				kind: Some(prost_wkt_types::value::Kind::StringValue(
-					crate::http::version_str(&req.version()).to_string(),
-				)),
-			},
-		),
-	])
 }

--- a/crates/agentgateway/src/http/ext_proc.rs
+++ b/crates/agentgateway/src/http/ext_proc.rs
@@ -504,6 +504,10 @@ impl ExtProcInstance {
 			.map_err(|_| Error::RequestSend)
 	}
 
+	fn request_sender(&self) -> Result<Sender<ProcessingRequest>, Error> {
+		self.tx_req.clone().ok_or(Error::RequestSend)
+	}
+
 	fn protocol_config_for_headers(
 		&self,
 		protocol_config: ProtocolConfiguration,
@@ -543,10 +547,7 @@ impl ExtProcInstance {
 				Self::send_body_stream(
 					metadata_context.clone(),
 					body,
-					self
-						.tx_req
-						.clone()
-						.expect("ext_proc request sender must exist before sending buffered body"),
+					self.request_sender()?,
 					body_direction,
 					send_trailers,
 					first_message,
@@ -565,10 +566,7 @@ impl ExtProcInstance {
 					FirstExtProcMessage::take_for_send(first_message);
 				Self::send_partial_body(
 					metadata_context.clone(),
-					self
-						.tx_req
-						.clone()
-						.expect("ext_proc request sender must exist before sending partial body"),
+					self.request_sender()?,
 					body_direction,
 					body,
 					end_stream,
@@ -920,8 +918,7 @@ impl ExtProcInstance {
 			self.spawn_body_stream(
 				&metadata_context,
 				&mut pending_full_duplex_body,
-				tx.clone()
-					.expect("ext_proc request sender must exist before streaming request body"),
+				tx.clone().ok_or(Error::RequestSend)?,
 				BodyStreamDirection::Request,
 				send_request_trailers,
 				first_message,
@@ -1127,8 +1124,7 @@ impl ExtProcInstance {
 					self.spawn_body_stream(
 						&metadata_context,
 						&mut pending_full_duplex_body,
-						tx.clone()
-							.expect("ext_proc request sender must exist before continuing request body stream"),
+						tx.clone().ok_or(Error::RequestSend)?,
 						BodyStreamDirection::Request,
 						send_request_trailers,
 						first_message,
@@ -1429,8 +1425,7 @@ impl ExtProcInstance {
 			self.spawn_body_stream(
 				&metadata_context,
 				&mut pending_response_body,
-				tx.clone()
-					.expect("ext_proc request sender must exist before streaming response body"),
+				tx.clone().ok_or(Error::RequestSend)?,
 				BodyStreamDirection::Response,
 				send_response_trailers,
 				first_message,
@@ -1461,9 +1456,7 @@ impl ExtProcInstance {
 				self.spawn_body_stream(
 					&metadata_context,
 					&mut pending_response_body,
-					tx.clone().expect(
-						"ext_proc request sender must exist before starting fallback response body stream",
-					),
+					tx.clone().ok_or(Error::RequestSend)?,
 					BodyStreamDirection::Response,
 					send_response_trailers,
 					first_message,
@@ -1574,9 +1567,7 @@ impl ExtProcInstance {
 						self.spawn_body_stream(
 							&metadata_context,
 							&mut pending_response_body,
-							tx.clone().expect(
-								"ext_proc request sender must exist before continuing response body stream",
-							),
+							tx.clone().ok_or(Error::RequestSend)?,
 							BodyStreamDirection::Response,
 							send_response_trailers,
 							first_message,

--- a/crates/agentgateway/src/http/ext_proc.rs
+++ b/crates/agentgateway/src/http/ext_proc.rs
@@ -53,10 +53,8 @@ pub enum Error {
 	BodyBuffer(String),
 	#[error("invalid body mutation: {0}")]
 	BodyMutation(String),
-	#[error("failed to evaluate gRPC initial metadata: {0}")]
-	MetadataEvaluation(String),
-	#[error("failed to convert metadata value: {0}")]
-	MetadataConversion(String),
+	#[error("invalid ext_proc metadata: {0}")]
+	Metadata(String),
 	#[error(transparent)]
 	InvalidHeaderName(#[from] http::header::InvalidHeaderName),
 	#[error(transparent)]
@@ -431,10 +429,7 @@ impl ExtProcInstance {
 		}
 	}
 
-	fn ensure_stream_started(
-		&mut self,
-		exec: &Executor<'_>,
-	) -> Result<(), Error> {
+	fn ensure_stream_started(&mut self, exec: &Executor<'_>) -> Result<(), Error> {
 		if self.tx_req.is_some() {
 			return Ok(());
 		}
@@ -1753,7 +1748,7 @@ fn standard_ext_proc_request_attributes(
 			"source.address".to_string(),
 			prost_wkt_types::Value {
 				kind: Some(prost_wkt_types::value::Kind::StringValue(
-					tcp.peer_addr.to_string(),
+					tcp.peer_addr.ip().to_string(),
 				)),
 			},
 		),
@@ -1769,7 +1764,7 @@ fn standard_ext_proc_request_attributes(
 			"destination.address".to_string(),
 			prost_wkt_types::Value {
 				kind: Some(prost_wkt_types::value::Kind::StringValue(
-					tcp.local_addr.to_string(),
+					tcp.local_addr.ip().to_string(),
 				)),
 			},
 		),

--- a/crates/agentgateway/src/http/ext_proc.rs
+++ b/crates/agentgateway/src/http/ext_proc.rs
@@ -433,12 +433,13 @@ impl ExtProcInstance {
 
 	fn ensure_stream_started(
 		&mut self,
-		grpc_initial_metadata: tonic::metadata::MetadataMap,
+		exec: &Executor<'_>,
 	) -> Result<(), Error> {
 		if self.tx_req.is_some() {
 			return Ok(());
 		}
 
+		let grpc_initial_metadata = build_grpc_initial_metadata(exec, self.metadata_context.as_ref());
 		let Some(mut client) = self.client.take() else {
 			return Err(Error::RequestSend);
 		};
@@ -828,8 +829,7 @@ impl ExtProcInstance {
 		let headers = req_to_header_map(&req);
 
 		let exec = cel::Executor::new_request(&req);
-		let grpc_initial_metadata = build_grpc_initial_metadata(&exec, self.metadata_context.as_ref())?;
-		self.ensure_stream_started(grpc_initial_metadata)?;
+		self.ensure_stream_started(&exec)?;
 		// request_attributes should only be sent on first ProcessingRequest
 		// this will need to be modified if we configure which Requests to send
 		// Wrap metadata_context in Arc for cheap cloning across body chunks
@@ -1340,8 +1340,7 @@ impl ExtProcInstance {
 		let send_response_headers = self.mode_state.response_header_mode == HeaderSendMode::Send;
 
 		let exec = cel::Executor::new_response(request, &response);
-		let grpc_initial_metadata = build_grpc_initial_metadata(&exec, self.metadata_context.as_ref())?;
-		self.ensure_stream_started(grpc_initial_metadata)?;
+		self.ensure_stream_started(&exec)?;
 		// Wrap metadata_context in Arc for cheap cloning across body chunks
 		let metadata_context = if self.metadata_context.is_none()
 			&& let Some(rd) = resolved_destination_metadata
@@ -1685,28 +1684,52 @@ fn build_request_attributes(
 fn build_grpc_initial_metadata(
 	exec: &Executor<'_>,
 	metadata_context: Option<&HashMap<String, HashMap<String, Arc<cel::Expression>>>>,
-) -> Result<tonic::metadata::MetadataMap, Error> {
+) -> tonic::metadata::MetadataMap {
 	let mut metadata = tonic::metadata::MetadataMap::new();
 	let Some(expressions) =
 		metadata_context.and_then(|ctx| ctx.get(EXTPROC_GRPC_INITIAL_METADATA_NAMESPACE))
 	else {
-		return Ok(metadata);
+		return metadata;
 	};
 
 	for (key, expr) in expressions {
-		let value =
-			eval_expression(exec, expr).map_err(|e| Error::MetadataEvaluation(e.to_string()))?;
+		let value = match eval_expression(exec, expr) {
+			Ok(value) => value,
+			Err(error) => {
+				warn!(
+					%key,
+					%error,
+					"failed to evaluate gRPC initial metadata CEL expression"
+				);
+				continue;
+			},
+		};
 		let Some(string_value) = prost_value_to_metadata_string(&value) else {
 			continue;
 		};
-		let metadata_key = tonic::metadata::MetadataKey::from_bytes(key.as_bytes())
-			.map_err(|e| Error::MetadataConversion(e.to_string()))?;
-		let metadata_value = tonic::metadata::MetadataValue::try_from(string_value.as_str())
-			.map_err(|e| Error::MetadataConversion(e.to_string()))?;
+		let metadata_key = match tonic::metadata::MetadataKey::from_bytes(key.as_bytes()) {
+			Ok(metadata_key) => metadata_key,
+			Err(error) => {
+				warn!(%key, %error, "failed to convert gRPC initial metadata key");
+				continue;
+			},
+		};
+		let metadata_value = match tonic::metadata::MetadataValue::try_from(string_value.as_str()) {
+			Ok(metadata_value) => metadata_value,
+			Err(error) => {
+				warn!(
+					%key,
+					value = %string_value,
+					%error,
+					"failed to convert gRPC initial metadata value"
+				);
+				continue;
+			},
+		};
 		metadata.insert(metadata_key, metadata_value);
 	}
 
-	Ok(metadata)
+	metadata
 }
 
 fn prost_value_to_metadata_string(value: &prost_wkt_types::Value) -> Option<String> {

--- a/crates/agentgateway/src/http/ext_proc/mutation.rs
+++ b/crates/agentgateway/src/http/ext_proc/mutation.rs
@@ -202,7 +202,7 @@ fn merge_dynamic_metadata(
 
 	for (key, value) in &metadata.fields {
 		let json_val = envoy_proto_common::prost_value_to_json(value)
-			.map_err(|e| Error::MetadataConversion(format!("failed to convert key '{}': {}", key, e)))?;
+			.map_err(|e| Error::Metadata(format!("failed to convert key '{}': {}", key, e)))?;
 		dynamic_metadata.0.insert(key.clone(), json_val);
 	}
 

--- a/crates/agentgateway/src/http/ext_proc/mutation.rs
+++ b/crates/agentgateway/src/http/ext_proc/mutation.rs
@@ -202,7 +202,7 @@ fn merge_dynamic_metadata(
 
 	for (key, value) in &metadata.fields {
 		let json_val = envoy_proto_common::prost_value_to_json(value)
-			.map_err(|e| Error::Metadata(format!("failed to convert key '{}': {}", key, e)))?;
+			.map_err(|e| Error::MetadataConversion(format!("failed to convert key '{}': {}", key, e)))?;
 		dynamic_metadata.0.insert(key.clone(), json_val);
 	}
 

--- a/crates/agentgateway/src/http/ext_proc_tests.rs
+++ b/crates/agentgateway/src/http/ext_proc_tests.rs
@@ -3782,12 +3782,14 @@ fn request_log() -> RequestLog {
 #[derive(Clone)]
 struct RequestRecorder {
 	requests: RequestLog,
+	open_metadata: Arc<Mutex<Vec<HashMap<String, String>>>>,
 }
 
 impl RequestRecorder {
 	fn new() -> Self {
 		Self {
 			requests: request_log(),
+			open_metadata: Arc::new(Mutex::new(Vec::new())),
 		}
 	}
 }
@@ -3796,6 +3798,18 @@ type MetadataTracker = RequestRecorder;
 
 #[async_trait::async_trait]
 impl Handler for RequestRecorder {
+	async fn on_open(&mut self, metadata: &tonic::metadata::MetadataMap) {
+		let mut values = HashMap::new();
+		for key_and_value in metadata.iter() {
+			if let tonic::metadata::KeyAndValueRef::Ascii(key, value) = key_and_value
+				&& let Ok(value) = value.to_str()
+			{
+				values.insert(key.to_string(), value.to_string());
+			}
+		}
+		self.open_metadata.lock().unwrap().push(values);
+	}
+
 	async fn on_request(&mut self, request: &proto::ProcessingRequest) {
 		self.requests.lock().unwrap().push(request.clone());
 	}
@@ -4603,6 +4617,116 @@ mod metadata_context_and_attributes {
 	}
 
 	#[tokio::test]
+	async fn test_reserved_metadata_context_becomes_grpc_initial_metadata() {
+		let mock = simple_mock().await;
+		let tracker = MetadataTracker::new();
+		let requests = tracker.requests.clone();
+		let open_metadata = tracker.open_metadata.clone();
+
+		let meta = HashMap::from([
+			(
+				super::super::EXTPROC_GRPC_INITIAL_METADATA_NAMESPACE.to_string(),
+				[(
+					"x-policy-ref".to_string(),
+					Arc::new(Expression::new_strict("'default/my-policy'").unwrap()),
+				)]
+				.into(),
+			),
+			(
+				"envoy.filters.http.ext_proc".to_string(),
+				[(
+					"still-present".to_string(),
+					Arc::new(Expression::new_strict("'value'").unwrap()),
+				)]
+				.into(),
+			),
+		]);
+
+		let (_mock, _ext_proc, _bind, io) = setup_ext_proc_mock_with_meta(
+			mock,
+			ext_proc::FailureMode::FailClosed,
+			ExtProcMock::new(move || tracker.clone()),
+			"{}",
+			Some(meta),
+			None,
+			None,
+		)
+		.await;
+
+		let res = send_request(io, Method::GET, "http://lo/test-path").await;
+		assert_eq!(res.status(), 200);
+
+		let open = open_metadata.lock().unwrap();
+		assert!(!open.is_empty());
+		assert_eq!(
+			open[0].get("x-policy-ref").map(String::as_str),
+			Some("default/my-policy")
+		);
+
+		let reqs = requests.lock().unwrap();
+		assert!(!reqs.is_empty());
+		let req = &reqs[0];
+		let meta_ctx = req
+			.metadata_context
+			.as_ref()
+			.expect("should have metadata_context");
+		assert!(
+			!meta_ctx
+				.filter_metadata
+				.contains_key(super::super::EXTPROC_GRPC_INITIAL_METADATA_NAMESPACE)
+		);
+		assert!(
+			meta_ctx
+				.filter_metadata
+				.contains_key("envoy.filters.http.ext_proc")
+		);
+	}
+
+	#[tokio::test]
+	async fn test_invalid_reserved_metadata_entries_are_skipped() {
+		let mock = simple_mock().await;
+		let tracker = MetadataTracker::new();
+		let open_metadata = tracker.open_metadata.clone();
+
+		let meta = HashMap::from([(
+			super::super::EXTPROC_GRPC_INITIAL_METADATA_NAMESPACE.to_string(),
+			[
+				(
+					"x-policy-ref".to_string(),
+					Arc::new(Expression::new_strict("'default/my-policy'").unwrap()),
+				),
+				(
+					"BadKey".to_string(),
+					Arc::new(Expression::new_strict("'should-be-skipped'").unwrap()),
+				),
+			]
+			.into(),
+		)]);
+
+		let (_mock, _ext_proc, _bind, io) = setup_ext_proc_mock_with_meta(
+			mock,
+			ext_proc::FailureMode::FailClosed,
+			ExtProcMock::new(move || tracker.clone()),
+			"{}",
+			Some(meta),
+			None,
+			None,
+		)
+		.await;
+
+		let res = send_request(io, Method::GET, "http://lo/test-path").await;
+		assert_eq!(res.status(), 200);
+
+		let open = open_metadata.lock().unwrap();
+		assert!(!open.is_empty());
+		assert_eq!(
+			open[0].get("x-policy-ref").map(String::as_str),
+			Some("default/my-policy")
+		);
+		assert!(!open[0].contains_key("BadKey"));
+	}
+
+	#[tokio::test]
 	async fn test_cel_req_attributes() {
 		let mock = simple_mock().await;
 		let tracker = MetadataTracker::new();
@@ -4647,6 +4771,80 @@ mod metadata_context_and_attributes {
 		match &ns_attrs.fields.get("method").unwrap().kind {
 			Some(prost_wkt_types::value::Kind::StringValue(s)) => assert_eq!(s, "GET"),
 			invalid => panic!("exepected a string got {:?}", invalid),
+		}
+	}
+
+	#[test]
+	fn test_request_attributes_can_be_supplied_by_cel() {
+		let mut req = Request::builder()
+			.method(Method::GET)
+			.uri("http://lo/foo")
+			.version(::http::Version::HTTP_2)
+			.body(Body::empty())
+			.unwrap();
+		let tcp = crate::transport::stream::TCPConnectionInfo {
+			peer_addr: "192.168.0.1:12345".parse().unwrap(),
+			local_addr: "10.0.0.1:8080".parse().unwrap(),
+			start: std::time::Instant::now(),
+			raw_peer_addr: None,
+		};
+		req
+			.extensions_mut()
+			.insert(crate::cel::SourceContext::from_tcp_connection(
+				&tcp, None, None,
+			));
+		req
+			.extensions_mut()
+			.insert(crate::cel::DestinationContext::from_tcp_connection(&tcp));
+
+		let exec = crate::cel::Executor::new_request(&req);
+		let attrs = HashMap::from([
+			(
+				"source.address".to_string(),
+				Arc::new(Expression::new_strict("source.address").unwrap()),
+			),
+			(
+				"source.port".to_string(),
+				Arc::new(Expression::new_strict("source.port").unwrap()),
+			),
+			(
+				"destination.address".to_string(),
+				Arc::new(Expression::new_strict("destination.address").unwrap()),
+			),
+			(
+				"destination.port".to_string(),
+				Arc::new(Expression::new_strict("destination.port").unwrap()),
+			),
+			(
+				"request.protocol".to_string(),
+				Arc::new(Expression::new_strict("request.version").unwrap()),
+			),
+		]);
+
+		let built = super::super::build_request_attributes(&exec, Some(&attrs));
+		let ext_proc = built
+			.get("envoy.filters.http.ext_proc")
+			.expect("envoy ext_proc namespace");
+
+		match &ext_proc.fields.get("source.address").unwrap().kind {
+			Some(prost_wkt_types::value::Kind::StringValue(s)) => assert_eq!(s, "192.168.0.1"),
+			invalid => panic!("expected source.address string, got {invalid:?}"),
+		}
+		match &ext_proc.fields.get("source.port").unwrap().kind {
+			Some(prost_wkt_types::value::Kind::NumberValue(n)) => assert_eq!(*n, 12345.0),
+			invalid => panic!("expected source.port number, got {invalid:?}"),
+		}
+		match &ext_proc.fields.get("destination.address").unwrap().kind {
+			Some(prost_wkt_types::value::Kind::StringValue(s)) => assert_eq!(s, "10.0.0.1"),
+			invalid => panic!("expected destination.address string, got {invalid:?}"),
+		}
+		match &ext_proc.fields.get("destination.port").unwrap().kind {
+			Some(prost_wkt_types::value::Kind::NumberValue(n)) => assert_eq!(*n, 8080.0),
+			invalid => panic!("expected destination.port number, got {invalid:?}"),
+		}
+		match &ext_proc.fields.get("request.protocol").unwrap().kind {
+			Some(prost_wkt_types::value::Kind::StringValue(s)) => assert_eq!(s, "HTTP/2"),
+			invalid => panic!("expected request.protocol string, got {invalid:?}"),
 		}
 	}
 

--- a/crates/agentgateway/src/http/ext_proc_tests.rs
+++ b/crates/agentgateway/src/http/ext_proc_tests.rs
@@ -4821,7 +4821,7 @@ mod metadata_context_and_attributes {
 			.expect("envoy ext_proc namespace");
 
 		match &ext_proc.fields.get("source.address").unwrap().kind {
-			Some(prost_wkt_types::value::Kind::StringValue(s)) => assert_eq!(s, "192.168.0.1:12345"),
+			Some(prost_wkt_types::value::Kind::StringValue(s)) => assert_eq!(s, "192.168.0.1"),
 			invalid => panic!("expected source.address string, got {invalid:?}"),
 		}
 		match &ext_proc.fields.get("source.port").unwrap().kind {
@@ -4829,7 +4829,7 @@ mod metadata_context_and_attributes {
 			invalid => panic!("expected source.port number, got {invalid:?}"),
 		}
 		match &ext_proc.fields.get("destination.address").unwrap().kind {
-			Some(prost_wkt_types::value::Kind::StringValue(s)) => assert_eq!(s, "10.0.0.1:8080"),
+			Some(prost_wkt_types::value::Kind::StringValue(s)) => assert_eq!(s, "10.0.0.1"),
 			invalid => panic!("expected destination.address string, got {invalid:?}"),
 		}
 		match &ext_proc.fields.get("destination.port").unwrap().kind {

--- a/crates/agentgateway/src/http/ext_proc_tests.rs
+++ b/crates/agentgateway/src/http/ext_proc_tests.rs
@@ -3782,12 +3782,14 @@ fn request_log() -> RequestLog {
 #[derive(Clone)]
 struct RequestRecorder {
 	requests: RequestLog,
+	open_metadata: Arc<Mutex<Vec<HashMap<String, String>>>>,
 }
 
 impl RequestRecorder {
 	fn new() -> Self {
 		Self {
 			requests: request_log(),
+			open_metadata: Arc::new(Mutex::new(Vec::new())),
 		}
 	}
 }
@@ -3796,6 +3798,18 @@ type MetadataTracker = RequestRecorder;
 
 #[async_trait::async_trait]
 impl Handler for RequestRecorder {
+	async fn on_open(&mut self, metadata: &tonic::metadata::MetadataMap) {
+		let mut values = HashMap::new();
+		for key_and_value in metadata.iter() {
+			if let tonic::metadata::KeyAndValueRef::Ascii(key, value) = key_and_value
+				&& let Ok(value) = value.to_str()
+			{
+				values.insert(key.to_string(), value.to_string());
+			}
+		}
+		self.open_metadata.lock().unwrap().push(values);
+	}
+
 	async fn on_request(&mut self, request: &proto::ProcessingRequest) {
 		self.requests.lock().unwrap().push(request.clone());
 	}
@@ -4603,6 +4617,72 @@ mod metadata_context_and_attributes {
 	}
 
 	#[tokio::test]
+	async fn test_reserved_metadata_context_becomes_grpc_initial_metadata() {
+		let mock = simple_mock().await;
+		let tracker = MetadataTracker::new();
+		let requests = tracker.requests.clone();
+		let open_metadata = tracker.open_metadata.clone();
+
+		let meta = HashMap::from([
+			(
+				super::super::EXTPROC_GRPC_INITIAL_METADATA_NAMESPACE.to_string(),
+				[(
+					"x-policy-ref".to_string(),
+					Arc::new(Expression::new_strict("'default/my-policy'").unwrap()),
+				)]
+				.into(),
+			),
+			(
+				"envoy.filters.http.ext_proc".to_string(),
+				[(
+					"still-present".to_string(),
+					Arc::new(Expression::new_strict("'value'").unwrap()),
+				)]
+				.into(),
+			),
+		]);
+
+		let (_mock, _ext_proc, _bind, io) = setup_ext_proc_mock_with_meta(
+			mock,
+			ext_proc::FailureMode::FailClosed,
+			ExtProcMock::new(move || tracker.clone()),
+			"{}",
+			Some(meta),
+			None,
+			None,
+		)
+		.await;
+
+		let res = send_request(io, Method::GET, "http://lo/test-path").await;
+		assert_eq!(res.status(), 200);
+
+		let open = open_metadata.lock().unwrap();
+		assert!(!open.is_empty());
+		assert_eq!(
+			open[0].get("x-policy-ref").map(String::as_str),
+			Some("default/my-policy")
+		);
+
+		let reqs = requests.lock().unwrap();
+		assert!(!reqs.is_empty());
+		let req = &reqs[0];
+		let meta_ctx = req
+			.metadata_context
+			.as_ref()
+			.expect("should have metadata_context");
+		assert!(
+			!meta_ctx
+				.filter_metadata
+				.contains_key(super::super::EXTPROC_GRPC_INITIAL_METADATA_NAMESPACE)
+		);
+		assert!(
+			meta_ctx
+				.filter_metadata
+				.contains_key("envoy.filters.http.ext_proc")
+		);
+	}
+
+	#[tokio::test]
 	async fn test_cel_req_attributes() {
 		let mock = simple_mock().await;
 		let tracker = MetadataTracker::new();
@@ -4647,6 +4727,74 @@ mod metadata_context_and_attributes {
 		match &ns_attrs.fields.get("method").unwrap().kind {
 			Some(prost_wkt_types::value::Kind::StringValue(s)) => assert_eq!(s, "GET"),
 			invalid => panic!("exepected a string got {:?}", invalid),
+		}
+	}
+
+	#[test]
+	fn test_standard_request_attributes_use_tcp_connection_info() {
+		let mut req = Request::builder()
+			.method(Method::GET)
+			.uri("http://lo/foo")
+			.version(::http::Version::HTTP_2)
+			.body(Body::empty())
+			.unwrap();
+		req
+			.extensions_mut()
+			.insert(crate::transport::stream::TCPConnectionInfo {
+				peer_addr: "192.168.0.1:12345".parse().unwrap(),
+				local_addr: "10.0.0.1:8080".parse().unwrap(),
+				start: std::time::Instant::now(),
+				raw_peer_addr: None,
+			});
+
+		let exec = crate::cel::Executor::new_request(&req);
+		let attrs = HashMap::from([
+			(
+				"source.address".to_string(),
+				Arc::new(Expression::new_strict("'ignored'").unwrap()),
+			),
+			(
+				"source.port".to_string(),
+				Arc::new(Expression::new_strict("0").unwrap()),
+			),
+			(
+				"destination.address".to_string(),
+				Arc::new(Expression::new_strict("'ignored'").unwrap()),
+			),
+			(
+				"destination.port".to_string(),
+				Arc::new(Expression::new_strict("0").unwrap()),
+			),
+			(
+				"request.protocol".to_string(),
+				Arc::new(Expression::new_strict("'ignored'").unwrap()),
+			),
+		]);
+
+		let built = super::super::build_request_attributes(&req, &exec, Some(&attrs));
+		let ext_proc = built
+			.get("envoy.filters.http.ext_proc")
+			.expect("envoy ext_proc namespace");
+
+		match &ext_proc.fields.get("source.address").unwrap().kind {
+			Some(prost_wkt_types::value::Kind::StringValue(s)) => assert_eq!(s, "192.168.0.1:12345"),
+			invalid => panic!("expected source.address string, got {invalid:?}"),
+		}
+		match &ext_proc.fields.get("source.port").unwrap().kind {
+			Some(prost_wkt_types::value::Kind::NumberValue(n)) => assert_eq!(*n, 12345.0),
+			invalid => panic!("expected source.port number, got {invalid:?}"),
+		}
+		match &ext_proc.fields.get("destination.address").unwrap().kind {
+			Some(prost_wkt_types::value::Kind::StringValue(s)) => assert_eq!(s, "10.0.0.1:8080"),
+			invalid => panic!("expected destination.address string, got {invalid:?}"),
+		}
+		match &ext_proc.fields.get("destination.port").unwrap().kind {
+			Some(prost_wkt_types::value::Kind::NumberValue(n)) => assert_eq!(*n, 8080.0),
+			invalid => panic!("expected destination.port number, got {invalid:?}"),
+		}
+		match &ext_proc.fields.get("request.protocol").unwrap().kind {
+			Some(prost_wkt_types::value::Kind::StringValue(s)) => assert_eq!(s, "HTTP/2"),
+			invalid => panic!("expected request.protocol string, got {invalid:?}"),
 		}
 	}
 

--- a/crates/agentgateway/src/http/ext_proc_tests.rs
+++ b/crates/agentgateway/src/http/ext_proc_tests.rs
@@ -4683,6 +4683,50 @@ mod metadata_context_and_attributes {
 	}
 
 	#[tokio::test]
+	async fn test_invalid_reserved_metadata_entries_are_skipped() {
+		let mock = simple_mock().await;
+		let tracker = MetadataTracker::new();
+		let open_metadata = tracker.open_metadata.clone();
+
+		let meta = HashMap::from([(
+			super::super::EXTPROC_GRPC_INITIAL_METADATA_NAMESPACE.to_string(),
+			[
+				(
+					"x-policy-ref".to_string(),
+					Arc::new(Expression::new_strict("'default/my-policy'").unwrap()),
+				),
+				(
+					"BadKey".to_string(),
+					Arc::new(Expression::new_strict("'should-be-skipped'").unwrap()),
+				),
+			]
+			.into(),
+		)]);
+
+		let (_mock, _ext_proc, _bind, io) = setup_ext_proc_mock_with_meta(
+			mock,
+			ext_proc::FailureMode::FailClosed,
+			ExtProcMock::new(move || tracker.clone()),
+			"{}",
+			Some(meta),
+			None,
+			None,
+		)
+		.await;
+
+		let res = send_request(io, Method::GET, "http://lo/test-path").await;
+		assert_eq!(res.status(), 200);
+
+		let open = open_metadata.lock().unwrap();
+		assert!(!open.is_empty());
+		assert_eq!(
+			open[0].get("x-policy-ref").map(String::as_str),
+			Some("default/my-policy")
+		);
+		assert!(!open[0].contains_key("BadKey"));
+	}
+
+	#[tokio::test]
 	async fn test_cel_req_attributes() {
 		let mock = simple_mock().await;
 		let tracker = MetadataTracker::new();

--- a/crates/agentgateway/src/http/ext_proc_tests.rs
+++ b/crates/agentgateway/src/http/ext_proc_tests.rs
@@ -3782,14 +3782,12 @@ fn request_log() -> RequestLog {
 #[derive(Clone)]
 struct RequestRecorder {
 	requests: RequestLog,
-	open_metadata: Arc<Mutex<Vec<HashMap<String, String>>>>,
 }
 
 impl RequestRecorder {
 	fn new() -> Self {
 		Self {
 			requests: request_log(),
-			open_metadata: Arc::new(Mutex::new(Vec::new())),
 		}
 	}
 }
@@ -3798,18 +3796,6 @@ type MetadataTracker = RequestRecorder;
 
 #[async_trait::async_trait]
 impl Handler for RequestRecorder {
-	async fn on_open(&mut self, metadata: &tonic::metadata::MetadataMap) {
-		let mut values = HashMap::new();
-		for key_and_value in metadata.iter() {
-			if let tonic::metadata::KeyAndValueRef::Ascii(key, value) = key_and_value
-				&& let Ok(value) = value.to_str()
-			{
-				values.insert(key.to_string(), value.to_string());
-			}
-		}
-		self.open_metadata.lock().unwrap().push(values);
-	}
-
 	async fn on_request(&mut self, request: &proto::ProcessingRequest) {
 		self.requests.lock().unwrap().push(request.clone());
 	}
@@ -4617,116 +4603,6 @@ mod metadata_context_and_attributes {
 	}
 
 	#[tokio::test]
-	async fn test_reserved_metadata_context_becomes_grpc_initial_metadata() {
-		let mock = simple_mock().await;
-		let tracker = MetadataTracker::new();
-		let requests = tracker.requests.clone();
-		let open_metadata = tracker.open_metadata.clone();
-
-		let meta = HashMap::from([
-			(
-				super::super::EXTPROC_GRPC_INITIAL_METADATA_NAMESPACE.to_string(),
-				[(
-					"x-policy-ref".to_string(),
-					Arc::new(Expression::new_strict("'default/my-policy'").unwrap()),
-				)]
-				.into(),
-			),
-			(
-				"envoy.filters.http.ext_proc".to_string(),
-				[(
-					"still-present".to_string(),
-					Arc::new(Expression::new_strict("'value'").unwrap()),
-				)]
-				.into(),
-			),
-		]);
-
-		let (_mock, _ext_proc, _bind, io) = setup_ext_proc_mock_with_meta(
-			mock,
-			ext_proc::FailureMode::FailClosed,
-			ExtProcMock::new(move || tracker.clone()),
-			"{}",
-			Some(meta),
-			None,
-			None,
-		)
-		.await;
-
-		let res = send_request(io, Method::GET, "http://lo/test-path").await;
-		assert_eq!(res.status(), 200);
-
-		let open = open_metadata.lock().unwrap();
-		assert!(!open.is_empty());
-		assert_eq!(
-			open[0].get("x-policy-ref").map(String::as_str),
-			Some("default/my-policy")
-		);
-
-		let reqs = requests.lock().unwrap();
-		assert!(!reqs.is_empty());
-		let req = &reqs[0];
-		let meta_ctx = req
-			.metadata_context
-			.as_ref()
-			.expect("should have metadata_context");
-		assert!(
-			!meta_ctx
-				.filter_metadata
-				.contains_key(super::super::EXTPROC_GRPC_INITIAL_METADATA_NAMESPACE)
-		);
-		assert!(
-			meta_ctx
-				.filter_metadata
-				.contains_key("envoy.filters.http.ext_proc")
-		);
-	}
-
-	#[tokio::test]
-	async fn test_invalid_reserved_metadata_entries_are_skipped() {
-		let mock = simple_mock().await;
-		let tracker = MetadataTracker::new();
-		let open_metadata = tracker.open_metadata.clone();
-
-		let meta = HashMap::from([(
-			super::super::EXTPROC_GRPC_INITIAL_METADATA_NAMESPACE.to_string(),
-			[
-				(
-					"x-policy-ref".to_string(),
-					Arc::new(Expression::new_strict("'default/my-policy'").unwrap()),
-				),
-				(
-					"BadKey".to_string(),
-					Arc::new(Expression::new_strict("'should-be-skipped'").unwrap()),
-				),
-			]
-			.into(),
-		)]);
-
-		let (_mock, _ext_proc, _bind, io) = setup_ext_proc_mock_with_meta(
-			mock,
-			ext_proc::FailureMode::FailClosed,
-			ExtProcMock::new(move || tracker.clone()),
-			"{}",
-			Some(meta),
-			None,
-			None,
-		)
-		.await;
-
-		let res = send_request(io, Method::GET, "http://lo/test-path").await;
-		assert_eq!(res.status(), 200);
-
-		let open = open_metadata.lock().unwrap();
-		assert!(!open.is_empty());
-		assert_eq!(
-			open[0].get("x-policy-ref").map(String::as_str),
-			Some("default/my-policy")
-		);
-		assert!(!open[0].contains_key("BadKey"));
-	}
-
-	#[tokio::test]
 	async fn test_cel_req_attributes() {
 		let mock = simple_mock().await;
 		let tracker = MetadataTracker::new();
@@ -4771,74 +4647,6 @@ mod metadata_context_and_attributes {
 		match &ns_attrs.fields.get("method").unwrap().kind {
 			Some(prost_wkt_types::value::Kind::StringValue(s)) => assert_eq!(s, "GET"),
 			invalid => panic!("exepected a string got {:?}", invalid),
-		}
-	}
-
-	#[test]
-	fn test_standard_request_attributes_use_tcp_connection_info() {
-		let mut req = Request::builder()
-			.method(Method::GET)
-			.uri("http://lo/foo")
-			.version(::http::Version::HTTP_2)
-			.body(Body::empty())
-			.unwrap();
-		req
-			.extensions_mut()
-			.insert(crate::transport::stream::TCPConnectionInfo {
-				peer_addr: "192.168.0.1:12345".parse().unwrap(),
-				local_addr: "10.0.0.1:8080".parse().unwrap(),
-				start: std::time::Instant::now(),
-				raw_peer_addr: None,
-			});
-
-		let exec = crate::cel::Executor::new_request(&req);
-		let attrs = HashMap::from([
-			(
-				"source.address".to_string(),
-				Arc::new(Expression::new_strict("'ignored'").unwrap()),
-			),
-			(
-				"source.port".to_string(),
-				Arc::new(Expression::new_strict("0").unwrap()),
-			),
-			(
-				"destination.address".to_string(),
-				Arc::new(Expression::new_strict("'ignored'").unwrap()),
-			),
-			(
-				"destination.port".to_string(),
-				Arc::new(Expression::new_strict("0").unwrap()),
-			),
-			(
-				"request.protocol".to_string(),
-				Arc::new(Expression::new_strict("'ignored'").unwrap()),
-			),
-		]);
-
-		let built = super::super::build_request_attributes(&req, &exec, Some(&attrs));
-		let ext_proc = built
-			.get("envoy.filters.http.ext_proc")
-			.expect("envoy ext_proc namespace");
-
-		match &ext_proc.fields.get("source.address").unwrap().kind {
-			Some(prost_wkt_types::value::Kind::StringValue(s)) => assert_eq!(s, "192.168.0.1"),
-			invalid => panic!("expected source.address string, got {invalid:?}"),
-		}
-		match &ext_proc.fields.get("source.port").unwrap().kind {
-			Some(prost_wkt_types::value::Kind::NumberValue(n)) => assert_eq!(*n, 12345.0),
-			invalid => panic!("expected source.port number, got {invalid:?}"),
-		}
-		match &ext_proc.fields.get("destination.address").unwrap().kind {
-			Some(prost_wkt_types::value::Kind::StringValue(s)) => assert_eq!(s, "10.0.0.1"),
-			invalid => panic!("expected destination.address string, got {invalid:?}"),
-		}
-		match &ext_proc.fields.get("destination.port").unwrap().kind {
-			Some(prost_wkt_types::value::Kind::NumberValue(n)) => assert_eq!(*n, 8080.0),
-			invalid => panic!("expected destination.port number, got {invalid:?}"),
-		}
-		match &ext_proc.fields.get("request.protocol").unwrap().kind {
-			Some(prost_wkt_types::value::Kind::StringValue(s)) => assert_eq!(s, "HTTP/2"),
-			invalid => panic!("expected request.protocol string, got {invalid:?}"),
 		}
 	}
 

--- a/crates/agentgateway/src/http/mod.rs
+++ b/crates/agentgateway/src/http/mod.rs
@@ -248,7 +248,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use tower_serve_static::private::mime;
 use url::{Url, form_urlencoded};
 
-use crate::cel::{BackendContext, LLMContext, RequestTime, SourceContext};
+use crate::cel::{BackendContext, DestinationContext, LLMContext, RequestTime, SourceContext};
 use crate::client::PoolKey;
 use crate::proxy::{ProxyError, ProxyResponse};
 use crate::transport::BufferLimit;
@@ -980,6 +980,9 @@ impl Debug for DebugExtensions<'_> {
 		}
 		if let Some(e) = ext.get::<SourceContext>() {
 			d.field("SourceContext", e);
+		}
+		if let Some(e) = ext.get::<DestinationContext>() {
+			d.field("DestinationContext", e);
 		}
 		if let Some(e) = ext.get::<RequestTime>() {
 			d.field("RequestTime", e);

--- a/crates/agentgateway/src/proxy/gateway.rs
+++ b/crates/agentgateway/src/proxy/gateway.rs
@@ -844,6 +844,7 @@ impl Gateway {
 			tls.and_then(|t| t.src_identity.clone()),
 			unverified_workload,
 		);
+		let dst = crate::cel::DestinationContext::from_tcp_connection(tcp);
 		// Surface CONNECT tunnel headers (captured in `terminate_connect_tunnel`) on
 		// the source context so request policies can reference `source.connectHeaders`.
 		// Move the map out of the stream extension (it has no other consumer) to avoid
@@ -857,6 +858,7 @@ impl Gateway {
 			anyhow::bail!("network authorization denied: {e}");
 		}
 		stream.ext_mut().insert(src);
+		stream.ext_mut().insert(dst);
 
 		let transport_metrics = inputs.metrics.clone();
 		let _max_dur_metrics = transport_metrics.clone();

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -549,6 +549,7 @@ impl HTTPProxy {
 			.clone();
 		connection.copy::<TLSConnectionInfo>(req.extensions_mut());
 		connection.copy::<cel::SourceContext>(req.extensions_mut());
+		connection.copy::<cel::DestinationContext>(req.extensions_mut());
 		connection.copy::<WaypointService>(req.extensions_mut());
 		req
 			.extensions_mut()

--- a/crates/agentgateway/src/test_helpers/extprocmock.rs
+++ b/crates/agentgateway/src/test_helpers/extprocmock.rs
@@ -86,6 +86,8 @@ pub fn response_header_response_with_dynamic_metadata(
 
 #[async_trait]
 pub trait Handler {
+	async fn on_open(&mut self, _metadata: &tonic::metadata::MetadataMap) {}
+
 	async fn on_request(&mut self, _request: &ProcessingRequest) {}
 
 	async fn handle_request_headers(
@@ -214,6 +216,7 @@ where
 		let (tx, rx) = mpsc::channel(32);
 
 		let mut handler = (self.handler.clone())();
+		handler.on_open(request.metadata()).await;
 
 		tokio::spawn(async move {
 			let mut request_stream = request.into_inner();

--- a/crates/agentgateway/src/test_helpers/extprocmock.rs
+++ b/crates/agentgateway/src/test_helpers/extprocmock.rs
@@ -86,8 +86,6 @@ pub fn response_header_response_with_dynamic_metadata(
 
 #[async_trait]
 pub trait Handler {
-	async fn on_open(&mut self, _metadata: &tonic::metadata::MetadataMap) {}
-
 	async fn on_request(&mut self, _request: &ProcessingRequest) {}
 
 	async fn handle_request_headers(
@@ -216,7 +214,6 @@ where
 		let (tx, rx) = mpsc::channel(32);
 
 		let mut handler = (self.handler.clone())();
-		handler.on_open(request.metadata()).await;
 
 		tokio::spawn(async move {
 			let mut request_stream = request.into_inner();

--- a/schema/cel.json
+++ b/schema/cel.json
@@ -826,6 +826,30 @@
       },
       "additionalProperties": false
     },
+    "destination": {
+      "description": "`destination` contains attributes about the downstream request destination at agentgateway.",
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "address": {
+          "description": "The IP address of the downstream request destination at agentgateway.",
+          "type": "string",
+          "format": "ip",
+          "default": "0.0.0.0"
+        },
+        "port": {
+          "description": "The port of the downstream request destination at agentgateway.",
+          "type": "integer",
+          "format": "uint16",
+          "minimum": 0,
+          "maximum": 65535,
+          "default": 0
+        }
+      },
+      "additionalProperties": false
+    },
     "mcp": {
       "description": "`mcp` contains attributes about the MCP request.\nRequest-time CEL only includes identity fields such as `tool`, `prompt`, or `resource`.\nPost-request CEL may also include fields like `methodName`, `sessionId`, and tool payloads.",
       "type": [

--- a/schema/cel.md
+++ b/schema/cel.md
@@ -115,6 +115,9 @@
 |`source.unverifiedWorkload.namespace`|string|The namespace of the source workload.|
 |`source.unverifiedWorkload.serviceAccount`|string|The service account of the source workload.|
 |`source.connectHeaders`|object|HTTP CONNECT request headers, when this stream originated from a CONNECT<br>tunnel. Empty otherwise. Exposed in CEL as `source.connectHeaders`, which<br>supports the same accessors as `request.headers` (indexing, `join()`,<br>`split()`, etc.).<br><br>CONNECT headers are client-supplied and unauthenticated at the transport<br>layer, so trust decisions should validate the values (e.g. signature or<br>issuer checks) rather than trusting header presence alone.|
+|`destination`|object|`destination` contains attributes about the downstream request destination at agentgateway.|
+|`destination.address`|string|The IP address of the downstream request destination at agentgateway.|
+|`destination.port`|integer|The port of the downstream request destination at agentgateway.|
 |`mcp`|object|`mcp` contains attributes about the MCP request.<br>Request-time CEL only includes identity fields such as `tool`, `prompt`, or `resource`.<br>Post-request CEL may also include fields like `methodName`, `sessionId`, and tool payloads.|
 |`mcp.methodName`|string||
 |`mcp.sessionId`|string||


### PR DESCRIPTION
This PR fixes extproc metadata and attributes handling in two areas:
- Adds support for a reserved metadata_context namespace that is translated into outbound gRPC initial metadata when the extproc stream is opened, while keeping that reserved namespace out of ProcessingRequest.metadata_context.
- Refactors request/response attribute construction so standard extproc request attributes like source/destination address, port, and protocol can be populated from TCPConnectionInfo.

Also hardens initial metadata handling so invalid entries are skipped instead of failing the whole mutation path, and adds relevant test coverage.