### PR TITLE
fix: classify REST A2A requests

### DIFF
--- a/crates/agentgateway/src/a2a/mod.rs
+++ b/crates/agentgateway/src/a2a/mod.rs
@@ -15,9 +15,11 @@ pub async fn apply_to_request(_: &A2aPolicy, req: &mut Request<Body>) -> Request
 }
 
 async fn classify_request(req: &mut Request<Body>) -> RequestType {
-	// Possible options are POST a JSON-RPC message or GET /.well-known/agent.json
+	// Possible options are POST a JSON-RPC or HTTP+JSON A2A message, or GET /.well-known/agent.json
 	// For agent card, we will process only on the response
-	match (req.method(), req.uri().path()) {
+	let method = req.method().clone();
+	let path = req.uri().path().to_string();
+	match (method, path.as_str()) {
 		// agent-card.json: v0.3.0+
 		// agent.json: older versions
 		(m, path)
@@ -34,9 +36,9 @@ async fn classify_request(req: &mut Request<Body>) -> RequestType {
 			let uri = crate::http::x_headers::apply_forwarded_scheme(uri, req.headers());
 			RequestType::AgentCard(uri)
 		},
-		(m, _) if m == http::Method::POST => {
+		(http::Method::POST, path) => {
 			let method = match crate::http::classify_content_type(req.headers()) {
-				crate::http::WellKnownContentTypes::Json => match inspect_method(req).await {
+				crate::http::WellKnownContentTypes::Json => match inspect_method(req, path).await {
 					Ok(method) => method,
 					Err(e) => {
 						warn!("failed to read a2a request: {e}");
@@ -49,6 +51,16 @@ async fn classify_request(req: &mut Request<Body>) -> RequestType {
 				},
 			};
 			RequestType::Call(method)
+		},
+		// The remaining REST operations are reads and deletes. They carry no body to
+		// inspect, so the operation is fully determined by the method and path.
+		(m, path) if m == http::Method::GET || m == http::Method::DELETE => {
+			match rest_method_from_path(&m, path) {
+				Some(method) => RequestType::Call(Strng::from(method)),
+				// Not an A2A operation we recognize; leave it unclassified rather than
+				// tagging unrelated traffic as A2A.
+				None => RequestType::Unknown,
+			}
 		},
 		_ => RequestType::Unknown,
 	}
@@ -198,11 +210,111 @@ async fn inspect_call_response(resp: &mut Response) -> Option<ResponseInfo> {
 
 #[derive(Deserialize)]
 struct JsonRpcMethod {
-	method: Strng,
+	method: Option<Strng>,
 }
 
-async fn inspect_method(req: &mut Request<Body>) -> anyhow::Result<Strng> {
-	Ok(json::inspect_body::<JsonRpcMethod>(req).await?.method)
+/// Determine the A2A method for a POST request.
+///
+/// A2A defines multiple wire formats for the same operations:
+///   - JSON-RPC: `{"jsonrpc": "2.0", "method": "SendMessage", "params": {...}}`
+///   - HTTP+JSON (REST): `{"message": {...}, "configuration": {...}}` POSTed to
+///     a method-specific path such as `/message:send` or `/tasks/{id}:cancel`.
+///
+/// The REST binding has no `method` field in the body — the method is
+/// conveyed by the URL path instead — so JSON-RPC's plain `body.method`
+/// extraction alone misclassifies every REST call as `unknown`.
+async fn inspect_method(req: &mut Request<Body>, path: &str) -> anyhow::Result<Strng> {
+	let body = json::inspect_body::<JsonRpcMethod>(req).await?;
+	// JSON-RPC carries the method verbatim. This is deliberately passed through
+	// unchanged so both the v0.3 (`message/send`) and v1.0 (`SendMessage`) spellings
+	// are reported as the client sent them.
+	if let Some(method) = body.method {
+		return Ok(method);
+	}
+	if let Some(method) = rest_method_from_path(&http::Method::POST, path) {
+		return Ok(Strng::from(method));
+	}
+	Ok(Strng::from("unknown"))
+}
+
+/// Map an A2A HTTP+JSON (REST) request to its canonical A2A method name.
+///
+/// The REST binding conveys the operation in the request line rather than the
+/// body (A2A v1.0 §11.3 "URL Patterns and HTTP Methods"), so the method is
+/// derived from the HTTP method plus the trailing path segments:
+///
+/// | Request                                                  | Method                            |
+/// |----------------------------------------------------------|-----------------------------------|
+/// | `POST   /message:send`                                     | `SendMessage`                     |
+/// | `POST   /message:stream`                                   | `SendStreamingMessage`            |
+/// | `GET    /tasks/{id}`                                       | `GetTask`                         |
+/// | `GET    /tasks`                                            | `ListTasks`                       |
+/// | `POST   /tasks/{id}:cancel`                                | `CancelTask`                      |
+/// | `POST   /tasks/{id}:subscribe`                             | `SubscribeToTask`                 |
+/// | `POST   /tasks/{id}/pushNotificationConfigs`               | `CreateTaskPushNotificationConfig`|
+/// | `GET    /tasks/{id}/pushNotificationConfigs/{configId}`    | `GetTaskPushNotificationConfig`   |
+/// | `GET    /tasks/{id}/pushNotificationConfigs`               | `ListTaskPushNotificationConfigs` |
+/// | `DELETE /tasks/{id}/pushNotificationConfigs/{configId}`    | `DeleteTaskPushNotificationConfig`|
+/// | `GET    /extendedAgentCard`                                | `GetExtendedAgentCard`            |
+///
+/// The returned names are the canonical method names from the spec's method
+/// mapping reference (§5.3), which are shared with the JSON-RPC and gRPC
+/// bindings. Reporting those keeps `a2a.method` comparable across bindings
+/// rather than inventing a REST-only spelling.
+///
+/// Matching is done on trailing segments because the gateway may host the agent
+/// under an arbitrary prefix (e.g. `/a2a/{agent}/tasks/{id}`), and `{id}` /
+/// `{configId}` are opaque and unbounded.
+fn rest_method_from_path(method: &http::Method, path: &str) -> Option<&'static str> {
+	let segments: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
+	// Segment counted from the end; 0 is the last segment.
+	let seg = |n: usize| -> Option<&str> {
+		segments
+			.len()
+			.checked_sub(n + 1)
+			.and_then(|i| segments.get(i).copied())
+	};
+	let last = seg(0)?;
+
+	if *method == http::Method::POST {
+		// The custom verb binds to the final segment with a `:` suffix. `{id}` is
+		// opaque, so match on the suffix rather than the whole segment.
+		match last.split_once(':') {
+			Some(("message", "send")) => Some("SendMessage"),
+			Some(("message", "stream")) => Some("SendStreamingMessage"),
+			Some((_, "cancel")) if seg(1) == Some("tasks") => Some("CancelTask"),
+			Some((_, "subscribe")) if seg(1) == Some("tasks") => Some("SubscribeToTask"),
+			Some(_) => None,
+			// Slash-style streaming path, accepted for compatibility with clients that
+			// predate the `:stream` custom-verb spelling.
+			None if last == "stream" && seg(1) == Some("message") => Some("SendStreamingMessage"),
+			None if last == "pushNotificationConfigs" && seg(1).is_some() && seg(2) == Some("tasks") => {
+				Some("CreateTaskPushNotificationConfig")
+			},
+			None => None,
+		}
+	} else if *method == http::Method::GET {
+		if last == "extendedAgentCard" {
+			Some("GetExtendedAgentCard")
+		} else if last == "pushNotificationConfigs" && seg(1).is_some() && seg(2) == Some("tasks") {
+			Some("ListTaskPushNotificationConfigs")
+		} else if seg(1) == Some("pushNotificationConfigs") && seg(3) == Some("tasks") {
+			Some("GetTaskPushNotificationConfig")
+		} else if seg(1) == Some("tasks") {
+			Some("GetTask")
+		} else if last == "tasks" {
+			Some("ListTasks")
+		} else {
+			None
+		}
+	} else if *method == http::Method::DELETE
+		&& seg(1) == Some("pushNotificationConfigs")
+		&& seg(3) == Some("tasks")
+	{
+		Some("DeleteTaskPushNotificationConfig")
+	} else {
+		None
+	}
 }
 
 fn build_agent_path(uri: Uri) -> String {

--- a/crates/agentgateway/src/a2a/tests.rs
+++ b/crates/agentgateway/src/a2a/tests.rs
@@ -81,6 +81,216 @@ async fn test_classify_request_extracts_method_and_preserves_body() {
 }
 
 #[tokio::test]
+async fn test_classify_request_extracts_rest_send_method_and_preserves_body() {
+	for content_type in ["application/json", "application/a2a+json"] {
+		let payload = json!({
+			"message": {
+				"messageId": "msg-123",
+				"role": "ROLE_USER",
+				"parts": [{ "text": "hello" }],
+			},
+			"configuration": { "returnImmediately": true },
+		});
+		let body = serde_json::to_vec(&payload).unwrap();
+		let mut req = ::http::Request::builder()
+			.method(Method::POST)
+			.uri("https://example.com/a2a/reviewer/message:send")
+			.header(header::CONTENT_TYPE, content_type)
+			.body(http::Body::from(body.clone()))
+			.unwrap();
+
+		let ty = classify_request(&mut req).await;
+
+		match ty {
+			RequestType::Call(method) => assert_eq!(method.as_str(), "SendMessage"),
+			other => panic!("expected call request, got {other:?}"),
+		}
+		assert_eq!(http::read_req_body(req).await.unwrap(), body);
+	}
+}
+
+#[test]
+fn test_rest_method_from_path_covers_spec_surface() {
+	// A2A v1.0 §11.3 "URL Patterns and HTTP Methods", reported using the canonical
+	// method names from the §5.3 method mapping reference.
+	let cases = vec![
+		(Method::POST, "/message:send", Some("SendMessage")),
+		(
+			Method::POST,
+			"/message:stream",
+			Some("SendStreamingMessage"),
+		),
+		(Method::GET, "/tasks/task-123", Some("GetTask")),
+		(Method::GET, "/tasks", Some("ListTasks")),
+		(Method::POST, "/tasks/task-123:cancel", Some("CancelTask")),
+		(
+			Method::POST,
+			"/tasks/task-123:subscribe",
+			Some("SubscribeToTask"),
+		),
+		(
+			Method::POST,
+			"/tasks/task-123/pushNotificationConfigs",
+			Some("CreateTaskPushNotificationConfig"),
+		),
+		(
+			Method::GET,
+			"/tasks/task-123/pushNotificationConfigs/cfg-1",
+			Some("GetTaskPushNotificationConfig"),
+		),
+		(
+			Method::GET,
+			"/tasks/task-123/pushNotificationConfigs",
+			Some("ListTaskPushNotificationConfigs"),
+		),
+		(
+			Method::DELETE,
+			"/tasks/task-123/pushNotificationConfigs/cfg-1",
+			Some("DeleteTaskPushNotificationConfig"),
+		),
+		(
+			Method::GET,
+			"/extendedAgentCard",
+			Some("GetExtendedAgentCard"),
+		),
+		// The gateway may host the agent under an arbitrary prefix.
+		(
+			Method::POST,
+			"/a2a/reviewer/message:send",
+			Some("SendMessage"),
+		),
+		(Method::GET, "/a2a/reviewer/tasks/task-123", Some("GetTask")),
+		(
+			Method::DELETE,
+			"/a2a/reviewer/tasks/task-123/pushNotificationConfigs/cfg-1",
+			Some("DeleteTaskPushNotificationConfig"),
+		),
+		// Slash-style streaming path kept for backwards compatibility.
+		(
+			Method::POST,
+			"/message/stream",
+			Some("SendStreamingMessage"),
+		),
+		// Task ids are opaque and may themselves look like a collection name.
+		(Method::GET, "/tasks/tasks", Some("GetTask")),
+		// Negative cases: not A2A operations.
+		(Method::GET, "/", None),
+		(Method::GET, "/healthz", None),
+		(Method::POST, "/message:explode", None),
+		(Method::POST, "/tasks/task-123:explode", None),
+		(Method::POST, "/tasks", None),
+		(Method::DELETE, "/tasks/task-123", None),
+		// Custom verbs are only defined on POST, and task ids are opaque strings that
+		// may themselves contain a colon, so a colon in a GET path is part of the id.
+		(Method::GET, "/tasks/task-123:cancel", Some("GetTask")),
+		// `pushNotificationConfigs` must hang off a task.
+		(Method::POST, "/pushNotificationConfigs", None),
+		(Method::GET, "/pushNotificationConfigs", None),
+	];
+
+	for (method, path, expected) in cases {
+		assert_eq!(
+			rest_method_from_path(&method, path),
+			expected,
+			"unexpected classification for {method} {path}"
+		);
+	}
+}
+
+#[tokio::test]
+async fn test_classify_request_classifies_rest_get_task_without_body() {
+	let mut req = ::http::Request::builder()
+		.method(Method::GET)
+		.uri("https://example.com/a2a/reviewer/tasks/task-123")
+		.body(http::Body::empty())
+		.unwrap();
+
+	let ty = classify_request(&mut req).await;
+
+	match ty {
+		RequestType::Call(method) => assert_eq!(method.as_str(), "GetTask"),
+		other => panic!("expected call request, got {other:?}"),
+	}
+}
+
+#[tokio::test]
+async fn test_classify_request_classifies_rest_delete_push_notification_config() {
+	let mut req = ::http::Request::builder()
+		.method(Method::DELETE)
+		.uri("https://example.com/tasks/task-123/pushNotificationConfigs/cfg-1")
+		.body(http::Body::empty())
+		.unwrap();
+
+	let ty = classify_request(&mut req).await;
+
+	match ty {
+		RequestType::Call(method) => {
+			assert_eq!(method.as_str(), "DeleteTaskPushNotificationConfig")
+		},
+		other => panic!("expected call request, got {other:?}"),
+	}
+}
+
+#[tokio::test]
+async fn test_classify_request_classifies_rest_cancel_without_message_field() {
+	// `tasks/{id}:cancel` has no `message` in the body, so the classification has to
+	// come from the path alone.
+	let body = serde_json::to_vec(&json!({})).unwrap();
+	let mut req = ::http::Request::builder()
+		.method(Method::POST)
+		.uri("https://example.com/a2a/reviewer/tasks/task-123:cancel")
+		.header(header::CONTENT_TYPE, "application/json")
+		.body(http::Body::from(body.clone()))
+		.unwrap();
+
+	let ty = classify_request(&mut req).await;
+
+	match ty {
+		RequestType::Call(method) => assert_eq!(method.as_str(), "CancelTask"),
+		other => panic!("expected call request, got {other:?}"),
+	}
+	assert_eq!(http::read_req_body(req).await.unwrap(), body);
+}
+
+#[tokio::test]
+async fn test_classify_request_leaves_unrelated_get_unclassified() {
+	let mut req = ::http::Request::builder()
+		.method(Method::GET)
+		.uri("https://example.com/healthz")
+		.body(http::Body::empty())
+		.unwrap();
+
+	match classify_request(&mut req).await {
+		RequestType::Unknown => {},
+		other => panic!("expected unknown request, got {other:?}"),
+	}
+}
+
+#[tokio::test]
+async fn test_classify_request_prefers_jsonrpc_method_over_path() {
+	// A JSON-RPC call posted to a REST-looking path must still report the method the
+	// client actually sent.
+	let payload = json!({
+		"jsonrpc": "2.0",
+		"id": "1",
+		"method": "SendMessage",
+		"params": { "message": { "messageId": "msg-1" } },
+	});
+	let body = serde_json::to_vec(&payload).unwrap();
+	let mut req = ::http::Request::builder()
+		.method(Method::POST)
+		.uri("https://example.com/tasks/task-123:cancel")
+		.header(header::CONTENT_TYPE, "application/json")
+		.body(http::Body::from(body))
+		.unwrap();
+
+	match classify_request(&mut req).await {
+		RequestType::Call(method) => assert_eq!(method.as_str(), "SendMessage"),
+		other => panic!("expected call request, got {other:?}"),
+	}
+}
+
+#[tokio::test]
 async fn test_classify_request_uses_original_url_for_agent_card() {
 	let original: Uri = "https://example.com/api/.well-known/agent-card.json"
 		.parse()

--- a/crates/agentgateway/src/http/mod.rs
+++ b/crates/agentgateway/src/http/mod.rs
@@ -660,7 +660,7 @@ where
 	}
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum WellKnownContentTypes {
 	Json,
 	Sse,
@@ -672,12 +672,18 @@ pub fn classify_content_type(h: &HeaderMap) -> WellKnownContentTypes {
 		&& let Ok(content_type_str) = content_type.to_str()
 		&& let Ok(mime) = content_type_str.parse::<mime::Mime>()
 	{
-		match (mime.type_(), mime.subtype()) {
-			(mime::APPLICATION, mime::JSON) => return WellKnownContentTypes::Json,
-			(mime::TEXT, mime::EVENT_STREAM) => {
-				return WellKnownContentTypes::Sse;
-			},
-			_ => {},
+		// Accept `+json` structured-syntax suffixes (RFC 6839) such as
+		// `application/a2a+json`, not just the exact `application/json`.
+		// The A2A HTTP+JSON (REST) binding uses `application/a2a+json` per
+		// the A2A specification, which the strict equality check below
+		// would otherwise misclassify as Unknown.
+		if mime.type_() == mime::APPLICATION
+			&& (mime.subtype() == mime::JSON || mime.suffix() == Some(mime::JSON))
+		{
+			return WellKnownContentTypes::Json;
+		}
+		if (mime.type_(), mime.subtype()) == (mime::TEXT, mime::EVENT_STREAM) {
+			return WellKnownContentTypes::Sse;
 		}
 	}
 	WellKnownContentTypes::Unknown
@@ -1014,5 +1020,42 @@ mod tests {
 
 			assert!(!is_grpc_request(&req), "{content_type}");
 		}
+	}
+
+	#[test]
+	fn classify_content_type_accepts_json_suffix_mime_types() {
+		// RFC 6839 structured-syntax suffixes: `application/<subtype>+json` is
+		// still JSON. The A2A HTTP+JSON (REST) binding uses
+		// `application/a2a+json` specifically (A2A specification, Section 11),
+		// which a strict `application/json` equality check misclassifies.
+		for content_type in [
+			"application/json",
+			"application/a2a+json",
+			"application/vnd.api+json",
+		] {
+			let mut headers = HeaderMap::new();
+			headers.insert(header::CONTENT_TYPE, content_type.parse().unwrap());
+			assert_eq!(
+				classify_content_type(&headers),
+				WellKnownContentTypes::Json,
+				"{content_type}"
+			);
+		}
+	}
+
+	#[test]
+	fn classify_content_type_rejects_unrelated_json_prefixed_subtype() {
+		// Guard against overly broad matching: `application/jsonlines` is not
+		// JSON despite starting with "json" — the suffix check must only match
+		// the `+json` structured-syntax suffix, not any subtype prefix.
+		let mut headers = HeaderMap::new();
+		headers.insert(
+			header::CONTENT_TYPE,
+			"application/jsonlines".parse().unwrap(),
+		);
+		assert_eq!(
+			classify_content_type(&headers),
+			WellKnownContentTypes::Unknown
+		);
 	}
 }


### PR DESCRIPTION
## Summary

The A2A specification defines an HTTP+JSON (REST) binding alongside JSON-RPC
(v1.0 §11). It conveys the operation in the request line rather than a top-level
`method` body field, so agentgateway's A2A classifier reported every REST
request as `unknown`.

This classifies the **full REST surface** from §11.3, addressing
@howardjohn's review comment — the first revision only handled
`message:send` / `message:stream`.

## Method mapping

Reported names are the canonical method names from the spec's method mapping
reference (§5.3), which are shared with the JSON-RPC and gRPC bindings:

| Request | Reported `a2a.method` |
|---|---|
| `POST /message:send` | `SendMessage` |
| `POST /message:stream` | `SendStreamingMessage` |
| `GET /tasks/{id}` | `GetTask` |
| `GET /tasks` | `ListTasks` |
| `POST /tasks/{id}:cancel` | `CancelTask` |
| `POST /tasks/{id}:subscribe` | `SubscribeToTask` |
| `POST /tasks/{id}/pushNotificationConfigs` | `CreateTaskPushNotificationConfig` |
| `GET /tasks/{id}/pushNotificationConfigs/{configId}` | `GetTaskPushNotificationConfig` |
| `GET /tasks/{id}/pushNotificationConfigs` | `ListTaskPushNotificationConfigs` |
| `DELETE /tasks/{id}/pushNotificationConfigs/{configId}` | `DeleteTaskPushNotificationConfig` |
| `GET /extendedAgentCard` | `GetExtendedAgentCard` |

Using the §5.3 canonical names (rather than a REST-only spelling such as
`message:send`, which is what the first revision reported) keeps `a2a.method`
comparable across bindings: a v1.0 JSON-RPC `SendMessage` and a REST
`POST /message:send` are the same operation and now log the same value. The
JSON-RPC path still passes `body.method` through verbatim, so both the v0.3
(`message/send`) and v1.0 (`SendMessage`) spellings are reported as the client
sent them. Happy to switch to the literal URL tokens instead if you'd prefer
the binding to stay visible in the telemetry.

## Notes on the implementation

- **Reads/deletes carry no body**, so `GET`/`DELETE` are classified from the
  method and path alone — no body inspection is added to those paths.
- **Anything that matches no A2A operation stays `Unknown`**, so unrelated
  traffic on an A2A backend is not tagged as A2A.
- **Matching is on trailing path segments**, because the gateway may host the
  agent under an arbitrary prefix (`/a2a/{agent}/tasks/{id}`) and `{id}` /
  `{configId}` are opaque.
- **Custom verbs are matched as a `:` suffix**, not as a whole segment, since
  `{id}` is unbounded. Custom verbs are only defined on `POST`; a colon in a
  `GET` path is treated as part of an opaque id (`GET /tasks/a:b` → `GetTask`).
- **SSE is unaffected**: `inspect_call_response` (added in #2646) returns early
  for non-JSON content types, so classifying `message:stream` / `:subscribe` as
  a `Call` does not buffer a `text/event-stream` response.
- `classify_content_type()` accepts any `application/*+json` structured-syntax
  suffix (RFC 6839), not just exact `application/json`, since the REST binding
  uses `application/a2a+json`.

## Testing

- `cargo test -p agentgateway --lib a2a::` — 26/26 pass
- `cargo test -p agentgateway --lib` — 1582 pass, 0 fail
- `cargo clippy -p agentgateway --lib -- -D warnings` — clean
- `cargo fmt -p agentgateway -- --check` — clean

New coverage: a table-driven test over all 11 operations (plus prefixed paths,
the legacy `/message/stream` spelling, and negative cases), end-to-end
classification tests for a `GET` read and a `DELETE`, a `POST :cancel` with no
`message` field in the body, a check that an unrelated `GET` stays `Unknown`,
and a check that a JSON-RPC body still wins over the path.

Rebased onto current `main` (picks up #2646), and the commit is now
signed off for DCO.