### PR TITLE
fix(llm): default missing choice index for Copilot completions

### DIFF
--- a/crates/agentgateway/src/llm/tests.rs
+++ b/crates/agentgateway/src/llm/tests.rs
@@ -608,6 +608,7 @@ mod response {
 		("openrouter_reasoning", ALL_COMPLETIONS),
 		("gemini_zero_completion_tokens", ALL_COMPLETIONS),
 		("gemini_with_completion_tokens", ALL_COMPLETIONS),
+		("copilot_missing_choice_index", ALL_COMPLETIONS),
 	];
 	const COMPLETIONS_STREAM_RESPONSES: &[(&str, &[&str])] = &[
 		("stream", ALL_COMPLETIONS),
@@ -1808,6 +1809,26 @@ fn completions_response_missing_message_and_usage_fields() {
 	assert_eq!(usage.prompt_tokens, 5);
 	assert_eq!(usage.completion_tokens, 0);
 	assert_eq!(usage.total_tokens, 12);
+}
+
+#[test]
+fn typed_completions_response_missing_choice_index() {
+	// GitHub Copilot's chat-completions responses omit `index` on choices.
+	let json = r#"{
+		"id": "chatcmpl-copilot",
+		"object": "chat.completion",
+		"created": 0,
+		"model": "claude-haiku-4.5",
+		"choices": [{
+			"message": {"role": "assistant", "content": "hello"},
+			"finish_reason": "stop"
+		}],
+		"usage": {"prompt_tokens": 10, "completion_tokens": 2, "total_tokens": 12}
+	}"#;
+	let resp: types::completions::typed::Response = serde_json::from_str(json).unwrap();
+	assert_eq!(resp.choices.len(), 1);
+	assert_eq!(resp.choices[0].index, 0);
+	assert_eq!(resp.choices[0].message.content.as_deref(), Some("hello"));
 }
 
 #[tokio::test]

--- a/crates/agentgateway/src/llm/tests/response/completions/copilot_missing_choice_index.completions-completions.snap
+++ b/crates/agentgateway/src/llm/tests/response/completions/copilot_missing_choice_index.completions-completions.snap
@@ -1,0 +1,46 @@
+---
+source: crates/agentgateway/src/llm/tests.rs
+description: src/llm/tests/response/completions/copilot_missing_choice_index.json
+info:
+  id: chatcmpl-copilot
+  object: chat.completion
+  created: 1775595226
+  model: claude-haiku-4.5
+  choices:
+    - message:
+        role: assistant
+        content: hello from copilot
+      finish_reason: stop
+  usage:
+    prompt_tokens: 10
+    completion_tokens: 2
+    total_tokens: 12
+---
+{
+  "response": {
+    "model": "claude-haiku-4.5",
+    "usage": {
+      "prompt_tokens": 10,
+      "completion_tokens": 2,
+      "total_tokens": 12
+    },
+    "choices": [
+      {
+        "message": {
+          "content": "hello from copilot",
+          "role": "assistant"
+        },
+        "finish_reason": "stop"
+      }
+    ],
+    "id": "[id]",
+    "object": "chat.completion",
+    "created": "[date]"
+  },
+  "parsed": {
+    "input_tokens": 10,
+    "output_tokens": 2,
+    "total_tokens": 12,
+    "provider_model": "claude-haiku-4.5"
+  }
+}

--- a/crates/agentgateway/src/llm/tests/response/completions/copilot_missing_choice_index.completions-detect.snap
+++ b/crates/agentgateway/src/llm/tests/response/completions/copilot_missing_choice_index.completions-detect.snap
@@ -1,0 +1,46 @@
+---
+source: crates/agentgateway/src/llm/tests.rs
+description: src/llm/tests/response/completions/copilot_missing_choice_index.json
+info:
+  id: chatcmpl-copilot
+  object: chat.completion
+  created: 1775595226
+  model: claude-haiku-4.5
+  choices:
+    - message:
+        role: assistant
+        content: hello from copilot
+      finish_reason: stop
+  usage:
+    prompt_tokens: 10
+    completion_tokens: 2
+    total_tokens: 12
+---
+{
+  "response": {
+    "id": "[id]",
+    "object": "chat.completion",
+    "created": "[date]",
+    "model": "claude-haiku-4.5",
+    "choices": [
+      {
+        "message": {
+          "role": "assistant",
+          "content": "hello from copilot"
+        },
+        "finish_reason": "stop"
+      }
+    ],
+    "usage": {
+      "prompt_tokens": 10,
+      "completion_tokens": 2,
+      "total_tokens": 12
+    }
+  },
+  "parsed": {
+    "input_tokens": 10,
+    "output_tokens": 2,
+    "total_tokens": 12,
+    "provider_model": "claude-haiku-4.5"
+  }
+}

--- a/crates/agentgateway/src/llm/tests/response/completions/copilot_missing_choice_index.completions-messages.snap
+++ b/crates/agentgateway/src/llm/tests/response/completions/copilot_missing_choice_index.completions-messages.snap
@@ -1,0 +1,44 @@
+---
+source: crates/agentgateway/src/llm/tests.rs
+description: src/llm/tests/response/completions/copilot_missing_choice_index.json
+info:
+  id: chatcmpl-copilot
+  object: chat.completion
+  created: 1775595226
+  model: claude-haiku-4.5
+  choices:
+    - message:
+        role: assistant
+        content: hello from copilot
+      finish_reason: stop
+  usage:
+    prompt_tokens: 10
+    completion_tokens: 2
+    total_tokens: 12
+---
+{
+  "response": {
+    "id": "[id]",
+    "type": "message",
+    "role": "assistant",
+    "content": [
+      {
+        "type": "text",
+        "text": "hello from copilot"
+      }
+    ],
+    "model": "claude-haiku-4.5",
+    "stop_reason": "end_turn",
+    "stop_sequence": null,
+    "usage": {
+      "input_tokens": 10,
+      "output_tokens": 2
+    }
+  },
+  "parsed": {
+    "input_tokens": 10,
+    "output_tokens": 2,
+    "total_tokens": 12,
+    "provider_model": "claude-haiku-4.5"
+  }
+}

--- a/crates/agentgateway/src/llm/tests/response/completions/copilot_missing_choice_index.json
+++ b/crates/agentgateway/src/llm/tests/response/completions/copilot_missing_choice_index.json
@@ -1,0 +1,20 @@
+{
+  "id": "chatcmpl-copilot",
+  "object": "chat.completion",
+  "created": 1775595226,
+  "model": "claude-haiku-4.5",
+  "choices": [
+    {
+      "message": {
+        "role": "assistant",
+        "content": "hello from copilot"
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 10,
+    "completion_tokens": 2,
+    "total_tokens": 12
+  }
+}

--- a/crates/agentgateway/src/llm/types/completions.rs
+++ b/crates/agentgateway/src/llm/types/completions.rs
@@ -591,6 +591,7 @@ pub mod typed {
 	#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 	pub struct ChatChoiceStream {
 		/// The index of the choice in the list of choices.
+		#[serde(default)]
 		pub index: u32,
 		pub delta: StreamResponseDelta,
 		/// The reason the model stopped generating tokens. This will be
@@ -652,6 +653,7 @@ pub mod typed {
 	#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 	pub struct ChatChoice {
 		/// The index of the choice in the list of choices.
+		#[serde(default)]
 		pub index: u32,
 		pub message: ResponseMessage,
 		/// The reason the model stopped generating tokens. This will be `stop` if the model hit a natural stop point or a provided stop sequence,


### PR DESCRIPTION
## Summary

GitHub Copilot's OpenAI-compatible `/chat/completions` responses omit the `index` field on `choices[]`. When agentgateway deserializes into `typed::ChatChoice`, serde fails with `missing field index`, and the gateway returns HTTP 503.

This PR adds `#[serde(default)]` to `ChatChoice.index` and `ChatChoiceStream.index` so omitted indices default to `0`, matching the leniency pattern from #1465 for other provider-omitted fields.

Fixes #2371

## Motivation

Custom Completions providers routed through agentgateway (including GitHub Copilot Enterprise) were unusable because response parsing failed before any translation could occur. Copilot returns valid completion payloads but omits `index`, which our typed OpenAI fork treated as required.

## Changes

- Add `#[serde(default)]` to `typed::ChatChoice.index` and `typed::ChatChoiceStream.index` in `completions.rs`
- Add unit test `typed_completions_response_missing_choice_index`
- Add `copilot_missing_choice_index.json` fixture and snapshot coverage for completions → messages/detect paths

## Tests

- `cargo test -p agentgateway typed_completions_response_missing_choice_index` — pass
- `INSTA_UPDATE=1 cargo test -p agentgateway from_completions` — pass (snapshots updated)

## Notes

- Default `index: 0` matches OpenAI behavior for single-choice (`n=1`) responses.
- Downstream conversion paths take the first choice by array order and do not rely on `choice.index` for routing.
- The untyped Completions passthrough path was already tolerant (no `index` field on the outer `Choice` struct); this fixes typed conversion paths used for Messages/Responses translation.