### PR TITLE
feat(mcp/okta): native /authorize redirect, /token proxy, and RFC 8414 issuer rewrite

### DIFF
--- a/crates/agentgateway/src/mcp/auth.rs
+++ b/crates/agentgateway/src/mcp/auth.rs
@@ -276,6 +276,14 @@ pub(super) async fn authorization_server_metadata(
 			{
 				*re = format!("{current_uri}/client-registration");
 			}
+
+			// RFC 8414 §3.3: the issuer in AS metadata MUST match the URL from which it was fetched.
+			// Strict clients (Claude Desktop, ChatGPT, Codex) reject metadata when issuer ≠ gateway URL.
+			if let Some(serde_json::Value::String(issuer_val)) =
+				json::traverse_mut(&mut resp, &["issuer"])
+			{
+				*issuer_val = issuer_from_metadata_uri(&current_uri.to_string());
+			}
 		},
 		Some(McpIDP::Descope {}) => {
 			// Descope supports RFC 8707, so no audience workaround needed.
@@ -439,6 +447,14 @@ async fn build_mock_dcr_response(
 	)
 }
 
+/// Strips the `/.well-known/...` suffix from a metadata URI to derive the gateway base URL,
+/// which becomes the `issuer` value satisfying RFC 8414 §3.3.
+fn issuer_from_metadata_uri(uri: &str) -> String {
+	uri.split_once("/.well-known/")
+		.map(|(base, _)| base.to_string())
+		.unwrap_or_else(|| uri.to_string())
+}
+
 #[cfg(test)]
 mod tests {
 	use std::sync::Arc;
@@ -528,6 +544,34 @@ mod tests {
 			.expect("request should build");
 		req.extensions_mut().insert(auth);
 		req
+	}
+
+	#[test]
+	fn issuer_strips_well_known_suffix_from_root_gateway() {
+		assert_eq!(
+			issuer_from_metadata_uri(
+				"https://gateway.example.com/.well-known/oauth-authorization-server"
+			),
+			"https://gateway.example.com"
+		);
+	}
+
+	#[test]
+	fn issuer_strips_well_known_suffix_from_path_prefixed_gateway() {
+		assert_eq!(
+			issuer_from_metadata_uri(
+				"https://gateway.example.com/base/path/.well-known/oauth-authorization-server"
+			),
+			"https://gateway.example.com/base/path"
+		);
+	}
+
+	#[test]
+	fn issuer_returns_uri_unchanged_when_no_well_known_present() {
+		assert_eq!(
+			issuer_from_metadata_uri("https://gateway.example.com"),
+			"https://gateway.example.com"
+		);
 	}
 
 	fn default_auth() -> McpAuthentication {

--- a/crates/agentgateway/src/mcp/auth.rs
+++ b/crates/agentgateway/src/mcp/auth.rs
@@ -19,6 +19,8 @@ use crate::types::agent::{McpAuthentication, McpIDP};
 pub(crate) fn is_well_known_endpoint(path: &str) -> bool {
 	path.starts_with("/.well-known/oauth-protected-resource")
 		|| path.starts_with("/.well-known/oauth-authorization-server")
+		|| path == "/authorize"
+		|| path == "/token"
 }
 
 pub(super) async fn apply_token_validation(
@@ -91,6 +93,30 @@ pub(crate) async fn handle_mcp_request(
 				})
 				.into_response(),
 		)),
+		path if path == "/authorize" => match &auth.provider {
+			Some(McpIDP::Okta {}) => Ok(Some(
+				okta_authorize_redirect(req, auth)
+					.await
+					.map_err(|e| {
+						warn!("okta_authorize_redirect error: {}", e);
+						StatusCode::INTERNAL_SERVER_ERROR
+					})
+					.into_response(),
+			)),
+			_ => Ok(None),
+		},
+		path if path == "/token" => match &auth.provider {
+			Some(McpIDP::Okta {}) => Ok(Some(
+				okta_token_proxy(req, auth, client.clone())
+					.await
+					.map_err(|e| {
+						warn!("okta_token_proxy error: {}", e);
+						StatusCode::INTERNAL_SERVER_ERROR
+					})
+					.into_response(),
+			)),
+			_ => Ok(None),
+		},
 		_ => {
 			// Not handled
 			Ok(None)
@@ -257,32 +283,38 @@ pub(super) async fn authorization_server_metadata(
 			}
 		},
 		Some(McpIDP::Okta {}) => {
-			// Okta does not support RFC 8707. Workaround by appending audience as a query param.
-			let Some(serde_json::Value::String(ae)) =
-				json::traverse_mut(&mut resp, &["authorization_endpoint"])
-			else {
-				return Err(ProxyError::ProcessingString(
-					"authorization_endpoint missing".to_string(),
-				));
-			};
-			if let Some(aud) = auth.audiences.first() {
-				ae.push_str(&format!("?audience={}", aud));
-			}
-
-			// Okta doesn't do CORS for client registrations — proxy it (same pattern as Keycloak)
 			let current_uri = request_uri_for_oauth_metadata(req);
-			if let Some(serde_json::Value::String(re)) =
-				json::traverse_mut(&mut resp, &["registration_endpoint"])
-			{
-				*re = format!("{current_uri}/client-registration");
-			}
 
-			// RFC 8414 §3.3: the issuer in AS metadata MUST match the URL from which it was fetched.
+			// RFC 8414 §3.3: issuer MUST match the URL from which the metadata was fetched.
 			// Strict clients (Claude Desktop, ChatGPT, Codex) reject metadata when issuer ≠ gateway URL.
 			if let Some(serde_json::Value::String(issuer_val)) =
 				json::traverse_mut(&mut resp, &["issuer"])
 			{
 				*issuer_val = issuer_from_metadata_uri(&current_uri.to_string());
+			}
+
+			// Rewrite authorization_endpoint and token_endpoint to gateway-local paths.
+			// Claude Desktop and claude.ai construct these from issuer ({issuer}/authorize,
+			// {issuer}/token) instead of reading metadata fields — agentgateway handles both
+			// paths natively: /authorize redirects to Okta (injecting audience), /token proxies
+			// the token exchange. This eliminates the need for an external nginx issuer-proxy.
+			if let Some(serde_json::Value::String(ae)) =
+				json::traverse_mut(&mut resp, &["authorization_endpoint"])
+			{
+				*ae = format!("{current_uri}/authorize");
+			}
+
+			if let Some(serde_json::Value::String(te)) =
+				json::traverse_mut(&mut resp, &["token_endpoint"])
+			{
+				*te = format!("{current_uri}/token");
+			}
+
+			// Okta doesn't do CORS for client registrations — proxy via gateway.
+			if let Some(serde_json::Value::String(re)) =
+				json::traverse_mut(&mut resp, &["registration_endpoint"])
+			{
+				*re = format!("{current_uri}/client-registration");
 			}
 		},
 		Some(McpIDP::Descope {}) => {
@@ -330,6 +362,71 @@ pub(super) async fn authorization_server_metadata(
 		)))?;
 
 	Ok(response)
+}
+
+/// Redirects /authorize to Okta's actual authorize endpoint, injecting `audience` (RFC 8707
+/// workaround — Okta does not support resource indicators natively) and a default `scope=openid`
+/// when the client omits scope entirely.
+async fn okta_authorize_redirect(
+	req: &Request,
+	auth: &McpAuthentication,
+) -> Result<Response, ProxyError> {
+	let issuer = auth.issuer.trim_end_matches('/');
+	let existing_query = req.uri().query().unwrap_or("");
+
+	let aud = auth.audiences.first().map(String::as_str).unwrap_or("");
+	let has_scope = existing_query.split('&').any(|p| p.starts_with("scope="));
+
+	let mut query = format!("audience={aud}");
+	if !has_scope {
+		query.push_str("&scope=openid");
+	}
+	if !existing_query.is_empty() {
+		query.push('&');
+		query.push_str(existing_query);
+	}
+
+	let location = format!("{issuer}/v1/authorize?{query}");
+	Ok(Response::builder()
+		.status(StatusCode::FOUND)
+		.header("location", location)
+		.body(axum::body::Body::empty())?)
+}
+
+/// Proxies POST /token to Okta's token endpoint.
+///
+/// OAuth clients must not follow redirects for token exchange (RFC 6749), so a 302 is not
+/// viable here — we proxy the request directly to Okta and return its response verbatim.
+async fn okta_token_proxy(
+	req: &mut Request,
+	auth: &McpAuthentication,
+	client: PolicyClient,
+) -> Result<Response, ProxyError> {
+	let issuer = auth.issuer.trim_end_matches('/');
+	let token_uri = format!("{issuer}/v1/token");
+
+	let content_type = req.headers().get("content-type").cloned();
+	let authorization = req.headers().get("authorization").cloned();
+
+	let body = std::mem::take(req.body_mut());
+
+	let mut builder = ::http::Request::builder()
+		.uri(token_uri)
+		.method(Method::POST);
+	if let Some(ct) = content_type {
+		builder = builder.header("content-type", ct);
+	}
+	if let Some(auth_hdr) = authorization {
+		builder = builder.header("authorization", auth_hdr);
+	}
+
+	let ureq = builder.body(body)?;
+	let upstream = client
+		.with_outbound(OutboundCallKind::Policy, OutboundCallSubtype::Oidc)
+		.simple_call(ureq)
+		.await?;
+
+	Ok(upstream)
 }
 
 pub(super) async fn client_registration(

--- a/crates/agentgateway/src/mcp/auth.rs
+++ b/crates/agentgateway/src/mcp/auth.rs
@@ -267,6 +267,11 @@ pub(super) async fn authorization_server_metadata(
 	let mut resp: serde_json::Value = from_body_with_limit(upstream.into_body(), limit)
 		.await
 		.map_err(ProxyError::Body)?;
+
+	// Pre-compute once — used in provider-specific rewrites below and in universal blocks.
+	let current_uri = request_uri_for_oauth_metadata(req);
+	let gateway_base = issuer_from_metadata_uri(current_uri.to_string());
+
 	match &auth.provider {
 		Some(McpIDP::Auth0 {}) => {
 			// Auth0 does not support RFC 8707. We can workaround this by prepending an audience
@@ -283,9 +288,6 @@ pub(super) async fn authorization_server_metadata(
 			}
 		},
 		Some(McpIDP::Okta {}) => {
-			let current_uri = request_uri_for_oauth_metadata(req);
-			let gateway_base = issuer_from_metadata_uri(current_uri.to_string());
-
 			// Rewrite authorization_endpoint and token_endpoint to gateway-local paths.
 			// Claude Desktop and claude.ai derive these from issuer ({issuer}/authorize,
 			// {issuer}/token) instead of reading metadata fields — agentgateway handles both
@@ -347,9 +349,8 @@ pub(super) async fn authorization_server_metadata(
 	// RFC 8414 §3.3: the issuer in AS metadata MUST match the URL from which it was fetched.
 	// Applied universally across all providers — strict clients (Claude Desktop, ChatGPT, Codex)
 	// validate this and abort if issuer ≠ gateway URL.
-	let current_uri = request_uri_for_oauth_metadata(req);
 	if let Some(serde_json::Value::String(issuer_val)) = json::traverse_mut(&mut resp, &["issuer"]) {
-		*issuer_val = issuer_from_metadata_uri(current_uri.to_string());
+		*issuer_val = gateway_base;
 	}
 
 	let response = ::http::Response::builder()
@@ -375,15 +376,25 @@ async fn okta_authorize_redirect(
 	let issuer = auth.issuer.trim_end_matches('/');
 	let existing_query = req.uri().query().unwrap_or("");
 
-	let aud = auth.audiences.first().map(String::as_str).unwrap_or("");
 	let has_scope = existing_query.split('&').any(|p| p.starts_with("scope="));
 
-	let mut query = format!("audience={aud}");
+	// Inject audience only when configured — sending audience= (empty) causes Okta to reject
+	// the request; absence of the param is preferable to an invalid value.
+	let mut query = auth
+		.audiences
+		.first()
+		.map(|aud| format!("audience={aud}"))
+		.unwrap_or_default();
 	if !has_scope {
-		query.push_str("&scope=openid");
+		if !query.is_empty() {
+			query.push('&');
+		}
+		query.push_str("scope=openid");
 	}
 	if !existing_query.is_empty() {
-		query.push('&');
+		if !query.is_empty() {
+			query.push('&');
+		}
 		query.push_str(existing_query);
 	}
 

--- a/crates/agentgateway/src/mcp/auth.rs
+++ b/crates/agentgateway/src/mcp/auth.rs
@@ -94,27 +94,34 @@ pub(crate) async fn handle_mcp_request(
 				.into_response(),
 		)),
 		path if path == "/authorize" => match &auth.provider {
-			Some(McpIDP::Okta {}) => Ok(Some(
-				okta_authorize_redirect(req, auth)
-					.await
-					.map_err(|e| {
-						warn!("okta_authorize_redirect error: {}", e);
-						StatusCode::INTERNAL_SERVER_ERROR
-					})
-					.into_response(),
-			)),
+			Some(McpIDP::Okta {}) => {
+				let existing_query = req.uri().query().unwrap_or("").to_owned();
+				Ok(Some(
+					okta_authorize_redirect(&existing_query, auth)
+						.map_err(|e| {
+							warn!("okta_authorize_redirect error: {}", e);
+							StatusCode::INTERNAL_SERVER_ERROR
+						})
+						.into_response(),
+				))
+			},
 			_ => Ok(None),
 		},
 		path if path == "/token" => match &auth.provider {
-			Some(McpIDP::Okta {}) => Ok(Some(
-				okta_token_proxy(req, auth, client.clone())
-					.await
-					.map_err(|e| {
-						warn!("okta_token_proxy error: {}", e);
-						StatusCode::INTERNAL_SERVER_ERROR
-					})
-					.into_response(),
-			)),
+			Some(McpIDP::Okta {}) => {
+				let content_type = req.headers().get("content-type").cloned();
+				let authorization = req.headers().get("authorization").cloned();
+				let body = std::mem::take(req.body_mut());
+				Ok(Some(
+					okta_token_proxy(content_type, authorization, body, auth, client.clone())
+						.await
+						.map_err(|e| {
+							warn!("okta_token_proxy error: {}", e);
+							StatusCode::INTERNAL_SERVER_ERROR
+						})
+						.into_response(),
+				))
+			},
 			_ => Ok(None),
 		},
 		_ => {
@@ -369,12 +376,11 @@ pub(super) async fn authorization_server_metadata(
 /// Redirects /authorize to Okta's actual authorize endpoint, injecting `audience` (RFC 8707
 /// workaround — Okta does not support resource indicators natively) and a default `scope=openid`
 /// when the client omits scope entirely.
-async fn okta_authorize_redirect(
-	req: &Request,
+fn okta_authorize_redirect(
+	existing_query: &str,
 	auth: &McpAuthentication,
 ) -> Result<Response, ProxyError> {
 	let issuer = auth.issuer.trim_end_matches('/');
-	let existing_query = req.uri().query().unwrap_or("");
 
 	let has_scope = existing_query.split('&').any(|p| p.starts_with("scope="));
 
@@ -410,17 +416,14 @@ async fn okta_authorize_redirect(
 /// OAuth clients must not follow redirects for token exchange (RFC 6749), so a 302 is not
 /// viable here — we proxy the request directly to Okta and return its response verbatim.
 async fn okta_token_proxy(
-	req: &mut Request,
+	content_type: Option<http::HeaderValue>,
+	authorization: Option<http::HeaderValue>,
+	body: Body,
 	auth: &McpAuthentication,
 	client: PolicyClient,
 ) -> Result<Response, ProxyError> {
 	let issuer = auth.issuer.trim_end_matches('/');
 	let token_uri = format!("{issuer}/v1/token");
-
-	let content_type = req.headers().get("content-type").cloned();
-	let authorization = req.headers().get("authorization").cloned();
-
-	let body = std::mem::take(req.body_mut());
 
 	let mut builder = ::http::Request::builder()
 		.uri(token_uri)

--- a/crates/agentgateway/src/mcp/auth.rs
+++ b/crates/agentgateway/src/mcp/auth.rs
@@ -284,30 +284,23 @@ pub(super) async fn authorization_server_metadata(
 		},
 		Some(McpIDP::Okta {}) => {
 			let current_uri = request_uri_for_oauth_metadata(req);
-
-			// RFC 8414 §3.3: issuer MUST match the URL from which the metadata was fetched.
-			// Strict clients (Claude Desktop, ChatGPT, Codex) reject metadata when issuer ≠ gateway URL.
-			if let Some(serde_json::Value::String(issuer_val)) =
-				json::traverse_mut(&mut resp, &["issuer"])
-			{
-				*issuer_val = issuer_from_metadata_uri(&current_uri.to_string());
-			}
+			let gateway_base = issuer_from_metadata_uri(current_uri.to_string());
 
 			// Rewrite authorization_endpoint and token_endpoint to gateway-local paths.
-			// Claude Desktop and claude.ai construct these from issuer ({issuer}/authorize,
+			// Claude Desktop and claude.ai derive these from issuer ({issuer}/authorize,
 			// {issuer}/token) instead of reading metadata fields — agentgateway handles both
 			// paths natively: /authorize redirects to Okta (injecting audience), /token proxies
 			// the token exchange. This eliminates the need for an external nginx issuer-proxy.
 			if let Some(serde_json::Value::String(ae)) =
 				json::traverse_mut(&mut resp, &["authorization_endpoint"])
 			{
-				*ae = format!("{current_uri}/authorize");
+				*ae = format!("{gateway_base}/authorize");
 			}
 
 			if let Some(serde_json::Value::String(te)) =
 				json::traverse_mut(&mut resp, &["token_endpoint"])
 			{
-				*te = format!("{current_uri}/token");
+				*te = format!("{gateway_base}/token");
 			}
 
 			// Okta doesn't do CORS for client registrations — proxy via gateway.
@@ -349,6 +342,14 @@ pub(super) async fn authorization_server_metadata(
 			*re = format!("{current_uri}/client-registration");
 		},
 		_ => {},
+	}
+
+	// RFC 8414 §3.3: the issuer in AS metadata MUST match the URL from which it was fetched.
+	// Applied universally across all providers — strict clients (Claude Desktop, ChatGPT, Codex)
+	// validate this and abort if issuer ≠ gateway URL.
+	let current_uri = request_uri_for_oauth_metadata(req);
+	if let Some(serde_json::Value::String(issuer_val)) = json::traverse_mut(&mut resp, &["issuer"]) {
+		*issuer_val = issuer_from_metadata_uri(current_uri.to_string());
 	}
 
 	let response = ::http::Response::builder()
@@ -544,12 +545,18 @@ async fn build_mock_dcr_response(
 	)
 }
 
-/// Strips the `/.well-known/...` suffix from a metadata URI to derive the gateway base URL,
-/// which becomes the `issuer` value satisfying RFC 8414 §3.3.
-fn issuer_from_metadata_uri(uri: &str) -> String {
-	uri.split_once("/.well-known/")
-		.map(|(base, _)| base.to_string())
-		.unwrap_or_else(|| uri.to_string())
+/// Derives the gateway issuer from an AS metadata URI, satisfying RFC 8414 §3.3.
+///
+/// Removes the `/.well-known/oauth-authorization-server` segment while preserving any
+/// path suffix that follows it, as required by the RFC §3.1 path-based issuer form:
+///   `https://example.com/.well-known/oauth-authorization-server/issuer1`
+///   → `https://example.com/issuer1`
+fn issuer_from_metadata_uri(mut uri: String) -> String {
+	const WELL_KNOWN: &str = "/.well-known/oauth-authorization-server";
+	if let Some(idx) = uri.find(WELL_KNOWN) {
+		uri.replace_range(idx..idx + WELL_KNOWN.len(), "");
+	}
+	uri
 }
 
 #[cfg(test)]
@@ -647,7 +654,7 @@ mod tests {
 	fn issuer_strips_well_known_suffix_from_root_gateway() {
 		assert_eq!(
 			issuer_from_metadata_uri(
-				"https://gateway.example.com/.well-known/oauth-authorization-server"
+				"https://gateway.example.com/.well-known/oauth-authorization-server".to_string()
 			),
 			"https://gateway.example.com"
 		);
@@ -658,15 +665,32 @@ mod tests {
 		assert_eq!(
 			issuer_from_metadata_uri(
 				"https://gateway.example.com/base/path/.well-known/oauth-authorization-server"
+					.to_string()
 			),
 			"https://gateway.example.com/base/path"
+		);
+	}
+
+	// RFC 8414 §3.1 path-based issuer form:
+	// issuer = https://example.com/issuer1
+	// metadata URL = https://example.com/.well-known/oauth-authorization-server/issuer1
+	// The /.well-known/oauth-authorization-server segment must be removed while the
+	// trailing /issuer1 path is preserved.
+	#[test]
+	fn issuer_preserves_path_suffix_after_well_known_segment() {
+		assert_eq!(
+			issuer_from_metadata_uri(
+				"https://gateway.example.com/.well-known/oauth-authorization-server/issuer1"
+					.to_string()
+			),
+			"https://gateway.example.com/issuer1"
 		);
 	}
 
 	#[test]
 	fn issuer_returns_uri_unchanged_when_no_well_known_present() {
 		assert_eq!(
-			issuer_from_metadata_uri("https://gateway.example.com"),
+			issuer_from_metadata_uri("https://gateway.example.com".to_string()),
 			"https://gateway.example.com"
 		);
 	}

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -1967,6 +1967,18 @@ fn mcp_matches() -> Vec<RouteMatch> {
 			method: None,
 			query: vec![],
 		},
+		RouteMatch {
+			headers: vec![],
+			path: PathMatch::Exact("/authorize".into()),
+			method: None,
+			query: vec![],
+		},
+		RouteMatch {
+			headers: vec![],
+			path: PathMatch::Exact("/token".into()),
+			method: None,
+			query: vec![],
+		},
 	]
 }
 


### PR DESCRIPTION
## Problem

The Okta MCP authentication provider proxies Okta's \`/.well-known/openid-configuration\` as \`/.well-known/oauth-authorization-server\`. It correctly rewrites \`authorization_endpoint\` (appending \`?audience=...\`) and \`registration_endpoint\` (DCR proxy) — but does **not** rewrite the \`issuer\` field.

[RFC 8414 §3.3](https://www.rfc-editor.org/rfc/rfc8414#section-3.3) requires:

> The \`issuer\` value returned MUST be identical to the Authorization Server Metadata URL from which the configuration information was obtained.

Strict clients — **Claude Desktop**, **ChatGPT**, **Codex** — validate this and reject metadata when \`issuer\` does not match the gateway URL. This causes the OAuth flow to fail immediately with errors like \`mcp_token_exchange_failed\`.

A second, related problem: **claude.ai** and Claude Desktop construct \`authorization_endpoint\` and \`token_endpoint\` directly from the \`issuer\` value (e.g. \`{issuer}/authorize\`, \`{issuer}/token\`) rather than reading them from metadata fields. When \`issuer\` is rewritten to the gateway URL, those derived paths must also be served by agentgateway — otherwise the auth flow breaks at the redirect and token-exchange steps.

## Solution

**Commit 1** — issuer rewrite (RFC 8414 §3.3):

In \`authorization_server_metadata\`, for the Okta provider arm, rewrite the \`issuer\` field in the AS metadata response to the gateway URL (derived from the request URI), satisfying the RFC requirement. This was the only missing rewrite; \`registration_endpoint\` and \`authorization_endpoint\` were already handled.

**Commit 2** — native \`/authorize\` redirect and \`/token\` proxy:

Extends the Okta arm to also rewrite \`authorization_endpoint\` → \`{gateway}/authorize\` and \`token_endpoint\` → \`{gateway}/token\` in the AS metadata. Two new handlers are added to \`handle_mcp_request\`:

- **\`GET /authorize\`** — 302 redirect to Okta's \`/v1/authorize\`, injecting \`audience\` (RFC 8707 workaround — Okta does not support resource indicators natively) and a default \`scope=openid\` when the client omits scope.
- **\`POST /token\`** — transparent proxy to Okta's \`/v1/token\`, forwarding \`Content-Type\` and \`Authorization\` headers verbatim. A redirect is not viable here: RFC 6749 requires POST for token exchange and HTTP clients do not follow redirects for POST.

Both paths are added to \`mcp_matches()\` (router dispatch) and \`is_well_known_endpoint()\` (bypass JWT validation — they are unauthenticated OAuth endpoints by definition).

## Flow after this PR

```
claude.ai / Claude Desktop
        │
        ▼
GET /.well-known/oauth-authorization-server
        │  agentgateway proxies Okta metadata, rewrites:
        │  issuer              → https://gateway.example.com
        │  authorization_endpoint → https://gateway.example.com/authorize
        │  token_endpoint      → https://gateway.example.com/token
        │  registration_endpoint → https://gateway.example.com/client-registration
        ▼
GET /authorize?... (client constructs from issuer)
        │  agentgateway: 302 → https://okta.example.com/oauth2/.../v1/authorize?audience=...&scope=openid&...
        ▼
POST /token (with code + code_verifier)
        │  agentgateway: proxy → https://okta.example.com/oauth2/.../v1/token
        ▼
Access token returned to client ✓
```

## Testing

Tested end-to-end with claude.ai connecting to an agentgateway instance backed by Okta (BetterMe production Okta org). The OAuth PKCE flow completes successfully: metadata is fetched, redirect happens, token exchange succeeds, and MCP tools are callable.

Signed-off-by: Mykola Palahniuk <mykola.palahniuk@betterme.world>