### PR TITLE
docs: clarify health CEL examples use response.code

### DIFF
--- a/ui/src/pages/models/ModelPolicyEditors.tsx
+++ b/ui/src/pages/models/ModelPolicyEditors.tsx
@@ -45,7 +45,7 @@ export function HealthPolicyEditor(props: {
           onChange={(value) =>
             patchHealth({ unhealthyExpression: value || null })
           }
-          placeholder="response.status >= 500"
+          placeholder="response.code >= 500"
         />
       </FieldGroup>
       <div className="form-grid">


### PR DESCRIPTION
Fix the LLM model health policy guidance to use `response.code` instead of `response.status` in CEL examples.

This updates:
- the model health editor placeholder in the UI
- the generated config docs entry for `llm.models[].health.unhealthyExpression`

## Why

While testing LLM backend eviction/failover for OpenAI-compatible providers, the current UI placeholder suggested:

```cel
response.status >= 500
```

But the codebase and test examples use `response.code` for HTTP status checks in health CEL expressions.

That mismatch makes it easy to configure an `unhealthyExpression` that looks valid but never matches at runtime.

## Changes

- UI placeholder:
  - `response.status >= 500` -> `response.code >= 500`
- Config docs:
  - explicitly note that HTTP status checks should use `response.code`
  - include examples such as `response.code >= 500` and `response.code == 429`

## Impact

This is a docs/UI clarification only. No runtime behavior changes. It should reduce confusion when configuring backend health eviction for LLM model routing.