### PR TITLE
feat(metrics): add agentgateway_controller_build_info metric and fix SetRegistry lifecycle bug 

### DIFF
--- a/controller/pkg/metrics/build_info.go
+++ b/controller/pkg/metrics/build_info.go
@@ -13,7 +13,7 @@ var buildInfoCollector = func() prometheus.Collector {
 	return prometheus.NewGaugeFunc(
 		prometheus.GaugeOpts{
 			Namespace: DefaultNamespace,
-			Name:      "build_info",
+			Name:      "controller_build_info",
 			Help:      "Agentgateway build metadata exposed as labels with a constant value of 1.",
 			ConstLabels: prometheus.Labels{
 				"version":    info.Controller,

--- a/controller/pkg/metrics/build_info.go
+++ b/controller/pkg/metrics/build_info.go
@@ -1,0 +1,37 @@
+package metrics
+
+import (
+	"runtime"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/agentgateway/agentgateway/controller/pkg/version"
+)
+
+var buildInfoCollector = func() prometheus.Collector {
+	info := version.Info()
+	return prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{
+			Namespace: DefaultNamespace,
+			Name:      "build_info",
+			Help:      "Agentgateway build metadata exposed as labels with a constant value of 1.",
+			ConstLabels: prometheus.Labels{
+				"version":    info.Controller,
+				"git_commit": info.Commit,
+				"build_date": info.Date,
+				"go_version": runtime.Version(),
+				"platform":   info.OS + "/" + info.Arch,
+			},
+		},
+		func() float64 { return 1 },
+	)
+}()
+
+// BuildInfoCollector returns the build info collector.
+func BuildInfoCollector() prometheus.Collector {
+	return buildInfoCollector
+}
+
+func init() {
+	registry.MustRegister(buildInfoCollector)
+}

--- a/controller/pkg/metrics/build_info_test.go
+++ b/controller/pkg/metrics/build_info_test.go
@@ -19,7 +19,7 @@ func TestBuildInfoMetric(t *testing.T) {
 	info := version.Info()
 	gathered := metricstest.MustGatherMetrics(t)
 
-	gathered.AssertMetric("agentgateway_build_info", &metricstest.ExpectedMetric{
+	gathered.AssertMetric("agentgateway_controller_build_info", &metricstest.ExpectedMetric{
 		Labels: []metrics.Label{
 			{Name: "version", Value: info.Controller},
 			{Name: "git_commit", Value: info.Commit},

--- a/controller/pkg/metrics/build_info_test.go
+++ b/controller/pkg/metrics/build_info_test.go
@@ -1,0 +1,32 @@
+package metrics_test
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/agentgateway/agentgateway/controller/pkg/metrics"
+	"github.com/agentgateway/agentgateway/controller/pkg/metrics/metricstest"
+	"github.com/agentgateway/agentgateway/controller/pkg/version"
+)
+
+func TestBuildInfoMetric(t *testing.T) {
+	metrics.SetRegistry(false, metrics.NewRegistry())
+
+	// Re-register the build info collector on the new test registry,
+	// since SetRegistry replaced the global one.
+	metrics.Registry().MustRegister(metrics.BuildInfoCollector())
+
+	info := version.Info()
+	gathered := metricstest.MustGatherMetrics(t)
+
+	gathered.AssertMetric("agentgateway_build_info", &metricstest.ExpectedMetric{
+		Labels: []metrics.Label{
+			{Name: "version", Value: info.Controller},
+			{Name: "git_commit", Value: info.Commit},
+			{Name: "build_date", Value: info.Date},
+			{Name: "go_version", Value: runtime.Version()},
+			{Name: "platform", Value: info.OS + "/" + info.Arch},
+		},
+		Value: 1.0,
+	})
+}

--- a/controller/pkg/metrics/metrics.go
+++ b/controller/pkg/metrics/metrics.go
@@ -323,15 +323,17 @@ func SetRegistry(useBuiltinRegistry bool, r RegistererGatherer) {
 	registryLock.Lock()
 	defer registryLock.Unlock()
 
-	if !useBuiltinRegistry {
-		metrics.Registry = registry
-	}
+	// Always point controller-runtime's metrics to our local registry,
+	// which already has process/go collectors and all init-registered metrics.
+	metrics.Registry = registry
 
 	if isNil(r) {
-		registry = metrics.Registry
-	} else {
-		registry = r
+		// Keep using our local registry.
+		return
 	}
+	registry = r
+	// Also update controller-runtime to use the external registry.
+	metrics.Registry = r
 }
 
 // isNil checks if the provided interface contains nil or a nil value.

--- a/controller/pkg/metrics/metrics_test.go
+++ b/controller/pkg/metrics/metrics_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	. "github.com/agentgateway/agentgateway/controller/pkg/metrics"
 	"github.com/agentgateway/agentgateway/controller/pkg/metrics/metricstest"
@@ -454,6 +455,102 @@ func (r exampleTypedLabels) toMetricsLabels() []Label {
 		{Name: "gateway", Value: r.GatewayName},
 		{Name: "port", Value: r.Port},
 	}
+}
+
+func TestSetRegistryWithNilAndBuiltinDisabled(t *testing.T) {
+	// Simulate the default setup path: SetRegistry(false, nil)
+	SetRegistry(false, nil)
+
+	// Registry() should return a non-nil registry.
+	r := Registry()
+	require.NotNil(t, r)
+
+	// The controller-runtime registry should be the same object as ours.
+	// Register a test gauge on our Registry() and verify it's visible via controller-runtime.
+	testGauge := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "setregistry_builtin_off_test",
+		Help: "test",
+	})
+	r.MustRegister(testGauge)
+	testGauge.Set(42)
+
+	families, err := crmetrics.Registry.Gather()
+	require.NoError(t, err)
+	found := false
+	for _, f := range families {
+		if f.GetName() == "setregistry_builtin_off_test" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "metric registered on Registry() should be visible via controller-runtime registry")
+}
+
+func TestSetRegistryWithNilAndBuiltinEnabled(t *testing.T) {
+	// Simulate the setup path when EnableBuiltinDefaultMetrics=true: SetRegistry(true, nil)
+	// This was previously buggy: the local registry (with init-registered metrics) was abandoned.
+	SetRegistry(true, nil)
+
+	r := Registry()
+	require.NotNil(t, r)
+
+	// Register a test gauge on our Registry() and verify it's visible via controller-runtime.
+	testGauge := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "setregistry_builtin_on_test",
+		Help: "test",
+	})
+	r.MustRegister(testGauge)
+	testGauge.Set(99)
+
+	families, err := crmetrics.Registry.Gather()
+	require.NoError(t, err)
+	found := false
+	for _, f := range families {
+		if f.GetName() == "setregistry_builtin_on_test" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "metric registered on Registry() should be visible via controller-runtime registry when EnableBuiltinDefaultMetrics=true")
+}
+
+func TestSetRegistryWithExternalRegistry(t *testing.T) {
+	external := prometheus.NewRegistry()
+	SetRegistry(false, external)
+
+	r := Registry()
+	require.NotNil(t, r)
+
+	// Register a test gauge and verify it's visible via the external registry.
+	testGauge := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "setregistry_external_test",
+		Help: "test",
+	})
+	r.MustRegister(testGauge)
+	testGauge.Set(77)
+
+	families, err := external.Gather()
+	require.NoError(t, err)
+	found := false
+	for _, f := range families {
+		if f.GetName() == "setregistry_external_test" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "metric registered on Registry() should be visible via the external registry")
+
+	// Controller-runtime should also point to the external registry.
+	families, err = crmetrics.Registry.Gather()
+	require.NoError(t, err)
+	found = false
+	for _, f := range families {
+		if f.GetName() == "setregistry_external_test" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "controller-runtime registry should also point to the external registry")
 }
 
 func BenchmarkCounter(b *testing.B) {

--- a/controller/pkg/version/version.go
+++ b/controller/pkg/version/version.go
@@ -18,10 +18,10 @@ var (
 	GitVersion string
 	// ref is the version of the agentgateway controller.
 	// Constructed from the build info during init
-	ref *version
+	ref *VersionInfo
 )
 
-type version struct {
+type VersionInfo struct {
 	Controller string `json:"version"`
 	Commit     string `json:"commit"`
 	Date       string `json:"buildDate"`
@@ -51,7 +51,7 @@ func init() {
 		v = UndefinedVersion
 		GitVersion = info.Main.Version
 	}
-	ref = &version{
+	ref = &VersionInfo{
 		Controller: v,
 		OS:         runtime.GOOS,
 		Arch:       runtime.GOARCH,
@@ -64,4 +64,9 @@ func init() {
 			ref.Date = setting.Value
 		}
 	}
+}
+
+// Info returns the build info of the controller.
+func Info() *VersionInfo {
+	return ref
 }


### PR DESCRIPTION
 ## Summary                                                                                                                                                                        
                                                                                                                                                                                    
  - Add `agentgateway_controller_build_info` gauge metric that exposes build metadata (version, git commit, build date, Go version, platform) as labels with a constant value of 1, following  
  the standard Prometheus `*_build_info` convention.                                    
  - Export `version.VersionInfo` struct and add `version.Info()` accessor so the metrics package can read build metadata without duplicating state.                                 
  - Fix a registry lifecycle bug in `SetRegistry`: when `EnableBuiltinDefaultMetrics=true`, the local registry (containing all init-registered metrics: process/go collectors, `build_info`, and all `NewCounter`/`NewHistogram`/`NewGauge` metrics) was silently abandoned, causing them to be missing from the metrics endpoint.  