### PR TITLE
fix(llm): normalize missing tool_call_id before Bedrock translation

### DIFF
--- a/crates/agentgateway/src/llm/conversion/bedrock.rs
+++ b/crates/agentgateway/src/llm/conversion/bedrock.rs
@@ -563,7 +563,7 @@ pub mod from_completions {
 		headers: Option<&http::HeaderMap>,
 		prompt_caching: Option<&crate::llm::policy::PromptCachingConfig>,
 	) -> Result<super::BedrockRequest, AIError> {
-		let typed = json::convert::<_, completions::Request>(req).map_err(AIError::RequestParsing)?;
+		let typed = req.to_typed_request()?;
 		let model_id = typed.model.clone().unwrap_or_default();
 		let (xlated, tool_name_map) =
 			translate_internal(typed, model_id, provider, headers, prompt_caching);

--- a/crates/agentgateway/src/llm/conversion/bedrock_tests.rs
+++ b/crates/agentgateway/src/llm/conversion/bedrock_tests.rs
@@ -1694,3 +1694,35 @@ fn test_messages_long_tool_name_round_trip_response() {
 
 	assert_eq!(tool_use_name, long_name);
 }
+
+#[test]
+fn test_to_typed_request_fills_missing_tool_call_id() {
+	let req: types::completions::Request = serde_json::from_value(json!({
+		"model": "claude",
+		"messages": [
+			{"role": "user", "content": "check status"},
+			{
+				"role": "assistant",
+				"content": null,
+				"tool_calls": [{
+					"id": "call_abc",
+					"type": "function",
+					"function": {"name": "k8s_get_resources", "arguments": "{}"}
+				}]
+			},
+			{"role": "tool", "name": "k8s_get_resources", "content": "pod-1 Running"}
+		]
+	}))
+	.expect("valid loose completions request");
+
+	let typed = req
+		.to_typed_request()
+		.expect("tool messages without tool_call_id should be normalized");
+
+	match &typed.messages[2] {
+		types::completions::typed::RequestMessage::Tool(tool) => {
+			assert_eq!(tool.tool_call_id, "call_abc");
+		},
+		other => panic!("expected tool message, got {other:?}"),
+	}
+}

--- a/crates/agentgateway/src/llm/conversion/bedrock_tests.rs
+++ b/crates/agentgateway/src/llm/conversion/bedrock_tests.rs
@@ -1695,29 +1695,139 @@ fn test_messages_long_tool_name_round_trip_response() {
 	assert_eq!(tool_use_name, long_name);
 }
 
+fn loose_tool_call_request(messages: serde_json::Value) -> types::completions::Request {
+	serde_json::from_value(json!({
+		"model": "claude",
+		"messages": messages
+	}))
+	.expect("valid loose completions request")
+}
+
 #[test]
 fn test_to_typed_request_fills_missing_tool_call_id() {
-	let req: types::completions::Request = serde_json::from_value(json!({
-		"model": "claude",
-		"messages": [
-			{"role": "user", "content": "check status"},
-			{
-				"role": "assistant",
-				"content": null,
-				"tool_calls": [{
-					"id": "call_abc",
-					"type": "function",
-					"function": {"name": "k8s_get_resources", "arguments": "{}"}
-				}]
-			},
-			{"role": "tool", "name": "k8s_get_resources", "content": "pod-1 Running"}
-		]
-	}))
-	.expect("valid loose completions request");
+	let req = loose_tool_call_request(json!([
+		{"role": "user", "content": "check status"},
+		{
+			"role": "assistant",
+			"content": null,
+			"tool_calls": [{
+				"id": "call_abc",
+				"type": "function",
+				"function": {"name": "k8s_get_resources", "arguments": "{}"}
+			}]
+		},
+		{"role": "tool", "name": "k8s_get_resources", "content": "pod-1 Running"}
+	]));
 
 	let typed = req
 		.to_typed_request()
 		.expect("tool messages without tool_call_id should be normalized");
+
+	match &typed.messages[2] {
+		types::completions::typed::RequestMessage::Tool(tool) => {
+			assert_eq!(tool.tool_call_id, "call_abc");
+		},
+		other => panic!("expected tool message, got {other:?}"),
+	}
+}
+
+#[test]
+fn test_to_typed_request_fills_parallel_missing_tool_call_ids() {
+	let req = loose_tool_call_request(json!([
+		{"role": "user", "content": "check status"},
+		{
+			"role": "assistant",
+			"content": null,
+			"tool_calls": [
+				{
+					"id": "call_1",
+					"type": "function",
+					"function": {"name": "tool_a", "arguments": "{}"}
+				},
+				{
+					"id": "call_2",
+					"type": "function",
+					"function": {"name": "tool_b", "arguments": "{}"}
+				}
+			]
+		},
+		{"role": "tool", "name": "tool_a", "content": "a"},
+		{"role": "tool", "name": "tool_b", "content": "b"}
+	]));
+
+	let typed = req.to_typed_request().expect("parallel tool ids should normalize");
+
+	match (&typed.messages[2], &typed.messages[3]) {
+		(
+			types::completions::typed::RequestMessage::Tool(first),
+			types::completions::typed::RequestMessage::Tool(second),
+		) => {
+			assert_eq!(first.tool_call_id, "call_1");
+			assert_eq!(second.tool_call_id, "call_2");
+		},
+		other => panic!("expected tool messages, got {other:?}"),
+	}
+}
+
+#[test]
+fn test_to_typed_request_mixed_explicit_and_missing_tool_call_ids() {
+	let req = loose_tool_call_request(json!([
+		{"role": "user", "content": "check status"},
+		{
+			"role": "assistant",
+			"content": null,
+			"tool_calls": [
+				{
+					"id": "call_1",
+					"type": "function",
+					"function": {"name": "tool_a", "arguments": "{}"}
+				},
+				{
+					"id": "call_2",
+					"type": "function",
+					"function": {"name": "tool_b", "arguments": "{}"}
+				}
+			]
+		},
+		{"role": "tool", "tool_call_id": "call_1", "name": "tool_a", "content": "a"},
+		{"role": "tool", "name": "tool_b", "content": "b"}
+	]));
+
+	let typed = req
+		.to_typed_request()
+		.expect("mixed explicit and inferred tool ids should normalize");
+
+	match (&typed.messages[2], &typed.messages[3]) {
+		(
+			types::completions::typed::RequestMessage::Tool(first),
+			types::completions::typed::RequestMessage::Tool(second),
+		) => {
+			assert_eq!(first.tool_call_id, "call_1");
+			assert_eq!(second.tool_call_id, "call_2");
+		},
+		other => panic!("expected tool messages, got {other:?}"),
+	}
+}
+
+#[test]
+fn test_to_typed_request_reads_call_id_from_rest() {
+	let req = loose_tool_call_request(json!([
+		{"role": "user", "content": "check status"},
+		{
+			"role": "assistant",
+			"content": null,
+			"tool_calls": [{
+				"id": "call_abc",
+				"type": "function",
+				"function": {"name": "tool_a", "arguments": "{}"}
+			}]
+		},
+		{"role": "tool", "call_id": "call_abc", "name": "tool_a", "content": "done"}
+	]));
+
+	let typed = req
+		.to_typed_request()
+		.expect("call_id in rest should satisfy typed parsing");
 
 	match &typed.messages[2] {
 		types::completions::typed::RequestMessage::Tool(tool) => {

--- a/crates/agentgateway/src/llm/types/completions.rs
+++ b/crates/agentgateway/src/llm/types/completions.rs
@@ -65,6 +65,62 @@ impl Request {
 			.as_deref()
 			.is_some_and(|model| model.starts_with("gpt-"))
 	}
+
+	/// Ensure tool messages carry a `tool_call_id` before converting to the tagged
+	/// async-openai message enum (which requires the field).
+	pub fn normalize_tool_message_ids(&mut self) {
+		let mut pending_tool_call_ids: Vec<String> = Vec::new();
+
+		for msg in &mut self.messages {
+			match msg.role.as_str() {
+				"assistant" => {
+					pending_tool_call_ids = extract_tool_call_ids(&msg.tool_calls);
+				},
+				"tool" => {
+					if msg.tool_call_id.is_none() {
+						msg.tool_call_id = extract_tool_call_id_from_value(&msg.rest);
+					}
+					if msg.tool_call_id.is_none() && !pending_tool_call_ids.is_empty() {
+						msg.tool_call_id = Some(pending_tool_call_ids.remove(0));
+					}
+				},
+				_ => {
+					pending_tool_call_ids.clear();
+				},
+			}
+		}
+	}
+
+	pub fn to_typed_request(&self) -> Result<typed::Request, AIError> {
+		let mut normalized = self.clone();
+		normalized.normalize_tool_message_ids();
+		json::convert::<_, typed::Request>(&normalized).map_err(AIError::RequestParsing)
+	}
+}
+
+fn extract_tool_call_ids(tool_calls: &Option<Vec<serde_json::Value>>) -> Vec<String> {
+	tool_calls
+		.iter()
+		.flatten()
+		.filter_map(|tool_call| {
+			tool_call
+				.get("id")
+				.and_then(serde_json::Value::as_str)
+				.map(ToString::to_string)
+		})
+		.collect()
+}
+
+fn extract_tool_call_id_from_value(value: &serde_json::Value) -> Option<String> {
+	if !value.is_object() {
+		return None;
+	}
+	for key in ["tool_call_id", "call_id", "id"] {
+		if let Some(id) = value.get(key).and_then(serde_json::Value::as_str) {
+			return Some(id.to_string());
+		}
+	}
+	None
 }
 
 /// Options for streaming response. Only set this when you set `stream: true`.
@@ -402,7 +458,12 @@ impl TryInto<typed::Request> for &Request {
 	type Error = AIError;
 
 	fn try_into(self) -> Result<typed::Request, Self::Error> {
-		json::convert::<_, typed::Request>(self).map_err(AIError::RequestMarshal)
+		self
+			.to_typed_request()
+			.map_err(|err| match err {
+				AIError::RequestParsing(err) => AIError::RequestMarshal(err),
+				other => other,
+			})
 	}
 }
 

--- a/crates/agentgateway/src/llm/types/completions.rs
+++ b/crates/agentgateway/src/llm/types/completions.rs
@@ -68,6 +68,10 @@ impl Request {
 
 	/// Ensure tool messages carry a `tool_call_id` before converting to the tagged
 	/// async-openai message enum (which requires the field).
+	///
+	/// When clients omit `tool_call_id`, IDs are inferred from the most recent
+	/// assistant `tool_calls` in FIFO order. Tool results are assumed to appear in
+	/// the same order as the assistant's `tool_calls` list.
 	pub fn normalize_tool_message_ids(&mut self) {
 		let mut pending_tool_call_ids: Vec<String> = Vec::new();
 
@@ -80,7 +84,11 @@ impl Request {
 					if msg.tool_call_id.is_none() {
 						msg.tool_call_id = extract_tool_call_id_from_value(&msg.rest);
 					}
-					if msg.tool_call_id.is_none() && !pending_tool_call_ids.is_empty() {
+					if let Some(id) = msg.tool_call_id.as_ref() {
+						if let Some(pos) = pending_tool_call_ids.iter().position(|p| p == id) {
+							pending_tool_call_ids.remove(pos);
+						}
+					} else if !pending_tool_call_ids.is_empty() {
 						msg.tool_call_id = Some(pending_tool_call_ids.remove(0));
 					}
 				},


### PR DESCRIPTION
## Summary

Normalize OpenAI-format tool result messages that omit `tool_call_id` before converting to the typed async-openai request model used for Bedrock translation.

## Motivation

Fixes #2403. Multi-turn tool conversations proxied to Bedrock failed with:

`failed to parse request: missing field tool_call_id`

when clients (e.g. kagent multi-agent orchestration) sent `role: tool` messages without an explicit `tool_call_id`, even though the preceding assistant message contained the matching `tool_calls` IDs.

## Changes

- Add `Request::normalize_tool_message_ids()` to infer missing IDs from:
  - preceding assistant `tool_calls` (FIFO, with explicit-ID dequeuing)
  - alternate flattened fields (`tool_call_id`, `call_id`, `id`)
- Add `Request::to_typed_request()` and route Bedrock completions translation through it
- Update `TryInto<typed::Request>` to use the same normalization path
- Add regression tests for single, parallel, mixed explicit/inferred, and `call_id` fallback cases

## Tests

```bash
cargo test -p agentgateway test_to_typed_request_
```

All 4 new tests pass.

## Notes

- Tool results are assumed to appear in the same order as the assistant `tool_calls` list when IDs are inferred.
- Anthropic/messages conversion paths still use raw `json::convert` and may need a follow-up if the same client behavior appears there.