### PR TITLE
Bedrock: sanitize tool names exceeding 64-char Converse limit

### DIFF
--- a/crates/agentgateway/src/cel/types.rs
+++ b/crates/agentgateway/src/cel/types.rs
@@ -1424,7 +1424,7 @@ impl From<llm::LLMRequest> for LLMContext {
 			streaming,
 			params,
 			prompt,
-			bedrock_tool_names: _,
+			provider_state: _,
 		} = info;
 		LLMContext {
 			streaming,

--- a/crates/agentgateway/src/cel/types.rs
+++ b/crates/agentgateway/src/cel/types.rs
@@ -1424,6 +1424,7 @@ impl From<llm::LLMRequest> for LLMContext {
 			streaming,
 			params,
 			prompt,
+			bedrock_tool_names: _,
 		} = info;
 		LLMContext {
 			streaming,

--- a/crates/agentgateway/src/llm/conversion/bedrock.rs
+++ b/crates/agentgateway/src/llm/conversion/bedrock.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 
 use rand::RngExt;
@@ -27,7 +27,6 @@ pub struct BedrockRequest {
 pub struct BedrockToolNameMap {
 	forward: HashMap<String, String>,
 	reverse: HashMap<String, String>,
-	used_sanitized: HashSet<String>,
 }
 
 impl BedrockToolNameMap {
@@ -46,14 +45,13 @@ impl BedrockToolNameMap {
 			return mapped.clone();
 		}
 
-		if is_valid_bedrock_tool_name(&original) && !self.used_sanitized.contains(&original) {
-			self.used_sanitized.insert(original.clone());
+		if is_valid_bedrock_tool_name(&original) && !self.forward.values().any(|used| used == &original)
+		{
 			self.forward.insert(original.clone(), original.clone());
 			return original;
 		}
 
-		let sanitized = make_valid_bedrock_tool_name(&original, &self.used_sanitized);
-		self.used_sanitized.insert(sanitized.clone());
+		let sanitized = make_valid_bedrock_tool_name(&original, self.forward.values());
 		self.forward.insert(original.clone(), sanitized.clone());
 		if sanitized != original {
 			self.reverse.insert(sanitized.clone(), original);
@@ -63,7 +61,8 @@ impl BedrockToolNameMap {
 
 	/// Restore the client-facing tool name from a Bedrock response.
 	pub fn restore(&self, sanitized: &str) -> String {
-		self.reverse
+		self
+			.reverse
 			.get(sanitized)
 			.cloned()
 			.unwrap_or_else(|| sanitized.to_string())
@@ -94,9 +93,12 @@ fn sanitize_bedrock_tool_name_chars(name: &str) -> String {
 	}
 }
 
-fn make_valid_bedrock_tool_name(original: &str, used: &HashSet<String>) -> String {
+fn make_valid_bedrock_tool_name<'a>(
+	original: &str,
+	used: impl Iterator<Item = &'a String> + Clone,
+) -> String {
 	let base = sanitize_bedrock_tool_name_chars(original);
-	if base.len() <= BEDROCK_TOOL_NAME_MAX_LEN && !used.contains(&base) {
+	if base.len() <= BEDROCK_TOOL_NAME_MAX_LEN && !used.clone().any(|used| used == &base) {
 		return base;
 	}
 
@@ -108,7 +110,7 @@ fn make_valid_bedrock_tool_name(original: &str, used: &HashSet<String>) -> Strin
 	let mut candidate = format!("{prefix}_{hash}");
 
 	let mut counter = 0u32;
-	while used.contains(&candidate) {
+	while used.clone().any(|used| used == &candidate) {
 		counter += 1;
 		let suffix = format!("_{counter:x}");
 		let trim = BEDROCK_TOOL_NAME_MAX_LEN.saturating_sub(suffix.len());
@@ -122,7 +124,8 @@ fn make_valid_bedrock_tool_name(original: &str, used: &HashSet<String>) -> Strin
 }
 
 fn restore_tool_name(map: Option<&BedrockToolNameMap>, name: &str) -> String {
-	map.map(|m| m.restore(name))
+	map
+		.map(|m| m.restore(name))
 		.unwrap_or_else(|| name.to_string())
 }
 
@@ -571,40 +574,6 @@ pub mod from_completions {
 		})
 	}
 
-	fn collect_completions_tool_names(req: &completions::Request) -> Vec<String> {
-		let mut names = Vec::new();
-		if let Some(tools) = &req.tools {
-			for tool in tools {
-				if let completions::Tool::Function(function_tool) = tool {
-					names.push(function_tool.function.name.clone());
-				}
-			}
-		}
-		if let Some(completions::ToolChoiceOption::Function(completions::NamedToolChoice {
-			function,
-		})) = &req.tool_choice
-		{
-			names.push(function.name.clone());
-		}
-		for msg in &req.messages {
-			if let completions::RequestMessage::Assistant(assistant) = msg {
-				if let Some(tool_calls) = &assistant.tool_calls {
-					for call in tool_calls {
-						match call {
-							completions::MessageToolCalls::Function(call) => {
-								names.push(call.function.name.clone());
-							},
-							completions::MessageToolCalls::Custom(call) => {
-								names.push(call.custom_tool.name.clone());
-							},
-						}
-					}
-				}
-			}
-		}
-		names
-	}
-
 	pub(super) fn translate_internal(
 		req: completions::Request,
 		model_id: String,
@@ -613,8 +582,35 @@ pub mod from_completions {
 		prompt_caching: Option<&crate::llm::policy::PromptCachingConfig>,
 	) -> (bedrock::ConverseRequest, super::BedrockToolNameMap) {
 		let mut tool_name_map = super::BedrockToolNameMap::default();
-		for name in collect_completions_tool_names(&req) {
-			tool_name_map.register(&name);
+		for tool in req.tools.iter().flatten() {
+			if let completions::Tool::Function(function_tool) = tool {
+				tool_name_map.register(&function_tool.function.name);
+			}
+		}
+		if let Some(completions::ToolChoiceOption::Function(completions::NamedToolChoice {
+			function,
+		})) = &req.tool_choice
+		{
+			tool_name_map.register(&function.name);
+		}
+		for msg in &req.messages {
+			let completions::RequestMessage::Assistant(assistant) = msg else {
+				continue;
+			};
+			for call in assistant
+				.tool_calls
+				.iter()
+				.flat_map(|tool_calls| tool_calls.iter())
+			{
+				match call {
+					completions::MessageToolCalls::Function(call) => {
+						tool_name_map.register(&call.function.name);
+					},
+					completions::MessageToolCalls::Custom(call) => {
+						tool_name_map.register(&call.custom_tool.name);
+					},
+				};
+			}
 		}
 		// Extract and join system prompts from completions format
 		let system_text = req
@@ -623,6 +619,55 @@ pub mod from_completions {
 			.filter_map(extract_system_text)
 			.collect::<Vec<String>>()
 			.join("\n");
+
+		let inference_config = bedrock::InferenceConfiguration {
+			max_tokens: req.max_tokens(),
+			temperature: req.temperature,
+			top_p: req.top_p,
+			// Map Anthropic-style vendor extension to Bedrock topK when provided
+			top_k: req.vendor_extensions.top_k,
+			stop_sequences: req.stop_sequence(),
+		};
+
+		let tool_choice = match req.tool_choice {
+			Some(completions::ToolChoiceOption::Function(completions::NamedToolChoice { function })) => {
+				Some(bedrock::ToolChoice::Tool {
+					name: tool_name_map.register(&function.name),
+				})
+			},
+			Some(completions::ToolChoiceOption::Mode(completions::ToolChoiceOptions::Auto)) => {
+				Some(bedrock::ToolChoice::Auto)
+			},
+			Some(completions::ToolChoiceOption::Mode(completions::ToolChoiceOptions::Required)) => {
+				Some(bedrock::ToolChoice::Any)
+			},
+			Some(completions::ToolChoiceOption::Mode(completions::ToolChoiceOptions::None)) => None,
+			_ => None,
+		};
+		let tools = req.tools.map(|tools| {
+			tools
+				.into_iter()
+				.filter_map(|tool| match tool {
+					completions::Tool::Function(function_tool) => {
+						let tool_spec = bedrock::ToolSpecification {
+							name: tool_name_map.register(&function_tool.function.name),
+							description: function_tool.function.description,
+							input_schema: function_tool
+								.function
+								.parameters
+								.map(bedrock::ToolInputSchema::Json),
+						};
+
+						Some(bedrock::Tool::ToolSpec(tool_spec))
+					},
+					_ => {
+						tracing::warn!("Unsupported tool type in Bedrock conversion");
+						None
+					},
+				})
+				.collect_vec()
+		});
+		let tool_config = tools.map(|tools| bedrock::ToolConfiguration { tools, tool_choice });
 
 		let messages = req
 			.messages
@@ -676,15 +721,6 @@ pub mod from_completions {
 				msgs
 			});
 
-		let inference_config = bedrock::InferenceConfiguration {
-			max_tokens: req.max_tokens(),
-			temperature: req.temperature,
-			top_p: req.top_p,
-			// Map Anthropic-style vendor extension to Bedrock topK when provided
-			top_k: req.vendor_extensions.top_k,
-			stop_sequences: req.stop_sequence(),
-		};
-
 		// Build guardrail configuration if specified
 		let guardrail_config = if let (Some(identifier), Some(version)) =
 			(&provider.guardrail_identifier, &provider.guardrail_version)
@@ -706,46 +742,6 @@ pub mod from_completions {
 		} else {
 			Some(metadata)
 		};
-
-		let tool_choice = match req.tool_choice {
-			Some(completions::ToolChoiceOption::Function(completions::NamedToolChoice { function })) => {
-				Some(bedrock::ToolChoice::Tool {
-					name: tool_name_map.register(&function.name),
-				})
-			},
-			Some(completions::ToolChoiceOption::Mode(completions::ToolChoiceOptions::Auto)) => {
-				Some(bedrock::ToolChoice::Auto)
-			},
-			Some(completions::ToolChoiceOption::Mode(completions::ToolChoiceOptions::Required)) => {
-				Some(bedrock::ToolChoice::Any)
-			},
-			Some(completions::ToolChoiceOption::Mode(completions::ToolChoiceOptions::None)) => None,
-			_ => None,
-		};
-		let tools = req.tools.map(|tools| {
-			tools
-				.into_iter()
-				.filter_map(|tool| match tool {
-					completions::Tool::Function(function_tool) => {
-						let tool_spec = bedrock::ToolSpecification {
-							name: tool_name_map.register(&function_tool.function.name),
-							description: function_tool.function.description,
-							input_schema: function_tool
-								.function
-								.parameters
-								.map(bedrock::ToolInputSchema::Json),
-						};
-
-						Some(bedrock::Tool::ToolSpec(tool_spec))
-					},
-					_ => {
-						tracing::warn!("Unsupported tool type in Bedrock conversion");
-						None
-					},
-				})
-				.collect_vec()
-		});
-		let tool_config = tools.map(|tools| bedrock::ToolConfiguration { tools, tool_choice });
 
 		let explicit_thinking_budget = req.vendor_extensions.thinking_budget_tokens;
 		let enabled_thinking_budget = explicit_thinking_budget.or_else(|| {
@@ -1197,34 +1193,24 @@ pub mod from_messages {
 		})
 	}
 
-	fn collect_messages_tool_names(req: &messages::Request) -> Vec<String> {
-		let mut names = Vec::new();
-		if let Some(tools) = &req.tools {
-			for tool in tools {
-				names.push(tool.name.clone());
-			}
-		}
-		if let Some(messages::ToolChoice::Tool { name, .. }) = &req.tool_choice {
-			names.push(name.clone());
-		}
-		for msg in &req.messages {
-			for block in &msg.content {
-				if let messages::ContentBlock::ToolUse { name, .. } = block {
-					names.push(name.clone());
-				}
-			}
-		}
-		names
-	}
-
 	pub(super) fn translate_internal(
 		req: messages::Request,
 		provider: &Provider,
 		headers: Option<&http::HeaderMap>,
 	) -> Result<(bedrock::ConverseRequest, super::BedrockToolNameMap), AIError> {
 		let mut tool_name_map = super::BedrockToolNameMap::default();
-		for name in collect_messages_tool_names(&req) {
-			tool_name_map.register(&name);
+		for tool in req.tools.iter().flatten() {
+			tool_name_map.register(&tool.name);
+		}
+		if let Some(messages::ToolChoice::Tool { name, .. }) = &req.tool_choice {
+			tool_name_map.register(name);
+		}
+		for msg in &req.messages {
+			for block in &msg.content {
+				if let messages::ContentBlock::ToolUse { name, .. } = block {
+					tool_name_map.register(name);
+				}
+			}
 		}
 		let mut cache_points_used = 0;
 		// Converse placement note (AWS docs):
@@ -1260,6 +1246,57 @@ pub mod from_messages {
 		// Bedrock applies strict inference/tool-choice constraints only to explicit extended thinking.
 		let thinking_enabled = requested_thinking
 			.is_some_and(|thinking| matches!(thinking, messages::ThinkingInput::Enabled { .. }));
+
+		// Prepare typed tools before messages so definitions keep priority if a previous tool-use
+		// name would otherwise collide. Cache points are inserted later in their original order.
+		let pending_tool_config = if let Some(tools) = req.tools {
+			let mut bedrock_tools = Vec::with_capacity(tools.len());
+			for tool in tools {
+				bedrock_tools.push((
+					bedrock::Tool::ToolSpec(bedrock::ToolSpecification {
+						name: tool_name_map.register(&tool.name),
+						description: tool.description,
+						input_schema: Some(bedrock::ToolInputSchema::Json(tool.input_schema)),
+					}),
+					tool.cache_control.is_some(),
+				));
+			}
+
+			if bedrock_tools.is_empty() {
+				None
+			} else {
+				let tool_choice = match req.tool_choice {
+					Some(messages::ToolChoice::Auto { .. }) => {
+						if thinking_enabled {
+							Some(bedrock::ToolChoice::Any)
+						} else {
+							Some(bedrock::ToolChoice::Auto)
+						}
+					},
+					Some(messages::ToolChoice::Any { .. }) => Some(bedrock::ToolChoice::Any),
+					Some(messages::ToolChoice::Tool { name, .. }) => {
+						if thinking_enabled {
+							Some(bedrock::ToolChoice::Any)
+						} else {
+							Some(bedrock::ToolChoice::Tool {
+								name: tool_name_map.register(&name),
+							})
+						}
+					},
+					Some(messages::ToolChoice::None {}) | None => {
+						if thinking_enabled {
+							Some(bedrock::ToolChoice::Any)
+						} else {
+							None
+						}
+					},
+				};
+
+				Some((bedrock_tools, tool_choice))
+			}
+		} else {
+			None
+		};
 
 		// Convert system prompt to Bedrock format with cache point insertion
 		// Note: Anthropic MessagesRequest.system is Option<SystemPrompt>, Bedrock wants Option<Vec<SystemContentBlock>>
@@ -1471,66 +1508,20 @@ pub mod from_messages {
 			stop_sequences: req.stop_sequences,
 		};
 
-		// Convert typed tools to Bedrock tool config
-		// NOTE: Only send toolConfig if we have at least one tool. Bedrock rejects empty tools arrays.
-		let tool_config = if let Some(tools) = req.tools {
-			let bedrock_tools: Vec<bedrock::Tool> = {
-				let mut result = Vec::with_capacity(tools.len() * 2);
-				for tool in tools {
-					let has_cache_control = tool.cache_control.is_some();
-
-					result.push(bedrock::Tool::ToolSpec(bedrock::ToolSpecification {
-						name: tool_name_map.register(&tool.name),
-						description: tool.description,
-						input_schema: Some(bedrock::ToolInputSchema::Json(tool.input_schema)),
-					}));
-
-					if has_cache_control && cache_points_used < 4 {
-						result.push(bedrock::Tool::CachePoint(helpers::create_cache_point()));
-						cache_points_used += 1;
-					}
+		let tool_config = pending_tool_config.map(|(tools, tool_choice)| {
+			let mut bedrock_tools = Vec::with_capacity(tools.len() * 2);
+			for (tool, has_cache_control) in tools {
+				bedrock_tools.push(tool);
+				if has_cache_control && cache_points_used < 4 {
+					bedrock_tools.push(bedrock::Tool::CachePoint(helpers::create_cache_point()));
+					cache_points_used += 1;
 				}
-				result
-			};
-
-			if bedrock_tools.is_empty() {
-				None
-			} else {
-				let tool_choice = match req.tool_choice {
-					Some(messages::ToolChoice::Auto { .. }) => {
-						if thinking_enabled {
-							Some(bedrock::ToolChoice::Any)
-						} else {
-							Some(bedrock::ToolChoice::Auto)
-						}
-					},
-					Some(messages::ToolChoice::Any { .. }) => Some(bedrock::ToolChoice::Any),
-					Some(messages::ToolChoice::Tool { name, .. }) => {
-						if thinking_enabled {
-							Some(bedrock::ToolChoice::Any)
-						} else {
-							Some(bedrock::ToolChoice::Tool {
-								name: tool_name_map.register(&name),
-							})
-						}
-					},
-					Some(messages::ToolChoice::None {}) | None => {
-						if thinking_enabled {
-							Some(bedrock::ToolChoice::Any)
-						} else {
-							None
-						}
-					},
-				};
-
-				Some(bedrock::ToolConfiguration {
-					tools: bedrock_tools,
-					tool_choice,
-				})
 			}
-		} else {
-			None
-		};
+			bedrock::ToolConfiguration {
+				tools: bedrock_tools,
+				tool_choice,
+			}
+		});
 
 		// Build Anthropic model-specific fields under Converse's additionalModelRequestFields.
 		let mut additional_fields = requested_thinking.map(|thinking| {
@@ -1989,35 +1980,6 @@ pub mod from_responses {
 		})
 	}
 
-	fn collect_responses_tool_names(req: &responses::CreateResponse) -> Vec<String> {
-		use responses::{
-			InputItem, InputParam, Item, Tool, ToolChoiceFunction, ToolChoiceParam,
-		};
-		let mut names = Vec::new();
-		if let Some(tools) = &req.tools {
-			for tool in tools {
-				if let Tool::Function(func) = tool {
-					names.push(func.name.clone());
-				}
-			}
-		}
-		if let Some(ToolChoiceParam::Function(ToolChoiceFunction { name })) = &req.tool_choice {
-			names.push(name.clone());
-		}
-		let items = match &req.input {
-			InputParam::Text(_) => vec![],
-			InputParam::Items(items) => items.clone(),
-		};
-		for item in items {
-			if let InputItem::Item(Item::FunctionCall(call)) = item {
-				names.push(call.name);
-			} else if let InputItem::Item(Item::CustomToolCall(call)) = item {
-				names.push(call.name);
-			}
-		}
-		names
-	}
-
 	pub(super) fn translate_internal(
 		req: responses::CreateResponse,
 		explicit_thinking_budget: Option<u64>,
@@ -2033,9 +1995,83 @@ pub mod from_responses {
 		};
 
 		let mut tool_name_map = super::BedrockToolNameMap::default();
-		for name in collect_responses_tool_names(&req) {
-			tool_name_map.register(&name);
+		for tool in req.tools.iter().flatten() {
+			if let responses::Tool::Function(func) = tool {
+				tool_name_map.register(&func.name);
+			}
 		}
+		if let Some(responses::ToolChoiceParam::Function(responses::ToolChoiceFunction { name })) =
+			&req.tool_choice
+		{
+			tool_name_map.register(name);
+		}
+		if let responses::InputParam::Items(items) = &req.input {
+			for item in items {
+				match item {
+					responses::InputItem::Item(responses::Item::FunctionCall(call)) => {
+						tool_name_map.register(&call.name);
+					},
+					responses::InputItem::Item(responses::Item::CustomToolCall(call)) => {
+						tool_name_map.register(&call.name);
+					},
+					_ => {},
+				}
+			}
+		}
+
+		// Convert tools from typed Responses API format to Bedrock format before messages so
+		// definitions keep priority if a previous tool-use name would otherwise collide.
+		let (tools, tool_choice) = if let Some(response_tools) = &req.tools {
+			let bedrock_tools: Vec<bedrock::Tool> = response_tools
+				.iter()
+				.filter_map(|tool_def| {
+					use responses::Tool;
+					match tool_def {
+						Tool::Function(func) => Some(bedrock::Tool::ToolSpec(bedrock::ToolSpecification {
+							name: tool_name_map.register(&func.name),
+							description: func.description.clone(),
+							input_schema: Some(bedrock::ToolInputSchema::Json(
+								func.parameters.clone().unwrap_or_default(),
+							)),
+						})),
+						_ => {
+							tracing::warn!("Unsupported tool type in Responses API: {:?}", tool_def);
+							None
+						},
+					}
+				})
+				.collect();
+
+			let bedrock_tool_choice = req.tool_choice.as_ref().and_then(|tc| {
+				use responses::{ToolChoiceFunction, ToolChoiceOptions, ToolChoiceParam};
+				match tc {
+					ToolChoiceParam::Mode(ToolChoiceOptions::Auto) => Some(bedrock::ToolChoice::Auto),
+					ToolChoiceParam::Mode(ToolChoiceOptions::Required) => Some(bedrock::ToolChoice::Any),
+					ToolChoiceParam::Mode(ToolChoiceOptions::None) => None,
+					ToolChoiceParam::Function(ToolChoiceFunction { name }) => {
+						Some(bedrock::ToolChoice::Tool {
+							name: tool_name_map.register(&name),
+						})
+					},
+					ToolChoiceParam::Hosted(_) => {
+						tracing::warn!("Hosted tool choice not supported for Bedrock");
+						None
+					},
+					ToolChoiceParam::AllowedTools(_)
+					| ToolChoiceParam::Mcp(_)
+					| ToolChoiceParam::Custom(_)
+					| ToolChoiceParam::ApplyPatch
+					| ToolChoiceParam::Shell => {
+						tracing::warn!("Unsupported tool choice for Bedrock: {:?}", tc);
+						None
+					},
+				}
+			});
+
+			(bedrock_tools, bedrock_tool_choice)
+		} else {
+			(vec![], None)
+		};
 
 		let supports_caching = req.model.as_deref().is_some_and(supports_prompt_caching);
 
@@ -2323,59 +2359,6 @@ pub mod from_responses {
 				}
 			})
 		});
-
-		// Convert tools from typed Responses API format to Bedrock format
-		let (tools, tool_choice) = if let Some(response_tools) = &req.tools {
-			let bedrock_tools: Vec<bedrock::Tool> = response_tools
-				.iter()
-				.filter_map(|tool_def| {
-					use responses::Tool;
-					match tool_def {
-						Tool::Function(func) => Some(bedrock::Tool::ToolSpec(bedrock::ToolSpecification {
-							name: tool_name_map.register(&func.name),
-							description: func.description.clone(),
-							input_schema: Some(bedrock::ToolInputSchema::Json(
-								func.parameters.clone().unwrap_or_default(),
-							)),
-						})),
-						_ => {
-							tracing::warn!("Unsupported tool type in Responses API: {:?}", tool_def);
-							None
-						},
-					}
-				})
-				.collect();
-
-			let bedrock_tool_choice = req.tool_choice.as_ref().and_then(|tc| {
-				use responses::{ToolChoiceFunction, ToolChoiceOptions, ToolChoiceParam};
-				match tc {
-					ToolChoiceParam::Mode(ToolChoiceOptions::Auto) => Some(bedrock::ToolChoice::Auto),
-					ToolChoiceParam::Mode(ToolChoiceOptions::Required) => Some(bedrock::ToolChoice::Any),
-					ToolChoiceParam::Mode(ToolChoiceOptions::None) => None,
-					ToolChoiceParam::Function(ToolChoiceFunction { name }) => {
-						Some(bedrock::ToolChoice::Tool {
-							name: tool_name_map.register(&name),
-						})
-					},
-					ToolChoiceParam::Hosted(_) => {
-						tracing::warn!("Hosted tool choice not supported for Bedrock");
-						None
-					},
-					ToolChoiceParam::AllowedTools(_)
-					| ToolChoiceParam::Mcp(_)
-					| ToolChoiceParam::Custom(_)
-					| ToolChoiceParam::ApplyPatch
-					| ToolChoiceParam::Shell => {
-						tracing::warn!("Unsupported tool choice for Bedrock: {:?}", tc);
-						None
-					},
-				}
-			});
-
-			(bedrock_tools, bedrock_tool_choice)
-		} else {
-			(vec![], None)
-		};
 
 		let tool_config = if !tools.is_empty() {
 			Some(bedrock::ToolConfiguration { tools, tool_choice })

--- a/crates/agentgateway/src/llm/conversion/bedrock.rs
+++ b/crates/agentgateway/src/llm/conversion/bedrock.rs
@@ -931,7 +931,6 @@ pub mod from_completions {
 		let mut tool_calls: HashMap<i32, String> = HashMap::new();
 		let model = model.to_string();
 		let message_id = message_id.to_string();
-		let tool_name_map = tool_name_map;
 		let body = parse::aws_sse::transform(b, buffer_limit, move |f| {
 			let res = bedrock::ConverseStreamOutput::deserialize(f).ok()?;
 			let mk = |choices: Vec<completions::ChatChoiceStream>, usage: Option<completions::Usage>| {
@@ -1688,7 +1687,6 @@ pub mod from_messages {
 		let mut pending_usage: Option<bedrock::TokenUsage> = None;
 		let mut completion = include_completion_in_log.then(String::new);
 		let model = model.to_string();
-		let tool_name_map = tool_name_map;
 		parse::aws_sse::transform_multi(b, buffer_limit, move |aws_event| {
 			let event = match bedrock::ConverseStreamOutput::deserialize(aws_event) {
 				Ok(e) => e,
@@ -2050,7 +2048,7 @@ pub mod from_responses {
 					ToolChoiceParam::Mode(ToolChoiceOptions::None) => None,
 					ToolChoiceParam::Function(ToolChoiceFunction { name }) => {
 						Some(bedrock::ToolChoice::Tool {
-							name: tool_name_map.register(&name),
+							name: tool_name_map.register(name),
 						})
 					},
 					ToolChoiceParam::Hosted(_) => {
@@ -2561,7 +2559,6 @@ pub mod from_responses {
 		// Track message item ID for text content
 		let message_item_id = format!("msg_{:016x}", rand::rng().random::<u64>());
 		let model = model.to_string();
-		let tool_name_map = tool_name_map;
 
 		let response_builder = crate::llm::types::responses::ResponseBuilder::new(response_id, model);
 

--- a/crates/agentgateway/src/llm/conversion/bedrock.rs
+++ b/crates/agentgateway/src/llm/conversion/bedrock.rs
@@ -1,3 +1,6 @@
+use std::collections::{HashMap, HashSet};
+use std::hash::{Hash, Hasher};
+
 use rand::RngExt;
 use tracing::trace;
 
@@ -9,6 +12,119 @@ use crate::llm::types::{bedrock, messages, responses};
 #[cfg(test)]
 #[path = "bedrock_tests.rs"]
 mod tests;
+
+/// Bedrock Converse `toolSpec.name` length limit.
+pub const BEDROCK_TOOL_NAME_MAX_LEN: usize = 64;
+
+/// Serialized Bedrock request body plus any tool-name remapping applied for that request.
+pub struct BedrockRequest {
+	pub body: Vec<u8>,
+	pub tool_name_map: BedrockToolNameMap,
+}
+
+/// Per-request mapping between client tool names and Bedrock-safe tool names.
+#[derive(Debug, Clone, Default)]
+pub struct BedrockToolNameMap {
+	forward: HashMap<String, String>,
+	reverse: HashMap<String, String>,
+	used_sanitized: HashSet<String>,
+}
+
+impl BedrockToolNameMap {
+	pub fn is_empty(&self) -> bool {
+		self.reverse.is_empty()
+	}
+
+	/// Return the Bedrock-safe name for `original`, registering a reverse mapping when sanitized.
+	pub fn register(&mut self, original: &str) -> String {
+		let original = if original.is_empty() {
+			"tool".to_string()
+		} else {
+			original.to_string()
+		};
+		if let Some(mapped) = self.forward.get(&original) {
+			return mapped.clone();
+		}
+
+		if is_valid_bedrock_tool_name(&original) && !self.used_sanitized.contains(&original) {
+			self.used_sanitized.insert(original.clone());
+			self.forward.insert(original.clone(), original.clone());
+			return original;
+		}
+
+		let sanitized = make_valid_bedrock_tool_name(&original, &self.used_sanitized);
+		self.used_sanitized.insert(sanitized.clone());
+		self.forward.insert(original.clone(), sanitized.clone());
+		if sanitized != original {
+			self.reverse.insert(sanitized.clone(), original);
+		}
+		sanitized
+	}
+
+	/// Restore the client-facing tool name from a Bedrock response.
+	pub fn restore(&self, sanitized: &str) -> String {
+		self.reverse
+			.get(sanitized)
+			.cloned()
+			.unwrap_or_else(|| sanitized.to_string())
+	}
+}
+
+fn is_valid_bedrock_tool_name(name: &str) -> bool {
+	!name.is_empty()
+		&& name.len() <= BEDROCK_TOOL_NAME_MAX_LEN
+		&& name
+			.chars()
+			.all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+}
+
+fn sanitize_bedrock_tool_name_chars(name: &str) -> String {
+	let mut out = String::with_capacity(name.len());
+	for c in name.chars() {
+		if c.is_ascii_alphanumeric() || c == '_' || c == '-' {
+			out.push(c);
+		} else {
+			out.push('_');
+		}
+	}
+	if out.is_empty() {
+		"tool".to_string()
+	} else {
+		out
+	}
+}
+
+fn make_valid_bedrock_tool_name(original: &str, used: &HashSet<String>) -> String {
+	let base = sanitize_bedrock_tool_name_chars(original);
+	if base.len() <= BEDROCK_TOOL_NAME_MAX_LEN && !used.contains(&base) {
+		return base;
+	}
+
+	let mut hasher = std::collections::hash_map::DefaultHasher::new();
+	original.hash(&mut hasher);
+	let hash = format!("{:06x}", hasher.finish() & 0xFFFFFF);
+	let prefix_len = BEDROCK_TOOL_NAME_MAX_LEN - 7;
+	let prefix: String = base.chars().take(prefix_len).collect();
+	let mut candidate = format!("{prefix}_{hash}");
+
+	let mut counter = 0u32;
+	while used.contains(&candidate) {
+		counter += 1;
+		let suffix = format!("_{counter:x}");
+		let trim = BEDROCK_TOOL_NAME_MAX_LEN.saturating_sub(suffix.len());
+		candidate = format!(
+			"{}{}",
+			candidate.chars().take(trim).collect::<String>(),
+			suffix
+		);
+	}
+	candidate
+}
+
+fn restore_tool_name(map: Option<&BedrockToolNameMap>, name: &str) -> String {
+	map.map(|m| m.restore(name))
+		.unwrap_or_else(|| name.to_string())
+}
 
 fn error_message(bytes: &[u8]) -> String {
 	serde_json::from_slice::<bedrock::ConverseErrorResponse>(bytes)
@@ -334,6 +450,7 @@ pub mod from_completions {
 
 	fn assistant_content_to_bedrock(
 		msg: &completions::RequestAssistantMessage,
+		tool_name_map: &mut super::BedrockToolNameMap,
 	) -> Vec<bedrock::ContentBlock> {
 		let mut content = Vec::new();
 		// Replay a previously-emitted thinking block first. Anthropic (via Bedrock Converse) requires
@@ -389,7 +506,7 @@ pub mod from_completions {
 							.unwrap_or_else(|_| serde_json::Value::String(call.function.arguments.clone()));
 						content.push(bedrock::ContentBlock::ToolUse(bedrock::ToolUseBlock {
 							tool_use_id: call.id.clone(),
-							name: call.function.name.clone(),
+							name: tool_name_map.register(&call.function.name),
 							input,
 						}));
 					},
@@ -398,7 +515,7 @@ pub mod from_completions {
 							.unwrap_or_else(|_| serde_json::Value::String(call.custom_tool.input.clone()));
 						content.push(bedrock::ContentBlock::ToolUse(bedrock::ToolUseBlock {
 							tool_use_id: call.id.clone(),
-							name: call.custom_tool.name.clone(),
+							name: tool_name_map.register(&call.custom_tool.name),
 							input,
 						}));
 					},
@@ -442,11 +559,50 @@ pub mod from_completions {
 		provider: &Provider,
 		headers: Option<&http::HeaderMap>,
 		prompt_caching: Option<&crate::llm::policy::PromptCachingConfig>,
-	) -> Result<Vec<u8>, AIError> {
+	) -> Result<super::BedrockRequest, AIError> {
 		let typed = json::convert::<_, completions::Request>(req).map_err(AIError::RequestParsing)?;
 		let model_id = typed.model.clone().unwrap_or_default();
-		let xlated = translate_internal(typed, model_id, provider, headers, prompt_caching);
-		serde_json::to_vec(&xlated).map_err(AIError::RequestMarshal)
+		let (xlated, tool_name_map) =
+			translate_internal(typed, model_id, provider, headers, prompt_caching);
+		let body = serde_json::to_vec(&xlated).map_err(AIError::RequestMarshal)?;
+		Ok(super::BedrockRequest {
+			body,
+			tool_name_map,
+		})
+	}
+
+	fn collect_completions_tool_names(req: &completions::Request) -> Vec<String> {
+		let mut names = Vec::new();
+		if let Some(tools) = &req.tools {
+			for tool in tools {
+				if let completions::Tool::Function(function_tool) = tool {
+					names.push(function_tool.function.name.clone());
+				}
+			}
+		}
+		if let Some(completions::ToolChoiceOption::Function(completions::NamedToolChoice {
+			function,
+		})) = &req.tool_choice
+		{
+			names.push(function.name.clone());
+		}
+		for msg in &req.messages {
+			if let completions::RequestMessage::Assistant(assistant) = msg {
+				if let Some(tool_calls) = &assistant.tool_calls {
+					for call in tool_calls {
+						match call {
+							completions::MessageToolCalls::Function(call) => {
+								names.push(call.function.name.clone());
+							},
+							completions::MessageToolCalls::Custom(call) => {
+								names.push(call.custom_tool.name.clone());
+							},
+						}
+					}
+				}
+			}
+		}
+		names
 	}
 
 	pub(super) fn translate_internal(
@@ -455,7 +611,11 @@ pub mod from_completions {
 		provider: &Provider,
 		headers: Option<&http::HeaderMap>,
 		prompt_caching: Option<&crate::llm::policy::PromptCachingConfig>,
-	) -> bedrock::ConverseRequest {
+	) -> (bedrock::ConverseRequest, super::BedrockToolNameMap) {
+		let mut tool_name_map = super::BedrockToolNameMap::default();
+		for name in collect_completions_tool_names(&req) {
+			tool_name_map.register(&name);
+		}
 		// Extract and join system prompts from completions format
 		let system_text = req
 			.messages
@@ -481,7 +641,7 @@ pub mod from_completions {
 					}
 				},
 				completions::RequestMessage::Assistant(assistant) => {
-					let content = assistant_content_to_bedrock(assistant);
+					let content = assistant_content_to_bedrock(assistant, &mut tool_name_map);
 					if content.is_empty() {
 						None
 					} else {
@@ -550,7 +710,7 @@ pub mod from_completions {
 		let tool_choice = match req.tool_choice {
 			Some(completions::ToolChoiceOption::Function(completions::NamedToolChoice { function })) => {
 				Some(bedrock::ToolChoice::Tool {
-					name: function.name,
+					name: tool_name_map.register(&function.name),
 				})
 			},
 			Some(completions::ToolChoiceOption::Mode(completions::ToolChoiceOptions::Auto)) => {
@@ -568,7 +728,7 @@ pub mod from_completions {
 				.filter_map(|tool| match tool {
 					completions::Tool::Function(function_tool) => {
 						let tool_spec = bedrock::ToolSpecification {
-							name: function_tool.function.name,
+							name: tool_name_map.register(&function_tool.function.name),
 							description: function_tool.function.description,
 							input_schema: function_tool
 								.function
@@ -669,7 +829,7 @@ pub mod from_completions {
 			}
 		}
 
-		bedrock_request
+		(bedrock_request, tool_name_map)
 	}
 
 	fn reasoning_effort_to_enabled_budget(effort: &completions::ReasoningEffort) -> Option<u64> {
@@ -721,10 +881,14 @@ pub mod from_completions {
 		})
 	}
 
-	pub fn translate_response(bytes: &Bytes, model: &str) -> Result<Box<dyn ResponseType>, AIError> {
+	pub fn translate_response(
+		bytes: &Bytes,
+		model: &str,
+		tool_name_map: Option<&super::BedrockToolNameMap>,
+	) -> Result<Box<dyn ResponseType>, AIError> {
 		let resp = serde_json::from_slice::<bedrock::ConverseResponse>(bytes)
 			.map_err(logged_response_parsing(bytes))?;
-		let openai = translate_response_internal(resp, model)?;
+		let openai = translate_response_internal(resp, model, tool_name_map)?;
 		let passthrough = json::convert::<_, types::completions::Response>(&openai)
 			.map_err(AIError::ResponseParsing)?;
 		Ok(Box::new(passthrough))
@@ -733,9 +897,10 @@ pub mod from_completions {
 	fn translate_response_internal(
 		resp: bedrock::ConverseResponse,
 		model: &str,
+		tool_name_map: Option<&super::BedrockToolNameMap>,
 	) -> Result<types::completions::typed::Response, AIError> {
 		let adapter = super::ConverseResponseAdapter::from_response(resp, model)?;
-		Ok(adapter.to_completions())
+		Ok(adapter.to_completions(tool_name_map))
 	}
 
 	pub fn translate_error(bytes: &Bytes) -> Result<Bytes, AIError> {
@@ -761,6 +926,7 @@ pub mod from_completions {
 		log: AmendOnDrop,
 		model: &str,
 		message_id: &str,
+		tool_name_map: Option<super::BedrockToolNameMap>,
 	) -> Body {
 		// This is static for all chunks!
 		let created = chrono::Utc::now().timestamp() as u32;
@@ -769,6 +935,7 @@ pub mod from_completions {
 		let mut tool_calls: HashMap<i32, String> = HashMap::new();
 		let model = model.to_string();
 		let message_id = message_id.to_string();
+		let tool_name_map = tool_name_map;
 		let body = parse::aws_sse::transform(b, buffer_limit, move |f| {
 			let res = bedrock::ConverseStreamOutput::deserialize(f).ok()?;
 			let mk = |choices: Vec<completions::ChatChoiceStream>, usage: Option<completions::Usage>| {
@@ -796,7 +963,7 @@ pub mod from_completions {
 								id: Some(tu.tool_use_id),
 								r#type: Some(completions::FunctionType::Function),
 								function: Some(completions::FunctionCallStream {
-									name: Some(tu.name),
+									name: Some(super::restore_tool_name(tool_name_map.as_ref(), &tu.name)),
 									arguments: None,
 								}),
 							}]),
@@ -1020,17 +1187,45 @@ pub mod from_messages {
 		req: &types::messages::Request,
 		provider: &Provider,
 		headers: Option<&http::HeaderMap>,
-	) -> Result<Vec<u8>, AIError> {
+	) -> Result<super::BedrockRequest, AIError> {
 		let typed = json::convert::<_, messages::Request>(req).map_err(AIError::RequestParsing)?;
-		let xlated = translate_internal(typed, provider, headers)?;
-		serde_json::to_vec(&xlated).map_err(AIError::RequestMarshal)
+		let (xlated, tool_name_map) = translate_internal(typed, provider, headers)?;
+		let body = serde_json::to_vec(&xlated).map_err(AIError::RequestMarshal)?;
+		Ok(super::BedrockRequest {
+			body,
+			tool_name_map,
+		})
+	}
+
+	fn collect_messages_tool_names(req: &messages::Request) -> Vec<String> {
+		let mut names = Vec::new();
+		if let Some(tools) = &req.tools {
+			for tool in tools {
+				names.push(tool.name.clone());
+			}
+		}
+		if let Some(messages::ToolChoice::Tool { name, .. }) = &req.tool_choice {
+			names.push(name.clone());
+		}
+		for msg in &req.messages {
+			for block in &msg.content {
+				if let messages::ContentBlock::ToolUse { name, .. } = block {
+					names.push(name.clone());
+				}
+			}
+		}
+		names
 	}
 
 	pub(super) fn translate_internal(
 		req: messages::Request,
 		provider: &Provider,
 		headers: Option<&http::HeaderMap>,
-	) -> Result<bedrock::ConverseRequest, AIError> {
+	) -> Result<(bedrock::ConverseRequest, super::BedrockToolNameMap), AIError> {
+		let mut tool_name_map = super::BedrockToolNameMap::default();
+		for name in collect_messages_tool_names(&req) {
+			tool_name_map.register(&name);
+		}
 		let mut cache_points_used = 0;
 		// Converse placement note (AWS docs):
 		// - Anthropic-specific params are sent via additionalModelRequestFields for Converse:
@@ -1169,7 +1364,7 @@ pub mod from_messages {
 					} => (
 						bedrock::ContentBlock::ToolUse(bedrock::ToolUseBlock {
 							tool_use_id: id,
-							name,
+							name: tool_name_map.register(&name),
 							input,
 						}),
 						cache_control.is_some(),
@@ -1285,7 +1480,7 @@ pub mod from_messages {
 					let has_cache_control = tool.cache_control.is_some();
 
 					result.push(bedrock::Tool::ToolSpec(bedrock::ToolSpecification {
-						name: tool.name,
+						name: tool_name_map.register(&tool.name),
 						description: tool.description,
 						input_schema: Some(bedrock::ToolInputSchema::Json(tool.input_schema)),
 					}));
@@ -1314,7 +1509,9 @@ pub mod from_messages {
 						if thinking_enabled {
 							Some(bedrock::ToolChoice::Any)
 						} else {
-							Some(bedrock::ToolChoice::Tool { name })
+							Some(bedrock::ToolChoice::Tool {
+								name: tool_name_map.register(&name),
+							})
 						}
 					},
 					Some(messages::ToolChoice::None {}) | None => {
@@ -1403,20 +1600,23 @@ pub mod from_messages {
 			Some(metadata)
 		};
 
-		Ok(bedrock::ConverseRequest {
-			model_id: req.model,
-			messages,
-			system: system_content,
-			inference_config: Some(inference_config),
-			output_config,
-			tool_config,
-			guardrail_config,
-			additional_model_request_fields: additional_fields,
-			prompt_variables: None,
-			additional_model_response_field_paths: None,
-			request_metadata: metadata,
-			performance_config: None,
-		})
+		Ok((
+			bedrock::ConverseRequest {
+				model_id: req.model,
+				messages,
+				system: system_content,
+				inference_config: Some(inference_config),
+				output_config,
+				tool_config,
+				guardrail_config,
+				additional_model_request_fields: additional_fields,
+				prompt_variables: None,
+				additional_model_response_field_paths: None,
+				request_metadata: metadata,
+				performance_config: None,
+			},
+			tool_name_map,
+		))
 	}
 
 	fn messages_output_format_to_bedrock_output_config(
@@ -1446,10 +1646,14 @@ pub mod from_messages {
 		})
 	}
 
-	pub fn translate_response(bytes: &Bytes, model: &str) -> Result<Box<dyn ResponseType>, AIError> {
+	pub fn translate_response(
+		bytes: &Bytes,
+		model: &str,
+		tool_name_map: Option<&super::BedrockToolNameMap>,
+	) -> Result<Box<dyn ResponseType>, AIError> {
 		let resp = serde_json::from_slice::<bedrock::ConverseResponse>(bytes)
 			.map_err(logged_response_parsing(bytes))?;
-		let openai = translate_response_internal(resp, model)?;
+		let openai = translate_response_internal(resp, model, tool_name_map)?;
 		let passthrough =
 			json::convert::<_, types::messages::Response>(&openai).map_err(AIError::ResponseParsing)?;
 		Ok(Box::new(passthrough))
@@ -1458,9 +1662,10 @@ pub mod from_messages {
 	fn translate_response_internal(
 		resp: bedrock::ConverseResponse,
 		model: &str,
+		tool_name_map: Option<&super::BedrockToolNameMap>,
 	) -> Result<types::messages::typed::MessagesResponse, AIError> {
 		let adapter = super::ConverseResponseAdapter::from_response(resp, model)?;
-		adapter.to_anthropic()
+		adapter.to_anthropic(tool_name_map)
 	}
 
 	pub fn translate_error(bytes: &Bytes) -> Result<Bytes, AIError> {
@@ -1484,6 +1689,7 @@ pub mod from_messages {
 		model: &str,
 		_message_id: &str,
 		include_completion_in_log: bool,
+		tool_name_map: Option<super::BedrockToolNameMap>,
 	) -> Body {
 		let mut saw_token = false;
 		let mut seen_blocks: HashSet<i32> = HashSet::new();
@@ -1491,6 +1697,7 @@ pub mod from_messages {
 		let mut pending_usage: Option<bedrock::TokenUsage> = None;
 		let mut completion = include_completion_in_log.then(String::new);
 		let model = model.to_string();
+		let tool_name_map = tool_name_map;
 		parse::aws_sse::transform_multi(b, buffer_limit, move |aws_event| {
 			let event = match bedrock::ConverseStreamOutput::deserialize(aws_event) {
 				Ok(e) => e,
@@ -1539,7 +1746,7 @@ pub mod from_messages {
 					let content_block = match start.start {
 						Some(bedrock::ContentBlockStart::ToolUse(s)) => messages::ContentBlock::ToolUse {
 							id: s.tool_use_id,
-							name: s.name,
+							name: super::restore_tool_name(tool_name_map.as_ref(), &s.name),
 							input: serde_json::json!({}),
 							cache_control: None,
 						},
@@ -1762,12 +1969,12 @@ pub mod from_responses {
 		provider: &Provider,
 		headers: Option<&http::HeaderMap>,
 		prompt_caching: Option<&crate::llm::policy::PromptCachingConfig>,
-	) -> Result<Vec<u8>, AIError> {
+	) -> Result<super::BedrockRequest, AIError> {
 		let typed =
 			json::convert::<_, responses::CreateResponse>(req).map_err(AIError::RequestMarshal)?;
 		let explicit_thinking_budget = extract_responses_thinking_budget_tokens(req);
 		let model_id = typed.model.clone().unwrap_or_default();
-		let xlated = translate_internal(
+		let (xlated, tool_name_map) = translate_internal(
 			typed,
 			explicit_thinking_budget,
 			model_id,
@@ -1775,7 +1982,40 @@ pub mod from_responses {
 			headers,
 			prompt_caching,
 		);
-		serde_json::to_vec(&xlated).map_err(AIError::RequestMarshal)
+		let body = serde_json::to_vec(&xlated).map_err(AIError::RequestMarshal)?;
+		Ok(super::BedrockRequest {
+			body,
+			tool_name_map,
+		})
+	}
+
+	fn collect_responses_tool_names(req: &responses::CreateResponse) -> Vec<String> {
+		use responses::{
+			InputItem, InputParam, Item, Tool, ToolChoiceFunction, ToolChoiceParam,
+		};
+		let mut names = Vec::new();
+		if let Some(tools) = &req.tools {
+			for tool in tools {
+				if let Tool::Function(func) = tool {
+					names.push(func.name.clone());
+				}
+			}
+		}
+		if let Some(ToolChoiceParam::Function(ToolChoiceFunction { name })) = &req.tool_choice {
+			names.push(name.clone());
+		}
+		let items = match &req.input {
+			InputParam::Text(_) => vec![],
+			InputParam::Items(items) => items.clone(),
+		};
+		for item in items {
+			if let InputItem::Item(Item::FunctionCall(call)) = item {
+				names.push(call.name);
+			} else if let InputItem::Item(Item::CustomToolCall(call)) = item {
+				names.push(call.name);
+			}
+		}
+		names
 	}
 
 	pub(super) fn translate_internal(
@@ -1785,12 +2025,17 @@ pub mod from_responses {
 		provider: &Provider,
 		headers: Option<&http::HeaderMap>,
 		prompt_caching: Option<&crate::llm::policy::PromptCachingConfig>,
-	) -> bedrock::ConverseRequest {
+	) -> (bedrock::ConverseRequest, super::BedrockToolNameMap) {
 		use responses::{
 			CustomToolCallOutput, CustomToolCallOutputOutput, EasyInputContent, FunctionCallOutput,
 			InputContent, InputItem, InputMessage, InputParam, InputRole, InputTextContent, Item,
 			MessageItem, OutputMessageContent, Role as ResponsesRole,
 		};
+
+		let mut tool_name_map = super::BedrockToolNameMap::default();
+		for name in collect_responses_tool_names(&req) {
+			tool_name_map.register(&name);
+		}
 
 		let supports_caching = req.model.as_deref().is_some_and(supports_prompt_caching);
 
@@ -1929,7 +2174,7 @@ pub mod from_responses {
 							role: bedrock::Role::Assistant,
 							content: vec![bedrock::ContentBlock::ToolUse(bedrock::ToolUseBlock {
 								tool_use_id: call.call_id,
-								name: call.name,
+								name: tool_name_map.register(&call.name),
 								input,
 							})],
 						},
@@ -1971,7 +2216,7 @@ pub mod from_responses {
 							role: bedrock::Role::Assistant,
 							content: vec![bedrock::ContentBlock::ToolUse(bedrock::ToolUseBlock {
 								tool_use_id: call.call_id,
-								name: call.name,
+								name: tool_name_map.register(&call.name),
 								input: serde_json::json!({ "input": call.input }),
 							})],
 						},
@@ -2087,7 +2332,7 @@ pub mod from_responses {
 					use responses::Tool;
 					match tool_def {
 						Tool::Function(func) => Some(bedrock::Tool::ToolSpec(bedrock::ToolSpecification {
-							name: func.name.clone(),
+							name: tool_name_map.register(&func.name),
 							description: func.description.clone(),
 							input_schema: Some(bedrock::ToolInputSchema::Json(
 								func.parameters.clone().unwrap_or_default(),
@@ -2108,7 +2353,9 @@ pub mod from_responses {
 					ToolChoiceParam::Mode(ToolChoiceOptions::Required) => Some(bedrock::ToolChoice::Any),
 					ToolChoiceParam::Mode(ToolChoiceOptions::None) => None,
 					ToolChoiceParam::Function(ToolChoiceFunction { name }) => {
-						Some(bedrock::ToolChoice::Tool { name: name.clone() })
+						Some(bedrock::ToolChoice::Tool {
+							name: tool_name_map.register(&name),
+						})
 					},
 					ToolChoiceParam::Hosted(_) => {
 						tracing::warn!("Hosted tool choice not supported for Bedrock");
@@ -2207,7 +2454,7 @@ pub mod from_responses {
 				.and_then(|tc| tc.tool_choice.as_ref())
 		);
 
-		bedrock_request
+		(bedrock_request, tool_name_map)
 	}
 
 	fn extract_responses_thinking_budget_tokens(req: &types::responses::Request) -> Option<u64> {
@@ -2266,11 +2513,15 @@ pub mod from_responses {
 		})
 	}
 
-	pub fn translate_response(bytes: &Bytes, model: &str) -> Result<Box<dyn ResponseType>, AIError> {
+	pub fn translate_response(
+		bytes: &Bytes,
+		model: &str,
+		tool_name_map: Option<&super::BedrockToolNameMap>,
+	) -> Result<Box<dyn ResponseType>, AIError> {
 		let resp = serde_json::from_slice::<bedrock::ConverseResponse>(bytes)
 			.map_err(logged_response_parsing(bytes))?;
 		let adapter = super::ConverseResponseAdapter::from_response(resp, model)?;
-		let typed = adapter.to_responses_typed();
+		let typed = adapter.to_responses_typed(tool_name_map);
 		let mut passthrough =
 			json::convert::<_, types::responses::Response>(&typed).map_err(AIError::ResponseParsing)?;
 		passthrough.rest = serde_json::Value::Object(serde_json::Map::new());
@@ -2306,6 +2557,7 @@ pub mod from_responses {
 		log: AmendOnDrop,
 		model: &str,
 		_message_id: &str,
+		tool_name_map: Option<super::BedrockToolNameMap>,
 	) -> Body {
 		let mut saw_token = false;
 		let mut pending_stop_reason: Option<bedrock::StopReason> = None;
@@ -2326,6 +2578,7 @@ pub mod from_responses {
 		// Track message item ID for text content
 		let message_item_id = format!("msg_{:016x}", rand::rng().random::<u64>());
 		let model = model.to_string();
+		let tool_name_map = tool_name_map;
 
 		let response_builder = crate::llm::types::responses::ResponseBuilder::new(response_id, model);
 
@@ -2393,11 +2646,12 @@ pub mod from_responses {
 							let tool_call_item_id = format!("call_{:016x}", rand::rng().random::<u64>());
 							let output_index = next_output_index;
 							next_output_index += 1;
+							let restored_name = super::restore_tool_name(tool_name_map.as_ref(), &tu.name);
 							tool_calls.insert(
 								start.content_block_index,
 								(
 									tool_call_item_id.clone(),
-									tu.name.clone(),
+									restored_name.clone(),
 									String::new(),
 									output_index,
 								),
@@ -2412,7 +2666,7 @@ pub mod from_responses {
 										arguments: String::new(),
 										call_id: tool_call_item_id.clone(),
 										namespace: None,
-										name: tu.name,
+										name: restored_name,
 										id: Some(tool_call_item_id),
 										status: Some(OutputStatus::InProgress),
 									}),
@@ -2945,7 +3199,10 @@ impl ConverseResponseAdapter {
 		})
 	}
 
-	fn to_completions(&self) -> crate::llm::types::completions::typed::Response {
+	fn to_completions(
+		&self,
+		tool_name_map: Option<&BedrockToolNameMap>,
+	) -> crate::llm::types::completions::typed::Response {
 		use crate::llm::types::completions::typed as completions;
 		let mut tool_calls: Vec<completions::MessageToolCalls> = Vec::new();
 		let mut content = None;
@@ -2985,7 +3242,7 @@ impl ConverseResponseAdapter {
 						completions::MessageToolCall {
 							id: tu.tool_use_id.clone(),
 							function: completions::FunctionCall {
-								name: tu.name.clone(),
+								name: restore_tool_name(tool_name_map, &tu.name),
 								arguments: args,
 							},
 						},
@@ -3055,7 +3312,10 @@ impl ConverseResponseAdapter {
 		}
 	}
 
-	fn to_responses_typed(&self) -> responses::typed::Response {
+	fn to_responses_typed(
+		&self,
+		tool_name_map: Option<&BedrockToolNameMap>,
+	) -> responses::typed::Response {
 		use crate::llm::types::responses::typed as responsest;
 		let response_id = format!("resp_{:016x}", rand::rng().random::<u64>());
 		let response_builder =
@@ -3101,7 +3361,7 @@ impl ConverseResponseAdapter {
 							arguments: arguments_str,
 							call_id: tool_use.tool_use_id.clone(),
 							namespace: None,
-							name: tool_use.name.clone(),
+							name: restore_tool_name(tool_name_map, &tool_use.name),
 							id: Some(tool_use.tool_use_id.clone()),
 							status: Some(responsest::OutputStatus::Completed),
 						},
@@ -3180,10 +3440,14 @@ impl ConverseResponseAdapter {
 		response
 	}
 
-	fn to_anthropic(&self) -> Result<messages::typed::MessagesResponse, AIError> {
+	fn to_anthropic(
+		&self,
+		tool_name_map: Option<&BedrockToolNameMap>,
+	) -> Result<messages::typed::MessagesResponse, AIError> {
 		use crate::llm::types::messages::typed as messagest;
 		fn translate_content_block_to_anthropic(
 			block: &bedrock::ContentBlock,
+			tool_name_map: Option<&BedrockToolNameMap>,
 		) -> Option<messagest::ContentBlock> {
 			match block {
 				bedrock::ContentBlock::Text(text) => {
@@ -3209,7 +3473,7 @@ impl ConverseResponseAdapter {
 				},
 				bedrock::ContentBlock::ToolUse(tool_use) => Some(messagest::ContentBlock::ToolUse {
 					id: tool_use.tool_use_id.clone(),
-					name: tool_use.name.clone(),
+					name: restore_tool_name(tool_name_map, &tool_use.name),
 					input: tool_use.input.clone(),
 					cache_control: None,
 				}),
@@ -3231,7 +3495,7 @@ impl ConverseResponseAdapter {
 			.message
 			.content
 			.iter()
-			.filter_map(translate_content_block_to_anthropic)
+			.filter_map(|block| translate_content_block_to_anthropic(block, tool_name_map))
 			.collect();
 
 		let usage = self

--- a/crates/agentgateway/src/llm/conversion/bedrock_tests.rs
+++ b/crates/agentgateway/src/llm/conversion/bedrock_tests.rs
@@ -155,7 +155,7 @@ fn test_metadata_from_header() {
 		output_config: None,
 	};
 
-	let out = super::from_messages::translate_internal(req, &provider, Some(&headers)).unwrap();
+	let (out, _) = super::from_messages::translate_internal(req, &provider, Some(&headers)).unwrap();
 	let metadata = out.request_metadata.unwrap();
 
 	assert_eq!(metadata.get("user_id"), Some(&"user123".to_string()));
@@ -210,7 +210,7 @@ fn test_messages_metadata_is_preserved_in_additional_model_request_fields() {
 		output_config: None,
 	};
 
-	let out = super::from_messages::translate_internal(req, &provider, None).unwrap();
+	let (out, _) = super::from_messages::translate_internal(req, &provider, None).unwrap();
 	let additional_fields = out.additional_model_request_fields.unwrap();
 	let metadata = additional_fields.get("metadata").unwrap();
 
@@ -259,7 +259,7 @@ fn test_output_config_effort_without_thinking_is_passed_through() {
 		}),
 	};
 
-	let out = super::from_messages::translate_internal(req, &provider, None).unwrap();
+	let (out, _) = super::from_messages::translate_internal(req, &provider, None).unwrap();
 	assert_eq!(
 		out.additional_model_request_fields,
 		Some(json!({
@@ -324,7 +324,7 @@ fn test_output_config_format_maps_to_converse_output_config() {
 		}),
 	};
 
-	let out = super::from_messages::translate_internal(req, &provider, None).unwrap();
+	let (out, _) = super::from_messages::translate_internal(req, &provider, None).unwrap();
 	assert_eq!(
 		out.additional_model_request_fields,
 		Some(json!({
@@ -390,7 +390,7 @@ fn test_explicit_empty_output_config_is_preserved() {
 		}),
 	};
 
-	let out = super::from_messages::translate_internal(req, &provider, None).unwrap();
+	let (out, _) = super::from_messages::translate_internal(req, &provider, None).unwrap();
 	assert_eq!(
 		out.additional_model_request_fields,
 		Some(json!({
@@ -449,7 +449,7 @@ fn test_thinking_and_output_config_are_both_passed_through() {
 		}),
 	};
 
-	let out = super::from_messages::translate_internal(req, &provider, None).unwrap();
+	let (out, _) = super::from_messages::translate_internal(req, &provider, None).unwrap();
 	assert_eq!(
 		out.additional_model_request_fields,
 		Some(json!({
@@ -515,7 +515,7 @@ fn test_adaptive_thinking_preserves_sampling_and_tool_choice() {
 		output_config: None,
 	};
 
-	let out = super::from_messages::translate_internal(req, &provider, None).unwrap();
+	let (out, _) = super::from_messages::translate_internal(req, &provider, None).unwrap();
 	let inference = out.inference_config.unwrap();
 	assert_eq!(inference.temperature, Some(0.7));
 	assert_eq!(inference.top_p, Some(0.8));
@@ -592,7 +592,7 @@ fn test_enabled_thinking_applies_sampling_and_tool_choice_constraints() {
 		output_config: None,
 	};
 
-	let out = super::from_messages::translate_internal(req, &provider, None).unwrap();
+	let (out, _) = super::from_messages::translate_internal(req, &provider, None).unwrap();
 	let inference = out.inference_config.unwrap();
 	assert_eq!(inference.temperature, None);
 	assert_eq!(inference.top_p, None);
@@ -719,7 +719,7 @@ fn test_completions_request_metadata_only_uses_bedrock_header() {
 			.unwrap(),
 	);
 
-	let out = super::from_completions::translate_internal(
+	let (out, _) = super::from_completions::translate_internal(
 		req,
 		"anthropic.claude-3-sonnet".to_string(),
 		&provider,
@@ -810,7 +810,7 @@ fn test_completions_json_schema_response_format_maps_to_converse_output_config()
 		reasoning_effort: None,
 	};
 
-	let out = super::from_completions::translate_internal(
+	let (out, _) = super::from_completions::translate_internal(
 		req,
 		"anthropic.claude-3-sonnet".to_string(),
 		&provider,
@@ -890,7 +890,7 @@ fn test_completions_reasoning_effort_maps_to_enabled_thinking_budget() {
 		reasoning_effort: Some(types::completions::typed::ReasoningEffort::Xhigh),
 	};
 
-	let out = super::from_completions::translate_internal(
+	let (out, _) = super::from_completions::translate_internal(
 		req,
 		"anthropic.claude-3-sonnet".to_string(),
 		&provider,
@@ -968,7 +968,7 @@ fn test_completions_explicit_thinking_budget_forces_enabled_thinking() {
 		reasoning_effort: Some(types::completions::typed::ReasoningEffort::High),
 	};
 
-	let out = super::from_completions::translate_internal(
+	let (out, _) = super::from_completions::translate_internal(
 		req,
 		"anthropic.claude-3-sonnet".to_string(),
 		&provider,
@@ -1021,7 +1021,9 @@ fn test_responses_json_schema_text_format_maps_to_converse_output_config() {
 	}))
 	.expect("valid responses request");
 
-	let translated = super::from_responses::translate(&req, &provider, None, None).unwrap();
+	let translated = super::from_responses::translate(&req, &provider, None, None)
+		.unwrap()
+		.body;
 	let translated: serde_json::Value = serde_json::from_slice(&translated).unwrap();
 
 	assert_eq!(
@@ -1072,7 +1074,9 @@ fn test_responses_request_metadata_only_uses_bedrock_header() {
 			.unwrap(),
 	);
 
-	let translated = super::from_responses::translate(&req, &provider, Some(&headers), None).unwrap();
+	let translated = super::from_responses::translate(&req, &provider, Some(&headers), None)
+		.unwrap()
+		.body;
 	let translated: serde_json::Value = serde_json::from_slice(&translated).unwrap();
 	let metadata = translated["requestMetadata"]
 		.as_object()
@@ -1107,7 +1111,9 @@ fn test_responses_reasoning_effort_maps_to_enabled_thinking_budget() {
 	}))
 	.expect("valid responses request");
 
-	let translated = super::from_responses::translate(&req, &provider, None, None).unwrap();
+	let translated = super::from_responses::translate(&req, &provider, None, None)
+		.unwrap()
+		.body;
 	let translated: serde_json::Value = serde_json::from_slice(&translated).unwrap();
 
 	assert_eq!(
@@ -1145,7 +1151,9 @@ fn test_responses_explicit_thinking_budget_forces_enabled_thinking() {
 	}))
 	.expect("valid responses request");
 
-	let translated = super::from_responses::translate(&req, &provider, None, None).unwrap();
+	let translated = super::from_responses::translate(&req, &provider, None, None)
+		.unwrap()
+		.body;
 	let translated: serde_json::Value = serde_json::from_slice(&translated).unwrap();
 
 	assert_eq!(
@@ -1180,7 +1188,9 @@ fn test_responses_vendor_extension_thinking_budget_forces_enabled_thinking() {
 	}))
 	.expect("valid responses request");
 
-	let translated = super::from_responses::translate(&req, &provider, None, None).unwrap();
+	let translated = super::from_responses::translate(&req, &provider, None, None)
+		.unwrap()
+		.body;
 	let translated: serde_json::Value = serde_json::from_slice(&translated).unwrap();
 
 	assert_eq!(
@@ -1496,4 +1506,186 @@ fn test_insert_cache_point_empty_messages_noop() {
 	let mut msgs: Vec<types::bedrock::Message> = vec![];
 	helpers::insert_message_cache_point(&mut msgs, 0);
 	assert!(msgs.is_empty());
+}
+
+#[test]
+fn test_bedrock_tool_name_sanitizes_long_mcp_names() {
+	let long_name = "mcp__plugin_atlassian_atlassian__createCompassComponentRelationship";
+	assert!(long_name.len() > super::BEDROCK_TOOL_NAME_MAX_LEN);
+
+	let mut map = super::BedrockToolNameMap::default();
+	let sanitized = map.register(long_name);
+
+	assert!(sanitized.len() <= super::BEDROCK_TOOL_NAME_MAX_LEN);
+	assert!(sanitized.chars().all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-'));
+	assert_eq!(map.restore(&sanitized), long_name);
+}
+
+#[test]
+fn test_bedrock_tool_name_preserves_valid_short_names() {
+	let mut map = super::BedrockToolNameMap::default();
+	let name = "get_weather";
+	assert_eq!(map.register(name), name);
+	assert_eq!(map.restore(name), name);
+	assert!(map.is_empty());
+}
+
+#[test]
+fn test_bedrock_tool_name_sanitizes_invalid_characters() {
+	let mut map = super::BedrockToolNameMap::default();
+	let sanitized = map.register("my.tool/name");
+	assert_eq!(sanitized, "my_tool_name");
+}
+
+#[test]
+fn test_messages_long_tool_names_fit_bedrock_tool_config() {
+	use types::messages::typed as messages;
+
+	let long_name = "mcp__plugin_atlassian_atlassian__createCompassComponentRelationship";
+	let provider = Provider {
+		model: None,
+		region: strng::new("us-west-2"),
+		guardrail_identifier: None,
+		guardrail_version: None,
+		source_credentials_cache: Default::default(),
+		assume_role_cache: Default::default(),
+	};
+
+	let req = messages::Request {
+		model: "anthropic.claude-sonnet-4-20250514-v1:0".to_string(),
+		max_tokens: 1024,
+		messages: vec![messages::Message {
+			role: messages::Role::User,
+			content: vec![messages::ContentBlock::Text(messages::ContentTextBlock {
+				text: "hello".to_string(),
+				citations: None,
+				cache_control: None,
+			})],
+		}],
+		tools: Some(vec![messages::Tool {
+			name: long_name.to_string(),
+			description: Some("test".to_string()),
+			input_schema: serde_json::json!({"type": "object"}),
+			cache_control: None,
+		}]),
+		tool_choice: None,
+		system: None,
+		metadata: None,
+		stop_sequences: vec![],
+		stream: false,
+		temperature: None,
+		top_p: None,
+		top_k: None,
+		thinking: None,
+		output_config: None,
+	};
+
+	let (out, tool_map) = super::from_messages::translate_internal(req, &provider, None).unwrap();
+	let bedrock_name = out
+		.tool_config
+		.as_ref()
+		.and_then(|tc| tc.tools.first())
+		.and_then(|tool| match tool {
+			types::bedrock::Tool::ToolSpec(spec) => Some(spec.name.clone()),
+			_ => None,
+		})
+		.expect("tool spec");
+
+	assert!(bedrock_name.len() <= super::BEDROCK_TOOL_NAME_MAX_LEN);
+	assert_eq!(tool_map.restore(&bedrock_name), long_name);
+}
+
+#[test]
+fn test_messages_long_tool_name_round_trip_response() {
+	use types::messages::typed as messages;
+
+	let long_name = "mcp__plugin_atlassian_atlassian__createCompassComponentRelationship";
+	let provider = Provider {
+		model: None,
+		region: strng::new("us-west-2"),
+		guardrail_identifier: None,
+		guardrail_version: None,
+		source_credentials_cache: Default::default(),
+		assume_role_cache: Default::default(),
+	};
+
+	let req = messages::Request {
+		model: "anthropic.claude-sonnet-4-20250514-v1:0".to_string(),
+		max_tokens: 1024,
+		messages: vec![messages::Message {
+			role: messages::Role::User,
+			content: vec![messages::ContentBlock::Text(messages::ContentTextBlock {
+				text: "hello".to_string(),
+				citations: None,
+				cache_control: None,
+			})],
+		}],
+		tools: Some(vec![messages::Tool {
+			name: long_name.to_string(),
+			description: Some("test".to_string()),
+			input_schema: serde_json::json!({"type": "object"}),
+			cache_control: None,
+		}]),
+		tool_choice: None,
+		system: None,
+		metadata: None,
+		stop_sequences: vec![],
+		stream: false,
+		temperature: None,
+		top_p: None,
+		top_k: None,
+		thinking: None,
+		output_config: None,
+	};
+
+	let (bedrock_req, tool_map) = super::from_messages::translate_internal(req, &provider, None).unwrap();
+	let bedrock_name = bedrock_req
+		.tool_config
+		.as_ref()
+		.and_then(|tc| tc.tools.first())
+		.and_then(|tool| match tool {
+			types::bedrock::Tool::ToolSpec(spec) => Some(spec.name.clone()),
+			_ => None,
+		})
+		.expect("sanitized tool name");
+	let model = "anthropic.claude-sonnet-4-20250514-v1:0";
+
+	let bedrock_response = json!({
+		"output": {
+			"message": {
+				"role": "assistant",
+				"content": [{
+					"toolUse": {
+						"toolUseId": "toolu_01TestRoundTrip",
+						"name": bedrock_name,
+						"input": {"query": "test"}
+					}
+				}]
+			}
+		},
+		"stopReason": "tool_use",
+		"usage": {
+			"inputTokens": 100,
+			"outputTokens": 20,
+			"totalTokens": 120
+		}
+	});
+	let bytes = Bytes::from(serde_json::to_vec(&bedrock_response).unwrap());
+
+	let response = super::from_messages::translate_response(&bytes, model, Some(&tool_map)).unwrap();
+	let response_json: serde_json::Value =
+		serde_json::from_slice(&response.serialize().unwrap()).unwrap();
+	let tool_use_name = response_json["content"]
+		.as_array()
+		.and_then(|blocks| {
+			blocks.iter().find_map(|block| {
+				block
+					.get("name")
+					.and_then(|n| n.as_str())
+					.filter(|_| block.get("type").and_then(|t| t.as_str()) == Some("tool_use"))
+			})
+		})
+		.expect("tool use block in response");
+
+	assert_eq!(tool_use_name, long_name);
 }

--- a/crates/agentgateway/src/llm/conversion/bedrock_tests.rs
+++ b/crates/agentgateway/src/llm/conversion/bedrock_tests.rs
@@ -1517,7 +1517,11 @@ fn test_bedrock_tool_name_sanitizes_long_mcp_names() {
 	let sanitized = map.register(long_name);
 
 	assert!(sanitized.len() <= super::BEDROCK_TOOL_NAME_MAX_LEN);
-	assert!(sanitized.chars().all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-'));
+	assert!(
+		sanitized
+			.chars()
+			.all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+	);
 	assert_eq!(map.restore(&sanitized), long_name);
 }
 
@@ -1638,7 +1642,8 @@ fn test_messages_long_tool_name_round_trip_response() {
 		output_config: None,
 	};
 
-	let (bedrock_req, tool_map) = super::from_messages::translate_internal(req, &provider, None).unwrap();
+	let (bedrock_req, tool_map) =
+		super::from_messages::translate_internal(req, &provider, None).unwrap();
 	let bedrock_name = bedrock_req
 		.tool_config
 		.as_ref()

--- a/crates/agentgateway/src/llm/cost/mod.rs
+++ b/crates/agentgateway/src/llm/cost/mod.rs
@@ -646,7 +646,7 @@ mod tests {
 				streaming: false,
 				params: Default::default(),
 				prompt: None,
-				bedrock_tool_names: None,
+				provider_state: None,
 			},
 			response: LLMResponse {
 				input_tokens: Some(1_000_000),

--- a/crates/agentgateway/src/llm/cost/mod.rs
+++ b/crates/agentgateway/src/llm/cost/mod.rs
@@ -646,6 +646,7 @@ mod tests {
 				streaming: false,
 				params: Default::default(),
 				prompt: None,
+				bedrock_tool_names: None,
 			},
 			response: LLMResponse {
 				input_tokens: Some(1_000_000),

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -1665,21 +1665,21 @@ impl AIProvider {
 				conversion::bedrock::from_completions::translate_response(
 					bytes,
 					&req.request_model,
-					bedrock_tool_name_map(&req),
+					bedrock_tool_name_map(req),
 				)
 			},
 			(AIProvider::Bedrock(_), InputFormat::Messages) => {
 				conversion::bedrock::from_messages::translate_response(
 					bytes,
 					&req.request_model,
-					bedrock_tool_name_map(&req),
+					bedrock_tool_name_map(req),
 				)
 			},
 			(AIProvider::Bedrock(_), InputFormat::Responses) => {
 				conversion::bedrock::from_responses::translate_response(
 					bytes,
 					&req.request_model,
-					bedrock_tool_name_map(&req),
+					bedrock_tool_name_map(req),
 				)
 			},
 			(AIProvider::Vertex(p), InputFormat::Completions) => {

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -175,6 +175,8 @@ pub struct LLMRequest {
 	pub streaming: bool,
 	pub params: LLMRequestParams,
 	pub prompt: Option<Arc<Vec<SimpleChatCompletionMessage>>>,
+	/// Reverse mapping from Bedrock-safe tool names back to client tool names.
+	pub bedrock_tool_names: Option<Arc<conversion::bedrock::BedrockToolNameMap>>,
 }
 
 /// Whether an upstream's reported `input_tokens` already includes cached tokens.
@@ -1153,7 +1155,6 @@ impl AIProvider {
 		{
 			llm_info.prompt = Some(req.get_messages().into());
 		}
-		parts.extensions.insert(llm_info.clone());
 
 		let request_model = llm_info.request_model.as_str();
 		let new_request = if original_format == InputFormat::CountTokens {
@@ -1235,13 +1236,21 @@ impl AIProvider {
 					}
 				},
 				AIProvider::Anthropic(_) => req.to_anthropic()?,
-				AIProvider::Bedrock(p) => req.to_bedrock(
-					p,
-					Some(&parts.headers),
-					policies.and_then(|p| p.prompt_caching.as_ref()),
-				)?,
+				AIProvider::Bedrock(p) => {
+					let bedrock = req.to_bedrock(
+						p,
+						Some(&parts.headers),
+						policies.and_then(|p| p.prompt_caching.as_ref()),
+					)?;
+					if !bedrock.tool_name_map.is_empty() {
+						llm_info.bedrock_tool_names = Some(Arc::new(bedrock.tool_name_map));
+					}
+					bedrock.body
+				},
 			}
 		};
+
+		parts.extensions.insert(llm_info.clone());
 
 		parts.headers.remove(header::CONTENT_LENGTH);
 		let req = Request::from_parts(parts, Body::from(new_request));
@@ -1644,13 +1653,25 @@ impl AIProvider {
 				conversion::messages::from_completions::translate_response(bytes)
 			},
 			(AIProvider::Bedrock(_), InputFormat::Completions) => {
-				conversion::bedrock::from_completions::translate_response(bytes, &req.request_model)
+				conversion::bedrock::from_completions::translate_response(
+					bytes,
+					&req.request_model,
+					req.bedrock_tool_names.as_deref(),
+				)
 			},
 			(AIProvider::Bedrock(_), InputFormat::Messages) => {
-				conversion::bedrock::from_messages::translate_response(bytes, &req.request_model)
+				conversion::bedrock::from_messages::translate_response(
+					bytes,
+					&req.request_model,
+					req.bedrock_tool_names.as_deref(),
+				)
 			},
 			(AIProvider::Bedrock(_), InputFormat::Responses) => {
-				conversion::bedrock::from_responses::translate_response(bytes, &req.request_model)
+				conversion::bedrock::from_responses::translate_response(
+					bytes,
+					&req.request_model,
+					req.bedrock_tool_names.as_deref(),
+				)
 			},
 			(AIProvider::Vertex(p), InputFormat::Completions) => {
 				if p.is_anthropic_model(Some(&req.request_model)) {
@@ -1709,6 +1730,7 @@ impl AIProvider {
 		let model = req.request_model.clone();
 		let input_format = req.input_format;
 		let native_format = req.native_format;
+		let bedrock_tool_names = req.bedrock_tool_names.clone();
 		// Store an empty response, as we stream in info we will parse into it
 		let llmresp = llm::LLMInfo {
 			request: req,
@@ -1869,12 +1891,21 @@ impl AIProvider {
 			},
 			(AIProvider::Bedrock(_), InputFormat::Completions, _) => {
 				let msg = conversion::bedrock::message_id(&resp);
+				let tool_name_map = bedrock_tool_names.as_ref().map(|m| m.as_ref().clone());
 				resp.map(move |b| {
-					conversion::bedrock::from_completions::translate_stream(b, buffer, logger, &model, &msg)
+					conversion::bedrock::from_completions::translate_stream(
+						b,
+						buffer,
+						logger,
+						&model,
+						&msg,
+						tool_name_map,
+					)
 				})
 			},
 			(AIProvider::Bedrock(_), InputFormat::Messages, _) => {
 				let msg = conversion::bedrock::message_id(&resp);
+				let tool_name_map = bedrock_tool_names.as_ref().map(|m| m.as_ref().clone());
 				resp.map(move |b| {
 					conversion::bedrock::from_messages::translate_stream(
 						b,
@@ -1883,13 +1914,22 @@ impl AIProvider {
 						&model,
 						&msg,
 						include_completion_in_log,
+						tool_name_map,
 					)
 				})
 			},
 			(AIProvider::Bedrock(_), InputFormat::Responses, _) => {
 				let msg = conversion::bedrock::message_id(&resp);
+				let tool_name_map = bedrock_tool_names.as_ref().map(|m| m.as_ref().clone());
 				resp.map(move |b| {
-					conversion::bedrock::from_responses::translate_stream(b, buffer, logger, &model, &msg)
+					conversion::bedrock::from_responses::translate_stream(
+						b,
+						buffer,
+						logger,
+						&model,
+						&msg,
+						tool_name_map,
+					)
 				})
 			},
 			(_, InputFormat::Realtime, _) => {

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -175,8 +175,15 @@ pub struct LLMRequest {
 	pub streaming: bool,
 	pub params: LLMRequestParams,
 	pub prompt: Option<Arc<Vec<SimpleChatCompletionMessage>>>,
-	/// Reverse mapping from Bedrock-safe tool names back to client tool names.
-	pub bedrock_tool_names: Option<Arc<conversion::bedrock::BedrockToolNameMap>>,
+	pub provider_state: Option<ProviderState>,
+}
+
+#[derive(Debug, Clone)]
+pub enum ProviderState {
+	Bedrock {
+		/// Reverse mapping from Bedrock-safe tool names back to client tool names.
+		tool_names: Arc<conversion::bedrock::BedrockToolNameMap>,
+	},
 }
 
 /// Whether an upstream's reported `input_tokens` already includes cached tokens.
@@ -1243,7 +1250,9 @@ impl AIProvider {
 						policies.and_then(|p| p.prompt_caching.as_ref()),
 					)?;
 					if !bedrock.tool_name_map.is_empty() {
-						llm_info.bedrock_tool_names = Some(Arc::new(bedrock.tool_name_map));
+						llm_info.provider_state = Some(ProviderState::Bedrock {
+							tool_names: Arc::new(bedrock.tool_name_map),
+						});
 					}
 					bedrock.body
 				},
@@ -1656,21 +1665,21 @@ impl AIProvider {
 				conversion::bedrock::from_completions::translate_response(
 					bytes,
 					&req.request_model,
-					req.bedrock_tool_names.as_deref(),
+					bedrock_tool_name_map(&req),
 				)
 			},
 			(AIProvider::Bedrock(_), InputFormat::Messages) => {
 				conversion::bedrock::from_messages::translate_response(
 					bytes,
 					&req.request_model,
-					req.bedrock_tool_names.as_deref(),
+					bedrock_tool_name_map(&req),
 				)
 			},
 			(AIProvider::Bedrock(_), InputFormat::Responses) => {
 				conversion::bedrock::from_responses::translate_response(
 					bytes,
 					&req.request_model,
-					req.bedrock_tool_names.as_deref(),
+					bedrock_tool_name_map(&req),
 				)
 			},
 			(AIProvider::Vertex(p), InputFormat::Completions) => {
@@ -1730,7 +1739,7 @@ impl AIProvider {
 		let model = req.request_model.clone();
 		let input_format = req.input_format;
 		let native_format = req.native_format;
-		let bedrock_tool_names = req.bedrock_tool_names.clone();
+		let bedrock_tool_name_map = bedrock_tool_name_map(&req).cloned();
 		// Store an empty response, as we stream in info we will parse into it
 		let llmresp = llm::LLMInfo {
 			request: req,
@@ -1891,7 +1900,7 @@ impl AIProvider {
 			},
 			(AIProvider::Bedrock(_), InputFormat::Completions, _) => {
 				let msg = conversion::bedrock::message_id(&resp);
-				let tool_name_map = bedrock_tool_names.as_ref().map(|m| m.as_ref().clone());
+				let tool_name_map = bedrock_tool_name_map.clone();
 				resp.map(move |b| {
 					conversion::bedrock::from_completions::translate_stream(
 						b,
@@ -1905,7 +1914,7 @@ impl AIProvider {
 			},
 			(AIProvider::Bedrock(_), InputFormat::Messages, _) => {
 				let msg = conversion::bedrock::message_id(&resp);
-				let tool_name_map = bedrock_tool_names.as_ref().map(|m| m.as_ref().clone());
+				let tool_name_map = bedrock_tool_name_map.clone();
 				resp.map(move |b| {
 					conversion::bedrock::from_messages::translate_stream(
 						b,
@@ -1920,7 +1929,7 @@ impl AIProvider {
 			},
 			(AIProvider::Bedrock(_), InputFormat::Responses, _) => {
 				let msg = conversion::bedrock::message_id(&resp);
-				let tool_name_map = bedrock_tool_names.as_ref().map(|m| m.as_ref().clone());
+				let tool_name_map = bedrock_tool_name_map.clone();
 				resp.map(move |b| {
 					conversion::bedrock::from_responses::translate_stream(
 						b,
@@ -2109,6 +2118,13 @@ impl AIProvider {
 				"this provider and format is not supported"
 			))),
 		}
+	}
+}
+
+fn bedrock_tool_name_map(req: &LLMRequest) -> Option<&conversion::bedrock::BedrockToolNameMap> {
+	match &req.provider_state {
+		Some(ProviderState::Bedrock { tool_names }) => Some(tool_names.as_ref()),
+		_ => None,
 	}
 }
 

--- a/crates/agentgateway/src/llm/tests.rs
+++ b/crates/agentgateway/src/llm/tests.rs
@@ -21,7 +21,7 @@ fn llm_request_with_tokens(input_tokens: Option<u64>) -> LLMRequest {
 		streaming: true,
 		params: Default::default(),
 		prompt: None,
-		bedrock_tool_names: None,
+		provider_state: None,
 	}
 }
 
@@ -811,7 +811,7 @@ mod response {
 			streaming: false,
 			params: Default::default(),
 			prompt: None,
-			bedrock_tool_names: None,
+			provider_state: None,
 		}
 	}
 
@@ -1365,7 +1365,7 @@ async fn process_response_routes_streaming_error_to_buffered_path() {
 		streaming: true,
 		params: Default::default(),
 		prompt: None,
-		bedrock_tool_names: None,
+		provider_state: None,
 	};
 
 	let body = Body::from(error_json.as_bytes().to_vec());
@@ -1454,7 +1454,7 @@ async fn process_streaming_bedrock_completions_normalizes_sse_headers_and_done()
 				streaming: true,
 				params: Default::default(),
 				prompt: None,
-				bedrock_tool_names: None,
+				provider_state: None,
 			},
 			LLMResponsePolicies::default(),
 			None,
@@ -1555,7 +1555,7 @@ fn setup_request_custom_path_override_wins_over_format_path() {
 		streaming: false,
 		params: Default::default(),
 		prompt: None,
-		bedrock_tool_names: None,
+		provider_state: None,
 	};
 	let mut req = crate::http::tests_common::request(
 		"https://proxy.example.com/v1/chat/completions?trace=repro",
@@ -1589,7 +1589,7 @@ fn llm_request_for_path(request_model: &str) -> LLMRequest {
 		streaming: false,
 		params: Default::default(),
 		prompt: None,
-		bedrock_tool_names: None,
+		provider_state: None,
 	}
 }
 
@@ -1719,7 +1719,7 @@ async fn bedrock_from_messages_stream_captures_completion() {
 			streaming: true,
 			params: Default::default(),
 			prompt: None,
-			bedrock_tool_names: None,
+			provider_state: None,
 		},
 		response: LLMResponse::default(),
 	};
@@ -1767,7 +1767,7 @@ async fn bedrock_from_messages_stream_skips_completion_when_disabled() {
 			streaming: true,
 			params: Default::default(),
 			prompt: None,
-			bedrock_tool_names: None,
+			provider_state: None,
 		},
 		response: LLMResponse::default(),
 	};
@@ -1811,7 +1811,7 @@ async fn messages_passthrough_stream_captures_completion() {
 			streaming: true,
 			params: Default::default(),
 			prompt: None,
-			bedrock_tool_names: None,
+			provider_state: None,
 		},
 		response: LLMResponse::default(),
 	};
@@ -1852,7 +1852,7 @@ async fn messages_passthrough_stream_skips_completion_when_disabled() {
 			streaming: true,
 			params: Default::default(),
 			prompt: None,
-			bedrock_tool_names: None,
+			provider_state: None,
 		},
 		response: LLMResponse::default(),
 	};
@@ -1888,7 +1888,7 @@ async fn responses_passthrough_stream_captures_completion() {
 			streaming: true,
 			params: Default::default(),
 			prompt: None,
-			bedrock_tool_names: None,
+			provider_state: None,
 		},
 		response: LLMResponse::default(),
 	};
@@ -1925,7 +1925,7 @@ async fn responses_passthrough_stream_skips_completion_when_disabled() {
 			streaming: true,
 			params: Default::default(),
 			prompt: None,
-			bedrock_tool_names: None,
+			provider_state: None,
 		},
 		response: LLMResponse::default(),
 	};

--- a/crates/agentgateway/src/llm/tests.rs
+++ b/crates/agentgateway/src/llm/tests.rs
@@ -21,6 +21,7 @@ fn llm_request_with_tokens(input_tokens: Option<u64>) -> LLMRequest {
 		streaming: true,
 		params: Default::default(),
 		prompt: None,
+		bedrock_tool_names: None,
 	}
 }
 
@@ -324,8 +325,10 @@ mod requests {
 			assume_role_cache: Default::default(),
 		};
 
-		let bedrock =
-			|i| conversion::bedrock::from_completions::translate(&i, &bedrock_provider, None, None);
+		let bedrock = |i| {
+			conversion::bedrock::from_completions::translate(&i, &bedrock_provider, None, None)
+				.map(|r| r.body)
+		};
 		let anthropic = |i| conversion::messages::from_completions::translate(&i);
 
 		for (name, providers) in COMPLETION_REQUESTS {
@@ -363,8 +366,9 @@ mod requests {
 			project_id: strng::new("test-project-123"),
 		};
 
-		let bedrock_request =
-			|i| conversion::bedrock::from_messages::translate(&i, &bedrock_provider, None);
+		let bedrock_request = |i| {
+			conversion::bedrock::from_messages::translate(&i, &bedrock_provider, None).map(|r| r.body)
+		};
 		let vertex_request = |input: types::messages::Request| -> Result<Vec<u8>, AIError> {
 			let anthropic_body = serde_json::to_vec(&input).map_err(AIError::RequestMarshal)?;
 			vertex_provider.prepare_anthropic_message_body(anthropic_body)
@@ -400,6 +404,7 @@ mod requests {
 				match *provider {
 					BEDROCK => test_request(BEDROCK, test, |req| {
 						conversion::bedrock::from_responses::translate(&req, &bedrock_provider, None, None)
+							.map(|r| r.body)
 					}),
 					GEMINI => test_request(GEMINI, test, |req| {
 						conversion::openai_compat::from_responses::translate(&req)
@@ -806,6 +811,7 @@ mod response {
 			streaming: false,
 			params: Default::default(),
 			prompt: None,
+			bedrock_tool_names: None,
 		}
 	}
 
@@ -1359,6 +1365,7 @@ async fn process_response_routes_streaming_error_to_buffered_path() {
 		streaming: true,
 		params: Default::default(),
 		prompt: None,
+		bedrock_tool_names: None,
 	};
 
 	let body = Body::from(error_json.as_bytes().to_vec());
@@ -1447,6 +1454,7 @@ async fn process_streaming_bedrock_completions_normalizes_sse_headers_and_done()
 				streaming: true,
 				params: Default::default(),
 				prompt: None,
+				bedrock_tool_names: None,
 			},
 			LLMResponsePolicies::default(),
 			None,
@@ -1547,6 +1555,7 @@ fn setup_request_custom_path_override_wins_over_format_path() {
 		streaming: false,
 		params: Default::default(),
 		prompt: None,
+		bedrock_tool_names: None,
 	};
 	let mut req = crate::http::tests_common::request(
 		"https://proxy.example.com/v1/chat/completions?trace=repro",
@@ -1580,6 +1589,7 @@ fn llm_request_for_path(request_model: &str) -> LLMRequest {
 		streaming: false,
 		params: Default::default(),
 		prompt: None,
+		bedrock_tool_names: None,
 	}
 }
 
@@ -1709,6 +1719,7 @@ async fn bedrock_from_messages_stream_captures_completion() {
 			streaming: true,
 			params: Default::default(),
 			prompt: None,
+			bedrock_tool_names: None,
 		},
 		response: LLMResponse::default(),
 	};
@@ -1722,6 +1733,7 @@ async fn bedrock_from_messages_stream_captures_completion() {
 		"us.anthropic.claude-haiku-4-5-20251001-v1:0",
 		"msg_123",
 		true,
+		None,
 	);
 	let _ = body.collect().await.unwrap();
 	let info = log2
@@ -1755,6 +1767,7 @@ async fn bedrock_from_messages_stream_skips_completion_when_disabled() {
 			streaming: true,
 			params: Default::default(),
 			prompt: None,
+			bedrock_tool_names: None,
 		},
 		response: LLMResponse::default(),
 	};
@@ -1768,6 +1781,7 @@ async fn bedrock_from_messages_stream_skips_completion_when_disabled() {
 		"us.anthropic.claude-haiku-4-5-20251001-v1:0",
 		"msg_123",
 		false,
+		None,
 	);
 	let _ = body.collect().await.unwrap();
 	let info = log2
@@ -1797,6 +1811,7 @@ async fn messages_passthrough_stream_captures_completion() {
 			streaming: true,
 			params: Default::default(),
 			prompt: None,
+			bedrock_tool_names: None,
 		},
 		response: LLMResponse::default(),
 	};
@@ -1837,6 +1852,7 @@ async fn messages_passthrough_stream_skips_completion_when_disabled() {
 			streaming: true,
 			params: Default::default(),
 			prompt: None,
+			bedrock_tool_names: None,
 		},
 		response: LLMResponse::default(),
 	};
@@ -1872,6 +1888,7 @@ async fn responses_passthrough_stream_captures_completion() {
 			streaming: true,
 			params: Default::default(),
 			prompt: None,
+			bedrock_tool_names: None,
 		},
 		response: LLMResponse::default(),
 	};
@@ -1908,6 +1925,7 @@ async fn responses_passthrough_stream_skips_completion_when_disabled() {
 			streaming: true,
 			params: Default::default(),
 			prompt: None,
+			bedrock_tool_names: None,
 		},
 		response: LLMResponse::default(),
 	};

--- a/crates/agentgateway/src/llm/types/completions.rs
+++ b/crates/agentgateway/src/llm/types/completions.rs
@@ -303,7 +303,7 @@ impl super::RequestType for Request {
 				dimensions: None,
 			},
 			prompt: Default::default(),
-			bedrock_tool_names: None,
+			provider_state: None,
 		};
 		Ok(llm)
 	}

--- a/crates/agentgateway/src/llm/types/completions.rs
+++ b/crates/agentgateway/src/llm/types/completions.rs
@@ -254,7 +254,7 @@ impl super::RequestType for Request {
 		provider: &Provider,
 		headers: Option<&::http::HeaderMap>,
 		prompt_caching: Option<&crate::llm::policy::PromptCachingConfig>,
-	) -> Result<Vec<u8>, AIError> {
+	) -> Result<crate::llm::conversion::bedrock::BedrockRequest, AIError> {
 		conversion::bedrock::from_completions::translate(self, provider, headers, prompt_caching)
 	}
 
@@ -303,6 +303,7 @@ impl super::RequestType for Request {
 				dimensions: None,
 			},
 			prompt: Default::default(),
+			bedrock_tool_names: None,
 		};
 		Ok(llm)
 	}

--- a/crates/agentgateway/src/llm/types/count_tokens.rs
+++ b/crates/agentgateway/src/llm/types/count_tokens.rs
@@ -46,7 +46,7 @@ impl RequestType for Request {
 			streaming: false,
 			params: Default::default(),
 			prompt: Default::default(),
-			bedrock_tool_names: None,
+			provider_state: None,
 		})
 	}
 

--- a/crates/agentgateway/src/llm/types/count_tokens.rs
+++ b/crates/agentgateway/src/llm/types/count_tokens.rs
@@ -46,6 +46,7 @@ impl RequestType for Request {
 			streaming: false,
 			params: Default::default(),
 			prompt: Default::default(),
+			bedrock_tool_names: None,
 		})
 	}
 

--- a/crates/agentgateway/src/llm/types/detect.rs
+++ b/crates/agentgateway/src/llm/types/detect.rs
@@ -104,7 +104,7 @@ impl RequestType for Request {
 				dimensions: self.lookup(lookups::DIMENSIONS, |v| v.as_u64()),
 			},
 			prompt: Default::default(),
-			bedrock_tool_names: None,
+			provider_state: None,
 		})
 	}
 
@@ -203,7 +203,7 @@ mod tests {
 			streaming: false,
 			params: Default::default(),
 			prompt: None,
-			bedrock_tool_names: None,
+			provider_state: None,
 		}
 	}
 

--- a/crates/agentgateway/src/llm/types/detect.rs
+++ b/crates/agentgateway/src/llm/types/detect.rs
@@ -104,6 +104,7 @@ impl RequestType for Request {
 				dimensions: self.lookup(lookups::DIMENSIONS, |v| v.as_u64()),
 			},
 			prompt: Default::default(),
+			bedrock_tool_names: None,
 		})
 	}
 
@@ -129,8 +130,11 @@ impl RequestType for Request {
 		_provider: &Provider,
 		_headers: Option<&HeaderMap>,
 		_prompt_caching: Option<&PromptCachingConfig>,
-	) -> Result<Vec<u8>, AIError> {
-		self.to_openai()
+	) -> Result<crate::llm::conversion::bedrock::BedrockRequest, AIError> {
+		Ok(crate::llm::conversion::bedrock::BedrockRequest {
+			body: self.to_openai()?,
+			tool_name_map: Default::default(),
+		})
 	}
 	fn to_bedrock_token_count(&self, _headers: &::http::HeaderMap) -> Result<Vec<u8>, AIError> {
 		self.to_openai()
@@ -199,6 +203,7 @@ mod tests {
 			streaming: false,
 			params: Default::default(),
 			prompt: None,
+			bedrock_tool_names: None,
 		}
 	}
 

--- a/crates/agentgateway/src/llm/types/embeddings.rs
+++ b/crates/agentgateway/src/llm/types/embeddings.rs
@@ -85,7 +85,7 @@ impl RequestType for Request {
 				dimensions: self.dimensions.map(|d| d as u64),
 			},
 			prompt: Default::default(),
-			bedrock_tool_names: None,
+			provider_state: None,
 		})
 	}
 

--- a/crates/agentgateway/src/llm/types/embeddings.rs
+++ b/crates/agentgateway/src/llm/types/embeddings.rs
@@ -85,6 +85,7 @@ impl RequestType for Request {
 				dimensions: self.dimensions.map(|d| d as u64),
 			},
 			prompt: Default::default(),
+			bedrock_tool_names: None,
 		})
 	}
 
@@ -105,8 +106,11 @@ impl RequestType for Request {
 		provider: &crate::llm::bedrock::Provider,
 		_headers: Option<&::http::HeaderMap>,
 		_prompt_caching: Option<&crate::llm::policy::PromptCachingConfig>,
-	) -> Result<Vec<u8>, AIError> {
-		crate::llm::conversion::bedrock::from_embeddings::translate(self, provider)
+	) -> Result<crate::llm::conversion::bedrock::BedrockRequest, AIError> {
+		Ok(crate::llm::conversion::bedrock::BedrockRequest {
+			body: crate::llm::conversion::bedrock::from_embeddings::translate(self, provider)?,
+			tool_name_map: Default::default(),
+		})
 	}
 
 	fn to_vertex(&self, _provider: &crate::llm::vertex::Provider) -> Result<Vec<u8>, AIError> {

--- a/crates/agentgateway/src/llm/types/messages.rs
+++ b/crates/agentgateway/src/llm/types/messages.rs
@@ -221,6 +221,7 @@ impl RequestType for Request {
 				dimensions: None,
 			},
 			prompt: Default::default(),
+			bedrock_tool_names: None,
 		};
 		Ok(llm)
 	}
@@ -264,7 +265,7 @@ impl RequestType for Request {
 		provider: &crate::llm::bedrock::Provider,
 		headers: Option<&::http::HeaderMap>,
 		_prompt_caching: Option<&crate::llm::policy::PromptCachingConfig>,
-	) -> Result<Vec<u8>, AIError> {
+	) -> Result<crate::llm::conversion::bedrock::BedrockRequest, AIError> {
 		conversion::bedrock::from_messages::translate(self, provider, headers)
 	}
 

--- a/crates/agentgateway/src/llm/types/messages.rs
+++ b/crates/agentgateway/src/llm/types/messages.rs
@@ -221,7 +221,7 @@ impl RequestType for Request {
 				dimensions: None,
 			},
 			prompt: Default::default(),
-			bedrock_tool_names: None,
+			provider_state: None,
 		};
 		Ok(llm)
 	}

--- a/crates/agentgateway/src/llm/types/mod.rs
+++ b/crates/agentgateway/src/llm/types/mod.rs
@@ -54,7 +54,7 @@ pub trait RequestType: Send + Sync {
 		_provider: &crate::llm::bedrock::Provider,
 		_headers: Option<&::http::HeaderMap>,
 		_prompt_caching: Option<&crate::llm::policy::PromptCachingConfig>,
-	) -> Result<Vec<u8>, AIError> {
+	) -> Result<crate::llm::conversion::bedrock::BedrockRequest, AIError> {
 		Err(AIError::UnsupportedConversion(strng::literal!("bedrock")))
 	}
 

--- a/crates/agentgateway/src/llm/types/rerank.rs
+++ b/crates/agentgateway/src/llm/types/rerank.rs
@@ -115,6 +115,7 @@ impl RequestType for Request {
 			streaming: false,
 			params: LLMRequestParams::default(),
 			prompt: Default::default(),
+			bedrock_tool_names: None,
 		})
 	}
 
@@ -136,8 +137,11 @@ impl RequestType for Request {
 		provider: &crate::llm::bedrock::Provider,
 		_headers: Option<&::http::HeaderMap>,
 		_prompt_caching: Option<&crate::llm::policy::PromptCachingConfig>,
-	) -> Result<Vec<u8>, AIError> {
-		crate::llm::conversion::bedrock::from_rerank::translate(self, provider)
+	) -> Result<crate::llm::conversion::bedrock::BedrockRequest, AIError> {
+		Ok(crate::llm::conversion::bedrock::BedrockRequest {
+			body: crate::llm::conversion::bedrock::from_rerank::translate(self, provider)?,
+			tool_name_map: Default::default(),
+		})
 	}
 
 	fn to_vertex(&self, provider: &crate::llm::vertex::Provider) -> Result<Vec<u8>, AIError> {

--- a/crates/agentgateway/src/llm/types/rerank.rs
+++ b/crates/agentgateway/src/llm/types/rerank.rs
@@ -115,7 +115,7 @@ impl RequestType for Request {
 			streaming: false,
 			params: LLMRequestParams::default(),
 			prompt: Default::default(),
-			bedrock_tool_names: None,
+			provider_state: None,
 		})
 	}
 

--- a/crates/agentgateway/src/llm/types/responses.rs
+++ b/crates/agentgateway/src/llm/types/responses.rs
@@ -352,7 +352,7 @@ impl RequestType for Request {
 				dimensions: None,
 			},
 			prompt: Default::default(),
-			bedrock_tool_names: None,
+			provider_state: None,
 		})
 	}
 

--- a/crates/agentgateway/src/llm/types/responses.rs
+++ b/crates/agentgateway/src/llm/types/responses.rs
@@ -352,6 +352,7 @@ impl RequestType for Request {
 				dimensions: None,
 			},
 			prompt: Default::default(),
+			bedrock_tool_names: None,
 		})
 	}
 
@@ -393,7 +394,7 @@ impl RequestType for Request {
 		provider: &crate::llm::bedrock::Provider,
 		headers: Option<&http::HeaderMap>,
 		prompt_caching: Option<&crate::llm::policy::PromptCachingConfig>,
-	) -> Result<Vec<u8>, AIError> {
+	) -> Result<crate::llm::conversion::bedrock::BedrockRequest, AIError> {
 		conversion::bedrock::from_responses::translate(self, provider, headers, prompt_caching)
 	}
 

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -2373,6 +2373,7 @@ async fn make_backend_call(
 								input_tokens: None,
 								params: Default::default(),
 								prompt: Default::default(),
+								bedrock_tool_names: None,
 							})
 						});
 					}
@@ -3064,6 +3065,7 @@ mod tests {
 			streaming: true,
 			params: Default::default(),
 			prompt: None,
+			bedrock_tool_names: None,
 		}
 	}
 

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -2373,7 +2373,7 @@ async fn make_backend_call(
 								input_tokens: None,
 								params: Default::default(),
 								prompt: Default::default(),
-								bedrock_tool_names: None,
+								provider_state: None,
 							})
 						});
 					}
@@ -3065,7 +3065,7 @@ mod tests {
 			streaming: true,
 			params: Default::default(),
 			prompt: None,
-			bedrock_tool_names: None,
+			provider_state: None,
 		}
 	}
 

--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -2212,7 +2212,7 @@ mod tests {
 			streaming: false,
 			params: llm::LLMRequestParams::default(),
 			prompt: None,
-			bedrock_tool_names: None,
+			provider_state: None,
 		};
 		let response = llm::LLMResponse {
 			input_tokens: Some(1_000_000),

--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -2212,6 +2212,7 @@ mod tests {
 			streaming: false,
 			params: llm::LLMRequestParams::default(),
 			prompt: None,
+			bedrock_tool_names: None,
 		};
 		let response = llm::LLMResponse {
 			input_tokens: Some(1_000_000),


### PR DESCRIPTION
## Summary

- Add `BedrockToolNameMap` to normalize tool names to Bedrock Converse constraints (≤64 chars, `[a-zA-Z0-9_-]+`) with deterministic truncate + hash suffix on collision
- Apply sanitization outbound in `from_messages`, `from_completions`, and `from_responses` (tool definitions, `tool_choice`, and historical `toolUse` blocks)
- Restore original client tool names in buffered and streaming Bedrock responses via per-request mapping stored on `LLMRequest`

Fixes #2379

## Problem

Claude Code bundled MCP plugins (e.g. Atlassian) embed tools in the Messages API body with names like `mcp__plugin_atlassian_atlassian__createCompassComponentRelationship` (67 chars). AgentGateway forwarded these verbatim to Bedrock, causing HTTP 400 before inference.

## Test plan

- [x] `cargo test -p agentgateway bedrock_tool_name` (sanitizer unit tests)
- [x] `cargo test -p agentgateway test_messages_long_tool_names_fit_bedrock_tool_config`
- [x] `cargo test -p agentgateway test_messages_long_tool_name_round_trip_response` (request → mock Bedrock response → restored client name)
- [x] `cargo test -p agentgateway llm::conversion::bedrock::tests` (40 tests, all pass)

Supersedes #2382 (closed after DCO signoff rebase).


Made with [Cursor](https://cursor.com)