### PR TITLE
openapi: support application/octet-stream request bodies in MCP tool generation

### DIFF
--- a/crates/agentgateway/src/mcp/upstream/openapi/mod.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/mod.rs
@@ -28,7 +28,8 @@ pub struct UpstreamOpenAPICall {
 	pub method: String, /* TODO: Switch to Method, but will require getting rid of Serialize/Deserialize */
 	pub path: String,
 	pub allowed_headers: HashSet<String>,
-	// todo: params
+	#[serde(default)]
+	pub content_type: Option<String>,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -332,24 +333,35 @@ pub(crate) fn parse_openapi_schema(
 							// Build the schema
 							let mut final_schema = JsonSchema::default();
 
+							let mut request_content_type: Option<String> = None;
 							let body: Option<(String, serde_json::Value, bool)> = match op.request_body.as_ref() {
 								Some(body) => {
 									let body = resolve_request_body(body, open_api)?;
-									match body.content.get("application/json") {
-										Some(media_type) => {
-											let schema_ref = media_type
-												.schema
-												.as_ref()
-												.ok_or(ParseError::MissingReference("application/json".to_string()))?;
-											let schema = resolve_nested_schema(schema_ref, open_api)?;
-											let body_schema =
-												serde_json::to_value(schema).map_err(ParseError::SerdeError)?;
-											final_schema
-												.properties
-												.insert(BODY_NAME.clone(), body_schema.clone());
-											Some((BODY_NAME.clone(), body_schema, body.required))
-										},
-										None => None,
+									if let Some(media_type) = body.content.get("application/json") {
+										let schema_ref = media_type
+											.schema
+											.as_ref()
+											.ok_or(ParseError::MissingReference("application/json".to_string()))?;
+										let schema = resolve_nested_schema(schema_ref, open_api)?;
+										let body_schema =
+											serde_json::to_value(schema).map_err(ParseError::SerdeError)?;
+										final_schema
+											.properties
+											.insert(BODY_NAME.clone(), body_schema.clone());
+										Some((BODY_NAME.clone(), body_schema, body.required))
+									} else if body.content.contains_key("application/octet-stream") {
+										request_content_type = Some("application/octet-stream".to_string());
+										let body_schema = json!({
+											"type": "string",
+											"format": "byte",
+											"description": "Base64-encoded binary content"
+										});
+										final_schema
+											.properties
+											.insert(BODY_NAME.clone(), body_schema.clone());
+										Some((BODY_NAME.clone(), body_schema, body.required))
+									} else {
+										None
 									}
 								},
 								None => None,
@@ -453,6 +465,7 @@ pub(crate) fn parse_openapi_schema(
 								method: method.to_string(),
 								path: path.clone(),
 								allowed_headers,
+								content_type: request_content_type,
 							};
 							Ok((tool, upstream))
 						},
@@ -851,8 +864,23 @@ impl Handler {
 
 		// Build request body
 		let body = if let Some(body_val) = body_value {
-			rb = rb.header(CONTENT_TYPE, HeaderValue::from_static("application/json"));
-			serde_json::to_vec(&body_val).map_err(|e| UpstreamError::OpenAPIError(e.into()))?
+			match info.content_type.as_deref() {
+				Some("application/octet-stream") => {
+					rb = rb.header(
+						CONTENT_TYPE,
+						HeaderValue::from_static("application/octet-stream"),
+					);
+					let s = body_val.as_str().unwrap_or_default();
+					use base64::Engine;
+					base64::engine::general_purpose::STANDARD
+						.decode(s)
+						.map_err(|e| UpstreamError::OpenAPIError(e.into()))?
+				},
+				_ => {
+					rb = rb.header(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+					serde_json::to_vec(&body_val).map_err(|e| UpstreamError::OpenAPIError(e.into()))?
+				},
+			}
 		} else {
 			Vec::new()
 		};

--- a/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
@@ -95,6 +95,7 @@ async fn setup_with_prefix(prefix: &str) -> (MockServer, Handler) {
 		method: "GET".to_string(),
 		path: "/users/{user_id}".to_string(),
 		allowed_headers: HashSet::from(["X-Request-ID".to_string()]),
+		content_type: None,
 	};
 
 	let test_tool_post = Tool::new(
@@ -136,6 +137,7 @@ async fn setup_with_prefix(prefix: &str) -> (MockServer, Handler) {
 		method: "POST".to_string(),
 		path: "/users".to_string(),
 		allowed_headers: HashSet::from(["X-API-Key".to_string()]),
+		content_type: None,
 	};
 
 	let backend = SimpleBackend::Opaque(
@@ -1560,4 +1562,275 @@ async fn test_openapi_from_url() {
 			panic!("Expected OpenAPI target spec, got {:?}", target.spec);
 		}
 	}
+}
+
+#[test]
+fn test_parse_openapi_schema_octet_stream_body() {
+	let raw = r#"{
+		"openapi": "3.0.0",
+		"info": {"title": "Binary Upload", "version": "1.0.0"},
+		"paths": {
+			"/upload": {
+				"post": {
+					"operationId": "uploadFile",
+					"requestBody": {
+						"required": true,
+						"content": {
+							"application/octet-stream": {
+								"schema": {"type": "string", "format": "binary"}
+							}
+						}
+					},
+					"responses": {
+						"200": {"description": "ok"}
+					}
+				}
+			}
+		}
+	}"#;
+	let open_api: OpenAPI = serde_json::from_str(raw).expect("valid OpenAPI schema");
+	let tools = super::parse_openapi_schema(&open_api).expect("schema should parse");
+
+	let (tool, upstream) = tools
+		.iter()
+		.find(|(tool, _)| tool.name == "uploadFile")
+		.expect("tool should exist");
+
+	assert_eq!(
+		upstream.content_type.as_deref(),
+		Some("application/octet-stream")
+	);
+
+	let schema = &*tool.input_schema;
+	let properties = schema
+		.get("properties")
+		.and_then(serde_json::Value::as_object)
+		.expect("root schema should include properties");
+	assert!(
+		properties.contains_key("body"),
+		"body property should exist"
+	);
+
+	let body_schema = properties
+		.get("body")
+		.and_then(serde_json::Value::as_object)
+		.expect("body should be an object");
+	assert_eq!(body_schema.get("type"), Some(&json!("string")));
+	assert_eq!(body_schema.get("format"), Some(&json!("byte")));
+
+	let required = schema
+		.get("required")
+		.and_then(serde_json::Value::as_array)
+		.expect("root schema should include required array");
+	assert!(
+		required.iter().any(|v| v == "body"),
+		"body should be required"
+	);
+}
+
+#[test]
+fn test_parse_openapi_schema_json_preferred_over_octet_stream() {
+	let raw = r#"{
+		"openapi": "3.0.0",
+		"info": {"title": "Multi Content", "version": "1.0.0"},
+		"paths": {
+			"/data": {
+				"post": {
+					"operationId": "postData",
+					"requestBody": {
+						"required": true,
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"name": {"type": "string"}
+									}
+								}
+							},
+							"application/octet-stream": {
+								"schema": {"type": "string", "format": "binary"}
+							}
+						}
+					},
+					"responses": {
+						"200": {"description": "ok"}
+					}
+				}
+			}
+		}
+	}"#;
+	let open_api: OpenAPI = serde_json::from_str(raw).expect("valid OpenAPI schema");
+	let tools = super::parse_openapi_schema(&open_api).expect("schema should parse");
+
+	let (_tool, upstream) = tools
+		.iter()
+		.find(|(tool, _)| tool.name == "postData")
+		.expect("tool should exist");
+
+	assert_eq!(
+		upstream.content_type, None,
+		"JSON path should be taken, no special content_type"
+	);
+}
+
+#[test]
+fn test_parse_openapi_schema_unsupported_content_type_no_body_param() {
+	let raw = r#"{
+		"openapi": "3.0.0",
+		"info": {"title": "XML Only", "version": "1.0.0"},
+		"paths": {
+			"/xml": {
+				"post": {
+					"operationId": "postXml",
+					"requestBody": {
+						"required": true,
+						"content": {
+							"text/xml": {
+								"schema": {"type": "string"}
+							}
+						}
+					},
+					"responses": {
+						"200": {"description": "ok"}
+					}
+				}
+			}
+		}
+	}"#;
+	let open_api: OpenAPI = serde_json::from_str(raw).expect("valid OpenAPI schema");
+	let tools = super::parse_openapi_schema(&open_api).expect("schema should parse");
+
+	let (tool, _upstream) = tools
+		.iter()
+		.find(|(tool, _)| tool.name == "postXml")
+		.expect("tool should exist");
+
+	let schema = &*tool.input_schema;
+	let properties = schema
+		.get("properties")
+		.and_then(serde_json::Value::as_object);
+	let has_body = properties.is_some_and(|p| p.contains_key("body"));
+	assert!(
+		!has_body,
+		"unsupported content type should not produce a body parameter"
+	);
+}
+
+struct BinaryBodyMatcher {
+	expected_bytes: Vec<u8>,
+}
+
+impl Match for BinaryBodyMatcher {
+	fn matches(&self, request: &Request) -> bool {
+		request.body == self.expected_bytes
+	}
+}
+
+#[tokio::test]
+async fn test_call_tool_with_binary_body() {
+	let server = MockServer::start().await;
+	let host = server.uri();
+	let parsed = reqwest::Url::parse(&host).unwrap();
+	let config = crate::config::parse_config("{}".to_string(), None).unwrap();
+	let encoder = config.session_encoder.clone();
+	let stores = Stores::with_ipv6_enabled(config.ipv6_enabled);
+	let client = Client::new(
+		&client::Config {
+			resolver_cfg: hickory_resolver::config::ResolverConfig::default(),
+			resolver_opts: hickory_resolver::config::ResolverOpts::default(),
+		},
+		None,
+		BackendConfig::default(),
+		None,
+	);
+	let pi = Arc::new(ProxyInputs {
+		cfg: Arc::new(config),
+		stores: stores.clone(),
+		metrics: Arc::new(crate::metrics::Metrics::new(
+			agent_core::metrics::sub_registry(&mut prometheus_client::registry::Registry::default()),
+			Default::default(),
+		)),
+		model_catalog: crate::llm::cost::ModelCatalog::empty(),
+		admin: None,
+		upstream: client.clone(),
+		ca: None,
+		mcp_state: mcp::router::App::new(stores.clone(), encoder),
+	});
+
+	let client = PolicyClient::new(pi.clone());
+
+	let test_tool_upload = Tool::new(
+		Cow::Borrowed("upload_file"),
+		Cow::Borrowed("Upload a binary file"),
+		Arc::new(
+			json!({
+				"type": "object",
+				"properties": {
+					"body": {
+						"type": "string",
+						"format": "byte",
+						"description": "Base64-encoded binary content"
+					}
+				},
+				"required": ["body"]
+			})
+			.as_object()
+			.unwrap()
+			.clone(),
+		),
+	);
+	let upstream_call_upload = UpstreamOpenAPICall {
+		method: "POST".to_string(),
+		path: "/upload".to_string(),
+		allowed_headers: HashSet::new(),
+		content_type: Some("application/octet-stream".to_string()),
+	};
+
+	let backend = SimpleBackend::Opaque(
+		ResourceName::new(strng::literal!("dummy"), "".into()),
+		Target::Hostname(
+			parsed.host().unwrap().to_string().into(),
+			parsed.port().unwrap_or(8080),
+		),
+	);
+	let upstream_client = super::super::McpHttpClient::new(
+		client,
+		backend,
+		BackendPolicies::default(),
+		false,
+		"test-target".to_string(),
+	);
+	let handler = Handler::new(
+		upstream_client,
+		vec![(test_tool_upload, upstream_call_upload)],
+		"".to_string(),
+	);
+
+	let binary_data: Vec<u8> = vec![0x00, 0x01, 0x02, 0xFF, 0xFE, 0xFD];
+	use base64::Engine;
+	let encoded = base64::engine::general_purpose::STANDARD.encode(&binary_data);
+	let expected_response = json!({ "status": "uploaded" });
+
+	Mock::given(method("POST"))
+		.and(path("/upload"))
+		.and(header("content-type", "application/octet-stream"))
+		.and(BinaryBodyMatcher {
+			expected_bytes: binary_data,
+		})
+		.respond_with(ResponseTemplate::new(200).set_body_json(&expected_response))
+		.mount(&server)
+		.await;
+
+	let args = json!({ "body": encoded });
+	let result = handler
+		.call_tool(
+			"upload_file",
+			Some(args.as_object().unwrap().clone()),
+			&IncomingRequestContext::empty(),
+		)
+		.await;
+
+	assert!(result.is_ok(), "Expected success, got: {:?}", result.err());
+	assert_eq!(result.unwrap(), expected_response);
 }


### PR DESCRIPTION
## Summary

Endpoints with `application/octet-stream` request bodies get MCP tools generated without a body parameter, calling them sends an empty HTTP body. This adds support by exposing a base64-encoded string parameter and decoding it on execution.

  - Adds `content_type` field to `UpstreamOpenAPICall` (`#[serde(default)]` for backwards compatibility)
  - Falls back to `application/octet-stream` when `application/json` isn't available
  - On execution, base64-decodes the body and sets correct Content-Type header
  - JSON is still preferred when both content types are available

  Fixes #2304

  ## Test plan

  - [x] `test_parse_openapi_schema_octet_stream_body`: schema generation produces body param with format "byte"
  - [x] `test_call_tool_with_binary_body`: base64 argument decoded to raw bytes, correct Content-Type sent
  - [x] `test_parse_openapi_schema_json_preferred_over_octet_stream`: JSON path taken when both available
  - [x] `test_parse_openapi_schema_unsupported_content_type_no_body_param`: existing behavior preserved
  - [x] All existing tests pass, `make lint` clean

## Verification

Tested locally against a mock `application/octet-stream` endpoint:

**Setup:** agentgateway built from branch → pointed at a test OpenAPI spec with `POST /upload` (octet-stream body) → Python backend echoing received bytes.

**`tools/list`: body parameter now appears for octet-stream endpoints:**
<img width="1304" height="944" alt="image" src="https://github.com/user-attachments/assets/d7ccfbf0-a4dd-4f85-a7e0-dbe14ca7e693" />

**`tools/call`: base64 input decoded and forwarded as raw bytes:**
<img width="1359" height="626" alt="image" src="https://github.com/user-attachments/assets/004fdb16-4d99-47ac-8299-00b80de5042f" />

**Gateway logs: request routed correctly:**
<img width="2031" height="357" alt="image" src="https://github.com/user-attachments/assets/6d450579-8f03-483b-b538-a722f7b130f5" />

<img width="570" height="217" alt="image" src="https://github.com/user-attachments/assets/101dea3f-5264-4a46-8ea9-bcf71e2ff9b5" />

The backend confirms:
  - `content_type_received: application/octet-stream` (correct header)
  - `bytes_received: 20` (correct length)
  - `raw_hex: 48656c6c6f2c2062696e61727920776f726c6421` = "Hello, binary world!" (byte-perfect decode)


Signed-off-by: Dhruv Behl <dhruvbhl@gmail.com>