### PR TITLE
Match repeated HTTP headers individually

### DIFF
--- a/crates/agentgateway/src/http/mod.rs
+++ b/crates/agentgateway/src/http/mod.rs
@@ -250,7 +250,7 @@ use crate::cel::{BackendContext, DestinationContext, LLMContext, RequestTime, So
 use crate::client::PoolKey;
 use crate::proxy::{ProxyError, ProxyResponse};
 use crate::transport::stream::TCPConnectionInfo;
-use crate::types::agent::PathMatch;
+use crate::types::agent::{HeaderValueMatch, PathMatch};
 
 /// Represents either an HTTP header or an HTTP/2 pseudo-header
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -445,6 +445,22 @@ pub fn get_pseudo_or_header_value<'a>(
 		HeaderOrPseudo::Header(v) => req.headers().get(v).map(std::borrow::Cow::Borrowed),
 		_ => get_pseudo_header_value(pseudo, req)
 			.and_then(|v| HeaderValue::try_from(&v).ok().map(std::borrow::Cow::Owned)),
+	}
+}
+
+/// Match repeated header fields independently without splitting commas within a field value.
+pub(crate) fn request_header_matches(
+	name: &HeaderOrPseudo,
+	value: &HeaderValueMatch,
+	req: &Request,
+) -> bool {
+	match name {
+		HeaderOrPseudo::Header(name) => req
+			.headers()
+			.get_all(name)
+			.iter()
+			.any(|have| value.matches(have)),
+		_ => get_pseudo_or_header_value(name, req).is_some_and(|have| value.matches(have.as_ref())),
 	}
 }
 

--- a/crates/agentgateway/src/http/route.rs
+++ b/crates/agentgateway/src/http/route.rs
@@ -11,7 +11,7 @@ use crate::http::Request;
 use crate::proxy::dtrace;
 use crate::types::agent;
 use crate::types::agent::{
-	BackendReference, HeaderMatch, HeaderValueMatch, Listener, PathMatch, QueryValueMatch, Route,
+	BackendReference, HeaderMatch, Listener, PathMatch, QueryValueMatch, Route,
 	RouteBackendReference, RouteMatch, RouteName, RouteSet,
 };
 use crate::*;
@@ -54,27 +54,8 @@ fn matches_request(m: &RouteMatch, request: &Request) -> bool {
 		return false;
 	}
 	for HeaderMatch { name, value } in &m.headers {
-		let Some(have) = http::get_pseudo_or_header_value(name, request) else {
+		if !http::request_header_matches(name, value, request) {
 			return false;
-		};
-		match value {
-			HeaderValueMatch::Exact(want) => {
-				if have.as_ref() != *want {
-					return false;
-				}
-			},
-			HeaderValueMatch::Regex(want) => {
-				let Some(have_str) = have.to_str().ok() else {
-					return false;
-				};
-				let Some(m) = want.find(have_str) else {
-					return false;
-				};
-				if !(m.start() == 0 && m.end() == have_str.len()) {
-					return false;
-				}
-			},
-			HeaderValueMatch::Invalid => return false,
 		}
 	}
 	// TODO: this re-parses the query string on every call; hoist to caller if this becomes a hot path.

--- a/crates/agentgateway/src/http/route_test.rs
+++ b/crates/agentgateway/src/http/route_test.rs
@@ -398,11 +398,37 @@ fn test_header_matching() {
 			expected_route: Some("exact-header"),
 		},
 		TestCase {
+			name: "exact header matches any repeated value",
+			headers: vec![
+				("content-type", "text/html"),
+				("content-type", "application/json"),
+			],
+			expected_route: Some("exact-header"),
+		},
+		TestCase {
+			name: "exact repeated header match is order independent",
+			headers: vec![
+				("content-type", "application/json"),
+				("content-type", "text/html"),
+			],
+			expected_route: Some("exact-header"),
+		},
+		TestCase {
+			name: "comma-joined header remains a single value",
+			headers: vec![("content-type", "text/html,application/json")],
+			expected_route: Some("no-headers"),
+		},
+		TestCase {
 			name: "regex header match",
 			headers: vec![(
 				"user-agent",
 				"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
 			)],
+			expected_route: Some("regex-header"),
+		},
+		TestCase {
+			name: "regex header matches any repeated value",
+			headers: vec![("user-agent", "curl/8.0"), ("user-agent", "Mozilla/5.0")],
 			expected_route: Some("regex-header"),
 		},
 		TestCase {

--- a/crates/agentgateway/src/llm/model_router.rs
+++ b/crates/agentgateway/src/llm/model_router.rs
@@ -11,8 +11,7 @@ use serde_json::Value;
 use crate::http::transformation_cel::TransformationMetadata;
 use crate::http::{self, Request, Response};
 use crate::types::agent::{
-	Authorization, BackendReference, BackendTrafficPolicy, HeaderMatch, HeaderValueMatch,
-	RouteBackendReference,
+	Authorization, BackendReference, BackendTrafficPolicy, HeaderMatch, RouteBackendReference,
 };
 use crate::{apply, cel, llm, schema_enum};
 
@@ -368,27 +367,8 @@ fn header_matches(matches: &[Vec<HeaderMatch>], req: &Request) -> bool {
 
 fn headers_match(headers: &[HeaderMatch], req: &Request) -> bool {
 	for HeaderMatch { name, value } in headers {
-		let Some(have) = http::get_pseudo_or_header_value(name, req) else {
+		if !http::request_header_matches(name, value, req) {
 			return false;
-		};
-		match value {
-			HeaderValueMatch::Exact(want) => {
-				if have.as_ref() != *want {
-					return false;
-				}
-			},
-			HeaderValueMatch::Regex(want) => {
-				let Some(have_str) = have.to_str().ok() else {
-					return false;
-				};
-				let Some(m) = want.find(have_str) else {
-					return false;
-				};
-				if !(m.start() == 0 && m.end() == have_str.len()) {
-					return false;
-				}
-			},
-			HeaderValueMatch::Invalid => return false,
 		}
 	}
 	true

--- a/crates/agentgateway/src/llm/policy/mod.rs
+++ b/crates/agentgateway/src/llm/policy/mod.rs
@@ -12,9 +12,7 @@ use crate::llm::policy::webhook::{MaskActionBody, RequestAction, ResponseAction}
 use crate::llm::{AIError, RequestType, ResponseType};
 use crate::proxy::httpproxy::PolicyClient;
 use crate::telemetry::log::RequestLog;
-use crate::types::agent::{
-	BackendTrafficPolicy, HeaderMatch, HeaderValueMatch, SimpleBackendReference,
-};
+use crate::types::agent::{BackendTrafficPolicy, HeaderMatch, SimpleBackendReference};
 use crate::*;
 
 fn with_default_timeout(mut req: crate::http::Request) -> crate::http::Request {
@@ -1136,31 +1134,13 @@ impl Policy {
 				crate::http::HeaderOrPseudo::Header(h) => h,
 				_ => continue, // Skip pseudo headers
 			};
-			let Some(have) = http_headers.get(header_name.as_str()) else {
+			let values = http_headers.get_all(header_name.as_str());
+			if !values.iter().any(|have| value.matches(have)) {
 				continue;
-			};
-			match value {
-				HeaderValueMatch::Exact(want) => {
-					if have != want {
-						continue;
-					}
-				},
-				HeaderValueMatch::Regex(want) => {
-					// Must be a valid string to do regex match
-					let Some(have_str) = have.to_str().ok() else {
-						continue;
-					};
-					let Some(m) = want.find(have_str) else {
-						continue;
-					};
-					// Make sure we matched the entire thing
-					if !(m.start() == 0 && m.end() == have_str.len()) {
-						continue;
-					}
-				},
-				HeaderValueMatch::Invalid => continue,
 			}
-			headers.insert(header_name, have.clone());
+			for have in values {
+				headers.append(header_name.clone(), have.clone());
+			}
 		}
 		headers
 	}

--- a/crates/agentgateway/src/llm/policy/tests.rs
+++ b/crates/agentgateway/src/llm/policy/tests.rs
@@ -1,6 +1,7 @@
 use ::http::{HeaderName, HeaderValue};
 
 use super::*;
+use crate::types::agent::HeaderValueMatch;
 
 /// When a webhook guard fails open, exactly one metric must be emitted (`FailOpen`); the caller
 /// must not additionally record `Allow`.
@@ -57,7 +58,8 @@ async fn webhook_fail_open_emits_single_metric() {
 #[test]
 fn test_get_webhook_forward_headers() {
 	let mut headers = HeaderMap::new();
-	headers.insert("x-test-header", HeaderValue::from_static("test-value"));
+	headers.append("x-test-header", HeaderValue::from_static("first-value"));
+	headers.append("x-test-header", HeaderValue::from_static("test-value"));
 	headers.insert(
 		"x-another-header",
 		HeaderValue::from_static("another-value"),
@@ -65,6 +67,10 @@ fn test_get_webhook_forward_headers() {
 	headers.insert(
 		"x-regex-header",
 		HeaderValue::from_static("regex-match-123"),
+	);
+	headers.insert(
+		"x-comma-header",
+		HeaderValue::from_static("first-value,test-value"),
 	);
 
 	let header_matches = vec![
@@ -84,19 +90,31 @@ fn test_get_webhook_forward_headers() {
 			name: crate::http::HeaderOrPseudo::Header(HeaderName::from_static("x-missing-header")),
 			value: HeaderValueMatch::Exact(HeaderValue::from_static("some-value")),
 		},
+		HeaderMatch {
+			name: crate::http::HeaderOrPseudo::Header(HeaderName::from_static("x-comma-header")),
+			value: HeaderValueMatch::Exact(HeaderValue::from_static("test-value")),
+		},
 	];
 
 	let result = Policy::get_webhook_forward_headers(&headers, &header_matches);
 
-	assert_eq!(result.len(), 2);
+	assert_eq!(result.len(), 3);
 	assert_eq!(
-		result.get("x-test-header").unwrap(),
-		&HeaderValue::from_static("test-value")
+		result
+			.get_all("x-test-header")
+			.iter()
+			.cloned()
+			.collect::<Vec<_>>(),
+		vec![
+			HeaderValue::from_static("first-value"),
+			HeaderValue::from_static("test-value"),
+		]
 	);
 	assert_eq!(
 		result.get("x-regex-header").unwrap(),
 		&HeaderValue::from_static("regex-match-123")
 	);
+	assert!(!result.contains_key("x-comma-header"));
 }
 
 #[test]

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -1092,6 +1092,20 @@ pub enum HeaderValueMatch {
 	Invalid,
 }
 
+impl HeaderValueMatch {
+	pub(crate) fn matches(&self, have: &HeaderValue) -> bool {
+		match self {
+			HeaderValueMatch::Exact(want) => have == want,
+			HeaderValueMatch::Regex(want) => have
+				.to_str()
+				.ok()
+				.and_then(|have| want.find(have).map(|m| (have, m)))
+				.is_some_and(|(have, m)| m.start() == 0 && m.end() == have.len()),
+			HeaderValueMatch::Invalid => false,
+		}
+	}
+}
+
 #[apply(schema!)]
 pub enum PathMatch {
 	Exact(Strng),


### PR DESCRIPTION
Check each separately supplied header value so later values are not ignored, while keeping comma-joined fields atomic.

Signed-off-by: John Howard <john.howard@solo.io>
