### PR TITLE
Feat: Add Descope as an MCP authentication provider

### DIFF
--- a/api/resource.pb.go
+++ b/api/resource.pb.go
@@ -15607,7 +15607,7 @@ const file_resource_proto_rawDesc = "" +
 	"\vPolicyPhase\x12\t\n" +
 	"\x05ROUTE\x10\x00\x12\v\n" +
 	"\aGATEWAY\x10\x01B\x06\n" +
-	"\x04kind\"\xd6X\n" +
+	"\x04kind\"\xe3X\n" +
 	"\x11BackendPolicySpec\x12D\n" +
 	"\x03a2a\x18\x01 \x01(\v20.agentgateway.dev.resource.BackendPolicySpec.A2aH\x00R\x03a2a\x12l\n" +
 	"\x11inference_routing\x18\x02 \x01(\v2=.agentgateway.dev.resource.BackendPolicySpec.InferenceRoutingH\x00R\x10inferenceRouting\x12Z\n" +
@@ -15836,7 +15836,7 @@ const file_resource_proto_rawDesc = "" +
 	"\x10McpAuthorization\x12\x14\n" +
 	"\x05allow\x18\x01 \x03(\tR\x05allow\x12\x12\n" +
 	"\x04deny\x18\x02 \x03(\tR\x04deny\x12\x18\n" +
-	"\arequire\x18\x03 \x03(\tR\arequire\x1a\xed\a\n" +
+	"\arequire\x18\x03 \x03(\tR\arequire\x1a\xfa\a\n" +
 	"\x11McpAuthentication\x12\x16\n" +
 	"\x06issuer\x18\x01 \x01(\tR\x06issuer\x12\x1c\n" +
 	"\taudiences\x18\x02 \x03(\tR\taudiences\x12\x1f\n" +
@@ -15859,7 +15859,7 @@ const file_resource_proto_rawDesc = "" +
 	"\x05AUTH0\x10\x01\x12\f\n" +
 	"\bKEYCLOAK\x10\x02\x12\b\n" +
 	"\x04OKTA\x10\x03\x12\v\n" +
-	"\x07DESCOPE\x10\x04\"0\n" +
+	"\aDESCOPE\x10\x04\"0\n" +
 	"\x04Mode\x12\f\n" +
 	"\bOPTIONAL\x10\x00\x12\n" +
 	"\n" +

--- a/api/resource.pb.go
+++ b/api/resource.pb.go
@@ -1920,6 +1920,7 @@ const (
 	BackendPolicySpec_McpAuthentication_AUTH0       BackendPolicySpec_McpAuthentication_McpIDP = 1
 	BackendPolicySpec_McpAuthentication_KEYCLOAK    BackendPolicySpec_McpAuthentication_McpIDP = 2
 	BackendPolicySpec_McpAuthentication_OKTA        BackendPolicySpec_McpAuthentication_McpIDP = 3
+	BackendPolicySpec_McpAuthentication_DESCOPE     BackendPolicySpec_McpAuthentication_McpIDP = 4
 )
 
 // Enum value maps for BackendPolicySpec_McpAuthentication_McpIDP.
@@ -1929,12 +1930,14 @@ var (
 		1: "AUTH0",
 		2: "KEYCLOAK",
 		3: "OKTA",
+		4: "DESCOPE",
 	}
 	BackendPolicySpec_McpAuthentication_McpIDP_value = map[string]int32{
 		"UNSPECIFIED": 0,
 		"AUTH0":       1,
 		"KEYCLOAK":    2,
 		"OKTA":        3,
+		"DESCOPE":     4,
 	}
 )
 
@@ -15850,12 +15853,13 @@ const file_resource_proto_rawDesc = "" +
 	"\n" +
 	"ExtraEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12,\n" +
-	"\x05value\x18\x02 \x01(\v2\x16.google.protobuf.ValueR\x05value:\x028\x01\"<\n" +
+	"\x05value\x18\x02 \x01(\v2\x16.google.protobuf.ValueR\x05value:\x028\x01\"I\n" +
 	"\x06McpIDP\x12\x0f\n" +
 	"\vUNSPECIFIED\x10\x00\x12\t\n" +
 	"\x05AUTH0\x10\x01\x12\f\n" +
 	"\bKEYCLOAK\x10\x02\x12\b\n" +
-	"\x04OKTA\x10\x03\"0\n" +
+	"\x04OKTA\x10\x03\x12\v\n" +
+	"\x07DESCOPE\x10\x04\"0\n" +
 	"\x04Mode\x12\f\n" +
 	"\bOPTIONAL\x10\x00\x12\n" +
 	"\n" +

--- a/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
+++ b/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
@@ -1716,6 +1716,7 @@ const (
 	Auth0    McpIDP = "Auth0"
 	Keycloak McpIDP = "Keycloak"
 	Okta     McpIDP = "Okta"
+	Descope  McpIDP = "Descope"
 )
 
 type BackendTunnel struct {

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
@@ -12198,6 +12198,7 @@ spec:
                             description: Identity provider to use for authentication.
                             enum:
                             - Auth0
+                            - Descope
                             - Keycloak
                             - Okta
                             type: string

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
@@ -5015,6 +5015,7 @@ spec:
                             description: Identity provider to use for authentication.
                             enum:
                             - Auth0
+                            - Descope
                             - Keycloak
                             - Okta
                             type: string
@@ -9092,6 +9093,7 @@ spec:
                               flows.
                             enum:
                             - Auth0
+                            - Descope
                             - Keycloak
                             - Okta
                             type: string

--- a/controller/pkg/agentgateway/plugins/backend_policies.go
+++ b/controller/pkg/agentgateway/plugins/backend_policies.go
@@ -670,6 +670,9 @@ func translateMcpIDP(provider *agentgateway.McpIDP) api.BackendPolicySpec_McpAut
 	if *provider == agentgateway.Okta {
 		return api.BackendPolicySpec_McpAuthentication_OKTA
 	}
+	if *provider == agentgateway.Descope {
+		return api.BackendPolicySpec_McpAuthentication_DESCOPE
+	}
 	return api.BackendPolicySpec_McpAuthentication_UNSPECIFIED
 }
 

--- a/crates/agentgateway/src/mcp/auth.rs
+++ b/crates/agentgateway/src/mcp/auth.rs
@@ -353,11 +353,7 @@ pub(super) async fn client_registration(
 			let parsed: url::Url = issuer
 				.parse()
 				.map_err(|e| ProxyError::ProcessingString(format!("invalid issuer URL: {e}")))?;
-			let segments: Vec<&str> = parsed
-				.path()
-				.trim_start_matches('/')
-				.split('/')
-				.collect();
+			let segments: Vec<&str> = parsed.path().trim_start_matches('/').split('/').collect();
 			if segments.len() >= 5
 				&& segments[0] == "v1"
 				&& segments[1] == "apps"

--- a/crates/agentgateway/src/mcp/auth.rs
+++ b/crates/agentgateway/src/mcp/auth.rs
@@ -223,9 +223,9 @@ pub(super) async fn authorization_server_metadata(
 	// RFC 8414 URL for standard AS metadata. Keycloak does not implement RFC 8414; it only
 	// exposes OpenID Provider Metadata at {issuer}/.well-known/openid-configuration (OIDC Discovery).
 	let metadata_uri = match &auth.provider {
-		// Keycloak and Okta do not support the RFC 8414 path-based issuer format;
+		// Keycloak, Okta, and Descope do not support the RFC 8414 path-based issuer format;
 		// they serve metadata at {issuer}/.well-known/openid-configuration (OIDC Discovery).
-		Some(McpIDP::Keycloak { .. }) | Some(McpIDP::Okta {}) => {
+		Some(McpIDP::Keycloak { .. }) | Some(McpIDP::Okta {}) | Some(McpIDP::Descope {}) => {
 			openid_configuration_metadata_url(&auth.issuer)
 		},
 		_ => authorization_server_metadata_url(&auth.issuer),
@@ -270,6 +270,17 @@ pub(super) async fn authorization_server_metadata(
 			}
 
 			// Okta doesn't do CORS for client registrations — proxy it (same pattern as Keycloak)
+			let current_uri = request_uri_for_oauth_metadata(req);
+			if let Some(serde_json::Value::String(re)) =
+				json::traverse_mut(&mut resp, &["registration_endpoint"])
+			{
+				*re = format!("{current_uri}/client-registration");
+			}
+		},
+		Some(McpIDP::Descope {}) => {
+			// Descope supports RFC 8707, so no audience workaround needed.
+			// Management DCR endpoint likely lacks CORS — proxy it.
+			// Note: DCR requires a management key; recommend using clientId short-circuit instead.
 			let current_uri = request_uri_for_oauth_metadata(req);
 			if let Some(serde_json::Value::String(re)) =
 				json::traverse_mut(&mut resp, &["registration_endpoint"])
@@ -335,6 +346,31 @@ pub(super) async fn client_registration(
 				.map_err(|e| ProxyError::ProcessingString(format!("invalid issuer URL: {e}")))?;
 			let origin = parsed.origin().ascii_serialization();
 			format!("{origin}/oauth2/v1/clients")
+		},
+		Some(McpIDP::Descope {}) => {
+			// DCR endpoint: https://api.descope.com/v1/mgmt/mcp/client/{project-id}/{server-id}/register
+			// Derived from agentic issuer: https://api.descope.com/v1/apps/agentic/{project-id}/{server-id}
+			let parsed: url::Url = issuer
+				.parse()
+				.map_err(|e| ProxyError::ProcessingString(format!("invalid issuer URL: {e}")))?;
+			let segments: Vec<&str> = parsed
+				.path()
+				.trim_start_matches('/')
+				.split('/')
+				.collect();
+			if segments.len() >= 5
+				&& segments[0] == "v1"
+				&& segments[1] == "apps"
+				&& segments[2] == "agentic"
+			{
+				let (project_id, server_id) = (segments[3], segments[4]);
+				let origin = parsed.origin().ascii_serialization();
+				format!("{origin}/v1/mgmt/mcp/client/{project_id}/{server_id}/register")
+			} else {
+				return Err(ProxyError::ProcessingString(
+					"Descope DCR requires an agentic issuer URL".to_string(),
+				));
+			}
 		},
 		// Keycloak and default
 		_ => format!("{issuer}/clients-registrations/openid-connect"),

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -2682,11 +2682,7 @@ impl LocalMcpAuthentication {
 							// For agentic issuers (https://api.descope.com/v1/apps/agentic/{project-id}/{server-id}),
 							// JWKS lives at the project level: https://api.descope.com/{project-id}/.well-known/jwks.json
 							let parsed: url::Url = self.issuer.parse()?;
-							let segments: Vec<&str> = parsed
-								.path()
-								.trim_start_matches('/')
-								.split('/')
-								.collect();
+							let segments: Vec<&str> = parsed.path().trim_start_matches('/').split('/').collect();
 							if segments.len() >= 5
 								&& segments[0] == "v1"
 								&& segments[1] == "apps"

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -2678,6 +2678,32 @@ impl LocalMcpAuthentication {
 						None | Some(McpIDP::Auth0 { .. }) | Some(McpIDP::Okta { .. }) => {
 							format!("{}/.well-known/jwks.json", self.issuer).parse()?
 						},
+						Some(McpIDP::Descope {}) => {
+							// For agentic issuers (https://api.descope.com/v1/apps/agentic/{project-id}/{server-id}),
+							// JWKS lives at the project level: https://api.descope.com/{project-id}/.well-known/jwks.json
+							let parsed: url::Url = self.issuer.parse()?;
+							let segments: Vec<&str> = parsed
+								.path()
+								.trim_start_matches('/')
+								.split('/')
+								.collect();
+							if segments.len() >= 5
+								&& segments[0] == "v1"
+								&& segments[1] == "apps"
+								&& segments[2] == "agentic"
+							{
+								let project_id = segments[3];
+								let base = format!(
+									"{}://{}/{}",
+									parsed.scheme(),
+									parsed.host_str().unwrap_or_default(),
+									project_id
+								);
+								format!("{base}/.well-known/jwks.json").parse()?
+							} else {
+								format!("{}/.well-known/jwks.json", self.issuer).parse()?
+							}
+						},
 						Some(McpIDP::Keycloak { .. }) => {
 							format!("{}/protocol/openid-connect/certs", self.issuer).parse()?
 						},
@@ -2721,6 +2747,7 @@ pub enum McpIDP {
 	Auth0 {},
 	Keycloak {},
 	Okta {},
+	Descope {},
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -490,6 +490,7 @@ fn convert_mcp_provider(provider: i32) -> Option<McpIDP> {
 		x if x == McpIdp::Auth0 as i32 => Some(McpIDP::Auth0 {}),
 		x if x == McpIdp::Keycloak as i32 => Some(McpIDP::Keycloak {}),
 		x if x == McpIdp::Okta as i32 => Some(McpIDP::Okta {}),
+		x if x == McpIdp::Descope as i32 => Some(McpIDP::Descope {}),
 		_ => None,
 	}
 }

--- a/crates/protos/proto/resource.proto
+++ b/crates/protos/proto/resource.proto
@@ -1457,6 +1457,7 @@ message BackendPolicySpec {
       AUTH0 = 1;
       KEYCLOAK = 2;
       OKTA = 3;
+      DESCOPE = 4;
     }
 
     // Validation mode for JWT authentication

--- a/examples/mcp-authentication/README.md
+++ b/examples/mcp-authentication/README.md
@@ -118,7 +118,7 @@ Also in `examples/mcp-authentication/config.yaml`:
 ### Scenario C: Adapting a vendor Authorization Server (e.g., Keycloak)
 
 When your Authorization Server doesn’t implement the spec as-is, agentgateway can fill in the gaps.
-Currently, three providers are supported: Keycloak, Auth0, and Okta.
+Currently, four providers are supported: Keycloak, Auth0, Okta, and Descope.
 
 Excerpt from `examples/mcp-authentication/config.yaml`:
 
@@ -165,6 +165,7 @@ What setting a provider does (high level):
   - Auth0 → `<issuer>/.well-known/jwks.json`
   - Keycloak → `<issuer>/protocol/openid-connect/certs`
   - Okta → `<issuer>/.well-known/jwks.json`
+  - Descope → `https://api.descope.com/{project-id}/.well-known/jwks.json` (derived from agentic issuer path)
 
 Auth0-specific notes:
 - Gateway appends `?audience=...` to the authorization endpoint it exposes.
@@ -176,8 +177,14 @@ Keycloak-specific notes:
 Okta-specific notes:
 - Okta supports RFC 8414 (like Auth0), so the gateway uses standard AS metadata discovery.
 - No RFC 8707 support; gateway appends `?audience=...` to the authorization endpoint (same workaround as Auth0).
-- Client registration is proxied by the gateway at `.../client-registration` to forward to Okta's `oauth2/v1/clients`.
+- Client registration is proxied by the gateway at `.../client-registration` to forward to Okta’s `oauth2/v1/clients`.
 - Okta DCR requires an SSWS API token; the gateway proxies the request and the MCP client must provide the token.
+
+Descope-specific notes:
+- Uses OIDC discovery (`{issuer}/.well-known/openid-configuration`), not RFC 8414.
+- Supports RFC 8707 resource indicators — no audience workaround needed.
+- DCR requires a management key belonging to the server operator (not the MCP client). **Prefer setting `clientId` in config to skip DCR entirely.**
+- Client registration is proxied by the gateway at `.../client-registration` to forward to Descope’s management DCR endpoint.
 
 Notes:
 - Omit the `provider` block for spec-compliant servers. Use it only when adaptation is needed.

--- a/examples/mcp-authentication/config.yaml
+++ b/examples/mcp-authentication/config.yaml
@@ -219,5 +219,47 @@ binds:
             #         - query
             #         resourceDocumentation: http://localhost:3000/okta/docs
             #         resourcePolicyUri: http://localhost:3000/okta/policies
+            # Example configuration for Descope:
+            # - backends:
+            #   - mcp:
+            #       targets:
+            #       - name: everything
+            #         stdio:
+            #           args:
+            #           - '@modelcontextprotocol/server-everything'
+            #           cmd: npx
+            #   matches:
+            #   - path:
+            #       exact: /descope/mcp
+            #   - path:
+            #       exact: /.well-known/oauth-protected-resource/descope/mcp
+            #   - path:
+            #       exact: /.well-known/oauth-authorization-server/descope/mcp
+            #   - path:
+            #       exact: /.well-known/oauth-authorization-server/descope/mcp/client-registration
+            #   policies:
+            #     cors:
+            #       allowHeaders:
+            #       - mcp-protocol-version
+            #       - content-type
+            #       allowOrigins:
+            #       - '*'
+            #     mcpAuthentication:
+            #       issuer: https://api.descope.com/v1/apps/agentic/<project-id>/<server-id>
+            #       audiences:
+            #       - <your-audience>
+            #       provider:
+            #         descope: {}
+            #       # clientId is recommended — DCR requires a management key not available to MCP clients
+            #       clientId: <pre-registered-client-id>
+            #       resourceMetadata:
+            #         resource: http://localhost:3000/descope/mcp
+            #         scopesSupported:
+            #         - openid
+            #         - profile
+            #         bearerMethodsSupported:
+            #         - header
+            #         resourceDocumentation: http://localhost:3000/descope/docs
+            #         resourcePolicyUri: http://localhost:3000/descope/policies
   # Public port to listen on
   port: 3000

--- a/schema/config.json
+++ b/schema/config.json
@@ -3501,6 +3501,19 @@
             "okta"
           ],
           "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "descope": {
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "descope"
+          ],
+          "additionalProperties": false
         }
       ]
     },

--- a/schema/config.md
+++ b/schema/config.md
@@ -318,6 +318,7 @@
 |`binds[].listeners[].routes[].policies.mcpAuthentication.provider.auth0`|object||
 |`binds[].listeners[].routes[].policies.mcpAuthentication.provider.keycloak`|object||
 |`binds[].listeners[].routes[].policies.mcpAuthentication.provider.okta`|object||
+|`binds[].listeners[].routes[].policies.mcpAuthentication.provider.descope`|object||
 |`binds[].listeners[].routes[].policies.mcpAuthentication.resourceMetadata`|object|Protected resource metadata returned to MCP clients.|
 |`binds[].listeners[].routes[].policies.mcpAuthentication.jwks`|object|JSON Web Key Set used to verify token signatures. Can be inline, from a file, or fetched remotely.|
 |`binds[].listeners[].routes[].policies.mcpAuthentication.jwks.file`|string||
@@ -8080,6 +8081,7 @@
 |`policies[].policy.mcpAuthentication.provider.auth0`|object||
 |`policies[].policy.mcpAuthentication.provider.keycloak`|object||
 |`policies[].policy.mcpAuthentication.provider.okta`|object||
+|`policies[].policy.mcpAuthentication.provider.descope`|object||
 |`policies[].policy.mcpAuthentication.resourceMetadata`|object|Protected resource metadata returned to MCP clients.|
 |`policies[].policy.mcpAuthentication.jwks`|object|JSON Web Key Set used to verify token signatures. Can be inline, from a file, or fetched remotely.|
 |`policies[].policy.mcpAuthentication.jwks.file`|string||
@@ -14680,6 +14682,7 @@
 |`routeGroups[].routes[].policies.mcpAuthentication.provider.auth0`|object||
 |`routeGroups[].routes[].policies.mcpAuthentication.provider.keycloak`|object||
 |`routeGroups[].routes[].policies.mcpAuthentication.provider.okta`|object||
+|`routeGroups[].routes[].policies.mcpAuthentication.provider.descope`|object||
 |`routeGroups[].routes[].policies.mcpAuthentication.resourceMetadata`|object|Protected resource metadata returned to MCP clients.|
 |`routeGroups[].routes[].policies.mcpAuthentication.jwks`|object|JSON Web Key Set used to verify token signatures. Can be inline, from a file, or fetched remotely.|
 |`routeGroups[].routes[].policies.mcpAuthentication.jwks.file`|string||
@@ -24488,6 +24491,7 @@
 |`mcp.policies.mcpAuthentication.provider.auth0`|object||
 |`mcp.policies.mcpAuthentication.provider.keycloak`|object||
 |`mcp.policies.mcpAuthentication.provider.okta`|object||
+|`mcp.policies.mcpAuthentication.provider.descope`|object||
 |`mcp.policies.mcpAuthentication.resourceMetadata`|object|Protected resource metadata returned to MCP clients.|
 |`mcp.policies.mcpAuthentication.jwks`|object|JSON Web Key Set used to verify token signatures. Can be inline, from a file, or fetched remotely.|
 |`mcp.policies.mcpAuthentication.jwks.file`|string||


### PR DESCRIPTION
# Add Descope as an MCP authentication provider

## Description

Update Agentgateway with a new Descope provider similarly to the Okta, Keycloak, and Auth0 providers.

## Changes

1. Authorization Server Metadata (mcp/auth.rs): Routes Descope to the OIDC Discovery endpoint (/.well-known/openid-configuration) rather than RFC 8414's path-based format like Keycloak/Okta. Rewrites the registration_endpoint in the AS metadata to proxy DCR through agentgateway (same CORS workaround as other providers).
2. DCR (Dynamic Client Registration) (mcp/auth.rs): Derives the Descope DCR URL from its agentic issuer format: `https://api.descope.com/v1/apps/agentic/{project-id}/{server-id}` -> `https://api.descope.com/v1/mgmt/mcp/client/{project-id}/{server-id}/register`. Will return a clear error if the issuer URL doesn't match the expected agentic format.
3. JWKS URL (types/agent.rs): Descope's JWKS lives at the project level, not the issuer level. For agentic issuers the JWKS URL is derived as `https://api.descope.com/{project-id}/.well-known/jwks.json`
4. Proto: resource.proto is modified to add DESCOPE = 4 to the McpIDP enum, and api/resource.pb.go is the regenerated Go protobuf output reflecting that change.
5. Config/Schema/Docs: `McpIDP::Descope {}` added as a new enum variant, `schema/config.json` and `schema/config.md` updated to expose `descope: {}` as a valid provider option, `examples/mcp-authentication/config.yaml` gets a fully commented-out Descope example block, including a note that setting up a client in the Descope Console and using its `clientId` is recommended over DCR because DCR requires a management key.
