### PR TITLE
fix(llm): decode Content-Encoding on request bodies before JSON parse

### DIFF
--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -1967,10 +1967,26 @@ impl AIProvider {
 		log: &mut Option<&mut RequestLog>,
 	) -> Result<(Parts, T), AIError> {
 		let buffer = http::buffer_limit(&hreq);
-		let (parts, body) = hreq.into_parts();
-		let Ok(bytes) = http::read_body_with_limit(body, buffer).await else {
-			return Err(AIError::RequestTooLarge);
-		};
+		let (mut parts, body) = hreq.into_parts();
+		// Decode Content-Encoding (gzip/deflate/br/zstd) before parsing the body as
+		// JSON. Clients such as the Claude Code harness gzip-compress request bodies
+		// above a size threshold; without decoding, the reader would hand the
+		// compressed bytes straight to serde_json and fail with a misleading
+		// "LLM request body must be valid JSON" 400, even for tiny payloads. This
+		// mirrors the response path, which already decompresses via the same helper.
+		let ce = parts.headers.typed_get::<ContentEncoding>();
+		let (encoding, bytes) =
+			match http::compression::to_bytes_with_decompression(body, ce.as_ref(), buffer).await {
+				Ok(v) => v,
+				Err(http::compression::Error::LimitExceeded) => return Err(AIError::RequestTooLarge),
+				Err(e) => return Err(map_compression_error(e, &parts.headers)),
+			};
+		// Strip encoding headers now that the body is plaintext so downstream
+		// translation/marshalling and upstream forwarding see a consistent body.
+		if encoding.is_some() {
+			parts.headers.remove(header::CONTENT_ENCODING);
+			parts.headers.remove(header::TRANSFER_ENCODING);
+		}
 
 		if self.override_model().is_none()
 			&& types::detect::extract_model_from_path(parts.uri.path()).is_none()

--- a/crates/agentgateway/src/llm/tests.rs
+++ b/crates/agentgateway/src/llm/tests.rs
@@ -2079,6 +2079,69 @@ fn custom_provider(format: custom::ProviderFormat) -> AIProvider {
 	})
 }
 
+#[tokio::test]
+async fn read_body_decodes_gzip_request_before_json_parse() {
+	// Regression: a gzip-compressed request body (Content-Encoding: gzip) must be
+	// decompressed before the JSON parse. Clients such as the Claude Code harness
+	// gzip request bodies above a size threshold; previously the reader handed the
+	// raw compressed bytes to serde_json and failed with a misleading
+	// "LLM request body must be valid JSON" 400, even for tiny payloads.
+	let provider = custom_provider(custom::ProviderFormat::Messages);
+
+	let plaintext =
+		br#"{"model":"claude-sonnet-4-5","max_tokens":8,"messages":[{"role":"user","content":"hi"}]}"#;
+	let gz = crate::http::compression::encode_body(plaintext, "gzip")
+		.await
+		.expect("gzip encode");
+	// The payload is genuinely compressed (gzip magic) and tiny, so this exercises
+	// content-encoding decoding rather than the buffer-size path.
+	assert_eq!(&gz[..2], &[0x1f, 0x8b]);
+
+	let req = ::http::Request::builder()
+		.uri("/v1/messages")
+		.header(::http::header::CONTENT_TYPE, "application/json")
+		.header(::http::header::CONTENT_ENCODING, "gzip")
+		.body(Body::from(gz.to_vec()))
+		.unwrap();
+
+	let (parts, parsed) = provider
+		.read_body_and_default_model::<types::messages::Request>(None, req, &mut None)
+		.await
+		.expect("gzip request body should decode and parse as JSON");
+
+	assert_eq!(parsed.model.as_deref(), Some("claude-sonnet-4-5"));
+	// The encoding header is stripped now that the body is plaintext.
+	assert!(
+		parts
+			.headers
+			.get(::http::header::CONTENT_ENCODING)
+			.is_none()
+	);
+}
+
+#[tokio::test]
+async fn read_body_still_parses_plaintext_request() {
+	// A plaintext (unencoded) request body must continue to parse unchanged — the
+	// decompression path is a no-op when no Content-Encoding is present.
+	let provider = custom_provider(custom::ProviderFormat::Messages);
+
+	let req = ::http::Request::builder()
+		.uri("/v1/messages")
+		.header(::http::header::CONTENT_TYPE, "application/json")
+		.body(Body::from(
+			br#"{"model":"claude-sonnet-4-5","max_tokens":8,"messages":[{"role":"user","content":"hi"}]}"#
+				.to_vec(),
+		))
+		.unwrap();
+
+	let (_parts, parsed) = provider
+		.read_body_and_default_model::<types::messages::Request>(None, req, &mut None)
+		.await
+		.expect("plaintext request body should parse as JSON");
+
+	assert_eq!(parsed.model.as_deref(), Some("claude-sonnet-4-5"));
+}
+
 #[test]
 fn provider_capabilities_select_native_formats() {
 	use custom::ProviderFormat::{


### PR DESCRIPTION
## Problem

The LLM inference request-body reader parses the request body as JSON **without first honoring `Content-Encoding`**. When a client sends a compressed request body (e.g. `Content-Encoding: gzip`), the raw compressed bytes are handed straight to `serde_json`, which fails with a misleading:

```json
{"error":{"type":"invalid_request_body","message":"LLM request body must be valid JSON"}}
```

This reproduces for **any** compressed body, including tiny ones — so it is not the buffer-size issue (#2350) nor the truncation issue (#2359).

Real-world trigger: the Claude Code / Anthropic harness gzip-compresses request bodies above a size threshold. Routed through agentgateway's LLM listener (`/v1/messages`), every large call arrives gzip-compressed and gets rejected, while small (uncompressed) probes succeed — so it looks intermittent.

## Root cause

`crates/agentgateway/src/llm/mod.rs`, `read_body_and_default_model`:

```rust
let (parts, body) = hreq.into_parts();
let Ok(bytes) = http::read_body_with_limit(body, buffer).await else { ... };
let mut req: T = ... serde_json::from_slice(bytes.as_ref()) ...; // raw (possibly gzipped) bytes
```

The **response** path already decompresses via `http::compression::to_bytes_with_decompression`, and `http/compression/mod.rs` fully supports gzip/deflate/br/zstd. The **request** reader simply never called it — this is the unfulfilled request half of #318 ("llm: support encoded requests/responses").

## Fix

Decode `Content-Encoding` in the request reader before the JSON parse, reusing the exact helper the response path already uses:

- Read the body via `http::compression::to_bytes_with_decompression`, honoring `Content-Encoding` (gzip/deflate/br/zstd; `identity`/absent = no-op).
- Strip `Content-Encoding`/`Transfer-Encoding` once the body is plaintext, so downstream translation/marshalling and upstream forwarding see a consistent body.
- Map a buffer-limit overflow to `RequestTooLarge` (preserving prior behavior); unsupported/multi-encodings now surface a clear encoding error instead of a bogus invalid-JSON parse failure.

## Tests

Two regression tests in `crates/agentgateway/src/llm/tests.rs`:

- `read_body_decodes_gzip_request_before_json_parse` — a tiny gzip-compressed `/v1/messages` body decodes and parses, and the encoding header is stripped.
- `read_body_still_parses_plaintext_request` — a plaintext body still parses unchanged (decode is a no-op without `Content-Encoding`).

Both pass; `cargo check`, `cargo fmt --check`, and `cargo clippy` on the crate are clean.

Fixes #2402
