### PR TITLE
test: add goleak to detect goroutine leaks in controller packages

### DIFF
--- a/controller/hack/utils/oss_compliance/osa_provided.md
+++ b/controller/hack/utils/oss_compliance/osa_provided.md
@@ -27,6 +27,7 @@ Name|Version|License
 [spf13/pflag](https://github.com/spf13/pflag)|v1.0.10|BSD 3-clause "New" or "Revised" License
 [stretchr/testify](https://github.com/stretchr/testify)|v1.11.1|MIT License
 [go.uber.org/atomic](https://go.uber.org/atomic)|v1.11.0|MIT License
+[go.uber.org/goleak](https://go.uber.org/goleak)|v1.3.0|MIT License
 [go.uber.org/zap](https://go.uber.org/zap)|v1.28.0|MIT License
 [x/clipboard](https://golang.design/x/clipboard)|v0.8.0|MIT License
 [x/net](https://golang.org/x/net)|v0.56.0|BSD 3-clause "New" or "Revised" License

--- a/controller/pkg/admin/main_test.go
+++ b/controller/pkg/admin/main_test.go
@@ -1,0 +1,11 @@
+package admin
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/controller/pkg/agentgateway/jwks/lookup_test.go
+++ b/controller/pkg/agentgateway/jwks/lookup_test.go
@@ -36,9 +36,10 @@ func TestLookupFailsClosedWhenKeysetIsMissing(t *testing.T) {
 	stop := test.NewStop(t)
 	target := remotehttp.FetchTarget{URL: "https://issuer.example/jwks"}
 	persisted := NewPersistedEntriesFromCollection(
-		krt.NewStaticCollection[*corev1.ConfigMap](alwaysSynced{}, nil, krt.WithName("jwks/LookupMissingPersistedConfigMaps")),
+		krt.NewStaticCollection[*corev1.ConfigMap](alwaysSynced{}, nil, krt.WithName("jwks/LookupMissingPersistedConfigMaps"), krt.WithStop(stop)),
 		DefaultJwksStorePrefix,
 		"agentgateway-system",
+		krt.WithStop(stop),
 	)
 	lookupIndex := NewLookup(
 		persisted,
@@ -75,9 +76,10 @@ func TestLookupReturnsPersistedKeyset(t *testing.T) {
 	assert.NoError(t, SetJwksInConfigMap(cm, keyset))
 
 	persisted := NewPersistedEntriesFromCollection(
-		krt.NewStaticCollection[*corev1.ConfigMap](alwaysSynced{}, []*corev1.ConfigMap{cm}, krt.WithName("jwks/LookupPersistedConfigMaps")),
+		krt.NewStaticCollection[*corev1.ConfigMap](alwaysSynced{}, []*corev1.ConfigMap{cm}, krt.WithName("jwks/LookupPersistedConfigMaps"), krt.WithStop(stop)),
 		DefaultJwksStorePrefix,
 		"agentgateway-system",
+		krt.WithStop(stop),
 	)
 	lookupIndex := NewLookup(
 		persisted,
@@ -115,9 +117,10 @@ func TestLookupRequiresCanonicalPersistedKeysetName(t *testing.T) {
 	assert.NoError(t, SetJwksInConfigMap(cm, keyset))
 
 	persisted := NewPersistedEntriesFromCollection(
-		krt.NewStaticCollection[*corev1.ConfigMap](alwaysSynced{}, []*corev1.ConfigMap{cm}, krt.WithName("jwks/LookupLegacyNameConfigMaps")),
+		krt.NewStaticCollection[*corev1.ConfigMap](alwaysSynced{}, []*corev1.ConfigMap{cm}, krt.WithName("jwks/LookupLegacyNameConfigMaps"), krt.WithStop(stop)),
 		DefaultJwksStorePrefix,
 		"agentgateway-system",
+		krt.WithStop(stop),
 	)
 	lookupIndex := NewLookup(
 		persisted,
@@ -138,11 +141,13 @@ func TestLookupRequiresCanonicalPersistedKeysetName(t *testing.T) {
 
 func TestLookupPropagatesResolverError(t *testing.T) {
 	sentinel := errors.New("resolver failed")
+	stop := test.NewStop(t)
 	lookupIndex := NewLookup(
 		NewPersistedEntriesFromCollection(
-			krt.NewStaticCollection[*corev1.ConfigMap](alwaysSynced{}, nil, krt.WithName("jwks/LookupResolverErrorConfigMaps")),
+			krt.NewStaticCollection[*corev1.ConfigMap](alwaysSynced{}, nil, krt.WithName("jwks/LookupResolverErrorConfigMaps"), krt.WithStop(stop)),
 			DefaultJwksStorePrefix,
 			"agentgateway-system",
+			krt.WithStop(stop),
 		),
 		staticLookupResolver{err: sentinel},
 	)

--- a/controller/pkg/agentgateway/jwks/main_test.go
+++ b/controller/pkg/agentgateway/jwks/main_test.go
@@ -1,0 +1,11 @@
+package jwks
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/controller/pkg/agentgateway/jwks/persistence_test.go
+++ b/controller/pkg/agentgateway/jwks/persistence_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"istio.io/istio/pkg/kube/krt"
+	"istio.io/istio/pkg/test"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -72,6 +73,7 @@ func TestSetAndReadConfigMapRoundTrip(t *testing.T) {
 }
 
 func TestPersistedEntriesLoadPrefersNewestKeysetAcrossDuplicates(t *testing.T) {
+	stop := test.NewStop(t)
 	requestKey := remotehttp.FetchTarget{URL: "https://issuer.example/jwks"}.Key()
 	canonical := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -102,9 +104,10 @@ func TestPersistedEntriesLoadPrefersNewestKeysetAcrossDuplicates(t *testing.T) {
 	}))
 
 	persisted := NewPersistedEntriesFromCollection(
-		krt.NewStaticCollection[*corev1.ConfigMap](alwaysSynced{}, []*corev1.ConfigMap{legacy, canonical}, krt.WithName("jwks/PersistedKeysetsPreferNewestConfigMaps")),
+		krt.NewStaticCollection[*corev1.ConfigMap](alwaysSynced{}, []*corev1.ConfigMap{legacy, canonical}, krt.WithName("jwks/PersistedKeysetsPreferNewestConfigMaps"), krt.WithStop(stop)),
 		DefaultJwksStorePrefix,
 		"agentgateway-system",
+		krt.WithStop(stop),
 	)
 	reader := newPersistedKeysetReader(persisted)
 
@@ -118,6 +121,7 @@ func TestPersistedEntriesLoadPrefersNewestKeysetAcrossDuplicates(t *testing.T) {
 }
 
 func TestLoadPersistedKeysetsPrefersCanonicalEntryWhenFetchedAtTies(t *testing.T) {
+	stop := test.NewStop(t)
 	requestKey := remotehttp.FetchTarget{URL: "https://issuer.example/jwks"}.Key()
 	canonicalName := JwksConfigMapName(DefaultJwksStorePrefix, requestKey)
 
@@ -150,9 +154,10 @@ func TestLoadPersistedKeysetsPrefersCanonicalEntryWhenFetchedAtTies(t *testing.T
 	}))
 
 	persisted := NewPersistedEntriesFromCollection(
-		krt.NewStaticCollection[*corev1.ConfigMap](alwaysSynced{}, []*corev1.ConfigMap{legacy, canonical}, krt.WithName("jwks/PersistedKeysetsCanonicalTieConfigMaps")),
+		krt.NewStaticCollection[*corev1.ConfigMap](alwaysSynced{}, []*corev1.ConfigMap{legacy, canonical}, krt.WithName("jwks/PersistedKeysetsCanonicalTieConfigMaps"), krt.WithStop(stop)),
 		DefaultJwksStorePrefix,
 		"agentgateway-system",
+		krt.WithStop(stop),
 	)
 	reader := newPersistedKeysetReader(persisted)
 
@@ -165,6 +170,7 @@ func TestLoadPersistedKeysetsPrefersCanonicalEntryWhenFetchedAtTies(t *testing.T
 }
 
 func TestLoadPersistedKeysetsUsesDeterministicNameTieBreakForNonCanonicalDuplicates(t *testing.T) {
+	stop := test.NewStop(t)
 	requestKey := remotehttp.FetchTarget{URL: "https://issuer.example/jwks"}.Key()
 
 	olderByName := &corev1.ConfigMap{
@@ -196,9 +202,10 @@ func TestLoadPersistedKeysetsUsesDeterministicNameTieBreakForNonCanonicalDuplica
 	}))
 
 	persisted := NewPersistedEntriesFromCollection(
-		krt.NewStaticCollection[*corev1.ConfigMap](alwaysSynced{}, []*corev1.ConfigMap{laterByName, olderByName}, krt.WithName("jwks/PersistedKeysetsNameTieConfigMaps")),
+		krt.NewStaticCollection[*corev1.ConfigMap](alwaysSynced{}, []*corev1.ConfigMap{laterByName, olderByName}, krt.WithName("jwks/PersistedKeysetsNameTieConfigMaps"), krt.WithStop(stop)),
 		DefaultJwksStorePrefix,
 		"agentgateway-system",
+		krt.WithStop(stop),
 	)
 	reader := newPersistedKeysetReader(persisted)
 

--- a/controller/pkg/agentgateway/jwks/store_test.go
+++ b/controller/pkg/agentgateway/jwks/store_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-jose/go-jose/v4"
 	"github.com/stretchr/testify/assert"
 	"istio.io/istio/pkg/kube/krt"
+	"istio.io/istio/pkg/test"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -105,6 +106,7 @@ func TestStoreTracksSharedRequestCollectionLifecycle(t *testing.T) {
 		staticJwksConfigMaps(t, krtOpts, nil),
 		DefaultJwksStorePrefix,
 		"agentgateway-system",
+		krtOpts.ToOptions("jwks/PersistedEntries")...,
 	)
 	store := NewStore(requests, persisted, DefaultJwksStorePrefix)
 	store.jwksFetcher.defaultJwksClient = offlineStubJwksClient{}
@@ -152,6 +154,7 @@ func TestStoreDropsOldFetchStateWhenPolicyRetargets(t *testing.T) {
 		staticJwksConfigMaps(t, krtOpts, nil),
 		DefaultJwksStorePrefix,
 		"agentgateway-system",
+		krtOpts.ToOptions("jwks/PersistedEntries")...,
 	)
 	store := NewStore(collections.SharedRequests, persisted, DefaultJwksStorePrefix)
 	store.jwksFetcher.defaultJwksClient = offlineStubJwksClient{}
@@ -201,6 +204,7 @@ func TestStoreLoadsPersistedKeysetsBeforeServing(t *testing.T) {
 		staticJwksConfigMaps(t, krtOpts, []*corev1.ConfigMap{cm}),
 		DefaultJwksStorePrefix,
 		"agentgateway-system",
+		krtOpts.ToOptions("jwks/PersistedEntries")...,
 	)
 	store := NewStore(requests, persisted, DefaultJwksStorePrefix)
 	store.jwksFetcher.defaultJwksClient = offlineStubJwksClient{}
@@ -243,6 +247,7 @@ func TestStoreClearsCacheWhenLastPolicyDeleted(t *testing.T) {
 		staticJwksConfigMaps(t, krtOpts, nil),
 		DefaultJwksStorePrefix,
 		"agentgateway-system",
+		krtOpts.ToOptions("jwks/PersistedEntries")...,
 	)
 	store := NewStore(collections.SharedRequests, persisted, DefaultJwksStorePrefix)
 	store.jwksFetcher.defaultJwksClient = offlineStubJwksClient{}
@@ -299,6 +304,7 @@ func TestStoreClearsCacheWhenAllSharedPoliciesDeleted(t *testing.T) {
 		staticJwksConfigMaps(t, krtOpts, nil),
 		DefaultJwksStorePrefix,
 		"agentgateway-system",
+		krtOpts.ToOptions("jwks/PersistedEntries")...,
 	)
 	store := NewStore(collections.SharedRequests, persisted, DefaultJwksStorePrefix)
 	store.jwksFetcher.defaultJwksClient = offlineStubJwksClient{}
@@ -363,6 +369,7 @@ func TestStoreClearsCacheWhenPolicyDeletedAfterWarmStart(t *testing.T) {
 		staticJwksConfigMaps(t, krtOpts, []*corev1.ConfigMap{cm}),
 		DefaultJwksStorePrefix,
 		"agentgateway-system",
+		krtOpts.ToOptions("jwks/PersistedEntries")...,
 	)
 	store := NewStore(collections.SharedRequests, persisted, DefaultJwksStorePrefix)
 	store.jwksFetcher.defaultJwksClient = offlineStubJwksClient{}
@@ -424,6 +431,7 @@ func TestStoreClearsOrphanCacheAtStartup(t *testing.T) {
 		staticJwksConfigMaps(t, krtOpts, []*corev1.ConfigMap{cm}),
 		DefaultJwksStorePrefix,
 		"agentgateway-system",
+		krtOpts.ToOptions("jwks/PersistedEntries")...,
 	)
 	store := NewStore(collections.SharedRequests, persisted, DefaultJwksStorePrefix)
 	store.jwksFetcher.defaultJwksClient = offlineStubJwksClient{}
@@ -470,7 +478,7 @@ func (f jwksResolverFunc) ResolveOwner(_ krt.HandlerContext, owner RemoteJwksOwn
 
 func testKrtOptions(t *testing.T) krtutil.KrtOptions {
 	t.Helper()
-	return krtutil.NewKrtOptions(t.Context().Done(), new(krt.DebugHandler))
+	return krtutil.NewKrtOptions(test.NewStop(t), new(krt.DebugHandler))
 }
 
 func testRemotePolicy(name, uri string, ttl time.Duration) *agentgateway.AgentgatewayPolicy {

--- a/controller/pkg/agentgateway/plugins/credential_ref_auth_test.go
+++ b/controller/pkg/agentgateway/plugins/credential_ref_auth_test.go
@@ -7,6 +7,7 @@ import (
 
 	"istio.io/istio/pkg/kube/krt"
 	"istio.io/istio/pkg/ptr"
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/util/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,7 +26,8 @@ func simpleAuthPolicyCtx(col *AgwCollections, res kubeutils.CredentialResolver) 
 }
 
 func TestAwsAuthResolvesConfiguredCredentialRef(t *testing.T) {
-	secrets := krt.NewStaticCollection[*corev1.Secret](nil, nil, krt.WithName("plugins/TestAwsAuthResolvesConfiguredCredentialRef"))
+	stop := test.NewStop(t)
+	secrets := krt.NewStaticCollection[*corev1.Secret](nil, nil, krt.WithName("plugins/TestAwsAuthResolvesConfiguredCredentialRef"), krt.WithStop(stop))
 	ctx := simpleAuthPolicyCtx(
 		&AgwCollections{
 			Secrets: secrets,
@@ -100,7 +102,8 @@ func TestAwsAuthAssumeRoleOmitsUnsetSessionNameAndTags(t *testing.T) {
 }
 
 func TestAzureAuthResolvesConfiguredCredentialRef(t *testing.T) {
-	secrets := krt.NewStaticCollection[*corev1.Secret](nil, nil, krt.WithName("plugins/TestAzureAuthResolvesConfiguredCredentialRef"))
+	stop := test.NewStop(t)
+	secrets := krt.NewStaticCollection[*corev1.Secret](nil, nil, krt.WithName("plugins/TestAzureAuthResolvesConfiguredCredentialRef"), krt.WithStop(stop))
 	ctx := simpleAuthPolicyCtx(&AgwCollections{
 		Secrets: secrets,
 	}, kubeutils.NewSecretCredentialResolver(secrets))
@@ -118,7 +121,8 @@ func TestAzureAuthResolvesConfiguredCredentialRef(t *testing.T) {
 }
 
 func TestAzureAuthBuildsExplicitAndImplicitConfigs(t *testing.T) {
-	secrets := krt.NewStaticCollection[*corev1.Secret](nil, nil, krt.WithName("plugins/TestAzureAuthBuildsExplicitAndImplicitConfigs"))
+	stop := test.NewStop(t)
+	secrets := krt.NewStaticCollection[*corev1.Secret](nil, nil, krt.WithName("plugins/TestAzureAuthBuildsExplicitAndImplicitConfigs"), krt.WithStop(stop))
 	ctx := simpleAuthPolicyCtx(&AgwCollections{
 		Secrets: secrets,
 	}, kubeutils.NewSecretCredentialResolver(secrets))
@@ -141,6 +145,7 @@ func TestAzureAuthBuildsExplicitAndImplicitConfigs(t *testing.T) {
 }
 
 func TestBasicAuthCanUseInjectedCredentialResolver(t *testing.T) {
+	stop := test.NewStop(t)
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
@@ -150,7 +155,7 @@ func TestBasicAuthCanUseInjectedCredentialResolver(t *testing.T) {
 			".htaccess": "alice:hash",
 		},
 	}
-	configMaps := krt.NewStaticCollection[*corev1.ConfigMap](nil, []*corev1.ConfigMap{configMap}, krt.WithName("plugins/TestBasicAuthCanUseInjectedCredentialResolver"))
+	configMaps := krt.NewStaticCollection[*corev1.ConfigMap](nil, []*corev1.ConfigMap{configMap}, krt.WithName("plugins/TestBasicAuthCanUseInjectedCredentialResolver"), krt.WithStop(stop))
 	ctx := simpleAuthPolicyCtx(nil, configMapCredentialResolver{configMaps: configMaps})
 
 	policy, err := processBasicAuthenticationPolicy(ctx, &agentgateway.BasicAuthentication{
@@ -169,6 +174,7 @@ func TestBasicAuthCanUseInjectedCredentialResolver(t *testing.T) {
 }
 
 func TestBasicAuthFallsBackToSecretResolverWithInjectedCredentialResolver(t *testing.T) {
+	stop := test.NewStop(t)
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
@@ -178,7 +184,7 @@ func TestBasicAuthFallsBackToSecretResolverWithInjectedCredentialResolver(t *tes
 			".htaccess": []byte("bob:hash"),
 		},
 	}
-	secrets := krt.NewStaticCollection[*corev1.Secret](nil, []*corev1.Secret{secret}, krt.WithName("plugins/TestBasicAuthFallsBackToSecretResolverWithInjectedCredentialResolver"))
+	secrets := krt.NewStaticCollection[*corev1.Secret](nil, []*corev1.Secret{secret}, krt.WithName("plugins/TestBasicAuthFallsBackToSecretResolverWithInjectedCredentialResolver"), krt.WithStop(stop))
 	ctx := simpleAuthPolicyCtx(
 		&AgwCollections{
 			Secrets: secrets,
@@ -204,6 +210,7 @@ func TestBasicAuthFallsBackToSecretResolverWithInjectedCredentialResolver(t *tes
 }
 
 func TestBasicAuthCustomResolverDoesNotImplicitlyFallbackToSecret(t *testing.T) {
+	stop := test.NewStop(t)
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
@@ -213,7 +220,7 @@ func TestBasicAuthCustomResolverDoesNotImplicitlyFallbackToSecret(t *testing.T) 
 			".htaccess": []byte("bob:hash"),
 		},
 	}
-	secrets := krt.NewStaticCollection[*corev1.Secret](nil, []*corev1.Secret{secret}, krt.WithName("plugins/TestBasicAuthCustomResolverDoesNotImplicitlyFallbackToSecret"))
+	secrets := krt.NewStaticCollection[*corev1.Secret](nil, []*corev1.Secret{secret}, krt.WithName("plugins/TestBasicAuthCustomResolverDoesNotImplicitlyFallbackToSecret"), krt.WithStop(stop))
 	ctx := simpleAuthPolicyCtx(&AgwCollections{
 		Secrets: secrets,
 	}, configMapCredentialResolver{})

--- a/controller/pkg/agentgateway/testutils/main_test.go
+++ b/controller/pkg/agentgateway/testutils/main_test.go
@@ -1,0 +1,11 @@
+package testutils
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/controller/pkg/agentgateway/testutils/util.go
+++ b/controller/pkg/agentgateway/testutils/util.go
@@ -216,7 +216,7 @@ func BuildMockPolicyContext(t test.Failer, inputs []any) plugins.PolicyCtx {
 		Grants:      grants,
 		References:  plugins.BuildReferenceIndex(nil, nil, plugins.DefaultReferenceTypes(collections)),
 		Resolver:    resolver,
-		JWKSLookup:  jwks.NewLookup(jwks.NewPersistedEntriesFromCollection(collections.ConfigMaps, jwks.DefaultJwksStorePrefix, collections.SystemNamespace), jwks.NewResolver(resolver)),
+		JWKSLookup:  jwks.NewLookup(jwks.NewPersistedEntriesFromCollection(collections.ConfigMaps, jwks.DefaultJwksStorePrefix, collections.SystemNamespace, collections.KrtOpts.ToOptions("jwks/PersistedEntries")...), jwks.NewResolver(resolver)),
 
 		CredentialResolver: plugins.DefaultCredentialResolverFactory(collections),
 	}
@@ -224,6 +224,8 @@ func BuildMockPolicyContext(t test.Failer, inputs []any) plugins.PolicyCtx {
 
 func BuildMockCollection(t test.Failer, inputs []any) *plugins.AgwCollections {
 	mock := krttest.NewMock(t, inputs)
+	// Create a stop channel for collections that need it
+	krtOpts := krtutil.NewKrtOptions(test.NewStop(t), nil)
 	col := &plugins.AgwCollections{
 		Namespaces:           krttest.GetMockCollection[*corev1.Namespace](mock),
 		Nodes:                krttest.GetMockCollection[*corev1.Node](mock),
@@ -250,6 +252,7 @@ func BuildMockCollection(t test.Failer, inputs []any) *plugins.AgwCollections {
 		SystemNamespace:      "agentgateway-system",
 		IstioNamespace:       "istio-system",
 		IstioClusterId:       "Kubernetes",
+		KrtOpts:              krtOpts,
 	}
 	col.SetupIndexes()
 	return col

--- a/controller/pkg/cli/kubeutil/main_test.go
+++ b/controller/pkg/cli/kubeutil/main_test.go
@@ -1,0 +1,11 @@
+package kubeutil
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/controller/pkg/cli/proxy/trace/main_test.go
+++ b/controller/pkg/cli/proxy/trace/main_test.go
@@ -1,0 +1,11 @@
+package trace
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/controller/pkg/setup/main_test.go
+++ b/controller/pkg/setup/main_test.go
@@ -1,0 +1,11 @@
+package setup
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/controller/pkg/syncer/krtxds/main_test.go
+++ b/controller/pkg/syncer/krtxds/main_test.go
@@ -1,0 +1,11 @@
+package krtxds
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/controller/pkg/syncer/krtxds/xds_test.go
+++ b/controller/pkg/syncer/krtxds/xds_test.go
@@ -70,6 +70,7 @@ func NewFakeDiscoveryServerWith(t *testing.T, initialAddress []syncer.Address, i
 		}
 	}()
 	t.Cleanup(func() {
+		s.Shutdown()
 		grpcServer.Stop()
 		_ = listener.Close()
 	})

--- a/controller/pkg/syncer/status/main_test.go
+++ b/controller/pkg/syncer/status/main_test.go
@@ -1,0 +1,11 @@
+package status
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/atomic v1.11.0
+	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.28.0
 	golang.design/x/clipboard v0.8.0
 	golang.org/x/net v0.56.0


### PR DESCRIPTION
  ## Summary

  Add `go.uber.org/goleak` to key controller packages that spawn goroutines, ensuring goroutine leaks are caught during `go test`.

  ## Changes

  - Add `main_test.go` with `goleak.VerifyTestMain(m)` to 8 packages:                                                                                                                                                                 
    - `pkg/syncer/krtxds` — XDS discovery server push goroutines
    - `pkg/cli/proxy/trace` — proxy trace streaming                                                                                                                                                                                   
    - `pkg/admin` — admin server                                                                                                                                                                                                      
    - `pkg/setup` — control plane setup                                                                                                                                                                                               
    - `pkg/agentgateway/jwks` — JWKS fetch/store workers                                                                                                                                                                              
    - `pkg/agentgateway/testutils` — test utilities with krt collections                                                                                                                                                            
    - `pkg/syncer/status` — status worker pool                                                                                                                                                                                        
    - `pkg/cli/kubeutil` — Kubernetes client port-forwarding