### PR TITLE
fix(embeddings): accept responses without usage field

### DIFF
--- a/crates/agentgateway/src/llm/conversion/bedrock_tests.rs
+++ b/crates/agentgateway/src/llm/conversion/bedrock_tests.rs
@@ -1358,7 +1358,7 @@ fn test_embeddings_response_translation_titan() {
 		.unwrap();
 
 	assert_eq!(openai_resp.object, "list");
-	assert_eq!(openai_resp.usage.prompt_tokens, 3);
+	assert_eq!(openai_resp.usage.as_ref().unwrap().prompt_tokens, 3);
 }
 
 #[test]
@@ -1379,7 +1379,7 @@ fn test_embeddings_response_titan_embeddings_by_type_fallback() {
 		.and_then(|b| serde_json::from_slice::<types::embeddings::Response>(&b))
 		.unwrap();
 
-	assert_eq!(openai_resp.usage.prompt_tokens, 5);
+	assert_eq!(openai_resp.usage.as_ref().unwrap().prompt_tokens, 5);
 }
 
 #[test]
@@ -1401,7 +1401,7 @@ fn test_embeddings_response_translation_cohere() {
 		.unwrap();
 
 	assert_eq!(openai_resp.object, "list");
-	assert_eq!(openai_resp.usage.prompt_tokens, 10);
+	assert_eq!(openai_resp.usage.as_ref().unwrap().prompt_tokens, 10);
 }
 
 #[test]

--- a/crates/agentgateway/src/llm/conversion/vertex_tests.rs
+++ b/crates/agentgateway/src/llm/conversion/vertex_tests.rs
@@ -100,8 +100,8 @@ fn test_embeddings_response_translation() {
 
 	assert_eq!(resp.object, "list");
 	assert_eq!(resp.model, "text-embedding-004");
-	assert_eq!(resp.usage.prompt_tokens, 7);
-	assert_eq!(resp.usage.total_tokens, 7);
+	assert_eq!(resp.usage.as_ref().unwrap().prompt_tokens, 7);
+	assert_eq!(resp.usage.as_ref().unwrap().total_tokens, 7);
 }
 
 #[test]
@@ -119,5 +119,5 @@ fn test_embeddings_response_missing_statistics() {
 		.and_then(|b| serde_json::from_slice::<types::embeddings::Response>(&b))
 		.unwrap();
 
-	assert_eq!(resp.usage.prompt_tokens, 0);
+	assert_eq!(resp.usage.as_ref().unwrap().prompt_tokens, 0);
 }

--- a/crates/agentgateway/src/llm/types/embeddings.rs
+++ b/crates/agentgateway/src/llm/types/embeddings.rs
@@ -10,7 +10,8 @@ use crate::llm::{AIError, InputFormat, LLMRequest, LLMRequestParams, SimpleChatC
 pub struct Response {
 	pub object: String,
 	pub model: String,
-	pub usage: Usage,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub usage: Option<Usage>,
 	#[serde(flatten, default)]
 	pub rest: serde_json::Value,
 }
@@ -100,11 +101,11 @@ impl RequestType for Request {
 impl crate::llm::types::ResponseType for Response {
 	fn to_llm_response(&self, _include_completion_in_log: bool) -> crate::llm::LLMResponse {
 		crate::llm::LLMResponse {
-			input_tokens: Some(self.usage.prompt_tokens as u64),
+			input_tokens: self.usage.as_ref().map(|u| u.prompt_tokens as u64),
 			input_image_tokens: None,
 			input_text_tokens: None,
 			input_audio_tokens: None,
-			total_tokens: Some(self.usage.total_tokens as u64),
+			total_tokens: self.usage.as_ref().map(|u| u.total_tokens as u64),
 			output_tokens: None,
 			output_image_tokens: None,
 			output_text_tokens: None,
@@ -199,5 +200,54 @@ pub mod typed {
 	pub struct Usage {
 		pub prompt_tokens: u32,
 		pub total_tokens: u32,
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::llm::types::ResponseType;
+
+	#[test]
+	fn response_parses_without_usage_field() {
+		let raw = r#"{
+			"object": "list",
+			"model": "gemini-embedding-001",
+			"data": [{
+				"object": "embedding",
+				"index": 0,
+				"embedding": [0.1, 0.2, 0.3]
+			}]
+		}"#;
+		let resp: Response = serde_json::from_str(raw).unwrap();
+		assert_eq!(resp.model, "gemini-embedding-001");
+		assert!(resp.usage.is_none());
+		let llm_resp = resp.to_llm_response(false);
+		assert!(llm_resp.input_tokens.is_none());
+		assert!(llm_resp.total_tokens.is_none());
+	}
+
+	#[test]
+	fn response_parses_with_usage_field() {
+		let raw = r#"{
+			"object": "list",
+			"model": "text-embedding-3-small",
+			"data": [{
+				"object": "embedding",
+				"index": 0,
+				"embedding": [0.1, 0.2]
+			}],
+			"usage": {
+				"prompt_tokens": 8,
+				"total_tokens": 8
+			}
+		}"#;
+		let resp: Response = serde_json::from_str(raw).unwrap();
+		let usage = resp.usage.as_ref().unwrap();
+		assert_eq!(usage.prompt_tokens, 8);
+		assert_eq!(usage.total_tokens, 8);
+		let llm_resp = resp.to_llm_response(false);
+		assert_eq!(llm_resp.input_tokens, Some(8));
+		assert_eq!(llm_resp.total_tokens, Some(8));
 	}
 }


### PR DESCRIPTION
## Summary

Make the `usage` field optional when parsing OpenAI-compatible embedding responses. Gemini's OpenAI-compatible `/v1/embeddings` endpoint returns valid `object`, `data`, and `model` fields but omits `usage`, which caused agentgateway to fail with `failed to parse response: missing field 'usage'` and return 503.

## Motivation

Fixes #2451. Chat completions already tolerate missing `usage`; embeddings should behave the same for OpenAI-compatible providers like Gemini.

## Changes

- Change `types::embeddings::Response.usage` from `Usage` to `Option<Usage>`
- Update `to_llm_response()` to map token fields via `.as_ref().map()`, matching completions
- Add unit tests for parsing responses with and without `usage`
- Update Bedrock/Vertex converter test assertions for optional usage

## Tests

```bash
cargo test -p agentgateway embeddings
```

Result: 19 unit tests + 5 integration tests passed.

## Notes

- Bedrock and Vertex converters still populate `usage` via the internal `typed::Response` bridge
- When `usage` is absent, token telemetry fields are omitted (same behavior as completions without usage)
- Passthrough responses are returned to clients unchanged; parsing is only for internal metrics

Fixes #2451