### PR TITLE
llm guardrails: add built-in secret detectors

### DIFF
--- a/api/resource.pb.go
+++ b/api/resource.pb.go
@@ -1488,17 +1488,31 @@ const (
 	BackendPolicySpec_Ai_PHONE_NUMBER        BackendPolicySpec_Ai_BuiltinRegexRule = 3
 	BackendPolicySpec_Ai_EMAIL               BackendPolicySpec_Ai_BuiltinRegexRule = 4
 	BackendPolicySpec_Ai_CA_SIN              BackendPolicySpec_Ai_BuiltinRegexRule = 5
+	BackendPolicySpec_Ai_API_KEY             BackendPolicySpec_Ai_BuiltinRegexRule = 6
+	BackendPolicySpec_Ai_PRIVATE_KEY         BackendPolicySpec_Ai_BuiltinRegexRule = 7
+	BackendPolicySpec_Ai_GITHUB_TOKEN        BackendPolicySpec_Ai_BuiltinRegexRule = 8
+	BackendPolicySpec_Ai_AWS_ACCESS_KEY      BackendPolicySpec_Ai_BuiltinRegexRule = 9
+	BackendPolicySpec_Ai_SLACK_TOKEN         BackendPolicySpec_Ai_BuiltinRegexRule = 10
+	BackendPolicySpec_Ai_JWT                 BackendPolicySpec_Ai_BuiltinRegexRule = 11
+	BackendPolicySpec_Ai_GCP_API_KEY         BackendPolicySpec_Ai_BuiltinRegexRule = 12
 )
 
 // Enum value maps for BackendPolicySpec_Ai_BuiltinRegexRule.
 var (
 	BackendPolicySpec_Ai_BuiltinRegexRule_name = map[int32]string{
-		0: "BUILTIN_UNSPECIFIED",
-		1: "SSN",
-		2: "CREDIT_CARD",
-		3: "PHONE_NUMBER",
-		4: "EMAIL",
-		5: "CA_SIN",
+		0:  "BUILTIN_UNSPECIFIED",
+		1:  "SSN",
+		2:  "CREDIT_CARD",
+		3:  "PHONE_NUMBER",
+		4:  "EMAIL",
+		5:  "CA_SIN",
+		6:  "API_KEY",
+		7:  "PRIVATE_KEY",
+		8:  "GITHUB_TOKEN",
+		9:  "AWS_ACCESS_KEY",
+		10: "SLACK_TOKEN",
+		11: "JWT",
+		12: "GCP_API_KEY",
 	}
 	BackendPolicySpec_Ai_BuiltinRegexRule_value = map[string]int32{
 		"BUILTIN_UNSPECIFIED": 0,
@@ -1507,6 +1521,13 @@ var (
 		"PHONE_NUMBER":        3,
 		"EMAIL":               4,
 		"CA_SIN":              5,
+		"API_KEY":             6,
+		"PRIVATE_KEY":         7,
+		"GITHUB_TOKEN":        8,
+		"AWS_ACCESS_KEY":      9,
+		"SLACK_TOKEN":         10,
+		"JWT":                 11,
+		"GCP_API_KEY":         12,
 	}
 )
 
@@ -16289,7 +16310,7 @@ const file_resource_proto_rawDesc = "" +
 	"\vPolicyPhase\x12\t\n" +
 	"\x05ROUTE\x10\x00\x12\v\n" +
 	"\aGATEWAY\x10\x01B\x06\n" +
-	"\x04kind\"\xf2X\n" +
+	"\x04kind\"\xe2Y\n" +
 	"\x11BackendPolicySpec\x12D\n" +
 	"\x03a2a\x18\x01 \x01(\v20.agentgateway.dev.resource.BackendPolicySpec.A2aH\x00R\x03a2a\x12l\n" +
 	"\x11inference_routing\x18\x02 \x01(\v2=.agentgateway.dev.resource.BackendPolicySpec.InferenceRoutingH\x00R\x10inferenceRouting\x12Z\n" +
@@ -16311,7 +16332,7 @@ const file_resource_proto_rawDesc = "" +
 	"\x06health\x18\x0f \x01(\v23.agentgateway.dev.resource.BackendPolicySpec.HealthH\x00R\x06health\x12c\n" +
 	"\x0ebackend_tunnel\x18\x10 \x01(\v2:.agentgateway.dev.resource.BackendPolicySpec.BackendTunnelH\x00R\rbackendTunnel\x12X\n" +
 	"\text_authz\x18\x11 \x01(\v29.agentgateway.dev.resource.TrafficPolicySpec.ExternalAuthH\x00R\bextAuthz\x12c\n" +
-	"\x0emcp_guardrails\x18\x12 \x01(\v2:.agentgateway.dev.resource.BackendPolicySpec.McpGuardrailsH\x00R\rmcpGuardrails\x1a\xc1,\n" +
+	"\x0emcp_guardrails\x18\x12 \x01(\v2:.agentgateway.dev.resource.BackendPolicySpec.McpGuardrailsH\x00R\rmcpGuardrails\x1a\xb1-\n" +
 	"\x02Ai\x12^\n" +
 	"\fprompt_guard\x18\x01 \x01(\v2;.agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuardR\vpromptGuard\x12Y\n" +
 	"\bdefaults\x18\x02 \x03(\v2=.agentgateway.dev.resource.BackendPolicySpec.Ai.DefaultsEntryR\bdefaults\x12\\\n" +
@@ -16432,7 +16453,7 @@ const file_resource_proto_rawDesc = "" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1at\n" +
 	"\vRoutesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12O\n" +
-	"\x05value\x18\x02 \x01(\x0e29.agentgateway.dev.resource.BackendPolicySpec.Ai.RouteTypeR\x05value:\x028\x01\"n\n" +
+	"\x05value\x18\x02 \x01(\x0e29.agentgateway.dev.resource.BackendPolicySpec.Ai.RouteTypeR\x05value:\x028\x01\"\xdd\x01\n" +
 	"\x10BuiltinRegexRule\x12\x17\n" +
 	"\x13BUILTIN_UNSPECIFIED\x10\x00\x12\a\n" +
 	"\x03SSN\x10\x01\x12\x0f\n" +
@@ -16440,7 +16461,15 @@ const file_resource_proto_rawDesc = "" +
 	"\fPHONE_NUMBER\x10\x03\x12\t\n" +
 	"\x05EMAIL\x10\x04\x12\n" +
 	"\n" +
-	"\x06CA_SIN\x10\x05\":\n" +
+	"\x06CA_SIN\x10\x05\x12\v\n" +
+	"\aAPI_KEY\x10\x06\x12\x0f\n" +
+	"\vPRIVATE_KEY\x10\a\x12\x10\n" +
+	"\fGITHUB_TOKEN\x10\b\x12\x12\n" +
+	"\x0eAWS_ACCESS_KEY\x10\t\x12\x0f\n" +
+	"\vSLACK_TOKEN\x10\n" +
+	"\x12\a\n" +
+	"\x03JWT\x10\v\x12\x0f\n" +
+	"\vGCP_API_KEY\x10\f\":\n" +
 	"\n" +
 	"ActionKind\x12\x16\n" +
 	"\x12ACTION_UNSPECIFIED\x10\x00\x12\b\n" +

--- a/crates/agentgateway/src/llm/policy/mod.rs
+++ b/crates/agentgateway/src/llm/policy/mod.rs
@@ -1189,6 +1189,13 @@ impl Policy {
 						Builtin::PhoneNumber => &*pii::PHONE,
 						Builtin::Email => &*pii::EMAIL,
 						Builtin::CaSin => &*pii::CA_SIN,
+						Builtin::ApiKey => &*pii::API_KEY,
+						Builtin::PrivateKey => &*pii::PRIVATE_KEY,
+						Builtin::GithubToken => &*pii::GITHUB_TOKEN,
+						Builtin::AwsAccessKey => &*pii::AWS_ACCESS_KEY,
+						Builtin::SlackToken => &*pii::SLACK_TOKEN,
+						Builtin::Jwt => &*pii::JWT,
+						Builtin::GcpApiKey => &*pii::GCP_API_KEY,
 					};
 					let results = pii::recognizer(rec, working.as_deref().unwrap_or(original_content));
 					if results.is_empty() {
@@ -1428,6 +1435,20 @@ pub enum Builtin {
 	Email,
 	/// Canadian Social Insurance Number pattern.
 	CaSin,
+	/// Generic API key pattern.
+	ApiKey,
+	/// Private key (PEM/PGP block) pattern.
+	PrivateKey,
+	/// GitHub token pattern.
+	GithubToken,
+	/// AWS access key ID pattern.
+	AwsAccessKey,
+	/// Slack token pattern.
+	SlackToken,
+	/// JSON Web Token pattern.
+	Jwt,
+	/// GCP API key pattern.
+	GcpApiKey,
 }
 
 #[apply(schema!)]

--- a/crates/agentgateway/src/llm/policy/pii/api_key_recognizer.rs
+++ b/crates/agentgateway/src/llm/policy/pii/api_key_recognizer.rs
@@ -1,0 +1,144 @@
+use crate::llm::policy::pii::pattern_recognizer::PatternRecognizer;
+use crate::llm::policy::pii::recognizer::Recognizer;
+
+pub struct ApiKeyRecognizer {
+	recognizer: PatternRecognizer,
+}
+
+impl ApiKeyRecognizer {
+	pub fn new() -> Self {
+		let mut recognizer = PatternRecognizer::new(
+			"API_KEY",
+			vec![
+				"api".to_string(),
+				"key".to_string(),
+				"apikey".to_string(),
+				"api_key".to_string(),
+				"api-key".to_string(),
+				"secret".to_string(),
+				"token".to_string(),
+			],
+		);
+
+		// OpenAI-style secret keys (sk- prefix followed by a long alphanumeric string).
+		recognizer.add_pattern("OpenAI secret key", r"\bsk-[A-Za-z0-9]{20,}\b", 0.6);
+
+		// Stripe live secret key (sk_live_ prefix).
+		recognizer.add_pattern(
+			"Stripe live secret key",
+			r"\bsk_live_[A-Za-z0-9]{16,}\b",
+			0.7,
+		);
+
+		// Stripe test secret key (sk_test_ prefix).
+		recognizer.add_pattern(
+			"Stripe test secret key",
+			r"\bsk_test_[A-Za-z0-9]{16,}\b",
+			0.6,
+		);
+
+		// Generic api_key/apikey/api-key assignment, e.g. api_key="abcdef0123456789..." or apikey: 'abc...'
+		recognizer.add_pattern(
+			"Generic API key assignment (weak)",
+			r#"(?i)\bapi[_-]?key\b\s*[:=]\s*['"]?[A-Za-z0-9_\-]{16,}['"]?"#,
+			0.4,
+		);
+
+		// Generic Bearer token in an Authorization header.
+		recognizer.add_pattern(
+			"Bearer token (weak)",
+			r"(?i)\bBearer\s+[A-Za-z0-9\-_.=]{20,}\b",
+			0.4,
+		);
+
+		Self { recognizer }
+	}
+}
+
+impl Recognizer for ApiKeyRecognizer {
+	fn recognize(&self, text: &str) -> Vec<super::recognizer_result::RecognizerResult> {
+		self.recognizer.recognize(text)
+	}
+	fn name(&self) -> &str {
+		self.recognizer.name()
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn test_openai_style_key_detected() {
+		let recognizer = ApiKeyRecognizer::new();
+
+		let text = "My OpenAI key is sk-abcdefghijklmnopqrstuvwxyz123456 please don't share it.";
+		let results = recognizer.recognize(text);
+
+		assert!(!results.is_empty());
+		for result in &results {
+			assert!(result.score > 0.0);
+		}
+		assert!(
+			results
+				.iter()
+				.any(|r| r.matched.contains("sk-abcdefghijklmnopqrstuvwxyz123456"))
+		);
+	}
+
+	#[test]
+	fn test_stripe_style_key_detected() {
+		let recognizer = ApiKeyRecognizer::new();
+
+		// Deliberately low-entropy/repetitive placeholder (not a real Stripe key
+		// shape) so it doesn't trip GitHub's secret-scanning push protection.
+		let text = "Stripe secret: sk_test_AAAABBBBCCCCDDDD use in tests only.";
+		let results = recognizer.recognize(text);
+
+		assert!(!results.is_empty());
+		for result in &results {
+			assert!(result.score > 0.0);
+		}
+		assert!(
+			results
+				.iter()
+				.any(|r| r.matched.contains("sk_test_AAAABBBBCCCCDDDD"))
+		);
+	}
+
+	#[test]
+	fn test_generic_api_key_assignment_detected() {
+		let recognizer = ApiKeyRecognizer::new();
+
+		let text = r#"config.api_key = "FAKE1234567890ABCDEFGHIJ""#;
+		let results = recognizer.recognize(text);
+
+		assert!(!results.is_empty());
+		for result in &results {
+			assert!(result.score > 0.0);
+		}
+	}
+
+	#[test]
+	fn test_bearer_token_detected() {
+		let recognizer = ApiKeyRecognizer::new();
+
+		let text = "Authorization: Bearer FAKEabcdefghijklmnopqrstuvwxyz0123456789";
+		let results = recognizer.recognize(text);
+
+		assert!(!results.is_empty());
+		for result in &results {
+			assert!(result.score > 0.0);
+		}
+	}
+
+	#[test]
+	fn test_plain_text_no_false_positive() {
+		let recognizer = ApiKeyRecognizer::new();
+
+		let text = "This is just a normal sentence with no secrets in it.";
+		let results = recognizer.recognize(text);
+
+		assert!(results.is_empty());
+	}
+}

--- a/crates/agentgateway/src/llm/policy/pii/aws_access_key_recognizer.rs
+++ b/crates/agentgateway/src/llm/policy/pii/aws_access_key_recognizer.rs
@@ -1,0 +1,78 @@
+use crate::llm::policy::pii::pattern_recognizer::PatternRecognizer;
+use crate::llm::policy::pii::recognizer::Recognizer;
+
+pub struct AwsAccessKeyRecognizer {
+	recognizer: PatternRecognizer,
+}
+
+impl AwsAccessKeyRecognizer {
+	pub fn new() -> Self {
+		let mut recognizer = PatternRecognizer::new(
+			"AWS_ACCESS_KEY",
+			vec![
+				"aws".to_string(),
+				"amazon".to_string(),
+				"access key".to_string(),
+				"akid".to_string(),
+				"access_key_id".to_string(),
+			],
+		);
+		// Standard long-term access key ID (e.g. AKIA...)
+		recognizer.add_pattern("AWS_ACCESS_KEY_STANDARD", r"\bAKIA[0-9A-Z]{16}\b", 0.85);
+		// Temporary/STS access key ID (e.g. ASIA...)
+		recognizer.add_pattern("AWS_ACCESS_KEY_TEMPORARY", r"\bASIA[0-9A-Z]{16}\b", 0.85);
+
+		Self { recognizer }
+	}
+}
+
+impl Recognizer for AwsAccessKeyRecognizer {
+	fn recognize(&self, text: &str) -> Vec<super::recognizer_result::RecognizerResult> {
+		self.recognizer.recognize(text)
+	}
+	fn name(&self) -> &str {
+		self.recognizer.name()
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn test_aws_access_key_standard_detected() {
+		let recognizer = AwsAccessKeyRecognizer::new();
+		let text = "My aws access key is AKIA1234567890ABCDEF, keep it secret.";
+		let results = recognizer.recognize(text);
+
+		assert!(!results.is_empty());
+		for result in &results {
+			assert!(result.score > 0.0);
+			assert!(result.matched.starts_with("AKIA"));
+		}
+		assert!(results.iter().any(|r| r.matched == "AKIA1234567890ABCDEF"));
+	}
+
+	#[test]
+	fn test_aws_access_key_temporary_detected() {
+		let recognizer = AwsAccessKeyRecognizer::new();
+		let text = "Temporary access_key_id: ASIA1234567890ABCDEF for STS session.";
+		let results = recognizer.recognize(text);
+
+		assert!(!results.is_empty());
+		for result in &results {
+			assert!(result.score > 0.0);
+			assert!(result.matched.starts_with("ASIA"));
+		}
+		assert!(results.iter().any(|r| r.matched == "ASIA1234567890ABCDEF"));
+	}
+
+	#[test]
+	fn test_plain_sentence_no_matches() {
+		let recognizer = AwsAccessKeyRecognizer::new();
+		let text = "This is just a plain sentence with no secrets in it at all.";
+		let results = recognizer.recognize(text);
+
+		assert!(results.is_empty());
+	}
+}

--- a/crates/agentgateway/src/llm/policy/pii/gcp_api_key_recognizer.rs
+++ b/crates/agentgateway/src/llm/policy/pii/gcp_api_key_recognizer.rs
@@ -1,0 +1,65 @@
+use crate::llm::policy::pii::pattern_recognizer::PatternRecognizer;
+use crate::llm::policy::pii::recognizer::Recognizer;
+
+pub struct GcpApiKeyRecognizer {
+	recognizer: PatternRecognizer,
+}
+
+impl GcpApiKeyRecognizer {
+	pub fn new() -> Self {
+		let mut recognizer = PatternRecognizer::new(
+			"GCP_API_KEY",
+			vec![
+				"gcp".to_string(),
+				"google".to_string(),
+				"api key".to_string(),
+				"aiza".to_string(),
+			],
+		);
+		recognizer.add_pattern("GCP_API_KEY (high)", r"\bAIza[0-9A-Za-z_-]{35}\b", 0.85);
+
+		Self { recognizer }
+	}
+}
+
+impl Recognizer for GcpApiKeyRecognizer {
+	fn recognize(&self, text: &str) -> Vec<super::recognizer_result::RecognizerResult> {
+		self.recognizer.recognize(text)
+	}
+	fn name(&self) -> &str {
+		self.recognizer.name()
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn test_gcp_api_key_recognizer_detects_key() {
+		let recognizer = GcpApiKeyRecognizer::new();
+
+		// Fake GCP API key: "AIza" + 35 chars = 39 chars total.
+		let fake_key = "AIzaSyABCDEFGHIJKLMNOPQRSTUVWXYZ0123456";
+		assert_eq!(fake_key.len(), 39);
+
+		let text = format!("My GCP API key is {} - do not share it.", fake_key);
+		let results = recognizer.recognize(&text);
+
+		assert!(!results.is_empty());
+		for result in &results {
+			assert!(result.score > 0.0);
+			assert_eq!(result.matched, fake_key);
+		}
+	}
+
+	#[test]
+	fn test_gcp_api_key_recognizer_no_match_on_plain_text() {
+		let recognizer = GcpApiKeyRecognizer::new();
+
+		let text = "This is just a plain sentence with no secrets in it at all.";
+		let results = recognizer.recognize(text);
+
+		assert!(results.is_empty());
+	}
+}

--- a/crates/agentgateway/src/llm/policy/pii/github_token_recognizer.rs
+++ b/crates/agentgateway/src/llm/policy/pii/github_token_recognizer.rs
@@ -1,0 +1,121 @@
+use crate::llm::policy::pii::pattern_recognizer::PatternRecognizer;
+use crate::llm::policy::pii::recognizer::Recognizer;
+
+pub struct GithubTokenRecognizer {
+	recognizer: PatternRecognizer,
+}
+
+impl GithubTokenRecognizer {
+	pub fn new() -> Self {
+		let mut recognizer = PatternRecognizer::new(
+			"GITHUB_TOKEN",
+			vec![
+				"github".to_string(),
+				"token".to_string(),
+				"pat".to_string(),
+				"gh".to_string(),
+			],
+		);
+		// Personal access token (classic)
+		recognizer.add_pattern("GITHUB_PAT_CLASSIC", r"\bghp_[A-Za-z0-9]{36}\b", 0.9);
+		// OAuth token
+		recognizer.add_pattern("GITHUB_OAUTH_TOKEN", r"\bgho_[A-Za-z0-9]{36}\b", 0.9);
+		// User-to-server token
+		recognizer.add_pattern(
+			"GITHUB_USER_TO_SERVER_TOKEN",
+			r"\bghu_[A-Za-z0-9]{36}\b",
+			0.9,
+		);
+		// Server-to-server token
+		recognizer.add_pattern(
+			"GITHUB_SERVER_TO_SERVER_TOKEN",
+			r"\bghs_[A-Za-z0-9]{36}\b",
+			0.9,
+		);
+		// Refresh token
+		recognizer.add_pattern("GITHUB_REFRESH_TOKEN", r"\bghr_[A-Za-z0-9]{36}\b", 0.9);
+		// Fine-grained personal access token
+		recognizer.add_pattern(
+			"GITHUB_PAT_FINE_GRAINED",
+			r"\bgithub_pat_[A-Za-z0-9_]{60,}\b",
+			0.9,
+		);
+
+		Self { recognizer }
+	}
+}
+
+impl Recognizer for GithubTokenRecognizer {
+	fn recognize(&self, text: &str) -> Vec<super::recognizer_result::RecognizerResult> {
+		self.recognizer.recognize(text)
+	}
+	fn name(&self) -> &str {
+		self.recognizer.name()
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn test_github_pat_classic() {
+		let recognizer = GithubTokenRecognizer::new();
+		let text = "My token is ghp_abcdefghij1234567890ABCDEFGHIJ123456 please keep it secret";
+		let results = recognizer.recognize(text);
+
+		assert!(!results.is_empty());
+		for result in &results {
+			assert!(result.score > 0.0);
+		}
+		assert!(
+			results
+				.iter()
+				.any(|r| r.matched == "ghp_abcdefghij1234567890ABCDEFGHIJ123456")
+		);
+	}
+
+	#[test]
+	fn test_github_oauth_token() {
+		let recognizer = GithubTokenRecognizer::new();
+		let text = "gho_abcdefghij1234567890ABCDEFGHIJ123456 is an oauth token";
+		let results = recognizer.recognize(text);
+
+		assert!(!results.is_empty());
+		for result in &results {
+			assert!(result.score > 0.0);
+		}
+	}
+
+	#[test]
+	fn test_github_fine_grained_pat() {
+		let recognizer = GithubTokenRecognizer::new();
+		let text = "github_pat_11ABCDEFGHIJKLMNOPQRST_abcdefghij1234567890ABCDEFGHIJ1234567890abcdefghijklmno is a fine-grained pat";
+		let results = recognizer.recognize(text);
+
+		assert!(!results.is_empty());
+		for result in &results {
+			assert!(result.score > 0.0);
+		}
+		assert!(results.iter().any(|r| r.matched.starts_with("github_pat_")));
+	}
+
+	#[test]
+	fn test_no_false_positive_on_plain_text() {
+		let recognizer = GithubTokenRecognizer::new();
+		let text = "The quick brown fox jumps over the lazy dog near the github repository page.";
+		let results = recognizer.recognize(text);
+
+		assert!(results.is_empty());
+	}
+
+	#[test]
+	fn test_no_match_on_short_token_like_string() {
+		let recognizer = GithubTokenRecognizer::new();
+		// Too short to be a valid token, should not match.
+		let text = "ghp_short";
+		let results = recognizer.recognize(text);
+
+		assert!(results.is_empty());
+	}
+}

--- a/crates/agentgateway/src/llm/policy/pii/jwt_recognizer.rs
+++ b/crates/agentgateway/src/llm/policy/pii/jwt_recognizer.rs
@@ -1,0 +1,74 @@
+use crate::llm::policy::pii::pattern_recognizer::PatternRecognizer;
+use crate::llm::policy::pii::recognizer::Recognizer;
+
+pub struct JwtRecognizer {
+	recognizer: PatternRecognizer,
+}
+
+impl JwtRecognizer {
+	pub fn new() -> Self {
+		let mut recognizer = PatternRecognizer::new(
+			"JWT",
+			vec![
+				"jwt".to_string(),
+				"token".to_string(),
+				"bearer".to_string(),
+				"authorization".to_string(),
+			],
+		);
+		recognizer.add_pattern(
+			"JWT (medium)",
+			r"\beyJ[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\b",
+			0.8,
+		);
+
+		Self { recognizer }
+	}
+}
+
+impl Recognizer for JwtRecognizer {
+	fn recognize(&self, text: &str) -> Vec<super::recognizer_result::RecognizerResult> {
+		self.recognizer.recognize(text)
+	}
+	fn name(&self) -> &str {
+		self.recognizer.name()
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn test_jwt_recognizer_detects_fake_jwt() {
+		let recognizer = JwtRecognizer::new();
+		let text = "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIn0.dQw4w9WgXcQ_fakefakefakefake";
+		let results = recognizer.recognize(text);
+
+		assert!(!results.is_empty());
+		for result in &results {
+			assert!(result.score > 0.0);
+			assert_eq!(result.entity_type, "JWT");
+		}
+	}
+
+	#[test]
+	fn test_jwt_recognizer_detects_another_fake_jwt() {
+		let recognizer = JwtRecognizer::new();
+		let text =
+			"token=eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyIjoiYWxpY2UiLCJyb2xlIjoiYWRtaW4ifQ.abc123XYZ_-fakeSig";
+		let results = recognizer.recognize(text);
+
+		assert!(!results.is_empty());
+		assert!(results[0].score > 0.0);
+	}
+
+	#[test]
+	fn test_jwt_recognizer_no_match_on_plain_sentence() {
+		let recognizer = JwtRecognizer::new();
+		let text = "This is just a plain sentence with no tokens or secrets in it at all.";
+		let results = recognizer.recognize(text);
+
+		assert!(results.is_empty());
+	}
+}

--- a/crates/agentgateway/src/llm/policy/pii/mod.rs
+++ b/crates/agentgateway/src/llm/policy/pii/mod.rs
@@ -6,13 +6,20 @@ use crate::llm::policy::pii::email_recognizer::EmailRecognizer;
 use crate::llm::policy::pii::phone_recognizer::PhoneRecognizer;
 use crate::llm::policy::pii::recognizer::Recognizer;
 
+mod api_key_recognizer;
+mod aws_access_key_recognizer;
 mod ca_sin_recognizer;
 mod credit_card_recognizer;
 mod email_recognizer;
+mod gcp_api_key_recognizer;
+mod github_token_recognizer;
+mod jwt_recognizer;
 mod pattern_recognizer;
 mod phone_recognizer;
+mod private_key_recognizer;
 mod recognizer;
 mod recognizer_result;
+mod slack_token_recognizer;
 mod url_recognizer;
 mod us_ssn_recognizer;
 
@@ -30,6 +37,27 @@ pub static SSN: Lazy<Box<dyn Recognizer + Sync + Send + 'static>> =
 
 pub static CA_SIN: Lazy<Box<dyn Recognizer + Sync + Send + 'static>> =
 	Lazy::new(|| Box::new(ca_sin_recognizer::CaSinRecognizer::new()));
+
+pub static API_KEY: Lazy<Box<dyn Recognizer + Sync + Send + 'static>> =
+	Lazy::new(|| Box::new(api_key_recognizer::ApiKeyRecognizer::new()));
+
+pub static PRIVATE_KEY: Lazy<Box<dyn Recognizer + Sync + Send + 'static>> =
+	Lazy::new(|| Box::new(private_key_recognizer::PrivateKeyRecognizer::new()));
+
+pub static GITHUB_TOKEN: Lazy<Box<dyn Recognizer + Sync + Send + 'static>> =
+	Lazy::new(|| Box::new(github_token_recognizer::GithubTokenRecognizer::new()));
+
+pub static AWS_ACCESS_KEY: Lazy<Box<dyn Recognizer + Sync + Send + 'static>> =
+	Lazy::new(|| Box::new(aws_access_key_recognizer::AwsAccessKeyRecognizer::new()));
+
+pub static SLACK_TOKEN: Lazy<Box<dyn Recognizer + Sync + Send + 'static>> =
+	Lazy::new(|| Box::new(slack_token_recognizer::SlackTokenRecognizer::new()));
+
+pub static JWT: Lazy<Box<dyn Recognizer + Sync + Send + 'static>> =
+	Lazy::new(|| Box::new(jwt_recognizer::JwtRecognizer::new()));
+
+pub static GCP_API_KEY: Lazy<Box<dyn Recognizer + Sync + Send + 'static>> =
+	Lazy::new(|| Box::new(gcp_api_key_recognizer::GcpApiKeyRecognizer::new()));
 
 #[allow(clippy::borrowed_box)]
 pub fn recognizer(

--- a/crates/agentgateway/src/llm/policy/pii/private_key_recognizer.rs
+++ b/crates/agentgateway/src/llm/policy/pii/private_key_recognizer.rs
@@ -1,0 +1,111 @@
+use crate::llm::policy::pii::pattern_recognizer::PatternRecognizer;
+use crate::llm::policy::pii::recognizer::Recognizer;
+
+pub struct PrivateKeyRecognizer {
+	recognizer: PatternRecognizer,
+}
+
+impl PrivateKeyRecognizer {
+	pub fn new() -> Self {
+		let mut recognizer = PatternRecognizer::new(
+			"PRIVATE_KEY",
+			vec![
+				"private".to_string(),
+				"key".to_string(),
+				"rsa".to_string(),
+				"openssh".to_string(),
+				"pem".to_string(),
+				"pgp".to_string(),
+			],
+		);
+
+		// Generic PEM private key block, e.g. RSA, EC, DSA, OPENSSH, ENCRYPTED, or plain
+		// "-----BEGIN PRIVATE KEY-----" ... "-----END PRIVATE KEY-----".
+		recognizer.add_pattern(
+			"PEM_PRIVATE_KEY_BLOCK",
+			r"(?s)-----BEGIN (?:[A-Z0-9]+ )?PRIVATE KEY-----.*?-----END (?:[A-Z0-9]+ )?PRIVATE KEY-----",
+			0.95,
+		);
+
+		// PGP private key block.
+		recognizer.add_pattern(
+			"PGP_PRIVATE_KEY_BLOCK",
+			r"(?s)-----BEGIN PGP PRIVATE KEY BLOCK-----.*?-----END PGP PRIVATE KEY BLOCK-----",
+			0.95,
+		);
+
+		Self { recognizer }
+	}
+}
+
+impl Recognizer for PrivateKeyRecognizer {
+	fn recognize(&self, text: &str) -> Vec<super::recognizer_result::RecognizerResult> {
+		self.recognizer.recognize(text)
+	}
+	fn name(&self) -> &str {
+		self.recognizer.name()
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn test_rsa_pem_private_key_block() {
+		let recognizer = PrivateKeyRecognizer::new();
+
+		let text = "Here is a key:\n-----BEGIN RSA PRIVATE KEY-----\nMIIFakeBASE64garbageDATAxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\nAAAAfakefakefakefakefakefakefakefakefakefakefakefakefakefakefa\nkefakefakefakefakefakefakefakefakefakefakefakefakefakefake==\n-----END RSA PRIVATE KEY-----\nend of message";
+
+		let results = recognizer.recognize(text);
+
+		assert!(!results.is_empty());
+		for result in &results {
+			assert!(result.score > 0.0);
+			assert!(result.matched.contains("BEGIN"));
+			assert!(result.matched.contains("END"));
+		}
+	}
+
+	#[test]
+	fn test_openssh_private_key_block() {
+		let recognizer = PrivateKeyRecognizer::new();
+
+		let text = "-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1mYWtlZmFrZWZha2VmYWtlZmFrZWZha2VmYWtlZmFrZWZha2VmYWtl\nZmFrZWZha2VmYWtlZmFrZWZha2VmYWtlZmFrZWZha2VmYWtlZmFrZWZha2VmYWtl\n-----END OPENSSH PRIVATE KEY-----";
+
+		let results = recognizer.recognize(text);
+
+		assert!(!results.is_empty());
+		for result in &results {
+			assert!(result.score > 0.0);
+			assert!(result.matched.contains("BEGIN"));
+			assert!(result.matched.contains("END"));
+		}
+	}
+
+	#[test]
+	fn test_pgp_private_key_block() {
+		let recognizer = PrivateKeyRecognizer::new();
+
+		let text = "-----BEGIN PGP PRIVATE KEY BLOCK-----\nVersion: FakeGPG v1\n\nlQFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFake\nFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFake==\n-----END PGP PRIVATE KEY BLOCK-----";
+
+		let results = recognizer.recognize(text);
+
+		assert!(!results.is_empty());
+		for result in &results {
+			assert!(result.score > 0.0);
+			assert!(result.matched.contains("BEGIN"));
+			assert!(result.matched.contains("END"));
+		}
+	}
+
+	#[test]
+	fn test_no_false_positive_on_plain_text() {
+		let recognizer = PrivateKeyRecognizer::new();
+
+		let text = "This is just a normal sentence about my private key management process.";
+		let results = recognizer.recognize(text);
+
+		assert!(results.is_empty());
+	}
+}

--- a/crates/agentgateway/src/llm/policy/pii/slack_token_recognizer.rs
+++ b/crates/agentgateway/src/llm/policy/pii/slack_token_recognizer.rs
@@ -1,0 +1,92 @@
+use crate::llm::policy::pii::pattern_recognizer::PatternRecognizer;
+use crate::llm::policy::pii::recognizer::Recognizer;
+
+pub struct SlackTokenRecognizer {
+	recognizer: PatternRecognizer,
+}
+
+impl SlackTokenRecognizer {
+	pub fn new() -> Self {
+		let mut recognizer = PatternRecognizer::new(
+			"SLACK_TOKEN",
+			vec![
+				"slack".to_string(),
+				"token".to_string(),
+				"webhook".to_string(),
+			],
+		);
+		recognizer.add_pattern(
+			"SLACK_API_TOKEN",
+			r"\bxox[baprs]-[0-9A-Za-z-]{10,72}\b",
+			0.85,
+		);
+		recognizer.add_pattern(
+			"SLACK_WEBHOOK_URL",
+			r"\bhttps://hooks\.slack\.com/services/[A-Za-z0-9]+/[A-Za-z0-9]+/[A-Za-z0-9]+\b",
+			0.9,
+		);
+
+		Self { recognizer }
+	}
+}
+
+impl Recognizer for SlackTokenRecognizer {
+	fn recognize(&self, text: &str) -> Vec<super::recognizer_result::RecognizerResult> {
+		self.recognizer.recognize(text)
+	}
+	fn name(&self) -> &str {
+		self.recognizer.name()
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn test_slack_bot_token_detected() {
+		let recognizer = SlackTokenRecognizer::new();
+		// Deliberately non-standard segment shapes (real Slack tokens use
+		// digit-digit-alnum groups) so this doesn't trip secret-scanning push
+		// protection while still exercising our (intentionally lenient) pattern.
+		let text =
+			"Our slack token is xoxb-notarealteam-notarealbotuser-notarealsecretvalue, keep it secret.";
+		let results = recognizer.recognize(text);
+
+		assert!(!results.is_empty());
+		for result in &results {
+			assert!(result.score > 0.0);
+		}
+		assert!(
+			results
+				.iter()
+				.any(|r| r.matched.starts_with("xoxb-notarealteam"))
+		);
+	}
+
+	#[test]
+	fn test_slack_webhook_url_detected() {
+		let recognizer = SlackTokenRecognizer::new();
+		let text = "Send messages via this webhook: https://hooks.slack.com/services/notarealteam/notarealbotuser/notarealsecretvalue";
+		let results = recognizer.recognize(text);
+
+		assert!(!results.is_empty());
+		for result in &results {
+			assert!(result.score > 0.0);
+		}
+		assert!(
+			results
+				.iter()
+				.any(|r| r.matched.contains("hooks.slack.com/services"))
+		);
+	}
+
+	#[test]
+	fn test_plain_sentence_no_matches() {
+		let recognizer = SlackTokenRecognizer::new();
+		let text = "This is just a plain sentence with no secrets or tokens in it.";
+		let results = recognizer.recognize(text);
+
+		assert!(results.is_empty());
+	}
+}

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -3452,6 +3452,27 @@ fn convert_regex_rules(
 							proto::agent::backend_policy_spec::ai::BuiltinRegexRule::CaSin => {
 								llm::policy::Builtin::CaSin
 							},
+							proto::agent::backend_policy_spec::ai::BuiltinRegexRule::ApiKey => {
+								llm::policy::Builtin::ApiKey
+							},
+							proto::agent::backend_policy_spec::ai::BuiltinRegexRule::PrivateKey => {
+								llm::policy::Builtin::PrivateKey
+							},
+							proto::agent::backend_policy_spec::ai::BuiltinRegexRule::GithubToken => {
+								llm::policy::Builtin::GithubToken
+							},
+							proto::agent::backend_policy_spec::ai::BuiltinRegexRule::AwsAccessKey => {
+								llm::policy::Builtin::AwsAccessKey
+							},
+							proto::agent::backend_policy_spec::ai::BuiltinRegexRule::SlackToken => {
+								llm::policy::Builtin::SlackToken
+							},
+							proto::agent::backend_policy_spec::ai::BuiltinRegexRule::Jwt => {
+								llm::policy::Builtin::Jwt
+							},
+							proto::agent::backend_policy_spec::ai::BuiltinRegexRule::GcpApiKey => {
+								llm::policy::Builtin::GcpApiKey
+							},
 							_ => {
 								diagnostics.add_warning(format!("unknown builtin regex rule value {b}; skipping"));
 								return None;

--- a/crates/protos/proto/resource.proto
+++ b/crates/protos/proto/resource.proto
@@ -1184,6 +1184,13 @@ message BackendPolicySpec {
       PHONE_NUMBER = 3;
       EMAIL = 4;
       CA_SIN = 5;
+      API_KEY = 6;
+      PRIVATE_KEY = 7;
+      GITHUB_TOKEN = 8;
+      AWS_ACCESS_KEY = 9;
+      SLACK_TOKEN = 10;
+      JWT = 11;
+      GCP_API_KEY = 12;
     }
 
     message RegexRule {

--- a/schema/config.json
+++ b/schema/config.json
@@ -4585,6 +4585,41 @@
           "description": "Canadian Social Insurance Number pattern.",
           "type": "string",
           "const": "caSin"
+        },
+        {
+          "description": "Generic API key pattern.",
+          "type": "string",
+          "const": "apiKey"
+        },
+        {
+          "description": "Private key (PEM/PGP block) pattern.",
+          "type": "string",
+          "const": "privateKey"
+        },
+        {
+          "description": "GitHub token pattern.",
+          "type": "string",
+          "const": "githubToken"
+        },
+        {
+          "description": "AWS access key ID pattern.",
+          "type": "string",
+          "const": "awsAccessKey"
+        },
+        {
+          "description": "Slack token pattern.",
+          "type": "string",
+          "const": "slackToken"
+        },
+        {
+          "description": "JSON Web Token pattern.",
+          "type": "string",
+          "const": "jwt"
+        },
+        {
+          "description": "GCP API key pattern.",
+          "type": "string",
+          "const": "gcpApiKey"
         }
       ]
     },

--- a/ui/src/pages/Guardrails.tsx
+++ b/ui/src/pages/Guardrails.tsx
@@ -47,7 +47,19 @@ import bedrockIcon from "../assets/providers/bedrock.svg";
 import googleCloudIcon from "../assets/providers/googlecloud.svg";
 import openAiIcon from "../assets/providers/openai.svg";
 
-type BuiltinRule = "ssn" | "creditCard" | "phoneNumber" | "email" | "caSin";
+type BuiltinRule =
+  | "ssn"
+  | "creditCard"
+  | "phoneNumber"
+  | "email"
+  | "caSin"
+  | "apiKey"
+  | "privateKey"
+  | "githubToken"
+  | "awsAccessKey"
+  | "slackToken"
+  | "jwt"
+  | "gcpApiKey";
 type GuardPhase = "request" | "response";
 type GuardObject = NonNullable<LlmGuardrail["request"]>[number];
 type GuardKind =
@@ -134,6 +146,13 @@ const builtinOptions: Array<{ value: BuiltinRule; label: string }> = [
   { value: "creditCard", label: "Credit card" },
   { value: "ssn", label: "SSN" },
   { value: "caSin", label: "CA SIN" },
+  { value: "apiKey", label: "API key" },
+  { value: "privateKey", label: "Private key" },
+  { value: "githubToken", label: "GitHub token" },
+  { value: "awsAccessKey", label: "AWS access key" },
+  { value: "slackToken", label: "Slack token" },
+  { value: "jwt", label: "JWT" },
+  { value: "gcpApiKey", label: "GCP API key" },
 ];
 
 const requestGuardKinds: Array<EnumSelectorOption<GuardKind>> = [


### PR DESCRIPTION
## Summary
- Adds 7 new built-in regex-based secret detectors to the LLM prompt/response guardrails `regex.rules[].builtin` list, alongside the existing SSN/credit card/phone/email/CA SIN detectors:
  - Generic API key (OpenAI-style, Stripe live/test, generic `api_key=...` assignment, Bearer token)
  - Private key (PEM and PGP private key blocks)
  - GitHub token (`ghp_`, `gho_`, `ghu_`, `ghs_`, `ghr_`, `github_pat_`)
  - AWS access key ID (`AKIA`/`ASIA`)
  - Slack token (`xox[baprs]-...`) and incoming webhook URLs
  - JWT
  - GCP API key (`AIza...`)
- Each detector is implemented as its own `Recognizer` in `crates/agentgateway/src/llm/policy/pii/`, following the existing pattern (`PatternRecognizer` + regex/score pairs), with self-contained unit tests using synthetic fixtures.
- Wired through the `Builtin` enum, the `BuiltinRegexRule` proto enum, xDS conversion, and the UI's built-in detector dropdown (`ui/src/pages/Guardrails.tsx`).
- Regenerated `schema/config.json` / `schema/config.md` via `cargo xtask schema`.

## Test plan
- [x] `cargo test -p agentgateway llm::policy::pii::` — 37/37 passing (includes all 7 new recognizers plus existing ones)
- [x] `cargo build -p agentgateway`
- [x] `cd ui && npm run typecheck`
- [x] Verified `schema/config.json` / `schema/config.md` diffs only add the new `Builtin` enum entries