### PR TITLE
fix: honor TLS for tracing HTTPS endpoints

### DIFF
--- a/crates/agentgateway/src/config.rs
+++ b/crates/agentgateway/src/config.rs
@@ -871,6 +871,15 @@ fn parse_headers(prefix: &str) -> Result<Vec<(String, String)>, anyhow::Error> {
 }
 
 #[cfg(test)]
+static ENV_LOCK: std::sync::LazyLock<std::sync::Mutex<()>> =
+	std::sync::LazyLock::new(|| std::sync::Mutex::new(()));
+
+#[cfg(test)]
+pub(crate) fn lock_env_for_tests() -> std::sync::MutexGuard<'static, ()> {
+	ENV_LOCK.lock().expect("env mutex poisoned")
+}
+
+#[cfg(test)]
 mod parse_headers_tests {
 	use std::env;
 	use std::ffi::OsString;
@@ -950,14 +959,11 @@ mod parse_headers_tests {
 mod tests {
 	use std::env;
 	use std::ffi::OsString;
-	use std::sync::{LazyLock, Mutex};
 
 	use super::*;
 
-	static ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
-
 	fn lock_env() -> std::sync::MutexGuard<'static, ()> {
-		ENV_LOCK.lock().expect("env mutex poisoned")
+		lock_env_for_tests()
 	}
 
 	struct TempEnvVar {

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -201,7 +201,7 @@ fn merge_deprecated_frontend_policies(
 			path,
 		} = tracing;
 
-		let policies = if !headers.is_empty() {
+		let mut policies = if !headers.is_empty() {
 			let backend_xfm = transformation_cel::LocalTransformationConfig {
 				request: Some(transformation_cel::LocalTransform {
 					set: headers
@@ -218,17 +218,15 @@ fn merge_deprecated_frontend_policies(
 			Vec::new()
 		};
 		if let Some(ep) = endpoint {
-			// Strip the scheme (http://, https://), or grpc://) from the endpoint URL to get host:port
-			let host_port = ep
-				.strip_prefix("http://")
-				.or_else(|| ep.strip_prefix("https://"))
-				.or_else(|| ep.strip_prefix("grpc://"))
-				.unwrap_or(&ep);
+			let (backend, use_tls) = parse_deprecated_tracing_endpoint(&ep)
+				.with_context(|| format!("failed parsing tracing endpoint: {}", ep))?;
+			if use_tls {
+				policies.push(BackendTrafficPolicy::BackendTLS(
+					LocalBackendTLS::default().try_into()?,
+				));
+			}
 			frontend_policies.tracing = Some(TracingConfig {
-				provider_backend: SimpleBackendReference::InlineBackend(
-					Target::try_from(host_port)
-						.with_context(|| format!("failed parsing tracing endpoint: {}", ep))?,
-				),
+				provider_backend: SimpleBackendReference::InlineBackend(backend),
 				policies,
 				attributes: Arc::unwrap_or_clone(fields.add),
 				resources: Default::default(), // Not supported in the old config
@@ -245,6 +243,33 @@ fn merge_deprecated_frontend_policies(
 		}
 	}
 	Ok(())
+}
+
+fn parse_deprecated_tracing_endpoint(endpoint: &str) -> anyhow::Result<(Target, bool)> {
+	if !endpoint.contains("://") {
+		return Ok((Target::try_from(endpoint)?, false));
+	}
+
+	let uri = Uri::try_from(endpoint)?;
+	let Some(scheme) = uri.scheme_str() else {
+		return Ok((Target::try_from(endpoint)?, false));
+	};
+	if !matches!(scheme, "http" | "https" | "grpc") {
+		anyhow::bail!("unsupported tracing endpoint scheme: {scheme}");
+	}
+	let host = uri
+		.host()
+		.with_context(|| format!("tracing endpoint {endpoint} must include a host"))?;
+	let port = uri.port_u16().or_else(|| match scheme {
+		"http" => Some(80),
+		"https" => Some(443),
+		"grpc" => Some(4317),
+		_ => unreachable!("unsupported tracing endpoint scheme checked above"),
+	});
+	let Some(port) = port else {
+		anyhow::bail!("unsupported tracing endpoint scheme: {scheme}");
+	};
+	Ok((Target::from((host, port)), scheme == "https"))
 }
 
 #[derive(Debug, Clone, serde::Serialize)]

--- a/crates/agentgateway/src/types/local_tests.rs
+++ b/crates/agentgateway/src/types/local_tests.rs
@@ -15,6 +15,57 @@ use crate::*;
 
 const TEST_OIDC_JWKS: &str = r#"{"keys":[{"use":"sig","kty":"EC","kid":"kid-1","crv":"P-256","alg":"ES256","x":"WM7udBHga09KxC5kxq6GhrZ9M3Y8S9ZThq_XxsOcDhk","y":"xc7T4afkXmwjEbJMzQXCdQcU3PZKiLFlHl23GE1z4ug"}]}"#;
 
+struct ClearTracingEnv {
+	_guard: std::sync::MutexGuard<'static, ()>,
+	values: Vec<(&'static str, Option<std::ffi::OsString>)>,
+}
+
+impl ClearTracingEnv {
+	fn new() -> Self {
+		let guard = crate::config::lock_env_for_tests();
+		let keys = [
+			"OTLP_ENDPOINT",
+			"OTLP_HEADERS",
+			"OTLP_PROTOCOL",
+			"OTEL_EXPORTER_OTLP_ENDPOINT",
+			"OTEL_EXPORTER_OTLP_HEADERS",
+			"OTEL_EXPORTER_OTLP_PROTOCOL",
+			"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+			"OTEL_EXPORTER_OTLP_TRACES_HEADERS",
+			"OTEL_EXPORTER_OTLP_TRACES_PROTOCOL",
+		];
+		let values = keys
+			.into_iter()
+			.map(|key| {
+				let value = std::env::var_os(key);
+				unsafe {
+					std::env::remove_var(key);
+				}
+				(key, value)
+			})
+			.collect();
+		Self {
+			_guard: guard,
+			values,
+		}
+	}
+}
+
+impl Drop for ClearTracingEnv {
+	fn drop(&mut self) {
+		for (key, value) in &self.values {
+			match value {
+				Some(value) => unsafe {
+					std::env::set_var(key, value);
+				},
+				None => unsafe {
+					std::env::remove_var(key);
+				},
+			}
+		}
+	}
+}
+
 fn test_client() -> client::Client {
 	client::Client::new(
 		&client::Config {
@@ -1140,6 +1191,7 @@ binds:
 
 #[test]
 fn test_migrate_deprecated_local_config_moves_fields() {
+	let _env = ClearTracingEnv::new();
 	let input = r#"
 config:
   logging:
@@ -1184,6 +1236,53 @@ config:
 	assert_eq!(tracing.get("protocol").unwrap(), "http");
 }
 
+#[test]
+fn test_migrate_deprecated_tracing_https_endpoint_adds_backend_tls() {
+	let _env = ClearTracingEnv::new();
+	let input = r#"
+config:
+  tracing:
+    otlpEndpoint: https://tracing.example.com:4318
+    otlpProtocol: http
+"#;
+	let out = super::migrate_deprecated_local_config(input).unwrap();
+	let v: serde_json::Value = crate::serdes::yamlviajson::from_str(&out).unwrap();
+	let tracing = v.get("frontendPolicies").unwrap().get("tracing").unwrap();
+	let policies = tracing
+		.get("policies")
+		.and_then(serde_json::Value::as_array)
+		.expect("https tracing endpoint should add backend TLS policy");
+	assert!(
+		policies.iter().any(|policy| {
+			policy
+				.get("backendTLS")
+				.and_then(|tls| tls.get("systemRoots"))
+				.and_then(serde_json::Value::as_bool)
+				.unwrap_or(false)
+		}),
+		"https tracing endpoint should use system root TLS"
+	);
+}
+
+#[test]
+fn test_migrate_deprecated_tracing_https_endpoint_uses_default_port_and_path() {
+	let _env = ClearTracingEnv::new();
+	let input = r#"
+config:
+  tracing:
+    otlpEndpoint: https://tracing.example.com/api/public/otel/v1/traces
+    otlpProtocol: http
+"#;
+	let out = super::migrate_deprecated_local_config(input).unwrap();
+	let v: serde_json::Value = crate::serdes::yamlviajson::from_str(&out).unwrap();
+	let tracing = v.get("frontendPolicies").unwrap().get("tracing").unwrap();
+	assert_eq!(
+		tracing.get("inlineBackend").unwrap(),
+		"tracing.example.com:443"
+	);
+	assert_eq!(tracing.get("path").unwrap(), "/api/public/otel/v1/traces");
+}
+
 #[rstest::rstest]
 #[case::https_scheme("https://tracing.example.com:4318", "http", "tracing.example.com:4318")]
 #[case::http_scheme("http://tracing.example.com:4318", "http", "tracing.example.com:4318")]
@@ -1194,6 +1293,7 @@ fn test_deprecated_tracing_endpoint_schemes(
 	#[case] protocol: &str,
 	#[case] expected: &str,
 ) {
+	let _env = ClearTracingEnv::new();
 	let input =
 		format!("config:\n  tracing:\n    otlpEndpoint: {endpoint}\n    otlpProtocol: {protocol}\n");
 	let out = super::migrate_deprecated_local_config(&input).unwrap();
@@ -1205,6 +1305,7 @@ fn test_deprecated_tracing_endpoint_schemes(
 #[rstest::rstest]
 #[case::unrecognized_scheme("nateisgreat://tracing.example.com:4317")]
 fn test_deprecated_tracing_endpoint_unrecognized_scheme_error(#[case] endpoint: &str) {
+	let _env = ClearTracingEnv::new();
 	let input =
 		format!("config:\n  tracing:\n    otlpEndpoint: {endpoint}\n    otlpProtocol: grpc\n");
 	let err = super::migrate_deprecated_local_config(&input)


### PR DESCRIPTION
## Summary

Fixes #2343.

Honor TLS when migrating deprecated `config.tracing.otlpEndpoint` values that use
`https://`.

The deprecated tracing migration keeps endpoint hosts and paths, but it used to
drop the endpoint scheme before building the inline backend. That made
`https://` OTLP/HTTP endpoints use the default cleartext backend path, and URL
forms without an explicit port failed because the migration expected
`host:port` after stripping the scheme.

## Changes

- Parse deprecated tracing endpoint URL schemes during migration.
- Add a default `backendTLS` policy for `https://` OTLP endpoints.
- Apply default ports for URL-form endpoints that omit an explicit port.
- Preserve OTLP paths extracted from HTTPS endpoints.
- Keep existing no-scheme `host:port` behavior and unsupported-scheme errors.
- Add regression coverage for HTTPS TLS migration, default-port path handling,
  existing endpoint schemes, and unsupported schemes.

## Verification

```text
cargo test -p agentgateway deprecated_tracing_endpoint
cargo test -p agentgateway tracing_
cargo test -p agentgateway --test validate_examples
cargo fmt --check
```

The focused deprecated tracing tests cover the regression directly. The broader
tracing tests cover the related OTLP environment and migration paths, and
`validate_examples` covers checked-in example configurations including HTTPS OTLP
tracing.
