### PR TITLE
fix: Remove duplicate CEL validation markers

### DIFF
--- a/controller/api/v1alpha1/agentgateway/ai_policy.go
+++ b/controller/api/v1alpha1/agentgateway/ai_policy.go
@@ -352,7 +352,6 @@ type AIPromptGuard struct {
 // Note: The `field` values correspond to keys in the JSON request body, not fields in this CRD.
 type FieldDefault struct {
 	// Name of the field.
-	// +kubebuilder:validation:MinLength=1
 	// +required
 	Field ShortString `json:"field"`
 
@@ -367,7 +366,6 @@ type FieldDefault struct {
 // is assigned to the configured field.
 type FieldTransformation struct {
 	// Name of the field to set.
-	// +kubebuilder:validation:MinLength=1
 	// +required
 	Field ShortString `json:"field"`
 

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
@@ -444,11 +444,9 @@ spec:
                                             this CRD."
                                           properties:
                                             field:
-                                              allOf:
-                                              - minLength: 1
-                                              - minLength: 1
                                               description: Name of the field.
                                               maxLength: 256
+                                              minLength: 1
                                               type: string
                                             value:
                                               description: Default value for the field.
@@ -505,11 +503,9 @@ spec:
                                             this CRD."
                                           properties:
                                             field:
-                                              allOf:
-                                              - minLength: 1
-                                              - minLength: 1
                                               description: Name of the field.
                                               maxLength: 256
+                                              minLength: 1
                                               type: string
                                             value:
                                               description: Default value for the field.
@@ -5149,11 +5145,9 @@ spec:
                                               minLength: 1
                                               type: string
                                             field:
-                                              allOf:
-                                              - minLength: 1
-                                              - minLength: 1
                                               description: Name of the field to set.
                                               maxLength: 256
+                                              minLength: 1
                                               type: string
                                           required:
                                           - expression
@@ -7563,11 +7557,9 @@ spec:
                             body, not fields in this CRD."
                           properties:
                             field:
-                              allOf:
-                              - minLength: 1
-                              - minLength: 1
                               description: Name of the field.
                               maxLength: 256
+                              minLength: 1
                               type: string
                             value:
                               description: Default value for the field. This can be
@@ -7614,11 +7606,9 @@ spec:
                             body, not fields in this CRD."
                           properties:
                             field:
-                              allOf:
-                              - minLength: 1
-                              - minLength: 1
                               description: Name of the field.
                               maxLength: 256
+                              minLength: 1
                               type: string
                             value:
                               description: Default value for the field. This can be
@@ -11813,11 +11803,9 @@ spec:
                               minLength: 1
                               type: string
                             field:
-                              allOf:
-                              - minLength: 1
-                              - minLength: 1
                               description: Name of the field to set.
                               maxLength: 256
+                              minLength: 1
                               type: string
                           required:
                           - expression

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
@@ -109,11 +109,9 @@ spec:
                             body, not fields in this CRD."
                           properties:
                             field:
-                              allOf:
-                              - minLength: 1
-                              - minLength: 1
                               description: Name of the field.
                               maxLength: 256
+                              minLength: 1
                               type: string
                             value:
                               description: Default value for the field. This can be
@@ -160,11 +158,9 @@ spec:
                             body, not fields in this CRD."
                           properties:
                             field:
-                              allOf:
-                              - minLength: 1
-                              - minLength: 1
                               description: Name of the field.
                               maxLength: 256
+                              minLength: 1
                               type: string
                             value:
                               description: Default value for the field. This can be
@@ -4359,11 +4355,9 @@ spec:
                               minLength: 1
                               type: string
                             field:
-                              allOf:
-                              - minLength: 1
-                              - minLength: 1
                               description: Name of the field to set.
                               maxLength: 256
+                              minLength: 1
                               type: string
                           required:
                           - expression


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                           
  
  - Remove redundant `+kubebuilder:validation:MinLength=1` markers from `FieldDefault.Field` and `FieldTransformation.Field` in `ai_policy.go `                                                                                             
  - The `ShortString` type alias already includes `MinLength=1` validation, causing duplicate validation rules                                                                                                                        
  - Eliminates kubebuilder warnings about mismatched comments on type aliases                                                                                                                                                       
  - Simplifies generated CRD YAML from `allOf: [minLength: 1, minLength: 1]` to single `minLength: 1`