### PR TITLE
deployer: populate InternalPorts in GatewayIRFrom fallback

### DIFF
--- a/controller/pkg/deployer/agentgateway_parameters.go
+++ b/controller/pkg/deployer/agentgateway_parameters.go
@@ -573,6 +573,10 @@ func GatewayIRFrom(gw *gwv1.Gateway, controllerNameGuess string) *collections.Ga
 		},
 		ControllerName: controllerNameGuess,
 		Ports:          smallset.New(ports.UnsortedList()...),
+		// This guess path has no ListenerSets, so internal ports are derived from the
+		// Gateway annotation only. Without this, internal (routing-only) ports would be
+		// incorrectly exposed via Service/container ports in GetPortsValues.
+		InternalPorts: collections.ComputeInternalPorts(gw, nil),
 	}
 }
 func DeepMergeResourceRequirements(dst, src *corev1.ResourceRequirements) *corev1.ResourceRequirements {

--- a/controller/pkg/deployer/agentgateway_parameters_test.go
+++ b/controller/pkg/deployer/agentgateway_parameters_test.go
@@ -18,6 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	"github.com/agentgateway/agentgateway/controller/api/annotations"
 	"github.com/agentgateway/agentgateway/controller/api/v1alpha1/agentgateway"
 	"github.com/agentgateway/agentgateway/controller/pkg/apiclient/fake"
 )
@@ -33,6 +34,37 @@ func newSyncedSecretClient(t *testing.T, objects ...client.Object) kclient.Clien
 	fakeClient.RunAndWait(stop)
 	kube.WaitForCacheSync("test", stop, secretClient.HasSynced)
 	return secretClient
+}
+
+// TestGatewayIRFromInternalPorts guards the IR-fallback path (used when a Gateway
+// isn't yet in the IR): internal (routing-only) ports must be populated from the
+// annotation so GetPortsValues excludes them from the Service/container ports.
+func TestGatewayIRFromInternalPorts(t *testing.T) {
+	gw := &gwv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "gw",
+			Namespace:   "ns",
+			Annotations: map[string]string{annotations.InternalPorts: "8080"},
+		},
+		Spec: gwv1.GatewaySpec{
+			Listeners: []gwv1.Listener{
+				{Name: "internal", Port: 8080, Protocol: gwv1.HTTPProtocolType},
+				{Name: "public", Port: 8443, Protocol: gwv1.HTTPProtocolType},
+			},
+		},
+	}
+
+	ir := GatewayIRFrom(gw, "example.com/controller")
+	assert.True(t, ir.InternalPorts.Contains(8080), "internal port 8080 should be recorded")
+	assert.False(t, ir.InternalPorts.Contains(8443), "public port 8443 should not be internal")
+
+	ports := GetPortsValues(ir, 0)
+	got := map[int32]bool{}
+	for _, p := range ports {
+		got[*p.Port] = true
+	}
+	assert.False(t, got[8080], "internal port 8080 must not be exposed via Service/container ports")
+	assert.True(t, got[8443], "public port 8443 should be exposed")
 }
 
 func TestAgentgatewayParametersApplier_ApplyToHelmValues_Image(t *testing.T) {

--- a/controller/pkg/pluginsdk/collections/deployer.go
+++ b/controller/pkg/pluginsdk/collections/deployer.go
@@ -79,19 +79,19 @@ func GatewaysForDeployerTransformationFunc(
 			},
 			ControllerName:  string(gwClass.Spec.ControllerName),
 			Ports:           smallset.New(ports.UnsortedList()...),
-			InternalPorts:   computeInternalPorts(gw, lsets),
+			InternalPorts:   ComputeInternalPorts(gw, lsets),
 			MeshTrustDomain: td,
 		}
 		return ir
 	}
 }
 
-// computeInternalPorts returns the ports whose bind is internal, mirroring the bind-mode
+// ComputeInternalPorts returns the ports whose bind is internal, mirroring the bind-mode
 // decision in the syncer: a port is internal only if every contributing listener (across
 // the Gateway and its ListenerSets) agrees. Disagreement leaves the port standard (and is
 // surfaced as Accepted=False during translation). Invalid annotations are ignored here;
 // translation reports them.
-func computeInternalPorts(gw *gwv1.Gateway, lsets []*gwv1.ListenerSet) smallset.Set[int32] {
+func ComputeInternalPorts(gw *gwv1.Gateway, lsets []*gwv1.ListenerSet) smallset.Set[int32] {
 	sawInternal := sets.New[int32]()
 	sawStandard := sets.New[int32]()
 

--- a/controller/pkg/pluginsdk/collections/deployer_internalports_test.go
+++ b/controller/pkg/pluginsdk/collections/deployer_internalports_test.go
@@ -84,10 +84,10 @@ func TestComputeInternalPorts(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := slices.Sort(computeInternalPorts(tt.gw, tt.lsets).List())
+			got := slices.Sort(ComputeInternalPorts(tt.gw, tt.lsets).List())
 			want := slices.Sort(tt.want)
 			if !slices.Equal(got, want) {
-				t.Fatalf("computeInternalPorts = %v, want %v", got, want)
+				t.Fatalf("ComputeInternalPorts = %v, want %v", got, want)
 			}
 		})
 	}


### PR DESCRIPTION
GetPortsValues excludes internal (routing-only) ports from the generated Service and container ports via gw.InternalPorts. The IR-fallback path GatewayIRFrom (used when a Gateway isn't yet in the IR) only set Ports, leaving InternalPorts empty, so internal ports leaked into the Service.

Follow-up to e2b51589