### PR TITLE
feat: dynamic (CEL) RoleSessionName for AWS assume-role auth

### DIFF
--- a/api/resource.pb.go
+++ b/api/resource.pb.go
@@ -5044,9 +5044,15 @@ type AwsAssumeRole struct {
 	// Session tags passed to STS AssumeRole. Once activated as cost allocation
 	// tags, they surface as columns in the AWS Cost & Usage Report for per-tenant
 	// cost attribution.
-	Tags          []*AwsSessionTag `protobuf:"bytes,3,rep,name=tags,proto3" json:"tags,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Tags []*AwsSessionTag `protobuf:"bytes,3,rep,name=tags,proto3" json:"tags,omitempty"`
+	// CEL expression evaluated against each request to produce the session name
+	// (RoleSessionName), for example `jwt.sub` or `request.headers["x-team"]`. If
+	// the expression does not produce a valid session name at request time, the
+	// request is rejected. At most one of session_name and session_name_expression
+	// may be set.
+	SessionNameExpression string `protobuf:"bytes,4,opt,name=session_name_expression,json=sessionNameExpression,proto3" json:"session_name_expression,omitempty"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
 }
 
 func (x *AwsAssumeRole) Reset() {
@@ -5098,6 +5104,13 @@ func (x *AwsAssumeRole) GetTags() []*AwsSessionTag {
 		return x.Tags
 	}
 	return nil
+}
+
+func (x *AwsAssumeRole) GetSessionNameExpression() string {
+	if x != nil {
+		return x.SessionNameExpression
+	}
+	return ""
 }
 
 // AWS STS session tag passed to AssumeRole for cost attribution.
@@ -15740,11 +15753,12 @@ const file_resource_proto_rawDesc = "" +
 	"\x06region\x18\x03 \x01(\tR\x06region\x12(\n" +
 	"\rsession_token\x18\x04 \x01(\tH\x00R\fsessionToken\x88\x01\x01B\x10\n" +
 	"\x0e_session_token\"\r\n" +
-	"\vAwsImplicit\"\x8b\x01\n" +
+	"\vAwsImplicit\"\xc3\x01\n" +
 	"\rAwsAssumeRole\x12\x19\n" +
 	"\brole_arn\x18\x01 \x01(\tR\aroleArn\x12!\n" +
 	"\fsession_name\x18\x02 \x01(\tR\vsessionName\x12<\n" +
-	"\x04tags\x18\x03 \x03(\v2(.agentgateway.dev.resource.AwsSessionTagR\x04tags\"W\n" +
+	"\x04tags\x18\x03 \x03(\v2(.agentgateway.dev.resource.AwsSessionTagR\x04tags\x126\n" +
+	"\x17session_name_expression\x18\x04 \x01(\tR\x15sessionNameExpression\"W\n" +
 	"\rAwsSessionTag\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value\x12\x1e\n" +

--- a/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
+++ b/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
@@ -1623,6 +1623,8 @@ type AwsAuth struct {
 }
 
 // AWS STS AssumeRole settings for backend authentication.
+//
+// +kubebuilder:validation:AtMostOneOf=sessionName;sessionNameExpression
 type AwsAssumeRole struct {
 	// AWS IAM role ARN to assume.
 	//
@@ -1637,6 +1639,14 @@ type AwsAssumeRole struct {
 	// +optional
 	// +kubebuilder:validation:Pattern="^[\\w+=,.@-]{2,64}$"
 	SessionName *string `json:"sessionName,omitempty"`
+
+	// SessionNameExpression is a CEL expression evaluated against each request
+	// to produce the session name (RoleSessionName), for example `jwt.sub` or
+	// `request.headers["x-team"]`. If the expression does not produce a valid
+	// session name at request time, the request is rejected.
+	//
+	// +optional
+	SessionNameExpression *CELExpression `json:"sessionNameExpression,omitempty"`
 
 	// Tags are session tags passed to STS AssumeRole. Once activated as cost
 	// allocation tags, they appear in the AWS Cost & Usage Report for cost

--- a/controller/api/v1alpha1/agentgateway/zz_generated.deepcopy.go
+++ b/controller/api/v1alpha1/agentgateway/zz_generated.deepcopy.go
@@ -924,6 +924,11 @@ func (in *AwsAssumeRole) DeepCopyInto(out *AwsAssumeRole) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.SessionNameExpression != nil {
+		in, out := &in.SessionNameExpression, &out.SessionNameExpression
+		*out = new(CELExpression)
+		**out = **in
+	}
 	if in.Tags != nil {
 		in, out := &in.Tags, &out.Tags
 		*out = make([]AwsSessionTag, len(*in))

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
@@ -664,6 +664,15 @@ spec:
                                                                         Cost & Usage Report attribution. If unset, AWS generates a random name.
                                                                       pattern: ^[\w+=,.@-]{2,64}$
                                                                       type: string
+                                                                    sessionNameExpression:
+                                                                      description: |-
+                                                                        SessionNameExpression is a CEL expression evaluated against each request
+                                                                        to produce the session name (RoleSessionName), for example `jwt.sub` or
+                                                                        `request.headers["x-team"]`. If the expression does not produce a valid
+                                                                        session name at request time, the request is rejected.
+                                                                      maxLength: 16384
+                                                                      minLength: 1
+                                                                      type: string
                                                                     tags:
                                                                       description: |-
                                                                         Tags are session tags passed to STS AssumeRole. Once activated as cost
@@ -719,6 +728,14 @@ spec:
                                                                   required:
                                                                   - roleArn
                                                                   type: object
+                                                                  x-kubernetes-validations:
+                                                                  - message: at most
+                                                                      one of the fields
+                                                                      in [sessionName
+                                                                      sessionNameExpression]
+                                                                      may be set
+                                                                    rule: '[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size()
+                                                                      <= 1'
                                                                 secretRef:
                                                                   description: |-
                                                                     Credential source, defaulting to a Kubernetes
@@ -2150,6 +2167,15 @@ spec:
                                                                         Cost & Usage Report attribution. If unset, AWS generates a random name.
                                                                       pattern: ^[\w+=,.@-]{2,64}$
                                                                       type: string
+                                                                    sessionNameExpression:
+                                                                      description: |-
+                                                                        SessionNameExpression is a CEL expression evaluated against each request
+                                                                        to produce the session name (RoleSessionName), for example `jwt.sub` or
+                                                                        `request.headers["x-team"]`. If the expression does not produce a valid
+                                                                        session name at request time, the request is rejected.
+                                                                      maxLength: 16384
+                                                                      minLength: 1
+                                                                      type: string
                                                                     tags:
                                                                       description: |-
                                                                         Tags are session tags passed to STS AssumeRole. Once activated as cost
@@ -2205,6 +2231,14 @@ spec:
                                                                   required:
                                                                   - roleArn
                                                                   type: object
+                                                                  x-kubernetes-validations:
+                                                                  - message: at most
+                                                                      one of the fields
+                                                                      in [sessionName
+                                                                      sessionNameExpression]
+                                                                      may be set
+                                                                    rule: '[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size()
+                                                                      <= 1'
                                                                 secretRef:
                                                                   description: |-
                                                                     Credential source, defaulting to a Kubernetes
@@ -3632,6 +3666,15 @@ spec:
                                                                         Cost & Usage Report attribution. If unset, AWS generates a random name.
                                                                       pattern: ^[\w+=,.@-]{2,64}$
                                                                       type: string
+                                                                    sessionNameExpression:
+                                                                      description: |-
+                                                                        SessionNameExpression is a CEL expression evaluated against each request
+                                                                        to produce the session name (RoleSessionName), for example `jwt.sub` or
+                                                                        `request.headers["x-team"]`. If the expression does not produce a valid
+                                                                        session name at request time, the request is rejected.
+                                                                      maxLength: 16384
+                                                                      minLength: 1
+                                                                      type: string
                                                                     tags:
                                                                       description: |-
                                                                         Tags are session tags passed to STS AssumeRole. Once activated as cost
@@ -3687,6 +3730,14 @@ spec:
                                                                   required:
                                                                   - roleArn
                                                                   type: object
+                                                                  x-kubernetes-validations:
+                                                                  - message: at most
+                                                                      one of the fields
+                                                                      in [sessionName
+                                                                      sessionNameExpression]
+                                                                      may be set
+                                                                    rule: '[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size()
+                                                                      <= 1'
                                                                 secretRef:
                                                                   description: |-
                                                                     Credential source, defaulting to a Kubernetes
@@ -5346,6 +5397,15 @@ spec:
                                                                         Cost & Usage Report attribution. If unset, AWS generates a random name.
                                                                       pattern: ^[\w+=,.@-]{2,64}$
                                                                       type: string
+                                                                    sessionNameExpression:
+                                                                      description: |-
+                                                                        SessionNameExpression is a CEL expression evaluated against each request
+                                                                        to produce the session name (RoleSessionName), for example `jwt.sub` or
+                                                                        `request.headers["x-team"]`. If the expression does not produce a valid
+                                                                        session name at request time, the request is rejected.
+                                                                      maxLength: 16384
+                                                                      minLength: 1
+                                                                      type: string
                                                                     tags:
                                                                       description: |-
                                                                         Tags are session tags passed to STS AssumeRole. Once activated as cost
@@ -5401,6 +5461,14 @@ spec:
                                                                   required:
                                                                   - roleArn
                                                                   type: object
+                                                                  x-kubernetes-validations:
+                                                                  - message: at most
+                                                                      one of the fields
+                                                                      in [sessionName
+                                                                      sessionNameExpression]
+                                                                      may be set
+                                                                    rule: '[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size()
+                                                                      <= 1'
                                                                 secretRef:
                                                                   description: |-
                                                                     Credential source, defaulting to a Kubernetes
@@ -6832,6 +6900,15 @@ spec:
                                                                         Cost & Usage Report attribution. If unset, AWS generates a random name.
                                                                       pattern: ^[\w+=,.@-]{2,64}$
                                                                       type: string
+                                                                    sessionNameExpression:
+                                                                      description: |-
+                                                                        SessionNameExpression is a CEL expression evaluated against each request
+                                                                        to produce the session name (RoleSessionName), for example `jwt.sub` or
+                                                                        `request.headers["x-team"]`. If the expression does not produce a valid
+                                                                        session name at request time, the request is rejected.
+                                                                      maxLength: 16384
+                                                                      minLength: 1
+                                                                      type: string
                                                                     tags:
                                                                       description: |-
                                                                         Tags are session tags passed to STS AssumeRole. Once activated as cost
@@ -6887,6 +6964,14 @@ spec:
                                                                   required:
                                                                   - roleArn
                                                                   type: object
+                                                                  x-kubernetes-validations:
+                                                                  - message: at most
+                                                                      one of the fields
+                                                                      in [sessionName
+                                                                      sessionNameExpression]
+                                                                      may be set
+                                                                    rule: '[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size()
+                                                                      <= 1'
                                                                 secretRef:
                                                                   description: |-
                                                                     Credential source, defaulting to a Kubernetes
@@ -8609,6 +8694,15 @@ spec:
                                                   Cost & Usage Report attribution. If unset, AWS generates a random name.
                                                 pattern: ^[\w+=,.@-]{2,64}$
                                                 type: string
+                                              sessionNameExpression:
+                                                description: |-
+                                                  SessionNameExpression is a CEL expression evaluated against each request
+                                                  to produce the session name (RoleSessionName), for example `jwt.sub` or
+                                                  `request.headers["x-team"]`. If the expression does not produce a valid
+                                                  session name at request time, the request is rejected.
+                                                maxLength: 16384
+                                                minLength: 1
+                                                type: string
                                               tags:
                                                 description: |-
                                                   Tags are session tags passed to STS AssumeRole. Once activated as cost
@@ -8654,6 +8748,12 @@ spec:
                                             required:
                                             - roleArn
                                             type: object
+                                            x-kubernetes-validations:
+                                            - message: at most one of the fields in
+                                                [sessionName sessionNameExpression]
+                                                may be set
+                                              rule: '[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size()
+                                                <= 1'
                                           secretRef:
                                             description: |-
                                               Credential source, defaulting to a Kubernetes
@@ -10801,6 +10901,15 @@ spec:
                                                 Cost & Usage Report attribution. If unset, AWS generates a random name.
                                               pattern: ^[\w+=,.@-]{2,64}$
                                               type: string
+                                            sessionNameExpression:
+                                              description: |-
+                                                SessionNameExpression is a CEL expression evaluated against each request
+                                                to produce the session name (RoleSessionName), for example `jwt.sub` or
+                                                `request.headers["x-team"]`. If the expression does not produce a valid
+                                                session name at request time, the request is rejected.
+                                              maxLength: 16384
+                                              minLength: 1
+                                              type: string
                                             tags:
                                               description: |-
                                                 Tags are session tags passed to STS AssumeRole. Once activated as cost
@@ -10845,6 +10954,12 @@ spec:
                                           required:
                                           - roleArn
                                           type: object
+                                          x-kubernetes-validations:
+                                          - message: at most one of the fields in
+                                              [sessionName sessionNameExpression]
+                                              may be set
+                                            rule: '[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size()
+                                              <= 1'
                                         secretRef:
                                           description: |-
                                             Credential source, defaulting to a Kubernetes
@@ -12256,6 +12371,15 @@ spec:
                                                         Cost & Usage Report attribution. If unset, AWS generates a random name.
                                                       pattern: ^[\w+=,.@-]{2,64}$
                                                       type: string
+                                                    sessionNameExpression:
+                                                      description: |-
+                                                        SessionNameExpression is a CEL expression evaluated against each request
+                                                        to produce the session name (RoleSessionName), for example `jwt.sub` or
+                                                        `request.headers["x-team"]`. If the expression does not produce a valid
+                                                        session name at request time, the request is rejected.
+                                                      maxLength: 16384
+                                                      minLength: 1
+                                                      type: string
                                                     tags:
                                                       description: |-
                                                         Tags are session tags passed to STS AssumeRole. Once activated as cost
@@ -12303,6 +12427,12 @@ spec:
                                                   required:
                                                   - roleArn
                                                   type: object
+                                                  x-kubernetes-validations:
+                                                  - message: at most one of the fields
+                                                      in [sessionName sessionNameExpression]
+                                                      may be set
+                                                    rule: '[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size()
+                                                      <= 1'
                                                 secretRef:
                                                   description: |-
                                                     Credential source, defaulting to a Kubernetes
@@ -13531,6 +13661,15 @@ spec:
                                                         Cost & Usage Report attribution. If unset, AWS generates a random name.
                                                       pattern: ^[\w+=,.@-]{2,64}$
                                                       type: string
+                                                    sessionNameExpression:
+                                                      description: |-
+                                                        SessionNameExpression is a CEL expression evaluated against each request
+                                                        to produce the session name (RoleSessionName), for example `jwt.sub` or
+                                                        `request.headers["x-team"]`. If the expression does not produce a valid
+                                                        session name at request time, the request is rejected.
+                                                      maxLength: 16384
+                                                      minLength: 1
+                                                      type: string
                                                     tags:
                                                       description: |-
                                                         Tags are session tags passed to STS AssumeRole. Once activated as cost
@@ -13578,6 +13717,12 @@ spec:
                                                   required:
                                                   - roleArn
                                                   type: object
+                                                  x-kubernetes-validations:
+                                                  - message: at most one of the fields
+                                                      in [sessionName sessionNameExpression]
+                                                      may be set
+                                                    rule: '[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size()
+                                                      <= 1'
                                                 secretRef:
                                                   description: |-
                                                     Credential source, defaulting to a Kubernetes
@@ -14801,6 +14946,15 @@ spec:
                                                         Cost & Usage Report attribution. If unset, AWS generates a random name.
                                                       pattern: ^[\w+=,.@-]{2,64}$
                                                       type: string
+                                                    sessionNameExpression:
+                                                      description: |-
+                                                        SessionNameExpression is a CEL expression evaluated against each request
+                                                        to produce the session name (RoleSessionName), for example `jwt.sub` or
+                                                        `request.headers["x-team"]`. If the expression does not produce a valid
+                                                        session name at request time, the request is rejected.
+                                                      maxLength: 16384
+                                                      minLength: 1
+                                                      type: string
                                                     tags:
                                                       description: |-
                                                         Tags are session tags passed to STS AssumeRole. Once activated as cost
@@ -14848,6 +15002,12 @@ spec:
                                                   required:
                                                   - roleArn
                                                   type: object
+                                                  x-kubernetes-validations:
+                                                  - message: at most one of the fields
+                                                      in [sessionName sessionNameExpression]
+                                                      may be set
+                                                    rule: '[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size()
+                                                      <= 1'
                                                 secretRef:
                                                   description: |-
                                                     Credential source, defaulting to a Kubernetes
@@ -16297,6 +16457,15 @@ spec:
                                                         Cost & Usage Report attribution. If unset, AWS generates a random name.
                                                       pattern: ^[\w+=,.@-]{2,64}$
                                                       type: string
+                                                    sessionNameExpression:
+                                                      description: |-
+                                                        SessionNameExpression is a CEL expression evaluated against each request
+                                                        to produce the session name (RoleSessionName), for example `jwt.sub` or
+                                                        `request.headers["x-team"]`. If the expression does not produce a valid
+                                                        session name at request time, the request is rejected.
+                                                      maxLength: 16384
+                                                      minLength: 1
+                                                      type: string
                                                     tags:
                                                       description: |-
                                                         Tags are session tags passed to STS AssumeRole. Once activated as cost
@@ -16344,6 +16513,12 @@ spec:
                                                   required:
                                                   - roleArn
                                                   type: object
+                                                  x-kubernetes-validations:
+                                                  - message: at most one of the fields
+                                                      in [sessionName sessionNameExpression]
+                                                      may be set
+                                                    rule: '[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size()
+                                                      <= 1'
                                                 secretRef:
                                                   description: |-
                                                     Credential source, defaulting to a Kubernetes
@@ -17572,6 +17747,15 @@ spec:
                                                         Cost & Usage Report attribution. If unset, AWS generates a random name.
                                                       pattern: ^[\w+=,.@-]{2,64}$
                                                       type: string
+                                                    sessionNameExpression:
+                                                      description: |-
+                                                        SessionNameExpression is a CEL expression evaluated against each request
+                                                        to produce the session name (RoleSessionName), for example `jwt.sub` or
+                                                        `request.headers["x-team"]`. If the expression does not produce a valid
+                                                        session name at request time, the request is rejected.
+                                                      maxLength: 16384
+                                                      minLength: 1
+                                                      type: string
                                                     tags:
                                                       description: |-
                                                         Tags are session tags passed to STS AssumeRole. Once activated as cost
@@ -17619,6 +17803,12 @@ spec:
                                                   required:
                                                   - roleArn
                                                   type: object
+                                                  x-kubernetes-validations:
+                                                  - message: at most one of the fields
+                                                      in [sessionName sessionNameExpression]
+                                                      may be set
+                                                    rule: '[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size()
+                                                      <= 1'
                                                 secretRef:
                                                   description: |-
                                                     Credential source, defaulting to a Kubernetes
@@ -19130,6 +19320,15 @@ spec:
                                   Cost & Usage Report attribution. If unset, AWS generates a random name.
                                 pattern: ^[\w+=,.@-]{2,64}$
                                 type: string
+                              sessionNameExpression:
+                                description: |-
+                                  SessionNameExpression is a CEL expression evaluated against each request
+                                  to produce the session name (RoleSessionName), for example `jwt.sub` or
+                                  `request.headers["x-team"]`. If the expression does not produce a valid
+                                  session name at request time, the request is rejected.
+                                maxLength: 16384
+                                minLength: 1
+                                type: string
                               tags:
                                 description: |-
                                   Tags are session tags passed to STS AssumeRole. Once activated as cost
@@ -19173,6 +19372,11 @@ spec:
                             required:
                             - roleArn
                             type: object
+                            x-kubernetes-validations:
+                            - message: at most one of the fields in [sessionName sessionNameExpression]
+                                may be set
+                              rule: '[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size()
+                                <= 1'
                           secretRef:
                             description: |-
                               Credential source, defaulting to a Kubernetes

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
@@ -313,6 +313,15 @@ spec:
                                                         Cost & Usage Report attribution. If unset, AWS generates a random name.
                                                       pattern: ^[\w+=,.@-]{2,64}$
                                                       type: string
+                                                    sessionNameExpression:
+                                                      description: |-
+                                                        SessionNameExpression is a CEL expression evaluated against each request
+                                                        to produce the session name (RoleSessionName), for example `jwt.sub` or
+                                                        `request.headers["x-team"]`. If the expression does not produce a valid
+                                                        session name at request time, the request is rejected.
+                                                      maxLength: 16384
+                                                      minLength: 1
+                                                      type: string
                                                     tags:
                                                       description: |-
                                                         Tags are session tags passed to STS AssumeRole. Once activated as cost
@@ -360,6 +369,12 @@ spec:
                                                   required:
                                                   - roleArn
                                                   type: object
+                                                  x-kubernetes-validations:
+                                                  - message: at most one of the fields
+                                                      in [sessionName sessionNameExpression]
+                                                      may be set
+                                                    rule: '[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size()
+                                                      <= 1'
                                                 secretRef:
                                                   description: |-
                                                     Credential source, defaulting to a Kubernetes
@@ -1588,6 +1603,15 @@ spec:
                                                         Cost & Usage Report attribution. If unset, AWS generates a random name.
                                                       pattern: ^[\w+=,.@-]{2,64}$
                                                       type: string
+                                                    sessionNameExpression:
+                                                      description: |-
+                                                        SessionNameExpression is a CEL expression evaluated against each request
+                                                        to produce the session name (RoleSessionName), for example `jwt.sub` or
+                                                        `request.headers["x-team"]`. If the expression does not produce a valid
+                                                        session name at request time, the request is rejected.
+                                                      maxLength: 16384
+                                                      minLength: 1
+                                                      type: string
                                                     tags:
                                                       description: |-
                                                         Tags are session tags passed to STS AssumeRole. Once activated as cost
@@ -1635,6 +1659,12 @@ spec:
                                                   required:
                                                   - roleArn
                                                   type: object
+                                                  x-kubernetes-validations:
+                                                  - message: at most one of the fields
+                                                      in [sessionName sessionNameExpression]
+                                                      may be set
+                                                    rule: '[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size()
+                                                      <= 1'
                                                 secretRef:
                                                   description: |-
                                                     Credential source, defaulting to a Kubernetes
@@ -2858,6 +2888,15 @@ spec:
                                                         Cost & Usage Report attribution. If unset, AWS generates a random name.
                                                       pattern: ^[\w+=,.@-]{2,64}$
                                                       type: string
+                                                    sessionNameExpression:
+                                                      description: |-
+                                                        SessionNameExpression is a CEL expression evaluated against each request
+                                                        to produce the session name (RoleSessionName), for example `jwt.sub` or
+                                                        `request.headers["x-team"]`. If the expression does not produce a valid
+                                                        session name at request time, the request is rejected.
+                                                      maxLength: 16384
+                                                      minLength: 1
+                                                      type: string
                                                     tags:
                                                       description: |-
                                                         Tags are session tags passed to STS AssumeRole. Once activated as cost
@@ -2905,6 +2944,12 @@ spec:
                                                   required:
                                                   - roleArn
                                                   type: object
+                                                  x-kubernetes-validations:
+                                                  - message: at most one of the fields
+                                                      in [sessionName sessionNameExpression]
+                                                      may be set
+                                                    rule: '[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size()
+                                                      <= 1'
                                                 secretRef:
                                                   description: |-
                                                     Credential source, defaulting to a Kubernetes
@@ -4354,6 +4399,15 @@ spec:
                                                         Cost & Usage Report attribution. If unset, AWS generates a random name.
                                                       pattern: ^[\w+=,.@-]{2,64}$
                                                       type: string
+                                                    sessionNameExpression:
+                                                      description: |-
+                                                        SessionNameExpression is a CEL expression evaluated against each request
+                                                        to produce the session name (RoleSessionName), for example `jwt.sub` or
+                                                        `request.headers["x-team"]`. If the expression does not produce a valid
+                                                        session name at request time, the request is rejected.
+                                                      maxLength: 16384
+                                                      minLength: 1
+                                                      type: string
                                                     tags:
                                                       description: |-
                                                         Tags are session tags passed to STS AssumeRole. Once activated as cost
@@ -4401,6 +4455,12 @@ spec:
                                                   required:
                                                   - roleArn
                                                   type: object
+                                                  x-kubernetes-validations:
+                                                  - message: at most one of the fields
+                                                      in [sessionName sessionNameExpression]
+                                                      may be set
+                                                    rule: '[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size()
+                                                      <= 1'
                                                 secretRef:
                                                   description: |-
                                                     Credential source, defaulting to a Kubernetes
@@ -5629,6 +5689,15 @@ spec:
                                                         Cost & Usage Report attribution. If unset, AWS generates a random name.
                                                       pattern: ^[\w+=,.@-]{2,64}$
                                                       type: string
+                                                    sessionNameExpression:
+                                                      description: |-
+                                                        SessionNameExpression is a CEL expression evaluated against each request
+                                                        to produce the session name (RoleSessionName), for example `jwt.sub` or
+                                                        `request.headers["x-team"]`. If the expression does not produce a valid
+                                                        session name at request time, the request is rejected.
+                                                      maxLength: 16384
+                                                      minLength: 1
+                                                      type: string
                                                     tags:
                                                       description: |-
                                                         Tags are session tags passed to STS AssumeRole. Once activated as cost
@@ -5676,6 +5745,12 @@ spec:
                                                   required:
                                                   - roleArn
                                                   type: object
+                                                  x-kubernetes-validations:
+                                                  - message: at most one of the fields
+                                                      in [sessionName sessionNameExpression]
+                                                      may be set
+                                                    rule: '[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size()
+                                                      <= 1'
                                                 secretRef:
                                                   description: |-
                                                     Credential source, defaulting to a Kubernetes
@@ -7187,6 +7262,15 @@ spec:
                                   Cost & Usage Report attribution. If unset, AWS generates a random name.
                                 pattern: ^[\w+=,.@-]{2,64}$
                                 type: string
+                              sessionNameExpression:
+                                description: |-
+                                  SessionNameExpression is a CEL expression evaluated against each request
+                                  to produce the session name (RoleSessionName), for example `jwt.sub` or
+                                  `request.headers["x-team"]`. If the expression does not produce a valid
+                                  session name at request time, the request is rejected.
+                                maxLength: 16384
+                                minLength: 1
+                                type: string
                               tags:
                                 description: |-
                                   Tags are session tags passed to STS AssumeRole. Once activated as cost
@@ -7230,6 +7314,11 @@ spec:
                             required:
                             - roleArn
                             type: object
+                            x-kubernetes-validations:
+                            - message: at most one of the fields in [sessionName sessionNameExpression]
+                                may be set
+                              rule: '[has(self.sessionName),has(self.sessionNameExpression)].filter(x,x==true).size()
+                                <= 1'
                           secretRef:
                             description: |-
                               Credential source, defaulting to a Kubernetes

--- a/controller/pkg/agentgateway/plugins/backend_policies.go
+++ b/controller/pkg/agentgateway/plugins/backend_policies.go
@@ -1275,6 +1275,9 @@ func buildAwsAuthPolicy(ctx PolicyCtx, auth *agentgateway.AwsAuth, namespace str
 		if auth.AssumeRole.SessionName != nil {
 			assumeRole.SessionName = *auth.AssumeRole.SessionName
 		}
+		if auth.AssumeRole.SessionNameExpression != nil {
+			assumeRole.SessionNameExpression = string(*auth.AssumeRole.SessionNameExpression)
+		}
 	}
 
 	awsAuth := &api.Aws{

--- a/controller/pkg/agentgateway/plugins/credential_ref_auth_test.go
+++ b/controller/pkg/agentgateway/plugins/credential_ref_auth_test.go
@@ -110,6 +110,28 @@ func TestAwsAuthPropagatesDynamicSessionTags(t *testing.T) {
 	assert.Equal(t, tags[1].GetExpression(), `request.headers["x-app"]`)
 }
 
+func TestAwsAuthPropagatesDynamicSessionName(t *testing.T) {
+	secrets := krt.NewStaticCollection[*corev1.Secret](nil, nil, krt.WithName("plugins/TestAwsAuthPropagatesDynamicSessionName"))
+	ctx := simpleAuthPolicyCtx(
+		&AgwCollections{
+			Secrets: secrets,
+		}, kubeutils.NewSecretCredentialResolver(secrets))
+
+	expression := agentgateway.CELExpression(`jwt.sub`)
+	policy, err := buildAwsAuthPolicy(ctx, &agentgateway.AwsAuth{
+		AssumeRole: &agentgateway.AwsAssumeRole{
+			RoleArn:               "arn:aws:iam::111122223333:role/bedrock-caller",
+			SessionNameExpression: &expression,
+		},
+	}, "default")
+	assert.NoError(t, err)
+
+	assumeRole := policy.GetAws().GetAssumeRole()
+	assert.Equal(t, assumeRole != nil, true)
+	assert.Equal(t, assumeRole.GetSessionName(), "")
+	assert.Equal(t, assumeRole.GetSessionNameExpression(), "jwt.sub")
+}
+
 func TestAwsAuthAssumeRoleOmitsUnsetSessionNameAndTags(t *testing.T) {
 	secrets := krt.NewStaticCollection[*corev1.Secret](nil, nil, krt.WithName("plugins/TestAwsAuthAssumeRoleOmitsUnsetSessionNameAndTags"))
 	ctx := simpleAuthPolicyCtx(

--- a/crates/agentgateway/src/http/auth/aws.rs
+++ b/crates/agentgateway/src/http/auth/aws.rs
@@ -131,10 +131,11 @@ pub struct AwsAssumeRole {
 	/// AWS IAM role ARN to assume.
 	pub role_arn: String,
 	/// Custom session name (RoleSessionName) for CloudTrail and Cost & Usage Report
-	/// attribution. Max 64 chars, matching `[\w+=,.@-]`. If unset, the AWS SDK
-	/// generates a random session name.
+	/// attribution. Either a static string or `{expression: ...}` with a CEL
+	/// expression evaluated against each request. Max 64 chars, matching
+	/// `[\w+=,.@-]`. If unset, the AWS SDK generates a random session name.
 	#[serde(skip_serializing_if = "Option::is_none")]
-	pub session_name: Option<String>,
+	pub session_name: Option<AwsSessionName>,
 	/// Session tags passed to STS AssumeRole for cost attribution. Once activated as
 	/// cost allocation tags, each tag surfaces in the AWS Cost & Usage Report under
 	/// `resourceTags/user:TagKey`. A tag value is either static (`value`) or a CEL
@@ -163,6 +164,119 @@ pub struct AwsSessionTag {
 	/// produce a valid tag value at request time, the request is rejected.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub expression: Option<Arc<cel::Expression>>,
+}
+
+/// Session name (RoleSessionName) in configuration form: a static string, or a
+/// CEL expression evaluated against each request. Untagged, so a plain string
+/// keeps its existing meaning.
+#[apply(schema!)]
+#[serde(
+	untagged,
+	expecting = "a session name string, or `{expression: ...}` with a valid CEL expression"
+)]
+pub enum AwsSessionName {
+	/// Static session name.
+	Static(String),
+	/// CEL expression evaluated against each request to produce the session
+	/// name, for example `jwt.sub` or `request.headers["x-team"]`. If the
+	/// expression does not produce a valid session name at request time, the
+	/// request is rejected.
+	Dynamic { expression: Arc<cel::Expression> },
+}
+
+impl AwsSessionName {
+	fn static_name(&self) -> Option<&str> {
+		match self {
+			Self::Static(name) => Some(name),
+			Self::Dynamic { .. } => None,
+		}
+	}
+
+	fn expression(&self) -> Option<&Arc<cel::Expression>> {
+		match self {
+			Self::Static(_) => None,
+			Self::Dynamic { expression } => Some(expression),
+		}
+	}
+
+	/// Evaluates a dynamic session name against the request. Fails closed: an
+	/// expression that cannot produce a valid session name is an error. Static
+	/// names resolve to themselves unvalidated, unchanged from before; STS
+	/// rejects an invalid static name loudly on first use.
+	fn resolve(&self, req: &http::Request) -> anyhow::Result<String> {
+		match self {
+			Self::Static(name) => Ok(name.clone()),
+			Self::Dynamic { expression } => {
+				let exec = cel::Executor::new_request(req);
+				exec
+					.eval(expression)
+					.map_err(anyhow::Error::from)
+					.and_then(cel_value_to_string)
+					.and_then(|name| {
+						validate_session_name(&name)?;
+						Ok(name)
+					})
+					.map_err(|e| {
+						anyhow::anyhow!(
+							"session name (expression {:?}): {e}",
+							expression.original_expression
+						)
+					})
+			},
+		}
+	}
+}
+
+// Dynamic session names cannot derive equality; compare by source expression,
+// which is exactly what determines their behavior (same as AwsSessionTags).
+impl PartialEq for AwsSessionName {
+	fn eq(&self, other: &Self) -> bool {
+		match (self, other) {
+			(Self::Static(a), Self::Static(b)) => a == b,
+			(Self::Dynamic { expression: a }, Self::Dynamic { expression: b }) => {
+				a.original_expression == b.original_expression
+			},
+			_ => false,
+		}
+	}
+}
+
+impl Eq for AwsSessionName {}
+
+impl std::hash::Hash for AwsSessionName {
+	fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+		match self {
+			Self::Static(name) => {
+				0u8.hash(state);
+				name.hash(state);
+			},
+			Self::Dynamic { expression } => {
+				1u8.hash(state);
+				expression.original_expression.hash(state);
+			},
+		}
+	}
+}
+
+// STS RoleSessionName limits: https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html
+const MIN_SESSION_NAME_LEN: usize = 2;
+const MAX_SESSION_NAME_LEN: usize = 64;
+
+/// The characters STS accepts in a RoleSessionName.
+static SESSION_NAME_CHARSET: LazyLock<Regex> =
+	LazyLock::new(|| Regex::new(r"^[\w+=,.@-]*$").expect("static regex compiles"));
+
+fn validate_session_name(name: &str) -> anyhow::Result<()> {
+	let len = name.chars().count();
+	if !(MIN_SESSION_NAME_LEN..=MAX_SESSION_NAME_LEN).contains(&len) {
+		anyhow::bail!(
+			"session name must be {MIN_SESSION_NAME_LEN}-{MAX_SESSION_NAME_LEN} characters, got {len}"
+		);
+	}
+	if !SESSION_NAME_CHARSET.is_match(name) {
+		anyhow::bail!("session name {name:?} contains characters STS does not accept");
+	}
+	Ok(())
 }
 
 // STS session tag limits: https://docs.aws.amazon.com/STS/latest/APIReference/API_Tag.html
@@ -263,7 +377,7 @@ impl AwsSessionTags {
 			let value = exec
 				.eval(expr)
 				.map_err(anyhow::Error::from)
-				.and_then(session_tag_value)
+				.and_then(cel_value_to_string)
 				.and_then(|value| {
 					if value.is_empty() {
 						anyhow::bail!("expression produced an empty value");
@@ -331,10 +445,11 @@ fn validate_session_tag_value(key: &str, value: &str) -> anyhow::Result<()> {
 	Ok(())
 }
 
-/// Coerces a CEL evaluation result into a tag value. Strings, numbers, and
-/// booleans (common JWT claim types) stringify via [`cel::Value::as_string`];
-/// anything else (null, lists, maps) is an error so misattribution fails closed.
-fn session_tag_value(v: cel::Value) -> anyhow::Result<String> {
+/// Coerces a CEL evaluation result into a tag value or session name. Strings,
+/// numbers, and booleans (common JWT claim types) stringify via
+/// [`cel::Value::as_string`]; anything else (null, lists, maps) is an error so
+/// misattribution fails closed.
+fn cel_value_to_string(v: cel::Value) -> anyhow::Result<String> {
 	// Materialize Dynamic so nested lookups (e.g. JWT claims) are concrete values.
 	v.always_materialize_owned()
 		.as_string()
@@ -395,12 +510,17 @@ impl AwsAuth {
 	}
 
 	/// CEL expressions this auth config evaluates per request (dynamic session
-	/// tags), for registration with the CEL context builder.
+	/// tags and session name), for registration with the CEL context builder.
 	pub fn cel_expressions(&self) -> impl Iterator<Item = &cel::Expression> {
-		self
-			.assume_role()
-			.into_iter()
-			.flat_map(|assume_role| assume_role.tags.expressions())
+		self.assume_role().into_iter().flat_map(|assume_role| {
+			assume_role.tags.expressions().chain(
+				assume_role
+					.session_name
+					.as_ref()
+					.and_then(|name| name.expression())
+					.map(|e| e.as_ref()),
+			)
+		})
 	}
 
 	fn source_credentials_cache(&self) -> Option<&AwsCredentialsCache> {
@@ -430,12 +550,17 @@ pub(super) async fn sign_request(
 	req: &mut http::Request,
 	aws_auth: &AwsAuth,
 ) -> anyhow::Result<()> {
-	// Resolve any dynamic (CEL) session tags first, while the request is intact.
-	// The CEL context reads headers and extensions (JWT claims, etc.), which the
-	// proxy keeps on the request until after late backend auth. Fails closed: an
-	// expression that cannot produce a valid tag value rejects the request.
+	// Resolve any dynamic (CEL) session tags and session name first, while the
+	// request is intact. The CEL context reads headers and extensions (JWT
+	// claims, etc.), which the proxy keeps on the request until after late
+	// backend auth. Fails closed: an expression that cannot produce a valid
+	// value rejects the request.
 	let resolved_tags = match aws_auth.assume_role() {
 		Some(assume_role) if assume_role.tags.has_dynamic() => Some(assume_role.tags.resolve(req)?),
+		_ => None,
+	};
+	let resolved_session_name = match aws_auth.assume_role().and_then(|a| a.session_name.as_ref()) {
+		Some(name @ AwsSessionName::Dynamic { .. }) => Some(name.resolve(req)?),
 		_ => None,
 	};
 	let lim = crate::http::buffer_limit(req);
@@ -459,9 +584,14 @@ pub(super) async fn sign_request(
 			}
 		},
 	};
-	let creds = Box::pin(load_credentials(aws_auth, region, resolved_tags))
-		.await?
-		.into();
+	let creds = Box::pin(load_credentials(
+		aws_auth,
+		region,
+		resolved_tags,
+		resolved_session_name,
+	))
+	.await?
+	.into();
 
 	let service = signing_service_name(req, aws_auth);
 	trace!("AWS signing with region: {}, service: {}", region, service);
@@ -525,9 +655,17 @@ async fn load_credentials(
 	aws_auth: &AwsAuth,
 	signing_region: &str,
 	resolved_tags: Option<Arc<[(String, String)]>>,
+	resolved_session_name: Option<String>,
 ) -> anyhow::Result<Credentials> {
 	if let (Some(assume_role), Some(cache)) = (aws_auth.assume_role(), aws_auth.assume_role_cache()) {
-		load_assumed_credentials(assume_role, cache, signing_region, resolved_tags).await
+		load_assumed_credentials(
+			assume_role,
+			cache,
+			signing_region,
+			resolved_tags,
+			resolved_session_name,
+		)
+		.await
 	} else {
 		load_source_credentials(aws_auth).await
 	}
@@ -594,6 +732,20 @@ struct AssumeRoleCacheKey {
 	tags: Arc<[(String, String)]>,
 }
 
+/// The session name for the STS call: the per-request resolved name when the
+/// configured name is dynamic, otherwise the configured static name.
+fn effective_session_name(
+	assume_role: &AwsAssumeRole,
+	resolved_session_name: Option<String>,
+) -> Option<String> {
+	resolved_session_name.or_else(|| {
+		assume_role
+			.session_name
+			.as_ref()
+			.and_then(|name| name.static_name().map(String::from))
+	})
+}
+
 const ASSUMED_CREDENTIAL_REFRESH_BUFFER: Duration = Duration::from_secs(60);
 
 async fn load_assumed_credentials(
@@ -601,15 +753,18 @@ async fn load_assumed_credentials(
 	cache: &AwsAssumeRoleCache,
 	signing_region: &str,
 	resolved_tags: Option<Arc<[(String, String)]>>,
+	resolved_session_name: Option<String>,
 ) -> anyhow::Result<Credentials> {
 	let sts_region = resolve_sts_region(assume_role, signing_region).await?;
-	// resolved_tags is Some iff dynamic tags are configured (see sign_request);
-	// static-only configs use the pre-sorted static set via a cheap Arc clone.
+	// resolved_tags and resolved_session_name are Some iff the corresponding
+	// dynamic config is set (see sign_request); static-only configs use the
+	// configured values directly.
 	let tags = resolved_tags.unwrap_or_else(|| assume_role.tags.static_tags());
+	let session_name = effective_session_name(assume_role, resolved_session_name);
 	let key = AssumeRoleCacheKey {
 		role_arn: assume_role.role_arn.clone(),
 		resolved_sts_region: sts_region.clone(),
-		session_name: assume_role.session_name.clone(),
+		session_name,
 		tags,
 	};
 
@@ -620,8 +775,8 @@ async fn load_assumed_credentials(
 				.configure(config)
 				.region(Region::new(sts_region));
 
-			if let Some(session_name) = &assume_role.session_name {
-				builder = builder.session_name(session_name);
+			if let Some(session_name) = &key.session_name {
+				builder = builder.session_name(session_name.clone());
 			}
 
 			if !key.tags.is_empty() {
@@ -676,7 +831,10 @@ mod cache_key_tests {
 		AssumeRoleCacheKey {
 			role_arn: assume_role.role_arn.clone(),
 			resolved_sts_region: region.to_string(),
-			session_name: assume_role.session_name.clone(),
+			session_name: assume_role
+				.session_name
+				.as_ref()
+				.and_then(|name| name.static_name().map(String::from)),
 			tags: assume_role.tags.static_tags(),
 		}
 	}
@@ -685,14 +843,55 @@ mod cache_key_tests {
 	fn different_session_names_produce_different_keys() {
 		let base = AwsAssumeRole {
 			role_arn: "arn:aws:iam::123456789012:role/backend".to_string(),
-			session_name: Some("team-a".to_string()),
+			session_name: Some(AwsSessionName::Static("team-a".to_string())),
 			tags: tags(&[]),
 		};
 		let other = AwsAssumeRole {
-			session_name: Some("team-b".to_string()),
+			session_name: Some(AwsSessionName::Static("team-b".to_string())),
 			..base.clone()
 		};
 		assert_ne!(key_for(&base, "us-east-1"), key_for(&other, "us-east-1"));
+	}
+
+	#[test]
+	fn effective_session_name_prefers_resolved_over_static() {
+		let static_config = AwsAssumeRole {
+			role_arn: "arn:aws:iam::123456789012:role/backend".to_string(),
+			session_name: Some(AwsSessionName::Static("static-name".to_string())),
+			tags: tags(&[]),
+		};
+		// Static config, nothing resolved: the configured name is used.
+		assert_eq!(
+			effective_session_name(&static_config, None),
+			Some("static-name".to_string())
+		);
+		// A resolved name always wins; it only exists when the config is dynamic.
+		assert_eq!(
+			effective_session_name(&static_config, Some("resolved-name".to_string())),
+			Some("resolved-name".to_string())
+		);
+		let unset = AwsAssumeRole {
+			session_name: None,
+			..static_config
+		};
+		assert_eq!(effective_session_name(&unset, None), None);
+	}
+
+	#[test]
+	fn dynamic_session_name_resolving_to_static_value_produces_equal_key() {
+		// A dynamic session name that evaluates to X keys the cache identically to
+		// a static session name X: only the resolved value matters.
+		let static_key = AssumeRoleCacheKey {
+			role_arn: "arn:aws:iam::123456789012:role/backend".to_string(),
+			resolved_sts_region: "us-east-1".to_string(),
+			session_name: Some("team-a-invoicer".to_string()),
+			tags: tags(&[]).static_tags(),
+		};
+		let resolved_key = AssumeRoleCacheKey {
+			session_name: Some("team-a-invoicer".to_string()),
+			..static_key.clone()
+		};
+		assert_eq!(static_key, resolved_key);
 	}
 
 	#[test]
@@ -911,6 +1110,132 @@ mod resolve_tags_tests {
 		assert!(
 			err.to_string().contains("App"),
 			"error names the tag: {err}"
+		);
+	}
+}
+
+#[cfg(test)]
+mod resolve_session_name_tests {
+	use secrecy::SecretString;
+
+	use super::*;
+	use crate::http::jwt::Claims;
+
+	fn dynamic(expression: &str) -> AwsSessionName {
+		AwsSessionName::Dynamic {
+			expression: Arc::new(
+				cel::Expression::new_strict(expression).expect("expression should compile"),
+			),
+		}
+	}
+
+	fn request(headers: &[(&str, &str)], claims: Option<serde_json::Value>) -> http::Request {
+		let mut builder = ::http::Request::builder().uri("http://example.com/");
+		for (k, v) in headers {
+			builder = builder.header(*k, *v);
+		}
+		let mut req = builder.body(crate::http::Body::empty()).expect("request");
+		if let Some(serde_json::Value::Object(claims)) = claims {
+			req.extensions_mut().insert(Claims {
+				inner: claims,
+				jwt: SecretString::new("header.payload.signature".into()),
+			});
+		}
+		req
+	}
+
+	#[test]
+	fn resolves_from_header_and_jwt() {
+		let name = dynamic(r#"request.headers["x-team"] + "-" + jwt.sub"#);
+		let req = request(
+			&[("x-team", "acme")],
+			Some(serde_json::json!({"sub": "user@example.com"})),
+		);
+		assert_eq!(
+			name.resolve(&req).expect("should resolve"),
+			"acme-user@example.com"
+		);
+	}
+
+	#[test]
+	fn stringifies_numeric_claim() {
+		let name = dynamic("jwt.org_id");
+		let req = request(&[], Some(serde_json::json!({"org_id": 42})));
+		assert_eq!(name.resolve(&req).expect("should resolve"), "42");
+	}
+
+	#[test]
+	fn static_name_resolves_to_itself() {
+		let name = AwsSessionName::Static("team-a".to_string());
+		assert_eq!(
+			name.resolve(&request(&[], None)).expect("resolves"),
+			"team-a"
+		);
+	}
+
+	#[test]
+	fn missing_header_fails_closed() {
+		let name = dynamic(r#"request.headers["x-team"]"#);
+		let err = name.resolve(&request(&[], None)).expect_err("should fail");
+		assert!(
+			err.to_string().contains("session name"),
+			"error names the session name: {err}"
+		);
+	}
+
+	#[test]
+	fn too_short_fails_closed() {
+		let name = dynamic(r#"request.headers["x-team"]"#);
+		let err = name
+			.resolve(&request(&[("x-team", "a")], None))
+			.expect_err("should fail");
+		assert!(err.to_string().contains("2-64"), "got: {err}");
+	}
+
+	#[test]
+	fn too_long_fails_closed() {
+		let name = dynamic(r#"request.headers["x-team"]"#);
+		let long = "a".repeat(MAX_SESSION_NAME_LEN + 1);
+		let err = name
+			.resolve(&request(&[("x-team", long.as_str())], None))
+			.expect_err("should fail");
+		assert!(err.to_string().contains("2-64"), "got: {err}");
+	}
+
+	#[test]
+	fn invalid_charset_fails_closed() {
+		// RoleSessionName is stricter than session tag values: spaces and colons
+		// are accepted in tags but not in the session name.
+		let name = dynamic(r#"request.headers["x-team"]"#);
+		let err = name
+			.resolve(&request(&[("x-team", "team a")], None))
+			.expect_err("should fail");
+		assert!(
+			err.to_string().contains("STS does not accept"),
+			"got: {err}"
+		);
+	}
+
+	#[tokio::test]
+	async fn sign_request_fails_closed_when_session_name_cannot_resolve() {
+		let auth = AwsAuth::Implicit {
+			service_name: None,
+			assume_role: Some(AwsAssumeRole {
+				role_arn: "arn:aws:iam::123456789012:role/backend".to_string(),
+				session_name: Some(dynamic(r#"request.headers["x-team"]"#)),
+				tags: Default::default(),
+			}),
+			source_credentials_cache: Default::default(),
+			assume_role_cache: Default::default(),
+		};
+		// No x-team header: resolution fails before any credential loading or STS call.
+		let mut req = request(&[], None);
+		let err = sign_request(&mut req, &auth)
+			.await
+			.expect_err("must reject the request rather than sign it misattributed");
+		assert!(
+			err.to_string().contains("session name"),
+			"error names the session name: {err}"
 		);
 	}
 }

--- a/crates/agentgateway/src/http/auth/tests.rs
+++ b/crates/agentgateway/src/http/auth/tests.rs
@@ -45,9 +45,12 @@ fn test_aws_auth_deserializes_assume_role_with_session_name_and_tags() {
 			..
 		} => {
 			assert_eq!(ar.role_arn, "arn:aws:iam::123456789012:role/my-role");
+			// A plain string keeps its existing (static) meaning.
 			assert_eq!(
-				ar.session_name.as_deref(),
-				Some("acme-payments-invoice-processor")
+				ar.session_name,
+				Some(aws::AwsSessionName::Static(
+					"acme-payments-invoice-processor".to_string()
+				))
 			);
 			// Tags are stored sorted by key, regardless of configured order.
 			assert_eq!(
@@ -111,6 +114,85 @@ fn test_aws_session_tags_round_trip_through_serialization() {
 	let round_tripped: AwsAssumeRole =
 		serde_json::from_value(serialized).expect("serialized form should deserialize");
 	assert_eq!(ar.tags, round_tripped.tags);
+}
+
+#[test]
+fn test_aws_auth_deserializes_dynamic_session_name() {
+	let implicit: AwsAuth = serde_json::from_value(serde_json::json!({
+		"assumeRole": {
+			"roleArn": "arn:aws:iam::123456789012:role/my-role",
+			"sessionName": {"expression": "jwt.sub"}
+		}
+	}))
+	.expect("should deserialize dynamic session name");
+	match implicit {
+		AwsAuth::Implicit {
+			assume_role: Some(ar),
+			..
+		} => match ar.session_name {
+			Some(aws::AwsSessionName::Dynamic { expression }) => {
+				assert_eq!(expression.original_expression.as_str(), "jwt.sub");
+			},
+			other => panic!("expected dynamic session name, got {other:?}"),
+		},
+		_ => panic!("expected implicit AWS auth with assume role"),
+	}
+}
+
+#[test]
+fn test_aws_session_name_round_trips_through_serialization() {
+	for source in [
+		// Static form serializes back to a plain string.
+		serde_json::json!({
+			"roleArn": "arn:aws:iam::123456789012:role/my-role",
+			"sessionName": "acme-payments"
+		}),
+		// Dynamic form serializes back to {expression: ...}.
+		serde_json::json!({
+			"roleArn": "arn:aws:iam::123456789012:role/my-role",
+			"sessionName": {"expression": "jwt.sub"}
+		}),
+	] {
+		let ar: AwsAssumeRole = serde_json::from_value(source.clone()).expect("should deserialize");
+		let serialized = serde_json::to_value(&ar).expect("should serialize");
+		assert_eq!(
+			serialized.get("sessionName"),
+			source.get("sessionName"),
+			"sessionName should round-trip in its original form"
+		);
+	}
+}
+
+#[test]
+fn test_aws_auth_cel_expressions_include_tags_and_session_name() {
+	let auth: AwsAuth = serde_json::from_value(serde_json::json!({
+		"assumeRole": {
+			"roleArn": "arn:aws:iam::123456789012:role/my-role",
+			"sessionName": {"expression": "jwt.sub"},
+			"tags": [
+				{"key": "App", "expression": "request.headers[\"x-app\"]"}
+			]
+		}
+	}))
+	.expect("should deserialize");
+	let expressions: Vec<&str> = auth
+		.cel_expressions()
+		.map(|e| e.original_expression.as_str())
+		.collect();
+	assert_eq!(
+		expressions,
+		vec![r#"request.headers["x-app"]"#, "jwt.sub"],
+		"both tag and session name expressions must register with the CEL context"
+	);
+}
+
+#[test]
+fn test_aws_session_name_rejects_invalid_expression() {
+	let result = serde_json::from_value::<AwsAssumeRole>(serde_json::json!({
+		"roleArn": "arn:aws:iam::123456789012:role/my-role",
+		"sessionName": {"expression": "this is not cel ("}
+	}));
+	assert!(result.is_err(), "invalid CEL expression should be rejected");
 }
 
 #[test]

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -1035,13 +1035,32 @@ fn backend_auth_from_proto(
 							})
 						})
 						.collect::<Result<Vec<_>, _>>()?;
+					// An unset proto string is indistinguishable from an empty one; treat
+					// empty as unset for both session name forms.
+					let session_name = match (
+						assume_role.session_name.is_empty(),
+						assume_role.session_name_expression.is_empty(),
+					) {
+						(true, true) => None,
+						(false, true) => Some(auth::aws::AwsSessionName::Static(assume_role.session_name)),
+						// Permissive: a bad expression fails requests that hit this policy
+						// (fail closed) instead of rejecting the whole policy update.
+						(true, false) => Some(auth::aws::AwsSessionName::Dynamic {
+							expression: permissive_cel_expression_arc(
+								diagnostics,
+								"AWS session name",
+								assume_role.session_name_expression,
+							),
+						}),
+						(false, false) => {
+							return Err(ProtoError::Generic(
+								"assumeRole sets both sessionName and sessionNameExpression".to_string(),
+							));
+						},
+					};
 					Ok(auth::AwsAssumeRole {
 						role_arn: assume_role.role_arn,
-						session_name: if assume_role.session_name.is_empty() {
-							None
-						} else {
-							Some(assume_role.session_name)
-						},
+						session_name,
 						tags: auth::aws::AwsSessionTags::try_new(tags)
 							.map_err(|e| ProtoError::Generic(e.to_string()))?,
 					})

--- a/crates/protos/proto/resource.proto
+++ b/crates/protos/proto/resource.proto
@@ -447,6 +447,12 @@ message AwsAssumeRole {
   // tags, they surface as columns in the AWS Cost & Usage Report for per-tenant
   // cost attribution.
   repeated AwsSessionTag tags = 3;
+  // CEL expression evaluated against each request to produce the session name
+  // (RoleSessionName), for example `jwt.sub` or `request.headers["x-team"]`. If
+  // the expression does not produce a valid session name at request time, the
+  // request is rejected. At most one of session_name and session_name_expression
+  // may be set.
+  string session_name_expression = 4;
 }
 
 // AWS STS session tag passed to AssumeRole for cost attribution.

--- a/schema/config.json
+++ b/schema/config.json
@@ -3109,10 +3109,14 @@
           "type": "string"
         },
         "sessionName": {
-          "description": "Custom session name (RoleSessionName) for CloudTrail and Cost & Usage Report\nattribution. Max 64 chars, matching `[\\w+=,.@-]`. If unset, the AWS SDK\ngenerates a random session name.",
-          "type": [
-            "string",
-            "null"
+          "description": "Custom session name (RoleSessionName) for CloudTrail and Cost & Usage Report\nattribution. Either a static string or `{expression: ...}` with a CEL\nexpression evaluated against each request. Max 64 chars, matching\n`[\\w+=,.@-]`. If unset, the AWS SDK generates a random session name.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AwsSessionName"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "tags": {
@@ -3126,6 +3130,28 @@
       "additionalProperties": false,
       "required": [
         "roleArn"
+      ]
+    },
+    "AwsSessionName": {
+      "description": "Session name (RoleSessionName) in configuration form: a static string, or a\nCEL expression evaluated against each request. Untagged, so a plain string\nkeeps its existing meaning.",
+      "anyOf": [
+        {
+          "description": "Static session name.",
+          "type": "string"
+        },
+        {
+          "description": "CEL expression evaluated against each request to produce the session\nname, for example `jwt.sub` or `request.headers[\"x-team\"]`. If the\nexpression does not produce a valid session name at request time, the\nrequest is rejected.",
+          "type": "object",
+          "properties": {
+            "expression": {
+              "$ref": "#/$defs/Expression"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "expression"
+          ]
+        }
       ]
     },
     "AwsSessionTag": {


### PR DESCRIPTION
**What**: `sessionName` on assumeRole now takes either a plain string (unchanged) or
`{expression: ...}`, a CEL expression evaluated per request. K8s side: new
`sessionNameExpression` field, at most one of the two (kubebuilder AtMostOneOf).

**Why**: session tags (#2447) carry attribution into Cost Explorer, but the CUR's
line-item identity column comes from RoleSessionName, which stayed one static string
per config. With a dynamic name (for example `request.headers["x-team"] + "-" + jwt.sub`),
per-request identity reaches the CUR itself and is queryable in Athena. This is what we do today. I named this feature as a follow-up in #2447's review discussion.

**Design, mirroring #2447's decisions**:
- Resolved at signing time while the request is intact, same place tags resolve.
- Part of the AssumeRole cache key, so distinct names are distinct STS sessions
  (bounded single-flight cache from #2447 absorbs the cardinality).
- xds compiles the expression permissively: a bad expression fails requests that
  hit the policy, never the whole policy update.
- Fails closed at request time: no valid name, no unattributed/misattributed session.
- Validation of resolved values against RoleSessionName constraints
  (`[\w+=,.@-]`, 2-64 chars) before any STS call.
- Local config uses an untagged enum, so string configs keep their meaning and the
  both-set state is unrepresentable; serde `expecting` gives a readable config error.
- Static session names keep their exact previous behavior (passed through unvalidated;
  STS rejects invalid ones loudly on first use). No behavior change for existing configs.

**Tests**: serde round-trips both forms (string form byte-identical to before),
invalid CEL rejected at config load, resolution from headers/JWT incl. numeric claim
stringification, fail-closed cases (missing header, too short/long, charset),
sign_request end-to-end fail-closed, cache-key equality (dynamic-resolving-to-X ==
static-X), resolved-beats-static precedence, CEL context registration includes the
session name expression, Go translation test for sessionNameExpression.

**Verification** (all green): cargo test -p agentgateway --lib (1366), cargo clippy,
cargo fmt --check, cargo xtask schema (committed), make generate-apis, controller
code generation (deepcopy + CRD YAML regenerated and committed, gofmt clean),
go build ./..., go test ./pkg/agentgateway/plugins/.

**Worth mentioning**:
- The local config models the session name as one field accepting either a string or `{expression: ...}`, while the CRD uses two fields (`sessionName` / `sessionNameExpression`) with AtMostOneOf. Each layer uses its idiomatic exclusivity mechanism: in the local config the both-set state is unrepresentable, and on the k8s side the API server enforces it with the built-in marker, so neither path needs hand-written validation.
- When both tags and the session name are dynamic, each resolve constructs its own CEL executor. Kept separate to leave the tags resolve path from #2447 untouched, and because the executor is cheap to construct.

**Use of AI assistance**: parts of this change were developed with AI assistance. I've reviewed the code, verified the behavior against the test suite, and take full ownership of the implementation.
