### PR TITLE
docs: add Xquik remote MCP example

### DIFF
--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -56,9 +56,10 @@ backends:
     - name: xquik
       mcp:
         host: https://xquik.com/mcp
-  requestHeaderModifier:
-    set:
-      authorization: "Bearer <XQUIK_API_KEY>"
+  policies:
+    requestHeaderModifier:
+      set:
+        authorization: "Bearer <XQUIK_API_KEY>"
 ```
 
 Now that we have the gateway running, we can use the [mcpinspector](https://github.com/modelcontextprotocol/inspector) to try it out.

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -47,6 +47,20 @@ targets:
 
 When clients connect to the gateway, the `cmd` will be executed to serve the traffic.
 
+For a remote Streamable HTTP MCP server that expects a bearer token, configure an HTTP MCP target and set the upstream header on the backend:
+
+```yaml
+backends:
+- mcp:
+    targets:
+    - name: xquik
+      mcp:
+        host: https://xquik.com/mcp
+  requestHeaderModifier:
+    set:
+      authorization: "Bearer <XQUIK_API_KEY>"
+```
+
 Now that we have the gateway running, we can use the [mcpinspector](https://github.com/modelcontextprotocol/inspector) to try it out.
 ```bash
 npx @modelcontextprotocol/inspector


### PR DESCRIPTION
Summary:
- Add a remote Streamable HTTP MCP example for Xquik.
- Show how to set the upstream bearer auth header on the backend.

Validation:
- Duplicate gate: no Xquik entries in examples, no all-state PRs or issues found.
- Source truth: live Xquik MCP manifest advertises https://xquik.com/mcp with bearer API key auth.
- `git diff --check`
