### PR TITLE
standalone: optimize logging writes to database

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,6 +352,7 @@ dependencies = [
  "typespec_client_core",
  "url",
  "uuid",
+ "value-bag",
  "vector-map",
  "websocket-sans-io",
  "which 8.0.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -232,7 +232,7 @@ tracing-subscriber = { version = "0.3", features = [
     "json",
 ] }
 url = "2.5"
-uuid = { version = "1.23", features = ["v4"] }
+uuid = { version = "1.23", features = ["v4", "v7"] }
 wiremock = { version = "0.6", features = ["tls"] }
 x509-parser = { version = "0.18", default-features = false, features = ["verify-aws"] }
 which = "8.0"

--- a/crates/agentgateway-app/src/commands/run.rs
+++ b/crates/agentgateway-app/src/commands/run.rs
@@ -5,7 +5,7 @@ use agent_core::{strng, telemetry, version};
 use agentgateway::app::Bound;
 use agentgateway::types::agent::ListenerTarget;
 use agentgateway::{BackendConfig, Config, LoggingFormat, client, serdes};
-use tracing::info;
+use tracing::{error, info};
 
 use crate::{RunArgs, read_config_contents};
 
@@ -46,8 +46,19 @@ pub(crate) fn execute(args: RunArgs) -> anyhow::Result<()> {
 				&config.logging.level,
 				config.logging.format == LoggingFormat::Json,
 			);
+			info!("version: {}", version::BuildInfo::new());
+			info!(
+				"running with config: {}",
+				serdes::yamlviajson::to_string(&config)?
+			);
 			let request_log_store = match config.database.as_ref() {
-				Some(cfg) => Some(agentgateway::telemetry::log_store::setup(cfg).await?),
+				Some(cfg) => match agentgateway::telemetry::log_store::setup(cfg).await {
+					Ok(store) => Some(store),
+					Err(err) => {
+						error!(?err, "failed to initialize request log database");
+						return Err(err);
+					},
+				},
 				None => None,
 			};
 			let result = proxy(Arc::new(config)).await;
@@ -139,11 +150,6 @@ fn spawn_readiness(bound: &Bound) {
 }
 
 async fn proxy(cfg: Arc<Config>) -> anyhow::Result<()> {
-	info!("version: {}", version::BuildInfo::new());
-	info!(
-		"running with config: {}",
-		serdes::yamlviajson::to_string(&cfg)?
-	);
 	let bound = agentgateway::app::run(cfg).await?;
 	spawn_readiness(&bound);
 	bound.wait_termination().await

--- a/crates/agentgateway/Cargo.toml
+++ b/crates/agentgateway/Cargo.toml
@@ -152,6 +152,7 @@ tracing.workspace = true
 typespec_client_core.workspace = true
 url.workspace = true
 uuid.workspace = true
+value-bag.workspace = true
 x509-parser.workspace = true
 reqwest.workspace = true
 websocket-sans-io.workspace = true

--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -30,6 +30,7 @@ use serde::ser::SerializeMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
 use tracing::{Level, debug, trace};
+use value_bag::visit::Visit;
 
 use crate::cel::{ContextBuilder, Expression, LLMContext};
 use crate::http::{Request, health};
@@ -56,25 +57,83 @@ fn u128_to_i64(value: u128) -> i64 {
 	value.min(i64::MAX as u128) as i64
 }
 
-fn kv_to_json(kv: &[(&str, Option<ValueBag>)]) -> Value {
-	let mut map = serde_json::Map::with_capacity(kv.len());
-	for (key, value) in kv {
-		if let Some(value) = value
-			&& let Ok(value) = serde_json::to_value(value)
-		{
-			map.insert((*key).to_string(), value);
-		}
-	}
-	Value::Object(map)
+struct DatabaseAttributes {
+	json: Box<str>,
+	agentgateway_user: Option<String>,
+	agentgateway_group: Option<String>,
+	user_agent_name: Option<String>,
 }
 
-fn string_attribute(attributes: &Value, key: &str) -> Option<String> {
-	attributes
-		.get(key)
-		.and_then(Value::as_str)
-		.map(str::trim)
-		.filter(|value| !value.is_empty())
-		.map(ToOwned::to_owned)
+fn database_attributes(kv: &[(&str, Option<ValueBag>)]) -> DatabaseAttributes {
+	let mut agentgateway_user = None;
+	let mut agentgateway_group = None;
+	let mut user_agent_name = None;
+	for (key, value) in kv {
+		let Some(value) = value else {
+			continue;
+		};
+		match *key {
+			"agentgateway.user" => {
+				agentgateway_user = string_attribute(value);
+			},
+			"agentgateway.group" => {
+				agentgateway_group = string_attribute(value);
+			},
+			"user_agent.name" => {
+				user_agent_name = string_attribute(value);
+			},
+			_ => {},
+		}
+	}
+	let json = serde_json::to_string(&DatabaseAttributeMap(kv))
+		.unwrap_or_else(|_| "{}".to_string())
+		.into_boxed_str();
+	DatabaseAttributes {
+		json,
+		agentgateway_user,
+		agentgateway_group,
+		user_agent_name,
+	}
+}
+
+struct DatabaseAttributeMap<'a>(&'a [(&'a str, Option<ValueBag<'a>>)]);
+
+impl Serialize for DatabaseAttributeMap<'_> {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: Serializer,
+	{
+		let len = self.0.iter().filter(|(_, value)| value.is_some()).count();
+		let mut map = serializer.serialize_map(Some(len))?;
+		for (key, value) in self.0 {
+			if let Some(value) = value {
+				map.serialize_entry(key, value)?;
+			}
+		}
+		map.end()
+	}
+}
+
+fn string_attribute(value: &ValueBag) -> Option<String> {
+	struct StringVisitor(Option<String>);
+
+	impl<'v> Visit<'v> for StringVisitor {
+		fn visit_any(&mut self, _value: ValueBag) -> Result<(), value_bag::Error> {
+			Ok(())
+		}
+
+		fn visit_str(&mut self, value: &str) -> Result<(), value_bag::Error> {
+			let value = value.trim();
+			if !value.is_empty() {
+				self.0 = Some(value.to_string());
+			}
+			Ok(())
+		}
+	}
+
+	let mut visitor = StringVisitor(None);
+	let _ = value.visit(&mut visitor);
+	visitor.0
 }
 
 fn user_agent_name(req: Option<&cel::RequestSnapshot>) -> Option<String> {
@@ -1608,10 +1667,7 @@ impl Drop for DropOnLog {
 							db_kv.push((*k, eval));
 						}
 					}
-					let attributes_json = kv_to_json(&db_kv);
-					let agentgateway_user = string_attribute(&attributes_json, "agentgateway.user");
-					let agentgateway_group = string_attribute(&attributes_json, "agentgateway.group");
-					let user_agent_name = string_attribute(&attributes_json, "user_agent.name");
+					let attributes = database_attributes(&db_kv);
 					let payload = llm_response.as_ref().and_then(|info| {
 						let request_prompt_json = info
 							.prompt
@@ -1635,7 +1691,7 @@ impl Drop for DropOnLog {
 							.or_else(|| Some(llm.input_tokens? + llm.output_tokens?))
 					});
 					log_store::emit(log_store::StoredRequestLog {
-						id: uuid::Uuid::new_v4().to_string(),
+						id: uuid::Uuid::now_v7().to_string(),
 						started_at: log.start.as_datetime().with_timezone(&chrono::Utc),
 						completed_at: end_time.as_datetime().with_timezone(&chrono::Utc),
 						duration_ms: u128_to_i64(duration.as_millis()),
@@ -1665,11 +1721,11 @@ impl Drop for DropOnLog {
 						output_tokens: u64_to_i64(llm_response.as_ref().and_then(|llm| llm.output_tokens)),
 						total_tokens: u64_to_i64(total_tokens),
 						cost: cost.and_then(|cost| cost.total().to_f64()),
-						agentgateway_user,
-						agentgateway_group,
-						user_agent_name,
+						agentgateway_user: attributes.agentgateway_user,
+						agentgateway_group: attributes.agentgateway_group,
+						user_agent_name: attributes.user_agent_name,
 						has_payload,
-						attributes_json,
+						attributes_json: attributes.json,
 						payload,
 					});
 				}

--- a/crates/agentgateway/src/telemetry/log_store.rs
+++ b/crates/agentgateway/src/telemetry/log_store.rs
@@ -1,6 +1,8 @@
 use std::collections::BTreeMap;
 use std::sync::OnceLock;
-use std::thread;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Instant;
+use std::{env, thread};
 
 use chrono::{DateTime, Duration, Utc};
 use crossbeam::channel::{Receiver, Sender, TryRecvError};
@@ -11,63 +13,11 @@ use tracing::{debug, warn};
 
 use crate::{apply, schema};
 
-const INSERT_LOG_PREFIX: &str = r#"
-INSERT INTO request_logs (
-	id, started_at, completed_at, duration_ms, trace_id, span_id, http_status, error,
-	gen_ai_operation_name, gen_ai_provider_name, gen_ai_request_model, gen_ai_response_model,
-	input_tokens, output_tokens, total_tokens, cost, agentgateway_user, agentgateway_group,
-	user_agent_name, has_payload, attributes_json
-) "#;
-
-const INSERT_PAYLOAD_PREFIX: &str = r#"
-INSERT INTO request_log_payloads (log_id, request_prompt_json, response_completion_json) 
-"#;
-
-macro_rules! push_request_log_row {
-	($row:expr, $record:expr) => {{
-		$row
-			.push_bind(&$record.id)
-			.push_bind($record.started_at)
-			.push_bind($record.completed_at)
-			.push_bind($record.duration_ms)
-			.push_bind(&$record.trace_id)
-			.push_bind(&$record.span_id)
-			.push_bind($record.http_status)
-			.push_bind(&$record.error)
-			.push_bind(&$record.gen_ai_operation_name)
-			.push_bind(&$record.gen_ai_provider_name)
-			.push_bind(&$record.gen_ai_request_model)
-			.push_bind(&$record.gen_ai_response_model)
-			.push_bind($record.input_tokens)
-			.push_bind($record.output_tokens)
-			.push_bind($record.total_tokens)
-			.push_bind($record.cost)
-			.push_bind(&$record.agentgateway_user)
-			.push_bind(&$record.agentgateway_group)
-			.push_bind(&$record.user_agent_name)
-			.push_bind($record.has_payload)
-			.push_bind(sqlx::types::Json(&$record.attributes_json));
-	}};
-}
-
-macro_rules! push_request_log_payload_row {
-	($row:expr, $record:expr, $payload:expr) => {{
-		$row
-			.push_bind(&$record.id)
-			.push_bind($payload.request_prompt_json.as_ref().map(sqlx::types::Json))
-			.push_bind(
-				$payload
-					.response_completion_json
-					.as_ref()
-					.map(sqlx::types::Json),
-			);
-	}};
-}
-
 mod postgres;
 mod sqlite;
 
 static REQUEST_LOG_STORE: OnceLock<RequestLogStore> = OnceLock::new();
+static REQUEST_LOG_STORE_BACKLOG: AtomicUsize = AtomicUsize::new(0);
 
 #[apply(schema!)]
 pub struct Config {
@@ -81,7 +31,9 @@ pub struct RequestLogStore {
 
 impl RequestLogStore {
 	pub fn emit(&self, record: StoredRequestLog) {
+		REQUEST_LOG_STORE_BACKLOG.fetch_add(1, Ordering::Relaxed);
 		if let Err(err) = self.tx.send(LogStoreMsg::Record(record)) {
+			REQUEST_LOG_STORE_BACKLOG.fetch_sub(1, Ordering::Relaxed);
 			warn!(target: "request", ?err, "failed to enqueue request log database record");
 		}
 	}
@@ -188,7 +140,9 @@ impl Drop for RequestLogStoreGuard {
 	}
 }
 
-const LOG_STORE_BATCH_SIZE: usize = 64;
+// Testing shows this to achieve a pretty good throughput for both postgres and sqlite
+const DEFAULT_LOG_STORE_BATCH_SIZE: usize = 16384;
+const LOG_STORE_BATCH_SIZE_ENV: &str = "REQUEST_LOG_STORE_BATCH_SIZE";
 
 #[allow(clippy::large_enum_variant)] // The StoredRequestLog, which is used 99.9% of the time, is the large one
 enum LogStoreMsg {
@@ -263,6 +217,13 @@ impl LogStoreWorker {
 	}
 
 	async fn work_async(mut self) {
+		let batch_size = match log_store_batch_size() {
+			Ok(batch_size) => batch_size,
+			Err(err) => {
+				self.notify_ready(Err(err));
+				return;
+			},
+		};
 		let backend = match Backend::connect(&self.cfg).await {
 			Ok(backend) => backend,
 			Err(err) => {
@@ -271,7 +232,7 @@ impl LogStoreWorker {
 			},
 		};
 		self.notify_ready(Ok(()));
-		let mut batch = Vec::with_capacity(LOG_STORE_BATCH_SIZE);
+		let mut batch = Vec::with_capacity(batch_size);
 		loop {
 			match self.receiver.recv() {
 				Ok(msg) => {
@@ -326,6 +287,22 @@ impl LogStoreWorker {
 	}
 }
 
+fn log_store_batch_size() -> anyhow::Result<usize> {
+	let Ok(value) = env::var(LOG_STORE_BATCH_SIZE_ENV) else {
+		return Ok(DEFAULT_LOG_STORE_BATCH_SIZE);
+	};
+	let batch_size = value.parse::<usize>().map_err(|err| {
+		anyhow::anyhow!(
+			"invalid env var {LOG_STORE_BATCH_SIZE_ENV}={value} ({})",
+			err
+		)
+	})?;
+	if batch_size == 0 {
+		anyhow::bail!("invalid env var {LOG_STORE_BATCH_SIZE_ENV}=0 (must be greater than 0)");
+	}
+	Ok(batch_size)
+}
+
 async fn process_log_store_msg(
 	backend: &Backend,
 	batch: &mut Vec<StoredRequestLog>,
@@ -364,9 +341,21 @@ async fn flush_log_store_batch(backend: &Backend, batch: &mut Vec<StoredRequestL
 	if batch.is_empty() {
 		return;
 	}
+	let t0 = Instant::now();
+	let count = batch.len();
 	if let Err(err) = backend.insert_batch(batch).await {
-		warn!(target: "request", ?err, count = batch.len(), "failed to persist request log batch");
+		warn!(target: "request", ?err, count, "failed to persist request log batch");
 	}
+	let backlog = REQUEST_LOG_STORE_BACKLOG.fetch_sub(count, Ordering::Relaxed) - count;
+	let latency = t0.elapsed();
+	let throughput = count as f64 / latency.as_secs_f64();
+	debug!(
+		count,
+		backlog,
+		?latency,
+		throughput,
+		"flushed request log database batch"
+	);
 	batch.clear();
 }
 
@@ -392,7 +381,7 @@ pub struct StoredRequestLog {
 	pub agentgateway_group: Option<String>,
 	pub user_agent_name: Option<String>,
 	pub has_payload: bool,
-	pub attributes_json: Value,
+	pub attributes_json: Box<str>,
 	pub payload: Option<StoredRequestLogPayload>,
 }
 

--- a/crates/agentgateway/src/telemetry/log_store/postgres.rs
+++ b/crates/agentgateway/src/telemetry/log_store/postgres.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use anyhow::Context;
 use serde_json::Value;
 use sqlx::postgres::PgPoolOptions;
@@ -6,10 +8,10 @@ use sqlx::{PgPool, Postgres, QueryBuilder, Row};
 
 use super::{
 	AnalyticsGroup, AnalyticsSummaryRequest, AnalyticsSummaryResponse, AnalyticsTimeBucket,
-	GenAiEntry, GetRequest, GetResponse, GroupBy, GroupByField, INSERT_LOG_PREFIX,
-	INSERT_PAYLOAD_PREFIX, LogEntry, LogFilters, PayloadEntry, SearchRequest, SearchResponse,
-	StoredRequestLog, TailRequest, TailResponse, TimeRange, UsageEntry, analytics_window,
-	attr_filter_values, decode_cursor, encode_cursor, limit, promoted_attribute_column,
+	GenAiEntry, GetRequest, GetResponse, GroupBy, GroupByField, LogEntry, LogFilters, PayloadEntry,
+	SearchRequest, SearchResponse, StoredRequestLog, StoredRequestLogPayload, TailRequest,
+	TailResponse, TimeRange, UsageEntry, analytics_window, attr_filter_values, decode_cursor,
+	encode_cursor, limit, promoted_attribute_column,
 };
 
 pub struct PostgresLogStore {
@@ -34,23 +36,24 @@ impl PostgresLogStore {
 			return Ok(());
 		}
 		let mut tx = self.pool.begin().await?;
-		let mut logs = QueryBuilder::<Postgres>::new(INSERT_LOG_PREFIX);
-		logs.push_values(records, |mut row, record| {
-			push_request_log_row!(row, record);
-		});
-		logs.build().execute(&mut *tx).await?;
+		let mut logs = String::new();
+		for record in records {
+			push_request_log_copy_row(&mut logs, record)?;
+		}
+		let mut copy = tx.copy_in_raw(COPY_REQUEST_LOGS).await?;
+		copy.send(logs.as_bytes()).await?;
+		copy.finish().await?;
 
 		if records.iter().any(|record| record.payload.is_some()) {
-			let mut payloads = QueryBuilder::<Postgres>::new(INSERT_PAYLOAD_PREFIX);
-			payloads.push_values(
-				records
-					.iter()
-					.filter_map(|record| record.payload.as_ref().map(|payload| (record, payload))),
-				|mut row, (record, payload)| {
-					push_request_log_payload_row!(row, record, payload);
-				},
-			);
-			payloads.build().execute(&mut *tx).await?;
+			let mut payloads = String::new();
+			for record in records {
+				if let Some(payload) = &record.payload {
+					push_request_log_payload_copy_row(&mut payloads, &record.id, payload)?;
+				}
+			}
+			let mut copy = tx.copy_in_raw(COPY_REQUEST_LOG_PAYLOADS).await?;
+			copy.send(payloads.as_bytes()).await?;
+			copy.finish().await?;
 		}
 		tx.commit().await?;
 		Ok(())
@@ -250,6 +253,97 @@ impl PostgresLogStore {
 			.last()
 			.map(|log| encode_cursor(log.completed_at, &log.id));
 		Ok(TailResponse { logs, next_cursor })
+	}
+}
+
+fn push_request_log_copy_row(buf: &mut String, record: &StoredRequestLog) -> anyhow::Result<()> {
+	let mut first = true;
+	push_copy_text_column(buf, &mut first, Some(&record.id));
+	push_copy_text_column(buf, &mut first, Some(&record.started_at.to_rfc3339()));
+	push_copy_text_column(buf, &mut first, Some(&record.completed_at.to_rfc3339()));
+	push_copy_display_column(buf, &mut first, Some(record.duration_ms));
+	push_copy_text_column(buf, &mut first, record.trace_id.as_deref());
+	push_copy_text_column(buf, &mut first, record.span_id.as_deref());
+	push_copy_display_column(buf, &mut first, record.http_status);
+	push_copy_text_column(buf, &mut first, record.error.as_deref());
+	push_copy_text_column(buf, &mut first, record.gen_ai_operation_name.as_deref());
+	push_copy_text_column(buf, &mut first, record.gen_ai_provider_name.as_deref());
+	push_copy_text_column(buf, &mut first, record.gen_ai_request_model.as_deref());
+	push_copy_text_column(buf, &mut first, record.gen_ai_response_model.as_deref());
+	push_copy_display_column(buf, &mut first, record.input_tokens);
+	push_copy_display_column(buf, &mut first, record.output_tokens);
+	push_copy_display_column(buf, &mut first, record.total_tokens);
+	push_copy_display_column(buf, &mut first, record.cost);
+	push_copy_text_column(buf, &mut first, record.agentgateway_user.as_deref());
+	push_copy_text_column(buf, &mut first, record.agentgateway_group.as_deref());
+	push_copy_text_column(buf, &mut first, record.user_agent_name.as_deref());
+	push_copy_display_column(buf, &mut first, Some(record.has_payload));
+	push_copy_text_column(buf, &mut first, Some(record.attributes_json.as_ref()));
+	buf.push('\n');
+	Ok(())
+}
+
+fn push_request_log_payload_copy_row(
+	buf: &mut String,
+	log_id: &str,
+	payload: &StoredRequestLogPayload,
+) -> anyhow::Result<()> {
+	let mut first = true;
+	push_copy_text_column(buf, &mut first, Some(log_id));
+	push_copy_json_column(buf, &mut first, payload.request_prompt_json.as_ref())?;
+	push_copy_json_column(buf, &mut first, payload.response_completion_json.as_ref())?;
+	buf.push('\n');
+	Ok(())
+}
+
+fn push_copy_text_column(buf: &mut String, first: &mut bool, value: Option<&str>) {
+	push_copy_column_separator(buf, first);
+	let Some(value) = value else {
+		buf.push_str(r"\N");
+		return;
+	};
+	push_copy_escaped(buf, value);
+}
+
+fn push_copy_display_column<T: Display>(buf: &mut String, first: &mut bool, value: Option<T>) {
+	push_copy_column_separator(buf, first);
+	match value {
+		Some(value) => buf.push_str(&value.to_string()),
+		None => buf.push_str(r"\N"),
+	}
+}
+
+fn push_copy_json_column(
+	buf: &mut String,
+	first: &mut bool,
+	value: Option<&Value>,
+) -> anyhow::Result<()> {
+	push_copy_column_separator(buf, first);
+	let Some(value) = value else {
+		buf.push_str(r"\N");
+		return Ok(());
+	};
+	push_copy_escaped(buf, &serde_json::to_string(value)?);
+	Ok(())
+}
+
+fn push_copy_column_separator(buf: &mut String, first: &mut bool) {
+	if *first {
+		*first = false;
+	} else {
+		buf.push('\t');
+	}
+}
+
+fn push_copy_escaped(buf: &mut String, value: &str) {
+	for ch in value.chars() {
+		match ch {
+			'\\' => buf.push_str(r"\\"),
+			'\n' => buf.push_str(r"\n"),
+			'\r' => buf.push_str(r"\r"),
+			'\t' => buf.push_str(r"\t"),
+			_ => buf.push(ch),
+		}
 	}
 }
 
@@ -474,6 +568,19 @@ fn group_key(group: &GroupBy) -> String {
 			.unwrap_or_else(|| "attributes".to_string()),
 	}
 }
+
+const COPY_REQUEST_LOGS: &str = r#"
+COPY request_logs (
+	id, started_at, completed_at, duration_ms, trace_id, span_id, http_status, error,
+	gen_ai_operation_name, gen_ai_provider_name, gen_ai_request_model, gen_ai_response_model,
+	input_tokens, output_tokens, total_tokens, cost, agentgateway_user, agentgateway_group,
+	user_agent_name, has_payload, attributes_json
+) FROM STDIN
+"#;
+
+const COPY_REQUEST_LOG_PAYLOADS: &str = r#"
+COPY request_log_payloads (log_id, request_prompt_json, response_completion_json) FROM STDIN
+"#;
 
 const SCHEMA: &str = r#"
 CREATE TABLE IF NOT EXISTS request_logs (

--- a/crates/agentgateway/src/telemetry/log_store/sqlite.rs
+++ b/crates/agentgateway/src/telemetry/log_store/sqlite.rs
@@ -4,14 +4,14 @@ use anyhow::Context;
 use serde_json::Value;
 use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous};
 use sqlx::types::Json;
-use sqlx::{QueryBuilder, Row, Sqlite, SqlitePool};
+use sqlx::{QueryBuilder, Row, Sqlite, SqlitePool, query_builder};
 
 use super::{
 	AnalyticsGroup, AnalyticsSummaryRequest, AnalyticsSummaryResponse, AnalyticsTimeBucket,
-	GenAiEntry, GetRequest, GetResponse, GroupBy, GroupByField, INSERT_LOG_PREFIX,
-	INSERT_PAYLOAD_PREFIX, LogEntry, LogFilters, PayloadEntry, SearchRequest, SearchResponse,
-	StoredRequestLog, TailRequest, TailResponse, TimeRange, UsageEntry, analytics_window,
-	attr_filter_values, decode_cursor, encode_cursor, limit, promoted_attribute_column,
+	GenAiEntry, GetRequest, GetResponse, GroupBy, GroupByField, LogEntry, LogFilters, PayloadEntry,
+	SearchRequest, SearchResponse, StoredRequestLog, StoredRequestLogPayload, TailRequest,
+	TailResponse, TimeRange, UsageEntry, analytics_window, attr_filter_values, decode_cursor,
+	encode_cursor, limit, promoted_attribute_column,
 };
 
 pub struct SqliteLogStore {
@@ -19,6 +19,60 @@ pub struct SqliteLogStore {
 }
 
 const ANALYTICS_FILTER_OPTION_LIMIT: i64 = 500;
+// Leave room below SQLite's 32,766-parameter limit for two more log fields or one payload field.
+const LOG_INSERT_CHUNK_SIZE: usize = 1_400;
+const PAYLOAD_INSERT_CHUNK_SIZE: usize = 8_000;
+const INSERT_LOG_PREFIX: &str = r#"
+INSERT INTO request_logs (
+	id, started_at, completed_at, duration_ms, trace_id, span_id, http_status, error,
+	gen_ai_operation_name, gen_ai_provider_name, gen_ai_request_model, gen_ai_response_model,
+	input_tokens, output_tokens, total_tokens, cost, agentgateway_user, agentgateway_group,
+	user_agent_name, has_payload, attributes_json
+) 
+"#;
+
+const INSERT_PAYLOAD_PREFIX: &str = r#"
+INSERT INTO request_log_payloads (log_id, request_prompt_json, response_completion_json)
+"#;
+
+fn push_request_log_row(
+	row: &mut query_builder::Separated<'_, Sqlite, &'static str>,
+	record: &StoredRequestLog,
+) {
+	row
+		.push_bind(&record.id)
+		.push_bind(record.started_at)
+		.push_bind(record.completed_at)
+		.push_bind(record.duration_ms)
+		.push_bind(&record.trace_id)
+		.push_bind(&record.span_id)
+		.push_bind(record.http_status)
+		.push_bind(&record.error)
+		.push_bind(&record.gen_ai_operation_name)
+		.push_bind(&record.gen_ai_provider_name)
+		.push_bind(&record.gen_ai_request_model)
+		.push_bind(&record.gen_ai_response_model)
+		.push_bind(record.input_tokens)
+		.push_bind(record.output_tokens)
+		.push_bind(record.total_tokens)
+		.push_bind(record.cost)
+		.push_bind(&record.agentgateway_user)
+		.push_bind(&record.agentgateway_group)
+		.push_bind(&record.user_agent_name)
+		.push_bind(record.has_payload)
+		.push_bind(record.attributes_json.as_ref());
+}
+
+fn push_request_log_payload_row(
+	row: &mut query_builder::Separated<'_, Sqlite, &'static str>,
+	record: &StoredRequestLog,
+	payload: &StoredRequestLogPayload,
+) {
+	row
+		.push_bind(&record.id)
+		.push_bind(payload.request_prompt_json.as_ref().map(Json))
+		.push_bind(payload.response_completion_json.as_ref().map(Json));
+}
 
 impl SqliteLogStore {
 	pub async fn connect(url: &str) -> anyhow::Result<Self> {
@@ -43,22 +97,23 @@ impl SqliteLogStore {
 			return Ok(());
 		}
 		let mut tx = self.pool.begin().await?;
-		let mut logs = QueryBuilder::<Sqlite>::new(INSERT_LOG_PREFIX);
-		logs.push_values(records, |mut row, record| {
-			push_request_log_row!(row, record);
-		});
-		logs.build().execute(&mut *tx).await?;
+		for chunk in records.chunks(LOG_INSERT_CHUNK_SIZE) {
+			let mut logs = QueryBuilder::<Sqlite>::new(INSERT_LOG_PREFIX);
+			logs.push_values(chunk, |mut row, record| {
+				push_request_log_row(&mut row, record);
+			});
+			logs.build().execute(&mut *tx).await?;
+		}
 
-		if records.iter().any(|record| record.payload.is_some()) {
+		let payload_records = records
+			.iter()
+			.filter_map(|record| record.payload.as_ref().map(|payload| (record, payload)))
+			.collect::<Vec<_>>();
+		for chunk in payload_records.chunks(PAYLOAD_INSERT_CHUNK_SIZE) {
 			let mut payloads = QueryBuilder::<Sqlite>::new(INSERT_PAYLOAD_PREFIX);
-			payloads.push_values(
-				records
-					.iter()
-					.filter_map(|record| record.payload.as_ref().map(|payload| (record, payload))),
-				|mut row, (record, payload)| {
-					push_request_log_payload_row!(row, record, payload);
-				},
-			);
+			payloads.push_values(chunk, |mut row, (record, payload)| {
+				push_request_log_payload_row(&mut row, record, payload);
+			});
 			payloads.build().execute(&mut *tx).await?;
 		}
 		tx.commit().await?;
@@ -552,13 +607,13 @@ CREATE TABLE IF NOT EXISTS request_logs (
 	agentgateway_group TEXT,
 	user_agent_name TEXT,
 	has_payload INTEGER NOT NULL,
-	attributes_json TEXT NOT NULL CHECK (json_valid(attributes_json))
+	attributes_json TEXT NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS request_log_payloads (
 	log_id TEXT PRIMARY KEY REFERENCES request_logs(id) ON DELETE CASCADE,
-	request_prompt_json TEXT CHECK (request_prompt_json IS NULL OR json_valid(request_prompt_json)),
-	response_completion_json TEXT CHECK (response_completion_json IS NULL OR json_valid(response_completion_json))
+	request_prompt_json TEXT,
+	response_completion_json TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_request_logs_completed_at ON request_logs(completed_at DESC, id DESC);

--- a/examples/README.md
+++ b/examples/README.md
@@ -15,6 +15,7 @@ This directory contains examples of how to use agentgateway. Each example is nam
 ### LLM
 
 * [llm-basic](llm-basic/README.md): proxy LLM requests to OpenAI and Anthropic with provider-specific model prefixes.
+* [llm-ollama-postgres](llm-ollama-postgres/README.md): proxy local Ollama models and store request logs in Postgres.
 * [llm-prompt-enrichment](llm-prompt-enrichment/README.md): append or prepend prompts to agentgateway AI requests.
 * [llm-prompt-guard](llm-prompt-guard/README.md): configure prompt guards for LLM requests and responses.
 * [llm-standalone-epp](llm-standalone-epp/README.md): run agentgateway as the sidecar proxy next to a standalone EPP deployment on Kubernetes.

--- a/examples/llm-ollama-postgres/README.md
+++ b/examples/llm-ollama-postgres/README.md
@@ -1,0 +1,45 @@
+## LLM Ollama + Postgres Example
+
+This example configures agentgateway as an OpenAI-compatible LLM proxy for local Ollama models and stores request logs in Postgres.
+
+### Running the example
+
+Start Postgres:
+
+```bash
+docker compose -f examples/llm-ollama-postgres/docker-compose.yaml up -d
+```
+
+Start Ollama and make sure the model you want to use is available:
+
+```bash
+ollama pull llama3.2
+```
+
+Start agentgateway:
+
+```bash
+cargo run -- -f examples/llm-ollama-postgres/config.yaml
+```
+
+Send a request through agentgateway:
+
+```bash
+curl http://localhost:4000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "llama3.2",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Say hello from Ollama"
+      }
+    ]
+  }'
+```
+
+The Postgres database is exposed at:
+
+```text
+postgresql://agentgateway:agentgateway@localhost:5432/agentgateway
+```

--- a/examples/llm-ollama-postgres/config.yaml
+++ b/examples/llm-ollama-postgres/config.yaml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://agentgateway.dev/schema/config
+config:
+  database:
+    url: postgresql://agentgateway:agentgateway@localhost:4333/agentgateway
+
+llm:
+  port: 4000
+  models:
+  - name: '*'
+    provider: ollama

--- a/examples/llm-ollama-postgres/config.yaml
+++ b/examples/llm-ollama-postgres/config.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
 config:
   database:
-    url: postgresql://agentgateway:agentgateway@localhost:4333/agentgateway
+    url: postgresql://agentgateway:agentgateway@localhost:5432/agentgateway
 
 llm:
   port: 4000

--- a/examples/llm-ollama-postgres/docker-compose.yaml
+++ b/examples/llm-ollama-postgres/docker-compose.yaml
@@ -1,0 +1,19 @@
+services:
+  postgres:
+    image: postgres:17
+    environment:
+      POSTGRES_DB: agentgateway
+      POSTGRES_USER: agentgateway
+      POSTGRES_PASSWORD: agentgateway
+    ports:
+    - "127.0.0.1:5432:5432"
+    volumes:
+    - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U agentgateway -d agentgateway"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+
+volumes:
+  postgres-data:


### PR DESCRIPTION
Fixes https://github.com/agentgateway/agentgateway/issues/2463

Before we used fixed batch size of 64, many INSERTs instead of COPY, and
double JSON serialization.

Now we default to a 16k batch size (tuneable). On my machine this can
sustain about 50k QPS for both sqlite and postgres.

Signed-off-by: John Howard <john.howard@solo.io>
