### PR TITLE
jwks: set explicit User-Agent on controller JWKS fetches

### DIFF
--- a/controller/pkg/agentgateway/jwks/fetcher.go
+++ b/controller/pkg/agentgateway/jwks/fetcher.go
@@ -18,6 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/remotehttp"
+	"github.com/agentgateway/agentgateway/controller/pkg/version"
 )
 
 const (
@@ -26,6 +27,11 @@ const (
 	maxRetryShift     = 30
 	clientTimeout     = 10 * time.Second
 )
+
+// fetchUserAgent identifies controller-originated JWKS fetches. Go's default
+// Go-http-client/1.1 UA is fingerprinted as automated traffic by some
+// enterprise secure web gateways, which respond with synthetic errors.
+var fetchUserAgent = "agentgateway-controller/" + version.GitVersion
 
 type fetchAt struct {
 	At           time.Time
@@ -479,6 +485,7 @@ func (c *jwksHttpClientImpl) FetchJwks(ctx context.Context, target remotehttp.Fe
 	if err != nil {
 		return jose.JSONWebKeySet{}, fmt.Errorf("could not build request to get JWKS: %w", err)
 	}
+	request.Header.Set("User-Agent", fetchUserAgent)
 
 	response, err := c.Client.Do(request)
 	if err != nil {

--- a/controller/pkg/agentgateway/jwks/fetcher_test.go
+++ b/controller/pkg/agentgateway/jwks/fetcher_test.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -453,6 +454,24 @@ func TestMakeFetchClientRejectsInvalidProxyURL(t *testing.T) {
 	_, err := makeFetchClient(nil, "://missing-scheme", nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "error parsing proxy URL")
+}
+
+func TestFetchJwksSetsExplicitUserAgent(t *testing.T) {
+	userAgents := make(chan string, 1)
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		userAgents <- r.Header.Get("User-Agent")
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, sampleJWKS)
+	}))
+	defer backend.Close()
+
+	f := NewFetcher(NewCache())
+	_, err := f.defaultJwksClient.FetchJwks(t.Context(), remotehttp.FetchTarget{URL: backend.URL})
+	require.NoError(t, err)
+
+	ua := <-userAgents
+	assert.Equal(t, fetchUserAgent, ua)
+	assert.True(t, strings.HasPrefix(ua, "agentgateway-controller/"), "unexpected user agent %q", ua)
 }
 
 func TestProxyURLAffectsFetchKey(t *testing.T) {


### PR DESCRIPTION
## What
Controller-originated JWKS fetch requests currently go out with Go's default `Go-http-client/1.1` User-Agent. Set an explicit `agentgateway-controller/<version>` User-Agent (version from `controller/pkg/version`) instead.

## Why
Enterprise secure web gateways fingerprint the default Go UA as automated traffic and can block it with misleading synthetic responses. Observed in a customer environment (Netskope): JWKS fetches for MSFT Entra through a corporate CONNECT proxy received a synthetic `404` that looked like it came from `login.microsoftonline.com`, sending debugging in the wrong direction. An identifiable UA avoids the fingerprint and makes the controller's traffic attributable in proxy logs.

## Testing
- Added a test asserting the outbound request carries `agentgateway-controller/<version>` instead of the Go default.
- `jwks` package tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)