### PR TITLE
ui: add read-only LLM/MCP dump-mode views

### DIFF
--- a/ui/src/components/Shell.tsx
+++ b/ui/src/components/Shell.tsx
@@ -89,13 +89,18 @@ export function Shell() {
     mobileNavOpen,
     () => setMobileNavOpen(false),
   );
+  // In dump mode (XDS-managed gateway) there is no writable local config to
+  // check for presence of an `llm`/`mcp` section — always show the nav items
+  // and let each read-only dump view report "nothing configured" itself,
+  // rather than falling back to the standalone-mode "get started" wizard
+  // (which requires config writes that don't work here).
   const hasLlm = dumpMode
-    ? false
+    ? true
     : config.data
       ? Boolean(config.data.llm)
       : true;
   const hasMcp = dumpMode
-    ? false
+    ? true
     : mcpData.data
       ? Boolean(mcpData.data.mcp)
       : true;
@@ -249,67 +254,65 @@ function navigationGroups(options: {
       items: [{ to: "/", label: "Home", icon: Home }],
     },
   ];
-  if (!options.dumpMode) {
-    groups.push({
-      title: "LLM",
-      items: options.hasLlm
-        ? [
-            { to: "/llm/models", label: "Models", icon: Bot },
-            { to: "/llm/providers", label: "Providers", icon: Boxes },
+  groups.push({
+    title: "LLM",
+    items: options.hasLlm
+      ? [
+          { to: "/llm/models", label: "Models", icon: Bot },
+          { to: "/llm/providers", label: "Providers", icon: Boxes },
 
-            {
-              to: "/llm/policies",
-              label: "Policies",
-              icon: Bolt,
-              groupStart: true,
-            },
-            { to: "/llm/guardrails", label: "Guardrails", icon: Shield },
-            { to: "/llm/keys", label: "Virtual API Keys", icon: KeyRound },
-            { to: "/llm/costs", label: "Costs", icon: Coins },
+          {
+            to: "/llm/policies",
+            label: "Policies",
+            icon: Bolt,
+            groupStart: true,
+          },
+          { to: "/llm/guardrails", label: "Guardrails", icon: Shield },
+          { to: "/llm/keys", label: "Virtual API Keys", icon: KeyRound },
+          { to: "/llm/costs", label: "Costs", icon: Coins },
 
-            {
-              to: "/llm/analytics",
-              label: "Analytics",
-              icon: BarChart3,
-              groupStart: true,
-            },
-            { to: "/llm/logs", label: "Logs", icon: ScrollText },
+          {
+            to: "/llm/analytics",
+            label: "Analytics",
+            icon: BarChart3,
+            groupStart: true,
+          },
+          { to: "/llm/logs", label: "Logs", icon: ScrollText },
 
-            {
-              to: "/llm/client-setup",
-              label: "Client Setup",
-              icon: Cable,
-              groupStart: true,
-            },
-            { to: "/llm/playground", label: "Chat Playground", icon: Play },
-          ]
-        : [
-            {
-              to: "/llm/get-started",
-              label: "Get started",
-              icon: Bot,
-              placeholder: true,
-            },
-          ],
-    });
-    groups.push({
-      title: "MCP",
-      items: options.hasMcp
-        ? [
-            { to: "/mcp/servers", label: "Servers", icon: Server },
-            { to: "/mcp/policies", label: "Policies", icon: ShieldCheck },
-            { to: "/mcp/playground", label: "Tool Playground", icon: Play },
-          ]
-        : [
-            {
-              to: "/mcp/get-started",
-              label: "Get started",
-              icon: Server,
-              placeholder: true,
-            },
-          ],
-    });
-  }
+          {
+            to: "/llm/client-setup",
+            label: "Client Setup",
+            icon: Cable,
+            groupStart: true,
+          },
+          { to: "/llm/playground", label: "Chat Playground", icon: Play },
+        ]
+      : [
+          {
+            to: "/llm/get-started",
+            label: "Get started",
+            icon: Bot,
+            placeholder: true,
+          },
+        ],
+  });
+  groups.push({
+    title: "MCP",
+    items: options.hasMcp
+      ? [
+          { to: "/mcp/servers", label: "Servers", icon: Server },
+          { to: "/mcp/policies", label: "Policies", icon: ShieldCheck },
+          { to: "/mcp/playground", label: "Tool Playground", icon: Play },
+        ]
+      : [
+          {
+            to: "/mcp/get-started",
+            label: "Get started",
+            icon: Server,
+            placeholder: true,
+          },
+        ],
+  });
   groups.push({
     title: "Traffic",
     items: options.dumpMode

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -1,5 +1,22 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
+  GuardedGuardrailsPage,
+  GuardedKeysPage,
+  GuardedLlmPoliciesPage,
+  GuardedMcpPoliciesPage,
+  GuardedMcpServersPage,
+  GuardedModelsPage,
+  GuardedProvidersPage,
+} from "./pages/xdsGuardedLlmMcpPages";
+import {
+  GuardedAnalyticsPage,
+  GuardedClientSetupPage,
+  GuardedCostsPage,
+  GuardedLogsPage,
+  GuardedMcpPlaygroundPage,
+  GuardedPlaygroundPage,
+} from "./pages/xdsGuardedPages";
+import {
   RouterProvider,
   createRootRoute,
   createRoute,
@@ -10,24 +27,13 @@ import { createRoot } from "react-dom/client";
 import { routerBasePath } from "./basePath";
 import { Shell } from "./components/Shell";
 import { CelPage } from "./pages/Cel";
-import { ClientSetupPage } from "./pages/ClientSetup";
-import { CostsPage } from "./pages/Costs";
 import { DumpPoliciesPage } from "./pages/DumpPolicies";
 import {
   LlmGetStartedPage,
   McpGetStartedPage,
   TrafficGetStartedPage,
 } from "./pages/GetStarted";
-import { GuardrailsPage } from "./pages/Guardrails";
 import { HomePage } from "./pages/Home";
-import { KeysPage } from "./pages/Keys";
-import { AnalyticsPage, LogsPage } from "./pages/Logs";
-import { McpPlaygroundPage } from "./pages/McpPlayground";
-import { McpServersPage } from "./pages/McpServers";
-import { ModelsPage } from "./pages/Models";
-import { McpPoliciesPage, PoliciesPage } from "./pages/Policies";
-import { PlaygroundPage } from "./pages/Playground";
-import { ProvidersPage } from "./pages/Providers";
 import { RawSettingsPage } from "./pages/RawSettings";
 import { TrafficGatewaysPage } from "./pages/TrafficGateways";
 import { TrafficListenersPage } from "./pages/TrafficListeners";
@@ -64,7 +70,7 @@ const dumpPoliciesRoute = createRoute({
 const modelsRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/llm/models",
-  component: ModelsPage,
+  component: GuardedModelsPage,
 });
 
 const llmGetStartedRoute = createRoute({
@@ -76,67 +82,67 @@ const llmGetStartedRoute = createRoute({
 const providersRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/llm/providers",
-  component: ProvidersPage,
+  component: GuardedProvidersPage,
 });
 
 const logsRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/llm/logs",
-  component: LogsPage,
+  component: GuardedLogsPage,
 });
 
 const analyticsRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/llm/analytics",
-  component: AnalyticsPage,
+  component: GuardedAnalyticsPage,
 });
 
 const policiesRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/llm/policies",
-  component: PoliciesPage,
+  component: GuardedLlmPoliciesPage,
 });
 
 const guardrailsRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/llm/guardrails",
-  component: GuardrailsPage,
+  component: GuardedGuardrailsPage,
 });
 
 const costsRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/llm/costs",
-  component: CostsPage,
+  component: GuardedCostsPage,
 });
 
 const keysRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/llm/keys",
-  component: KeysPage,
+  component: GuardedKeysPage,
 });
 
 const playgroundRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/llm/playground",
-  component: PlaygroundPage,
+  component: GuardedPlaygroundPage,
 });
 
 const clientSetupRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/llm/client-setup",
-  component: ClientSetupPage,
+  component: GuardedClientSetupPage,
 });
 
 const mcpServersRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/mcp/servers",
-  component: McpServersPage,
+  component: GuardedMcpServersPage,
 });
 
 const mcpPoliciesRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/mcp/policies",
-  component: McpPoliciesPage,
+  component: GuardedMcpPoliciesPage,
 });
 
 const mcpGetStartedRoute = createRoute({
@@ -148,7 +154,7 @@ const mcpGetStartedRoute = createRoute({
 const mcpPlaygroundRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/mcp/playground",
-  component: McpPlaygroundPage,
+  component: GuardedMcpPlaygroundPage,
 });
 
 const trafficListenersRoute = createRoute({

--- a/ui/src/pages/GuardrailsDump.tsx
+++ b/ui/src/pages/GuardrailsDump.tsx
@@ -1,0 +1,135 @@
+import { Eye, Shield } from "lucide-react";
+import {
+  Drawer,
+  EmptyState,
+  PageHeader,
+  Panel,
+  StatusBanner,
+  Tooltip,
+  YamlBlock,
+} from "../components/Primitives";
+import { useStickyQueryParam } from "../drawerRouteState";
+import { useConfigDumpMode } from "../hooks";
+import { ReadonlyModeBanner } from "./traffic/TrafficConfigDumpPanel";
+import {
+  isTargetedPolicy,
+  policyInheritanceLabel,
+  policyMatchesKeywords,
+  policyName,
+  policyTargetLabel,
+  policyTypeLabel,
+  type TargetedPolicy,
+} from "./policyDumpUtils";
+
+const GUARDRAIL_KEYWORDS = ["guard", "moderation", "modelarmor"];
+
+export function GuardrailsDumpPage() {
+  const mode = useConfigDumpMode();
+  const [selectedKey, setSelectedKey] = useStickyQueryParam("guardrail");
+  const dumpMode = mode.data?.mode === "dump";
+  const allPolicies = (mode.data?.dump?.policies ?? []).filter(
+    isTargetedPolicy,
+  );
+  const policies = allPolicies.filter((p) =>
+    policyMatchesKeywords(p, GUARDRAIL_KEYWORDS),
+  );
+  const selectedPolicy = policies.find((policy) => policy.key === selectedKey);
+
+  return (
+    <div className="page-stack">
+      <PageHeader
+        title="Guardrails"
+        description="Read-only view of prompt-guard / content-moderation policies from the active gateway dump."
+      />
+      <ReadonlyModeBanner />
+
+      <Panel>
+        {mode.isLoading ? (
+          <StatusBanner state="loading" title="Loading runtime policies" />
+        ) : mode.error ? (
+          <StatusBanner state="bad" title="Config dump unavailable">
+            {mode.error.message}
+          </StatusBanner>
+        ) : !dumpMode ? (
+          <StatusBanner state="warn" title="Readonly guardrails unavailable">
+            Guardrail policies are only viewable here when the gateway is
+            running from XDS config.
+          </StatusBanner>
+        ) : !policies.length ? (
+          <EmptyState
+            title="No guardrail policies configured"
+            description={`No policies matching a prompt-guard/moderation type were found among ${allPolicies.length} total policies in the active dump. Guardrails are configured via an AgentgatewayPolicy resource's backend.ai.promptGuard field (regex, webhook, OpenAI Moderations, AWS Bedrock Guardrails, or Google Model Armor) — none has been created yet.`}
+          />
+        ) : (
+          <GuardrailsTable policies={policies} onSelect={setSelectedKey} />
+        )}
+      </Panel>
+
+      {selectedPolicy ? (
+        <Drawer
+          title={policyName(selectedPolicy)}
+          headerActions={
+            <span className="badge">
+              <Shield size={14} /> {policyTypeLabel(selectedPolicy.policy)}
+            </span>
+          }
+          onClose={() => setSelectedKey(null)}
+        >
+          <YamlBlock value={selectedPolicy} />
+        </Drawer>
+      ) : null}
+    </div>
+  );
+}
+
+function GuardrailsTable(props: {
+  policies: TargetedPolicy[];
+  onSelect: (key: string) => void;
+}) {
+  return (
+    <div className="table-wrap">
+      <table className="dump-policies-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Target</th>
+            <th>Type</th>
+            <th>Inheritance</th>
+            <th aria-label="Actions" />
+          </tr>
+        </thead>
+        <tbody>
+          {props.policies.map((policy) => (
+            <tr key={policy.key}>
+              <td>
+                <div className="resource-name-cell">
+                  <strong>{policyName(policy)}</strong>
+                  <small>{policy.name?.kind ?? "Policy"}</small>
+                </div>
+              </td>
+              <td>{policyTargetLabel(policy.target)}</td>
+              <td>
+                <span className="badge">
+                  {policyTypeLabel(policy.policy)}
+                </span>
+              </td>
+              <td>{policyInheritanceLabel(policy.inheritance)}</td>
+              <td className="row-actions">
+                <Tooltip content="View policy">
+                  <button
+                    className="icon-button"
+                    type="button"
+                    aria-label={`View ${policyName(policy)}`}
+                    onClick={() => props.onSelect(policy.key)}
+                  >
+                    <Eye size={16} />
+                  </button>
+                </Tooltip>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/ui/src/pages/LlmBackendsDump.tsx
+++ b/ui/src/pages/LlmBackendsDump.tsx
@@ -1,0 +1,216 @@
+import { Eye, Bot } from "lucide-react";
+import {
+  Drawer,
+  EmptyState,
+  PageHeader,
+  Panel,
+  StatusBanner,
+  Tooltip,
+  YamlBlock,
+} from "../components/Primitives";
+import { useStickyQueryParam } from "../drawerRouteState";
+import { useConfigDumpMode } from "../hooks";
+import { ReadonlyModeBanner } from "./traffic/TrafficConfigDumpPanel";
+
+type AiBackendEndpoint = {
+  name?: string;
+  provider?: Record<string, unknown> | null;
+  hostOverride?: string | null;
+  pathOverride?: string | null;
+} | null;
+
+type AiBackendInfo = {
+  health?: number;
+  requestLatency?: number;
+  pendingRequests?: number;
+  totalRequests?: number;
+  consecutiveFailures?: number;
+  timesEjected?: number;
+} | null;
+
+type AiBackendActiveEntry = {
+  endpoint?: AiBackendEndpoint;
+  info?: AiBackendInfo;
+  capacity?: number;
+};
+
+type AiBackendProviderEntry = {
+  // Keyed by the endpoint's own name (arbitrary per-config), not a fixed
+  // field name — e.g. {"backend": {...}} or {"nvidia-nim-x": {...}}.
+  active?: Record<string, AiBackendActiveEntry> | null;
+  rejected?: unknown;
+};
+
+type AiBackend = {
+  name?: string;
+  namespace?: string;
+  target?: {
+    providers?: AiBackendProviderEntry[];
+  } | null;
+};
+
+type BackendEntry = {
+  backend?: {
+    ai?: AiBackend;
+    [k: string]: unknown;
+  };
+  [key: string]: unknown;
+};
+
+function backendKey(entry: BackendEntry, index: number) {
+  const ai = entry.backend?.ai;
+  return ai ? `${ai.namespace ?? "default"}/${ai.name ?? index}` : `backend-${index}`;
+}
+
+function isAiBackend(entry: unknown): entry is BackendEntry {
+  return Boolean(
+    entry &&
+      typeof entry === "object" &&
+      (entry as BackendEntry).backend &&
+      typeof (entry as BackendEntry).backend === "object" &&
+      (entry as BackendEntry).backend?.ai,
+  );
+}
+
+function firstActiveProvider(ai: AiBackend | undefined) {
+  const providers = ai?.target?.providers ?? [];
+  return providers.find((p) => p.active) ?? providers[0];
+}
+
+function firstActiveEntry(
+  provider: AiBackendProviderEntry | undefined,
+): AiBackendActiveEntry | null {
+  if (!provider?.active) return null;
+  const values = Object.values(provider.active);
+  return values[0] ?? null;
+}
+
+function providerTypeLabel(endpoint: AiBackendEndpoint) {
+  const provider = endpoint?.provider;
+  if (!provider || typeof provider !== "object") return "unknown";
+  const key = Object.keys(provider)[0];
+  return key ?? "unknown";
+}
+
+function healthLabel(info: AiBackendInfo) {
+  if (!info || typeof info.health !== "number") return "unknown";
+  if (info.health >= 1) return "healthy";
+  if (info.health > 0) return "degraded";
+  return "unhealthy";
+}
+
+export function LlmBackendsDumpPage() {
+  const mode = useConfigDumpMode();
+  const [selectedKey, setSelectedKey] = useStickyQueryParam("backend");
+  const dumpMode = mode.data?.mode === "dump";
+  const backends = ((mode.data?.dump?.backends ?? []) as unknown[]).filter(
+    isAiBackend,
+  );
+  const selectedIndex = backends.findIndex(
+    (entry, index) => backendKey(entry, index) === selectedKey,
+  );
+  const selected = selectedIndex >= 0 ? backends[selectedIndex] : undefined;
+
+  return (
+    <div className="page-stack">
+      <PageHeader
+        title="Models"
+        description="Read-only LLM backends (models and providers) from the active gateway dump."
+      />
+      <ReadonlyModeBanner />
+
+      <Panel>
+        {mode.isLoading ? (
+          <StatusBanner state="loading" title="Loading runtime backends" />
+        ) : mode.error ? (
+          <StatusBanner state="bad" title="Config dump unavailable">
+            {mode.error.message}
+          </StatusBanner>
+        ) : !dumpMode ? (
+          <StatusBanner state="warn" title="Readonly backends unavailable">
+            The runtime backend list is only available when the gateway is
+            running from XDS config.
+          </StatusBanner>
+        ) : !backends.length ? (
+          <EmptyState
+            title="No LLM backends"
+            description="No AI/LLM backends are present in the active gateway dump."
+          />
+        ) : (
+          <div className="table-wrap">
+            <table className="dump-policies-table">
+              <thead>
+                <tr>
+                  <th>Model</th>
+                  <th>Provider</th>
+                  <th>Endpoint</th>
+                  <th>Health</th>
+                  <th>Total requests</th>
+                  <th aria-label="Actions" />
+                </tr>
+              </thead>
+              <tbody>
+                {backends.map((entry, index) => {
+                  const ai = entry.backend?.ai;
+                  const key = backendKey(entry, index);
+                  const provider = firstActiveProvider(ai);
+                  const activeEntry = firstActiveEntry(provider);
+                  const endpoint = activeEntry?.endpoint ?? null;
+                  const info = activeEntry?.info ?? null;
+                  return (
+                    <tr key={key}>
+                      <td>
+                        <div className="resource-name-cell">
+                          <strong>{ai?.name ?? "model"}</strong>
+                          <small>{ai?.namespace ?? "default"}</small>
+                        </div>
+                      </td>
+                      <td>
+                        <span className="badge">
+                          {providerTypeLabel(endpoint)}
+                        </span>
+                      </td>
+                      <td>{endpoint?.hostOverride ?? "unknown"}</td>
+                      <td>
+                        <span className={`badge status-${healthLabel(info)}`}>
+                          {healthLabel(info)}
+                        </span>
+                      </td>
+                      <td>{info?.totalRequests ?? 0}</td>
+                      <td className="row-actions">
+                        <Tooltip content="View backend">
+                          <button
+                            className="icon-button"
+                            type="button"
+                            aria-label={`View ${ai?.name ?? "backend"}`}
+                            onClick={() => setSelectedKey(key)}
+                          >
+                            <Eye size={16} />
+                          </button>
+                        </Tooltip>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </Panel>
+
+      {selected ? (
+        <Drawer
+          title={selected.backend?.ai?.name ?? "Backend"}
+          headerActions={
+            <span className="badge">
+              <Bot size={14} /> LLM backend
+            </span>
+          }
+          onClose={() => setSelectedKey(null)}
+        >
+          <YamlBlock value={selected} />
+        </Drawer>
+      ) : null}
+    </div>
+  );
+}

--- a/ui/src/pages/McpBackendsDump.tsx
+++ b/ui/src/pages/McpBackendsDump.tsx
@@ -1,0 +1,138 @@
+import { Eye, Server } from "lucide-react";
+import {
+  Drawer,
+  EmptyState,
+  PageHeader,
+  Panel,
+  StatusBanner,
+  Tooltip,
+  YamlBlock,
+} from "../components/Primitives";
+import { useStickyQueryParam } from "../drawerRouteState";
+import { useConfigDumpMode } from "../hooks";
+import { ReadonlyModeBanner } from "./traffic/TrafficConfigDumpPanel";
+
+type McpBackendEntry = {
+  backend?: {
+    mcp?: {
+      name?: string;
+      namespace?: string;
+      [k: string]: unknown;
+    };
+    [k: string]: unknown;
+  };
+  [key: string]: unknown;
+};
+
+function isMcpBackend(entry: unknown): entry is McpBackendEntry {
+  return Boolean(
+    entry &&
+      typeof entry === "object" &&
+      (entry as McpBackendEntry).backend &&
+      typeof (entry as McpBackendEntry).backend === "object" &&
+      (entry as McpBackendEntry).backend?.mcp,
+  );
+}
+
+function backendKey(entry: McpBackendEntry, index: number) {
+  const mcp = entry.backend?.mcp;
+  return mcp
+    ? `${mcp.namespace ?? "default"}/${mcp.name ?? index}`
+    : `mcp-backend-${index}`;
+}
+
+export function McpBackendsDumpPage() {
+  const mode = useConfigDumpMode();
+  const [selectedKey, setSelectedKey] = useStickyQueryParam("mcp-backend");
+  const dumpMode = mode.data?.mode === "dump";
+  const backends = ((mode.data?.dump?.backends ?? []) as unknown[]).filter(
+    isMcpBackend,
+  );
+  const selectedIndex = backends.findIndex(
+    (entry, index) => backendKey(entry, index) === selectedKey,
+  );
+  const selected = selectedIndex >= 0 ? backends[selectedIndex] : undefined;
+
+  return (
+    <div className="page-stack">
+      <PageHeader
+        title="MCP Servers"
+        description="Read-only MCP backends from the active gateway dump."
+      />
+      <ReadonlyModeBanner />
+
+      <Panel>
+        {mode.isLoading ? (
+          <StatusBanner state="loading" title="Loading runtime backends" />
+        ) : mode.error ? (
+          <StatusBanner state="bad" title="Config dump unavailable">
+            {mode.error.message}
+          </StatusBanner>
+        ) : !dumpMode ? (
+          <StatusBanner state="warn" title="Readonly backends unavailable">
+            The runtime backend list is only available when the gateway is
+            running from XDS config.
+          </StatusBanner>
+        ) : !backends.length ? (
+          <EmptyState
+            title="No MCP backends on this gateway"
+            description="This gateway currently routes zero MCP backends — no AgentgatewayBackend of kind mcp targets it. If MCP traffic is ever routed through this gateway, real MCP backends will appear here automatically."
+          />
+        ) : (
+          <div className="table-wrap">
+            <table className="dump-policies-table">
+              <thead>
+                <tr>
+                  <th>Server</th>
+                  <th aria-label="Actions" />
+                </tr>
+              </thead>
+              <tbody>
+                {backends.map((entry, index) => {
+                  const mcp = entry.backend?.mcp;
+                  const key = backendKey(entry, index);
+                  return (
+                    <tr key={key}>
+                      <td>
+                        <div className="resource-name-cell">
+                          <strong>{mcp?.name ?? "server"}</strong>
+                          <small>{mcp?.namespace ?? "default"}</small>
+                        </div>
+                      </td>
+                      <td className="row-actions">
+                        <Tooltip content="View backend">
+                          <button
+                            className="icon-button"
+                            type="button"
+                            aria-label={`View ${mcp?.name ?? "backend"}`}
+                            onClick={() => setSelectedKey(key)}
+                          >
+                            <Eye size={16} />
+                          </button>
+                        </Tooltip>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </Panel>
+
+      {selected ? (
+        <Drawer
+          title={selected.backend?.mcp?.name ?? "MCP backend"}
+          headerActions={
+            <span className="badge">
+              <Server size={14} /> MCP backend
+            </span>
+          }
+          onClose={() => setSelectedKey(null)}
+        >
+          <YamlBlock value={selected} />
+        </Drawer>
+      ) : null}
+    </div>
+  );
+}

--- a/ui/src/pages/McpPoliciesDump.tsx
+++ b/ui/src/pages/McpPoliciesDump.tsx
@@ -1,0 +1,126 @@
+import { Eye, ShieldCheck } from "lucide-react";
+import {
+  Drawer,
+  EmptyState,
+  PageHeader,
+  Panel,
+  StatusBanner,
+  Tooltip,
+  YamlBlock,
+} from "../components/Primitives";
+import { useStickyQueryParam } from "../drawerRouteState";
+import { useConfigDumpMode } from "../hooks";
+import { ReadonlyModeBanner } from "./traffic/TrafficConfigDumpPanel";
+import {
+  isTargetedPolicy,
+  policyInheritanceLabel,
+  policyName,
+  policyTargetLabel,
+  policyTypeLabel,
+  type TargetedPolicy,
+} from "./policyDumpUtils";
+
+function isMcpTargeted(policy: TargetedPolicy) {
+  const target = policyTargetLabel(policy.target).toLowerCase();
+  return target.includes("mcp") || policy.key.toLowerCase().includes("mcp");
+}
+
+export function McpPoliciesDumpPage() {
+  const mode = useConfigDumpMode();
+  const [selectedKey, setSelectedKey] = useStickyQueryParam("mcp-policy");
+  const dumpMode = mode.data?.mode === "dump";
+  const allPolicies = (mode.data?.dump?.policies ?? []).filter(
+    isTargetedPolicy,
+  );
+  const policies = allPolicies.filter(isMcpTargeted);
+  const selectedPolicy = policies.find((policy) => policy.key === selectedKey);
+
+  return (
+    <div className="page-stack">
+      <PageHeader
+        title="MCP Policies"
+        description="Read-only policies targeting MCP backends/routes from the active gateway dump."
+      />
+      <ReadonlyModeBanner />
+
+      <Panel>
+        {mode.isLoading ? (
+          <StatusBanner state="loading" title="Loading runtime policies" />
+        ) : mode.error ? (
+          <StatusBanner state="bad" title="Config dump unavailable">
+            {mode.error.message}
+          </StatusBanner>
+        ) : !dumpMode ? (
+          <StatusBanner state="warn" title="Readonly policies unavailable">
+            MCP policies are only viewable here when the gateway is running
+            from XDS config.
+          </StatusBanner>
+        ) : !policies.length ? (
+          <EmptyState
+            title="No MCP-targeted policies"
+            description={`No policies targeting an MCP backend/route were found among ${allPolicies.length} total policies in the active dump — this gateway currently has no MCP backends configured (see MCP > Servers). Any AgentgatewayPolicy targeting an MCP backend will appear here once one exists.`}
+          />
+        ) : (
+          <div className="table-wrap">
+            <table className="dump-policies-table">
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Target</th>
+                  <th>Type</th>
+                  <th>Inheritance</th>
+                  <th aria-label="Actions" />
+                </tr>
+              </thead>
+              <tbody>
+                {policies.map((policy) => (
+                  <tr key={policy.key}>
+                    <td>
+                      <div className="resource-name-cell">
+                        <strong>{policyName(policy)}</strong>
+                        <small>{policy.name?.kind ?? "Policy"}</small>
+                      </div>
+                    </td>
+                    <td>{policyTargetLabel(policy.target)}</td>
+                    <td>
+                      <span className="badge">
+                        {policyTypeLabel(policy.policy)}
+                      </span>
+                    </td>
+                    <td>{policyInheritanceLabel(policy.inheritance)}</td>
+                    <td className="row-actions">
+                      <Tooltip content="View policy">
+                        <button
+                          className="icon-button"
+                          type="button"
+                          aria-label={`View ${policyName(policy)}`}
+                          onClick={() => setSelectedKey(policy.key)}
+                        >
+                          <Eye size={16} />
+                        </button>
+                      </Tooltip>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </Panel>
+
+      {selectedPolicy ? (
+        <Drawer
+          title={policyName(selectedPolicy)}
+          headerActions={
+            <span className="badge">
+              <ShieldCheck size={14} /> {policyTypeLabel(selectedPolicy.policy)}
+            </span>
+          }
+          onClose={() => setSelectedKey(null)}
+        >
+          <YamlBlock value={selectedPolicy} />
+        </Drawer>
+      ) : null}
+    </div>
+  );
+}

--- a/ui/src/pages/VirtualKeysDump.tsx
+++ b/ui/src/pages/VirtualKeysDump.tsx
@@ -1,0 +1,135 @@
+import { Eye, KeyRound } from "lucide-react";
+import {
+  Drawer,
+  EmptyState,
+  PageHeader,
+  Panel,
+  StatusBanner,
+  Tooltip,
+  YamlBlock,
+} from "../components/Primitives";
+import { useStickyQueryParam } from "../drawerRouteState";
+import { useConfigDumpMode } from "../hooks";
+import { ReadonlyModeBanner } from "./traffic/TrafficConfigDumpPanel";
+import {
+  isTargetedPolicy,
+  policyInheritanceLabel,
+  policyMatchesKeywords,
+  policyName,
+  policyTargetLabel,
+  policyTypeLabel,
+  type TargetedPolicy,
+} from "./policyDumpUtils";
+
+const KEY_KEYWORDS = ["apikey", "api_key", "virtualkey"];
+
+export function VirtualKeysDumpPage() {
+  const mode = useConfigDumpMode();
+  const [selectedKey, setSelectedKey] = useStickyQueryParam("apikey");
+  const dumpMode = mode.data?.mode === "dump";
+  const allPolicies = (mode.data?.dump?.policies ?? []).filter(
+    isTargetedPolicy,
+  );
+  const policies = allPolicies.filter((p) =>
+    policyMatchesKeywords(p, KEY_KEYWORDS),
+  );
+  const selectedPolicy = policies.find((policy) => policy.key === selectedKey);
+
+  return (
+    <div className="page-stack">
+      <PageHeader
+        title="Virtual API Keys"
+        description="Read-only view of API-key-authentication policies from the active gateway dump."
+      />
+      <ReadonlyModeBanner />
+
+      <Panel>
+        {mode.isLoading ? (
+          <StatusBanner state="loading" title="Loading runtime policies" />
+        ) : mode.error ? (
+          <StatusBanner state="bad" title="Config dump unavailable">
+            {mode.error.message}
+          </StatusBanner>
+        ) : !dumpMode ? (
+          <StatusBanner state="warn" title="Readonly keys unavailable">
+            API key policies are only viewable here when the gateway is
+            running from XDS config.
+          </StatusBanner>
+        ) : !policies.length ? (
+          <EmptyState
+            title="No API key policies configured"
+            description={`No policies matching an API-key-authentication type were found among ${allPolicies.length} total policies in the active dump. This gateway currently authenticates via the WSO2 JWT policy (see Traffic > Policies); API key auth is configured via AgentgatewayPolicy's apiKeyAuthentication field and has not been created.`}
+          />
+        ) : (
+          <KeysTable policies={policies} onSelect={setSelectedKey} />
+        )}
+      </Panel>
+
+      {selectedPolicy ? (
+        <Drawer
+          title={policyName(selectedPolicy)}
+          headerActions={
+            <span className="badge">
+              <KeyRound size={14} /> {policyTypeLabel(selectedPolicy.policy)}
+            </span>
+          }
+          onClose={() => setSelectedKey(null)}
+        >
+          <YamlBlock value={selectedPolicy} />
+        </Drawer>
+      ) : null}
+    </div>
+  );
+}
+
+function KeysTable(props: {
+  policies: TargetedPolicy[];
+  onSelect: (key: string) => void;
+}) {
+  return (
+    <div className="table-wrap">
+      <table className="dump-policies-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Target</th>
+            <th>Type</th>
+            <th>Inheritance</th>
+            <th aria-label="Actions" />
+          </tr>
+        </thead>
+        <tbody>
+          {props.policies.map((policy) => (
+            <tr key={policy.key}>
+              <td>
+                <div className="resource-name-cell">
+                  <strong>{policyName(policy)}</strong>
+                  <small>{policy.name?.kind ?? "Policy"}</small>
+                </div>
+              </td>
+              <td>{policyTargetLabel(policy.target)}</td>
+              <td>
+                <span className="badge">
+                  {policyTypeLabel(policy.policy)}
+                </span>
+              </td>
+              <td>{policyInheritanceLabel(policy.inheritance)}</td>
+              <td className="row-actions">
+                <Tooltip content="View policy">
+                  <button
+                    className="icon-button"
+                    type="button"
+                    aria-label={`View ${policyName(policy)}`}
+                    onClick={() => props.onSelect(policy.key)}
+                  >
+                    <Eye size={16} />
+                  </button>
+                </Tooltip>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/ui/src/pages/XdsUnavailable.tsx
+++ b/ui/src/pages/XdsUnavailable.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from "react";
+import { EmptyState, PageHeader, Panel } from "../components/Primitives";
+import { ReadonlyModeBanner } from "./traffic/TrafficConfigDumpPanel";
+
+/**
+ * Shared placeholder for LLM/MCP UI pages that fundamentally cannot be
+ * sourced from the read-only XDS config dump, because the data they show
+ * (local prompt/response logs, in-UI cost bookkeeping, generated client
+ * snippets) was never part of gateway *config* to begin with — it lived in
+ * the standalone binary's own local state, which doesn't exist when the
+ * gateway is Kubernetes/XDS-managed. Rather than silently rendering broken
+ * (empty query, misleading UI), this explains why and points at the real
+ * equivalent for this deployment.
+ */
+export function XdsUnavailablePage(props: {
+  title: string;
+  description: string;
+  reason: string;
+  alternative?: ReactNode;
+}) {
+  return (
+    <div className="page-stack">
+      <PageHeader title={props.title} description={props.description} />
+      <ReadonlyModeBanner />
+      <Panel>
+        <EmptyState
+          title="Not available for this deployment"
+          description={props.reason}
+          action={props.alternative}
+        />
+      </Panel>
+    </div>
+  );
+}

--- a/ui/src/pages/policyDumpUtils.ts
+++ b/ui/src/pages/policyDumpUtils.ts
@@ -1,0 +1,133 @@
+// Shared helpers for read-only, XDS-config-dump-sourced policy views.
+// Duplicated (not imported) from DumpPolicies.tsx deliberately: that page is
+// already working in production and is left untouched to avoid regression
+// risk. These are pure, side-effect-free formatting helpers only.
+
+export type TargetedPolicy = {
+  key: string;
+  name?: { kind?: string; namespace?: string; name?: string } | null;
+  target?: unknown;
+  policy?: unknown;
+  inheritance?: unknown;
+  [key: string]: unknown;
+};
+
+export function isTargetedPolicy(value: unknown): value is TargetedPolicy {
+  return Boolean(
+    value &&
+      typeof value === "object" &&
+      typeof (value as { key?: unknown }).key === "string",
+  );
+}
+
+export function policyName(policy: TargetedPolicy) {
+  return policy.name
+    ? `${policy.name.namespace}/${policy.name.name}`
+    : policy.key;
+}
+
+export function policyInheritanceLabel(value: unknown) {
+  return typeof value === "string" && value ? value : "default";
+}
+
+const policyMetadataKeys = new Set(["phase", "inheritance"]);
+
+function firstPolicyKey(record: Record<string, unknown>) {
+  return Object.keys(record).find((key) => !policyMetadataKeys.has(key));
+}
+
+export function policyTypeLabel(policy: unknown) {
+  if (!policy || typeof policy !== "object") return "policy";
+  const record = policy as Record<string, unknown>;
+  const outer = firstPolicyKey(record);
+  const inner = outer ? record[outer] : null;
+  if (inner && typeof inner === "object") {
+    const child = firstPolicyKey(inner as Record<string, unknown>);
+    return child ?? outer;
+  }
+  return outer ?? "policy";
+}
+
+export function policyTargetLabel(target: unknown) {
+  if (!target || typeof target !== "object") return "unknown target";
+  const record = target as Record<string, unknown>;
+  if ("gateway" in record) return gatewayTargetLabel(record.gateway);
+  if ("route" in record) return routeTargetLabel(record.route);
+  if ("backend" in record) return backendTargetLabel(record.backend);
+  if ("listenerSet" in record)
+    return listenerSetTargetLabel(record.listenerSet);
+  return "target";
+}
+
+function gatewayTargetLabel(value: unknown) {
+  const gateway = value as {
+    gatewayName?: string;
+    gatewayNamespace?: string;
+    listenerName?: string | null;
+  } | null;
+  if (!gateway) return "Gateway";
+  const listener = gateway.listenerName ? ` · ${gateway.listenerName}` : "";
+  return `Gateway ${gateway.gatewayNamespace ?? "default"}/${gateway.gatewayName ?? "gateway"}${listener}`;
+}
+
+function routeTargetLabel(value: unknown) {
+  const route = value as {
+    namespace?: string;
+    name?: string;
+    ruleName?: string | null;
+    kind?: string | null;
+  } | null;
+  if (!route) return "Route";
+  const kind = route.kind ? `${route.kind} ` : "Route ";
+  const rule = route.ruleName ? ` · ${route.ruleName}` : "";
+  return `${kind}${route.namespace ?? "default"}/${route.name ?? "route"}${rule}`;
+}
+
+function backendTargetLabel(value: unknown) {
+  if (typeof value === "string") return `Backend ${value}`;
+  if (!value || typeof value !== "object") return "Backend";
+  const backend = value as Record<string, unknown>;
+  if ("backend" in backend) {
+    const named = backend.backend as {
+      namespace?: string;
+      name?: string;
+      section?: string | null;
+    } | null;
+    const section = named?.section ? ` · ${named.section}` : "";
+    return `Backend ${named?.namespace ?? "default"}/${named?.name ?? "backend"}${section}`;
+  }
+  if ("service" in backend) {
+    const service = backend.service as {
+      namespace?: string;
+      hostname?: string;
+      port?: number | null;
+    } | null;
+    return `Service ${service?.namespace ?? "default"}/${service?.hostname ?? "service"}${service?.port ? `:${service.port}` : ""}`;
+  }
+  return "Backend";
+}
+
+function listenerSetTargetLabel(value: unknown) {
+  const listenerSet = value as {
+    namespace?: string;
+    name?: string;
+    section?: string | null;
+  } | null;
+  if (!listenerSet) return "ListenerSet";
+  const section = listenerSet.section ? ` · ${listenerSet.section}` : "";
+  return `ListenerSet ${listenerSet.namespace ?? "default"}/${listenerSet.name ?? "listener-set"}${section}`;
+}
+
+/**
+ * Best-effort classification of a policy's "family" for the purposes of the
+ * Guardrails / Virtual API Keys filtered views. Matches on the type label
+ * agentgateway itself reports in the dump (via policyTypeLabel), using
+ * case-insensitive substring matching since the exact runtime key name isn't
+ * guaranteed to match the CRD's Go json tag 1:1 (the dump is produced by the
+ * Rust data plane, not the Go controller).
+ */
+export function policyMatchesKeywords(policy: TargetedPolicy, keywords: string[]) {
+  const label = (policyTypeLabel(policy.policy) ?? "policy").toLowerCase();
+  const key = policy.key.toLowerCase();
+  return keywords.some((kw) => label.includes(kw) || key.includes(kw));
+}

--- a/ui/src/pages/xdsGuardedLlmMcpPages.tsx
+++ b/ui/src/pages/xdsGuardedLlmMcpPages.tsx
@@ -1,0 +1,71 @@
+// Parent-level guards (full component swap, no conditional hooks — see
+// xdsGuardedPages.tsx for rationale) wiring each LLM/MCP nav destination to
+// a real read-only dump view when the gateway is XDS-managed, falling back
+// to the original standalone-mode-only page otherwise.
+import { StatusBanner } from "../components/Primitives";
+import { useConfigDumpMode } from "../hooks";
+import { ModelsPage } from "./Models";
+import { ProvidersPage } from "./Providers";
+import { GuardrailsPage } from "./Guardrails";
+import { KeysPage } from "./Keys";
+import { McpServersPage } from "./McpServers";
+import { PoliciesPage, McpPoliciesPage } from "./Policies";
+import { LlmBackendsDumpPage } from "./LlmBackendsDump";
+import { McpBackendsDumpPage } from "./McpBackendsDump";
+import { GuardrailsDumpPage } from "./GuardrailsDump";
+import { VirtualKeysDumpPage } from "./VirtualKeysDump";
+import { DumpPoliciesPage } from "./DumpPolicies";
+import { McpPoliciesDumpPage } from "./McpPoliciesDump";
+
+function useIsDumpMode() {
+  const mode = useConfigDumpMode();
+  return { isLoading: mode.isLoading, isDump: mode.data?.mode === "dump" };
+}
+
+export function GuardedModelsPage() {
+  const { isLoading, isDump } = useIsDumpMode();
+  if (isLoading) return <StatusBanner state="loading" title="Loading" />;
+  return isDump ? <LlmBackendsDumpPage /> : <ModelsPage />;
+}
+
+export function GuardedProvidersPage() {
+  const { isLoading, isDump } = useIsDumpMode();
+  if (isLoading) return <StatusBanner state="loading" title="Loading" />;
+  // Our runtime dump doesn't distinguish "providers" from "models" the way
+  // standalone config does (each AI backend already carries its provider
+  // endpoint) — the same read-only backends view serves both nav items.
+  return isDump ? <LlmBackendsDumpPage /> : <ProvidersPage />;
+}
+
+export function GuardedLlmPoliciesPage() {
+  const { isLoading, isDump } = useIsDumpMode();
+  if (isLoading) return <StatusBanner state="loading" title="Loading" />;
+  // Reuses the same generic, already-production-proven policy dump view
+  // used by Traffic > Policies — agentgateway has one unified policy CRD,
+  // so there's nothing LLM-specific to filter here.
+  return isDump ? <DumpPoliciesPage /> : <PoliciesPage />;
+}
+
+export function GuardedGuardrailsPage() {
+  const { isLoading, isDump } = useIsDumpMode();
+  if (isLoading) return <StatusBanner state="loading" title="Loading" />;
+  return isDump ? <GuardrailsDumpPage /> : <GuardrailsPage />;
+}
+
+export function GuardedKeysPage() {
+  const { isLoading, isDump } = useIsDumpMode();
+  if (isLoading) return <StatusBanner state="loading" title="Loading" />;
+  return isDump ? <VirtualKeysDumpPage /> : <KeysPage />;
+}
+
+export function GuardedMcpServersPage() {
+  const { isLoading, isDump } = useIsDumpMode();
+  if (isLoading) return <StatusBanner state="loading" title="Loading" />;
+  return isDump ? <McpBackendsDumpPage /> : <McpServersPage />;
+}
+
+export function GuardedMcpPoliciesPage() {
+  const { isLoading, isDump } = useIsDumpMode();
+  if (isLoading) return <StatusBanner state="loading" title="Loading" />;
+  return isDump ? <McpPoliciesDumpPage /> : <McpPoliciesPage />;
+}

--- a/ui/src/pages/xdsGuardedPages.tsx
+++ b/ui/src/pages/xdsGuardedPages.tsx
@@ -1,0 +1,123 @@
+// Thin wrappers that gate the original (standalone-mode-only) LLM pages
+// behind an XDS/dump-mode check, swapping in an honest "not available"
+// placeholder instead. Implemented as parent-level component swaps (not
+// conditional hook calls inside the original components) so there is no
+// Rules-of-Hooks risk: React fully mounts/unmounts one tree or the other.
+import { StatusBanner } from "../components/Primitives";
+import { useConfigDumpMode } from "../hooks";
+import { AnalyticsPage, LogsPage } from "./Logs";
+import { ClientSetupPage } from "./ClientSetup";
+import { CostsPage } from "./Costs";
+import { PlaygroundPage } from "./Playground";
+import { McpPlaygroundPage } from "./McpPlayground";
+import { XdsUnavailablePage } from "./XdsUnavailable";
+
+// NOTE: all guards below use a parent-level full-component swap (never
+// mounting the original page in dump mode) rather than an early-return
+// inside the original component after its hooks run. CostsPage originally
+// used the latter pattern and caused an infinite render loop in dump mode:
+// configuredCostSources(undefined) returns a fresh `[]` reference every
+// render, so a useEffect keyed on that array kept "changing" and
+// re-triggering forever. Full component swap avoids this class of bug
+// entirely since the original component's hooks never run at all.
+export function GuardedCostsPage() {
+  const mode = useConfigDumpMode();
+  if (mode.isLoading) {
+    return <StatusBanner state="loading" title="Loading" />;
+  }
+  if (mode.data?.mode === "dump") {
+    return (
+      <XdsUnavailablePage
+        title="Costs"
+        description="Per-model/provider cost tracking."
+        reason="Cost tracking here is a local, standalone-mode-only bookkeeping feature — it reads a config flag and a local log store that don't exist when the gateway is Kubernetes/XDS-managed. If this deployment exports OpenTelemetry traces/metrics, that telemetry stack is a stronger source of per-request cost/latency/token data than this page would show."
+      />
+    );
+  }
+  return <CostsPage />;
+}
+
+export function GuardedLogsPage() {
+  const mode = useConfigDumpMode();
+  if (mode.isLoading) {
+    return <StatusBanner state="loading" title="Loading" />;
+  }
+  if (mode.data?.mode === "dump") {
+    return (
+      <XdsUnavailablePage
+        title="Logs"
+        description="Request/response log viewer."
+        reason="This page reads from a local prompt/response log store that only exists in standalone mode — there is no equivalent surfaced by the XDS config dump. Request logs for an XDS-managed gateway are typically available via kubectl logs and/or whatever observability stack (OpenTelemetry, etc.) this deployment exports to."
+      />
+    );
+  }
+  return <LogsPage />;
+}
+
+export function GuardedAnalyticsPage() {
+  const mode = useConfigDumpMode();
+  if (mode.isLoading) {
+    return <StatusBanner state="loading" title="Loading" />;
+  }
+  if (mode.data?.mode === "dump") {
+    return (
+      <XdsUnavailablePage
+        title="Analytics"
+        description="Usage charts."
+        reason="Analytics here reads the same local, standalone-mode-only log store as the Logs page, aggregated in the browser. For an XDS-managed gateway, use whatever telemetry stack this deployment exports OpenTelemetry data to instead."
+      />
+    );
+  }
+  return <AnalyticsPage />;
+}
+
+export function GuardedClientSetupPage() {
+  const mode = useConfigDumpMode();
+  if (mode.isLoading) {
+    return <StatusBanner state="loading" title="Loading" />;
+  }
+  if (mode.data?.mode === "dump") {
+    return (
+      <XdsUnavailablePage
+        title="Client Setup"
+        description="Generated client/SDK snippets for calling this gateway."
+        reason="This wizard builds snippets from the local writable model/virtual-key config, which is empty in XDS mode. See the Models page for the real list of configured models, and use this gateway's real hostname as the base URL — a plain curl/OpenAI-SDK call against /v1/chat/completions works the same way this wizard would have generated."
+      />
+    );
+  }
+  return <ClientSetupPage />;
+}
+
+export function GuardedPlaygroundPage() {
+  const mode = useConfigDumpMode();
+  if (mode.isLoading) {
+    return <StatusBanner state="loading" title="Loading" />;
+  }
+  if (mode.data?.mode === "dump") {
+    return (
+      <XdsUnavailablePage
+        title="Chat Playground"
+        description="Send a real chat completion request through the configured gateway."
+        reason="This form makes a direct browser fetch() to the gateway's own /v1/chat/completions, which requires both a CORS-allow policy for this origin and a writable local model list — neither works in XDS mode (the 'Apply CORS' write is a no-op, and the model dropdown only reads the local config store, not the XDS dump). The exact same request is one curl call away: curl -X POST &lt;gateway-url&gt;/v1/chat/completions -H 'Content-Type: application/json' -d '{&quot;model&quot;:&quot;&lt;model-name-from-Models-page&gt;&quot;,&quot;messages&quot;:[{&quot;role&quot;:&quot;user&quot;,&quot;content&quot;:&quot;hello&quot;}]}' — no CORS restriction applies outside a browser."
+      />
+    );
+  }
+  return <PlaygroundPage />;
+}
+
+export function GuardedMcpPlaygroundPage() {
+  const mode = useConfigDumpMode();
+  if (mode.isLoading) {
+    return <StatusBanner state="loading" title="Loading" />;
+  }
+  if (mode.data?.mode === "dump") {
+    return (
+      <XdsUnavailablePage
+        title="Tool Playground"
+        description="Send a real MCP JSON-RPC call through the configured gateway."
+        reason="Same limitation as Chat Playground: a direct browser fetch() blocked by CORS in XDS mode, plus this gateway currently has no MCP backends configured at all (see MCP > Servers). Use a direct JSON-RPC call from curl/an MCP client instead."
+      />
+    );
+  }
+  return <McpPlaygroundPage />;
+}


### PR DESCRIPTION
## Summary

Traffic (Listeners/Routes/Policies) already has a real read-only rendering path when the gateway is XDS-managed (`dumpMode`), sourced from the config dump instead of the local writable config store. The LLM and MCP nav sections never got the equivalent treatment — those entire sections are hidden outright in `dumpMode`, even though most of that data (backends/models, policies) is fully present in the same config dump Traffic already reads from.

This adds the missing read-only views for an XDS-managed gateway:

- **Models / Providers**: a new backends dump view sourced from `dump.backends[]`, showing each AI backend's provider type, endpoint, health, and request count.
- **LLM Policies**: reuses the existing, already-working generic `DumpPoliciesPage` — no new code needed, since policies are a single unified CRD type regardless of LLM/MCP/Traffic.
- **Guardrails / Virtual API Keys**: filtered views over the same policy dump, matching on the policy's reported type (`promptGuard`/moderation family, `apiKeyAuthentication` family respectively).
- **MCP Servers / Policies**: same treatment for MCP backends/policies.
- **Costs / Analytics / Logs / Client Setup / Chat & Tool Playground**: these read from local-only state (a standalone-mode log/bookkeeping store, or require a live browser-to-gateway request that needs a CORS-allow config write) that has no XDS-dump equivalent at all. Rather than leave them silently hidden or rendering a broken/empty writable form, they now show an explicit "not available in this deployment mode" message explaining why, plus the real alternative (`kubectl logs` / OpenTelemetry / a direct `curl` call).

All new views are pure read-only renders of the config dump — nothing here adds a new write path or changes standalone-mode behavior at all.

## Implementation note (a bug found along the way)

Guard components use full parent-level component swaps (mount either the dump view or the original standalone-mode page, never both) rather than early-returning inside the original component after some of its hooks have already run. The latter pattern was tried first for the Costs page and caused an infinite render loop: a local helper (`configuredCostSources`) returns a fresh empty-array reference on every render when config data is absent/disabled, which kept "changing" a `useEffect` dependency indefinitely. Full component swaps sidestep this class of bug entirely since the original component's hooks never execute at all in dump mode.

## Testing

- `npm run generate-schema && tsc -b` passes clean.
- `npm run build` produces a clean production bundle.
- Manually verified every new/changed route against a real running XDS-managed gateway (via `kubectl port-forward` to a live cluster) — confirmed real backend data renders correctly (provider, endpoint, health, request counts), confirmed the "not available" pages render their explanation instead of a broken/empty form, and confirmed no infinite-loop/console errors on any page.