### PR TITLE
gateway: support internal bind mode via annotation

### DIFF
--- a/controller/api/annotations/agentgateway.go
+++ b/controller/api/annotations/agentgateway.go
@@ -1,5 +1,13 @@
 package annotations
 
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
 // LegacyMCPServiceHTTPPath is the legacy annotation used to specify the HTTP path for the MCP service. Users should switch to MCPServiceHTTPPath.
 const LegacyMCPServiceHTTPPath = "kgateway.dev/mcp-path"
 
@@ -9,3 +17,42 @@ const MCPServiceHTTPPath = "agentgateway.dev/mcp-path"
 // MCPServiceTargetName is the annotation used to specify the target name for the MCP service.
 // The value must be a valid Gateway API SectionName.
 const MCPServiceTargetName = "agentgateway.dev/mcp-target-name"
+
+// InternalPorts is a comma-separated list of ports whose bind should be internal
+// (routing-only: no OS listener socket, no Service port, no container port). It may
+// be set on a Gateway or a ListenerSet, and may only reference ports defined by that
+// same object's listeners.
+const InternalPorts = "agentgateway.dev/internal-ports"
+
+// ParseInternalPorts parses the InternalPorts annotation value into the set of ports
+// marked internal. isListenerPort reports whether a port is defined by the annotated
+// object's own listeners; any referenced port that is malformed, out of range, or not
+// an own listener port is returned as an error message so the caller can surface an
+// Accepted=False condition. On any error the returned set is empty (the annotation is
+// rejected wholesale rather than partially applied). The membership check is passed as
+// a closure so callers can use whichever set type they already have.
+func ParseInternalPorts(value string, isListenerPort func(port int32) bool) (sets.Set[int32], []string) {
+	internal := sets.New[int32]()
+	var errs []string
+	for raw := range strings.SplitSeq(value, ",") {
+		p := strings.TrimSpace(raw)
+		if p == "" {
+			continue
+		}
+		n, err := strconv.ParseInt(p, 10, 32)
+		if err != nil || n < 1 || n > 65535 {
+			errs = append(errs, fmt.Sprintf("invalid port %q: must be an integer between 1 and 65535", p))
+			continue
+		}
+		port := int32(n)
+		if !isListenerPort(port) {
+			errs = append(errs, fmt.Sprintf("port %d is not defined by any listener on this resource", port))
+			continue
+		}
+		internal.Insert(port)
+	}
+	if len(errs) > 0 {
+		return sets.New[int32](), errs
+	}
+	return internal, errs
+}

--- a/controller/api/annotations/agentgateway_test.go
+++ b/controller/api/annotations/agentgateway_test.go
@@ -1,0 +1,51 @@
+package annotations
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func TestParseInternalPorts(t *testing.T) {
+	listeners := sets.New[int32](80, 8080, 443)
+	isListenerPort := func(p int32) bool { return listeners.Has(p) }
+
+	tests := []struct {
+		name    string
+		value   string
+		want    []int32
+		wantErr bool
+	}{
+		{name: "empty", value: "", want: nil},
+		{name: "single", value: "8080", want: []int32{8080}},
+		{name: "multiple with spaces", value: "80, 8080 ,443", want: []int32{80, 443, 8080}},
+		{name: "trailing comma ignored", value: "8080,", want: []int32{8080}},
+		{name: "non-numeric rejects all", value: "http", wantErr: true},
+		{name: "zero out of range", value: "0", wantErr: true},
+		{name: "above range", value: "70000", wantErr: true},
+		{name: "unmatched port", value: "9999", wantErr: true},
+		{name: "any error rejects whole annotation", value: "8080,9999", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, errs := ParseInternalPorts(tt.value, isListenerPort)
+			if tt.wantErr {
+				if len(errs) == 0 {
+					t.Fatalf("expected errors, got none (set=%v)", got.UnsortedList())
+				}
+				if got.Len() != 0 {
+					t.Fatalf("on error the set must be empty, got %v", got.UnsortedList())
+				}
+				return
+			}
+			if len(errs) != 0 {
+				t.Fatalf("unexpected errors: %v", errs)
+			}
+			want := sets.New(tt.want...)
+			if !got.Equal(want) {
+				t.Fatalf("got %v, want %v", got.UnsortedList(), tt.want)
+			}
+		})
+	}
+}

--- a/controller/pkg/agentgateway/plugins/interfaces.go
+++ b/controller/pkg/agentgateway/plugins/interfaces.go
@@ -101,6 +101,10 @@ type ParentInfo struct {
 	Port           gwv1.PortNumber
 	Protocol       gwv1.ProtocolType
 	TLSPassthrough bool
+	// Internal marks this listener's bind as internal (routing-only): no OS listener
+	// socket, no Service port, no container port. Sourced from the agentgateway.dev/internal-ports
+	// annotation on the listener's parent Gateway or ListenerSet.
+	Internal bool
 }
 
 func (g ParentInfo) Equals(other ParentInfo) bool {
@@ -114,6 +118,7 @@ func (g ParentInfo) Equals(other ParentInfo) bool {
 		g.Port == other.Port &&
 		g.Protocol == other.Protocol &&
 		g.TLSPassthrough == other.TLSPassthrough &&
+		g.Internal == other.Internal &&
 		g.CreationTimestamp == other.CreationTimestamp &&
 		slices.EqualFunc(g.AllowedKinds, other.AllowedKinds, func(a, b gwv1.RouteGroupKind) bool {
 			return a.Kind == b.Kind && ptr.Equal(a.Group, b.Group)

--- a/controller/pkg/agentgateway/translator/gateway_collection.go
+++ b/controller/pkg/agentgateway/translator/gateway_collection.go
@@ -20,6 +20,7 @@ import (
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/agentgateway/agentgateway/api"
+	"github.com/agentgateway/agentgateway/controller/api/annotations"
 	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/ir"
 	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/plugins"
 	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/utils"
@@ -264,6 +265,20 @@ func GatewayTransformationFunc(cfg GatewayCollectionConfig) func(ctx krt.Handler
 			return rm.BuildGWStatus(context.Background(), *obj, 0), nil
 		}
 
+		// Ports whose bind should be internal, from the gateway's internal-ports annotation.
+		// May only reference this gateway's own listener ports.
+		internalPorts, internalErrs := annotations.ParseInternalPorts(
+			obj.GetAnnotations()[annotations.InternalPorts],
+			func(p int32) bool {
+				for _, l := range kgw.Listeners {
+					if int32(l.Port) == p {
+						return true
+					}
+				}
+				return false
+			},
+		)
+
 		for i, l := range kgw.Listeners {
 			// Attached Routes count starts at 0 and gets updated later in the status syncer
 			// when the real count is available after route processing
@@ -301,6 +316,7 @@ func GatewayTransformationFunc(cfg GatewayCollectionConfig) func(ctx krt.Handler
 				Port:                   l.Port,
 				Protocol:               l.Protocol,
 				TLSPassthrough:         l.TLS != nil && l.TLS.Mode != nil && *l.TLS.Mode == gwv1.TLSModePassthrough,
+				Internal:               internalPorts.Has(l.Port),
 			}
 
 			res := &GatewayListener{
@@ -323,6 +339,14 @@ func GatewayTransformationFunc(cfg GatewayCollectionConfig) func(ctx krt.Handler
 				Reason: gwv1.GatewayReasonAccepted,
 			})
 			result = append(result, res)
+		}
+		if len(internalErrs) > 0 {
+			gwReporter.SetCondition(reporter.GatewayCondition{
+				Type:    gwv1.GatewayConditionAccepted,
+				Status:  metav1.ConditionFalse,
+				Reason:  gwv1.GatewayReasonInvalid,
+				Message: "invalid " + annotations.InternalPorts + " annotation: " + strings.Join(internalErrs, "; "),
+			})
 		}
 		listenersFromSets := krt.Fetch(ctx, cfg.ListenerSets, krt.FilterIndex(cfg.listenerIndex, config.NamespacedName(obj)))
 		// Sort by listener precedence
@@ -358,6 +382,14 @@ func GatewayTransformationFunc(cfg GatewayCollectionConfig) func(ctx krt.Handler
 			})
 		}
 		validateListenerConflicts(result)
+		if ports := internalPortDisagreements(result); len(ports) > 0 {
+			gwReporter.SetCondition(reporter.GatewayCondition{
+				Type:    gwv1.GatewayConditionAccepted,
+				Status:  metav1.ConditionFalse,
+				Reason:  gwv1.GatewayReasonInvalid,
+				Message: fmt.Sprintf("conflicting %s annotation: port(s) %v are marked internal by some listeners but standard by others", annotations.InternalPorts, ports),
+			})
+		}
 		uniqueListenerSets := sets.New[utils.TypedNamespacedName]()
 		for _, ls := range result {
 			if !(ls.Valid && ls.Conflict == "" && ls.ParentObject.Kind == wellknown.ListenerSetGVK.Kind) {
@@ -383,6 +415,33 @@ const (
 	ListenerConflictHostname = "hostname"
 	ListenerConflictProtocol = "protocol"
 )
+
+// internalPortDisagreements returns the sorted set of ports for which non-conflicting
+// listeners disagree on internal vs standard bind mode. A bind is per-port and shared,
+// so such a port cannot be resolved to a single mode and must be reported as invalid.
+func internalPortDisagreements(listeners []*GatewayListener) []int32 {
+	var sawInternal, sawStandard sets.Set[gwv1.PortNumber]
+	sawInternal = sets.New[gwv1.PortNumber]()
+	sawStandard = sets.New[gwv1.PortNumber]()
+	for _, l := range listeners {
+		if l.Conflict != "" {
+			continue
+		}
+		if l.ParentInfo.Internal {
+			sawInternal.Insert(l.ParentInfo.Port)
+		} else {
+			sawStandard.Insert(l.ParentInfo.Port)
+		}
+	}
+	var conflicting []int32
+	for port := range sawInternal {
+		if sawStandard.Contains(port) {
+			conflicting = append(conflicting, int32(port))
+		}
+	}
+	slices.Sort(conflicting)
+	return conflicting
+}
 
 func validateListenerConflicts(listeners []*GatewayListener) {
 	portMap := make(map[gwv1.PortNumber]*portProtocol)
@@ -484,6 +543,20 @@ func ListenerSetBuilder(
 		return status, nil
 	}
 
+	// Ports whose bind should be internal, from the ListenerSet's internal-ports
+	// annotation. May only reference this ListenerSet's own listener ports.
+	internalPorts, internalErrs := annotations.ParseInternalPorts(
+		obj.GetAnnotations()[annotations.InternalPorts],
+		func(p int32) bool {
+			for _, l := range ls.Listeners {
+				if port, err := kubeutils.DetectListenerPortNumber(l.Protocol, l.Port); err == nil && int32(port) == p {
+					return true
+				}
+			}
+			return false
+		},
+	)
+
 	for i, l := range ls.Listeners {
 		port, portErr := kubeutils.DetectListenerPortNumber(l.Protocol, l.Port)
 		l.Port = port
@@ -510,6 +583,7 @@ func ListenerSetBuilder(
 			Port:             l.Port,
 			Protocol:         l.Protocol,
 			TLSPassthrough:   l.TLS != nil && l.TLS.Mode != nil && *l.TLS.Mode == gwv1.TLSModePassthrough,
+			Internal:         internalPorts.Has(l.Port),
 		}
 
 		res := ListenerSet{
@@ -521,6 +595,16 @@ func ListenerSetBuilder(
 			ParentInfo:    pri,
 		}
 		result = append(result, res)
+	}
+
+	if len(internalErrs) > 0 {
+		status.Conditions = SetConditions(obj.Generation, status.Conditions, map[string]*Condition{
+			string(gwv1.GatewayConditionAccepted): {
+				Reason:  string(gwv1.GatewayReasonInvalid),
+				Status:  metav1.ConditionFalse,
+				Message: "invalid " + annotations.InternalPorts + " annotation: " + strings.Join(internalErrs, "; "),
+			},
+		})
 	}
 
 	reportListenerSetStatus(obj, status)

--- a/controller/pkg/agentgateway/translator/testdata/gateways/internal-bind-disagreement.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/gateways/internal-bind-disagreement.yaml
@@ -1,0 +1,173 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: example
+  namespace: default
+  annotations:
+    agentgateway.dev/internal-ports: "8080"
+spec:
+  gatewayClassName: agentgateway
+  listeners:
+    - name: gw-8080
+      protocol: HTTP
+      port: 8080
+      hostname: a.example.com
+  allowedListeners:
+    namespaces:
+      from: All
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: foo
+  namespace: default
+spec:
+  parentRef:
+    name: example
+    kind: Gateway
+    group: gateway.networking.k8s.io
+  listeners:
+    - name: ls-8080
+      protocol: HTTP
+      port: 8080
+      hostname: b.example.com
+      allowedRoutes:
+        namespaces:
+          from: All
+
+---
+# Output
+output:
+- gateway:
+    Name: example
+    Namespace: default
+  resource:
+    bind:
+      key: 8080/default/example
+      port: 8080
+- gateway:
+    Name: example
+    Namespace: default
+  resource:
+    listener:
+      bindKey: 8080/default/example
+      hostname: a.example.com
+      key: default/example.gw-8080
+      name:
+        gatewayName: example
+        gatewayNamespace: default
+        listenerName: gw-8080
+      protocol: HTTP
+- gateway:
+    Name: example
+    Namespace: default
+  resource:
+    listener:
+      bindKey: 8080/default/example
+      hostname: b.example.com
+      key: default/foo.ls-8080
+      name:
+        gatewayName: example
+        gatewayNamespace: default
+        listenerName: ls-8080
+        listenerSet:
+          name: foo
+          namespace: default
+      protocol: HTTP
+status:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: ListenerSet
+  metadata:
+    name: foo
+    namespace: default
+  spec: null
+  status:
+    conditions:
+    - lastTransitionTime: fake
+      message: Resource accepted
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: fake
+      message: Resource programmed
+      reason: Programmed
+      status: "True"
+      type: Programmed
+    listeners:
+    - attachedRoutes: 0
+      conditions:
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: ls-8080
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: Gateway
+  metadata:
+    name: example
+    namespace: default
+  spec: null
+  status:
+    attachedListenerSets: 1
+    conditions:
+    - lastTransitionTime: fake
+      message: 'conflicting agentgateway.dev/internal-ports annotation: port(s) [8080]
+        are marked internal by some listeners but standard by others'
+      reason: Invalid
+      status: "False"
+      type: Accepted
+    - lastTransitionTime: fake
+      message: Successfully programmed Gateway
+      reason: Programmed
+      status: "True"
+      type: Programmed
+    listeners:
+    - attachedRoutes: 0
+      conditions:
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: gw-8080
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute

--- a/controller/pkg/agentgateway/translator/testdata/gateways/internal-bind-invalid.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/gateways/internal-bind-invalid.yaml
@@ -1,0 +1,86 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: test-gateway
+  namespace: default
+  annotations:
+    agentgateway.dev/internal-ports: "9999"
+spec:
+  gatewayClassName: agentgateway
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+
+---
+# Output
+output:
+- gateway:
+    Name: test-gateway
+    Namespace: default
+  resource:
+    bind:
+      key: 80/default/test-gateway
+      port: 80
+- gateway:
+    Name: test-gateway
+    Namespace: default
+  resource:
+    listener:
+      bindKey: 80/default/test-gateway
+      key: default/test-gateway.http
+      name:
+        gatewayName: test-gateway
+        gatewayNamespace: default
+        listenerName: http
+      protocol: HTTP
+status:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: Gateway
+  metadata:
+    name: test-gateway
+    namespace: default
+  spec: null
+  status:
+    attachedListenerSets: 0
+    conditions:
+    - lastTransitionTime: fake
+      message: 'invalid agentgateway.dev/internal-ports annotation: port 9999 is not
+        defined by any listener on this resource'
+      reason: Invalid
+      status: "False"
+      type: Accepted
+    - lastTransitionTime: fake
+      message: Successfully programmed Gateway
+      reason: Programmed
+      status: "True"
+      type: Programmed
+    listeners:
+    - attachedRoutes: 0
+      conditions:
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute

--- a/controller/pkg/agentgateway/translator/testdata/gateways/internal-bind-listenerset.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/gateways/internal-bind-listenerset.yaml
@@ -1,0 +1,176 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: example
+  namespace: default
+spec:
+  gatewayClassName: agentgateway
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+  allowedListeners:
+    namespaces:
+      from: All
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: foo
+  namespace: default
+  annotations:
+    agentgateway.dev/internal-ports: "9090"
+spec:
+  parentRef:
+    name: example
+    kind: Gateway
+    group: gateway.networking.k8s.io
+  listeners:
+    - name: http-9090
+      protocol: HTTP
+      port: 9090
+      allowedRoutes:
+        namespaces:
+          from: All
+
+---
+# Output
+output:
+- gateway:
+    Name: example
+    Namespace: default
+  resource:
+    bind:
+      key: 80/default/example
+      port: 80
+- gateway:
+    Name: example
+    Namespace: default
+  resource:
+    bind:
+      key: 9090/default/example
+      mode: INTERNAL
+      port: 9090
+- gateway:
+    Name: example
+    Namespace: default
+  resource:
+    listener:
+      bindKey: 80/default/example
+      key: default/example.http
+      name:
+        gatewayName: example
+        gatewayNamespace: default
+        listenerName: http
+      protocol: HTTP
+- gateway:
+    Name: example
+    Namespace: default
+  resource:
+    listener:
+      bindKey: 9090/default/example
+      key: default/foo.http-9090
+      name:
+        gatewayName: example
+        gatewayNamespace: default
+        listenerName: http-9090
+        listenerSet:
+          name: foo
+          namespace: default
+      protocol: HTTP
+status:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: ListenerSet
+  metadata:
+    name: foo
+    namespace: default
+  spec: null
+  status:
+    conditions:
+    - lastTransitionTime: fake
+      message: Resource accepted
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: fake
+      message: Resource programmed
+      reason: Programmed
+      status: "True"
+      type: Programmed
+    listeners:
+    - attachedRoutes: 0
+      conditions:
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http-9090
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: Gateway
+  metadata:
+    name: example
+    namespace: default
+  spec: null
+  status:
+    attachedListenerSets: 1
+    conditions:
+    - lastTransitionTime: fake
+      message: ""
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: fake
+      message: Successfully programmed Gateway
+      reason: Programmed
+      status: "True"
+      type: Programmed
+    listeners:
+    - attachedRoutes: 0
+      conditions:
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: http
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute

--- a/controller/pkg/agentgateway/translator/testdata/gateways/internal-bind.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/gateways/internal-bind.yaml
@@ -1,0 +1,136 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: test-gateway
+  namespace: default
+  annotations:
+    agentgateway.dev/internal-ports: "8080"
+spec:
+  gatewayClassName: agentgateway
+  listeners:
+    - name: public
+      port: 80
+      protocol: HTTP
+    - name: internal
+      port: 8080
+      protocol: HTTP
+
+---
+# Output
+output:
+- gateway:
+    Name: test-gateway
+    Namespace: default
+  resource:
+    bind:
+      key: 80/default/test-gateway
+      port: 80
+- gateway:
+    Name: test-gateway
+    Namespace: default
+  resource:
+    bind:
+      key: 8080/default/test-gateway
+      mode: INTERNAL
+      port: 8080
+- gateway:
+    Name: test-gateway
+    Namespace: default
+  resource:
+    listener:
+      bindKey: 8080/default/test-gateway
+      key: default/test-gateway.internal
+      name:
+        gatewayName: test-gateway
+        gatewayNamespace: default
+        listenerName: internal
+      protocol: HTTP
+- gateway:
+    Name: test-gateway
+    Namespace: default
+  resource:
+    listener:
+      bindKey: 80/default/test-gateway
+      key: default/test-gateway.public
+      name:
+        gatewayName: test-gateway
+        gatewayNamespace: default
+        listenerName: public
+      protocol: HTTP
+status:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: Gateway
+  metadata:
+    name: test-gateway
+    namespace: default
+  spec: null
+  status:
+    attachedListenerSets: 0
+    conditions:
+    - lastTransitionTime: fake
+      message: ""
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: fake
+      message: Successfully programmed Gateway
+      reason: Programmed
+      status: "True"
+      type: Programmed
+    listeners:
+    - attachedRoutes: 0
+      conditions:
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: public
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+    - attachedRoutes: 0
+      conditions:
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: internal
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute

--- a/controller/pkg/deployer/deployer_test.go
+++ b/controller/pkg/deployer/deployer_test.go
@@ -231,6 +231,16 @@ func TestGatewayAndListenerSetPortModifications(t *testing.T) {
 		assert.Equal(t, true, has3000)
 	})
 
+	t.Run("GetPortsValues skips internal ports", func(t *testing.T) {
+		// 8080 is internal (routing-only): it must not appear as a Service/container port.
+		gw := createGatewayForDeployer(80, 8080)
+		gw.InternalPorts = smallset.New[int32](8080)
+		ports := deployer.GetPortsValues(gw, 0)
+
+		assert.Equal(t, 1, len(ports))
+		assert.Equal(t, int32(80), *ports[0].Port)
+	})
+
 	t.Run("GetPortsValues skips reserved ports", func(t *testing.T) {
 		// Include a reserved port (15020) alongside normal ports
 		gw := createGatewayForDeployer(8080, 15020, 9090)

--- a/controller/pkg/deployer/values_helpers.go
+++ b/controller/pkg/deployer/values_helpers.go
@@ -33,6 +33,11 @@ func GetPortsValues(gw *collections.GatewayForDeployer, noListenersDummyPort int
 
 	// Add ports from Gateway listeners
 	for _, port := range listenerPorts {
+		// Internal binds are routing-only; they open no socket and must not be exposed
+		// via a Service port or container port.
+		if gw.InternalPorts.Contains(port) {
+			continue
+		}
 		portName := GenerateListenerNameFromPort(port)
 		if err := validateListenerPortForParent(port); err != nil {
 			// skip invalid ports; statuses are handled in the translator

--- a/controller/pkg/pluginsdk/collections/deployer.go
+++ b/controller/pkg/pluginsdk/collections/deployer.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	"github.com/agentgateway/agentgateway/controller/api/annotations"
 	"github.com/agentgateway/agentgateway/controller/pkg/utils/kubeutils"
 	"github.com/agentgateway/agentgateway/controller/pkg/wellknown"
 )
@@ -78,10 +79,73 @@ func GatewaysForDeployerTransformationFunc(
 			},
 			ControllerName:  string(gwClass.Spec.ControllerName),
 			Ports:           smallset.New(ports.UnsortedList()...),
+			InternalPorts:   computeInternalPorts(gw, lsets),
 			MeshTrustDomain: td,
 		}
 		return ir
 	}
+}
+
+// computeInternalPorts returns the ports whose bind is internal, mirroring the bind-mode
+// decision in the syncer: a port is internal only if every contributing listener (across
+// the Gateway and its ListenerSets) agrees. Disagreement leaves the port standard (and is
+// surfaced as Accepted=False during translation). Invalid annotations are ignored here;
+// translation reports them.
+func computeInternalPorts(gw *gwv1.Gateway, lsets []*gwv1.ListenerSet) smallset.Set[int32] {
+	sawInternal := sets.New[int32]()
+	sawStandard := sets.New[int32]()
+
+	gwInternal, _ := annotations.ParseInternalPorts(
+		gw.GetAnnotations()[annotations.InternalPorts],
+		func(p int32) bool {
+			for _, l := range gw.Spec.Listeners {
+				if int32(l.Port) == p {
+					return true
+				}
+			}
+			return false
+		},
+	)
+	for _, l := range gw.Spec.Listeners {
+		if gwInternal.Has(l.Port) {
+			sawInternal.Insert(l.Port)
+		} else {
+			sawStandard.Insert(l.Port)
+		}
+	}
+
+	for _, ls := range lsets {
+		lsInternal, _ := annotations.ParseInternalPorts(
+			ls.GetAnnotations()[annotations.InternalPorts],
+			func(p int32) bool {
+				for _, l := range ls.Spec.Listeners {
+					if port, err := kubeutils.DetectListenerPortNumber(l.Protocol, l.Port); err == nil && int32(port) == p {
+						return true
+					}
+				}
+				return false
+			},
+		)
+		for _, l := range ls.Spec.Listeners {
+			port, err := kubeutils.DetectListenerPortNumber(l.Protocol, l.Port)
+			if err != nil {
+				continue
+			}
+			if lsInternal.Has(port) {
+				sawInternal.Insert(port)
+			} else {
+				sawStandard.Insert(port)
+			}
+		}
+	}
+
+	internal := []int32{}
+	for p := range sawInternal {
+		if !sawStandard.Contains(p) {
+			internal = append(internal, p)
+		}
+	}
+	return smallset.New(internal...)
 }
 
 type GatewayForDeployer struct {
@@ -90,6 +154,10 @@ type GatewayForDeployer struct {
 	ControllerName string
 	// All ports from all listeners
 	Ports smallset.Set[int32]
+	// InternalPorts are ports whose bind is internal (routing-only). They are excluded
+	// from the generated Service and container ports. Derived from the
+	// agentgateway.dev/internal-ports annotation on the Gateway and its ListenerSets.
+	InternalPorts smallset.Set[int32]
 	// MeshTrustDomain changes should trigger reconciliation
 	// this field isn't read outside of Equals for a trigger
 	MeshTrustDomain string
@@ -146,5 +214,6 @@ func (c GatewayForDeployer) Equals(in GatewayForDeployer) bool {
 	return c.ObjectSource.Equals(in.ObjectSource) &&
 		c.ControllerName == in.ControllerName &&
 		c.MeshTrustDomain == in.MeshTrustDomain &&
-		slices.Equal(c.Ports.List(), in.Ports.List())
+		slices.Equal(c.Ports.List(), in.Ports.List()) &&
+		slices.Equal(c.InternalPorts.List(), in.InternalPorts.List())
 }

--- a/controller/pkg/pluginsdk/collections/deployer_internalports_test.go
+++ b/controller/pkg/pluginsdk/collections/deployer_internalports_test.go
@@ -1,0 +1,94 @@
+package collections
+
+import (
+	"testing"
+
+	"istio.io/istio/pkg/slices"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/agentgateway/agentgateway/controller/api/annotations"
+)
+
+func gw(annotation string, ports ...gwv1.PortNumber) *gwv1.Gateway {
+	g := &gwv1.Gateway{}
+	if annotation != "" {
+		g.Annotations = map[string]string{annotations.InternalPorts: annotation}
+	}
+	for i, p := range ports {
+		g.Spec.Listeners = append(g.Spec.Listeners, gwv1.Listener{
+			Name:     gwv1.SectionName(string(rune('a' + i))),
+			Protocol: gwv1.HTTPProtocolType,
+			Port:     p,
+		})
+	}
+	return g
+}
+
+func ls(annotation string, ports ...gwv1.PortNumber) *gwv1.ListenerSet {
+	l := &gwv1.ListenerSet{ObjectMeta: metav1.ObjectMeta{Name: "ls"}}
+	if annotation != "" {
+		l.Annotations = map[string]string{annotations.InternalPorts: annotation}
+	}
+	for i, p := range ports {
+		l.Spec.Listeners = append(l.Spec.Listeners, gwv1.ListenerEntry{
+			Name:     gwv1.SectionName(string(rune('a' + i))),
+			Protocol: gwv1.HTTPProtocolType,
+			Port:     p,
+		})
+	}
+	return l
+}
+
+func TestComputeInternalPorts(t *testing.T) {
+	tests := []struct {
+		name  string
+		gw    *gwv1.Gateway
+		lsets []*gwv1.ListenerSet
+		want  []int32
+	}{
+		{
+			name: "gateway annotation marks its port internal",
+			gw:   gw("8080", 80, 8080),
+			want: []int32{8080},
+		},
+		{
+			name:  "listenerset annotation marks its port internal",
+			gw:    gw("", 80),
+			lsets: []*gwv1.ListenerSet{ls("9090", 9090)},
+			want:  []int32{9090},
+		},
+		{
+			name:  "disagreement on shared port stays standard",
+			gw:    gw("8080", 8080),
+			lsets: []*gwv1.ListenerSet{ls("", 8080)},
+			want:  nil,
+		},
+		{
+			name:  "agreement on shared port is internal",
+			gw:    gw("8080", 8080),
+			lsets: []*gwv1.ListenerSet{ls("8080", 8080)},
+			want:  []int32{8080},
+		},
+		{
+			name: "invalid annotation is ignored",
+			gw:   gw("9999", 80),
+			want: nil,
+		},
+		{
+			name: "no annotation",
+			gw:   gw("", 80, 8080),
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := slices.Sort(computeInternalPorts(tt.gw, tt.lsets).List())
+			want := slices.Sort(tt.want)
+			if !slices.Equal(got, want) {
+				t.Fatalf("computeInternalPorts = %v, want %v", got, want)
+			}
+		})
+	}
+}

--- a/controller/pkg/syncer/syncer.go
+++ b/controller/pkg/syncer/syncer.go
@@ -561,6 +561,8 @@ func (s *Syncer) buildBindsFromGateway(listeners []*translator.GatewayListener) 
 	type bindInfo struct {
 		protocol       api.Bind_Protocol
 		tunnelProtocol api.Bind_TunnelProtocol
+		sawInternal    bool
+		sawStandard    bool
 	}
 	byPort := map[uint32]*bindInfo{}
 	for _, listener := range listeners {
@@ -580,18 +582,31 @@ func (s *Syncer) buildBindsFromGateway(listeners []*translator.GatewayListener) 
 			if tp := s.getTunnelProtocol(listener); tp != api.Bind_DIRECT {
 				bi.tunnelProtocol = tp
 			}
+			// A bind is internal only if every contributing listener agrees. Disagreement
+			// (sawInternal && sawStandard) is reported as Accepted=False in translation and
+			// leaves the bind standard here.
+			if listener.ParentInfo.Internal {
+				bi.sawInternal = true
+			} else {
+				bi.sawStandard = true
+			}
 		}
 	}
 
 	binds := make([]agwir.AgwResource, 0, len(byPort))
 	for _, port := range slices.Sort(maps.Keys(byPort)) { // sorted for deterministic output
 		bi := byPort[port]
+		mode := api.Bind_STANDARD
+		if bi.sawInternal && !bi.sawStandard {
+			mode = api.Bind_INTERNAL
+		}
 		bind := translator.AgwBind{
 			Bind: &api.Bind{
 				Key:            fmt.Sprint(port) + "/" + parentGateway.String(),
 				Port:           port,
 				Protocol:       bi.protocol,
 				TunnelProtocol: bi.tunnelProtocol,
+				Mode:           mode,
 			},
 		}
 		binds = append(binds, translator.ToResourceForGateway(parentGateway, bind))


### PR DESCRIPTION
Add agentgateway.dev/internal-ports, a list of ports settable on a Gateway
or ListenerSet, marking those ports' binds internal. For internal ports, the
dataplane opens no socket and the Deployer omits them from the Service and
container ports.

- annotations: InternalPorts constant + ParseInternalPorts helper (validates
  numeric/1-65535/own-listener-port; rejects the whole annotation on error)
- translation: set ParentInfo.Internal per-listener from the object's own
  annotation; Accepted=False on invalid/unmatched ports or same-port
  internal/standard disagreement
- syncer: emit Bind_INTERNAL only when all contributors on a port agree;
  disagreement leaves the bind standard
- deployer: GatewayForDeployer.InternalPorts; GetPortsValues skips internal
  ports for Service and container ports
 ---

Built on top of https://github.com/agentgateway/agentgateway/pull/2363