### PR TITLE
Resolve Istio CRDs via `go mod download`

### DIFF
--- a/controller/Makefile
+++ b/controller/Makefile
@@ -640,11 +640,9 @@ endif
 # The controller consumes Istio's ambient collections (WorkloadEntry,
 # ServiceEntry, AuthorizationPolicy...) so these CRDs must exist for those
 # informers to receive objects.
-ISTIO_CRDS_FILE := $(shell go list -m -f '{{.Dir}}' istio.io/istio)/manifests/charts/base/files/crd-all.gen.yaml
-
 .PHONY: istio-crds
 istio-crds: ## Install Istio CRDs (WorkloadEntry, ServiceEntry, etc.) from the vendored istio module
-	kubectl apply --server-side -f "$(ISTIO_CRDS_FILE)"
+	kubectl apply --server-side -f "$$(go mod download -json istio.io/istio | awk -F'"' '/"Dir":/ {print $$4; exit}')/manifests/charts/base/files/crd-all.gen.yaml"
 
 .PHONY: metallb
 metallb: ## Install the MetalLB load balancer


### PR DESCRIPTION
`make -C controller run` is currently broken on `main` when `istio.io/istio` isn't present in the local Go cache:

```shell
# Remove local Istio module from Go cache (might need sudo)
$ rm -rf $(go list -m -f '{{.Dir}}' istio.io/istio)

# Try to deploy agentgateway on Kind cluster
$ make -C controller run
kind get clusters | grep kind || kind create cluster --name kind --image kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5
No kind clusters found.
Creating cluster "kind" ...
 ✓ Ensuring node image (kindest/node:v1.36.1) 🖼
 ✓ Preparing nodes 📦
 ✓ Writing configuration 📜
 ✓ Starting control-plane 🕹️
 ✓ Installing CNI 🔌
 ✓ Installing StorageClass 💾
Set kubectl context to "kind-kind"
You can now use your cluster with:

kubectl cluster-info --context kind-kind

Not sure what to do next? 😅  Check out https://kind.sigs.k8s.io/docs/user/quick-start/
kubectl apply --server-side -f "https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.0/experimental-install.yaml"
customresourcedefinition.apiextensions.k8s.io/backendtlspolicies.gateway.networking.k8s.io serverside-applied
customresourcedefinition.apiextensions.k8s.io/gatewayclasses.gateway.networking.k8s.io serverside-applied
customresourcedefinition.apiextensions.k8s.io/gateways.gateway.networking.k8s.io serverside-applied
customresourcedefinition.apiextensions.k8s.io/grpcroutes.gateway.networking.k8s.io serverside-applied
customresourcedefinition.apiextensions.k8s.io/httproutes.gateway.networking.k8s.io serverside-applied
customresourcedefinition.apiextensions.k8s.io/listenersets.gateway.networking.k8s.io serverside-applied
customresourcedefinition.apiextensions.k8s.io/referencegrants.gateway.networking.k8s.io serverside-applied
customresourcedefinition.apiextensions.k8s.io/tcproutes.gateway.networking.k8s.io serverside-applied
customresourcedefinition.apiextensions.k8s.io/tlsroutes.gateway.networking.k8s.io serverside-applied
customresourcedefinition.apiextensions.k8s.io/udproutes.gateway.networking.k8s.io serverside-applied
validatingadmissionpolicy.admissionregistration.k8s.io/safe-upgrades.gateway.networking.k8s.io serverside-applied
validatingadmissionpolicybinding.admissionregistration.k8s.io/safe-upgrades.gateway.networking.k8s.io serverside-applied
customresourcedefinition.apiextensions.k8s.io/xbackends.gateway.networking.x-k8s.io serverside-applied
customresourcedefinition.apiextensions.k8s.io/xbackendtrafficpolicies.gateway.networking.x-k8s.io serverside-applied
customresourcedefinition.apiextensions.k8s.io/xmeshes.gateway.networking.x-k8s.io serverside-applied
kubectl apply -f "https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/v1.5.0/manifests.yaml"
customresourcedefinition.apiextensions.k8s.io/inferencemodelrewrites.inference.networking.x-k8s.io created
customresourcedefinition.apiextensions.k8s.io/inferenceobjectives.inference.networking.x-k8s.io created
customresourcedefinition.apiextensions.k8s.io/inferencepoolimports.inference.networking.x-k8s.io created
customresourcedefinition.apiextensions.k8s.io/inferencepools.inference.networking.k8s.io created
kubectl apply --server-side -f "/manifests/charts/base/files/crd-all.gen.yaml"
error: the path "/manifests/charts/base/files/crd-all.gen.yaml" does not exist
make: *** [istio-crds] Error 1
```

This is because as of https://github.com/agentgateway/agentgateway/pull/1566 the Makefile assumes the module is present in local cache.

Fix this by using `go mod download` which checks the cache and downloads only when necessary.