### PR TITLE
xds: version resources

### DIFF
--- a/controller/hack/utils/oss_compliance/osa_provided.md
+++ b/controller/hack/utils/oss_compliance/osa_provided.md
@@ -2,6 +2,7 @@ Name|Version|License
 ---|---|---
 [semver/v3](https://github.com/Masterminds/semver)|v3.5.0|MIT License
 [retry-go/v4](https://github.com/avast/retry-go)|v4.7.0|MIT License
+[xxhash/v2](https://github.com/cespare/xxhash)|v2.3.0|MIT License
 [xds/go](https://github.com/cncf/xds)|v0.0.0-20260202195803-dba9d589def2|Apache License 2.0
 [go-control-plane/envoy](https://github.com/envoyproxy/go-control-plane)|v1.37.1-0.20260627225610-70ff85c381ff|Apache License 2.0
 [tcell/v2](https://github.com/gdamore/tcell)|v2.13.10|Apache License 2.0

--- a/controller/pkg/syncer/krtxds/xds.go
+++ b/controller/pkg/syncer/krtxds/xds.go
@@ -15,6 +15,7 @@ import (
 	stdatomic "sync/atomic"
 	"time"
 
+	"github.com/cespare/xxhash/v2"
 	envoycorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/google/uuid"
@@ -33,7 +34,6 @@ import (
 	"istio.io/istio/pkg/maps"
 	"istio.io/istio/pkg/ptr"
 	"istio.io/istio/pkg/security"
-	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/util/sets"
 	"istio.io/istio/pkg/xds"
 	"k8s.io/apimachinery/pkg/types"
@@ -140,11 +140,13 @@ func PerGatewayCollection[T IntoProto[TT], TT proto.Message](collection krt.Coll
 			if extract != nil {
 				forGateway = new(extract(i))
 			}
+			resource := protoconv.MessageToAny(i.IntoProto())
 			return &DiscoveryResource{
 				Resource: &discovery.Resource{
-					Name:         getKey(i),
-					Version:      "",
-					Resource:     protoconv.MessageToAny(i.IntoProto()),
+					Name: getKey(i),
+					// Content hashes remain stable across controller replicas.
+					Version:      strconv.FormatUint(xxhash.Sum64(resource.Value), 16),
+					Resource:     resource,
 					Ttl:          nil,
 					CacheControl: nil,
 					Metadata:     nil,
@@ -527,7 +529,8 @@ func (s *DiscoveryServer) processDeltaRequest(req *discovery.DeltaDiscoveryReque
 
 	subs, _, _ := deltaWatchedResources(nil, req)
 	request := &PushRequest{
-		IsFromRequest: true,
+		IsFromRequest:           true,
+		InitialResourceVersions: req.InitialResourceVersions,
 		Delta: model.ResourceDelta{
 			// Record sub/unsub, but drop synthetic wildcard info
 			Subscribed:   subs,
@@ -1171,16 +1174,18 @@ type CollectionGenerator struct {
 // On-demand clients are expected to handle this (for wildcard, this is not applicable, as they don't specify any resources at all).
 func (e CollectionGenerator) GenerateDeltas(req *PushRequest, w *model.WatchedResource, gw types.NamespacedName) (model.Resources, model.DeletedResources, error) {
 	if req.IsRequest() {
-		// Full update, expect everything
-		res := slices.MapFilter(e.Col.List(), func(e DiscoveryResource) **discovery.Resource {
-			if !e.IsForGateway(gw) {
-				return nil
-			}
-			return &e.Resource
-		})
+		res := make(model.Resources, 0)
 		toDeleted := req.Delta.Subscribed
-		for _, r := range res {
+		for _, r := range e.Col.List() {
+			if !r.IsForGateway(gw) {
+				continue
+			}
 			toDeleted.Delete(r.Name)
+			// The client already retained resources with matching content.
+			if version := req.InitialResourceVersions[r.Name]; version != "" && version == r.Version {
+				continue
+			}
+			res = append(res, r.Resource)
 		}
 		deletes := sets.SortedList(toDeleted)
 		return res, deletes, nil
@@ -1233,6 +1238,8 @@ type PushRequest struct {
 	ConfigsUpdated map[TypeUrl]sets.String
 
 	IsFromRequest bool
+	// InitialResourceVersions contains the versions the client retained across a reconnect.
+	InitialResourceVersions map[string]string
 
 	// PushVersion represent the version of the push
 	PushVersion string

--- a/controller/pkg/syncer/krtxds/xds_test.go
+++ b/controller/pkg/syncer/krtxds/xds_test.go
@@ -148,9 +148,17 @@ func TestXDSUpdate(t *testing.T) {
 
 func TestXDSDisconnect(t *testing.T) {
 	t.Run("addresses", func(t *testing.T) {
-		s := NewFakeDiscoveryServer(t, testWorkload1)
+		stable := syncer.Address{
+			Workload: new(syncer.PrecomputeWorkload(model.WorkloadInfo{Workload: &workloadapi.Workload{Uid: "stable"}})),
+		}
+		s := NewFakeDiscoveryServer(t, testWorkload1, stable)
 		ads := s.ConnectDeltaADS().WithType(krtxds.TargetTypeAddressUrl)
-		ads.RequestResponseAck(nil)
+		initial := ads.RequestResponseAck(nil)
+		initialVersions := make(map[string]string, len(initial.Resources))
+		for _, resource := range initial.Resources {
+			assert.Equal(t, resource.Version != "", true)
+			initialVersions[resource.Name] = resource.Version
+		}
 		ads.Cleanup()
 
 		wl2 := syncer.Address{
@@ -167,14 +175,14 @@ func TestXDSDisconnect(t *testing.T) {
 		ads.Request(&discovery.DeltaDiscoveryRequest{
 			ResourceNamesSubscribe:   []string{"*"},
 			ResourceNamesUnsubscribe: []string{"*"},
-			InitialResourceVersions: map[string]string{
-				"wl1": "",
-			},
+			InitialResourceVersions:  initialVersions,
 		})
 		resp := ads.ExpectResponse()
-		// We should see wl1 deleted, wl2 added
+		// We should see wl1 deleted and wl2 added, while stable is not resent.
 		assert.Equal(t, len(resp.Resources), 1)
+		assert.Equal(t, resp.Resources[0].Name, "wl2")
 		assert.Equal(t, len(resp.RemovedResources), 1)
+		assert.Equal(t, resp.RemovedResources[0], "wl1")
 	})
 	t.Run("resource", func(t *testing.T) {
 		bind1 := agwir.AgwResource{

--- a/crates/xds/src/client.rs
+++ b/crates/xds/src/client.rs
@@ -211,6 +211,13 @@ impl<T: 'static + prost::Message + Default + Debug> RawHandler for HandlerWrappe
 		let decode_failures: Vec<_> = decode_failures
 			.map(|r| r.expect_err("must be err"))
 			.collect();
+		// Do not advertise rejected resources as retained on reconnect.
+		let rejected_names: HashSet<_> = decode_failures
+			.iter()
+			.chain(result.as_ref().err().into_iter().flatten())
+			.filter(|reject| matches!(reject.severity, RejectedConfigSeverity::Error))
+			.map(|reject| reject.name.clone())
+			.collect();
 
 		for name in res.removed_resources {
 			let k = ResourceKey {
@@ -228,7 +235,9 @@ impl<T: 'static + prost::Message + Default + Debug> RawHandler for HandlerWrappe
 				name: r.name.into(),
 				type_url: type_url.clone(),
 			};
-			state.add_resource(key.type_url, key.name);
+			if !rejected_names.contains(&key.name) {
+				state.add_resource(key.type_url, key.name, r.version.into());
+			}
 		}
 
 		// Either can fail. Merge the results
@@ -322,17 +331,17 @@ impl Config {
 }
 
 pub struct State {
-	/// Stores all known workload resources. Map from type_url to name
-	known_resources: HashMap<Strng, HashSet<Strng>>,
+	/// Stores all known resources. Map from type_url to name to version.
+	known_resources: HashMap<Strng, HashMap<Strng, Strng>>,
 }
 
 impl State {
-	fn add_resource(&mut self, type_url: Strng, name: Strng) {
+	fn add_resource(&mut self, type_url: Strng, name: Strng, version: Strng) {
 		self
 			.known_resources
 			.entry(type_url)
 			.or_default()
-			.insert(name.clone());
+			.insert(name, version);
 	}
 }
 
@@ -486,8 +495,8 @@ impl AdsClient {
 		&self.config
 	}
 
-	async fn run_loop(&mut self, backoff: Duration) -> Duration {
-		match self.run_internal().await {
+	async fn run_loop(&mut self, mut backoff: Duration) -> Duration {
+		match self.run_internal(&mut backoff).await {
 			Err(e @ Error::Connection(_)) => {
 				// For connection errors, we add backoff
 				let backoff = std::cmp::min(MAX_BACKOFF, backoff * 2);
@@ -575,7 +584,7 @@ impl AdsClient {
 		}
 	}
 
-	async fn run_internal(&mut self) -> Result<(), Error> {
+	async fn run_internal(&mut self, backoff: &mut Duration) -> Result<(), Error> {
 		let (discovery_req_tx, mut discovery_req_rx) = mpsc::channel::<DeltaDiscoveryRequest>(100);
 		// For each type in initial_watches we will send a request on connection to subscribe
 		let initial_requests: Vec<DeltaDiscoveryRequest> = self
@@ -588,9 +597,10 @@ impl AdsClient {
 					.state
 					.known_resources
 					.get(&strng::new(&req.type_url))
-					.map(|hs| {
-						hs.iter()
-							.map(|n| (n.to_string(), "".to_string())) // Proto expects Name -> Version. We don't care about version
+					.map(|resources| {
+						resources
+							.iter()
+							.map(|(name, version)| (name.to_string(), version.to_string()))
 							.collect()
 					})
 					.unwrap_or_default();
@@ -639,6 +649,8 @@ impl AdsClient {
 						// This could be an explicit OK response, or if the stream is reset without a gRPC status.
 						return Ok(());
 					};
+					// A response proves the connection recovered from prior failures.
+					*backoff = INITIAL_BACKOFF;
 					let mut received_type = None;
 					if !self.types_to_expect.is_empty() {
 						received_type = Some(msg.type_url.clone())

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/agentgateway/agentgateway/api v0.0.0
 	github.com/avast/retry-go/v4 v4.7.0
+	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2
 	github.com/envoyproxy/go-control-plane/envoy v1.37.1-0.20260627225610-70ff85c381ff
 	github.com/gdamore/tcell/v2 v2.13.10
@@ -81,7 +82,6 @@ require (
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cbeuw/connutil v1.0.1 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
-	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/chai2010/gettext-go v1.0.3 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	github.com/cloudflare/circl v1.6.3 // indirect


### PR DESCRIPTION
This implements (2) from https://github.com/istio/istio/issues/54499.

Thi avoids reconnects sending a full push. Not only is this expensive,
we attach state to objects, so re-pushing with the same contents clears
the state (health checks, etc) which is not good.

Signed-off-by: John Howard <john.howard@solo.io>
