### PR TITLE
Bump istio version to fix broken startup due to TCPRoute 1.6.0

### DIFF
--- a/controller/hack/utils/oss_compliance/osa_provided.md
+++ b/controller/hack/utils/oss_compliance/osa_provided.md
@@ -40,7 +40,7 @@ Name|Version|License
 [helm/v4](https://helm.sh/helm/v4)|v4.2.2|Apache License 2.0
 [istio.io/api](https://istio.io/api)|v1.30.0-alpha.1.0.20260626010135-ac56ebb29e59|Apache License 2.0
 [istio.io/client-go](https://istio.io/client-go)|v1.30.0-beta.0|Apache License 2.0
-[istio.io/istio](https://istio.io/istio)|v0.0.0-20260701162249-99f2f4f55d5c|Apache License 2.0
+[istio.io/istio](https://istio.io/istio)|v0.0.0-20260704181517-116e8ec30db4|Apache License 2.0
 [k8s.io/api](https://k8s.io/api)|v0.36.2|Apache License 2.0
 [k8s.io/apiextensions-apiserver](https://k8s.io/apiextensions-apiserver)|v0.36.2|Apache License 2.0
 [k8s.io/apimachinery](https://k8s.io/apimachinery)|v0.36.2|Apache License 2.0
@@ -50,10 +50,10 @@ Name|Version|License
 [k8s.io/utils](https://k8s.io/utils)|v0.0.0-20260626114624-be93311217bd|Apache License 2.0
 [sigs.k8s.io/controller-runtime](https://sigs.k8s.io/controller-runtime)|v0.24.1|Apache License 2.0
 [sigs.k8s.io/controller-tools](https://sigs.k8s.io/controller-tools)|v0.21.0|Apache License 2.0
-[sigs.k8s.io/gateway-api](https://sigs.k8s.io/gateway-api)|v1.6.0-rc.1|Apache License 2.0
+[sigs.k8s.io/gateway-api](https://sigs.k8s.io/gateway-api)|v1.6.0|Apache License 2.0
 [sigs.k8s.io/gateway-api-inference-extension](https://sigs.k8s.io/gateway-api-inference-extension)|v1.5.0|Apache License 2.0
 [gateway-api-inference-extension/conformance](https://sigs.k8s.io/gateway-api-inference-extension/conformance)|v0.0.0-20260610234253-d7447d7420de|Apache License 2.0
-[gateway-api/conformance](https://sigs.k8s.io/gateway-api/conformance)|v1.6.0-rc.1|Apache License 2.0
+[gateway-api/conformance](https://sigs.k8s.io/gateway-api/conformance)|v1.6.0|Apache License 2.0
 [sigs.k8s.io/yaml](https://sigs.k8s.io/yaml)|v1.6.0|MIT License
 [cmd/goimports](https://golang.org/x/tools/cmd/goimports)|latest|MIT License
 [gogo/protobuf](https://github.com/gogo/protobuf)|latest|MIT License

--- a/controller/test/conformance/conformance_helpers_test.go
+++ b/controller/test/conformance/conformance_helpers_test.go
@@ -41,6 +41,36 @@ func TestChooseMetallbAddressSkipsUsedAndIPv6Addresses(t *testing.T) {
 	require.Equal(t, "192.0.2.11", got)
 }
 
+func TestChooseMetallbAddressRejectsStaticAutoAssignedOverlap(t *testing.T) {
+	_, err := chooseMetallbAddress([]metalLBAddressPool{
+		{
+			name:       "default",
+			autoAssign: true,
+			addresses:  []string{"192.0.2.10", "192.0.2.11"},
+		},
+		{
+			name:       "static",
+			autoAssign: false,
+			addresses:  []string{"192.0.2.10"},
+		},
+	}, nil)
+
+	require.ErrorContains(t, err, "non-auto-assigned")
+}
+
+func TestChooseMetallbAddressFallsBackToAutoAssignedPool(t *testing.T) {
+	got, err := chooseMetallbAddress([]metalLBAddressPool{
+		{
+			name:       "default",
+			autoAssign: true,
+			addresses:  []string{"192.0.2.10"},
+		},
+	}, nil)
+
+	require.NoError(t, err)
+	require.Equal(t, "192.0.2.10", got)
+}
+
 func TestCandidateIPv4Addresses(t *testing.T) {
 	require.Equal(t, []string{"192.0.2.9", "192.0.2.1"}, candidateIPv4Addresses("192.0.2.1-192.0.2.9"))
 	require.Equal(t, []string{"192.0.2.7"}, candidateIPv4Addresses("192.0.2.4/30"))

--- a/controller/test/conformance/conformance_helpers_test.go
+++ b/controller/test/conformance/conformance_helpers_test.go
@@ -1,0 +1,48 @@
+//go:build conformance
+
+package conformance_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestChooseMetallbAddressPrefersStaticOnlyPool(t *testing.T) {
+	got, err := chooseMetallbAddress([]metalLBAddressPool{
+		{
+			name:       "default",
+			autoAssign: true,
+			addresses:  []string{"192.0.2.10"},
+		},
+		{
+			name:       "static",
+			autoAssign: false,
+			addresses:  []string{"192.0.2.20"},
+		},
+	}, nil)
+
+	require.NoError(t, err)
+	require.Equal(t, "192.0.2.20", got)
+}
+
+func TestChooseMetallbAddressSkipsUsedAndIPv6Addresses(t *testing.T) {
+	got, err := chooseMetallbAddress([]metalLBAddressPool{
+		{
+			name:       "static",
+			autoAssign: false,
+			addresses:  []string{"2001:db8::1", "192.0.2.10", "192.0.2.11"},
+		},
+	}, map[string]struct{}{
+		"192.0.2.10": {},
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "192.0.2.11", got)
+}
+
+func TestCandidateIPv4Addresses(t *testing.T) {
+	require.Equal(t, []string{"192.0.2.9", "192.0.2.1"}, candidateIPv4Addresses("192.0.2.1-192.0.2.9"))
+	require.Equal(t, []string{"192.0.2.7"}, candidateIPv4Addresses("192.0.2.4/30"))
+	require.Nil(t, candidateIPv4Addresses("2001:db8::1"))
+}

--- a/controller/test/conformance/conformance_test.go
+++ b/controller/test/conformance/conformance_test.go
@@ -5,10 +5,13 @@ package conformance_test
 import (
 	"context"
 	"fmt"
+	"net/netip"
+	"slices"
 	"strings"
 	"testing"
 
 	"istio.io/istio/pkg/ptr"
+	corev1 "k8s.io/api/core/v1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -201,28 +204,38 @@ func guessFromIPAddressPool(cfg *rest.Config) (string, error) {
 		Resource: "ipaddresspools",
 	}
 
-	pools, err := dynamicClient.Resource(gvr).List(context.Background(), metav1.ListOptions{})
+	poolList, err := dynamicClient.Resource(gvr).List(context.Background(), metav1.ListOptions{})
 	if err != nil {
 		return "", fmt.Errorf("failed to list IPAddressPools: %w", err)
 	}
 
-	// Collect all address strings
-	var allAddresses []string
-	for _, pool := range pools.Items {
+	usedAddresses, err := usedLoadBalancerAddresses(cfg)
+	if err != nil {
+		return "", fmt.Errorf("failed to list used LoadBalancer addresses: %w", err)
+	}
+
+	var pools []metalLBAddressPool
+	for _, pool := range poolList.Items {
 		addresses, found, err := unstructured.NestedStringSlice(pool.Object, "spec", "addresses")
 		if err != nil || !found || len(addresses) == 0 {
 			continue
 		}
-		allAddresses = append(allAddresses, addresses...)
+		autoAssign, found, err := unstructured.NestedBool(pool.Object, "spec", "autoAssign")
+		if err != nil {
+			return "", fmt.Errorf("failed to read autoAssign for IPAddressPool %s: %w", pool.GetName(), err)
+		}
+		pools = append(pools, metalLBAddressPool{
+			name:       pool.GetName(),
+			addresses:  addresses,
+			autoAssign: !found || autoAssign,
+		})
 	}
 
-	if len(allAddresses) == 0 {
+	if len(pools) == 0 {
 		return "", fmt.Errorf("no addresses found in IPAddressPool resources")
 	}
 
-	// Pick the last address string
-	lastAddr := strings.TrimSpace(allAddresses[len(allAddresses)-1])
-	return extractLastFromAddress(lastAddr), nil
+	return chooseMetallbAddress(pools, usedAddresses)
 }
 
 // guessFromConfigMap tries to get an address from the ConfigMap format
@@ -252,40 +265,149 @@ func guessFromConfigMap(cfg *rest.Config) (string, error) {
 		return "", fmt.Errorf("failed to parse config YAML: %w", err)
 	}
 
-	// Collect all address strings
-	var allAddresses []string
+	var pools []metalLBAddressPool
 	for _, pool := range config.AddressPools {
 		if len(pool.Addresses) > 0 {
-			allAddresses = append(allAddresses, pool.Addresses...)
+			pools = append(pools, metalLBAddressPool{addresses: pool.Addresses, autoAssign: true})
 		}
 	}
 
-	if len(allAddresses) == 0 {
+	if len(pools) == 0 {
 		return "", fmt.Errorf("no addresses found in ConfigMap")
 	}
 
-	// Pick the last address string
-	lastAddr := strings.TrimSpace(allAddresses[len(allAddresses)-1])
-	// Remove trailing comma if present
-	lastAddr = strings.TrimSuffix(lastAddr, ",")
-	return extractLastFromAddress(lastAddr), nil
+	return chooseMetallbAddress(pools, nil)
 }
 
-// extractLastFromAddress extracts the last part from an address string.
-// For ranges "a-b", returns "b". For single addresses or CIDRs, returns as-is.
-func extractLastFromAddress(addr string) string {
-	addr = strings.TrimSpace(addr)
-	if strings.Contains(addr, "-") {
-		parts := strings.Split(addr, "-")
-		if len(parts) == 2 {
-			return strings.TrimSpace(parts[1])
+type metalLBAddressPool struct {
+	name       string
+	addresses  []string
+	autoAssign bool
+}
+
+func chooseMetallbAddress(pools []metalLBAddressPool, usedAddresses map[string]struct{}) (string, error) {
+	slices.SortStableFunc(pools, func(a, b metalLBAddressPool) int {
+		if a.autoAssign != b.autoAssign {
+			if !a.autoAssign {
+				return -1
+			}
+			return 1
+		}
+		return strings.Compare(a.name, b.name)
+	})
+
+	var firstAutoAssigned string
+	for _, pool := range pools {
+		for _, address := range pool.addresses {
+			for _, candidate := range candidateIPv4Addresses(address) {
+				if _, used := usedAddresses[candidate]; used {
+					continue
+				}
+				if !pool.autoAssign {
+					return candidate, nil
+				}
+				if firstAutoAssigned == "" {
+					firstAutoAssigned = candidate
+				}
+			}
 		}
 	}
-	// For CIDR or single IP, just return it
-	if strings.Contains(addr, "/") {
-		// Extract IP part from CIDR
-		parts := strings.Split(addr, "/")
-		return strings.TrimSpace(parts[0])
+	if firstAutoAssigned != "" {
+		return firstAutoAssigned, nil
 	}
-	return addr
+
+	return "", fmt.Errorf("no unused IPv4 addresses found in MetalLB address pools")
+}
+
+func candidateIPv4Addresses(address string) []string {
+	address = strings.TrimSuffix(strings.TrimSpace(address), ",")
+	if address == "" {
+		return nil
+	}
+	if strings.Contains(address, "-") {
+		parts := strings.Split(address, "-")
+		if len(parts) != 2 {
+			return nil
+		}
+		return validIPv4Candidates(strings.TrimSpace(parts[1]), strings.TrimSpace(parts[0]))
+	}
+	if strings.Contains(address, "/") {
+		prefix, err := netip.ParsePrefix(address)
+		if err != nil {
+			return nil
+		}
+		if last, ok := lastIPv4InPrefix(prefix); ok {
+			return []string{last.String()}
+		}
+		return nil
+	}
+	return validIPv4Candidates(address)
+}
+
+func validIPv4Candidates(addresses ...string) []string {
+	var candidates []string
+	for _, address := range addresses {
+		addr, err := netip.ParseAddr(address)
+		if err == nil && addr.Is4() {
+			candidates = append(candidates, addr.String())
+		}
+	}
+	return candidates
+}
+
+func lastIPv4InPrefix(prefix netip.Prefix) (netip.Addr, bool) {
+	prefix = prefix.Masked()
+	addr := prefix.Addr()
+	if !addr.Is4() {
+		return netip.Addr{}, false
+	}
+	bits := prefix.Bits()
+	if bits < 0 || bits > 32 {
+		return netip.Addr{}, false
+	}
+	raw := addr.As4()
+	value := uint32(raw[0])<<24 | uint32(raw[1])<<16 | uint32(raw[2])<<8 | uint32(raw[3])
+	hostBits := 32 - bits
+	if hostBits > 0 {
+		value |= (uint32(1) << hostBits) - 1
+	}
+	return netip.AddrFrom4([4]byte{
+		byte(value >> 24),
+		byte(value >> 16),
+		byte(value >> 8),
+		byte(value),
+	}), true
+}
+
+func usedLoadBalancerAddresses(cfg *rest.Config) (map[string]struct{}, error) {
+	clientset, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create clientset: %w", err)
+	}
+	services, err := clientset.CoreV1().Services("").List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	used := map[string]struct{}{}
+	for _, svc := range services.Items {
+		for _, ip := range serviceAddresses(svc) {
+			used[ip] = struct{}{}
+		}
+	}
+	return used, nil
+}
+
+func serviceAddresses(svc corev1.Service) []string {
+	var addresses []string
+	if svc.Spec.LoadBalancerIP != "" {
+		addresses = append(addresses, svc.Spec.LoadBalancerIP)
+	}
+	addresses = append(addresses, svc.Spec.ExternalIPs...)
+	for _, ingress := range svc.Status.LoadBalancer.Ingress {
+		if ingress.IP != "" {
+			addresses = append(addresses, ingress.IP)
+		}
+	}
+	return addresses
 }

--- a/controller/test/conformance/conformance_test.go
+++ b/controller/test/conformance/conformance_test.go
@@ -286,6 +286,20 @@ type metalLBAddressPool struct {
 }
 
 func chooseMetallbAddress(pools []metalLBAddressPool, usedAddresses map[string]struct{}) (string, error) {
+	autoAssignedCandidates := map[string]struct{}{}
+	hasStaticPool := false
+	for _, pool := range pools {
+		if !pool.autoAssign {
+			hasStaticPool = true
+			continue
+		}
+		for _, address := range pool.addresses {
+			for _, candidate := range candidateIPv4Addresses(address) {
+				autoAssignedCandidates[candidate] = struct{}{}
+			}
+		}
+	}
+
 	slices.SortStableFunc(pools, func(a, b metalLBAddressPool) int {
 		if a.autoAssign != b.autoAssign {
 			if !a.autoAssign {
@@ -304,6 +318,9 @@ func chooseMetallbAddress(pools []metalLBAddressPool, usedAddresses map[string]s
 					continue
 				}
 				if !pool.autoAssign {
+					if _, overlaps := autoAssignedCandidates[candidate]; overlaps {
+						continue
+					}
 					return candidate, nil
 				}
 				if firstAutoAssigned == "" {
@@ -311,6 +328,9 @@ func chooseMetallbAddress(pools []metalLBAddressPool, usedAddresses map[string]s
 				}
 			}
 		}
+	}
+	if hasStaticPool {
+		return "", fmt.Errorf("no unused IPv4 addresses found in non-auto-assigned MetalLB address pools")
 	}
 	if firstAutoAssigned != "" {
 		return firstAutoAssigned, nil

--- a/controller/test/setup/setup-kind-ci.sh
+++ b/controller/test/setup/setup-kind-ci.sh
@@ -129,6 +129,13 @@ step_deploy_metallb() {
     fi
   fi
 
+  # Reserve one IP from the far end before building the auto-assigned pool.
+  # GatewayStaticAddresses needs this address to remain unused until the test
+  # explicitly requests it.
+  STATIC_CONFORMANCE_INDEX=$((${#METALLB_IPS4[@]} - 1))
+  STATIC_CONFORMANCE_IP="${METALLB_IPS4[$STATIC_CONFORMANCE_INDEX]}"
+  unset 'METALLB_IPS4[$STATIC_CONFORMANCE_INDEX]'
+
   # Give this cluster some auto-assigned IPs, plus one static-only IP that
   # conformance can request without racing parallel LoadBalancer allocations.
   RANGE="["
@@ -141,8 +148,6 @@ step_deploy_metallb() {
     fi
   done
   RANGE="${RANGE%?}]"
-  STATIC_CONFORMANCE_IP="${METALLB_IPS4[1]}"
-  METALLB_IPS4=("${METALLB_IPS4[@]:1}")
 
   echo '
 apiVersion: metallb.io/v1beta1

--- a/controller/test/setup/setup-kind-ci.sh
+++ b/controller/test/setup/setup-kind-ci.sh
@@ -129,7 +129,8 @@ step_deploy_metallb() {
     fi
   fi
 
-  # Give this cluster of those IPs
+  # Give this cluster some auto-assigned IPs, plus one static-only IP that
+  # conformance can request without racing parallel LoadBalancer allocations.
   RANGE="["
   for i in {0..19}; do
     RANGE+="${METALLB_IPS4[1]},"
@@ -140,6 +141,8 @@ step_deploy_metallb() {
     fi
   done
   RANGE="${RANGE%?}]"
+  STATIC_CONFORMANCE_IP="${METALLB_IPS4[1]}"
+  METALLB_IPS4=("${METALLB_IPS4[@]:1}")
 
   echo '
 apiVersion: metallb.io/v1beta1
@@ -151,6 +154,16 @@ spec:
   addresses: '"$RANGE"'
 ---
 apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: static-conformance-pool
+  namespace: metallb-system
+spec:
+  autoAssign: false
+  addresses:
+  - '"${STATIC_CONFORMANCE_IP}"'
+---
+apiVersion: metallb.io/v1beta1
 kind: L2Advertisement
 metadata:
   name: default-l2
@@ -158,6 +171,7 @@ metadata:
 spec:
   ipAddressPools:
   - default-pool
+  - static-conformance-pool
 ' | kubectl apply -f -
 }
 

--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	helm.sh/helm/v4 v4.2.2
 	istio.io/api v1.30.0-alpha.1.0.20260626010135-ac56ebb29e59
 	istio.io/client-go v1.30.0-beta.0
-	istio.io/istio v0.0.0-20260701162249-99f2f4f55d5c
+	istio.io/istio v0.0.0-20260704181517-116e8ec30db4
 	k8s.io/api v0.36.2
 	k8s.io/apiextensions-apiserver v0.36.2
 	k8s.io/apimachinery v0.36.2
@@ -57,10 +57,10 @@ require (
 	k8s.io/utils v0.0.0-20260626114624-be93311217bd
 	sigs.k8s.io/controller-runtime v0.24.1
 	sigs.k8s.io/controller-tools v0.21.0
-	sigs.k8s.io/gateway-api v1.6.0-rc.1
+	sigs.k8s.io/gateway-api v1.6.0
 	sigs.k8s.io/gateway-api-inference-extension v1.5.0
 	sigs.k8s.io/gateway-api-inference-extension/conformance v1.5.0
-	sigs.k8s.io/gateway-api/conformance v1.6.0-rc.1
+	sigs.k8s.io/gateway-api/conformance v1.6.0
 	sigs.k8s.io/yaml v1.6.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -745,6 +745,8 @@ istio.io/client-go v1.30.0-beta.0 h1:lZhK5Kbkw0Z+lw1+zySH0m1ST1VYsMrXOpAJQdlY+T0
 istio.io/client-go v1.30.0-beta.0/go.mod h1:HRZAHMJsEmf/oDYBoCpDO9wZEEnqWeMsP20iuEA77qY=
 istio.io/istio v0.0.0-20260701162249-99f2f4f55d5c h1:fGJlheN+3GC5BtnAk13zCXVHA5G71U3wbRdHBfcUnLA=
 istio.io/istio v0.0.0-20260701162249-99f2f4f55d5c/go.mod h1:bY0H3K7VwsLVrhENlfu4NlSxA5zfFdovXqLom4TurFQ=
+istio.io/istio v0.0.0-20260704181517-116e8ec30db4 h1:464ea9D1k9bUklbPEFDrCmHMdZBoyS4bzm6V2L4K9Pc=
+istio.io/istio v0.0.0-20260704181517-116e8ec30db4/go.mod h1:Hv+gSktTtaTnYikCEgi/TI1ygh0oD+FU66476mh5TTk=
 k8s.io/api v0.36.2 h1:TF6YDLIzKfccK7cq9YpTcGX8TJmEkHVRv78DM51fRYY=
 k8s.io/api v0.36.2/go.mod h1:F4LbMO4brjZYh7yFkXWhynSvtB7YauxV4c+HHkNRGNg=
 k8s.io/apiextensions-apiserver v0.36.2 h1:3O5gqOj/dt2XWWbpMe+TXWpE9yU6pjM/tXxtHHJT/K4=
@@ -779,10 +781,14 @@ sigs.k8s.io/controller-tools v0.21.0 h1:KXDQza3bgjlPY6xLR63tI/40gzjhyUAvkCrwzd2/
 sigs.k8s.io/controller-tools v0.21.0/go.mod h1:DLIypi3Q2+azVAP8jr/mHXJgveYYHFjhnNOUuBJ10JE=
 sigs.k8s.io/gateway-api v1.6.0-rc.1 h1:P0WmBguVrYPnkiFiW/rmxVq3adEGufbPEnOs1kjfBEQ=
 sigs.k8s.io/gateway-api v1.6.0-rc.1/go.mod h1:FVfx3t389ybeXOqvDghLbdvJdSCfI/PReqCUI3lu3mY=
+sigs.k8s.io/gateway-api v1.6.0 h1:735YBRj5NXFrOGX0GoSjwzUIzbz8kiEOfADsqHFmHgE=
+sigs.k8s.io/gateway-api v1.6.0/go.mod h1:FVfx3t389ybeXOqvDghLbdvJdSCfI/PReqCUI3lu3mY=
 sigs.k8s.io/gateway-api-inference-extension v1.5.0 h1:w9Awt60cmI1vM7Y6N81h8wDCBP0WkmxpdI7GKY0v070=
 sigs.k8s.io/gateway-api-inference-extension v1.5.0/go.mod h1:ZeIlzI43XH2qWKipFq/Qa12yB2s/D+Xp1XJVlpMxklA=
 sigs.k8s.io/gateway-api/conformance v1.6.0-rc.1 h1:pULw1PTazpxoubhu9GdYOhXe5tLbDB116J8yi5hDmAk=
 sigs.k8s.io/gateway-api/conformance v1.6.0-rc.1/go.mod h1:JD6CHFrpzVyvgivIzhu0My27sOk3I3IphxJe4CIjGb4=
+sigs.k8s.io/gateway-api/conformance v1.6.0 h1:jyH7Jtx46hEeBQnmSErn2cbp0k4OmT3FLRBnu77c4Ko=
+sigs.k8s.io/gateway-api/conformance v1.6.0/go.mod h1:JD6CHFrpzVyvgivIzhu0My27sOk3I3IphxJe4CIjGb4=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/kustomize/api v0.21.1 h1:lzqbzvz2CSvsjIUZUBNFKtIMsEw7hVLJp0JeSIVmuJs=

--- a/go.sum
+++ b/go.sum
@@ -743,8 +743,6 @@ istio.io/api v1.30.0-alpha.1.0.20260626010135-ac56ebb29e59 h1:8VgMOLCCCptQb5USAH
 istio.io/api v1.30.0-alpha.1.0.20260626010135-ac56ebb29e59/go.mod h1:+brQWcBHoROuyA6fv8rbgg8Kfn0RCGuqoY0duCMuSLA=
 istio.io/client-go v1.30.0-beta.0 h1:lZhK5Kbkw0Z+lw1+zySH0m1ST1VYsMrXOpAJQdlY+T0=
 istio.io/client-go v1.30.0-beta.0/go.mod h1:HRZAHMJsEmf/oDYBoCpDO9wZEEnqWeMsP20iuEA77qY=
-istio.io/istio v0.0.0-20260701162249-99f2f4f55d5c h1:fGJlheN+3GC5BtnAk13zCXVHA5G71U3wbRdHBfcUnLA=
-istio.io/istio v0.0.0-20260701162249-99f2f4f55d5c/go.mod h1:bY0H3K7VwsLVrhENlfu4NlSxA5zfFdovXqLom4TurFQ=
 istio.io/istio v0.0.0-20260704181517-116e8ec30db4 h1:464ea9D1k9bUklbPEFDrCmHMdZBoyS4bzm6V2L4K9Pc=
 istio.io/istio v0.0.0-20260704181517-116e8ec30db4/go.mod h1:Hv+gSktTtaTnYikCEgi/TI1ygh0oD+FU66476mh5TTk=
 k8s.io/api v0.36.2 h1:TF6YDLIzKfccK7cq9YpTcGX8TJmEkHVRv78DM51fRYY=
@@ -779,14 +777,10 @@ sigs.k8s.io/controller-runtime v0.24.1 h1:miPEwrmirImAvgME1L9qebGHrOnGJoVmVdtOU9
 sigs.k8s.io/controller-runtime v0.24.1/go.mod h1:vFkfY5fGt5xAC/sKb8IBFKgWPNKG9OUG29dR8Y2wImw=
 sigs.k8s.io/controller-tools v0.21.0 h1:KXDQza3bgjlPY6xLR63tI/40gzjhyUAvkCrwzd2/6cs=
 sigs.k8s.io/controller-tools v0.21.0/go.mod h1:DLIypi3Q2+azVAP8jr/mHXJgveYYHFjhnNOUuBJ10JE=
-sigs.k8s.io/gateway-api v1.6.0-rc.1 h1:P0WmBguVrYPnkiFiW/rmxVq3adEGufbPEnOs1kjfBEQ=
-sigs.k8s.io/gateway-api v1.6.0-rc.1/go.mod h1:FVfx3t389ybeXOqvDghLbdvJdSCfI/PReqCUI3lu3mY=
 sigs.k8s.io/gateway-api v1.6.0 h1:735YBRj5NXFrOGX0GoSjwzUIzbz8kiEOfADsqHFmHgE=
 sigs.k8s.io/gateway-api v1.6.0/go.mod h1:FVfx3t389ybeXOqvDghLbdvJdSCfI/PReqCUI3lu3mY=
 sigs.k8s.io/gateway-api-inference-extension v1.5.0 h1:w9Awt60cmI1vM7Y6N81h8wDCBP0WkmxpdI7GKY0v070=
 sigs.k8s.io/gateway-api-inference-extension v1.5.0/go.mod h1:ZeIlzI43XH2qWKipFq/Qa12yB2s/D+Xp1XJVlpMxklA=
-sigs.k8s.io/gateway-api/conformance v1.6.0-rc.1 h1:pULw1PTazpxoubhu9GdYOhXe5tLbDB116J8yi5hDmAk=
-sigs.k8s.io/gateway-api/conformance v1.6.0-rc.1/go.mod h1:JD6CHFrpzVyvgivIzhu0My27sOk3I3IphxJe4CIjGb4=
 sigs.k8s.io/gateway-api/conformance v1.6.0 h1:jyH7Jtx46hEeBQnmSErn2cbp0k4OmT3FLRBnu77c4Ko=
 sigs.k8s.io/gateway-api/conformance v1.6.0/go.mod h1:JD6CHFrpzVyvgivIzhu0My27sOk3I3IphxJe4CIjGb4=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=


### PR DESCRIPTION
Follow up to #2389 to ignore older TCPRoute CRD versions (based on gateway api version annotation). Otherwise, we''ll fail to start up