### PR TITLE
controller: update the cost catalog configmap loading

### DIFF
--- a/controller/pkg/helm/agentgateway/templates/_helpers.tpl
+++ b/controller/pkg/helm/agentgateway/templates/_helpers.tpl
@@ -262,7 +262,7 @@ spec:
       {{- $catalogPaths := list }}
       {{- range ($gateway.modelCatalog).sources }}
       {{- if .configMap }}
-      {{- $catalogPaths = append $catalogPaths (printf "/etc/agentgateway/model-catalog/%s.json" .configMap.name) }}
+      {{- $catalogPaths = append $catalogPaths (printf "/etc/agentgateway/model-catalog/%s/%s.json" .configMap.name .configMap.name) }}
       {{- end }}
       {{- end }}
       {{- if $catalogPaths }}
@@ -300,8 +300,7 @@ spec:
         {{- range ($gateway.modelCatalog).sources }}
         {{- if .configMap }}
         - name: model-catalog-{{ .configMap.name }}
-          mountPath: /etc/agentgateway/model-catalog/{{ .configMap.name }}.json
-          subPath: {{ .configMap.name }}.json
+          mountPath: /etc/agentgateway/model-catalog/{{ .configMap.name }}
           readOnly: true
         {{- end }}
         {{- end }}

--- a/controller/test/deployer/internal_helm_test.go
+++ b/controller/test/deployer/internal_helm_test.go
@@ -576,10 +576,12 @@ wIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQBtestcertdata
 				t.Helper()
 				assert.Contains(t, outputYaml, "MODEL_CATALOG_PATHS",
 					"deployment should set MODEL_CATALOG_PATHS to the mounted ConfigMap file path")
-				assert.Contains(t, outputYaml, "/etc/agentgateway/model-catalog/my-model-costs.json",
+				assert.Contains(t, outputYaml, "/etc/agentgateway/model-catalog/my-model-costs/my-model-costs.json",
 					"MODEL_CATALOG_PATHS should point to the ConfigMap mount path")
-				assert.Contains(t, outputYaml, "mountPath: /etc/agentgateway/model-catalog/my-model-costs.json",
-					"deployment should have a volume mount for the model catalog ConfigMap")
+				assert.Contains(t, outputYaml, "mountPath: /etc/agentgateway/model-catalog/my-model-costs",
+					"deployment should have a directory volume mount for the model catalog ConfigMap so kubelet's atomic symlink swap on update is visible")
+				assert.NotContains(t, outputYaml, "subPath: my-model-costs.json",
+					"model catalog ConfigMap must not be mounted via subPath, since subPath mounts never receive ConfigMap updates")
 				assert.Contains(t, outputYaml, "name: my-model-costs",
 					"deployment volumes should reference the model catalog ConfigMap by name")
 			},

--- a/controller/test/deployer/testdata/agentgateway-model-catalog-configmap-out.yaml
+++ b/controller/test/deployer/testdata/agentgateway-model-catalog-configmap-out.yaml
@@ -135,7 +135,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: MODEL_CATALOG_PATHS
-          value: /etc/agentgateway/model-catalog/my-model-costs.json
+          value: /etc/agentgateway/model-catalog/my-model-costs/my-model-costs.json
         image: cr.agentgateway.dev/agentgateway:99.99.99
         name: agentgateway
         ports:
@@ -175,10 +175,9 @@ spec:
         - mountPath: /var/run/secrets/xds-tokens
           name: xds-token
           readOnly: true
-        - mountPath: /etc/agentgateway/model-catalog/my-model-costs.json
+        - mountPath: /etc/agentgateway/model-catalog/my-model-costs
           name: model-catalog-my-model-costs
           readOnly: true
-          subPath: my-model-costs.json
       securityContext:
         sysctls:
         - name: net.ipv4.ip_unprivileged_port_start

--- a/controller/test/e2e/modelcatalog_test.go
+++ b/controller/test/e2e/modelcatalog_test.go
@@ -123,9 +123,6 @@ func TestModelCatalogCost(tt *testing.T) {
 			if err != nil {
 				return err
 			}
-			// The pre-patch sentinel-rate cost never leaves the log, so we can't compare
-			// against the max; instead look for any request logged below the ceiling,
-			// which is only possible once the reloaded (low-rate) catalog is in effect.
 			if !hasLoggedCostBelow(logs, minSentinelCost) {
 				return fmt.Errorf("no agw.ai.usage.cost.total below ceiling %v in gateway logs (ConfigMap update not yet reflected by running pod)", minSentinelCost)
 			}

--- a/controller/test/e2e/modelcatalog_test.go
+++ b/controller/test/e2e/modelcatalog_test.go
@@ -5,7 +5,7 @@ package e2e_test
 import (
 	"fmt"
 	"regexp"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -71,7 +71,7 @@ func TestModelCatalogCost(tt *testing.T) {
 			curl.WithHeader("Content-Type", "application/json"),
 		)
 		gomega.NewWithT(t).Eventually(func() error {
-			logs, err := gatewayAccessLogs(t, modelCatalogNamespace, modelCatalogGatewayName)
+			logs, err := gatewayAccessLogs(t, modelCatalogGatewayName)
 			if err != nil {
 				return err
 			}
@@ -95,10 +95,10 @@ func TestModelCatalogCost(tt *testing.T) {
 
 		g := gomega.NewWithT(t)
 
-		podsBefore, err := gatewayPodNames(t, modelCatalogNamespace, modelCatalogGatewayName)
+		podsBefore, err := gatewayPodNames(t, modelCatalogGatewayName)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
-		baseline, err := gatewayAccessLogs(t, modelCatalogNamespace, modelCatalogGatewayName)
+		baseline, err := gatewayAccessLogs(t, modelCatalogGatewayName)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 		baselineLen := len(baseline)
 
@@ -111,7 +111,7 @@ func TestModelCatalogCost(tt *testing.T) {
 				curl.WithPostBody(`{"messages": [{"role": "user", "content": "What is the name of this project?"}]}`),
 				curl.WithHeader("Content-Type", "application/json"),
 			)
-			logs, err := gatewayAccessLogs(t, modelCatalogNamespace, modelCatalogGatewayName)
+			logs, err := gatewayAccessLogs(t, modelCatalogGatewayName)
 			if err != nil {
 				return err
 			}
@@ -128,7 +128,7 @@ func TestModelCatalogCost(tt *testing.T) {
 			return nil
 		}).WithTimeout(45 * time.Second).WithPolling(2 * time.Second).Should(gomega.Succeed())
 
-		podsAfter, err := gatewayPodNames(t, modelCatalogNamespace, modelCatalogGatewayName)
+		podsAfter, err := gatewayPodNames(t, modelCatalogGatewayName)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 		g.Expect(podsAfter).To(gomega.Equal(podsBefore),
 			"gateway pod must not have restarted for the ConfigMap update to take effect")
@@ -151,7 +151,7 @@ func TestModelCatalogCost(tt *testing.T) {
 			curl.WithHeader("Content-Type", "application/json"),
 		)
 		gomega.NewWithT(t).Eventually(func() error {
-			logs, err := gatewayAccessLogs(t, modelCatalogNamespace, modelCatalogAltGatewayName)
+			logs, err := gatewayAccessLogs(t, modelCatalogAltGatewayName)
 			if err != nil {
 				return err
 			}
@@ -169,9 +169,9 @@ func TestModelCatalogCost(tt *testing.T) {
 
 // gatewayPodNames returns the sorted names of the running gateway pods, so callers
 // can assert that a ConfigMap update took effect without a pod restart/rollout.
-func gatewayPodNames(t base.Test, ns, gatewayName string) ([]string, error) {
+func gatewayPodNames(t base.Test, gatewayName string) ([]string, error) {
 	cluster := t.TestInstallation.ClusterContext
-	pods, err := cluster.Client.Kube().CoreV1().Pods(ns).List(t.Ctx, metav1.ListOptions{
+	pods, err := cluster.Client.Kube().CoreV1().Pods(modelCatalogNamespace).List(t.Ctx, metav1.ListOptions{
 		LabelSelector: "gateway.networking.k8s.io/gateway-name=" + gatewayName,
 	})
 	if err != nil {
@@ -181,24 +181,24 @@ func gatewayPodNames(t base.Test, ns, gatewayName string) ([]string, error) {
 	for _, pod := range pods.Items {
 		names = append(names, string(pod.UID))
 	}
-	sort.Strings(names)
+	slices.Sort(names)
 	return names, nil
 }
 
-func gatewayAccessLogs(t base.Test, ns, gatewayName string) (string, error) {
+func gatewayAccessLogs(t base.Test, gatewayName string) (string, error) {
 	cluster := t.TestInstallation.ClusterContext
-	pods, err := cluster.Client.Kube().CoreV1().Pods(ns).List(t.Ctx, metav1.ListOptions{
+	pods, err := cluster.Client.Kube().CoreV1().Pods(modelCatalogNamespace).List(t.Ctx, metav1.ListOptions{
 		LabelSelector: "gateway.networking.k8s.io/gateway-name=" + gatewayName,
 	})
 	if err != nil {
 		return "", err
 	}
 	if len(pods.Items) == 0 {
-		return "", fmt.Errorf("no gateway pods found for %s/%s", ns, gatewayName)
+		return "", fmt.Errorf("no gateway pods found for %s/%s", modelCatalogNamespace, gatewayName)
 	}
 	var sb strings.Builder
 	for _, pod := range pods.Items {
-		logs, err := cluster.Client.PodLogs(t.Ctx, pod.Name, ns, "agentgateway", false)
+		logs, err := cluster.Client.PodLogs(t.Ctx, pod.Name, modelCatalogNamespace, "agentgateway", false)
 		if err != nil {
 			return "", fmt.Errorf("failed to read logs for pod %s: %w", pod.Name, err)
 		}

--- a/controller/test/e2e/modelcatalog_test.go
+++ b/controller/test/e2e/modelcatalog_test.go
@@ -5,6 +5,7 @@ package e2e_test
 import (
 	"fmt"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -19,8 +20,9 @@ import (
 )
 
 var (
-	modelCatalogSetupManifest = manifest("modelcatalog", "setup.yaml")
-	modelCatalogAltManifest   = manifest("modelcatalog", "alt-catalog.yaml")
+	modelCatalogSetupManifest   = manifest("modelcatalog", "setup.yaml")
+	modelCatalogAltManifest     = manifest("modelcatalog", "alt-catalog.yaml")
+	modelCatalogUpdatedManifest = manifest("modelcatalog", "updated-catalog.yaml")
 )
 
 const (
@@ -34,6 +36,19 @@ const (
 
 // costTotalRe extracts agw.ai.usage.cost.total, tolerant of logfmt, quoted, and JSON renderings.
 var costTotalRe = regexp.MustCompile(`agw\.ai\.usage\.cost\.total[^0-9-]*([0-9]+(?:\.[0-9]+)?)`)
+
+// maxLoggedCost returns the highest agw.ai.usage.cost.total value found in logs, or -1 if none is present.
+func maxLoggedCost(logs string) float64 {
+	maxCost := -1.0
+	for line := range strings.SplitSeq(logs, "\n") {
+		if m := costTotalRe.FindStringSubmatch(line); m != nil {
+			if cost, err := strconv.ParseFloat(m[1], 64); err == nil && cost > maxCost {
+				maxCost = cost
+			}
+		}
+	}
+	return maxCost
+}
 
 func TestModelCatalogCost(tt *testing.T) {
 	t := New(tt, base.WithMinGwApiVersion(base.GwApiRequireRouteNames))
@@ -60,14 +75,7 @@ func TestModelCatalogCost(tt *testing.T) {
 			if err != nil {
 				return err
 			}
-			maxCost := -1.0
-			for line := range strings.SplitSeq(logs, "\n") {
-				if m := costTotalRe.FindStringSubmatch(line); m != nil {
-					if cost, err := strconv.ParseFloat(m[1], 64); err == nil && cost > maxCost {
-						maxCost = cost
-					}
-				}
-			}
+			maxCost := maxLoggedCost(logs)
 			if maxCost < 0 {
 				return fmt.Errorf("no agw.ai.usage.cost.total in gateway logs (catalog ConfigMap not loaded?)")
 			}
@@ -76,6 +84,54 @@ func TestModelCatalogCost(tt *testing.T) {
 			}
 			return nil
 		}).WithTimeout(30 * time.Second).WithPolling(2 * time.Second).Should(gomega.Succeed())
+	})
+
+	t.Run("ConfigMapUpdatePropagatesWithoutRestart", func(t base.Test) {
+		gwName := types.NamespacedName{Name: modelCatalogGatewayName, Namespace: modelCatalogNamespace}
+		gw := base.Gateway{
+			NamespacedName: gwName,
+			Address:        base.ResolveGatewayAddress(t, t.Ctx, t.TestInstallation, gwName),
+		}
+
+		g := gomega.NewWithT(t)
+
+		podsBefore, err := gatewayPodNames(t, modelCatalogNamespace, modelCatalogGatewayName)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		baseline, err := gatewayAccessLogs(t, modelCatalogNamespace, modelCatalogGatewayName)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		baselineLen := len(baseline)
+
+		t.Apply(modelCatalogUpdatedManifest)
+		g.Eventually(func() error {
+			gw.Send(
+				t,
+				base.ExpectBody(gomega.ContainSubstring("The name of this project is agentgateway")),
+				curl.WithPath("/v1/chat/completions"),
+				curl.WithPostBody(`{"messages": [{"role": "user", "content": "What is the name of this project?"}]}`),
+				curl.WithHeader("Content-Type", "application/json"),
+			)
+			logs, err := gatewayAccessLogs(t, modelCatalogNamespace, modelCatalogGatewayName)
+			if err != nil {
+				return err
+			}
+			if len(logs) <= baselineLen {
+				return fmt.Errorf("no new gateway logs since ConfigMap patch")
+			}
+			maxCost := maxLoggedCost(logs[baselineLen:])
+			if maxCost < 0 {
+				return fmt.Errorf("no agw.ai.usage.cost.total in gateway logs since ConfigMap patch")
+			}
+			if maxCost >= minSentinelCost {
+				return fmt.Errorf("logged cost %v >= ceiling %v (ConfigMap update not yet reflected by running pod)", maxCost, minSentinelCost)
+			}
+			return nil
+		}).WithTimeout(45 * time.Second).WithPolling(2 * time.Second).Should(gomega.Succeed())
+
+		podsAfter, err := gatewayPodNames(t, modelCatalogNamespace, modelCatalogGatewayName)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		g.Expect(podsAfter).To(gomega.Equal(podsBefore),
+			"gateway pod must not have restarted for the ConfigMap update to take effect")
 	})
 
 	t.Run("AlternativeCatalog", func(t base.Test) {
@@ -99,14 +155,7 @@ func TestModelCatalogCost(tt *testing.T) {
 			if err != nil {
 				return err
 			}
-			maxCost := -1.0
-			for line := range strings.SplitSeq(logs, "\n") {
-				if m := costTotalRe.FindStringSubmatch(line); m != nil {
-					if cost, err := strconv.ParseFloat(m[1], 64); err == nil && cost > maxCost {
-						maxCost = cost
-					}
-				}
-			}
+			maxCost := maxLoggedCost(logs)
 			if maxCost < 0 {
 				return fmt.Errorf("no agw.ai.usage.cost.total in gateway logs (catalog ConfigMap not loaded?)")
 			}
@@ -116,6 +165,24 @@ func TestModelCatalogCost(tt *testing.T) {
 			return nil
 		}).WithTimeout(30 * time.Second).WithPolling(2 * time.Second).Should(gomega.Succeed())
 	})
+}
+
+// gatewayPodNames returns the sorted names of the running gateway pods, so callers
+// can assert that a ConfigMap update took effect without a pod restart/rollout.
+func gatewayPodNames(t base.Test, ns, gatewayName string) ([]string, error) {
+	cluster := t.TestInstallation.ClusterContext
+	pods, err := cluster.Client.Kube().CoreV1().Pods(ns).List(t.Ctx, metav1.ListOptions{
+		LabelSelector: "gateway.networking.k8s.io/gateway-name=" + gatewayName,
+	})
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(pods.Items))
+	for _, pod := range pods.Items {
+		names = append(names, string(pod.UID))
+	}
+	sort.Strings(names)
+	return names, nil
 }
 
 func gatewayAccessLogs(t base.Test, ns, gatewayName string) (string, error) {

--- a/controller/test/e2e/modelcatalog_test.go
+++ b/controller/test/e2e/modelcatalog_test.go
@@ -50,6 +50,18 @@ func maxLoggedCost(logs string) float64 {
 	return maxCost
 }
 
+// hasLoggedCostBelow reports whether logs contain an agw.ai.usage.cost.total value strictly below ceiling.
+func hasLoggedCostBelow(logs string, ceiling float64) bool {
+	for line := range strings.SplitSeq(logs, "\n") {
+		if m := costTotalRe.FindStringSubmatch(line); m != nil {
+			if cost, err := strconv.ParseFloat(m[1], 64); err == nil && cost < ceiling {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func TestModelCatalogCost(tt *testing.T) {
 	t := New(tt, base.WithMinGwApiVersion(base.GwApiRequireRouteNames))
 
@@ -95,12 +107,8 @@ func TestModelCatalogCost(tt *testing.T) {
 
 		g := gomega.NewWithT(t)
 
-		podsBefore, err := gatewayPodNames(t, modelCatalogGatewayName)
+		podsBefore, err := gatewayPodUIDs(t, modelCatalogGatewayName)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
-
-		baseline, err := gatewayAccessLogs(t, modelCatalogGatewayName)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		baselineLen := len(baseline)
 
 		t.Apply(modelCatalogUpdatedManifest)
 		g.Eventually(func() error {
@@ -115,20 +123,16 @@ func TestModelCatalogCost(tt *testing.T) {
 			if err != nil {
 				return err
 			}
-			if len(logs) <= baselineLen {
-				return fmt.Errorf("no new gateway logs since ConfigMap patch")
-			}
-			maxCost := maxLoggedCost(logs[baselineLen:])
-			if maxCost < 0 {
-				return fmt.Errorf("no agw.ai.usage.cost.total in gateway logs since ConfigMap patch")
-			}
-			if maxCost >= minSentinelCost {
-				return fmt.Errorf("logged cost %v >= ceiling %v (ConfigMap update not yet reflected by running pod)", maxCost, minSentinelCost)
+			// The pre-patch sentinel-rate cost never leaves the log, so we can't compare
+			// against the max; instead look for any request logged below the ceiling,
+			// which is only possible once the reloaded (low-rate) catalog is in effect.
+			if !hasLoggedCostBelow(logs, minSentinelCost) {
+				return fmt.Errorf("no agw.ai.usage.cost.total below ceiling %v in gateway logs (ConfigMap update not yet reflected by running pod)", minSentinelCost)
 			}
 			return nil
 		}).WithTimeout(45 * time.Second).WithPolling(2 * time.Second).Should(gomega.Succeed())
 
-		podsAfter, err := gatewayPodNames(t, modelCatalogGatewayName)
+		podsAfter, err := gatewayPodUIDs(t, modelCatalogGatewayName)
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 		g.Expect(podsAfter).To(gomega.Equal(podsBefore),
 			"gateway pod must not have restarted for the ConfigMap update to take effect")
@@ -167,9 +171,9 @@ func TestModelCatalogCost(tt *testing.T) {
 	})
 }
 
-// gatewayPodNames returns the sorted names of the running gateway pods, so callers
+// gatewayPodUIDs returns the sorted UIDs of the running gateway pods, so callers
 // can assert that a ConfigMap update took effect without a pod restart/rollout.
-func gatewayPodNames(t base.Test, gatewayName string) ([]string, error) {
+func gatewayPodUIDs(t base.Test, gatewayName string) ([]string, error) {
 	cluster := t.TestInstallation.ClusterContext
 	pods, err := cluster.Client.Kube().CoreV1().Pods(modelCatalogNamespace).List(t.Ctx, metav1.ListOptions{
 		LabelSelector: "gateway.networking.k8s.io/gateway-name=" + gatewayName,
@@ -177,12 +181,12 @@ func gatewayPodNames(t base.Test, gatewayName string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	names := make([]string, 0, len(pods.Items))
+	uids := make([]string, 0, len(pods.Items))
 	for _, pod := range pods.Items {
-		names = append(names, string(pod.UID))
+		uids = append(uids, string(pod.UID))
 	}
-	slices.Sort(names)
-	return names, nil
+	slices.Sort(uids)
+	return uids, nil
 }
 
 func gatewayAccessLogs(t base.Test, gatewayName string) (string, error) {

--- a/controller/test/e2e/modelcatalog_test.go
+++ b/controller/test/e2e/modelcatalog_test.go
@@ -111,6 +111,18 @@ func TestModelCatalogCost(tt *testing.T) {
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
 		t.Apply(modelCatalogUpdatedManifest)
+
+		podClient := t.TestInstallation.ClusterContext.Client.Kube().CoreV1().Pods(modelCatalogNamespace)
+		pods, err := podClient.List(t.Ctx, metav1.ListOptions{
+			LabelSelector: "gateway.networking.k8s.io/gateway-name=" + modelCatalogGatewayName,
+		})
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+		g.Expect(pods.Items).To(gomega.HaveLen(1), "expected a single gateway pod")
+		pod := pods.Items[0]
+		metav1.SetMetaDataAnnotation(&pod.ObjectMeta, "throwawaytoupdateconfigmapdata", "true")
+		_, err = podClient.Update(t.Ctx, &pod, metav1.UpdateOptions{})
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
 		g.Eventually(func() error {
 			gw.Send(
 				t,
@@ -127,7 +139,7 @@ func TestModelCatalogCost(tt *testing.T) {
 				return fmt.Errorf("no agw.ai.usage.cost.total below ceiling %v in gateway logs (ConfigMap update not yet reflected by running pod)", minSentinelCost)
 			}
 			return nil
-		}).WithTimeout(45 * time.Second).WithPolling(2 * time.Second).Should(gomega.Succeed())
+		}).WithTimeout(10 * time.Second).WithPolling(1 * time.Second).Should(gomega.Succeed())
 
 		podsAfter, err := gatewayPodUIDs(t, modelCatalogGatewayName)
 		g.Expect(err).NotTo(gomega.HaveOccurred())

--- a/controller/test/e2e/testdata/modelcatalog/updated-catalog.yaml
+++ b/controller/test/e2e/testdata/modelcatalog/updated-catalog.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: catalog
+  namespace: default
+data:
+  catalog.json: |
+    {
+      "providers": {
+        "openai": {
+          "models": {
+            "gpt-4o-mini": {
+              "rates": {
+                "input": "1",
+                "output": "1"
+              }
+            }
+          }
+        }
+      }
+    }


### PR DESCRIPTION
Adopt https://github.com/agentgateway/agentgateway/issues/2512 


if this flakes alot we can also consider adding a kubeadmConfigPatches like below but it felt like a bigger change than needed out the gate here.

diff --git a/controller/test/setup/setup-kind-ci.sh b/controller/test/setup/setup-kind-ci.sh
index eb4f53ad..c456e87d 100755
--- a/controller/test/setup/setup-kind-ci.sh
+++ b/controller/test/setup/setup-kind-ci.sh
@@ -97,6 +97,10 @@ kubeadmConfigPatches:
       extraArgs:
         "kube-api-burst": "500"
         "kube-api-qps": "250"
+  - |
+    kind: KubeletConfiguration
+    configMapAndSecretChangeDetectionStrategy: Watch
+    syncFrequency: 2s
 networking:
   dnsSearch: []
 nodes:
