### PR TITLE
fix(mcp): skip upstream JSON-RPC error frames in FailOpen fanout merge

### DIFF
--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -3187,10 +3187,12 @@ async fn test_runtime_fanout_fail_open_skips_jsonrpc_error_frames() {
 
 	let streams = vec![("ok".into(), ok_stream), ("bad".into(), err_stream)];
 
-	let merge = Box::new(|results: Vec<(Strng, rmcp::model::ServerResult)>, _cel: &_| {
-		assert_eq!(results.len(), 1);
-		Ok(results.into_iter().next().unwrap().1)
-	});
+	let merge = Box::new(
+		|results: Vec<(Strng, rmcp::model::ServerResult)>, _cel: &_| {
+			assert_eq!(results.len(), 1);
+			Ok(results.into_iter().next().unwrap().1)
+		},
+	);
 
 	let mut ms = MergeStream::new(
 		streams,

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -3166,6 +3166,51 @@ async fn test_runtime_fanout_fail_open() {
 }
 
 #[tokio::test]
+async fn test_runtime_fanout_fail_open_skips_jsonrpc_error_frames() {
+	use futures_util::StreamExt;
+	use rmcp::model::{ErrorData, ListToolsResult, RequestId, ServerJsonRpcMessage};
+
+	use crate::mcp::mergestream::{MergeStream, Messages};
+
+	let ok_msg = ServerJsonRpcMessage::response(
+		rmcp::model::ServerResult::ListToolsResult(ListToolsResult {
+			tools: vec![],
+			..Default::default()
+		}),
+		RequestId::Number(1),
+	);
+	let ok_stream = Messages::from(ok_msg);
+	let err_stream = Messages::from(Ok(ServerJsonRpcMessage::error(
+		ErrorData::internal_error("failed to unmarshal response: no result in response", None),
+		Some(RequestId::Number(1)),
+	)));
+
+	let streams = vec![("ok".into(), ok_stream), ("bad".into(), err_stream)];
+
+	let merge = Box::new(|results: Vec<(Strng, rmcp::model::ServerResult)>, _cel: &_| {
+		assert_eq!(results.len(), 1);
+		Ok(results.into_iter().next().unwrap().1)
+	});
+
+	let mut ms = MergeStream::new(
+		streams,
+		RequestId::Number(1),
+		merge,
+		empty_cel(),
+		FailureMode::FailOpen,
+	);
+
+	let res = ms.next().await;
+	assert!(res.is_some());
+	let res = res.unwrap();
+	assert!(
+		res.is_ok(),
+		"expected merged success with FailOpen when one upstream returns a JSON-RPC error frame: {:?}",
+		res.err()
+	);
+}
+
+#[tokio::test]
 async fn test_runtime_fanout_fail_open_all_fail() {
 	use futures_util::StreamExt;
 	use rmcp::model::{ListToolsResult, RequestId};

--- a/crates/agentgateway/src/mcp/mergestream.rs
+++ b/crates/agentgateway/src/mcp/mergestream.rs
@@ -202,6 +202,18 @@ impl Stream for MergeStream {
 							self.terminal_messages[i] = Some((k, r.result));
 							// This stream is done, never look at it again
 						},
+						Ok(ServerJsonRpcMessage::Error(e)) => {
+							if self.failure_mode == FailureMode::FailOpen {
+								warn!(
+									"upstream JSON-RPC error, skipping (failure_mode=FailOpen): {:?}",
+									e
+								);
+								drop = true;
+							} else {
+								self.complete = true;
+								return Poll::Ready(Some(Ok(ServerJsonRpcMessage::Error(e))));
+							}
+						},
 						Err(e) => {
 							if self.failure_mode == FailureMode::FailOpen {
 								warn!(


### PR DESCRIPTION
## Summary

Prevent FailOpen MCP group fanout from emitting duplicate JSON-RPC responses when an upstream returns a JSON-RPC error frame before the merged success result.

## Motivation

Fixes #2421. Under `failureMode: FailOpen`, a malformed upstream response produced two `data:` frames for the same request id (error, then merged result). Spec-compliant MCP clients latch onto the first frame and treat the session as failed.

`MergeStream` already skipped transport-level `Err(...)` items in FailOpen mode, but `Ok(ServerJsonRpcMessage::Error(...))` frames were forwarded immediately via the catch-all arm.

## Changes

- Handle upstream JSON-RPC error frames in `MergeStream::poll_next`:
  - **FailOpen**: log, drop the upstream, continue merging successful results
  - **FailClosed**: short-circuit and return the error frame
- Add regression test `test_runtime_fanout_fail_open_skips_jsonrpc_error_frames`

## Tests

```bash
cargo test runtime_fanout_fail_open --package agentgateway
```

Result: **3 passed** (including new regression test)

## Notes

- Minimal change localized to fanout merge behavior; no API changes.
- DCO sign-off included in commit.

Fixes #2421
Fixes https://github.com/agentgateway/agentgateway/issues/2373