### PR TITLE
examples: support Responses semantic routing

### DIFF
--- a/examples/llm-semantic-routing/README.md
+++ b/examples/llm-semantic-routing/README.md
@@ -151,9 +151,12 @@ codex --profile agentgateway
 
 The gateway authenticates to OpenAI with its configured provider credential and
 records the selected model and cost as it does for other OpenAI-compatible
-clients. Users can still select a concrete model unless the organization
-separately enforces or rewrites direct model requests at the gateway. Treat
-`auto` as the supported client path when testing this policy.
+clients. Agentgateway can [rewrite client-facing model names with model
+aliases](https://agentgateway.dev/docs/kubernetes/latest/llm/alias/). An
+organization can also [validate and reject unsupported request-body model
+values](https://agentgateway.dev/docs/kubernetes/latest/traffic-management/transformations/validate/),
+such as any value other than `auto`. Treat `auto` as the supported client path
+when testing this policy.
 
 ## Cleanup
 

--- a/examples/llm-semantic-routing/README.md
+++ b/examples/llm-semantic-routing/README.md
@@ -128,8 +128,9 @@ events so it can send the same `auto` model name through the gateway. Create a
 user-level Codex profile:
 
 ```bash
-mkdir -p ~/.codex
-cat > ~/.codex/agentgateway.config.toml <<'EOF'
+export CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
+mkdir -p "$CODEX_HOME"
+cat > "$CODEX_HOME/agentgateway.config.toml" <<'EOF'
 model = "auto"
 model_provider = "agentgateway"
 

--- a/examples/llm-semantic-routing/README.md
+++ b/examples/llm-semantic-routing/README.md
@@ -119,13 +119,19 @@ Agentgateway’s model catalog, metrics, logs, and traces remain the cost and
 observability source of record. Use isolated evaluation traffic with forced
 lower-cost and always-expensive baselines before adopting the policy broadly.
 
-## Optional: Use Codex CLI Through the Gateway
+## Optional: Use Codex Through the Gateway
 
 The gateway works with any OpenAI API-compatible client or agent. This optional
-section configures the Codex CLI. It was tested with `codex-cli 0.144.4`. Codex
-CLI uses the OpenAI Responses API, and the nightly vSR image configured above
-translates streamed Responses events so it can send the same `auto` model name
-through the gateway. Create a user-level Codex CLI profile:
+section configures Codex to use the gateway's stable `auto` model name. Codex
+uses the OpenAI Responses API, and the nightly vSR image configured above
+translates streamed Responses events before forwarding to the selected model.
+
+### Codex CLI
+
+This configuration was tested with `codex-cli 0.144.4`. The
+[Codex CLI profile documentation](https://learn.chatgpt.com/docs/config-file/config-advanced#profiles)
+describes how `--profile` overlays a named user-level configuration file.
+Create the profile:
 
 ```bash
 export CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
@@ -142,21 +148,50 @@ model_provider = "agentgateway"
 name = "Corporate agentgateway"
 base_url = "${AGENTGATEWAY_BASE_URL}"
 wire_api = "responses"
-env_key = "OPENAI_API_KEY"
 EOF
 ```
 
-Set your OpenAI API key, then start Codex with that profile:
+Start Codex with that profile:
 
 ```bash
-export OPENAI_API_KEY='sk-...'
 codex --profile agentgateway
 ```
 
-### Verify Codex CLI Routing
+### Codex in the ChatGPT Desktop App
 
-After sending a task from Codex CLI, inspect the vSR decision and the completed
-agentgateway request:
+Codex is available in the ChatGPT desktop app as a Codex environment. This
+configuration was tested with ChatGPT desktop app version `26.707.72221`.
+See the [Codex environment documentation](https://learn.chatgpt.com/docs/environments/modes)
+and [Codex configuration basics](https://learn.chatgpt.com/docs/config-file/config-basic).
+
+For the same gateway configuration, back up and replace the user-level config,
+then restart the ChatGPT desktop app:
+
+```bash
+export AGENTGATEWAY_BASE_URL="http://$(kubectl get gateway agentgateway-proxy \
+  -n agentgateway-system \
+  -o jsonpath='{.status.addresses[0].value}')/v1"
+# For a TLS-enabled corporate gateway, set AGENTGATEWAY_BASE_URL to its https URL.
+cp ~/.codex/config.toml ~/.codex/config.toml.bak
+cat > ~/.codex/config.toml <<EOF
+model = "auto"
+model_provider = "agentgateway"
+
+[model_providers.agentgateway]
+name = "Corporate agentgateway"
+base_url = "${AGENTGATEWAY_BASE_URL}"
+wire_api = "responses"
+EOF
+```
+
+Replacing `~/.codex/config.toml` also replaces other user-level Codex settings.
+To edit that file through the app instead, open **Settings > Configuration >
+Open config.toml** and apply the same configuration.
+
+### Verify Codex Routing
+
+After sending a task from Codex CLI or the ChatGPT desktop app, inspect the vSR
+decision and the completed agentgateway request:
 
 ```bash
 kubectl logs -n agentgateway-system deploy/semantic-router --since=5m \
@@ -173,10 +208,10 @@ successful `response_status`. The agentgateway output identifies the
 `openai-semantic-routing` route, the selected request and response model,
 catalog-priced token usage, and the realized request cost.
 
-Codex CLI also probes `/v1/models` to discover model metadata. Until
-[agentgateway issue #1462](https://github.com/agentgateway/agentgateway/issues/1462)
-adds a gateway-generated model list, Codex may warn that metadata for `auto` is
-not found. That warning does not prevent `/v1/responses` traffic from routing.
+Codex also probes `/v1/models` to discover model metadata. Until [agentgateway
+issue #1462](https://github.com/agentgateway/agentgateway/issues/1462) adds a
+gateway-generated model list, Codex may warn that metadata for `auto` is not
+found. That warning does not prevent `/v1/responses` traffic from routing.
 
 The gateway authenticates to OpenAI with its configured provider credential and
 records the selected model and cost as it does for other OpenAI-compatible

--- a/examples/llm-semantic-routing/README.md
+++ b/examples/llm-semantic-routing/README.md
@@ -153,6 +153,31 @@ export OPENAI_API_KEY='sk-...'
 codex --profile agentgateway
 ```
 
+### Verify Codex CLI Routing
+
+After sending a task from Codex CLI, inspect the vSR decision and the completed
+agentgateway request:
+
+```bash
+kubectl logs -n agentgateway-system deploy/semantic-router --since=5m \
+  | grep -E '"event":"routing_decision"|"event":"router_replay_complete"' \
+  | tail -n 4
+
+kubectl logs -n agentgateway-system deploy/agentgateway-proxy --since=5m \
+  | grep 'http.path=/v1/responses' \
+  | tail -n 4
+```
+
+The vSR output identifies `original_model: auto`, the `selected_model`, and a
+successful `response_status`. The agentgateway output identifies the
+`openai-semantic-routing` route, the selected request and response model,
+catalog-priced token usage, and the realized request cost.
+
+Codex CLI also probes `/v1/models` to discover model metadata. Until
+[agentgateway issue #1462](https://github.com/agentgateway/agentgateway/issues/1462)
+adds a gateway-generated model list, Codex may warn that metadata for `auto` is
+not found. That warning does not prevent `/v1/responses` traffic from routing.
+
 The gateway authenticates to OpenAI with its configured provider credential and
 records the selected model and cost as it does for other OpenAI-compatible
 clients. Agentgateway can [rewrite client-facing model names with model

--- a/examples/llm-semantic-routing/README.md
+++ b/examples/llm-semantic-routing/README.md
@@ -122,11 +122,10 @@ lower-cost and always-expensive baselines before adopting the policy broadly.
 ## Optional: Use Codex CLI Through the Gateway
 
 The gateway works with any OpenAI API-compatible client or agent. This optional
-section configures the Codex CLI, not the Codex desktop GUI app. It was tested
-with `codex-cli 0.144.4`. Codex CLI uses the OpenAI Responses API, and the
-nightly vSR image configured above translates streamed Responses events so it
-can send the same `auto` model name through the gateway. Create a user-level
-Codex CLI profile:
+section configures the Codex CLI. It was tested with `codex-cli 0.144.4`. Codex
+CLI uses the OpenAI Responses API, and the nightly vSR image configured above
+translates streamed Responses events so it can send the same `auto` model name
+through the gateway. Create a user-level Codex CLI profile:
 
 ```bash
 export CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"

--- a/examples/llm-semantic-routing/README.md
+++ b/examples/llm-semantic-routing/README.md
@@ -122,9 +122,9 @@ lower-cost and always-expensive baselines before adopting the policy broadly.
 ## Optional: Use Codex Through the Gateway
 
 The gateway works with any OpenAI API-compatible client or agent. This optional
-section configures Codex to use the gateway's stable `auto` model name. Codex
-uses the OpenAI Responses API, and the nightly vSR image configured above
-translates streamed Responses events before forwarding to the selected model.
+section configures Codex to use the gateway's `auto` model name. Codex uses the
+OpenAI Responses API and vSR translates streamed Responses events before the
+gateway forwards the request to the selected model.
 
 ### Codex CLI
 

--- a/examples/llm-semantic-routing/README.md
+++ b/examples/llm-semantic-routing/README.md
@@ -32,18 +32,20 @@ The `AgentgatewayBackend` in `k8s/agentgateway-routing.yaml` expects an
 ## Configure Routing
 
 Replace any existing `HTTPRoute` attached to this Gateway that matches
-`/v1/chat/completions` before applying this example.
+`/v1/chat/completions` or `/v1/responses` before applying this example.
 
 Install vLLM Semantic Router:
 
 ```bash
-export VSR_VERSION=0.3.0
+export VSR_CHART_VERSION=0.0.0-latest
+export VSR_IMAGE_TAG=latest
 
 helm upgrade -i semantic-router oci://ghcr.io/vllm-project/charts/semantic-router \
-  --version "${VSR_VERSION}" \
+  --version "${VSR_CHART_VERSION}" \
   --namespace agentgateway-system \
   -f examples/llm-semantic-routing/k8s/semantic-router-values.yaml \
-  --set-string "image.tag=v${VSR_VERSION}"
+  --set-string "image.tag=${VSR_IMAGE_TAG}" \
+  --set "image.pullPolicy=Always"
 
 kubectl wait --for=condition=Available deployment/semantic-router \
   -n agentgateway-system \
@@ -62,8 +64,10 @@ kubectl describe httproute openai-semantic-routing -n agentgateway-system
 kubectl describe agentgatewaypolicy semantic-router-extproc -n agentgateway-system
 ```
 
-`VSR_VERSION` sets both the chart version and the matching `v<version>`
-`extproc` image tag.
+This example defaults to the latest vSR chart and image, which include the
+[Responses API streaming fix](https://github.com/vllm-project/semantic-router/issues/2446).
+For a repeatable historical deployment, override both values with released
+chart and image versions that contain the fix.
 
 > **Note:** This example uses buffered ExtProc while the streamed-body issue in
 > [vLLM Semantic Router #2486](https://github.com/vllm-project/semantic-router/issues/2486)
@@ -119,6 +123,37 @@ by application traffic.
 Agentgateway’s model catalog, metrics, logs, and traces remain the cost and
 observability source of record. Use isolated evaluation traffic with forced
 lower-cost and always-expensive baselines before adopting the policy broadly.
+
+## Use Codex Through the Gateway
+
+Codex uses the OpenAI Responses API. The nightly vSR image configured above
+translates streamed Responses events, so Codex can send the same `auto` model
+name through the gateway. Configure a user-level Codex profile:
+
+```toml
+# ~/.codex/agentgateway.config.toml
+model = "auto"
+model_provider = "agentgateway"
+
+[model_providers.agentgateway]
+name = "Corporate agentgateway"
+base_url = "https://my.corp.agentgateway.com/v1"
+wire_api = "responses"
+env_key = "OPENAI_API_KEY"
+```
+
+Set your OpenAI API key, then start Codex with the profile:
+
+```bash
+export OPENAI_API_KEY='sk-...'
+codex --profile agentgateway
+```
+
+The gateway authenticates to OpenAI with its configured provider credential and
+records the selected model and cost as it does for other OpenAI-compatible
+clients. Users can still select a concrete model unless the organization
+separately enforces or rewrites direct model requests at the gateway. Treat
+`auto` as the supported client path when testing this policy.
 
 ## Cleanup
 

--- a/examples/llm-semantic-routing/README.md
+++ b/examples/llm-semantic-routing/README.md
@@ -129,14 +129,18 @@ user-level Codex profile:
 
 ```bash
 export CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
+export AGENTGATEWAY_BASE_URL="http://$(kubectl get gateway agentgateway-proxy \
+  -n agentgateway-system \
+  -o jsonpath='{.status.addresses[0].value}')/v1"
+# For a TLS-enabled corporate gateway, set AGENTGATEWAY_BASE_URL to its https URL.
 mkdir -p "$CODEX_HOME"
-cat > "$CODEX_HOME/agentgateway.config.toml" <<'EOF'
+cat > "$CODEX_HOME/agentgateway.config.toml" <<EOF
 model = "auto"
 model_provider = "agentgateway"
 
 [model_providers.agentgateway]
 name = "Corporate agentgateway"
-base_url = "https://my.corp.agentgateway.com/v1"
+base_url = "${AGENTGATEWAY_BASE_URL}"
 wire_api = "responses"
 env_key = "OPENAI_API_KEY"
 EOF

--- a/examples/llm-semantic-routing/README.md
+++ b/examples/llm-semantic-routing/README.md
@@ -124,11 +124,12 @@ lower-cost and always-expensive baselines before adopting the policy broadly.
 The gateway works with any OpenAI API-compatible client or agent. This optional
 section shows a Codex-specific configuration. Codex uses the OpenAI Responses
 API, and the nightly vSR image configured above translates streamed Responses
-events so it can send the same `auto` model name through the gateway. Configure
-a user-level Codex profile:
+events so it can send the same `auto` model name through the gateway. Create a
+user-level Codex profile:
 
-```toml
-# ~/.codex/agentgateway.config.toml
+```bash
+mkdir -p ~/.codex
+cat > ~/.codex/agentgateway.config.toml <<'EOF'
 model = "auto"
 model_provider = "agentgateway"
 
@@ -137,9 +138,10 @@ name = "Corporate agentgateway"
 base_url = "https://my.corp.agentgateway.com/v1"
 wire_api = "responses"
 env_key = "OPENAI_API_KEY"
+EOF
 ```
 
-Set your OpenAI API key, then start Codex with the profile:
+Set your OpenAI API key, then start Codex with that profile:
 
 ```bash
 export OPENAI_API_KEY='sk-...'

--- a/examples/llm-semantic-routing/README.md
+++ b/examples/llm-semantic-routing/README.md
@@ -52,7 +52,7 @@ kubectl wait --for=condition=Available deployment/semantic-router \
   --timeout=600s
 ```
 
-Apply the routed backend, route, and buffered ExtProc policy:
+Apply the routed backend, route, and streamed ExtProc policy:
 
 ```bash
 kubectl apply -f examples/llm-semantic-routing/k8s/agentgateway-routing.yaml
@@ -65,17 +65,12 @@ kubectl describe agentgatewaypolicy semantic-router-extproc -n agentgateway-syst
 ```
 
 This example defaults to the latest vSR chart and image, which include the
-[Responses API streaming fix](https://github.com/vllm-project/semantic-router/issues/2446).
+[Responses API streaming fix](https://github.com/vllm-project/semantic-router/issues/2446)
+and the [FullDuplexStreamed request-body fix](https://github.com/vllm-project/semantic-router/issues/2486).
 For a repeatable historical deployment, override both values with released
-chart and image versions that contain the fix.
+chart and image versions that contain both fixes.
 
-> **Note:** This example uses buffered ExtProc while the streamed-body issue in
-> [vLLM Semantic Router #2486](https://github.com/vllm-project/semantic-router/issues/2486)
-> is unresolved. When that issue is fixed and this example is returned to
-> streamed mode, restore the `Verify Streamed ExtProc` section and its
-> deterministic immediate-response probe.
-
-## Run a Request
+## Verify Streamed ExtProc
 
 Set your gateway address:
 
@@ -84,6 +79,29 @@ export INGRESS_GW_ADDRESS="http://$(kubectl get gateway agentgateway-proxy \
   -n agentgateway-system \
   -o jsonpath='{.status.addresses[0].value}')"
 ```
+
+The values include a narrow, deterministic immediate-response probe. It proves
+that `FullDuplexStreamed` request processing reaches vSR without sending tokens
+to OpenAI:
+
+```bash
+curl -sS -i "$INGRESS_GW_ADDRESS/v1/chat/completions" \
+  -H "Content-Type: application/json" \
+  -H "X-VSR-Debug: true" \
+  -d '{
+    "model": "auto",
+    "messages": [
+      {"role": "user", "content": "VSR_IMMEDIATE_RESPONSE_PROBE"}
+    ],
+    "max_tokens": 16
+  }'
+```
+
+Expect a `200` response with `x-vsr-fast-response`; the request should not
+reach OpenAI. Remove the probe signal and decision before using this policy in
+a production route.
+
+## Run a Request
 
 Routine coding prompts should use the lower-cost model:
 

--- a/examples/llm-semantic-routing/README.md
+++ b/examples/llm-semantic-routing/README.md
@@ -70,7 +70,7 @@ and the [FullDuplexStreamed request-body fix](https://github.com/vllm-project/se
 For a repeatable historical deployment, override both values with released
 chart and image versions that contain both fixes.
 
-## Verify Streamed ExtProc
+## Run a Request
 
 Set your gateway address:
 
@@ -79,29 +79,6 @@ export INGRESS_GW_ADDRESS="http://$(kubectl get gateway agentgateway-proxy \
   -n agentgateway-system \
   -o jsonpath='{.status.addresses[0].value}')"
 ```
-
-The values include a narrow, deterministic immediate-response probe. It proves
-that `FullDuplexStreamed` request processing reaches vSR without sending tokens
-to OpenAI:
-
-```bash
-curl -sS -i "$INGRESS_GW_ADDRESS/v1/chat/completions" \
-  -H "Content-Type: application/json" \
-  -H "X-VSR-Debug: true" \
-  -d '{
-    "model": "auto",
-    "messages": [
-      {"role": "user", "content": "VSR_IMMEDIATE_RESPONSE_PROBE"}
-    ],
-    "max_tokens": 16
-  }'
-```
-
-Expect a `200` response with `x-vsr-fast-response`; the request should not
-reach OpenAI. Remove the probe signal and decision before using this policy in
-a production route.
-
-## Run a Request
 
 Routine coding prompts should use the lower-cost model:
 

--- a/examples/llm-semantic-routing/README.md
+++ b/examples/llm-semantic-routing/README.md
@@ -124,11 +124,13 @@ Agentgateway’s model catalog, metrics, logs, and traces remain the cost and
 observability source of record. Use isolated evaluation traffic with forced
 lower-cost and always-expensive baselines before adopting the policy broadly.
 
-## Use Codex Through the Gateway
+## Optional: Use Codex Through the Gateway
 
-Codex uses the OpenAI Responses API. The nightly vSR image configured above
-translates streamed Responses events, so Codex can send the same `auto` model
-name through the gateway. Configure a user-level Codex profile:
+The gateway works with any OpenAI API-compatible client or agent. This optional
+section shows a Codex-specific configuration. Codex uses the OpenAI Responses
+API, and the nightly vSR image configured above translates streamed Responses
+events so it can send the same `auto` model name through the gateway. Configure
+a user-level Codex profile:
 
 ```toml
 # ~/.codex/agentgateway.config.toml

--- a/examples/llm-semantic-routing/README.md
+++ b/examples/llm-semantic-routing/README.md
@@ -119,13 +119,14 @@ Agentgateway’s model catalog, metrics, logs, and traces remain the cost and
 observability source of record. Use isolated evaluation traffic with forced
 lower-cost and always-expensive baselines before adopting the policy broadly.
 
-## Optional: Use Codex Through the Gateway
+## Optional: Use Codex CLI Through the Gateway
 
 The gateway works with any OpenAI API-compatible client or agent. This optional
-section shows a Codex-specific configuration. Codex uses the OpenAI Responses
-API, and the nightly vSR image configured above translates streamed Responses
-events so it can send the same `auto` model name through the gateway. Create a
-user-level Codex profile:
+section configures the Codex CLI, not the Codex desktop GUI app. It was tested
+with `codex-cli 0.144.4`. Codex CLI uses the OpenAI Responses API, and the
+nightly vSR image configured above translates streamed Responses events so it
+can send the same `auto` model name through the gateway. Create a user-level
+Codex CLI profile:
 
 ```bash
 export CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"

--- a/examples/llm-semantic-routing/k8s/agentgateway-routing.yaml
+++ b/examples/llm-semantic-routing/k8s/agentgateway-routing.yaml
@@ -62,7 +62,9 @@ spec:
         port: 50051
       processingOptions:
         requestHeaderMode: Send
-        requestBodyMode: Buffered
+        requestBodyMode: FullDuplexStreamed
         responseHeaderMode: Send
         responseBodyMode: Buffered
+        requestTrailerMode: Send
+        responseTrailerMode: Send
         allowModeOverride: true

--- a/examples/llm-semantic-routing/k8s/agentgateway-routing.yaml
+++ b/examples/llm-semantic-routing/k8s/agentgateway-routing.yaml
@@ -33,6 +33,9 @@ spec:
     - path:
         type: PathPrefix
         value: /v1/chat/completions
+    - path:
+        type: PathPrefix
+        value: /v1/responses
     backendRefs:
     - group: agentgateway.dev
       kind: AgentgatewayBackend

--- a/examples/llm-semantic-routing/k8s/semantic-router-values.yaml
+++ b/examples/llm-semantic-routing/k8s/semantic-router-values.yaml
@@ -93,14 +93,6 @@ config:
       # avoid inheriting the chart's general-purpose domain defaults.
       domains: []
       keywords:
-      - name: immediate_response_probe
-        operator: OR
-        method: ngram
-        keywords:
-        - VSR_IMMEDIATE_RESPONSE_PROBE
-        case_sensitive: true
-        ngram_threshold: 0.95
-        ngram_arity: 3
       - name: advanced_markers
         operator: OR
         # Leave method unset to use literal, word-boundary-aware matching.
@@ -305,20 +297,6 @@ config:
           gte: 0.35
 
     decisions:
-    # This narrow probe verifies the streamed immediate-response path. It is
-    # never selected by normal coding traffic.
-    - name: immediate_response_probe
-      description: Deterministic immediate response for streamed ExtProc verification.
-      priority: 1000
-      rules:
-        operator: AND
-        conditions:
-        - type: keyword
-          name: immediate_response_probe
-      plugins:
-      - type: fast_response
-        configuration:
-          message: Semantic Router immediate response probe matched before the request reached the upstream model.
     - name: route_to_expensive
       description: Escalate advanced distributed systems, formal verification, hard debugging, and research synthesis.
       priority: 200

--- a/examples/llm-semantic-routing/k8s/semantic-router-values.yaml
+++ b/examples/llm-semantic-routing/k8s/semantic-router-values.yaml
@@ -93,6 +93,14 @@ config:
       # avoid inheriting the chart's general-purpose domain defaults.
       domains: []
       keywords:
+      - name: immediate_response_probe
+        operator: OR
+        method: ngram
+        keywords:
+        - VSR_IMMEDIATE_RESPONSE_PROBE
+        case_sensitive: true
+        ngram_threshold: 0.95
+        ngram_arity: 3
       - name: advanced_markers
         operator: OR
         # Leave method unset to use literal, word-boundary-aware matching.
@@ -297,6 +305,20 @@ config:
           gte: 0.35
 
     decisions:
+    # This narrow probe verifies the streamed immediate-response path. It is
+    # never selected by normal coding traffic.
+    - name: immediate_response_probe
+      description: Deterministic immediate response for streamed ExtProc verification.
+      priority: 1000
+      rules:
+        operator: AND
+        conditions:
+        - type: keyword
+          name: immediate_response_probe
+      plugins:
+      - type: fast_response
+        configuration:
+          message: Semantic Router immediate response probe matched before the request reached the upstream model.
     - name: route_to_expensive
       description: Escalate advanced distributed systems, formal verification, hard debugging, and research synthesis.
       priority: 200
@@ -327,7 +349,11 @@ config:
       auto_model_name: auto
       strategy: priority
       streamed_body:
-        enabled: false
+        enabled: true
+        # Explicit guardrails for accumulated full-duplex request bodies; these
+        # values are not vSR defaults.
+        max_bytes: 10485760
+        timeout_sec: 30
       skip_processing:
         enabled: true
     services:


### PR DESCRIPTION
## Summary
- route OpenAI Responses API traffic through the semantic-routing example
- default the example to the latest vSR chart and ExtProc image for streamed Responses support
- document the `auto` semantic-routing model and link to the product client guide

## Validation
- ran routine and advanced development-client requests through agentgateway; vSR selected `gpt-5.4-nano` and `gpt-5.5`, respectively
- verified the example README links and Markdown formatting