### PR TITLE
examples: suppress semantic router domain defaults

### DIFF
--- a/examples/llm-semantic-routing/k8s/semantic-router-values.yaml
+++ b/examples/llm-semantic-routing/k8s/semantic-router-values.yaml
@@ -3,6 +3,10 @@ router:
   skipProcessing:
     enabled: true
 
+# The model runtime is configured below. Do not inherit the chart's qwen3
+# embedding override, which conflicts with the configured mmbert model.
+env: []
+
 args:
 - --secure=false
 

--- a/examples/llm-semantic-routing/k8s/semantic-router-values.yaml
+++ b/examples/llm-semantic-routing/k8s/semantic-router-values.yaml
@@ -77,6 +77,9 @@ config:
       tags: [premium, expensive, deep-reasoning]
 
     signals:
+      # This coding policy does not use domain signals. Set an empty list to
+      # avoid inheriting the chart's general-purpose domain defaults.
+      domains: []
       keywords:
       - name: immediate_response_probe
         operator: OR


### PR DESCRIPTION
- Suppress unused vSR domain defaults in the coding-focused example.
- Prevent vSR 0.3.0 from receiving unsupported domain categories.