### PR TITLE
standalone: allow simpler host + TLS configuration

### DIFF
--- a/crates/agentgateway/src/http/auth/oauth/cross_app_access.rs
+++ b/crates/agentgateway/src/http/auth/oauth/cross_app_access.rs
@@ -1,5 +1,4 @@
 use std::collections::BTreeMap;
-use std::sync::Arc;
 
 #[cfg(feature = "schema")]
 use super::TokenCacheConfig;
@@ -9,7 +8,7 @@ use super::{
 	TokenSpec, default_token_cache, deserialize_token_cache,
 };
 use crate::http::auth::AuthorizationLocation;
-use crate::types::agent::{BackendTrafficPolicy, SimpleBackendReference};
+use crate::types::agent::SimpleBackendReferenceWithPolicies;
 use crate::{apply, schema};
 
 #[apply(schema!)]
@@ -61,7 +60,6 @@ impl CrossAppAccessAuth {
 	pub(crate) fn apply_local_defaults(&mut self) -> Result<(), String> {
 		self.oauth = Some(OAuthTokenExchangeAuth {
 			target: self.identity_provider.target.clone(),
-			policies: self.identity_provider.policies.clone(),
 			token_endpoint_path: self.identity_provider.token_endpoint_path.clone(),
 			grant_type: OAuthGrantType::TokenExchange,
 			subject_token: TokenSpec {
@@ -99,21 +97,9 @@ impl CrossAppAccessAuth {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub(super) struct CrossAppAccessEndpoint {
-	/// Token endpoint backend.
+	/// Token endpoint backend and policies used when connecting to it.
 	#[serde(flatten)]
-	#[cfg_attr(
-		feature = "schema",
-		schemars(with = "crate::types::local::SimpleLocalBackend")
-	)]
-	pub(super) target: Arc<SimpleBackendReference>,
-	/// Backend policies (TLS, request timeout, ...) used when connecting to the token endpoint.
-	#[serde(default, skip_serializing_if = "Vec::is_empty")]
-	#[serde(deserialize_with = "crate::types::local::de_from_local_backend_policy")]
-	#[cfg_attr(
-		feature = "schema",
-		schemars(with = "Option<crate::types::local::SimpleLocalBackendPolicies>")
-	)]
-	pub(super) policies: Vec<BackendTrafficPolicy>,
+	pub(super) target: SimpleBackendReferenceWithPolicies,
 	/// Token endpoint path on the backend; defaults to "/".
 	#[serde(default, skip_serializing_if = "String::is_empty")]
 	pub(super) token_endpoint_path: String,
@@ -140,7 +126,6 @@ impl CrossAppAccessEndpoint {
 	fn as_chained_exchange(&self, scopes: &[String]) -> ChainedExchange {
 		ChainedExchange {
 			target: self.target.clone(),
-			policies: self.policies.clone(),
 			token_endpoint_path: self.token_endpoint_path.clone(),
 			client_auth: Some(self.client_auth.clone()),
 			audiences: Vec::new(),

--- a/crates/agentgateway/src/http/auth/oauth/mod.rs
+++ b/crates/agentgateway/src/http/auth/oauth/mod.rs
@@ -15,6 +15,8 @@ use crate::http::oauth::{TOKEN_TYPE_ACCESS, TOKEN_TYPE_ID, TOKEN_TYPE_ID_JAG, TO
 use crate::proxy::ProxyError;
 use crate::proxy::httpproxy::PolicyClient;
 use crate::serdes::schema;
+use crate::types::agent::SimpleBackendReferenceWithPolicies;
+#[cfg(test)]
 use crate::types::agent::{BackendTrafficPolicy, SimpleBackendReference};
 use crate::types::agent_xds::{
 	Diagnostics, authorization_location, optional_authorization_location,
@@ -44,17 +46,9 @@ use crate::serdes::FileOrInline;
 #[apply(schema!)]
 pub struct OAuthTokenExchangeAuth {
 	// ----- Token endpoint -----
-	/// Backend serving the RFC 8693 token endpoint.
+	/// Backend serving the RFC 8693 token endpoint and policies used when connecting to it.
 	#[serde(flatten)]
-	target: Arc<SimpleBackendReference>,
-	/// Backend policies (TLS, request timeout, ...) used when connecting to the token endpoint.
-	#[serde(default, skip_serializing_if = "Vec::is_empty")]
-	#[serde(deserialize_with = "crate::types::local::de_from_local_backend_policy")]
-	#[cfg_attr(
-		feature = "schema",
-		schemars(with = "Option<crate::types::local::SimpleLocalBackendPolicies>")
-	)]
-	policies: Vec<BackendTrafficPolicy>,
+	target: SimpleBackendReferenceWithPolicies,
 	/// Token endpoint path on the backend; defaults to "/".
 	#[serde(default, skip_serializing_if = "String::is_empty")]
 	token_endpoint_path: String,
@@ -122,13 +116,9 @@ pub struct OAuthTokenExchangeAuth {
 #[derive(Debug, Clone, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 struct ChainedExchange {
-	/// Backend serving the chained RFC 7523 token endpoint.
+	/// Backend serving the chained RFC 7523 token endpoint and policies used when connecting to it.
 	#[serde(flatten)]
-	target: Arc<SimpleBackendReference>,
-	/// Backend policies (TLS, request timeout, ...) used when connecting to the token endpoint.
-	#[serde(default, skip_serializing_if = "Vec::is_empty")]
-	#[serde(deserialize_with = "crate::types::local::de_from_local_backend_policy")]
-	policies: Vec<BackendTrafficPolicy>,
+	target: SimpleBackendReferenceWithPolicies,
 	/// Token endpoint path on the backend; defaults to "/".
 	#[serde(default, skip_serializing_if = "String::is_empty")]
 	token_endpoint_path: String,
@@ -306,10 +296,12 @@ impl OAuthTokenExchangeAuth {
 		let cache = token_cache_from_proto(t.cache)?;
 
 		let auth = Self {
-			target: Arc::new(target),
-			// Inline connection policies are not supported from xDS;
-			// the backend resource carries its own policies there.
-			policies: Vec::new(),
+			target: SimpleBackendReferenceWithPolicies {
+				target: Arc::new(target),
+				// Inline connection policies are not supported from xDS;
+				// the backend resource carries its own policies there.
+				policies: Vec::new(),
+			},
 			token_endpoint_path,
 			grant_type,
 			subject_token,

--- a/crates/agentgateway/src/http/auth/oauth/tests.rs
+++ b/crates/agentgateway/src/http/auth/oauth/tests.rs
@@ -52,8 +52,10 @@ fn endpoint(mock: &MockServer) -> Arc<SimpleBackendReference> {
 
 fn base_auth(endpoint: Arc<SimpleBackendReference>) -> OAuthTokenExchangeAuth {
 	OAuthTokenExchangeAuth {
-		target: endpoint,
-		policies: vec![],
+		target: SimpleBackendReferenceWithPolicies {
+			target: endpoint,
+			policies: vec![],
+		},
 		token_endpoint_path: "/token".into(),
 		grant_type: OAuthGrantType::TokenExchange,
 		subject_token: TokenSpec::default(),
@@ -79,8 +81,10 @@ fn auth(endpoint: Arc<SimpleBackendReference>) -> OAuthTokenExchangeAuth {
 
 fn cross_app_access_endpoint(endpoint: Arc<SimpleBackendReference>) -> CrossAppAccessEndpoint {
 	CrossAppAccessEndpoint {
-		target: endpoint,
-		policies: vec![],
+		target: SimpleBackendReferenceWithPolicies {
+			target: endpoint,
+			policies: vec![],
+		},
 		token_endpoint_path: "/token".into(),
 		client_auth: OAuthClientAuth {
 			client_id: "gateway-client".into(),
@@ -200,7 +204,7 @@ fn assert_proto_err_contains(proto: proto::OAuthTokenExchange, expected: &str) {
 fn deserializes_minimal_config() {
 	let a: OAuthTokenExchangeAuth = serde_json::from_str(r#"{"host": "localhost:8089"}"#).unwrap();
 	assert!(matches!(
-		a.target.as_ref(),
+		a.target.target.as_ref(),
 		SimpleBackendReference::InlineBackend(_)
 	));
 	assert!(a.token_endpoint_path.is_empty());
@@ -257,13 +261,11 @@ async fn fails_closed_on_slow_endpoint() {
 			.set_delay(Duration::from_secs(2)),
 	)
 	.await;
-	let a = OAuthTokenExchangeAuth {
-		policies: vec![BackendTrafficPolicy::HTTP(crate::types::backend::HTTP {
-			request_timeout: Some(Duration::from_millis(50)),
-			..Default::default()
-		})],
-		..base_auth(endpoint(&mock))
-	};
+	let mut a = base_auth(endpoint(&mock));
+	a.target.policies = vec![BackendTrafficPolicy::HTTP(crate::types::backend::HTTP {
+		request_timeout: Some(Duration::from_millis(50)),
+		..Default::default()
+	})];
 
 	let err = fetch_token(
 		&policy_client(),

--- a/crates/agentgateway/src/http/auth/oauth/transport.rs
+++ b/crates/agentgateway/src/http/auth/oauth/transport.rs
@@ -168,8 +168,8 @@ pub(super) struct TokenRequestSpec<'a> {
 impl<'a> From<&'a OAuthTokenExchangeAuth> for TokenRequestSpec<'a> {
 	fn from(auth: &'a OAuthTokenExchangeAuth) -> Self {
 		Self {
-			target: auth.target.as_ref(),
-			policies: &auth.policies,
+			target: auth.target.target.as_ref(),
+			policies: &auth.target.policies,
 			token_endpoint_path: &auth.token_endpoint_path,
 			grant_type: auth.grant_type,
 			client_auth: auth.client_auth.as_ref(),
@@ -185,8 +185,8 @@ impl<'a> From<&'a OAuthTokenExchangeAuth> for TokenRequestSpec<'a> {
 impl<'a> From<&'a ChainedExchange> for TokenRequestSpec<'a> {
 	fn from(auth: &'a ChainedExchange) -> Self {
 		Self {
-			target: auth.target.as_ref(),
-			policies: &auth.policies,
+			target: auth.target.target.as_ref(),
+			policies: &auth.target.policies,
 			token_endpoint_path: &auth.token_endpoint_path,
 			grant_type: OAuthGrantType::JwtBearer,
 			client_auth: auth.client_auth.as_ref(),

--- a/crates/agentgateway/src/http/ext_authz.rs
+++ b/crates/agentgateway/src/http/ext_authz.rs
@@ -18,7 +18,6 @@ use crate::http::ext_authz::proto::check_response::HttpResponse;
 use crate::http::ext_authz::proto::{
 	AttributeContext, CheckRequest, DeniedHttpResponse, HeaderValueOption, Metadata, OkHttpResponse,
 };
-use crate::http::ext_proc::GrpcReferenceChannel;
 use crate::http::filters::BackendRequestTimeout;
 use crate::http::{
 	HeaderName, HeaderOrPseudo, PolicyResponse, Request, RequestOrResponse, Response,
@@ -30,7 +29,7 @@ use crate::proxy::{ProxyError, ProxyResponse, dtrace};
 use crate::telemetry::log::RequestLog;
 use crate::telemetry::metrics::{OutboundCallKind, OutboundCallSubtype};
 use crate::transport::stream::{TCPConnectionInfo, TLSConnectionInfo};
-use crate::types::agent::{BackendTrafficPolicy, SimpleBackendReference};
+use crate::types::agent::SimpleBackendReferenceWithPolicies;
 use crate::*;
 
 const TRACE_POLICY_KIND: &str = "ext_auth";
@@ -173,17 +172,9 @@ where
 
 #[apply(schema!)]
 pub struct ExtAuthz {
-	/// Backend that receives authorization checks.
+	/// Backend that receives authorization checks and policies used when connecting to it.
 	#[serde(flatten)]
-	pub target: Arc<SimpleBackendReference>,
-	/// Backend policies used when connecting to the authorization service.
-	#[serde(default, skip_serializing_if = "Vec::is_empty")]
-	#[serde(deserialize_with = "crate::types::local::de_from_local_backend_policy")]
-	#[cfg_attr(
-		feature = "schema",
-		schemars(with = "Option<crate::types::local::SimpleLocalBackendPolicies>")
-	)]
-	pub policies: Vec<BackendTrafficPolicy>,
+	pub target: SimpleBackendReferenceWithPolicies,
 	/// Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.
 	#[serde(default)]
 	pub protocol: Protocol,
@@ -370,11 +361,11 @@ impl ExtAuthz {
 		req: &mut Request,
 	) -> Result<PolicyResponse, ProxyError> {
 		if matches!(self.protocol, Protocol::Http { .. }) {
-			trace!(protocol = "http", "connecting to {:?}", self.target);
+			trace!(protocol = "http", "connecting to {:?}", self.target.target);
 			return self.check_http(client, req).await;
 		}
 		let start = dtrace::timed_start();
-		trace!(protocol = "grpc", "connecting to {:?}", self.target);
+		trace!(protocol = "grpc", "connecting to {:?}", self.target.target);
 
 		let Protocol::Grpc { context, metadata } = &self.protocol else {
 			unreachable!();
@@ -385,11 +376,9 @@ impl ExtAuthz {
 			return cached_response.apply(req);
 		}
 		pol_event!(Severity::Info, "{}", cache_lookup);
-		let chan = GrpcReferenceChannel {
-			target: self.target.clone(),
-			policies: Arc::new(self.policies.clone()),
-			client: client.with_outbound(OutboundCallKind::Policy, OutboundCallSubtype::ExtAuthz),
-		};
+		let chan = self
+			.target
+			.grpc_channel(client.with_outbound(OutboundCallKind::Policy, OutboundCallSubtype::ExtAuthz));
 		let mut grpc_client = AuthorizationClient::new(chan);
 		// Get connection info with proper error handling
 		// Clone the fields we need to avoid borrow checker issues
@@ -848,7 +837,11 @@ impl ExtAuthz {
 		let scope = dtrace::start_scope("ext_authz");
 		let resp = client
 			.with_outbound(OutboundCallKind::Policy, OutboundCallSubtype::ExtAuthz)
-			.call_reference(check_req, &self.target)
+			.call_reference_with_policies(
+				check_req,
+				&self.target.target,
+				self.target.policies.as_slice(),
+			)
 			.await;
 		let mut resp = match resp {
 			Ok(r) => r,

--- a/crates/agentgateway/src/http/ext_authz_tests.rs
+++ b/crates/agentgateway/src/http/ext_authz_tests.rs
@@ -10,14 +10,18 @@ use crate::http::ext_authz::proto::{
 	HeaderValue as ProtoHeaderValue, HeaderValueOption, QueryParameter,
 };
 use crate::http::ext_authz::{BodyOptions, ExtAuthz, ExtAuthzDynamicMetadata, FailureMode};
-use crate::types::agent::SimpleBackendReference;
+use crate::types::agent::{
+	BackendTrafficPolicy, SimpleBackendReference, SimpleBackendReferenceWithPolicies, Target,
+};
 use crate::*;
 
 impl Default for ExtAuthz {
 	fn default() -> Self {
 		Self {
-			target: Arc::new(SimpleBackendReference::Invalid),
-			policies: Default::default(),
+			target: SimpleBackendReferenceWithPolicies {
+				target: Arc::new(SimpleBackendReference::Invalid),
+				policies: Default::default(),
+			},
 			failure_mode: FailureMode::default(),
 			include_request_headers: Vec::new(),
 			include_request_body: None,
@@ -29,6 +33,23 @@ impl Default for ExtAuthz {
 			},
 		}
 	}
+}
+
+#[test]
+fn ext_authz_https_host_defaults_port_and_tls_policy() {
+	let authz: ExtAuthz = serde_json::from_value(serde_json::json!({
+		"host": "https://foo.com/",
+	}))
+	.expect("deserialize ext_authz");
+
+	assert!(matches!(
+		authz.target.target.as_ref(),
+		SimpleBackendReference::InlineBackend(Target::Hostname(host, 443)) if host.as_str() == "foo.com"
+	));
+	assert!(matches!(
+		authz.target.policies.as_slice(),
+		[BackendTrafficPolicy::BackendTLS(_)]
+	));
 }
 
 #[test]

--- a/crates/agentgateway/src/http/ext_authz_tests.rs
+++ b/crates/agentgateway/src/http/ext_authz_tests.rs
@@ -53,6 +53,21 @@ fn ext_authz_https_host_defaults_port_and_tls_policy() {
 }
 
 #[test]
+fn ext_authz_url_host_rejects_unknown_scheme_with_explicit_port() {
+	let err = serde_json::from_value::<ExtAuthz>(serde_json::json!({
+		"host": "foo://example.com:123",
+	}))
+	.expect_err("unsupported scheme should be rejected");
+
+	assert!(
+		err
+			.to_string()
+			.contains("backend URL scheme must be http or https"),
+		"got: {err}"
+	);
+}
+
+#[test]
 fn test_process_headers_with_allowlist() {
 	let mut req = ::http::Request::builder()
 		.uri("http://example.com")

--- a/crates/agentgateway/src/http/ext_proc.rs
+++ b/crates/agentgateway/src/http/ext_proc.rs
@@ -24,7 +24,7 @@ use crate::proxy::ProxyError;
 use crate::proxy::dtrace::{self, pol_result};
 use crate::proxy::httpproxy::PolicyClient;
 use crate::telemetry::metrics::{OutboundCallKind, OutboundCallSubtype};
-use crate::types::agent::{BackendTrafficPolicy, SimpleBackendReference};
+use crate::types::agent::{SimpleBackendReference, SimpleBackendReferenceWithPolicies};
 use crate::{http, *};
 
 /// The namespace key used for ext_proc attributes in ProcessingRequest.attributes
@@ -180,8 +180,10 @@ impl InferenceRouting {
 			destination_mode: self.destination_mode,
 			ext_proc: Some(ExtProcInstance::new(
 				client,
-				Vec::new(),
-				self.target.clone(),
+				SimpleBackendReferenceWithPolicies {
+					target: self.target.clone(),
+					policies: Vec::new(),
+				},
 				self.failure_mode,
 				None,
 				None,
@@ -246,17 +248,9 @@ impl InferencePoolRouter {
 
 #[apply(schema!)]
 pub struct ExtProc {
-	/// Backend that receives external processing calls.
+	/// Backend that receives external processing calls and policies used when connecting to it.
 	#[serde(flatten)]
-	pub target: Arc<SimpleBackendReference>,
-	/// Backend policies used when connecting to the external processing service.
-	#[serde(default, skip_serializing_if = "Vec::is_empty")]
-	#[serde(deserialize_with = "crate::types::local::de_from_local_backend_policy")]
-	#[cfg_attr(
-		feature = "schema",
-		schemars(with = "Option<crate::types::local::SimpleLocalBackendPolicies>")
-	)]
-	pub policies: Vec<BackendTrafficPolicy>,
+	pub target: SimpleBackendReferenceWithPolicies,
 	/// Behavior when the external processing service is unavailable or returns an error.
 	#[serde(default)]
 	pub failure_mode: FailureMode,
@@ -282,7 +276,6 @@ impl ExtProc {
 		ExtProcRequest {
 			ext_proc: Some(ExtProcInstance::new(
 				client,
-				self.policies.clone(),
 				self.target.clone(),
 				self.failure_mode,
 				self.metadata_context.clone(),
@@ -398,20 +391,16 @@ impl ExtProcInstance {
 	#[allow(clippy::too_many_arguments)]
 	fn new(
 		client: PolicyClient,
-		policies: Vec<BackendTrafficPolicy>,
-		target: Arc<SimpleBackendReference>,
+		target: SimpleBackendReferenceWithPolicies,
 		failure_mode: FailureMode,
 		metadata_context: Option<HashMap<String, HashMap<String, Arc<cel::Expression>>>>,
 		req_attributes: Option<HashMap<String, Arc<cel::Expression>>>,
 		resp_attributes: Option<HashMap<String, Arc<cel::Expression>>>,
 		processing_options: ProcessingOptions,
 	) -> ExtProcInstance {
-		trace!("connecting to {:?}", target);
-		let chan = GrpcReferenceChannel {
-			target,
-			client: client.with_outbound(OutboundCallKind::Policy, OutboundCallSubtype::ExtProc),
-			policies: Arc::new(policies),
-		};
+		trace!("connecting to {:?}", target.target);
+		let chan = target
+			.grpc_channel(client.with_outbound(OutboundCallKind::Policy, OutboundCallSubtype::ExtProc));
 		Self {
 			skipped: Default::default(),
 			request_body_immediate_response: Arc::new(Mutex::new(None)),

--- a/crates/agentgateway/src/http/ext_proc_tests.rs
+++ b/crates/agentgateway/src/http/ext_proc_tests.rs
@@ -2049,10 +2049,12 @@ fn build_ext_proc_request_for_test(
 	let bind = setup_proxy_test("{}").unwrap().with_backend(ext_proc_addr);
 	let client = crate::proxy::httpproxy::PolicyClient::new(bind.inputs());
 	super::ExtProc {
-		target: Arc::new(crate::types::agent::SimpleBackendReference::Backend(
-			strng::format!("/{}", ext_proc_addr),
-		)),
-		policies: Vec::new(),
+		target: crate::types::agent::SimpleBackendReferenceWithPolicies {
+			target: Arc::new(crate::types::agent::SimpleBackendReference::Backend(
+				strng::format!("/{}", ext_proc_addr),
+			)),
+			policies: Vec::new(),
+		},
 		failure_mode: ext_proc::FailureMode::FailClosed,
 		metadata_context: None,
 		request_attributes: None,

--- a/crates/agentgateway/src/http/remoteratelimit.rs
+++ b/crates/agentgateway/src/http/remoteratelimit.rs
@@ -2,7 +2,6 @@ use ::http::{HeaderMap, StatusCode};
 use itertools::Itertools;
 
 use crate::cel::{Executor, Expression};
-use crate::http::ext_proc::GrpcReferenceChannel;
 use crate::http::localratelimit::RateLimitType;
 use crate::http::remoteratelimit::proto::rate_limit_descriptor::Entry;
 use crate::http::remoteratelimit::proto::rate_limit_service_client::RateLimitServiceClient;
@@ -11,7 +10,7 @@ use crate::http::{PolicyResponse, Request, envoy_proto_common};
 use crate::proxy::ProxyError;
 use crate::proxy::httpproxy::PolicyClient;
 use crate::telemetry::metrics::{OutboundCallKind, OutboundCallSubtype};
-use crate::types::agent::{BackendTrafficPolicy, SimpleBackendReference};
+use crate::types::agent::SimpleBackendReferenceWithPolicies;
 use crate::*;
 
 #[cfg(test)]
@@ -53,17 +52,9 @@ pub enum FailureMode {
 pub struct RemoteRateLimit {
 	/// Rate limit domain sent to the remote rate limit service.
 	pub domain: String,
-	/// Backend that receives rate limit checks.
+	/// Backend that receives rate limit checks and policies used when connecting to it.
 	#[serde(flatten)]
-	pub target: Arc<SimpleBackendReference>,
-	/// Backend policies used when connecting to the remote rate limit service.
-	#[serde(default, skip_serializing_if = "Vec::is_empty")]
-	#[serde(deserialize_with = "crate::types::local::de_from_local_backend_policy")]
-	#[cfg_attr(
-		feature = "schema",
-		schemars(with = "Option<crate::types::local::SimpleLocalBackendPolicies>")
-	)]
-	pub policies: Vec<BackendTrafficPolicy>,
+	pub target: SimpleBackendReferenceWithPolicies,
 	/// Descriptors sent to the remote rate limit service.
 	pub descriptors: Arc<DescriptorSet>,
 	/// Behavior when the remote rate limit service is unavailable or returns an error.
@@ -400,7 +391,7 @@ impl RemoteRateLimit {
 		client: PolicyClient,
 		request: proto::RateLimitRequest,
 	) -> Result<proto::RateLimitResponse, ProxyError> {
-		trace!("connecting to {:?}", self.target);
+		trace!("connecting to {:?}", self.target.target);
 		trace!(
 			"ratelimit request summary (domain: {}): descriptors={} {}",
 			request.domain,
@@ -418,11 +409,9 @@ impl RemoteRateLimit {
 				})
 				.join(" | ")
 		);
-		let chan = GrpcReferenceChannel {
-			target: self.target.clone(),
-			policies: Arc::new(self.policies.clone()),
-			client: client.with_outbound(OutboundCallKind::Policy, OutboundCallSubtype::RateLimit),
-		};
+		let chan = self
+			.target
+			.grpc_channel(client.with_outbound(OutboundCallKind::Policy, OutboundCallSubtype::RateLimit));
 		let mut client = RateLimitServiceClient::new(chan);
 		let resp = client.should_rate_limit(request).await;
 		trace!("check response: {:?}", resp);

--- a/crates/agentgateway/src/http/remoteratelimit_tests.rs
+++ b/crates/agentgateway/src/http/remoteratelimit_tests.rs
@@ -4,13 +4,16 @@ use super::*;
 use crate::cel;
 use crate::http::jwt;
 use crate::http::localratelimit::RateLimitType;
+use crate::types::agent::{SimpleBackendReference, SimpleBackendReferenceWithPolicies};
 
 /// Helper: build a `RemoteRateLimit` with the given descriptor entries.
 fn make_rate_limit(descriptor_entries: Vec<DescriptorEntry>) -> RemoteRateLimit {
 	RemoteRateLimit {
 		domain: "test-domain".to_string(),
-		policies: Default::default(),
-		target: Arc::new(SimpleBackendReference::Invalid),
+		target: SimpleBackendReferenceWithPolicies {
+			target: Arc::new(SimpleBackendReference::Invalid),
+			policies: Default::default(),
+		},
 		descriptors: Arc::new(DescriptorSet(descriptor_entries)),
 		failure_mode: FailureMode::default(),
 	}

--- a/crates/agentgateway/src/mcp/guardrails/client.rs
+++ b/crates/agentgateway/src/mcp/guardrails/client.rs
@@ -255,11 +255,7 @@ fn eval_to_value(
 }
 
 fn build_client(remote: &Remote, client: PolicyClient) -> ExtMcpClient<GrpcReferenceChannel> {
-	ExtMcpClient::new(GrpcReferenceChannel {
-		target: remote.target.clone(),
-		client,
-		policies: Arc::new(remote.policies.clone()),
-	})
+	ExtMcpClient::new(remote.target.grpc_channel(client))
 }
 
 // Snapshot the incoming request headers for the policy server, applying the

--- a/crates/agentgateway/src/mcp/guardrails/mod.rs
+++ b/crates/agentgateway/src/mcp/guardrails/mod.rs
@@ -16,7 +16,9 @@ use bytes::Bytes;
 
 use crate::mcp::upstream::IncomingRequestContext;
 use crate::proxy::httpproxy::PolicyClient;
-use crate::types::agent::{BackendTrafficPolicy, SimpleBackendReference};
+#[cfg(test)]
+use crate::types::agent::SimpleBackendReference;
+use crate::types::agent::SimpleBackendReferenceWithPolicies;
 use crate::*;
 
 /// Per-request bag of values that `mcpGuardrails` request-phase processors attach via
@@ -122,17 +124,9 @@ impl McpGuardrails {
 // TLS/auth may also be set inline via `policies`.
 #[apply(schema!)]
 pub struct Remote {
-	/// Reference to the external MCP policy service backend.
+	/// Reference to the external MCP policy service backend and policies used when connecting to it.
 	#[serde(flatten)]
-	pub target: Arc<SimpleBackendReference>,
-	/// Policies to connect to the backend.
-	#[serde(default, skip_serializing_if = "Vec::is_empty")]
-	#[serde(deserialize_with = "crate::types::local::de_from_local_backend_policy")]
-	#[cfg_attr(
-		feature = "schema",
-		schemars(with = "Option<crate::types::local::SimpleLocalBackendPolicies>")
-	)]
-	pub policies: Vec<BackendTrafficPolicy>,
+	pub target: SimpleBackendReferenceWithPolicies,
 	/// Behavior when the processor is unavailable or returns an error.
 	#[serde(default)]
 	pub failure_mode: FailureMode,
@@ -311,11 +305,11 @@ processors:
 		assert_eq!(d0.methods.get("*/list"), Some(&Phase::Response));
 		let ProcessorKind::Remote(r0) = &d0.kind;
 		assert!(matches!(
-			r0.target.as_ref(),
+			r0.target.target.as_ref(),
 			SimpleBackendReference::InlineBackend(_)
 		));
 		assert_eq!(r0.failure_mode, FailureMode::FailOpen);
-		assert_eq!(r0.policies.len(), 1, "backendTLS should translate");
+		assert_eq!(r0.target.policies.len(), 1, "backendTLS should translate");
 		assert_eq!(r0.request_headers.allowed.len(), 1);
 		assert!(
 			r0.request_headers
@@ -325,7 +319,7 @@ processors:
 
 		let ProcessorKind::Remote(r1) = &ext.processors[1].kind;
 		assert!(matches!(
-			r1.target.as_ref(),
+			r1.target.target.as_ref(),
 			SimpleBackendReference::Backend(_)
 		));
 		assert_eq!(r1.failure_mode, FailureMode::FailClosed);
@@ -336,8 +330,10 @@ processors:
 			processors: vec![Processor {
 				methods: pairs.iter().map(|(k, v)| (k.to_string(), *v)).collect(),
 				kind: ProcessorKind::Remote(Remote {
-					target: Arc::new(SimpleBackendReference::Backend("b".into())),
-					policies: Vec::new(),
+					target: SimpleBackendReferenceWithPolicies {
+						target: Arc::new(SimpleBackendReference::Backend("b".into())),
+						policies: Vec::new(),
+					},
 					failure_mode: FailureMode::default(),
 					metadata: HashMap::new(),
 					request_headers: HeaderFilter::default(),

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -3434,7 +3434,9 @@ mod guardrails_test_support {
 	use rmcp::model::CallToolResult;
 
 	use crate::mcp::guardrails;
-	use crate::types::agent::{BackendTrafficPolicy, SimpleBackendReference, Target};
+	use crate::types::agent::{
+		BackendTrafficPolicy, SimpleBackendReference, SimpleBackendReferenceWithPolicies, Target,
+	};
 
 	// Default test allowlist: every method exercised in this module's tests,
 	// all at Phase::Full. Tests that need narrower coverage build their own.
@@ -3461,8 +3463,10 @@ mod guardrails_test_support {
 		metadata: HashMap<String, Arc<crate::cel::Expression>>,
 	) -> BackendTrafficPolicy {
 		let remote = guardrails::Remote {
-			target: Arc::new(SimpleBackendReference::InlineBackend(Target::Address(addr))),
-			policies: Vec::new(),
+			target: SimpleBackendReferenceWithPolicies {
+				target: Arc::new(SimpleBackendReference::InlineBackend(Target::Address(addr))),
+				policies: Vec::new(),
+			},
 			failure_mode,
 			metadata,
 			request_headers: Default::default(),

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -25,16 +25,19 @@ use serde_json::Value;
 use crate::control::caclient::CaClient;
 use crate::http::auth::BackendAuth;
 use crate::http::authorization::RuleSet;
+use crate::http::backendtls::ResolvedBackendTLS;
+use crate::http::ext_proc::GrpcReferenceChannel;
 use crate::http::{
 	HeaderOrPseudo, HeaderValue, ext_authz, ext_proc, filters, health, remoteratelimit, retry,
 	timeout,
 };
 use crate::mcp::{FailureMode, McpAuthorization};
+use crate::proxy::httpproxy::PolicyClient;
 use crate::store::RequestPolicy;
 use crate::telemetry::log::OrderedStringMap;
 use crate::transport::tls;
 use crate::types::discovery::{NamespacedHostname, Service};
-use crate::types::local::{InternalBackend, SimpleLocalBackend};
+use crate::types::local::{InternalBackend, SimpleLocalBackend, TargetOrUri};
 use crate::types::{agent, backend, frontend};
 use crate::*;
 
@@ -1355,6 +1358,146 @@ impl<'de> serde::Deserialize<'de> for SimpleBackendReference {
 			SimpleLocalBackend::Opaque(t) => Ok(SimpleBackendReference::InlineBackend(t)),
 			SimpleLocalBackend::Backend(n) => Ok(SimpleBackendReference::Backend(n)),
 			SimpleLocalBackend::Invalid => Ok(SimpleBackendReference::Invalid),
+		}
+	}
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+pub struct SimpleBackendReferenceWithPolicies {
+	#[serde(flatten)]
+	#[cfg_attr(
+		feature = "schema",
+		schemars(with = "crate::types::local::SimpleLocalBackend")
+	)]
+	pub target: Arc<SimpleBackendReference>,
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	#[cfg_attr(
+		feature = "schema",
+		schemars(with = "Option<crate::types::local::SimpleLocalBackendPolicies>")
+	)]
+	/// Backend policies used when connecting to the service.
+	pub policies: Vec<BackendTrafficPolicy>,
+}
+
+impl<'de> serde::Deserialize<'de> for SimpleBackendReferenceWithPolicies {
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: serde::Deserializer<'de>,
+	{
+		#[derive(Debug, Clone, serde::Deserialize)]
+		#[serde(rename_all = "camelCase", deny_unknown_fields)]
+		pub struct Input {
+			// Keep these wire fields explicit instead of flattening
+			// SimpleLocalBackendWithSchema. Outer structs may use
+			// deny_unknown_fields with #[serde(flatten)] target; if this helper
+			// hides `host` behind another flattened enum, serde can report `host`
+			// as unknown before this type gets to consume it.
+			#[serde(default)]
+			pub name: Option<NamespacedHostname>,
+			#[serde(default)]
+			pub port: Option<u16>,
+			#[serde(default)]
+			pub host: Option<TargetOrUri>,
+			#[serde(default)]
+			pub backend: Option<BackendKey>,
+
+			#[serde(default, skip_serializing_if = "Vec::is_empty")]
+			#[serde(deserialize_with = "crate::types::local::de_from_local_backend_policy")]
+			/// Backend policies used when connecting to the service.
+			pub policies: Vec<BackendTrafficPolicy>,
+		}
+
+		let Input {
+			name,
+			port,
+			host,
+			backend,
+			mut policies,
+		} = Input::deserialize(deserializer)?;
+
+		let service = match (name, port) {
+			(Some(name), Some(port)) => Some((name, port)),
+			(None, None) => None,
+			_ => {
+				return Err(serde::de::Error::custom(
+					"service backend requires both name and port",
+				));
+			},
+		};
+
+		let (target, tls) = match (service, host, backend) {
+			(Some((name, port)), None, None) => (SimpleBackendReference::Service { name, port }, false),
+			(None, Some(TargetOrUri::Target(t)), None) => {
+				(SimpleBackendReference::InlineBackend(t), false)
+			},
+			(None, Some(TargetOrUri::Uri(uri)), None) => {
+				let Some(uri_host) = uri.host() else {
+					return Err(serde::de::Error::custom(anyhow::anyhow!(
+						"backend URL must include a host"
+					)));
+				};
+				let path = uri.path();
+				if !path.is_empty() && path != "/" {
+					return Err(serde::de::Error::custom(anyhow::anyhow!(
+						"backend URL paths are not supported"
+					)));
+				}
+				let Some(scheme) = uri.scheme_str() else {
+					return Err(serde::de::Error::custom(anyhow::anyhow!(
+						"backend URL must include a scheme"
+					)));
+				};
+				let port = uri.port_u16().or(match scheme {
+					"http" => Some(80),
+					"https" => Some(443),
+					_ => None,
+				});
+				let Some(port) = port else {
+					return Err(serde::de::Error::custom(anyhow::anyhow!(
+						"backend URL scheme must be http, https, or unset"
+					)));
+				};
+				(
+					SimpleBackendReference::InlineBackend(Target::from((uri_host, port))),
+					scheme == "https",
+				)
+			},
+			(None, None, Some(b)) => (SimpleBackendReference::Backend(b), false),
+			(None, None, None) => (SimpleBackendReference::Invalid, false),
+			_ => {
+				return Err(serde::de::Error::custom(
+					"backend must be exactly one of service, host, or backend",
+				));
+			},
+		};
+
+		if tls
+			&& !policies
+				.iter()
+				.any(|policy| matches!(policy, BackendTrafficPolicy::BackendTLS(_)))
+		{
+			policies.push(BackendTrafficPolicy::BackendTLS(
+				ResolvedBackendTLS::default()
+					.try_into()
+					.map_err(serde::de::Error::custom)?,
+			));
+		}
+
+		Ok(Self {
+			target: Arc::new(target),
+			policies,
+		})
+	}
+}
+
+impl SimpleBackendReferenceWithPolicies {
+	pub fn grpc_channel(&self, client: PolicyClient) -> GrpcReferenceChannel {
+		GrpcReferenceChannel {
+			target: self.target.clone(),
+			client,
+			policies: Arc::new(self.policies.clone()),
 		}
 	}
 }

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -1449,16 +1449,16 @@ impl<'de> serde::Deserialize<'de> for SimpleBackendReferenceWithPolicies {
 						"backend URL must include a scheme"
 					)));
 				};
-				let port = uri.port_u16().or(match scheme {
-					"http" => Some(80),
-					"https" => Some(443),
-					_ => None,
-				});
-				let Some(port) = port else {
-					return Err(serde::de::Error::custom(anyhow::anyhow!(
-						"backend URL scheme must be http, https, or unset"
-					)));
+				let default_port = match scheme {
+					"http" => 80,
+					"https" => 443,
+					_ => {
+						return Err(serde::de::Error::custom(anyhow::anyhow!(
+							"backend URL scheme must be http or https"
+						)));
+					},
 				};
+				let port = uri.port_u16().unwrap_or(default_port);
 				(
 					SimpleBackendReference::InlineBackend(Target::from((uri_host, port))),
 					scheme == "https",

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -625,8 +625,10 @@ fn convert_mcp_guardrails(
 			),
 		};
 		Ok(crate::mcp::guardrails::Remote {
-			target,
-			policies: Vec::new(),
+			target: SimpleBackendReferenceWithPolicies {
+				target,
+				policies: Vec::new(),
+			},
 			failure_mode,
 			metadata,
 			request_headers,
@@ -2105,9 +2107,11 @@ fn traffic_policy_from_proto(
 			TrafficPolicy::RemoteRateLimit(RequestPolicy::single(
 				http::remoteratelimit::RemoteRateLimit {
 					domain: rrl.domain.clone(),
-					target: Arc::new(target),
-					// Not supported inline from xDS
-					policies: Vec::new(),
+					target: SimpleBackendReferenceWithPolicies {
+						target: Arc::new(target),
+						// Not supported inline from xDS
+						policies: Vec::new(),
+					},
 					descriptors: Arc::new(http::remoteratelimit::DescriptorSet(descriptors)),
 					failure_mode,
 				},
@@ -2162,9 +2166,11 @@ fn traffic_policy_from_proto(
 				}
 			}
 			TrafficPolicy::ExtProc(RequestPolicy::single(http::ext_proc::ExtProc {
-				target: Arc::new(target),
-				// Not supported inline from xDS
-				policies: Vec::new(),
+				target: SimpleBackendReferenceWithPolicies {
+					target: Arc::new(target),
+					// Not supported inline from xDS
+					policies: Vec::new(),
+				},
 				failure_mode,
 				request_attributes: to_cel_attrs(
 					diagnostics,
@@ -2549,8 +2555,10 @@ fn external_auth_from_proto(
 		.unwrap_or_else(crate::http::ext_authz::default_cache_store);
 	Ok(http::ext_authz::ExtAuthz {
 		protocol,
-		target: Arc::new(target),
-		policies: Vec::new(),
+		target: SimpleBackendReferenceWithPolicies {
+			target: Arc::new(target),
+			policies: Vec::new(),
+		},
 		failure_mode,
 		include_request_headers: ea
 			.include_request_headers

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -1825,6 +1825,33 @@ pub struct LocalTCPRouteBackend {
 
 #[apply(schema_de!)]
 #[cfg_attr(feature = "schema", schemars(with = "SimpleLocalBackendSerde"))]
+pub enum SimpleLocalBackendWithSchema {
+	/// Service reference. Service must be defined in the top level services list.
+	Service { name: NamespacedHostname, port: u16 },
+	/// Hostname and port, with an optional scheme. Examples: `https://example.com`, `example.com:80`.
+	#[serde(rename = "host")]
+	Opaque(
+		/// Hostname and port, with an optional scheme. Examples: `https://example.com`, `example.com:80`.
+		TargetOrUri,
+	),
+	Backend(
+		/// Explicit backend reference. Backend must be defined in the top level backends list
+		BackendKey,
+	),
+	#[cfg_attr(feature = "schema", schemars(skip))]
+	Invalid,
+}
+
+#[apply(schema_de!)]
+#[cfg_attr(feature = "schema", schemars(with = "String"))]
+#[serde(untagged)]
+pub enum TargetOrUri {
+	Target(Target),
+	Uri(#[serde(with = "http_serde::uri")] Uri),
+}
+
+#[apply(schema_de!)]
+#[cfg_attr(feature = "schema", schemars(with = "SimpleLocalBackendSerde"))]
 pub enum SimpleLocalBackend {
 	/// Service reference. Service must be defined in the top level services list.
 	Service { name: NamespacedHostname, port: u16 },

--- a/examples/traffic-identity-assertion/config.yaml
+++ b/examples/traffic-identity-assertion/config.yaml
@@ -37,9 +37,7 @@ binds:
           crossAppAccess:
             # The user's IdP authorization server (performs the RFC 8693 token exchange).
             identityProvider:
-              host: idp.example.com:443
-              policies:
-                backendTLS: {}
+              host: https://idp.example.com
               tokenEndpointPath: /oauth2/token
               clientAuth:
                 clientId: gateway-at-idp
@@ -48,9 +46,7 @@ binds:
             # The resource's authorization server (exchanges the ID-JAG for an access token).
             # Note this is a different client registration than the IdP one above.
             resourceAuthorizationServer:
-              host: chat.example.com:443
-              policies:
-                backendTLS: {}
+              host: https://chat.example.com
               tokenEndpointPath: /oauth2/token
               clientAuth:
                 clientId: gateway-at-chat

--- a/schema/config.json
+++ b/schema/config.json
@@ -2308,7 +2308,7 @@
           "type": "object",
           "properties": {
             "policies": {
-              "description": "Policies to connect to the backend.",
+              "description": "Backend policies used when connecting to the service.",
               "anyOf": [
                 {
                   "$ref": "#/$defs/SimpleLocalBackendPolicies"
@@ -3263,7 +3263,7 @@
       "type": "object",
       "properties": {
         "policies": {
-          "description": "Backend policies (TLS, request timeout, ...) used when connecting to the token endpoint.",
+          "description": "Backend policies used when connecting to the service.",
           "anyOf": [
             {
               "$ref": "#/$defs/SimpleLocalBackendPolicies"
@@ -3696,7 +3696,7 @@
       "type": "object",
       "properties": {
         "policies": {
-          "description": "Backend policies (TLS, request timeout, ...) used when connecting to the token endpoint.",
+          "description": "Backend policies used when connecting to the service.",
           "anyOf": [
             {
               "$ref": "#/$defs/SimpleLocalBackendPolicies"
@@ -5012,7 +5012,7 @@
           "type": "string"
         },
         "policies": {
-          "description": "Backend policies used when connecting to the remote rate limit service.",
+          "description": "Backend policies used when connecting to the service.",
           "anyOf": [
             {
               "$ref": "#/$defs/SimpleLocalBackendPolicies"
@@ -5191,7 +5191,7 @@
           "type": "string"
         },
         "policies": {
-          "description": "Backend policies used when connecting to the remote rate limit service.",
+          "description": "Backend policies used when connecting to the service.",
           "anyOf": [
             {
               "$ref": "#/$defs/SimpleLocalBackendPolicies"
@@ -5687,7 +5687,7 @@
           "default": null
         },
         "policies": {
-          "description": "Backend policies used when connecting to the authorization service.",
+          "description": "Backend policies used when connecting to the service.",
           "anyOf": [
             {
               "$ref": "#/$defs/SimpleLocalBackendPolicies"
@@ -5990,7 +5990,7 @@
       "type": "object",
       "properties": {
         "policies": {
-          "description": "Backend policies used when connecting to the authorization service.",
+          "description": "Backend policies used when connecting to the service.",
           "anyOf": [
             {
               "$ref": "#/$defs/SimpleLocalBackendPolicies"
@@ -6141,7 +6141,7 @@
           "default": null
         },
         "policies": {
-          "description": "Backend policies used when connecting to the external processing service.",
+          "description": "Backend policies used when connecting to the service.",
           "anyOf": [
             {
               "$ref": "#/$defs/SimpleLocalBackendPolicies"
@@ -6370,7 +6370,7 @@
       "type": "object",
       "properties": {
         "policies": {
-          "description": "Backend policies used when connecting to the external processing service.",
+          "description": "Backend policies used when connecting to the service.",
           "anyOf": [
             {
               "$ref": "#/$defs/SimpleLocalBackendPolicies"


### PR DESCRIPTION
This allows using a domain like `https://idp.com`/ instead of
`idp.com:443` + `backendTls: {}`. This mirrors MCP code and how k8s will
prob work in the future.

This doesn't let you use path yet since it would be pretty annoying to
do