### PR TITLE
guardrails: default timeouts for callouts

### DIFF
--- a/crates/agentgateway/src/http/ext_authz.rs
+++ b/crates/agentgateway/src/http/ext_authz.rs
@@ -844,7 +844,7 @@ impl ExtAuthz {
 		// Set the default request timeout. This can be overridden by a timeout on the Backend object itself.
 		check_req
 			.extensions_mut()
-			.insert(BackendRequestTimeout(Duration::from_millis(200)));
+			.insert(BackendRequestTimeout(Duration::from_secs(2)));
 		let scope = dtrace::start_scope("ext_authz");
 		let resp = client
 			.with_outbound(OutboundCallKind::Policy, OutboundCallSubtype::ExtAuthz)

--- a/crates/agentgateway/src/llm/policy/azure_content_safety.rs
+++ b/crates/agentgateway/src/llm/policy/azure_content_safety.rs
@@ -6,7 +6,9 @@ use tracing::{debug, warn};
 use crate::http::auth::BackendAuth;
 use crate::http::jwt::Claims;
 use crate::llm::RequestType;
-use crate::llm::policy::{AnalyzeTextConfig, AzureContentSafety, DetectJailbreakConfig};
+use crate::llm::policy::{
+	AnalyzeTextConfig, AzureContentSafety, DetectJailbreakConfig, with_default_timeout,
+};
 use crate::proxy::httpproxy::PolicyClient;
 use crate::telemetry::metrics::{OutboundCallKind, OutboundCallSubtype};
 use crate::types::agent::{Backend, BackendTrafficPolicy, ResourceName};
@@ -245,7 +247,7 @@ async fn send_content_safety_request<Req: Serialize, Resp: serde::de::Deserializ
 
 	let resp = client
 		.with_outbound(OutboundCallKind::Policy, OutboundCallSubtype::Guardrail)
-		.call_with_explicit_policies_list(req, mock_be, pols)
+		.call_with_explicit_policies_list(with_default_timeout(req), mock_be, pols)
 		.await?;
 
 	let status = resp.status();

--- a/crates/agentgateway/src/llm/policy/bedrock_guardrails.rs
+++ b/crates/agentgateway/src/llm/policy/bedrock_guardrails.rs
@@ -6,7 +6,7 @@ use crate::http::auth::{AwsAuth, BackendAuth};
 use crate::http::jwt::Claims;
 use crate::llm::RequestType;
 use crate::llm::bedrock::AwsRegion;
-use crate::llm::policy::BedrockGuardrails;
+use crate::llm::policy::{BedrockGuardrails, with_default_timeout};
 use crate::proxy::httpproxy::PolicyClient;
 use crate::telemetry::metrics::{OutboundCallKind, OutboundCallSubtype};
 use crate::types::agent::{Backend, BackendTrafficPolicy, ResourceName};
@@ -228,7 +228,7 @@ async fn send_guardrail_request(
 
 	let resp = client
 		.with_outbound(OutboundCallKind::Policy, OutboundCallSubtype::Guardrail)
-		.call_with_explicit_policies_list(req, mock_be, pols)
+		.call_with_explicit_policies_list(with_default_timeout(req), mock_be, pols)
 		.await?;
 
 	let status = resp.status();

--- a/crates/agentgateway/src/llm/policy/google_model_armor.rs
+++ b/crates/agentgateway/src/llm/policy/google_model_armor.rs
@@ -13,7 +13,7 @@ use crate::http::auth::{BackendAuth, GcpAuth};
 use crate::http::jwt::Claims;
 use crate::json;
 use crate::llm::RequestType;
-use crate::llm::policy::GoogleModelArmor;
+use crate::llm::policy::{GoogleModelArmor, with_default_timeout};
 use crate::proxy::httpproxy::PolicyClient;
 use crate::telemetry::metrics::{OutboundCallKind, OutboundCallSubtype};
 use crate::types::agent::{Backend, BackendTrafficPolicy, ResourceName};
@@ -376,7 +376,7 @@ async fn send_model_armor_request<T: Serialize>(
 
 	let resp = client
 		.with_outbound(OutboundCallKind::Policy, OutboundCallSubtype::Guardrail)
-		.call_with_explicit_policies_list(req, mock_be, pols)
+		.call_with_explicit_policies_list(with_default_timeout(req), mock_be, pols)
 		.await?;
 
 	let resp: SanitizeResponse = json::from_response_body(resp).await?;

--- a/crates/agentgateway/src/llm/policy/mod.rs
+++ b/crates/agentgateway/src/llm/policy/mod.rs
@@ -20,7 +20,7 @@ use crate::*;
 fn with_default_timeout(mut req: crate::http::Request) -> crate::http::Request {
 	req
 		.extensions_mut()
-		.insert(BackendRequestTimeout(Duration::from_millis(5000)));
+		.insert(BackendRequestTimeout(Duration::from_secs(10)));
 	req
 }
 

--- a/crates/agentgateway/src/llm/policy/mod.rs
+++ b/crates/agentgateway/src/llm/policy/mod.rs
@@ -5,7 +5,7 @@ use itertools::Itertools;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use crate::http::filters::HeaderModifier;
+use crate::http::filters::{BackendRequestTimeout, HeaderModifier};
 use crate::http::jwt::Claims;
 use crate::http::{Response, StatusCode, auth};
 use crate::llm::policy::webhook::{MaskActionBody, RequestAction, ResponseAction};
@@ -16,6 +16,13 @@ use crate::types::agent::{
 	BackendTrafficPolicy, HeaderMatch, HeaderValueMatch, SimpleBackendReference,
 };
 use crate::*;
+
+fn with_default_timeout(mut req: crate::http::Request) -> crate::http::Request {
+	req
+		.extensions_mut()
+		.insert(BackendRequestTimeout(Duration::from_millis(5000)));
+	req
+}
 
 pub mod webhook;
 

--- a/crates/agentgateway/src/llm/policy/moderation.rs
+++ b/crates/agentgateway/src/llm/policy/moderation.rs
@@ -4,7 +4,7 @@ use itertools::Itertools;
 use crate::http::jwt::Claims;
 use crate::json;
 use crate::llm::RequestType;
-use crate::llm::policy::Moderation;
+use crate::llm::policy::{Moderation, with_default_timeout};
 use crate::proxy::httpproxy::PolicyClient;
 use crate::telemetry::metrics::{OutboundCallKind, OutboundCallSubtype};
 use crate::types::agent::{Backend, BackendTrafficPolicy, ResourceName};
@@ -48,7 +48,7 @@ pub async fn send_request(
 	);
 	let resp = client
 		.with_outbound(OutboundCallKind::Policy, OutboundCallSubtype::Guardrail)
-		.call_with_explicit_policies_list(req, mock_be, pols)
+		.call_with_explicit_policies_list(with_default_timeout(req), mock_be, pols)
 		.await?;
 	let resp: async_openai::types::moderations::CreateModerationResponse =
 		json::from_response_body(resp).await?;

--- a/crates/agentgateway/src/llm/policy/webhook.rs
+++ b/crates/agentgateway/src/llm/policy/webhook.rs
@@ -2,6 +2,7 @@ use ::http::header::CONTENT_TYPE;
 use ::http::{HeaderMap, HeaderValue, header};
 use serde::{Deserialize, Serialize};
 
+use crate::llm::policy::with_default_timeout;
 use crate::proxy::httpproxy::PolicyClient;
 use crate::telemetry::metrics::{OutboundCallKind, OutboundCallSubtype};
 use crate::types::agent::SimpleBackendReference;
@@ -177,7 +178,7 @@ pub async fn send_request(
 	http_headers: &HeaderMap,
 	messages: Vec<Message>,
 ) -> anyhow::Result<GuardrailsPromptResponse> {
-	let whr = build_request_for_request(http_headers, messages)?;
+	let whr = with_default_timeout(build_request_for_request(http_headers, messages)?);
 	let res = Box::pin(
 		client
 			.with_outbound(OutboundCallKind::Policy, OutboundCallSubtype::Guardrail)
@@ -194,7 +195,7 @@ pub async fn send_response(
 	http_headers: &HeaderMap,
 	choices: Vec<ResponseChoice>,
 ) -> anyhow::Result<GuardrailsResponseResponse> {
-	let whr = build_request_for_response(http_headers, choices)?;
+	let whr = with_default_timeout(build_request_for_response(http_headers, choices)?);
 	let res = client
 		.with_outbound(OutboundCallKind::Policy, OutboundCallSubtype::Guardrail)
 		.call_reference(whr, target)

--- a/crates/agentgateway/src/mcp/guardrails/client.rs
+++ b/crates/agentgateway/src/mcp/guardrails/client.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+use std::time::Duration;
 
 use ::http::HeaderName;
 use bytes::Bytes;
@@ -11,6 +12,7 @@ use tracing::{debug, warn};
 use crate::cel;
 use crate::http::envoy_proto_common::json_to_prost_value;
 use crate::http::ext_proc::GrpcReferenceChannel;
+use crate::http::filters::BackendRequestTimeout;
 use crate::mcp::guardrails::wire::ext_mcp_client::ExtMcpClient;
 use crate::mcp::guardrails::wire::{
 	self, AuthorizationError, McpRequest, McpResponse, mcp_request_result, mcp_response_result,
@@ -20,6 +22,14 @@ use crate::mcp::guardrails::{
 };
 use crate::mcp::upstream::IncomingRequestContext;
 use crate::proxy::httpproxy::PolicyClient;
+
+fn with_default_timeout<T>(msg: T) -> tonic::Request<T> {
+	let mut req = tonic::Request::new(msg);
+	req
+		.extensions_mut()
+		.insert(BackendRequestTimeout(Duration::from_millis(5000)));
+	req
+}
 
 pub(crate) async fn check_request<P: serde::de::DeserializeOwned>(
 	remote: &Remote,
@@ -41,7 +51,7 @@ pub(crate) async fn check_request<P: serde::de::DeserializeOwned>(
 		headers,
 	};
 	let mut grpc = build_client(remote, client.clone());
-	let tonic_req = tonic::Request::new(req);
+	let tonic_req = with_default_timeout(req);
 	let resp = match grpc.check_request(tonic_req).await {
 		Ok(resp) => resp.into_inner(),
 		Err(status) => return on_grpc_error(remote, method, backends, "checkRequest", status),
@@ -191,7 +201,7 @@ pub(crate) async fn check_response(
 		mcp_response,
 	};
 	let mut grpc = build_client(remote, client.clone());
-	let tonic_req = tonic::Request::new(req);
+	let tonic_req = with_default_timeout(req);
 	let result = match grpc.check_response(tonic_req).await {
 		Ok(resp) => resp.into_inner().result,
 		Err(status) => return on_grpc_error(remote, method, backends, "checkResponse", status),

--- a/crates/agentgateway/src/mcp/guardrails/client.rs
+++ b/crates/agentgateway/src/mcp/guardrails/client.rs
@@ -27,7 +27,7 @@ fn with_default_timeout<T>(msg: T) -> tonic::Request<T> {
 	let mut req = tonic::Request::new(msg);
 	req
 		.extensions_mut()
-		.insert(BackendRequestTimeout(Duration::from_millis(5000)));
+		.insert(BackendRequestTimeout(Duration::from_secs(10)));
 	req
 }
 


### PR DESCRIPTION
Per https://github.com/agentgateway/agentgateway/issues/2387 we dont have default timeouts for remote guardrails and we have prior art in our extauth call outs.

This pr attempts to mimic 
https://github.com/agentgateway/agentgateway/blob/8729cd04a85bd374701d00a7f2140e6408df7b1a/crates/agentgateway/src/http/ext_authz.rs#L847

The major difference is plumbing and chose to push down the calling responsibility to each guardrail itself rather than as a super but that was mainly as it felt that a) there might be some guardrails that wont need it in the future if they arent to a real backend b) the guard rails each own their request life right now and it didnt feel right to change that


Open Question: What timeout really makes sense. Guardrails can seem to range in duration by a lot so it might be dangerous for current consumers if it was less than 1 second. 
I started with the 200 millis per extauth but figured it could be interesting on the  potentially non-deterministic guardrail calls to have something larger.