### PR TITLE
fix(standalone): classify dual-role policies for backend targets

### DIFF
--- a/crates/agentgateway/src/test_helpers/proxymock.rs
+++ b/crates/agentgateway/src/test_helpers/proxymock.rs
@@ -972,7 +972,9 @@ impl TestBind {
 	pub async fn attached_backend_policy(&mut self, addr: &SocketAddr, p: serde_json::Value) {
 		let pol: local::FilterOrPolicy = serde_json::from_value(p).unwrap();
 		let resources = crate::resource_manager::ResourceFetcher::direct(self.pi.upstream.clone());
-		let pols = local::split_policies(&resources, pol, None).await.unwrap();
+		let pols = local::split_policies_for_target(&resources, pol, None, true)
+			.await
+			.unwrap();
 		for v in pols.backend_policies.into_iter() {
 			self.policies += 1;
 			self.with_policy(TargetedPolicy {

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -5197,9 +5197,7 @@ pub(crate) async fn split_policies_for_target(
 	if let Some(p) = transformations {
 		if backend_target {
 			let LocalExplicitOrConditional::Explicit(cfg) = p else {
-				bail!(
-					"conditional transformations are not supported on backend-targeted policies"
-				);
+				bail!("conditional transformations are not supported on backend-targeted policies");
 			};
 			backend_policies.push(BackendTrafficPolicy::Transformation(Arc::new(
 				Transformation::try_from_local_config(cfg, true)?,
@@ -5222,8 +5220,7 @@ pub(crate) async fn split_policies_for_target(
 	}
 	if let Some(p) = ext_authz {
 		if backend_target {
-			let LocalExplicitOrConditional::Explicit(cfg) = configure_ext_authz_cache_store(p)
-			else {
+			let LocalExplicitOrConditional::Explicit(cfg) = configure_ext_authz_cache_store(p) else {
 				bail!("conditional extAuthz is not supported on backend-targeted policies");
 			};
 			backend_policies.push(BackendTrafficPolicy::ExtAuthz(Arc::new(cfg)));

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -2803,7 +2803,14 @@ async fn convert(
 	for p in policies {
 		p.target.validate()?;
 		let policy_key = p.name.to_string();
-		let res = split_policies(resources, p.policy, config.as_policy_context(&policy_key)).await?;
+		let backend_target = matches!(p.target, PolicyTarget::Backend(_));
+		let res = split_policies_for_target(
+			resources,
+			p.policy,
+			config.as_policy_context(&policy_key),
+			backend_target,
+		)
+		.await?;
 		if (res.route_policies.len() + res.backend_policies.len()) != 1 {
 			bail!("'policies' must contain exactly 1 policy");
 		}
@@ -5015,6 +5022,18 @@ pub(crate) async fn split_policies(
 	pol: FilterOrPolicy,
 	attached: Option<AttachedPolicyContext<'_>>,
 ) -> Result<ResolvedPolicies, Error> {
+	split_policies_for_target(resources, pol, attached, false).await
+}
+
+/// Like [`split_policies`], but when `backend_target` is true dual-role policy
+/// types (transformations, header modifiers, etc.) become [`BackendTrafficPolicy`]
+/// so top-level `policies` with `target.backend` apply via `as_backend()`.
+pub(crate) async fn split_policies_for_target(
+	resources: &crate::resource_manager::ResourceFetcher,
+	pol: FilterOrPolicy,
+	attached: Option<AttachedPolicyContext<'_>>,
+	backend_target: bool,
+) -> Result<ResolvedPolicies, Error> {
 	let mut resolved = ResolvedPolicies::default();
 	let ResolvedPolicies {
 		backend_policies,
@@ -5052,23 +5071,39 @@ pub(crate) async fn split_policies(
 		retry,
 	} = pol;
 	if let Some(p) = request_header_modifier {
-		route_policies.push(TrafficPolicy::RequestHeaderModifier(RequestPolicy::single(
-			p,
-		)));
+		if backend_target {
+			backend_policies.push(BackendTrafficPolicy::RequestHeaderModifier(p));
+		} else {
+			route_policies.push(TrafficPolicy::RequestHeaderModifier(RequestPolicy::single(
+				p,
+			)));
+		}
 	}
 	if let Some(p) = response_header_modifier {
-		route_policies.push(TrafficPolicy::ResponseHeaderModifier(
-			RequestPolicy::single(p),
-		));
+		if backend_target {
+			backend_policies.push(BackendTrafficPolicy::ResponseHeaderModifier(Arc::new(p)));
+		} else {
+			route_policies.push(TrafficPolicy::ResponseHeaderModifier(
+				RequestPolicy::single(p),
+			));
+		}
 	}
 	if let Some(p) = request_redirect {
-		route_policies.push(TrafficPolicy::RequestRedirect(RequestPolicy::single(p)));
+		if backend_target {
+			backend_policies.push(BackendTrafficPolicy::RequestRedirect(p));
+		} else {
+			route_policies.push(TrafficPolicy::RequestRedirect(RequestPolicy::single(p)));
+		}
 	}
 	if let Some(p) = url_rewrite {
 		route_policies.push(TrafficPolicy::UrlRewrite(RequestPolicy::single(p)));
 	}
 	if let Some(p) = request_mirror {
-		route_policies.push(TrafficPolicy::RequestMirror(vec![p]));
+		if backend_target {
+			backend_policies.push(BackendTrafficPolicy::RequestMirror(vec![p]));
+		} else {
+			route_policies.push(TrafficPolicy::RequestMirror(vec![p]));
+		}
 	}
 
 	// Filters
@@ -5113,10 +5148,14 @@ pub(crate) async fn split_policies(
 		backend_policies.push(BackendTrafficPolicy::BackendAuth(p))
 	}
 
-	// Route policies
+	// Route policies (AI is dual-role when targeting a backend)
 	if let Some(mut p) = ai {
 		p.compile_model_alias_patterns();
-		route_policies.push(TrafficPolicy::AI(Arc::new(p)))
+		if backend_target {
+			backend_policies.push(BackendTrafficPolicy::AI(Arc::new(p)));
+		} else {
+			route_policies.push(TrafficPolicy::AI(Arc::new(p)));
+		}
 	}
 	if let Some(p) = jwt_auth {
 		route_policies.push(TrafficPolicy::JwtAuth(RequestPolicy::single(
@@ -5156,20 +5195,43 @@ pub(crate) async fn split_policies(
 		route_policies.push(TrafficPolicy::APIKey(RequestPolicy::single(p.into())));
 	}
 	if let Some(p) = transformations {
-		route_policies.push(TrafficPolicy::Transformation(
-			p.into_transformation_policy()?,
-		));
+		if backend_target {
+			let LocalExplicitOrConditional::Explicit(cfg) = p else {
+				bail!(
+					"conditional transformations are not supported on backend-targeted policies"
+				);
+			};
+			backend_policies.push(BackendTrafficPolicy::Transformation(Arc::new(
+				Transformation::try_from_local_config(cfg, true)?,
+			)));
+		} else {
+			route_policies.push(TrafficPolicy::Transformation(
+				p.into_transformation_policy()?,
+			));
+		}
 	}
 	if let Some(p) = csrf {
 		route_policies.push(TrafficPolicy::Csrf(RequestPolicy::single(p)))
 	}
 	if let Some(p) = authorization {
-		route_policies.push(TrafficPolicy::Authorization(p))
+		if backend_target {
+			backend_policies.push(BackendTrafficPolicy::Authorization(p));
+		} else {
+			route_policies.push(TrafficPolicy::Authorization(p));
+		}
 	}
 	if let Some(p) = ext_authz {
-		route_policies.push(TrafficPolicy::ExtAuthz(
-			configure_ext_authz_cache_store(p).into_policy()?,
-		))
+		if backend_target {
+			let LocalExplicitOrConditional::Explicit(cfg) = configure_ext_authz_cache_store(p)
+			else {
+				bail!("conditional extAuthz is not supported on backend-targeted policies");
+			};
+			backend_policies.push(BackendTrafficPolicy::ExtAuthz(Arc::new(cfg)));
+		} else {
+			route_policies.push(TrafficPolicy::ExtAuthz(
+				configure_ext_authz_cache_store(p).into_policy()?,
+			));
+		}
 	}
 	if let Some(p) = ext_proc {
 		route_policies.push(TrafficPolicy::ExtProc(p.into_policy()?))

--- a/crates/agentgateway/src/types/local_tests.rs
+++ b/crates/agentgateway/src/types/local_tests.rs
@@ -1852,6 +1852,109 @@ fn test_mcp_backend_host_rejects_mixed_host_and_backend() {
 }
 
 #[tokio::test]
+async fn test_top_level_backend_targeted_transformations_are_backend_policies() {
+	let normalized = normalize_test_yaml(
+		r#"
+backends:
+- name: upstream-1
+  host: 127.0.0.1:8000
+policies:
+- name:
+    name: add-header
+    namespace: ""
+  target:
+    backend:
+      backend:
+        name: upstream-1
+        namespace: ""
+  policy:
+    transformations:
+      request:
+        set:
+          x-test: "'backend'"
+binds:
+- port: 3000
+  listeners:
+  - routes:
+    - backends:
+      - backend: upstream-1
+"#,
+	)
+	.await
+	.expect("backend-targeted transformations should normalize");
+
+	let policy = normalized
+		.policies
+		.iter()
+		.find(|policy| {
+			policy
+				.name
+				.as_ref()
+				.is_some_and(|name| name.name.as_str() == "add-header")
+		})
+		.expect("expected top-level add-header policy");
+
+	assert!(
+		matches!(policy.target, PolicyTarget::Backend(_)),
+		"expected backend target, got {:?}",
+		policy.target
+	);
+	assert!(
+		matches!(
+			&policy.policy,
+			PolicyType::Backend(BackendTrafficPolicy::Transformation(_))
+		),
+		"expected BackendTrafficPolicy::Transformation, got {:?}",
+		policy.policy
+	);
+	assert!(
+		policy.policy.as_backend().is_some(),
+		"backend-targeted transformations must surface via as_backend()"
+	);
+}
+
+#[tokio::test]
+async fn test_top_level_backend_targeted_conditional_transformations_are_rejected() {
+	let err = normalize_test_yaml(
+		r#"
+backends:
+- name: upstream-1
+  host: 127.0.0.1:8000
+policies:
+- name:
+    name: add-header
+    namespace: ""
+  target:
+    backend:
+      backend:
+        name: upstream-1
+        namespace: ""
+  policy:
+    transformations:
+      conditional:
+      - request:
+          set:
+            x-test: "'backend'"
+binds:
+- port: 3000
+  listeners:
+  - routes:
+    - backends:
+      - backend: upstream-1
+"#,
+	)
+	.await
+	.expect_err("conditional transformations on backend targets should fail");
+
+	assert!(
+		err
+			.to_string()
+			.contains("conditional transformations are not supported on backend-targeted policies"),
+		"unexpected error: {err}"
+	);
+}
+
+#[tokio::test]
 async fn test_oauth_token_exchange_reports_validation_errors_from_local_config() {
 	let err = normalize_test_yaml(
 		r#"


### PR DESCRIPTION
## Summary

Top-level `policies` with `target.backend` could not apply dual-role types such as `transformations`, because `split_policies` always classified them as `TrafficPolicy`. They never surfaced through `as_backend()`.

## Approach

- Add `split_policies_for_target` so dual-role types become `BackendTrafficPolicy` when the policy target is a backend
- Reject conditional `transformations` / `extAuthz` on backend targets (inline backend policies only accept the explicit form)
- Cover normalize success and rejection paths in `local_tests`

## Test plan

- [x] `cargo test --lib top_level_backend_targeted`

Fixes #1440
