### PR TITLE
fix(bedrock): propagate cache-write tokens to access log for completi…

### DIFF
--- a/crates/agentgateway/src/llm/conversion/bedrock.rs
+++ b/crates/agentgateway/src/llm/conversion/bedrock.rs
@@ -877,6 +877,39 @@ pub mod from_completions {
 		})
 	}
 
+	// Bedrock reports cache-write tokens, but the OpenAI Completions type has no field
+	// for them, so completions::Response::to_llm_response reports None. Re-attach the
+	// value to the access-log LLMResponse here, mirroring the streaming path which sets
+	// r.response.cache_creation_input_tokens directly. The body and the OpenAI type are
+	// left untouched.
+	struct BedrockCompletionsResponse {
+		inner: types::completions::Response,
+		cache_creation_input_tokens: Option<u64>,
+	}
+
+	impl ResponseType for BedrockCompletionsResponse {
+		fn to_llm_response(&self, include_completion_in_log: bool) -> crate::llm::LLMResponse {
+			let mut r = self.inner.to_llm_response(include_completion_in_log);
+			r.cache_creation_input_tokens = self.cache_creation_input_tokens;
+			r
+		}
+
+		fn to_webhook_choices(&self) -> Vec<crate::llm::policy::webhook::ResponseChoice> {
+			self.inner.to_webhook_choices()
+		}
+
+		fn set_webhook_choices(
+			&mut self,
+			resp: Vec<crate::llm::policy::webhook::ResponseChoice>,
+		) -> anyhow::Result<()> {
+			self.inner.set_webhook_choices(resp)
+		}
+
+		fn serialize(&self) -> serde_json::Result<Vec<u8>> {
+			self.inner.serialize()
+		}
+	}
+
 	pub fn translate_response(
 		bytes: &Bytes,
 		model: &str,
@@ -885,9 +918,18 @@ pub mod from_completions {
 		let resp = serde_json::from_slice::<bedrock::ConverseResponse>(bytes)
 			.map_err(logged_response_parsing(bytes))?;
 		let openai = translate_response_internal(resp, model, tool_name_map)?;
+		// The typed response carries Bedrock's cache-write count; capture it before
+		// json::convert demotes it into the untyped OpenAI Completions `rest` bucket.
+		let cache_creation_input_tokens = openai
+			.usage
+			.as_ref()
+			.and_then(|u| u.cache_creation_input_tokens);
 		let passthrough = json::convert::<_, types::completions::Response>(&openai)
 			.map_err(AIError::ResponseParsing)?;
-		Ok(Box::new(passthrough))
+		Ok(Box::new(BedrockCompletionsResponse {
+			inner: passthrough,
+			cache_creation_input_tokens,
+		}))
 	}
 
 	fn translate_response_internal(

--- a/crates/agentgateway/src/llm/conversion/bedrock.rs
+++ b/crates/agentgateway/src/llm/conversion/bedrock.rs
@@ -877,39 +877,6 @@ pub mod from_completions {
 		})
 	}
 
-	// Bedrock reports cache-write tokens, but the OpenAI Completions type has no field
-	// for them, so completions::Response::to_llm_response reports None. Re-attach the
-	// value to the access-log LLMResponse here, mirroring the streaming path which sets
-	// r.response.cache_creation_input_tokens directly. The body and the OpenAI type are
-	// left untouched.
-	struct BedrockCompletionsResponse {
-		inner: types::completions::Response,
-		cache_creation_input_tokens: Option<u64>,
-	}
-
-	impl ResponseType for BedrockCompletionsResponse {
-		fn to_llm_response(&self, include_completion_in_log: bool) -> crate::llm::LLMResponse {
-			let mut r = self.inner.to_llm_response(include_completion_in_log);
-			r.cache_creation_input_tokens = self.cache_creation_input_tokens;
-			r
-		}
-
-		fn to_webhook_choices(&self) -> Vec<crate::llm::policy::webhook::ResponseChoice> {
-			self.inner.to_webhook_choices()
-		}
-
-		fn set_webhook_choices(
-			&mut self,
-			resp: Vec<crate::llm::policy::webhook::ResponseChoice>,
-		) -> anyhow::Result<()> {
-			self.inner.set_webhook_choices(resp)
-		}
-
-		fn serialize(&self) -> serde_json::Result<Vec<u8>> {
-			self.inner.serialize()
-		}
-	}
-
 	pub fn translate_response(
 		bytes: &Bytes,
 		model: &str,
@@ -918,18 +885,9 @@ pub mod from_completions {
 		let resp = serde_json::from_slice::<bedrock::ConverseResponse>(bytes)
 			.map_err(logged_response_parsing(bytes))?;
 		let openai = translate_response_internal(resp, model, tool_name_map)?;
-		// The typed response carries Bedrock's cache-write count; capture it before
-		// json::convert demotes it into the untyped OpenAI Completions `rest` bucket.
-		let cache_creation_input_tokens = openai
-			.usage
-			.as_ref()
-			.and_then(|u| u.cache_creation_input_tokens);
 		let passthrough = json::convert::<_, types::completions::Response>(&openai)
 			.map_err(AIError::ResponseParsing)?;
-		Ok(Box::new(BedrockCompletionsResponse {
-			inner: passthrough,
-			cache_creation_input_tokens,
-		}))
+		Ok(Box::new(passthrough))
 	}
 
 	fn translate_response_internal(

--- a/crates/agentgateway/src/llm/tests.rs
+++ b/crates/agentgateway/src/llm/tests.rs
@@ -573,8 +573,6 @@ mod response {
 		// reasoning_signature on the completions path), `reasoning_unsigned` does not.
 		("reasoning", ALL_BEDROCK),
 		("reasoning_unsigned", ALL_BEDROCK),
-		// Prompt-cache write: cacheWriteInputTokens must reach the access-log usage
-		// (cache_creation_input_tokens) on the completions path, not just the body.
 		("cache_write", &[BEDROCK_TO_COMPLETIONS]),
 	];
 	const BEDROCK_STREAM_RESPONSES: &[(&str, &[&str])] = &[

--- a/crates/agentgateway/src/llm/tests.rs
+++ b/crates/agentgateway/src/llm/tests.rs
@@ -573,6 +573,9 @@ mod response {
 		// reasoning_signature on the completions path), `reasoning_unsigned` does not.
 		("reasoning", ALL_BEDROCK),
 		("reasoning_unsigned", ALL_BEDROCK),
+		// Prompt-cache write: cacheWriteInputTokens must reach the access-log usage
+		// (cache_creation_input_tokens) on the completions path, not just the body.
+		("cache_write", &[BEDROCK_TO_COMPLETIONS]),
 	];
 	const BEDROCK_STREAM_RESPONSES: &[(&str, &[&str])] = &[
 		("basic", ALL_BEDROCK),

--- a/crates/agentgateway/src/llm/tests/response/anthropic/basic.messages-completions.snap
+++ b/crates/agentgateway/src/llm/tests/response/anthropic/basic.messages-completions.snap
@@ -50,6 +50,7 @@ info:
     "input_tokens": 15,
     "output_tokens": 21,
     "total_tokens": 36,
+    "cache_creation_input_tokens": 13,
     "cached_input_tokens": 12,
     "service_tier": "standard",
     "provider_model": "claude-haiku-4-5-20251001"

--- a/crates/agentgateway/src/llm/tests/response/anthropic/thinking.messages-completions.snap
+++ b/crates/agentgateway/src/llm/tests/response/anthropic/thinking.messages-completions.snap
@@ -57,6 +57,7 @@ info:
     "input_tokens": 47,
     "output_tokens": 251,
     "total_tokens": 298,
+    "cache_creation_input_tokens": 1,
     "cached_input_tokens": 2,
     "service_tier": "standard",
     "provider_model": "claude-opus-4-6"

--- a/crates/agentgateway/src/llm/tests/response/anthropic/tool.messages-completions.snap
+++ b/crates/agentgateway/src/llm/tests/response/anthropic/tool.messages-completions.snap
@@ -65,6 +65,7 @@ info:
     "input_tokens": 558,
     "output_tokens": 48,
     "total_tokens": 606,
+    "cache_creation_input_tokens": 1,
     "cached_input_tokens": 2,
     "service_tier": "standard",
     "provider_model": "claude-opus-4-6"

--- a/crates/agentgateway/src/llm/tests/response/bedrock/cache_write.bedrock-completions.snap
+++ b/crates/agentgateway/src/llm/tests/response/bedrock/cache_write.bedrock-completions.snap
@@ -1,0 +1,55 @@
+---
+source: crates/agentgateway/src/llm/tests.rs
+description: src/llm/tests/response/bedrock/cache_write.json
+info:
+  output:
+    message:
+      role: assistant
+      content:
+        - text: ok
+  stopReason: end_turn
+  usage:
+    inputTokens: 16
+    outputTokens: 9
+    totalTokens: 2412
+    cacheReadInputTokens: 0
+    cacheWriteInputTokens: 2387
+  metrics:
+    latencyMs: 2083
+---
+{
+  "response": {
+    "model": "input-model",
+    "usage": {
+      "prompt_tokens": 16,
+      "completion_tokens": 9,
+      "total_tokens": 2412,
+      "prompt_tokens_details": {
+        "cached_tokens": 0
+      },
+      "cache_read_input_tokens": 0,
+      "cache_creation_input_tokens": 2387
+    },
+    "choices": [
+      {
+        "message": {
+          "content": "ok",
+          "role": "assistant"
+        },
+        "index": 0,
+        "finish_reason": "stop"
+      }
+    ],
+    "id": "[id]",
+    "created": "[date]",
+    "object": "chat.completion"
+  },
+  "parsed": {
+    "input_tokens": 16,
+    "output_tokens": 9,
+    "total_tokens": 2412,
+    "cache_creation_input_tokens": 2387,
+    "cached_input_tokens": 0,
+    "provider_model": "input-model"
+  }
+}

--- a/crates/agentgateway/src/llm/tests/response/bedrock/cache_write.json
+++ b/crates/agentgateway/src/llm/tests/response/bedrock/cache_write.json
@@ -1,0 +1,23 @@
+{
+  "output": {
+    "message": {
+      "role": "assistant",
+      "content": [
+        {
+          "text": "ok"
+        }
+      ]
+    }
+  },
+  "stopReason": "end_turn",
+  "usage": {
+    "inputTokens": 16,
+    "outputTokens": 9,
+    "totalTokens": 2412,
+    "cacheReadInputTokens": 0,
+    "cacheWriteInputTokens": 2387
+  },
+  "metrics": {
+    "latencyMs": 2083
+  }
+}

--- a/crates/agentgateway/src/llm/types/completions.rs
+++ b/crates/agentgateway/src/llm/types/completions.rs
@@ -143,6 +143,10 @@ pub struct Usage {
 	/// Breakdown of tokens used in the prompt.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub prompt_tokens_details: Option<UsagePromptDetails>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub cache_read_input_tokens: Option<u64>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub cache_creation_input_tokens: Option<u64>,
 	#[serde(flatten, default)]
 	pub rest: serde_json::Value,
 }
@@ -177,11 +181,16 @@ impl ResponseType for Response {
 					.and_then(|d| d.reasoning_tokens)
 			}),
 			cached_input_tokens: self.usage.as_ref().and_then(|u| {
-				u.prompt_tokens_details
-					.as_ref()
-					.and_then(|d| d.cached_tokens)
+				u.cache_read_input_tokens.or_else(|| {
+					u.prompt_tokens_details
+						.as_ref()
+						.and_then(|d| d.cached_tokens)
+				})
 			}),
-			cache_creation_input_tokens: None,
+			cache_creation_input_tokens: self
+				.usage
+				.as_ref()
+				.and_then(|u| u.cache_creation_input_tokens),
 			service_tier: self.service_tier.as_deref().map(Into::into),
 			provider_model: Some(strng::new(&self.model)),
 			completion: if include_completion_in_log {


### PR DESCRIPTION
Fixes #2443 

## What

Non-streaming Bedrock requests via /v1/chat/completions return cache_creation_input_tokens correctly in the response body, but the value is dropped from the access log (gen_ai.usage.cache_creation.input_tokens). cache_read logs fine on this path — only cache-write is missing.

Follow-up to #1991/#1993: that fix touched the streaming OpenAI-compat passthrough path, which Bedrock doesn't use. Non-streaming Bedrock goes through bedrock::from_completions::translate_response → completions::Response::to_llm_response, which hardcodes the field to None.

Root cause: to_completions() sets the value on the typed response, but converting to the untyped OpenAI completions::Response demotes it into the flattened rest bucket (no first-class field on that type), so to_llm_response never sees it.

## Fix

Capture the value before the json::convert demotes it, and re-attach it to the access-log LLMResponse via a thin ResponseType wrapper — mirrors what the streaming Bedrock path already does. No change to the shared OpenAI type or response body.

## Testing

- New snapshot test (cache_write.json) asserting the field is present in the parsed access log.
- cargo fmt/clippy clean; full lib suite passes, no new failures.