### PR TITLE
examples: use buffered semantic routing ExtProc

### DIFF
--- a/examples/llm-semantic-routing/README.md
+++ b/examples/llm-semantic-routing/README.md
@@ -9,6 +9,9 @@ The included policy is tuned for coding prompts: routine implementation,
 refactoring, unit tests, documentation, and simple debugging go to
 `gpt-5.4-nano`. It escalates advanced distributed-systems design, formal
 verification, difficult debugging, and research synthesis to `gpt-5.5`.
+Its advanced keyword signal uses literal high-specificity phrases, while the
+remaining semantic, complexity, context, and structure signals handle less
+obvious requests.
 Customize the signals, candidates, weights, and thresholds for your traffic by
 following the [vLLM Semantic Router configuration guide](https://vllm-semantic-router.com/docs/installation/configuration/).
 

--- a/examples/llm-semantic-routing/README.md
+++ b/examples/llm-semantic-routing/README.md
@@ -47,7 +47,7 @@ kubectl wait --for=condition=Available deployment/semantic-router \
   --timeout=600s
 ```
 
-Apply the routed backend, route, and Streamed ExtProc policy:
+Apply the routed backend, route, and buffered ExtProc policy:
 
 ```bash
 kubectl apply -f examples/llm-semantic-routing/k8s/agentgateway-routing.yaml
@@ -62,7 +62,7 @@ kubectl describe agentgatewaypolicy semantic-router-extproc -n agentgateway-syst
 `VSR_VERSION` sets both the chart version and the matching `v<version>`
 `extproc` image tag.
 
-## Verify Streamed ExtProc
+## Run a Request
 
 Set your gateway address:
 
@@ -71,29 +71,6 @@ export INGRESS_GW_ADDRESS="http://$(kubectl get gateway agentgateway-proxy \
   -n agentgateway-system \
   -o jsonpath='{.status.addresses[0].value}')"
 ```
-
-The values include a narrow, deterministic immediate-response probe. It proves
-that `FullDuplexStreamed` request processing reaches vSR without sending tokens
-to OpenAI:
-
-```bash
-curl -i "$INGRESS_GW_ADDRESS/v1/chat/completions" \
-  -H "Content-Type: application/json" \
-  -H "X-VSR-Debug: true" \
-  -d '{
-    "model": "auto",
-    "messages": [
-      {"role": "user", "content": "VSR_IMMEDIATE_RESPONSE_PROBE"}
-    ],
-    "max_tokens": 16
-  }'
-```
-
-Expect a `200` response with `x-vsr-fast-response`; the request should not
-reach OpenAI. Remove the probe signal and decision from the values before using
-this policy in a production route.
-
-## Run a Request
 
 Routine coding prompts should use the lower-cost model:
 

--- a/examples/llm-semantic-routing/README.md
+++ b/examples/llm-semantic-routing/README.md
@@ -65,6 +65,12 @@ kubectl describe agentgatewaypolicy semantic-router-extproc -n agentgateway-syst
 `VSR_VERSION` sets both the chart version and the matching `v<version>`
 `extproc` image tag.
 
+> **Note:** This example uses buffered ExtProc while the streamed-body issue in
+> [vLLM Semantic Router #2486](https://github.com/vllm-project/semantic-router/issues/2486)
+> is unresolved. When that issue is fixed and this example is returned to
+> streamed mode, restore the `Verify Streamed ExtProc` section and its
+> deterministic immediate-response probe.
+
 ## Run a Request
 
 Set your gateway address:

--- a/examples/llm-semantic-routing/k8s/agentgateway-routing.yaml
+++ b/examples/llm-semantic-routing/k8s/agentgateway-routing.yaml
@@ -59,9 +59,7 @@ spec:
         port: 50051
       processingOptions:
         requestHeaderMode: Send
-        requestBodyMode: FullDuplexStreamed
+        requestBodyMode: Buffered
         responseHeaderMode: Send
         responseBodyMode: Buffered
-        requestTrailerMode: Send
-        responseTrailerMode: Send
         allowModeOverride: true

--- a/examples/llm-semantic-routing/k8s/semantic-router-values.yaml
+++ b/examples/llm-semantic-routing/k8s/semantic-router-values.yaml
@@ -30,8 +30,15 @@ config:
   providers:
     defaults:
       default_model: gpt-5.4-nano
+      # Preserve OpenAI's top-level reasoning_effort request parameter when
+      # vSR rewrites model:auto to either configured model.
+      reasoning_families:
+        gpt:
+          type: reasoning_effort
+          parameter: reasoning_effort
     models:
     - name: gpt-5.4-nano
+      reasoning_family: gpt
       provider_model_id: gpt-5.4-nano
       api_format: openai
       pricing:
@@ -43,10 +50,11 @@ config:
         openai: gpt-5.4-nano
       backend_refs:
       - name: agentgateway-openai
-        endpoint: api.openai.com:443
-        protocol: https
+        base_url: https://api.openai.com/v1
+        provider: openai
         weight: 100
     - name: gpt-5.5
+      reasoning_family: gpt
       provider_model_id: gpt-5.5
       api_format: openai
       pricing:
@@ -58,8 +66,8 @@ config:
         openai: gpt-5.5
       backend_refs:
       - name: agentgateway-openai
-        endpoint: api.openai.com:443
-        protocol: https
+        base_url: https://api.openai.com/v1
+        provider: openai
         weight: 100
 
   routing:

--- a/examples/llm-semantic-routing/k8s/semantic-router-values.yaml
+++ b/examples/llm-semantic-routing/k8s/semantic-router-values.yaml
@@ -3,6 +3,10 @@ router:
   skipProcessing:
     enabled: true
 
+# The model runtime is configured below. Do not inherit the chart's qwen3
+# embedding override, which conflicts with the configured mmbert model.
+env: []
+
 args:
 - --secure=false
 

--- a/examples/llm-semantic-routing/k8s/semantic-router-values.yaml
+++ b/examples/llm-semantic-routing/k8s/semantic-router-values.yaml
@@ -85,14 +85,6 @@ config:
       # avoid inheriting the chart's general-purpose domain defaults.
       domains: []
       keywords:
-      - name: immediate_response_probe
-        operator: OR
-        method: ngram
-        keywords:
-        - VSR_IMMEDIATE_RESPONSE_PROBE
-        case_sensitive: true
-        ngram_threshold: 0.95
-        ngram_arity: 3
       - name: advanced_markers
         operator: OR
         method: bm25
@@ -275,20 +267,7 @@ config:
         - name: expensive_lane
           gte: 0.35
 
-    # The immediate probe verifies ExtProc; the remaining decisions route traffic.
     decisions:
-    - name: immediate_response_probe
-      description: Deterministic immediate response used only to verify streamed ExtProc short-circuit behavior.
-      priority: 1000
-      rules:
-        operator: AND
-        conditions:
-        - type: keyword
-          name: immediate_response_probe
-      plugins:
-      - type: fast_response
-        configuration:
-          message: Semantic Router immediate response probe matched before the request reached the upstream model.
     - name: route_to_expensive
       description: Escalate advanced distributed systems, formal verification, hard debugging, and research synthesis.
       priority: 200
@@ -319,9 +298,7 @@ config:
       auto_model_name: auto
       strategy: priority
       streamed_body:
-        enabled: true
-        max_bytes: 10485760
-        timeout_sec: 30
+        enabled: false
       skip_processing:
         enabled: true
     services:

--- a/examples/llm-semantic-routing/k8s/semantic-router-values.yaml
+++ b/examples/llm-semantic-routing/k8s/semantic-router-values.yaml
@@ -77,6 +77,9 @@ config:
       tags: [premium, expensive, deep-reasoning]
 
     signals:
+      # This coding policy does not use domain signals. Set an empty list to
+      # avoid inheriting the chart's general-purpose domain defaults.
+      domains: []
       keywords:
       - name: immediate_response_probe
         operator: OR

--- a/examples/llm-semantic-routing/k8s/semantic-router-values.yaml
+++ b/examples/llm-semantic-routing/k8s/semantic-router-values.yaml
@@ -87,12 +87,13 @@ config:
       keywords:
       - name: advanced_markers
         operator: OR
-        method: bm25
-        # Prefer high-specificity multi-word cues. Routine coding follow-ups
-        # should not escalate merely because the conversation mentions tests,
-        # errors, or a generic implementation detail.
+        # Leave method unset to use literal, word-boundary-aware matching.
+        # BM25 topic matching over-escalates routine coding follow-ups that
+        # merely resemble advanced work. The phrases below are deliberate,
+        # high-specificity escalation cues.
         keywords:
         - distributed systems
+        - distributed rate limiter
         - consensus
         - raft
         - paxos
@@ -119,9 +120,11 @@ config:
         - durable idempotency
         - idempotency boundary
         - fencing token
+        - fencing tokens
         - stale writer
         - regional failover
         - network partition
+        - network partitions
         - replicated state
         - exactly-once
         - at-least-once
@@ -131,8 +134,14 @@ config:
         - operational transform
         - conflict resolution
         - compare tradeoffs
+        - dual writes
+        - durable state transition
+        - duplicate business effects
+        - configuration replicas
+        - eventual-consistency
+        - leased message
+        - delayed, duplicated, and reordered
         case_sensitive: false
-        bm25_threshold: 0.3
       - name: routine_coding_markers
         operator: OR
         method: bm25

--- a/examples/llm-semantic-routing/k8s/semantic-router-values.yaml
+++ b/examples/llm-semantic-routing/k8s/semantic-router-values.yaml
@@ -88,6 +88,9 @@ config:
       - name: advanced_markers
         operator: OR
         method: bm25
+        # Prefer high-specificity multi-word cues. Routine coding follow-ups
+        # should not escalate merely because the conversation mentions tests,
+        # errors, or a generic implementation detail.
         keywords:
         - distributed systems
         - consensus
@@ -101,26 +104,35 @@ config:
         - Alloy
         - Coq
         - Lean
-        - invariant
-        - proof
-        - prove
+        - safety invariant
+        - liveness invariant
+        - proof obligation
+        - counterexample
         - convergence
         - monotonicity
         - temporal logic
-        - advanced debugging
         - root cause
         - heisenbug
         - deadlock
         - race condition
         - memory ordering
+        - durable idempotency
+        - idempotency boundary
+        - fencing token
+        - stale writer
+        - regional failover
+        - network partition
+        - replicated state
+        - exactly-once
+        - at-least-once
+        - bounded staleness
         - research synthesis
-        - synthesize
         - literature review
         - operational transform
         - conflict resolution
         - compare tradeoffs
         case_sensitive: false
-        bm25_threshold: 0.1
+        bm25_threshold: 0.3
       - name: routine_coding_markers
         operator: OR
         method: bm25


### PR DESCRIPTION
## Summary
- configure the semantic-routing example for buffered ExtProc request and response bodies
- keep its coding signals focused on literal advanced-work cues
- preserve OpenAI reasoning request parameters when vSR rewrites `model: auto`

## Validation
- `helm template` with the v0.3.0 semantic-router chart
- full kind-based semantic-routing demo with catalog-backed metrics, logs, and traces