### PR TITLE
ui: allow overriding playground endpoint URL

### DIFF
--- a/ui/src/pages/McpPlayground.tsx
+++ b/ui/src/pages/McpPlayground.tsx
@@ -45,6 +45,7 @@ type McpResponse = {
 
 const storageKeys = {
   tool: "mcpPlaygroundTool",
+  baseUrlOverride: "mcpPlaygroundBaseUrlOverride",
 };
 
 export function McpPlaygroundPage() {
@@ -55,7 +56,11 @@ export function McpPlaygroundPage() {
     config.data?.mcp?.port ?? 3000,
     "/mcp",
   );
-  const baseUrl = derivedBaseUrl;
+  const [baseUrlOverride, setBaseUrlOverride] = useStoredStringState(
+    storageKeys.baseUrlOverride,
+    "",
+  );
+  const baseUrl = baseUrlOverride.trim() || derivedBaseUrl;
   const [initialized, setInitialized] = useState(false);
   const [sessionId, setSessionId] = useState("");
   const [tools, setTools] = useState<McpTool[]>([]);
@@ -264,6 +269,26 @@ export function McpPlaygroundPage() {
                 spellCheck={false}
                 onChange={(event) => setBearerToken(event.target.value)}
                 placeholder="Optional token"
+              />
+            </Field>
+          </details>
+
+          <details className="schema-details mcp-endpoint-details">
+            <summary>Endpoint URL</summary>
+            <Field
+              label="MCP endpoint URL"
+              hint={`Auto-derived from config: ${derivedBaseUrl}. Leave blank to use the default; override only when the listener is exposed on a different host:port (e.g. behind a reverse proxy or a non-default docker-compose port mapping).`}
+            >
+              <input
+                type="text"
+                value={baseUrlOverride}
+                placeholder={derivedBaseUrl}
+                autoComplete="off"
+                autoCorrect="off"
+                autoCapitalize="none"
+                spellCheck={false}
+                onChange={(event) => setBaseUrlOverride(event.target.value)}
+                style={{ fontFamily: "monospace" }}
               />
             </Field>
           </details>

--- a/ui/src/pages/Playground.tsx
+++ b/ui/src/pages/Playground.tsx
@@ -105,6 +105,7 @@ const storageKeys = {
   specificModel: "playgroundSpecificModel",
   apiKeyMode: "playgroundApiKeyMode",
   selectedKey: "playgroundSelectedKeyRef",
+  llmBaseUrlOverride: "playgroundLlmBaseUrlOverride",
 };
 
 const legacySecretStorageKeys = [
@@ -162,7 +163,12 @@ export function PlaygroundPage() {
     "",
   );
   const [model, setModel] = useState(() => queryModel() ?? storedModel);
-  const llmBaseUrl = gatewayOrigin(config.data?.llm?.port ?? 4000);
+  const autoDerivedLlmBaseUrl = gatewayOrigin(config.data?.llm?.port ?? 4000);
+  const [llmBaseUrlOverride, setLlmBaseUrlOverride] = useStoredStringState(
+    storageKeys.llmBaseUrlOverride,
+    "",
+  );
+  const llmBaseUrl = llmBaseUrlOverride.trim() || autoDerivedLlmBaseUrl;
   const [specificModel, setSpecificModel] = useStoredStringState(
     storageKeys.specificModel,
     "",
@@ -702,6 +708,24 @@ export function PlaygroundPage() {
                 </label>
               </div>
             ) : null}
+          </div>
+          <div className="playground-control-row">
+            <Field
+              label="LLM endpoint URL"
+              hint={`Auto-derived from config: ${autoDerivedLlmBaseUrl}. Leave blank to use the default; override only when the listener is exposed on a different host:port (e.g. behind a reverse proxy or a non-default docker-compose port mapping).`}
+            >
+              <input
+                type="text"
+                value={llmBaseUrlOverride}
+                placeholder={autoDerivedLlmBaseUrl}
+                autoComplete="off"
+                autoCorrect="off"
+                autoCapitalize="none"
+                spellCheck={false}
+                onChange={(event) => setLlmBaseUrlOverride(event.target.value)}
+                style={{ fontFamily: "monospace" }}
+              />
+            </Field>
           </div>
           <details
             className="system-prompt-details"


### PR DESCRIPTION
Fixes the URL-unreachable bug surfaced in #2430 (standalone mode) and
#1650 (XDS mode). The admin-UI Playground derives the LLM/MCP target
URL from `config.data.<listener>.port`, which only works when the
host port equals the container port. With any port mapping
(`8201:4000`), reverse proxy, or remote-host deployment, the browser
POSTs to an unreachable port and the user has no UI way to fix it.

### What this PR changes

- `ui/src/pages/Playground.tsx`: read `playgroundLlmBaseUrlOverride`
  from localStorage; if non-empty, use it instead of
  `gatewayOrigin(config.data.llm.port ?? 4000)`. Add an editable
  "LLM endpoint URL" field whose placeholder is the auto-derived
  URL.
- `ui/src/pages/McpPlayground.tsx`: same treatment for MCP
  (`mcpPlaygroundBaseUrlOverride`). The MCP baseUrl includes the
  `/mcp` path, so the override is the full URL, not just the origin.
  Field is inside a collapsible "Endpoint URL" `<details>` so it
  doesn't crowd the main controls.
- Storage follows the existing `useStoredStringState` pattern
  (`storageKeys` map in `Playground.tsx:103`).

### Out of scope

- #1650's XDS-mode endpoint editor (second bullet: "endpoint field
  is read-only"). That lives behind `configDumpToLocalConfig` and
  needs the dump-mode URL resolution, which is a separate data path.
  This PR only addresses the standalone-mode URL derivation.
- Auto-detecting reverse-proxy hostnames. Too magical; explicit
  override is simpler and matches the existing model/apiKey override
  pattern.

### Manual test

1. Stand up the canonical quickstart compose (`docker run -p 4000:4000 -p 3000:3000 -p 15000:15000 agentgateway`).
2. Open `/ui/llm/playground`. The new "LLM endpoint URL" field shows
   the auto-derived URL as a placeholder; messages flow through.
3. Type `http://localhost:9999` into the field, send a message —
   DevTools shows the request hitting `:9999` and the response is
   whatever's there.
4. Clear the override (empty string), send another message — the
   auto-derived URL is restored.
5. Repeat for the MCP Playground: "Endpoint URL" collapsible now
   appears below "Authorization header".

### Verification

- `npm run lint` (typecheck + format:check): clean
- `npm run build` (vite build): clean
- `npm run generate-schema`: clean

I did not run `npm run test:e2e` (Playwright not configured in this
dev env). Manual test plan above is the next step before merge.

### Checklist

- [x] `npm run lint`
- [x] `npm run generate-schema && tsc -b`
- [x] `npm run build`
- [x] Manual test plan documented
- [ ] Manual test executed against a live gateway (need reviewer with
  a running stack)
- [ ] E2E tests added (Playwright)

Refs #2430, #1650