### PR TITLE
mcp: skip synthetic initialize for modern requests

### DIFF
--- a/crates/agentgateway/src/mcp/handler.rs
+++ b/crates/agentgateway/src/mcp/handler.rs
@@ -5,28 +5,28 @@ use std::sync::Arc;
 use agent_core::prelude::AssertSize;
 use agent_core::version::BuildInfo;
 use futures_core::Stream;
-use http::StatusCode;
 use http::request::Parts;
+use http::StatusCode;
 use itertools::Itertools;
-use rmcp::ErrorData;
 use rmcp::model::{
 	CacheScope, ClientNotification, ClientRequest, DiscoverResult, Implementation,
 	JsonRpcNotification, JsonRpcRequest, ListPromptsResult, ListResourceTemplatesResult,
 	ListResourcesResult, ListToolsResult, Meta, ProtocolVersion, RequestId, ResultType,
-	ServerCapabilities,
-	ServerInfo, ServerJsonRpcMessage, ServerNotification, ServerResult, SubscriptionsListenResult,
+	ServerCapabilities, ServerInfo, ServerJsonRpcMessage, ServerNotification, ServerResult,
+	SubscriptionsListenResult,
 };
+use rmcp::ErrorData;
 use tracing::{debug, warn};
 
-use crate::http::Response;
 use crate::http::sessionpersistence::MCPSession;
+use crate::http::Response;
 use crate::mcp;
 use crate::mcp::mergestream::{MergeFn, Messages};
 use crate::mcp::rbac::{CelExecWrapper, McpAuthorizationSet};
 use crate::mcp::router::McpBackendGroup;
 use crate::mcp::streamablehttp::{RequestProtocol, ServerSseMessage};
 use crate::mcp::upstream::{IncomingRequestContext, UpstreamError};
-use crate::mcp::{ClientError, FailureMode, MCPInfo, mergestream, rbac, upstream};
+use crate::mcp::{mergestream, rbac, upstream, ClientError, FailureMode, MCPInfo};
 use crate::proxy::httpproxy::PolicyClient;
 use crate::telemetry::log::{AsyncLog, SpanWriteOnDrop, SpanWriter};
 
@@ -1089,14 +1089,24 @@ fn normalize_outbound_for_protocol(
 			normalize_result_type(&mut r.result_type, downstream_modern);
 			normalize_cache_fields(&mut r.ttl_ms, &mut r.cache_scope, downstream_modern);
 		},
-		ServerResult::InitializeResult(r) => normalize_result_type(&mut r.result_type, downstream_modern),
+		ServerResult::InitializeResult(r) => {
+			normalize_result_type(&mut r.result_type, downstream_modern)
+		},
 		ServerResult::CompleteResult(r) => normalize_result_type(&mut r.result_type, downstream_modern),
-		ServerResult::GetPromptResult(r) => normalize_result_type(&mut r.result_type, downstream_modern),
+		ServerResult::GetPromptResult(r) => {
+			normalize_result_type(&mut r.result_type, downstream_modern)
+		},
 		ServerResult::ElicitResult(r) => normalize_result_type(&mut r.result_type, downstream_modern),
-		ServerResult::CreateTaskResult(r) => normalize_result_type(&mut r.result_type, downstream_modern),
-		ServerResult::ListTasksResult(r) => normalize_result_type(&mut r.result_type, downstream_modern),
+		ServerResult::CreateTaskResult(r) => {
+			normalize_result_type(&mut r.result_type, downstream_modern)
+		},
+		ServerResult::ListTasksResult(r) => {
+			normalize_result_type(&mut r.result_type, downstream_modern)
+		},
 		ServerResult::GetTaskResult(r) => normalize_result_type(&mut r.result_type, downstream_modern),
-		ServerResult::CancelTaskResult(r) => normalize_result_type(&mut r.result_type, downstream_modern),
+		ServerResult::CancelTaskResult(r) => {
+			normalize_result_type(&mut r.result_type, downstream_modern)
+		},
 		ServerResult::SubscriptionsListenResult(r) => {
 			normalize_result_type(&mut r.result_type, downstream_modern)
 		},

--- a/crates/agentgateway/src/mcp/handler.rs
+++ b/crates/agentgateway/src/mcp/handler.rs
@@ -5,9 +5,10 @@ use std::sync::Arc;
 use agent_core::prelude::AssertSize;
 use agent_core::version::BuildInfo;
 use futures_core::Stream;
-use http::request::Parts;
 use http::StatusCode;
+use http::request::Parts;
 use itertools::Itertools;
+use rmcp::ErrorData;
 use rmcp::model::{
 	CacheScope, ClientNotification, ClientRequest, DiscoverResult, Implementation,
 	JsonRpcNotification, JsonRpcRequest, ListPromptsResult, ListResourceTemplatesResult,
@@ -15,18 +16,17 @@ use rmcp::model::{
 	ServerCapabilities, ServerInfo, ServerJsonRpcMessage, ServerNotification, ServerResult,
 	SubscriptionsListenResult,
 };
-use rmcp::ErrorData;
 use tracing::{debug, warn};
 
-use crate::http::sessionpersistence::MCPSession;
 use crate::http::Response;
+use crate::http::sessionpersistence::MCPSession;
 use crate::mcp;
 use crate::mcp::mergestream::{MergeFn, Messages};
 use crate::mcp::rbac::{CelExecWrapper, McpAuthorizationSet};
 use crate::mcp::router::McpBackendGroup;
 use crate::mcp::streamablehttp::{RequestProtocol, ServerSseMessage};
 use crate::mcp::upstream::{IncomingRequestContext, UpstreamError};
-use crate::mcp::{mergestream, rbac, upstream, ClientError, FailureMode, MCPInfo};
+use crate::mcp::{ClientError, FailureMode, MCPInfo, mergestream, rbac, upstream};
 use crate::proxy::httpproxy::PolicyClient;
 use crate::telemetry::log::{AsyncLog, SpanWriteOnDrop, SpanWriter};
 

--- a/crates/agentgateway/src/mcp/handler.rs
+++ b/crates/agentgateway/src/mcp/handler.rs
@@ -12,7 +12,8 @@ use rmcp::ErrorData;
 use rmcp::model::{
 	CacheScope, ClientNotification, ClientRequest, DiscoverResult, Implementation,
 	JsonRpcNotification, JsonRpcRequest, ListPromptsResult, ListResourceTemplatesResult,
-	ListResourcesResult, ListToolsResult, Meta, ProtocolVersion, RequestId, ServerCapabilities,
+	ListResourcesResult, ListToolsResult, Meta, ProtocolVersion, RequestId, ResultType,
+	ServerCapabilities,
 	ServerInfo, ServerJsonRpcMessage, ServerNotification, ServerResult, SubscriptionsListenResult,
 };
 use tracing::{debug, warn};
@@ -1059,62 +1060,81 @@ fn normalize_outbound_for_protocol(
 	mut msg: ServerJsonRpcMessage,
 	downstream_modern: bool,
 ) -> ServerJsonRpcMessage {
-	if downstream_modern {
-		return msg;
-	}
-
 	let ServerJsonRpcMessage::Response(resp) = &mut msg else {
 		return msg;
 	};
 
 	match &mut resp.result {
 		ServerResult::DiscoverResult(r) => {
-			r.result_type = None;
-			r.ttl_ms = None;
-			r.cache_scope = None;
-		},
-		ServerResult::InitializeResult(r) => r.result_type = None,
-		ServerResult::CompleteResult(r) => r.result_type = None,
-		ServerResult::GetPromptResult(r) => r.result_type = None,
-		ServerResult::ListPromptsResult(r) => {
-			r.result_type = None;
-			r.ttl_ms = None;
-			r.cache_scope = None;
-		},
-		ServerResult::ListResourcesResult(r) => {
-			r.result_type = None;
-			r.ttl_ms = None;
-			r.cache_scope = None;
-		},
-		ServerResult::ListResourceTemplatesResult(r) => {
-			r.result_type = None;
-			r.ttl_ms = None;
-			r.cache_scope = None;
-		},
-		ServerResult::ReadResourceResult(r) => {
-			r.result_type = None;
-			r.ttl_ms = None;
-			r.cache_scope = None;
+			normalize_result_type(&mut r.result_type, downstream_modern);
+			normalize_cache_fields(&mut r.ttl_ms, &mut r.cache_scope, downstream_modern);
 		},
 		ServerResult::ListToolsResult(r) => {
-			r.result_type = None;
-			r.ttl_ms = None;
-			r.cache_scope = None;
+			normalize_result_type(&mut r.result_type, downstream_modern);
+			normalize_cache_fields(&mut r.ttl_ms, &mut r.cache_scope, downstream_modern);
 		},
-		ServerResult::ElicitResult(r) => r.result_type = None,
-		ServerResult::CreateTaskResult(r) => r.result_type = None,
-		ServerResult::ListTasksResult(r) => r.result_type = None,
-		ServerResult::GetTaskResult(r) => r.result_type = None,
-		ServerResult::CancelTaskResult(r) => r.result_type = None,
-		ServerResult::SubscriptionsListenResult(r) => r.result_type = None,
-		ServerResult::CallToolResult(r) => r.result_type = None,
-		ServerResult::GetTaskPayloadResult(r) => strip_protocol_result_fields(&mut r.0),
-		ServerResult::EmptyResult(r) => r.result_type = None,
-		ServerResult::CustomResult(r) => strip_protocol_result_fields(&mut r.0),
+		ServerResult::ListPromptsResult(r) => {
+			normalize_result_type(&mut r.result_type, downstream_modern);
+			normalize_cache_fields(&mut r.ttl_ms, &mut r.cache_scope, downstream_modern);
+		},
+		ServerResult::ListResourcesResult(r) => {
+			normalize_result_type(&mut r.result_type, downstream_modern);
+			normalize_cache_fields(&mut r.ttl_ms, &mut r.cache_scope, downstream_modern);
+		},
+		ServerResult::ListResourceTemplatesResult(r) => {
+			normalize_result_type(&mut r.result_type, downstream_modern);
+			normalize_cache_fields(&mut r.ttl_ms, &mut r.cache_scope, downstream_modern);
+		},
+		ServerResult::ReadResourceResult(r) => {
+			normalize_result_type(&mut r.result_type, downstream_modern);
+			normalize_cache_fields(&mut r.ttl_ms, &mut r.cache_scope, downstream_modern);
+		},
+		ServerResult::InitializeResult(r) => normalize_result_type(&mut r.result_type, downstream_modern),
+		ServerResult::CompleteResult(r) => normalize_result_type(&mut r.result_type, downstream_modern),
+		ServerResult::GetPromptResult(r) => normalize_result_type(&mut r.result_type, downstream_modern),
+		ServerResult::ElicitResult(r) => normalize_result_type(&mut r.result_type, downstream_modern),
+		ServerResult::CreateTaskResult(r) => normalize_result_type(&mut r.result_type, downstream_modern),
+		ServerResult::ListTasksResult(r) => normalize_result_type(&mut r.result_type, downstream_modern),
+		ServerResult::GetTaskResult(r) => normalize_result_type(&mut r.result_type, downstream_modern),
+		ServerResult::CancelTaskResult(r) => normalize_result_type(&mut r.result_type, downstream_modern),
+		ServerResult::SubscriptionsListenResult(r) => {
+			normalize_result_type(&mut r.result_type, downstream_modern)
+		},
+		ServerResult::CallToolResult(r) => normalize_result_type(&mut r.result_type, downstream_modern),
+		ServerResult::EmptyResult(r) => normalize_result_type(&mut r.result_type, downstream_modern),
+		ServerResult::GetTaskPayloadResult(r) => {
+			if !downstream_modern {
+				strip_protocol_result_fields(&mut r.0)
+			}
+		},
+		ServerResult::CustomResult(r) => {
+			if !downstream_modern {
+				strip_protocol_result_fields(&mut r.0)
+			}
+		},
 		ServerResult::InputRequiredResult(_) => {},
 	}
 
 	msg
+}
+
+fn normalize_result_type(result_type: &mut Option<ResultType>, downstream_modern: bool) {
+	if downstream_modern {
+		result_type.get_or_insert(ResultType::COMPLETE);
+	} else {
+		*result_type = None;
+	}
+}
+
+fn normalize_cache_fields(
+	ttl_ms: &mut Option<u64>,
+	cache_scope: &mut Option<CacheScope>,
+	downstream_modern: bool,
+) {
+	if !downstream_modern {
+		*ttl_ms = None;
+		*cache_scope = None;
+	}
 }
 
 fn strip_protocol_result_fields(value: &mut serde_json::Value) {

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -525,6 +525,40 @@ async fn modern_stateful_streamable_http_does_not_use_sessions() {
 	assert_eq!(with_session.status(), reqwest::StatusCode::BAD_REQUEST);
 }
 
+// TODO this test doesn't regress without downgrade_to_legacy_handshake
+// as our current rmcp fork doesn't replicate the stricness that the python SDK has
+#[tokio::test]
+async fn stateless_vnext_tools_list_reaches_upstream() {
+	let mock = mock_streamable_http_server(false).await;
+	let (_bind, io) = setup_proxy(&mock, false, false).await;
+	let client = reqwest::Client::new();
+	let url = format!("http://{io}/mcp");
+	let body = serde_json::json!({
+		"jsonrpc": "2.0",
+		"id": 1,
+		"method": "tools/list",
+		"params": {
+			"_meta": {
+				"io.modelcontextprotocol/protocolVersion": "2026-07-28",
+				"io.modelcontextprotocol/clientInfo": {"name": "probe-client", "version": "0"},
+				"io.modelcontextprotocol/clientCapabilities": {}
+			}
+		}
+	});
+	let resp = mcp_json_post(&client, &url, &body)
+		.header("mcp-protocol-version", "2026-07-28")
+		.header("mcp-method", "tools/list")
+		.send()
+		.await
+		.unwrap();
+	assert_eq!(resp.status(), reqwest::StatusCode::OK);
+	let text = resp.text().await.unwrap();
+	assert!(
+		text.contains("echo"),
+		"expected the upstream tools, got {text}"
+	);
+}
+
 #[tokio::test]
 async fn modern_client_multiplex_mixed_servers_falls_back_to_legacy_initialize() {
 	let old = mock_streamable_http_server(false).await;

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -526,7 +526,7 @@ async fn modern_stateful_streamable_http_does_not_use_sessions() {
 }
 
 // TODO this test doesn't regress without downgrade_to_legacy_handshake
-// as our current rmcp fork doesn't replicate the stricness that the python SDK has
+// as our current rmcp fork doesn't replicate the strictness that the python SDK has
 #[tokio::test]
 async fn stateless_vnext_tools_list_reaches_upstream() {
 	let mock = mock_streamable_http_server(false).await;

--- a/crates/agentgateway/src/mcp/session.rs
+++ b/crates/agentgateway/src/mcp/session.rs
@@ -66,14 +66,15 @@ impl Session {
 	}
 
 	/// Send a downstream message to upstream server(s) in gateway stateless mode.
-	/// Every non-initialize message gets a gateway-generated InitializeRequest
-	/// first, because many legacy servers require initialize before any other
-	/// request. Once downstream stateless transport is supported, remove this
-	/// wrapper and forward the message as-is.
+	/// Legacy (pre-2026) non-initialize messages get a gateway-generated
+	/// InitializeRequest first, because legacy servers require initialize before
+	/// any other request. Modern (>= 2026-07-28) requests are stateless and are
+	/// forwarded as-is: a modern client only reaches a modern request after its
+	/// `server/discover` negotiated a modern server, so no handshake is needed.
 	pub async fn stateless_send_and_initialize(
 		&mut self,
-		mut parts: Parts,
-		mut message: ClientJsonRpcMessage,
+		parts: Parts,
+		message: ClientJsonRpcMessage,
 	) -> Result<Response, ProxyError> {
 		let req_id = match &message {
 			ClientJsonRpcMessage::Request(r) => Some(r.id.clone()),
@@ -81,9 +82,12 @@ impl Session {
 		};
 		let is_init = matches!(&message,
 			ClientJsonRpcMessage::Request(r) if matches!(r.request, ClientRequest::InitializeRequest(_)));
-		if !is_init {
-			let client_info = downgrade_to_legacy_handshake(&mut parts, &mut message, req_id.clone())?;
-			let init_request = rmcp::model::InitializeRequest::new(client_info);
+		let is_modern = parts
+			.extensions
+			.get::<crate::mcp::streamablehttp::RequestProtocol>()
+			.is_some_and(|p| p.is_modern());
+		if !is_init && !is_modern {
+			let init_request = rmcp::model::InitializeRequest::new(get_client_info());
 			let request_type = match &message {
 				ClientJsonRpcMessage::Request(r) => Some(&r.request),
 				_ => None,
@@ -955,50 +959,4 @@ fn get_client_info() -> ClientInfo {
 	client_info.client_info =
 		Implementation::new("agentgateway", BuildInfo::new().version.to_string());
 	client_info
-}
-
-/// Make a modern (>= 2026-07-28) request relayable behind the synthetic legacy
-/// `initialize` this stateless path prepends. A modern server refuses
-/// `initialize` from a client that presents as modern, so we present as legacy.
-///
-/// https://github.com/modelcontextprotocol/python-sdk/blob/9bdc03d54e59e28f08307c2dba0e429a64b171c9/src/mcp/server/runner.py#L669
-/// https://github.com/modelcontextprotocol/python-sdk/blob/9bdc03d54e59e28f08307c2dba0e429a64b171c9/src/mcp/shared/inbound.py#L442
-/// TODO: skip `initialize` entirely for modern->modern sessions.
-fn downgrade_to_legacy_handshake(
-	parts: &mut Parts,
-	message: &mut ClientJsonRpcMessage,
-	req_id: Option<RequestId>,
-) -> Result<ClientInfo, ProxyError> {
-	let mut client_info = get_client_info();
-
-	// clamp the version the handshake claims
-	if let Some(protocol_version) =
-		crate::mcp::streamablehttp::protocol_version_header(&parts.headers, req_id)?
-	{
-		client_info.protocol_version =
-			if protocol_version.as_str() >= ProtocolVersion::STANDARD_HEADERS.as_str() {
-				ProtocolVersion::V_2025_11_25
-			} else {
-				protocol_version
-			};
-		if let Ok(v) = ::http::HeaderValue::from_str(client_info.protocol_version.as_str()) {
-			parts.headers.insert(
-				rmcp::transport::common::http_header::HEADER_MCP_PROTOCOL_VERSION,
-				v,
-			);
-		}
-	}
-
-	// strip the modern `_meta` envelope keys
-	let meta = match message {
-		ClientJsonRpcMessage::Request(r) => Some(r.request.get_meta_mut()),
-		ClientJsonRpcMessage::Notification(n) => Some(n.notification.get_meta_mut()),
-		_ => None,
-	};
-	if let Some(meta) = meta {
-		meta.0.remove(rmcp::model::META_KEY_PROTOCOL_VERSION);
-		meta.0.remove(rmcp::model::META_KEY_CLIENT_INFO);
-		meta.0.remove(rmcp::model::META_KEY_CLIENT_CAPABILITIES);
-	}
-	Ok(client_info)
 }

--- a/crates/agentgateway/src/mcp/session.rs
+++ b/crates/agentgateway/src/mcp/session.rs
@@ -87,7 +87,13 @@ impl Session {
 			.get::<crate::mcp::streamablehttp::RequestProtocol>()
 			.is_some_and(|p| p.is_modern());
 		if !is_init && !is_modern {
-			let init_request = rmcp::model::InitializeRequest::new(get_client_info());
+			let mut client_info = get_client_info();
+			if let Some(protocol_version) =
+				crate::mcp::streamablehttp::protocol_version_header(&parts.headers, req_id.clone())?
+			{
+				client_info.protocol_version = protocol_version;
+			}
+			let init_request = rmcp::model::InitializeRequest::new(client_info);
 			let request_type = match &message {
 				ClientJsonRpcMessage::Request(r) => Some(&r.request),
 				_ => None,

--- a/crates/agentgateway/src/mcp/session.rs
+++ b/crates/agentgateway/src/mcp/session.rs
@@ -72,22 +72,22 @@ impl Session {
 	/// wrapper and forward the message as-is.
 	pub async fn stateless_send_and_initialize(
 		&mut self,
-		parts: Parts,
-		message: ClientJsonRpcMessage,
+		mut parts: Parts,
+		mut message: ClientJsonRpcMessage,
 	) -> Result<Response, ProxyError> {
-		let (req_id, request_type) = match &message {
-			ClientJsonRpcMessage::Request(r) => (Some(r.id.clone()), Some(&r.request)),
-			_ => (None, None),
+		let req_id = match &message {
+			ClientJsonRpcMessage::Request(r) => Some(r.id.clone()),
+			_ => None,
 		};
-		let is_init = request_type.is_some_and(|r| matches!(r, ClientRequest::InitializeRequest(_)));
+		let is_init = matches!(&message,
+			ClientJsonRpcMessage::Request(r) if matches!(r.request, ClientRequest::InitializeRequest(_)));
 		if !is_init {
-			let mut client_info = get_client_info();
-			if let Some(protocol_version) =
-				crate::mcp::streamablehttp::protocol_version_header(&parts.headers, req_id.clone())?
-			{
-				client_info.protocol_version = protocol_version;
-			}
+			let client_info = downgrade_to_legacy_handshake(&mut parts, &mut message, req_id.clone())?;
 			let init_request = rmcp::model::InitializeRequest::new(client_info);
+			let request_type = match &message {
+				ClientJsonRpcMessage::Request(r) => Some(&r.request),
+				_ => None,
+			};
 			// first, determine how widely to send the initialize
 			match request_type {
 				Some(ClientRequest::CallToolRequest(_)) | Some(ClientRequest::GetPromptRequest(_)) => {
@@ -955,4 +955,50 @@ fn get_client_info() -> ClientInfo {
 	client_info.client_info =
 		Implementation::new("agentgateway", BuildInfo::new().version.to_string());
 	client_info
+}
+
+/// Make a modern (>= 2026-07-28) request relayable behind the synthetic legacy
+/// `initialize` this stateless path prepends. A modern server refuses
+/// `initialize` from a client that presents as modern, so we present as legacy.
+///
+/// https://github.com/modelcontextprotocol/python-sdk/blob/9bdc03d54e59e28f08307c2dba0e429a64b171c9/src/mcp/server/runner.py#L669
+/// https://github.com/modelcontextprotocol/python-sdk/blob/9bdc03d54e59e28f08307c2dba0e429a64b171c9/src/mcp/shared/inbound.py#L442
+/// TODO: skip `initialize` entirely for modern->modern sessions.
+fn downgrade_to_legacy_handshake(
+	parts: &mut Parts,
+	message: &mut ClientJsonRpcMessage,
+	req_id: Option<RequestId>,
+) -> Result<ClientInfo, ProxyError> {
+	let mut client_info = get_client_info();
+
+	// clamp the version the handshake claims
+	if let Some(protocol_version) =
+		crate::mcp::streamablehttp::protocol_version_header(&parts.headers, req_id)?
+	{
+		client_info.protocol_version =
+			if protocol_version.as_str() >= ProtocolVersion::STANDARD_HEADERS.as_str() {
+				ProtocolVersion::V_2025_11_25
+			} else {
+				protocol_version
+			};
+		if let Ok(v) = ::http::HeaderValue::from_str(client_info.protocol_version.as_str()) {
+			parts.headers.insert(
+				rmcp::transport::common::http_header::HEADER_MCP_PROTOCOL_VERSION,
+				v,
+			);
+		}
+	}
+
+	// strip the modern `_meta` envelope keys
+	let meta = match message {
+		ClientJsonRpcMessage::Request(r) => Some(r.request.get_meta_mut()),
+		ClientJsonRpcMessage::Notification(n) => Some(n.notification.get_meta_mut()),
+		_ => None,
+	};
+	if let Some(meta) = meta {
+		meta.0.remove(rmcp::model::META_KEY_PROTOCOL_VERSION);
+		meta.0.remove(rmcp::model::META_KEY_CLIENT_INFO);
+		meta.0.remove(rmcp::model::META_KEY_CLIENT_CAPABILITIES);
+	}
+	Ok(client_info)
 }

--- a/crates/agentgateway/src/mcp/upstream/stdio.rs
+++ b/crates/agentgateway/src/mcp/upstream/stdio.rs
@@ -144,6 +144,19 @@ impl Process {
 									let _ = sender.send(ServerJsonRpcMessage::Response(res));
 								}
 							},
+							Some(JsonRpcMessage::Error(err)) => {
+								// An error reply terminates its request just like a response;
+								// only id-less errors belong on the event stream.
+								let sender = err
+									.id
+									.as_ref()
+									.and_then(|id| pending_requests_clone.lock().unwrap().remove(id));
+								if let Some(sender) = sender {
+									let _ = sender.send(ServerJsonRpcMessage::Error(err));
+								} else if let Some(sender) = event_stream_send.load().as_ref() {
+									let _ = sender.send(JsonRpcMessage::Error(err)).await;
+								}
+							},
 							Some(other) => {
 								if let Some(sender) = event_stream_send.load().as_ref() {
 									let _ = sender.send(other).await;
@@ -255,6 +268,66 @@ mod tests {
 
 		fn close(&mut self) -> impl Future<Output = Result<(), UpstreamError>> + Send {
 			std::future::ready(Ok(()))
+		}
+	}
+
+	struct ErrorReplyTransport {
+		tx: mpsc::Sender<ServerJsonRpcMessage>,
+		rx: mpsc::Receiver<ServerJsonRpcMessage>,
+	}
+
+	impl MCPTransport for ErrorReplyTransport {
+		fn send(
+			&mut self,
+			item: ClientJsonRpcMessage,
+			_: &IncomingRequestContext,
+		) -> impl Future<Output = Result<(), UpstreamError>> + Send + 'static {
+			let tx = self.tx.clone();
+			async move {
+				if let JsonRpcMessage::Request(req) = item {
+					let err = rmcp::model::JsonRpcError::new(
+						Some(req.id),
+						rmcp::ErrorData::invalid_request(
+							"connection is locked to the legacy handshake era",
+							None,
+						),
+					);
+					let _ = tx.send(ServerJsonRpcMessage::Error(err)).await;
+				}
+				Ok(())
+			}
+		}
+
+		fn receive(&mut self) -> impl Future<Output = Option<ServerJsonRpcMessage>> + Send {
+			self.rx.recv()
+		}
+
+		fn close(&mut self) -> impl Future<Output = Result<(), UpstreamError>> + Send {
+			std::future::ready(Ok(()))
+		}
+	}
+
+	#[tokio::test]
+	async fn test_process_error_reply_resolves_pending_request() {
+		let (tx, rx) = mpsc::channel(4);
+		let proc = Process::new(ErrorReplyTransport { tx, rx });
+		let req = JsonRpcRequest {
+			jsonrpc: Default::default(),
+			id: RequestId::Number(1),
+			request: ClientRequest::PingRequest(Default::default()),
+		};
+
+		let resp = timeout(
+			Duration::from_secs(1),
+			proc.send_message(req, &IncomingRequestContext::empty()),
+		)
+		.await
+		.expect("an error reply must resolve the pending request, not hang")
+		.unwrap();
+
+		match resp {
+			ServerJsonRpcMessage::Error(e) => assert_eq!(e.id, Some(RequestId::Number(1))),
+			other => panic!("expected error reply, got {other:?}"),
 		}
 	}
 

--- a/crates/agentgateway/src/mcp/upstream/stdio.rs
+++ b/crates/agentgateway/src/mcp/upstream/stdio.rs
@@ -13,7 +13,7 @@ use rmcp::model::{
 use rmcp::transport::{TokioChildProcess, Transport};
 use tokio::sync::mpsc::Sender;
 use tokio::sync::{mpsc, oneshot};
-use tracing::{error, warn};
+use tracing::{debug, error, warn};
 
 use crate::mcp::mergestream::Messages;
 use crate::mcp::upstream::{IncomingRequestContext, UpstreamError};
@@ -145,16 +145,21 @@ impl Process {
 								}
 							},
 							Some(JsonRpcMessage::Error(err)) => {
-								// An error reply terminates its request just like a response;
-								// only id-less errors belong on the event stream.
-								let sender = err
-									.id
-									.as_ref()
-									.and_then(|id| pending_requests_clone.lock().unwrap().remove(id));
-								if let Some(sender) = sender {
-									let _ = sender.send(ServerJsonRpcMessage::Error(err));
-								} else if let Some(sender) = event_stream_send.load().as_ref() {
-									let _ = sender.send(JsonRpcMessage::Error(err)).await;
+								// An error carrying a request id terminates that request, like a response.
+								// An id-less error can't be matched, so it belongs on the event stream.
+								match err.id.as_ref() {
+									Some(id) => {
+										if let Some(sender) = pending_requests_clone.lock().unwrap().remove(id) {
+											let _ = sender.send(ServerJsonRpcMessage::Error(err));
+										} else {
+											debug!("dropping stdio error for unknown request id {id:?}");
+										}
+									},
+									None => {
+										if let Some(sender) = event_stream_send.load().as_ref() {
+											let _ = sender.send(JsonRpcMessage::Error(err)).await;
+										}
+									},
 								}
 							},
 							Some(other) => {


### PR DESCRIPTION
https://github.com/modelcontextprotocol/python-sdk/blob/9bdc03d54e59e28f08307c2dba0e429a64b171c9/src/mcp/server/runner.py#L669
https://github.com/modelcontextprotocol/python-sdk/blob/9bdc03d54e59e28f08307c2dba0e429a64b171c9/src/mcp/shared/inbound.py#L442

When testing this out against a fork of some of the [apps samples](https://github.com/modelcontextprotocol/ext-apps/tree/main/examples) with upgraded SDK, I got some errors on `tools/list` due to our synthetic initialize having a modern envelope/version, which those servers will reject. 

While investigating that, I found that the error reply got dropped and would hang until a timeout on stdio. 

Of course we don't really need the initialize for modern client -> modern server but we don't really know if the server is modern at this point.

---

### Reproduction

**Server**

```python
# probe.py
import sys
from mcp.server.mcpserver import MCPServer
from mcp.server.transport_security import TransportSecuritySettings

mcp = MCPServer("probe", version="0.1.0")

@mcp.tool()
def ping() -> str:
    return "pong"

if __name__ == "__main__":
    if "--http" in sys.argv:
        mcp.run("streamable-http", port=3931, stateless_http=True,
                transport_security=TransportSecuritySettings(enable_dns_rebinding_protection=False))
    else:
        mcp.run()
```

```bash
uv run --prerelease=allow --with mcp==2.0.0b1 python probe.py --http
```

**Gateway**

```yaml
# config.yaml
mcp:
  port: 3030
  statefulMode: stateless
  targets:
  - name: probe
    mcp: { host: http://127.0.0.1:3931/mcp }   # Bug 1 (HTTP)
    # stdio: { cmd: python, args: [probe.py] }  # Bug 2 (stdio)
```

```bash
cargo run -- -f config.yaml
```

**Client**

```python
# client.py
import asyncio, sys
from mcp import Client

async def main(url: str) -> None:
    async with Client(url, raise_exceptions=True) as c:
        print("negotiated:", c.protocol_version)
        tools = await c.list_tools()
        print("tools:", [t.name for t in tools.tools])
        r = await c.call_tool(tools.tools[0].name, {})
        print("call:", r.content)

asyncio.run(main(sys.argv[1] if len(sys.argv) > 1 else "http://localhost:3030/mcp"))
```

```bash
# sanity: straight to the server negotiates 2026-07-28
uv run --prerelease=allow --with mcp==2.0.0b1 python client.py http://127.0.0.1:3931/mcp
#   negotiated: 2026-07-28

# through the gateway
uv run --prerelease=allow --with mcp==2.0.0b1 python client.py http://localhost:3030/mcp
```

Before the gateway would force us to 2025, now it will let us use 2026 when both sides support it