### PR TITLE
fix: apply discoveryNamespaceSelectors filter to AgentgatewayBackend and AgentgatewayPolicy informers

### DIFF
--- a/controller/pkg/agentgateway/plugins/collection.go
+++ b/controller/pkg/agentgateway/plugins/collection.go
@@ -206,8 +206,8 @@ func NewAgwCollections(
 		InferencePools: krt.NewStaticCollection[*inf.InferencePool](nil, nil, krtOptions.ToOptions("disable/inferencepools")...),
 
 		// agentgateway-specific CRDs
-		AgentgatewayPolicies: krt.NewInformer[*agentgateway.AgentgatewayPolicy](client, krtOptions.ToOptions("informer/AgentgatewayPolicies")...),
-		Backends:             krt.NewInformer[*agentgateway.AgentgatewayBackend](client, krtOptions.ToOptions("informer/AgentgatewayBackends")...),
+		AgentgatewayPolicies: krt.NewFilteredInformer[*agentgateway.AgentgatewayPolicy](client, filter, krtOptions.ToOptions("informer/AgentgatewayPolicies")...),
+		Backends:             krt.NewFilteredInformer[*agentgateway.AgentgatewayBackend](client, filter, krtOptions.ToOptions("informer/AgentgatewayBackends")...),
 	}
 
 	if settings.EnableInferExt {


### PR DESCRIPTION
## Summary

`discoveryNamespaceSelectors` restricts the operator to watching only selected namespaces. This works correctly for all Gateway API and core Kubernetes resource informers, which all pass `filter` (built from `client.ObjectFilter()`) to `krt.NewFilteredInformer` / `kclient.NewFiltered*`.

`AgentgatewayPolicy` and `AgentgatewayBackend` were using `krt.NewInformer` instead, which does not accept a filter argument, causing both CRDs to be watched cluster-wide regardless of the `discoveryNamespaceSelectors` configuration.

## Reproduction

Run two operator instances in different namespaces, each with `discoveryNamespaceSelectors` scoped to its own namespace. The operators still reconcile each other's `AgentgatewayBackend` and `AgentgatewayPolicy` resources, producing errors like:

```
error processing policy
policy: jwtAuthentication agentgateway-development/jwt-test-google
error: backend agentgateway-development/google-jwks not found
```

## Fix

Pass the already-defined `filter` variable to `krt.NewFilteredInformer` for both CRDs, consistent with every other informer in the same function (`collection.go`).

```go
// Before
AgentgatewayPolicies: krt.NewInformer[*agentgateway.AgentgatewayPolicy](client, ...),
Backends:             krt.NewInformer[*agentgateway.AgentgatewayBackend](client, ...),

// After
AgentgatewayPolicies: krt.NewFilteredInformer[*agentgateway.AgentgatewayPolicy](client, filter, ...),
Backends:             krt.NewFilteredInformer[*agentgateway.AgentgatewayBackend](client, filter, ...),
```

## Test plan

- [x] `go build ./controller/...` passes
- [x] `go test ./controller/...` passes (all packages)