### PR TITLE
fix(jwt): no owners from policy fetch for targetSelectors

### DIFF
--- a/controller/pkg/agentgateway/jwks/owner.go
+++ b/controller/pkg/agentgateway/jwks/owner.go
@@ -47,7 +47,7 @@ func (o RemoteJwksOwner) Equals(other RemoteJwksOwner) bool {
 }
 
 func OwnersFromPolicy(policy *agentgateway.AgentgatewayPolicy) []RemoteJwksOwner {
-	if len(policy.Spec.TargetRefs) == 0 {
+	if len(policy.Spec.TargetRefs) == 0 && len(policy.Spec.TargetSelectors) == 0 {
 		return nil
 	}
 

--- a/controller/pkg/agentgateway/jwks/owner_test.go
+++ b/controller/pkg/agentgateway/jwks/owner_test.go
@@ -41,7 +41,7 @@ func TestOwnersFromPolicyUseCanonicalSpecScopedPaths(t *testing.T) {
 	assert.Equal(t, PolicyBackendMCPAuthenticationLookupOwner(policy.Namespace, policy.Name, policy.Spec.Backend.MCP.Authentication.JWKS), owners[1])
 }
 
-func TestOwnersFromPolicyRequireAtLeastOneTargetRef(t *testing.T) {
+func TestOwnersFromPolicyRequireAtLeastOneTarget(t *testing.T) {
 	policy := &agentgateway.AgentgatewayPolicy{}
 	policy.Namespace = "default"
 	policy.Name = "example"
@@ -54,4 +54,22 @@ func TestOwnersFromPolicyRequireAtLeastOneTargetRef(t *testing.T) {
 	}
 
 	assert.Nil(t, OwnersFromPolicy(policy))
+}
+
+func TestOwnersFromPolicyWithTargetSelectors(t *testing.T) {
+	policy := &agentgateway.AgentgatewayPolicy{}
+	policy.Namespace = "default"
+	policy.Name = "example"
+	policy.Spec.TargetSelectors = make([]agentgateway.LocalPolicyTargetSelectorWithSectionName, 1)
+	policy.Spec.Traffic = &agentgateway.Traffic{
+		JWTAuthentication: &agentgateway.JWTAuthentication{
+			Providers: []agentgateway.JWTProvider{{
+				JWKS: agentgateway.JWKS{Remote: &agentgateway.RemoteJWKS{}},
+			}},
+		},
+	}
+
+	owners := OwnersFromPolicy(policy)
+	assert.Len(t, owners, 1)
+	assert.Equal(t, "AgentgatewayPolicy/default/example#spec.traffic.jwtAuthentication.providers[0].jwks.remote", owners[0].ID.String())
 }


### PR DESCRIPTION
When jwt auth on a policy is configured with a remote JWKS, `ownersFromPolicy` should fetch the IdPs public singing keys. The guard at the beginning of this function is broken, it will return `nil` only if targetRefs is not set, when it should be when both of them aren't set. We add a test for this in `owner_test.go`

Fixes #2413 