### PR TITLE
route gpt-5.6 openai models through chat completions

### DIFF
--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -763,6 +763,9 @@ impl AIProvider {
 
 	fn supported_chat_formats(&self, request_model: Option<&str>) -> Vec<ChatFormat> {
 		match self {
+			AIProvider::OpenAI(_) if openai::Provider::prefers_completions_only_for_model(request_model) => {
+				vec![ChatFormat::OpenAICompletions]
+			},
 			AIProvider::OpenAI(_) => {
 				vec![ChatFormat::OpenAIResponses, ChatFormat::OpenAICompletions]
 			},

--- a/crates/llm/src/openai.rs
+++ b/crates/llm/src/openai.rs
@@ -18,6 +18,15 @@ pub const DEFAULT_HOST: Strng = strng::literal!(DEFAULT_HOST_STR);
 
 pub const DEFAULT_BASE_PATH: &str = "/v1";
 
+impl Provider {
+	pub fn prefers_completions_only_for_model(request_model: Option<&str>) -> bool {
+		matches!(
+			request_model,
+			Some("gpt-5.6-sol" | "gpt-5.6-luna" | "gpt-5.6-terra")
+		)
+	}
+}
+
 pub fn path_suffix(route: RouteType) -> &'static str {
 	match route {
 		RouteType::Responses => "/responses",


### PR DESCRIPTION
Force gpt-5.6-sol, gpt-5.6-luna, and gpt-5.6-terra to use the
OpenAI chat completions path instead of native responses routing.

These models expose a responses/tool-schema incompatibility in the
current upstream stack, while chat completions continues to work.
Keep the workaround narrowly scoped to the affected model ids.
