### PR TITLE
Refactor LLM translation paths

### DIFF
--- a/crates/agentgateway/src/cel/types.rs
+++ b/crates/agentgateway/src/cel/types.rs
@@ -1417,7 +1417,6 @@ impl From<llm::LLMRequest> for LLMContext {
 		let LLMRequest {
 			input_tokens,
 			input_format: _, // Expose this?
-			native_format: _,
 			cache_convention: _,
 			request_model,
 			provider,

--- a/crates/agentgateway/src/llm/conversion/bedrock.rs
+++ b/crates/agentgateway/src/llm/conversion/bedrock.rs
@@ -2880,7 +2880,6 @@ pub mod from_responses {
 }
 
 pub mod from_anthropic_token_count {
-	use crate::llm::types::RequestType;
 	use crate::llm::{AIError, types};
 
 	pub fn translate(
@@ -2893,7 +2892,7 @@ pub mod from_anthropic_token_count {
 			.and_then(|v| v.to_str().ok())
 			.unwrap_or("2023-06-01");
 
-		let body = req.to_anthropic()?;
+		let body = serde_json::to_vec(req).map_err(AIError::RequestMarshal)?;
 		let mut body: serde_json::Map<String, serde_json::Value> =
 			serde_json::from_slice(&body).map_err(AIError::RequestMarshal)?;
 

--- a/crates/agentgateway/src/llm/copilot.rs
+++ b/crates/agentgateway/src/llm/copilot.rs
@@ -1,7 +1,7 @@
 use agent_core::strng;
 use agent_core::strng::Strng;
 
-use crate::llm::RouteType;
+use crate::llm::{ChatFormat, RouteType};
 use crate::*;
 
 #[apply(schema!)]
@@ -15,11 +15,49 @@ impl super::Provider for Provider {
 	const NAME: Strng = strng::literal!("copilot");
 }
 
+impl Provider {
+	pub fn is_anthropic_model(request_model: Option<&str>) -> bool {
+		request_model.is_some_and(|model| model.to_ascii_lowercase().starts_with("claude-"))
+	}
+	pub(super) fn supported_formats_for_model(request_model: Option<&str>) -> Vec<ChatFormat> {
+		let Some(m) = request_model else {
+			// If we have no model not much we can do...
+			return vec![ChatFormat::OpenAICompletions];
+		};
+		// Truth table from `curl https://api.githubcopilot.com/models -H "Authorization: Bearer ghu_..." | '.data[] | {id,supported_endpoints}'`
+		match m {
+			m if m.starts_with("claude-") => {
+				// Copilot supports Completions even for Anthropic
+				// This is enabled so we can do Responses --> Completions [--> Anthropic, within copilot, presumably].
+				// If we add native Responses --> Anthropic we should drop this
+				vec![ChatFormat::AnthropicMessages, ChatFormat::OpenAICompletions]
+			},
+			m if m.starts_with("mai-") => {
+				vec![ChatFormat::OpenAIResponses]
+			},
+			m if m.starts_with("gemini-") => {
+				vec![ChatFormat::OpenAICompletions]
+			},
+			m if m.starts_with("gpt-3") || m.starts_with("gpt-4") => {
+				vec![ChatFormat::OpenAICompletions]
+			},
+			"gpt-5.4" | "gpt-5-mini" => {
+				vec![ChatFormat::OpenAICompletions, ChatFormat::OpenAIResponses]
+			},
+			m if m.starts_with("gpt-") => {
+				vec![ChatFormat::OpenAIResponses]
+			},
+			_ => vec![ChatFormat::OpenAICompletions],
+		}
+	}
+}
+
 pub const DEFAULT_HOST_STR: &str = "api.githubcopilot.com";
 pub const DEFAULT_HOST: Strng = strng::literal!(DEFAULT_HOST_STR);
 
 pub fn path_suffix(route: RouteType) -> &'static str {
 	match route {
+		RouteType::Messages => "/v1/messages",
 		RouteType::Responses => "/responses",
 		RouteType::Embeddings => "/embeddings",
 		RouteType::Rerank => "/rerank",

--- a/crates/agentgateway/src/llm/cost/mod.rs
+++ b/crates/agentgateway/src/llm/cost/mod.rs
@@ -637,7 +637,6 @@ mod tests {
 			request: crate::llm::LLMRequest {
 				input_tokens: None,
 				input_format: crate::llm::InputFormat::Completions,
-				native_format: None,
 				cache_convention: CacheTokenConvention::InputIncludesCache,
 				request_model: request_model.into(),
 				provider: "openai".into(),

--- a/crates/agentgateway/src/llm/custom.rs
+++ b/crates/agentgateway/src/llm/custom.rs
@@ -25,20 +25,16 @@ impl Provider {
 			.any(|supported| supported.format == format)
 	}
 
-	pub fn native_format_for(&self, input_format: InputFormat) -> Option<ProviderFormat> {
-		input_format
-			.provider_format_preferences()
-			.iter()
-			.copied()
-			.find(|format| self.supports(*format))
-	}
-
 	pub fn path_for(&self, format: ProviderFormat) -> Option<&str> {
 		self
 			.formats
 			.iter()
 			.find(|supported| supported.format == format)
 			.and_then(|supported| supported.path.as_deref())
+	}
+
+	pub fn path_for_route(&self, route_type: RouteType) -> Option<&str> {
+		ProviderFormat::from_route_type(route_type).and_then(|format| self.path_for(format))
 	}
 }
 
@@ -48,11 +44,19 @@ impl super::Provider for Provider {
 
 #[apply(schema!)]
 pub struct ProviderFormatConfig {
+	/// Upstream API shape this custom provider says it accepts.
 	#[serde(rename = "type")]
 	pub format: ProviderFormat,
+	/// Optional path override for this specific upstream format.
 	pub path: Option<Strng>,
 }
 
+/// A custom provider's advertised upstream wire format.
+///
+/// Unlike `InputFormat`, this describes what the backend accepts, not what the
+/// client sent. Unlike `RouteType`, it is only for LLM payload endpoints that
+/// can be converted or passed through; generic routes such as models,
+/// passthrough, and detect do not have a `ProviderFormat`.
 #[apply(schema!)]
 #[derive(Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum ProviderFormat {
@@ -66,6 +70,19 @@ pub enum ProviderFormat {
 }
 
 impl ProviderFormat {
+	pub fn from_route_type(route_type: RouteType) -> Option<Self> {
+		Some(match route_type {
+			RouteType::Completions => Self::Completions,
+			RouteType::Messages => Self::Messages,
+			RouteType::Responses => Self::Responses,
+			RouteType::Embeddings => Self::Embeddings,
+			RouteType::AnthropicTokenCount => Self::AnthropicTokenCount,
+			RouteType::Realtime => Self::Realtime,
+			RouteType::Rerank => Self::Rerank,
+			RouteType::Models | RouteType::Passthrough | RouteType::Detect => return None,
+		})
+	}
+
 	pub fn input_format(self) -> InputFormat {
 		match self {
 			Self::Completions => InputFormat::Completions,
@@ -94,42 +111,6 @@ impl ProviderFormat {
 #[cfg(test)]
 mod tests {
 	use super::*;
-
-	fn provider(supported_formats: Vec<ProviderFormat>) -> Provider {
-		Provider {
-			model: None,
-			provider_override: None,
-			formats: supported_formats
-				.into_iter()
-				.map(|format| ProviderFormatConfig { format, path: None })
-				.collect(),
-		}
-	}
-
-	#[test]
-	fn native_format_selection_uses_preference_table() {
-		let messages_only = provider(vec![ProviderFormat::Messages]);
-		assert_eq!(
-			messages_only.native_format_for(InputFormat::Completions),
-			Some(ProviderFormat::Messages)
-		);
-
-		let completions_only = provider(vec![ProviderFormat::Completions]);
-		assert_eq!(
-			completions_only.native_format_for(InputFormat::Messages),
-			Some(ProviderFormat::Completions)
-		);
-		assert_eq!(
-			completions_only.native_format_for(InputFormat::Responses),
-			Some(ProviderFormat::Completions)
-		);
-
-		let embeddings_only = provider(vec![ProviderFormat::Embeddings]);
-		assert_eq!(
-			embeddings_only.native_format_for(InputFormat::Completions),
-			None
-		);
-	}
 
 	#[test]
 	fn path_for_returns_format_path() {

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -282,14 +282,12 @@ impl InputFormat {
 /// The concrete upstream chat wire format selected by the conversion table.
 ///
 /// This is intentionally narrower than `ProviderFormat`: it only covers chat
-/// conversions, and it includes provider-specific variants where the same public
-/// API shape has different wire details.
+/// conversions.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ChatFormat {
 	OpenAICompletions,
 	OpenAIResponses,
 	AnthropicMessages,
-	VertexAnthropicMessages,
 	BedrockConverse,
 }
 
@@ -359,13 +357,8 @@ const CHAT_TRANSLATIONS: &[ChatTranslation] = {
 		// Completions
 		chat(InputFormat::Completions, ChatFormat::AnthropicMessages),
 		chat(InputFormat::Completions, ChatFormat::BedrockConverse),
-		chat(
-			InputFormat::Completions,
-			ChatFormat::VertexAnthropicMessages,
-		),
 		// Messages
 		chat(InputFormat::Messages, ChatFormat::OpenAICompletions),
-		chat(InputFormat::Messages, ChatFormat::VertexAnthropicMessages),
 		chat(InputFormat::Messages, ChatFormat::BedrockConverse),
 		// Missing: Messages --> Responses
 		//
@@ -457,9 +450,7 @@ impl ChatTranslation {
 		match self.output {
 			ChatFormat::OpenAICompletions => custom::ProviderFormat::Completions,
 			ChatFormat::OpenAIResponses => custom::ProviderFormat::Responses,
-			ChatFormat::AnthropicMessages | ChatFormat::VertexAnthropicMessages => {
-				custom::ProviderFormat::Messages
-			},
+			ChatFormat::AnthropicMessages => custom::ProviderFormat::Messages,
 			ChatFormat::BedrockConverse => match self.input {
 				// Bedrock chat always renders to Converse. This format is only used for
 				// shared bookkeeping (route type, cache convention, custom-style labels);
@@ -480,10 +471,10 @@ impl ChatTranslation {
 		let body = match self.output {
 			ChatFormat::OpenAICompletions => req.render_openai_completions(),
 			ChatFormat::OpenAIResponses => req.render_openai_responses(),
-			ChatFormat::AnthropicMessages => req.render_anthropic_messages(),
-			ChatFormat::VertexAnthropicMessages => {
+			ChatFormat::AnthropicMessages if matches!(ctx.provider, AIProvider::Vertex(_)) => {
 				vertex::prepare_anthropic_message_body(req.render_anthropic_messages()?)
 			},
+			ChatFormat::AnthropicMessages => req.render_anthropic_messages(),
 			ChatFormat::BedrockConverse => return req.render_bedrock_converse(ctx),
 		}?;
 		Ok(RenderedChatRequest {
@@ -520,7 +511,7 @@ impl ChatTranslation {
 					self.input
 				))),
 			},
-			ChatFormat::AnthropicMessages | ChatFormat::VertexAnthropicMessages => match self.input {
+			ChatFormat::AnthropicMessages => match self.input {
 				InputFormat::Messages => AIProvider::parse_response::<types::messages::Response>(bytes),
 				InputFormat::Completions => {
 					conversion::messages::from_completions::translate_response(bytes)
@@ -585,7 +576,7 @@ impl ChatTranslation {
 				_ => resp,
 			},
 
-			ChatFormat::AnthropicMessages | ChatFormat::VertexAnthropicMessages => match self.input {
+			ChatFormat::AnthropicMessages => match self.input {
 				InputFormat::Messages => resp.map(|b| {
 					conversion::messages::passthrough_stream(
 						b,
@@ -694,7 +685,7 @@ impl ChatTranslation {
 				_ => unsupported(),
 			},
 
-			ChatFormat::AnthropicMessages | ChatFormat::VertexAnthropicMessages => match format {
+			ChatFormat::AnthropicMessages => match format {
 				ChatErrorFormat::Anthropic => match self.input {
 					InputFormat::Messages => conversion::messages::translate_anthropic_error(bytes, status),
 					InputFormat::Completions => {
@@ -939,7 +930,7 @@ impl AIProvider {
 			AIProvider::Bedrock(_) => vec![ChatFormat::BedrockConverse],
 
 			AIProvider::Vertex(p) if p.is_anthropic_model(request_model) => {
-				vec![ChatFormat::VertexAnthropicMessages]
+				vec![ChatFormat::AnthropicMessages]
 			},
 			AIProvider::Vertex(_) => vec![ChatFormat::OpenAICompletions],
 
@@ -969,9 +960,7 @@ impl AIProvider {
 				ChatErrorFormat::Google
 			},
 			(_, ChatFormat::BedrockConverse) => ChatErrorFormat::Bedrock,
-			(_, ChatFormat::AnthropicMessages | ChatFormat::VertexAnthropicMessages) => {
-				ChatErrorFormat::Anthropic
-			},
+			(_, ChatFormat::AnthropicMessages) => ChatErrorFormat::Anthropic,
 			(_, ChatFormat::OpenAICompletions | ChatFormat::OpenAIResponses) => ChatErrorFormat::OpenAI,
 		}
 	}
@@ -1806,7 +1795,7 @@ impl AIProvider {
 			None
 		};
 		let chat_translation = self.chat_translation(original_format, request_model.as_deref())?;
-		let provider_format = Some(chat_translation.provider_format());
+		let provider_format = chat_translation.provider_format();
 		let prepared = self
 			.prepare_request(
 				backend_info,
@@ -1814,7 +1803,7 @@ impl AIProvider {
 				original_format,
 				&mut req,
 				&mut parts,
-				provider_format,
+				Some(provider_format),
 				tokenize,
 				log,
 			)
@@ -1838,9 +1827,7 @@ impl AIProvider {
 		Ok(RequestResult::Success {
 			request: req,
 			llm_request: llm_info,
-			upstream_route_type: provider_format
-				.expect("chat requests always have an upstream provider format")
-				.route_type(),
+			upstream_route_type: provider_format.route_type(),
 		})
 	}
 

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -109,6 +109,16 @@ pub struct NamedAIProvider {
 	pub inline_policies: Vec<BackendTrafficPolicy>,
 }
 
+/// The HTTP endpoint class, such as `/v1/chat/completions` or `/v1/messages`.
+///
+/// This is used both for the client route we matched and for the upstream route
+/// we finally send to. For chat, those can differ: a client Anthropic
+/// `/v1/messages` request is `RouteType::Messages` and `InputFormat::Messages`,
+/// but it may be translated and sent upstream as `RouteType::Completions`.
+///
+/// `RouteType` is about the HTTP endpoint. `InputFormat` is about the parsed
+/// client payload and the response shape we owe back to that client. The main
+/// difference is this type includes things like Detect and Passthrough.
 #[apply(schema!)]
 #[derive(Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum RouteType {
@@ -167,8 +177,9 @@ trait Provider {
 pub struct LLMRequest {
 	/// Input tokens derived by tokenizing the request. Not always enabled
 	pub input_tokens: Option<u64>,
+	/// The parsed client payload format, kept as the response contract even when
+	/// the upstream route/wire format differs.
 	pub input_format: InputFormat,
-	pub native_format: Option<custom::ProviderFormat>,
 	pub cache_convention: CacheTokenConvention,
 	pub request_model: Strng,
 	pub provider: Strng,
@@ -197,7 +208,7 @@ pub enum CacheTokenConvention {
 }
 
 impl CacheTokenConvention {
-	/// Placeholder used while request conversion lacks provider/native-format
+	/// Placeholder used while request conversion lacks provider format
 	/// context. `process_request` replaces this with the classified convention.
 	pub(crate) fn pending() -> Self {
 		Self::InputIncludesCache
@@ -209,23 +220,31 @@ impl CacheTokenConvention {
 /// provider's native semantics (e.g. Vertex serving Anthropic models).
 fn cache_convention_for(
 	provider: &AIProvider,
-	native_format: Option<custom::ProviderFormat>,
+	provider_format: Option<custom::ProviderFormat>,
 	request_model: &str,
 ) -> CacheTokenConvention {
 	use CacheTokenConvention::*;
 	use custom::ProviderFormat::{AnthropicTokenCount, Messages};
 	match provider {
 		AIProvider::Anthropic(_) | AIProvider::Bedrock(_) => InputExcludesCache,
+		AIProvider::Copilot(_) if copilot::Provider::is_anthropic_model(Some(request_model)) => {
+			InputExcludesCache
+		},
 		AIProvider::Vertex(p) if p.is_anthropic_model(Some(request_model)) => InputExcludesCache,
-		AIProvider::Custom(_) => match native_format {
+		AIProvider::Custom(_) => match provider_format {
 			Some(Messages | AnthropicTokenCount) => InputExcludesCache,
-			// TODO(mk): Detect/passthrough mode has native_format = None. Need to confirm if there is an issue with classification
 			_ => InputIncludesCache,
 		},
-		_ => InputIncludesCache, // openai, azure, copilot, gemini, vertex non-anthropic
+		_ => InputIncludesCache, // openai, azure, gemini, copilot/vertex non-anthropic
 	}
 }
 
+/// The parsed client request/response family accepted by the gateway.
+///
+/// For chat, this is the API contract the client used: OpenAI chat completions,
+/// Anthropic messages, or OpenAI responses. It stays stable for policy,
+/// telemetry, and response translation. The upstream may use a different
+/// `RouteType`/`ChatFormat`, but the response is translated back to this shape.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum InputFormat {
 	Completions,
@@ -239,6 +258,13 @@ pub enum InputFormat {
 }
 
 impl InputFormat {
+	fn is_chat(&self) -> bool {
+		matches!(
+			self,
+			InputFormat::Completions | InputFormat::Messages | InputFormat::Responses
+		)
+	}
+
 	pub fn supports_prompt_guard(&self) -> bool {
 		match self {
 			InputFormat::Completions => true,
@@ -251,18 +277,451 @@ impl InputFormat {
 			InputFormat::Rerank => false,
 		}
 	}
+}
 
-	fn provider_format_preferences(&self) -> &'static [custom::ProviderFormat] {
-		use custom::ProviderFormat::*;
+/// The concrete upstream chat wire format selected by the conversion table.
+///
+/// This is intentionally narrower than `ProviderFormat`: it only covers chat
+/// conversions, and it includes provider-specific variants where the same public
+/// API shape has different wire details.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ChatFormat {
+	OpenAICompletions,
+	OpenAIResponses,
+	AnthropicMessages,
+	VertexAnthropicMessages,
+	BedrockConverse,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ChatErrorFormat {
+	OpenAI,
+	Google,
+	Anthropic,
+	Bedrock,
+}
+
+struct ChatTranslation {
+	/// Client-facing chat request/response shape.
+	input: InputFormat,
+	/// Upstream chat wire format used for request, response, stream, and error translation.
+	output: ChatFormat,
+}
+
+/// Result of translating a chat request before it is sent upstream.
+///
+/// `body` is the upstream request payload. `provider_state` carries any
+/// conversion state needed to translate the later response/stream back to the
+/// original `InputFormat`; most providers do not need it.
+struct RenderedChatRequest {
+	body: Vec<u8>,
+	provider_state: Option<ProviderState>,
+}
+
+// Context provider to each request translation
+struct ChatRequestContext<'a> {
+	provider: &'a AIProvider,
+	headers: &'a HeaderMap,
+	prompt_caching: Option<&'a policy::PromptCachingConfig>,
+}
+
+// Context provider to each response translation
+struct ChatResponseContext<'a> {
+	model: &'a str,
+	tool_name_map: Option<&'a conversion::bedrock::BedrockToolNameMap>,
+}
+
+// Context provider to each response translation (streaming)
+struct ChatStreamContext {
+	buffer_limit: usize,
+	logger: AmendOnDrop,
+	model: String,
+	include_completion_in_log: bool,
+	tool_name_map: Option<conversion::bedrock::BedrockToolNameMap>,
+}
+
+/// Ordered chat conversion table.
+///
+/// For a client `InputFormat`, pick the first entry whose `ChatFormat` is
+/// supported by the selected provider/model. Put cheaper or more native
+/// translations before broader fallbacks.
+const CHAT_TRANSLATIONS: &[ChatTranslation] = {
+	const fn chat(input: InputFormat, output: ChatFormat) -> ChatTranslation {
+		ChatTranslation { input, output }
+	}
+	&[
+		// Direct passthrough
+		chat(InputFormat::Responses, ChatFormat::OpenAIResponses),
+		chat(InputFormat::Completions, ChatFormat::OpenAICompletions),
+		chat(InputFormat::Messages, ChatFormat::AnthropicMessages),
+		// Missing: Bedrock --> Bedrock
+		//
+		// Completions
+		chat(InputFormat::Completions, ChatFormat::AnthropicMessages),
+		chat(InputFormat::Completions, ChatFormat::BedrockConverse),
+		chat(
+			InputFormat::Completions,
+			ChatFormat::VertexAnthropicMessages,
+		),
+		// Messages
+		chat(InputFormat::Messages, ChatFormat::OpenAICompletions),
+		chat(InputFormat::Messages, ChatFormat::VertexAnthropicMessages),
+		chat(InputFormat::Messages, ChatFormat::BedrockConverse),
+		// Missing: Messages --> Responses
+		//
+		// Responses
+		chat(InputFormat::Responses, ChatFormat::OpenAICompletions),
+		chat(InputFormat::Responses, ChatFormat::BedrockConverse),
+		// Missing: Responses -> Messages
+	]
+};
+
+impl types::ChatRequest<'_> {
+	fn render_openai_completions(self) -> Result<Vec<u8>, AIError> {
 		match self {
-			InputFormat::Completions => &[Completions, Messages],
-			InputFormat::Messages => &[Messages, Completions],
-			InputFormat::Responses => &[Responses, Completions],
-			InputFormat::Embeddings => &[Embeddings],
-			InputFormat::Realtime => &[Realtime],
-			InputFormat::CountTokens => &[AnthropicTokenCount],
-			InputFormat::Detect => &[],
-			InputFormat::Rerank => &[Rerank],
+			types::ChatRequest::Completions(req) => {
+				serde_json::to_vec(req).map_err(AIError::RequestMarshal)
+			},
+			types::ChatRequest::Messages(req) => conversion::completions::from_messages::translate(req),
+			types::ChatRequest::Responses(req) => {
+				conversion::openai_compat::from_responses::translate(req)
+			},
+		}
+	}
+
+	fn render_openai_responses(self) -> Result<Vec<u8>, AIError> {
+		match self {
+			types::ChatRequest::Responses(req) => {
+				serde_json::to_vec(req).map_err(AIError::RequestMarshal)
+			},
+			_ => Err(AIError::UnsupportedConversion(strng::literal!(
+				"expected responses request"
+			))),
+		}
+	}
+
+	fn render_anthropic_messages(self) -> Result<Vec<u8>, AIError> {
+		match self {
+			types::ChatRequest::Completions(req) => {
+				conversion::messages::from_completions::translate(req)
+			},
+			types::ChatRequest::Messages(req) => serde_json::to_vec(req).map_err(AIError::RequestMarshal),
+			types::ChatRequest::Responses(_) => Err(AIError::UnsupportedConversion(strng::literal!(
+				"responses to messages"
+			))),
+		}
+	}
+
+	fn render_bedrock_converse(
+		self,
+		ctx: &ChatRequestContext<'_>,
+	) -> Result<RenderedChatRequest, AIError> {
+		let AIProvider::Bedrock(provider) = ctx.provider else {
+			return Err(AIError::UnsupportedConversion(strng::literal!(
+				"expected bedrock provider"
+			)));
+		};
+		let bedrock = match self {
+			types::ChatRequest::Completions(req) => conversion::bedrock::from_completions::translate(
+				req,
+				provider,
+				Some(ctx.headers),
+				ctx.prompt_caching,
+			),
+			types::ChatRequest::Messages(req) => {
+				conversion::bedrock::from_messages::translate(req, provider, Some(ctx.headers))
+			},
+			types::ChatRequest::Responses(req) => conversion::bedrock::from_responses::translate(
+				req,
+				provider,
+				Some(ctx.headers),
+				ctx.prompt_caching,
+			),
+		}?;
+		let provider_state = if bedrock.tool_name_map.is_empty() {
+			None
+		} else {
+			Some(ProviderState::Bedrock {
+				tool_names: Arc::new(bedrock.tool_name_map),
+			})
+		};
+		Ok(RenderedChatRequest {
+			body: bedrock.body,
+			provider_state,
+		})
+	}
+}
+
+impl ChatTranslation {
+	fn provider_format(&self) -> custom::ProviderFormat {
+		match self.output {
+			ChatFormat::OpenAICompletions => custom::ProviderFormat::Completions,
+			ChatFormat::OpenAIResponses => custom::ProviderFormat::Responses,
+			ChatFormat::AnthropicMessages | ChatFormat::VertexAnthropicMessages => {
+				custom::ProviderFormat::Messages
+			},
+			ChatFormat::BedrockConverse => match self.input {
+				// Bedrock chat always renders to Converse. This format is only used for
+				// shared bookkeeping (route type, cache convention, custom-style labels);
+				// Bedrock path setup ignores these chat distinctions for Converse.
+				InputFormat::Completions => custom::ProviderFormat::Completions,
+				InputFormat::Messages => custom::ProviderFormat::Messages,
+				InputFormat::Responses => custom::ProviderFormat::Responses,
+				_ => unreachable!("chat translation selected for non-chat input"),
+			},
+		}
+	}
+
+	fn render_request(
+		&self,
+		req: types::ChatRequest<'_>,
+		ctx: &ChatRequestContext<'_>,
+	) -> Result<RenderedChatRequest, AIError> {
+		let body = match self.output {
+			ChatFormat::OpenAICompletions => req.render_openai_completions(),
+			ChatFormat::OpenAIResponses => req.render_openai_responses(),
+			ChatFormat::AnthropicMessages => req.render_anthropic_messages(),
+			ChatFormat::VertexAnthropicMessages => {
+				vertex::prepare_anthropic_message_body(req.render_anthropic_messages()?)
+			},
+			ChatFormat::BedrockConverse => return req.render_bedrock_converse(ctx),
+		}?;
+		Ok(RenderedChatRequest {
+			body,
+			provider_state: None,
+		})
+	}
+
+	fn render_response(
+		&self,
+		bytes: &Bytes,
+		ctx: &ChatResponseContext<'_>,
+	) -> Result<Box<dyn ResponseType>, AIError> {
+		match self.output {
+			ChatFormat::OpenAICompletions => match self.input {
+				InputFormat::Completions => {
+					AIProvider::parse_response::<types::completions::Response>(bytes)
+				},
+				InputFormat::Messages => conversion::completions::from_messages::translate_response(bytes),
+				InputFormat::Responses => {
+					conversion::openai_compat::to_responses::translate_response(bytes, ctx.model)
+				},
+				_ => Err(AIError::UnsupportedConversion(strng::format!(
+					"from {:?} to {:?}",
+					self.output,
+					self.input
+				))),
+			},
+			ChatFormat::OpenAIResponses => match self.input {
+				InputFormat::Responses => AIProvider::parse_response::<types::responses::Response>(bytes),
+				_ => Err(AIError::UnsupportedConversion(strng::format!(
+					"from {:?} to {:?}",
+					self.output,
+					self.input
+				))),
+			},
+			ChatFormat::AnthropicMessages | ChatFormat::VertexAnthropicMessages => match self.input {
+				InputFormat::Messages => AIProvider::parse_response::<types::messages::Response>(bytes),
+				InputFormat::Completions => {
+					conversion::messages::from_completions::translate_response(bytes)
+				},
+				_ => Err(AIError::UnsupportedConversion(strng::format!(
+					"from {:?} to {:?}",
+					self.output,
+					self.input
+				))),
+			},
+			ChatFormat::BedrockConverse => match self.input {
+				InputFormat::Completions => conversion::bedrock::from_completions::translate_response(
+					bytes,
+					ctx.model,
+					ctx.tool_name_map,
+				),
+				InputFormat::Messages => conversion::bedrock::from_messages::translate_response(
+					bytes,
+					ctx.model,
+					ctx.tool_name_map,
+				),
+				InputFormat::Responses => conversion::bedrock::from_responses::translate_response(
+					bytes,
+					ctx.model,
+					ctx.tool_name_map,
+				),
+				_ => Err(AIError::UnsupportedConversion(strng::format!(
+					"from {:?} to {:?}",
+					self.output,
+					self.input
+				))),
+			},
+		}
+	}
+
+	fn stream(&self, resp: Response, ctx: ChatStreamContext) -> Response {
+		match self.output {
+			ChatFormat::OpenAICompletions => match self.input {
+				InputFormat::Completions => conversion::completions::passthrough_stream(
+					ctx.logger,
+					ctx.include_completion_in_log,
+					resp,
+				),
+				InputFormat::Messages => resp.map(|b| {
+					conversion::completions::from_messages::translate_stream(b, ctx.buffer_limit, ctx.logger)
+				}),
+				InputFormat::Responses => resp.map(|b| {
+					conversion::openai_compat::to_responses::translate_stream(b, ctx.buffer_limit, ctx.logger)
+				}),
+				_ => resp,
+			},
+
+			ChatFormat::OpenAIResponses => match self.input {
+				InputFormat::Responses => resp.map(|b| {
+					conversion::responses::passthrough_stream(
+						b,
+						ctx.buffer_limit,
+						ctx.logger,
+						ctx.include_completion_in_log,
+					)
+				}),
+				_ => resp,
+			},
+
+			ChatFormat::AnthropicMessages | ChatFormat::VertexAnthropicMessages => match self.input {
+				InputFormat::Messages => resp.map(|b| {
+					conversion::messages::passthrough_stream(
+						b,
+						ctx.buffer_limit,
+						ctx.logger,
+						ctx.include_completion_in_log,
+					)
+				}),
+				InputFormat::Completions => resp.map(|b| {
+					conversion::messages::from_completions::translate_stream(b, ctx.buffer_limit, ctx.logger)
+				}),
+				_ => resp,
+			},
+
+			ChatFormat::BedrockConverse => match self.input {
+				InputFormat::Completions => {
+					let msg = conversion::bedrock::message_id(&resp);
+					let tool_name_map = ctx.tool_name_map.clone();
+					resp.map(move |b| {
+						conversion::bedrock::from_completions::translate_stream(
+							b,
+							ctx.buffer_limit,
+							ctx.logger,
+							&ctx.model,
+							&msg,
+							tool_name_map,
+						)
+					})
+				},
+				InputFormat::Messages => {
+					let msg = conversion::bedrock::message_id(&resp);
+					let tool_name_map = ctx.tool_name_map.clone();
+					resp.map(move |b| {
+						conversion::bedrock::from_messages::translate_stream(
+							b,
+							ctx.buffer_limit,
+							ctx.logger,
+							&ctx.model,
+							&msg,
+							ctx.include_completion_in_log,
+							tool_name_map,
+						)
+					})
+				},
+				InputFormat::Responses => {
+					let msg = conversion::bedrock::message_id(&resp);
+					let tool_name_map = ctx.tool_name_map.clone();
+					resp.map(move |b| {
+						conversion::bedrock::from_responses::translate_stream(
+							b,
+							ctx.buffer_limit,
+							ctx.logger,
+							&ctx.model,
+							&msg,
+							tool_name_map,
+						)
+					})
+				},
+				_ => resp,
+			},
+		}
+	}
+
+	fn error(
+		&self,
+		bytes: &Bytes,
+		status: ::http::StatusCode,
+		format: ChatErrorFormat,
+	) -> Result<Bytes, AIError> {
+		let unsupported = || {
+			Err(AIError::UnsupportedConversion(strng::format!(
+				"from {:?} error to {:?}",
+				format,
+				self.input
+			)))
+		};
+		match self.output {
+			ChatFormat::OpenAICompletions => match format {
+				ChatErrorFormat::OpenAI => match self.input {
+					InputFormat::Completions => Ok(bytes.clone()),
+					InputFormat::Messages => {
+						conversion::completions::from_messages::translate_error(bytes, status)
+					},
+					InputFormat::Responses => Ok(bytes.clone()),
+					_ => unsupported(),
+				},
+				ChatErrorFormat::Google => match self.input {
+					InputFormat::Messages => conversion::messages::translate_google_error(bytes),
+					InputFormat::Responses => conversion::gemini::from_responses::translate_error(bytes),
+					_ => conversion::completions::translate_google_error(bytes),
+				},
+				ChatErrorFormat::Anthropic => match self.input {
+					InputFormat::Messages => {
+						conversion::completions::from_messages::translate_error(bytes, status)
+					},
+					_ => unsupported(),
+				},
+				ChatErrorFormat::Bedrock => unsupported(),
+			},
+
+			ChatFormat::OpenAIResponses => match format {
+				ChatErrorFormat::OpenAI => match self.input {
+					InputFormat::Responses => Ok(bytes.clone()),
+					_ => unsupported(),
+				},
+				_ => unsupported(),
+			},
+
+			ChatFormat::AnthropicMessages | ChatFormat::VertexAnthropicMessages => match format {
+				ChatErrorFormat::Anthropic => match self.input {
+					InputFormat::Messages => conversion::messages::translate_anthropic_error(bytes, status),
+					InputFormat::Completions => {
+						conversion::messages::from_completions::translate_error(bytes)
+					},
+					_ => unsupported(),
+				},
+				ChatErrorFormat::OpenAI => match self.input {
+					InputFormat::Messages => Ok(bytes.clone()),
+					_ => unsupported(),
+				},
+				_ => unsupported(),
+			},
+
+			ChatFormat::BedrockConverse => match format {
+				ChatErrorFormat::Bedrock => match self.input {
+					InputFormat::Completions => conversion::bedrock::from_completions::translate_error(bytes),
+					InputFormat::Messages => conversion::bedrock::from_messages::translate_error(bytes),
+					InputFormat::Responses => conversion::bedrock::from_responses::translate_error(bytes),
+					_ => unsupported(),
+				},
+				ChatErrorFormat::OpenAI => match self.input {
+					InputFormat::Messages => Ok(bytes.clone()),
+					_ => unsupported(),
+				},
+				_ => unsupported(),
+			},
 		}
 	}
 }
@@ -359,8 +818,23 @@ pub struct LLMResponse {
 #[derive(Debug)]
 #[allow(clippy::large_enum_variant)]
 pub enum RequestResult {
-	Success(Request, LLMRequest),
+	Success {
+		request: Request,
+		llm_request: LLMRequest,
+		upstream_route_type: RouteType,
+	},
 	Rejected(Response),
+}
+
+enum PreparedRequest {
+	Ready(LLMRequest),
+	Rejected(Response),
+}
+
+struct BufferedResponse {
+	parts: ::http::response::Parts,
+	bytes: Bytes,
+	encoding: Option<&'static str>,
 }
 
 impl AIProvider {
@@ -404,7 +878,13 @@ impl AIProvider {
 		use custom::ProviderFormat::*;
 		match self {
 			AIProvider::OpenAI(_) => vec![Completions, Responses, Embeddings, Realtime, Rerank],
-			AIProvider::Copilot(_) => vec![Completions, Responses, Rerank],
+			AIProvider::Copilot(_) => {
+				if copilot::Provider::is_anthropic_model(request_model) {
+					vec![Messages]
+				} else {
+					vec![Completions, Responses, Rerank, Embeddings]
+				}
+			},
 			AIProvider::Azure(p) => {
 				let mut formats = vec![Completions, Responses, Embeddings, Rerank];
 				if matches!(p.resource_type, azure::AzureResourceType::Foundry)
@@ -436,6 +916,85 @@ impl AIProvider {
 		}
 	}
 
+	fn supported_chat_formats(&self, request_model: Option<&str>) -> Vec<ChatFormat> {
+		match self {
+			AIProvider::OpenAI(_) => {
+				vec![ChatFormat::OpenAIResponses, ChatFormat::OpenAICompletions]
+			},
+
+			AIProvider::Copilot(_) => copilot::Provider::supported_formats_for_model(request_model),
+
+			AIProvider::Azure(p)
+				if matches!(p.resource_type, azure::AzureResourceType::Foundry)
+					&& p.is_anthropic_model(request_model) =>
+			{
+				// Foundry Claude models require the Anthropic-native endpoint; the
+				// OpenAI-compatible chat/responses endpoints return api_not_supported.
+				vec![ChatFormat::AnthropicMessages]
+			},
+			AIProvider::Azure(_) => vec![ChatFormat::OpenAIResponses, ChatFormat::OpenAICompletions],
+
+			AIProvider::Gemini(_) => vec![ChatFormat::OpenAICompletions],
+			AIProvider::Anthropic(_) => vec![ChatFormat::AnthropicMessages],
+			AIProvider::Bedrock(_) => vec![ChatFormat::BedrockConverse],
+
+			AIProvider::Vertex(p) if p.is_anthropic_model(request_model) => {
+				vec![ChatFormat::VertexAnthropicMessages]
+			},
+			AIProvider::Vertex(_) => vec![ChatFormat::OpenAICompletions],
+
+			AIProvider::Custom(p) => p
+				.formats
+				.iter()
+				.filter_map(|f| match f.format {
+					custom::ProviderFormat::Completions => Some(ChatFormat::OpenAICompletions),
+					custom::ProviderFormat::Messages => Some(ChatFormat::AnthropicMessages),
+					custom::ProviderFormat::Responses => Some(ChatFormat::OpenAIResponses),
+					_ => None,
+				})
+				.collect(),
+		}
+	}
+
+	fn chat_error_format(
+		&self,
+		translation: &ChatTranslation,
+		request_model: Option<&str>,
+	) -> ChatErrorFormat {
+		match (self, translation.output) {
+			(AIProvider::Gemini(_), ChatFormat::OpenAICompletions) => ChatErrorFormat::Google,
+			(AIProvider::Vertex(p), ChatFormat::OpenAICompletions)
+				if !p.is_anthropic_model(request_model) =>
+			{
+				ChatErrorFormat::Google
+			},
+			(_, ChatFormat::BedrockConverse) => ChatErrorFormat::Bedrock,
+			(_, ChatFormat::AnthropicMessages | ChatFormat::VertexAnthropicMessages) => {
+				ChatErrorFormat::Anthropic
+			},
+			(_, ChatFormat::OpenAICompletions | ChatFormat::OpenAIResponses) => ChatErrorFormat::OpenAI,
+		}
+	}
+
+	fn chat_translation(
+		&self,
+		input_format: InputFormat,
+		request_model: Option<&str>,
+	) -> Result<&'static ChatTranslation, AIError> {
+		let supported = self.supported_chat_formats(request_model);
+		CHAT_TRANSLATIONS
+			.iter()
+			.find(|translation| {
+				translation.input == input_format && supported.contains(&translation.output)
+			})
+			.ok_or_else(|| {
+				AIError::UnsupportedConversion(strng::format!(
+					"from {input_format:?} to provider {} (supported: {supported:?})",
+					self.provider()
+				))
+			})
+	}
+
 	pub fn supports_format(
 		&self,
 		format: custom::ProviderFormat,
@@ -444,23 +1003,25 @@ impl AIProvider {
 		self.supported_formats(request_model).contains(&format)
 	}
 
-	pub fn native_format_for(
+	fn non_chat_provider_format_for(
 		&self,
 		input_format: InputFormat,
 		request_model: Option<&str>,
 	) -> Option<custom::ProviderFormat> {
-		// Vertex currently supports Responses only in the streaming response mapper; the
-		// request path does not translate Responses bodies to its OpenAI-compatible chat endpoint.
-		if matches!(self, AIProvider::Vertex(_)) && input_format == InputFormat::Responses {
-			return None;
-		}
-
-		let supported = self.supported_formats(request_model);
-		input_format
-			.provider_format_preferences()
-			.iter()
-			.copied()
-			.find(|format| supported.contains(format))
+		use custom::ProviderFormat::*;
+		let format = match input_format {
+			InputFormat::Embeddings => Embeddings,
+			InputFormat::Realtime => Realtime,
+			InputFormat::CountTokens => AnthropicTokenCount,
+			InputFormat::Rerank => Rerank,
+			InputFormat::Detect
+			| InputFormat::Completions
+			| InputFormat::Messages
+			| InputFormat::Responses => return None,
+		};
+		self
+			.supports_format(format, request_model)
+			.then_some(format)
 	}
 
 	/// Default backend policies (TLS + auth) for connecting to the provider. Split from
@@ -696,28 +1257,24 @@ impl AIProvider {
 			}),
 			AIProvider::Custom(provider) => http::modify_req(req, |req| {
 				http::modify_uri(req, |uri| {
-					let Some(native_format) = llm_request.and_then(|l| l.native_format) else {
-						return Ok(());
-					};
-					if let Some(path) = provider.path_for(native_format) {
+					if let Some(path) = provider.path_for_route(route_type) {
 						Self::set_path_and_query(uri, path)?;
 						return Ok(());
 					}
-					let native_route_type = native_format.route_type();
-					let path = match native_route_type {
+					let path = match route_type {
 						RouteType::Messages | RouteType::AnthropicTokenCount => format!(
 							"{}{}",
 							path_prefix.map_or(anthropic::DEFAULT_BASE_PATH, |prefix| {
 								prefix.trim_end_matches('/')
 							}),
-							anthropic::path_suffix(native_route_type)
+							anthropic::path_suffix(route_type)
 						),
 						_ => format!(
 							"{}{}",
 							path_prefix.map_or(openai::DEFAULT_BASE_PATH, |prefix| {
 								prefix.trim_end_matches('/')
 							}),
-							openai::path_suffix(native_route_type)
+							openai::path_suffix(route_type)
 						),
 					};
 					Self::set_path_and_query(uri, &path)?;
@@ -858,6 +1415,7 @@ impl AIProvider {
 		let (parts, mut req) = self
 			.read_body_and_default_model::<types::completions::Request>(policies, req, log)
 			.await?;
+		self.apply_model_alias(policies, &mut req);
 
 		// If a user doesn't request usage, we will not get token information which we need
 		// We always set it.
@@ -871,11 +1429,14 @@ impl AIProvider {
 				rest: Default::default(),
 			});
 		}
-		if matches!(self, AIProvider::OpenAI(_)) {
+		if matches!(
+			self,
+			AIProvider::OpenAI(_) | AIProvider::Copilot(_) | AIProvider::Azure(_)
+		) {
 			req.normalize_openai_token_limit();
 		}
 		self
-			.process_request(
+			.process_chat_request(
 				backend_info,
 				policies,
 				InputFormat::Completions,
@@ -883,6 +1444,7 @@ impl AIProvider {
 				parts,
 				tokenize,
 				log,
+				|req| types::ChatRequest::Completions(req),
 			)
 			.await
 	}
@@ -895,12 +1457,13 @@ impl AIProvider {
 		tokenize: bool,
 		log: &mut Option<&mut RequestLog>,
 	) -> Result<RequestResult, AIError> {
-		let (parts, req) = self
+		let (parts, mut req) = self
 			.read_body_and_default_model::<types::messages::Request>(policies, req, log)
 			.await?;
+		self.apply_model_alias(policies, &mut req);
 
 		self
-			.process_request(
+			.process_chat_request(
 				backend_info,
 				policies,
 				InputFormat::Messages,
@@ -908,6 +1471,7 @@ impl AIProvider {
 				parts,
 				tokenize,
 				log,
+				|req| types::ChatRequest::Messages(req),
 			)
 			.await
 	}
@@ -920,12 +1484,13 @@ impl AIProvider {
 		tokenize: bool,
 		log: &mut Option<&mut RequestLog>,
 	) -> Result<RequestResult, AIError> {
-		let (parts, req) = self
+		let (parts, mut req) = self
 			.read_body_and_default_model::<types::embeddings::Request>(policies, req, log)
 			.await?;
+		self.apply_model_alias(policies, &mut req);
 
 		self
-			.process_request(
+			.process_non_chat_request(
 				backend_info,
 				policies,
 				InputFormat::Embeddings,
@@ -933,6 +1498,7 @@ impl AIProvider {
 				parts,
 				tokenize,
 				log,
+				|provider, req, _, _| provider.render_embeddings_request(req),
 			)
 			.await
 	}
@@ -945,12 +1511,13 @@ impl AIProvider {
 		tokenize: bool,
 		log: &mut Option<&mut RequestLog>,
 	) -> Result<RequestResult, AIError> {
-		let (parts, req) = self
+		let (parts, mut req) = self
 			.read_body_and_default_model::<types::rerank::Request>(policies, req, log)
 			.await?;
+		self.apply_model_alias(policies, &mut req);
 
 		self
-			.process_request(
+			.process_non_chat_request(
 				backend_info,
 				policies,
 				InputFormat::Rerank,
@@ -958,6 +1525,7 @@ impl AIProvider {
 				parts,
 				tokenize,
 				log,
+				|provider, req, _, _| provider.render_rerank_request(req),
 			)
 			.await
 	}
@@ -970,9 +1538,10 @@ impl AIProvider {
 		tokenize: bool,
 		log: &mut Option<&mut RequestLog>,
 	) -> Result<RequestResult, AIError> {
-		let (mut parts, req) = self
+		let (mut parts, mut req) = self
 			.read_body_and_default_model::<types::responses::Request>(policies, req, log)
 			.await?;
+		self.apply_model_alias(policies, &mut req);
 
 		// Strip client-specific headers that cause AWS signature mismatches for Bedrock
 		if matches!(self, AIProvider::Bedrock(_)) {
@@ -981,7 +1550,7 @@ impl AIProvider {
 		}
 
 		self
-			.process_request(
+			.process_chat_request(
 				backend_info,
 				policies,
 				InputFormat::Responses,
@@ -989,6 +1558,7 @@ impl AIProvider {
 				parts,
 				tokenize,
 				log,
+				|req| types::ChatRequest::Responses(req),
 			)
 			.await
 	}
@@ -1000,9 +1570,10 @@ impl AIProvider {
 		policies: Option<&Policy>,
 		log: &mut Option<&mut RequestLog>,
 	) -> Result<RequestResult, AIError> {
-		let (parts, req) = self
+		let (parts, mut req) = self
 			.read_body_and_default_model::<types::count_tokens::Request>(policies, req, log)
 			.await?;
+		self.apply_model_alias(policies, &mut req);
 
 		// Some Anthropic-compatible clients (e.g. Claude Code) always call
 		// `/v1/messages/count_tokens`. For providers/models without a native
@@ -1029,7 +1600,7 @@ impl AIProvider {
 		}
 
 		self
-			.process_request(
+			.process_non_chat_request(
 				backend_info,
 				policies,
 				InputFormat::CountTokens,
@@ -1037,6 +1608,9 @@ impl AIProvider {
 				parts,
 				false,
 				log,
+				|provider, req, parts, request_model| {
+					provider.render_count_tokens_request(req, &parts.headers, request_model)
+				},
 			)
 			.await
 	}
@@ -1076,7 +1650,7 @@ impl AIProvider {
 		};
 
 		self
-			.process_request(
+			.process_non_chat_request(
 				backend_info,
 				policies,
 				InputFormat::Detect,
@@ -1084,54 +1658,112 @@ impl AIProvider {
 				parts,
 				false,
 				log,
+				|_, req, _, _| match req {
+					types::detect::Request::Raw(bytes) => Ok(bytes.to_vec()),
+					types::detect::Request::Json(value) => {
+						serde_json::to_vec(value).map_err(AIError::RequestMarshal)
+					},
+				},
 			)
 			.await
 	}
 
+	fn render_count_tokens_request(
+		&self,
+		req: &types::count_tokens::Request,
+		headers: &HeaderMap,
+		request_model: &str,
+	) -> Result<Vec<u8>, AIError> {
+		match self {
+			AIProvider::Anthropic(_) | AIProvider::Custom(_) => {
+				serde_json::to_vec(req).map_err(AIError::RequestMarshal)
+			},
+			AIProvider::Bedrock(_) => {
+				conversion::bedrock::from_anthropic_token_count::translate(req, headers)
+			},
+			AIProvider::Vertex(provider) => {
+				let body = serde_json::to_vec(req).map_err(AIError::RequestMarshal)?;
+				provider.prepare_anthropic_count_tokens_body(body)
+			},
+			AIProvider::Azure(p)
+				if matches!(p.resource_type, azure::AzureResourceType::Foundry)
+					&& p.is_anthropic_model(Some(request_model)) =>
+			{
+				serde_json::to_vec(req).map_err(AIError::RequestMarshal)
+			},
+			_ => Err(AIError::UnsupportedConversion(strng::literal!(
+				"count_tokens not supported for this provider"
+			))),
+		}
+	}
+
+	fn render_embeddings_request(
+		&self,
+		req: &types::embeddings::Request,
+	) -> Result<Vec<u8>, AIError> {
+		match self {
+			AIProvider::Custom(_)
+			| AIProvider::OpenAI(_)
+			| AIProvider::Copilot(_)
+			| AIProvider::Azure(_)
+			| AIProvider::Gemini(_)
+			| AIProvider::Anthropic(_) => serde_json::to_vec(req).map_err(AIError::RequestMarshal),
+			AIProvider::Vertex(_) => conversion::vertex::from_embeddings::translate(req),
+			AIProvider::Bedrock(p) => conversion::bedrock::from_embeddings::translate(req, p),
+		}
+	}
+
+	fn render_rerank_request(&self, req: &types::rerank::Request) -> Result<Vec<u8>, AIError> {
+		match self {
+			AIProvider::Custom(_)
+			| AIProvider::OpenAI(_)
+			| AIProvider::Copilot(_)
+			| AIProvider::Azure(_)
+			| AIProvider::Gemini(_)
+			| AIProvider::Anthropic(_) => serde_json::to_vec(req).map_err(AIError::RequestMarshal),
+			AIProvider::Vertex(p) => conversion::vertex::from_rerank::translate(req, p),
+			AIProvider::Bedrock(p) => conversion::bedrock::from_rerank::translate(req, p),
+		}
+	}
+
+	fn apply_model_alias(&self, policies: Option<&Policy>, req: &mut impl RequestType) {
+		if let Some(p) = policies {
+			// Apply model alias resolution
+			if req.supports_model()
+				&& let Some(model) = req.model()
+				&& let Some(aliased) = p.resolve_model_alias(model.as_str())
+			{
+				*model = aliased.to_string();
+			}
+		}
+	}
+
 	#[allow(clippy::too_many_arguments)]
-	async fn process_request(
+	async fn prepare_request(
 		&self,
 		backend_info: &crate::http::auth::BackendInfo,
 		policies: Option<&Policy>,
 		original_format: InputFormat,
-		mut req: impl RequestType,
-		mut parts: ::http::request::Parts,
+		req: &mut impl RequestType,
+		parts: &mut Parts,
+		provider_format: Option<custom::ProviderFormat>,
 		tokenize: bool,
 		log: &mut Option<&mut RequestLog>,
-	) -> Result<RequestResult, AIError> {
-		let request_model = if req.supports_model() {
-			req.model().as_deref().map(str::to_string)
-		} else {
-			None
-		};
-		let native_format = if original_format == InputFormat::Detect {
-			None
-		} else {
-			self
-				.native_format_for(original_format, request_model.as_deref())
-				.ok_or_else(|| {
-					AIError::UnsupportedConversion(strng::format!(
-						"from {original_format:?} to provider {}",
-						self.provider()
-					))
-				})?
-				.into()
-		};
-
+	) -> Result<PreparedRequest, AIError> {
 		if let Some(p) = policies {
-			p.apply_prompt_enrichment(&mut req);
+			p.apply_prompt_enrichment(req);
 
 			if original_format.supports_prompt_guard() {
 				let http_headers = &parts.headers;
 				let claims = parts.extensions.get::<Claims>().cloned();
 				if let Some(dr) = p
-					.apply_prompt_guard(backend_info, &mut req, http_headers, claims)
+					.apply_prompt_guard(backend_info, req, http_headers, claims)
 					.await
 					.map_err(|e| {
 						warn!("failed to call prompt guard webhook: {e}");
 						AIError::PromptWebhookError
 					})? {
-					return Ok(RequestResult::Rejected(dr));
+					return Ok(PreparedRequest::Rejected(dr));
 				}
 			}
 		}
@@ -1140,8 +1772,8 @@ impl AIProvider {
 		if original_format == InputFormat::Detect {
 			types::detect::amend_request_info(&mut llm_info, parts.uri.path());
 		}
-		llm_info.native_format = native_format;
-		llm_info.cache_convention = cache_convention_for(self, native_format, &llm_info.request_model);
+		llm_info.cache_convention =
+			cache_convention_for(self, provider_format, &llm_info.request_model);
 		if let Some(log) = log
 			&& log.cel.cel_context.needs_llm_prompt()
 			&& original_format.supports_prompt_guard()
@@ -1149,107 +1781,130 @@ impl AIProvider {
 			llm_info.prompt = Some(req.get_messages().into());
 		}
 
-		let request_model = llm_info.request_model.as_str();
-		let new_request = if original_format == InputFormat::CountTokens {
-			match self {
-				AIProvider::Anthropic(_) => req.to_anthropic()?,
-				AIProvider::Custom(_) => req.to_anthropic()?,
-				AIProvider::Bedrock(_) => req.to_bedrock_token_count(&parts.headers)?,
-				AIProvider::Vertex(provider) => {
-					let body = req.to_anthropic()?;
-					provider.prepare_anthropic_count_tokens_body(body)?
-				},
-				AIProvider::Azure(p)
-					if matches!(p.resource_type, azure::AzureResourceType::Foundry)
-						&& p.is_anthropic_model(Some(request_model)) =>
-				{
-					// Foundry's Anthropic-native count_tokens endpoint accepts the Anthropic wire format
-					// as-is (the model stays in the body, unlike Vertex which strips it).
-					req.to_anthropic()?
-				},
-				_ => {
-					return Err(AIError::UnsupportedConversion(strng::literal!(
-						"count_tokens not supported for this provider"
-					)));
-				},
-			}
+		Ok(PreparedRequest::Ready(llm_info))
+	}
+
+	#[allow(clippy::too_many_arguments)]
+	async fn process_chat_request<T, F>(
+		&self,
+		backend_info: &crate::http::auth::BackendInfo,
+		policies: Option<&Policy>,
+		original_format: InputFormat,
+		mut req: T,
+		mut parts: Parts,
+		tokenize: bool,
+		log: &mut Option<&mut RequestLog>,
+		chat_request: F,
+	) -> Result<RequestResult, AIError>
+	where
+		T: RequestType,
+		F: for<'a> FnOnce(&'a T) -> types::ChatRequest<'a>,
+	{
+		let request_model = if req.supports_model() {
+			req.model().as_deref().map(str::to_string)
 		} else {
-			match self {
-				AIProvider::Custom(_) => match (original_format, native_format) {
-					(_, None) => req.to_openai()?,
-					(InputFormat::Completions, Some(custom::ProviderFormat::Completions))
-					| (InputFormat::Embeddings, Some(custom::ProviderFormat::Embeddings))
-					| (InputFormat::Rerank, Some(custom::ProviderFormat::Rerank))
-					| (InputFormat::Messages, Some(custom::ProviderFormat::Completions))
-					| (InputFormat::Responses, Some(custom::ProviderFormat::Responses)) => req.to_openai()?,
-					(InputFormat::Completions, Some(custom::ProviderFormat::Messages))
-					| (InputFormat::Messages, Some(custom::ProviderFormat::Messages)) => req.to_anthropic()?,
-					(InputFormat::Responses, Some(custom::ProviderFormat::Completions)) => {
-						req.to_openai_chat_completions()?
-					},
-					(InputFormat::CountTokens | InputFormat::Realtime, _) => {
-						return Err(AIError::UnsupportedConversion(strng::literal!(
-							"this request format does not use this codepath"
-						)));
-					},
-					(_, Some(unsupported)) => {
-						return Err(AIError::UnsupportedConversion(strng::format!(
-							"unsupported custom native format {unsupported:?}"
-						)));
-					},
-				},
-				AIProvider::OpenAI(_) | AIProvider::Copilot(_) => req.to_openai()?,
-				AIProvider::Azure(p) => {
-					if matches!(p.resource_type, azure::AzureResourceType::Foundry)
-						&& p.is_anthropic_model(Some(request_model))
-					{
-						// Foundry's Anthropic-native endpoint requires the Anthropic wire format,
-						// but only for Claude models; GPT models use the OpenAI completions format.
-						match original_format {
-							InputFormat::Messages | InputFormat::CountTokens => req.to_anthropic()?,
-							_ => req.to_openai()?,
-						}
-					} else {
-						req.to_openai()?
-					}
-				},
-				AIProvider::Vertex(p) => {
-					if p.is_anthropic_model(Some(request_model)) {
-						let body = req.to_anthropic()?;
-						p.prepare_anthropic_message_body(body)?
-					} else {
-						req.to_vertex(p)?
-					}
-				},
-				AIProvider::Gemini(_) => {
-					if original_format == InputFormat::Responses {
-						req.to_openai_chat_completions()?
-					} else {
-						req.to_openai()?
-					}
-				},
-				AIProvider::Anthropic(_) => req.to_anthropic()?,
-				AIProvider::Bedrock(p) => {
-					let bedrock = req.to_bedrock(
-						p,
-						Some(&parts.headers),
-						policies.and_then(|p| p.prompt_caching.as_ref()),
-					)?;
-					if !bedrock.tool_name_map.is_empty() {
-						llm_info.provider_state = Some(ProviderState::Bedrock {
-							tool_names: Arc::new(bedrock.tool_name_map),
-						});
-					}
-					bedrock.body
-				},
-			}
+			None
+		};
+		let chat_translation = self.chat_translation(original_format, request_model.as_deref())?;
+		let provider_format = Some(chat_translation.provider_format());
+		let prepared = self
+			.prepare_request(
+				backend_info,
+				policies,
+				original_format,
+				&mut req,
+				&mut parts,
+				provider_format,
+				tokenize,
+				log,
+			)
+			.await?;
+		let mut llm_info = match prepared {
+			PreparedRequest::Ready(llm_info) => llm_info,
+			PreparedRequest::Rejected(resp) => return Ok(RequestResult::Rejected(resp)),
 		};
 
-		parts.extensions.insert(llm_info.clone());
-
+		let rendered = chat_translation.render_request(
+			chat_request(&req),
+			&ChatRequestContext {
+				provider: self,
+				headers: &parts.headers,
+				prompt_caching: policies.and_then(|p| p.prompt_caching.as_ref()),
+			},
+		)?;
+		llm_info.provider_state = rendered.provider_state;
 		parts.headers.remove(header::CONTENT_LENGTH);
-		let req = Request::from_parts(parts, Body::from(new_request));
-		Ok(RequestResult::Success(req, llm_info))
+		let req = Request::from_parts(parts, Body::from(rendered.body));
+		Ok(RequestResult::Success {
+			request: req,
+			llm_request: llm_info,
+			upstream_route_type: provider_format
+				.expect("chat requests always have an upstream provider format")
+				.route_type(),
+		})
+	}
+
+	#[allow(clippy::too_many_arguments)]
+	async fn process_non_chat_request<T, F>(
+		&self,
+		backend_info: &crate::http::auth::BackendInfo,
+		policies: Option<&Policy>,
+		original_format: InputFormat,
+		mut req: T,
+		mut parts: Parts,
+		tokenize: bool,
+		log: &mut Option<&mut RequestLog>,
+		render: F,
+	) -> Result<RequestResult, AIError>
+	where
+		T: RequestType,
+		F: FnOnce(&AIProvider, &T, &Parts, &str) -> Result<Vec<u8>, AIError>,
+	{
+		let request_model = if req.supports_model() {
+			req.model().as_deref().map(str::to_string)
+		} else {
+			None
+		};
+		let provider_format = if original_format == InputFormat::Detect {
+			None
+		} else {
+			self
+				.non_chat_provider_format_for(original_format, request_model.as_deref())
+				.ok_or_else(|| {
+					AIError::UnsupportedConversion(strng::format!(
+						"from {original_format:?} to provider {}",
+						self.provider()
+					))
+				})?
+				.into()
+		};
+		let prepared = self
+			.prepare_request(
+				backend_info,
+				policies,
+				original_format,
+				&mut req,
+				&mut parts,
+				provider_format,
+				tokenize,
+				log,
+			)
+			.await?;
+		let llm_info = match prepared {
+			PreparedRequest::Ready(llm_info) => llm_info,
+			PreparedRequest::Rejected(resp) => return Ok(RequestResult::Rejected(resp)),
+		};
+		let request_model = llm_info.request_model.as_str();
+		let body = render(self, &req, &parts, request_model)?;
+		parts.headers.remove(header::CONTENT_LENGTH);
+		let req = Request::from_parts(parts, Body::from(body));
+		Ok(RequestResult::Success {
+			request: req,
+			llm_request: llm_info,
+			upstream_route_type: provider_format
+				.map(custom::ProviderFormat::route_type)
+				.unwrap_or(RouteType::Detect),
+		})
 	}
 
 	#[allow(clippy::too_many_arguments)]
@@ -1281,121 +1936,58 @@ impl AIProvider {
 		}
 		let model_catalog = model_catalog.map(Arc::as_ref);
 
-		// Buffer the body
-		let buffer_limit = http::response_buffer_limit(&resp);
-		let (mut parts, body) = resp.into_parts();
-		let body = dtrace::TracingBody::maybe_wrap("llm raw response", body, buffer_limit);
-		let ce = parts.headers.typed_get::<ContentEncoding>();
-		let (encoding, bytes) =
-			http::compression::to_bytes_with_decompression(body, ce.as_ref(), buffer_limit)
-				.await
-				.map_err(|e| map_compression_error(e, &parts.headers))?;
+		let buffered = Self::buffer_response(resp).await?;
 
-		// Snapshot decompressed bytes for CEL response.body access before re-compression,
-		// so maybe_buffer_response_body can skip decompression entirely.
-		// Also strip encoding headers now that the body is decompressed; the chat
-		// completions path re-adds Content-Encoding when it re-compresses.
-		if encoding.is_some() {
-			parts
-				.extensions
-				.insert(crate::cel::BufferedBody(bytes.clone()));
-			parts.headers.remove(header::CONTENT_ENCODING);
-			parts.headers.remove(header::TRANSFER_ENCODING);
+		match req.input_format {
+			InputFormat::CountTokens => {
+				self.process_count_tokens_response(req, buffered, model_catalog, &log)
+			},
+			InputFormat::Embeddings => {
+				self.process_embeddings_buffered_response(req, buffered, model_catalog, &log)
+			},
+			InputFormat::Rerank => {
+				self.process_rerank_buffered_response(req, buffered, model_catalog, &log)
+			},
+			_ => {
+				self
+					.process_chat_or_detect_buffered_response(
+						client,
+						req,
+						rate_limit,
+						req_snapshot,
+						log,
+						include_completion_in_log,
+						model_catalog,
+						buffered,
+					)
+					.await
+			},
 		}
+	}
 
-		// count_tokens has simplified response handling (just format translation)
-		if req.input_format == InputFormat::CountTokens {
-			let (bytes, count) = match self {
-				AIProvider::Anthropic(_) | AIProvider::Vertex(_) | AIProvider::Bedrock(_) => {
-					types::count_tokens::Response::translate_response(bytes)?
-				},
-				AIProvider::Azure(p)
-					if matches!(p.resource_type, azure::AzureResourceType::Foundry)
-						&& p.is_anthropic_model(Some(&req.request_model)) =>
-				{
-					// Foundry returns the Anthropic-native count_tokens shape for Claude models.
-					types::count_tokens::Response::translate_response(bytes)?
-				},
-				AIProvider::Custom(p) if p.supports(custom::ProviderFormat::AnthropicTokenCount) => {
-					types::count_tokens::Response::translate_response(bytes)?
-				},
-				_ => {
-					return Err(AIError::UnsupportedConversion(strng::literal!(
-						"count_tokens response not supported for this provider"
-					)));
-				},
-			};
-
-			parts.headers.remove(header::CONTENT_LENGTH);
-			let llm_resp = LLMResponse {
-				count_tokens: Some(count),
-				..Default::default()
-			};
-			return Ok(Self::finalize_response(
-				parts,
-				bytes.into(),
-				req,
-				llm_resp,
-				model_catalog,
-				&log,
-			));
-		}
-
-		// embeddings has simplified response handling
-		if req.input_format == InputFormat::Embeddings {
-			parts.headers.remove(header::CONTENT_LENGTH);
-			if !parts.status.is_success() {
-				let body = self.process_error(&req, parts.status, &bytes)?;
-				return Ok(Self::finalize_response(
-					parts,
-					body.into(),
-					req,
-					LLMResponse::default(),
-					model_catalog,
-					&log,
-				));
-			}
-			let (llm_resp, bytes) = self.process_embeddings_response(&req, &parts.headers, bytes)?;
-			return Ok(Self::finalize_response(
-				parts,
-				bytes.into(),
-				req,
-				llm_resp,
-				model_catalog,
-				&log,
-			));
-		}
-
-		// rerank has simplified response handling (like embeddings)
-		if req.input_format == InputFormat::Rerank {
-			parts.headers.remove(header::CONTENT_LENGTH);
-			if !parts.status.is_success() {
-				let body = self.process_error(&req, parts.status, &bytes)?;
-				return Ok(Self::finalize_response(
-					parts,
-					body.into(),
-					req,
-					LLMResponse::default(),
-					model_catalog,
-					&log,
-				));
-			}
-			let (llm_resp, bytes) = self.process_rerank_response(bytes)?;
-			return Ok(Self::finalize_response(
-				parts,
-				bytes.into(),
-				req,
-				llm_resp,
-				model_catalog,
-				&log,
-			));
-		}
+	#[allow(clippy::too_many_arguments)]
+	async fn process_chat_or_detect_buffered_response(
+		&self,
+		client: PolicyClient,
+		req: LLMRequest,
+		rate_limit: LLMResponsePolicies,
+		req_snapshot: Option<Arc<RequestSnapshot>>,
+		log: AsyncLog<llm::LLMInfo>,
+		include_completion_in_log: bool,
+		model_catalog: Option<&cost::ModelCatalog>,
+		buffered: BufferedResponse,
+	) -> Result<Response, AIError> {
+		let BufferedResponse {
+			mut parts,
+			bytes,
+			encoding,
+		} = buffered;
 
 		let (llm_resp, body) = if !parts.status.is_success() {
 			let body = self.process_error(&req, parts.status, &bytes)?;
 			(LLMResponse::default(), body)
 		} else {
-			let mut resp = self.process_success(&req, &bytes)?;
+			let mut resp = self.translate_chat_or_detect_response(&req, &bytes)?;
 			let prompt_guard_headers =
 				response_prompt_guard_headers(&parts.headers, rate_limit.request_traceparent.as_ref());
 
@@ -1451,6 +2043,33 @@ impl AIProvider {
 		Ok(resp)
 	}
 
+	async fn buffer_response(resp: Response) -> Result<BufferedResponse, AIError> {
+		let buffer_limit = http::response_buffer_limit(&resp);
+		let (mut parts, body) = resp.into_parts();
+		let body = dtrace::TracingBody::maybe_wrap("llm raw response", body, buffer_limit);
+		let ce = parts.headers.typed_get::<ContentEncoding>();
+		let (encoding, bytes) =
+			http::compression::to_bytes_with_decompression(body, ce.as_ref(), buffer_limit)
+				.await
+				.map_err(|e| map_compression_error(e, &parts.headers))?;
+
+		// Snapshot decompressed bytes for CEL response.body access before re-compression,
+		// so maybe_buffer_response_body can skip decompression entirely.
+		if encoding.is_some() {
+			parts
+				.extensions
+				.insert(crate::cel::BufferedBody(bytes.clone()));
+			parts.headers.remove(header::CONTENT_ENCODING);
+			parts.headers.remove(header::TRANSFER_ENCODING);
+		}
+
+		Ok(BufferedResponse {
+			parts,
+			bytes,
+			encoding,
+		})
+	}
+
 	fn finalize_response(
 		mut parts: ::http::response::Parts,
 		body: Body,
@@ -1468,6 +2087,117 @@ impl AIProvider {
 			));
 		log.store(Some(llm_info));
 		Response::from_parts(parts, body)
+	}
+
+	fn process_count_tokens_response(
+		&self,
+		req: LLMRequest,
+		buffered: BufferedResponse,
+		model_catalog: Option<&cost::ModelCatalog>,
+		log: &AsyncLog<llm::LLMInfo>,
+	) -> Result<Response, AIError> {
+		let BufferedResponse {
+			mut parts, bytes, ..
+		} = buffered;
+		let (bytes, count) = match self {
+			AIProvider::Anthropic(_) | AIProvider::Vertex(_) | AIProvider::Bedrock(_) => {
+				types::count_tokens::Response::translate_response(bytes)?
+			},
+			AIProvider::Azure(p)
+				if matches!(p.resource_type, azure::AzureResourceType::Foundry)
+					&& p.is_anthropic_model(Some(&req.request_model)) =>
+			{
+				// Foundry returns the Anthropic-native count_tokens shape for Claude models.
+				types::count_tokens::Response::translate_response(bytes)?
+			},
+			AIProvider::Custom(p) if p.supports(custom::ProviderFormat::AnthropicTokenCount) => {
+				types::count_tokens::Response::translate_response(bytes)?
+			},
+			_ => {
+				return Err(AIError::UnsupportedConversion(strng::literal!(
+					"count_tokens response not supported for this provider"
+				)));
+			},
+		};
+
+		parts.headers.remove(header::CONTENT_LENGTH);
+		Ok(Self::finalize_response(
+			parts,
+			bytes.into(),
+			req,
+			LLMResponse {
+				count_tokens: Some(count),
+				..Default::default()
+			},
+			model_catalog,
+			log,
+		))
+	}
+
+	fn process_embeddings_buffered_response(
+		&self,
+		req: LLMRequest,
+		buffered: BufferedResponse,
+		model_catalog: Option<&cost::ModelCatalog>,
+		log: &AsyncLog<llm::LLMInfo>,
+	) -> Result<Response, AIError> {
+		let BufferedResponse {
+			mut parts, bytes, ..
+		} = buffered;
+		parts.headers.remove(header::CONTENT_LENGTH);
+		if !parts.status.is_success() {
+			let body = self.process_error(&req, parts.status, &bytes)?;
+			return Ok(Self::finalize_response(
+				parts,
+				body.into(),
+				req,
+				LLMResponse::default(),
+				model_catalog,
+				log,
+			));
+		}
+		let (llm_resp, bytes) = self.process_embeddings_response(&req, &parts.headers, bytes)?;
+		Ok(Self::finalize_response(
+			parts,
+			bytes.into(),
+			req,
+			llm_resp,
+			model_catalog,
+			log,
+		))
+	}
+
+	fn process_rerank_buffered_response(
+		&self,
+		req: LLMRequest,
+		buffered: BufferedResponse,
+		model_catalog: Option<&cost::ModelCatalog>,
+		log: &AsyncLog<llm::LLMInfo>,
+	) -> Result<Response, AIError> {
+		let BufferedResponse {
+			mut parts, bytes, ..
+		} = buffered;
+		parts.headers.remove(header::CONTENT_LENGTH);
+		if !parts.status.is_success() {
+			let body = self.process_error(&req, parts.status, &bytes)?;
+			return Ok(Self::finalize_response(
+				parts,
+				body.into(),
+				req,
+				LLMResponse::default(),
+				model_catalog,
+				log,
+			));
+		}
+		let (llm_resp, bytes) = self.process_rerank_response(bytes)?;
+		Ok(Self::finalize_response(
+			parts,
+			bytes.into(),
+			req,
+			llm_resp,
+			model_catalog,
+			log,
+		))
 	}
 
 	fn process_embeddings_response(
@@ -1524,179 +2254,35 @@ impl AIProvider {
 		}
 	}
 
-	fn parse_completions_response(bytes: &Bytes) -> Result<Box<dyn ResponseType>, AIError> {
+	fn parse_response<T>(bytes: &Bytes) -> Result<Box<dyn ResponseType>, AIError>
+	where
+		T: ResponseType + DeserializeOwned + 'static,
+	{
 		Ok(Box::new(
-			serde_json::from_slice::<types::completions::Response>(bytes).map_err(|e| {
-				warn!(
-					error = %e,
-					body = %String::from_utf8_lossy(bytes),
-					"failed to parse completions response"
-				);
-				AIError::ResponseParsing(e)
-			})?,
+			serde_json::from_slice::<T>(bytes).map_err(logged_response_parsing(bytes))?,
 		))
 	}
 
-	fn parse_responses_response(bytes: &Bytes) -> Result<Box<dyn ResponseType>, AIError> {
-		Ok(Box::new(
-			serde_json::from_slice::<types::responses::Response>(bytes).map_err(|e| {
-				warn!(
-					error = %e,
-					body = %String::from_utf8_lossy(bytes),
-					"failed to parse responses response"
-				);
-				AIError::ResponseParsing(e)
-			})?,
-		))
-	}
-
-	fn parse_messages_response(bytes: &Bytes) -> Result<Box<dyn ResponseType>, AIError> {
-		Ok(Box::new(
-			serde_json::from_slice::<types::messages::Response>(bytes)
-				.map_err(AIError::ResponseParsing)?,
-		))
-	}
-
-	fn process_custom_success(
-		req: &LLMRequest,
-		bytes: &Bytes,
-	) -> Result<Box<dyn ResponseType>, AIError> {
-		match (req.input_format, req.native_format) {
-			(InputFormat::Completions, Some(custom::ProviderFormat::Completions)) => {
-				Self::parse_completions_response(bytes)
-			},
-			(InputFormat::Completions, Some(custom::ProviderFormat::Messages)) => {
-				conversion::messages::from_completions::translate_response(bytes)
-			},
-			(InputFormat::Messages, Some(custom::ProviderFormat::Messages)) => {
-				Self::parse_messages_response(bytes)
-			},
-			(InputFormat::Messages, Some(custom::ProviderFormat::Completions)) => {
-				conversion::completions::from_messages::translate_response(bytes)
-			},
-			(InputFormat::Responses, Some(custom::ProviderFormat::Responses)) => {
-				Self::parse_responses_response(bytes)
-			},
-			(InputFormat::Responses, Some(custom::ProviderFormat::Completions)) => {
-				conversion::openai_compat::to_responses::translate_response(bytes, &req.request_model)
-			},
-			(InputFormat::Detect, None) => Ok(Box::new(
-				serde_json::from_slice::<types::detect::Response>(bytes)
-					.unwrap_or_else(|_| types::detect::Response::new_raw(bytes.clone())),
-			)),
-			(input, native) => Err(AIError::UnsupportedConversion(strng::format!(
-				"custom provider cannot translate {native:?} response to {input:?}"
-			))),
-		}
-	}
-
-	fn process_success(
+	fn translate_chat_or_detect_response(
 		&self,
 		req: &LLMRequest,
 		bytes: &Bytes,
 	) -> Result<Box<dyn ResponseType>, AIError> {
-		match (self, req.input_format) {
-			(_, InputFormat::Detect) => Ok(Box::new(
+		if req.input_format == InputFormat::Detect {
+			return Ok(Box::new(
 				serde_json::from_slice::<types::detect::Response>(bytes)
 					.unwrap_or_else(|_| types::detect::Response::new_raw(bytes.clone())),
-			)),
-			(AIProvider::Custom(_), _) => Self::process_custom_success(req, bytes),
-			// Completions with OpenAI: just passthrough
-			(
-				AIProvider::OpenAI(_)
-				| AIProvider::Copilot(_)
-				| AIProvider::Gemini(_)
-				| AIProvider::Azure(_),
-				InputFormat::Completions,
-			) => Self::parse_completions_response(bytes),
-			// Responses with OpenAI/Azure: just passthrough
-			(
-				AIProvider::OpenAI(_) | AIProvider::Copilot(_) | AIProvider::Azure(_),
-				InputFormat::Responses,
-			) => Self::parse_responses_response(bytes),
-			// Vertex messages: passthrough only for Anthropic models, otherwise translate from completions
-			(AIProvider::Vertex(p), InputFormat::Messages) => {
-				if p.is_anthropic_model(Some(&req.request_model)) {
-					Ok(Box::new(
-						serde_json::from_slice::<types::messages::Response>(bytes)
-							.map_err(logged_response_parsing(bytes))?,
-					))
-				} else {
-					conversion::completions::from_messages::translate_response(bytes)
-				}
-			},
-			// Anthropic messages: passthrough
-			(AIProvider::Anthropic(_), InputFormat::Messages) => Self::parse_messages_response(bytes),
-			// Azure messages: Foundry+Claude uses Anthropic-native passthrough;
-			// all other Azure (OpenAI resource or GPT models) translate from chat completions.
-			(AIProvider::Azure(p), InputFormat::Messages) => {
-				if matches!(p.resource_type, azure::AzureResourceType::Foundry)
-					&& p.is_anthropic_model(Some(&req.request_model))
-				{
-					Self::parse_messages_response(bytes)
-				} else {
-					conversion::completions::from_messages::translate_response(bytes)
-				}
-			},
-			// OpenAI/Gemini messages: translate from chat completions
-			(
-				AIProvider::OpenAI(_) | AIProvider::Copilot(_) | AIProvider::Gemini(_),
-				InputFormat::Messages,
-			) => conversion::completions::from_messages::translate_response(bytes),
-			// Supported paths with conversion...
-			(AIProvider::Anthropic(_), InputFormat::Completions) => {
-				conversion::messages::from_completions::translate_response(bytes)
-			},
-			(AIProvider::Bedrock(_), InputFormat::Completions) => {
-				conversion::bedrock::from_completions::translate_response(
-					bytes,
-					&req.request_model,
-					bedrock_tool_name_map(req),
-				)
-			},
-			(AIProvider::Bedrock(_), InputFormat::Messages) => {
-				conversion::bedrock::from_messages::translate_response(
-					bytes,
-					&req.request_model,
-					bedrock_tool_name_map(req),
-				)
-			},
-			(AIProvider::Bedrock(_), InputFormat::Responses) => {
-				conversion::bedrock::from_responses::translate_response(
-					bytes,
-					&req.request_model,
-					bedrock_tool_name_map(req),
-				)
-			},
-			(AIProvider::Vertex(p), InputFormat::Completions) => {
-				if p.is_anthropic_model(Some(&req.request_model)) {
-					conversion::messages::from_completions::translate_response(bytes)
-				} else {
-					Ok(Box::new(
-						serde_json::from_slice::<types::completions::Response>(bytes)
-							.map_err(logged_response_parsing(bytes))?,
-					))
-				}
-			},
-			(AIProvider::Gemini(_), InputFormat::Responses) => {
-				conversion::openai_compat::to_responses::translate_response(bytes, &req.request_model)
-			},
-			(_, InputFormat::Responses) => Err(AIError::UnsupportedConversion(strng::literal!(
-				"this provider does not support Responses"
-			))),
-			(_, InputFormat::Realtime) => Err(AIError::UnsupportedConversion(strng::literal!(
-				"realtime does not use this codepath"
-			))),
-			(_, InputFormat::CountTokens) => {
-				unreachable!("CountTokens should be handled by process_count_tokens_response")
-			},
-			(_, InputFormat::Embeddings) => {
-				unreachable!("Embeddings should be handled by process_embeddings_response")
-			},
-			(_, InputFormat::Rerank) => {
-				unreachable!("Rerank should be handled by process_rerank_response")
-			},
+			));
 		}
+
+		let translation = self.chat_translation(req.input_format, Some(&req.request_model))?;
+		translation.render_response(
+			bytes,
+			&ChatResponseContext {
+				model: &req.request_model,
+				tool_name_map: bedrock_tool_name_map(req),
+			},
+		)
 	}
 
 	#[allow(clippy::too_many_arguments)]
@@ -1711,21 +2297,14 @@ impl AIProvider {
 		model_catalog: Option<Arc<cost::ModelCatalog>>,
 		resp: Response,
 	) -> Result<Response, AIError> {
-		let is_vertex_anthropic = match self {
-			AIProvider::Vertex(p) => p.is_anthropic_model(Some(&req.request_model)),
-			_ => false,
-		};
-		let is_foundry_anthropic = match self {
-			AIProvider::Azure(p) => {
-				matches!(p.resource_type, azure::AzureResourceType::Foundry)
-					&& p.is_anthropic_model(Some(&req.request_model))
-			},
-			_ => false,
-		};
 		let model = req.request_model.clone();
 		let input_format = req.input_format;
-		let native_format = req.native_format;
 		let bedrock_tool_name_map = bedrock_tool_name_map(&req).cloned();
+		let chat_translation = if input_format.is_chat() {
+			Some(self.chat_translation(input_format, Some(&model))?)
+		} else {
+			None
+		};
 		// Store an empty response, as we stream in info we will parse into it
 		let llmresp = llm::LLMInfo {
 			request: req,
@@ -1789,168 +2368,40 @@ impl AIProvider {
 			trace.llm_streaming_translation(
 				self.provider().to_string(),
 				format!("{input_format:?}"),
-				native_format.map(|f| format!("{f:?}")),
+				chat_translation
+					.map(|translation| format!("{:?}", translation.provider_format().route_type())),
 				stream_format.to_string(),
 			)
 		});
-		let translated = match (self, input_format, native_format) {
-			(
-				AIProvider::Custom(_),
-				InputFormat::Completions,
-				Some(custom::ProviderFormat::Completions),
-			) => conversion::completions::passthrough_stream(logger, include_completion_in_log, resp),
-			(AIProvider::Custom(_), InputFormat::Completions, Some(custom::ProviderFormat::Messages)) => {
-				resp.map(|b| conversion::messages::from_completions::translate_stream(b, buffer, logger))
-			},
-			(AIProvider::Custom(_), InputFormat::Messages, Some(custom::ProviderFormat::Messages)) => {
-				resp.map(|b| {
-					conversion::messages::passthrough_stream(b, buffer, logger, include_completion_in_log)
-				})
-			},
-			(AIProvider::Custom(_), InputFormat::Messages, Some(custom::ProviderFormat::Completions)) => {
-				resp.map(|b| conversion::completions::from_messages::translate_stream(b, buffer, logger))
-			},
-			(AIProvider::Custom(_), InputFormat::Responses, Some(custom::ProviderFormat::Responses)) => {
-				resp.map(|b| {
-					conversion::responses::passthrough_stream(b, buffer, logger, include_completion_in_log)
-				})
-			},
-			(
-				AIProvider::Custom(_),
-				InputFormat::Responses,
-				Some(custom::ProviderFormat::Completions),
-			) => {
-				resp.map(|b| conversion::openai_compat::to_responses::translate_stream(b, buffer, logger))
-			},
-			// Completions with OpenAI: just passthrough
-			(
-				AIProvider::OpenAI(_)
-				| AIProvider::Copilot(_)
-				| AIProvider::Gemini(_)
-				| AIProvider::Azure(_),
-				InputFormat::Completions,
-				_,
-			) => conversion::completions::passthrough_stream(logger, include_completion_in_log, resp),
-			// Vertex completions: passthrough for OpenAI-compatible models, translate for Anthropic models
-			(AIProvider::Vertex(_), InputFormat::Completions, _) if is_vertex_anthropic => {
-				resp.map(|b| conversion::messages::from_completions::translate_stream(b, buffer, logger))
-			},
-			(AIProvider::Vertex(_), InputFormat::Completions, _) => {
-				conversion::completions::passthrough_stream(logger, include_completion_in_log, resp)
-			},
-			(AIProvider::Bedrock(_), InputFormat::Detect, _) => {
-				types::detect::passthrough_aws_stream(logger, resp)
-			},
-			(_, InputFormat::Detect, _) => types::detect::passthrough_stream(logger, resp),
-			// Responses with OpenAI: just passthrough
-			(
-				AIProvider::OpenAI(_)
-				| AIProvider::Copilot(_)
-				| AIProvider::Azure(_)
-				| AIProvider::Vertex(_),
-				InputFormat::Responses,
-				_,
-			) => resp.map(|b| {
-				conversion::responses::passthrough_stream(b, buffer, logger, include_completion_in_log)
-			}),
-			(AIProvider::Gemini(_), InputFormat::Responses, _) => {
-				resp.map(|b| conversion::openai_compat::to_responses::translate_stream(b, buffer, logger))
-			},
-			// Vertex messages: passthrough only for Anthropic models, otherwise translate from completions
-			(AIProvider::Vertex(_), InputFormat::Messages, _) if is_vertex_anthropic => resp.map(|b| {
-				conversion::messages::passthrough_stream(b, buffer, logger, include_completion_in_log)
-			}),
-			(AIProvider::Vertex(_), InputFormat::Messages, _) => {
-				resp.map(|b| conversion::completions::from_messages::translate_stream(b, buffer, logger))
-			},
-			// Anthropic messages: passthrough
-			(AIProvider::Anthropic(_), InputFormat::Messages, _) => resp.map(|b| {
-				conversion::messages::passthrough_stream(b, buffer, logger, include_completion_in_log)
-			}),
-			// Foundry + Claude model: Anthropic-native SSE stream, passthrough as-is
-			(AIProvider::Azure(_), InputFormat::Messages, _) if is_foundry_anthropic => resp.map(|b| {
-				conversion::messages::passthrough_stream(b, buffer, logger, include_completion_in_log)
-			}),
-			// OpenAI/Gemini/Azure messages: translate from chat completions
-			(
-				AIProvider::OpenAI(_)
-				| AIProvider::Copilot(_)
-				| AIProvider::Gemini(_)
-				| AIProvider::Azure(_),
-				InputFormat::Messages,
-				_,
-			) => resp.map(|b| conversion::completions::from_messages::translate_stream(b, buffer, logger)),
-			// Supported paths with conversion...
-			(AIProvider::Anthropic(_), InputFormat::Completions, _) => {
-				resp.map(|b| conversion::messages::from_completions::translate_stream(b, buffer, logger))
-			},
-			(AIProvider::Bedrock(_), InputFormat::Completions, _) => {
-				let msg = conversion::bedrock::message_id(&resp);
-				let tool_name_map = bedrock_tool_name_map.clone();
-				resp.map(move |b| {
-					conversion::bedrock::from_completions::translate_stream(
-						b,
-						buffer,
-						logger,
-						&model,
-						&msg,
-						tool_name_map,
-					)
-				})
-			},
-			(AIProvider::Bedrock(_), InputFormat::Messages, _) => {
-				let msg = conversion::bedrock::message_id(&resp);
-				let tool_name_map = bedrock_tool_name_map.clone();
-				resp.map(move |b| {
-					conversion::bedrock::from_messages::translate_stream(
-						b,
-						buffer,
-						logger,
-						&model,
-						&msg,
-						include_completion_in_log,
-						tool_name_map,
-					)
-				})
-			},
-			(AIProvider::Bedrock(_), InputFormat::Responses, _) => {
-				let msg = conversion::bedrock::message_id(&resp);
-				let tool_name_map = bedrock_tool_name_map.clone();
-				resp.map(move |b| {
-					conversion::bedrock::from_responses::translate_stream(
-						b,
-						buffer,
-						logger,
-						&model,
-						&msg,
-						tool_name_map,
-					)
-				})
-			},
-			(_, InputFormat::Realtime, _) => {
-				return Err(AIError::UnsupportedConversion(strng::literal!(
-					"realtime does not use streaming codepath"
-				)));
-			},
-			(_, InputFormat::Responses, _) => {
-				return Err(AIError::UnsupportedConversion(strng::literal!(
-					"this provider does not support Responses for streaming"
-				)));
-			},
-			(_, InputFormat::CountTokens, _) => {
-				unreachable!("CountTokens should be handled by process_count_tokens_response")
-			},
-			(_, InputFormat::Embeddings, _) => {
-				unreachable!("Embeddings should be handled by process_embeddings_response")
-			},
-			(_, InputFormat::Rerank, _) => {
-				unreachable!("Rerank should be handled by process_rerank_response")
-			},
-			(AIProvider::Custom(_), input, native) => {
-				return Err(AIError::UnsupportedConversion(strng::format!(
-					"custom provider cannot translate {native:?} stream to {input:?}"
-				)));
-			},
+		let translated = if input_format.is_chat() {
+			let translation = chat_translation.expect("chat translation was selected for chat input");
+			translation.stream(
+				resp,
+				ChatStreamContext {
+					buffer_limit: buffer,
+					logger,
+					model: model.to_string(),
+					include_completion_in_log,
+					tool_name_map: bedrock_tool_name_map,
+				},
+			)
+		} else {
+			match (self, input_format) {
+				(AIProvider::Bedrock(_), InputFormat::Detect) => {
+					types::detect::passthrough_aws_stream(logger, resp)
+				},
+				(_, InputFormat::Detect) => types::detect::passthrough_stream(logger, resp),
+				(_, InputFormat::Realtime) => {
+					return Err(AIError::UnsupportedConversion(strng::literal!(
+						"realtime does not use streaming codepath"
+					)));
+				},
+				(_, _) => {
+					return Err(AIError::UnsupportedConversion(strng::format!(
+						"{input_format:?} does not use streaming response translation"
+					)));
+				},
+			}
 		};
 
 		if !evaluators.is_empty() {
@@ -1978,13 +2429,8 @@ impl AIProvider {
 		{
 			let mut req: T = serde_json::from_slice(bytes.as_ref()).map_err(AIError::RequestParsing)?;
 			let model = req.model();
-			let Some(model_value) = model.as_deref() else {
+			if model.as_deref().is_none() {
 				return Err(AIError::MissingField("model not specified".into()));
-			};
-			if let Some(p) = policies
-				&& let Some(aliased) = p.resolve_model_alias(model_value)
-			{
-				*model = Some(aliased.to_string());
 			}
 			return Ok((parts, req));
 		}
@@ -1997,7 +2443,7 @@ impl AIProvider {
 		} else {
 			request
 		};
-		self.finalize_request_model(policies, &mut request)?;
+		self.finalize_request_model(&mut request)?;
 		let req: T = serde_json::from_value(request).map_err(AIError::RequestParsing)?;
 
 		Ok((parts, req))
@@ -2027,24 +2473,16 @@ impl AIProvider {
 		Ok(())
 	}
 
-	fn finalize_request_model(
-		&self,
-		policies: Option<&Policy>,
-		req: &mut serde_json::Value,
-	) -> Result<(), AIError> {
+	fn finalize_request_model(&self, req: &mut serde_json::Value) -> Result<(), AIError> {
 		let Some(obj) = req.as_object_mut() else {
 			return Err(AIError::MissingField("request must be an object".into()));
 		};
-		let Some(model) = obj.get("model").and_then(serde_json::Value::as_str) else {
-			return Err(AIError::MissingField("model not specified".into()));
-		};
-		if let Some(p) = policies
-			&& let Some(aliased) = p.resolve_model_alias(model)
+		if obj
+			.get("model")
+			.and_then(serde_json::Value::as_str)
+			.is_none()
 		{
-			obj.insert(
-				"model".to_string(),
-				serde_json::Value::String(aliased.to_string()),
-			);
+			return Err(AIError::MissingField("model not specified".into()));
 		}
 		Ok(())
 	}
@@ -2055,112 +2493,53 @@ impl AIProvider {
 		status: ::http::StatusCode,
 		bytes: &Bytes,
 	) -> Result<Bytes, AIError> {
-		match (self, req.input_format, req.native_format) {
-			(
-				AIProvider::Custom(_),
-				InputFormat::Completions,
-				Some(custom::ProviderFormat::Completions),
-			)
-			| (
-				AIProvider::Custom(_),
-				InputFormat::Responses,
-				Some(custom::ProviderFormat::Completions | custom::ProviderFormat::Responses),
-			)
-			| (
-				AIProvider::Custom(_),
-				InputFormat::Embeddings,
-				Some(custom::ProviderFormat::Embeddings),
-			) => Ok(bytes.clone()),
-			(AIProvider::Custom(_), InputFormat::Completions, Some(custom::ProviderFormat::Messages)) => {
-				conversion::messages::from_completions::translate_error(bytes)
-			},
-			(AIProvider::Custom(_), InputFormat::Messages, Some(custom::ProviderFormat::Completions)) => {
-				conversion::completions::from_messages::translate_error(bytes, status)
-			},
-			(AIProvider::Custom(_), InputFormat::Messages, Some(custom::ProviderFormat::Messages)) => {
-				Ok(bytes.clone())
-			},
+		if req.input_format.is_chat() {
+			let translation = self.chat_translation(req.input_format, Some(&req.request_model))?;
+			return translation.error(
+				bytes,
+				status,
+				self.chat_error_format(translation, Some(&req.request_model)),
+			);
+		}
+		match (self, req.input_format) {
+			(AIProvider::Custom(_), InputFormat::Embeddings) => Ok(bytes.clone()),
 			(
 				AIProvider::OpenAI(_) | AIProvider::Copilot(_) | AIProvider::Azure(_),
-				InputFormat::Completions | InputFormat::Responses | InputFormat::Embeddings,
-				_,
+				InputFormat::Embeddings,
 			) => {
 				// Passthrough; nothing needed
 				Ok(bytes.clone())
 			},
-			(AIProvider::Gemini(_), InputFormat::Completions, _) => {
-				conversion::completions::translate_google_error(bytes)
-			},
-			(AIProvider::Gemini(_), InputFormat::Responses, _) => {
-				conversion::gemini::from_responses::translate_error(bytes)
-			},
-			(AIProvider::Gemini(_), InputFormat::Embeddings, _) => {
+			(AIProvider::Gemini(_), InputFormat::Embeddings) => {
 				// Passthrough; Gemini embeddings endpoint already returns OpenAI-compatible errors.
 				Ok(bytes.clone())
 			},
-			(AIProvider::Vertex(p), InputFormat::Completions, _) => {
-				if p.is_anthropic_model(Some(&req.request_model)) {
-					Ok(bytes.clone())
-				} else {
-					conversion::completions::translate_google_error(bytes)
-				}
-			},
-			(AIProvider::Vertex(_), InputFormat::Embeddings, _) => {
+			(AIProvider::Vertex(_), InputFormat::Embeddings) => {
 				// Passthrough; Vertex embeddings endpoint already returns OpenAI-compatible errors.
 				Ok(bytes.clone())
 			},
-			(
-				AIProvider::OpenAI(_) | AIProvider::Copilot(_) | AIProvider::Azure(_),
-				InputFormat::Messages,
-				_,
-			) => conversion::completions::from_messages::translate_error(bytes, status),
-			(AIProvider::Gemini(_), InputFormat::Messages, _) => {
-				conversion::messages::translate_google_error(bytes)
-			},
-			(AIProvider::Vertex(p), InputFormat::Messages, _) => {
-				if p.is_anthropic_model(Some(&req.request_model)) {
-					Ok(bytes.clone())
-				} else {
-					conversion::messages::translate_google_error(bytes)
-				}
-			},
-			(AIProvider::Anthropic(_), InputFormat::Messages, _) => {
-				conversion::messages::translate_anthropic_error(bytes, status)
-			},
-			(_, InputFormat::Detect, _) => {
+			(_, InputFormat::Detect) => {
 				// Passthrough; nothing needed
 				Ok(bytes.clone())
 			},
-			(AIProvider::Anthropic(_), InputFormat::Completions, _) => {
-				conversion::messages::from_completions::translate_error(bytes)
-			},
-			(AIProvider::Bedrock(_), InputFormat::Completions, _) => {
-				conversion::bedrock::from_completions::translate_error(bytes)
-			},
-			(AIProvider::Bedrock(_), InputFormat::Messages, _) => {
-				conversion::bedrock::from_messages::translate_error(bytes)
-			},
-			(AIProvider::Bedrock(_), InputFormat::Responses, _) => {
-				conversion::bedrock::from_responses::translate_error(bytes)
-			},
-			(AIProvider::Bedrock(_), InputFormat::Embeddings, _) => {
+			(AIProvider::Bedrock(_), InputFormat::Embeddings) => {
 				conversion::bedrock::from_embeddings::translate_error(bytes)
 			},
-			(AIProvider::Custom(_), InputFormat::Rerank, Some(custom::ProviderFormat::Rerank)) => {
-				Ok(bytes.clone())
-			},
+			(AIProvider::Custom(_), InputFormat::Rerank) => Ok(bytes.clone()),
 			(
 				AIProvider::OpenAI(_) | AIProvider::Copilot(_) | AIProvider::Azure(_),
 				InputFormat::Rerank,
-				_,
 			) => Ok(bytes.clone()),
-			(AIProvider::Bedrock(_), InputFormat::Rerank, _) => {
+			(AIProvider::Bedrock(_), InputFormat::Rerank) => {
 				conversion::bedrock::from_rerank::translate_error(bytes)
 			},
-			(AIProvider::Vertex(_), InputFormat::Rerank, _) => {
+			(AIProvider::Vertex(_), InputFormat::Rerank) => {
 				conversion::vertex::from_rerank::translate_error(bytes)
 			},
-			(_, _, _) => Err(AIError::UnsupportedConversion(strng::literal!(
+			(_, InputFormat::Realtime) => Err(AIError::UnsupportedConversion(strng::literal!(
+				"realtime does not use this codepath"
+			))),
+			(_, _) => Err(AIError::UnsupportedConversion(strng::literal!(
 				"this provider and format is not supported"
 			))),
 		}

--- a/crates/agentgateway/src/llm/tests.rs
+++ b/crates/agentgateway/src/llm/tests.rs
@@ -14,7 +14,6 @@ fn llm_request_with_tokens(input_tokens: Option<u64>) -> LLMRequest {
 	LLMRequest {
 		input_tokens,
 		input_format: InputFormat::Completions,
-		native_format: Some(custom::ProviderFormat::Completions),
 		cache_convention: CacheTokenConvention::pending(),
 		request_model: "test-model".into(),
 		provider: "test-provider".into(),
@@ -435,16 +434,12 @@ mod requests {
 			assume_role_cache: Default::default(),
 		};
 
-		let vertex_provider = vertex::Provider {
-			model: Some(strng::new("text-embedding-004")),
-			region: Some(strng::new("us-central1")),
-			project_id: strng::new("test-project-123"),
-		};
-
 		let titan_request = |i| conversion::bedrock::from_embeddings::translate(&i, &titan_provider);
 		let cohere_request = |i| conversion::bedrock::from_embeddings::translate(&i, &cohere_provider);
-		let vertex_request = |i: types::embeddings::Request| i.to_vertex(&vertex_provider);
-		let openai_request = |i: types::embeddings::Request| i.to_openai();
+		let vertex_request =
+			|i: types::embeddings::Request| conversion::vertex::from_embeddings::translate(&i);
+		let openai_request =
+			|i: types::embeddings::Request| serde_json::to_vec(&i).map_err(AIError::RequestMarshal);
 		for (name, providers) in EMBEDDINGS_REQUESTS {
 			for provider in *providers {
 				match *provider {
@@ -499,8 +494,10 @@ mod requests {
 		let bedrock_request = |i: types::rerank::Request| {
 			conversion::bedrock::from_rerank::translate(&i, &bedrock_provider)
 		};
-		let vertex_request = |i: types::rerank::Request| i.to_vertex(&vertex_provider);
-		let cohere_request = |i: types::rerank::Request| i.to_openai();
+		let vertex_request =
+			|i: types::rerank::Request| conversion::vertex::from_rerank::translate(&i, &vertex_provider);
+		let cohere_request =
+			|i: types::rerank::Request| serde_json::to_vec(&i).map_err(AIError::RequestMarshal);
 		for (name, providers) in RERANK_REQUESTS {
 			for provider in *providers {
 				let path = format!("requests/rerank/{name}.json");
@@ -524,11 +521,13 @@ mod requests {
 			project_id: strng::new("test-project-123"),
 		};
 
-		let bedrock_request =
-			|input: types::count_tokens::Request| input.to_bedrock_token_count(&headers);
-		let anthropic_request = |i: types::count_tokens::Request| i.to_anthropic();
+		let bedrock_request = |input: types::count_tokens::Request| {
+			conversion::bedrock::from_anthropic_token_count::translate(&input, &headers)
+		};
+		let anthropic_request =
+			|i: types::count_tokens::Request| serde_json::to_vec(&i).map_err(AIError::RequestMarshal);
 		let vertex_request = |input: types::count_tokens::Request| -> Result<Vec<u8>, AIError> {
-			let anthropic_body = input.to_anthropic()?;
+			let anthropic_body = serde_json::to_vec(&input).map_err(AIError::RequestMarshal)?;
 			vertex_provider.prepare_anthropic_count_tokens_body(anthropic_body)
 		};
 		for (name, providers) in COUNT_TOKENS_REQUESTS {
@@ -723,7 +722,7 @@ mod response {
 
 	fn test_response_for_provider(provider: &str, test: &str) {
 		let (p, r) = build_provider_request(provider);
-		let test_fn = |i: Bytes| p.process_success(&r, &i);
+		let test_fn = |i: Bytes| p.translate_chat_or_detect_response(&r, &i);
 		test_response(provider, test, test_fn)
 	}
 
@@ -804,7 +803,6 @@ mod response {
 		LLMRequest {
 			input_tokens: None,
 			input_format,
-			native_format: input_format.provider_format_preferences().first().copied(),
 			cache_convention: CacheTokenConvention::pending(),
 			request_model: "input-model".into(),
 			provider: Default::default(),
@@ -962,7 +960,11 @@ async fn openai_provider_normalizes_max_tokens_before_forwarding() {
 		))
 		.unwrap();
 
-	let RequestResult::Success(forwarded, llm_request) = provider
+	let RequestResult::Success {
+		request: forwarded,
+		llm_request,
+		..
+	} = provider
 		.process_completions_request(&backend_info, None, req, false, &mut None)
 		.await
 		.expect("OpenAI completions request should process")
@@ -976,6 +978,63 @@ async fn openai_provider_normalizes_max_tokens_before_forwarding() {
 
 	assert!(forwarded_json.get("max_tokens").is_none());
 	assert_eq!(forwarded_json["max_completion_tokens"], json!(1024));
+	assert_eq!(llm_request.params.max_tokens, Some(1024));
+}
+
+#[tokio::test]
+async fn openai_provider_normalizes_max_tokens_after_model_alias() {
+	use crate::http::auth::BackendInfo;
+	use crate::llm::policy::Policy;
+	use crate::test_helpers::proxymock::setup_proxy_test;
+	use crate::types::agent::BackendTarget;
+
+	let provider = AIProvider::OpenAI(openai::Provider { model: None });
+	let inputs = setup_proxy_test("{}").unwrap().pi;
+	let backend_info = BackendInfo {
+		target: BackendTarget::Invalid,
+		call_target: Target::from(("api.openai.com", 443)),
+		inputs,
+	};
+	let policy = Policy {
+		model_aliases: std::collections::HashMap::from([(
+			strng::new("fast-model"),
+			strng::new("gpt-5.4"),
+		)]),
+		..Default::default()
+	};
+	let req = ::http::Request::builder()
+		.uri("/v1/chat/completions")
+		.header(::http::header::CONTENT_TYPE, "application/json")
+		.body(Body::from(
+			br#"{
+				"model": "fast-model",
+				"max_tokens": 1024,
+				"messages": [{"role": "user", "content": "hello"}]
+			}"#
+				.to_vec(),
+		))
+		.unwrap();
+
+	let RequestResult::Success {
+		request: forwarded,
+		llm_request,
+		..
+	} = provider
+		.process_completions_request(&backend_info, Some(&policy), req, false, &mut None)
+		.await
+		.expect("OpenAI completions request should process")
+	else {
+		panic!("expected forwarded request");
+	};
+
+	let forwarded_body = forwarded.collect().await.unwrap().to_bytes();
+	let forwarded_json: Value =
+		serde_json::from_slice(&forwarded_body).expect("forwarded request should be JSON");
+
+	assert_eq!(forwarded_json["model"], json!("gpt-5.4"));
+	assert!(forwarded_json.get("max_tokens").is_none());
+	assert_eq!(forwarded_json["max_completion_tokens"], json!(1024));
+	assert_eq!(llm_request.request_model, "gpt-5.4");
 	assert_eq!(llm_request.params.max_tokens, Some(1024));
 }
 
@@ -1005,7 +1064,11 @@ async fn openai_provider_preserves_max_tokens_for_non_gpt_models() {
 		))
 		.unwrap();
 
-	let RequestResult::Success(forwarded, llm_request) = provider
+	let RequestResult::Success {
+		request: forwarded,
+		llm_request,
+		..
+	} = provider
 		.process_completions_request(&backend_info, None, req, false, &mut None)
 		.await
 		.expect("OpenAI-compatible completions request should process")
@@ -1055,7 +1118,11 @@ async fn count_tokens_resolves_model_alias_once_for_upstream_request() {
 		))
 		.unwrap();
 
-	let RequestResult::Success(forwarded, llm_request) = provider
+	let RequestResult::Success {
+		request: forwarded,
+		llm_request,
+		..
+	} = provider
 		.process_count_tokens_request(&backend_info, req, Some(&policy), &mut None)
 		.await
 		.expect("count_tokens request should process")
@@ -1069,6 +1136,65 @@ async fn count_tokens_resolves_model_alias_once_for_upstream_request() {
 
 	assert_eq!(forwarded_json["model"], json!("middle-name"));
 	assert_eq!(llm_request.request_model, "middle-name");
+}
+
+#[tokio::test]
+async fn count_tokens_uses_native_endpoint_after_model_alias() {
+	use crate::http::auth::BackendInfo;
+	use crate::llm::policy::Policy;
+	use crate::test_helpers::proxymock::setup_proxy_test;
+	use crate::types::agent::BackendTarget;
+
+	let provider = AIProvider::Vertex(vertex::Provider {
+		model: None,
+		region: None,
+		project_id: strng::new("test-project"),
+	});
+	let inputs = setup_proxy_test("{}").unwrap().pi;
+	let backend_info = BackendInfo {
+		target: BackendTarget::Invalid,
+		call_target: Target::from(("us-central1-aiplatform.googleapis.com", 443)),
+		inputs,
+	};
+	let policy = Policy {
+		model_aliases: std::collections::HashMap::from([(
+			strng::new("short-name"),
+			strng::new("claude-3-5-sonnet"),
+		)]),
+		..Default::default()
+	};
+	let req = ::http::Request::builder()
+		.uri("/v1/messages/count_tokens")
+		.header(::http::header::CONTENT_TYPE, "application/json")
+		.body(Body::from(
+			br#"{
+				"model": "short-name",
+				"messages": [{"role": "user", "content": "hello"}]
+			}"#
+				.to_vec(),
+		))
+		.unwrap();
+
+	let RequestResult::Success {
+		request: forwarded,
+		llm_request,
+		upstream_route_type,
+		..
+	} = provider
+		.process_count_tokens_request(&backend_info, req, Some(&policy), &mut None)
+		.await
+		.expect("count_tokens request should process")
+	else {
+		panic!("expected forwarded request");
+	};
+
+	let forwarded_body = forwarded.collect().await.unwrap().to_bytes();
+	let forwarded_json: Value =
+		serde_json::from_slice(&forwarded_body).expect("forwarded request should be JSON");
+
+	assert_eq!(upstream_route_type, RouteType::AnthropicTokenCount);
+	assert_eq!(forwarded_json["model"], json!("claude-3-5-sonnet"));
+	assert_eq!(llm_request.request_model, "claude-3-5-sonnet");
 }
 
 #[tokio::test]
@@ -1112,7 +1238,11 @@ async fn provider_model_is_set_before_llm_transformations() {
 		))
 		.unwrap();
 
-	let RequestResult::Success(forwarded, llm_request) = provider
+	let RequestResult::Success {
+		request: forwarded,
+		llm_request,
+		..
+	} = provider
 		.process_completions_request(&backend_info, Some(&policy), req, false, &mut None)
 		.await
 		.expect("OpenAI completions request should process")
@@ -1164,7 +1294,11 @@ async fn llm_transformations_can_set_missing_model() {
 		))
 		.unwrap();
 
-	let RequestResult::Success(forwarded, llm_request) = provider
+	let RequestResult::Success {
+		request: forwarded,
+		llm_request,
+		..
+	} = provider
 		.process_completions_request(&backend_info, Some(&policy), req, false, &mut None)
 		.await
 		.expect("OpenAI completions request should process")
@@ -1178,6 +1312,71 @@ async fn llm_transformations_can_set_missing_model() {
 
 	assert_eq!(forwarded_json["model"], json!("transformed-model"));
 	assert_eq!(llm_request.request_model, "transformed-model");
+}
+
+#[tokio::test]
+async fn copilot_anthropic_model_uses_messages_route() {
+	use crate::http::auth::BackendInfo;
+	use crate::test_helpers::proxymock::setup_proxy_test;
+	use crate::types::agent::BackendTarget;
+
+	let provider = AIProvider::Copilot(copilot::Provider { model: None });
+	let inputs = setup_proxy_test("{}").unwrap().pi;
+	let backend_info = BackendInfo {
+		target: BackendTarget::Invalid,
+		call_target: Target::from(("api.githubcopilot.com", 443)),
+		inputs,
+	};
+	let req = ::http::Request::builder()
+		.uri("/v1/messages")
+		.header(::http::header::CONTENT_TYPE, "application/json")
+		.body(Body::from(
+			br#"{
+				"model": "claude-sonnet-4",
+				"max_tokens": 64,
+				"messages": [{"role": "user", "content": "say hi"}]
+			}"#
+				.to_vec(),
+		))
+		.unwrap();
+
+	let RequestResult::Success {
+		request: forwarded,
+		llm_request,
+		upstream_route_type,
+	} = provider
+		.process_messages_request(&backend_info, None, req, false, &mut None)
+		.await
+		.expect("Copilot Anthropic messages request should process")
+	else {
+		panic!("expected forwarded request");
+	};
+
+	assert_eq!(upstream_route_type, RouteType::Messages);
+	assert_eq!(
+		llm_request.cache_convention,
+		CacheTokenConvention::InputExcludesCache
+	);
+
+	let mut setup_req =
+		crate::http::tests_common::request("https://example.com/v1/messages", http::Method::POST, &[]);
+	provider
+		.setup_request(
+			&mut setup_req,
+			upstream_route_type,
+			Some(&llm_request),
+			None,
+			None,
+			false,
+		)
+		.expect("setup_request should succeed");
+	assert_eq!(setup_req.uri().path(), "/v1/messages");
+
+	let forwarded_body = forwarded.collect().await.unwrap().to_bytes();
+	let forwarded_json: Value =
+		serde_json::from_slice(&forwarded_body).expect("forwarded request should be JSON");
+	assert_eq!(forwarded_json["model"], json!("claude-sonnet-4"));
+	assert_eq!(forwarded_json["max_tokens"], json!(64));
 }
 
 #[test]
@@ -1467,7 +1666,6 @@ async fn process_response_routes_streaming_error_to_buffered_path() {
 	let req = LLMRequest {
 		input_tokens: None,
 		input_format: InputFormat::Completions,
-		native_format: Some(custom::ProviderFormat::Completions),
 		cache_convention: CacheTokenConvention::pending(),
 		request_model: "input-model".into(),
 		provider: Default::default(),
@@ -1522,6 +1720,72 @@ async fn process_response_routes_streaming_error_to_buffered_path() {
 	);
 }
 
+#[test]
+fn openai_completions_error_translates_to_messages_client() {
+	let provider = AIProvider::OpenAI(openai::Provider { model: None });
+	let mut req = llm_request_with_tokens(None);
+	req.input_format = InputFormat::Messages;
+	req.request_model = "gpt-4o".into();
+
+	let error = Bytes::from_static(
+		br#"{"error":{"message":"bad request","type":"invalid_request_error","param":null,"code":null}}"#,
+	);
+	let translated = provider
+		.process_error(&req, ::http::StatusCode::BAD_REQUEST, &error)
+		.expect("OpenAI error should translate to messages error");
+	let body: Value = serde_json::from_slice(&translated).expect("translated error should be JSON");
+
+	assert_eq!(body["type"], json!("error"));
+	assert_eq!(body["error"]["type"], json!("invalid_request_error"));
+	assert_eq!(body["error"]["message"], json!("bad request"));
+}
+
+#[test]
+fn custom_messages_error_translates_to_completions_client() {
+	let provider = custom_provider(custom::ProviderFormat::Messages);
+	let mut req = llm_request_with_tokens(None);
+	req.input_format = InputFormat::Completions;
+	req.request_model = "claude-test".into();
+
+	let error = Bytes::from_static(
+		br#"{"type":"error","error":{"type":"invalid_request_error","message":"bad request"}}"#,
+	);
+	let translated = provider
+		.process_error(&req, ::http::StatusCode::BAD_REQUEST, &error)
+		.expect("Anthropic error should translate to completions error");
+	let body: Value = serde_json::from_slice(&translated).expect("translated error should be JSON");
+
+	assert_eq!(body["error"]["type"], json!("invalid_request_error"));
+	assert_eq!(body["error"]["message"], json!("bad request"));
+}
+
+#[test]
+fn foundry_claude_messages_error_uses_anthropic_shape() {
+	let provider = AIProvider::Azure(azure::Provider {
+		model: None,
+		resource_name: strng::new("example"),
+		resource_type: azure::AzureResourceType::Foundry,
+		api_version: None,
+		project_name: Some(strng::new("project")),
+		cached_cred: Default::default(),
+	});
+	let mut req = llm_request_with_tokens(None);
+	req.input_format = InputFormat::Messages;
+	req.request_model = "claude-haiku-4-5".into();
+
+	let error = Bytes::from_static(
+		br#"{"type":"error","error":{"type":"invalid_request_error","message":"bad request"}}"#,
+	);
+	let translated = provider
+		.process_error(&req, ::http::StatusCode::BAD_REQUEST, &error)
+		.expect("Foundry Claude messages error should stay Anthropic-shaped");
+	let body: Value = serde_json::from_slice(&translated).expect("translated error should be JSON");
+
+	assert_eq!(body["type"], json!("error"));
+	assert_eq!(body["error"]["type"], json!("invalid_request_error"));
+	assert_eq!(body["error"]["message"], json!("bad request"));
+}
+
 #[tokio::test]
 async fn process_streaming_bedrock_completions_normalizes_sse_headers_and_done() {
 	use crate::proxy::httpproxy::PolicyClient;
@@ -1556,7 +1820,6 @@ async fn process_streaming_bedrock_completions_normalizes_sse_headers_and_done()
 			LLMRequest {
 				input_tokens: None,
 				input_format: InputFormat::Completions,
-				native_format: Some(custom::ProviderFormat::Completions),
 				cache_convention: CacheTokenConvention::pending(),
 				request_model: "input-model".into(),
 				provider: Default::default(),
@@ -1657,7 +1920,6 @@ fn setup_request_custom_path_override_wins_over_format_path() {
 	let llm_request = LLMRequest {
 		input_tokens: None,
 		input_format: InputFormat::Completions,
-		native_format: Some(custom::ProviderFormat::Messages),
 		cache_convention: CacheTokenConvention::pending(),
 		request_model: "input-model".into(),
 		provider: Default::default(),
@@ -1691,7 +1953,6 @@ fn llm_request_for_path(request_model: &str) -> LLMRequest {
 	LLMRequest {
 		input_tokens: None,
 		input_format: InputFormat::Messages,
-		native_format: Some(custom::ProviderFormat::Messages),
 		cache_convention: CacheTokenConvention::pending(),
 		request_model: request_model.into(),
 		provider: Default::default(),
@@ -1810,6 +2071,32 @@ fn completions_response_missing_message_and_usage_fields() {
 	assert_eq!(usage.total_tokens, 12);
 }
 
+#[test]
+fn completions_to_messages_response_allows_missing_openai_metadata() {
+	let body = Bytes::from_static(
+		br#"{
+			"id": "chatcmpl-1",
+			"model": "gpt-5-mini",
+			"choices": [{
+				"message": {"role": "assistant", "content": "hi"},
+				"finish_reason": "stop"
+			}],
+			"usage": {
+				"completion_tokens": 16,
+				"prompt_tokens": 9,
+				"prompt_tokens_details": {"cached_tokens": 0},
+				"total_tokens": 25
+			},
+			"copilot_usage": {
+				"token_details": []
+			}
+		}"#,
+	);
+
+	conversion::completions::from_messages::translate_response(&body)
+		.expect("messages response translation should not require OpenAI metadata");
+}
+
 #[tokio::test]
 async fn bedrock_from_messages_stream_captures_completion() {
 	let input_bytes =
@@ -1821,7 +2108,6 @@ async fn bedrock_from_messages_stream_captures_completion() {
 		request: LLMRequest {
 			input_tokens: None,
 			input_format: InputFormat::Messages,
-			native_format: Some(custom::ProviderFormat::Messages),
 			cache_convention: CacheTokenConvention::pending(),
 			request_model: "us.anthropic.claude-haiku-4-5-20251001-v1:0".into(),
 			provider: "bedrock".into(),
@@ -1869,7 +2155,6 @@ async fn bedrock_from_messages_stream_skips_completion_when_disabled() {
 		request: LLMRequest {
 			input_tokens: None,
 			input_format: InputFormat::Messages,
-			native_format: Some(custom::ProviderFormat::Messages),
 			cache_convention: CacheTokenConvention::pending(),
 			request_model: "us.anthropic.claude-haiku-4-5-20251001-v1:0".into(),
 			provider: "bedrock".into(),
@@ -1913,7 +2198,6 @@ async fn messages_passthrough_stream_captures_completion() {
 		request: LLMRequest {
 			input_tokens: None,
 			input_format: InputFormat::Messages,
-			native_format: Some(custom::ProviderFormat::Messages),
 			cache_convention: CacheTokenConvention::pending(),
 			request_model: "claude-haiku-4-5-20251001".into(),
 			provider: "anthropic".into(),
@@ -1954,7 +2238,6 @@ async fn messages_passthrough_stream_skips_completion_when_disabled() {
 		request: LLMRequest {
 			input_tokens: None,
 			input_format: InputFormat::Messages,
-			native_format: Some(custom::ProviderFormat::Messages),
 			cache_convention: CacheTokenConvention::pending(),
 			request_model: "claude-haiku-4-5-20251001".into(),
 			provider: "anthropic".into(),
@@ -1990,7 +2273,6 @@ async fn responses_passthrough_stream_captures_completion() {
 		request: LLMRequest {
 			input_tokens: None,
 			input_format: InputFormat::Responses,
-			native_format: Some(custom::ProviderFormat::Responses),
 			cache_convention: CacheTokenConvention::pending(),
 			request_model: "gpt-4.1-mini".into(),
 			provider: "openai".into(),
@@ -2027,7 +2309,6 @@ async fn responses_passthrough_stream_skips_completion_when_disabled() {
 		request: LLMRequest {
 			input_tokens: None,
 			input_format: InputFormat::Responses,
-			native_format: Some(custom::ProviderFormat::Responses),
 			cache_convention: CacheTokenConvention::pending(),
 			request_model: "gpt-4.1-mini".into(),
 			provider: "openai".into(),
@@ -2060,153 +2341,12 @@ fn vertex_provider(model: &str) -> AIProvider {
 	})
 }
 
-fn bedrock_provider(model: &str) -> AIProvider {
-	AIProvider::Bedrock(bedrock::Provider {
-		model: Some(strng::new(model)),
-		region: strng::new("us-west-2"),
-		guardrail_identifier: None,
-		guardrail_version: None,
-		source_credentials_cache: Default::default(),
-		assume_role_cache: Default::default(),
-	})
-}
-
 fn custom_provider(format: custom::ProviderFormat) -> AIProvider {
 	AIProvider::Custom(custom::Provider {
 		model: None,
 		provider_override: None,
 		formats: vec![custom::ProviderFormatConfig { format, path: None }],
 	})
-}
-
-#[test]
-fn provider_capabilities_select_native_formats() {
-	use custom::ProviderFormat::{
-		AnthropicTokenCount, Completions, Embeddings, Messages, Realtime, Rerank, Responses,
-	};
-
-	let openai = AIProvider::OpenAI(openai::Provider { model: None });
-	assert_eq!(
-		openai.native_format_for(InputFormat::Messages, Some("gpt-4.1")),
-		Some(Completions)
-	);
-	assert_eq!(
-		openai.native_format_for(InputFormat::Responses, Some("gpt-4.1")),
-		Some(Responses)
-	);
-	assert_eq!(
-		openai.native_format_for(InputFormat::CountTokens, Some("gpt-4.1")),
-		None
-	);
-	assert_eq!(
-		openai.native_format_for(InputFormat::Realtime, Some("gpt-4o-realtime-preview")),
-		Some(Realtime)
-	);
-
-	let anthropic = AIProvider::Anthropic(anthropic::Provider { model: None });
-	assert_eq!(
-		anthropic.native_format_for(InputFormat::Completions, Some("claude-sonnet-4-5")),
-		Some(Messages)
-	);
-	assert_eq!(
-		anthropic.native_format_for(InputFormat::CountTokens, Some("claude-sonnet-4-5")),
-		Some(AnthropicTokenCount)
-	);
-	assert_eq!(
-		anthropic.native_format_for(InputFormat::Embeddings, Some("claude-sonnet-4-5")),
-		None
-	);
-
-	let azure_foundry = AIProvider::Azure(azure::Provider {
-		model: None,
-		resource_name: strng::new("example"),
-		resource_type: azure::AzureResourceType::Foundry,
-		api_version: None,
-		project_name: Some(strng::new("project")),
-		cached_cred: Default::default(),
-	});
-	assert_eq!(
-		azure_foundry.native_format_for(InputFormat::Messages, Some("claude-sonnet-4-5")),
-		Some(Messages)
-	);
-	assert_eq!(
-		azure_foundry.native_format_for(InputFormat::CountTokens, Some("claude-sonnet-4-5")),
-		Some(AnthropicTokenCount)
-	);
-	assert_eq!(
-		azure_foundry.native_format_for(InputFormat::CountTokens, Some("gpt-4.1")),
-		None
-	);
-
-	let gemini = AIProvider::Gemini(gemini::Provider { model: None });
-	assert_eq!(
-		gemini.native_format_for(InputFormat::Responses, Some("gemini-2.5-pro")),
-		Some(Completions)
-	);
-	assert_eq!(
-		gemini.native_format_for(InputFormat::Embeddings, Some("text-embedding-004")),
-		Some(Embeddings)
-	);
-	assert_eq!(
-		gemini.native_format_for(InputFormat::Rerank, Some("semantic-ranker")),
-		None
-	);
-
-	let vertex_anthropic = vertex_provider("anthropic/claude-sonnet-4-5");
-	assert_eq!(
-		vertex_anthropic.native_format_for(InputFormat::Completions, None),
-		Some(Messages)
-	);
-	assert_eq!(
-		vertex_anthropic.native_format_for(InputFormat::CountTokens, None),
-		Some(AnthropicTokenCount)
-	);
-
-	let vertex_openai_compat = vertex_provider("gemini-2.0-flash");
-	assert_eq!(
-		vertex_openai_compat.native_format_for(InputFormat::Messages, None),
-		Some(Completions)
-	);
-	assert_eq!(
-		vertex_openai_compat.native_format_for(InputFormat::Responses, None),
-		None
-	);
-	assert_eq!(
-		vertex_openai_compat.native_format_for(InputFormat::Rerank, None),
-		Some(Rerank)
-	);
-
-	let bedrock_anthropic = bedrock_provider("anthropic.claude-3-5-sonnet-20241022-v2:0");
-	assert_eq!(
-		bedrock_anthropic.native_format_for(InputFormat::CountTokens, None),
-		Some(AnthropicTokenCount)
-	);
-	let bedrock_titan = bedrock_provider("amazon.titan-embed-text-v2:0");
-	assert_eq!(
-		bedrock_titan.native_format_for(InputFormat::CountTokens, None),
-		None
-	);
-}
-
-#[test]
-fn custom_provider_capabilities_use_shared_preferences() {
-	let messages_only = custom_provider(custom::ProviderFormat::Messages);
-	assert_eq!(
-		messages_only.native_format_for(InputFormat::Completions, Some("model")),
-		Some(custom::ProviderFormat::Messages)
-	);
-
-	let completions_only = custom_provider(custom::ProviderFormat::Completions);
-	assert_eq!(
-		completions_only.native_format_for(InputFormat::Responses, Some("model")),
-		Some(custom::ProviderFormat::Completions)
-	);
-
-	let rerank_only = custom_provider(custom::ProviderFormat::Rerank);
-	assert_eq!(
-		rerank_only.native_format_for(InputFormat::Messages, Some("model")),
-		None
-	);
 }
 
 #[test]

--- a/crates/agentgateway/src/llm/tests.rs
+++ b/crates/agentgateway/src/llm/tests.rs
@@ -1198,6 +1198,60 @@ async fn count_tokens_uses_native_endpoint_after_model_alias() {
 }
 
 #[tokio::test]
+async fn vertex_anthropic_messages_prepares_vertex_body() {
+	use crate::http::auth::BackendInfo;
+	use crate::test_helpers::proxymock::setup_proxy_test;
+	use crate::types::agent::BackendTarget;
+
+	let provider = AIProvider::Vertex(vertex::Provider {
+		model: None,
+		region: Some(strng::new("us-central1")),
+		project_id: strng::new("test-project"),
+	});
+	let inputs = setup_proxy_test("{}").unwrap().pi;
+	let backend_info = BackendInfo {
+		target: BackendTarget::Invalid,
+		call_target: Target::from(("us-central1-aiplatform.googleapis.com", 443)),
+		inputs,
+	};
+	let req = ::http::Request::builder()
+		.uri("/v1/messages")
+		.header(::http::header::CONTENT_TYPE, "application/json")
+		.body(Body::from(
+			br#"{
+				"model": "claude-haiku-4-5-20251001",
+				"max_tokens": 64,
+				"messages": [{"role": "user", "content": "say hi"}]
+			}"#
+				.to_vec(),
+		))
+		.unwrap();
+
+	let RequestResult::Success {
+		request: forwarded,
+		upstream_route_type,
+		..
+	} = provider
+		.process_messages_request(&backend_info, None, req, false, &mut None)
+		.await
+		.expect("Vertex Anthropic messages request should process")
+	else {
+		panic!("expected forwarded request");
+	};
+
+	let forwarded_body = forwarded.collect().await.unwrap().to_bytes();
+	let forwarded_json: Value =
+		serde_json::from_slice(&forwarded_body).expect("forwarded request should be JSON");
+
+	assert_eq!(upstream_route_type, RouteType::Messages);
+	assert!(forwarded_json.get("model").is_none());
+	assert_eq!(
+		forwarded_json["anthropic_version"],
+		json!("vertex-2023-10-16")
+	);
+}
+
+#[tokio::test]
 async fn provider_model_is_set_before_llm_transformations() {
 	use crate::http::auth::BackendInfo;
 	use crate::llm::policy::Policy;

--- a/crates/agentgateway/src/llm/types/completions.rs
+++ b/crates/agentgateway/src/llm/types/completions.rs
@@ -3,10 +3,9 @@ use agent_core::strng::Strng;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
-use crate::llm::bedrock::Provider;
 use crate::llm::policy::webhook::{Message, ResponseChoice};
 use crate::llm::types::{ResponseType, SimpleChatCompletionMessage};
-use crate::llm::{AIError, InputFormat, LLMRequest, LLMRequestParams, LLMResponse, conversion};
+use crate::llm::{AIError, InputFormat, LLMRequest, LLMRequestParams, LLMResponse};
 use crate::{json, llm};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -245,32 +244,6 @@ impl super::RequestType for Request {
 			.extend(prompts.into_iter().map(convert_message));
 	}
 
-	fn to_anthropic(&self) -> Result<Vec<u8>, AIError> {
-		conversion::messages::from_completions::translate(self)
-	}
-
-	fn to_bedrock(
-		&self,
-		provider: &Provider,
-		headers: Option<&::http::HeaderMap>,
-		prompt_caching: Option<&crate::llm::policy::PromptCachingConfig>,
-	) -> Result<crate::llm::conversion::bedrock::BedrockRequest, AIError> {
-		conversion::bedrock::from_completions::translate(self, provider, headers, prompt_caching)
-	}
-
-	fn to_openai(&self) -> Result<Vec<u8>, AIError> {
-		serde_json::to_vec(&self).map_err(AIError::RequestMarshal)
-	}
-
-	fn to_vertex(&self, provider: &crate::llm::vertex::Provider) -> Result<Vec<u8>, AIError> {
-		if provider.is_anthropic_model(self.model.as_deref()) {
-			let body = self.to_anthropic()?;
-			provider.prepare_anthropic_message_body(body)
-		} else {
-			self.to_openai()
-		}
-	}
-
 	fn to_llm_request(&self, provider: Strng, tokenize: bool) -> Result<LLMRequest, AIError> {
 		let model = strng::new(self.model.as_deref().unwrap_or_default());
 		let input_tokens = if tokenize {
@@ -284,7 +257,6 @@ impl super::RequestType for Request {
 		let llm = LLMRequest {
 			input_tokens,
 			input_format: InputFormat::Completions,
-			native_format: Some(crate::llm::custom::ProviderFormat::Completions),
 			cache_convention: crate::llm::CacheTokenConvention::pending(),
 			request_model: model,
 			provider,
@@ -502,6 +474,7 @@ pub mod typed {
 		/// A list of chat completion choices. Can be more than one if `n` is greater than 1.
 		pub choices: Vec<ChatChoice>,
 		/// The Unix timestamp (in seconds) of when the chat completion was created.
+		#[serde(default)]
 		pub created: u32,
 		/// The model used for the chat completion.
 		pub model: String,
@@ -515,6 +488,7 @@ pub mod typed {
 		pub system_fingerprint: Option<String>,
 
 		/// The object type, which is always `chat.completion`.
+		#[serde(default, skip_serializing_if = "String::is_empty")]
 		pub object: String,
 		pub usage: Option<Usage>,
 	}
@@ -572,6 +546,7 @@ pub mod typed {
 		pub choices: Vec<ChatChoiceStream>,
 
 		/// The Unix timestamp (in seconds) of when the chat completion was created. Each chunk has the same timestamp.
+		#[serde(default)]
 		pub created: u32,
 		/// The model to generate the completion.
 		pub model: String,
@@ -581,6 +556,7 @@ pub mod typed {
 		/// Can be used in conjunction with the `seed` request parameter to understand when backend changes have been made that might impact determinism.
 		pub system_fingerprint: Option<String>,
 		/// The object type, which is always `chat.completion.chunk`.
+		#[serde(default)]
 		pub object: String,
 
 		/// An optional field that will only be present when you set `stream_options: {"include_usage": true}` in your request.
@@ -591,6 +567,7 @@ pub mod typed {
 	#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 	pub struct ChatChoiceStream {
 		/// The index of the choice in the list of choices.
+		#[serde(default)]
 		pub index: u32,
 		pub delta: StreamResponseDelta,
 		/// The reason the model stopped generating tokens. This will be
@@ -652,6 +629,7 @@ pub mod typed {
 	#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 	pub struct ChatChoice {
 		/// The index of the choice in the list of choices.
+		#[serde(default)]
 		pub index: u32,
 		pub message: ResponseMessage,
 		/// The reason the model stopped generating tokens. This will be `stop` if the model hit a natural stop point or a provided stop sequence,

--- a/crates/agentgateway/src/llm/types/count_tokens.rs
+++ b/crates/agentgateway/src/llm/types/count_tokens.rs
@@ -5,8 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::llm::types::{RequestType, messages};
 use crate::llm::{
-	AIError, InputFormat, LLMRequest, SimpleChatCompletionMessage, conversion,
-	logged_response_parsing,
+	AIError, InputFormat, LLMRequest, SimpleChatCompletionMessage, logged_response_parsing,
 };
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
@@ -39,7 +38,6 @@ impl RequestType for Request {
 			// We never tokenize these, so always empty
 			input_tokens: None,
 			input_format: InputFormat::CountTokens,
-			native_format: Some(crate::llm::custom::ProviderFormat::AnthropicTokenCount),
 			cache_convention: crate::llm::CacheTokenConvention::pending(),
 			request_model: model,
 			provider,
@@ -58,19 +56,6 @@ impl RequestType for Request {
 		unimplemented!(
 			"set_messages is used for prompt guard; prompt guard is disable for token counting."
 		)
-	}
-
-	fn to_anthropic(&self) -> Result<Vec<u8>, AIError> {
-		serde_json::to_vec(&self).map_err(AIError::RequestMarshal)
-	}
-
-	fn to_bedrock_token_count(&self, headers: &::http::HeaderMap) -> Result<Vec<u8>, AIError> {
-		conversion::bedrock::from_anthropic_token_count::translate(self, headers)
-	}
-
-	fn to_vertex(&self, provider: &crate::llm::vertex::Provider) -> Result<Vec<u8>, AIError> {
-		let body = self.to_anthropic()?;
-		provider.prepare_anthropic_count_tokens_body(body)
 	}
 }
 

--- a/crates/agentgateway/src/llm/types/detect.rs
+++ b/crates/agentgateway/src/llm/types/detect.rs
@@ -1,15 +1,12 @@
 use agent_core::prelude::Strng;
 use agent_core::strng;
 use bytes::Bytes;
-use http::HeaderMap;
 use percent_encoding::percent_decode_str;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 use tracing::debug;
 use x509_parser::nom::AsBytes;
 
-use crate::llm::bedrock::Provider;
-use crate::llm::policy::PromptCachingConfig;
 use crate::llm::policy::webhook::ResponseChoice;
 use crate::llm::{
 	AIError, AmendOnDrop, InputFormat, LLMRequest, LLMRequestParams, LLMResponse, RequestType,
@@ -64,6 +61,7 @@ impl RequestType for Request {
 	fn supports_model(&self) -> bool {
 		false
 	}
+
 	fn model(&mut self) -> &mut Option<String> {
 		unimplemented!("model is not available");
 	}
@@ -81,7 +79,6 @@ impl RequestType for Request {
 			// We never tokenize these, so always empty
 			input_tokens: None,
 			input_format: InputFormat::Detect,
-			native_format: None,
 			cache_convention: crate::llm::CacheTokenConvention::pending(),
 			request_model: self
 				.lookup(lookups::MODEL, |v| v.as_str())
@@ -114,33 +111,6 @@ impl RequestType for Request {
 
 	fn set_messages(&mut self, _messages: Vec<SimpleChatCompletionMessage>) {
 		unimplemented!("set_messages is used for prompt guard; prompt guard is disabled for detect.")
-	}
-	fn to_openai(&self) -> Result<Vec<u8>, AIError> {
-		match self {
-			Self::Raw(bytes) => Ok(bytes.to_vec()),
-			Self::Json(v) => serde_json::to_vec(v).map_err(AIError::RequestMarshal),
-		}
-	}
-	fn to_anthropic(&self) -> Result<Vec<u8>, AIError> {
-		self.to_openai()
-	}
-
-	fn to_bedrock(
-		&self,
-		_provider: &Provider,
-		_headers: Option<&HeaderMap>,
-		_prompt_caching: Option<&PromptCachingConfig>,
-	) -> Result<crate::llm::conversion::bedrock::BedrockRequest, AIError> {
-		Ok(crate::llm::conversion::bedrock::BedrockRequest {
-			body: self.to_openai()?,
-			tool_name_map: Default::default(),
-		})
-	}
-	fn to_bedrock_token_count(&self, _headers: &::http::HeaderMap) -> Result<Vec<u8>, AIError> {
-		self.to_openai()
-	}
-	fn to_vertex(&self, _provider: &crate::llm::vertex::Provider) -> Result<Vec<u8>, AIError> {
-		self.to_openai()
 	}
 }
 
@@ -196,7 +166,6 @@ mod tests {
 		LLMRequest {
 			input_tokens: None,
 			input_format: crate::llm::InputFormat::Detect,
-			native_format: None,
 			cache_convention: crate::llm::CacheTokenConvention::pending(),
 			request_model: strng::new("unknown"),
 			provider: strng::new("aws.bedrock"),

--- a/crates/agentgateway/src/llm/types/embeddings.rs
+++ b/crates/agentgateway/src/llm/types/embeddings.rs
@@ -66,7 +66,6 @@ impl RequestType for Request {
 			// We never tokenize these, so always empty
 			input_tokens: None,
 			input_format: InputFormat::Embeddings,
-			native_format: Some(crate::llm::custom::ProviderFormat::Embeddings),
 			cache_convention: crate::llm::CacheTokenConvention::pending(),
 			request_model: model,
 			provider,
@@ -95,26 +94,6 @@ impl RequestType for Request {
 
 	fn set_messages(&mut self, _messages: Vec<SimpleChatCompletionMessage>) {
 		unimplemented!("set_messages is used for prompt guard; prompt guard is disable for embeddings.")
-	}
-
-	fn to_openai(&self) -> Result<Vec<u8>, AIError> {
-		serde_json::to_vec(&self).map_err(AIError::RequestMarshal)
-	}
-
-	fn to_bedrock(
-		&self,
-		provider: &crate::llm::bedrock::Provider,
-		_headers: Option<&::http::HeaderMap>,
-		_prompt_caching: Option<&crate::llm::policy::PromptCachingConfig>,
-	) -> Result<crate::llm::conversion::bedrock::BedrockRequest, AIError> {
-		Ok(crate::llm::conversion::bedrock::BedrockRequest {
-			body: crate::llm::conversion::bedrock::from_embeddings::translate(self, provider)?,
-			tool_name_map: Default::default(),
-		})
-	}
-
-	fn to_vertex(&self, _provider: &crate::llm::vertex::Provider) -> Result<Vec<u8>, AIError> {
-		crate::llm::conversion::vertex::from_embeddings::translate(self)
 	}
 }
 

--- a/crates/agentgateway/src/llm/types/messages.rs
+++ b/crates/agentgateway/src/llm/types/messages.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::llm::policy::webhook::{Message, ResponseChoice};
 use crate::llm::types::{RequestType, ResponseType, SimpleChatCompletionMessage};
-use crate::llm::{AIError, InputFormat, LLMRequest, LLMRequestParams, LLMResponse, conversion};
+use crate::llm::{AIError, InputFormat, LLMRequest, LLMRequestParams, LLMResponse};
 
 #[derive(Debug, Deserialize, Clone, Serialize, Default)]
 pub struct Request {
@@ -205,7 +205,6 @@ impl RequestType for Request {
 		let llm = LLMRequest {
 			input_tokens,
 			input_format: InputFormat::Messages,
-			native_format: Some(crate::llm::custom::ProviderFormat::Messages),
 			cache_convention: crate::llm::CacheTokenConvention::pending(),
 			request_model: model,
 			provider,
@@ -250,32 +249,6 @@ impl RequestType for Request {
 			))
 		};
 		self.messages = message_prompts.into_iter().map(Into::into).collect();
-	}
-
-	fn to_openai(&self) -> Result<Vec<u8>, AIError> {
-		conversion::completions::from_messages::translate(self)
-	}
-
-	fn to_anthropic(&self) -> Result<Vec<u8>, AIError> {
-		serde_json::to_vec(&self).map_err(AIError::RequestMarshal)
-	}
-
-	fn to_bedrock(
-		&self,
-		provider: &crate::llm::bedrock::Provider,
-		headers: Option<&::http::HeaderMap>,
-		_prompt_caching: Option<&crate::llm::policy::PromptCachingConfig>,
-	) -> Result<crate::llm::conversion::bedrock::BedrockRequest, AIError> {
-		conversion::bedrock::from_messages::translate(self, provider, headers)
-	}
-
-	fn to_vertex(&self, provider: &crate::llm::vertex::Provider) -> Result<Vec<u8>, AIError> {
-		if provider.is_anthropic_model(self.model.as_deref()) {
-			let body = self.to_anthropic()?;
-			provider.prepare_anthropic_message_body(body)
-		} else {
-			self.to_openai()
-		}
 	}
 }
 

--- a/crates/agentgateway/src/llm/types/mod.rs
+++ b/crates/agentgateway/src/llm/types/mod.rs
@@ -16,6 +16,12 @@ use crate::apply;
 use crate::llm::{AIError, LLMRequest, LLMResponse};
 use crate::serdes::schema;
 
+pub enum ChatRequest<'a> {
+	Completions(&'a completions::Request),
+	Messages(&'a messages::Request),
+	Responses(&'a responses::Request),
+}
+
 /// ResponseType is an abstraction over provider/endpoint specific response formats that enables
 /// uniform policy enforcement and observability
 pub trait ResponseType: Send + Sync {
@@ -40,39 +46,6 @@ pub trait RequestType: Send + Sync {
 	fn to_llm_request(&self, provider: Strng, tokenize: bool) -> Result<LLMRequest, AIError>;
 	fn get_messages(&self) -> Vec<SimpleChatCompletionMessage>;
 	fn set_messages(&mut self, messages: Vec<SimpleChatCompletionMessage>);
-
-	fn to_openai(&self) -> Result<Vec<u8>, AIError> {
-		Err(AIError::UnsupportedConversion(strng::literal!("openai")))
-	}
-
-	fn to_anthropic(&self) -> Result<Vec<u8>, AIError> {
-		Err(AIError::UnsupportedConversion(strng::literal!("anthropic")))
-	}
-
-	fn to_bedrock(
-		&self,
-		_provider: &crate::llm::bedrock::Provider,
-		_headers: Option<&::http::HeaderMap>,
-		_prompt_caching: Option<&crate::llm::policy::PromptCachingConfig>,
-	) -> Result<crate::llm::conversion::bedrock::BedrockRequest, AIError> {
-		Err(AIError::UnsupportedConversion(strng::literal!("bedrock")))
-	}
-
-	fn to_bedrock_token_count(&self, _headers: &::http::HeaderMap) -> Result<Vec<u8>, AIError> {
-		Err(AIError::UnsupportedConversion(strng::literal!(
-			"bedrock token count"
-		)))
-	}
-
-	fn to_openai_chat_completions(&self) -> Result<Vec<u8>, AIError> {
-		Err(AIError::UnsupportedConversion(strng::literal!(
-			"openai-compatible chat completions"
-		)))
-	}
-
-	fn to_vertex(&self, _provider: &crate::llm::vertex::Provider) -> Result<Vec<u8>, AIError> {
-		Err(AIError::UnsupportedConversion(strng::literal!("vertex")))
-	}
 }
 
 /// SimpleChatCompletionMessage is a simplified chat message

--- a/crates/agentgateway/src/llm/types/rerank.rs
+++ b/crates/agentgateway/src/llm/types/rerank.rs
@@ -108,7 +108,6 @@ impl RequestType for Request {
 		Ok(LLMRequest {
 			input_tokens: None,
 			input_format: InputFormat::Rerank,
-			native_format: Some(crate::llm::custom::ProviderFormat::Rerank),
 			cache_convention: crate::llm::CacheTokenConvention::pending(),
 			request_model: model,
 			provider,
@@ -125,27 +124,6 @@ impl RequestType for Request {
 
 	fn set_messages(&mut self, _messages: Vec<SimpleChatCompletionMessage>) {
 		unimplemented!("set_messages is used for prompt guard; prompt guard is disabled for rerank.")
-	}
-
-	fn to_openai(&self) -> Result<Vec<u8>, AIError> {
-		// Passthrough to Cohere-compatible backends (Cohere, Jina, vLLM, Azure Foundry).
-		serde_json::to_vec(&self).map_err(AIError::RequestMarshal)
-	}
-
-	fn to_bedrock(
-		&self,
-		provider: &crate::llm::bedrock::Provider,
-		_headers: Option<&::http::HeaderMap>,
-		_prompt_caching: Option<&crate::llm::policy::PromptCachingConfig>,
-	) -> Result<crate::llm::conversion::bedrock::BedrockRequest, AIError> {
-		Ok(crate::llm::conversion::bedrock::BedrockRequest {
-			body: crate::llm::conversion::bedrock::from_rerank::translate(self, provider)?,
-			tool_name_map: Default::default(),
-		})
-	}
-
-	fn to_vertex(&self, provider: &crate::llm::vertex::Provider) -> Result<Vec<u8>, AIError> {
-		crate::llm::conversion::vertex::from_rerank::translate(self, provider)
 	}
 }
 
@@ -243,7 +221,7 @@ mod tests {
 		// Voyage-style extra field must survive passthrough via `rest`.
 		let raw = r#"{"model":"rerank-2","query":"q","documents":["a","b"],"truncation":true}"#;
 		let req: Request = serde_json::from_str(raw).unwrap();
-		let out = String::from_utf8(req.to_openai().unwrap()).unwrap();
+		let out = String::from_utf8(serde_json::to_vec(&req).unwrap()).unwrap();
 		assert!(out.contains("\"truncation\":true"));
 		assert!(out.contains("\"query\":\"q\""));
 	}

--- a/crates/agentgateway/src/llm/types/responses.rs
+++ b/crates/agentgateway/src/llm/types/responses.rs
@@ -9,7 +9,6 @@ use self::typed::{
 use super::*;
 use crate::llm::{
 	AIError, InputFormat, LLMRequest, LLMRequestParams, LLMResponse, RequestType, ResponseType,
-	conversion,
 };
 
 /// Raw Responses API input — preserves the wire format for passthrough fidelity.
@@ -336,7 +335,6 @@ impl RequestType for Request {
 		Ok(LLMRequest {
 			input_tokens,
 			input_format: InputFormat::Responses,
-			native_format: Some(crate::llm::custom::ProviderFormat::Responses),
 			cache_convention: crate::llm::CacheTokenConvention::pending(),
 			request_model: model,
 			provider,
@@ -378,28 +376,6 @@ impl RequestType for Request {
 				.map(RawInputItem::from_simple_message)
 				.collect(),
 		);
-	}
-
-	fn to_openai(&self) -> Result<Vec<u8>, AIError> {
-		// Passthrough - just serialize
-		serde_json::to_vec(&self).map_err(AIError::RequestMarshal)
-	}
-
-	fn to_openai_chat_completions(&self) -> Result<Vec<u8>, AIError> {
-		conversion::openai_compat::from_responses::translate(self)
-	}
-
-	fn to_bedrock(
-		&self,
-		provider: &crate::llm::bedrock::Provider,
-		headers: Option<&http::HeaderMap>,
-		prompt_caching: Option<&crate::llm::policy::PromptCachingConfig>,
-	) -> Result<crate::llm::conversion::bedrock::BedrockRequest, AIError> {
-		conversion::bedrock::from_responses::translate(self, provider, headers, prompt_caching)
-	}
-
-	fn to_vertex(&self, _provider: &crate::llm::vertex::Provider) -> Result<Vec<u8>, AIError> {
-		self.to_openai()
 	}
 }
 

--- a/crates/agentgateway/src/llm/vertex.rs
+++ b/crates/agentgateway/src/llm/vertex.rs
@@ -28,6 +28,12 @@ impl super::Provider for Provider {
 	const NAME: Strng = strng::literal!("gcp.vertex_ai");
 }
 
+pub fn prepare_anthropic_message_body(body: Vec<u8>) -> Result<Vec<u8>, AIError> {
+	prepare_anthropic_body(body, |b| {
+		b.remove("model");
+	})
+}
+
 impl Provider {
 	fn configured_model<'a>(&'a self, request_model: Option<&'a str>) -> Option<&'a str> {
 		self.model.as_deref().or(request_model)
@@ -38,13 +44,11 @@ impl Provider {
 	}
 
 	pub fn prepare_anthropic_message_body(&self, body: Vec<u8>) -> Result<Vec<u8>, AIError> {
-		self.prepare_anthropic_body(body, |b| {
-			b.remove("model");
-		})
+		prepare_anthropic_message_body(body)
 	}
 
 	pub fn prepare_anthropic_count_tokens_body(&self, body: Vec<u8>) -> Result<Vec<u8>, AIError> {
-		self.prepare_anthropic_body(body, |b| {
+		prepare_anthropic_body(body, |b| {
 			if let Some(Value::String(model)) = b.get("model") {
 				let normalized = self
 					.configured_model(Some(model))
@@ -54,25 +58,26 @@ impl Provider {
 			}
 		})
 	}
+}
 
-	/// Shared pipeline for Vertex Anthropic requests: parse, inject version,
-	/// apply caller-specific model handling, strip unsupported fields, serialize.
-	fn prepare_anthropic_body(
-		&self,
-		body: Vec<u8>,
-		apply: impl FnOnce(&mut Map<String, Value>),
-	) -> Result<Vec<u8>, AIError> {
-		let mut body: Map<String, Value> =
-			serde_json::from_slice(&body).map_err(AIError::RequestParsing)?;
-		body.insert(
-			"anthropic_version".to_string(),
-			Value::String(ANTHROPIC_VERSION.to_string()),
-		);
-		apply(&mut body);
-		remove_unsupported_vertex_fields(&mut body);
-		serde_json::to_vec(&body).map_err(AIError::RequestMarshal)
-	}
+/// Shared pipeline for Vertex Anthropic requests: parse, inject version,
+/// apply caller-specific model handling, strip unsupported fields, serialize.
+fn prepare_anthropic_body(
+	body: Vec<u8>,
+	apply: impl FnOnce(&mut Map<String, Value>),
+) -> Result<Vec<u8>, AIError> {
+	let mut body: Map<String, Value> =
+		serde_json::from_slice(&body).map_err(AIError::RequestParsing)?;
+	body.insert(
+		"anthropic_version".to_string(),
+		Value::String(ANTHROPIC_VERSION.to_string()),
+	);
+	apply(&mut body);
+	remove_unsupported_vertex_fields(&mut body);
+	serde_json::to_vec(&body).map_err(AIError::RequestMarshal)
+}
 
+impl Provider {
 	pub fn get_path_for_model(
 		&self,
 		route: RouteType,

--- a/crates/agentgateway/src/proxy/dtrace.rs
+++ b/crates/agentgateway/src/proxy/dtrace.rs
@@ -366,14 +366,14 @@ pub enum MessageType {
 	LlmRequestDetected {
 		provider: String,
 		inputFormat: String,
-		nativeFormat: Option<String>,
+		upstreamRouteType: Option<String>,
 		requestModel: String,
 		streaming: bool,
 	},
 	LlmStreamingTranslation {
 		provider: String,
 		inputFormat: String,
-		nativeFormat: Option<String>,
+		upstreamRouteType: Option<String>,
 		streamFormat: String,
 	},
 	RequestFinished,
@@ -748,14 +748,14 @@ impl DebugTracer {
 		&self,
 		provider: String,
 		input_format: String,
-		native_format: Option<String>,
+		upstream_route_type: Option<String>,
 		request_model: String,
 		streaming: bool,
 	) {
 		self.send(MessageType::LlmRequestDetected {
 			provider,
 			inputFormat: input_format,
-			nativeFormat: native_format,
+			upstreamRouteType: upstream_route_type,
 			requestModel: request_model,
 			streaming,
 		})
@@ -764,13 +764,13 @@ impl DebugTracer {
 		&self,
 		provider: String,
 		input_format: String,
-		native_format: Option<String>,
+		upstream_route_type: Option<String>,
 		stream_format: String,
 	) {
 		self.send(MessageType::LlmStreamingTranslation {
 			provider,
 			inputFormat: input_format,
-			nativeFormat: native_format,
+			upstreamRouteType: upstream_route_type,
 			streamFormat: stream_format,
 		})
 	}

--- a/crates/agentgateway/src/proxy/gateway_test.rs
+++ b/crates/agentgateway/src/proxy/gateway_test.rs
@@ -1862,7 +1862,7 @@ async fn llm_custom_provider_routes_to_provider_backend() {
 }
 
 #[tokio::test]
-async fn llm_custom_provider_uses_native_format_fallback() {
+async fn llm_custom_provider_uses_upstream_route_fallback() {
 	let mock = body_mock(include_bytes!("../llm/tests/response/anthropic/basic.json")).await;
 	let (mock, _bind, io) =
 		setup_custom_llm_provider_backend_mock(mock, vec![custom::ProviderFormat::Messages]);

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -2304,15 +2304,19 @@ async fn make_backend_call(
 						.map_err(|e| ProxyError::Processing(e.into()))?,
 						_ => unreachable!(),
 					};
-					let (mut req, llm_request) = match r {
-						RequestResult::Success(r, lr) => (r, lr),
+					let (mut req, llm_request, upstream_route_type) = match r {
+						RequestResult::Success {
+							request,
+							llm_request,
+							upstream_route_type,
+						} => (request, llm_request, upstream_route_type),
 						RequestResult::Rejected(dr) => return Err(ProxyResponse::DirectResponse(Box::new(dr))),
 					};
 					dtrace::trace(|trace| {
 						trace.llm_request_detected(
 							llm_provider.clone(),
 							format!("{:?}", llm_request.input_format),
-							llm_request.native_format.map(|f| format!("{f:?}")),
+							Some(format!("{upstream_route_type:?}")),
 							llm_request.request_model.to_string(),
 							llm_request.streaming,
 						);
@@ -2323,7 +2327,7 @@ async fn make_backend_call(
 						.provider
 						.setup_request(
 							&mut req,
-							route_type,
+							upstream_route_type,
 							Some(&llm_request),
 							llm.path_override.as_deref(),
 							llm.path_prefix.as_deref(),
@@ -2387,7 +2391,6 @@ async fn make_backend_call(
 						log.add(|l| {
 							l.llm_request = Some(LLMRequest {
 								input_format: InputFormat::Realtime,
-								native_format: Some(llm::custom::ProviderFormat::Realtime),
 								cache_convention: llm::CacheTokenConvention::pending(),
 								request_model,
 								streaming: true,
@@ -3082,7 +3085,6 @@ mod tests {
 		llm::LLMRequest {
 			input_tokens: None,
 			input_format: llm::InputFormat::Completions,
-			native_format: Some(llm::custom::ProviderFormat::Completions),
 			cache_convention: llm::CacheTokenConvention::pending(),
 			request_model: "test-model".into(),
 			provider: "test-provider".into(),

--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -2244,7 +2244,6 @@ mod tests {
 		let request = llm::LLMRequest {
 			input_tokens: None,
 			input_format: InputFormat::Completions,
-			native_format: None,
 			cache_convention: llm::CacheTokenConvention::InputIncludesCache,
 			request_model: strng::literal!("my-model"),
 			provider: strng::literal!("openai"),

--- a/schema/config.json
+++ b/schema/config.json
@@ -4309,6 +4309,7 @@
       "additionalProperties": false
     },
     "RouteType": {
+      "description": "The HTTP endpoint class, such as `/v1/chat/completions` or `/v1/messages`.\n\nThis is used both for the client route we matched and for the upstream route\nwe finally send to. For chat, those can differ: a client Anthropic\n`/v1/messages` request is `RouteType::Messages` and `InputFormat::Messages`,\nbut it may be translated and sent upstream as `RouteType::Completions`.\n\n`RouteType` is about the HTTP endpoint. `InputFormat` is about the parsed\nclient payload and the response shape we owe back to that client. The main\ndifference is this type includes things like Detect and Passthrough.",
       "oneOf": [
         {
           "description": "OpenAI /v1/chat/completions",
@@ -7184,9 +7185,11 @@
       "type": "object",
       "properties": {
         "type": {
+          "description": "Upstream API shape this custom provider says it accepts.",
           "$ref": "#/$defs/ProviderFormat"
         },
         "path": {
+          "description": "Optional path override for this specific upstream format.",
           "type": [
             "string",
             "null"
@@ -7199,6 +7202,7 @@
       ]
     },
     "ProviderFormat": {
+      "description": "A custom provider's advertised upstream wire format.\n\nUnlike `InputFormat`, this describes what the backend accepts, not what the\nclient sent. Unlike `RouteType`, it is only for LLM payload endpoints that\ncan be converted or passed through; generic routes such as models,\npassthrough, and detect do not have a `ProviderFormat`.",
       "type": "string",
       "enum": [
         "completions",

--- a/schema/config.md
+++ b/schema/config.md
@@ -2613,8 +2613,8 @@
 |`binds[].listeners[].routes[].backends[].ai.provider.custom.model`|string||
 |`binds[].listeners[].routes[].backends[].ai.provider.custom.providerOverride`|string|Provider identity for cost-catalog lookup and telemetry. Built-in named providers<br>(cohere, mistral, ...) set this so their cost resolves under the right catalog key;<br>a bare custom provider may set it to match a catalog entry. Falls back to "custom".|
 |`binds[].listeners[].routes[].backends[].ai.provider.custom.formats`|[]object||
-|`binds[].listeners[].routes[].backends[].ai.provider.custom.formats[].type`|enum|Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `realtime`, `rerank`.|
-|`binds[].listeners[].routes[].backends[].ai.provider.custom.formats[].path`|string||
+|`binds[].listeners[].routes[].backends[].ai.provider.custom.formats[].type`|enum|Upstream API shape this custom provider says it accepts.<br>Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `realtime`, `rerank`.|
+|`binds[].listeners[].routes[].backends[].ai.provider.custom.formats[].path`|string|Optional path override for this specific upstream format.|
 |`binds[].listeners[].routes[].backends[].ai.hostOverride`|string|Override the upstream host for this provider.|
 |`binds[].listeners[].routes[].backends[].ai.pathOverride`|string|Override the upstream path for this provider.|
 |`binds[].listeners[].routes[].backends[].ai.pathPrefix`|string|Override the default base path prefix for this provider.|
@@ -4001,8 +4001,8 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].provider.custom.model`|string||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].provider.custom.providerOverride`|string|Provider identity for cost-catalog lookup and telemetry. Built-in named providers<br>(cohere, mistral, ...) set this so their cost resolves under the right catalog key;<br>a bare custom provider may set it to match a catalog entry. Falls back to "custom".|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].provider.custom.formats`|[]object||
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].provider.custom.formats[].type`|enum|Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `realtime`, `rerank`.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].provider.custom.formats[].path`|string||
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].provider.custom.formats[].type`|enum|Upstream API shape this custom provider says it accepts.<br>Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `realtime`, `rerank`.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].provider.custom.formats[].path`|string|Optional path override for this specific upstream format.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].hostOverride`|string|Override the upstream host for this provider.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].pathOverride`|string|Override the upstream path for this provider.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].pathPrefix`|string|Override the default base path prefix for this provider.|
@@ -10388,8 +10388,8 @@
 |`backends[].ai.provider.custom.model`|string||
 |`backends[].ai.provider.custom.providerOverride`|string|Provider identity for cost-catalog lookup and telemetry. Built-in named providers<br>(cohere, mistral, ...) set this so their cost resolves under the right catalog key;<br>a bare custom provider may set it to match a catalog entry. Falls back to "custom".|
 |`backends[].ai.provider.custom.formats`|[]object||
-|`backends[].ai.provider.custom.formats[].type`|enum|Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `realtime`, `rerank`.|
-|`backends[].ai.provider.custom.formats[].path`|string||
+|`backends[].ai.provider.custom.formats[].type`|enum|Upstream API shape this custom provider says it accepts.<br>Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `realtime`, `rerank`.|
+|`backends[].ai.provider.custom.formats[].path`|string|Optional path override for this specific upstream format.|
 |`backends[].ai.hostOverride`|string|Override the upstream host for this provider.|
 |`backends[].ai.pathOverride`|string|Override the upstream path for this provider.|
 |`backends[].ai.pathPrefix`|string|Override the default base path prefix for this provider.|
@@ -11776,8 +11776,8 @@
 |`backends[].ai.groups[].providers[].provider.custom.model`|string||
 |`backends[].ai.groups[].providers[].provider.custom.providerOverride`|string|Provider identity for cost-catalog lookup and telemetry. Built-in named providers<br>(cohere, mistral, ...) set this so their cost resolves under the right catalog key;<br>a bare custom provider may set it to match a catalog entry. Falls back to "custom".|
 |`backends[].ai.groups[].providers[].provider.custom.formats`|[]object||
-|`backends[].ai.groups[].providers[].provider.custom.formats[].type`|enum|Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `realtime`, `rerank`.|
-|`backends[].ai.groups[].providers[].provider.custom.formats[].path`|string||
+|`backends[].ai.groups[].providers[].provider.custom.formats[].type`|enum|Upstream API shape this custom provider says it accepts.<br>Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `realtime`, `rerank`.|
+|`backends[].ai.groups[].providers[].provider.custom.formats[].path`|string|Optional path override for this specific upstream format.|
 |`backends[].ai.groups[].providers[].hostOverride`|string|Override the upstream host for this provider.|
 |`backends[].ai.groups[].providers[].pathOverride`|string|Override the upstream path for this provider.|
 |`backends[].ai.groups[].providers[].pathPrefix`|string|Override the default base path prefix for this provider.|
@@ -17007,8 +17007,8 @@
 |`routeGroups[].routes[].backends[].ai.provider.custom.model`|string||
 |`routeGroups[].routes[].backends[].ai.provider.custom.providerOverride`|string|Provider identity for cost-catalog lookup and telemetry. Built-in named providers<br>(cohere, mistral, ...) set this so their cost resolves under the right catalog key;<br>a bare custom provider may set it to match a catalog entry. Falls back to "custom".|
 |`routeGroups[].routes[].backends[].ai.provider.custom.formats`|[]object||
-|`routeGroups[].routes[].backends[].ai.provider.custom.formats[].type`|enum|Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `realtime`, `rerank`.|
-|`routeGroups[].routes[].backends[].ai.provider.custom.formats[].path`|string||
+|`routeGroups[].routes[].backends[].ai.provider.custom.formats[].type`|enum|Upstream API shape this custom provider says it accepts.<br>Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `realtime`, `rerank`.|
+|`routeGroups[].routes[].backends[].ai.provider.custom.formats[].path`|string|Optional path override for this specific upstream format.|
 |`routeGroups[].routes[].backends[].ai.hostOverride`|string|Override the upstream host for this provider.|
 |`routeGroups[].routes[].backends[].ai.pathOverride`|string|Override the upstream path for this provider.|
 |`routeGroups[].routes[].backends[].ai.pathPrefix`|string|Override the default base path prefix for this provider.|
@@ -18395,8 +18395,8 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].provider.custom.model`|string||
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].provider.custom.providerOverride`|string|Provider identity for cost-catalog lookup and telemetry. Built-in named providers<br>(cohere, mistral, ...) set this so their cost resolves under the right catalog key;<br>a bare custom provider may set it to match a catalog entry. Falls back to "custom".|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].provider.custom.formats`|[]object||
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].provider.custom.formats[].type`|enum|Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `realtime`, `rerank`.|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].provider.custom.formats[].path`|string||
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].provider.custom.formats[].type`|enum|Upstream API shape this custom provider says it accepts.<br>Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `realtime`, `rerank`.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].provider.custom.formats[].path`|string|Optional path override for this specific upstream format.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].hostOverride`|string|Override the upstream host for this provider.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].pathOverride`|string|Override the upstream path for this provider.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].pathPrefix`|string|Override the default base path prefix for this provider.|
@@ -21147,8 +21147,8 @@
 |`llm.providers[].provider.custom.model`|string||
 |`llm.providers[].provider.custom.providerOverride`|string|Provider identity for cost-catalog lookup and telemetry. Built-in named providers<br>(cohere, mistral, ...) set this so their cost resolves under the right catalog key;<br>a bare custom provider may set it to match a catalog entry. Falls back to "custom".|
 |`llm.providers[].provider.custom.formats`|[]object||
-|`llm.providers[].provider.custom.formats[].type`|enum|Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `realtime`, `rerank`.|
-|`llm.providers[].provider.custom.formats[].path`|string||
+|`llm.providers[].provider.custom.formats[].type`|enum|Upstream API shape this custom provider says it accepts.<br>Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `realtime`, `rerank`.|
+|`llm.providers[].provider.custom.formats[].path`|string|Optional path override for this specific upstream format.|
 |`llm.providers[].defaults`|object|defaults defines provider-level policy defaults. Model-level policy fields override these.|
 |`llm.providers[].defaults.defaults`|object||
 |`llm.providers[].defaults.overrides`|object||
@@ -21295,8 +21295,8 @@
 |`llm.models[].provider.custom.model`|string||
 |`llm.models[].provider.custom.providerOverride`|string|Provider identity for cost-catalog lookup and telemetry. Built-in named providers<br>(cohere, mistral, ...) set this so their cost resolves under the right catalog key;<br>a bare custom provider may set it to match a catalog entry. Falls back to "custom".|
 |`llm.models[].provider.custom.formats`|[]object||
-|`llm.models[].provider.custom.formats[].type`|enum|Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `realtime`, `rerank`.|
-|`llm.models[].provider.custom.formats[].path`|string||
+|`llm.models[].provider.custom.formats[].type`|enum|Upstream API shape this custom provider says it accepts.<br>Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `realtime`, `rerank`.|
+|`llm.models[].provider.custom.formats[].path`|string|Optional path override for this specific upstream format.|
 |`llm.models[].passthrough`|enum|passthrough controls how requests are handled.<br>By default, requests will be parsed and translated as needed.<br>With passthrough, they will be unmodified and optionally inspected (with `detect`).<br>In this mode, requests must be sent in the native format of the provider.<br>Possible values: `detect`, `opaque`.|
 |`llm.models[].authorization`|object|authorization configures HTTP authorization rules for requests to this model.|
 |`llm.models[].authorization.rules`|[]object|CEL authorization rules to evaluate for a request.|

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -33,14 +33,14 @@ import type {
   McpPrefixMode as GeneratedMcpPrefixMode,
   McpStatefulMode as GeneratedMcpStatefulMode,
   CustomProvider as GeneratedCustomProvider,
-  ProviderFormat as GeneratedProviderFormat,
+  ProviderFormatConfig as GeneratedProviderFormatConfig,
 } from "./gateway-config";
 import type { StoresDump } from "./gateway-admin";
 
 export type ProviderName =
   | Extract<LocalLLMModels["provider"], string>
   | keyof Extract<LocalLLMModels["provider"], { custom: unknown }>;
-export type ProviderFormat = GeneratedProviderFormat;
+export type ProviderFormat = GeneratedProviderFormatConfig["type"];
 export type CustomProvider = GeneratedCustomProvider;
 export type ModelProvider = LocalLLMModels["provider"];
 export type ProviderAuth = BackendAuthCompat;


### PR DESCRIPTION
Before, we had a lot of various `match (provider + input format + blah)` claims.

This modifies things a bit to have a more N+M instead of NxM approach:

* Providers specify a list of formats they support
* We have a mapping of input format -> output formats we can translate
* We pick the best mapping (i.e. completions in will always use completions out if possible)

This is mostly a refactoring with some intentional fixes:
* Azure foundry can do completions --> anthropic models (fixes https://github.com/agentgateway/agentgateway/issues/2310)
* Vertex requests can now use Responses
* Copilot can now use anthropic models and more generally has a lot more support across paths
* Fixes https://github.com/agentgateway/agentgateway/issues/2371