### PR TITLE
fix: resolve kubebuilder mismatched comments warnings

### DIFF
--- a/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
+++ b/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
@@ -312,20 +312,112 @@ type BackendFull struct {
 
 // +kubebuilder:validation:MinLength=1
 // +kubebuilder:validation:MaxLength=64
-type TinyString = string
+type TinyString string
 
 // +kubebuilder:validation:MinLength=1
 // +kubebuilder:validation:MaxLength=256
-type ShortString = string
+type ShortString string
 
 // +kubebuilder:validation:MinLength=1
 // +kubebuilder:validation:MaxLength=1024
-type LongString = string
+type LongString string
 
 // +kubebuilder:validation:MinLength=1
 // +kubebuilder:validation:MaxLength=253
 // +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
-type SNI = string
+type SNI string
+
+// String converts TinyString to string
+func (t TinyString) String() string {
+	return string(t)
+}
+
+// String converts ShortString to string
+func (s ShortString) String() string {
+	return string(s)
+}
+
+// String converts LongString to string
+func (l LongString) String() string {
+	return string(l)
+}
+
+// String converts SNI to string
+func (s SNI) String() string {
+	return string(s)
+}
+
+// ConvertTinyStrings converts []TinyString to []string
+func ConvertTinyStrings(in []TinyString) []string {
+	if in == nil {
+		return nil
+	}
+	out := make([]string, len(in))
+	for i, v := range in {
+		out[i] = string(v)
+	}
+	return out
+}
+
+// ConvertShortStrings converts []ShortString to []string
+func ConvertShortStrings(in []ShortString) []string {
+	if in == nil {
+		return nil
+	}
+	out := make([]string, len(in))
+	for i, v := range in {
+		out[i] = string(v)
+	}
+	return out
+}
+
+// ConvertLongStrings converts []LongString to []string
+func ConvertLongStrings(in []LongString) []string {
+	if in == nil {
+		return nil
+	}
+	out := make([]string, len(in))
+	for i, v := range in {
+		out[i] = string(v)
+	}
+	return out
+}
+
+// ConvertStringPtr converts *ShortString to *string
+func ConvertStringPtr(in *ShortString) *string {
+	if in == nil {
+		return nil
+	}
+	s := string(*in)
+	return &s
+}
+
+// ConvertLongStringPtr converts *LongString to *string
+func ConvertLongStringPtr(in *LongString) *string {
+	if in == nil {
+		return nil
+	}
+	s := string(*in)
+	return &s
+}
+
+// ConvertTinyStringPtr converts *TinyString to *string
+func ConvertTinyStringPtr(in *TinyString) *string {
+	if in == nil {
+		return nil
+	}
+	s := string(*in)
+	return &s
+}
+
+// ConvertSNIPtr converts *SNI to *string
+func ConvertSNIPtr(in *SNI) *string {
+	if in == nil {
+		return nil
+	}
+	s := string(*in)
+	return &s
+}
 
 // Byte quantity that must fit in the data plane size limit.
 // +kubebuilder:validation:XIntOrString

--- a/controller/api/v1alpha1/agentgateway/ai_policy.go
+++ b/controller/api/v1alpha1/agentgateway/ai_policy.go
@@ -352,7 +352,6 @@ type AIPromptGuard struct {
 // Note: The `field` values correspond to keys in the JSON request body, not fields in this CRD.
 type FieldDefault struct {
 	// Name of the field.
-	// +kubebuilder:validation:MinLength=1
 	// +required
 	Field ShortString `json:"field"`
 
@@ -367,7 +366,6 @@ type FieldDefault struct {
 // is assigned to the configured field.
 type FieldTransformation struct {
 	// Name of the field to set.
-	// +kubebuilder:validation:MinLength=1
 	// +required
 	Field ShortString `json:"field"`
 

--- a/controller/api/v1alpha1/agentgateway/zz_generated.deepcopy.go
+++ b/controller/api/v1alpha1/agentgateway/zz_generated.deepcopy.go
@@ -336,7 +336,7 @@ func (in *AgentgatewayBackendSpec) DeepCopyInto(out *AgentgatewayBackendSpec) {
 	if in.A2A != nil {
 		in, out := &in.A2A, &out.A2A
 		*out = new(A2ABackend)
-		(*in).DeepCopyInto(*out)
+		**out = **in
 	}
 	if in.AI != nil {
 		in, out := &in.AI, &out.AI
@@ -1126,9 +1126,7 @@ func (in *BackendAI) DeepCopyInto(out *BackendAI) {
 	if in.Transformations != nil {
 		in, out := &in.Transformations, &out.Transformations
 		*out = make([]FieldTransformation, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		copy(*out, *in)
 	}
 	if in.ModelAliases != nil {
 		in, out := &in.ModelAliases, &out.ModelAliases
@@ -1569,7 +1567,7 @@ func (in *BedrockConfig) DeepCopyInto(out *BedrockConfig) {
 	if in.Guardrail != nil {
 		in, out := &in.Guardrail, &out.Guardrail
 		*out = new(AWSGuardrailConfig)
-		(*in).DeepCopyInto(*out)
+		**out = **in
 	}
 }
 
@@ -1709,9 +1707,7 @@ func (in *CustomProvider) DeepCopyInto(out *CustomProvider) {
 	if in.Formats != nil {
 		in, out := &in.Formats, &out.Formats
 		*out = make([]ProviderFormatConfig, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		copy(*out, *in)
 	}
 }
 
@@ -2958,9 +2954,7 @@ func (in *LogTracingAttributes) DeepCopyInto(out *LogTracingAttributes) {
 	if in.Add != nil {
 		in, out := &in.Add, &out.Add
 		*out = make([]AttributeAdd, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		copy(*out, *in)
 	}
 }
 
@@ -3227,9 +3221,7 @@ func (in *MetricAttributes) DeepCopyInto(out *MetricAttributes) {
 	if in.Add != nil {
 		in, out := &in.Add, &out.Add
 		*out = make([]AttributeAdd, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		copy(*out, *in)
 	}
 }
 
@@ -3737,9 +3729,7 @@ func (in *RateLimitDescriptor) DeepCopyInto(out *RateLimitDescriptor) {
 	if in.Entries != nil {
 		in, out := &in.Entries, &out.Entries
 		*out = make([]RateLimitDescriptorEntry, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		copy(*out, *in)
 	}
 	if in.Unit != nil {
 		in, out := &in.Unit, &out.Unit
@@ -4045,9 +4035,7 @@ func (in *Tracing) DeepCopyInto(out *Tracing) {
 	if in.Resources != nil {
 		in, out := &in.Resources, &out.Resources
 		*out = make([]ResourceAdd, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		copy(*out, *in)
 	}
 	if in.RandomSampling != nil {
 		in, out := &in.RandomSampling, &out.RandomSampling

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
@@ -444,11 +444,9 @@ spec:
                                             this CRD."
                                           properties:
                                             field:
-                                              allOf:
-                                              - minLength: 1
-                                              - minLength: 1
                                               description: Name of the field.
                                               maxLength: 256
+                                              minLength: 1
                                               type: string
                                             value:
                                               description: Default value for the field.
@@ -505,11 +503,9 @@ spec:
                                             this CRD."
                                           properties:
                                             field:
-                                              allOf:
-                                              - minLength: 1
-                                              - minLength: 1
                                               description: Name of the field.
                                               maxLength: 256
+                                              minLength: 1
                                               type: string
                                             value:
                                               description: Default value for the field.
@@ -4949,11 +4945,9 @@ spec:
                                               minLength: 1
                                               type: string
                                             field:
-                                              allOf:
-                                              - minLength: 1
-                                              - minLength: 1
                                               description: Name of the field to set.
                                               maxLength: 256
+                                              minLength: 1
                                               type: string
                                           required:
                                           - expression
@@ -7292,11 +7286,9 @@ spec:
                             body, not fields in this CRD."
                           properties:
                             field:
-                              allOf:
-                              - minLength: 1
-                              - minLength: 1
                               description: Name of the field.
                               maxLength: 256
+                              minLength: 1
                               type: string
                             value:
                               description: Default value for the field. This can be
@@ -7343,11 +7335,9 @@ spec:
                             body, not fields in this CRD."
                           properties:
                             field:
-                              allOf:
-                              - minLength: 1
-                              - minLength: 1
                               description: Name of the field.
                               maxLength: 256
+                              minLength: 1
                               type: string
                             value:
                               description: Default value for the field. This can be
@@ -11362,11 +11352,9 @@ spec:
                               minLength: 1
                               type: string
                             field:
-                              allOf:
-                              - minLength: 1
-                              - minLength: 1
                               description: Name of the field to set.
                               maxLength: 256
+                              minLength: 1
                               type: string
                           required:
                           - expression

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
@@ -109,11 +109,9 @@ spec:
                             body, not fields in this CRD."
                           properties:
                             field:
-                              allOf:
-                              - minLength: 1
-                              - minLength: 1
                               description: Name of the field.
                               maxLength: 256
+                              minLength: 1
                               type: string
                             value:
                               description: Default value for the field. This can be
@@ -160,11 +158,9 @@ spec:
                             body, not fields in this CRD."
                           properties:
                             field:
-                              allOf:
-                              - minLength: 1
-                              - minLength: 1
                               description: Name of the field.
                               maxLength: 256
+                              minLength: 1
                               type: string
                             value:
                               description: Default value for the field. This can be
@@ -4179,11 +4175,9 @@ spec:
                               minLength: 1
                               type: string
                             field:
-                              allOf:
-                              - minLength: 1
-                              - minLength: 1
                               description: Name of the field to set.
                               maxLength: 256
+                              minLength: 1
                               type: string
                           required:
                           - expression

--- a/controller/pkg/agentgateway/jwks/request_test.go
+++ b/controller/pkg/agentgateway/jwks/request_test.go
@@ -201,7 +201,7 @@ func staticBackend(name, host string, port int32, tlsPolicy *agentgateway.Backen
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
 		Spec: agentgateway.AgentgatewayBackendSpec{
 			Static: &agentgateway.StaticBackend{
-				Host: host,
+				Host: agentgateway.ShortString(host),
 				Port: port,
 			},
 			Policies: &agentgateway.BackendFull{

--- a/controller/pkg/agentgateway/plugins/ai_policies.go
+++ b/controller/pkg/agentgateway/plugins/ai_policies.go
@@ -212,7 +212,7 @@ func processRegex(regex *agentgateway.Regex) *api.BackendPolicySpec_Ai_RegexRule
 	}
 
 	for _, match := range regex.Matches {
-		rules.Rules = append(rules.Rules, processRegexRule(match))
+		rules.Rules = append(rules.Rules, processRegexRule(string(match)))
 	}
 
 	for _, builtin := range regex.Builtins {
@@ -251,9 +251,9 @@ func processBedrockGuardrails(ctx PolicyCtx, namespace string, guardrails *agent
 	}
 
 	pgGuardrails := &api.BackendPolicySpec_Ai_BedrockGuardrails{
-		Identifier: guardrails.GuardrailIdentifier,
-		Version:    guardrails.GuardrailVersion,
-		Region:     guardrails.Region,
+		Identifier: string(guardrails.GuardrailIdentifier),
+		Version:    string(guardrails.GuardrailVersion),
+		Region:     string(guardrails.Region),
 	}
 
 	if guardrails.Policies != nil {
@@ -277,13 +277,13 @@ func processGoogleModelArmor(ctx PolicyCtx, namespace string, armor *agentgatewa
 	}
 
 	pgArmor := &api.BackendPolicySpec_Ai_GoogleModelArmor{
-		TemplateId: armor.TemplateID,
-		ProjectId:  armor.ProjectID,
+		TemplateId: string(armor.TemplateID),
+		ProjectId:  string(armor.ProjectID),
 	}
 
 	// Set location with default value if not specified
 	if armor.Location != nil {
-		pgArmor.Location = new(*armor.Location)
+		pgArmor.Location = agentgateway.ConvertStringPtr(armor.Location)
 	} else {
 		pgArmor.Location = new("us-central1")
 	}

--- a/controller/pkg/agentgateway/plugins/backend_policies.go
+++ b/controller/pkg/agentgateway/plugins/backend_policies.go
@@ -433,9 +433,9 @@ func translateBackendTLS(ctx PolicyCtx, policy *agentgateway.AgentgatewayPolicy)
 	}
 
 	if len(tls.VerifySubjectAltNames) > 0 {
-		p.VerifySubjectAltNames = tls.VerifySubjectAltNames
+		p.VerifySubjectAltNames = agentgateway.ConvertShortStrings(tls.VerifySubjectAltNames)
 	}
-	p.Hostname = tls.Sni
+	p.Hostname = agentgateway.ConvertSNIPtr(tls.Sni)
 
 	if tls.InsecureSkipVerify != nil {
 		switch *tls.InsecureSkipVerify {
@@ -447,7 +447,7 @@ func translateBackendTLS(ctx PolicyCtx, policy *agentgateway.AgentgatewayPolicy)
 	}
 
 	if tls.AlpnProtocols != nil {
-		p.Alpn = &api.Alpn{Protocols: *tls.AlpnProtocols}
+		p.Alpn = &api.Alpn{Protocols: agentgateway.ConvertTinyStrings(*tls.AlpnProtocols)}
 	}
 	p.KeyExchangeGroups = convertTLSKeyExchangeGroups(tls.KeyExchangeGroups)
 
@@ -629,7 +629,7 @@ func translateMCPAuthenticationSpec(
 	}
 
 	mcpAuthn := &api.BackendPolicySpec_McpAuthentication{
-		Issuer:    authnPolicy.Issuer,
+		Issuer:    string(authnPolicy.Issuer),
 		Audiences: authnPolicy.Audiences,
 		Provider:  idp,
 		ResourceMetadata: &api.BackendPolicySpec_McpAuthentication_ResourceMetadata{
@@ -717,7 +717,7 @@ func translateBackendAI(ctx PolicyCtx, agwPolicy *agentgateway.AgentgatewayPolic
 		if translatedAIPolicy.Defaults == nil {
 			translatedAIPolicy.Defaults = make(map[string]string)
 		}
-		translatedAIPolicy.Defaults[def.Field] = val
+		translatedAIPolicy.Defaults[string(def.Field)] = val
 	}
 
 	for _, def := range aiSpec.Overrides {
@@ -730,7 +730,7 @@ func translateBackendAI(ctx PolicyCtx, agwPolicy *agentgateway.AgentgatewayPolic
 		if translatedAIPolicy.Overrides == nil {
 			translatedAIPolicy.Overrides = make(map[string]string)
 		}
-		translatedAIPolicy.Overrides[def.Field] = val
+		translatedAIPolicy.Overrides[string(def.Field)] = val
 	}
 	for _, xfm := range aiSpec.Transformations {
 		if translatedAIPolicy.Transformations == nil {
@@ -742,7 +742,7 @@ func translateBackendAI(ctx PolicyCtx, agwPolicy *agentgateway.AgentgatewayPolic
 		}
 
 		// Still set it so it wipes out the value on error, mirroring the header value.
-		translatedAIPolicy.Transformations[xfm.Field] = string(xfm.Expression)
+		translatedAIPolicy.Transformations[string(xfm.Field)] = string(xfm.Expression)
 	}
 
 	if aiSpec.PromptGuard != nil {
@@ -1151,7 +1151,7 @@ func buildGcpAuthPolicy(ctx PolicyCtx, auth *agentgateway.GcpAuth, namespace str
 	} else {
 		gcp.TokenType = &api.Gcp_IdToken_{
 			IdToken: &api.Gcp_IdToken{
-				Audience: auth.Audience,
+				Audience: agentgateway.ConvertStringPtr(auth.Audience),
 			},
 		}
 	}

--- a/controller/pkg/agentgateway/plugins/frontend_policies.go
+++ b/controller/pkg/agentgateway/plugins/frontend_policies.go
@@ -104,12 +104,12 @@ func translateFrontendTracing(ctx PolicyCtx, policy *agentgateway.AgentgatewayPo
 				errs = append(errs, fmt.Errorf("frontend tracing attribute %q is not a valid CEL expression: %s", add.Name, add.Expression))
 			}
 			addAttributes = append(addAttributes, &api.FrontendPolicySpec_TracingAttribute{
-				Name:  add.Name,
+				Name:  string(add.Name),
 				Value: string(add.Expression),
 			})
 		}
 		for _, rm := range tracing.Attributes.Remove {
-			rmAttributes = append(rmAttributes, rm)
+			rmAttributes = append(rmAttributes, string(rm))
 		}
 	}
 
@@ -120,7 +120,7 @@ func translateFrontendTracing(ctx PolicyCtx, policy *agentgateway.AgentgatewayPo
 				errs = append(errs, fmt.Errorf("frontend tracing resource %q is not a valid CEL expression: %s", add.Name, add.Expression))
 			}
 			addResources = append(addResources, &api.FrontendPolicySpec_TracingAttribute{
-				Name:  add.Name,
+				Name:  string(add.Name),
 				Value: string(add.Expression),
 			})
 		}
@@ -149,7 +149,7 @@ func translateFrontendTracing(ctx PolicyCtx, policy *agentgateway.AgentgatewayPo
 
 	var path *string
 	if tracing.Path != nil {
-		path = new(*tracing.Path)
+		path = agentgateway.ConvertLongStringPtr(tracing.Path)
 	}
 
 	var protocol api.FrontendPolicySpec_Tracing_Protocol
@@ -206,12 +206,12 @@ func translateFrontendAccessLog(ctx PolicyCtx, policy *agentgateway.Agentgateway
 				errs = append(errs, fmt.Errorf("frontend accessLog field %q is not a valid CEL expression: %s", add.Name, add.Expression))
 			}
 			fields = append(fields, &api.FrontendPolicySpec_Logging_Field{
-				Name:       add.Name,
+				Name:       string(add.Name),
 				Expression: string(add.Expression),
 			})
 		}
 		f := &api.FrontendPolicySpec_Logging_Fields{
-			Remove: a.Remove,
+			Remove: agentgateway.ConvertTinyStrings(a.Remove),
 			Add:    fields,
 		}
 		spec.Fields = f
@@ -234,7 +234,7 @@ func translateFrontendAccessLog(ctx PolicyCtx, policy *agentgateway.Agentgateway
 
 		var path *string
 		if otlp.Path != nil {
-			path = new(*otlp.Path)
+			path = agentgateway.ConvertLongStringPtr(otlp.Path)
 		}
 
 		var filter *string
@@ -252,12 +252,12 @@ func translateFrontendAccessLog(ctx PolicyCtx, policy *agentgateway.Agentgateway
 					errs = append(errs, fmt.Errorf("frontend accessLog OTLP field %q is not a valid CEL expression: %s", add.Name, add.Expression))
 				}
 				addedFields = append(addedFields, &api.FrontendPolicySpec_Logging_Field{
-					Name:       add.Name,
+					Name:       string(add.Name),
 					Expression: string(add.Expression),
 				})
 			}
 			fields = &api.FrontendPolicySpec_Logging_Fields{
-				Remove: a.Remove,
+				Remove: agentgateway.ConvertTinyStrings(a.Remove),
 				Add:    addedFields,
 			}
 		}
@@ -452,7 +452,7 @@ func translateFrontendTLS(policy *agentgateway.AgentgatewayPolicy, name string) 
 	}
 
 	if tls.AlpnProtocols != nil {
-		spec.Alpn = &api.Alpn{Protocols: *tls.AlpnProtocols}
+		spec.Alpn = &api.Alpn{Protocols: agentgateway.ConvertTinyStrings(*tls.AlpnProtocols)}
 	}
 
 	if tls.MaxTLSVersion != nil {
@@ -621,7 +621,7 @@ func translateFrontendMetrics(policy *agentgateway.AgentgatewayPolicy, name stri
 			errs = append(errs, fmt.Errorf("frontend metrics field %q is not a valid CEL expression: %s", add.Name, add.Expression))
 		}
 		fields = append(fields, &api.FrontendPolicySpec_Metrics_Field{
-			Name:       add.Name,
+			Name:       string(add.Name),
 			Expression: string(add.Expression),
 		})
 	}

--- a/controller/pkg/agentgateway/plugins/jwks_translation_test.go
+++ b/controller/pkg/agentgateway/plugins/jwks_translation_test.go
@@ -101,7 +101,7 @@ func TestTranslateMCPAuthenticationSpecWhenLookupReturnsErrorLeavesInlineEmptyAn
 	if spec.JwksInline != "" {
 		t.Fatalf("expected jwks inline to be empty, got %q", spec.JwksInline)
 	}
-	if spec.Issuer != authn.Issuer {
+	if spec.Issuer != string(authn.Issuer) {
 		t.Fatalf("expected issuer %q, got %q", authn.Issuer, spec.Issuer)
 	}
 	if len(spec.Audiences) != 1 || spec.Audiences[0] != authn.Audiences[0] {

--- a/controller/pkg/agentgateway/plugins/traffic_plugin.go
+++ b/controller/pkg/agentgateway/plugins/traffic_plugin.go
@@ -741,7 +741,7 @@ func processJWTAuthenticationPolicy(ctx PolicyCtx, jwt *agentgateway.JWTAuthenti
 	}
 	for idx, pp := range jwt.Providers {
 		jp := &api.TrafficPolicySpec_JWTProvider{
-			Issuer:    pp.Issuer,
+			Issuer:    string(pp.Issuer),
 			Audiences: pp.Audiences,
 		}
 		if i := pp.JWKS.Inline; i != nil {
@@ -1253,11 +1253,11 @@ func buildExtAuthSpec(
 			Path:                   path,
 			Redirect:               redirect,
 			Body:                   body,
-			IncludeResponseHeaders: h.AllowedResponseHeaders,
+			IncludeResponseHeaders: agentgateway.ConvertShortStrings(h.AllowedResponseHeaders),
 			AddRequestHeaders:      addRequestHeaders,
 			Metadata:               metadata,
 		}
-		spec.IncludeRequestHeaders = h.AllowedRequestHeaders
+		spec.IncludeRequestHeaders = agentgateway.ConvertShortStrings(h.AllowedRequestHeaders)
 		spec.Protocol = &api.TrafficPolicySpec_ExternalAuth_Http{
 			Http: p,
 		}
@@ -1674,7 +1674,7 @@ func processGlobalRateLimitTraffic(ctx PolicyCtx, grl *agentgateway.GlobalRateLi
 	return &api.Policy_Traffic{Traffic: &api.TrafficPolicySpec{
 		Kind: &api.TrafficPolicySpec_RemoteRateLimit_{
 			RemoteRateLimit: &api.TrafficPolicySpec_RemoteRateLimit{
-				Domain:      grl.Domain,
+				Domain:      string(grl.Domain),
 				Target:      be,
 				Descriptors: descriptors,
 				FailureMode: remoteRateLimitFailureMode(grl.FailureMode),
@@ -1712,7 +1712,7 @@ func processRateLimitDescriptor(descriptor agentgateway.RateLimitDescriptor) (*a
 			errs = append(errs, fmt.Errorf("rate limit descriptor entry %q is not a valid CEL expression: %s", entry.Name, entry.Expression))
 		}
 		entries = append(entries, &api.TrafficPolicySpec_RemoteRateLimit_Entry{
-			Key:   entry.Name,
+			Key:   string(entry.Name),
 			Value: string(entry.Expression),
 		})
 	}
@@ -1816,7 +1816,7 @@ func processCSRFPolicy(csrf *agentgateway.CSRF, basePolicyName string, policy ty
 			Traffic: &api.TrafficPolicySpec{
 				Kind: &api.TrafficPolicySpec_Csrf{
 					Csrf: &api.TrafficPolicySpec_CSRF{
-						AdditionalOrigins: csrf.AdditionalOrigins,
+						AdditionalOrigins: agentgateway.ConvertShortStrings(csrf.AdditionalOrigins),
 					},
 				},
 			},

--- a/controller/pkg/agentgateway/remotehttp/tls_resolver.go
+++ b/controller/pkg/agentgateway/remotehttp/tls_resolver.go
@@ -85,8 +85,8 @@ func resolvedTLSFromBackendTLS(
 
 	resolved := &resolvedTLS{
 		verification: verificationMode(btls.InsecureSkipVerify),
-		serverName:   ptr.OrEmpty(btls.Sni),
-		nextProtos:   ptr.OrEmpty(btls.AlpnProtocols),
+		serverName:   string(ptr.OrEmpty(btls.Sni)),
+		nextProtos:   agentgateway.ConvertTinyStrings(ptr.OrEmpty(btls.AlpnProtocols)),
 	}
 	resolved.tlsConfig = &tls.Config{
 		ServerName: resolved.serverName,

--- a/controller/pkg/syncer/backend/backend_plugin.go
+++ b/controller/pkg/syncer/backend/backend_plugin.go
@@ -282,7 +282,7 @@ func TranslateMCPBackends(ctx plugins.PolicyCtx, be *agentgateway.AgentgatewayBa
 						},
 						Port: uint32(s.Port), //nolint:gosec // G115: validated by the CRD schema
 					},
-					Path: ptr.OrEmpty(s.Path),
+					Path: string(ptr.OrEmpty(s.Path)),
 				}
 
 				switch ptr.OrEmpty(s.Protocol) {
@@ -303,7 +303,7 @@ func TranslateMCPBackends(ctx plugins.PolicyCtx, be *agentgateway.AgentgatewayBa
 				Name: plugins.ResourceName(be),
 				Kind: &api.Backend_Static{
 					Static: &api.StaticBackend{
-						Host: ptr.OrEmpty(s.Host),
+						Host: string(ptr.OrEmpty(s.Host)),
 						Port: s.Port,
 					},
 				},
@@ -328,7 +328,7 @@ func TranslateMCPBackends(ctx plugins.PolicyCtx, be *agentgateway.AgentgatewayBa
 						Backend: staticBackendRef,
 					},
 				},
-				Path: ptr.OrEmpty(s.Path),
+				Path: string(ptr.OrEmpty(s.Path)),
 			}
 
 			switch ptr.OrEmpty(s.Protocol) {
@@ -456,24 +456,26 @@ func translateLLMProvider(ctx plugins.PolicyCtx, namespace string, llm *agentgat
 
 	if llm.Host != "" {
 		provider.HostOverride = &api.AIBackend_HostOverride{
-			Host: llm.Host,
+			Host: string(llm.Host),
 			Port: ptr.NonEmptyOrDefault(llm.Port, 443), // Port is required when Host is set (CEL validated)
 		}
 	}
 
 	if llm.Path != "" {
-		provider.PathOverride = &llm.Path
+		path := string(llm.Path)
+		provider.PathOverride = &path
 	}
 
 	if llm.PathPrefix != "" {
-		provider.PathPrefix = &llm.PathPrefix
+		prefix := string(llm.PathPrefix)
+		provider.PathPrefix = &prefix
 	}
 
 	// Extract auth token and model based on provider
 	if llm.OpenAI != nil {
 		provider.Provider = &api.AIBackend_Provider_Openai{
 			Openai: &api.AIBackend_OpenAI{
-				Model: llm.OpenAI.Model,
+				Model: agentgateway.ConvertStringPtr(llm.OpenAI.Model),
 			},
 		}
 	} else if llm.AzureOpenAI != nil {
@@ -482,8 +484,8 @@ func translateLLMProvider(ctx plugins.PolicyCtx, namespace string, llm *agentgat
 			Azure: &api.AIBackend_Azure{
 				ResourceName: resourceName,
 				ResourceType: resourceType,
-				Model:        llm.AzureOpenAI.DeploymentName,
-				ApiVersion:   llm.AzureOpenAI.ApiVersion,
+				Model:        agentgateway.ConvertStringPtr(llm.AzureOpenAI.DeploymentName),
+				ApiVersion:   agentgateway.ConvertTinyStringPtr(llm.AzureOpenAI.ApiVersion),
 			},
 		}
 	} else if llm.Azure != nil {
@@ -495,43 +497,43 @@ func translateLLMProvider(ctx plugins.PolicyCtx, namespace string, llm *agentgat
 			Azure: &api.AIBackend_Azure{
 				ResourceName: string(llm.Azure.ResourceName),
 				ResourceType: resourceType,
-				Model:        llm.Azure.Model,
-				ApiVersion:   llm.Azure.ApiVersion,
-				ProjectName:  llm.Azure.ProjectName,
+				Model:        agentgateway.ConvertStringPtr(llm.Azure.Model),
+				ApiVersion:   agentgateway.ConvertTinyStringPtr(llm.Azure.ApiVersion),
+				ProjectName:  agentgateway.ConvertStringPtr(llm.Azure.ProjectName),
 			},
 		}
 	} else if llm.Anthropic != nil {
 		provider.Provider = &api.AIBackend_Provider_Anthropic{
 			Anthropic: &api.AIBackend_Anthropic{
-				Model: llm.Anthropic.Model,
+				Model: agentgateway.ConvertStringPtr(llm.Anthropic.Model),
 			},
 		}
 	} else if llm.Gemini != nil {
 		provider.Provider = &api.AIBackend_Provider_Gemini{
 			Gemini: &api.AIBackend_Gemini{
-				Model: llm.Gemini.Model,
+				Model: agentgateway.ConvertStringPtr(llm.Gemini.Model),
 			},
 		}
 	} else if llm.VertexAI != nil {
 		// TODO: publisher?
 		provider.Provider = &api.AIBackend_Provider_Vertex{
 			Vertex: &api.AIBackend_Vertex{
-				Region:    llm.VertexAI.Region,
-				Model:     llm.VertexAI.Model,
-				ProjectId: llm.VertexAI.ProjectId,
+				Region:    string(llm.VertexAI.Region),
+				Model:     agentgateway.ConvertStringPtr(llm.VertexAI.Model),
+				ProjectId: string(llm.VertexAI.ProjectId),
 			},
 		}
 	} else if llm.Bedrock != nil {
 		region := llm.Bedrock.Region
 		var guardrailIdentifier, guardrailVersion *string
 		if llm.Bedrock.Guardrail != nil {
-			guardrailIdentifier = &llm.Bedrock.Guardrail.GuardrailIdentifier
-			guardrailVersion = &llm.Bedrock.Guardrail.GuardrailVersion
+			guardrailIdentifier = agentgateway.ConvertStringPtr(&llm.Bedrock.Guardrail.GuardrailIdentifier)
+			guardrailVersion = agentgateway.ConvertStringPtr(&llm.Bedrock.Guardrail.GuardrailVersion)
 		}
 
 		provider.Provider = &api.AIBackend_Provider_Bedrock{
 			Bedrock: &api.AIBackend_Bedrock{
-				Model:               llm.Bedrock.Model,
+				Model:               agentgateway.ConvertStringPtr(llm.Bedrock.Model),
 				Region:              region,
 				GuardrailIdentifier: guardrailIdentifier,
 				GuardrailVersion:    guardrailVersion,
@@ -545,7 +547,7 @@ func translateLLMProvider(ctx plugins.PolicyCtx, namespace string, llm *agentgat
 		provider.Provider = &api.AIBackend_Provider_Custom{
 			Custom: &api.AIBackend_Custom{
 				Formats: formats,
-				Model:   llm.Custom.Model,
+				Model:   agentgateway.ConvertStringPtr(llm.Custom.Model),
 			},
 		}
 		if llm.Custom.BackendRef != nil {

--- a/controller/pkg/syncer/backend/backend_plugin_test.go
+++ b/controller/pkg/syncer/backend/backend_plugin_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"google.golang.org/protobuf/proto"
+	"istio.io/istio/pkg/ptr"
 	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/test/util/assert"
 	"istio.io/istio/pkg/util/protomarshal"
@@ -46,7 +47,7 @@ func TestBuildMCP(t *testing.T) {
 								Static: &agentgateway.McpTarget{
 									Host:     shortStringPtr("mcp-server.example.com"),
 									Port:     8080,
-									Path:     new("override-sse"),
+									Path:     ptr.Of(agentgateway.LongString("override-sse")),
 									Protocol: new(agentgateway.MCPProtocolSSE),
 								},
 							},
@@ -338,7 +339,7 @@ func TestBuildAIBackend(t *testing.T) {
 					AI: &agentgateway.AIBackend{
 						LLM: &agentgateway.LLMProvider{
 							OpenAI: &agentgateway.OpenAIConfig{
-								Model: new("gpt-4"),
+								Model: ptr.Of(agentgateway.ShortString("gpt-4")),
 							},
 						},
 					},
@@ -357,8 +358,8 @@ func TestBuildAIBackend(t *testing.T) {
 						LLM: &agentgateway.LLMProvider{
 							AzureOpenAI: &agentgateway.AzureOpenAIConfig{
 								Endpoint:       "endpoint-123.openai.azure.com",
-								DeploymentName: new("my-deployment"),
-								ApiVersion:     new("2024-02-15-preview"),
+								DeploymentName: ptr.Of(agentgateway.ShortString("my-deployment")),
+								ApiVersion:     ptr.Of(agentgateway.TinyString("2024-02-15-preview")),
 							},
 						},
 					},
@@ -378,9 +379,9 @@ func TestBuildAIBackend(t *testing.T) {
 							Azure: &agentgateway.AzureConfig{
 								ResourceName: "my-foundry-resource",
 								ResourceType: agentgateway.AzureResourceTypeFoundry,
-								Model:        new("gpt-4o-mini"),
-								ApiVersion:   new("2024-12-01-preview"),
-								ProjectName:  new("my-project"),
+								Model:        ptr.Of(agentgateway.ShortString("gpt-4o-mini")),
+								ApiVersion:   ptr.Of(agentgateway.TinyString("2024-12-01-preview")),
+								ProjectName:  ptr.Of(agentgateway.ShortString("my-project")),
 							},
 						},
 					},
@@ -398,7 +399,7 @@ func TestBuildAIBackend(t *testing.T) {
 					AI: &agentgateway.AIBackend{
 						LLM: &agentgateway.LLMProvider{
 							Anthropic: &agentgateway.AnthropicConfig{
-								Model: new("claude-3-sonnet"),
+								Model: ptr.Of(agentgateway.ShortString("claude-3-sonnet")),
 							},
 						},
 					},
@@ -416,7 +417,7 @@ func TestBuildAIBackend(t *testing.T) {
 					AI: &agentgateway.AIBackend{
 						LLM: &agentgateway.LLMProvider{
 							Gemini: &agentgateway.GeminiConfig{
-								Model: new("gemini-pro"),
+								Model: ptr.Of(agentgateway.ShortString("gemini-pro")),
 							},
 						},
 					},
@@ -434,7 +435,7 @@ func TestBuildAIBackend(t *testing.T) {
 					AI: &agentgateway.AIBackend{
 						LLM: &agentgateway.LLMProvider{
 							VertexAI: &agentgateway.VertexAIConfig{
-								Model: new("gemini-pro"),
+								Model: ptr.Of(agentgateway.ShortString("gemini-pro")),
 							},
 						},
 					},
@@ -532,7 +533,7 @@ func TestBuildAIBackend(t *testing.T) {
 					AI: &agentgateway.AIBackend{
 						LLM: &agentgateway.LLMProvider{
 							Bedrock: &agentgateway.BedrockConfig{
-								Model:  new("anthropic.claude-3-haiku-20240307-v1:0"),
+								Model:  ptr.Of(agentgateway.ShortString("anthropic.claude-3-haiku-20240307-v1:0")),
 								Region: "eu-west-1",
 								Guardrail: &agentgateway.AWSGuardrailConfig{
 									GuardrailIdentifier: "test-guardrail",
@@ -569,7 +570,7 @@ func TestBuildAIBackend(t *testing.T) {
 					AI: &agentgateway.AIBackend{
 						LLM: &agentgateway.LLMProvider{
 							OpenAI: &agentgateway.OpenAIConfig{
-								Model: new("gpt-3.5-turbo"),
+								Model: ptr.Of(agentgateway.ShortString("gpt-3.5-turbo")),
 							},
 						},
 					},
@@ -602,7 +603,7 @@ func TestBuildAIBackend(t *testing.T) {
 										},
 										LLMProvider: agentgateway.LLMProvider{
 											OpenAI: &agentgateway.OpenAIConfig{
-												Model: new("gpt-4"),
+												Model: ptr.Of(agentgateway.ShortString("gpt-4")),
 											},
 										},
 									},
@@ -615,7 +616,7 @@ func TestBuildAIBackend(t *testing.T) {
 										},
 										LLMProvider: agentgateway.LLMProvider{
 											Anthropic: &agentgateway.AnthropicConfig{
-												Model: new("claude-3"),
+												Model: ptr.Of(agentgateway.ShortString("claude-3")),
 											},
 										},
 									},
@@ -647,7 +648,7 @@ func TestBuildAIBackend(t *testing.T) {
 										},
 										LLMProvider: agentgateway.LLMProvider{
 											OpenAI: &agentgateway.OpenAIConfig{
-												Model: new("gpt-4"),
+												Model: ptr.Of(agentgateway.ShortString("gpt-4")),
 											},
 										},
 									},
@@ -660,7 +661,7 @@ func TestBuildAIBackend(t *testing.T) {
 										},
 										LLMProvider: agentgateway.LLMProvider{
 											Anthropic: &agentgateway.AnthropicConfig{
-												Model: new("claude-3-opus"),
+												Model: ptr.Of(agentgateway.ShortString("claude-3-opus")),
 											},
 										},
 									},
@@ -677,7 +678,7 @@ func TestBuildAIBackend(t *testing.T) {
 										},
 										LLMProvider: agentgateway.LLMProvider{
 											Gemini: &agentgateway.GeminiConfig{
-												Model: new("gemini-pro"),
+												Model: ptr.Of(agentgateway.ShortString("gemini-pro")),
 											},
 										},
 									},
@@ -709,7 +710,7 @@ func TestBuildAIBackend(t *testing.T) {
 					AI: &agentgateway.AIBackend{
 						LLM: &agentgateway.LLMProvider{
 							OpenAI: &agentgateway.OpenAIConfig{
-								Model: new("gpt-4o-mini"),
+								Model: ptr.Of(agentgateway.ShortString("gpt-4o-mini")),
 							},
 						},
 					},


### PR DESCRIPTION
## Summary
- Change custom string types (`TinyString`, `ShortString`, `LongString`, `SNI`) from type aliases to distinct types to eliminate `Mismatched comments on type string` warnings during code generation
- Add conversion helper methods (`String()`, `ConvertXxxStrings()`, `ConvertXxxPtr()`) to the CRD type file for ergonomic type conversions
- Update all usage sites with explicit type conversions
- Remove duplicated kubebuilder markers on fields that inherit validation from their type