### PR TITLE
llm: split credential cache from providers

### DIFF
--- a/crates/agentgateway/src/llm/azure.rs
+++ b/crates/agentgateway/src/llm/azure.rs
@@ -1,7 +1,6 @@
 use agent_core::strng;
 use agent_core::strng::Strng;
 
-use crate::http::auth::azure::AzureCredentialCache;
 use crate::llm::RouteType;
 use crate::*;
 
@@ -17,7 +16,7 @@ pub enum AzureResourceType {
 }
 
 #[apply(schema!)]
-#[cfg_attr(feature = "schema", schemars(rename = "AzureProvider"))]
+#[cfg_attr(feature = "schema", schemars(rename = "AzureProviderConfig"))]
 pub struct Provider {
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub model: Option<Strng>,
@@ -32,10 +31,6 @@ pub struct Provider {
 	/// This is distinct from `resourceName` which is used for the host.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub project_name: Option<Strng>,
-	/// Per-provider credential cache, shared across requests via Arc.
-	#[serde(skip)]
-	#[cfg_attr(feature = "schema", schemars(skip))]
-	pub cached_cred: AzureCredentialCache,
 }
 
 impl super::Provider for Provider {
@@ -128,7 +123,6 @@ mod tests {
 			resource_type,
 			api_version: None,
 			project_name: None,
-			cached_cred: AzureCredentialCache::default(),
 		}
 	}
 

--- a/crates/agentgateway/src/llm/bedrock.rs
+++ b/crates/agentgateway/src/llm/bedrock.rs
@@ -1,7 +1,6 @@
 use agent_core::prelude::Strng;
 use agent_core::strng;
 
-use crate::http::auth::aws::{AwsAssumeRoleCache, AwsCredentialsCache};
 use crate::*;
 
 #[derive(Debug, Clone)]
@@ -10,7 +9,7 @@ pub struct AwsRegion {
 }
 
 #[apply(schema!)]
-#[cfg_attr(feature = "schema", schemars(rename = "BedrockProvider"))]
+#[cfg_attr(feature = "schema", schemars(rename = "BedrockProviderConfig"))]
 pub struct Provider {
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub model: Option<Strng>, // Optional: model override for Bedrock API path
@@ -19,14 +18,6 @@ pub struct Provider {
 	pub guardrail_identifier: Option<Strng>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub guardrail_version: Option<Strng>,
-	/// Per-provider AWS source credential cache, shared across requests via Arc.
-	#[serde(skip)]
-	#[cfg_attr(feature = "schema", schemars(skip))]
-	pub source_credentials_cache: AwsCredentialsCache,
-	/// Per-provider AWS AssumeRole credential cache, shared across requests via Arc.
-	#[serde(skip)]
-	#[cfg_attr(feature = "schema", schemars(skip))]
-	pub assume_role_cache: AwsAssumeRoleCache,
 }
 
 impl super::Provider for Provider {

--- a/crates/agentgateway/src/llm/conversion/bedrock_tests.rs
+++ b/crates/agentgateway/src/llm/conversion/bedrock_tests.rs
@@ -116,8 +116,6 @@ fn test_metadata_from_header() {
 		region: strng::new("us-east-1"),
 		guardrail_identifier: None,
 		guardrail_version: None,
-		source_credentials_cache: Default::default(),
-		assume_role_cache: Default::default(),
 	};
 
 	// Simulate transformation CEL setting x-bedrock-metadata header
@@ -174,8 +172,6 @@ fn test_messages_metadata_is_preserved_in_additional_model_request_fields() {
 		region: strng::new("us-east-1"),
 		guardrail_identifier: None,
 		guardrail_version: None,
-		source_credentials_cache: Default::default(),
-		assume_role_cache: Default::default(),
 	};
 
 	let json_encoded_user_id = r#"{"device_id":"704cb53c2074e9","account_uuid":"","session_id":"180423cd-fe24-4f48-bbde-b4ab5bfd36e7"}"#;
@@ -226,8 +222,6 @@ fn test_output_config_effort_without_thinking_is_passed_through() {
 		region: strng::new("us-east-1"),
 		guardrail_identifier: None,
 		guardrail_version: None,
-		source_credentials_cache: Default::default(),
-		assume_role_cache: Default::default(),
 	};
 
 	let req = messages::typed::Request {
@@ -281,8 +275,6 @@ fn test_output_config_format_maps_to_converse_output_config() {
 		region: strng::new("us-east-1"),
 		guardrail_identifier: None,
 		guardrail_version: None,
-		source_credentials_cache: Default::default(),
-		assume_role_cache: Default::default(),
 	};
 
 	let schema = json!({
@@ -357,8 +349,6 @@ fn test_explicit_empty_output_config_is_preserved() {
 		region: strng::new("us-east-1"),
 		guardrail_identifier: None,
 		guardrail_version: None,
-		source_credentials_cache: Default::default(),
-		assume_role_cache: Default::default(),
 	};
 
 	let req = messages::typed::Request {
@@ -414,8 +404,6 @@ fn test_thinking_and_output_config_are_both_passed_through() {
 		region: strng::new("us-east-1"),
 		guardrail_identifier: None,
 		guardrail_version: None,
-		source_credentials_cache: Default::default(),
-		assume_role_cache: Default::default(),
 	};
 
 	let req = messages::typed::Request {
@@ -471,8 +459,6 @@ fn test_adaptive_thinking_preserves_sampling_and_tool_choice() {
 		region: strng::new("us-east-1"),
 		guardrail_identifier: None,
 		guardrail_version: None,
-		source_credentials_cache: Default::default(),
-		assume_role_cache: Default::default(),
 	};
 
 	let req = messages::typed::Request {
@@ -547,8 +533,6 @@ fn test_enabled_thinking_applies_sampling_and_tool_choice_constraints() {
 		region: strng::new("us-east-1"),
 		guardrail_identifier: None,
 		guardrail_version: None,
-		source_credentials_cache: Default::default(),
-		assume_role_cache: Default::default(),
 	};
 
 	let req = messages::typed::Request {
@@ -612,8 +596,6 @@ fn test_messages_image_url_to_bedrock_returns_error() {
 		region: strng::new("us-east-1"),
 		guardrail_identifier: None,
 		guardrail_version: None,
-		source_credentials_cache: Default::default(),
-		assume_role_cache: Default::default(),
 	};
 
 	let req = messages::typed::Request {
@@ -660,8 +642,6 @@ fn test_completions_request_metadata_only_uses_bedrock_header() {
 		region: strng::new("us-east-1"),
 		guardrail_identifier: None,
 		guardrail_version: None,
-		source_credentials_cache: Default::default(),
-		assume_role_cache: Default::default(),
 	};
 
 	let req = types::completions::typed::Request {
@@ -745,8 +725,6 @@ fn test_completions_json_schema_response_format_maps_to_converse_output_config()
 		region: strng::new("us-east-1"),
 		guardrail_identifier: None,
 		guardrail_version: None,
-		source_credentials_cache: Default::default(),
-		assume_role_cache: Default::default(),
 	};
 
 	let schema = json!({
@@ -841,8 +819,6 @@ fn test_completions_reasoning_effort_maps_to_enabled_thinking_budget() {
 		region: strng::new("us-east-1"),
 		guardrail_identifier: None,
 		guardrail_version: None,
-		source_credentials_cache: Default::default(),
-		assume_role_cache: Default::default(),
 	};
 
 	let req = types::completions::typed::Request {
@@ -916,8 +892,6 @@ fn test_completions_explicit_thinking_budget_forces_enabled_thinking() {
 		region: strng::new("us-east-1"),
 		guardrail_identifier: None,
 		guardrail_version: None,
-		source_credentials_cache: Default::default(),
-		assume_role_cache: Default::default(),
 	};
 
 	let req = types::completions::typed::Request {
@@ -994,8 +968,6 @@ fn test_responses_json_schema_text_format_maps_to_converse_output_config() {
 		region: strng::new("us-east-1"),
 		guardrail_identifier: None,
 		guardrail_version: None,
-		source_credentials_cache: Default::default(),
-		assume_role_cache: Default::default(),
 	};
 
 	let schema = json!({
@@ -1051,8 +1023,6 @@ fn test_responses_request_metadata_only_uses_bedrock_header() {
 		region: strng::new("us-east-1"),
 		guardrail_identifier: None,
 		guardrail_version: None,
-		source_credentials_cache: Default::default(),
-		assume_role_cache: Default::default(),
 	};
 
 	let req: types::responses::Request = serde_json::from_value(json!({
@@ -1097,8 +1067,6 @@ fn test_responses_reasoning_effort_maps_to_enabled_thinking_budget() {
 		region: strng::new("us-east-1"),
 		guardrail_identifier: None,
 		guardrail_version: None,
-		source_credentials_cache: Default::default(),
-		assume_role_cache: Default::default(),
 	};
 
 	let req: types::responses::Request = serde_json::from_value(json!({
@@ -1134,8 +1102,6 @@ fn test_responses_explicit_thinking_budget_forces_enabled_thinking() {
 		region: strng::new("us-east-1"),
 		guardrail_identifier: None,
 		guardrail_version: None,
-		source_credentials_cache: Default::default(),
-		assume_role_cache: Default::default(),
 	};
 
 	let req: types::responses::Request = serde_json::from_value(json!({
@@ -1174,8 +1140,6 @@ fn test_responses_vendor_extension_thinking_budget_forces_enabled_thinking() {
 		region: strng::new("us-east-1"),
 		guardrail_identifier: None,
 		guardrail_version: None,
-		source_credentials_cache: Default::default(),
-		assume_role_cache: Default::default(),
 	};
 
 	let req: types::responses::Request = serde_json::from_value(json!({
@@ -1211,8 +1175,6 @@ fn test_embeddings_translation_titan() {
 		region: strng::new("us-east-1"),
 		guardrail_identifier: None,
 		guardrail_version: None,
-		source_credentials_cache: Default::default(),
-		assume_role_cache: Default::default(),
 	};
 
 	let req = types::embeddings::Request {
@@ -1239,8 +1201,6 @@ fn test_embeddings_titan_with_encoding_format() {
 		region: strng::new("us-east-1"),
 		guardrail_identifier: None,
 		guardrail_version: None,
-		source_credentials_cache: Default::default(),
-		assume_role_cache: Default::default(),
 	};
 
 	let req = types::embeddings::Request {
@@ -1270,8 +1230,6 @@ fn test_embeddings_titan_rejects_array_input() {
 		region: strng::new("us-east-1"),
 		guardrail_identifier: None,
 		guardrail_version: None,
-		source_credentials_cache: Default::default(),
-		assume_role_cache: Default::default(),
 	};
 
 	let req = types::embeddings::Request {
@@ -1296,8 +1254,6 @@ fn test_embeddings_cohere_with_passthrough_fields() {
 		region: strng::new("us-east-1"),
 		guardrail_identifier: None,
 		guardrail_version: None,
-		source_credentials_cache: Default::default(),
-		assume_role_cache: Default::default(),
 	};
 
 	let req = types::embeddings::Request {
@@ -1324,8 +1280,6 @@ fn test_embeddings_rejects_invalid_input() {
 		region: strng::new("us-east-1"),
 		guardrail_identifier: None,
 		guardrail_version: None,
-		source_credentials_cache: Default::default(),
-		assume_role_cache: Default::default(),
 	};
 
 	for input in [json!(["hello", 42]), json!(42)] {
@@ -1551,8 +1505,6 @@ fn test_messages_long_tool_names_fit_bedrock_tool_config() {
 		region: strng::new("us-west-2"),
 		guardrail_identifier: None,
 		guardrail_version: None,
-		source_credentials_cache: Default::default(),
-		assume_role_cache: Default::default(),
 	};
 
 	let req = messages::Request {
@@ -1609,8 +1561,6 @@ fn test_messages_long_tool_name_round_trip_response() {
 		region: strng::new("us-west-2"),
 		guardrail_identifier: None,
 		guardrail_version: None,
-		source_credentials_cache: Default::default(),
-		assume_role_cache: Default::default(),
 	};
 
 	let req = messages::Request {

--- a/crates/agentgateway/src/llm/conversion/rerank_tests.rs
+++ b/crates/agentgateway/src/llm/conversion/rerank_tests.rs
@@ -10,8 +10,6 @@ fn bedrock_provider(model: &str, region: &str) -> crate::llm::bedrock::Provider 
 		region: agent_core::strng::new(region),
 		guardrail_identifier: None,
 		guardrail_version: None,
-		source_credentials_cache: Default::default(),
-		assume_role_cache: Default::default(),
 	}
 }
 
@@ -57,7 +55,7 @@ fn test_bedrock_connection_target_is_route_aware() {
 	use crate::llm::{AIProvider, RouteType};
 	use crate::types::agent::Target;
 
-	let provider = AIProvider::Bedrock(bedrock_provider("cohere.rerank-v3-5:0", "us-west-2"));
+	let provider = AIProvider::bedrock(bedrock_provider("cohere.rerank-v3-5:0", "us-west-2"));
 
 	let resolved_host = |route: RouteType| -> String {
 		match provider

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -151,10 +151,109 @@ pub enum AIProvider {
 	Gemini(gemini::Provider),
 	Vertex(vertex::Provider),
 	Anthropic(anthropic::Provider),
-	Bedrock(bedrock::Provider),
-	Azure(azure::Provider),
+	Bedrock(BedrockProvider),
+	Azure(AzureProvider),
 	Copilot(copilot::Provider),
 	Custom(custom::Provider),
+}
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BedrockProvider {
+	#[serde(flatten)]
+	pub provider: bedrock::Provider,
+	#[serde(skip)]
+	pub source_credentials_cache: crate::http::auth::aws::AwsCredentialsCache,
+	#[serde(skip)]
+	pub assume_role_cache: crate::http::auth::aws::AwsAssumeRoleCache,
+}
+
+impl BedrockProvider {
+	pub fn new(provider: bedrock::Provider) -> Self {
+		Self {
+			provider,
+			source_credentials_cache: Default::default(),
+			assume_role_cache: Default::default(),
+		}
+	}
+}
+
+#[cfg(feature = "schema")]
+impl schemars::JsonSchema for BedrockProvider {
+	fn schema_name() -> std::borrow::Cow<'static, str> {
+		std::borrow::Cow::Borrowed("BedrockProvider")
+	}
+
+	fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+		<bedrock::Provider as schemars::JsonSchema>::json_schema(generator)
+	}
+}
+
+impl std::ops::Deref for BedrockProvider {
+	type Target = bedrock::Provider;
+
+	fn deref(&self) -> &Self::Target {
+		&self.provider
+	}
+}
+
+impl std::ops::DerefMut for BedrockProvider {
+	fn deref_mut(&mut self) -> &mut Self::Target {
+		&mut self.provider
+	}
+}
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AzureProvider {
+	#[serde(flatten)]
+	pub provider: azure::Provider,
+	#[serde(skip)]
+	pub cached_cred: crate::http::auth::azure::AzureCredentialCache,
+}
+
+impl AzureProvider {
+	pub fn new(provider: azure::Provider) -> Self {
+		Self {
+			provider,
+			cached_cred: Default::default(),
+		}
+	}
+}
+
+#[cfg(feature = "schema")]
+impl schemars::JsonSchema for AzureProvider {
+	fn schema_name() -> std::borrow::Cow<'static, str> {
+		std::borrow::Cow::Borrowed("AzureProvider")
+	}
+
+	fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+		<azure::Provider as schemars::JsonSchema>::json_schema(generator)
+	}
+}
+
+impl std::ops::Deref for AzureProvider {
+	type Target = azure::Provider;
+
+	fn deref(&self) -> &Self::Target {
+		&self.provider
+	}
+}
+
+impl std::ops::DerefMut for AzureProvider {
+	fn deref_mut(&mut self) -> &mut Self::Target {
+		&mut self.provider
+	}
+}
+
+impl AIProvider {
+	pub fn bedrock(provider: bedrock::Provider) -> Self {
+		Self::Bedrock(BedrockProvider::new(provider))
+	}
+
+	pub fn azure(provider: azure::Provider) -> Self {
+		Self::Azure(AzureProvider::new(provider))
+	}
 }
 
 #[apply(schema!)]

--- a/crates/agentgateway/src/llm/tests.rs
+++ b/crates/agentgateway/src/llm/tests.rs
@@ -320,8 +320,6 @@ mod requests {
 			region: strng::new("us-west-2"),
 			guardrail_identifier: None,
 			guardrail_version: None,
-			source_credentials_cache: Default::default(),
-			assume_role_cache: Default::default(),
 		};
 
 		let bedrock = |i| {
@@ -356,8 +354,6 @@ mod requests {
 			region: strng::new("us-west-2"),
 			guardrail_identifier: None,
 			guardrail_version: None,
-			source_credentials_cache: Default::default(),
-			assume_role_cache: Default::default(),
 		};
 		let vertex_provider = vertex::Provider {
 			model: Some(strng::new("anthropic/claude-sonnet-4-5")),
@@ -393,8 +389,6 @@ mod requests {
 			region: strng::new("us-west-2"),
 			guardrail_identifier: None,
 			guardrail_version: None,
-			source_credentials_cache: Default::default(),
-			assume_role_cache: Default::default(),
 		};
 
 		for (name, providers) in RESPONSES_REQUESTS {
@@ -421,8 +415,6 @@ mod requests {
 			region: strng::new("us-west-2"),
 			guardrail_identifier: None,
 			guardrail_version: None,
-			source_credentials_cache: Default::default(),
-			assume_role_cache: Default::default(),
 		};
 
 		let cohere_provider = bedrock::Provider {
@@ -430,8 +422,6 @@ mod requests {
 			region: strng::new("us-west-2"),
 			guardrail_identifier: None,
 			guardrail_version: None,
-			source_credentials_cache: Default::default(),
-			assume_role_cache: Default::default(),
 		};
 
 		let titan_request = |i| conversion::bedrock::from_embeddings::translate(&i, &titan_provider);
@@ -482,8 +472,6 @@ mod requests {
 			region: strng::new("us-west-2"),
 			guardrail_identifier: None,
 			guardrail_version: None,
-			source_credentials_cache: Default::default(),
-			assume_role_cache: Default::default(),
 		};
 		let vertex_provider = vertex::Provider {
 			model: Some(strng::new("semantic-ranker-default@latest")),
@@ -750,13 +738,11 @@ mod response {
 	}
 
 	fn build_provider_request(provider: &str) -> (AIProvider, LLMRequest) {
-		let bedrock_provider = AIProvider::Bedrock(bedrock::Provider {
+		let bedrock_provider = AIProvider::bedrock(bedrock::Provider {
 			model: Some(strng::new("anthropic.claude-3-5-sonnet-20241022-v2:0")),
 			region: strng::new("us-west-2"),
 			guardrail_identifier: None,
 			guardrail_version: None,
-			source_credentials_cache: Default::default(),
-			assume_role_cache: Default::default(),
 		});
 		let (p, r) = match provider {
 			RESPONSES_TO_RESPONSES => (
@@ -1709,13 +1695,11 @@ async fn process_response_routes_streaming_error_to_buffered_path() {
 	use crate::proxy::httpproxy::PolicyClient;
 	use crate::test_helpers::proxymock::setup_proxy_test;
 
-	let bedrock = AIProvider::Bedrock(bedrock::Provider {
+	let bedrock = AIProvider::bedrock(bedrock::Provider {
 		model: Some(strng::new("anthropic.claude-3-5-sonnet-20241022-v2:0")),
 		region: strng::new("us-west-2"),
 		guardrail_identifier: None,
 		guardrail_version: None,
-		source_credentials_cache: Default::default(),
-		assume_role_cache: Default::default(),
 	});
 
 	let error_json = r#"{"message":"Expected toolResult blocks at messages.2.content for the following Ids: tooluse_abc123"}"#;
@@ -1818,13 +1802,12 @@ fn custom_messages_error_translates_to_completions_client() {
 
 #[test]
 fn foundry_claude_messages_error_uses_anthropic_shape() {
-	let provider = AIProvider::Azure(azure::Provider {
+	let provider = AIProvider::azure(azure::Provider {
 		model: None,
 		resource_name: strng::new("example"),
 		resource_type: azure::AzureResourceType::Foundry,
 		api_version: None,
 		project_name: Some(strng::new("project")),
-		cached_cred: Default::default(),
 	});
 	let mut req = llm_request_with_tokens(None);
 	req.input_format = InputFormat::Messages;
@@ -1847,13 +1830,11 @@ fn foundry_claude_messages_error_uses_anthropic_shape() {
 async fn process_streaming_bedrock_completions_normalizes_sse_headers_and_done() {
 	use crate::proxy::httpproxy::PolicyClient;
 	use crate::test_helpers::proxymock::setup_proxy_test;
-	let bedrock = AIProvider::Bedrock(bedrock::Provider {
+	let bedrock = AIProvider::bedrock(bedrock::Provider {
 		model: Some(strng::new("openai.gpt-oss-120b-1:0")),
 		region: strng::new("us-east-1"),
 		guardrail_identifier: None,
 		guardrail_version: None,
-		source_credentials_cache: Default::default(),
-		assume_role_cache: Default::default(),
 	});
 
 	let body = Body::from(
@@ -2075,13 +2056,11 @@ fn setup_request_vertex_applies_path_prefix_with_host_override() {
 #[test]
 fn setup_request_bedrock_applies_path_prefix_with_host_override() {
 	assert_prefixed_host_override_path(
-		AIProvider::Bedrock(bedrock::Provider {
+		AIProvider::bedrock(bedrock::Provider {
 			model: None,
 			region: strng::new("us-east-1"),
 			guardrail_identifier: None,
 			guardrail_version: None,
-			source_credentials_cache: Default::default(),
-			assume_role_cache: Default::default(),
 		}),
 		"anthropic.claude-3-5-sonnet-20241022-v2:0",
 		"/proxy/model/anthropic.claude-3-5-sonnet-20241022-v2:0/converse",
@@ -2092,13 +2071,12 @@ fn setup_request_bedrock_applies_path_prefix_with_host_override() {
 #[test]
 fn setup_request_azure_applies_path_prefix_with_host_override() {
 	assert_prefixed_host_override_path(
-		AIProvider::Azure(azure::Provider {
+		AIProvider::azure(azure::Provider {
 			model: None,
 			resource_name: strng::new("example"),
 			resource_type: azure::AzureResourceType::OpenAI,
 			api_version: Some(strng::new("2024-02-15-preview")),
 			project_name: None,
-			cached_cred: Default::default(),
 		}),
 		"gpt-4.1",
 		"/proxy/openai/deployments/gpt-4.1/chat/completions",

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -1360,13 +1360,11 @@ pub(crate) fn backend_with_policies_from_proto(
 							})
 						},
 						Some(provider::Provider::Bedrock(bedrock)) => {
-							AIProvider::Bedrock(llm::bedrock::Provider {
+							AIProvider::bedrock(llm::bedrock::Provider {
 								model: bedrock.model.as_deref().map(strng::new),
 								region: strng::new(&bedrock.region),
 								guardrail_identifier: bedrock.guardrail_identifier.as_deref().map(strng::new),
 								guardrail_version: bedrock.guardrail_version.as_deref().map(strng::new),
-								source_credentials_cache: Default::default(),
-								assume_role_cache: Default::default(),
 							})
 						},
 						Some(provider::Provider::Azure(azure)) => {
@@ -1376,13 +1374,12 @@ pub(crate) fn backend_with_policies_from_proto(
 								},
 								_ => llm::azure::AzureResourceType::OpenAI,
 							};
-							AIProvider::Azure(llm::azure::Provider {
+							AIProvider::azure(llm::azure::Provider {
 								model: azure.model.as_deref().map(strng::new),
 								resource_name: strng::new(&azure.resource_name),
 								resource_type,
 								api_version: azure.api_version.as_deref().map(strng::new),
 								project_name: azure.project_name.as_deref().map(strng::new),
-								cached_cred: Default::default(),
 							})
 						},
 						Some(provider::Provider::Azureopenai(_)) => {

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -3284,15 +3284,13 @@ async fn convert_llm_config(
 				region: p.vertex_region,
 				project_id: p.vertex_project.context("vertex requires vertex_project")?,
 			}),
-			LocalModelAIProvider::Bedrock => AIProvider::Bedrock(crate::llm::bedrock::Provider {
+			LocalModelAIProvider::Bedrock => AIProvider::bedrock(crate::llm::bedrock::Provider {
 				model,
 				region: p.aws_region.context("bedrock requires aws_region")?,
 				guardrail_identifier: None,
 				guardrail_version: None,
-				source_credentials_cache: Default::default(),
-				assume_role_cache: Default::default(),
 			}),
-			LocalModelAIProvider::Azure => AIProvider::Azure(crate::llm::azure::Provider {
+			LocalModelAIProvider::Azure => AIProvider::azure(crate::llm::azure::Provider {
 				model,
 				resource_name: p
 					.azure_resource_name
@@ -3302,7 +3300,6 @@ async fn convert_llm_config(
 					.context("azure requires azureResourceType")?,
 				api_version: p.azure_api_version,
 				project_name: p.azure_project_name,
-				cached_cred: Default::default(),
 			}),
 		};
 

--- a/crates/agentgateway/src/types/local_tests/llm_simple_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/llm_simple_normalized.snap
@@ -324,10 +324,10 @@ backends:
                     name: gpt-7-max
                     provider:
                       azure:
+                        apiVersion: v1
                         model: gpt-3.5-turbo
                         resourceName: my-azure-openai-endpoint
                         resourceType: openAI
-                        apiVersion: v1
                     hostOverride: ~
                     pathOverride: ~
                     pathPrefix: ~


### PR DESCRIPTION
This makes the providers purely operating on data that is needed for
conversion, ahead of a refactor in the future. This leaves the caching
layer, which we basically are just piggybacking storage on, out of the
main llm flow.

Refactor only, no behavior changes.