### PR TITLE
jwks: honor HTTPS_PROXY/NO_PROXY and validate tunnel Service refs

### DIFF
--- a/controller/pkg/agentgateway/jwks/fetcher.go
+++ b/controller/pkg/agentgateway/jwks/fetcher.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/go-jose/go-jose/v4"
+	"golang.org/x/net/http/httpproxy"
 	"istio.io/istio/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -136,12 +137,21 @@ func nextRetryDelay(retryAttempt int) time.Duration {
 	return next
 }
 
+// proxyFromEnvironment resolves HTTPS_PROXY/HTTP_PROXY/NO_PROXY for a request.
+// Unlike http.ProxyFromEnvironment, it re-reads the environment on each call
+// instead of caching it for the process lifetime.
+func proxyFromEnvironment(req *http.Request) (*url.URL, error) {
+	return httpproxy.FromEnvironment().ProxyFunc()(req.URL)
+}
+
 func makeFetchClient(tlsConfig *tls.Config, proxyURL string, proxyTLSConfig *tls.Config) (*http.Client, error) {
 	dialer := &net.Dialer{Timeout: 5 * time.Second}
 	transport := &http.Transport{
 		TLSClientConfig:   tlsConfig,
 		DialContext:       dialer.DialContext,
 		DisableKeepAlives: true,
+		// An explicit tunnel policy on the JWKS backend overrides this below.
+		Proxy: proxyFromEnvironment,
 	}
 	if proxyURL != "" {
 		parsed, err := url.Parse(proxyURL)
@@ -226,7 +236,8 @@ type jwksHttpClientImpl struct {
 }
 
 func NewFetcher(cache *JwksCache) *Fetcher {
-	// Default client has no TLS or proxy config, so makeFetchClient cannot fail.
+	// Default client has no TLS config or explicit tunnel proxy (it still
+	// honors HTTPS_PROXY/NO_PROXY), so makeFetchClient cannot fail.
 	defaultClient, _ := makeFetchClient(nil, "", nil)
 	return &Fetcher{
 		cache:             cache,

--- a/controller/pkg/agentgateway/jwks/fetcher_test.go
+++ b/controller/pkg/agentgateway/jwks/fetcher_test.go
@@ -455,6 +455,67 @@ func TestMakeFetchClientRejectsInvalidProxyURL(t *testing.T) {
 	assert.Contains(t, err.Error(), "error parsing proxy URL")
 }
 
+func TestFetchJwksViaEnvironmentProxy(t *testing.T) {
+	// Plain-HTTP forward proxy: requests arrive in absolute form and are
+	// answered directly without dialing the (nonexistent) target host.
+	var proxied atomic.Int32
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		proxied.Add(1)
+		assert.Equal(t, "jwks.env-proxy.invalid", r.Host)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, sampleJWKS)
+	}))
+	defer proxy.Close()
+
+	t.Setenv("HTTP_PROXY", proxy.URL)
+	t.Setenv("HTTPS_PROXY", proxy.URL)
+
+	source := testSourceWithURL("http://jwks.env-proxy.invalid/keys")
+
+	ctx := t.Context()
+	f := NewFetcher(NewCache())
+	require.NoError(t, f.AddOrUpdateKeyset(source))
+	updates := f.SubscribeToUpdates()
+
+	go f.maybeFetchJwks(ctx)
+
+	awaitJwksUpdate(t, updates, source.RequestKey)
+	keyset := awaitStoredKeyset(t, f.cache, source.RequestKey)
+	assert.Equal(t, sampleJWKS, keyset.JwksJSON)
+	assert.Equal(t, int32(1), proxied.Load(), "request should have been routed through the environment proxy")
+}
+
+func TestMakeFetchClientProxyFromEnvironment(t *testing.T) {
+	t.Setenv("HTTPS_PROXY", "http://corp-proxy:3128")
+	t.Setenv("NO_PROXY", "internal.example.com")
+
+	client, err := makeFetchClient(nil, "", nil)
+	require.NoError(t, err)
+	transport := client.Transport.(*http.Transport)
+
+	proxied, err := transport.Proxy(httptest.NewRequest(http.MethodGet, "https://login.microsoftonline.com/keys", nil))
+	require.NoError(t, err)
+	require.NotNil(t, proxied)
+	assert.Equal(t, "http://corp-proxy:3128", proxied.String())
+
+	direct, err := transport.Proxy(httptest.NewRequest(http.MethodGet, "https://internal.example.com/keys", nil))
+	require.NoError(t, err)
+	assert.Nil(t, direct, "NO_PROXY hosts should not be proxied")
+}
+
+func TestMakeFetchClientTunnelProxyOverridesEnvironment(t *testing.T) {
+	t.Setenv("HTTPS_PROXY", "http://env-proxy:3128")
+
+	client, err := makeFetchClient(nil, "http://tunnel-proxy:8080", nil)
+	require.NoError(t, err)
+	transport := client.Transport.(*http.Transport)
+
+	proxied, err := transport.Proxy(httptest.NewRequest(http.MethodGet, "https://login.microsoftonline.com/keys", nil))
+	require.NoError(t, err)
+	require.NotNil(t, proxied)
+	assert.Equal(t, "http://tunnel-proxy:8080", proxied.String())
+}
+
 func TestProxyURLAffectsFetchKey(t *testing.T) {
 	a := remotehttp.FetchTarget{URL: "https://example.com/jwks"}
 	b := remotehttp.FetchTarget{URL: "https://example.com/jwks", ProxyURL: "http://proxy:8080"}

--- a/controller/pkg/agentgateway/remotehttp/connection_resolver.go
+++ b/controller/pkg/agentgateway/remotehttp/connection_resolver.go
@@ -213,6 +213,19 @@ func (r *defaultResolver) resolveTunnelProxy(
 		}, nil
 
 	case string(kind) == wellknown.ServiceKind && string(group) == "":
+		nn := types.NamespacedName{Name: string(backendRef.Name), Namespace: refNamespace}
+		svc := ptr.Flatten(krt.FetchOne(krtctx, r.services, krt.FilterObjectName(nn)))
+		if svc == nil {
+			// A backendRef with no group/kind silently defaults to a core
+			// Service; call that out, since the ref usually meant to target an
+			// AgentgatewayBackend and the tunnel would otherwise retry forever.
+			hint := ""
+			if backendRef.Kind == nil {
+				hint = fmt.Sprintf("; backendRef defaulted to kind Service — to tunnel through an %s, set backendRef.group=%q and backendRef.kind=%q",
+					wellknown.AgentgatewayBackendGVK.Kind, wellknown.AgentgatewayBackendGVK.Group, wellknown.AgentgatewayBackendGVK.Kind)
+			}
+			return nil, fmt.Errorf("tunnel proxy Service %s not found%s", nn, hint)
+		}
 		host := kubeutils.GetServiceHostname(string(backendRef.Name), refNamespace)
 		port := ptr.OrEmpty(backendRef.Port)
 		if port == 0 {

--- a/controller/pkg/agentgateway/remotehttp/resolver_test.go
+++ b/controller/pkg/agentgateway/remotehttp/resolver_test.go
@@ -438,6 +438,75 @@ func TestResolve(t *testing.T) {
 	}
 }
 
+func TestResolveTunnelProxyServiceMustExist(t *testing.T) {
+	backendWithTunnel := func(tunnelRef gwv1.BackendObjectReference) *agentgateway.AgentgatewayBackend {
+		return &agentgateway.AgentgatewayBackend{
+			ObjectMeta: metav1.ObjectMeta{Name: "idp-jwks", Namespace: "default"},
+			Spec: agentgateway.AgentgatewayBackendSpec{
+				Static: &agentgateway.StaticBackend{Host: "idp.example.com", Port: 443},
+				Policies: &agentgateway.BackendFull{
+					BackendSimple: agentgateway.BackendSimple{
+						TLS:    &agentgateway.BackendTLS{},
+						Tunnel: &agentgateway.BackendTunnel{BackendRef: tunnelRef},
+					},
+				},
+			},
+		}
+	}
+	resolve := func(t *testing.T, inputs []any) (*remotehttp.ResolvedTarget, error) {
+		ctx := testutils.BuildMockPolicyContext(t, inputs)
+		resolver := testutils.BuildRemoteHTTPResolver(ctx.Collections)
+		return resolver.Resolve(ctx.Krt, remotehttp.ResolveInput{
+			ParentName:       "gw-policy",
+			DefaultNamespace: "default",
+			BackendRef: gwv1.BackendObjectReference{
+				Name:  gwv1.ObjectName("idp-jwks"),
+				Group: new(gwv1.Group(wellknown.AgentgatewayBackendGVK.Group)),
+				Kind:  new(gwv1.Kind(wellknown.AgentgatewayBackendGVK.Kind)),
+			},
+			Path: "/",
+		})
+	}
+
+	t.Run("existing service resolves proxy URL", func(t *testing.T) {
+		resolved, err := resolve(t, []any{
+			backendWithTunnel(gwv1.BackendObjectReference{
+				Name: gwv1.ObjectName("web-proxy"),
+				Kind: ptr.Of(gwv1.Kind("Service")),
+				Port: ptr.Of(gwv1.PortNumber(3128)),
+			}),
+			testService("web-proxy", "default", []corev1.ServicePort{{Name: "http", Port: 3128}}),
+		})
+		require.NoError(t, err)
+		require.Equal(t, "http://web-proxy.default.svc.cluster.local:3128", resolved.Target.ProxyURL)
+	})
+
+	t.Run("missing service is an error", func(t *testing.T) {
+		_, err := resolve(t, []any{
+			backendWithTunnel(gwv1.BackendObjectReference{
+				Name: gwv1.ObjectName("web-proxy"),
+				Kind: ptr.Of(gwv1.Kind("Service")),
+				Port: ptr.Of(gwv1.PortNumber(3128)),
+			}),
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "tunnel proxy Service default/web-proxy not found")
+		require.NotContains(t, err.Error(), "defaulted to kind Service")
+	})
+
+	t.Run("defaulted group and kind adds AgentgatewayBackend hint", func(t *testing.T) {
+		_, err := resolve(t, []any{
+			backendWithTunnel(gwv1.BackendObjectReference{
+				Name: gwv1.ObjectName("web-proxy"),
+				Port: ptr.Of(gwv1.PortNumber(3128)),
+			}),
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "tunnel proxy Service default/web-proxy not found")
+		require.Contains(t, err.Error(), "set backendRef.group")
+	})
+}
+
 func TestResolveWithAdditionalBackendResolver(t *testing.T) {
 	ctx := testutils.BuildMockPolicyContext(t, nil)
 	backendGK := schema.GroupKind{Group: "example.io", Kind: "ExampleBackend"}


### PR DESCRIPTION
## What
Two controller-side fixes for JWKS fetching through corporate egress:

1. **Honor `HTTPS_PROXY`/`HTTP_PROXY`/`NO_PROXY`.** The JWKS fetch client builds a custom `http.Transport` (for TLS config, dial timeout, keep-alives), which has no `Proxy` function — so proxy env vars on the controller deployment were silently ignored and the controller always dialed the IdP directly unless an explicit `policies.tunnel` was configured. The transport now defaults to resolving the proxy from the environment per request; an explicit tunnel policy on the JWKS backend still takes precedence. Env resolution uses `golang.org/x/net/http/httpproxy` per request rather than `http.ProxyFromEnvironment`, which caches env vars for the process lifetime.

2. **Fail loudly on unresolvable tunnel Service refs.** A `tunnel.backendRef` that omits `group`/`kind` silently defaults to core `Service` kind, and the resolver previously constructed the Service hostname without checking the Service exists — the JWKS fetch then retried forever against a phantom proxy with no signal on the policy. The resolver now returns an error when the Service is missing, and when the ref was defaulted the error includes a hint to set `backendRef.group`/`kind` (e.g. when the ref was meant to target an `AgentgatewayBackend`).

## Why
Observed in a customer environment fetching MSFT Entra JWKS (`login.microsoftonline.com`) from a cluster with proxy-only egress: setting `HTTPS_PROXY` did nothing, and an earlier misconfigured tunnel ref (missing `group`/`kind`) produced only endless fetch retries with no policy-level indication.

## Testing
- End-to-end fetch through an env-configured proxy, `NO_PROXY` bypass, and explicit-tunnel-overrides-env precedence tests in `jwks`.
- Tunnel Service resolution tests (existing Service resolves, missing Service errors, defaulted group/kind gets the hint) in `remotehttp`.
- Full controller test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)