### PR TITLE
fix: normalize cached token usage telemetry

### DIFF
--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -56,6 +56,15 @@ fn u128_to_i64(value: u128) -> i64 {
 	value.min(i64::MAX as u128) as i64
 }
 
+fn llm_context_for_logging(info: llm::LLMInfo, model_catalog: &ModelCatalog) -> LLMContext {
+	let input_tokens = info.telemetry_input_tokens();
+	let total_tokens = info.telemetry_total_tokens();
+	let mut context = LLMContext::from_llm_info(info, Some(model_catalog));
+	context.input_tokens = input_tokens;
+	context.total_tokens = total_tokens;
+	context
+}
+
 fn kv_to_json(kv: &[(&str, Option<ValueBag>)]) -> Value {
 	let mut map = serde_json::Map::with_capacity(kv.len());
 	for (key, value) in kv {
@@ -1097,7 +1106,7 @@ impl Drop for DropOnLog {
 			let mut llm_response: Option<LLMContext> = log
 				.llm_response
 				.take()
-				.map(|llm_info| LLMContext::from_llm_info(llm_info, Some(log.model_catalog.as_ref())));
+				.map(|info| llm_context_for_logging(info, log.model_catalog.as_ref()));
 			if let Some(llm_response) = llm_response.as_mut() {
 				llm_response.set_token_timing(log.start.as_instant(), end_time.as_instant());
 			}
@@ -2154,6 +2163,29 @@ mod tests {
 		)
 	}
 
+	fn test_llm_info(convention: llm::CacheTokenConvention, input_tokens: u64) -> llm::LLMInfo {
+		llm::LLMInfo::new(
+			llm::LLMRequest {
+				input_tokens: None,
+				input_format: InputFormat::Messages,
+				cache_convention: convention,
+				request_model: strng::literal!("test-model"),
+				provider: strng::literal!("test-provider"),
+				streaming: true,
+				params: Default::default(),
+				prompt: None,
+				provider_state: None,
+			},
+			llm::LLMResponse {
+				input_tokens: Some(input_tokens),
+				cached_input_tokens: Some(81_408),
+				output_tokens: Some(231),
+				total_tokens: Some(input_tokens + 231),
+				..Default::default()
+			},
+		)
+	}
+
 	fn test_request_log() -> RequestLog {
 		let cel = CelLogging {
 			cel_context: crate::cel::ContextBuilder::new(),
@@ -2178,6 +2210,26 @@ mod tests {
 				raw_peer_addr: None,
 			},
 		)
+	}
+
+	#[test]
+	fn logging_context_normalizes_cache_conventions() {
+		let catalog = ModelCatalog::empty();
+		let openai = llm_context_for_logging(
+			test_llm_info(llm::CacheTokenConvention::InputIncludesCache, 82_846),
+			catalog.as_ref(),
+		);
+		let anthropic = llm_context_for_logging(
+			test_llm_info(llm::CacheTokenConvention::InputExcludesCache, 1_438),
+			catalog.as_ref(),
+		);
+
+		for context in [openai, anthropic] {
+			assert_eq!(context.input_tokens, Some(1_438));
+			assert_eq!(context.cached_input_tokens, Some(81_408));
+			assert_eq!(context.output_tokens, Some(231));
+			assert_eq!(context.total_tokens, Some(83_077));
+		}
 	}
 
 	#[test]

--- a/crates/llm/src/conversion/completions.rs
+++ b/crates/llm/src/conversion/completions.rs
@@ -144,11 +144,39 @@ pub mod from_messages {
 		serde_json::to_vec(&xlated).map_err(AIError::RequestMarshal)
 	}
 
+	struct TranslatedResponse {
+		provider: types::completions::Response,
+		client: messages::MessagesResponse,
+	}
+
+	impl ResponseType for TranslatedResponse {
+		fn to_llm_response(&self, include_completion_in_log: bool) -> crate::LLMResponse {
+			self.provider.to_llm_response(include_completion_in_log)
+		}
+
+		fn to_webhook_choices(&self) -> Vec<crate::webhook::ResponseChoice> {
+			self.client.to_webhook_choices()
+		}
+
+		fn set_webhook_choices(
+			&mut self,
+			resp: Vec<crate::webhook::ResponseChoice>,
+		) -> anyhow::Result<()> {
+			self.client.set_webhook_choices(resp)
+		}
+
+		fn serialize(&self) -> serde_json::Result<Vec<u8>> {
+			self.client.serialize()
+		}
+	}
+
 	pub fn translate_response(bytes: &Bytes) -> Result<Box<dyn ResponseType>, AIError> {
-		let resp = serde_json::from_slice::<completions::Response>(bytes)
+		let provider = serde_json::from_slice::<types::completions::Response>(bytes)
 			.map_err(logged_response_parsing(bytes))?;
-		let anthropic = translate_response_internal(resp)?;
-		Ok(Box::new(anthropic))
+		let typed = serde_json::from_slice::<completions::Response>(bytes)
+			.map_err(logged_response_parsing(bytes))?;
+		let client = translate_response_internal(typed)?;
+		Ok(Box::new(TranslatedResponse { provider, client }))
 	}
 
 	fn translate_response_internal(
@@ -213,14 +241,33 @@ pub mod from_messages {
 			usage: messages::Usage {
 				input_tokens: usage
 					.as_ref()
-					.map(|u| u.prompt_tokens as usize)
+					.map(|u| {
+						let cached = u
+							.prompt_tokens_details
+							.as_ref()
+							.and_then(|d| d.cached_tokens)
+							.or(u.cache_read_input_tokens)
+							.unwrap_or(0);
+						(u.prompt_tokens as u64).saturating_sub(cached) as usize
+					})
 					.unwrap_or(0),
 				output_tokens: usage
 					.as_ref()
 					.map(|u| u.completion_tokens as usize)
 					.unwrap_or(0),
-				cache_creation_input_tokens: None,
-				cache_read_input_tokens: None,
+				cache_creation_input_tokens: usage
+					.as_ref()
+					.and_then(|u| u.cache_creation_input_tokens)
+					.map(|v| v as usize),
+				cache_read_input_tokens: usage
+					.as_ref()
+					.and_then(|u| {
+						u.prompt_tokens_details
+							.as_ref()
+							.and_then(|d| d.cached_tokens)
+							.or(u.cache_read_input_tokens)
+					})
+					.map(|v| v as usize),
 				service_tier,
 			},
 			input_audio_tokens: usage.as_ref().and_then(|u| {
@@ -402,10 +449,23 @@ pub mod from_messages {
 			close_text_block(state, events);
 			close_all_tool_blocks(state, events);
 
-			let (input_tokens, output_tokens) = usage
-				.as_ref()
-				.map(|u| (u.prompt_tokens as usize, u.completion_tokens as usize))
-				.unwrap_or((0, 0));
+			let (input_tokens, output_tokens, cache_read_input_tokens, cache_creation_input_tokens) =
+				usage
+					.as_ref()
+					.map(|u| {
+						let cached = u
+							.prompt_tokens_details
+							.as_ref()
+							.and_then(|d| d.cached_tokens)
+							.or(u.cache_read_input_tokens);
+						(
+							(u.prompt_tokens as u64).saturating_sub(cached.unwrap_or(0)) as usize,
+							u.completion_tokens as usize,
+							cached.map(|v| v as usize),
+							u.cache_creation_input_tokens.map(|v| v as usize),
+						)
+					})
+					.unwrap_or((0, 0, None, None));
 
 			push_event(
 				events,
@@ -417,8 +477,8 @@ pub mod from_messages {
 					usage: messages::MessageDeltaUsage {
 						input_tokens: Some(input_tokens),
 						output_tokens: Some(output_tokens),
-						cache_creation_input_tokens: None,
-						cache_read_input_tokens: None,
+						cache_creation_input_tokens,
+						cache_read_input_tokens,
 					},
 				},
 			);
@@ -430,6 +490,16 @@ pub mod from_messages {
 					r.response.input_tokens = Some(usage.prompt_tokens as u64);
 					r.response.output_tokens = Some(usage.completion_tokens as u64);
 					r.response.total_tokens = Some(usage.total_tokens as u64);
+					r.response.cached_input_tokens = usage
+						.prompt_tokens_details
+						.as_ref()
+						.and_then(|d| d.cached_tokens)
+						.or(usage.cache_read_input_tokens);
+					r.response.cache_creation_input_tokens = usage.cache_creation_input_tokens;
+					r.response.reasoning_tokens = usage
+						.completion_tokens_details
+						.as_ref()
+						.and_then(|d| d.reasoning_tokens);
 				});
 			}
 		}
@@ -952,6 +1022,79 @@ pub mod from_messages {
 			service_tier: None,
 			parallel_tool_calls,
 			web_search_options: None,
+		}
+	}
+
+	#[cfg(test)]
+	mod tests {
+		use std::sync::{Arc, Mutex};
+
+		use agent_core::strng;
+		use http_body_util::BodyExt;
+
+		use super::*;
+		use crate::{
+			CacheTokenConvention, InputFormat, LLMInfo, LLMRequest, LLMResponse, StreamingUsageReporter,
+		};
+
+		struct TestReporter(Arc<Mutex<LLMInfo>>);
+
+		impl StreamingUsageReporter for TestReporter {
+			fn update(&self, f: &mut dyn FnMut(&mut LLMInfo)) {
+				f(&mut self.0.lock().unwrap());
+			}
+
+			fn report_usage(&mut self) {}
+		}
+
+		fn test_usage_guard() -> (StreamingUsageGuard, Arc<Mutex<LLMInfo>>) {
+			let info = Arc::new(Mutex::new(LLMInfo::new(
+				LLMRequest {
+					input_tokens: None,
+					input_format: InputFormat::Messages,
+					cache_convention: CacheTokenConvention::InputIncludesCache,
+					request_model: strng::new("test-model"),
+					provider: strng::new("test-provider"),
+					streaming: true,
+					params: Default::default(),
+					prompt: None,
+					provider_state: None,
+				},
+				LLMResponse::default(),
+			)));
+			(
+				StreamingUsageGuard::new(Box::new(TestReporter(info.clone()))),
+				info,
+			)
+		}
+
+		#[tokio::test]
+		async fn translate_stream_preserves_cached_and_reasoning_tokens() {
+			let input = r#"data: {"id":"chatcmpl_1","object":"chat.completion.chunk","created":1,"model":"test-model","choices":[{"index":0,"delta":{"role":"assistant","content":"ok"},"finish_reason":null}],"usage":null}
+
+data: {"id":"chatcmpl_1","object":"chat.completion.chunk","created":1,"model":"test-model","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":null}
+
+data: {"id":"chatcmpl_1","object":"chat.completion.chunk","created":1,"model":"test-model","choices":[],"usage":{"prompt_tokens":250000,"completion_tokens":258,"total_tokens":250258,"prompt_tokens_details":{"cached_tokens":246272},"completion_tokens_details":{"reasoning_tokens":200}}}
+
+data: [DONE]
+
+"#;
+			let (guard, info) = test_usage_guard();
+			let output = translate_stream(Body::from(input), 1024 * 1024, guard)
+				.collect()
+				.await
+				.unwrap()
+				.to_bytes();
+			let output = String::from_utf8(output.to_vec()).unwrap();
+
+			assert!(output.contains("\"input_tokens\":3728"));
+			assert!(output.contains("\"cache_read_input_tokens\":246272"));
+			let response = &info.lock().unwrap().response;
+			assert_eq!(response.input_tokens, Some(250_000));
+			assert_eq!(response.cached_input_tokens, Some(246_272));
+			assert_eq!(response.output_tokens, Some(258));
+			assert_eq!(response.reasoning_tokens, Some(200));
+			assert_eq!(response.total_tokens, Some(250_258));
 		}
 	}
 }

--- a/crates/llm/src/conversion/messages.rs
+++ b/crates/llm/src/conversion/messages.rs
@@ -796,6 +796,9 @@ pub fn passthrough_stream(
 			},
 			messages::MessagesStreamEvent::MessageDelta { usage, delta: _ } => {
 				log.update(|r| {
+					if let Some(i) = usage.input_tokens {
+						r.response.input_tokens = Some(i as u64);
+					}
 					if let Some(o) = usage.output_tokens {
 						r.response.output_tokens = Some(o as u64);
 					}
@@ -821,4 +824,72 @@ pub fn passthrough_stream(
 			| messages::MessagesStreamEvent::Ping => {},
 		}
 	})
+}
+
+#[cfg(test)]
+mod tests {
+	use std::sync::{Arc, Mutex};
+
+	use agent_core::strng;
+	use http_body_util::BodyExt;
+
+	use super::*;
+	use crate::{
+		CacheTokenConvention, InputFormat, LLMInfo, LLMRequest, LLMResponse, StreamingUsageReporter,
+	};
+
+	struct TestReporter(Arc<Mutex<LLMInfo>>);
+
+	impl StreamingUsageReporter for TestReporter {
+		fn update(&self, f: &mut dyn FnMut(&mut LLMInfo)) {
+			f(&mut self.0.lock().unwrap());
+		}
+
+		fn report_usage(&mut self) {}
+	}
+
+	fn test_usage_guard() -> (StreamingUsageGuard, Arc<Mutex<LLMInfo>>) {
+		let info = Arc::new(Mutex::new(LLMInfo::new(
+			LLMRequest {
+				input_tokens: None,
+				input_format: InputFormat::Messages,
+				cache_convention: CacheTokenConvention::InputExcludesCache,
+				request_model: strng::new("test-model"),
+				provider: strng::new("test-provider"),
+				streaming: true,
+				params: Default::default(),
+				prompt: None,
+				provider_state: None,
+			},
+			LLMResponse::default(),
+		)));
+		(
+			StreamingUsageGuard::new(Box::new(TestReporter(info.clone()))),
+			info,
+		)
+	}
+
+	#[tokio::test]
+	async fn passthrough_stream_uses_final_input_tokens() {
+		let input = r#"event: message_start
+data: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","content":[],"model":"test-model","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":0,"output_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":16910,"output_tokens":13,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}
+
+event: message_stop
+data: {"type":"message_stop"}
+
+"#;
+		let (guard, info) = test_usage_guard();
+		passthrough_stream(Body::from(input), 1024 * 1024, guard, false)
+			.collect()
+			.await
+			.unwrap();
+
+		let response = &info.lock().unwrap().response;
+		assert_eq!(response.input_tokens, Some(16_910));
+		assert_eq!(response.output_tokens, Some(13));
+		assert_eq!(response.total_tokens, Some(16_923));
+	}
 }

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -227,6 +227,35 @@ impl LLMInfo {
 	pub fn input_tokens(&self) -> Option<u64> {
 		self.response.input_tokens.or(self.request.input_tokens)
 	}
+
+	/// Returns input tokens using a provider-independent telemetry convention:
+	/// cached input is reported separately and is not included in this value.
+	pub fn telemetry_input_tokens(&self) -> Option<u64> {
+		let input = self.input_tokens()?;
+		Some(match self.request.cache_convention {
+			CacheTokenConvention::InputIncludesCache => {
+				input.saturating_sub(self.response.cached_input_tokens.unwrap_or(0))
+			},
+			CacheTokenConvention::InputExcludesCache => input,
+		})
+	}
+
+	/// Returns total tokens using the same provider-independent convention as
+	/// [`Self::telemetry_input_tokens`].
+	pub fn telemetry_total_tokens(&self) -> Option<u64> {
+		let Some(input) = self.telemetry_input_tokens() else {
+			return self.response.total_tokens;
+		};
+		let Some(output) = self.response.output_tokens else {
+			return self.response.total_tokens;
+		};
+		Some(
+			input
+				.saturating_add(self.response.cached_input_tokens.unwrap_or(0))
+				.saturating_add(self.response.cache_creation_input_tokens.unwrap_or(0))
+				.saturating_add(output),
+		)
+	}
 }
 
 #[derive(Debug, Clone, Default, serde::Serialize)]
@@ -300,6 +329,107 @@ impl Default for StreamingUsageGuard {
 		}
 
 		Self::new(Box::new(NoopReporter))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn usage(
+		convention: CacheTokenConvention,
+		input: Option<u64>,
+		cache_read: Option<u64>,
+		cache_write: Option<u64>,
+		output: Option<u64>,
+		total: Option<u64>,
+	) -> LLMInfo {
+		LLMInfo::new(
+			LLMRequest {
+				input_tokens: None,
+				input_format: InputFormat::Messages,
+				cache_convention: convention,
+				request_model: Strng::default(),
+				provider: Strng::default(),
+				streaming: false,
+				params: Default::default(),
+				prompt: None,
+				provider_state: None,
+			},
+			LLMResponse {
+				input_tokens: input,
+				cached_input_tokens: cache_read,
+				cache_creation_input_tokens: cache_write,
+				output_tokens: output,
+				total_tokens: total,
+				..Default::default()
+			},
+		)
+	}
+
+	#[test]
+	fn telemetry_usage_normalizes_cache_conventions() {
+		let openai = usage(
+			CacheTokenConvention::InputIncludesCache,
+			Some(82_846),
+			Some(81_408),
+			None,
+			Some(231),
+			Some(83_077),
+		);
+		let anthropic = usage(
+			CacheTokenConvention::InputExcludesCache,
+			Some(1_438),
+			Some(81_408),
+			None,
+			Some(231),
+			Some(1_669),
+		);
+
+		for info in [openai, anthropic] {
+			assert_eq!(info.telemetry_input_tokens(), Some(1_438));
+			assert_eq!(info.telemetry_total_tokens(), Some(83_077));
+		}
+	}
+
+	#[test]
+	fn telemetry_usage_includes_cache_creation_in_total() {
+		let info = usage(
+			CacheTokenConvention::InputExcludesCache,
+			Some(1_000),
+			Some(300),
+			Some(200),
+			Some(500),
+			Some(1_500),
+		);
+
+		assert_eq!(info.telemetry_input_tokens(), Some(1_000));
+		assert_eq!(info.telemetry_total_tokens(), Some(2_000));
+	}
+
+	#[test]
+	fn telemetry_usage_handles_partial_and_invalid_usage() {
+		let partial = usage(
+			CacheTokenConvention::InputIncludesCache,
+			Some(1_000),
+			Some(300),
+			None,
+			None,
+			Some(1_500),
+		);
+		assert_eq!(partial.telemetry_input_tokens(), Some(700));
+		assert_eq!(partial.telemetry_total_tokens(), Some(1_500));
+
+		let invalid = usage(
+			CacheTokenConvention::InputIncludesCache,
+			Some(100),
+			Some(300),
+			None,
+			Some(50),
+			Some(150),
+		);
+		assert_eq!(invalid.telemetry_input_tokens(), Some(0));
+		assert_eq!(invalid.telemetry_total_tokens(), Some(350));
 	}
 }
 

--- a/crates/llm/src/tests/response/completions/audio.completions-messages.snap
+++ b/crates/llm/src/tests/response/completions/audio.completions-messages.snap
@@ -50,8 +50,9 @@ info:
     "stop_reason": "end_turn",
     "stop_sequence": null,
     "usage": {
-      "input_tokens": 320,
+      "input_tokens": 308,
       "output_tokens": 180,
+      "cache_read_input_tokens": 12,
       "service_tier": "default"
     }
   },
@@ -61,6 +62,8 @@ info:
     "output_tokens": 180,
     "output_audio_tokens": 90,
     "total_tokens": 500,
+    "reasoning_tokens": 15,
+    "cached_input_tokens": 12,
     "service_tier": "default",
     "provider_model": "gpt-4o-audio-preview"
   }

--- a/crates/llm/src/tests/response/completions/basic.completions-messages.snap
+++ b/crates/llm/src/tests/response/completions/basic.completions-messages.snap
@@ -47,6 +47,7 @@ info:
     "usage": {
       "input_tokens": 17,
       "output_tokens": 23,
+      "cache_read_input_tokens": 0,
       "service_tier": "default"
     }
   },
@@ -56,6 +57,8 @@ info:
     "output_tokens": 23,
     "output_audio_tokens": 0,
     "total_tokens": 40,
+    "reasoning_tokens": 0,
+    "cached_input_tokens": 0,
     "service_tier": "default",
     "provider_model": "gpt-3.5-turbo-0125"
   }

--- a/crates/llm/src/tests/response/completions/gemini_with_completion_tokens.completions-messages.snap
+++ b/crates/llm/src/tests/response/completions/gemini_with_completion_tokens.completions-messages.snap
@@ -39,7 +39,7 @@ info:
   "parsed": {
     "input_tokens": 7,
     "output_tokens": 12,
-    "total_tokens": 19,
+    "total_tokens": 402,
     "provider_model": "gemini-2.5-flash"
   }
 }

--- a/crates/llm/src/tests/response/completions/gemini_zero_completion_tokens.completions-messages.snap
+++ b/crates/llm/src/tests/response/completions/gemini_zero_completion_tokens.completions-messages.snap
@@ -33,7 +33,7 @@ info:
   "parsed": {
     "input_tokens": 7,
     "output_tokens": 0,
-    "total_tokens": 7,
+    "total_tokens": 8,
     "provider_model": "gemini-2.5-flash"
   }
 }

--- a/ui/src/pages/Logs.tsx
+++ b/ui/src/pages/Logs.tsx
@@ -1398,7 +1398,7 @@ function LogTimingPanel(props: { entry: LogEntry }) {
         <TokenBar
           input={inputTokens!}
           output={outputTokens!}
-          cache={cacheReadTokens ?? undefined}
+          cache={(cacheReadTokens ?? 0) + (cacheWriteTokens ?? 0)}
         />
       ) : null}
       <div className="log-fact-list">
@@ -1821,6 +1821,7 @@ function TokenSummary(props: { entry: LogEntry }) {
   const input = props.entry.usage.inputTokens;
   const output = props.entry.usage.outputTokens;
   const cache = attributeNumber(props.entry.attributes, [
+    "gen_ai.usage.cache_read.input_tokens",
     "cacheTokens",
     "cachedTokens",
     "cache_tokens",

--- a/ui/tests/e2e/fixtures.ts
+++ b/ui/tests/e2e/fixtures.ts
@@ -291,9 +291,12 @@ export async function mockGateway(
             responseModel: "claude-haiku-4-5",
           },
           usage: {
-            inputTokens: 12,
-            outputTokens: 18,
-            totalTokens: 30,
+            inputTokens: 1438,
+            outputTokens: 231,
+            totalTokens: 83077,
+          },
+          attributes: {
+            "gen_ai.usage.cache_read.input_tokens": 81408,
           },
           cost: 0.0005,
           hasPayload: true,
@@ -320,9 +323,12 @@ export async function mockGateway(
           responseModel: "claude-haiku-4-5",
         },
         usage: {
-          inputTokens: 12,
-          outputTokens: 18,
-          totalTokens: 30,
+          inputTokens: 1438,
+          outputTokens: 231,
+          totalTokens: 83077,
+        },
+        attributes: {
+          "gen_ai.usage.cache_read.input_tokens": 81408,
         },
         cost: 0.0005,
         hasPayload: true,

--- a/ui/tests/e2e/ui.spec.ts
+++ b/ui/tests/e2e/ui.spec.ts
@@ -41,6 +41,37 @@ test("core pages render with mocked gateway data", async ({ page }) => {
   }
 });
 
+test("logs display cache tokens as a separate usage bucket", async ({
+  page,
+}) => {
+  await mockGateway(page);
+  await page.goto("/llm/logs");
+
+  const summary = page.locator(".log-call-summary");
+  await expect(summary).toBeVisible();
+  await expect(summary.locator(".token-tooltip")).toContainText(
+    "in: 1,438\nout: 231\ncache: 81,408\ntotal: 83,077",
+  );
+
+  await summary.click();
+  const timing = page.locator(".log-debug-panel", {
+    has: page.getByRole("heading", { name: "Timing and usage" }),
+  });
+  await expect(timing).toContainText("1,438 tokens");
+  await expect(timing).toContainText("81,408 tokens");
+  await expect(timing).toContainText("83,077 tokens");
+
+  const widths = await timing
+    .locator(".token-bar")
+    .evaluate((bar) =>
+      Array.from(bar.children).map((child) =>
+        Number.parseFloat((child as HTMLElement).style.width),
+      ),
+    );
+  expect(widths.reduce((sum, width) => sum + width, 0)).toBeCloseTo(100);
+  expect(widths[2]).toBeGreaterThan(95);
+});
+
 test("onboards all surfaces from a completely empty config", async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary

- preserve final Anthropic streaming input usage and OpenAI-compatible cache/reasoning usage during response translation
- normalize telemetry input tokens to exclude cache reads across provider wire formats while keeping cache read/write as separate buckets
- compute telemetry totals from uncached input, cache read, cache write, and output tokens
- display the normalized usage consistently in stored logs, analytics, the log tooltip, detail panel, and token bar

## Problem

Provider usage conventions differ:

- OpenAI-compatible `prompt_tokens` generally includes cached tokens
- Anthropic `input_tokens` excludes `cache_read_input_tokens` and `cache_creation_input_tokens`

Persisting those provider-native values directly made `input_tokens` and `total_tokens` incomparable across providers. Anthropic streaming responses could also report the final input count only in `message_delta`, and OpenAI-to-Anthropic conversion omitted cache usage from the client-facing response.

## Behavior

Telemetry and stored logs now use independent buckets:

- `input_tokens`: uncached input only
- cache read/write: reported separately
- `total_tokens`: uncached input + cache read + cache write + output

Provider-native usage remains intact for protocol conversion and model cost calculation. Existing stored rows are not migrated; newly written logs use the normalized convention.

## Testing

- `make lint`
- `make test`
- `make generate-schema`
- `git diff --check`
- UI schema generation, TypeScript typecheck, and Prettier check
- focused Playwright test: `logs display cache tokens as a separate usage bucket`
- release build with embedded UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
